### PR TITLE
[AMD] Register 3 ROCm-portable JIT kernel tests for AMD CI

### DIFF
--- a/test/registered/jit/test_dsv32_indexer_fusion.py
+++ b/test/registered/jit/test_dsv32_indexer_fusion.py
@@ -27,12 +27,13 @@ from sglang.jit_kernel.fused_store_index_cache import (
     fused_store_index_k_cache,
 )
 from sglang.srt.utils import is_hip
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 _is_hip = is_hip()
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=90, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 HEAD_DIM = 128
 ROPE_DIM = 64

--- a/test/registered/jit/test_rmsnorm.py
+++ b/test/registered/jit/test_rmsnorm.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=240, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 
 EPS = 1e-6
@@ -35,7 +36,15 @@ def flashinfer_rmsnorm(
     output: torch.Tensor,
     eps: float = EPS,
 ) -> None:
-    from flashinfer.norm import rmsnorm
+    try:
+        from flashinfer.norm import rmsnorm
+    except ImportError:
+        # flashinfer is CUDA-only; on ROCm fall back to a torch reference so
+        # the sglang JIT kernel still gets validated (matches flashinfer math).
+        x = input.float()
+        normed = x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+        output.copy_((normed * weight.float()).to(output.dtype))
+        return
 
     rmsnorm(input, weight, out=output, eps=eps)
 

--- a/test/registered/jit/test_rmsnorm.py
+++ b/test/registered/jit/test_rmsnorm.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from sglang.jit_kernel.utils import get_ci_test_range
+from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -36,15 +37,16 @@ def flashinfer_rmsnorm(
     output: torch.Tensor,
     eps: float = EPS,
 ) -> None:
-    try:
-        from flashinfer.norm import rmsnorm
-    except ImportError:
-        # flashinfer is CUDA-only; on ROCm fall back to a torch reference so
-        # the sglang JIT kernel still gets validated (matches flashinfer math).
+    if is_hip():
+        # flashinfer is CUDA-only; on ROCm use a torch reference so the sglang
+        # JIT kernel still gets validated (matches flashinfer math). The NVIDIA
+        # path below is unchanged.
         x = input.float()
         normed = x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
         output.copy_((normed * weight.float()).to(output.dtype))
         return
+
+    from flashinfer.norm import rmsnorm
 
     rmsnorm(input, weight, out=output, eps=eps)
 

--- a/test/registered/jit/test_rmsnorm.py
+++ b/test/registered/jit/test_rmsnorm.py
@@ -37,18 +37,36 @@ def flashinfer_rmsnorm(
     output: torch.Tensor,
     eps: float = EPS,
 ) -> None:
-    if is_hip():
-        # flashinfer is CUDA-only; on ROCm use a torch reference so the sglang
-        # JIT kernel still gets validated (matches flashinfer math). The NVIDIA
-        # path below is unchanged.
-        x = input.float()
-        normed = x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
-        output.copy_((normed * weight.float()).to(output.dtype))
-        return
-
     from flashinfer.norm import rmsnorm
 
     rmsnorm(input, weight, out=output, eps=eps)
+
+
+def torch_rmsnorm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    output: torch.Tensor,
+    eps: float = EPS,
+) -> None:
+    x = input.float()
+    normed = x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+    output.copy_((normed * weight.float()).to(output.dtype))
+
+
+def reference_rmsnorm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    output: torch.Tensor,
+    eps: float = EPS,
+) -> None:
+    # NVIDIA uses flashinfer (the bitwise reference); flashinfer is CUDA-only,
+    # so on ROCm fall back to the torch reference (matches flashinfer math).
+    if is_hip():
+        torch_rmsnorm(input, weight, output=output, eps=eps)
+    else:
+        flashinfer_rmsnorm(input, weight, output=output, eps=eps)
 
 
 BS_LIST = [2**n for n in range(0, 14)]
