### PR TITLE
[refactor] Retire eight single-cohort dual-applies (stack 2/11)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1985,6 +1985,12 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # the dp-attention prerequisite check is a view-reading validation
         # pass.
         "enable_dp_lm_head",
+        # Sole production reader is the ModelRunner tf32 toggle, on the tier.
+        "enable_tf32_matmul",
+        # Model-file readers and the routed-experts capturer read the tier;
+        # the remaining __post_init__ writers are earlier imperative writes,
+        # captured by publish-time materialization.
+        "disable_shared_experts_fusion",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1994,6 +1994,18 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # Sampler construction, the deterministic force and the token-oracle
         # gate all read the tier; the hpu/cpu early writers stay imperative.
         "sampling_backend",
+        # Pool configurator reads the tier; the range check in
+        # _handle_cache_compatibility validates the pristine user input.
+        "swa_full_tokens_ratio",
+        # Communicator and capture-time runner read the tier; the
+        # deprecated-alias fill runs pre-declaration on pristine input.
+        "flashinfer_allreduce_fusion_backend",
+        # initialize_moe_config reads the tier for the draft MoE fields.
+        "speculative_moe_runner_backend",
+        "speculative_moe_a2a_backend",
+        # TBO / communicator / dp-attention init / the require_* helpers read
+        # the tier; check_server_args validates the pristine user input.
+        "moe_dense_tp_size",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1991,6 +1991,9 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # the remaining __post_init__ writers are earlier imperative writes,
         # captured by publish-time materialization.
         "disable_shared_experts_fusion",
+        # Sampler construction, the deterministic force and the token-oracle
+        # gate all read the tier; the hpu/cpu early writers stay imperative.
+        "sampling_backend",
     }
 )
 

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -760,7 +760,7 @@ class TboForwardBatchPreparer:
 
         # TODO improve, e.g. unify w/ `init_raw`
         if (
-            get_global_server_args().moe_dense_tp_size == 1
+            get_flags().moe_dense_tp_size == 1
             and batch.global_dp_buffer_len is not None
         ):
             sum_len = end_token_index - start_token_index

--- a/python/sglang/srt/kv_canary/token_oracle/install.py
+++ b/python/sglang/srt/kv_canary/token_oracle/install.py
@@ -15,7 +15,9 @@ def install_token_oracle_from_env(
 ) -> Optional[TokenOracleManager]:
     # Must be called before create_sampler() so the factory is present when the
     # Sampler is first constructed.
-    if server_args.sampling_backend != "token_oracle":
+    from sglang.srt.runtime_context import get_flags
+
+    if get_flags().sampling_backend != "token_oracle":
         return None
 
     oracle = HashOracle(vocab_size=vocab_size)

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -70,7 +70,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
@@ -169,7 +169,7 @@ def apply_flashinfer_allreduce_fusion(batch_size: int):
         and batch_size > 0
         and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
         and not is_dp_attention_enabled()
-        and get_global_server_args().flashinfer_allreduce_fusion_backend is not None
+        and get_flags().flashinfer_allreduce_fusion_backend is not None
         and not is_flashinfer_allreduce_unavailable()
     )
 
@@ -429,7 +429,7 @@ class LayerScatterModes:
 
 
 def enable_moe_dense_fully_dp():
