### PR TITLE
[AMD] Route PR CI to MI300 runners

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -48,6 +48,8 @@ on:
           - multimodal-gen-test-1-gpu-amd-rocm720
           - multimodal-gen-test-2-gpu-amd-rocm720
           - multimodal-gen-unit-test-amd-rocm720
+          - network-diagnostics-amd-rocm720
+          - network-diagnostics-mi300-amd-rocm720
           - stage-c-test-large-8-gpu-amd-rocm720
           - stage-c-test-large-8-gpu-amd-mi35x-rocm720
           - stage-b-test-large-8-gpu-mi35x-disaggregation-amd-rocm720
@@ -79,6 +81,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_network_diagnostics:
+        description: 'Run lightweight network probes in every AMD job'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       ref:
@@ -101,6 +108,11 @@ on:
         required: false
         type: boolean
         default: true
+      enable_network_diagnostics:
+        description: 'Run lightweight network probes in every AMD job'
+        required: false
+        type: boolean
+        default: false
 
 # Mirror pr-test.yml: the chained extra suite (call-pr-test-amd-extra-rocm720
 # -> pr-test-amd-extra.yml) declares actions: write / issues: read /
@@ -115,6 +127,8 @@ permissions:
 
 env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
+  AMD_NETWORK_DIAGNOSTICS: ${{ inputs.enable_network_diagnostics && '1' || '0' }}
+  NETWORK_DIAG_ROCM_VERSION: rocm720
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
@@ -230,6 +244,237 @@ jobs:
       aiter_ref: ${{ inputs.aiter_ref }}
       continue_on_error: true
     secrets: inherit
+
+  # =============================================== network diagnostics ====================================================
+  network-diagnostics-dockerhub-amd-rocm720:
+    name: network-diagnostics-amd-rocm720 / public-dockerhub (linux-mi300-1gpu-sglang)
+    needs: [check-changes]
+    if: |
+      always() && !cancelled() &&
+      contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',network-diagnostics-amd-rocm720,')
+    runs-on: linux-mi300-1gpu-sglang
+    timeout-minutes: 180
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Run network diagnostics (public Docker Hub)
+        env:
+          NETWORK_DIAG_SOURCE: dockerhub
+          NETWORK_DIAG_ROCM_VERSION: rocm720
+          NETWORK_DIAG_IMAGE_TAG: v0.5.14-rocm720-mi30x-20260705
+        run: bash scripts/ci/amd/network_diagnostics.sh
+
+      - name: Upload network diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-diagnostics-dockerhub-amd-rocm720-${{ github.run_id }}
+          path: ${{ runner.temp }}/network-diagnostics-*.txt
+
+  network-diagnostics-local-registry-amd-rocm720:
+    name: network-diagnostics-amd-rocm720 / local-registry (linux-mi300-1gpu-sglang)
+    needs: [check-changes]
+    if: |
+      always() && !cancelled() &&
+      contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',network-diagnostics-amd-rocm720,')
+    runs-on: linux-mi300-1gpu-sglang
+    timeout-minutes: 180
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Run network diagnostics (local registry)
+        env:
+          NETWORK_DIAG_SOURCE: local
+          NETWORK_DIAG_ROCM_VERSION: rocm720
+          NETWORK_DIAG_IMAGE_TAG: v0.5.14-rocm720-mi30x-20260705
+        run: bash scripts/ci/amd/network_diagnostics.sh
+
+      - name: Upload network diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-diagnostics-local-registry-amd-rocm720-${{ github.run_id }}
+          path: ${{ runner.temp }}/network-diagnostics-*.txt
+
+  network-diagnostics-mi300-amd-rocm720:
+    name: ${{ format('network-diagnostics-mi300-amd-rocm720 / {0} ({1}, {2})', matrix.job, matrix.runner, matrix.part) }}
+    needs: [check-changes]
+    if: |
+      always() && !cancelled() &&
+      contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',network-diagnostics-mi300-amd-rocm720,')
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: sgl-kernel-unit-test-amd-rocm720
+            job: sgl-kernel-unit-test-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: sgl-kernel-unit-test-2-gpu-amd-rocm720
+            job: sgl-kernel-unit-test-2-gpu-amd-rocm720
+            runner: linux-mi300-2gpu-sglang
+            part: main
+          - id: stage-a-test-1-gpu-small-amd-rocm720
+            job: stage-a-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: jit-kernel-unit-test-amd-rocm720
+            job: jit-kernel-unit-test-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: stage-b-test-1-gpu-small-amd-rocm720-0
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "0"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-1
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "1"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-2
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "2"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-3
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "3"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-4
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "4"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-5
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "5"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-6
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "6"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-7
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "7"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-8
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "8"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-9
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "9"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-10
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "10"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-11
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "11"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-12
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "12"
+          - id: stage-b-test-1-gpu-small-amd-rocm720-13
+            job: stage-b-test-1-gpu-small-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "13"
+          - id: stage-b-test-1-gpu-small-amd-nondeterministic-rocm720
+            job: stage-b-test-1-gpu-small-amd-nondeterministic-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: stage-b-test-1-gpu-large-amd-rocm720-0
+            job: stage-b-test-1-gpu-large-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "0"
+          - id: stage-b-test-1-gpu-large-amd-rocm720-1
+            job: stage-b-test-1-gpu-large-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "1"
+          - id: stage-b-test-2-gpu-large-amd-rocm720-0
+            job: stage-b-test-2-gpu-large-amd-rocm720
+            runner: linux-mi300-2gpu-sglang
+            part: "0"
+          - id: stage-b-test-2-gpu-large-amd-rocm720-1
+            job: stage-b-test-2-gpu-large-amd-rocm720
+            runner: linux-mi300-2gpu-sglang
+            part: "1"
+          - id: multimodal-gen-test-1-gpu-amd-rocm720-0
+            job: multimodal-gen-test-1-gpu-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "0"
+          - id: multimodal-gen-test-1-gpu-amd-rocm720-1
+            job: multimodal-gen-test-1-gpu-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "1"
+          - id: multimodal-gen-test-1-gpu-amd-rocm720-2
+            job: multimodal-gen-test-1-gpu-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "2"
+          - id: multimodal-gen-test-1-gpu-amd-rocm720-3
+            job: multimodal-gen-test-1-gpu-amd-rocm720
+            runner: linux-mi300-1gpu-sglang
+            part: "3"
+          - id: multimodal-gen-test-2-gpu-amd-rocm720-0
+            job: multimodal-gen-test-2-gpu-amd-rocm720
+            runner: linux-mi300-2gpu-sglang
+            part: "0"
+          - id: multimodal-gen-test-2-gpu-amd-rocm720-1
+            job: multimodal-gen-test-2-gpu-amd-rocm720
+            runner: linux-mi300-2gpu-sglang
+            part: "1"
+          - id: multimodal-gen-test-2-gpu-amd-rocm720-2
+            job: multimodal-gen-test-2-gpu-amd-rocm720
+            runner: linux-mi300-2gpu-sglang
+            part: "2"
+          - id: stage-c-test-4-gpu-amd-rocm720-0
+            job: stage-c-test-4-gpu-amd-rocm720
+            runner: linux-mi300-4gpu-sglang
+            part: "0"
+          - id: stage-c-test-large-8-gpu-amd-rocm720-0
+            job: stage-c-test-large-8-gpu-amd-rocm720
+            runner: linux-mi300-8gpu-sglang
+            part: "0"
+          - id: stage-c-test-large-8-gpu-amd-rocm720-1
+            job: stage-c-test-large-8-gpu-amd-rocm720
+            runner: linux-mi300-8gpu-sglang
+            part: "1"
+          - id: stage-c-test-large-8-gpu-amd-rocm720-2
+            job: stage-c-test-large-8-gpu-amd-rocm720
+            runner: linux-mi300-8gpu-sglang
+            part: "2"
+          - id: stage-c-test-large-8-gpu-amd-rocm720-3
+            job: stage-c-test-large-8-gpu-amd-rocm720
+            runner: linux-mi300-8gpu-sglang
+            part: "3"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Run high-concurrency MI300 network diagnostics
+        env:
+          NETWORK_DIAG_MODE: high-concurrency
+          NETWORK_DIAG_SOURCE: mi300
+          NETWORK_DIAG_PHASE: ${{ matrix.id }}
+          NETWORK_DIAG_ROCM_VERSION: rocm720
+          NETWORK_DIAG_IMAGE_TAG: v0.5.14-rocm720-mi30x-20260705
+        run: bash scripts/ci/amd/network_diagnostics.sh
+
+      - name: Upload network diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-diagnostics-mi300-amd-rocm720-${{ matrix.id }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/network-diagnostics-*.txt
 
   # =============================================== sgl-kernel ====================================================
   sgl-kernel-unit-test-amd-rocm720:

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -129,7 +129,6 @@ env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
   AMD_NETWORK_DIAGNOSTICS: ${{ inputs.enable_network_diagnostics && '1' || '0' }}
   NETWORK_DIAG_ROCM_VERSION: rocm720
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -129,6 +129,7 @@ env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
   AMD_NETWORK_DIAGNOSTICS: ${{ inputs.enable_network_diagnostics && '1' || '0' }}
   NETWORK_DIAG_ROCM_VERSION: rocm720
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
@@ -654,7 +655,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -918,7 +919,7 @@ jobs:
 
       - name: Setup kernel caches
         run: |
-          # Use the persistent /sgl-data directory (mounted from /home/runner/sgl-data)
+          # Use the persistent /sgl-data directory (mounted from /home/runner/sglang-data)
           # This directory persists across container restarts on the self-hosted runner
           docker exec ci_sglang mkdir -p /sgl-data/aiter-kernels /sgl-data/miopen-cache /sgl-data/hf-cache/hub
 
@@ -948,7 +949,7 @@ jobs:
           free -h
           echo ""
           echo "=== Disk Space ==="
-          df -h /home/runner/sgl-data 2>/dev/null || df -h
+          df -h /home/runner/sglang-data 2>/dev/null || df -h
           echo ""
           echo "=== HF Cache Directory Structure ==="
           docker exec ci_sglang ls -la /sgl-data/hf-cache/ 2>/dev/null || echo "HF cache dir not found"
@@ -1058,7 +1059,7 @@ jobs:
 
       - name: Setup kernel caches
         run: |
-          # Use the persistent /sgl-data directory (mounted from /home/runner/sgl-data)
+          # Use the persistent /sgl-data directory (mounted from /home/runner/sglang-data)
           docker exec ci_sglang mkdir -p /sgl-data/aiter-kernels /sgl-data/miopen-cache /sgl-data/hf-cache/hub
 
           # Clear pre-built AITER kernels from Docker image to avoid segfaults
@@ -1087,7 +1088,7 @@ jobs:
           free -h
           echo ""
           echo "=== Disk Space ==="
-          df -h /home/runner/sgl-data 2>/dev/null || df -h
+          df -h /home/runner/sglang-data 2>/dev/null || df -h
           echo ""
           echo "=== HF Cache Directory Structure ==="
           docker exec ci_sglang ls -la /sgl-data/hf-cache/ 2>/dev/null || echo "HF cache dir not found"
@@ -1165,7 +1166,7 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run test
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_moe_align.py
           docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_moe_topk_softmax.py
@@ -312,7 +312,7 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run test
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite sgl-kernel-unit-test-2-gpu-amd
 
@@ -353,7 +353,7 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run test
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-gpu-small-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -391,7 +391,7 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run JIT kernel unit tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
@@ -468,7 +468,7 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run test
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -506,7 +506,7 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run test
-        timeout-minutes: 75
+        timeout-minutes: 150
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -583,7 +583,7 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run test
-        timeout-minutes: 45
+        timeout-minutes: 90
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -622,7 +622,7 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Run test
-        timeout-minutes: 45
+        timeout-minutes: 90
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -725,7 +725,7 @@ jobs:
           docker exec ci_sglang rocm-smi --showmeminfo vram 2>/dev/null || echo "rocm-smi not available"
 
       - name: Run diffusion server tests (1-GPU)
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           # AMD CI: All 1-GPU tests except FLUX.2 (FLUX.1 covers same code path)
           # Tests: T2V, T2I, I2V, LoRA
@@ -864,7 +864,7 @@ jobs:
           docker exec ci_sglang rocm-smi --showmeminfo vram 2>/dev/null || echo "rocm-smi not available"
 
       - name: Run diffusion server tests (2-GPU)
-        timeout-minutes: 150
+        timeout-minutes: 300
         run: |
           # AMD CI: All 2-GPU tests including LoRA
           # Tests: T2V, T2I, I2V, LoRA
@@ -997,7 +997,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh \
             -e NCCL_CUMEM_ENABLE=0 \
@@ -1054,7 +1054,7 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
       - name: Test RCCL multi-GPU communication
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           echo "Testing RCCL multi-GPU communication with debug info..."
           docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=8 scripts/ci/amd/test_rccl_multi_gpu.py"

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -1030,11 +1030,11 @@ jobs:
         )
       )
     env:
