### PR TITLE
fix(server): capture legal multi-request prefill CUDA graph batches

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_config.py
+++ b/python/sglang/srt/model_executor/cuda_graph_config.py
@@ -53,8 +53,9 @@ ALLOWED_BACKENDS_PER_PHASE = {
         Backend.DISABLED,
     ),
     # full for prefill captures one whole-forward graph per num_tokens
-    # bucket (bs=1 only); replay pads num_tokens up to the nearest
-    # captured bucket. Opt-in: the padding waste is the operator's call.
+    # bucket with a fixed request-slot count; replay pads num_tokens up to
+    # the nearest captured bucket. Opt-in: the padding waste is the
+    # operator's call.
     Phase.PREFILL: (
         Backend.FULL,
         Backend.BREAKABLE,
@@ -66,8 +67,8 @@ ALLOWED_BACKENDS_PER_PHASE = {
 # Per-phase settings schema. Keys other than backend are runner-level
 # (read by any backend in that phase); tc_compiler is the lone
 # backend-specific knob (only meaningful when backend == tc_piecewise).
-# For prefill, bs carries the captured shape size (token count for Full and
-# tc_piecewise, request count for breakable) — one shape knob per phase.
+# For prefill, bs carries aggregate-token capture buckets for every backend;
+# full_prefill_max_req separately controls Full's fixed request-slot count.
 # full_prefill_max_req and full_prefill_prefix_chunk_tokens are prefill-only and
 # only meaningful when backend == full.
 ALLOWED_KEYS_PER_PHASE = {
@@ -95,8 +96,8 @@ class PhaseConfig:
     # Only meaningful for the prefill phase with backend == full: max number of
     # request slots baked into each captured graph. Real bs <= full_prefill_max_req
     # reuses the graph (unused slots become zero-length sentinels); larger
-    # batches fall back to eager. Ignored by BCG (bs=1 only) and TC_PIECEWISE
-    # (bs-invariant via torch.compile). None auto-derives chunked_prefill_size // 512.
+    # batches fall back to eager. Ignored by BCG and TC_PIECEWISE. None
+    # auto-derives chunked_prefill_size // 512.
     full_prefill_max_req: Optional[int] = None
     # Only meaningful for Full prefill CUDA graphs that capture a distinct
     # cached-prefix topology: aggregate cached-prefix tokens represented by one

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -206,22 +206,32 @@ def capture_prefill_graph(
         logger.warning("Disable prefill CUDA graph because the capture size is not set")
         return None
 
-    prefill_backend = model_runner.server_args.cuda_graph_config.prefill.backend
+    prefill_config = model_runner.server_args.cuda_graph_config.prefill
+    prefill_backend = prefill_config.backend
     context_length = model_runner.model_config.context_len
-    max_capture_tokens = (
-        model_runner.req_to_token_pool.size * context_length
-        if prefill_backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE)
-        else context_length
+    supports_multi_request_capture = prefill_backend in (
+        Backend.TC_PIECEWISE,
+        Backend.BREAKABLE,
     )
+    max_capture_requests = (
+        model_runner.req_to_token_pool.size if supports_multi_request_capture else 1
+    )
+    max_capture_tokens = max_capture_requests * context_length
     capture_num_tokens = sorted(
         num_tokens
-        for num_tokens in model_runner.server_args.cuda_graph_config.prefill.bs
+        for num_tokens in prefill_config.bs
         if num_tokens <= max_capture_tokens
     )
+    # Resolve the legal buckets once before constructing the runner so
+    # every capture backend consumes the same in-place configuration.
+    prefill_config.bs = capture_num_tokens
     if not capture_num_tokens:
         logger.warning(
             "Disable prefill CUDA graph capture because no configured "
-            "capture size fits context_length=%s and request-pool size=%s.",
+            "capture size fits backend=%s with max_capture_tokens=%s "
+            "(context_length=%s, request-pool size=%s).",
+            prefill_backend,
+            max_capture_tokens,
             context_length,
             model_runner.req_to_token_pool.size,
         )

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -209,29 +209,39 @@ def capture_prefill_graph(
     prefill_config = model_runner.server_args.cuda_graph_config.prefill
     prefill_backend = prefill_config.backend
     context_length = model_runner.model_config.context_len
-    supports_multi_request_capture = prefill_backend in (
-        Backend.TC_PIECEWISE,
-        Backend.BREAKABLE,
-    )
-    max_capture_requests = (
-        model_runner.req_to_token_pool.size if supports_multi_request_capture else 1
-    )
+    if prefill_backend == Backend.FULL:
+        max_capture_requests = prefill_config.full_prefill_max_req
+        if max_capture_requests is None:
+            max_capture_requests = max(
+                model_runner.server_args.chunked_prefill_size // 512, 1
+            )
+        max_capture_requests = min(
+            max_capture_requests, model_runner.req_to_token_pool.size
+        )
+        # Resolve Full's fixed request-axis shape once, just like bs below.
+        prefill_config.full_prefill_max_req = max_capture_requests
+    else:
+        max_capture_requests = model_runner.req_to_token_pool.size
+    # The capture dummy batch has at most max_capture_requests rows, and
+    # each row can contain at most context_length tokens. Their product is
+    # therefore the largest aggregate-token bucket capture can represent.
     max_capture_tokens = max_capture_requests * context_length
     capture_num_tokens = sorted(
         num_tokens
         for num_tokens in prefill_config.bs
         if num_tokens <= max_capture_tokens
     )
-    # Resolve the legal buckets once before constructing the runner so
-    # every capture backend consumes the same in-place configuration.
+    # Resolve the context- and request-capacity-bounded buckets once before
+    # constructing the runner so every backend consumes the same config.
     prefill_config.bs = capture_num_tokens
     if not capture_num_tokens:
         logger.warning(
             "Disable prefill CUDA graph capture because no configured "
             "capture size fits backend=%s with max_capture_tokens=%s "
-            "(context_length=%s, request-pool size=%s).",
+            "(max_capture_requests=%s, context_length=%s, request-pool size=%s).",
             prefill_backend,
             max_capture_tokens,
+            max_capture_requests,
             context_length,
             model_runner.req_to_token_pool.size,
         )

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -206,6 +206,27 @@ def capture_prefill_graph(
         logger.warning("Disable prefill CUDA graph because the capture size is not set")
         return None
 
+    prefill_backend = model_runner.server_args.cuda_graph_config.prefill.backend
+    context_length = model_runner.model_config.context_len
+    max_capture_tokens = (
+        model_runner.req_to_token_pool.size * context_length
+        if prefill_backend == Backend.TC_PIECEWISE
+        else context_length
+    )
+    capture_num_tokens = sorted(
+        num_tokens
+        for num_tokens in model_runner.server_args.cuda_graph_config.prefill.bs
+        if num_tokens <= max_capture_tokens
+    )
+    if not capture_num_tokens:
+        logger.warning(
+            "Disable prefill CUDA graph capture because no configured "
+            "capture size fits context_length=%s and request-pool size=%s.",
+            context_length,
+            model_runner.req_to_token_pool.size,
+        )
+        return eager_runner
+
     # Collect attention layers and moe layers from the model. Keep a VLM
     # wrapper that exposes ``language_model`` unchanged: assigning it to
     # ``model`` would register a duplicate module alias and duplicate the
@@ -246,7 +267,6 @@ def capture_prefill_graph(
 
     tic = time.perf_counter()
     before_mem = get_available_gpu_memory(model_runner.device, model_runner.gpu_id)
-    prefill_backend = model_runner.server_args.cuda_graph_config.prefill.backend
     if should_skip_auto_prefill_cuda_graph_for_memory(
         before_mem,
         getattr(model_runner.server_args, "_cuda_graph_config_locked", set()),
@@ -263,7 +283,6 @@ def capture_prefill_graph(
 
     role = "draft" if model_runner.is_draft_worker else "target"
     capture_name = f"{role} prefill"
-    capture_num_tokens = sorted(model_runner.server_args.cuda_graph_config.prefill.bs)
     logger.info(
         f"Capture {capture_name} CUDA graph begin. "
         f"backend={prefill_backend}, num_tokens={capture_num_tokens}, "

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -210,7 +210,7 @@ def capture_prefill_graph(
     context_length = model_runner.model_config.context_len
     max_capture_tokens = (
         model_runner.req_to_token_pool.size * context_length
-        if prefill_backend == Backend.TC_PIECEWISE
+        if prefill_backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE)
         else context_length
     )
     capture_num_tokens = sorted(

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1103,9 +1103,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 "req_pool_indices": torch.arange(bs, device=self.device),
                 "seq_lens": torch.tensor(capture_seq_lens, device=self.device),
                 "orig_seq_lens": torch.tensor(capture_seq_lens, device=self.device),
-                "extend_seq_lens": torch.tensor(
-                    capture_seq_lens, device=self.device
-                ),
+                "extend_seq_lens": torch.tensor(capture_seq_lens, device=self.device),
                 "extend_prefix_lens": torch.zeros((bs,), dtype=torch.int64),
                 "extend_start_loc": torch.tensor(
                     capture_start_locs, device=self.device

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1079,19 +1079,40 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         Returns ``(forward_batch, attn_backend)`` to mirror decode's
         capture_prepare signature.
         """
-        bs = self._capture_req_slots
-        # Slot 0 carries num_tokens; slots 1..bs-1 are zero-length sentinels.
-        lens_cpu = [num_tokens] + [0] * (bs - 1)
-        start_loc_cpu = [0] + [num_tokens] * (bs - 1)
+        if self.prefill_backend_name == Backend.FULL:
+            bs = self._capture_req_slots
+            # Slot 0 carries num_tokens; slots 1..bs-1 are zero-length sentinels.
+            capture_seq_lens = [num_tokens] + [0] * (bs - 1)
+            capture_start_locs = [0] + [num_tokens] * (bs - 1)
+        else:
+            context_length = self.model_runner.model_config.context_len
+            # Build a dummy prefill batch with num_tokens aggregate tokens while
+            # keeping every synthetic request at or below context_length.
+            capture_seq_lens = [
+                min(context_length, num_tokens - start)
+                for start in range(0, num_tokens, context_length)
+            ]
+            bs = len(capture_seq_lens)
+            assert bs <= self.max_bs, (
+                f"Capture batch needs {bs} request slots for {num_tokens} tokens, "
+                f"but the request pool has only {self.max_bs}."
+            )
+            capture_start_locs = [0]
+            for seq_len in capture_seq_lens[:-1]:
+                capture_start_locs.append(capture_start_locs[-1] + seq_len)
 
         with torch.device(self.device):
             shape_inputs = {
                 "req_pool_indices": torch.arange(bs, device=self.device),
-                "seq_lens": torch.tensor(lens_cpu, device=self.device),
-                "orig_seq_lens": torch.tensor(lens_cpu, device=self.device),
-                "extend_seq_lens": torch.tensor(lens_cpu, device=self.device),
+                "seq_lens": torch.tensor(capture_seq_lens, device=self.device),
+                "orig_seq_lens": torch.tensor(capture_seq_lens, device=self.device),
+                "extend_seq_lens": torch.tensor(
+                    capture_seq_lens, device=self.device
+                ),
                 "extend_prefix_lens": torch.zeros((bs,), dtype=torch.int64),
-                "extend_start_loc": torch.tensor(start_loc_cpu, device=self.device),
+                "extend_start_loc": torch.tensor(
+                    capture_start_locs, device=self.device
+                ),
             }
         if self._prefill_static_buffers is not None:
             s = self._prefill_static_buffers
@@ -1142,7 +1163,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 seq_lens=shape_inputs["seq_lens"],
                 next_token_logits_buffer=self._next_token_logits_buffer(bs),
                 orig_seq_lens=shape_inputs["orig_seq_lens"],
-                seq_lens_cpu=torch.tensor(lens_cpu, device="cpu"),
+                seq_lens_cpu=torch.tensor(capture_seq_lens, device="cpu"),
                 out_cache_loc=_slot("out_cache_loc"),
                 seq_lens_sum=num_tokens,
                 mamba_track_indices=(
@@ -1167,8 +1188,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 extend_prefix_lens=shape_inputs["extend_prefix_lens"],
                 extend_start_loc=shape_inputs["extend_start_loc"],
                 extend_prefix_lens_cpu=[0] * bs,
-                extend_seq_lens_cpu=list(lens_cpu),
-                extend_logprob_start_lens_cpu=list(lens_cpu),
+                extend_seq_lens_cpu=list(capture_seq_lens),
+                extend_logprob_start_lens_cpu=list(capture_seq_lens),
                 positions=_slot("positions"),
                 global_num_tokens_gpu=global_num_tokens_gpu,
                 global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -359,10 +359,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         self._is_full_backend = isinstance(self.backend, FullCudaGraphBackend)
         if self._is_full_backend:
             max_req = prefill_config.full_prefill_max_req
-            if max_req is None:
-                # Auto: scale request slots with the chunked prefill size.
-                max_req = max(model_runner.server_args.chunked_prefill_size // 512, 1)
-            self._capture_req_slots = min(max_req, self.max_bs)
+            assert max_req is not None, "full_prefill_max_req must be resolved"
+            self._capture_req_slots = max_req
         # BCG/Full record LoRA kernels, so the metadata they read must live in
         # static buffers refreshed in place per batch; unsupported LoRA
         # configs were already routed to the eager runner.
@@ -1079,27 +1077,26 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         Returns ``(forward_batch, attn_backend)`` to mirror decode's
         capture_prepare signature.
         """
+        context_length = self.model_runner.model_config.context_len
+        # A prefill bucket is an aggregate token count. Capture it as the
+        # fewest synthetic requests, with every request containing no more
+        # than context_length tokens.
+        capture_seq_lens = [
+            min(context_length, num_tokens - start)
+            for start in range(0, num_tokens, context_length)
+        ]
         if self.prefill_backend_name == Backend.FULL:
-            bs = self._capture_req_slots
-            # Slot 0 carries num_tokens; slots 1..bs-1 are zero-length sentinels.
-            capture_seq_lens = [num_tokens] + [0] * (bs - 1)
-            capture_start_locs = [0] + [num_tokens] * (bs - 1)
-        else:
-            context_length = self.model_runner.model_config.context_len
-            # Build a dummy prefill batch with num_tokens aggregate tokens while
-            # keeping every synthetic request at or below context_length.
-            capture_seq_lens = [
-                min(context_length, num_tokens - start)
-                for start in range(0, num_tokens, context_length)
-            ]
-            bs = len(capture_seq_lens)
-            assert bs <= self.max_bs, (
-                f"Capture batch needs {bs} request slots for {num_tokens} tokens, "
-                f"but the request pool has only {self.max_bs}."
-            )
-            capture_start_locs = [0]
-            for seq_len in capture_seq_lens[:-1]:
-                capture_start_locs.append(capture_start_locs[-1] + seq_len)
+            # Full captures a fixed request-axis shape; unused slots are
+            # zero-length sentinels after the context-bounded real requests.
+            capture_seq_lens += [0] * (self._capture_req_slots - len(capture_seq_lens))
+        bs = len(capture_seq_lens)
+        assert bs <= self.max_bs, (
+            f"Capture batch needs {bs} request slots for {num_tokens} tokens, "
+            f"but the request pool has only {self.max_bs}."
+        )
+        capture_start_locs = [0]
+        for seq_len in capture_seq_lens[:-1]:
+            capture_start_locs.append(capture_start_locs[-1] + seq_len)
 
         with torch.device(self.device):
             shape_inputs = {

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4625,14 +4625,6 @@ class ServerArgs:
                     prefill_cuda_graph_config.max_bs, 4096
                 )
 
-        # Clamp to context_length if explicitly set — prevents prefill CG
-        # warmup from compiling graphs with more tokens than the model
-        # buffers can hold, which causes illegal memory access (#21112).
-        if self.context_length is not None:
-            prefill_cuda_graph_config.max_bs = min(
-                prefill_cuda_graph_config.max_bs, self.context_length
-            )
-
         if prefill_cuda_graph_config.bs is None:
             prefill_cuda_graph_config.bs = (
                 self._generate_prefill_cuda_graph_batch_sizes(


### PR DESCRIPTION
[by Codex]

## Motivation

When `--context-length` is smaller than a prefill CUDA-graph capture bucket, the old capture path creates one synthetic request with `seq_len=num_tokens`. That exceeds the per-request context limit and can cause the #21112 illegal-memory-access failure during graph warm-up.

Clamping the aggregate prefill token ceiling to `context_length` avoids that crash, but unnecessarily disables graph replay for legal multi-request prefills whose total token count exceeds one request's context length.

## Design

This PR fixes the capture shape rather than applying a per-request cap to an aggregate-token setting:

- Resolve legal prefill capture buckets once in `ModelRunner.init_prefill_cuda_graph()` and write the filtered list back to `cuda_graph_config.prefill.bs` before constructing the runner.
- Keep every backend's capture buckets expressed in aggregate tokens and cap them at `context_length * max_capture_requests`: request-pool size for `tc_piecewise`/`breakable`, or the resolved fixed request-slot count for `full`.
- During capture, partition a bucket of `num_tokens` into the fewest synthetic requests such that every request has `seq_len <= context_length`.
- For `full`, preserve its fixed request-axis contract by padding any unused request slots with zero-length sentinels after the context-bounded synthetic requests.
- If filtering leaves no legal bucket, log the backend, context length, and request-pool capacity and fall back to eager prefill.
- Remove the earlier ServerArgs-time `context_length * max_running_requests` calculation because `max_running_requests` is not always resolved at that stage.
- For DeepSeek's MHA prefill path under BCG, register and select the existing `attn_mha` companion on CUDA as well as HIP. This ensures the captured attention op receives MHA head metadata instead of the same-layer-id `attn_mqa` metadata.

This preserves graph coverage for multi-request prefills while keeping every synthetic request within the per-request context bound.

## Validation

- `git diff --check`
- `python -m py_compile` on all five changed Python files
- Black check in `lmsysorg/sglang:dev-cu13`: all five changed files left unchanged

## 4xGB200 DSR1 NVFP4 verification

Passed on four NVIDIA GB200 GPUs at commit `aec6c63161` using a staged DeepSeek-R1-0528 ModelOpt NVFP4 checkpoint:

- TP4, FlashInfer attention, `context_length=2048`, `max_running_requests=8`, `chunked_prefill_size=4096`, decode CUDA graphs disabled, and FlashInfer autotuning disabled.
- Prefill graph configuration: `backend=breakable`, `bs=[4096]`. The only capture bucket is therefore larger than one request's context and is constructed as two legal synthetic requests.
- All four ranks completed `Capture target prefill CUDA graph` for 4,096 tokens in about 20.9 seconds; capture used about 1.41 GiB per GPU.
- The server reached readiness. A two-prompt `/generate` request returned four completion tokens for each prompt; server-reported prompt lengths were 1,301 and 1,301 tokens (2,602 aggregate, greater than the 2,048-token per-request context).
- Both runtime prefills logged `cuda graph: True`.
- AIHub Slurm step `4272943.2` completed with exit code `0:0`.

## Earlier H100 verification

Passed on one H100 80GB at commit `e689f496ba`:

- `Qwen/Qwen2.5-1.5B-Instruct` with `--context-length 2048 --mem-fraction-static 0.7 --attention-backend flashinfer --cuda-graph-backend-prefill tc_piecewise`.
- Piecewise prefill CUDA-graph capture completed across every configured bucket through 8,192 aggregate tokens (`4 * context_length`).
- The server reached readiness and completed its startup `/generate` request successfully.

## Related

- Fixes the capture-shape issue underlying #21112 / #22516.
- Follow-up to the discussion in #30206.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30425272323](https://github.com/sgl-project/sglang/actions/runs/30425272323)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30425272188](https://github.com/sgl-project/sglang/actions/runs/30425272188)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