-    return get_global_server_args().moe_dense_tp_size == 1
+    return get_flags().moe_dense_tp_size == 1
 
 
 class LayerCommunicator:

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -29,6 +29,7 @@ from sglang.srt.distributed import (
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import get_bool_env_var, is_hip
 
 if TYPE_CHECKING:
@@ -288,7 +289,7 @@ def initialize_dp_attention(
     )
     enable_dp_attention = server_args.enable_dp_attention
     dp_size = server_args.dp_size
-    moe_dense_tp_size = server_args.moe_dense_tp_size
+    moe_dense_tp_size = get_flags().moe_dense_tp_size
     attn_cp_size = server_args.attn_cp_size
 
     _ENABLE_DP_ATTENTION_FLAG = enable_dp_attention

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -665,8 +665,13 @@ def ensure_workspace_initialized(
     token_num = token_num or max_token_num
     group_key = (device_group, cpu_group)
     effective_dtype = dtype or torch.bfloat16
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # The auto-enable declaration lives on the declaration stash / flags
+    # tier; the retired server_args field stays pristine (None), so the
+    # backend must be resolved through the view.
     server_args = get_global_server_args()
-    backend = resolve_flashinfer_allreduce_fusion_backend(server_args)
+    backend = resolve_flashinfer_allreduce_fusion_backend(resolved_view(server_args))
     if backend is None:
         return False
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -273,14 +273,19 @@ def initialize_moe_config(server_args: ServerArgs):
 
     MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
     MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # Scheduler.init_moe_gemm_config calls this before init_model_worker
+    # publishes the flags tier: read the resolved values through the view.
+    view = resolved_view(server_args)
     SPECULATIVE_MOE_RUNNER_BACKEND = (
-        MoeRunnerBackend(server_args.speculative_moe_runner_backend)
-        if server_args.speculative_moe_runner_backend is not None
+        MoeRunnerBackend(view.speculative_moe_runner_backend)
+        if view.speculative_moe_runner_backend is not None
         else MOE_RUNNER_BACKEND
     )
     SPECULATIVE_MOE_A2A_BACKEND = (
-        MoeA2ABackend(server_args.speculative_moe_a2a_backend)
-        if server_args.speculative_moe_a2a_backend is not None
+        MoeA2ABackend(view.speculative_moe_a2a_backend)
+        if view.speculative_moe_a2a_backend is not None
         else MOE_A2A_BACKEND
     )
     DEEPEP_MODE = DeepEPMode(server_args.deepep_mode)

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -461,8 +461,7 @@ def register_sampler_backend(backend: str, factory: Callable[[], "Sampler"]) -> 
 def create_sampler(backend: Optional[str] = None) -> "Sampler":
     """Create a sampler honoring custom backend registrations."""
 
-    server_args = get_global_server_args()
-    backend = backend or (server_args.sampling_backend if server_args else None)
+    backend = backend or get_flags().sampling_backend
 
     if backend in _CUSTOM_SAMPLER_FACTORIES:
         sampler = _CUSTOM_SAMPLER_FACTORIES[backend]()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -997,7 +997,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             # would overwrite the target's process-global one.
             return
 
-        if not self.server_args.disable_shared_experts_fusion and hasattr(
+        if not get_flags().disable_shared_experts_fusion and hasattr(
             self.model, "num_fused_shared_experts"
         ):
             num_fused_shared_experts = self.model.num_fused_shared_experts

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -33,6 +33,7 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.mem_cache.common import get_alloc_len_per_decode
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils.common import (
     ceil_align,
     ceil_div,
@@ -300,7 +301,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
             self._swa_layers_num > 0
         ), "Hybrid SWA model must have at least one SWA layer"
 
-        self._swa_full_tokens_ratio = mr.server_args.swa_full_tokens_ratio
+        self._swa_full_tokens_ratio = get_flags().swa_full_tokens_ratio
 
         # Full layer per-token memory (bytes)
         self._full_per_token = (
@@ -533,7 +534,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 f"local={len(self.compression_ratios)}/{len(cfg.compress_ratios)}"
             )
         self.swa_page_size = cfg.window_size
-        self.swa_ratio = mr.server_args.swa_full_tokens_ratio
+        self.swa_ratio = get_flags().swa_full_tokens_ratio
         self.is_speculative = mr.server_args.speculative_algorithm is not None
         self.online_c128_mtp_max_draft_tokens = (
             mr.server_args.max_speculative_num_draft_tokens or 0

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -239,7 +239,7 @@ class BaseRunner(ABC):
         with custom_all_reduce.register_graph_buffers).
         """
         mr = self.model_runner
-        if mr.server_args.flashinfer_allreduce_fusion_backend is None:
+        if get_flags().flashinfer_allreduce_fusion_backend is None:
             return
 
         from sglang.srt.layers.communicator import FUSE_ALLREDUCE_MAX_BATCH_SIZE

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3459,7 +3459,7 @@ def require_mlp_tp_gather(server_args: ServerArgs):
         view = resolved_view(server_args)
         assert server_args.dp_size > 1, "dp_size must be greater than 1"
         if (
-            server_args.moe_dense_tp_size is None
+            view.moe_dense_tp_size is None
         ):  # TODO(ch-wan): some MoE models do not have dense layers
             return True
         elif not view.enable_dp_lm_head:
@@ -3467,10 +3467,7 @@ def require_mlp_tp_gather(server_args: ServerArgs):
         elif get_moe_a2a_backend().is_none():
             return True
         else:
-            return (
-                server_args.moe_dense_tp_size
-                > server_args.tp_size // server_args.dp_size
-            )
+            return view.moe_dense_tp_size > server_args.tp_size // server_args.dp_size
     else:
         return False
 
@@ -3486,9 +3483,13 @@ def require_attn_tp_gather(server_args: ServerArgs):
     if server_args.disable_attn_tp_gather:
         return False
 
+    from sglang.srt.arg_groups.overrides import resolved_view
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
-    if not get_moe_a2a_backend().is_none() or server_args.moe_dense_tp_size is not None:
+    if (
+        not get_moe_a2a_backend().is_none()
+        or resolved_view(server_args).moe_dense_tp_size is not None
+    ):
         if server_args.enable_dp_attention:
             return server_args.dp_size < server_args.tp_size
         else:

--- a/test/registered/mock_model/test_self_unit_install.py
+++ b/test/registered/mock_model/test_self_unit_install.py
@@ -17,6 +17,10 @@ register_amd_ci(est_time=60, suite="extra-a-test-1-gpu-small-amd")
 
 
 def _make_server_args(*, sampling_backend: str) -> SimpleNamespace:
+    # The install gate reads the resolved backend from the flags tier.
+    from sglang.srt.runtime_context import get_flags
+
+    get_flags().sampling_backend = sampling_backend
     return SimpleNamespace(sampling_backend=sampling_backend)
 
 

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -102,6 +102,10 @@ def _make_model_runner(
 
     sa = SimpleNamespace()
     sa.swa_full_tokens_ratio = swa_full_tokens_ratio
+    # The configurator reads the resolved ratio from the flags tier.
+    from sglang.srt.runtime_context import get_flags
+
+    get_flags().swa_full_tokens_ratio = swa_full_tokens_ratio
     sa.page_size = page_size
     sa.disable_radix_cache = disable_radix_cache
     sa.chunked_prefill_size = chunked_prefill_size

--- a/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
+++ b/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
@@ -42,8 +42,8 @@ class TestDeepseekV4SharedExpertFusionPolicy(unittest.TestCase):
 
         self.assertEqual(model.num_fused_shared_experts, 0)
         self.assertTrue(get_flags().disable_shared_experts_fusion)
-        # dual-apply transition: the published config carries the value too
-        self.assertTrue(server_args.disable_shared_experts_fusion)
+        # dual-apply retired: the published config keeps the pristine input
+        self.assertFalse(server_args.disable_shared_experts_fusion)
 
     def test_enables_shared_fusion_when_enforced(self):
         server_args = self._publish(enforce=True)

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -25,7 +25,7 @@ _SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
 # Baselines counted over python/sglang/srt/**/*.py, including each function's
 # own def line. Ratchet: decrease-only.
 _RATCHETS = [
-    ("get_global_server_args", r"\bget_global_server_args\s*\(", 280),
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 279),
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -25,7 +25,7 @@ _SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
 # Baselines counted over python/sglang/srt/**/*.py, including each function's
 # own def line. Ratchet: decrease-only.
 _RATCHETS = [
-    ("get_global_server_args", r"\bget_global_server_args\s*\(", 279),
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 276),
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -446,7 +446,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_minimax_m2_enables_tf32_matmul(self):
         sa = self._construct("MiniMaxM2ForCausalLM", "llama")
-        self.assertTrue(sa.enable_tf32_matmul)  # dual-apply == legacy write
+        self.assertFalse(sa.enable_tf32_matmul)  # dual-apply retired: pristine
         self.assertIn(
             ("_minimax_m2_overrides", {"enable_tf32_matmul": True}),
             sa._resolved_overrides,

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -569,7 +569,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
         sa = self._construct("LlamaForCausalLM", "llama")
         expected = "flashinfer" if is_flashinfer_available() else "pytorch"
-        self.assertEqual(sa.sampling_backend, expected)
+        self.assertIsNone(sa.sampling_backend)  # dual-apply retired: pristine
         self.assertIn(
             ("_sampling_backend_default", {"sampling_backend": expected}),
             sa._resolved_overrides,
@@ -587,8 +587,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "LlamaForCausalLM", "llama", enable_deterministic_inference=True
         )
         # two pass writers chain: default fill, then the deterministic force —
-        # last writer wins on the flags leaf and parity holds end-to-end.
-        self.assertEqual(sa.sampling_backend, "pytorch")
+        # last writer wins on the flags leaf; the server_args field stays
+        # pristine (dual-apply retired).
+        self.assertIsNone(sa.sampling_backend)
         flags = self._publish(sa)
         self.assertEqual(flags.sampling_backend, "pytorch")
         # the deterministic attention fill declared a compatible backend and

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -491,8 +491,8 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             config_extra=config_extra,
             enable_hierarchical_cache=True,
         )
-        # dual-apply == legacy writes
-        self.assertEqual(sa.swa_full_tokens_ratio, 1.0)
+        # dual-apply retired: the field stays pristine
+        self.assertEqual(sa.swa_full_tokens_ratio, 0.8)
         self.assertTrue(sa.disable_hybrid_swa_memory)
         flags = self._publish(sa)
         self.assertEqual(flags.swa_full_tokens_ratio, 1.0)
@@ -838,6 +838,32 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             assert_flag_parity(flags, args, {"page_size"})  # no raise
         with self.assertRaises(AssertionError):
             assert_flag_parity(flags, args, {"page_size"})
+
+    def test_initialize_moe_config_reads_resolving_state_prepublish(self):
+        # Scheduler.init_moe_gemm_config runs before the model worker
+        # publishes the flags tier: initialize_moe_config must read the
+        # declaration stash through the view, not the (still default)
+        # process-global flags.
+        import sglang.srt.layers.moe.utils as moe_utils
+        from sglang.srt.runtime_context import reset_context
+
+        sa = self._construct("LlamaForCausalLM", "llama")
+        sa._resolved_overrides.append(
+            ("test.declared", {"speculative_moe_runner_backend": "triton"})
+        )
+        reset_context()  # no publish: global flags stay default
+        try:
+            moe_utils.initialize_moe_config(sa)
+            self.assertEqual(
+                moe_utils.SPECULATIVE_MOE_RUNNER_BACKEND,
+                moe_utils.MoeRunnerBackend("triton"),
+            )
+        finally:
+            reset_context()
+            moe_utils.SPECULATIVE_MOE_RUNNER_BACKEND = None
+            moe_utils.MOE_A2A_BACKEND = None
+            moe_utils.MOE_RUNNER_BACKEND = None
+            moe_utils.SPECULATIVE_MOE_A2A_BACKEND = None
 
     def test_overlap_disable_passes(self):
         from sglang.srt.arg_groups.overrides import (


### PR DESCRIPTION
Unit 2 of a 4-PR stack continuing the config-resolution pipeline refactor (previous series: #30063–#30077, #30137). Based on #30228.

Retires the dual-apply for eight fields whose reader sweeps are small and self-contained:

- `enable_tf32_matmul` — sole production reader (the ModelRunner tf32 toggle) already reads the flags tier.
- `disable_shared_experts_fusion` — the last `server_args` reader (the routed-experts capturer gate, target-only and post-load) flips to the tier; the remaining `__post_init__` writers are earlier imperative writes, captured by publish-time materialization.
- `sampling_backend` — `create_sampler` and the token-oracle install gate flip to the tier; the hpu/cpu early writers stay imperative.
- `swa_full_tokens_ratio` — the pool configurator reads the tier; `_handle_cache_compatibility`'s range check correctly validates the pristine user input.
- `flashinfer_allreduce_fusion_backend` — the communicator and capture-time runner read the tier; the deprecated-alias fill runs pre-declaration.
- `speculative_moe_runner_backend`, `speculative_moe_a2a_backend` — `initialize_moe_config` reads the tier.
- `moe_dense_tp_size` — TBO / communicator / dp-attention init / the `require_*` helpers read the tier; `check_server_args` validates the pristine input.

Goldens flip from dual-apply asserts to pristine/leaf-split asserts. Getter ratchet 280 → 276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28810430529](https://github.com/sgl-project/sglang/actions/runs/28810430529)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28810430104](https://github.com/sgl-project/sglang/actions/runs/28810430104)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->