@@ -92,9 +110,9 @@ def test_rmsnorm(
     input = torch.randn(batch_size, hidden_size, device=DEVICE, dtype=dtype)
     weight = torch.randn(hidden_size, device=DEVICE, dtype=dtype)
 
-    input_flashinfer = input.clone()
-    output_flashinfer = torch.empty_like(input)
-    flashinfer_rmsnorm(input_flashinfer, weight, output=output_flashinfer)
+    input_ref = input.clone()
+    output_ref = torch.empty_like(input)
+    reference_rmsnorm(input_ref, weight, output=output_ref)
 
     if specify_out:
         output_sglang = torch.empty_like(input)
@@ -103,7 +121,7 @@ def test_rmsnorm(
         output_sglang = input.clone()
         sglang_jit_rmsnorm(output_sglang, weight, output=output_sglang)
 
-    torch.testing.assert_close(output_sglang, output_flashinfer, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(output_sglang, output_ref, atol=1e-2, rtol=1e-2)
 
 
 @pytest.mark.parametrize("hidden_size", [64, 128, 256, 512, 8192, 8704, 16384])

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -5,10 +5,11 @@ import torch
 import triton
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=64, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=256, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=64, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16
@@ -62,7 +63,13 @@ def flashinfer_rope(
     positions: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
+    try:
+        from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
+    except ImportError:
+        # flashinfer is CUDA-only; on ROCm fall back to the torch reference,
+        # which matches its cos/sin-cache application semantics.
+        torch_impl_rope(q, k, cos_sin_cache, positions, is_neox)
+        return
 
     head_size = q.shape[-1]
     # flashinfer expects [nnz, num_heads * head_size]
@@ -78,6 +85,31 @@ def flashinfer_rope(
     )
 
 
+def _rope_rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, is_neox: bool):
+    """Rotate the first ``rotary_dim`` channels of ``x`` in place.
+
+    ``x``: [nnz, num_heads, head_size]; ``cos``/``sin``: [nnz, rotary_dim // 2].
+    Matches flashinfer's ``apply_rope_with_cos_sin_cache_inplace`` convention:
+    NeoX splits the rotary block into halves; non-NeoX (GPT-J) uses interleaved
+    even/odd pairs. Channels beyond ``rotary_dim`` are left untouched.
+    """
+    rotary_dim = cos.shape[-1] * 2
+    xf = x[..., :rotary_dim].to(torch.float32)
+    cos = cos[:, None, :]  # [nnz, 1, rotary_dim // 2]
+    sin = sin[:, None, :]
+    if is_neox:
+        x1, x2 = xf[..., : rotary_dim // 2], xf[..., rotary_dim // 2 :]
+        out1 = x1 * cos - x2 * sin
+        out2 = x2 * cos + x1 * sin
+        rotated = torch.cat((out1, out2), dim=-1)
+    else:
+        x1, x2 = xf[..., 0::2], xf[..., 1::2]
+        out1 = x1 * cos - x2 * sin
+        out2 = x2 * cos + x1 * sin
+        rotated = torch.stack((out1, out2), dim=-1).flatten(-2)
+    x[..., :rotary_dim] = rotated.to(x.dtype)
+
+
 def torch_impl_rope(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -85,8 +117,13 @@ def torch_impl_rope(
     positions: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    # TODO: implement a pure-PyTorch reference for extra coverage
-    pass
+    """Pure-PyTorch RoPE reference (in place), used as the ROCm fallback."""
+    rotary_dim = cos_sin_cache.shape[-1]
+    half = rotary_dim // 2
+    gathered = cos_sin_cache[positions.long()]
+    cos, sin = gathered[:, :half], gathered[:, half:]
+    _rope_rotate(q, cos, sin, is_neox)
+    _rope_rotate(k, cos, sin, is_neox)
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -64,12 +64,6 @@ def flashinfer_rope(
     positions: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    if is_hip():
-        # flashinfer is CUDA-only; on ROCm use the torch reference, which
-        # matches its cos/sin-cache application semantics. NVIDIA path unchanged.
-        torch_impl_rope(q, k, cos_sin_cache, positions, is_neox)
-        return
-
     from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
 
     head_size = q.shape[-1]
@@ -127,6 +121,22 @@ def torch_impl_rope(
     _rope_rotate(k, cos, sin, is_neox)
 
 
+def reference_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    # NVIDIA uses flashinfer (the reference); flashinfer is CUDA-only, so on
+    # ROCm fall back to the torch reference (matches flashinfer's cos/sin-cache
+    # application semantics).
+    if is_hip():
+        torch_impl_rope(q, k, cos_sin_cache, positions, is_neox)
+    else:
+        flashinfer_rope(q, k, cos_sin_cache, positions, is_neox)
+
+
 # ---------------------------------------------------------------------------
 # Test parameters
 # ---------------------------------------------------------------------------
@@ -170,7 +180,7 @@ def test_rope(
     q_fi, k_fi = q.clone(), k.clone()
     q_jit, k_jit = q.clone(), k.clone()
 
-    flashinfer_rope(q_fi, k_fi, cos_sin_cache, positions, is_neox)
+    reference_rope(q_fi, k_fi, cos_sin_cache, positions, is_neox)
     sglang_jit_rope(q_jit, k_jit, cos_sin_cache, positions, is_neox)
 
     atol = rtol = 1e-2
@@ -192,7 +202,7 @@ def test_rope_position_dtypes(dtype: torch.dtype) -> None:
     q_fi, k_fi = q.clone(), k.clone()
     q_jit, k_jit = q.clone(), k.clone()
 
-    flashinfer_rope(q_fi, k_fi, cos_sin_cache, positions.long(), is_neox)
+    reference_rope(q_fi, k_fi, cos_sin_cache, positions.long(), is_neox)
     sglang_jit_rope(q_jit, k_jit, cos_sin_cache, positions, is_neox)
 
     atol = rtol = 1e-2
@@ -218,7 +228,7 @@ def test_partial_rope(batch_size: int, is_neox: bool, rope_dim: int, head_dim: i
     q_jit, k_jit = q.clone(), k.clone()
     rope = ..., slice(rope_dim)  # NOTE: flashinfer by default apply to first rope_dim
 
-    flashinfer_rope(q_fi, k_fi, cos_sin_cache, positions.long(), is_neox)
+    reference_rope(q_fi, k_fi, cos_sin_cache, positions.long(), is_neox)
     sglang_jit_rope(q_jit[rope], k_jit[rope], cos_sin_cache, positions, is_neox)
 
     atol = rtol = 1e-2
@@ -261,7 +271,7 @@ def test_fused_rope_store(
 
     # --- reference: separate RoPE then manual scatter ---
     q_ref, k_ref = q.clone(), k.clone()
-    flashinfer_rope(q_ref, k_ref, cos_sin_cache, positions, is_neox)
+    reference_rope(q_ref, k_ref, cos_sin_cache, positions, is_neox)
     k_cache_ref[out_loc] = k_ref.view(batch_size, -1)
     v_cache_ref[out_loc] = v.view(batch_size, -1)
 

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -5,6 +5,7 @@ import torch
 import triton
 
 from sglang.jit_kernel.utils import get_ci_test_range
+from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=64, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -63,13 +64,13 @@ def flashinfer_rope(
     positions: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    try:
-        from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
-    except ImportError:
-        # flashinfer is CUDA-only; on ROCm fall back to the torch reference,
-        # which matches its cos/sin-cache application semantics.
+    if is_hip():
+        # flashinfer is CUDA-only; on ROCm use the torch reference, which
+        # matches its cos/sin-cache application semantics. NVIDIA path unchanged.
         torch_impl_rope(q, k, cos_sin_cache, positions, is_neox)
         return
+
+    from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
 
     head_size = q.shape[-1]
     # flashinfer expects [nnz, num_heads * head_size]


### PR DESCRIPTION
## Summary
Moves the JIT kernel correctness tests that **actually compile and pass on ROCm** onto the registered `test/registered/jit/` path (the same mechanism NVIDIA uses via `register_cuda_ci`) by adding `register_amd_ci(suite="jit-kernel-unit-test-amd")`.

Registered tests:
- **`test_rmsnorm.py`** — on ROCm (`is_hip()`), `flashinfer_rmsnorm` uses a torch reference so the JIT rmsnorm is validated; the NVIDIA path is unchanged (flashinfer only).
- **`test_rope.py`** — implemented the previously-stubbed `torch_impl_rope` (NeoX + interleaved/GPT-J, partial-rope aware, matching the `[cos|sin]` cache layout); on ROCm (`is_hip()`) `flashinfer_rope` uses it, NVIDIA still uses flashinfer. Verified **bit-exact (0.0 error)** vs an independent complex-rotation reference; ROCm run reports 218 passed / 8 skipped.
- **`test_dsv32_indexer_fusion.py`** — has an `is_hip()` code path and passes on ROCm.

**NVIDIA behavior is unchanged**: the torch references are gated behind `is_hip()`, so on CUDA every test takes the original flashinfer path verbatim.

## Why only 3
This effort originally attempted ~22 JIT tests, but ROCm CI showed the large majority of these kernels are **CUDA-only at the source level** (`cuda_fp16.h` / `cuda_bf16.h` / `cuda_runtime.h` / `cub/cub.cuh` / `cooperative_groups.h` not found, `nv_bfloat16` types, CUDA inline-asm). Those cannot be registered for AMD until the kernels themselves are ported to HIP — not fixable from the test side. This PR registers exactly the ones that pass. (Supersedes #30213/#30219/#30220.)

## Test plan
Validated on **both** AMD ROCm CI lanes:
- [x] `scripts/ci/check_registered_tests.py` passes.
- [x] `collect_tests()` resolves all 3 to `suite=jit-kernel-unit-test-amd`.
- [x] `torch_impl_rope` matches an independent complex-rotation reference (NeoX + GPT-J), max err 0.0.
- [x] `jit-kernel-unit-test-amd` green on **ROCm 7.0** (`rocm700`) — run [28829593964](https://github.com/sgl-project/sglang/actions/runs/28829593964) ✅
- [x] `jit-kernel-unit-test-amd-rocm720` green on **ROCm 7.2** (`rocm720`) — run [28829596371](https://github.com/sgl-project/sglang/actions/runs/28829596371) ✅







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28918003403](https://github.com/sgl-project/sglang/actions/runs/28918003403)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28918003333](https://github.com/sgl-project/sglang/actions/runs/28918003333)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->