### PR TITLE
[fix] Populate CPU mirrors for EAGLE draft extend on gpu_only batches

### DIFF
--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -156,6 +156,14 @@ class EagleDraftWorkerBase(ABC):
             # Supply CPU mirror (extend_seq_lens are all num_draft_tokens) so
             # backend max() reads from list without a per-iter D2H sync.
             forward_batch.extend_seq_lens_cpu = [num_draft_tokens] * bs
+            # DSA DRAFT_EXTEND_V2 requires extend_prefix_lens_cpu; gpu_only
+            # init_new leaves *_cpu unset when prefix_lens is a device tensor.
+            seq_lens_cpu = forward_batch.seq_lens.cpu().to(torch.int32)
+            forward_batch.seq_lens_cpu = seq_lens_cpu
+            forward_batch.seq_lens_sum = int(seq_lens_cpu.sum())
+            forward_batch.extend_prefix_lens_cpu = (
+                seq_lens_cpu - num_draft_tokens
+            ).tolist()
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run_graph(
             forward_batch
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

EAGLE V2 / MTP on models using the DSA attention backend (e.g. GLM-5.2-FP8) crashes on the first draft extend step (DRAFT_EXTEND_V2) on ROCm (MI355X gfx950).

With overlap scheduling, prepare_for_draft_extend often takes the gpu_only path (batch.seq_lens_cpu is None). ForwardBatch.init_new intentionally leaves *_cpu mirrors unset when prefix_lens / extend_lens are device tensors. The existing gpu_only branch only sets extend_seq_lens_cpu, but dsa_backend.init_forward_metadata for DRAFT_EXTEND_V2 requires:

extend_seq_lens_cpu
extend_prefix_lens_cpu
seq_lens_cpu
Without them, the server fails during warmup with:

AssertionError: All of them must not be None
This is a batch metadata contract gap between EAGLE V2 draft extend and the DSA backend — not an ROCm kernel issue and not related to DSA index-topk sharing.

## Modifications

File: python/sglang/srt/speculative/base_spec_worker.py

In prepare_for_draft_extend, gpu_only branch, after updating forward_batch.seq_lens and setting extend_seq_lens_cpu:
Sync seq_lens to CPU once (seq_lens_cpu, seq_lens_sum)
Derive extend_prefix_lens_cpu as (seq_lens_cpu - num_draft_tokens).tolist()
This satisfies DSA DRAFT_EXTEND_V2 metadata requirements with a single D2H sync on the draft-extend path only.

## Accuracy Tests

<html>
<body>
<!--StartFragment--><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 36, 81); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This change does<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">not</span><span> </span>modify model weights, kernels, or sampling logic — only CPU-side batch metadata for attention scheduling.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 36, 81); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Smoke tests</span><span> </span>on MI355X (TP4, GLM-5.2-FP8, EAGLE V2 MTP):</p><div class="ui-scroll-area" data-scroll-padding="4" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; --scroll-area-scroll-padding: 4px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.8 0.8 0.8 / 0.08); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 36, 81); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain auto; scrollbar-width: none !important;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">
Profile | steps | draft_tokens | Result

safe | 3 | 4 | 1+1=? → 2; reasoning output coherent
balanced | 1 | 2 | same
low-latency | 5 | 6 | same

</div></div></div><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 36, 81); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">MTP accept rates observed: safe<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">0.74</span>, balanced<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">0.82</span>, low-latency<span> </span><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">0.50</span><span> </span>— speculative decoding is functioning.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(255, 255, 255); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 36, 81); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;"> </span></p><!--EndFragment-->
</body>
</html>

python3 -m sglang.launch_server \
  --model-path /GLM-5.2-FP8 \
  --tp 4 --trust-remote-code \
  --reasoning-parser glm45 --tool-call-parser glm47 \
  --dsa-prefill-backend tilelang --dsa-decode-backend tilelang \
  --kv-cache-dtype fp8_e4m3 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  ...

## Speed Tests and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28770562945](https://github.com/sgl-project/sglang/actions/runs/28770562945)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28770562879](https://github.com/sgl-project/sglang/actions/runs/28770562879)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->