### PR TITLE
Experiment: DSV4 Flash load-only affinity diagnostics

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1308,25 +1308,89 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
           bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
 
-      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4, unified_kv_triton)
+      - name: Dump ROCm NUMA diagnostics
+        run: |
+          cat > /tmp/sglang_rocm_numa_diag.sh <<'BASH'
+          #!/bin/bash
+          set -euxo pipefail
+          echo SGLANG_NUMA_DIAG_BEGIN
+          env | sort | grep -E '^(SGLANG|CUDA|HIP|ROCR|HSA|GPU_ARCHS)=' || true
+          lscpu | grep -E 'NUMA|Socket|Core|Thread|CPU\(s\)' || true
+          numactl --hardware || true
+          numactl --show || true
+          if command -v rocm-smi >/dev/null 2>&1; then
+            rocm-smi --showtoponuma --showbus || true
+          fi
+          for p in /sys/class/drm/renderD*/device/numa_node /sys/class/drm/card*/device/numa_node; do
+            [ -e "$p" ] && echo "$p=$(cat "$p")"
+          done
+          python3 - <<'PY'
+          import os
+          from types import SimpleNamespace
+
+          import torch
+
+          from sglang.srt.utils.common import is_cuda, is_cuda_alike, is_hip
+          from sglang.srt.utils import numa_utils
+
+          print(f"torch.version.cuda={torch.version.cuda}")
+          print(f"torch.version.hip={torch.version.hip}")
+          print(f"torch.cuda.is_available()={torch.cuda.is_available()}")
+          print(f"torch.cuda.device_count()={torch.cuda.device_count()}")
+          print(f"is_cuda()={is_cuda()}")
+          print(f"is_hip()={is_hip()}")
+          print(f"is_cuda_alike()={is_cuda_alike()}")
+          print(f"numa_utils._is_cuda={numa_utils._is_cuda}")
+          print(f"SGLANG_NUMA_BIND_V2={os.environ.get('SGLANG_NUMA_BIND_V2')}")
+          print(f"SGLANG_SET_CPU_AFFINITY={os.environ.get('SGLANG_SET_CPU_AFFINITY')}")
+          print(f"os.sched_getaffinity(0)={sorted(os.sched_getaffinity(0))}")
+          print(f"numa_utils._is_numa_available()={numa_utils._is_numa_available()}")
+          server_args = SimpleNamespace(numa_node=None)
+          for gpu_id in range(torch.cuda.device_count()):
+              try:
+                  queried = numa_utils._query_numa_node_for_gpu(gpu_id)
+              except Exception as exc:
+                  queried = f"error: {type(exc).__name__}: {exc}"
+              try:
+                  available = numa_utils.get_numa_node_if_available(
+                      server_args, gpu_id
+                  )
+              except Exception as exc:
+                  available = f"error: {type(exc).__name__}: {exc}"
+              print(
+                  f"gpu_id={gpu_id} queried_numa={queried} "
+                  f"available_numa={available}"
+              )
+          PY
+          echo SGLANG_NUMA_DIAG_END
+          BASH
+          chmod +x /tmp/sglang_rocm_numa_diag.sh
+          docker cp /tmp/sglang_rocm_numa_diag.sh ci_sglang:/tmp/sglang_rocm_numa_diag.sh
+          docker exec -w /sglang-checkout/test ci_sglang bash /tmp/sglang_rocm_numa_diag.sh
+
+      - name: Load-only Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4, affinity on)
         timeout-minutes: 300
         run: |
           > github_summary.md  # Clear summary file
-          echo "## SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
+          echo "## DSV4 Flash load-only, SGLANG_SET_CPU_AFFINITY=1, SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e SGLANG_DSV4_LOAD_ONLY=1 \
+            -e SGLANG_SET_CPU_AFFINITY=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-flash --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
 
-      - name: Accuracy + Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4, triton)
+      - name: Load-only Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8 + FP4, affinity off)
         if: ${{ !cancelled() }}
         timeout-minutes: 300
         run: |
           > github_summary.md  # Clear summary file
