### PR TITLE
[Spec] Add Qwen3-family DSpark draft model (extends #29538) + fix DeepSeek-V4 import crash for non-V4 DSpark targets

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -185,6 +185,10 @@ The generator currently picks values on the **conservative** side (mirroring an 
 - `high-throughput`: MTP disabled — at saturation the verify step costs more than it saves.
 - MTP runs on the v2 speculative path.
 
+**DSpark speculative decoding**
+
+DeepSeek-V4 also ships DSpark block speculative decoding in the `*-DSpark` checkpoints (`deepseek-ai/DeepSeek-V4-Flash-DSpark`, `deepseek-ai/DeepSeek-V4-Pro-DSpark`). Enable it with `--speculative-algorithm DSPARK`; the drafter lives inside the checkpoint, so there is no separate draft model. It is lossless at `temperature 0` (and verifies `temperature > 0` with target-only speculative sampling) and gives roughly 1.5x to 1.8x single-stream speedup. See [DSpark Decoding](../../../docs/advanced_features/speculative_decoding#dspark-decoding-deepseek-v4).
+
 **Compressed attention state dtype**
 
 DeepSeek-V4 uses hybrid compressed attention for long-context efficiency. `SGLANG_DSV4_COMPRESS_STATE_DTYPE` controls the dtype of the C4 / C128 compressed attention state pools. Supported values are `float32` / `fp32` (default: `float32`) and `bfloat16` / `bf16`. For BF16 on the offline compression path:

--- a/docs_new/docs/advanced_features/speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/speculative_decoding.mdx
@@ -16,7 +16,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
   - [EAGLE-3 Decoding](#eagle-3-decoding)
 - [Multi Token Prediction](#multi-token-prediction)
 - [DFlash Decoding](#dflash-decoding)
-- [DSpark Decoding (DeepSeek-V4)](#dspark-decoding-deepseek-v4)
+- [DSpark Decoding (DeepSeek-V4 and Qwen3)](#dspark-decoding-deepseek-v4-and-qwen3)
 - [Standalone Speculative Decoding (Small Draft Model)](#standalone-speculative-decoding-small-draft-model)
 - [Speculative Decoding V2 (Overlap Scheduler)](#speculative-decoding-v2-overlap-scheduler)
 - [Ngram Speculative Decoding](#ngram-speculative-decoding)
@@ -32,7 +32,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
 - **Lower `lm_head` overhead for EAGLE-2**: Enable **FR-Spec** with `--speculative-token-map`.
 - **Model is MTP-enabled**: Use **MTP via speculative decoding** (often with small `speculative_num_steps/topk/num_draft_tokens`, see the example section).
 - **You have a DFlash draft checkpoint**: Use **DFLASH** with `--speculative-algorithm DFLASH` and `--speculative-draft-model-path ...`.
-- **Serving DeepSeek-V4 DSpark checkpoints**: Use **DSpark** with `--speculative-algorithm DSPARK` (block drafting, greedy, lossless).
+- **Serving DSpark checkpoints (DeepSeek-V4 or Qwen3-family)**: Use **DSpark** with `--speculative-algorithm DSPARK` (block drafting, greedy, lossless).
 - **You have a smaller draft LLM**: Use **STANDALONE** (`--speculative-algorithm STANDALONE`).
 - **No extra model available**: Use **NGRAM** (`--speculative-algorithm NGRAM`, CUDA-only).
 
@@ -97,10 +97,10 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
     </tr>
 <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>DSpark</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DeepSeek-V4 block drafter (3-stage MTP + Markov/confidence heads) in the checkpoint</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>--speculative-algorithm DSPARK</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Greedy (lossless); DeepSeek-V4 DSpark checkpoints only; no <code>--enable-dp-attention</code>; <code>pp_size == 1</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DeepSeek-V4 (3-stage MTP + Markov/confidence heads in the checkpoint) or Qwen3-family (separate block-drafter checkpoint)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No (DeepSeek-V4) / Yes (Qwen3-family)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>--speculative-algorithm DSPARK</code> (+ <code>--speculative-draft-model-path ...</code> for Qwen3-family checkpoints)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Greedy (lossless); no <code>--enable-dp-attention</code>; <code>pp_size == 1</code></td>
     </tr>
 <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>STANDALONE</td>
@@ -507,9 +507,9 @@ print(response.choices[0].message.content)
 
 ---
 
-## DSpark Decoding (DeepSeek-V4)
+## DSpark Decoding (DeepSeek-V4 and Qwen3)
 
-**DSpark** is a block drafter for DeepSeek-V4. The DSpark checkpoints (`deepseek-ai/DeepSeek-V4-Flash-DSpark`, `deepseek-ai/DeepSeek-V4-Pro-DSpark`) ship the speculative module inside the model under the `mtp.*` namespace, so there is no separate draft model to download. Each decode step DSpark proposes a block of `block_size` tokens (inferred from the checkpoint, 5 by default) in one draft forward and the target verifies the whole block in one pass. The drafter is a three-stage MTP stack with a Markov head that refines the block autoregressively and a confidence head that scores each position; it runs off the target's fused hidden states rather than its own token KV. At `temperature 0`, verification is greedy and lossless: the accepted output matches the target's greedy decoding for any block size or confidence threshold. At `temperature > 0`, the block is verified with target-only speculative sampling, which preserves the target's sampling distribution without needing the draft's probabilities.
+**DSpark** is a block drafter, available for both DeepSeek-V4 and Qwen3-family targets through the same `DSparkWorkerV2`. The DeepSeek-V4 DSpark checkpoints (`deepseek-ai/DeepSeek-V4-Flash-DSpark`, `deepseek-ai/DeepSeek-V4-Pro-DSpark`) ship the speculative module inside the model under the `mtp.*` namespace, so there is no separate draft model to download; the Qwen3-family DSpark checkpoints are the opposite — a genuinely separate checkpoint passed via `--speculative-draft-model-path`, see [Qwen3-family checkpoints](#qwen3-family-dspark-checkpoints) below. Each decode step DSpark proposes a block of `block_size` tokens (inferred from the draft checkpoint, 5 by default on DeepSeek-V4) in one draft forward and the target verifies the whole block in one pass. The drafter is a three-stage MTP stack with a Markov head that refines the block autoregressively and a confidence head that scores each position; it runs off the target's fused hidden states rather than its own token KV. At `temperature 0`, verification is greedy and lossless: the accepted output matches the target's greedy decoding for any block size or confidence threshold. At `temperature > 0`, the block is verified with target-only speculative sampling, which preserves the target's sampling distribution without needing the draft's probabilities.
 
 `--speculative-algorithm DSPARK` is enough; the draft path defaults to the target checkpoint, and `--speculative-eagle-topk 1` / `--speculative-num-steps 1` are pinned automatically.
 
@@ -573,7 +573,7 @@ print(response.choices[0].message.content)
 
 **Notes**
 
-- DeepSeek-V4 DSpark checkpoints only. Requires `pp_size == 1` and does not support `--enable-dp-attention`; mixed chunked prefill is disabled automatically.
+- Requires `pp_size == 1` and does not support `--enable-dp-attention` on any DSpark target (DeepSeek-V4 or Qwen3-family); mixed chunked prefill is disabled automatically.
 - `temperature > 0` is verified with the same target-only speculative-sampling primitive as DFLASH, so sampled requests are not downgraded to greedy. Greedy (`temperature 0`) is the benchmark-validated path. If the sampling kernel is unavailable on a build, `temperature > 0` falls back to greedy with a one-time warning.
 - On `DeepSeek-V4-Flash-DSpark` (284B, 8x B200, tp8 ep8, greedy), acceptance length is roughly 3.2 to 3.6 tokens per target forward across math, code, and chat; single-stream throughput improves about 1.5x to 1.8x over no speculation; and GSM8K / MMLU match the no-speculation target within noise. See [sgl-project/sglang#29538](https://github.com/sgl-project/sglang/pull/29538) for full sweeps and raw logs.
 
@@ -588,6 +588,53 @@ The confidence threshold (`--speculative-dspark-confidence-threshold`) only shor
 On builds without the required `sgl_kernel` sampling ops (for example non-CUDA backends), `temperature > 0` falls back to greedy verification and the server logs a one-time warning. Per-request features that DSpark cannot verify are rejected up front rather than silently degraded: `return_logprob`, grammar-constrained decoding (JSON schema, regex, EBNF, or structural tags), and `return_hidden_states`.
 
 The DeepSpec reference implementation verifies with draft-probability rejection sampling driven by a sampled drafter; this integration instead uses SGLang's shared target-only scheme with a deterministic (greedy) drafter. Both are distribution-preserving and differ only in which probabilities drive the accept-or-reject test.
+
+### Qwen3-family DSpark checkpoints
+
+DSpark also serves Qwen3-family targets, through a plain GQA/RoPE block drafter (architecturally DFlash's non-causal block drafter, not DeepSeek-V4's MLA-specific one) rather than the MTP stack described above. Unlike the DeepSeek-V4 checkpoints, the Qwen3-family DSpark checkpoints are a genuinely separate draft checkpoint passed via `--speculative-draft-model-path`, and both `embed_tokens` and `lm_head` are trained in the draft checkpoint (`tie_word_embeddings: false`) rather than tied to the target's.
+
+One model class (`Qwen3DSparkModel`) serves two released checkpoints, config-gated purely by the checkpoint's own `markov_rank` / `enable_confidence_head` fields — no separate registration or flag needed to pick between them:
+
+<table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
+  <colgroup>
+    <col style={{width: "35%"}} />
+    <col style={{width: "40%"}} />
+    <col style={{width: "25%"}} />
+  </colgroup>
+  <thead>
+    <tr style={{borderBottom: "2px solid #d55816"}}>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.02)"}}>Checkpoint</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.05)"}}>Markov / confidence heads</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.02)"}}>Use with</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>deepseek-ai/dspark_qwen3_4b_block7</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Both (<code>markov_rank=256</code>, confidence head enabled)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-algorithm DSPARK</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>deepseek-ai/dflash_qwen3_4b_block7</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Neither (<code>markov_rank=0</code>)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-algorithm DFLASH</code></td>
+    </tr>
+  </tbody>
+</table>
+
+```bash Command
+python3 -m sglang.launch_server \
+    --model-path Qwen/Qwen3-4B \
+    --speculative-algorithm DSPARK \
+    --speculative-draft-model-path deepseek-ai/dspark_qwen3_4b_block7 \
+    --speculative-dspark-block-size 7 \
+    --attention-backend triton --mem-fraction-static 0.85
+```
+
+**Notes**
+
+- Measured on a single RTX A6000 (48GB, SM86/Ampere, bf16, `--attention-backend triton`): GSM8K 5-shot/200q/greedy accuracy holds at parity with the non-speculative target (0.875-0.885 vs. a 0.880 baseline), with 3.9-4.8 accepted tokens per verify round during GSM8K and roughly a 1.9x single-stream decode speedup.
+- `deepseek-ai/dflash_qwen3_4b_block7` is architecturally servable by the same `Qwen3DSparkModel` class but is meant to run under plain `DFLASH`, not `DSPARK` — see the table above.
 
 ---
 

--- a/docs_new/docs/advanced_features/speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/speculative_decoding.mdx
@@ -16,6 +16,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
   - [EAGLE-3 Decoding](#eagle-3-decoding)
 - [Multi Token Prediction](#multi-token-prediction)
 - [DFlash Decoding](#dflash-decoding)
+- [DSpark Decoding (DeepSeek-V4)](#dspark-decoding-deepseek-v4)
 - [Standalone Speculative Decoding (Small Draft Model)](#standalone-speculative-decoding-small-draft-model)
 - [Speculative Decoding V2 (Overlap Scheduler)](#speculative-decoding-v2-overlap-scheduler)
 - [Ngram Speculative Decoding](#ngram-speculative-decoding)
@@ -31,6 +32,7 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
 - **Lower `lm_head` overhead for EAGLE-2**: Enable **FR-Spec** with `--speculative-token-map`.
 - **Model is MTP-enabled**: Use **MTP via speculative decoding** (often with small `speculative_num_steps/topk/num_draft_tokens`, see the example section).
 - **You have a DFlash draft checkpoint**: Use **DFLASH** with `--speculative-algorithm DFLASH` and `--speculative-draft-model-path ...`.
+- **Serving DeepSeek-V4 DSpark checkpoints**: Use **DSpark** with `--speculative-algorithm DSPARK` (block drafting, greedy, lossless).
 - **You have a smaller draft LLM**: Use **STANDALONE** (`--speculative-algorithm STANDALONE`).
 - **No extra model available**: Use **NGRAM** (`--speculative-algorithm NGRAM`, CUDA-only).
 
@@ -92,6 +94,13 @@ SGLang provides several speculative decoding options, including EAGLE-2/EAGLE-3,
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Yes</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>--speculative-algorithm DFLASH</code> + <code>--speculative-draft-model-path ...</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No <code>--enable-dp-attention</code>; <code>pp_size == 1</code>; disables overlap scheduler &amp; mixed chunked prefill</td>
+    </tr>
+<tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>DSpark</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DeepSeek-V4 block drafter (3-stage MTP + Markov/confidence heads) in the checkpoint</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>--speculative-algorithm DSPARK</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Greedy (lossless); DeepSeek-V4 DSpark checkpoints only; no <code>--enable-dp-attention</code>; <code>pp_size == 1</code></td>
     </tr>
 <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>STANDALONE</td>
@@ -498,6 +507,90 @@ print(response.choices[0].message.content)
 
 ---
 
+## DSpark Decoding (DeepSeek-V4)
+
+**DSpark** is a block drafter for DeepSeek-V4. The DSpark checkpoints (`deepseek-ai/DeepSeek-V4-Flash-DSpark`, `deepseek-ai/DeepSeek-V4-Pro-DSpark`) ship the speculative module inside the model under the `mtp.*` namespace, so there is no separate draft model to download. Each decode step DSpark proposes a block of `block_size` tokens (inferred from the checkpoint, 5 by default) in one draft forward and the target verifies the whole block in one pass. The drafter is a three-stage MTP stack with a Markov head that refines the block autoregressively and a confidence head that scores each position; it runs off the target's fused hidden states rather than its own token KV. At `temperature 0`, verification is greedy and lossless: the accepted output matches the target's greedy decoding for any block size or confidence threshold. At `temperature > 0`, the block is verified with target-only speculative sampling, which preserves the target's sampling distribution without needing the draft's probabilities.
+
+`--speculative-algorithm DSPARK` is enough; the draft path defaults to the target checkpoint, and `--speculative-eagle-topk 1` / `--speculative-num-steps 1` are pinned automatically.
+
+Relevant parameters:
+
+<table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
+  <colgroup>
+    <col style={{width: "30%"}} />
+    <col style={{width: "50%"}} />
+    <col style={{width: "20%"}} />
+  </colgroup>
+  <thead>
+    <tr style={{borderBottom: "2px solid #d55816"}}>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.02)"}}>Parameter</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.05)"}}>Description</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700, whiteSpace: "nowrap", backgroundColor: "rgba(255,255,255,0.02)"}}>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dspark-block-size</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Draft block length (tokens proposed per step). Alias of <code>--speculative-num-draft-tokens</code> for DSpark.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code> (inferred from the draft checkpoint config, otherwise <code>5</code>)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dspark-confidence-threshold</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Truncate the draft block at the first position whose confidence-head probability falls below this value; <code>0</code> verifies the full block. Range <code>[0, 1]</code>.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>0.0</code></td>
+    </tr>
+  </tbody>
+</table>
+
+```bash Command
+python3 -m sglang.launch_server \
+    --model-path deepseek-ai/DeepSeek-V4-Flash-DSpark \
+    --trust-remote-code --tp 8 --ep-size 8 \
+    --moe-runner-backend flashinfer_mxfp4 \
+    --speculative-moe-runner-backend flashinfer_mxfp4 \
+    --speculative-algorithm DSPARK \
+    --mem-fraction-static 0.85 --cuda-graph-max-bs 32
+```
+
+**Send a request** (DSpark verifies greedily, so use `temperature=0`):
+
+```python Example
+import openai
+
+client = openai.Client(base_url="http://127.0.0.1:30000/v1", api_key="None")
+
+response = client.chat.completions.create(
+    model="deepseek-ai/DeepSeek-V4-Flash-DSpark",
+    messages=[
+        {"role": "user", "content": "List 3 countries and their capitals."},
+    ],
+    temperature=0,
+    max_tokens=64,
+)
+
+print(response.choices[0].message.content)
+```
+
+**Notes**
+
+- DeepSeek-V4 DSpark checkpoints only. Requires `pp_size == 1` and does not support `--enable-dp-attention`; mixed chunked prefill is disabled automatically.
+- `temperature > 0` is verified with the same target-only speculative-sampling primitive as DFLASH, so sampled requests are not downgraded to greedy. Greedy (`temperature 0`) is the benchmark-validated path. If the sampling kernel is unavailable on a build, `temperature > 0` falls back to greedy with a one-time warning.
+- On `DeepSeek-V4-Flash-DSpark` (284B, 8x B200, tp8 ep8, greedy), acceptance length is roughly 3.2 to 3.6 tokens per target forward across math, code, and chat; single-stream throughput improves about 1.5x to 1.8x over no speculation; and GSM8K / MMLU match the no-speculation target within noise. See [sgl-project/sglang#29538](https://github.com/sgl-project/sglang/pull/29538) for full sweeps and raw logs.
+
+### Sampling
+
+At `temperature 0`, DSpark verifies greedily and is lossless: the committed tokens match the target model's own greedy decode for any block size or confidence threshold. This is the accuracy-validated path (GSM8K / MMLU match the no-speculation target within noise).
+
+`temperature > 0` is supported. Each proposed block is verified with SGLang's shared target-only speculative rejection sampling, the same primitive DFLASH uses, so accepted tokens preserve the target model's sampling distribution without consulting the draft's probabilities. Verification is exact at the default acceptance thresholds (`--speculative-accept-threshold-single`, `--speculative-accept-threshold-acc`), and each request's `temperature`, `top_k`, and `top_p` are applied at verify time.
+
+The confidence threshold (`--speculative-dspark-confidence-threshold`) only shortens the committed block; it never biases the output distribution. When the confident prefix is shorter than the accepted run, the block is committed up to the confident length and the bonus token is taken from a position the verifier already accepted.
+
+On builds without the required `sgl_kernel` sampling ops (for example non-CUDA backends), `temperature > 0` falls back to greedy verification and the server logs a one-time warning. Per-request features that DSpark cannot verify are rejected up front rather than silently degraded: `return_logprob`, grammar-constrained decoding (JSON schema, regex, EBNF, or structural tags), and `return_hidden_states`.
+
+The DeepSpec reference implementation verifies with draft-probability rejection sampling driven by a sampled drafter; this integration instead uses SGLang's shared target-only scheme with a deterministic (greedy) drafter. Both are distribution-preserving and differ only in which probabilities drive the accept-or-reject test.
+
+---
+
 ## Standalone Speculative Decoding (Small Draft Model)
 
 Besides EAGLE/MTP, SGLang also supports **token-level speculative decoding** using a smaller **draft model**. Enable it with `--speculative-algorithm STANDALONE` and provide a draft model via `--speculative-draft-model-path`.
@@ -746,7 +839,7 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-algorithm</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>str</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Algorithm to use: <code>DFLASH</code>, <code>EAGLE</code>, <code>EAGLE3</code>, <code>STANDALONE</code>, <code>NGRAM</code>, <code>NEXTN</code> (alias of <code>EAGLE</code>)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Algorithm to use: <code>DFLASH</code>, <code>DSPARK</code>, <code>EAGLE</code>, <code>EAGLE3</code>, <code>STANDALONE</code>, <code>NGRAM</code>, <code>NEXTN</code> (alias of <code>EAGLE</code>)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-model-path</code></td>
@@ -795,6 +888,18 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>int</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DFlash-only draft KV sliding-window size</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dspark-block-size</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>int</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DSpark-only alias of <code>--speculative-num-draft-tokens</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dspark-confidence-threshold</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>float</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>0.0</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DSpark-only confident-prefix truncation threshold in <code>[0, 1]</code>; <code>0</code> verifies the full block</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-accept-threshold-single</code></td>

--- a/docs_new/docs/advanced_features/speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/speculative_decoding.mdx
@@ -617,7 +617,7 @@ One model class (`Qwen3DSparkModel`) serves two released checkpoints, config-gat
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>deepseek-ai/dflash_qwen3_4b_block7</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Neither (<code>markov_rank=0</code>)</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-algorithm DFLASH</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not currently servable — see Notes</td>
     </tr>
   </tbody>
 </table>
@@ -634,7 +634,7 @@ python3 -m sglang.launch_server \
 **Notes**
 
 - Measured on a single RTX A6000 (48GB, SM86/Ampere, bf16, `--attention-backend triton`): GSM8K 5-shot/200q/greedy accuracy holds at parity with the non-speculative target (0.875-0.885 vs. a 0.880 baseline), with 3.9-4.8 accepted tokens per verify round during GSM8K and roughly a 1.9x single-stream decode speedup.
-- `deepseek-ai/dflash_qwen3_4b_block7` is architecturally servable by the same `Qwen3DSparkModel` class but is meant to run under plain `DFLASH`, not `DSPARK` — see the table above.
+- `deepseek-ai/dflash_qwen3_4b_block7` declares the same `Qwen3DSparkModel` architecture string and loads through the same class, but is **not currently servable**: it is intended for plain `DFLASH`, and `DFlashWorkerV2` expects a flat draft-model shape this class does not provide, so a `DFLASH` launch fails cleanly at startup. Resolving that flat-vs-nested worker-shape split is tracked as an open question in the DSpark-Qwen3 PR.
 
 ---
 

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -53,12 +53,14 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
         )
 
     if server_args.speculative_algorithm is not None:
-        assert (
-            server_args.speculative_algorithm == "EAGLE"
-        ), f"Only EAGLE speculative algorithm is supported for {model_arch}"
-        assert (
-            server_args.speculative_eagle_topk == 1
-        ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
+        assert server_args.speculative_algorithm in (
+            "EAGLE",
+            "DSPARK",
+        ), f"Only EAGLE and DSPARK speculative algorithms are supported for {model_arch}"
+        assert server_args.speculative_eagle_topk in (
+            None,
+            1,
+        ), f"Only topk == 1 speculative decoding is supported for {model_arch}"
 
 
 def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -314,7 +314,12 @@ def _handle_dspark(server_args: ServerArgs) -> None:
                 revision=server_args.speculative_draft_model_revision,
                 model_override_args=model_override_args,
             )
+            # V4 DSpark checkpoints spell this `dspark_block_size`; Qwen3-family
+            # DSpark checkpoints (e.g. Qwen3DSparkModel) spell it plainly as
+            # `block_size` with no dspark_ prefix.
             block_size = getattr(draft_hf_config, "dspark_block_size", None)
+            if not block_size:
+                block_size = getattr(draft_hf_config, "block_size", None)
             if block_size:
                 inferred_block_size = int(block_size)
         except Exception as e:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -250,6 +250,114 @@ def _handle_dflash(server_args: ServerArgs) -> None:
         )
 
 
+def _handle_dspark(server_args: ServerArgs) -> None:
+    if server_args.enable_dp_attention:
+        raise ValueError(
+            "Currently DSpark speculative decoding does not support dp attention."
+        )
+
+    if server_args.pp_size != 1:
+        raise ValueError(
+            "Currently DSpark speculative decoding only supports pp_size == 1."
+        )
+
+    if server_args.speculative_draft_model_path is None:
+        server_args.speculative_draft_model_path = server_args.model_path
+        server_args.speculative_draft_model_revision = server_args.revision
+
+    if server_args.speculative_num_steps is None:
+        server_args.speculative_num_steps = 1
+    elif int(server_args.speculative_num_steps) != 1:
+        logger.warning(
+            "DSpark only supports speculative_num_steps == 1; overriding speculative_num_steps=%s to 1.",
+            server_args.speculative_num_steps,
+        )
+        server_args.speculative_num_steps = 1
+
+    if server_args.speculative_eagle_topk is None:
+        server_args.speculative_eagle_topk = 1
+    elif int(server_args.speculative_eagle_topk) != 1:
+        logger.warning(
+            "DSpark only supports speculative_eagle_topk == 1; overriding speculative_eagle_topk=%s to 1.",
+            server_args.speculative_eagle_topk,
+        )
+        server_args.speculative_eagle_topk = 1
+
+    if server_args.speculative_dspark_block_size is not None:
+        if int(server_args.speculative_dspark_block_size) <= 0:
+            raise ValueError(
+                "DSpark requires --speculative-dspark-block-size to be positive, "
+                f"got {server_args.speculative_dspark_block_size}."
+            )
+        if server_args.speculative_num_draft_tokens is not None and int(
+            server_args.speculative_num_draft_tokens
+        ) != int(server_args.speculative_dspark_block_size):
+            raise ValueError(
+                "Both --speculative-num-draft-tokens and --speculative-dspark-block-size are set "
+                "but they differ. For DSpark they must match. "
+                f"speculative_num_draft_tokens={server_args.speculative_num_draft_tokens}, "
+                f"speculative_dspark_block_size={server_args.speculative_dspark_block_size}."
+            )
+        server_args.speculative_num_draft_tokens = int(
+            server_args.speculative_dspark_block_size
+        )
+
+    if server_args.speculative_num_draft_tokens is None:
+        inferred_block_size = None
+        try:
+            from sglang.srt.utils.hf_transformers_utils import get_config
+
+            model_override_args = json.loads(server_args.json_model_override_args)
+            draft_hf_config = get_config(
+                server_args.speculative_draft_model_path,
+                trust_remote_code=server_args.trust_remote_code,
+                revision=server_args.speculative_draft_model_revision,
+                model_override_args=model_override_args,
+            )
+            block_size = getattr(draft_hf_config, "dspark_block_size", None)
+            if block_size:
+                inferred_block_size = int(block_size)
+        except Exception as e:
+            logger.warning(
+                "Failed to infer DSpark block_size from draft model config; "
+                "defaulting speculative_num_draft_tokens to 5. Error: %s",
+                e,
+            )
+        if inferred_block_size is None:
+            inferred_block_size = 5
+            logger.warning(
+                "speculative_num_draft_tokens is not set; defaulting to %d for DSpark.",
+                inferred_block_size,
+            )
+        server_args.speculative_num_draft_tokens = inferred_block_size
+
+    threshold = float(server_args.speculative_dspark_confidence_threshold)
+    if not 0.0 <= threshold <= 1.0:
+        raise ValueError(
+            "--speculative-dspark-confidence-threshold must be in [0, 1], got "
+            f"{threshold}."
+        )
+
+    if server_args.max_running_requests is None:
+        server_args.max_running_requests = 48
+        logger.warning(
+            "Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests."
+        )
+
+    if server_args.enable_mixed_chunk:
+        server_args.enable_mixed_chunk = False
+        logger.warning(
+            "Mixed chunked prefill is disabled because of using DSpark speculative decoding."
+        )
+
+    if not server_args.disable_overlap_schedule:
+        server_args.disable_overlap_schedule = True
+        logger.warning(
+            "DSpark uses synchronous (non-overlap) scheduling, which is the "
+            "recommended configuration for its lightweight draft."
+        )
+
+
 def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
     """Resolve `speculative_draft_attention_backend` to a final, supported value.
 

--- a/python/sglang/srt/configs/deepseek_v4.py
+++ b/python/sglang/srt/configs/deepseek_v4.py
@@ -108,3 +108,8 @@ class DeepSeekV4Config(PretrainedConfig):
     hc_mult: int = 4
     hc_sinkhorn_iters: int = 20
     hc_eps: float = 1e-6
+
+    dspark_block_size: int = 0
+    dspark_noise_token_id: int = 0
+    dspark_target_layer_ids: List[int] = field(default_factory=list)
+    dspark_markov_rank: int = 0

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -119,6 +119,7 @@ def is_deepseek_v4(config) -> bool:
     return _hf_arch(config) in (
         "DeepseekV4ForCausalLM",
         "DeepseekV4ForCausalLMNextN",
+        "DeepseekV4ForCausalLMDSpark",
     )
 
 
@@ -537,8 +538,11 @@ class ModelConfig:
             is_draft_model
             and self.hf_config.architectures[0] == "DeepseekV4ForCausalLM"
         ):
-            self.hf_config.architectures[0] = "DeepseekV4ForCausalLMNextN"
-            self.hf_config.num_nextn_predict_layers = 1
+            if getattr(self.hf_config, "dspark_block_size", 0):
+                self.hf_config.architectures[0] = "DeepseekV4ForCausalLMDSpark"
+            else:
+                self.hf_config.architectures[0] = "DeepseekV4ForCausalLMNextN"
+                self.hf_config.num_nextn_predict_layers = 1
 
         if is_draft_model and self.hf_config.architectures[0] == "Glm4MoeForCausalLM":
             self.hf_config.architectures[0] = "Glm4MoeForCausalLMNextN"
@@ -626,7 +630,12 @@ class ModelConfig:
             logger.info(f"Hybrid swa model: {self.hf_config.architectures=}")
 
             self.is_deepseek_v4_arch = any(
-                arch in ["DeepseekV4ForCausalLM", "DeepseekV4ForCausalLMNextN"]
+                arch
+                in [
+                    "DeepseekV4ForCausalLM",
+                    "DeepseekV4ForCausalLMNextN",
+                    "DeepseekV4ForCausalLMDSpark",
+                ]
                 for arch in self.hf_config.architectures
             )
 
@@ -775,6 +784,7 @@ class ModelConfig:
         elif (
             "DeepseekV4ForCausalLM" in self.hf_config.architectures
             or "DeepseekV4ForCausalLMNextN" in self.hf_config.architectures
+            or "DeepseekV4ForCausalLMDSpark" in self.hf_config.architectures
         ):
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
             self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
@@ -1695,6 +1705,7 @@ multimodal_model_archs = [
 piecewise_cuda_graph_disabled_model_archs = [
     "DeepseekV4ForCausalLM",
     "DeepseekV4ForCausalLMNextN",
+    "DeepseekV4ForCausalLMDSpark",
     "Qwen3NextForCausalLM",
     "BailingMoeV2_5ForCausalLM",
     "LLaDAModelLM",
@@ -1830,6 +1841,7 @@ def is_hybrid_swa_model(
         "Llama4ForConditionalGeneration",
         "DeepseekV4ForCausalLM",
         "DeepseekV4ForCausalLMNextN",
+        "DeepseekV4ForCausalLMDSpark",
         "GptOssForCausalLM",
         *MIMO_V2_MODEL_ARCHS,
         "MiMoV2MTP",

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -503,6 +503,7 @@ class DeepseekV4AttnBackend(
             model_runner.server_args.speculative_num_draft_tokens
         )
         self.speculative_step_id = speculative_step_id
+        self._dspark_block_full_attn = 0
         self.forward_metadata: Union[
             DSV4Metadata,
             DSV4RawVerifyMetadata,
@@ -942,6 +943,10 @@ class DeepseekV4AttnBackend(
         in_capture: bool = False,
     ) -> None:
         bucket = _GraphBucket.of(forward_batch.forward_mode)
+        self._dspark_block_full_attn = int(
+            getattr(getattr(forward_batch, "spec_info", None), "block_full_attn", 0)
+            or 0
+        )
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
@@ -1106,6 +1111,10 @@ class DeepseekV4AttnBackend(
         use_prefill_cuda_graph: bool = False,
     ):
         logical_forward_mode = _get_logical_forward_mode(forward_batch)
+        self._dspark_block_full_attn = int(
+            getattr(getattr(forward_batch, "spec_info", None), "block_full_attn", 0)
+            or 0
+        )
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens.to(torch.int32)
         seq_lens_cpu = forward_batch.seq_lens_cpu
@@ -1704,6 +1713,19 @@ class DeepseekV4AttnBackend(
 
         raw_positions = seq_lens_casual - 1
         swa_topk_lengths = torch.clamp(seq_lens_casual, max=SWA_WINDOW)
+
+        block_full = self._dspark_block_full_attn
+        n_qo = seq_lens_casual.size(0)
+        if block_full and n_qo % block_full == 0:
+            bs_blk = n_qo // block_full
+            last_row = (
+                torch.arange(
+                    bs_blk, device=seq_lens_casual.device, dtype=torch.long
+                ).repeat_interleave(block_full)
+                + 1
+            ) * block_full - 1
+            swa_page_indices = swa_page_indices[last_row]
+            swa_topk_lengths = swa_topk_lengths[last_row]
 
         page_table = req_to_token[
             req_pool_indices_repeated, : max_seq_len : self.page_size

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1718,7 +1718,10 @@ class FlashInferIndicesUpdaterPrefill:
             custom_mask = cross_attention_custom_mask
         else:
             assert isinstance(spec_info, SpecInput)
-            if spec_info.spec_input_type == SpecInputType.DFLASH_VERIFY:
+            if spec_info.spec_input_type in (
+                SpecInputType.DFLASH_VERIFY,
+                SpecInputType.DSPARK_VERIFY,
+            ):
                 kv_indices, kv_indptr, qo_indptr, custom_mask = (
                     spec_info.generate_attn_arg_prefill(
                         req_pool_indices,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -242,6 +242,7 @@ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import PortArgs, ServerArgs, get_global_server_args
 from sglang.srt.session.session_controller import SessionController
 from sglang.srt.speculative.dflash_utils import validate_dflash_request
+from sglang.srt.speculative.dspark_info import validate_dspark_request
 from sglang.srt.speculative.eagle_utils import get_draft_recurrent_hidden_state_spec
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
@@ -2159,6 +2160,14 @@ class Scheduler(
 
         if self.spec_algorithm.is_dflash():
             error_msg = validate_dflash_request(req, self.enable_overlap)
+            if error_msg is not None:
+                req.set_finish_with_abort(error_msg)
+                self.init_req_max_new_tokens(req)
+                self._add_request_to_queue(req)
+                return
+
+        if self.spec_algorithm.is_dspark():
+            error_msg = validate_dspark_request(req)
             if error_msg is not None:
                 req.set_finish_with_abort(error_msg)
                 self.init_req_max_new_tokens(req)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -554,9 +554,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     draft_model_config.hf_config
                 )
                 self.dspark_target_layer_ids = list(
-                    getattr(
-                        draft_model_config.hf_config, "dspark_target_layer_ids", []
-                    )
+                    getattr(draft_model_config.hf_config, "dspark_target_layer_ids", [])
                 )
             else:
                 # Generic (Qwen3-family) DSpark checkpoints use plain HF field

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -526,8 +526,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
 
         if self.spec_algorithm.is_dspark() and not self.is_draft_worker:
-            from sglang.srt.models.deepseek_v4_dspark import get_dspark_num_layers
-
             draft_model_config = self._build_model_config(
                 server_args,
                 model_path=server_args.speculative_draft_model_path,
@@ -535,15 +533,45 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 is_draft_model=True,
             )
             self.dspark_use_aux_hidden_state = True
-            self.dspark_draft_num_layers = get_dspark_num_layers(
-                draft_model_config.hf_config
+
+            # DeepSeek-V4's DSpark draft config spells these fields with a
+            # dspark_ prefix; only import deepseek_v4_dspark (which
+            # transitively imports DeepSeek-V4/V2's CUDA-kernel-heavy modules)
+            # when the TARGET actually is DeepSeek-V4 family, so a non-V4
+            # target (e.g. a Qwen3-family DSpark deployment) never pays that
+            # import cost -- an unconditional import here previously crashed
+            # non-V4 targets whenever those V4-only dependencies were
+            # unavailable/incompatible on the host.
+            target_is_deepseek_v4 = self.model_config.hf_config.architectures[0] in (
+                "DeepseekV4ForCausalLM",
+                "DeepseekV4ForCausalLMNextN",
+                "DeepseekV4ForCausalLMDSpark",
             )
-            self.dspark_target_layer_ids = list(
-                getattr(draft_model_config.hf_config, "dspark_target_layer_ids", [])
-            )
+            if target_is_deepseek_v4:
+                from sglang.srt.models.deepseek_v4_dspark import get_dspark_num_layers
+
+                self.dspark_draft_num_layers = get_dspark_num_layers(
+                    draft_model_config.hf_config
+                )
+                self.dspark_target_layer_ids = list(
+                    getattr(
+                        draft_model_config.hf_config, "dspark_target_layer_ids", []
+                    )
+                )
+            else:
+                # Generic (Qwen3-family) DSpark checkpoints use plain HF field
+                # names on the draft config: num_hidden_layers, target_layer_ids.
+                self.dspark_draft_num_layers = int(
+                    draft_model_config.hf_config.num_hidden_layers
+                )
+                self.dspark_target_layer_ids = list(
+                    getattr(draft_model_config.hf_config, "target_layer_ids", [])
+                )
+
             if not self.dspark_target_layer_ids:
                 raise ValueError(
-                    "DSpark requires dspark_target_layer_ids in the draft model config."
+                    "DSpark requires dspark_target_layer_ids (DeepSeek-V4 family) "
+                    "or target_layer_ids (Qwen3 family) in the draft model config."
                 )
 
         # Apply the rank zero filter to logger

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -439,6 +439,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.dflash_use_aux_hidden_state = False
         self.dflash_target_layer_ids = None
         self.dflash_draft_num_layers = None
+        self.dspark_use_aux_hidden_state = False
+        self.dspark_target_layer_ids = None
+        self.dspark_draft_num_layers = None
         if (
             (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_standalone())
             and not self.is_draft_worker
@@ -521,6 +524,27 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 target_num_layers=int(target_num_layers),
                 draft_num_layers=int(draft_num_layers),
             )
+
+        if self.spec_algorithm.is_dspark() and not self.is_draft_worker:
+            from sglang.srt.models.deepseek_v4_dspark import get_dspark_num_layers
+
+            draft_model_config = self._build_model_config(
+                server_args,
+                model_path=server_args.speculative_draft_model_path,
+                model_revision=server_args.speculative_draft_model_revision,
+                is_draft_model=True,
+            )
+            self.dspark_use_aux_hidden_state = True
+            self.dspark_draft_num_layers = get_dspark_num_layers(
+                draft_model_config.hf_config
+            )
+            self.dspark_target_layer_ids = list(
+                getattr(draft_model_config.hf_config, "dspark_target_layer_ids", [])
+            )
+            if not self.dspark_target_layer_ids:
+                raise ValueError(
+                    "DSpark requires dspark_target_layer_ids in the draft model config."
+                )
 
         # Apply the rank zero filter to logger
         if server_args.show_time_cost:
@@ -743,14 +767,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # the first forward (`set_mla_kv_buffer` -> `self.kv_buffer[layer_id - self.start_layer]`).
         _nnpl = self.model_config.num_nextn_predict_layers
         model_has_mtp_layers = _nnpl is not None and _nnpl > 0
-        model_num_layers = (
-            self.model_config.num_nextn_predict_layers
-            if self.is_draft_worker and model_has_mtp_layers
-            else max(
+        if self.is_draft_worker and self.spec_algorithm.is_dspark():
+            model_num_layers = int(self.model.num_dspark_layers)
+        elif self.is_draft_worker and model_has_mtp_layers:
+            model_num_layers = self.model_config.num_nextn_predict_layers
+        else:
+            model_num_layers = max(
                 self.model_config.num_hidden_layers,
                 self.model_config.num_attention_layers,
             )
-        )
         if self.model_config.hf_config.architectures[0] == "MiMoV2MTP":
             model_num_layers = 1
         elif self.model_config.hf_config.architectures[0] == "Step3p5MTP":
@@ -1059,6 +1084,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     "set_dflash_layers_to_capture, which is required for DFLASH."
                 )
             self.model.set_dflash_layers_to_capture(self.dflash_target_layer_ids)
+        if self.dspark_use_aux_hidden_state:
+            if not hasattr(self.model, "set_dspark_layers_to_capture"):
+                raise ValueError(
+                    f"Model {self.model.__class__.__name__} does not implement "
+                    "set_dspark_layers_to_capture, which is required for DSpark."
+                )
+            self.model.set_dspark_layers_to_capture(self.dspark_target_layer_ids)
 
     def remote_instance_init_transfer_engine(self):
         try:

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -141,7 +141,9 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
         # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
         # reuse the target architecture's attention config.
         if (
-            mr.spec_algorithm.is_eagle() or mr.spec_algorithm.is_standalone()
+            mr.spec_algorithm.is_eagle()
+            or mr.spec_algorithm.is_standalone()
+            or mr.spec_algorithm.is_dspark()
         ) and not mr.is_draft_worker:
             eagle_draft_num_layers = getattr(mr, "eagle_draft_num_layers", None)
             if (
@@ -161,6 +163,23 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             )
 
             draft_num_layers = mr.dflash_draft_num_layers
+            if (
+                draft_num_layers is not None
+                and int(draft_num_layers) > 0
+                and int(num_layers) > 0
+            ):
+                self._cell_size = scale_kv_cell_size_per_token_for_dflash(
+                    target_cell_size_per_token=self._cell_size,
+                    target_num_layers=int(num_layers),
+                    draft_num_layers=int(draft_num_layers),
+                )
+
+        if mr.spec_algorithm.is_dspark() and not mr.is_draft_worker:
+            from sglang.srt.speculative.dflash_utils import (
+                scale_kv_cell_size_per_token_for_dflash,
+            )
+
+            draft_num_layers = mr.dspark_draft_num_layers
             if (
                 draft_num_layers is not None
                 and int(draft_num_layers) > 0
@@ -572,7 +591,10 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             # per-token bytes by (target+draft)/target. Equivalent to dflash's
             # scale_kv_cell_size_per_token_for_dflash but applied to
             # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
-            draft_layers = 1
+            if mr.spec_algorithm.is_dspark():
+                draft_layers = int(mr.dspark_draft_num_layers)
+            else:
+                draft_layers = 1
             target_layers = self.num_layers_total
             self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -415,6 +415,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 if self.model_runner.spec_algorithm.is_eagle()
                 or self.model_runner.spec_algorithm.is_standalone()
                 or self.model_runner.spec_algorithm.is_dflash()
+                or self.model_runner.spec_algorithm.is_dspark()
                 else max(forward_batch.global_num_tokens_cpu)
             )
         else:
@@ -839,6 +840,21 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                             "hidden_states to capture into the graph."
                         )
                     dflash_sampler(out.hidden_states)
+                dspark_sampler = getattr(
+                    self.model_runner, "dspark_draft_sampler", None
+                )
+                if dspark_sampler is not None:
+                    # Capture the refine into the graph, else replay leaves stale
+                    # candidate buffers the worker reads as tokens.
+                    if (
+                        not isinstance(out, LogitsProcessorOutput)
+                        or out.hidden_states is None
+                    ):
+                        raise RuntimeError(
+                            "DSpark draft sampler set but the draft forward has "
+                            "no hidden_states to capture into the graph."
+                        )
+                    dspark_sampler(out.hidden_states, forward_batch.input_ids)
                 return out
 
             self.deepep_adapter.capture(is_extend_in_batch=False)
@@ -944,6 +960,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 if self.model_runner.spec_algorithm.is_eagle()
                 or self.model_runner.spec_algorithm.is_standalone()
                 or self.model_runner.spec_algorithm.is_dflash()
+                or self.model_runner.spec_algorithm.is_dspark()
                 else max_num_tokens
             )
             bs = self._pad_to_bucket(int(max_batch_size), self.capture_bs)
@@ -1022,10 +1039,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.load_batch(forward_batch, pp_proxy_tensors)
             # Publish a read-done event for the WAR barrier: a cuda-graph forward
             # finishes its shared req_to_token / SWA reads at this pre-replay
-            # snapshot, so plain DECODE and DFLASH TARGET_VERIFY both qualify.
+            # snapshot, so plain DECODE and DFLASH/DSPARK TARGET_VERIFY both qualify.
             if forward_batch.forward_mode.is_decode() or (
                 forward_batch.forward_mode.is_target_verify()
-                and self.model_runner.spec_algorithm.is_dflash()
+                and self.model_runner.spec_algorithm.supports_target_verify_for_draft()
             ):
                 read_done = self.device_module.Event()
                 read_done.record()
@@ -1124,6 +1141,26 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     CaptureHiddenMode.NULL
                     if self.model_runner.is_draft_worker
                     else CaptureHiddenMode.FULL
+                ),
+            )
+
+        elif self.model_runner.spec_algorithm.is_dspark():
+            from sglang.srt.speculative.dspark_info import DSparkVerifyInput
+
+            spec_info = DSparkVerifyInput(
+                draft_token=None,
+                positions=None,
+                draft_token_num=self.model_runner.server_args.speculative_num_draft_tokens,
+                custom_mask=None,
+                capture_hidden_mode=(
+                    CaptureHiddenMode.NULL
+                    if self.model_runner.is_draft_worker
+                    else CaptureHiddenMode.FULL
+                ),
+                block_full_attn=(
+                    self.model_runner.server_args.speculative_num_draft_tokens
+                    if self.model_runner.is_draft_worker
+                    else 0
                 ),
             )
 

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -172,6 +172,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         if (
             model_runner.server_args.enable_return_hidden_states
             or model_runner.spec_algorithm.is_dflash()
+            or model_runner.spec_algorithm.is_dspark()
         ):
             self.capture_hidden_mode = CaptureHiddenMode.FULL
         # EAGLE captures FULL hidden states for the target and LAST for the

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -565,6 +565,33 @@ class MQALayer(nn.Module):
         )
         return kv
 
+    def kv_from_hidden(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        attn_backend,
+    ) -> None:
+        from sglang.srt.layers.attention.dsv4.quant_k_cache import (
+            quant_to_nope_fp8_rope_bf16_pack_triton,
+        )
+
+        if self.fuse_wqa_wkv:
+            qkv_a, _ = self.wqkv_a(x)
+            kv = self._compute_kv_bf16(x, positions, qkv_a=qkv_a)
+        else:
+            kv = self._compute_kv_bf16(x, positions)
+
+        token_to_kv_pool = attn_backend.token_to_kv_pool
+        swa_loc = token_to_kv_pool.translate_loc_from_full_to_swa(cache_loc).to(
+            torch.int32
+        )
+        token_to_kv_pool.set_swa_key_buffer_radix(
+            layer_id=self.layer_id,
+            swa_loc=swa_loc,
+            cache_nope_fp8_rope_bf16_pack=quant_to_nope_fp8_rope_bf16_pack_triton(kv),
+        )
+
     def _forward_prepare_multi_stream(
         self,
         x: torch.Tensor,
@@ -1653,6 +1680,7 @@ class DeepseekV4Model(nn.Module):
         else:
             self.norm = PPMissingLayer()
         self.gemm_output_zero_allocator_size = 0
+        self.layers_to_capture = []
         self.hc_eps = config.hc_eps
         self.hc_mult = hc_mult = config.hc_mult
         self.norm_eps = config.rms_norm_eps
@@ -1743,6 +1771,7 @@ class DeepseekV4Model(nn.Module):
         use_fused = self.use_fused_mhc_post_pre
         prev_residual, prev_post, prev_comb = None, None, None
         last_layer = None
+        aux_hidden_states = []
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
             last_layer = layer
@@ -1762,6 +1791,14 @@ class DeepseekV4Model(nn.Module):
                     prev_post=prev_post,
                     prev_comb=prev_comb,
                 )
+            if i in self.layers_to_capture:
+                if prev_residual is not None:
+                    captured = layer.hc_post(
+                        hidden_states, prev_residual, prev_post, prev_comb
+                    )
+                else:
+                    captured = hidden_states
+                aux_hidden_states.append(captured.mean(dim=1))
         if use_fused and last_layer is not None:
             hidden_states = last_layer.hc_post(
                 hidden_states, prev_residual, prev_post, prev_comb
@@ -1775,6 +1812,21 @@ class DeepseekV4Model(nn.Module):
                 forward_batch,
                 torch.cuda.current_stream(),
             )
+            aux_hidden_states = [
+                cp_all_gather_rerange_output(
+                    aux,
+                    self.cp_size,
+                    forward_batch,
+                    torch.cuda.current_stream(),
+                )
+                for aux in aux_hidden_states
+            ]
+            if forward_batch.extend_seq_lens_cpu is not None:
+                real_n = int(sum(forward_batch.extend_seq_lens_cpu))
+                aux_hidden_states = [
+                    aux[:real_n] if aux.shape[0] > real_n else aux
+                    for aux in aux_hidden_states
+                ]
 
         if not self.pp_group.is_last_rank:
             # Flatten 3D mHC tensor for PP IPC.
@@ -1787,6 +1839,8 @@ class DeepseekV4Model(nn.Module):
         )
         hidden_states = self.norm(hidden_states)
 
+        if self.layers_to_capture:
+            return (hidden_states, pre_hc_head), aux_hidden_states
         return hidden_states, pre_hc_head
 
 
@@ -1931,20 +1985,36 @@ class DeepseekV4ForCausalLM(nn.Module):
             hidden_states, aux_hidden_states = hidden_states
         hidden_states, pre_hc_head = hidden_states
 
+        hidden_states_before_norm = (
+            None if aux_hidden_states is not None else pre_hc_head
+        )
+
         return self.logits_processor(
             input_ids,
             hidden_states,
             self.lm_head,
             forward_batch,
             aux_hidden_states,
-            hidden_states_before_norm=pre_hc_head,
+            hidden_states_before_norm=hidden_states_before_norm,
         )
 
-    def _setup_fp8_wo_a_scales(self, is_nextn: bool) -> None:
+    def set_dspark_layers_to_capture(self, layer_ids: List[int]):
+        if not self.pp_group.is_last_rank:
+            return
+        if not layer_ids:
+            raise ValueError(
+                "DSpark requires explicit layer_ids for aux hidden capture."
+            )
+        self.capture_aux_hidden_states = True
+        self.model.layers_to_capture = list(layer_ids)
+
+    def _setup_fp8_wo_a_scales(self, is_nextn: bool, is_dspark: bool = False) -> None:
         from deep_gemm import transform_sf_into_required_layout
 
         if is_nextn:
             layers = [self.model.decoder]
+        elif is_dspark:
+            layers = list(self.model.layers)
         else:
             layers = [
                 self.model.layers[layer_id]
@@ -1966,11 +2036,11 @@ class DeepseekV4ForCausalLM(nn.Module):
                 is_sfa=False,
             )
 
-    def post_load_weights(self, is_nextn=False, weight_names=None):
+    def post_load_weights(self, is_nextn=False, is_dspark=False, weight_names=None):
         if _FP8_WO_A_GEMM:
-            self._setup_fp8_wo_a_scales(is_nextn)
+            self._setup_fp8_wo_a_scales(is_nextn, is_dspark)
 
-        if is_nextn:
+        if is_nextn or is_dspark:
             return
         for layer_id in range(self.model.start_layer, self.model.end_layer):
             layer = self.model.layers[layer_id]
@@ -1991,6 +2061,7 @@ class DeepseekV4ForCausalLM(nn.Module):
     def remap_weight_name_to_dpsk_hf_format(
         name: str,
         is_nextn: bool = False,
+        is_dspark: bool = False,
         num_hidden_layers: Optional[int] = None,
     ) -> str:
         if name == "embed.weight":
@@ -2001,6 +2072,22 @@ class DeepseekV4ForCausalLM(nn.Module):
             return "model.norm.weight"
         if name.startswith("hc_head_"):
             return "model." + name
+
+        if is_dspark and name.startswith("mtp."):
+            parts = name.split(".", 2)
+            if len(parts) >= 3:
+                stage, rest = parts[1], parts[2]
+                if rest.startswith(("main_proj", "main_norm")):
+                    if rest == "main_proj.scale":
+                        rest = "main_proj.weight_scale_inv"
+                    return "model." + rest
+                if rest.startswith(("markov_head", "confidence_head")):
+                    return "model." + rest
+                if rest == "norm.weight":
+                    return "model.shared_head.norm.weight"
+                if rest.startswith("hc_head_"):
+                    return "model." + rest
+                name = f"layers.{stage}." + rest
 
         if is_nextn and name.startswith("mtp."):
             parts = name.split(".", 2)
@@ -2106,7 +2193,12 @@ class DeepseekV4ForCausalLM(nn.Module):
             time.perf_counter() - tic - compile_secs,
         )
 
-    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]], is_nextn=False):
+    def load_weights(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+        is_nextn=False,
+        is_dspark=False,
+    ):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
 
@@ -2183,9 +2275,11 @@ class DeepseekV4ForCausalLM(nn.Module):
                 try:
                     use_async_loading = should_async_load(loaded_weight)
 
+                    orig_name = name
                     name = self.remap_weight_name_to_dpsk_hf_format(
                         name,
                         is_nextn=is_nextn,
+                        is_dspark=is_dspark,
                         num_hidden_layers=self.config.num_hidden_layers,
                     )
 
@@ -2210,7 +2304,10 @@ class DeepseekV4ForCausalLM(nn.Module):
 
                     weight_names.append(name)
 
-                    if not is_nextn:
+                    if is_dspark:
+                        if not orig_name.startswith("mtp."):
+                            continue
+                    elif not is_nextn:
                         if hasattr(self.config, "num_nextn_predict_layers"):
                             num_nextn_layers = self.config.num_nextn_predict_layers
                             if num_nextn_layers > 0 and name.startswith("model.layers"):
@@ -2424,7 +2521,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         if not self.pp_group.is_last_rank:
             skipped_checking_patterns.append("model.norm.")
             skipped_checking_patterns.extend(["lm_head", "hc_head_"])
-        if is_nextn:
+        if is_nextn or is_dspark:
             skipped_checking_patterns.extend(["lm_head", "embed_tokens"])
         unloaded_params = {
             p
@@ -2439,7 +2536,9 @@ class DeepseekV4ForCausalLM(nn.Module):
                 f"Some weights are not initialized from checkpoints: {unloaded_params}"
             )
 
-        self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)
+        self.post_load_weights(
+            is_nextn=is_nextn, is_dspark=is_dspark, weight_names=weight_names
+        )
 
         if not is_nextn:
             self._prewarm_mhc_pre_kernels()

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -1,0 +1,284 @@
+import logging
+from typing import Iterable, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.models.deepseek_v4 import DeepseekV4DecoderLayer, DeepseekV4ForCausalLM
+from sglang.srt.runtime_context import get_flags, get_parallel
+from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+COMPRESS_RATIO_DSPARK_LAYER = 0
+
+
+class DSparkMarkovHead(nn.Module):
+    """Low-rank Markov refine head.
+
+    markov_w1 is replicated so the per-step token lookup is a local gather;
+    markov_w2 is vocab-sharded so its bias aligns with the sharded base logits.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        markov_rank: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.markov_w1 = VocabParallelEmbedding(
+            vocab_size,
+            markov_rank,
+            enable_tp=False,
+            prefix=add_prefix("markov_w1", prefix),
+        )
+        self.markov_w2 = ParallelLMHead(
+            vocab_size,
+            markov_rank,
+            quant_config=quant_config,
+            prefix=add_prefix("markov_w2", prefix),
+        )
+
+    def get_prev_embeddings(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.markov_w1(token_ids)
+
+    def project_bias(self, embeddings: torch.Tensor) -> torch.Tensor:
+        return F.linear(embeddings, self.markov_w2.weight)
+
+
+class DSparkConfidenceHead(nn.Module):
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1, bias=False, dtype=torch.float32)
+
+    def forward(self, hidden: torch.Tensor, markov_embed: torch.Tensor) -> torch.Tensor:
+        features = torch.cat([hidden, markov_embed], dim=-1)
+        return self.proj(features.float()).squeeze(-1)
+
+
+class DeepseekV4DSparkModel(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.vocab_size = config.vocab_size
+        self.hidden_size = config.hidden_size
+        self.rms_norm_eps = config.rms_norm_eps
+        self.hc_eps = config.hc_eps
+        self.hc_mult = hc_mult = config.hc_mult
+        self.block_size = config.dspark_block_size
+        self.markov_rank = config.dspark_markov_rank
+        self.noise_token_id = config.dspark_noise_token_id
+        self.target_layer_ids = list(config.dspark_target_layer_ids)
+        self.num_dspark_layers = num_dspark_layers = get_dspark_num_layers(config)
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            enable_tp=not is_dp_attention_enabled(),
+            prefix=add_prefix("embed_tokens", prefix),
+        )
+
+        self.main_proj = ReplicatedLinear(
+            len(self.target_layer_ids) * config.hidden_size,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("main_proj", prefix),
+        )
+        self.main_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.layers = nn.ModuleList(
+            [
+                DeepseekV4DecoderLayer(
+                    config,
+                    layer_id=layer_id,
+                    quant_config=quant_config,
+                    is_nextn=True,
+                    prefix=add_prefix(f"layers.{layer_id}", prefix),
+                    alt_streams=None,
+                    compress_ratio_override=COMPRESS_RATIO_DSPARK_LAYER,
+                )
+                for layer_id in range(num_dspark_layers)
+            ]
+        )
+
+        hc_dim = hc_mult * config.hidden_size
+        self.hc_head_fn = nn.Parameter(
+            torch.empty(hc_mult, hc_dim, dtype=torch.float32)
+        )
+        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+
+        self.markov_head = DSparkMarkovHead(
+            config.vocab_size,
+            config.dspark_markov_rank,
+            quant_config=quant_config,
+            prefix=add_prefix("markov_head", prefix),
+        )
+        self.confidence_head = DSparkConfidenceHead(
+            config.hidden_size + config.dspark_markov_rank
+        )
+
+        self.shared_head = nn.Module()
+        self.shared_head.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def hc_head(
+        self,
+        x: torch.Tensor,
+        hc_fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+    ) -> torch.Tensor:
+        shape, dtype = x.size(), x.dtype
+        x = x.flatten(1).float()
+        rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + self.rms_norm_eps)
+        mixes = F.linear(x, hc_fn) * rsqrt
+        pre = torch.sigmoid(mixes * hc_scale + hc_base) + self.hc_eps
+        y = torch.sum(pre.unsqueeze(-1) * x.view(shape), dim=1)
+        return y.to(dtype)
+
+    def project_main_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+        projected, _ = self.main_proj(main_hidden)
+        return self.main_norm(projected)
+
+    def forward_backbone(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+
+        prev_residual, prev_post, prev_comb = None, None, None
+        last_layer = None
+        for layer in self.layers:
+            last_layer = layer
+            hidden_states, prev_residual, prev_post, prev_comb = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+                input_ids=input_ids,
+                input_ids_global=input_ids,
+                prev_residual=prev_residual,
+                prev_post=prev_post,
+                prev_comb=prev_comb,
+            )
+        if last_layer is not None and prev_residual is not None:
+            hidden_states = last_layer.hc_post(
+                hidden_states, prev_residual, prev_post, prev_comb
+            )
+        return hidden_states
+
+    def collapse_block_hidden(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.hc_head(
+            hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        hidden_states = self.forward_backbone(input_ids, positions, forward_batch)
+        return self.collapse_block_hidden(hidden_states)
+
+
+DSPARK_DEFAULT_NUM_LAYERS = 3
+_warned_dspark_num_layers_fallback = False
+
+
+def get_dspark_num_layers(config: PretrainedConfig) -> int:
+    """Draft depth from the checkpoint config, or DSPARK_DEFAULT_NUM_LAYERS if unset."""
+    num_layers = getattr(config, "dspark_num_layers", None)
+    if num_layers is None or int(num_layers) <= 0:
+        global _warned_dspark_num_layers_fallback
+        if not _warned_dspark_num_layers_fallback:
+            _warned_dspark_num_layers_fallback = True
+            logger.warning(
+                "DSpark draft config has no positive dspark_num_layers; "
+                "falling back to %d layers.",
+                DSPARK_DEFAULT_NUM_LAYERS,
+            )
+        return DSPARK_DEFAULT_NUM_LAYERS
+    return int(num_layers)
+
+
+class DeepseekV4ForCausalLMDSpark(DeepseekV4ForCausalLM):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        # Parent load_weights prewarms MHC gated on this flag; parent __init__ (bypassed) would set it.
+        self._mhc_prewarmed_at_load = True
+        self.config = config
+        self.tp_size = get_parallel().tp_size
+        self.pp_group = get_pp_group()
+        self.quant_config = quant_config
+        self.determine_num_fused_shared_experts()
+
+        self.model = DeepseekV4DSparkModel(
+            config, quant_config, prefix=add_prefix("model", prefix)
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("model.shared_head.head", prefix),
+            use_attn_tp_group=get_flags().enable_dp_lm_head,
+        )
+        self.logits_processor = LogitsProcessor(config)
+
+    @property
+    def block_size(self) -> int:
+        return self.model.block_size
+
+    @property
+    def num_dspark_layers(self) -> int:
+        return self.model.num_dspark_layers
+
+    def project_main_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+        return self.model.project_main_hidden(main_hidden)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> LogitsProcessorOutput:
+        block_hidden = self.model(input_ids, positions, forward_batch)
+        return LogitsProcessorOutput(next_token_logits=None, hidden_states=block_hidden)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        super().load_weights(weights, is_nextn=False, is_dspark=True)
+
+    def post_load_weights(self, is_nextn=False, is_dspark=False, weight_names=None):
+        super().post_load_weights(is_dspark=True, weight_names=weight_names)
+
+
+EntryClass = [DeepseekV4ForCausalLMDSpark]

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -240,6 +240,11 @@ class DeepseekV4ForCausalLMDSpark(DeepseekV4ForCausalLM):
         self.pp_group = get_pp_group()
         self.quant_config = quant_config
         self.determine_num_fused_shared_experts()
+        # DSparkWorkerV2 ties embed_tokens/lm_head to the target for this
+        # family (see DSparkWorkerV2.__init__); this preserves that existing
+        # behavior explicitly rather than by attribute absence. Contrast
+        # Qwen3DSparkModel, which ships its own trained vocab weights.
+        self.owns_vocab_weights = False
 
         self.model = DeepseekV4DSparkModel(
             config, quant_config, prefix=add_prefix("model", prefix)

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -715,5 +715,23 @@ class Qwen3ForCausalLM(nn.Module):
         # layer `k` (HF-style), we capture before layer `k + 1`.
         self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
+    def set_dspark_layers_to_capture(self, layer_ids: List[int]):
+        # DSpark's target aux-hidden-state capture is mechanically identical
+        # to DFLASH's on this architecture: same `capture_aux_hidden_states`
+        # flag, same underlying `model.layers_to_capture` list, and the same
+        # "before layer i" -> "+1" offset requirement documented above (this
+        # model's `Qwen2Model.forward` records a layer's *input*, so capturing
+        # HF-style layer `k`'s *output* means capturing before layer `k + 1`).
+        # Only the downstream draft-side consumer (DSparkWorkerV2 vs
+        # DFlashWorkerV2) differs, so delegate rather than duplicate.
+        #
+        # NOTE: this is NOT the same as deepseek_v4.py's
+        # `set_dspark_layers_to_capture`, which passes `layer_ids` through
+        # unshifted -- that model's forward loop checks `layers_to_capture`
+        # *after* running each layer, so it needs no offset. Don't copy that
+        # version here; the offset is a property of this file's capture loop,
+        # not of the DSpark algorithm.
+        self.set_dflash_layers_to_capture(layer_ids)
+
 
 EntryClass = Qwen3ForCausalLM

--- a/python/sglang/srt/models/qwen3_dspark.py
+++ b/python/sglang/srt/models/qwen3_dspark.py
@@ -183,9 +183,7 @@ class Qwen3DSparkConfidenceHead(nn.Module):
         super().__init__()
         self.proj = nn.Linear(int(input_dim), 1, bias=True, dtype=torch.float32)
 
-    def forward(
-        self, hidden: torch.Tensor, markov_embed: torch.Tensor
-    ) -> torch.Tensor:
+    def forward(self, hidden: torch.Tensor, markov_embed: torch.Tensor) -> torch.Tensor:
         features = torch.cat([hidden, markov_embed], dim=-1)
         return self.proj(features.float()).squeeze(-1)
 
@@ -435,7 +433,9 @@ def resolve_qwen3_dspark_weight(
     if name.startswith("layers."):
         # Direct 1:1 renames under the backbone: input_layernorm,
         # post_attention_layernorm, self_attn.{q,k}_norm, self_attn.o_proj.
-        return Qwen3DSparkWeightMapping(checkpoint_name=name, dest_param="model." + name)
+        return Qwen3DSparkWeightMapping(
+            checkpoint_name=name, dest_param="model." + name
+        )
 
     if name in _TOP_LEVEL_PARAM_MAP:
         return Qwen3DSparkWeightMapping(

--- a/python/sglang/srt/models/qwen3_dspark.py
+++ b/python/sglang/srt/models/qwen3_dspark.py
@@ -1,0 +1,592 @@
+"""Qwen3-family DSpark draft model.
+
+Served through `DSparkWorkerV2` (python/sglang/srt/speculative/dspark_worker_v2.py),
+the same worker that already drives `DeepseekV4ForCausalLMDSpark`
+(python/sglang/srt/models/deepseek_v4_dspark.py). This file is the Qwen3-family
+analog of that V4 model.
+
+Design: subclass DFlash, not DeepSeek-V4
+-----------------------------------------
+A DSpark draft block for a Qwen3-family target is architecturally the *same*
+parallel, non-causal, context-KV-fed block drafter that
+`python/sglang/srt/models/dflash.py` (`DFlashDraftModel`) already implements
+for Qwen3-family targets: plain multi-head (GQA) attention with per-head
+q/k RMSNorm + RoPE + `RadixAttention` over a paged KV cache, where the KV
+cache is pre-seeded, once per committed token, with the projected target
+context feature (`fc` -> `hidden_norm`), and the block's own "noise" positions
+are computed by an ordinary forward pass reading the *same* cache. This is
+verified against the DeepSpec reference (`deepspec/modeling/dspark/qwen3/modeling.py`):
+`Qwen3DSparkAttention.forward` there concatenates `k_ctx = k_proj(target_hidden_states)`
+(the fused context feature, shared by every layer) with `k_noise = k_proj(hidden_states)`
+before attending; SGLang's paged-KV-cache serving path realizes that same
+concatenation by writing the context feature into the cache ahead of time
+(see `Qwen3DSparkAttention.kv_from_hidden` below) instead of concatenating
+tensors at every attention call. DeepSeek-V4's DSpark decoder layer
+(`DeepseekV4DecoderLayer`) is MLA-specific (compressed KV, fp8 packing, DSA)
+and does not generalize to a plain-MHA/GQA Qwen3 checkpoint, so this file
+subclasses DFlash's attention/decoder-layer machinery instead of V4's.
+
+This file deliberately imports nothing from `deepseek_v4_dspark.py` /
+`deepseek_v4.py`. `deepseek_v4.py` transitively imports `deepseek_v2.py`'s DSA
+indexer, which imports `deep_gemm` at module level; on a host without
+DeepSeek-V4's exact CUDA/deep_gemm build available, that import raises (e.g.
+`RuntimeError: ... libcudart.so.13`), independently observed while writing
+this file. That is exactly the "unconditional DSpark import crashes non-V4
+targets" bug this phase's model_runner.py fix addresses for the *target*
+model-runner path -- so this *draft* model file must not reintroduce the same
+fragility via a convenience import for non-V4 (Qwen3) deployments. The
+Markov head below is therefore a small, self-contained copy of
+`deepseek_v4_dspark.py`'s `DSparkMarkovHead` (generic vocab-parallel
+Embedding + LM-head-shaped Linear, no V4-specific assumptions in either
+version) rather than an import.
+
+What DSpark adds on top of a plain DFlash block, gated by config so ONE class
+serves every released Qwen3 DSpark checkpoint:
+  - The draft owns its OWN trained `embed_tokens` / `lm_head` (checkpoint has
+    `tie_word_embeddings=False` and ships both tensors) -- NOT tied to the
+    target, unlike `DeepseekV4ForCausalLMDSpark`. See `owns_vocab_weights`
+    below and the corresponding conditional in `DSparkWorkerV2.__init__`.
+  - An optional low-rank Markov refine head (`markov_head`, built iff
+    `config.markov_rank > 0`).
+  - An optional confidence ("accept-rate") head (`confidence_head`, built iff
+    `config.enable_confidence_head`).
+
+Two checkpoints are released under this exact architecture string today:
+`dspark_qwen3_4b_block7` (markov_rank=256, enable_confidence_head=true) and
+`dflash_qwen3_4b_block7` (markov_rank=0, enable_confidence_head=false, meant
+to run under the DFLASH algorithm/`DFlashWorkerV2`). This file only targets
+the `DSparkWorkerV2` contract; see the handoff notes for the open question
+around `DFlashWorkerV2` compatibility (that worker expects a flat
+`.layers`/`.fc`/`.project_target_hidden` shape, not this file's nested
+`.model.layers` shape).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional, Tuple, Union
+
+import msgspec
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.dflash import DFlashAttention, DFlashDecoderLayer
+from sglang.srt.runtime_context import get_flags
+from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen3DSparkAttention(DFlashAttention):
+    """`DFlashAttention` plus context-KV materialization.
+
+    `DSparkWorkerV2._materialize_main_hidden_to_draft_kv` seeds the draft's
+    paged KV cache with the projected target context feature once per
+    committed token, ahead of the block forward pass; the block forward's own
+    self-attention (inherited unmodified from `DFlashAttention`) then reads
+    that context transparently out of the same cache alongside the block's
+    own "noise" positions -- see the module docstring.
+
+    This mirrors `DeepseekV4Attention.kv_from_hidden` (deepseek_v4.py), which
+    is the MLA-specific version of the same idea. It is also exactly the math
+    DFlash's own worker already runs inline (`dflash_worker_v2.py`
+    `_append_target_hidden_sequential`: `kv_proj_only` -> `apply_k_norm` ->
+    `apply_k_rope` -> `set_kv_buffer`); it is exposed here as a method because
+    `DSparkWorkerV2` calls `layer.self_attn.kv_from_hidden(...)` directly.
+    """
+
+    def kv_from_hidden(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        attn_backend,
+    ) -> None:
+        k, v = self.kv_proj_only(x)
+        k = self.apply_k_norm(k)
+        k = self.apply_k_rope(positions, k)
+        k = k.view(-1, self.num_kv_heads, self.head_dim)
+        v = v.view(-1, self.num_kv_heads, self.head_dim)
+        attn_backend.token_to_kv_pool.set_kv_buffer(
+            self.attn, cache_loc, k, v, self.attn.k_scale, self.attn.v_scale
+        )
+
+
+class Qwen3DSparkDecoderLayer(DFlashDecoderLayer):
+    attention_cls = Qwen3DSparkAttention
+
+
+class Qwen3DSparkMarkovHead(nn.Module):
+    """Low-rank additive Markov refine head over the vocab ("VanillaMarkov").
+
+    Ground truth: `deepspec/modeling/dspark/markov_head.py` `VanillaMarkov`
+    (`markov_w1 = nn.Embedding(vocab, rank)`, `markov_w2 = nn.Linear(rank,
+    vocab, bias=False)`, additive logit bias `logits + markov_w2(markov_w1(
+    prev_token))`). `markov_w1` is replicated (`enable_tp=False`) so
+    `DSparkWorkerV2`'s per-step token lookup is a local gather; `markov_w2`
+    is vocab-sharded via `ParallelLMHead` so its bias aligns column-for-column
+    with the tied/sharded `lm_head` base logits it gets added to -- see
+    `DSparkWorkerV2._build_refine_refs`'s explicit shard-alignment check.
+    Shape- and semantics-identical to `deepseek_v4_dspark.py`'s
+    `DSparkMarkovHead`; kept as a separate copy rather than an import -- see
+    the module docstring.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        markov_rank: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.markov_w1 = VocabParallelEmbedding(
+            vocab_size,
+            markov_rank,
+            enable_tp=False,
+            prefix=add_prefix("markov_w1", prefix),
+        )
+        self.markov_w2 = ParallelLMHead(
+            vocab_size,
+            markov_rank,
+            quant_config=quant_config,
+            prefix=add_prefix("markov_w2", prefix),
+        )
+
+
+class Qwen3DSparkConfidenceHead(nn.Module):
+    """Accept-rate predictor over `[hidden_state ; markov_prev_embedding]`.
+
+    Ground truth: `deepspec/modeling/dspark/common.py` `AcceptRatePredictor`
+    (`nn.Linear(input_dim, 1)`, default `bias=True`) plus
+    `deepspec/modeling/dspark/qwen3/modeling.py` `predict_confidence_step`
+    (`features = cat([hidden_states, prev_embeddings], dim=-1)`, then
+    `.float()`). Mirrors `DSparkConfidenceHead` (deepseek_v4_dspark.py) --
+    same fp32 proj for numeric stability of the calibration signal -- except
+    this checkpoint's proj HAS a bias (`confidence_head.proj.bias` is a real
+    tensor here; V4's confidence head hardcodes `bias=False`).
+    """
+
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(int(input_dim), 1, bias=True, dtype=torch.float32)
+
+    def forward(
+        self, hidden: torch.Tensor, markov_embed: torch.Tensor
+    ) -> torch.Tensor:
+        features = torch.cat([hidden, markov_embed], dim=-1)
+        return self.proj(features.float()).squeeze(-1)
+
+
+class Qwen3DSparkBackbone(nn.Module):
+    """Backbone exposed to `DSparkWorkerV2` as `draft_model.model`.
+
+    Qwen3-family analog of `DeepseekV4DSparkModel`. Attribute names
+    (`embed_tokens`, `layers`, `markov_head`, `confidence_head`, `vocab_size`,
+    `noise_token_id`, `markov_rank`, `shared_head.norm`) are exactly what
+    `DSparkWorkerV2` reads off `self._draft_inner` -- see
+    `dspark_worker_v2.py` `_build_refine_refs` / `__init__`.
+    """
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.vocab_size = int(config.vocab_size)
+        self.hidden_size = int(config.hidden_size)
+        self.rms_norm_eps = float(config.rms_norm_eps)
+
+        # head_dim MUST come from config, never derived: for this checkpoint
+        # family hidden_size // num_attention_heads (2560 // 32 == 80) is NOT
+        # the real head_dim (128). DFlashAttention (subclassed below) already
+        # reads config.head_dim first via getattr and only derives as a
+        # fallback, so this checkpoint loads correctly either way -- this
+        # assertion just makes the requirement explicit and fails loudly
+        # instead of silently deriving 80 if a future config regresses it.
+        head_dim = getattr(config, "head_dim", None)
+        if not head_dim or int(head_dim) <= 0:
+            raise ValueError(
+                "Qwen3DSparkModel requires a positive config.head_dim (must not "
+                "be derived from hidden_size // num_attention_heads for this "
+                f"checkpoint family: {self.hidden_size}//{config.num_attention_heads} "
+                "!= head_dim)."
+            )
+
+        target_layer_ids = getattr(config, "target_layer_ids", None)
+        if not target_layer_ids:
+            raise ValueError(
+                "Qwen3DSparkModel requires a non-empty config.target_layer_ids."
+            )
+        self.target_layer_ids = [int(x) for x in target_layer_ids]
+
+        block_size = getattr(config, "block_size", None)
+        if not block_size or int(block_size) <= 0:
+            raise ValueError("Qwen3DSparkModel requires a positive config.block_size.")
+        self.block_size = int(block_size)
+
+        num_hidden_layers = getattr(config, "num_hidden_layers", None)
+        if not num_hidden_layers or int(num_hidden_layers) <= 0:
+            raise ValueError(
+                "Qwen3DSparkModel requires a positive config.num_hidden_layers."
+            )
+        self.num_dspark_layers = int(num_hidden_layers)
+
+        # DSparkWorkerV2 fills undrafted block positions with this id (the
+        # released checkpoints spell it `mask_token_id`, matching the
+        # DeepSpec reference's training-time `create_noise_embed`; V4's own
+        # config instead spells it `dspark_noise_token_id`).
+        mask_token_id = getattr(config, "mask_token_id", None)
+        if mask_token_id is None:
+            raise ValueError("Qwen3DSparkModel requires config.mask_token_id.")
+        self.noise_token_id = int(mask_token_id)
+
+        self.markov_rank = int(getattr(config, "markov_rank", 0) or 0)
+        self.enable_confidence_head = bool(
+            getattr(config, "enable_confidence_head", False)
+        )
+        # DSparkWorkerV2._refine_block_markov_sharded always calls the
+        # confidence head with the Markov embedding concatenated in; there is
+        # no served path for a hidden-only confidence head.
+        if self.enable_confidence_head and not getattr(
+            config, "confidence_head_with_markov", True
+        ):
+            raise ValueError(
+                "Qwen3DSparkModel/DSparkWorkerV2 only support "
+                "confidence_head_with_markov=True."
+            )
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            enable_tp=not is_dp_attention_enabled(),
+            prefix=add_prefix("embed_tokens", prefix),
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                Qwen3DSparkDecoderLayer(
+                    config=config, layer_id=i, quant_config=quant_config
+                )
+                for i in range(self.num_dspark_layers)
+            ]
+        )
+
+        # Combine step for the per-token target context feature: fc THEN
+        # hidden_norm, in that order (see module docstring / project_main_hidden).
+        # Do not skip hidden_norm and do not reorder -- DFlash's own
+        # `project_target_hidden` (dflash.py) does this correctly; copying
+        # the layer stack without also copying this exact order/composition
+        # would silently produce wrong context features.
+        self.fc = nn.Linear(
+            len(self.target_layer_ids) * self.hidden_size,
+            self.hidden_size,
+            bias=False,
+        )
+        self.hidden_norm = RMSNorm(self.hidden_size, eps=self.rms_norm_eps)
+
+        # Final backbone norm. Applied by
+        # DSparkWorkerV2._refine_block_markov_sharded (as `shared_head.norm`,
+        # matching DeepseekV4DSparkModel's own attribute path), NOT here:
+        # forward() must return the RAW block hidden state so the worker's
+        # fused Markov-refine loop can norm + lm_head-project it itself (and
+        # fold that whole step into one cuda-graph capture). Applying it
+        # again inside forward() would double-normalize.
+        self.shared_head = nn.Module()
+        self.shared_head.norm = RMSNorm(self.hidden_size, eps=self.rms_norm_eps)
+
+        self.markov_head: Optional[Qwen3DSparkMarkovHead] = None
+        if self.markov_rank > 0:
+            self.markov_head = Qwen3DSparkMarkovHead(
+                self.vocab_size,
+                self.markov_rank,
+                quant_config=quant_config,
+                prefix=add_prefix("markov_head", prefix),
+            )
+
+        self.confidence_head: Optional[Qwen3DSparkConfidenceHead] = None
+        if self.enable_confidence_head:
+            if self.markov_head is None:
+                raise ValueError(
+                    "Qwen3DSparkModel: enable_confidence_head requires "
+                    "markov_rank > 0 (DSparkWorkerV2 always calls the "
+                    "confidence head with the Markov embedding concatenated in)."
+                )
+            self.confidence_head = Qwen3DSparkConfidenceHead(
+                self.hidden_size + self.markov_rank
+            )
+
+    def project_main_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+        """fc THEN hidden_norm -- see the comment on `self.fc` above."""
+        return self.hidden_norm(self.fc(main_hidden))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        residual: Optional[torch.Tensor] = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions, hidden_states, forward_batch, residual
+            )
+        if hidden_states.numel() != 0 and residual is not None:
+            # Fold in the last layer's pending residual WITHOUT applying the
+            # final norm's weight scaling -- see the shared_head.norm comment
+            # in __init__. (DFlashDraftModel.forward instead calls
+            # `self.norm(hidden_states, residual)` and keeps the *normed*
+            # output here, which would double-normalize for this model.)
+            hidden_states = hidden_states + residual
+        return hidden_states
+
+
+class Qwen3DSparkWeightMapping(msgspec.Struct, omit_defaults=True):
+    """Resolution of one checkpoint tensor name for `Qwen3DSparkModel`.
+
+    Either `dest_param` (a `named_parameters()` key, plus `shard_id` for the
+    qkv_proj/gate_up_proj stacked params) is set, or `drop_reason` is set
+    (the tensor is legitimately absent from this config's parameter set, e.g.
+    a Markov/confidence tensor when that head is gated off). Exactly one of
+    the two is ever set. Deliberately dependency-light (no torch distributed,
+    no model instantiation) so it can be exercised standalone -- see the
+    phase-3 parity script.
+    """
+
+    checkpoint_name: str
+    dest_param: Optional[str] = None
+    shard_id: Optional[Union[str, int]] = None
+    drop_reason: Optional[str] = None
+
+
+# (param_name, weight_name, shard_id), identical in spirit to DFlashDraftModel's
+# own stacked_params_mapping (dflash.py) -- both checkpoints fuse q/k/v and
+# gate/up the same way.
+_STACKED_PARAMS: Tuple[Tuple[str, str, Union[str, int]], ...] = (
+    ("qkv_proj", "q_proj", "q"),
+    ("qkv_proj", "k_proj", "k"),
+    ("qkv_proj", "v_proj", "v"),
+    ("gate_up_proj", "gate_proj", 0),
+    ("gate_up_proj", "up_proj", 1),
+)
+
+# Top-level (non-"layers.*") checkpoint tensor -> destination parameter, for
+# tensors that are always present regardless of the markov/confidence gates.
+_TOP_LEVEL_PARAM_MAP = {
+    "embed_tokens.weight": "model.embed_tokens.weight",
+    "fc.weight": "model.fc.weight",
+    "hidden_norm.weight": "model.hidden_norm.weight",
+    "norm.weight": "model.shared_head.norm.weight",
+    "lm_head.weight": "lm_head.weight",
+}
+
+# Present only when config.markov_rank > 0.
+_MARKOV_PARAM_MAP = {
+    "markov_head.markov_w1.weight": "model.markov_head.markov_w1.weight",
+    "markov_head.markov_w2.weight": "model.markov_head.markov_w2.weight",
+}
+
+# Present only when config.enable_confidence_head.
+_CONFIDENCE_PARAM_MAP = {
+    "confidence_head.proj.weight": "model.confidence_head.proj.weight",
+    "confidence_head.proj.bias": "model.confidence_head.proj.bias",
+}
+
+
+def resolve_qwen3_dspark_weight(
+    name: str,
+    *,
+    has_markov_head: bool,
+    has_confidence_head: bool,
+) -> Qwen3DSparkWeightMapping:
+    """Map one raw checkpoint tensor name to its destination parameter.
+
+    Pure function (no `self`, no torch distributed) so both
+    `Qwen3DSparkModel.load_weights` and the standalone CPU parity/mapping
+    script can share exactly one source of truth for the mapping table.
+    Raises for a genuinely unrecognized name (a real mapping gap); returns a
+    `drop_reason` only for the specific, expected case of a Markov/confidence
+    tensor present in the checkpoint while this config gates that head off.
+    """
+    for param_name, weight_name, shard_id in _STACKED_PARAMS:
+        if f".{weight_name}." not in name:
+            continue
+        mapped = "model." + name.replace(weight_name, param_name)
+        return Qwen3DSparkWeightMapping(
+            checkpoint_name=name, dest_param=mapped, shard_id=shard_id
+        )
+
+    if name.startswith("layers."):
+        # Direct 1:1 renames under the backbone: input_layernorm,
+        # post_attention_layernorm, self_attn.{q,k}_norm, self_attn.o_proj.
+        return Qwen3DSparkWeightMapping(checkpoint_name=name, dest_param="model." + name)
+
+    if name in _TOP_LEVEL_PARAM_MAP:
+        return Qwen3DSparkWeightMapping(
+            checkpoint_name=name, dest_param=_TOP_LEVEL_PARAM_MAP[name]
+        )
+
+    if name in _MARKOV_PARAM_MAP:
+        if not has_markov_head:
+            return Qwen3DSparkWeightMapping(
+                checkpoint_name=name,
+                drop_reason=(
+                    "markov_head is not built for this checkpoint "
+                    "(config.markov_rank == 0)"
+                ),
+            )
+        return Qwen3DSparkWeightMapping(
+            checkpoint_name=name, dest_param=_MARKOV_PARAM_MAP[name]
+        )
+
+    if name in _CONFIDENCE_PARAM_MAP:
+        if not has_confidence_head:
+            return Qwen3DSparkWeightMapping(
+                checkpoint_name=name,
+                drop_reason=(
+                    "confidence_head is not built for this checkpoint "
+                    "(config.enable_confidence_head is false)"
+                ),
+            )
+        return Qwen3DSparkWeightMapping(
+            checkpoint_name=name, dest_param=_CONFIDENCE_PARAM_MAP[name]
+        )
+
+    raise ValueError(
+        f"Qwen3DSparkModel: checkpoint tensor {name!r} has no known destination "
+        "parameter and no stated drop reason -- add it to the mapping."
+    )
+
+
+class Qwen3DSparkModel(nn.Module):
+    """EntryClass.
+
+    The class name matches the checkpoint's `architectures` string exactly
+    (the model registry keys on `cls.__name__`, see
+    `python/sglang/srt/models/registry.py` `import_model_classes`), so this
+    resolves with zero config rewriting in
+    `ModelConfig._config_draft_model`. Do not rename this class: upstream
+    PR #29917 broke registration by adding a `Draft` suffix to the outer
+    class, which no longer matched `architectures[0]` == "Qwen3DSparkModel".
+
+    Serves both released Qwen3 DSpark checkpoints from one class via config
+    gates -- see `Qwen3DSparkBackbone`. `dspark_qwen3_4b_block7` has both
+    `markov_head` and `confidence_head`; the sibling `dflash_qwen3_4b_block7`
+    (markov_rank=0, enable_confidence_head=false) has neither and is meant to
+    run under the DFLASH algorithm/`DFlashWorkerV2` -- this class targets the
+    `DSparkWorkerV2` contract only (see the module docstring).
+    """
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.quant_config = quant_config
+        self.pp_group = get_pp_group()
+
+        # Unlike DeepseekV4ForCausalLMDSpark (which ties embed_tokens/lm_head
+        # to the target unconditionally), this checkpoint trains and ships
+        # its own embed_tokens/lm_head (config.tie_word_embeddings=False).
+        # DSparkWorkerV2.__init__ reads this flag to skip its target-weight
+        # tying for models that own real trained vocab weights.
+        self.owns_vocab_weights = True
+
+        self.model = Qwen3DSparkBackbone(
+            config, quant_config=quant_config, prefix=add_prefix("model", prefix)
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("lm_head", prefix),
+            use_attn_tp_group=get_flags().enable_dp_lm_head,
+        )
+        # Unused by forward() below: DSparkWorkerV2 computes logits itself
+        # (norm + lm_head + Markov refine fused into its own cuda-graph-
+        # capturable step, see _refine_block_markov_sharded). Constructed
+        # anyway for parity with every other CausalLM model class, matching
+        # DeepseekV4ForCausalLMDSpark's own unused self.logits_processor.
+        self.logits_processor = LogitsProcessor(config)
+
+    @property
+    def block_size(self) -> int:
+        return self.model.block_size
+
+    @property
+    def num_dspark_layers(self) -> int:
+        return self.model.num_dspark_layers
+
+    def project_main_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+        return self.model.project_main_hidden(main_hidden)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> LogitsProcessorOutput:
+        block_hidden = self.model(input_ids, positions, forward_batch)
+        return LogitsProcessorOutput(next_token_logits=None, hidden_states=block_hidden)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        has_markov_head = self.model.markov_head is not None
+        has_confidence_head = self.model.confidence_head is not None
+        params_dict = dict(self.named_parameters())
+        loaded_params: set = set()
+
+        for name, loaded_weight in weights:
+            mapping = resolve_qwen3_dspark_weight(
+                name,
+                has_markov_head=has_markov_head,
+                has_confidence_head=has_confidence_head,
+            )
+            if mapping.dest_param is None:
+                logger.info(
+                    "Qwen3DSparkModel: dropping checkpoint tensor %s (%s).",
+                    name,
+                    mapping.drop_reason,
+                )
+                continue
+            if mapping.dest_param not in params_dict:
+                raise ValueError(
+                    f"Qwen3DSparkModel: checkpoint tensor {name!r} mapped to "
+                    f"{mapping.dest_param!r}, which is not a model parameter."
+                )
+            param = params_dict[mapping.dest_param]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            if mapping.shard_id is not None:
+                weight_loader(param, loaded_weight, mapping.shard_id)
+            else:
+                weight_loader(param, loaded_weight)
+            loaded_params.add(mapping.dest_param)
+
+        missing = sorted(set(params_dict) - loaded_params)
+        if missing:
+            raise ValueError(
+                f"Qwen3DSparkModel: {len(missing)} parameter(s) never received "
+                f"a checkpoint weight: {missing}"
+            )
+
+
+EntryClass = [Qwen3DSparkModel]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1599,6 +1599,14 @@ class ServerArgs:
         Optional[int],
         "DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
     ] = None
+    speculative_dspark_block_size: A[
+        Optional[int],
+        "DSpark only. Block size (draft block length). Alias of --speculative-num-draft-tokens for DSpark.",
+    ] = None
+    speculative_dspark_confidence_threshold: A[
+        float,
+        "DSpark only. Truncate the draft block at the first position whose confidence-head probability falls below this threshold. 0 disables truncation (verify the full block).",
+    ] = 0.0
     speculative_accept_threshold_single: A[
         float,
         "Accept a draft token if its probability in the target model is greater than this threshold.",

--- a/python/sglang/srt/speculative/dspark_info.py
+++ b/python/sglang/srt/speculative/dspark_info.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import torch
+
+from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.mem_cache.common import (
+    alloc_paged_token_slots_extend,
+    alloc_token_slots,
+    get_last_loc,
+)
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.tp_worker import TpModelWorker
+
+
+@dataclass
+class DSparkVerifyInput(SpecInput):
+    draft_token: torch.Tensor
+    positions: torch.Tensor
+    draft_token_num: int
+    topk: int = 1
+    custom_mask: torch.Tensor | None = None
+    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
+    num_tokens_per_batch: int = -1
+    block_full_attn: int = 0
+
+    def __post_init__(self):
+        super().__init__(spec_input_type=SpecInputType.DSPARK_VERIFY)
+        if self.num_tokens_per_batch == -1:
+            self.num_tokens_per_batch = int(self.draft_token_num)
+
+    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
+        return self.draft_token_num, self.draft_token_num
+
+    def prepare_for_verify(
+        self,
+        batch: ScheduleBatch,
+        target_worker: TpModelWorker,
+    ) -> tuple[ForwardBatch, bool]:
+        batch.input_ids = self.draft_token
+        batch.spec_info = self
+        batch.forward_mode = (
+            ForwardMode.IDLE
+            if batch.forward_mode.is_idle()
+            else ForwardMode.TARGET_VERIFY
+        )
+        batch.capture_hidden_mode = self.capture_hidden_mode
+        verify_forward_batch = ForwardBatch.init_new(batch, target_worker.model_runner)
+
+        can_run_cuda_graph = bool(
+            target_worker.model_runner.decode_cuda_graph_runner
+            and target_worker.model_runner.decode_cuda_graph_runner.can_run_graph(
+                verify_forward_batch
+            )
+        )
+        if can_run_cuda_graph:
+            target_worker.model_runner.decode_cuda_graph_runner.load_batch(
+                verify_forward_batch
+            )
+        elif not batch.forward_mode.is_idle():
+            target_worker.model_runner.attn_backend.init_forward_metadata(
+                verify_forward_batch
+            )
+
+        return verify_forward_batch, can_run_cuda_graph
+
+    def generate_attn_arg_prefill(
+        self,
+        req_pool_indices: torch.Tensor,
+        paged_kernel_lens: torch.Tensor,
+        paged_kernel_lens_sum: int,
+        req_to_token: torch.Tensor,
+        kv_start_idx: Optional[torch.Tensor] = None,
+    ):
+        device = req_pool_indices.device
+        bs = len(req_pool_indices)
+
+        qo_indptr = torch.arange(
+            0,
+            (bs + 1) * self.draft_token_num,
+            step=self.draft_token_num,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        cum_kv_seq_len = torch.zeros((bs + 1,), dtype=torch.int32, device=device)
+        paged_kernel_lens = paged_kernel_lens + self.draft_token_num
+        cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
+
+        kv_indices = torch.empty(
+            paged_kernel_lens_sum + self.draft_token_num * bs,
+            dtype=torch.int32,
+            device=device,
+        )
+        create_flashinfer_kv_indices_triton[(bs,)](
+            req_to_token,
+            req_pool_indices,
+            paged_kernel_lens,
+            cum_kv_seq_len,
+            kv_start_idx,
+            kv_indices,
+            req_to_token.size(1),
+        )
+        mask = self.custom_mask
+        if mask is not None:
+            mask_numel = (
+                paged_kernel_lens_sum * self.draft_token_num
+                + (self.draft_token_num**2) * bs
+            )
+            if mask.numel() < mask_numel:
+                mask = torch.cat(
+                    [
+                        mask,
+                        torch.full(
+                            (mask_numel - mask.numel(),),
+                            True,
+                            dtype=torch.bool,
+                            device=device,
+                        ),
+                    ],
+                    dim=0,
+                )
+                self.custom_mask = mask
+        return kv_indices, cum_kv_seq_len, qo_indptr, mask
+
+
+@dataclass
+class DSparkDraftInputV2(SpecInput):
+    bonus_tokens: torch.Tensor
+    new_seq_lens: torch.Tensor
+    main_hidden: Optional[torch.Tensor] = None
+    confidence: Optional[torch.Tensor] = None
+    # Top-k scalars precomputed in prepare_for_decode to avoid a GPU->CPU sync at verify.
+    max_top_k: int = 1
+    uniform_top_k_value: Optional[int] = None
+    topk_p: torch.Tensor = field(
+        default_factory=lambda: torch.empty((0, 0), dtype=torch.float32)
+    )
+    topk_index: torch.Tensor = field(
+        default_factory=lambda: torch.empty((0, 0), dtype=torch.int64)
+    )
+    hidden_states: torch.Tensor = field(
+        default_factory=lambda: torch.empty((0, 0), dtype=torch.float16)
+    )
+    direct_carry_valid: bool = True
+    future_indices: Optional[torch.Tensor] = None
+
+    def __post_init__(self):
+        super().__init__(spec_input_type=SpecInputType.DSPARK_DRAFT)
+
+    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
+        return 1, 1
+
+    @classmethod
+    def create_idle_input(cls, device: torch.device) -> DSparkDraftInputV2:
+        return cls(
+            bonus_tokens=torch.empty((0,), device=device, dtype=torch.int64),
+            new_seq_lens=torch.empty((0,), device=device, dtype=torch.int64),
+            topk_p=torch.empty((0, 0), device=device, dtype=torch.float32),
+            topk_index=torch.empty((0, 0), device=device, dtype=torch.int64),
+            hidden_states=torch.empty((0, 0), device=device, dtype=torch.float16),
+        )
+
+    def prepare_for_decode(self, batch: ScheduleBatch):
+        bs = batch.batch_size()
+        if bs == 0:
+            return
+
+        from sglang.srt.runtime_context import get_server_args
+
+        block_size = int(get_server_args().speculative_num_draft_tokens)
+        if block_size <= 0:
+            raise ValueError(
+                f"DSpark invalid speculative_num_draft_tokens={block_size}."
+            )
+
+        device = batch.device
+        page_size = batch.token_to_kv_pool_allocator.page_size
+
+        cur_kv_lens_cpu = torch.empty((bs,), dtype=torch.int32, device="cpu")
+        nxt_kv_lens_cpu = torch.empty((bs,), dtype=torch.int32, device="cpu")
+        committed_cpu = torch.empty((bs,), dtype=torch.int64, device="cpu")
+        committed_sum = 0
+        num_needed_tokens = 0
+        max_top_k = 1
+        uniform_top_k_value = None
+        uniform_top_k = True
+        for i, req in enumerate(batch.reqs):
+            committed_len = int(req.kv_committed_len)
+            # req.kv_allocated_len is the real watermark; a carried CPU copy underestimates under page_size>1 rounding.
+            cur_alloc_len = int(req.kv_allocated_len)
+            reserved_len = max(cur_alloc_len, committed_len + 2 * block_size)
+            cur_kv_lens_cpu[i] = cur_alloc_len
+            nxt_kv_lens_cpu[i] = reserved_len
+            committed_cpu[i] = committed_len
+            committed_sum += committed_len
+            num_needed_tokens += reserved_len - cur_alloc_len
+
+            top_k = int(req.sampling_params.top_k)
+            if top_k > max_top_k:
+                max_top_k = top_k
+            if i == 0:
+                uniform_top_k_value = top_k
+            elif uniform_top_k and top_k != uniform_top_k_value:
+                uniform_top_k = False
+
+        cur_kv_lens = cur_kv_lens_cpu.to(device, non_blocking=True)
+        nxt_kv_lens = nxt_kv_lens_cpu.to(device, non_blocking=True)
+
+        if num_needed_tokens > 0:
+            if page_size == 1:
+                out_cache_loc = alloc_token_slots(batch.tree_cache, num_needed_tokens)
+            else:
+                last_loc = get_last_loc(
+                    batch.req_to_token_pool.req_to_token,
+                    batch.req_pool_indices,
+                    cur_kv_lens,
+                )
+                out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
+            assign_req_to_token_pool_func(
+                batch.req_pool_indices,
+                batch.req_to_token_pool.req_to_token,
+                cur_kv_lens,
+                nxt_kv_lens,
+                out_cache_loc,
+                bs,
+            )
+
+        for i, req in enumerate(batch.reqs):
+            req.kv_allocated_len = max(req.kv_allocated_len, int(nxt_kv_lens_cpu[i]))
+
+        batch.seq_lens_cpu = committed_cpu
+        batch.seq_lens_sum = committed_sum
+        self.max_top_k = max(max_top_k, 1)
+        self.uniform_top_k_value = uniform_top_k_value if uniform_top_k else None
+
+    def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
+        if self.future_indices is not None:
+            self.future_indices = self.future_indices[new_indices]
+            self.direct_carry_valid = False
+            return
+
+        self.bonus_tokens = self.bonus_tokens[new_indices]
+        self.new_seq_lens = self.new_seq_lens[new_indices]
+        if self.main_hidden is not None:
+            self.main_hidden = self.main_hidden[new_indices]
+        if self.confidence is not None:
+            self.confidence = self.confidence[new_indices]
+        if self.topk_p.numel() > 0:
+            self.topk_p = self.topk_p[new_indices]
+        if self.topk_index.numel() > 0:
+            self.topk_index = self.topk_index[new_indices]
+        if self.hidden_states.numel() > 0:
+            self.hidden_states = self.hidden_states[new_indices]
+
+    def merge_batch(self, spec_info: DSparkDraftInputV2):
+        if self.future_indices is not None:
+            assert spec_info.future_indices is not None
+            self.future_indices = torch.cat(
+                [self.future_indices, spec_info.future_indices]
+            )
+            self.direct_carry_valid = False
+            return
+
+        self.bonus_tokens = torch.cat(
+            [self.bonus_tokens, spec_info.bonus_tokens], dim=0
+        )
+        self.new_seq_lens = torch.cat(
+            [self.new_seq_lens, spec_info.new_seq_lens], dim=0
+        )
+        if self.main_hidden is not None and spec_info.main_hidden is not None:
+            self.main_hidden = torch.cat(
+                [self.main_hidden, spec_info.main_hidden], dim=0
+            )
+        if self.confidence is not None and spec_info.confidence is not None:
+            self.confidence = torch.cat([self.confidence, spec_info.confidence], dim=0)
+        self.topk_p = torch.cat([self.topk_p, spec_info.topk_p], dim=0)
+        self.topk_index = torch.cat([self.topk_index, spec_info.topk_index], dim=0)
+        self.hidden_states = torch.cat(
+            [self.hidden_states, spec_info.hidden_states], dim=0
+        )
+
+
+def validate_dspark_request(req: Req) -> Optional[str]:
+    if req.return_logprob:
+        return "DSpark speculative decoding does not support return_logprob yet."
+
+    # The target hidden states are consumed and nulled during draft, so they cannot be returned.
+    if req.return_hidden_states:
+        return "DSpark speculative decoding does not support return_hidden_states yet."
+
+    if (
+        req.sampling_params.json_schema is not None
+        or req.sampling_params.regex is not None
+        or req.sampling_params.ebnf is not None
+        or req.sampling_params.structural_tag is not None
+    ):
+        return (
+            "DSpark speculative decoding does not support "
+            "grammar-constrained decoding yet."
+        )
+
+    return None

--- a/python/sglang/srt/speculative/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_worker_v2.py
@@ -237,12 +237,18 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.draft_model = self.draft_model_runner.model
         self._draft_inner = self.draft_model.model
 
-        self.draft_model.model.embed_tokens.weight = (
-            self.target_worker.model_runner.model.model.embed_tokens.weight
-        )
-        self.draft_model.lm_head.weight = (
-            self.target_worker.model_runner.model.lm_head.weight
-        )
+        # DeepSeek-V4's DSpark draft ties embed_tokens/lm_head to the target
+        # (owns_vocab_weights=False); some draft families (e.g. Qwen3DSpark)
+        # instead ship their own trained embed_tokens/lm_head and must keep
+        # them (owns_vocab_weights=True). Every DSpark draft model sets this
+        # flag explicitly, so read it directly rather than defaulting it away.
+        if not self.draft_model.owns_vocab_weights:
+            self.draft_model.model.embed_tokens.weight = (
+                self.target_worker.model_runner.model.model.embed_tokens.weight
+            )
+            self.draft_model.lm_head.weight = (
+                self.target_worker.model_runner.model.lm_head.weight
+            )
 
         self.block_size = int(server_args.speculative_num_draft_tokens)
         model_block_size = int(getattr(self.draft_model, "block_size", self.block_size))

--- a/python/sglang/srt/speculative/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_worker_v2.py
@@ -1,0 +1,895 @@
+import logging
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.distributed import (
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+)
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.scheduler import GenerationBatchResult
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+    compute_position,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.srt.speculative.dflash_utils import (
+    apply_dflash_verify_logits_adjustments,
+    compute_dflash_correct_drafts_and_bonus,
+    compute_dflash_sampling_correct_drafts_and_bonus,
+    is_dflash_sampling_verify_available,
+)
+from sglang.srt.speculative.dspark_info import DSparkDraftInputV2, DSparkVerifyInput
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.triton_ops.cache_locs import assign_extend_cache_locs_func
+from sglang.srt.utils import get_available_gpu_memory, is_cuda
+
+logger = logging.getLogger(__name__)
+
+# -inf maps to the smallest radix key, so a masked padding column never wins the argmax.
+_DSPARK_NEG_INF = float("-inf")
+
+
+def _dspark_pack_value_index(
+    values: torch.Tensor, global_indices: torch.Tensor
+) -> torch.Tensor:
+    """Pack a bf16 value and global vocab index into a positive int64 ordered
+    value DESC, index ASC, so a cross-shard MAX reproduces argmax's first-index tie-break.
+
+    The order-preserving 16-bit key of the value goes in bits [32, 48); the index
+    goes in bits [0, 32) inverted so the smallest index wins ties.
+    """
+    # IEEE order-preserving flip so the 16-bit key sorts like the bf16 value.
+    bits = values.view(torch.int16).to(torch.int64)
+    mask = (bits >> 15) | 0x8000
+    key16 = (bits ^ mask) & 0xFFFF
+    inv_index = 0xFFFFFFFF - global_indices
+    return (key16 << 32) | inv_index
+
+
+def _dspark_decode_index(packed: torch.Tensor) -> torch.Tensor:
+    """Recover the winning global vocab index from a packed int64 produced by
+    _dspark_pack_value_index."""
+    return 0xFFFFFFFF - (packed & 0xFFFFFFFF)
+
+
+def _dspark_shard_argmax_pack(
+    refined_shard: torch.Tensor,
+    org_vocab_start: int,
+    pad_mask: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Shard-local argmax packed for a cross-shard MAX reduction. One packed int64
+    per row (see _dspark_pack_value_index).
+
+    The +0.0 collapses -0.0 to +0.0 so ties match torch.argmax.
+    """
+    refined = refined_shard + 0.0
+    if pad_mask is not None:
+        refined = refined.masked_fill(pad_mask, _DSPARK_NEG_INF)
+    local_val, local_arg = refined.max(dim=-1)
+    global_indices = local_arg.to(torch.int64) + org_vocab_start
+    return _dspark_pack_value_index(local_val, global_indices)
+
+
+class _DSparkRefineRefs:
+    """Static references and precomputed shard geometry shared by the eager and
+    cuda-graph-captured Markov refine paths (see _refine_block_markov_sharded)."""
+
+    def __init__(
+        self,
+        *,
+        norm,
+        lm_head_weight,
+        markov_w1,
+        markov_w2_weight,
+        confidence_head,
+        org_vocab_start,
+        pad_mask,
+        block_size,
+        tp_size,
+        tp_group_device,
+        use_confidence,
+    ):
+        self.norm = norm
+        self.lm_head_weight = lm_head_weight
+        self.markov_w1 = markov_w1
+        self.markov_w2_weight = markov_w2_weight
+        self.confidence_head = confidence_head
+        self.org_vocab_start = int(org_vocab_start)
+        self.pad_mask = pad_mask
+        self.block_size = int(block_size)
+        self.tp_size = int(tp_size)
+        self.tp_group_device = tp_group_device
+        self.use_confidence = bool(use_confidence)
+
+
+def _refine_block_markov_sharded(
+    block_hidden: torch.Tensor,
+    seeds: torch.Tensor,
+    refs: _DSparkRefineRefs,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Collective-free block Markov refine.
+
+    Each step computes a vocab-shard of the refined logits, takes a shard-local
+    argmax, and under TP resolves the global argmax with one int64 MAX all-reduce
+    (skipped at tp_size==1). Returns candidates [bs, block_size] and per-position
+    confidence [bs, block_size] (None when the confidence head is gated off).
+    """
+    bs = int(block_hidden.shape[0])
+    block_size = refs.block_size
+    out_tokens = torch.empty(
+        (bs, block_size + 1), dtype=torch.int64, device=block_hidden.device
+    )
+    out_tokens[:, 0] = seeds.view(-1).to(torch.int64)
+    markov_embeds = [] if refs.use_confidence else None
+
+    normed_hidden = refs.norm(block_hidden)
+    base_shard = F.linear(normed_hidden, refs.lm_head_weight)
+    for i in range(block_size):
+        prev_embed = refs.markov_w1(out_tokens[:, i])
+        bias_shard = F.linear(prev_embed, refs.markov_w2_weight)
+        refined_shard = base_shard[:, i] + bias_shard
+        packed = _dspark_shard_argmax_pack(
+            refined_shard, refs.org_vocab_start, refs.pad_mask
+        )
+        if refs.tp_size > 1:
+            torch.distributed.all_reduce(
+                packed,
+                op=torch.distributed.ReduceOp.MAX,
+                group=refs.tp_group_device,
+            )
+        out_tokens[:, i + 1] = _dspark_decode_index(packed)
+        if refs.use_confidence:
+            markov_embeds.append(prev_embed)
+
+    if refs.use_confidence:
+        stacked_embed = torch.stack(markov_embeds, dim=1)
+        confidence = refs.confidence_head(block_hidden, stacked_embed)
+    else:
+        confidence = None
+
+    candidates = out_tokens[:, :block_size].contiguous()
+    return candidates, confidence
+
+
+class _DSparkDraftSampler:
+    """Runs the Markov refine inside the draft decode cuda graph.
+
+    Candidates and confidence land in persistent buffers; the worker consumes
+    them into the verify input before the next replay, so the buffers are never
+    overwritten while still in use.
+    """
+
+    def __init__(self, *, refs: _DSparkRefineRefs, max_bs: int, device):
+        self.refs = refs
+        self.candidates_buf = torch.empty(
+            (int(max_bs), refs.block_size), dtype=torch.int64, device=device
+        )
+        self.confidence_buf = (
+            torch.empty(
+                (int(max_bs), refs.block_size), dtype=torch.float32, device=device
+            )
+            if refs.use_confidence
+            else None
+        )
+
+    def __call__(self, hidden_states: torch.Tensor, input_ids: torch.Tensor) -> None:
+        block_size = self.refs.block_size
+        bs = hidden_states.shape[0] // block_size
+        block_hidden = hidden_states.view(bs, block_size, -1)
+        # Column 0 is the seed bonus token the worker wrote into the static input before replay.
+        seeds = input_ids.view(bs, block_size)[:, 0]
+        candidates, confidence = _refine_block_markov_sharded(
+            block_hidden, seeds, self.refs
+        )
+        self.candidates_buf[:bs].copy_(candidates)
+        if self.confidence_buf is not None:
+            self.confidence_buf[:bs].copy_(confidence)
+
+
+class DSparkWorkerV2(BaseSpecWorker):
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        attn_cp_rank: int,
+        moe_dp_rank: int,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        self.server_args = server_args
+        self.gpu_id = gpu_id
+        self.tp_rank = tp_rank
+        self.dp_rank = dp_rank
+        self.moe_ep_rank = moe_ep_rank
+        self.attn_cp_rank = attn_cp_rank
+        self.moe_dp_rank = moe_dp_rank
+        self.nccl_port = nccl_port
+        self._target_worker = target_worker
+        self.model_runner = target_worker.model_runner
+        self.page_size = server_args.page_size
+        self.device = target_worker.device
+
+        self._draft_worker = TpModelWorker(
+            server_args=server_args,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+            moe_ep_rank=moe_ep_rank,
+            pp_rank=0,
+            attn_cp_rank=attn_cp_rank,
+            moe_dp_rank=moe_dp_rank,
+            dp_rank=dp_rank,
+            nccl_port=nccl_port,
+            is_draft_worker=True,
+            context_length=target_worker.model_runner.model_config.context_len,
+        )
+        self.draft_model_runner = self._draft_worker.model_runner
+        self._draft_worker.draft_runner = self.draft_model_runner
+        self.draft_model = self.draft_model_runner.model
+        self._draft_inner = self.draft_model.model
+
+        self.draft_model.model.embed_tokens.weight = (
+            self.target_worker.model_runner.model.model.embed_tokens.weight
+        )
+        self.draft_model.lm_head.weight = (
+            self.target_worker.model_runner.model.lm_head.weight
+        )
+
+        self.block_size = int(server_args.speculative_num_draft_tokens)
+        model_block_size = int(getattr(self.draft_model, "block_size", self.block_size))
+        if model_block_size != self.block_size:
+            logger.warning(
+                "DSpark block size mismatch: using speculative_num_draft_tokens=%s "
+                "but draft model block_size=%s.",
+                self.block_size,
+                model_block_size,
+            )
+        self.speculative_num_draft_tokens = int(self.block_size)
+
+        self.noise_token_id = int(self._draft_inner.noise_token_id)
+        self.markov_rank = int(self._draft_inner.markov_rank)
+        self.num_dspark_layers = int(self.draft_model.num_dspark_layers)
+        self.confidence_threshold = float(
+            server_args.speculative_dspark_confidence_threshold
+        )
+        # sigmoid(x) >= 0, so a 0.0 threshold never truncates; skip the confidence head then.
+        self.use_confidence = self.confidence_threshold > 0.0
+
+        self._block_pos_offsets = torch.arange(
+            self.block_size, device=self.device, dtype=torch.int64
+        )
+        self._sampling_verify_logged = False
+
+        # Ping-pong slots: the previous step's tensors may still be read D2H, so alternate.
+        self._decode_buffer_cap = 0
+        self._decode_buffer_slot = 0
+        self._block_ids_bufs = []
+        self._out_tokens_bufs = []
+        self._commit_lens_bufs = []
+        self._new_seq_lens_bufs = []
+
+        self._refine_refs = self._build_refine_refs()
+        self._draft_sampler = None
+
+        if self.tp_rank == 0:
+            logger.info(
+                "Initialized DSpark draft runner. model=%s, block_size=%s, "
+                "num_dspark_layers=%s, noise_token_id=%s, markov_rank=%s, "
+                "confidence_threshold=%s, collective_free_refine=True, "
+                "use_confidence=%s",
+                self.draft_model.__class__.__name__,
+                self.block_size,
+                self.num_dspark_layers,
+                self.noise_token_id,
+                self.markov_rank,
+                self.confidence_threshold,
+                self.use_confidence,
+            )
+
+    @property
+    def target_worker(self) -> TpModelWorker:
+        return self._target_worker
+
+    @property
+    def draft_worker(self):
+        return self._draft_worker
+
+    @property
+    def spec_v2_attn_backends(self) -> tuple:
+        return (
+            self._target_worker.model_runner.attn_backend,
+            self.draft_model_runner.attn_backend,
+        )
+
+    def alloc_memory_pool(
+        self,
+        memory_pool_config=None,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+    ):
+        self._draft_worker.alloc_memory_pool(
+            memory_pool_config=memory_pool_config,
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        )
+
+    def init_attention_backends(self):
+        self._draft_worker.init_attention_backends()
+
+    def init_cuda_graphs(self):
+        capture_decode_cuda_graph = not self.server_args.disable_cuda_graph
+        if is_cuda() and capture_decode_cuda_graph:
+            available_mem = get_available_gpu_memory(self.device, self.gpu_id)
+            if available_mem < 1.0:
+                capture_decode_cuda_graph = False
+                logger.warning(
+                    "Disable DSpark draft cuda graph because only %.2f GB GPU "
+                    "memory is available after target backend initialization.",
+                    available_mem,
+                )
+        if capture_decode_cuda_graph:
+            # Must run before capture so the draft graph folds the refine in.
+            self._draft_sampler = self._maybe_build_draft_sampler()
+            self.draft_model_runner.dspark_draft_sampler = self._draft_sampler
+        self._draft_worker.init_cuda_graphs(
+            capture_decode_cuda_graph=capture_decode_cuda_graph
+        )
+
+    def _maybe_build_draft_sampler(self):
+        if not torch.is_floating_point(self.draft_model.lm_head.weight):
+            # Quantized lm_head would break the static F.linear in the refine.
+            if self.tp_rank == 0:
+                logger.info("DSpark Markov refine kept eager (quantized lm_head).")
+            return None
+        if self.tp_rank == 0:
+            logger.info("DSpark Markov refine folded into the draft cuda graph.")
+        return _DSparkDraftSampler(
+            refs=self._refine_refs,
+            max_bs=max(self.server_args.cuda_graph_config.decode.bs),
+            device=self.device,
+        )
+
+    def clear_cache_pool(self):
+        pass
+
+    def __getattr__(self, name):
+        if name == "_target_worker":
+            raise AttributeError(name)
+        return getattr(self.target_worker, name)
+
+    def _materialize_main_hidden_to_draft_kv(
+        self,
+        *,
+        main_hidden: torch.Tensor,
+        cache_loc: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> None:
+        if main_hidden is None:
+            raise RuntimeError("DSpark missing target main_hidden context features.")
+        if main_hidden.numel() == 0:
+            return
+        if not main_hidden.shape[0] == cache_loc.shape[0] == positions.shape[0]:
+            raise RuntimeError(
+                "DSpark draft KV materialization row mismatch: "
+                f"main_hidden={main_hidden.shape[0]}, cache_loc={cache_loc.shape[0]}, "
+                f"positions={positions.shape[0]}. Under prefill context parallelism "
+                "the captured target hidden states must be gathered to full token order."
+            )
+
+        device = self.device
+        if main_hidden.device != device:
+            main_hidden = main_hidden.to(device, non_blocking=True)
+        if cache_loc.device != device:
+            cache_loc = cache_loc.to(device, non_blocking=True)
+        if positions.device != device:
+            positions = positions.to(device, non_blocking=True)
+        if cache_loc.dtype != torch.int64:
+            cache_loc = cache_loc.to(torch.int64)
+        if positions.dtype != torch.int64:
+            positions = positions.to(torch.int64)
+
+        attn_backend = self.draft_model_runner.attn_backend
+        with torch.inference_mode():
+            main_x = self.draft_model.project_main_hidden(main_hidden)
+            for layer in self._draft_inner.layers:
+                layer.self_attn.kv_from_hidden(
+                    main_x, positions, cache_loc, attn_backend
+                )
+
+    def _run_draft_block(
+        self,
+        *,
+        bs: int,
+        block_ids: torch.Tensor,
+        positions: torch.Tensor,
+        verify_out_cache_loc: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor] = None,
+        seq_lens_sum: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, bool]:
+        device = self.device
+        # Host seq_lens must be the committed lengths, not the reserved over-alloc:
+        # the backend adds +block for TARGET_VERIFY, so committed+block is the verify extent.
+        if seq_lens_cpu is None:
+            seq_lens_cpu = prefix_lens.to(device="cpu", dtype=torch.int32)
+        if seq_lens_sum is None:
+            seq_lens_sum = int(seq_lens_cpu.sum().item())
+        draft_block_spec_info = DSparkVerifyInput(
+            draft_token=block_ids.reshape(-1),
+            positions=positions,
+            draft_token_num=int(self.block_size),
+            custom_mask=None,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+            block_full_attn=int(self.block_size),
+        )
+        draft_forward_batch = ForwardBatch(
+            forward_mode=ForwardMode.TARGET_VERIFY,
+            batch_size=bs,
+            input_ids=block_ids.reshape(-1),
+            req_pool_indices=req_pool_indices,
+            seq_lens=prefix_lens,
+            out_cache_loc=verify_out_cache_loc,
+            seq_lens_sum=seq_lens_sum,
+            seq_lens_cpu=seq_lens_cpu,
+            positions=positions,
+            spec_algorithm=SpeculativeAlgorithm.DSPARK,
+            spec_info=draft_block_spec_info,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+        )
+
+        with torch.inference_mode():
+            draft_runner_out = self.draft_model_runner.forward(draft_forward_batch)
+
+        raw = draft_runner_out.logits_output
+        block_hidden = raw if isinstance(raw, torch.Tensor) else raw.hidden_states
+        if block_hidden is None:
+            raise RuntimeError("DSpark draft model returned no block hidden states.")
+        return (
+            block_hidden.view(bs, int(self.block_size), -1),
+            bool(draft_runner_out.can_run_graph),
+        )
+
+    def _build_refine_refs(self) -> _DSparkRefineRefs:
+        lm_head = self.draft_model.lm_head
+        markov_head = self._draft_inner.markov_head
+        markov_w2 = markov_head.markov_w2
+        vocab_size = int(self._draft_inner.vocab_size)
+
+        # lm_head base logits and markov_w2 bias must share the vocab partition, else
+        # the shard-local refine adds misaligned columns.
+        lm_shard = lm_head.shard_indices
+        w2_shard = markov_w2.shard_indices
+        if (
+            lm_shard.org_vocab_start_index != w2_shard.org_vocab_start_index
+            or lm_shard.num_org_elements_padded != w2_shard.num_org_elements_padded
+            or int(lm_shard.num_added_elements) != 0
+            or int(w2_shard.num_added_elements) != 0
+        ):
+            raise RuntimeError(
+                "DSpark shard-local refine requires markov_w2 and the tied lm_head "
+                "to share the vocab partition with no added vocab, but got "
+                f"lm_head(start={lm_shard.org_vocab_start_index}, "
+                f"added={lm_shard.num_added_elements}) vs "
+                f"markov_w2(start={w2_shard.org_vocab_start_index}, "
+                f"added={w2_shard.num_added_elements})."
+            )
+
+        org_vocab_start = int(lm_shard.org_vocab_start_index)
+        shard_width = int(lm_head.weight.shape[0])
+        # Shard column c is global id org_vocab_start + c; ids >= vocab_size are padding
+        # and must never win the argmax.
+        pad_mask = (
+            org_vocab_start
+            + torch.arange(shard_width, device=self.device, dtype=torch.int64)
+        ) >= vocab_size
+        if not bool(pad_mask.any()):
+            pad_mask = None
+
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_group_device = get_tp_group().device_group if tp_size > 1 else None
+
+        return _DSparkRefineRefs(
+            norm=self._draft_inner.shared_head.norm,
+            lm_head_weight=lm_head.weight,
+            markov_w1=markov_head.markov_w1,
+            markov_w2_weight=markov_w2.weight,
+            confidence_head=self._draft_inner.confidence_head,
+            org_vocab_start=org_vocab_start,
+            pad_mask=pad_mask,
+            block_size=self.block_size,
+            tp_size=tp_size,
+            tp_group_device=tp_group_device,
+            use_confidence=self.use_confidence,
+        )
+
+    def _confident_prefix(self, confidence: torch.Tensor) -> torch.Tensor:
+        keep = torch.sigmoid(confidence) >= self.confidence_threshold
+        return keep.to(torch.int32).cumprod(dim=1).sum(dim=1)
+
+    def _ensure_decode_buffers(self, bs: int) -> None:
+        if self._decode_buffer_cap >= int(bs):
+            return
+        new_cap = max(
+            int(bs),
+            self._decode_buffer_cap * 2 if self._decode_buffer_cap > 0 else int(bs),
+        )
+        device = self.device
+        block_size = int(self.block_size)
+        self._block_ids_bufs = [
+            torch.empty((new_cap, block_size), dtype=torch.int64, device=device)
+            for _ in range(2)
+        ]
+        self._out_tokens_bufs = [
+            torch.empty((new_cap, block_size), dtype=torch.int64, device=device)
+            for _ in range(2)
+        ]
+        self._commit_lens_bufs = [
+            torch.empty((new_cap,), dtype=torch.int32, device=device) for _ in range(2)
+        ]
+        self._new_seq_lens_bufs = [
+            torch.empty((new_cap,), dtype=torch.int64, device=device) for _ in range(2)
+        ]
+        self._decode_buffer_cap = new_cap
+
+    def _next_decode_buffers(self, bs: int) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        self._ensure_decode_buffers(bs)
+        slot = self._decode_buffer_slot
+        self._decode_buffer_slot = (slot + 1) % 2
+        return (
+            self._block_ids_bufs[slot][:bs],
+            self._out_tokens_bufs[slot][:bs],
+            self._commit_lens_bufs[slot][:bs],
+            self._new_seq_lens_bufs[slot][:bs],
+        )
+
+    def _make_next_draft_input_prefill(
+        self,
+        *,
+        bonus_tokens: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> DSparkDraftInputV2:
+        return DSparkDraftInputV2(
+            bonus_tokens=bonus_tokens.to(dtype=torch.int64),
+            new_seq_lens=seq_lens.to(dtype=torch.int64),
+        )
+
+    def _make_next_draft_input_decode(
+        self,
+        *,
+        bonus_tokens: torch.Tensor,
+        new_seq_lens: torch.Tensor,
+    ) -> DSparkDraftInputV2:
+        return DSparkDraftInputV2(
+            bonus_tokens=bonus_tokens.to(dtype=torch.int64),
+            new_seq_lens=new_seq_lens.to(dtype=torch.int64),
+        )
+
+    def forward_batch_generation(
+        self,
+        model_worker_batch: ScheduleBatch,
+        on_publish=None,
+    ) -> GenerationBatchResult:
+        if getattr(model_worker_batch, "return_logprob", False):
+            raise ValueError(
+                "DSpark speculative decoding does not support return_logprob yet."
+            )
+
+        sampling_info = getattr(model_worker_batch, "sampling_info", None)
+        if (
+            sampling_info is not None
+            and not sampling_info.is_all_greedy
+            and not is_dflash_sampling_verify_available()
+            and self.tp_rank == 0
+            and not getattr(self, "_warned_sampling", False)
+        ):
+            self._warned_sampling = True
+            logger.warning(
+                "DSpark sampling verification is unavailable on this build; "
+                "temperature>0 requests fall back to greedy verification."
+            )
+
+        if (
+            model_worker_batch.forward_mode.is_extend()
+            or model_worker_batch.is_extend_in_batch
+        ):
+            return self._forward_prefill(model_worker_batch, on_publish)
+
+        return self._forward_decode(model_worker_batch, on_publish)
+
+    def _forward_prefill(
+        self, model_worker_batch: ScheduleBatch, on_publish
+    ) -> GenerationBatchResult:
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        batch_output = self.target_worker.forward_batch_generation(model_worker_batch)
+
+        logits_output = batch_output.logits_output
+        next_token_ids = batch_output.next_token_ids
+        batch_output.new_seq_lens = model_worker_batch.seq_lens
+        if on_publish is not None:
+            on_publish(batch_output.new_seq_lens)
+
+        if logits_output.hidden_states is None:
+            raise RuntimeError(
+                "DSpark requires target aux hidden capture for prefill, but got None. "
+                "Make sure the target model has DSpark target layers configured."
+            )
+        if (
+            model_worker_batch.extend_lens is None
+            or model_worker_batch.prefix_lens is None
+        ):
+            raise RuntimeError(
+                "DSpark expected extend_lens / prefix_lens in extend mode, got None."
+            )
+        if model_worker_batch.out_cache_loc is None:
+            raise RuntimeError("DSpark prefill expected out_cache_loc, but got None.")
+
+        device = next_token_ids.device
+        ctx_lens = torch.tensor(
+            model_worker_batch.extend_lens, dtype=torch.int32, device=device
+        )
+        draft_seq_lens = torch.tensor(
+            model_worker_batch.prefix_lens, dtype=torch.int32, device=device
+        )
+        positions, _ = compute_position(
+            self.model_runner.server_args.attention_backend,
+            draft_seq_lens,
+            ctx_lens,
+            int(sum(model_worker_batch.extend_lens)),
+        )
+        self._materialize_main_hidden_to_draft_kv(
+            main_hidden=logits_output.hidden_states,
+            cache_loc=model_worker_batch.out_cache_loc,
+            positions=positions,
+        )
+
+        logits_output.hidden_states = None
+
+        batch_output.next_draft_input = self._make_next_draft_input_prefill(
+            bonus_tokens=next_token_ids,
+            seq_lens=model_worker_batch.seq_lens,
+        )
+        return batch_output
+
+    def _forward_decode(
+        self, model_worker_batch: ScheduleBatch, on_publish
+    ) -> GenerationBatchResult:
+        if model_worker_batch.spec_info is None:
+            model_worker_batch.spec_info = DSparkDraftInputV2.create_idle_input(
+                device=self.device
+            )
+        draft_input = model_worker_batch.spec_info
+        if not isinstance(draft_input, DSparkDraftInputV2):
+            raise RuntimeError(
+                "DSpark spec-v2 expected DSparkDraftInputV2 state on the running batch."
+            )
+
+        if model_worker_batch.forward_mode.is_idle():
+            return self._forward_idle(on_publish)
+
+        model_worker_batch.seq_lens.record_stream(
+            torch.get_device_module(self.device).current_stream()
+        )
+
+        device = self.device
+        bs = len(model_worker_batch.seq_lens)
+        block_size = int(self.block_size)
+        prefix_lens = model_worker_batch.seq_lens
+        req_pool_indices = model_worker_batch.req_pool_indices
+
+        block_ids, out_tokens, commit_lens, new_seq_lens = self._next_decode_buffers(bs)
+        block_ids.fill_(self.noise_token_id)
+        block_ids[:, 0].copy_(draft_input.bonus_tokens.view(-1))
+
+        positions_2d = prefix_lens.unsqueeze(1) + self._block_pos_offsets
+        positions = positions_2d.reshape(-1).to(torch.int64)
+
+        end_offset = prefix_lens + block_size
+        verify_out_cache_loc = assign_extend_cache_locs_func(
+            req_pool_indices=req_pool_indices,
+            req_to_token=self.model_runner.req_to_token_pool.req_to_token,
+            start_offset=prefix_lens,
+            end_offset=end_offset,
+            batch_size=bs,
+            draft_token_num=block_size,
+            device=device,
+        )
+
+        block_hidden, draft_ran_captured = self._run_draft_block(
+            bs=bs,
+            block_ids=block_ids,
+            positions=positions,
+            verify_out_cache_loc=verify_out_cache_loc,
+            prefix_lens=prefix_lens,
+            req_pool_indices=req_pool_indices,
+            seq_lens_cpu=model_worker_batch.seq_lens_cpu,
+            seq_lens_sum=model_worker_batch.seq_lens_sum,
+        )
+
+        if self._draft_sampler is not None and draft_ran_captured:
+            # The captured refine already ran inside the draft graph replay.
+            candidates = self._draft_sampler.candidates_buf[:bs]
+            confidence = (
+                self._draft_sampler.confidence_buf[:bs]
+                if self._draft_sampler.confidence_buf is not None
+                else None
+            )
+        else:
+            with torch.inference_mode():
+                candidates, confidence = _refine_block_markov_sharded(
+                    block_hidden, draft_input.bonus_tokens, self._refine_refs
+                )
+
+        verify_input = DSparkVerifyInput(
+            draft_token=candidates.reshape(-1),
+            positions=positions,
+            draft_token_num=block_size,
+            custom_mask=None,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+        )
+        model_worker_batch.out_cache_loc = verify_out_cache_loc
+        verify_forward_batch, _ = verify_input.prepare_for_verify(
+            model_worker_batch, self.target_worker
+        )
+        target_out = self.target_worker.forward_batch_generation(
+            batch=None,
+            forward_batch=verify_forward_batch,
+            is_verify=True,
+            skip_attn_backend_init=True,
+        )
+        logits_output = target_out.logits_output
+        can_run_cuda_graph = target_out.can_run_cuda_graph
+
+        sampling_info = getattr(model_worker_batch, "sampling_info", None)
+        if sampling_info is not None:
+            apply_dflash_verify_logits_adjustments(
+                next_token_logits=logits_output.next_token_logits,
+                sampling_info=sampling_info,
+                draft_token_num=block_size,
+            )
+        confident_prefix = (
+            self._confident_prefix(confidence) if confidence is not None else None
+        )
+
+        if (
+            sampling_info is not None
+            and not sampling_info.is_all_greedy
+            and is_dflash_sampling_verify_available()
+        ):
+            if self.tp_rank == 0 and not self._sampling_verify_logged:
+                self._sampling_verify_logged = True
+                logger.info(
+                    "DSpark target-only sampling verify is engaged for "
+                    "temperature>0 requests."
+                )
+            accept_len, sampled_bonus = (
+                compute_dflash_sampling_correct_drafts_and_bonus(
+                    candidates=candidates,
+                    next_token_logits=logits_output.next_token_logits,
+                    sampling_info=sampling_info,
+                    max_top_k=draft_input.max_top_k,
+                    uniform_top_k_value=draft_input.uniform_top_k_value,
+                )
+            )
+            # Broadcast rank 0's result so ranks commit identical tokens; diverging seq_lens hang collectives.
+            if get_tensor_model_parallel_world_size() > 1:
+                packed = torch.stack(
+                    [accept_len.to(torch.int64), sampled_bonus.to(torch.int64)],
+                    dim=0,
+                )
+                get_tp_group().broadcast(packed, src=0)
+                accept_len, sampled_bonus = packed[0], packed[1]
+            accept_len = accept_len.to(torch.int64)
+            if confident_prefix is not None:
+                # Lossless truncation: the bonus at candidates[correct_len+1] is a
+                # kernel-accepted token, so emitting it preserves the target distribution.
+                correct_len = torch.minimum(
+                    accept_len, confident_prefix.to(torch.int64)
+                )
+                truncated = correct_len < accept_len
+                next_draft = (
+                    candidates.gather(
+                        1, (correct_len + 1).clamp(max=block_size - 1).unsqueeze(1)
+                    )
+                    .squeeze(1)
+                    .to(torch.int64)
+                )
+                bonus_tokens = torch.where(
+                    truncated, next_draft, sampled_bonus.to(torch.int64)
+                )
+            else:
+                correct_len = accept_len
+                bonus_tokens = sampled_bonus.to(torch.int64)
+        else:
+            target_predict = torch.argmax(logits_output.next_token_logits, dim=-1).view(
+                bs, block_size
+            )
+            correct_len, _ = compute_dflash_correct_drafts_and_bonus(
+                candidates=candidates,
+                target_predict=target_predict,
+            )
+            correct_len = correct_len.to(torch.int64)
+            if confident_prefix is not None:
+                correct_len = torch.minimum(
+                    correct_len, confident_prefix.to(torch.int64)
+                )
+            bonus_tokens = target_predict.gather(1, correct_len.unsqueeze(1)).squeeze(1)
+
+        commit_lens.copy_(correct_len)
+        commit_lens.add_(1)
+
+        if block_size > 1:
+            out_tokens[:, : block_size - 1].copy_(candidates[:, 1:])
+        out_tokens[:, block_size - 1].fill_(0)
+        out_tokens.scatter_(
+            1, correct_len.unsqueeze(1), bonus_tokens.unsqueeze(1).to(torch.int64)
+        )
+
+        new_seq_lens.copy_(prefix_lens)
+        new_seq_lens.add_(commit_lens)
+        if on_publish is not None:
+            on_publish(new_seq_lens)
+
+        hidden = logits_output.hidden_states
+        if hidden is None:
+            raise RuntimeError(
+                "DSpark verify requires target main_hidden states, but got None."
+            )
+        # Write KV for all block positions, not just the committed prefix: uncommitted
+        # slots are never read before the next verify overwrites them.
+        hidden = hidden.view(bs, block_size, -1)
+        self._materialize_main_hidden_to_draft_kv(
+            main_hidden=hidden.reshape(-1, hidden.shape[-1]),
+            cache_loc=verify_out_cache_loc,
+            positions=positions,
+        )
+
+        logits_output.hidden_states = None
+
+        next_draft_input = self._make_next_draft_input_decode(
+            bonus_tokens=bonus_tokens,
+            new_seq_lens=new_seq_lens,
+        )
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=out_tokens.reshape(-1),
+            accept_lens=commit_lens,
+            can_run_cuda_graph=can_run_cuda_graph,
+            next_draft_input=next_draft_input,
+            speculative_num_draft_tokens=block_size,
+            new_seq_lens=new_seq_lens,
+        )
+
+    def _forward_idle(self, on_publish) -> GenerationBatchResult:
+        empty_ids = torch.empty((0,), dtype=torch.int64, device=self.device)
+        empty_lens = torch.empty((0,), dtype=torch.int32, device=self.device)
+        next_draft_input = self._make_next_draft_input_decode(
+            bonus_tokens=torch.empty((0,), device=self.device, dtype=torch.int64),
+            new_seq_lens=torch.empty((0,), device=self.device, dtype=torch.int64),
+        )
+        if on_publish is not None:
+            on_publish(next_draft_input.new_seq_lens)
+        return GenerationBatchResult(
+            logits_output=None,
+            next_token_ids=empty_ids,
+            accept_lens=empty_lens,
+            next_draft_input=next_draft_input,
+            can_run_cuda_graph=False,
+            speculative_num_draft_tokens=int(self.block_size),
+            new_seq_lens=next_draft_input.new_seq_lens,
+        )

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -33,6 +33,7 @@ class SpeculativeAlgorithm(Enum):
     """
 
     DFLASH = auto()
+    DSPARK = auto()
     EAGLE = auto()
     EAGLE3 = auto()
     FROZEN_KV_MTP = auto()
@@ -109,6 +110,9 @@ class SpeculativeAlgorithm(Enum):
     def is_dflash(self) -> bool:
         return self == SpeculativeAlgorithm.DFLASH
 
+    def is_dspark(self) -> bool:
+        return self == SpeculativeAlgorithm.DSPARK
+
     def is_standalone(self) -> bool:
         return self == SpeculativeAlgorithm.STANDALONE
 
@@ -116,7 +120,7 @@ class SpeculativeAlgorithm(Enum):
         return self == SpeculativeAlgorithm.NGRAM
 
     def supports_target_verify_for_draft(self) -> bool:
-        return self.is_dflash()
+        return self.is_dflash() or self.is_dspark()
 
     def has_draft_kv(self) -> bool:
         """Whether the draft phase writes KV chains. NGRAM does not (its tree
@@ -125,8 +129,9 @@ class SpeculativeAlgorithm(Enum):
         return not self.is_ngram()
 
     def carries_draft_hidden_states(self) -> bool:
-        """Whether the disagg prefill->decode transfer carries draft hidden
-        states (EAGLE-family only; STANDALONE's vanilla draft ignores them)."""
+        """Whether the disagg prefill->decode transfer carries draft hidden states
+        (EAGLE-family only). STANDALONE and DSpark feed their draft by other means.
+        """
         return self.is_eagle()
 
     def create_future_map(
@@ -166,6 +171,7 @@ class SpeculativeAlgorithm(Enum):
         """
         from sglang.srt.arg_groups.speculative_hook import (
             _handle_dflash,
+            _handle_dspark,
             _handle_eagle_family,
             _handle_frozen_kv_mtp,
             _handle_ngram,
@@ -173,6 +179,8 @@ class SpeculativeAlgorithm(Enum):
 
         if self.is_dflash():
             _handle_dflash(server_args)
+        elif self.is_dspark():
+            _handle_dspark(server_args)
         elif self.is_frozen_kv_mtp():
             _handle_frozen_kv_mtp(server_args)
         elif self.is_eagle() or self.is_standalone():
@@ -203,6 +211,11 @@ class SpeculativeAlgorithm(Enum):
             from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
 
             return DFlashWorkerV2
+
+        if self.is_dspark():
+            from sglang.srt.speculative.dspark_worker_v2 import DSparkWorkerV2
+
+            return DSparkWorkerV2
 
         if self.is_frozen_kv_mtp():
             # V2 worker drives both overlap and non-overlap (scheduler runs it
@@ -251,6 +264,8 @@ class SpecInputType(IntEnum):
     DFLASH_DRAFT = auto()
     DFLASH_VERIFY = auto()
     NGRAM_VERIFY = auto()
+    DSPARK_DRAFT = auto()
+    DSPARK_VERIFY = auto()
 
 
 class SpecInput(ABC):
@@ -267,6 +282,7 @@ class SpecInput(ABC):
             SpecInputType.EAGLE_DRAFT_EXTEND,
             SpecInputType.FROZEN_KV_MTP_DRAFT,
             SpecInputType.DFLASH_DRAFT,
+            SpecInputType.DSPARK_DRAFT,
         }
 
     def is_verify_input(self) -> bool:
@@ -275,6 +291,7 @@ class SpecInput(ABC):
             SpecInputType.FROZEN_KV_MTP_VERIFY,
             SpecInputType.DFLASH_VERIFY,
             SpecInputType.NGRAM_VERIFY,
+            SpecInputType.DSPARK_VERIFY,
         }
 
     @abstractmethod
@@ -329,6 +346,19 @@ def create_dummy_verify_input(
 
         # Dummy warmup only needs shape metadata; avoid forcing custom-mask mode.
         spec_info = DFlashVerifyInput(
+            draft_token=None,
+            positions=None,
+            draft_token_num=server_args.speculative_num_draft_tokens,
+            custom_mask=None,
+            capture_hidden_mode=(
+                CaptureHiddenMode.NULL if is_draft_worker else CaptureHiddenMode.FULL
+            ),
+        )
+
+    elif spec_algorithm.is_dspark():
+        from sglang.srt.speculative.dspark_info import DSparkVerifyInput
+
+        spec_info = DSparkVerifyInput(
             draft_token=None,
             positions=None,
             draft_token_num=server_args.speculative_num_draft_tokens,

--- a/python/sglang/srt/speculative/spec_registry.py
+++ b/python/sglang/srt/speculative/spec_registry.py
@@ -76,6 +76,9 @@ class CustomSpecAlgo:
     def is_dflash(self) -> bool:
         return False
 
+    def is_dspark(self) -> bool:
+        return False
+
     def is_standalone(self) -> bool:
         return False
 

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -183,9 +183,8 @@ def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:
         server_args = get_global_server_args()
 
     # STANDALONE drafts don't consume `spec_info.hidden_states` (vanilla LLM).
-    # multi_layer_eagle and DFLASH don't relay hidden_states through FutureMap.
     # TODO(lsyin): also skip when step == 1.
-    if server_args.speculative_algorithm in ("STANDALONE", "DFLASH"):
+    if server_args.speculative_algorithm in ("STANDALONE", "DFLASH", "DSPARK"):
         return False
     return not server_args.enable_multi_layer_eagle
 
@@ -674,10 +673,10 @@ def commit_mamba_states_after_verify(
 
 
 def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
-    """eagle/ngram share a stateless free function; dflash keeps stateful
-    prep on its draft input -- the dispatcher routes.
+    """eagle/ngram share a stateless free function; dflash and dspark keep
+    stateful prep on their draft input -- the dispatcher routes.
     """
-    if batch.spec_algorithm.is_dflash():
+    if batch.spec_algorithm.is_dflash() or batch.spec_algorithm.is_dspark():
         batch.spec_info.prepare_for_decode(batch)
     else:
         from sglang.srt.speculative.eagle_utils import eagle_prepare_for_decode

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -115,6 +115,10 @@ DEFAULT_DRAFT_MODEL_EAGLE3 = "lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B"
 DEFAULT_TARGET_MODEL_DFLASH = "meta-llama/Llama-3.1-8B-Instruct"
 DEFAULT_DRAFT_MODEL_DFLASH = "z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat"
 
+# DSpark model (Qwen3 family)
+DEFAULT_TARGET_MODEL_DSPARK_QWEN3 = "Qwen/Qwen3-4B"
+DEFAULT_DRAFT_MODEL_DSPARK_QWEN3 = "deepseek-ai/dspark_qwen3_4b_block7"
+
 # EAGLE2 with DP-Attention models
 DEFAULT_TARGET_MODEL_EAGLE_DP_ATTN = "Qwen/Qwen3-30B-A3B"
 DEFAULT_DRAFT_MODEL_EAGLE_DP_ATTN = "Tengyunw/qwen3_30b_moe_eagle3"

--- a/scripts/playground/dspark_qwen3_weight_parity.py
+++ b/scripts/playground/dspark_qwen3_weight_parity.py
@@ -1,0 +1,303 @@
+"""Standalone CPU parity + weight-mapping audit for Qwen3DSparkModel.
+
+Phase-3b (DSpark-for-SGLang, Qwen3 draft-model support) verification script.
+Runs entirely on CPU with real checkpoint weights; does NOT instantiate the
+full `sglang.srt.models.qwen3_dspark.Qwen3DSparkModel` (it composes
+`VocabParallelEmbedding` / `ParallelLMHead` / `RadixAttention`, which need a
+`torch.distributed` process group, and `sglang.srt.layers.layernorm.RMSNorm`,
+whose `forward()` dispatches to a custom CUDA kernel on this build regardless
+of tensor device -- both confirmed unavailable in this CPU sandbox while
+writing this script). Instead it checks two independent things:
+
+1. Component parity: for each of the three small, checkpoint-weight-bearing
+   computations DSparkWorkerV2 relies on (the additive Markov logit bias, the
+   fc-then-hidden_norm context-feature combine, and the confidence /
+   accept-rate head), run identical fp32 random inputs through:
+     (a) the DeepSpec reference implementation (deepspec-ref clone), and
+     (b) this repo's implementation -- reusing the real, dependency-light
+         `Qwen3DSparkConfidenceHead` class directly for the confidence head,
+         and a faithful pure-torch reproduction of the RMSNorm/vocab-parallel
+         math for the other two (see the docstrings on `rmsnorm_native` and
+         `mine_markov_bias` for exactly what is reproduced and why).
+   Both sides load the SAME real checkpoint tensors (cast to fp32). Expect
+   max-abs-diff at or near fp32 machine precision.
+
+2. Weight name-mapping audit: run `resolve_qwen3_dspark_weight` (the exact,
+   pure, import-light function `Qwen3DSparkModel.load_weights` uses) over
+   all 64 real tensor names from the checkpoint and print the full
+   name -> destination-parameter table, asserting zero unmapped names.
+
+Usage:
+    python3 scripts/playground/dspark_qwen3_weight_parity.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SGLANG_ROOT = Path(__file__).resolve().parents[2]
+DEEPSPEC_ROOT = Path(
+    "/tmp/claude-1000/-home-ubuntu/052d1f86-c10c-40cf-85f9-89f4e2bedc3b/"
+    "scratchpad/phase1/deepspec-ref"
+)
+TENSOR_NAMES_TXT = Path(
+    "/tmp/claude-1000/-home-ubuntu/052d1f86-c10c-40cf-85f9-89f4e2bedc3b/"
+    "scratchpad/phase1/pr29917/tensor_names.txt"
+)
+CHECKPOINT_ROOT = Path(
+    "/home/ubuntu/hf_cache/hub/models--deepseek-ai--dspark_qwen3_4b_block7"
+)
+
+sys.path.insert(0, str(SGLANG_ROOT / "python"))
+sys.path.insert(0, str(DEEPSPEC_ROOT))
+
+import torch  # noqa: E402
+import torch.nn.functional as F  # noqa: E402
+from safetensors.torch import load_file  # noqa: E402
+
+from deepspec.modeling.dspark.common import AcceptRatePredictor  # noqa: E402
+from deepspec.modeling.dspark.markov_head import VanillaMarkov  # noqa: E402
+from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm  # noqa: E402
+
+from sglang.srt.models.qwen3_dspark import (  # noqa: E402
+    Qwen3DSparkConfidenceHead,
+    resolve_qwen3_dspark_weight,
+)
+
+SEED = 0
+RMS_NORM_EPS = 1e-6  # matches the checkpoint's config.json rms_norm_eps
+# Reasonable-bug-catching bound, not a machine-precision bound: a real formula
+# mistake (wrong concat order, missing bias, wrong combine order, ...) shows up
+# as an O(1) difference, not something near this threshold.
+MAX_DIFF_TOLERANCE = 1e-3
+
+
+def find_checkpoint_file() -> Path:
+    candidates = sorted(CHECKPOINT_ROOT.glob("snapshots/*/model.safetensors"))
+    if not candidates:
+        raise FileNotFoundError(f"No model.safetensors found under {CHECKPOINT_ROOT}")
+    return candidates[0]
+
+
+def load_tensor_names() -> list[str]:
+    names = []
+    for line in TENSOR_NAMES_TXT.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("NUM TENSORS"):
+            continue
+        names.append(line.split()[0])
+    return names
+
+
+def max_abs_diff(a: torch.Tensor, b: torch.Tensor) -> float:
+    return (a.float() - b.float()).abs().max().item()
+
+
+def rmsnorm_native(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Faithful fp32 reproduction of the single-tensor call form of
+    `sglang.srt.layers.layernorm.RMSNorm.forward_native` (no residual):
+    variance-normalize in fp32, then multiply by weight, then cast back.
+
+    Reproduced rather than called directly: on this build, RMSNorm.forward()
+    dispatches to `sgl_kernel.rmsnorm` (a CUDA kernel) regardless of the
+    input tensor's device, which raises `NotImplementedError` for a CPU
+    tensor in this sandbox (confirmed while writing this script). Since the
+    inputs here are already fp32, the final `.to(orig_dtype)` is a no-op and
+    this is exactly the real forward path's arithmetic.
+    """
+    orig_dtype = x.dtype
+    x = x.float()
+    variance = x.pow(2).mean(dim=-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    return (x * weight.float()).to(orig_dtype)
+
+
+def mine_project_main_hidden(
+    main_hidden: torch.Tensor,
+    fc_weight: torch.Tensor,
+    hidden_norm_weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Reproduction of `Qwen3DSparkBackbone.project_main_hidden`: fc (a plain
+    `nn.Linear`, bias=False -- no distributed/CUDA-kernel dependency, so this
+    part IS the real op) THEN hidden_norm (reproduced via `rmsnorm_native`,
+    see above)."""
+    projected = F.linear(main_hidden, fc_weight)
+    return rmsnorm_native(projected, hidden_norm_weight, eps)
+
+
+def mine_markov_bias(
+    token_ids: torch.Tensor,
+    markov_w1_weight: torch.Tensor,
+    markov_w2_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reproduction of the additive Markov bias computed in
+    `dspark_worker_v2._refine_block_markov_sharded`:
+    `F.linear(markov_w1(token_ids), markov_w2_weight)`. `markov_w1` /
+    `markov_w2` are `Qwen3DSparkMarkovHead`'s `VocabParallelEmbedding` /
+    `ParallelLMHead` at tp_size=1, which reduce mathematically to a plain
+    embedding lookup and a bias-free linear; reproduced with
+    `F.embedding` / `F.linear` directly since those parallel wrapper classes'
+    real forward() requires an initialized `torch.distributed` process group
+    (confirmed unavailable in this sandbox while writing this script).
+
+    Returns (bias, prev_embedding) -- the embedding is also checked directly
+    since it is what feeds the confidence head's Markov features.
+    """
+    prev_embed = F.embedding(token_ids, markov_w1_weight)
+    bias = F.linear(prev_embed, markov_w2_weight)
+    return bias, prev_embed
+
+
+def run_component_parity(weights: dict) -> dict[str, float]:
+    torch.manual_seed(SEED)
+    results: dict[str, float] = {}
+
+    # ---- 1. VanillaMarkov: additive logit bias over the vocab ----
+    w1 = weights["markov_head.markov_w1.weight"].float()
+    w2 = weights["markov_head.markov_w2.weight"].float()
+    vocab_size, markov_rank = w1.shape
+
+    ref_markov = VanillaMarkov(vocab_size=vocab_size, markov_rank=markov_rank)
+    with torch.no_grad():
+        ref_markov.markov_w1.weight.copy_(w1)
+        ref_markov.markov_w2.weight.copy_(w2)
+
+    token_ids = torch.randint(0, vocab_size, (17,))
+    ref_bias = ref_markov.compute_step_bias(token_ids, None)
+    ref_embed = ref_markov.get_prev_embeddings(token_ids)
+    mine_bias, mine_embed = mine_markov_bias(token_ids, w1, w2)
+
+    results["markov_prev_embedding"] = max_abs_diff(ref_embed, mine_embed)
+    results["markov_additive_bias"] = max_abs_diff(ref_bias, mine_bias)
+
+    # ---- 2. fc THEN hidden_norm combine (context-feature projection) ----
+    fc_w = weights["fc.weight"].float()
+    hn_w = weights["hidden_norm.weight"].float()
+    hidden_size, fc_in_features = fc_w.shape
+    assert fc_in_features % hidden_size == 0
+    num_context_features = fc_in_features // hidden_size
+
+    ref_fc = torch.nn.Linear(fc_in_features, hidden_size, bias=False)
+    with torch.no_grad():
+        ref_fc.weight.copy_(fc_w)
+    ref_norm = Qwen3RMSNorm(hidden_size, eps=RMS_NORM_EPS)
+    with torch.no_grad():
+        ref_norm.weight.copy_(hn_w)
+
+    main_hidden = torch.randn(5, num_context_features * hidden_size)
+    ref_combined = ref_norm(ref_fc(main_hidden))
+    mine_combined = mine_project_main_hidden(main_hidden, fc_w, hn_w, RMS_NORM_EPS)
+    results["fc_then_hidden_norm_combine"] = max_abs_diff(ref_combined, mine_combined)
+
+    # ---- 3. confidence head (AcceptRatePredictor), using the REAL class ----
+    cw = weights["confidence_head.proj.weight"].float()
+    cb = weights["confidence_head.proj.bias"].float()
+    input_dim = cw.shape[1]
+
+    ref_head = AcceptRatePredictor(input_dim=input_dim)
+    with torch.no_grad():
+        ref_head.proj.weight.copy_(cw)
+        ref_head.proj.bias.copy_(cb)
+
+    hidden = torch.randn(9, hidden_size)
+    markov_embed = torch.randn(9, markov_rank)
+    # Reference call site (deepspec qwen3/modeling.py predict_confidence_step):
+    # features = cat([hidden_states, prev_embeddings], dim=-1); proj(features).float()
+    ref_conf = ref_head(torch.cat([hidden, markov_embed], dim=-1)).float()
+
+    mine_head = Qwen3DSparkConfidenceHead(input_dim)  # the REAL sglang class
+    with torch.no_grad():
+        mine_head.proj.weight.copy_(cw)
+        mine_head.proj.bias.copy_(cb)
+    mine_conf = mine_head(hidden, markov_embed)
+
+    results["confidence_head"] = max_abs_diff(ref_conf, mine_conf)
+
+    return results
+
+
+def run_weight_mapping_audit(names: list[str]):
+    rows = []
+    for name in names:
+        mapping = resolve_qwen3_dspark_weight(
+            name, has_markov_head=True, has_confidence_head=True
+        )
+        rows.append(mapping)
+    unmapped = [m for m in rows if m.dest_param is None]
+    return rows, unmapped
+
+
+def main() -> int:
+    ckpt_path = find_checkpoint_file()
+    print(f"Loading checkpoint tensors from {ckpt_path}")
+    weights = load_file(str(ckpt_path))
+    print(f"Loaded {len(weights)} tensors from safetensors.\n")
+
+    print("=" * 100)
+    print(
+        f"COMPONENT PARITY (DeepSpec reference vs sglang qwen3_dspark math), "
+        f"fp32, seed={SEED}"
+    )
+    print("=" * 100)
+    results = run_component_parity(weights)
+    all_ok = True
+    for name, diff in results.items():
+        ok = diff < MAX_DIFF_TOLERANCE
+        all_ok = all_ok and ok
+        print(f"  {name:32s} max_abs_diff = {diff:.3e}   {'PASS' if ok else 'FAIL'}")
+    print()
+
+    print("=" * 100)
+    print("WEIGHT NAME-MAPPING AUDIT (resolve_qwen3_dspark_weight) -- all 64 tensors")
+    print("=" * 100)
+    names = load_tensor_names()
+    print(f"tensor_names.txt lists {len(names)} tensors.\n")
+    rows, unmapped = run_weight_mapping_audit(names)
+    for mapping in rows:
+        if mapping.dest_param is not None:
+            shard = f"  (shard_id={mapping.shard_id!r})" if mapping.shard_id is not None else ""
+            print(f"  {mapping.checkpoint_name:45s} -> {mapping.dest_param}{shard}")
+        else:
+            print(f"  {mapping.checkpoint_name:45s} -> DROPPED: {mapping.drop_reason}")
+    print()
+    print(
+        f"Total tensors: {len(names)}; mapped: {len(names) - len(unmapped)}; "
+        f"unmapped: {len(unmapped)}"
+    )
+
+    # Cross-check every mapped destination is actually present among the
+    # checkpoint's own tensors where that makes sense (sanity on the table
+    # itself, not just on resolve_qwen3_dspark_weight not raising).
+    checkpoint_names = set(weights.keys())
+    names_set = set(names)
+    if checkpoint_names != names_set:
+        print(
+            "NOTE: tensor_names.txt and the live safetensors file's key set "
+            "differ:",
+            "extra in checkpoint:",
+            sorted(checkpoint_names - names_set),
+            "extra in tensor_names.txt:",
+            sorted(names_set - checkpoint_names),
+        )
+
+    if unmapped:
+        print("FAIL: unmapped tensors present:")
+        for m in unmapped:
+            print(f"  {m.checkpoint_name}: {m.drop_reason}")
+        all_ok = False
+    else:
+        print("PASS: zero unmapped tensors (all 64 map to a destination parameter).")
+
+    assert not unmapped, "weight mapping audit found unmapped tensors -- see above"
+
+    print()
+    print("=" * 100)
+    print("OVERALL:", "PASS" if all_ok else "FAIL")
+    print("=" * 100)
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/playground/dspark_qwen3_weight_parity.py
+++ b/scripts/playground/dspark_qwen3_weight_parity.py
@@ -54,10 +54,9 @@ sys.path.insert(0, str(DEEPSPEC_ROOT))
 
 import torch  # noqa: E402
 import torch.nn.functional as F  # noqa: E402
-from safetensors.torch import load_file  # noqa: E402
-
 from deepspec.modeling.dspark.common import AcceptRatePredictor  # noqa: E402
 from deepspec.modeling.dspark.markov_head import VanillaMarkov  # noqa: E402
+from safetensors.torch import load_file  # noqa: E402
 from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm  # noqa: E402
 
 from sglang.srt.models.qwen3_dspark import (  # noqa: E402
@@ -257,7 +256,11 @@ def main() -> int:
     rows, unmapped = run_weight_mapping_audit(names)
     for mapping in rows:
         if mapping.dest_param is not None:
-            shard = f"  (shard_id={mapping.shard_id!r})" if mapping.shard_id is not None else ""
+            shard = (
+                f"  (shard_id={mapping.shard_id!r})"
+                if mapping.shard_id is not None
+                else ""
+            )
             print(f"  {mapping.checkpoint_name:45s} -> {mapping.dest_param}{shard}")
         else:
             print(f"  {mapping.checkpoint_name:45s} -> DROPPED: {mapping.drop_reason}")
@@ -274,8 +277,7 @@ def main() -> int:
     names_set = set(names)
     if checkpoint_names != names_set:
         print(
-            "NOTE: tensor_names.txt and the live safetensors file's key set "
-            "differ:",
+            "NOTE: tensor_names.txt and the live safetensors file's key set " "differ:",
             "extra in checkpoint:",
             sorted(checkpoint_names - names_set),
             "extra in tensor_names.txt:",

--- a/test/registered/spec/dspark/test_dspark.py
+++ b/test/registered/spec/dspark/test_dspark.py
@@ -133,8 +133,17 @@ What is 2 + 2?<|im_end|>
         assert self.process.poll() is None
 
     def test_greedy_determinism(self):
+        # Compare two warm (radix-cache-hit) requests rather than cold-vs-warm:
+        # the first request on a fresh prefix runs the prefill kernel path
+        # while later identical requests reuse the cached prefix, and bf16
+        # exact logit ties can legitimately argmax-flip across those two
+        # kernel paths (observed on target-only Qwen3-4B with no speculation
+        # at all). Warm-vs-warm requests share one path and must match.
         client = openai.Client(base_url=self.base_url + "/v1", api_key="EMPTY")
         prompt = "The capital of France is"
+        client.completions.create(
+            model=self.model, prompt=prompt, max_tokens=32, temperature=0
+        )
         outputs = []
         for _ in range(2):
             response = client.completions.create(

--- a/test/registered/spec/dspark/test_dspark.py
+++ b/test/registered/spec/dspark/test_dspark.py
@@ -1,0 +1,153 @@
+"""GPU server-integration test for DSpark speculative decoding on a
+Qwen3-family target (extends the DeepSeek-V4-only baseline from #29538).
+Mirrors test/registered/spec/dflash/test_dflash.py's structure: a single
+shared server, CustomTestCase + MatchedStopMixin + GSM8KMixin.
+
+DSpark always forces synchronous (non-overlap) scheduling internally
+(``_handle_dspark`` in arg_groups/speculative_hook.py sets
+``disable_overlap_schedule=True`` unconditionally), so unlike DFlash there is
+no overlap/no-overlap variant to parametrize here.
+"""
+
+import unittest
+
+import openai
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.kits.matched_stop_kit import MatchedStopMixin
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_DSPARK_QWEN3,
+    DEFAULT_TARGET_MODEL_DSPARK_QWEN3,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=180, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestDSparkServerBase(CustomTestCase, MatchedStopMixin, GSM8KMixin):
+    model = DEFAULT_TARGET_MODEL_DSPARK_QWEN3
+    draft_model = DEFAULT_DRAFT_MODEL_DSPARK_QWEN3
+    attention_backend = "triton"
+    dspark_block_size = 7
+    mem_fraction_static = 0.85
+    # Measured on a single RTX A6000 48GB SM86, bf16, --attention-backend
+    # triton: GSM8K-200 5-shot greedy accuracy 0.875-0.885 across runs
+    # (non-speculative baseline 0.880; binomial noise at n=200 ~= 0.023),
+    # accept length 3.94-4.84 during GSM8K. Thresholds below sit at a safety
+    # margin under the measured floor, matching the dflash precedent's
+    # below-measured-floor convention (test_dflash.py: 0.75 acc / 2.8 accept
+    # against a "roughly 3.2-3.6" documented accept length).
+    gsm8k_accuracy_thres = 0.84
+    gsm8k_accept_length_thres = 3.0
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--attention-backend",
+                cls.attention_backend,
+                "--speculative-algorithm",
+                "DSPARK",
+                "--speculative-draft-model-path",
+                cls.draft_model,
+                "--speculative-dspark-block-size",
+                str(cls.dspark_block_size),
+                "--mem-fraction-static",
+                str(cls.mem_fraction_static),
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_early_stop(self):
+        client = openai.Client(base_url=self.base_url + "/v1", api_key="EMPTY")
+        for i in range(8):
+            max_tokens = (i % 3) + 1
+            response = client.completions.create(
+                model=self.model,
+                prompt=f"There are {i} apples on the table. How to divide them equally?",
+                max_tokens=max_tokens,
+                temperature=0,
+            )
+            text = response.choices[0].text
+            print(f"early_stop: max_tokens={max_tokens}, text={text!r}")
+        assert self.process.poll() is None
+
+    def test_finish_stop_eos(self):
+        # Overrides MatchedStopMixin.test_finish_stop_eos: the mixin's version
+        # hardcodes a Llama-3 chat prompt and Llama-3 special-token ids
+        # (128000/128009/2), inherited from the dflash precedent's Llama-3.1
+        # target. Qwen3's chat-template special tokens and EOS ids differ
+        # entirely, so the base version fails on any Qwen3 target regardless
+        # of DSpark. Verified directly against this server: both the raw
+        # completions endpoint (manually-templated prompt) and the chat
+        # endpoint stop with matched_stop=151645 (``<|im_end|>``) well inside
+        # 1000 tokens even with Qwen3's default thinking mode on;
+        # generation_config.json also lists 151643 (``<|endoftext|>``) as a
+        # valid EOS id, so both are accepted here.
+        qwen_format_prompt = """\
+<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+What is 2 + 2?<|im_end|>
+<|im_start|>assistant
+"""
+        eos_token_ids = [151643, 151645]
+        self._run_completions_generation(
+            prompt=qwen_format_prompt,
+            max_tokens=1000,
+            finish_reason="stop",
+            matched_stop=eos_token_ids,
+        )
+        self._run_chat_completions_generation(
+            prompt="What is 2 + 2?",
+            max_tokens=1000,
+            finish_reason="stop",
+            matched_stop=eos_token_ids,
+        )
+
+    def test_eos_handling(self):
+        client = openai.Client(base_url=self.base_url + "/v1", api_key="EMPTY")
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": "Today is a sunny day and I like"}],
+            max_tokens=256,
+            temperature=0.1,
+        )
+        text = response.choices[0].message.content
+        print(f"eos_handling: text={text!r}")
+        self.assertNotIn("<|im_end|>", text)
+        self.assertNotIn("<|endoftext|>", text)
+        assert self.process.poll() is None
+
+    def test_greedy_determinism(self):
+        client = openai.Client(base_url=self.base_url + "/v1", api_key="EMPTY")
+        prompt = "The capital of France is"
+        outputs = []
+        for _ in range(2):
+            response = client.completions.create(
+                model=self.model,
+                prompt=prompt,
+                max_tokens=32,
+                temperature=0,
+            )
+            outputs.append(response.choices[0].text)
+        print(f"determinism: {outputs=}")
+        self.assertEqual(outputs[0], outputs[1])
+        assert self.process.poll() is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -67,6 +67,11 @@ _OWNER_SITES = {
         "DFlashDraftInputV2.prepare_for_decode",
         "kv_allocated_len",
     ): 1,
+    (
+        "speculative/dspark_info.py",
+        "DSparkDraftInputV2.prepare_for_decode",
+        "kv_allocated_len",
+    ): 1,
     # disaggregation decode prealloc
     (
         "disaggregation/decode.py",

--- a/test/registered/unit/spec/test_dspark.py
+++ b/test/registered/unit/spec/test_dspark.py
@@ -1,0 +1,648 @@
+"""Unit tests for DSpark speculative-decoding registration and arg handling."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.arg_groups.speculative_hook import _handle_dspark
+from sglang.srt.speculative.spec_info import SpecInputType, SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestDSparkPredicates(CustomTestCase):
+    """Lock the DSpark predicate truth table that the scheduler / model_runner /
+    attention backends dispatch on."""
+
+    def setUp(self):
+        self.algo = SpeculativeAlgorithm.DSPARK
+
+    def test_identity_predicates(self):
+        self.assertTrue(self.algo.is_dspark())
+        self.assertTrue(self.algo.is_some())
+        self.assertTrue(self.algo.is_speculative())
+        for other in (
+            self.algo.is_none,
+            self.algo.is_eagle,
+            self.algo.is_eagle3,
+            self.algo.is_frozen_kv_mtp,
+            self.algo.is_dflash,
+            self.algo.is_standalone,
+            self.algo.is_ngram,
+        ):
+            self.assertFalse(other(), other.__name__)
+
+    def test_capability_predicates(self):
+        self.assertTrue(self.algo.supports_target_verify_for_draft())
+        self.assertTrue(self.algo.has_draft_kv())
+        self.assertFalse(self.algo.carries_draft_hidden_states())
+        self.assertFalse(self.algo.need_topk())
+
+    def test_from_string_resolves(self):
+        self.assertIs(
+            SpeculativeAlgorithm.from_string("DSPARK"), SpeculativeAlgorithm.DSPARK
+        )
+        self.assertIs(
+            SpeculativeAlgorithm.from_string("dspark"), SpeculativeAlgorithm.DSPARK
+        )
+
+    def test_spec_input_types_classified(self):
+        from sglang.srt.speculative.spec_info import SpecInput
+
+        draft = SimpleNamespace(spec_input_type=SpecInputType.DSPARK_DRAFT)
+        verify = SimpleNamespace(spec_input_type=SpecInputType.DSPARK_VERIFY)
+        self.assertTrue(SpecInput.is_draft_input(draft))
+        self.assertTrue(SpecInput.is_verify_input(verify))
+        self.assertFalse(SpecInput.is_verify_input(draft))
+        self.assertFalse(SpecInput.is_draft_input(verify))
+
+
+def _make_server_args(**overrides):
+    base = dict(
+        enable_dp_attention=False,
+        pp_size=1,
+        speculative_draft_model_path="deepseek-ai/DeepSeek-V4-Flash-DSpark",
+        speculative_draft_model_revision="main",
+        model_path="deepseek-ai/DeepSeek-V4-Flash-DSpark",
+        revision="main",
+        speculative_num_steps=None,
+        speculative_eagle_topk=None,
+        speculative_dspark_block_size=5,
+        speculative_num_draft_tokens=None,
+        speculative_dspark_confidence_threshold=0.0,
+        max_running_requests=None,
+        enable_mixed_chunk=False,
+        trust_remote_code=False,
+        json_model_override_args="{}",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestHandleDspark(CustomTestCase):
+    def test_pins_steps_and_topk_and_block_size(self):
+        args = _make_server_args()
+        _handle_dspark(args)
+        self.assertEqual(args.speculative_num_steps, 1)
+        self.assertEqual(args.speculative_eagle_topk, 1)
+        self.assertEqual(args.speculative_num_draft_tokens, 5)
+        self.assertEqual(args.max_running_requests, 48)
+
+    def test_block_size_alias_conflict_raises(self):
+        args = _make_server_args(
+            speculative_dspark_block_size=5, speculative_num_draft_tokens=8
+        )
+        with self.assertRaisesRegex(ValueError, "must match"):
+            _handle_dspark(args)
+
+    def test_nonpositive_block_size_raises(self):
+        args = _make_server_args(speculative_dspark_block_size=0)
+        with self.assertRaisesRegex(ValueError, "positive"):
+            _handle_dspark(args)
+
+    def test_confidence_threshold_bounds(self):
+        args = _make_server_args(speculative_dspark_confidence_threshold=1.5)
+        with self.assertRaisesRegex(ValueError, "confidence-threshold"):
+            _handle_dspark(args)
+
+    def test_draft_path_defaults_to_target(self):
+        args = _make_server_args(
+            speculative_draft_model_path=None,
+            speculative_draft_model_revision=None,
+            model_path="my/target",
+            revision="abc",
+        )
+        _handle_dspark(args)
+        self.assertEqual(args.speculative_draft_model_path, "my/target")
+        self.assertEqual(args.speculative_draft_model_revision, "abc")
+
+    def test_dp_attention_rejected(self):
+        args = _make_server_args(enable_dp_attention=True)
+        with self.assertRaisesRegex(ValueError, "dp attention"):
+            _handle_dspark(args)
+
+    def test_pipeline_parallel_rejected(self):
+        args = _make_server_args(pp_size=2)
+        with self.assertRaisesRegex(ValueError, "pp_size"):
+            _handle_dspark(args)
+
+    def test_mixed_chunk_disabled(self):
+        args = _make_server_args(enable_mixed_chunk=True)
+        _handle_dspark(args)
+        self.assertFalse(args.enable_mixed_chunk)
+
+
+class TestDSparkDraftInputBatch(CustomTestCase):
+    def setUp(self):
+        try:
+            import torch
+
+            from sglang.srt.speculative.dspark_info import DSparkDraftInputV2
+        except Exception as e:  # pragma: no cover - GPU-only deps on some runners
+            self.skipTest(f"dspark_info unavailable on this runner: {e}")
+        self.torch = torch
+        self.cls = DSparkDraftInputV2
+
+    def _make(self, bs):
+        t = self.torch
+        return self.cls(
+            bonus_tokens=t.arange(bs, dtype=t.int64),
+            new_seq_lens=t.full((bs,), 10, dtype=t.int64),
+        )
+
+    def test_merge_then_filter_concatenates_and_indexes(self):
+        a = self._make(2)
+        b = self._make(1)
+        a.merge_batch(b)
+        self.assertEqual(len(a.bonus_tokens), 3)
+        self.assertEqual(len(a.new_seq_lens), 3)
+        a.filter_batch(self.torch.tensor([0, 2], dtype=self.torch.int64))
+        self.assertEqual(len(a.bonus_tokens), 2)
+
+    def test_filter_batch_indexes_tensors(self):
+        a = self._make(4)
+        a.filter_batch(self.torch.tensor([1, 3], dtype=self.torch.int64))
+        self.assertEqual(a.bonus_tokens.tolist(), [1, 3])
+        self.assertEqual(a.new_seq_lens.tolist(), [10, 10])
+
+    def test_overlap_placeholders_inert_without_future_indices(self):
+        a = self._make(2)
+        self.assertTrue(a.direct_carry_valid)
+        self.assertIsNone(a.future_indices)
+        self.assertEqual(a.topk_p.numel(), 0)
+        a.filter_batch(self.torch.tensor([1], dtype=self.torch.int64))
+        self.assertEqual(len(a.bonus_tokens), 1)
+
+
+class TestDSparkRequestValidation(CustomTestCase):
+    """validate_dspark_request rejects features DSpark cannot serve and accepts a
+    plain request. Kept import-light: requests are duck-typed namespaces."""
+
+    def setUp(self):
+        try:
+            from sglang.srt.speculative.dspark_info import validate_dspark_request
+        except Exception as e:  # pragma: no cover - GPU-only deps on some runners
+            self.skipTest(f"dspark_info unavailable on this runner: {e}")
+        self.validate = validate_dspark_request
+
+    @staticmethod
+    def _make_req(**overrides):
+        sampling = SimpleNamespace(
+            json_schema=None, regex=None, ebnf=None, structural_tag=None
+        )
+        base = dict(
+            return_logprob=False,
+            return_hidden_states=False,
+            sampling_params=sampling,
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_accepts_plain_request(self):
+        self.assertIsNone(self.validate(self._make_req()))
+
+    def test_rejects_return_logprob(self):
+        msg = self.validate(self._make_req(return_logprob=True))
+        self.assertIsNotNone(msg)
+        self.assertIn("return_logprob", msg)
+
+    def test_rejects_return_hidden_states(self):
+        msg = self.validate(self._make_req(return_hidden_states=True))
+        self.assertIsNotNone(msg)
+        self.assertIn("return_hidden_states", msg)
+
+    def test_rejects_grammar_constrained(self):
+        for field_name in ("json_schema", "regex", "ebnf", "structural_tag"):
+            sampling = SimpleNamespace(
+                json_schema=None, regex=None, ebnf=None, structural_tag=None
+            )
+            setattr(sampling, field_name, "x")
+            msg = self.validate(self._make_req(sampling_params=sampling))
+            self.assertIsNotNone(msg, field_name)
+            self.assertIn("grammar", msg)
+
+
+class _DSparkMathBase(CustomTestCase):
+    """Base for the DSpark block-verify commit-math tests.
+
+    Imports torch lazily so the file collects on torch-less runners, and holds
+    python replicas of the pure commit helpers from dspark_worker_v2.
+    """
+
+    def setUp(self):
+        try:
+            import torch
+        except Exception as e:  # pragma: no cover - torch-less runner
+            self.skipTest(f"torch unavailable on this runner: {e}")
+        self.torch = torch
+
+    def _confident_prefix(self, confidence, threshold):
+        # Replica of DSparkWorkerV2._confident_prefix: leading run of sigmoid >= threshold
+        # (cumprod zeroes everything after the first fail).
+        keep = self.torch.sigmoid(confidence) >= threshold
+        return keep.to(self.torch.int32).cumprod(dim=1).sum(dim=1)
+
+    def _assemble_out_tokens(self, candidates, correct_len, bonus_tokens):
+        # Replica of the out_tokens assembly in _forward_decode: drafts candidates[:, 1:]
+        # then a 0 pad, with the bonus scattered at correct_len -> prefix [drafts.., bonus].
+        t = self.torch
+        bs, block_size = candidates.shape
+        out_tokens = t.empty((bs, block_size), dtype=t.int64)
+        if block_size > 1:
+            out_tokens[:, : block_size - 1].copy_(candidates[:, 1:])
+        out_tokens[:, block_size - 1].fill_(0)
+        out_tokens.scatter_(
+            1, correct_len.unsqueeze(1), bonus_tokens.unsqueeze(1).to(t.int64)
+        )
+        return out_tokens
+
+
+class TestDSparkGreedyVerifyMath(_DSparkMathBase):
+    """Lock in the greedy verify branch of _forward_decode: correct_len from
+    compute_dflash_correct_drafts_and_bonus, the confidence min-cap, the bonus
+    gather, out_tokens assembly, and commit_lens. Every value is cross-checked
+    against a brute-force per-row Python reference."""
+
+    def setUp(self):
+        super().setUp()
+        try:
+            from sglang.srt.speculative.dflash_utils import (
+                compute_dflash_correct_drafts_and_bonus,
+            )
+        except Exception as e:  # pragma: no cover - GPU-only deps on some runners
+            self.skipTest(f"dflash_utils unavailable on this runner: {e}")
+        self._compute_correct = compute_dflash_correct_drafts_and_bonus
+
+    # sigmoid(x) >= 0.5  <=>  x >= 0, so PASS/FAIL confidence values drive the
+    # confident-prefix deterministically at threshold 0.5.
+    THRESH = 0.5
+    PASS = 10.0
+    FAIL = -10.0
+
+    def _greedy_pipeline(self, candidates, target_predict, confidence, threshold):
+        t = self.torch
+        raw_correct, _ = self._compute_correct(
+            candidates=candidates, target_predict=target_predict
+        )
+        confident_prefix = self._confident_prefix(confidence, threshold)
+        correct_len = t.minimum(raw_correct.to(t.int64), confident_prefix.to(t.int64))
+        bonus_tokens = target_predict.gather(1, correct_len.unsqueeze(1)).squeeze(1)
+        commit_lens = correct_len.to(t.int32) + 1
+        out_tokens = self._assemble_out_tokens(candidates, correct_len, bonus_tokens)
+        return correct_len, bonus_tokens, commit_lens, out_tokens
+
+    @staticmethod
+    def _bruteforce(candidates, target_predict, confidence, threshold):
+        import math
+
+        bs, block_size = candidates.shape
+        correct_len, bonus, commit, out = [], [], [], []
+        for r in range(bs):
+            cand = candidates[r].tolist()
+            tgt = target_predict[r].tolist()
+            conf = confidence[r].tolist()
+            match_run = 0
+            for i in range(block_size - 1):
+                if cand[i + 1] == tgt[i]:
+                    match_run += 1
+                else:
+                    break
+            conf_run = 0
+            for x in conf:
+                if 1.0 / (1.0 + math.exp(-float(x))) >= threshold:
+                    conf_run += 1
+                else:
+                    break
+            cl = min(match_run, conf_run)
+            b = tgt[cl]
+            row = [0] * block_size
+            for k in range(block_size - 1):
+                row[k] = cand[k + 1]
+            row[cl] = b
+            correct_len.append(cl)
+            bonus.append(b)
+            commit.append(cl + 1)
+            out.append(row)
+        return correct_len, bonus, commit, out
+
+    def test_mixed_batch_matches_bruteforce(self):
+        t = self.torch
+        P, F = self.PASS, self.FAIL
+        # row0 full accept (drafts 1,2,3 all match)          -> correct_len 3
+        # row1 first-token reject (draft 5 != target 6)      -> correct_len 0
+        # row2 mid-block reject (draft 7 != target 8 at t=1) -> correct_len 1
+        # row3 confidence truncation BELOW match (raw 3, cp1)-> correct_len 1
+        # row4 confidence "truncation" ABOVE match (raw1,cp4)-> correct_len 1 (no-op)
+        candidates = t.tensor(
+            [
+                [50, 1, 2, 3],
+                [50, 5, 20, 21],
+                [50, 1, 7, 22],
+                [50, 1, 2, 3],
+                [50, 1, 30, 31],
+            ],
+            dtype=t.int64,
+        )
+        target_predict = t.tensor(
+            [
+                [1, 2, 3, 99],
+                [6, 60, 61, 62],
+                [1, 8, 70, 71],
+                [1, 2, 3, 88],
+                [1, 40, 41, 42],
+            ],
+            dtype=t.int64,
+        )
+        confidence = t.tensor(
+            [
+                [P, P, P, P],
+                [P, P, P, P],
+                [P, P, P, P],
+                [P, F, F, F],
+                [P, P, P, P],
+            ],
+            dtype=t.float32,
+        )
+        correct_len, bonus, commit, out = self._greedy_pipeline(
+            candidates, target_predict, confidence, self.THRESH
+        )
+        bf_cl, bf_bonus, bf_commit, bf_out = self._bruteforce(
+            candidates, target_predict, confidence, self.THRESH
+        )
+        self.assertEqual(correct_len.tolist(), bf_cl)
+        self.assertEqual(bonus.tolist(), bf_bonus)
+        self.assertEqual(commit.tolist(), bf_commit)
+        self.assertEqual(out.tolist(), bf_out)
+        # Explicit expected values (validated numerically offline).
+        self.assertEqual(correct_len.tolist(), [3, 0, 1, 1, 1])
+        self.assertEqual(bonus.tolist(), [99, 6, 8, 2, 40])
+        self.assertEqual(commit.tolist(), [4, 1, 2, 2, 2])
+        # Committed prefix of every row is exactly [drafts.., bonus].
+        for r in range(candidates.shape[0]):
+            cl = int(correct_len[r])
+            committed = out[r, : cl + 1].tolist()
+            expected = candidates[r, 1 : cl + 1].tolist() + [int(bonus[r])]
+            self.assertEqual(committed, expected)
+
+    def test_block_size_one_edge(self):
+        t = self.torch
+        # block_size == 1: there are no drafts, so correct_len is always 0 and
+        # the single committed token is the target's bonus at column 0.
+        candidates = t.tensor([[50], [51]], dtype=t.int64)
+        target_predict = t.tensor([[7], [8]], dtype=t.int64)
+        confidence = t.tensor([[self.PASS], [self.FAIL]], dtype=t.float32)
+        correct_len, bonus, commit, out = self._greedy_pipeline(
+            candidates, target_predict, confidence, self.THRESH
+        )
+        self.assertEqual(correct_len.tolist(), [0, 0])
+        self.assertEqual(bonus.tolist(), [7, 8])
+        self.assertEqual(commit.tolist(), [1, 1])
+        self.assertEqual(out.tolist(), [[7], [8]])
+
+    def test_threshold_zero_disables_truncation(self):
+        t = self.torch
+        # With threshold 0, sigmoid(confidence) >= 0 always holds, so the
+        # confident prefix never shortens the accepted run: correct_len equals
+        # the raw greedy match length even when confidence is all-negative.
+        candidates = t.tensor([[50, 1, 2, 3]], dtype=t.int64)
+        target_predict = t.tensor([[1, 2, 3, 99]], dtype=t.int64)
+        confidence = t.full((1, 4), self.FAIL, dtype=t.float32)
+        correct_len, bonus, commit, _ = self._greedy_pipeline(
+            candidates, target_predict, confidence, 0.0
+        )
+        self.assertEqual(correct_len.tolist(), [3])
+        self.assertEqual(bonus.tolist(), [99])
+        self.assertEqual(commit.tolist(), [4])
+
+
+class TestDSparkSampledCommitMath(_DSparkMathBase):
+    """Post-kernel logic of the SAMPLED verify branch of _forward_decode. The
+    kernel result (accept_len, sampled_bonus) is supplied synthetically.
+
+    Losslessness invariant: confidence only shortens the committed block. A
+    truncated row commits candidates[correct_len+1], and correct_len+1 <=
+    accept_len, so that token is one the kernel already accepted; the output
+    distribution is preserved.
+    """
+
+    def _sampled_pipeline(
+        self, candidates, accept_len, sampled_bonus, confident_prefix, block_size
+    ):
+        t = self.torch
+        accept_len = accept_len.to(t.int64)
+        correct_len = t.minimum(accept_len, confident_prefix.to(t.int64))
+        truncated = correct_len < accept_len
+        idx = (correct_len + 1).clamp(max=block_size - 1)
+        next_draft = candidates.gather(1, idx.unsqueeze(1)).squeeze(1).to(t.int64)
+        bonus_tokens = t.where(truncated, next_draft, sampled_bonus.to(t.int64))
+        commit_lens = correct_len.to(t.int32) + 1
+        out_tokens = self._assemble_out_tokens(candidates, correct_len, bonus_tokens)
+        return correct_len, truncated, idx, bonus_tokens, commit_lens, out_tokens
+
+    def test_sampled_commit_and_invariants(self):
+        t = self.torch
+        block_size = 4  # columns: [current, draft_1, draft_2, draft_3]
+        candidates = t.tensor(
+            [
+                [50, 11, 12, 13],  # r0 not truncated (accept 2, cp 4)
+                [50, 21, 22, 23],  # r1 truncated (accept 3, cp 1) -> bonus=cand[2]
+                [50, 31, 32, 33],  # r2 accept 0, not truncated -> bonus=sampled
+                [50, 41, 42, 43],  # r3 truncated (accept 3, cp 2) -> bonus=cand[3]
+                [50, 51, 52, 53],  # r4 full accept 3, cp 3 -> bonus=sampled
+            ],
+            dtype=t.int64,
+        )
+        accept_len = t.tensor([2, 3, 0, 3, 3], dtype=t.int64)
+        sampled_bonus = t.tensor([900, 901, 902, 903, 904], dtype=t.int64)
+        confident_prefix = t.tensor([4, 1, 4, 2, 3], dtype=t.int64)
+
+        correct_len, truncated, idx, bonus, commit, out = self._sampled_pipeline(
+            candidates, accept_len, sampled_bonus, confident_prefix, block_size
+        )
+
+        # Explicit expected values (validated numerically offline).
+        self.assertEqual(correct_len.tolist(), [2, 1, 0, 2, 3])
+        self.assertEqual(truncated.tolist(), [False, True, False, True, False])
+        self.assertEqual(bonus.tolist(), [900, 22, 902, 43, 904])
+        self.assertEqual(commit.tolist(), [3, 2, 1, 3, 4])
+
+        for r in range(candidates.shape[0]):
+            cl = int(correct_len[r])
+            if bool(truncated[r]):
+                # (a) the committed bonus is a kernel-accepted token.
+                self.assertLessEqual(cl + 1, int(accept_len[r]))
+                # (d) the clamp at block_size-1 never changes a truncated index.
+                self.assertEqual(int(idx[r]), cl + 1)
+                self.assertEqual(int(bonus[r]), int(candidates[r, cl + 1]))
+            else:
+                # (b) an untruncated row commits the kernel bonus.
+                self.assertEqual(int(bonus[r]), int(sampled_bonus[r]))
+            # (c) committed prefix equals [drafts.., bonus].
+            committed = out[r, : cl + 1].tolist()
+            expected = candidates[r, 1 : cl + 1].tolist() + [int(bonus[r])]
+            self.assertEqual(committed, expected)
+
+    def test_accept_len_zero_commits_sampled_bonus(self):
+        t = self.torch
+        block_size = 4
+        candidates = t.tensor([[50, 11, 12, 13]], dtype=t.int64)
+        accept_len = t.tensor([0], dtype=t.int64)
+        sampled_bonus = t.tensor([777], dtype=t.int64)
+        confident_prefix = t.tensor([4], dtype=t.int64)
+        correct_len, truncated, _, bonus, commit, out = self._sampled_pipeline(
+            candidates, accept_len, sampled_bonus, confident_prefix, block_size
+        )
+        self.assertEqual(correct_len.tolist(), [0])
+        self.assertEqual(truncated.tolist(), [False])
+        self.assertEqual(bonus.tolist(), [777])
+        self.assertEqual(commit.tolist(), [1])
+        self.assertEqual(out[0, :1].tolist(), [777])
+
+
+class TestDSparkConfidentPrefix(_DSparkMathBase):
+    """Lock in the leading-run semantics of DSparkWorkerV2._confident_prefix."""
+
+    THRESH = 0.5
+    PASS = 10.0
+    FAIL = -10.0
+
+    def test_all_above_returns_block_size(self):
+        t = self.torch
+        conf = t.full((1, 5), self.PASS, dtype=t.float32)
+        self.assertEqual(self._confident_prefix(conf, self.THRESH).tolist(), [5])
+
+    def test_all_below_returns_zero(self):
+        t = self.torch
+        conf = t.full((1, 5), self.FAIL, dtype=t.float32)
+        self.assertEqual(self._confident_prefix(conf, self.THRESH).tolist(), [0])
+
+    def test_gap_in_middle_stops_the_run(self):
+        t = self.torch
+        # A below-threshold position ends the run; later above-threshold
+        # positions must NOT be counted.
+        conf = t.tensor(
+            [[self.PASS, self.PASS, self.FAIL, self.PASS, self.PASS]],
+            dtype=t.float32,
+        )
+        self.assertEqual(self._confident_prefix(conf, self.THRESH).tolist(), [2])
+
+    def test_threshold_zero_returns_block_size(self):
+        t = self.torch
+        # threshold 0 disables truncation: sigmoid(confidence) >= 0 always holds.
+        conf = t.full((1, 5), self.FAIL, dtype=t.float32)
+        self.assertEqual(self._confident_prefix(conf, 0.0).tolist(), [5])
+
+    def test_multi_row_batch(self):
+        t = self.torch
+        conf = t.tensor(
+            [
+                [self.PASS, self.PASS, self.PASS],
+                [self.FAIL, self.PASS, self.PASS],
+                [self.PASS, self.FAIL, self.PASS],
+            ],
+            dtype=t.float32,
+        )
+        self.assertEqual(self._confident_prefix(conf, self.THRESH).tolist(), [3, 0, 1])
+
+
+class TestDSparkShardArgmaxPack(_DSparkMathBase):
+    """Exactness of the shard-local argmax packing used by the collective-free
+    Markov refine: pack (bf16 value, global index) into one int64 whose MAX
+    across vocab shards reproduces torch.argmax's first-index tie-break exactly.
+    Tests the real helpers from dspark_worker_v2."""
+
+    def setUp(self):
+        super().setUp()
+        try:
+            from sglang.srt.speculative.dspark_worker_v2 import (
+                _dspark_decode_index,
+                _dspark_pack_value_index,
+                _dspark_shard_argmax_pack,
+            )
+        except Exception as e:  # pragma: no cover - GPU-only deps on some runners
+            self.skipTest(f"dspark_worker_v2 unavailable on this runner: {e}")
+        self.pack = _dspark_pack_value_index
+        self.decode = _dspark_decode_index
+        self.shard_pack = _dspark_shard_argmax_pack
+
+    def _sharded_argmax(self, full_padded, real_vocab, tp):
+        t = self.torch
+        width = full_padded.shape[1] // tp
+        merged = None
+        for r in range(tp):
+            shard = full_padded[:, r * width : (r + 1) * width]
+            cols = r * width + t.arange(width)
+            mask = cols >= real_vocab
+            packed = self.shard_pack(
+                shard, r * width, mask if bool(mask.any()) else None
+            )
+            # Elementwise max across shards simulates the NCCL MAX all-reduce.
+            merged = packed if merged is None else t.maximum(merged, packed)
+        return self.decode(merged)
+
+    def _check(self, full_padded, real_vocab, tp):
+        t = self.torch
+        ref = t.argmax(full_padded[:, :real_vocab].float(), dim=-1)
+        got = self._sharded_argmax(full_padded, real_vocab, tp)
+        self.assertTrue(bool((got == ref).all()), f"tp={tp}: {got} vs {ref}")
+
+    def test_padded_vocab_with_forced_ties(self):
+        t = self.torch
+        t.manual_seed(7)
+        vocab, padded, tp = 1000, 1024, 4
+        for _ in range(20):
+            x = t.randn(256, padded).to(t.bfloat16)
+            # Hostile garbage in the padding columns must never win.
+            x[:, vocab:] = t.randn(256, padded - vocab).to(t.bfloat16) * 100
+            row_max = x[:, :vocab].max(dim=-1).values
+            for _ in range(3):
+                idx = t.randint(0, vocab, (256,))
+                x[t.arange(256), idx] = row_max
+            self._check(x, vocab, tp)
+
+    def test_all_negative_and_signed_zero_ties(self):
+        t = self.torch
+        t.manual_seed(11)
+        vocab, padded = 1000, 1024
+        x = (-t.rand(512, padded) - 0.5).to(t.bfloat16)
+        zi = t.randint(0, vocab, (512, 2))
+        x[t.arange(512), zi[:, 0]] = t.tensor(-0.0, dtype=t.bfloat16)
+        x[t.arange(512), zi[:, 1]] = t.tensor(0.0, dtype=t.bfloat16)
+        self._check(x, vocab, 4)
+
+    def test_real_vocab_shape_tp8(self):
+        t = self.torch
+        t.manual_seed(13)
+        x = (t.randn(64, 129280) * 4).to(t.bfloat16)
+        row_max = x.max(dim=-1).values
+        idx = t.randint(0, 129280, (64,))
+        x[t.arange(64), idx] = row_max
+        self._check(x, 129280, 8)
+        self._check(x, 129280, 1)
+
+    def test_key_order_monotone_across_bf16_range(self):
+        t = self.torch
+        vals = t.tensor(
+            [
+                float("-inf"),
+                -3e38,
+                -1.0,
+                -1e-38,
+                -0.0,
+                0.0,
+                1e-38,
+                1.0,
+                3e38,
+                float("inf"),
+            ],
+            dtype=t.bfloat16,
+        )
+        vals = vals + 0.0  # the -0.0 normalize applied by _dspark_shard_argmax_pack
+        keys = self.pack(vals, t.zeros(len(vals), dtype=t.int64))
+        self.assertTrue(bool((keys[1:] >= keys[:-1]).all()), keys.tolist())
+        self.assertEqual(int(keys[4]), int(keys[5]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/spec/test_dspark.py
+++ b/test/registered/unit/spec/test_dspark.py
@@ -75,6 +75,7 @@ def _make_server_args(**overrides):
         enable_mixed_chunk=False,
         trust_remote_code=False,
         json_model_override_args="{}",
+        disable_overlap_schedule=False,
     )
     base.update(overrides)
     return SimpleNamespace(**base)


### PR DESCRIPTION
## Motivation

Adds Qwen3-family support to DSpark speculative decoding by extending the architecture landed in #29538 (DeepSeek-V4-only). One new model class, `Qwen3DSparkModel` (`python/sglang/srt/models/qwen3_dspark.py`), serves both released Qwen3 DSpark checkpoints — `deepseek-ai/dspark_qwen3_4b_block7` (Markov head + confidence head) and `deepseek-ai/dflash_qwen3_4b_block7` (neither) — through the existing `DSparkWorkerV2`, gated purely by checkpoint config. Also included: a fix for a pre-existing bug in #29538 that crashes any non-DeepSeek-V4 target the instant `--speculative-algorithm DSPARK` is selected, a one-line test-fixture fix that turns #29538's own 33-test suite green, and a block-size config-field fallback for the Qwen3 checkpoint family's naming convention.

Validated end-to-end on a single RTX A6000 (48GB, SM86/Ampere, bf16, `--attention-backend triton`): GSM8K-200 5-shot greedy accuracy holds at parity with the non-speculative baseline (0.875-0.885 vs 0.880), with a measured ~1.9-2x single-stream decode speedup and 3.9-4.8 accepted tokens/round.

## How to read this diff

Branch `dspark-qwen3` starts with a squash-import of #29538 @ `f6320807` (commit `b5ea3053`, full implementation credit to @adityakamat24 — see "Relationship to #29538" below) because #29538 hasn't merged yet and we needed something to build against locally. **We are not proposing that squashed commit as our own contribution, and we are not asking for it to be re-reviewed here.** Once #29538 merges, the actual delta we'd want reviewed is just the commits on top of it:

| Commit | What |
|---|---|
| `91adffc7` | Test-fixture fix: `_make_server_args()` in `test_dspark.py` was missing `disable_overlap_schedule`, failing 3/33 tests in #29538's own suite as submitted |
| `f751af66` | `models/qwen3_dspark.py` (new) + the `ModelRunner` / `speculative_hook.py` / `dspark_worker_v2.py` adjustments described below |
| `f082480e` | CPU-only weight-mapping + component-parity script vs. the DeepSpec reference implementation |
| `a1cfcfab` | `qwen3.py`: `set_dspark_layers_to_capture` aux-hidden-state capture hook |
| `2dd29f7b` | Lint/format pass (isort/black) on the three files above that fail `pre-commit run --all-files`; whitespace/import-order only, no semantic change |
| `d49c85c2` | Registered GPU server-integration test, `test/registered/spec/dspark/test_dspark.py` (see Test plan) |
| `51e63059` | `docs_new` update: corrects the "DeepSeek-V4 only" / "no separate draft model" language and adds a Qwen3-family subsection |
| `1e43baab` | Audit fixes: greedy-determinism test compares two warm (same-kernel-path) requests instead of cold-vs-warm, removing a latent bf16 tie-flip CI flake; docs corrected — the `dflash_qwen3_4b_block7` sibling is not currently servable under DFLASH (flat-vs-nested worker-shape conflict, tracked as an open question) |

If maintainers would rather review the import-gate fix and the fixture fix as small standalone patches directly against #29538 (they're useful independent of whether Qwen3 support lands at all), we're happy to split them out — see "Open questions" below.

## Relationship to #29538 and #29488

- **#29538** ("[Spec] Add DSpark speculative decoding for DeepSeek-V4", @adityakamat24): this PR *extends*, and does not compete with, #29538. #29538 introduces the real architectural machinery this depends on — the `DSPARK` `SpeculativeAlgorithm` enum member, `DSparkWorkerV2(BaseSpecWorker)`, the CLI surface (`--speculative-dspark-block-size`, `--speculative-dspark-confidence-threshold`), and the DeepSeek-V4 draft model. All of that is @adityakamat24's design and implementation; we did not reimplement or duplicate any of it. #29538 should be reviewed and merged on its own merits for DeepSeek-V4 regardless of this PR's outcome. (For orientation: #29705 and #29938 also build on #29538, adding PD/dp-attention support and temperature-sampling respectively — both orthogonal to this PR's Qwen3 addition, not touched here.)
- **#29488**: the DSpark tracking issue. A validation summary (what we measured on single-GPU Ampere, cross-referencing this PR) is prepared and can follow as a comment there.

## Modifications

### What this adds

1. **`python/sglang/srt/models/qwen3_dspark.py`** (new): `Qwen3DSparkModel`, the Qwen3-family analog of `DeepseekV4ForCausalLMDSpark`, served through the same `DSparkWorkerV2`.
2. **`model_runner.py`**: gates the `deepseek_v4_dspark` import (and its `dspark_num_layers`/`dspark_target_layer_ids` field reads) on the target actually being DeepSeek-V4 family, instead of firing unconditionally whenever `is_dspark()`. This is the one change here that's useful independent of Qwen3 support — see "Bug fix" below.
3. **`qwen3.py`**: `set_dspark_layers_to_capture`, the aux-hidden-state capture hook DSpark needs on a Qwen3 target (delegates to the existing DFLASH hook — see design notes).
4. **`speculative_hook.py`**: `_handle_dspark`'s block-size auto-inference now also checks the bare `block_size` config field (the Qwen3 checkpoint family's spelling), not just DeepSeek-V4's `dspark_block_size`.
5. **`dspark_worker_v2.py`**: target-weight tying (`embed_tokens`/`lm_head`) is now conditional on a new `draft_model.owns_vocab_weights` flag, so a draft that ships its own vocab weights (Qwen3 DSpark, `tie_word_embeddings=false`) isn't force-tied to the target's.
6. **Test-fixture fix** (`test_dspark.py`): `disable_overlap_schedule` added to `_make_server_args()`, fixing 3 pre-existing failures in #29538's own CPU test suite (unrelated to Qwen3 — a gap in the original PR's fixture).
7. **CPU parity script** (`scripts/playground/dspark_qwen3_weight_parity.py`, new): validates weight mapping and small-component math against the DeepSpec reference implementation, no GPU required.
8. **Registered GPU integration test** (`test/registered/spec/dspark/test_dspark.py`, new): mirrors `test/registered/spec/dflash/test_dflash.py`'s structure — see Test plan.
9. **Docs** (`docs_new/docs/advanced_features/speculative_decoding.mdx`): corrects the DeepSeek-V4-only language and adds a Qwen3-family subsection (checkpoints, launch example, measured numbers).

### Design notes

**One class, two checkpoints, config-gated.** `deepseek-ai/dspark_qwen3_4b_block7` and `deepseek-ai/dflash_qwen3_4b_block7` both ship `"architectures": ["Qwen3DSparkModel"]`; they differ only in `markov_rank` (256 vs. 0) and `enable_confidence_head` (true vs. false). `Qwen3DSparkModel` builds `markov_head`/`confidence_head` iff those config values are set, so one class and one `EntryClass` registration serves both checkpoints with zero config rewriting. This also matters concretely: `EntryClass = [Qwen3DSparkModel]` matches the checkpoint's actual `architectures` string exactly, which is where #29917 runs into trouble (its detection keys on a `Draft`-suffixed class name that no released checkpoint declares).

**Subclasses DFlash, not DeepSeek-V4.** A DSpark draft block for a Qwen3-family target is architecturally DFlash's parallel, non-causal, context-KV-fed block drafter (plain GQA + per-head q/k RMSNorm + RoPE + `RadixAttention` over a paged KV cache pre-seeded with the projected target-context feature), not DeepSeek-V4's MLA/hybrid-compression-specific block. `Qwen3DSparkAttention`/`Qwen3DSparkDecoderLayer` subclass `dflash.py`'s attention/decoder-layer classes directly, adding only a `kv_from_hidden` method (the plain-MHA/GQA analog of `DeepseekV4Attention.kv_from_hidden`, since `DSparkWorkerV2` calls it directly). The Markov head is a small self-contained copy of `deepseek_v4_dspark.py`'s `DSparkMarkovHead` rather than an import, deliberately — see the bug-fix note below for why importing anything from `deepseek_v4.py`'s module chain is unsafe for a non-V4 deployment.

**Capture-hook convention, and why it isn't a copy-paste of V4's.** `model_runner.py`'s aux-hidden-state capture requires the target model to implement `set_dspark_layers_to_capture()`; `qwen3.py` only had the DFLASH-named analog. We delegate to the existing `set_dflash_layers_to_capture()` rather than duplicating it, because on this architecture (`Qwen3Model` -> `Qwen2Model.forward`) capture is mechanically identical for DFLASH and DSpark: same flag, same `layers_to_capture` list, same **+1 offset** (the forward loop checks `layers_to_capture` *before* running each layer, so capturing HF-style layer `k`'s output requires listing `k+1`). `deepseek_v4.py`'s `set_dspark_layers_to_capture` has *no* offset — correct there only because that file's forward loop checks the list *after* running each layer. Copying V4's version verbatim into `qwen3.py` would have silently captured the wrong layers while still "running" (no crash, just silently wrong hidden states). Verified directly: `target_layer_ids=[1,9,17,25,33]` (the checkpoint's own value) maps to `model.layers_to_capture=[2,10,18,26,34]`, matching the DFLASH hook's existing, already-correct convention.

**`owns_vocab_weights`.** `DeepseekV4ForCausalLMDSpark`'s draft doesn't ship its own `embed_tokens`/`lm_head` — `DSparkWorkerV2.__init__` ties them directly to the target's live weights. Qwen3 DSpark checkpoints are the opposite: `tie_word_embeddings=false`, and both `embed_tokens.weight` and `lm_head.weight` are present and trained in the checkpoint (confirmed against the real safetensors header). We added `owns_vocab_weights: bool` on the draft model class (`False` on the V4 class, unchanged behavior; `True` on `Qwen3DSparkModel`) and made the worker's tying step conditional on it, so neither checkpoint family silently ends up with the wrong vocab weights.

**Bug fix — unconditional DeepSeek-V4 import crashes non-V4 targets.** Choosing `--speculative-algorithm DSPARK` for *any* target unconditionally imports `deepseek_v4_dspark` -> `deepseek_v4` -> `deepseek_v2`'s DSA indexer -> `deep_gemm` at module level, inside `ModelRunner.__init__` (`model_runner.py:528` on #29538's tip). On any host without DeepSeek-V4's exact `deep_gemm`/CUDA build, this crashes — reproduced live on our box:

```
$ python -m sglang.launch_server --model-path Qwen/Qwen3-4B \
    --speculative-algorithm DSPARK \
    --speculative-draft-model-path deepseek-ai/dspark_qwen3_4b_block7 \
    --speculative-dspark-block-size 7 --attention-backend triton --port 30000
...
  File ".../model_executor/model_runner.py", line 528, in __init__
    from sglang.srt.models.deepseek_v4_dspark import get_dspark_num_layers
  File ".../models/deepseek_v4_dspark.py", line 20, in <module>
    from sglang.srt.models.deepseek_v4 import DeepseekV4DecoderLayer, DeepseekV4ForCausalLM
  File ".../models/deepseek_v4.py", line 22, in <module>
    import sglang.srt.models.deepseek_v2 as deepseek_v2
  File ".../models/deepseek_v2.py", line 61, in <module>
    from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
  File ".../layers/attention/dsa/dsa_indexer.py", line 74, in <module>
    import deep_gemm
  ...
RuntimeError: Check failed: (lib_handle_ != nullptr) is false: Failed to load dynamic
shared library .../deep_gemm/_C.so libcudart.so.13: cannot open shared object file
```

Two-layered root cause: (1) `deep_gemm`'s compiled extension wants `libcudart.so.13`, which a CUDA-12.x-pinned box doesn't have; (2) `dsa_indexer.py`'s own `import deep_gemm` is wrapped in `except ImportError`, which doesn't catch the `RuntimeError` a broken native `.so` actually raises (pre-existing, not part of #29538's diff). No flag works around it — the import fires unconditionally as soon as `spec_algorithm.is_dspark()` is true, with no gate on the target's actual architecture. Our fix threads the existing `is_dspark()` check through an additional check on target arch, so a non-DeepSeek-V4 target reads the generic HF config fields (`num_hidden_layers`, `target_layer_ids`) directly instead of importing V4's module chain at all.

**A note on `getattr` usage.** The diff reads several optional fields off third-party HuggingFace `PretrainedConfig`-style objects with `getattr(config, "field", default)` (`block_size`, `markov_rank`, `mask_token_id`, etc.). This resembles the pattern the repo's `no-getattr-defensive.md` house rule warns against, but it's a different situation: those fields genuinely vary by checkpoint family (DeepSeek-V4 vs. Qwen3-family config schemas differ), so there's no single "always present" field to access directly the way the rule's own example (an sglang-internal `server_args.revision`) has. The one remaining `getattr(param, "weight_loader", default_weight_loader)` call is the standard repo-wide `load_weights` idiom for `torch.nn.Parameter`, not something specific to this PR.

## Accuracy Tests

GSM8K 5-shot/200q/greedy holds at parity with the non-speculative baseline across every configuration we measured: 0.875-0.885 (DSpark, confidence threshold off) vs. 0.880 (target-only), and 0.875-0.880 across confidence thresholds 0.3-0.8 — all within the ≈0.023 binomial-noise band at n=200. See [Measurements](#measurements) below for the full breakdown, including the confidence-threshold sweep and the bench-trio comparison against an existing DFlash checkpoint.

## Speed Tests and Profiling

Single-stream decode latency improves ~1.95x (13.15 -> 6.76 ms/tok) with 3.9-4.8 accepted tokens per verify round during GSM8K; batched GSM8K throughput and the confidence-truncation mechanism's measured cost/benefit are covered in [Measurements](#measurements) below.

## Measurements

All single-GPU, RTX A6000 48GB SM86, bf16, `--attention-backend triton`, GSM8K 5-shot/200q/greedy unless noted (`python -m sglang.test.few_shot_gsm8k`, all defaults). Session-to-session batched throughput varies roughly ±10% on this box; single-request latency and accept-length are the more stable signals.

**Baseline vs. DSpark (confidence threshold off, the shipped default):**

| Config | GSM8K acc. (n=200) | Batched GSM8K throughput | Single-stream latency | Accept length |
|---|---|---|---|---|
| Target-only (no spec) | 0.880 | ~1865 tok/s | 13.15 ms/tok | n/a |
| DSpark block7, τ=0 | 0.875-0.885 across runs (binomial noise at n=200 ≈ 0.023) | 1347-1543 tok/s (session variance ±10%) | 6.76 ms/tok (**~1.95x**) | 3.94-4.84 during GSM8K |

**Confidence-threshold (τ) sweep — accuracy** (separate measurement session from the row above):

| τ | GSM8K acc. |
|---|---|
| 0.3 | 0.880 |
| 0.5 | 0.880 |
| 0.8 | 0.875 |

All within the ≈0.023 noise band of the 0.880 baseline — truncation is lossless as designed, at every τ we tried.

**Confidence-truncation mechanism — fixed 128-token single-stream probe, same session:**

| τ | Accept length | Verify rounds |
|---|---|---|
| 0 (off) | 2.844 | 45 |
| 0.3 | 2.510 | 51 |
| 0.5 | 2.510 | 51 |
| 0.8 | 2.510 | 51 |

Accuracy is flat across τ — but the probe shows the gate is doing real work, and not for free: it fires and saturates by τ=0.3 (the confidence distribution is bimodal), and costs ~13% *more* verify rounds at every τ>0 than τ off, while committing *fewer* tokens per round. That's because `dspark_worker_v2.py` applies the confidence prefix as `min(kernel_accept_len, confident_prefix)` **after** the full-block target-verify forward already ran (confidence computed at `dspark_worker_v2.py:770-771`, applied via `torch.minimum` at line 806 in the sampling-verify branch and line 833 in the greedy branch) — the full `block_size`-length candidate tensor is always shipped to the target, so truncation can only shrink what gets *committed*, never what gets *verified*. a design sketch of moving truncation before the verify forward is written up and available on request.

**Bench trio vs. an existing DFLASH checkpoint** (z-lab's DFlash block16, same target, same box):

| | DSpark block7 | DFlash block16 |
|---|---|---|
| GSM8K acc. | 0.875 | 0.870 |
| Single-stream latency | 6.758 ms/tok | 8.899 ms/tok |
| Batch-8 throughput | 887 tok/s | 632 tok/s |
| Accept **rate** during GSM8K | 0.49-0.61 | 0.19-0.21 |

(Accept *rate*, not accept length, is the fair comparison here — block sizes differ, 7 vs. 16.)

## Test plan

**Automated, CPU-only, no GPU needed:**
```
pytest test/registered/unit/spec/test_dspark.py -q
```
33/33 passing on this branch (30/33 on #29538's own tip before the fixture fix in `91adffc7` — see that commit for the one-line diagnosis). Also CPU-only:
```
python scripts/playground/dspark_qwen3_weight_parity.py
```
maps all 64 real checkpoint tensors to a destination parameter (0 unmapped) and checks the Markov-bias, previous-token-embedding, `fc`-then-`hidden_norm` combine, and confidence-head math against a pure-Torch reproduction of the DeepSpec reference — all four come back `max_abs_diff = 0.000e+00` against the real trained weights.

**Automated, GPU required (registered CI test, `1-gpu-small` runner):**
```
pytest test/registered/spec/dspark/test_dspark.py -v -s
```
8/8 passing, run locally on a single RTX A6000 (`--attention-backend triton`): GSM8K score 0.880 (n=200), `avg_spec_accept_length` 4.0035, plus early-stop / EOS-handling / greedy-determinism / matched-stop checks (`CustomTestCase` + `MatchedStopMixin` + `GSM8KMixin`, mirroring `test/registered/spec/dflash/test_dflash.py`). `gsm8k_accuracy_thres=0.84` and `gsm8k_accept_length_thres=3.0` sit below our measured floor (0.875-0.885 / 3.94-4.84) with margin, mirroring `test_dflash.py`'s own below-measured-floor convention (0.75 acc. / 2.8 accept length against a documented "roughly 3.2-3.6"). `MatchedStopMixin.test_finish_stop_eos` is overridden with a Qwen3-correct prompt/token-id version — the inherited one hardcodes Llama-3 special tokens from `test_dflash.py`'s Llama-3.1 target. Registered CUDA-only for now; we have no AMD hardware to validate against, unlike `test_dflash.py`'s dual CUDA+AMD registration.

A methodology note, since it affects how any future correctness test should be written: we initially compared DSpark's greedy output against target-only token-for-token and got 3/5 exact matches on a small prompt set. Both divergences turned out to be positions where the target's own top-2 logprobs are tied at *exactly* 0.000000 (bf16), with the next-nearest logit 1.6-5.9 away — i.e., genuine ties, not an accept/reject logic bug. Target-only's own multi-token verify-extend kernel path and its single-token decode path are free to (and do) break an exact tie differently; separately, target-only output by itself is not reproducible warm-RadixCache-vs-cold on this box (2/5 self-match, pre-existing and DSpark-unrelated). That's why the registered test above gates DSpark correctness on GSM8K accuracy + accept-length rather than exact-match, matching `test_dflash.py`'s own convention — exactness isn't a reachable bar across kernel paths even for target-only alone.

## Explicitly NOT covered by this PR

- **Pre-verify confidence truncation** (moving truncation before the target-verify forward so it actually saves compute) — design sketch written up (available on request), not implemented.
- **Real load-aware scheduling** (the paper's Algorithm 1, a hardware-aware prefix scheduler against a profiled throughput table) — not implemented anywhere we could find, including the DeepSpec reference, vLLM, or TRT-LLM.
- **Large-batch validation** — everything above was measured up to batch 8 on a single GPU; we have no data at production batch sizes.
- **Hopper/FP8** — developed and tested entirely on Ampere/bf16; no coverage of FP8 paths or SM90+-specific kernels.
- **CUDA-graph coverage for variable-length verify** — today's graphs (both the target's verify graph and the draft's own decode graph) assume a fixed per-round token count; a pre-verify-truncation future would need to address this.
- **The EAGLE3-Qwen3 gap** — unrelated to DSpark directly, but hit while gathering the bench trio: neither `AngelSlim/Qwen3-4B_eagle3` (`Eagle3LlamaForCausalLM`) nor `deepseek-ai/eagle3_qwen3_4b_ttt7` (`Qwen3Eagle3Model`) resolves against any registered model class — no `qwen3_eagle3.py` exists. Flagged separately as a small side-item.

## Open questions for maintainers

1. Would you rather the `ModelRunner` import-gate fix and the test-fixture fix land as small standalone commits directly against #29538 (useful regardless of Qwen3 support), separate from the Qwen3 model addition? We bundled them on one branch purely for our own validation convenience.
2. Given #29538 and #29917 are two independent, architecturally-divergent implementations of Qwen3/DeepSeek-V4 DSpark support (dedicated `DSparkWorkerV2` vs. aliasing into `DFlashWorkerV2`), is there an intended convergence point, or is the plan to let both mature and pick one later? This PR assumes #29538's `DSparkWorkerV2` design; if the intended direction turns out to be closer to #29917's DFLASH-alias approach, most of this would need to be re-targeted.
3. ~~Is a GPU server-integration test (mirroring `test/registered/spec/dflash/test_dflash.py`'s `GSM8KMixin`-based `TestDFlashServerBase`) wanted for DSpark?~~ **Resolved**: added `test/registered/spec/dspark/test_dspark.py` (see Test plan). Open sub-question: worth also adding a stage-a `test_basic_sanity_dspark.py` companion (mirroring `test_basic_sanity_dflash.py`) and/or the page-size / chunked-prefill / no-cuda-graph subclass variants `test_dflash.py` has? We scoped this draft to the single base-class GSM8K/matched-stop suite.
4. `dflash_qwen3_4b_block7` (the `markov_rank=0` sibling checkpoint) is architecturally servable by this same class but is meant to run under plain DFLASH, not DSpark — is routing it through `DFlashWorkerV2` instead (same checkpoint, different worker) in scope for this PR, or a separate follow-up?

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28766391378](https://github.com/sgl-project/sglang/actions/runs/28766391378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28766391279](https://github.com/sgl-project/sglang/actions/runs/28766391279)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->