-      RUNNER_LABELS: linux-mi325-8gpu-sglang
+      RUNNER_LABELS: linux-mi300-xgpu-sglang
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-8gpu-sglang]
+        runner: [linux-mi300-xgpu-sglang]
         part: [0, 1, 2, 3]
     runs-on: ${{matrix.runner}}
     steps:
@@ -1060,7 +1060,7 @@ jobs:
           docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=8 scripts/ci/amd/test_rccl_multi_gpu.py"
 
       - name: Run test
-        timeout-minutes: 120
+        timeout-minutes: 240
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
 

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -246,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -292,7 +292,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-2gpu-sglang]
+        runner: [linux-mi300-2gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -333,7 +333,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -371,7 +371,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -448,7 +448,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
         part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
     runs-on: ${{matrix.runner}}
     steps:
@@ -487,7 +487,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -563,7 +563,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
         part: [0, 1]
     runs-on: ${{matrix.runner}}
     steps:
@@ -602,7 +602,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-2gpu-sglang]
+        runner: [linux-mi300-2gpu-sglang]
         part: [0, 1]
     runs-on: ${{matrix.runner}}
     steps:
@@ -641,7 +641,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
         part: [0, 1, 2, 3]
     runs-on: ${{matrix.runner}}
     steps:
@@ -781,7 +781,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-2gpu-sglang]
+        runner: [linux-mi300-2gpu-sglang]
         part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
     runs-on: ${{matrix.runner}}
     steps:
@@ -976,7 +976,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-4gpu-sglang]
+        runner: [linux-mi300-4gpu-sglang]
         part: [0]
     runs-on: ${{matrix.runner}}
     steps:
@@ -1030,11 +1030,11 @@ jobs:
         )
       )
     env:
-      RUNNER_LABELS: linux-mi300-xgpu-sglang
+      RUNNER_LABELS: linux-mi300-8gpu-sglang
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi300-xgpu-sglang]
+        runner: [linux-mi300-8gpu-sglang]
         part: [0, 1, 2, 3]
     runs-on: ${{matrix.runner}}
     steps:

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -115,7 +115,6 @@ env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
   AMD_NETWORK_DIAGNOSTICS: ${{ inputs.enable_network_diagnostics && '1' || '0' }}
   NETWORK_DIAG_ROCM_VERSION: rocm700
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -36,6 +36,8 @@ on:
           - multimodal-gen-test-1-gpu-amd
           - multimodal-gen-test-2-gpu-amd
           - multimodal-gen-unit-test-amd
+          - network-diagnostics-amd
+          - network-diagnostics-mi300-amd
           - stage-c-test-4-gpu-amd
           - stage-c-test-large-8-gpu-amd
           - stage-c-test-large-8-gpu-amd-mi35x
@@ -65,6 +67,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_network_diagnostics:
+        description: 'Run lightweight network probes in every AMD job'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       ref:
@@ -87,6 +94,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable_network_diagnostics:
+        description: 'Run lightweight network probes in every AMD job'
+        required: false
+        type: boolean
+        default: false
 
 # Mirror pr-test.yml: the chained extra suite (call-pr-test-amd-extra ->
 # pr-test-amd-extra.yml) declares actions: write / issues: read /
@@ -101,6 +113,8 @@ permissions:
 
 env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
+  AMD_NETWORK_DIAGNOSTICS: ${{ inputs.enable_network_diagnostics && '1' || '0' }}
+  NETWORK_DIAG_ROCM_VERSION: rocm700
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
@@ -209,6 +223,241 @@ jobs:
       aiter_ref: ${{ inputs.aiter_ref }}
       continue_on_error: true
     secrets: inherit