-          echo "## SGLANG_HACK_FLASHMLA_BACKEND=triton" >> github_summary.md
+          echo "## DSV4 Flash load-only, SGLANG_SET_CPU_AFFINITY=0, SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-            -e SGLANG_HACK_FLASHMLA_BACKEND=triton \
+            -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e SGLANG_DSV4_LOAD_ONLY=1 \
+            -e SGLANG_SET_CPU_AFFINITY=0 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-flash --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true

--- a/test/registered/amd/test_deepseek_v4_flash_fp4.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp4.py
@@ -35,6 +35,7 @@ DEEPSEEK_V4_FP4_MODEL_PATH = os.environ.get(
 )
 SERVER_LAUNCH_TIMEOUT = 3600
 FLASHMLA_BACKEND = os.environ.get("SGLANG_HACK_FLASHMLA_BACKEND", "unified_kv_triton")
+LOAD_ONLY = os.environ.get("SGLANG_DSV4_LOAD_ONLY") == "1"
 
 COMMON_ENV_VARS = {
     "SGLANG_DEFAULT_THINKING": "1",
@@ -97,6 +98,18 @@ class TestDeepseekV4Fp4(CustomTestCase):
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
 
+    @unittest.skipIf(not LOAD_ONLY, "SGLANG_DSV4_LOAD_ONLY is not set")
+    def test_0_load_only(self):
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_load_only (deepseek-v4-flash-fp4, {FLASHMLA_BACKEND})\n"
+                "server launched successfully\n"
+            )
+
+    @unittest.skipIf(
+        LOAD_ONLY,
+        "SGLANG_DSV4_LOAD_ONLY=1: load-only run (skipping accuracy)",
+    )
     def test_a_gsm8k(self):
         # `a` prefix to run first (alphabetical) and warm up the server.
         args = SimpleNamespace(
@@ -119,8 +132,8 @@ class TestDeepseekV4Fp4(CustomTestCase):
             self.assertGreater(metrics["accuracy"], 0.91)
 
     @unittest.skipIf(
-        os.environ.get("SGLANG_DSV4_ACCURACY_ONLY") == "1",
-        "SGLANG_DSV4_ACCURACY_ONLY=1: accuracy-only run (skipping perf)",
+        LOAD_ONLY or os.environ.get("SGLANG_DSV4_ACCURACY_ONLY") == "1",
+        "load-only or accuracy-only run (skipping perf)",
     )
     def test_b_perf_8k_1k(self):
         json_output = "/tmp/deepseek_v4_flash_fp4_perf.json"

--- a/test/registered/amd/test_deepseek_v4_flash_fp8.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8.py
@@ -35,6 +35,7 @@ DEEPSEEK_V4_FP8_MODEL_PATH = os.environ.get(
 )
 SERVER_LAUNCH_TIMEOUT = 3600
 FLASHMLA_BACKEND = os.environ.get("SGLANG_HACK_FLASHMLA_BACKEND", "unified_kv_triton")
+LOAD_ONLY = os.environ.get("SGLANG_DSV4_LOAD_ONLY") == "1"
 
 COMMON_ENV_VARS = {
     "SGLANG_DEFAULT_THINKING": "1",
@@ -97,6 +98,18 @@ class TestDeepseekV4Fp8(CustomTestCase):
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
 
+    @unittest.skipIf(not LOAD_ONLY, "SGLANG_DSV4_LOAD_ONLY is not set")
+    def test_0_load_only(self):
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_load_only (deepseek-v4-flash-fp8, {FLASHMLA_BACKEND})\n"
+                "server launched successfully\n"
+            )
+
+    @unittest.skipIf(
+        LOAD_ONLY,
+        "SGLANG_DSV4_LOAD_ONLY=1: load-only run (skipping accuracy)",
+    )
     def test_a_gsm8k(self):
         # `a` prefix to run first (alphabetical) and warm up the server.
         args = SimpleNamespace(
@@ -119,8 +132,8 @@ class TestDeepseekV4Fp8(CustomTestCase):
             self.assertGreater(metrics["accuracy"], 0.91)
 
     @unittest.skipIf(
-        os.environ.get("SGLANG_DSV4_ACCURACY_ONLY") == "1",
-        "SGLANG_DSV4_ACCURACY_ONLY=1: accuracy-only run (skipping perf)",
+        LOAD_ONLY or os.environ.get("SGLANG_DSV4_ACCURACY_ONLY") == "1",
+        "load-only or accuracy-only run (skipping perf)",
     )
     def test_b_perf_8k_1k(self):
         json_output = "/tmp/deepseek_v4_flash_fp8_perf.json"


### PR DESCRIPTION
## Summary
- Use the smaller DeepSeek-V4-Flash ROCm720 job as a lower-cost proxy for the persistent DeepSeek-V4-Pro weight-load tail.
- Add a load-only mode for the Flash FP8/FP4 tests so CI still launches the server and emits `Load weight end`, but skips GSM8K and performance benchmarking.
- Replace the Flash job's accuracy/perf backend sweep with an explicit `SGLANG_SET_CPU_AFFINITY=1` vs `SGLANG_SET_CPU_AFFINITY=0` load-only A/B, both on `unified_kv_triton`.

## Why this experiment should be useful
The previous expensive Pro experiments showed HF cache hits and contiguous CPU -> GPU `copy` as the slow path, while async-loader disable and source-contiguous materialization did not remove the TP0/TP7 tail. The prior affinity experiment was suggestive, but the default env was not proven because the diagnostics heredoc did not execute through `amd_ci_exec.sh`.

This job is designed to avoid that ambiguity:
- The diagnostics step prints the container's default `SGLANG_SET_CPU_AFFINITY`, `SGLANG_NUMA_BIND_V2`, ROCm/PyTorch backend detection, process affinity, NUMA hardware, ROCm topology, and SGLang NUMA helper state.
- The A/B conditions are explicit forced-on vs forced-off affinity, so the result is useful even if the container default is unset or image-dependent.
- Both FP8 and FP4 Flash files run in load-only mode, preserving dtype coverage while avoiding eval/bench cost.

## Expected signal
- If Flash reproduces a TP0/TP7-style long tail, it is a valid lower-cost proxy for the Pro load-tail issue.
- If forced affinity-on is much slower than forced affinity-off, CPU affinity is a real amplifier and we should not spend more Pro runs on loader-layout hypotheses until affinity/NUMA is resolved.
- If both conditions are similarly slow, affinity is not sufficient; the next high-value experiment should target H2D copy scheduling/concurrency directly.
- If diagnostics show `is_hip()=True`, `is_cuda()=False`, and `numa_utils._is_cuda=False`, SGLang NUMA v2 is currently skipped on ROCm; that would explain why automatic NUMA binding may not be helping.

## Testing
- `python3 -m py_compile test/registered/amd/test_deepseek_v4_flash_fp4.py test/registered/amd/test_deepseek_v4_flash_fp8.py`
- YAML parsing and workflow step assertions passed for `.github/workflows/nightly-test-amd-rocm720.yml`.
- Extracted diagnostics script passed `bash -n`.
- AST assertions passed for the load-only skip decorators in both Flash test files.
- `git diff --check`
- `pre-commit run --files .github/workflows/nightly-test-amd-rocm720.yml test/registered/amd/test_deepseek_v4_flash_fp4.py test/registered/amd/test_deepseek_v4_flash_fp8.py`

Local unittest import discovery was not run because this workstation is missing `orjson`; CI installs the test dependencies before execution.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28766927753](https://github.com/sgl-project/sglang/actions/runs/28766927753)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28766927588](https://github.com/sgl-project/sglang/actions/runs/28766927588)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->