### PR TITLE
Fix HIP-only gating of bf16-nextn speculative MoE default (FP4 + EAGLE illegal memory access on sm100)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1195,8 +1195,6 @@ def _deepseek_spec_moe_resolution(view: Any) -> dict:
     model_arch = hf_config.architectures[0]
     if model_arch not in _DEEPSEEK_FAMILY_ARCHS:
         return {}
-    if not is_hip():
-        return {}
     if not (
         view.quantization == "modelopt_fp4"
         and view.speculative_algorithm == "EAGLE"


### PR DESCRIPTION
Fixes #30209.

## Motivation
The #30137 config-pipeline refactor gated the "triton fused moe by default for bf16 nextn layer" resolution behind `is_hip()`; the legacy in-branch code (DeepseekV3 arch branch in server_args.py) had no platform gate. With the gate, CUDA deployments of `_DEEPSEEK_FAMILY_ARCHS` FP4 checkpoints + EAGLE default the draft MoE to `flashinfer_trtllm`, whose bf16 batched-GEMM cubins (`Bmm_Bfloat16..._dynB_sm100f`) hit illegal memory accesses on sm100 under speculative load (exception-state coredump in the issue; kernel family = sibling of flashinfer-ai/flashinfer#3722).

## Modification
Remove the two-line `is_hip()` early-return so the default resolves on all platforms — restoring pre-#30137 semantics and covering the newly-added family members (incl. `GlmMoeDsaForCausalLM`).

## Validation
Production A/B on synchronized-mirrored identical traffic (GLM-5.2-NVFP4, 8xB200): flashinfer_trtllm spec-MoE control crashed 5× in 5h; triton arm 0 restarts. 24h+ crash-free in production since, healthy speculation (accept len 3.19 / rate 0.44), 2.5-2.8× TPOT improvement vs no-spec on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28767358067](https://github.com/sgl-project/sglang/actions/runs/28767358067)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28767357925](https://github.com/sgl-project/sglang/actions/runs/28767357925)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->