### PR TITLE
[AMD] Register 6 remaining ROCm-portable JIT kernel tests for AMD CI

### DIFF
--- a/test/registered/jit/deepseek_v4/test_topk_v2.py
+++ b/test/registered/jit/deepseek_v4/test_topk_v2.py
@@ -30,9 +30,10 @@ import pytest
 import torch
 
 from sglang.jit_kernel.dsv4.topk import plan_topk_v2, topk_transform_512_v2
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=90, suite="jit-kernel-unit-test-amd")
 
 PAGE_SIZE = 64  # c4 page size = 256 // 4
 PAGE_BITS = PAGE_SIZE.bit_length() - 1

--- a/test/registered/jit/minimax/test_minimax_qknorm_rope.py
+++ b/test/registered/jit/minimax/test_minimax_qknorm_rope.py
@@ -12,10 +12,11 @@ from sglang.jit_kernel.minimax_qknorm_rope import (
     minimax_qknorm_rope,
     minimax_qknorm_rope_grouped,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+register_amd_ci(est_time=30, suite="jit-kernel-unit-test-amd")
 
 dev = "cuda"
 HEAD_DIM, ROTARY_DIM, BASE, EPS = 128, 64, 5_000_000, 1e-6

--- a/test/registered/jit/test_awq_dequantize.py
+++ b/test/registered/jit/test_awq_dequantize.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.awq_dequantize import awq_dequantize as jit_awq_dequantize
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=9, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=9, suite="jit-kernel-unit-test-amd")
 
 try:
     from sgl_kernel import awq_dequantize as aot_awq_dequantize

--- a/test/registered/jit/test_dsv32_indexer_fusion.py
+++ b/test/registered/jit/test_dsv32_indexer_fusion.py
@@ -27,12 +27,13 @@ from sglang.jit_kernel.fused_store_index_cache import (
     fused_store_index_k_cache,
 )
 from sglang.srt.utils import is_hip
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 _is_hip = is_hip()
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=90, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 HEAD_DIM = 128
 ROPE_DIM = 64

--- a/test/registered/jit/test_hicache.py
+++ b/test/registered/jit/test_hicache.py
@@ -14,10 +14,11 @@ from sglang.srt.mem_cache.pool_host.common import (
     alloc_with_pin_memory,
 )
 from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=10, suite="jit-kernel-unit-test-amd")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available()

--- a/test/registered/jit/test_kpool_topk_transform.py
+++ b/test/registered/jit/test_kpool_topk_transform.py
@@ -15,9 +15,10 @@ import pytest
 import torch
 
 from sglang.jit_kernel.kpool_topk_transform import fast_kpool_topk_transform_fused
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=60, suite="jit-kernel-unit-test-amd")
 
 
 def _ref_torch_kpool_transform_impl(


### PR DESCRIPTION
## Summary
- Third/final batch of the JIT-kernel coverage push, moving the remaining ROCm-portable JIT kernel correctness tests onto the registered `test/registered/jit/` path (the same mechanism NVIDIA uses via `register_cuda_ci`) by adding `register_amd_ci(est_time=..., suite="jit-kernel-unit-test-amd")`.
- Follows batch 1 (#30212) and batch 2 (#30213); together these close the AMD-vs-NVIDIA "JIT kernels — separate AMD path" gap on the [CI coverage dashboard](https://rocm.github.io/sglang-ci/coverage/) down to the genuinely NV-only kernels.

Registered tests:
- `test_hicache.py` (explicit ROCm support: `is_hip()` page-size path)
- `test_awq_dequantize.py`
- `test_kpool_topk_transform.py` (ported from the AMD-run `sgl-kernel/tests/test_topk.py`)
- `minimax/test_minimax_qknorm_rope.py`
- `deepseek_v4/test_topk_v2.py` (`dsv4.topk` is hip-aware)
- `test_dsv32_indexer_fusion.py` (has an `is_hip()` code path)

## What's intentionally left unregistered (the true remainder)
- **NV-only kernels:** `nvfp4_*`, `*marlin*`, `mxfp8_moe`, `cutedsl_*`, `flash_attention_3/4`, `sparse_mla_q8kv8_prefill_sm90`, `symm_mem_all_gather`, `silu_and_mul_scaled_fp4_*`, `deepseek_v4/test_fp4_indexer`, `minimax/test_minimax_decode_topk_page_table` (flashinfer/trtllm Blackwell).
- **Skips on ROCm (no coverage gain):** `test_dsv3_fused_a_gemm`, `test_dsv3_router_gemm` (`pytest.skip("SM90+ required")` on `is_hip_runtime()`), `test_fused_eh_norm` (`torch.version.cuda is None`).
- **Multi-GPU (not the 1-GPU AMD JIT suite):** `test_custom_all_reduce`, `test_tp_qknorm`.
- **Module-level `ImportError` without the AOT op:** `test_per_token_group_quant_8bit_v2`.

## Test plan
- [x] `scripts/ci/check_registered_tests.py` passes.
- [x] `collect_tests()` resolves all 6 to `suite=jit-kernel-unit-test-amd`.
- [ ] `jit-kernel-unit-test-amd` job green — ROCm 7.14 dispatched run: https://github.com/sgl-project/sglang/actions/runs/28770895437
- [ ] `jit-kernel-unit-test-amd-rocm720` job green — ROCm 7.2 dispatched run: https://github.com/sgl-project/sglang/actions/runs/28770896639





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28770890731](https://github.com/sgl-project/sglang/actions/runs/28770890731)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28770895645](https://github.com/sgl-project/sglang/actions/runs/28770895645)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->