### PR TITLE
Fix immediate profiler step range boundary

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -144,7 +144,7 @@ class SchedulerProfilerManager:
                     self.profiler_start_forward_ct + num_steps
                 )
             else:
-                self.profiler_target_forward_ct = self.get_forward_ct() + num_steps
+                self.profiler_target_forward_ct = self.get_forward_ct() + num_steps + 1
             # The caller will be notified when reaching profiler_target_forward_ct
         else:
             self.profiler_target_forward_ct = None


### PR DESCRIPTION
## Summary

- capture all requested batch steps when profiling starts immediately
- preserve the existing explicit start_step range behavior

## Root cause

The scheduler increments the forward counter and checks profiler boundaries before executing each batch. The delayed-start path already accounts for this ordering by clamping profiler_start_forward_ct to get_forward_ct() + 1. The immediate-start target calculation omitted the corresponding +1, so a target of current plus num_steps stopped before the final requested batch and captured only num_steps minus one batches.

For the minimal case where the current forward count is 0 and num_steps is 1, the old target is 1. The first run_batch increments the counter to 1 and triggers profiler stop before that batch executes, so the trace contains zero batch steps.

## Fix

Add the missing analogous +1 to the immediate-profile exclusive stop boundary so all requested batch steps execute before profiling stops. Explicit start_step ranges remain unchanged.

## Validation

- uvx --from pre-commit pre-commit run --all-files --show-diff-on-failure

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28769677263](https://github.com/sgl-project/sglang/actions/runs/28769677263)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28769677215](https://github.com/sgl-project/sglang/actions/runs/28769677215)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->