### PR TITLE
[AMD] Register 8 MLA/quant/moe/hadamard JIT kernel tests for AMD CI

### DIFF
--- a/test/registered/jit/test_concat_mla.py
+++ b/test/registered/jit/test_concat_mla.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 import triton
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=17, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=17, suite="jit-kernel-unit-test-amd")
 
 
 def torch_concat_mla_k(

--- a/test/registered/jit/test_hadamard_jit.py
+++ b/test/registered/jit/test_hadamard_jit.py
@@ -14,10 +14,11 @@ from sglang.jit_kernel.hadamard import (
     hadamard_transform_28n,
     hadamard_transform_40n,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=128, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=512, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=128, suite="jit-kernel-unit-test-amd")
 
 # Exact M×N Hadamard matrices (±1 entries) copied from
 # python/sglang/jit_kernel/csrc/fast-hadamard-transform/code_gen.py.

--- a/test/registered/jit/test_moe_fused_gate.py
+++ b/test/registered/jit/test_moe_fused_gate.py
@@ -24,9 +24,10 @@ import torch
 from sglang.jit_kernel.moe_fused_gate import moe_fused_gate, moe_fused_gate_jit
 from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.srt.layers.moe.topk import biased_grouped_topk_impl
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=8, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"
 

--- a/test/registered/jit/test_moe_lora_align_block_size.py
+++ b/test/registered/jit/test_moe_lora_align_block_size.py
@@ -9,10 +9,11 @@ import torch
 # IMPORT PREBUILT KERNEL
 # ---------------------------------------------------------
 from sglang.jit_kernel.moe_lora_align import moe_lora_align_block_size
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=28, suite="jit-kernel-unit-test-amd")
 
 
 def round_up(x, base):

--- a/test/registered/jit/test_per_tensor_quant_fp8.py
+++ b/test/registered/jit/test_per_tensor_quant_fp8.py
@@ -7,10 +7,11 @@ import torch
 
 from sglang.jit_kernel.per_tensor_quant_fp8 import per_tensor_quant_fp8
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 try:
     from sglang.srt.utils import is_hip

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -9,10 +9,11 @@ from sglang.jit_kernel.per_token_group_quant_8bit import (
 )
 from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.srt.utils import is_hip
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)

--- a/test/registered/jit/test_set_mla_kv_buffer.py
+++ b/test/registered/jit/test_set_mla_kv_buffer.py
@@ -8,9 +8,10 @@ from sglang.jit_kernel.set_mla_kv_buffer import (
     set_mla_kv_buffer,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"
 CACHE_SIZE = 4096

--- a/test/registered/jit/test_timestep_embedding.py
+++ b/test/registered/jit/test_timestep_embedding.py
@@ -14,10 +14,11 @@ from sglang.jit_kernel.timestep_embedding import (
     timestep_embedding as timestep_embedding_cuda,
 )
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=16, suite="jit-kernel-unit-test-amd")
 
 CORRECTNESS_BATCH_SIZES = get_ci_test_range(
     [1, 2, 8, 128, 256, 512, 1536, 2048, 4096, 11008, 16384],


### PR DESCRIPTION
## Summary
- Second batch moving ROCm-portable JIT kernel correctness tests onto the registered `test/registered/jit/` path (the same mechanism NVIDIA uses via `register_cuda_ci`) by adding `register_amd_ci(est_time=..., suite="jit-kernel-unit-test-amd")`.
- Further closes the AMD-vs-NVIDIA "JIT kernels — separate AMD path" coverage gap on the [CI coverage dashboard](https://rocm.github.io/sglang-ci/coverage/).
- Follows batch 1 (#30212) and the established pattern (#29671, #29693, #29694, #29822).

Registered tests:
- `test_concat_mla.py`
- `test_set_mla_kv_buffer.py`
- `test_hadamard_jit.py`
- `test_timestep_embedding.py`
- `test_moe_lora_align_block_size.py`
- `test_per_token_group_quant_8bit.py`
- `test_per_tensor_quant_fp8.py`
- `test_moe_fused_gate.py`

Each keeps its `register_cuda_ci` lines unchanged; only an AMD registration (mirroring the CUDA base est_time) is added. NV-only kernels (nvfp4/marlin/cutedsl/flash-attn3-4/mxfp8/sm90), benchmarks, multi-GPU tests, `test_fused_eh_norm` (hard-skips on ROCm via `torch.version.cuda is None`), and `test_per_token_group_quant_8bit_v2` (module-level `ImportError` when the AOT op is unavailable) are intentionally excluded.

## Test plan
- [x] `scripts/ci/check_registered_tests.py` passes.
- [x] `collect_tests()` resolves all 8 to `suite=jit-kernel-unit-test-amd`.
- [ ] `jit-kernel-unit-test-amd` job green (ROCm 7.14) — dispatched run TBD.
- [ ] `jit-kernel-unit-test-amd-rocm720` job green (ROCm 7.2) — dispatched run TBD.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28768596735](https://github.com/sgl-project/sglang/actions/runs/28768596735)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28768600632](https://github.com/sgl-project/sglang/actions/runs/28768600632)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->