### PR TITLE
[AMD] Register rope/qknorm/fused_add_rmsnorm JIT tests with torch fallbacks

### DIFF
--- a/test/registered/jit/test_fused_add_rmsnorm.py
+++ b/test/registered/jit/test_fused_add_rmsnorm.py
@@ -5,10 +5,11 @@ import pytest
 import torch
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=10, suite="jit-kernel-unit-test-amd")
 
 
 def sglang_jit_fused_add_rmsnorm(
@@ -29,7 +30,17 @@ def sglang_jit_fused_add_rmsnorm(
 def flashinfer_fused_add_rmsnorm(
     input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float
 ) -> None:
-    from flashinfer.norm import fused_add_rmsnorm
+    try:
+        from flashinfer.norm import fused_add_rmsnorm
+    except ImportError:
+        # flashinfer is CUDA-only; on ROCm fall back to a torch reference that
+        # matches its semantics (weight multiplied in fp32, i.e. no pre-cast).
+        sum_fp32 = input.to(torch.float32) + residual.to(torch.float32)
+        residual.copy_(sum_fp32.to(input.dtype))
+        variance = sum_fp32.pow(2).mean(-1, keepdim=True)
+        normed = sum_fp32 * torch.rsqrt(variance + eps)
+        input.copy_((weight.to(torch.float32) * normed).to(input.dtype))
+        return
 
     fused_add_rmsnorm(input, residual, weight, eps=eps)
 

--- a/test/registered/jit/test_qknorm.py
+++ b/test/registered/jit/test_qknorm.py
@@ -6,10 +6,13 @@ import torch
 import triton
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
+# test_qknorm compares the sgl_kernel AOT rmsnorm against the JIT kernel (both
+# available on ROCm); the flashinfer_qknorm helper below is unused by the test.
+register_amd_ci(est_time=37, suite="jit-kernel-unit-test-amd")
 
 
 def sglang_aot_qknorm(

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -5,10 +5,11 @@ import torch
 import triton
 
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=64, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=256, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=64, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16
@@ -62,7 +63,13 @@ def flashinfer_rope(
     positions: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
+    try:
+        from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
+    except ImportError:
+        # flashinfer is CUDA-only; on ROCm fall back to the torch reference,
+        # which matches its cos/sin-cache application semantics.
+        torch_impl_rope(q, k, cos_sin_cache, positions, is_neox)
+        return
 
     head_size = q.shape[-1]
     # flashinfer expects [nnz, num_heads * head_size]
@@ -78,6 +85,31 @@ def flashinfer_rope(
     )
 
 
+def _rope_rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, is_neox: bool):
+    """Rotate the first ``rotary_dim`` channels of ``x`` in place.
+
+    ``x``: [nnz, num_heads, head_size]; ``cos``/``sin``: [nnz, rotary_dim // 2].
+    Matches flashinfer's ``apply_rope_with_cos_sin_cache_inplace`` convention:
+    NeoX splits the rotary block into halves; non-NeoX (GPT-J) uses interleaved
+    even/odd pairs. Channels beyond ``rotary_dim`` are left untouched.
+    """
+    rotary_dim = cos.shape[-1] * 2
+    xf = x[..., :rotary_dim].to(torch.float32)
+    cos = cos[:, None, :]  # [nnz, 1, rotary_dim // 2]
+    sin = sin[:, None, :]
+    if is_neox:
+        x1, x2 = xf[..., : rotary_dim // 2], xf[..., rotary_dim // 2 :]
+        out1 = x1 * cos - x2 * sin
+        out2 = x2 * cos + x1 * sin
+        rotated = torch.cat((out1, out2), dim=-1)
+    else:
+        x1, x2 = xf[..., 0::2], xf[..., 1::2]
+        out1 = x1 * cos - x2 * sin
+        out2 = x2 * cos + x1 * sin
+        rotated = torch.stack((out1, out2), dim=-1).flatten(-2)
+    x[..., :rotary_dim] = rotated.to(x.dtype)
+
+
 def torch_impl_rope(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -85,8 +117,13 @@ def torch_impl_rope(
     positions: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    # TODO: implement a pure-PyTorch reference for extra coverage
-    pass
+    """Pure-PyTorch RoPE reference (in place), used as the ROCm fallback."""
+    rotary_dim = cos_sin_cache.shape[-1]
+    half = rotary_dim // 2
+    gathered = cos_sin_cache[positions.long()]
+    cos, sin = gathered[:, :half], gathered[:, half:]
+    _rope_rotate(q, cos, sin, is_neox)
+    _rope_rotate(k, cos, sin, is_neox)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Batch 4 of the JIT-kernel AMD coverage push (follows #30212, #30213, #30219). Brings the three remaining norm/rope JIT kernel tests that used a **flashinfer** reference oracle onto the AMD registered path via `register_amd_ci(suite="jit-kernel-unit-test-amd")`.
- flashinfer is CUDA-only (`ModuleNotFoundError` on ROCm), which is exactly what turned batch 1 red. Instead of skipping, these now compute a torch reference on ROCm so the JIT kernels are genuinely validated. **NV behavior is unchanged** — flashinfer is used whenever it is importable.

## Per-file
- **`test_rope.py`** — implemented the previously-stubbed `torch_impl_rope` (NeoX + interleaved/GPT-J, partial-rope aware, matching the `[cos|sin]` cache layout) and routed `flashinfer_rope` to it on `ImportError`. The reference was verified **bit-exact (0.0 max error)** against an independent complex-rotation RoPE for both conventions.
- **`test_fused_add_rmsnorm.py`** — `flashinfer_fused_add_rmsnorm` falls back to a torch reference matching flashinfer's semantics (weight multiplied in fp32, no pre-cast).
- **`test_qknorm.py`** — no logic change; the test already compares `sgl_kernel` AOT rmsnorm vs the JIT kernel (both available on ROCm), and the `flashinfer_qknorm` helper was unused.

## Test plan
- [x] `scripts/ci/check_registered_tests.py` passes.
- [x] `collect_tests()` resolves all 3 to `suite=jit-kernel-unit-test-amd`.
- [x] `torch_impl_rope` matches an independent complex-rotation reference (NeoX + GPT-J), max err 0.0.
- [ ] `jit-kernel-unit-test-amd` job green — ROCm 7.14 run: https://github.com/sgl-project/sglang/actions/runs/28771585972
- [ ] `jit-kernel-unit-test-amd-rocm720` job green — ROCm 7.2 run: https://github.com/sgl-project/sglang/actions/runs/28771576547



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28771569878](https://github.com/sgl-project/sglang/actions/runs/28771569878)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28771576456](https://github.com/sgl-project/sglang/actions/runs/28771576456)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->