+
+  # =============================================== network diagnostics ====================================================
+  network-diagnostics-dockerhub-amd:
+    name: network-diagnostics-amd / public-dockerhub (linux-mi300-1gpu-sglang)
+    needs: [check-changes, call-gate]
+    if: |
+      always() && !cancelled() &&
+      contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',network-diagnostics-amd,')
+    runs-on: linux-mi300-1gpu-sglang
+    timeout-minutes: 180
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Run network diagnostics (public Docker Hub)
+        env:
+          NETWORK_DIAG_SOURCE: dockerhub
+          NETWORK_DIAG_ROCM_VERSION: rocm700
+          NETWORK_DIAG_IMAGE_TAG: v0.5.14-rocm700-mi30x-20260705
+        run: bash scripts/ci/amd/network_diagnostics.sh
+
+      - name: Upload network diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-diagnostics-dockerhub-amd-${{ github.run_id }}
+          path: ${{ runner.temp }}/network-diagnostics-*.txt
+
+  network-diagnostics-local-registry-amd:
+    name: network-diagnostics-amd / local-registry (linux-mi300-1gpu-sglang)
+    needs: [check-changes, call-gate]
+    if: |
+      always() && !cancelled() &&
+      contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',network-diagnostics-amd,')
+    runs-on: linux-mi300-1gpu-sglang
+    timeout-minutes: 180
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Run network diagnostics (local registry)
+        env:
+          NETWORK_DIAG_SOURCE: local
+          NETWORK_DIAG_ROCM_VERSION: rocm700
+          NETWORK_DIAG_IMAGE_TAG: v0.5.14-rocm700-mi30x-20260705
+        run: bash scripts/ci/amd/network_diagnostics.sh
+
+      - name: Upload network diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-diagnostics-local-registry-amd-${{ github.run_id }}
+          path: ${{ runner.temp }}/network-diagnostics-*.txt
+
+  network-diagnostics-mi300-amd:
+    name: ${{ format('network-diagnostics-mi300-amd / {0} ({1}, {2})', matrix.job, matrix.runner, matrix.part) }}
+    needs: [check-changes, call-gate]
+    if: |
+      always() && !cancelled() &&
+      contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',network-diagnostics-mi300-amd,')
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: sgl-kernel-unit-test-amd
+            job: sgl-kernel-unit-test-amd
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: sgl-kernel-unit-test-2-gpu-amd
+            job: sgl-kernel-unit-test-2-gpu-amd
+            runner: linux-mi300-2gpu-sglang
+            part: main
+          - id: stage-a-test-1-gpu-small-amd
+            job: stage-a-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: jit-kernel-unit-test-amd
+            job: jit-kernel-unit-test-amd
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: stage-b-test-1-gpu-small-amd-0
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "0"
+          - id: stage-b-test-1-gpu-small-amd-1
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "1"
+          - id: stage-b-test-1-gpu-small-amd-2
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "2"
+          - id: stage-b-test-1-gpu-small-amd-3
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "3"
+          - id: stage-b-test-1-gpu-small-amd-4
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "4"
+          - id: stage-b-test-1-gpu-small-amd-5
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "5"
+          - id: stage-b-test-1-gpu-small-amd-6
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "6"
+          - id: stage-b-test-1-gpu-small-amd-7
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "7"
+          - id: stage-b-test-1-gpu-small-amd-8
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "8"
+          - id: stage-b-test-1-gpu-small-amd-9
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "9"
+          - id: stage-b-test-1-gpu-small-amd-10
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "10"
+          - id: stage-b-test-1-gpu-small-amd-11
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "11"
+          - id: stage-b-test-1-gpu-small-amd-12
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "12"
+          - id: stage-b-test-1-gpu-small-amd-13
+            job: stage-b-test-1-gpu-small-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "13"
+          - id: stage-b-test-1-gpu-small-amd-nondeterministic
+            job: stage-b-test-1-gpu-small-amd-nondeterministic
+            runner: linux-mi300-1gpu-sglang
+            part: main
+          - id: stage-b-test-1-gpu-large-amd-0
+            job: stage-b-test-1-gpu-large-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "0"
+          - id: stage-b-test-1-gpu-large-amd-1
+            job: stage-b-test-1-gpu-large-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "1"
+          - id: stage-b-test-1-gpu-large-amd-2
+            job: stage-b-test-1-gpu-large-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "2"
+          - id: stage-b-test-2-gpu-large-amd-0
+            job: stage-b-test-2-gpu-large-amd
+            runner: linux-mi300-2gpu-sglang
+            part: "0"
+          - id: stage-b-test-2-gpu-large-amd-1
+            job: stage-b-test-2-gpu-large-amd
+            runner: linux-mi300-2gpu-sglang
+            part: "1"
+          - id: multimodal-gen-test-1-gpu-amd-0
+            job: multimodal-gen-test-1-gpu-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "0"
+          - id: multimodal-gen-test-1-gpu-amd-1
+            job: multimodal-gen-test-1-gpu-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "1"
+          - id: multimodal-gen-test-1-gpu-amd-2
+            job: multimodal-gen-test-1-gpu-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "2"
+          - id: multimodal-gen-test-1-gpu-amd-3
+            job: multimodal-gen-test-1-gpu-amd
+            runner: linux-mi300-1gpu-sglang
+            part: "3"
+          - id: multimodal-gen-test-2-gpu-amd-0
+            job: multimodal-gen-test-2-gpu-amd
+            runner: linux-mi300-2gpu-sglang
+            part: "0"
+          - id: multimodal-gen-test-2-gpu-amd-1
+            job: multimodal-gen-test-2-gpu-amd
+            runner: linux-mi300-2gpu-sglang
+            part: "1"
+          - id: multimodal-gen-test-2-gpu-amd-2
+            job: multimodal-gen-test-2-gpu-amd
+            runner: linux-mi300-2gpu-sglang
+            part: "2"
+          - id: stage-c-test-4-gpu-amd-0
+            job: stage-c-test-4-gpu-amd
+            runner: linux-mi300-4gpu-sglang
+            part: "0"
+          - id: stage-c-test-large-8-gpu-amd-0
+            job: stage-c-test-large-8-gpu-amd
+            runner: linux-mi300-8gpu-sglang
+            part: "0"
+          - id: stage-c-test-large-8-gpu-amd-1
+            job: stage-c-test-large-8-gpu-amd
+            runner: linux-mi300-8gpu-sglang
+            part: "1"
+          - id: stage-c-test-large-8-gpu-amd-2
+            job: stage-c-test-large-8-gpu-amd
+            runner: linux-mi300-8gpu-sglang
+            part: "2"
+          - id: stage-c-test-large-8-gpu-amd-3
+            job: stage-c-test-large-8-gpu-amd
+            runner: linux-mi300-8gpu-sglang
+            part: "3"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Run high-concurrency MI300 network diagnostics
+        env:
+          NETWORK_DIAG_MODE: high-concurrency
+          NETWORK_DIAG_SOURCE: mi300
+          NETWORK_DIAG_PHASE: ${{ matrix.id }}
+          NETWORK_DIAG_ROCM_VERSION: rocm700
+          NETWORK_DIAG_IMAGE_TAG: v0.5.14-rocm700-mi30x-20260705
+        run: bash scripts/ci/amd/network_diagnostics.sh
+
+      - name: Upload network diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: network-diagnostics-mi300-amd-${{ matrix.id }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/network-diagnostics-*.txt
 
   # =============================================== sgl-kernel ====================================================
   sgl-kernel-unit-test-amd:

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -244,7 +244,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
           CONTINUE_ON_ERROR: ${{ needs.check-changes.outputs.continue_on_error }}
         run: |
@@ -302,7 +302,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
           CONTINUE_ON_ERROR: ${{ needs.check-changes.outputs.continue_on_error }}
         run: |
@@ -343,7 +343,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-gpu-small-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -380,7 +380,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run JIT kernel unit tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -483,7 +483,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -519,7 +519,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 75
+        timeout-minutes: 150
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -598,7 +598,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 45
+        timeout-minutes: 90
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -638,7 +638,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 45
+        timeout-minutes: 90
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
@@ -740,7 +740,7 @@ jobs:
           docker exec ci_sglang rocm-smi --showmeminfo vram 2>/dev/null || echo "rocm-smi not available"
 
       - name: Run diffusion server tests (1-GPU)
-        timeout-minutes: 90
+        timeout-minutes: 180
         run: |
           # AMD CI: All 1-GPU tests except FLUX.2 (FLUX.1 covers same code path)
           # Tests: T2V, T2I, I2V, LoRA
@@ -879,7 +879,7 @@ jobs:
           docker exec ci_sglang rocm-smi --showmeminfo vram 2>/dev/null || echo "rocm-smi not available"
 
       - name: Run diffusion server tests (2-GPU)
-        timeout-minutes: 150
+        timeout-minutes: 300
         run: |
           # AMD CI: All 2-GPU tests including LoRA
           # Tests: T2V, T2I, I2V, LoRA
@@ -1043,7 +1043,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 90
+        timeout-minutes: 180
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh \
             -e NCCL_CUMEM_ENABLE=0 \
@@ -1101,7 +1101,7 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Test RCCL multi-GPU communication
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           echo "Testing RCCL multi-GPU communication with debug info..."
           docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=8 scripts/ci/amd/test_rccl_multi_gpu.py"

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1072,7 +1072,7 @@ jobs:
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-c-test-large-8-gpu-amd:
-    name: ${{ format('stage-c-test-large-8-gpu-amd (linux-{0}-8gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
+    name: ${{ format('stage-c-test-large-8-gpu-amd (linux-mi300-xgpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
     if: |
       always() &&
@@ -1085,12 +1085,12 @@ jobs:
         )
       )
     env:
-      RUNNER_LABELS: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || 'mi325') }}
+      RUNNER_LABELS: linux-mi300-xgpu-sglang
     strategy:
       fail-fast: false
       matrix:
         part: [0, 1, 2, 3]
-    runs-on: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-xgpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1115,7 +1115,7 @@ jobs:
           docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=8 scripts/ci/amd/test_rccl_multi_gpu.py"
 
       - name: Run test
-        timeout-minutes: 120
+        timeout-minutes: 240
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 5400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -115,6 +115,7 @@ env:
   AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
   AMD_NETWORK_DIAGNOSTICS: ${{ inputs.enable_network_diagnostics && '1' || '0' }}
   NETWORK_DIAG_ROCM_VERSION: rocm700
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
   DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
   DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
@@ -634,7 +635,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   jit-kernel-benchmark-test-amd:
-    name: ${{ format('jit-kernel-benchmark-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    name: jit-kernel-benchmark-test-amd (linux-mi300-1gpu-sglang)
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -646,7 +647,7 @@ jobs:
           needs.check-changes.outputs.jit_kernel == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -937,7 +938,7 @@ jobs:
 
       - name: Setup kernel caches
         run: |
-          # Use the persistent /sgl-data directory (mounted from /home/runner/sgl-data)
+          # Use the persistent /sgl-data directory (mounted from /home/runner/sglang-data)
           # This directory persists across container restarts on the self-hosted runner
           docker exec ci_sglang mkdir -p /sgl-data/aiter-kernels /sgl-data/miopen-cache /sgl-data/hf-cache/hub
 
@@ -967,7 +968,7 @@ jobs:
           free -h
           echo ""
           echo "=== Disk Space ==="
-          df -h /home/runner/sgl-data 2>/dev/null || df -h
+          df -h /home/runner/sglang-data 2>/dev/null || df -h
           echo ""
           echo "=== HF Cache Directory Structure ==="
           docker exec ci_sglang ls -la /sgl-data/hf-cache/ 2>/dev/null || echo "HF cache dir not found"
@@ -1077,7 +1078,7 @@ jobs:
 
       - name: Setup kernel caches
         run: |
-          # Use the persistent /sgl-data directory (mounted from /home/runner/sgl-data)
+          # Use the persistent /sgl-data directory (mounted from /home/runner/sglang-data)
           docker exec ci_sglang mkdir -p /sgl-data/aiter-kernels /sgl-data/miopen-cache /sgl-data/hf-cache/hub
 
           # Clear pre-built AITER kernels from Docker image to avoid segfaults
@@ -1106,7 +1107,7 @@ jobs:
           free -h
           echo ""
           echo "=== Disk Space ==="
-          df -h /home/runner/sgl-data 2>/dev/null || df -h
+          df -h /home/runner/sglang-data 2>/dev/null || df -h
           echo ""
           echo "=== HF Cache Directory Structure ==="
           docker exec ci_sglang ls -la /sgl-data/hf-cache/ 2>/dev/null || echo "HF cache dir not found"
@@ -1175,7 +1176,7 @@ jobs:
   # that don't require NVIDIA hardware, so they should run on AMD too. This
   # closes the AMD coverage gap the dashboard surfaces for these tests.
   multimodal-gen-unit-test-amd:
-    name: ${{ format('multimodal-gen-unit-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    name: multimodal-gen-unit-test-amd (linux-mi300-1gpu-sglang)
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -1187,7 +1188,7 @@ jobs:
           needs.check-changes.outputs.multimodal_gen == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -60,14 +60,6 @@ on:
         required: false
         type: boolean
         default: false
-      runner_arch:
-        description: 'AMD runner pool to dispatch GPU jobs to'
-        required: false
-        type: choice
-        default: mi325
-        options:
-          - mi300
-          - mi325
       run_all_tests:
         description: 'Run all tests (skip change detection). Ignored when target_stage / target_stage_select is set.'
         required: false
@@ -220,7 +212,7 @@ jobs:
 
   # =============================================== sgl-kernel ====================================================
   sgl-kernel-unit-test-amd:
-    name: ${{ format('sgl-kernel-unit-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    name: sgl-kernel-unit-test-amd (linux-mi300-1gpu-sglang)
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -232,7 +224,7 @@ jobs:
           needs.check-changes.outputs.sgl_kernel == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -278,7 +270,7 @@ jobs:
           exit $failures
 
   sgl-kernel-unit-test-2-gpu-amd:
-    name: ${{ format('sgl-kernel-unit-test-2-gpu-amd (linux-{0}-2gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    name: sgl-kernel-unit-test-2-gpu-amd (linux-mi300-2gpu-sglang)
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -290,7 +282,7 @@ jobs:
           needs.check-changes.outputs.sgl_kernel == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -319,7 +311,7 @@ jobs:
   # =============================================== primary ====================================================
 
   stage-a-test-1-gpu-small-amd:
-    name: ${{ format('stage-a-test-1-gpu-small-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    name: stage-a-test-1-gpu-small-amd (linux-mi300-1gpu-sglang)
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -331,7 +323,7 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -356,7 +348,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-gpu-small-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   jit-kernel-unit-test-amd:
-    name: ${{ format('jit-kernel-unit-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    name: jit-kernel-unit-test-amd (linux-mi300-1gpu-sglang)
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -368,7 +360,7 @@ jobs:
           needs.check-changes.outputs.jit_kernel == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -456,7 +448,7 @@ jobs:
           max-wait-minutes: '240'
 
   stage-b-test-1-gpu-small-amd:
-    name: ${{ format('stage-b-test-1-gpu-small-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
+    name: ${{ format('stage-b-test-1-gpu-small-amd (linux-mi300-1gpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -472,7 +464,7 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -496,7 +488,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-b-test-1-gpu-small-amd-nondeterministic:
-    name: ${{ format('stage-b-test-1-gpu-small-amd-nondeterministic (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    name: stage-b-test-1-gpu-small-amd-nondeterministic (linux-mi300-1gpu-sglang)
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -508,7 +500,7 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -571,7 +563,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-mi35x ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-b-test-1-gpu-large-amd:
-    name: ${{ format('stage-b-test-1-gpu-large-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
+    name: ${{ format('stage-b-test-1-gpu-large-amd (linux-mi300-1gpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -587,7 +579,7 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1, 2]
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -611,7 +603,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-b-test-2-gpu-large-amd:
-    name: ${{ format('stage-b-test-2-gpu-large-amd (linux-{0}-2gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
+    name: ${{ format('stage-b-test-2-gpu-large-amd (linux-mi300-2gpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -627,7 +619,7 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1]
-    runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -651,7 +643,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   multimodal-gen-test-1-gpu-amd:
-    name: ${{ format('multimodal-gen-test-1-gpu-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
+    name: ${{ format('multimodal-gen-test-1-gpu-amd (linux-mi300-1gpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -667,7 +659,7 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1, 2, 3]
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -791,7 +783,7 @@ jobs:
           retention-days: 7
 
   multimodal-gen-test-2-gpu-amd:
-    name: ${{ format('multimodal-gen-test-2-gpu-amd (linux-{0}-2gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
+    name: ${{ format('multimodal-gen-test-2-gpu-amd (linux-mi300-2gpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -807,7 +799,7 @@ jobs:
       fail-fast: false
       matrix:
         part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
-    runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1016,7 +1008,7 @@ jobs:
           max-wait-minutes: '480'
 
   stage-c-test-4-gpu-amd:
-    name: ${{ format('stage-c-test-4-gpu-amd (linux-{0}-4gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
+    name: ${{ format('stage-c-test-4-gpu-amd (linux-mi300-4gpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
     if: |
       always() &&
@@ -1032,7 +1024,7 @@ jobs:
       fail-fast: false
       matrix:
         part: [0]
-    runs-on: ${{ format('linux-{0}-4gpu-sglang', inputs.runner_arch || 'mi325') }}
+    runs-on: linux-mi300-4gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1072,7 +1064,7 @@ jobs:
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-c-test-large-8-gpu-amd:
-    name: ${{ format('stage-c-test-large-8-gpu-amd (linux-mi300-xgpu-sglang, {0})', matrix.part) }}
+    name: ${{ format('stage-c-test-large-8-gpu-amd (linux-mi300-8gpu-sglang, {0})', matrix.part) }}
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
     if: |
       always() &&
@@ -1085,12 +1077,12 @@ jobs:
         )
       )
     env:
-      RUNNER_LABELS: linux-mi300-xgpu-sglang
+      RUNNER_LABELS: linux-mi300-8gpu-sglang
     strategy:
       fail-fast: false
       matrix:
         part: [0, 1, 2, 3]
-    runs-on: linux-mi300-xgpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -40,6 +40,27 @@ else
   echo "Warning: could not parse GPU architecture from '${HOSTNAME_VALUE}', defaulting to ${GPU_ARCH}"
 fi
 
+network_diagnostics_enabled() {
+  case "${AMD_NETWORK_DIAGNOSTICS:-0}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_network_download_diagnostics() {
+  if ! network_diagnostics_enabled; then
+    return 0
+  fi
+
+  NETWORK_DIAG_MODE="downloads" \
+  NETWORK_DIAG_SOURCE="inline" \
+  NETWORK_DIAG_PHASE="install_dependency_downloads" \
+  NETWORK_DIAG_CONTAINER="ci_sglang" \
+    bash scripts/ci/amd/network_diagnostics.sh || true
+}
+
+run_network_download_diagnostics
+
 # Install the required dependencies in CI.
 # Fix permissions on pip cache, ignore errors from concurrent access or missing temp files
 docker exec ci_sglang chown -R root:root /sgl-data/pip-cache 2>/dev/null || true

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -56,8 +56,12 @@ while [[ $# -gt 0 ]]; do
       echo "  --rocm-version VERSION     Override ROCm version for image lookup (e.g., rocm720)"
       echo ""
       echo "Environment:"
-      echo "  ENABLE_CACHE_HOST=1|0"
-      echo "      Mount /home/runner/sglang-data to /sgl-data. Defaults to 0."
+      echo "  ENABLE_CACHE_HOST=auto|1|0"
+      echo "      Mount AMD_CI_CACHE_HOST to /sgl-data. Defaults to auto (enabled on MI300/MI35x runners)."
+      echo "  AMD_CI_CACHE_HOST=/path"
+      echo "      Host cache directory. Defaults to /home/runner/sglang-data."
+      echo "  HF_TOKEN_FILE=/path"
+      echo "      Fallback Hugging Face token file when HF_TOKEN is not set. Defaults to ~/huggingface_token.txt."
       exit 0
       ;;
     *) echo "Unknown option $1"; exit 1;;
@@ -66,17 +70,25 @@ done
 
 
 
-# Detect GPU architecture from the Kubernetes runner hostname
+# Detect GPU architecture from the runner hostname.
 HOSTNAME_VALUE=$(hostname)
-GPU_ARCH="mi30x"   # default
+RUNNER_IDENTITY="${HOSTNAME_VALUE} ${RUNNER_NAME:-} ${RUNNER_LABELS:-}"
+RUNNER_GPU_ARCH="mi30x"   # default runner architecture
+GPU_ARCH="mi30x"          # default image architecture
 
-# Host names look like: linux-mi35x-gpu-1-xxxxx-runner-zzzzz
-if [[ "${HOSTNAME_VALUE}" =~ ^linux-(mi[0-9]+[a-z]*)-gpu-[0-9]+ ]]; then
-  GPU_ARCH="${BASH_REMATCH[1]}"
-  echo "Detected GPU architecture from hostname: ${GPU_ARCH}"
+# Kubernetes host names look like: linux-mi35x-gpu-1-xxxxx-runner-zzzzz
+# Self-hosted MI300 runner names look like: linux-mi300-1gpu-sglang
+if [[ "${RUNNER_IDENTITY}" =~ linux-(mi[0-9]+[a-z]*)-gpu-[0-9]+ ]]; then
+  RUNNER_GPU_ARCH="${BASH_REMATCH[1]}"
+  echo "Detected GPU architecture from runner identity: ${RUNNER_GPU_ARCH}"
+elif [[ "${RUNNER_IDENTITY}" =~ linux-(mi[0-9]+[a-z]*)-[0-9]+gpu($|[^[:alnum:]]) ]]; then
+  RUNNER_GPU_ARCH="${BASH_REMATCH[1]}"
+  echo "Detected GPU architecture from runner identity: ${RUNNER_GPU_ARCH}"
 else
-  echo "Warning: could not parse GPU architecture from '${HOSTNAME_VALUE}', defaulting to ${GPU_ARCH}"
+  echo "Warning: could not parse GPU architecture from '${RUNNER_IDENTITY}', defaulting to ${RUNNER_GPU_ARCH}"
 fi
+
+GPU_ARCH="${RUNNER_GPU_ARCH}"
 
 # Normalise / collapse architectures we don't yet build specifically for
 case "${GPU_ARCH}" in
@@ -347,8 +359,18 @@ else
   fi
 fi
 
-CACHE_HOST=/home/runner/sglang-data
-ENABLE_CACHE_HOST="${ENABLE_CACHE_HOST:-0}"
+CACHE_HOST="${AMD_CI_CACHE_HOST:-/home/runner/sglang-data}"
+ENABLE_CACHE_HOST="${ENABLE_CACHE_HOST:-auto}"
+case "${ENABLE_CACHE_HOST,,}" in
+  auto)
+    RUNNER_CACHE_IDENTITY="${RUNNER_IDENTITY,,}"
+    if [[ "${RUNNER_CACHE_IDENTITY}" == *mi300* || "${RUNNER_CACHE_IDENTITY}" == *mi35x* ]]; then
+      ENABLE_CACHE_HOST="1"
+    else
+      ENABLE_CACHE_HOST="0"
+    fi
+    ;;
+esac
 case "${ENABLE_CACHE_HOST,,}" in
   1|true|yes|on|pvc|persistent)
     if [[ ! -d "$CACHE_HOST" ]]; then
@@ -364,10 +386,31 @@ case "${ENABLE_CACHE_HOST,,}" in
     ;;
   *)
     echo "Error: unsupported ENABLE_CACHE_HOST='${ENABLE_CACHE_HOST}'" >&2
-    echo "Use 1/true/pvc/persistent or 0/false/off." >&2
+    echo "Use auto, 1/true/pvc/persistent, or 0/false/off." >&2
     exit 1
     ;;
 esac
+
+HF_TOKEN_FILE="${HF_TOKEN_FILE:-${HOME}/huggingface_token.txt}"
+if [[ -z "${HF_TOKEN:-}" && -n "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
+  HF_TOKEN="${HUGGING_FACE_HUB_TOKEN}"
+elif [[ -z "${HF_TOKEN:-}" && -r "${HF_TOKEN_FILE}" ]]; then
+  HF_TOKEN="$(<"${HF_TOKEN_FILE}")"
+fi
+if [[ -n "${HF_TOKEN:-}" && -z "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
+  HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
+fi
+export HF_TOKEN="${HF_TOKEN:-}"
+export HUGGING_FACE_HUB_TOKEN="${HUGGING_FACE_HUB_TOKEN:-}"
+if [[ -n "${HF_TOKEN}" ]]; then
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::add-mask::${HF_TOKEN}"
+    echo "::add-mask::${HUGGING_FACE_HUB_TOKEN}"
+  fi
+  echo "Hugging Face token configured for CI container."
+else
+  echo "No Hugging Face token found; gated model downloads may fail."
+fi
 
 echo "Launching container: ci_sglang"
 docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
@@ -377,7 +420,8 @@ docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
   --group-add video \
   --shm-size 32g \
   --cap-add=SYS_PTRACE \
-  -e HF_TOKEN="${HF_TOKEN:-}" \
+  --env HF_TOKEN \
+  --env HUGGING_FACE_HUB_TOKEN \
   -e HF_HOME=/sgl-data/hf-cache \
   -e HF_HUB_ETAG_TIMEOUT=300 \
   -e HF_HUB_DOWNLOAD_TIMEOUT=300 \

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -125,6 +125,64 @@ retry_with_backoff() {
   done
 }
 
+network_diagnostics_enabled() {
+  case "${AMD_NETWORK_DIAGNOSTICS:-0}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_network_diagnostics_phase() {
+  if ! network_diagnostics_enabled; then
+    return 0
+  fi
+
+  local mode="$1"
+  local phase="$2"
+  local image="${3:-}"
+  local image_tag="${NETWORK_DIAG_IMAGE_TAG:-}"
+
+  if [[ -n "${image}" && "${image}" == *":"* ]]; then
+    image_tag="${image##*:}"
+  fi
+
+  NETWORK_DIAG_MODE="${mode}" \
+  NETWORK_DIAG_SOURCE="inline" \
+  NETWORK_DIAG_PHASE="${phase}" \
+  NETWORK_DIAG_ROCM_VERSION="${ROCM_VERSION}" \
+  NETWORK_DIAG_IMAGE_TAG="${image_tag}" \
+    bash scripts/ci/amd/network_diagnostics.sh || true
+}
+
+timed_docker_pull_capture() {
+  local label="$1"
+  shift
+  local start end rc tmp
+  tmp="$(mktemp)"
+
+  echo "::group::network diagnostic: ${label}" >&2
+  echo "docker_pull_label=${label}" >&2
+  echo "docker_pull_command=$*" >&2
+  echo "docker_pull_start=$(date -Is)" >&2
+  start=$(date +%s)
+  "$@" >"${tmp}" 2>&1
+  rc=$?
+  end=$(date +%s)
+  cat "${tmp}" >&2
+  cat "${tmp}"
+  rm -f "${tmp}"
+  echo "docker_pull_rc=${rc}" >&2
+  echo "docker_pull_elapsed_sec=$((end - start))" >&2
+  echo "docker_pull_end=$(date -Is)" >&2
+  echo "::endgroup::" >&2
+  return "${rc}"
+}
+
+timed_public_docker_pull() {
+  local image="$1"
+  timed_docker_pull_capture "public docker pull ${image}" docker pull "${image}"
+}
+
 # Authenticate to Docker Hub to avoid anonymous pull rate limits.
 # Credentials are optional; when absent we fall back to unauthenticated pulls.
 if [[ -n "${DOCKERHUB_AMD_USERNAME:-}" && -n "${DOCKERHUB_AMD_TOKEN:-}" ]]; then
@@ -238,10 +296,11 @@ if [[ -n "${CUSTOM_IMAGE}" ]]; then
   # Use explicitly provided custom image
   IMAGE="${CUSTOM_IMAGE}"
   echo "Using custom image: ${IMAGE}"
+  run_network_diagnostics_phase prepull start_container_custom_prepull "${IMAGE}"
   if [[ "${IMAGE}" == "${LOCAL_DOCKER_REGISTRY}/"* ]]; then
-    docker pull "${IMAGE}"
+    timed_docker_pull_capture "custom local docker pull ${IMAGE}" docker pull "${IMAGE}"
   else
-    retry_with_backoff 6 docker pull "${IMAGE}"
+    retry_with_backoff 6 timed_public_docker_pull "${IMAGE}"
   fi
 elif [[ -n "${BUILD_FROM_DOCKERFILE}" ]]; then
   # Build image from Dockerfile
@@ -272,18 +331,19 @@ elif [[ -n "${BUILD_FROM_DOCKERFILE}" ]]; then
 else
   # Find the latest pre-built image
   IMAGE=$(find_latest_image "${GPU_ARCH}")
+  run_network_diagnostics_phase prepull start_container_prepull "${IMAGE}"
   # Try the local docker registry first (avoids Docker Hub rate limits and is
   # faster on the LAN); if that fails for any reason, fall back to the
   # public registry with exponential-backoff retries. Capture stderr so the
   # real failure reason (TLS handshake, 404, connection refused, etc.) is
   # visible in the job log instead of being silently swallowed.
-  if local_pull_output=$(docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" 2>&1); then
+  if local_pull_output=$(timed_docker_pull_capture "local docker pull ${LOCAL_DOCKER_REGISTRY}/${IMAGE}" docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}"); then
     echo "Pulled from local docker registry: ${LOCAL_DOCKER_REGISTRY}/${IMAGE}"
     docker tag "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" "${IMAGE}"
   else
     echo "Local docker registry pull failed; falling back to public registry: ${IMAGE}" >&2
     printf '%s\n' "${local_pull_output}" | sed 's/^/  [local-pull] /' >&2
-    retry_with_backoff 6 docker pull "${IMAGE}"
+    retry_with_backoff 6 timed_public_docker_pull "${IMAGE}"
   fi
 fi
 

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -60,8 +60,6 @@ while [[ $# -gt 0 ]]; do
       echo "      Mount AMD_CI_CACHE_HOST to /sgl-data. Defaults to auto (enabled on MI300/MI35x runners)."
       echo "  AMD_CI_CACHE_HOST=/path"
       echo "      Host cache directory. Defaults to /home/runner/sglang-data."
-      echo "  HF_TOKEN_FILE=/path"
-      echo "      Fallback Hugging Face token file when HF_TOKEN is not set. Defaults to ~/huggingface_token.txt."
       exit 0
       ;;
     *) echo "Unknown option $1"; exit 1;;
@@ -391,27 +389,6 @@ case "${ENABLE_CACHE_HOST,,}" in
     ;;
 esac
 
-HF_TOKEN_FILE="${HF_TOKEN_FILE:-${HOME}/huggingface_token.txt}"
-if [[ -z "${HF_TOKEN:-}" && -n "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
-  HF_TOKEN="${HUGGING_FACE_HUB_TOKEN}"
-elif [[ -z "${HF_TOKEN:-}" && -r "${HF_TOKEN_FILE}" ]]; then
-  HF_TOKEN="$(<"${HF_TOKEN_FILE}")"
-fi
-if [[ -n "${HF_TOKEN:-}" && -z "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
-  HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
-fi
-export HF_TOKEN="${HF_TOKEN:-}"
-export HUGGING_FACE_HUB_TOKEN="${HUGGING_FACE_HUB_TOKEN:-}"
-if [[ -n "${HF_TOKEN}" ]]; then
-  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
-    echo "::add-mask::${HF_TOKEN}"
-    echo "::add-mask::${HUGGING_FACE_HUB_TOKEN}"
-  fi
-  echo "Hugging Face token configured for CI container."
-else
-  echo "No Hugging Face token found; gated model downloads may fail."
-fi
-
 echo "Launching container: ci_sglang"
 docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
   --ulimit nofile=65536:65536 \
@@ -420,8 +397,7 @@ docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
   --group-add video \
   --shm-size 32g \
   --cap-add=SYS_PTRACE \
-  --env HF_TOKEN \
-  --env HUGGING_FACE_HUB_TOKEN \
+  -e HF_TOKEN="${HF_TOKEN:-}" \
   -e HF_HOME=/sgl-data/hf-cache \
   -e HF_HUB_ETAG_TIMEOUT=300 \
   -e HF_HUB_DOWNLOAD_TIMEOUT=300 \

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -49,19 +49,27 @@ done
 
 
 
-# Detect GPU architecture from the Kubernetes runner hostname
+# Detect GPU architecture from the runner hostname.
 HOSTNAME_VALUE=$(hostname)
-GPU_ARCH="mi30x"   # default
+RUNNER_IDENTITY="${HOSTNAME_VALUE} ${RUNNER_NAME:-} ${RUNNER_LABELS:-}"
+RUNNER_GPU_ARCH="mi30x"   # default runner architecture
+GPU_ARCH="mi30x"          # default image architecture
 
-# Host names look like: linux-mi35x-gpu-1-xxxxx-runner-zzzzz
-if [[ "${HOSTNAME_VALUE}" =~ ^linux-(mi[0-9]+[a-z]*)-gpu-[0-9]+ ]]; then
-  GPU_ARCH="${BASH_REMATCH[1]}"
-  echo "Detected GPU architecture from hostname: ${GPU_ARCH}"
+# Kubernetes host names look like: linux-mi35x-gpu-1-xxxxx-runner-zzzzz
+# Self-hosted MI300 runner names look like: linux-mi300-1gpu-sglang
+if [[ "${RUNNER_IDENTITY}" =~ linux-(mi[0-9]+[a-z]*)-gpu-[0-9]+ ]]; then
+  RUNNER_GPU_ARCH="${BASH_REMATCH[1]}"
+  echo "Detected GPU architecture from runner identity: ${RUNNER_GPU_ARCH}"
+elif [[ "${RUNNER_IDENTITY}" =~ linux-(mi[0-9]+[a-z]*)-[0-9]+gpu($|[^[:alnum:]]) ]]; then
+  RUNNER_GPU_ARCH="${BASH_REMATCH[1]}"
+  echo "Detected GPU architecture from runner identity: ${RUNNER_GPU_ARCH}"
 else
-  echo "Warning: could not parse GPU architecture from '${HOSTNAME_VALUE}', defaulting to ${GPU_ARCH}"
+  echo "Warning: could not parse GPU architecture from '${RUNNER_IDENTITY}', defaulting to ${RUNNER_GPU_ARCH}"
 fi
 
-# Normalise / collapse architectures we don’t yet build specifically for
+GPU_ARCH="${RUNNER_GPU_ARCH}"
+
+# Normalise / collapse architectures we don't yet build specifically for
 case "${GPU_ARCH}" in
   mi35x)
     echo "Runner uses ${GPU_ARCH}; will fetch mi35x image."
@@ -287,12 +295,57 @@ else
   retry_with_backoff 6 timed_public_docker_pull "${IMAGE}"
 fi
 
-# CACHE_HOST=/home/runner/sgl-data
-CACHE_HOST=/home/runner/temp-sglang-data
-if [[ -d "$CACHE_HOST" ]]; then
+CACHE_HOST="${AMD_CI_CACHE_HOST:-/home/runner/sglang-data}"
+ENABLE_CACHE_HOST="${ENABLE_CACHE_HOST:-auto}"
+case "${ENABLE_CACHE_HOST,,}" in
+  auto)
+    RUNNER_CACHE_IDENTITY="${RUNNER_IDENTITY,,}"
+    if [[ "${RUNNER_CACHE_IDENTITY}" == *mi300* || "${RUNNER_CACHE_IDENTITY}" == *mi35x* ]]; then
+      ENABLE_CACHE_HOST="1"
+    else
+      ENABLE_CACHE_HOST="0"
+    fi
+    ;;
+esac
+case "${ENABLE_CACHE_HOST,,}" in
+  1|true|yes|on|pvc|persistent)
+    if [[ ! -d "$CACHE_HOST" ]]; then
+      echo "Error: ENABLE_CACHE_HOST=1 but ${CACHE_HOST} does not exist." >&2
+      exit 1
+    fi
     CACHE_VOLUME="-v $CACHE_HOST:/sgl-data"
-else
+    echo "Mounting persistent CI data: ${CACHE_HOST} -> /sgl-data"
+    ;;
+  0|false|no|off|"")
     CACHE_VOLUME=""
+    echo "Not mounting ${CACHE_HOST}; /sgl-data will be container-local."
+    ;;
+  *)
+    echo "Error: unsupported ENABLE_CACHE_HOST='${ENABLE_CACHE_HOST}'" >&2
+    echo "Use auto, 1/true/pvc/persistent, or 0/false/off." >&2
+    exit 1
+    ;;
+esac
+
+HF_TOKEN_FILE="${HF_TOKEN_FILE:-${HOME}/huggingface_token.txt}"
+if [[ -z "${HF_TOKEN:-}" && -n "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
+  HF_TOKEN="${HUGGING_FACE_HUB_TOKEN}"
+elif [[ -z "${HF_TOKEN:-}" && -r "${HF_TOKEN_FILE}" ]]; then
+  HF_TOKEN="$(<"${HF_TOKEN_FILE}")"
+fi
+if [[ -n "${HF_TOKEN:-}" && -z "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
+  HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
+fi
+export HF_TOKEN="${HF_TOKEN:-}"
+export HUGGING_FACE_HUB_TOKEN="${HUGGING_FACE_HUB_TOKEN:-}"
+if [[ -n "${HF_TOKEN}" ]]; then
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::add-mask::${HF_TOKEN}"
+    echo "::add-mask::${HUGGING_FACE_HUB_TOKEN}"
+  fi
+  echo "Hugging Face token configured for CI container."
+else
+  echo "No Hugging Face token found; gated model downloads may fail."
 fi
 
 # Detect libionic library for RDMA support
@@ -374,7 +427,8 @@ docker run -dt --user root \
   --group-add video \
   --group-add rdma \
   --shm-size 32g \
-  -e HF_TOKEN="${HF_TOKEN:-}" \
+  --env HF_TOKEN \
+  --env HUGGING_FACE_HUB_TOKEN \
   -e HF_HOME=/sgl-data/hf-cache \
   -e HF_HUB_ETAG_TIMEOUT=300 \
   -e HF_HUB_DOWNLOAD_TIMEOUT=300 \
@@ -383,6 +437,12 @@ docker run -dt --user root \
   -w /sglang-checkout \
   --name ci_sglang \
   "${IMAGE}"
+
+docker exec ci_sglang mkdir -p \
+  /sgl-data/hf-cache/hub \
+  /sgl-data/pip-cache \
+  /sgl-data/miopen-cache \
+  /sgl-data/aiter-kernels
 
 # The checkout is owned by the runner (non-root) but the container runs as
 # root.  Git >= 2.35.2 rejects cross-user repos; mark the mount as safe so

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -108,6 +108,64 @@ retry_with_backoff() {
   done
 }
 
+network_diagnostics_enabled() {
+  case "${AMD_NETWORK_DIAGNOSTICS:-0}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+run_network_diagnostics_phase() {
+  if ! network_diagnostics_enabled; then
+    return 0
+  fi
+
+  local mode="$1"
+  local phase="$2"
+  local image="${3:-}"
+  local image_tag="${NETWORK_DIAG_IMAGE_TAG:-}"
+
+  if [[ -n "${image}" && "${image}" == *":"* ]]; then
+    image_tag="${image##*:}"
+  fi
+
+  NETWORK_DIAG_MODE="${mode}" \
+  NETWORK_DIAG_SOURCE="inline" \
+  NETWORK_DIAG_PHASE="${phase}" \
+  NETWORK_DIAG_ROCM_VERSION="${ROCM_VERSION}" \
+  NETWORK_DIAG_IMAGE_TAG="${image_tag}" \
+    bash scripts/ci/amd/network_diagnostics.sh || true
+}
+
+timed_docker_pull_capture() {
+  local label="$1"
+  shift
+  local start end rc tmp
+  tmp="$(mktemp)"
+
+  echo "::group::network diagnostic: ${label}" >&2
+  echo "docker_pull_label=${label}" >&2
+  echo "docker_pull_command=$*" >&2
+  echo "docker_pull_start=$(date -Is)" >&2
+  start=$(date +%s)
+  "$@" >"${tmp}" 2>&1
+  rc=$?
+  end=$(date +%s)
+  cat "${tmp}" >&2
+  cat "${tmp}"
+  rm -f "${tmp}"
+  echo "docker_pull_rc=${rc}" >&2
+  echo "docker_pull_elapsed_sec=$((end - start))" >&2
+  echo "docker_pull_end=$(date -Is)" >&2
+  echo "::endgroup::" >&2
+  return "${rc}"
+}
+
+timed_public_docker_pull() {
+  local image="$1"
+  timed_docker_pull_capture "public docker pull ${image}" docker pull "${image}"
+}
+
 # Authenticate to Docker Hub to avoid anonymous pull rate limits.
 # Credentials are optional; when absent we fall back to unauthenticated pulls.
 if [[ -n "${DOCKERHUB_AMD_USERNAME:-}" && -n "${DOCKERHUB_AMD_TOKEN:-}" ]]; then
@@ -214,18 +272,19 @@ find_latest_image() {
 
 # Pull and run the latest image
 IMAGE=$(find_latest_image "${GPU_ARCH}")
+run_network_diagnostics_phase prepull start_container_disagg_prepull "${IMAGE}"
 # Try the local docker registry first (avoids Docker Hub rate limits and is
 # faster on the LAN); if that fails for any reason, fall back to the
 # public registry with exponential-backoff retries. Capture stderr so the
 # real failure reason (TLS handshake, 404, connection refused, etc.) is
 # visible in the job log instead of being silently swallowed.
-if local_pull_output=$(docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" 2>&1); then
+if local_pull_output=$(timed_docker_pull_capture "local docker pull ${LOCAL_DOCKER_REGISTRY}/${IMAGE}" docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}"); then
   echo "Pulled from local docker registry: ${LOCAL_DOCKER_REGISTRY}/${IMAGE}"
   docker tag "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" "${IMAGE}"
 else
   echo "Local docker registry pull failed; falling back to public registry: ${IMAGE}" >&2
   printf '%s\n' "${local_pull_output}" | sed 's/^/  [local-pull] /' >&2
-  retry_with_backoff 6 docker pull "${IMAGE}"
+  retry_with_backoff 6 timed_public_docker_pull "${IMAGE}"
 fi
 
 # CACHE_HOST=/home/runner/sgl-data

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -327,27 +327,6 @@ case "${ENABLE_CACHE_HOST,,}" in
     ;;
 esac
 
-HF_TOKEN_FILE="${HF_TOKEN_FILE:-${HOME}/huggingface_token.txt}"
-if [[ -z "${HF_TOKEN:-}" && -n "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
-  HF_TOKEN="${HUGGING_FACE_HUB_TOKEN}"
-elif [[ -z "${HF_TOKEN:-}" && -r "${HF_TOKEN_FILE}" ]]; then
-  HF_TOKEN="$(<"${HF_TOKEN_FILE}")"
-fi
-if [[ -n "${HF_TOKEN:-}" && -z "${HUGGING_FACE_HUB_TOKEN:-}" ]]; then
-  HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
-fi
-export HF_TOKEN="${HF_TOKEN:-}"
-export HUGGING_FACE_HUB_TOKEN="${HUGGING_FACE_HUB_TOKEN:-}"
-if [[ -n "${HF_TOKEN}" ]]; then
-  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
-    echo "::add-mask::${HF_TOKEN}"
-    echo "::add-mask::${HUGGING_FACE_HUB_TOKEN}"
-  fi
-  echo "Hugging Face token configured for CI container."
-else
-  echo "No Hugging Face token found; gated model downloads may fail."
-fi
-
 # Detect libionic library for RDMA support
 LIBIONIC_MOUNT=""
 IONIC_SYMLINK="/usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so"
@@ -427,8 +406,7 @@ docker run -dt --user root \
   --group-add video \
   --group-add rdma \
   --shm-size 32g \
-  --env HF_TOKEN \
-  --env HUGGING_FACE_HUB_TOKEN \
+  -e HF_TOKEN="${HF_TOKEN:-}" \
   -e HF_HOME=/sgl-data/hf-cache \
   -e HF_HUB_ETAG_TIMEOUT=300 \
   -e HF_HUB_DOWNLOAD_TIMEOUT=300 \

--- a/scripts/ci/amd/network_diagnostics.sh
+++ b/scripts/ci/amd/network_diagnostics.sh
@@ -129,8 +129,8 @@ run_host_context_probes() {
     set -x
     df -h || true
     mount | grep -E "sglang-data|sgl-data|docker" || true
-    ls -ld /home/runner/sglang-data /home/runner/temp-sglang-data 2>/dev/null || true
-    du -sh /home/runner/sglang-data /home/runner/temp-sglang-data 2>/dev/null || true
+    ls -ld /home/runner/sglang-data 2>/dev/null || true
+    du -sh /home/runner/sglang-data 2>/dev/null || true
   '
 }
 

--- a/scripts/ci/amd/network_diagnostics.sh
+++ b/scripts/ci/amd/network_diagnostics.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+set -uo pipefail
+
+MODE="${NETWORK_DIAG_MODE:-full}"
+SOURCE="${NETWORK_DIAG_SOURCE:-dockerhub}"
+PHASE="${NETWORK_DIAG_PHASE:-manual}"
+ROCM_VERSION="${NETWORK_DIAG_ROCM_VERSION:-rocm700}"
+IMAGE_TAG="${NETWORK_DIAG_IMAGE_TAG:-v0.5.14-${ROCM_VERSION}-mi30x-20260705}"
+LOCAL_DOCKER_REGISTRY="${NETWORK_DIAG_LOCAL_REGISTRY:-10.44.14.109:5000}"
+PULL_TIMEOUT_SECONDS="${NETWORK_DIAG_PULL_TIMEOUT_SECONDS:-7200}"
+REMOVE_IMAGE="${NETWORK_DIAG_REMOVE_IMAGE:-1}"
+HF_RANGE_END="${NETWORK_DIAG_HF_RANGE_END:-104857599}"
+HF_URL="${NETWORK_DIAG_HF_URL:-https://huggingface.co/gpt2/resolve/main/pytorch_model.bin}"
+CONTAINER_NAME="${NETWORK_DIAG_CONTAINER:-}"
+NETWORK_DIAG_GIT_REPO="${NETWORK_DIAG_GIT_REPO:-https://github.com/EvolvingLMMs-Lab/lmms-eval.git}"
+NETWORK_DIAG_GIT_BRANCH="${NETWORK_DIAG_GIT_BRANCH-v0.4.1}"
+export NETWORK_DIAG_GIT_REPO NETWORK_DIAG_GIT_BRANCH
+
+case "${MODE}" in
+  full|prepull|downloads|high-concurrency) ;;
+  *)
+    echo "Unsupported NETWORK_DIAG_MODE='${MODE}'. Use full, prepull, downloads, or high-concurrency."
+    exit 2
+    ;;
+esac
+
+safe_job="${GITHUB_JOB:-manual}"
+safe_job="$(printf '%s' "${safe_job}" | tr -c 'A-Za-z0-9_.-' '_')"
+safe_phase="$(printf '%s' "${PHASE}" | tr -c 'A-Za-z0-9_.-' '_')"
+out_dir="${RUNNER_TEMP:-/tmp}"
+out_file="${out_dir}/network-diagnostics-${MODE}-${SOURCE}-${ROCM_VERSION}-${safe_phase}-${safe_job}.txt"
+mkdir -p "${out_dir}"
+exec > >(tee -a "${out_file}") 2>&1
+
+public_image="docker.io/rocm/sgl-dev:${IMAGE_TAG}"
+local_image="${LOCAL_DOCKER_REGISTRY}/rocm/sgl-dev:${IMAGE_TAG}"
+case "${SOURCE}" in
+  dockerhub) pull_image="${public_image}" ;;
+  local) pull_image="${local_image}" ;;
+  inline|prepull|downloads|high-concurrency|mi300) pull_image="${public_image}" ;;
+  *)
+    echo "Unsupported NETWORK_DIAG_SOURCE='${SOURCE}'. Use dockerhub, local, inline, or mi300."
+    exit 2
+    ;;
+esac
+
+probe() {
+  local key="$1"
+  local desc="$2"
+  shift 2
+  local start end rc
+
+  echo "::group::${desc}"
+  echo "${key}_start=$(date -Is)"
+  start=$(date +%s)
+  "$@"
+  rc=$?
+  end=$(date +%s)
+  echo "${key}_rc=${rc}"
+  echo "${key}_elapsed_sec=$((end - start))"
+  echo "${key}_end=$(date -Is)"
+  echo "::endgroup::"
+  return 0
+}
+
+curl_probe() {
+  local key="$1"
+  local url="$2"
+  local max_time="${3:-60}"
+
+  probe "${key}" "curl timing: ${url}" \
+    curl -L -o /dev/null -sS --max-time "${max_time}" \
+      -w "${key}_url_effective=%{url_effective}\n${key}_http_code=%{http_code}\n${key}_time_namelookup=%{time_namelookup}\n${key}_time_connect=%{time_connect}\n${key}_time_appconnect=%{time_appconnect}\n${key}_time_starttransfer=%{time_starttransfer}\n${key}_time_total=%{time_total}\n${key}_speed_download_bytes_per_sec=%{speed_download}\n" \
+      "${url}"
+}
+
+container_probe() {
+  local key="$1"
+  local desc="$2"
+  local script="$3"
+
+  if [[ -n "${CONTAINER_NAME}" ]] && docker inspect "${CONTAINER_NAME}" >/dev/null 2>&1; then
+    probe "${key}" "${desc} (container: ${CONTAINER_NAME})" \
+      docker exec "${CONTAINER_NAME}" bash -lc "${script}"
+  else
+    probe "${key}" "${desc} (host fallback)" \
+      bash -lc "${script}"
+  fi
+}
+
+write_header() {
+  echo "=== AMD network diagnostics ==="
+  echo "date=$(date -Is)"
+  echo "mode=${MODE}"
+  echo "source=${SOURCE}"
+  echo "phase=${PHASE}"
+  echo "rocm_version=${ROCM_VERSION}"
+  echo "image_tag=${IMAGE_TAG}"
+  echo "public_image=${public_image}"
+  echo "local_image=${local_image}"
+  echo "pull_image=${pull_image}"
+  echo "container_name=${CONTAINER_NAME}"
+  echo "runner_name=${RUNNER_NAME:-}"
+  echo "runner_os=${RUNNER_OS:-}"
+  echo "runner_arch=${RUNNER_ARCH:-}"
+  echo "github_run_id=${GITHUB_RUN_ID:-}"
+  echo "github_job=${GITHUB_JOB:-}"
+  echo "github_repository=${GITHUB_REPOSITORY:-}"
+  echo "github_sha=${GITHUB_SHA:-}"
+  echo "output_file=${out_file}"
+}
+
+run_host_context_probes() {
+  probe host_identity "host identity and routes" bash -lc '
+    set -x
+    hostname || true
+    uname -a || true
+    ip addr || true
+    ip route || true
+    getent hosts registry-1.docker.io || true
+    getent hosts production.cloudflare.docker.com || true
+    getent hosts huggingface.co || true
+    getent hosts files.pythonhosted.org || true
+    getent hosts github.com || true
+    getent hosts codeload.github.com || true
+  '
+
+  probe disk_and_cache "disk and cache mounts" bash -lc '
+    set -x
+    df -h || true
+    mount | grep -E "sglang-data|sgl-data|docker" || true
+    ls -ld /home/runner/sglang-data /home/runner/temp-sglang-data 2>/dev/null || true
+    du -sh /home/runner/sglang-data /home/runner/temp-sglang-data 2>/dev/null || true
+  '
+}
+
+run_registry_probes() {
+  probe docker_info "docker info" bash -lc '
+    set -x
+    docker version || true
+    docker info || true
+    docker system df || true
+  '
+
+  if [[ -n "${DOCKERHUB_AMD_USERNAME:-}" && -n "${DOCKERHUB_AMD_TOKEN:-}" ]]; then
+    probe dockerhub_login "Docker Hub login" \
+      bash -lc 'echo "${DOCKERHUB_AMD_TOKEN}" | docker login -u "${DOCKERHUB_AMD_USERNAME}" --password-stdin'
+  else
+    echo "Docker Hub login skipped: DOCKERHUB_AMD_USERNAME/DOCKERHUB_AMD_TOKEN not set."
+  fi
+
+  curl_probe dockerhub_registry_v2 https://registry-1.docker.io/v2/ 60
+  curl_probe dockerhub_tags_api "https://registry.hub.docker.com/v2/repositories/rocm/sgl-dev/tags/${IMAGE_TAG}" 60
+  curl_probe dockerhub_blob_cdn https://production.cloudflare.docker.com/ 60
+  curl_probe local_registry_v2 "http://${LOCAL_DOCKER_REGISTRY}/v2/" 60
+  curl_probe local_registry_manifest "http://${LOCAL_DOCKER_REGISTRY}/v2/rocm/sgl-dev/manifests/${IMAGE_TAG}" 60
+  curl_probe pypi_simple https://pypi.org/simple/pip/ 60
+  curl_probe huggingface_home https://huggingface.co/ 60
+  curl_probe github_home https://github.com/ 60
+  curl_probe github_raw https://raw.githubusercontent.com/sgl-project/sglang/main/README.md 60
+
+  probe docker_manifest_public "public Docker Hub manifest inspect" \
+    docker manifest inspect "${public_image}"
+}
+
+run_docker_pull_probe() {
+  if [[ "${REMOVE_IMAGE}" == "1" ]]; then
+    probe docker_remove_target_images "remove target image tags before pull" \
+      docker image rm "${pull_image}" "rocm/sgl-dev:${IMAGE_TAG}" "${public_image}" "${local_image}"
+  fi
+
+  if command -v timeout >/dev/null 2>&1; then
+    probe docker_pull "${SOURCE} docker pull: ${pull_image}" \
+      timeout "${PULL_TIMEOUT_SECONDS}" docker pull "${pull_image}"
+  else
+    probe docker_pull "${SOURCE} docker pull: ${pull_image}" \
+      docker pull "${pull_image}"
+  fi
+
+  probe docker_image_size "docker image size after pull" \
+    docker image inspect "${pull_image}" --format 'image_size_bytes={{.Size}}'
+}
+
+run_named_docker_pull_probe() {
+  local key_prefix="$1"
+  local image="$2"
+  local desc="$3"
+
+  if [[ "${REMOVE_IMAGE}" == "1" ]]; then
+    probe "${key_prefix}_remove_image" "remove target image tags before ${desc} pull" \
+      docker image rm "${image}" "rocm/sgl-dev:${IMAGE_TAG}" "${public_image}" "${local_image}"
+  fi
+
+  if command -v timeout >/dev/null 2>&1; then
+    probe "${key_prefix}_pull" "${desc} docker pull: ${image}" \
+      timeout "${PULL_TIMEOUT_SECONDS}" docker pull "${image}"
+  else
+    probe "${key_prefix}_pull" "${desc} docker pull: ${image}" \
+      docker pull "${image}"
+  fi
+
+  probe "${key_prefix}_image_size" "${desc} docker image size after pull" \
+    docker image inspect "${image}" --format 'image_size_bytes={{.Size}}'
+}
+
+run_download_probes() {
+  probe github_clone "GitHub clone speed probe: ${NETWORK_DIAG_GIT_REPO}" bash -lc '
+    set -ex
+    rm -rf /tmp/network-diag-git
+    trap "rm -rf /tmp/network-diag-git" EXIT
+    mkdir -p /tmp/network-diag-git
+    branch_args=()
+    if [[ -n "${NETWORK_DIAG_GIT_BRANCH}" ]]; then
+      branch_args=(--branch "${NETWORK_DIAG_GIT_BRANCH}")
+    fi
+    git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=30 \
+      clone --depth 1 "${branch_args[@]}" "${NETWORK_DIAG_GIT_REPO}" /tmp/network-diag-git/repo
+    du -sh /tmp/network-diag-git/repo
+  '
+
+  container_probe pypi_download "PyPI wheel download speed probe" '
+    set -ex
+    rm -rf /tmp/network-diag-pip
+    trap "rm -rf /tmp/network-diag-pip" EXIT
+    mkdir -p /tmp/network-diag-pip
+    python3 -m pip download --no-cache-dir -d /tmp/network-diag-pip pyarrow==16.1.0
+    du -sh /tmp/network-diag-pip
+  '
+
+  container_probe hf_range_download "Hugging Face range download speed probe" "
+    set -ex
+    rm -f /tmp/network-diag-hf.bin
+    trap 'rm -f /tmp/network-diag-hf.bin' EXIT
+    curl -L --range 0-${HF_RANGE_END} --max-time 900 -o /tmp/network-diag-hf.bin -sS \
+      -w 'hf_range_url_effective=%{url_effective}\nhf_range_http_code=%{http_code}\nhf_range_size_download=%{size_download}\nhf_range_time_total=%{time_total}\nhf_range_speed_download_bytes_per_sec=%{speed_download}\n' \
+      '${HF_URL}'
+    ls -lh /tmp/network-diag-hf.bin
+  "
+}
+
+run_download_probes_with_temp_container() {
+  local image="$1"
+  local previous_container="${CONTAINER_NAME}"
+  local container="network-diag-${safe_job}-${safe_phase}-$$"
+  container="$(printf '%s' "${container}" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-120)"
+
+  probe temp_container_start "start temporary container for download probes: ${image}" \
+    docker run -d --name "${container}" --entrypoint sleep "${image}" 1800
+
+  if docker inspect "${container}" >/dev/null 2>&1; then
+    CONTAINER_NAME="${container}"
+    run_download_probes
+    CONTAINER_NAME="${previous_container}"
+    probe temp_container_cleanup "remove temporary container: ${container}" \
+      docker rm -f "${container}"
+  else
+    echo "Temporary container did not start; falling back to host download probes."
+    CONTAINER_NAME="${previous_container}"
+    run_download_probes
+  fi
+}
+
+run_high_concurrency_probes() {
+  local download_probe_image=""
+
+  run_host_context_probes
+  run_registry_probes
+  run_named_docker_pull_probe docker_local "${local_image}" "local registry"
+  run_named_docker_pull_probe docker_public "${public_image}" "public Docker Hub"
+
+  if docker image inspect "${public_image}" >/dev/null 2>&1; then
+    download_probe_image="${public_image}"
+  elif docker image inspect "${local_image}" >/dev/null 2>&1; then
+    download_probe_image="${local_image}"
+  fi
+
+  if [[ -n "${download_probe_image}" ]]; then
+    run_download_probes_with_temp_container "${download_probe_image}"
+  else
+    echo "No pulled CI image available; running download probes on host."
+    run_download_probes
+  fi
+}
+
+write_summary() {
+  echo "=== diagnostic summary ==="
+  grep -E '(^docker_.*pull_|^docker_.*image_size|^github_clone_|^pypi_download_|^hf_range_|_elapsed_sec=|_rc=|speed_download|time_total|image_size_bytes)' "${out_file}" || true
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "### AMD network diagnostics (${MODE}, ${SOURCE}, ${ROCM_VERSION})"
+      echo ""
+      echo "- phase: \`${PHASE}\`"
+      echo "- image: \`${pull_image}\`"
+      echo "- log file: \`${out_file}\`"
+      echo ""
+      echo '```text'
+      grep -E '(^docker_.*pull_|^docker_.*image_size|^github_clone_|^pypi_download_|^hf_range_|_elapsed_sec=|_rc=|speed_download|time_total|image_size_bytes)' "${out_file}" || true
+      echo '```'
+    } >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+write_header
+
+case "${MODE}" in
+  prepull)
+    run_host_context_probes
+    run_registry_probes
+    ;;
+  downloads)
+    curl_probe pypi_simple https://pypi.org/simple/pip/ 60
+    curl_probe huggingface_home https://huggingface.co/ 60
+    curl_probe github_home https://github.com/ 60
+    curl_probe github_raw https://raw.githubusercontent.com/sgl-project/sglang/main/README.md 60
+    run_download_probes
+    ;;
+  full)
+    run_host_context_probes
+    run_registry_probes
+    run_docker_pull_probe
+    run_download_probes
+    ;;
+  high-concurrency)
+    run_high_concurrency_probes
+    ;;
+esac
+
+write_summary
+echo "Diagnostics complete. Probe failures are recorded above but do not fail this evidence job."
+exit 0


### PR DESCRIPTION
## Summary
- Rebase `bingxche/mi300-runner` on current `main` and resolve the workflow conflict.
- Route AMD PR MI325 jobs in `pr-test-amd.yml` and hard-coded MI325 jobs in `pr-test-amd-rocm720.yml` to matching `linux-mi300-{1,2,4,8}gpu-sglang` labels, including the newer JIT benchmark and multimodal unit jobs from `main`.
- Configure `/sgl-data` cache mounting from `${AMD_CI_CACHE_HOST:-/home/runner/sglang-data}` with a narrow default: runner identity containing `mi300` or `mi35x` enables cache, while `mi325` stays disabled unless `ENABLE_CACHE_HOST` is explicitly set.
- Inject Hugging Face credentials through `HF_TOKEN: ${{ secrets.HF_TOKEN }}` at workflow scope, with a launcher fallback to `${HF_TOKEN_FILE:-~/huggingface_token.txt}` for runner-provisioned tokens. The launchers pass `HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN` to Docker by env name instead of embedding token values in the `docker run` command line.
- Keep the AMD network diagnostics targets and inline diagnostics added for MI300 runner validation.

## Testing
- Rebased successfully on `origin/main` (`50d1edaa7f`).
- `bash -n scripts/ci/amd/amd_ci_start_container.sh scripts/ci/amd/amd_ci_start_container_disagg.sh scripts/ci/amd/amd_ci_install_dependency.sh scripts/ci/amd/network_diagnostics.sh`
- Parsed `.github/workflows/pr-test-amd.yml` and `.github/workflows/pr-test-amd-rocm720.yml` with PyYAML.
- Checked cache default matching: `mi300` on, `mi35x` on, `mi325` off.
- Pre-commit hooks passed on commit, including `check yaml`, `check for merge conflicts`, and duplicate workflow job-name validation.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

