### PR TITLE
[refactor] Per-field dual-apply retirement: full-stack review (11-PR series)

### DIFF
--- a/STACK_REVIEW_PLACEHOLDER.md
+++ b/STACK_REVIEW_PLACEHOLDER.md
@@ -1,0 +1,6 @@
+# Stack review placeholder — do not merge this file
+
+This file exists only so the full-stack review PR (#30232) carries a commit
+of its own on top of the stack tip. It must not land on `main`: if this PR
+is squash-merged as the vehicle for the series, drop this file first (or
+remove it in an immediate follow-up).

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -80,6 +80,7 @@ from sglang.srt.mem_cache.base_prefix_cache import EvictParams
 from sglang.srt.model_executor.cuda_graph_config import Phase
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -509,7 +510,7 @@ def _maybe_prepare_mlp_sync_batch(batch: ScheduleBatch, model_runner):
             get_idle_batch=None,
             disable_cuda_graph=model_runner.server_args.disable_cuda_graph,
             require_mlp_tp_gather=require_mlp_tp_gather(model_runner.server_args),
-            disable_overlap_schedule=model_runner.server_args.disable_overlap_schedule,
+            disable_overlap_schedule=get_flags().disable_overlap_schedule,
             offload_tags=set(),
         )
 

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -554,7 +554,7 @@ class _MlxBenchRunner:
             trust_remote_code=server_args.trust_remote_code,
             disable_radix_cache=True,
             mem_fraction_static=server_args.mem_fraction_static,
-            quantization=server_args.quantization,
+            quantization=get_flags().quantization,
         )
         if server_args.max_total_tokens is not None:
             init_kwargs["pool_size"] = server_args.max_total_tokens

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -298,7 +298,12 @@ class BenchArgs:
 def load_model(server_args, port_args, gpu_id, tp_rank):
     suppress_other_loggers()
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
-    moe_ep_rank = tp_rank // (server_args.tp_size // server_args.ep_size)
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # Pre-publish (the ModelRunner below performs the publish): read the
+    # resolved ep_size through the view.
+    ep_size = resolved_view(server_args).ep_size
+    moe_ep_rank = tp_rank // (server_args.tp_size // ep_size)
 
     model_config = ModelConfig.from_server_args(server_args)
     runner_kwargs = dict(
@@ -308,7 +313,7 @@ def load_model(server_args, port_args, gpu_id, tp_rank):
         tp_rank=tp_rank,
         tp_size=server_args.tp_size,
         moe_ep_rank=moe_ep_rank,
-        moe_ep_size=server_args.ep_size,
+        moe_ep_size=ep_size,
         pp_rank=0,
         pp_size=1,
         nccl_port=port_args.nccl_port,

--- a/python/sglang/srt/arg_groups/hisparse_hook.py
+++ b/python/sglang/srt/arg_groups/hisparse_hook.py
@@ -43,21 +43,30 @@ def _hisparse_allowed_backends(kv_cache_dtype: str) -> set[str]:
 def validate_hisparse_dsa_backend(
     server_args: ServerArgs, attr: str, label: str
 ) -> None:
-    backend = getattr(server_args, attr)
-    allowed_backends = _hisparse_allowed_backends(server_args.kv_cache_dtype)
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # Invoked after the DSA kv-cache-dtype / split-backend declarations:
+    # read the resolving state through the view.
+    view = resolved_view(server_args)
+    backend = getattr(view, attr)
+    kv_cache_dtype = view.kv_cache_dtype
+    allowed_backends = _hisparse_allowed_backends(kv_cache_dtype)
     if backend is not None and backend not in allowed_backends:
         raise ValueError(
             f"HiSparse supports DSA {label} backend(s) {sorted(allowed_backends)} "
-            f"on this platform with --kv-cache-dtype={server_args.kv_cache_dtype}, "
+            f"on this platform with --kv-cache-dtype={kv_cache_dtype}, "
             f"but got --dsa-{label}-backend={backend}. "
             f"Please use --dsa-{label}-backend="
-            f"{_hisparse_default_backend(server_args.kv_cache_dtype)} "
+            f"{_hisparse_default_backend(kv_cache_dtype)} "
             "or omit it."
         )
 
 
 def validate_hisparse_kv_cache_dtype(server_args: ServerArgs) -> None:
-    if server_args.kv_cache_dtype in HISPARSE_KV_CACHE_DTYPES:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    kv_cache_dtype = resolved_view(server_args).kv_cache_dtype
+    if kv_cache_dtype in HISPARSE_KV_CACHE_DTYPES:
         return
 
     choices = " or ".join(
@@ -65,7 +74,7 @@ def validate_hisparse_kv_cache_dtype(server_args: ServerArgs) -> None:
     )
     raise ValueError(
         f"HiSparse requires one of {HISPARSE_KV_CACHE_DTYPES} KV cache dtypes, "
-        f"but got --kv-cache-dtype={server_args.kv_cache_dtype}. Please use {choices}."
+        f"but got --kv-cache-dtype={kv_cache_dtype}. Please use {choices}."
     )
 
 
@@ -112,7 +121,13 @@ def validate_hisparse(server_args: ServerArgs) -> None:
             )
         return
 
-    if server_args.kv_cache_dtype not in ("bfloat16", "auto", "fp8_e4m3"):
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).kv_cache_dtype not in (
+        "bfloat16",
+        "auto",
+        "fp8_e4m3",
+    ):
         validate_hisparse_kv_cache_dtype(server_args)
 
     for attr, label in [

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -162,14 +162,31 @@ def register_post_process(fn: Callable[..., dict]) -> Callable[..., dict]:
     return fn
 
 
+def _retired_field_overlay(server_args: Any) -> Dict[str, Any]:
+    """Accumulated declared values for dual-apply-retired fields: those no
+    longer live on ``server_args`` mid-resolution, so pass views overlay them
+    from the declaration stash (last writer wins, like the gate)."""
+    if not DUAL_APPLY_RETIRED:
+        return {}
+    overlay: Dict[str, Any] = {}
+    for _source, declared in getattr(server_args, "_resolved_overrides", None) or ():
+        for field, value in declared.items():
+            if field in DUAL_APPLY_RETIRED:
+                overlay[field] = value
+    return overlay
+
+
 def run_post_process_pass(server_args: Any, fn: Callable[..., dict]) -> None:
     """Transition-period invocation of one pass at its legacy handler slot.
 
-    Evaluates the pass on the live state (through a read-only view), appends
+    Evaluates the pass on the live state (through a read-only view; fields
+    with retired dual-apply are overlaid from the declaration stash), appends
     its declaration to the declaration stash, and dual-applies it in place —
     byte-identical to the imperative handler write this replaces.
     """
-    declared = fn(ResolvedView(server_args))
+    declared = fn(
+        ResolvedView(server_args, overlay=_retired_field_overlay(server_args))
+    )
     if not isinstance(declared, dict):
         raise TypeError(
             f"post-process pass {fn.__qualname__} must return a dict, "
@@ -187,6 +204,13 @@ def run_post_process_pass(server_args: Any, fn: Callable[..., dict]) -> None:
             stash = server_args._resolved_overrides = []
         stash.append(entry)
         apply_declarations_to_server_args(server_args, [entry])
+
+
+def resolved_view(server_args: Any) -> ResolvedView:
+    """Transition helper for mid-resolution code that is not a pass: a
+    read-only view of the resolving configuration (dual-apply-retired fields
+    overlaid from the declaration stash)."""
+    return ResolvedView(server_args, overlay=_retired_field_overlay(server_args))
 
 
 def declare_load_time_override(source: str, declared: Dict[str, Any]) -> None:
@@ -1937,6 +1961,14 @@ def apply_model_overrides(
     return records
 
 
+# Fields whose transition dual-apply is retired: every reader of the resolved
+# value goes through the flags tier (post-publish reads) or the pass view
+# (mid-resolution reads), so declarations no longer mutate server_args and
+# the field stays pristine user input. Grown per field as reader sweeps
+# complete; the publish parity assert skips these fields.
+DUAL_APPLY_RETIRED: frozenset = frozenset()
+
+
 def apply_declarations_to_server_args(
     server_args: Any,
     declarations: Sequence[Tuple[str, Dict[str, Any]]],
@@ -1967,6 +1999,8 @@ def apply_declarations_to_server_args(
                 )
     for _source, decl in list(declarations) + list(terminal):
         for field, value in decl.items():
+            if field in DUAL_APPLY_RETIRED:
+                continue
             setattr(server_args, field, value)
 
 
@@ -2002,6 +2036,10 @@ def assert_flag_parity(
     (dual-applied) ``server_args`` value."""
     mismatches = []
     for field in fields:
+        if field in DUAL_APPLY_RETIRED:
+            # server_args stays pristine for retired fields; the leaf alone
+            # carries the resolved value.
+            continue
         owner, leaf = resolve_flag_leaf(flags, field, leaf_map=leaf_map)
         flag_value = getattr(owner, leaf)
         args_value = getattr(server_args, field)

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1699,6 +1699,18 @@ def _data_parallelism_defaults(view: Any) -> dict:
 
 
 @register_post_process
+def _dp_lm_head_validation(view: Any) -> dict:
+    """Read-only validation pass: dp-attention is a prerequisite for the
+    dp LM head. Reads the mid-resolution values through the view (the field
+    is dual-apply-retired)."""
+    if view.enable_dp_lm_head:
+        assert (
+            view.enable_dp_attention
+        ), "Please enable dp attention when setting enable_dp_lm_head. "
+    return {}
+
+
+@register_post_process
 def _moe_runner_backend_quant_constraints(view: Any) -> dict:
     """The quantization-driven moe_runner_backend resolutions at the head of
     _handle_moe_kernel_config. The backend-compatibility asserts and the

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1978,7 +1978,15 @@ def apply_model_overrides(
 # (mid-resolution reads), so declarations no longer mutate server_args and
 # the field stays pristine user input. Grown per field as reader sweeps
 # complete; the publish parity assert skips these fields.
-DUAL_APPLY_RETIRED: frozenset = frozenset()
+DUAL_APPLY_RETIRED: frozenset = frozenset(
+    {
+        # All readers flipped: model LM-head constructions + the logits
+        # processor read get_flags(); require_mlp_tp_gather reads the leaf;
+        # the dp-attention prerequisite check is a view-reading validation
+        # pass.
+        "enable_dp_lm_head",
+    }
+)
 
 
 def apply_declarations_to_server_args(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2182,6 +2182,17 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # the spec registry read the leaf; the pp / pdmux asserts read
         # views; the mps early disable is pre-resolution input synthesis.
         "disable_overlap_schedule",
+        # Every ModelConfig construction (mid-resolution cached, scheduler
+        # post-publish, launcher-side) captures these through the view in
+        # from_server_args — which also removes the timing skew between the
+        # pre- and post-declaration constructions; the sm<80 float16 force
+        # is a load-time declaration; MoE / DSA / gguf mid-resolution reads
+        # go through views; the runtime quantization readers are on the
+        # tier; the unquant normalization and the draft-quantization copy
+        # run pre-declaration on pristine input.
+        "dtype",
+        "quantization",
+        "disable_hybrid_swa_memory",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1985,6 +1985,12 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # the dp-attention prerequisite check is a view-reading validation
         # pass.
         "enable_dp_lm_head",
+        # Sole production reader is the ModelRunner tf32 toggle, on the tier.
+        "enable_tf32_matmul",
+        # Model-file readers and the routed-experts capturer read the tier;
+        # the remaining __post_init__ writers are earlier imperative writes,
+        # captured by publish-time materialization.
+        "disable_shared_experts_fusion",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2102,6 +2102,13 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # reset writes the pristine default.
         "uses_mamba_radix_cache",
         "mamba_radix_cache_strategy",
+        # Runtime readers are on the mapped leaf (flags.attn.backend) or
+        # resolved_attention_backends(); every mid-resolution consumer reads
+        # a pass view; the hpu/cpu/npu early defaults are pre-resolution
+        # input synthesis; the HRM-Text runner force is a load-time
+        # declaration; the engine flashinfer preflight and the registry
+        # dispatch callables read the pristine input by design.
+        "attention_backend",
     }
 )
 
@@ -2141,25 +2148,18 @@ def apply_declarations_to_server_args(
             setattr(server_args, field, value)
 
 
-def refresh_declared_fields(server_args: Any, fields: Iterable[str]) -> None:
-    """Transition helper for legacy code that overwrites a resolved field
-    AFTER the override collection in ``__post_init__`` (e.g.
-    ``ModelRunner.model_specific_adjustment`` forcing ``attention_backend``
-    for HRM-Text). Redeclares the live value so publish parity holds and the
-    flags tier materializes the adjusted end state.
-    """
-    _missing = object()
-    declarations = server_args._resolved_overrides
-    for field in fields:
-        effective = _missing
-        for _source, decl in declarations:
-            if field in decl:
-                effective = decl[field]
-        if effective is _missing:
-            continue
-        live = getattr(server_args, field)
-        if effective != live:
-            declarations.append((f"runtime_adjustment[{field}]", {field: live}))
+def _hrm_text_attention_force(view: Any) -> dict:
+    """HRM-Text's bidirectional prefix attention only works on the Triton
+    backend. Invoked from ModelRunner.model_specific_adjustment (pre-publish,
+    once the architecture is known) at the legacy overwrite's slot."""
+    if view.attention_backend not in (None, "triton"):
+        logger.warning(
+            f"Overriding --attention-backend "
+            f"{view.attention_backend!r} -> 'triton': only the "
+            "Triton backend supports HRM-Text's bidirectional prefix "
+            "attention."
+        )
+    return {"attention_backend": "triton"}
 
 
 def assert_flag_parity(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1956,14 +1956,23 @@ def _dllm_overlap_disable(view: Any) -> dict:
 
 @register_post_process
 def _dllm_page_size(view: Any) -> dict:
-    if view.dllm_algorithm is None or view.disable_radix_cache:
+    if view.dllm_algorithm is None:
         return {}
     from sglang.srt.dllm.config import DllmConfig
 
     config = DllmConfig.from_server_args(view)
-    if view.page_size % config.block_size != 0:
+    if not view.disable_radix_cache and view.page_size % config.block_size != 0:
         logger.warning(
             f"Setting page size to {config.block_size} for diffusion LLM inference"
+        )
+        return {"page_size": config.block_size}
+    if view.page_size > config.block_size:
+        # Legacy scheduler-init fallback, folded into the pass: the page
+        # size must not exceed the dllm block size.
+        logger.warning(
+            "WARNING: "
+            f"The page size {view.page_size} should not be larger than dllm block size {config.block_size}."
+            f"Page size now falls back to {config.block_size}"
         )
         return {"page_size": config.block_size}
     return {}
@@ -2109,6 +2118,14 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # declaration; the engine flashinfer preflight and the registry
         # dispatch callables read the pristine input by design.
         "attention_backend",
+        # KV sizing, workers and attention backends read the leaf; the
+        # scheduler / ModelRunner pre-publish captures, the
+        # mamba_cache_chunk_size property, the chunked-prefill divisibility
+        # check, the kv-events describe (launcher-side) and the
+        # default-backend spec gate read the view; the dllm scheduler-init
+        # page fallback is folded into the _dllm_page_size pass; the npu
+        # early default is pre-resolution input synthesis.
+        "page_size",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1994,6 +1994,18 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # Sampler construction, the deterministic force and the token-oracle
         # gate all read the tier; the hpu/cpu early writers stay imperative.
         "sampling_backend",
+        # Pool configurator reads the tier; the range check in
+        # _handle_cache_compatibility validates the pristine user input.
+        "swa_full_tokens_ratio",
+        # Communicator and capture-time runner read the tier; the
+        # deprecated-alias fill runs pre-declaration on pristine input.
+        "flashinfer_allreduce_fusion_backend",
+        # initialize_moe_config reads the tier for the draft MoE fields.
+        "speculative_moe_runner_backend",
+        "speculative_moe_a2a_backend",
+        # TBO / communicator / dp-attention init / the require_* helpers read
+        # the tier; check_server_args validates the pristine user input.
+        "moe_dense_tp_size",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2198,6 +2198,14 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # builder and the eager runner read the leaf; the two dispatch
         # declarers (MiMoV2, Step3p5/3p7) read the pristine input.
         "enable_multi_layer_eagle",
+        # The launcher / tokenizer / ray-controller processes (where no
+        # publish exists) and the pre-publish scheduler/runner captures read
+        # views over the instance-carried declaration stash; scheduler-
+        # process runtime readers are on the leaves; the __post_init__
+        # validation chains read views at their slots.
+        "enable_dp_attention",
+        "ep_size",
+        "attn_cp_size",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -117,14 +117,10 @@ def _invoke_provider(
 
 class ResolvedView:
     """Read-only view of the resolving configuration handed to post-process
-    passes.
-
-    During the dual-apply transition the view forwards every read to the live
-    ``server_args`` — the pristine input plus the declarations replayed so far
-    plus any residual imperative writes — which is exactly the state the
-    legacy handler at the same slot observed. In the end state (dual-apply
-    retired) the same type overlays the accumulated declarations on the
-    pristine object. Writes are rejected: passes return declarations.
+    passes: the accumulated declarations overlaid on the pristine
+    ``server_args`` (residual imperative writes of non-resolved fields show
+    through the fallthrough) — exactly the state the legacy handler at the
+    same slot observed. Writes are rejected: passes return declarations.
     """
 
     __slots__ = ("_server_args", "_overlay")
@@ -162,31 +158,25 @@ def register_post_process(fn: Callable[..., dict]) -> Callable[..., dict]:
     return fn
 
 
-def _retired_field_overlay(server_args: Any) -> Dict[str, Any]:
-    """Accumulated declared values for dual-apply-retired fields: those no
-    longer live on ``server_args`` mid-resolution, so pass views overlay them
-    from the declaration stash (last writer wins, like the gate)."""
-    if not DUAL_APPLY_RETIRED:
-        return {}
+def _declaration_overlay(server_args: Any) -> Dict[str, Any]:
+    """Accumulated declared values: declarations never mutate
+    ``server_args``, so mid-resolution readers overlay them from the
+    declaration stash (last writer wins, like the gate)."""
     overlay: Dict[str, Any] = {}
     for _source, declared in getattr(server_args, "_resolved_overrides", None) or ():
-        for field, value in declared.items():
-            if field in DUAL_APPLY_RETIRED:
-                overlay[field] = value
+        overlay.update(declared)
     return overlay
 
 
 def run_post_process_pass(server_args: Any, fn: Callable[..., dict]) -> None:
-    """Transition-period invocation of one pass at its legacy handler slot.
+    """Invoke one pass at its legacy handler slot.
 
-    Evaluates the pass on the live state (through a read-only view; fields
-    with retired dual-apply are overlaid from the declaration stash), appends
-    its declaration to the declaration stash, and dual-applies it in place —
-    byte-identical to the imperative handler write this replaces.
+    Evaluates the pass on the resolving state (a read-only view with the
+    accumulated declarations overlaid from the stash) and appends its
+    declaration to the stash; ``server_args`` itself is never mutated — the
+    flags tier materializes the declared values at publish.
     """
-    declared = fn(
-        ResolvedView(server_args, overlay=_retired_field_overlay(server_args))
-    )
+    declared = fn(ResolvedView(server_args, overlay=_declaration_overlay(server_args)))
     if not isinstance(declared, dict):
         raise TypeError(
             f"post-process pass {fn.__qualname__} must return a dict, "
@@ -203,14 +193,14 @@ def run_post_process_pass(server_args: Any, fn: Callable[..., dict]) -> None:
             # must sit at or after it in __post_init__ order.
             stash = server_args._resolved_overrides = []
         stash.append(entry)
-        apply_declarations_to_server_args(server_args, [entry])
+        validate_declarations(server_args, [entry])
 
 
 def resolved_view(server_args: Any) -> ResolvedView:
-    """Transition helper for mid-resolution code that is not a pass: a
-    read-only view of the resolving configuration (dual-apply-retired fields
-    overlaid from the declaration stash)."""
-    return ResolvedView(server_args, overlay=_retired_field_overlay(server_args))
+    """Read-only view of the resolving configuration for code that is not a
+    pass: the accumulated declarations are overlaid from the stash. Valid in
+    any process and at any timing — the stash rides the instance."""
+    return ResolvedView(server_args, overlay=_declaration_overlay(server_args))
 
 
 def attention_backends_of(cfg: Any) -> tuple:
@@ -240,16 +230,12 @@ def mamba_extra_buffer_of(cfg: Any) -> bool:
 
 
 def declare_load_time_override(source: str, declared: Dict[str, Any]) -> None:
-    """Transition helper for load-time resolved fields (model-file config
-    overrides, weight-resolved dtypes): dual-apply the declaration onto the
-    published ``server_args`` — byte-identical to the imperative write this
-    replaces — and record it into the flags tier through the runtime gate."""
+    """Record a load-time resolved field (model-file config overrides,
+    weight-resolved dtypes) into the flags tier through the runtime gate;
+    ``server_args`` stays pristine."""
     from sglang.srt.runtime_context import get_context
 
-    ctx = get_context()
-    entry = (source, dict(declared))
-    apply_declarations_to_server_args(ctx.server_args, [entry])
-    ctx.record_runtime_overrides([entry])
+    get_context().record_runtime_overrides([(source, dict(declared))])
 
 
 def collect_model_override_declarations(
@@ -1576,7 +1562,7 @@ def _mla_backend_page_constraints(view: Any) -> dict:
 def _mla_kv_cache_dtype_checks(view: Any) -> dict:
     """Read-only validation pass in the attention-backend compatibility
     handler: the TRT-LLM and tokenspeed MLA backends constrain the resolved
-    kv-cache dtype (the field is dual-apply-retired, so the checks must read
+    kv-cache dtype (declarations never reach the field, so the checks read
     the view)."""
     if (
         view.attention_backend == "trtllm_mla"
@@ -1622,7 +1608,7 @@ def _cutedsl_prefill_backend_fill(view: Any) -> dict:
     """Slot pass in the attention-backend compatibility handler: CuteDSL MLA
     is decode-only, so validate the combination and default the prefill side
     to trtllm_mla. The trtllm_mha check that follows at the legacy slot reads
-    the dual-applied value."""
+    the resolved value through the view."""
     if not (
         view.attention_backend == "cutedsl_mla"
         or view.decode_attention_backend == "cutedsl_mla"
@@ -1775,8 +1761,7 @@ def _data_parallelism_defaults(view: Any) -> dict:
 @register_post_process
 def _dp_lm_head_validation(view: Any) -> dict:
     """Read-only validation pass: dp-attention is a prerequisite for the
-    dp LM head. Reads the mid-resolution values through the view (the field
-    is dual-apply-retired)."""
+    dp LM head. Reads the mid-resolution values through the view."""
     if view.enable_dp_lm_head:
         assert (
             view.enable_dp_attention
@@ -2099,150 +2084,27 @@ def apply_model_overrides(
     return records
 
 
-# Fields whose transition dual-apply is retired: every reader of the resolved
-# value goes through the flags tier (post-publish reads) or the pass view
-# (mid-resolution reads), so declarations no longer mutate server_args and
-# the field stays pristine user input. Grown per field as reader sweeps
-# complete; the publish parity assert skips these fields.
-DUAL_APPLY_RETIRED: frozenset = frozenset(
-    {
-        # All readers flipped: model LM-head constructions + the logits
-        # processor read get_flags(); require_mlp_tp_gather reads the leaf;
-        # the dp-attention prerequisite check is a view-reading validation
-        # pass.
-        "enable_dp_lm_head",
-        # Sole production reader is the ModelRunner tf32 toggle, on the tier.
-        "enable_tf32_matmul",
-        # Model-file readers and the routed-experts capturer read the tier;
-        # the remaining __post_init__ writers are earlier imperative writes,
-        # captured by publish-time materialization.
-        "disable_shared_experts_fusion",
-        # Sampler construction, the deterministic force and the token-oracle
-        # gate all read the tier; the hpu/cpu early writers stay imperative.
-        "sampling_backend",
-        # Pool configurator reads the tier; the range check in
-        # _handle_cache_compatibility validates the pristine user input.
-        "swa_full_tokens_ratio",
-        # Communicator and capture-time runner read the tier; the
-        # deprecated-alias fill runs pre-declaration on pristine input.
-        "flashinfer_allreduce_fusion_backend",
-        # initialize_moe_config reads the tier for the draft MoE fields.
-        "speculative_moe_runner_backend",
-        "speculative_moe_a2a_backend",
-        # TBO / communicator / dp-attention init / the require_* helpers read
-        # the tier; check_server_args validates the pristine user input.
-        "moe_dense_tp_size",
-        # Attention backends / disagg handshake / configure_kv_cache_dtype /
-        # model init read the tier; the MLA and hisparse validations are
-        # view-reading passes; the kv4/prefill-only gates key on values no
-        # declaration produces.
-        "kv_cache_dtype",
-        # DSA backend init, the kv-cache mixin and the DeepSeek forward
-        # methods read the tier; hisparse validation reads the view.
-        "dsa_prefill_backend",
-        "dsa_decode_backend",
-        # ModelRunner / sarvam forward dispatch / frozen-KV draft selection
-        # read resolved_attention_backends(); every mid-resolution consumer
-        # goes through _resolved_attention_backends() (view-reading); the
-        # registry dispatch callables read the pristine input by design; the
-        # NPU early defaults are pre-resolution input synthesis.
-        "prefill_attention_backend",
-        "decode_attention_backend",
-        # KV-cache builder / runners / schedule-batch hot path read the
-        # mamba_extra_buffer_* helpers on the tier; the mamba validators and
-        # the optimistic-prefill gate read the view; the __post_init__ False
-        # reset writes the pristine default.
-        "uses_mamba_radix_cache",
-        "mamba_radix_cache_strategy",
-        # Runtime readers are on the mapped leaf (flags.attn.backend) or
-        # resolved_attention_backends(); every mid-resolution consumer reads
-        # a pass view; the hpu/cpu/npu early defaults are pre-resolution
-        # input synthesis; the HRM-Text runner force is a load-time
-        # declaration; the engine flashinfer preflight and the registry
-        # dispatch callables read the pristine input by design.
-        "attention_backend",
-        # KV sizing, workers and attention backends read the leaf; the
-        # scheduler / ModelRunner pre-publish captures, the
-        # mamba_cache_chunk_size property, the chunked-prefill divisibility
-        # check, the kv-events describe (launcher-side) and the
-        # default-backend spec gate read the view; the dllm scheduler-init
-        # page fallback is folded into the _dllm_page_size pass; the npu
-        # early default is pre-resolution input synthesis.
-        "page_size",
-        # initialize_moe_config, the eplb recorder, the autotune runner and
-        # init-MoE wiring read the leaves; the kernel-config and a2a chains
-        # read views, with their fusion writes converted to the
-        # _moe_runner_fusion_disable / _a2a_fusion_adjustments passes; the
-        # cuda-graph compat lambdas and the TBO / budget validators read
-        # views; the registry dispatch callables read the pristine input.
-        "moe_runner_backend",
-        "moe_a2a_backend",
-        # Scheduler / TpWorker pre-publish captures read views; workers,
-        # pool sizing, the kv mixin, dp-attn wiring, the prefill delayer and
-        # the spec registry read the leaf; the pp / pdmux asserts read
-        # views; the mps early disable is pre-resolution input synthesis.
-        "disable_overlap_schedule",
-        # Every ModelConfig construction (mid-resolution cached, scheduler
-        # post-publish, launcher-side) captures these through the view in
-        # from_server_args — which also removes the timing skew between the
-        # pre- and post-declaration constructions; the sm<80 float16 force
-        # is a load-time declaration; MoE / DSA / gguf mid-resolution reads
-        # go through views; the runtime quantization readers are on the
-        # tier; the unquant normalization and the draft-quantization copy
-        # run pre-declaration on pristine input.
-        "dtype",
-        "quantization",
-        "disable_hybrid_swa_memory",
-        # ModelConfig captures through the view; the spec hook / adaptive
-        # gates and the worker-shape helpers read views; the disagg draft
-        # builder and the eager runner read the leaf; the two dispatch
-        # declarers (MiMoV2, Step3p5/3p7) read the pristine input.
-        "enable_multi_layer_eagle",
-        # The launcher / tokenizer / ray-controller processes (where no
-        # publish exists) and the pre-publish scheduler/runner captures read
-        # views over the instance-carried declaration stash; scheduler-
-        # process runtime readers are on the leaves; the __post_init__
-        # validation chains read views at their slots.
-        "enable_dp_attention",
-        "ep_size",
-        "attn_cp_size",
-    }
-)
-
-
-def apply_declarations_to_server_args(
+def validate_declarations(
     server_args: Any,
     declarations: Sequence[Tuple[str, Dict[str, Any]]],
-    *,
-    terminal: Sequence[Tuple[str, Dict[str, Any]]] = (),
 ) -> None:
-    """Transition-period dual-apply: replay declarations onto ``server_args``
-    in gate order, byte-identical to the legacy imperative writes.
-
-    Retired per field once that field's readers have all flipped to the flags
-    tier (at which point the server_args field returns to pristine).
-
-    Validates against the same whitelist as the publish gate BEFORE any write:
-    a registry typo or a not-yet-resolvable field must fail fast here, not
-    mutate ``server_args`` and only be rejected at publish time.
+    """Fail-fast whitelist check at declaration time: a registry typo or a
+    not-yet-resolvable field must be rejected at its slot, not only at
+    publish time. Declarations never mutate ``server_args``.
     """
     # Non-dataclass fixtures carry no Arg metadata (mirrors the
     # resolvable_fields escape); only real ServerArgs is validated.
-    if dataclasses.is_dataclass(type(server_args)):
-        whitelist = resolvable_fields(type(server_args))
-        for source, decl in list(declarations) + list(terminal):
-            unknown = set(decl) - whitelist
-            if unknown:
-                raise ValueError(
-                    f"{source}: {sorted(unknown)} not model-overridable; the "
-                    "transition dual-apply refuses fields the publish gate "
-                    "would reject."
-                )
-    for _source, decl in list(declarations) + list(terminal):
-        for field, value in decl.items():
-            if field in DUAL_APPLY_RETIRED:
-                continue
-            setattr(server_args, field, value)
+    if not dataclasses.is_dataclass(type(server_args)):
+        return
+    whitelist = resolvable_fields(type(server_args))
+    for source, decl in declarations:
+        unknown = set(decl) - whitelist
+        if unknown:
+            raise ValueError(
+                f"{source}: {sorted(unknown)} not model-overridable; "
+                "declarations are limited to the fields the publish gate "
+                "accepts."
+            )
 
 
 def _hrm_text_attention_force(view: Any) -> dict:
@@ -2257,29 +2119,3 @@ def _hrm_text_attention_force(view: Any) -> dict:
             "attention."
         )
     return {"attention_backend": "triton"}
-
-
-def assert_flag_parity(
-    flags: Any,
-    server_args: Any,
-    fields: Iterable[str],
-    *,
-    leaf_map: Optional[Dict[str, str]] = None,
-) -> None:
-    """Dual-apply drift guard: each migrated field's flag leaf must equal the
-    (dual-applied) ``server_args`` value."""
-    mismatches = []
-    for field in fields:
-        if field in DUAL_APPLY_RETIRED:
-            # server_args stays pristine for retired fields; the leaf alone
-            # carries the resolved value.
-            continue
-        owner, leaf = resolve_flag_leaf(flags, field, leaf_map=leaf_map)
-        flag_value = getattr(owner, leaf)
-        args_value = getattr(server_args, field)
-        if flag_value != args_value:
-            mismatches.append(
-                f"{field}: flags={flag_value!r} server_args={args_value!r}"
-            )
-    if mismatches:
-        raise AssertionError("flag/server_args parity broken: " + "; ".join(mismatches))

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1838,6 +1838,49 @@ def _moe_runner_backend_quant_constraints(view: Any) -> dict:
 
 
 @register_post_process
+def _moe_runner_fusion_disable(view: Any) -> dict:
+    """FlashInfer CuteDSL / TRT-LLM / TRT-LLM-routed MoE runners require the
+    shared-experts fusion disabled; declared at the legacy write slots in
+    _handle_moe_kernel_config (before the deprecated cutlass env override, so
+    the runner value observed is the pre-override one)."""
+    runner = view.moe_runner_backend
+    if runner == "flashinfer_cutedsl":
+        logger.warning(
+            "FlashInfer CuteDSL MoE is enabled. --disable-shared-experts-fusion is automatically set."
+        )
+        return {"disable_shared_experts_fusion": True}
+    if runner in ("flashinfer_trtllm", "experimental_sgl_trtllm"):
+        logger.warning(
+            "FlashInfer TRTLLM MoE is enabled. --disable-shared-experts-fusion is automatically set."
+        )
+        return {"disable_shared_experts_fusion": True}
+    if runner == "flashinfer_trtllm_routed":
+        logger.warning(
+            "FlashInfer TRTLLM routed MoE is enabled. --disable-shared-experts-fusion is automatically set."
+        )
+        return {"disable_shared_experts_fusion": True}
+    return {}
+
+
+def _a2a_fusion_adjustments(view: Any) -> dict:
+    """A2A-backend-driven shared-experts fusion adjustments, declared at the
+    legacy write slots in _handle_a2a_moe: DeepEP Waterfill requires the
+    fusion enabled; FlashInfer A2A requires it disabled."""
+    if view.moe_a2a_backend == "deepep" and view.enable_deepep_waterfill:
+        if view.disable_shared_experts_fusion:
+            logger.warning(
+                "disable_shared_experts_fusion is overridden to False because DeepEP Waterfill requires shared expert fusion."
+            )
+            return {"disable_shared_experts_fusion": False}
+        return {}
+    if view.moe_a2a_backend == "flashinfer":
+        logger.warning(
+            "Flashinfer MoE A2A is enabled. --disable-shared-experts-fusion is automatically set."
+        )
+        return {"disable_shared_experts_fusion": True}
+    return {}
+
+
 def _cutlass_moe_env_override(view: Any) -> dict:
     from sglang.srt.environ import envs
 
@@ -2126,6 +2169,19 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # page fallback is folded into the _dllm_page_size pass; the npu
         # early default is pre-resolution input synthesis.
         "page_size",
+        # initialize_moe_config, the eplb recorder, the autotune runner and
+        # init-MoE wiring read the leaves; the kernel-config and a2a chains
+        # read views, with their fusion writes converted to the
+        # _moe_runner_fusion_disable / _a2a_fusion_adjustments passes; the
+        # cuda-graph compat lambdas and the TBO / budget validators read
+        # views; the registry dispatch callables read the pristine input.
+        "moe_runner_backend",
+        "moe_a2a_backend",
+        # Scheduler / TpWorker pre-publish captures read views; workers,
+        # pool sizing, the kv mixin, dp-attn wiring, the prefill delayer and
+        # the spec registry read the leaf; the pp / pdmux asserts read
+        # views; the mps early disable is pre-resolution input synthesis.
+        "disable_overlap_schedule",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2193,6 +2193,11 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         "dtype",
         "quantization",
         "disable_hybrid_swa_memory",
+        # ModelConfig captures through the view; the spec hook / adaptive
+        # gates and the worker-shape helpers read views; the disagg draft
+        # builder and the eager runner read the leaf; the two dispatch
+        # declarers (MiMoV2, Step3p5/3p7) read the pristine input.
+        "enable_multi_layer_eagle",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -213,6 +213,32 @@ def resolved_view(server_args: Any) -> ResolvedView:
     return ResolvedView(server_args, overlay=_retired_field_overlay(server_args))
 
 
+def attention_backends_of(cfg: Any) -> tuple:
+    """(prefill, decode) attention backends of a config-shaped object (a
+    ResolvedView mid-resolution, or pristine server_args at dispatch time):
+    split fields fall back to the base backend."""
+    prefill = (
+        cfg.prefill_attention_backend
+        if cfg.prefill_attention_backend
+        else cfg.attention_backend
+    )
+    decode = (
+        cfg.decode_attention_backend
+        if cfg.decode_attention_backend
+        else cfg.attention_backend
+    )
+    return prefill, decode
+
+
+def mamba_extra_buffer_of(cfg: Any) -> bool:
+    """Mid-resolution equivalent of runtime_context.mamba_extra_buffer_enabled:
+    reads the (possibly overlaid) strategy from a config-shaped object."""
+    return cfg.disable_radix_cache is False and cfg.mamba_radix_cache_strategy in (
+        "extra_buffer",
+        "extra_buffer_lazy",
+    )
+
+
 def declare_load_time_override(source: str, declared: Dict[str, Any]) -> None:
     """Transition helper for load-time resolved fields (model-file config
     overrides, weight-resolved dtypes): dual-apply the declaration onto the
@@ -765,8 +791,11 @@ def _qwen3_5_hybrid_overrides(server_args: Any, hf_config: Any) -> dict:
         use_mla_backend=server_args.use_mla_backend(),
         model_config=server_args.get_model_config(),
     )
+    # The mamba radix-cache pass runs before this dispatch: read the
+    # declared strategy through the view (the legacy branch observed the
+    # already-written field here).
     if default_attn_backend == "trtllm_mha" and not (
-        not server_args.enable_mamba_extra_buffer()
+        not mamba_extra_buffer_of(resolved_view(server_args))
         and not server_args.disable_radix_cache
         and server_args.speculative_algorithm is None
     ):
@@ -1679,7 +1708,7 @@ def _attention_backend_platform_fallbacks(view: Any) -> dict:
 
 @register_post_process
 def _intel_xpu_page_constraint(view: Any) -> dict:
-    _, decode_backend = view.get_attention_backends()
+    _, decode_backend = attention_backends_of(view)
     if decode_backend == "intel_xpu":
         if view.use_mla_backend():
             supported_page_sizes = [16, 32, 64, 128]
@@ -2060,6 +2089,19 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # methods read the tier; hisparse validation reads the view.
         "dsa_prefill_backend",
         "dsa_decode_backend",
+        # ModelRunner / sarvam forward dispatch / frozen-KV draft selection
+        # read resolved_attention_backends(); every mid-resolution consumer
+        # goes through _resolved_attention_backends() (view-reading); the
+        # registry dispatch callables read the pristine input by design; the
+        # NPU early defaults are pre-resolution input synthesis.
+        "prefill_attention_backend",
+        "decode_attention_backend",
+        # KV-cache builder / runners / schedule-batch hot path read the
+        # mamba_extra_buffer_* helpers on the tier; the mamba validators and
+        # the optimistic-prefill gate read the view; the __post_init__ False
+        # reset writes the pristine default.
+        "uses_mamba_radix_cache",
+        "mamba_radix_cache_strategy",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1544,6 +1544,51 @@ def _mla_backend_page_constraints(view: Any) -> dict:
 
 
 @register_post_process
+def _mla_kv_cache_dtype_checks(view: Any) -> dict:
+    """Read-only validation pass in the attention-backend compatibility
+    handler: the TRT-LLM and tokenspeed MLA backends constrain the resolved
+    kv-cache dtype (the field is dual-apply-retired, so the checks must read
+    the view)."""
+    if (
+        view.attention_backend == "trtllm_mla"
+        or view.decode_attention_backend == "trtllm_mla"
+    ):
+        if not is_blackwell_supported():
+            raise ValueError(
+                "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100/SM12x). Please use a different backend."
+            )
+        if view.kv_cache_dtype not in ["fp8_e4m3", "fp4_e2m1", "bf16", "auto"]:
+            raise ValueError(
+                "TensorRT-LLM MLA backend only supports kv-cache-dtype of fp8_e4m3, fp4_e2m1, bf16, or auto."
+            )
+    if (
+        view.attention_backend == "tokenspeed_mla"
+        or view.decode_attention_backend == "tokenspeed_mla"
+    ):
+        if not is_blackwell_supported():
+            raise ValueError(
+                "tokenspeed_mla backend is only supported on Blackwell GPUs (SM100/SM12x)."
+            )
+        if view.kv_cache_dtype not in ["fp8_e4m3"]:
+            raise ValueError(
+                "tokenspeed_mla backend requires kv-cache-dtype=fp8_e4m3, "
+                f"got {view.kv_cache_dtype}."
+            )
+    return {}
+
+
+@register_post_process
+def _hisparse_validation(view: Any) -> dict:
+    """Read-only validation pass: --enable-hisparse constraints (model class,
+    radix cache, kv dtype, DSA backends) read the resolved values through the
+    view."""
+    from sglang.srt.arg_groups.hisparse_hook import validate_hisparse
+
+    validate_hisparse(view)
+    return {}
+
+
+@register_post_process
 def _cutedsl_prefill_backend_fill(view: Any) -> dict:
     """Slot pass in the attention-backend compatibility handler: CuteDSL MLA
     is decode-only, so validate the combination and default the prefill side
@@ -2006,6 +2051,15 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # TBO / communicator / dp-attention init / the require_* helpers read
         # the tier; check_server_args validates the pristine user input.
         "moe_dense_tp_size",
+        # Attention backends / disagg handshake / configure_kv_cache_dtype /
+        # model init read the tier; the MLA and hisparse validations are
+        # view-reading passes; the kv4/prefill-only gates key on values no
+        # declaration produces.
+        "kv_cache_dtype",
+        # DSA backend init, the kv-cache mixin and the DeepSeek forward
+        # methods read the tier; hisparse validation reads the view.
+        "dsa_prefill_backend",
+        "dsa_decode_backend",
     }
 )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1991,6 +1991,9 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # the remaining __post_init__ writers are earlier imperative writes,
         # captured by publish-time materialization.
         "disable_shared_experts_fusion",
+        # Sampler construction, the deterministic force and the token-oracle
+        # gate all read the tier; the hpu/cpu early writers stay imperative.
+        "sampling_backend",
     }
 )
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -424,7 +424,9 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
                 "--enable-deterministic-inference; the sampling kernel draws "
                 "coins from the global RNG and is not batch-invariant."
             )
-        if server_args.enable_multi_layer_eagle:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if resolved_view(server_args).enable_multi_layer_eagle:
             raise NotImplementedError(
                 "--speculative-use-rejection-sampling is not supported with "
                 "multi-layer EAGLE (--enable-multi-layer-eagle)."

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -135,7 +135,9 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
 
 
 def _handle_dflash(server_args: ServerArgs) -> None:
-    if server_args.enable_dp_attention:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).enable_dp_attention:
         raise ValueError(
             "Currently DFLASH speculative decoding does not support dp attention."
         )
@@ -264,7 +266,12 @@ def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
 
     draft_backend = server_args.speculative_draft_attention_backend
     if draft_backend is None:
-        draft_backend, _ = server_args.get_attention_backends()
+        from sglang.srt.arg_groups.overrides import (
+            attention_backends_of,
+            resolved_view,
+        )
+
+        draft_backend, _ = attention_backends_of(resolved_view(server_args))
     if draft_backend is None:
         draft_backend = fallback_backend
     elif draft_backend == "trtllm_mha":
@@ -305,9 +312,14 @@ def _handle_frozen_kv_mtp(server_args: ServerArgs) -> None:
 
 
 def _handle_eagle_family(server_args: ServerArgs) -> None:
+    from sglang.srt.arg_groups.overrides import (
+        attention_backends_of,
+        resolved_view,
+    )
+
     if (
         server_args.speculative_algorithm == "STANDALONE"
-        and server_args.enable_dp_attention
+        and resolved_view(server_args).enable_dp_attention
     ):
         # TODO: support dp attention for standalone speculative decoding
         raise ValueError(
@@ -320,7 +332,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             "Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests."
         )
 
-    if server_args.disable_overlap_schedule:
+    if resolved_view(server_args).disable_overlap_schedule:
         logger.warning(
             "Non-overlap (synchronous) spec v2 is used for eagle/eagle3/standalone "
             "speculative decoding."
@@ -375,11 +387,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             server_args.speculative_num_draft_tokens,
         ) = _auto_choose_speculative_params(server_args, model_arch)
 
-    if (
-        server_args.attention_backend == "trtllm_mha"
-        or server_args.decode_attention_backend == "trtllm_mha"
-        or server_args.prefill_attention_backend == "trtllm_mha"
-    ):
+    if "trtllm_mha" in attention_backends_of(resolved_view(server_args)):
         if server_args.speculative_eagle_topk > 1:
             raise ValueError(
                 "trtllm_mha backend only supports topk = 1 for speculative decoding."
@@ -440,15 +448,16 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
     # pass + per-branch expand pass with prefix-tail dup). Only these backends implement
     # it; flashmla / trtllm_mla / cutlass_mla can't express the per-branch tree, so reject.
     _PAGE_TREE_SPEC_BACKENDS = ("flashinfer", "fa3", "triton")
+    view = resolved_view(server_args)
     if (
         server_args.speculative_eagle_topk > 1
-        and server_args.page_size > 1
-        and server_args.attention_backend not in _PAGE_TREE_SPEC_BACKENDS
+        and view.page_size > 1
+        and view.attention_backend not in _PAGE_TREE_SPEC_BACKENDS
     ):
         raise ValueError(
             f"speculative_eagle_topk > 1 with page_size > 1 is only supported on "
             f"{_PAGE_TREE_SPEC_BACKENDS}; got attention_backend="
-            f"{server_args.attention_backend!r}. Use page_size == 1 or one of those backends."
+            f"{view.attention_backend!r}. Use page_size == 1 or one of those backends."
         )
 
 
@@ -499,18 +508,21 @@ def _handle_ngram(server_args: ServerArgs) -> None:
         "using ngram speculative decoding."
     )
 
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    view = resolved_view(server_args)
     if (
         server_args.speculative_eagle_topk > 1
-        and server_args.page_size > 1
-        and server_args.attention_backend != "flashinfer"
+        and view.page_size > 1
+        and view.attention_backend != "flashinfer"
     ):
         raise ValueError(
             f"speculative_eagle_topk({server_args.speculative_eagle_topk}) > 1 "
-            f"with page_size({server_args.page_size}) > 1 is unstable "
+            f"with page_size({view.page_size}) > 1 is unstable "
             "and produces incorrect results for paged attention backends. "
             "This combination is only supported for the 'flashinfer' backend."
         )
-    if server_args.enable_dp_attention:
+    if view.enable_dp_attention:
         # TODO: support dp attention for ngram speculative decoding
         raise ValueError(
             "Currently ngram speculative decoding does not support dp attention."

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -760,7 +760,7 @@ class TboForwardBatchPreparer:
 
         # TODO improve, e.g. unify w/ `init_raw`
         if (
-            get_global_server_args().moe_dense_tp_size == 1
+            get_flags().moe_dense_tp_size == 1
             and batch.global_dp_buffer_len is not None
         ):
             sum_len = end_token_index - start_token_index

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -521,7 +521,7 @@ class ModelConfig:
             sampling_defaults=server_args.sampling_defaults,
             quantize_and_serve=server_args.quantize_and_serve,
             override_config_file=override_config_file,
-            is_multi_layer_eagle=server_args.enable_multi_layer_eagle,
+            is_multi_layer_eagle=view.enable_multi_layer_eagle,
             language_only=server_args.language_only,
             encoder_only=server_args.encoder_only,
             is_draft_model=is_draft_model,

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -491,7 +491,7 @@ class ModelConfig:
         # dtype / quantization / disable_hybrid_swa_memory are pipeline-
         # resolved: read them through the view so every construction —
         # mid-resolution, scheduler-process post-publish, or launcher-side —
-        # captures the declared values (dual-apply retired).
+        # captures the declared values.
         view = resolved_view(server_args)
         quantization = (
             server_args.speculative_draft_model_quantization

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -486,10 +486,17 @@ class ModelConfig:
         context_length: Optional[int] = None,
         **kwargs,
     ):
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        # dtype / quantization / disable_hybrid_swa_memory are pipeline-
+        # resolved: read them through the view so every construction —
+        # mid-resolution, scheduler-process post-publish, or launcher-side —
+        # captures the declared values (dual-apply retired).
+        view = resolved_view(server_args)
         quantization = (
             server_args.speculative_draft_model_quantization
             if is_draft_model
-            else server_args.quantization
+            else view.quantization
         )
         override_config_file = (
             server_args.decrypted_draft_config_file
@@ -508,7 +515,7 @@ class ModelConfig:
             model_override_args=server_args.json_model_override_args,
             is_embedding=server_args.is_embedding,
             enable_multimodal=server_args.enable_multimodal,
-            dtype=server_args.dtype,
+            dtype=view.dtype,
             quantization=quantization,
             model_impl=server_args.model_impl,
             sampling_defaults=server_args.sampling_defaults,
@@ -518,7 +525,7 @@ class ModelConfig:
             language_only=server_args.language_only,
             encoder_only=server_args.encoder_only,
             is_draft_model=is_draft_model,
-            disable_hybrid_swa_memory=server_args.disable_hybrid_swa_memory,
+            disable_hybrid_swa_memory=view.disable_hybrid_swa_memory,
             model_config_parser=server_args.model_config_parser,
             **kwargs,
         )

--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -75,7 +75,7 @@ patches:
       - match: |
           if (
               server_args.speculative_algorithm is not None
-              and server_args.page_size > 1
+              and (resolved_view(server_args).page_size or 1) > 1
               and (server_args.speculative_eagle_topk or 1) > 1
           ):
               extra = max(extra, get_alloc_reserve_per_decode(server_args))

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -39,6 +39,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_tp_rank,
     get_attention_tp_size,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.network import (
     NetworkAddress,
@@ -265,11 +266,11 @@ class CommonKVManager(BaseKVManager):
 
         if (
             info.kv_cache_dtype is not None
-            and info.kv_cache_dtype != self.server_args.kv_cache_dtype
+            and info.kv_cache_dtype != get_flags().kv_cache_dtype
         ):
             raise RuntimeError(
                 f"KV cache dtype mismatch: prefill server has kv_cache_dtype={info.kv_cache_dtype}, "
-                f"but decode server has kv_cache_dtype={self.server_args.kv_cache_dtype}. "
+                f"but decode server has kv_cache_dtype={get_flags().kv_cache_dtype}. "
                 f"Both servers must use the same --kv-cache-dtype value."
             )
 
@@ -418,7 +419,7 @@ class CommonKVManager(BaseKVManager):
             "rank_ip": self.local_ip,
             "rank_port": self.rank_port,
             "page_size": self.kv_args.page_size,
-            "kv_cache_dtype": self.server_args.kv_cache_dtype,
+            "kv_cache_dtype": get_flags().kv_cache_dtype,
             "load_balance_method": self.server_args.load_balance_method,
         }
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -15,6 +15,7 @@ import torch.distributed as dist
 import zmq
 from aiohttp import web
 
+from sglang.srt.arg_groups.overrides import resolved_view
 from sglang.srt.disaggregation.base.conn import (
     BaseKVBootstrapServer,
     BaseKVManager,
@@ -132,7 +133,7 @@ class CommonKVManager(BaseKVManager):
         self.attn_dp_size = get_attention_dp_size()
         self.attn_dp_rank = get_attention_dp_rank()
         self.system_dp_size = (
-            1 if server_args.enable_dp_attention else server_args.dp_size
+            1 if resolved_view(server_args).enable_dp_attention else server_args.dp_size
         )
         self.system_dp_rank = (
             self.kv_args.system_dp_rank if self.kv_args.system_dp_rank else 0

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.memory_pool_host import (
     MLATokenToKVPoolHost,
     get_mha_host_pool_cls,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import ceil_align
 
@@ -44,7 +45,7 @@ class DecodeKVCacheOffloadManager:
     ) -> None:
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.server_args = server_args
         self.request_counter = 0
         self.tree_cache = tree_cache

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1436,17 +1436,22 @@ def _compute_parallelism_ranks(
     server_args: ServerArgs, tp_rank: int
 ) -> Tuple[int, int, int]:
     """Compute attention-CP, MoE-DP, and MoE-EP ranks for a TP rank."""
-    attn_dp_size = server_args.dp_size if server_args.enable_dp_attention else 1
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # Launcher process: no publish exists here; the resolved parallel shape
+    # lives on the declaration stash carried by the instance.
+    view = resolved_view(server_args)
+    attn_dp_size = server_args.dp_size if view.enable_dp_attention else 1
 
     # Parallelism hierarchy (outermost to innermost):
     # - Attention: Global(TP) -> DP -> ATTN_CP -> ATTN_TP (innermost)
     # - MoE: Global(TP) -> MOE_DP -> EP -> MOE_TP (innermost)
-    attn_tp_size = server_args.tp_size // attn_dp_size // server_args.attn_cp_size
-    attn_cp_rank = (tp_rank // attn_tp_size) % server_args.attn_cp_size
+    attn_tp_size = server_args.tp_size // attn_dp_size // view.attn_cp_size
+    attn_cp_rank = (tp_rank // attn_tp_size) % view.attn_cp_size
     moe_dp_rank = tp_rank // (server_args.tp_size // server_args.moe_dp_size)
     moe_ep_rank = (
         tp_rank
         % (server_args.tp_size // server_args.moe_dp_size)
-        // (server_args.tp_size // server_args.moe_dp_size // server_args.ep_size)
+        // (server_args.tp_size // server_args.moe_dp_size // view.ep_size)
     )
     return attn_cp_rank, moe_dp_rank, moe_ep_rank

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -35,6 +35,7 @@ from sglang.srt.observability.metrics_collector import (
     ExpertDispatchCollector,
     resolve_collector_class,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import Withable, get_device, get_int_env_var
 
@@ -313,18 +314,18 @@ class _SinglePassGatherer(ABC):
                 server_args, expert_location_metadata, rank
             )
 
-        if server_args.moe_a2a_backend == "mori":
+        if get_flags().moe_a2a_backend == "mori":
             return _DeepepLowLatencySinglePassGatherer(expert_location_metadata, rank)
 
         if server_args.expert_distribution_recorder_mode == "stat_approx":
-            if server_args.moe_a2a_backend != "none" and (
+            if get_flags().moe_a2a_backend != "none" and (
                 server_args.deepep_mode == "normal"
             ):
                 return _DeepepNormalSinglePassGatherer(expert_location_metadata, rank)
             else:
                 raise NotImplementedError
 
-        if server_args.moe_a2a_backend != "none":
+        if get_flags().moe_a2a_backend != "none":
             if server_args.deepep_mode == "normal":
                 return _SelectExpertsSinglePassGatherer(expert_location_metadata, rank)
             elif server_args.deepep_mode == "low_latency":

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -199,7 +199,9 @@ class ExpertLocationMetadata:
             model_config_for_expert_location.num_logical_experts
             + server_args.ep_num_redundant_experts
         )
-        ep_size = server_args.ep_size
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        ep_size = resolved_view(server_args).ep_size
         assert num_physical_experts % ep_size == 0
         num_local_physical_experts = num_physical_experts // ep_size
 
@@ -391,7 +393,9 @@ def _compute_logical_to_all_physical_map(
 
     # Replace by the physical expert on local GPU or node if possible
     if moe_ep_rank is not None:
-        num_gpus_per_node = server_args.ep_size // server_args.nnodes
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        num_gpus_per_node = resolved_view(server_args).ep_size // server_args.nnodes
         num_local_gpu_physical_experts = num_physical_experts // ep_size
         num_local_node_physical_experts = (
             num_local_gpu_physical_experts * num_gpus_per_node
@@ -448,7 +452,9 @@ def compute_logical_to_rank_dispatch_physical_map(
     logical_to_all_physical_map = logical_to_all_physical_map.cpu()
 
     num_local_gpu_physical_experts = num_physical_experts // ep_size
-    num_gpus_per_node = server_args.ep_size // server_args.nnodes
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    num_gpus_per_node = resolved_view(server_args).ep_size // server_args.nnodes
     num_local_node_physical_experts = num_local_gpu_physical_experts * num_gpus_per_node
     num_layers, num_logical_experts, _ = logical_to_all_physical_map.shape
     dtype = logical_to_all_physical_map.dtype

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -18,6 +18,7 @@ from typing import Optional, Union
 import mlx.core as mx
 import torch
 
+from sglang.srt.arg_groups.overrides import resolved_view
 from sglang.srt.hardware_backend.mlx.model_runner import (
     MlxPendingDecode,
     MlxPendingExtend,
@@ -53,7 +54,7 @@ class MlxTpModelWorker(TpModelWorker):
             trust_remote_code=self.server_args.trust_remote_code,
             disable_radix_cache=self.server_args.disable_radix_cache,
             mem_fraction_static=self.server_args.mem_fraction_static,
-            quantization=self.server_args.quantization,
+            quantization=resolved_view(self.server_args).quantization,
         )
         if self.server_args.max_total_tokens is not None:
             init_kwargs["pool_size"] = self.server_args.max_total_tokens

--- a/python/sglang/srt/kv_canary/token_oracle/install.py
+++ b/python/sglang/srt/kv_canary/token_oracle/install.py
@@ -15,7 +15,9 @@ def install_token_oracle_from_env(
 ) -> Optional[TokenOracleManager]:
     # Must be called before create_sampler() so the factory is present when the
     # Sampler is first constructed.
-    if server_args.sampling_backend != "token_oracle":
+    from sglang.srt.runtime_context import get_flags
+
+    if get_flags().sampling_backend != "token_oracle":
         return None
 
     oracle = HashOracle(vocab_size=vocab_size)

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -72,6 +72,7 @@ from sglang.srt.layers.attention.utils import (
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import get_bool_env_var
 
 logger = logging.getLogger(__name__)
@@ -145,7 +146,7 @@ class AiterAttnBackend(AttentionBackend):
 
         self.input_dtype = model_runner.model_config.dtype
 
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
         self.extend_attention_fwd = torch.compiler.disable(extend_attention_fwd)
 
@@ -2795,7 +2796,7 @@ class AiterMultiStepDraftBackend:
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
     def common_template(
         self, forward_batch: ForwardBatch, kv_indices_buffer: torch.Tensor, call_fn: int

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -290,16 +290,19 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
         initialize_linear_attn_config(runner.server_args)
         hybrid_backend_cls = HybridLinearAttnBackend
         if runner.hybrid_gdn_config is not None:
+            from sglang.srt.runtime_context import get_flags
+
+            attention_backend = get_flags().attn.backend
             if is_blackwell():
-                assert (
-                    runner.server_args.attention_backend == "triton"
-                    or runner.server_args.attention_backend == "trtllm_mha"
-                    or runner.server_args.attention_backend == "fa4"
-                    or runner.server_args.attention_backend == "flashinfer"
+                assert attention_backend in (
+                    "triton",
+                    "trtllm_mha",
+                    "fa4",
+                    "flashinfer",
                 ), "triton, trtllm_mha, fa4, or flashinfer backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend to specify the backend."
             if is_npu():
                 assert (
-                    runner.server_args.attention_backend == "ascend"
+                    attention_backend == "ascend"
                 ), "ascend backend is the only supported backend on NPU for hybrid GDN models, use --attention-backend ascend to specify the backend."
             logger.info(f"Using hybrid linear attention backend for hybrid GDN models.")
             linear_attn_backend = GDNAttnBackend(runner)

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -34,7 +34,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_parallel, resolved_attention_backends
 from sglang.srt.state_capturer.indexer_topk import (
     maybe_capture_indexer_topk,
 )
@@ -121,7 +121,7 @@ def _is_in_piecewise_or_breakable_cuda_graph() -> bool:
 def _uses_dsa_attention_backend(forward_batch: ForwardBatch) -> bool:
     attn_backend = get_attn_backend()
     server_args = get_global_server_args()
-    prefill_backend, decode_backend = server_args.get_attention_backends()
+    prefill_backend, decode_backend = resolved_attention_backends()
     prefill_backend = (
         getattr(attn_backend, "prefill_attention_backend_str", None) or prefill_backend
     )

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -15,7 +15,7 @@ from typing import (
 import torch
 
 from sglang.srt.configs.model_config import get_dsa_index_topk, is_deepseek_dsa
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 
 logger = logging.getLogger(__name__)
 from sglang.srt.environ import envs
@@ -366,10 +366,8 @@ class DeepseekSparseAttnBackend(
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
 
         self.use_mha: bool = False
-        self.dsa_prefill_impl: _DSA_IMPL_T = (
-            model_runner.server_args.dsa_prefill_backend
-        )
-        self.dsa_decode_impl: _DSA_IMPL_T = model_runner.server_args.dsa_decode_backend
+        self.dsa_prefill_impl: _DSA_IMPL_T = get_flags().dsa_prefill_backend
+        self.dsa_decode_impl: _DSA_IMPL_T = get_flags().dsa_decode_backend
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend(
             model_runner.server_args.dsa_topk_backend
         )

--- a/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
@@ -24,7 +24,7 @@ from sglang.srt.layers.attention.flashattention_backend import (
     FlashAttentionMetadata,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
@@ -125,7 +125,7 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.kv_cache_dtype = model_runner.kv_cache_dtype
-        self.kv_cache_dtype_str = model_runner.server_args.kv_cache_dtype
+        self.kv_cache_dtype_str = get_flags().kv_cache_dtype
         self.page_size = model_runner.page_size
 
         assert self.num_heads % self.num_kv_heads == 0

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -28,6 +28,7 @@ from sglang.srt.layers.utils.cp_utils import (
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.utils import get_compiler_backend
@@ -242,7 +243,7 @@ class FlashAttentionBackend(AttentionBackend):
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.kv_cache_dtype = model_runner.kv_cache_dtype
-        self.kv_cache_dtype_str = model_runner.server_args.kv_cache_dtype
+        self.kv_cache_dtype_str = get_flags().kv_cache_dtype
         self.page_size = model_runner.page_size
         # Static page-table width (upper bound). The device-side page-table build
         # sizes to this constant, so no runtime host max is needed.

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -34,6 +34,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.speculative.spec_utils import (
@@ -968,7 +969,7 @@ class FlashInferMLAMultiStepDraftBackend:
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
     def common_template(
         self,

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -19,6 +19,7 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.runtime_context import mamba_extra_buffer_enabled
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.spec_info import SpecInput
@@ -691,7 +692,7 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
             model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape
         )
 
-        if model_runner.server_args.enable_mamba_extra_buffer():
+        if mamba_extra_buffer_enabled():
             assert (
                 self.conv_states_shape[-1] < self.mamba_chunk_size
             ), f"{self.conv_states_shape[-1]=} should be less than {self.mamba_chunk_size}"

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -15,7 +15,7 @@ from sglang.srt.layers.attention.linear.seg_la import SegLaMeta, seg_la_fwd
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         self.device = model_runner.device
         self.decode_cuda_graph_metadata = {}
         self.kv_cache_dtype = model_runner.kv_cache_dtype
-        self.kv_cache_dtype_str = model_runner.server_args.kv_cache_dtype
+        self.kv_cache_dtype_str = get_flags().kv_cache_dtype
         self.BLOCK = (
             model_runner.model_config.block
             if hasattr(model_runner.model_config, "block")

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -27,7 +27,7 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.cuda_graph_config import cuda_graph_fully_disabled
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
     draft_kv_indices_used_len,
@@ -1817,7 +1817,7 @@ class TritonMultiStepDraftBackend:
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
     def common_template(
         self,

--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -16,6 +16,7 @@ from sglang.srt.managers.schedule_batch import get_global_server_args
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.runtime_context import get_flags
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
@@ -69,7 +70,7 @@ class XPUAttentionBackend(AttentionBackend):
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.kv_cache_dtype = model_runner.kv_cache_dtype
-        self.kv_cache_dtype_str = model_runner.server_args.kv_cache_dtype
+        self.kv_cache_dtype_str = get_flags().kv_cache_dtype
         self.page_size = model_runner.page_size
         self.use_mla = model_runner.model_config.attention_arch == AttentionArch.MLA
         self.skip_prefill = skip_prefill

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -70,7 +70,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
@@ -169,7 +169,7 @@ def apply_flashinfer_allreduce_fusion(batch_size: int):
         and batch_size > 0
         and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
         and not is_dp_attention_enabled()
-        and get_global_server_args().flashinfer_allreduce_fusion_backend is not None
+        and get_flags().flashinfer_allreduce_fusion_backend is not None
         and not is_flashinfer_allreduce_unavailable()
     )
 
@@ -429,7 +429,7 @@ class LayerScatterModes:
 
 
 def enable_moe_dense_fully_dp():
-    return get_global_server_args().moe_dense_tp_size == 1
+    return get_flags().moe_dense_tp_size == 1
 
 
 class LayerCommunicator:

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -287,10 +287,10 @@ def initialize_dp_attention(
     _DP_MAX_LEN_WITH_IDLE = (
         getattr(model_config.hf_config, "hybrid_override_pattern", None) is not None
     )
-    enable_dp_attention = server_args.enable_dp_attention
+    enable_dp_attention = get_flags().enable_dp_attention
     dp_size = server_args.dp_size
     moe_dense_tp_size = get_flags().moe_dense_tp_size
-    attn_cp_size = server_args.attn_cp_size
+    attn_cp_size = get_flags().attn_cp_size
 
     _ENABLE_DP_ATTENTION_FLAG = enable_dp_attention
 
@@ -836,7 +836,9 @@ def is_enable_moe_cp_allgather() -> bool:
     from sglang.srt.server_args import get_global_server_args
 
     sa = get_global_server_args()
-    return sa.attn_cp_size > sa.moe_dp_size
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return resolved_view(sa).attn_cp_size > sa.moe_dp_size
 
 
 def moe_cp_all_gather_into_tensor(output: torch.Tensor, input: torch.Tensor):

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -29,6 +29,7 @@ from sglang.srt.distributed import (
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import get_bool_env_var, is_hip
 
 if TYPE_CHECKING:
@@ -288,7 +289,7 @@ def initialize_dp_attention(
     )
     enable_dp_attention = server_args.enable_dp_attention
     dp_size = server_args.dp_size
-    moe_dense_tp_size = server_args.moe_dense_tp_size
+    moe_dense_tp_size = get_flags().moe_dense_tp_size
     attn_cp_size = server_args.attn_cp_size
 
     _ENABLE_DP_ATTENTION_FLAG = enable_dp_attention

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -665,8 +665,13 @@ def ensure_workspace_initialized(
     token_num = token_num or max_token_num
     group_key = (device_group, cpu_group)
     effective_dtype = dtype or torch.bfloat16
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # The auto-enable declaration lives on the declaration stash / flags
+    # tier; the retired server_args field stays pristine (None), so the
+    # backend must be resolved through the view.
     server_args = get_global_server_args()
-    backend = resolve_flashinfer_allreduce_fusion_backend(server_args)
+    backend = resolve_flashinfer_allreduce_fusion_backend(resolved_view(server_args))
     if backend is None:
         return False
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -66,7 +66,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.model_loader.weight_utils import narrow_padded_param_and_loaded_weight
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     cpu_has_amx_support,
@@ -301,7 +301,7 @@ class FusedMoE(torch.nn.Module):
         print_info_once(
             "FlashInfer TRTLLM MoE deferred finalize is "
             f"{'enabled' if self.supports_deferred_finalize else 'disabled'} "
-            f"(moe_runner_backend={server_args.moe_runner_backend}, "
+            f"(moe_runner_backend={get_flags().moe.runner_backend}, "
             f"quant_method={type(self.quant_method).__name__})."
         )
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -271,13 +271,13 @@ def initialize_moe_config(server_args: ServerArgs):
     global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
     global MOE_QUANTIZATION
 
-    MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
-    MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
     from sglang.srt.arg_groups.overrides import resolved_view
 
     # Scheduler.init_moe_gemm_config calls this before init_model_worker
     # publishes the flags tier: read the resolved values through the view.
     view = resolved_view(server_args)
+    MOE_A2A_BACKEND = MoeA2ABackend(view.moe_a2a_backend)
+    MOE_RUNNER_BACKEND = MoeRunnerBackend(view.moe_runner_backend)
     SPECULATIVE_MOE_RUNNER_BACKEND = (
         MoeRunnerBackend(view.speculative_moe_runner_backend)
         if view.speculative_moe_runner_backend is not None

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -301,7 +301,7 @@ def initialize_moe_config(server_args: ServerArgs):
     DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = (
         server_args.disable_flashinfer_cutlass_moe_fp4_allgather
     )
-    MOE_QUANTIZATION = server_args.quantization
+    MOE_QUANTIZATION = view.quantization
 
 
 def get_moe_a2a_backend() -> MoeA2ABackend:

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -273,14 +273,19 @@ def initialize_moe_config(server_args: ServerArgs):
 
     MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
     MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # Scheduler.init_moe_gemm_config calls this before init_model_worker
+    # publishes the flags tier: read the resolved values through the view.
+    view = resolved_view(server_args)
     SPECULATIVE_MOE_RUNNER_BACKEND = (
-        MoeRunnerBackend(server_args.speculative_moe_runner_backend)
-        if server_args.speculative_moe_runner_backend is not None
+        MoeRunnerBackend(view.speculative_moe_runner_backend)
+        if view.speculative_moe_runner_backend is not None
         else MOE_RUNNER_BACKEND
     )
     SPECULATIVE_MOE_A2A_BACKEND = (
-        MoeA2ABackend(server_args.speculative_moe_a2a_backend)
-        if server_args.speculative_moe_a2a_backend is not None
+        MoeA2ABackend(view.speculative_moe_a2a_backend)
+        if view.speculative_moe_a2a_backend is not None
         else MOE_A2A_BACKEND
     )
     DEEPEP_MODE = DeepEPMode(server_args.deepep_mode)

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -19,6 +19,7 @@ from sglang.srt.utils.common import torch_release
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
+from sglang.srt.arg_groups.overrides import resolved_view
 from sglang.srt.layers.quantization.fp8_kernel import (
     fp8_dtype,
     fp8_max,
@@ -535,7 +536,7 @@ def initialize_fp8_gemm_config(server_args: ServerArgs) -> None:
 
     if (
         backend.is_auto()
-        and server_args.quantization == "mxfp8"
+        and resolved_view(server_args).quantization == "mxfp8"
         and _is_sm100_supported
         and is_flashinfer_available()
     ):

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -461,8 +461,7 @@ def register_sampler_backend(backend: str, factory: Callable[[], "Sampler"]) -> 
 def create_sampler(backend: Optional[str] = None) -> "Sampler":
     """Create a sampler honoring custom backend registrations."""
 
-    server_args = get_global_server_args()
-    backend = backend or (server_args.sampling_backend if server_args else None)
+    backend = backend or get_flags().sampling_backend
 
     if backend in _CUSTOM_SAMPLER_FACTORIES:
         sampler = _CUSTOM_SAMPLER_FACTORIES[backend]()

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -181,7 +181,9 @@ class DataParallelController:
         self.workers: List[zmq.Socket] = [None] * server_args.dp_size
         self.status: List[bool] = [True] * server_args.dp_size
 
-        if server_args.enable_dp_attention:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if resolved_view(server_args).enable_dp_attention:
             self.launch_dp_attention_schedulers(server_args, port_args)
             # When local control broadcast is enabled, send control messages to
             # every DP group leader (attn_tp_rank=0) so each leader broadcasts
@@ -492,7 +494,9 @@ class DataParallelController:
         dp_rank: Optional[int],
         worker_ports: Optional[List[int]] = None,
     ):
-        if not server_args.enable_dp_attention:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if not resolved_view(server_args).enable_dp_attention:
             logger.info(f"Launch DP{dp_rank} starting at GPU #{base_gpu_id}.")
 
         memory_saver_adapter = TorchMemorySaverAdapter.create(
@@ -517,18 +521,21 @@ class DataParallelController:
 
         attn_cp_rank = 0
         moe_dp_rank = 0
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        view = resolved_view(server_args)
         for pp_rank in pp_rank_range:
             for tp_rank in tp_rank_range:
                 rank_port_args = port_args
 
-                if server_args.enable_dp_attention:
+                if view.enable_dp_attention:
                     # dp attention has different sharding logic
                     _, _, dp_rank, _ = compute_dp_attention_world_info(
-                        server_args.enable_dp_attention,
+                        view.enable_dp_attention,
                         tp_rank,
                         server_args.tp_size,
                         server_args.dp_size,
-                        server_args.attn_cp_size,
+                        view.attn_cp_size,
                     )
                     # compute zmq ports for this dp rank
                     rank_port_args = PortArgs.init_new(
@@ -546,28 +553,20 @@ class DataParallelController:
                     + ((pp_rank % pp_size_per_node) * tp_size_per_node)
                     + (tp_rank % tp_size_per_node) * server_args.gpu_id_step
                 )
-                attn_dp_size = (
-                    server_args.dp_size if server_args.enable_dp_attention else 1
-                )
+                attn_dp_size = server_args.dp_size if view.enable_dp_attention else 1
 
                 # Parallelism hierarchy (outermost to innermost):
                 # - Attention: Global(TP) -> DP -> ATTN_CP -> ATTN_TP (innermost)
                 # - MoE: Global(TP) -> MOE_DP -> EP -> MOE_TP (innermost)
-                attn_tp_size = (
-                    server_args.tp_size // attn_dp_size // server_args.attn_cp_size
-                )
-                attn_cp_rank = (tp_rank // attn_tp_size) % server_args.attn_cp_size
+                attn_tp_size = server_args.tp_size // attn_dp_size // view.attn_cp_size
+                attn_cp_rank = (tp_rank // attn_tp_size) % view.attn_cp_size
                 moe_dp_rank = tp_rank // (
                     server_args.tp_size // server_args.moe_dp_size
                 )
                 moe_ep_rank = (
                     tp_rank
                     % (server_args.tp_size // server_args.moe_dp_size)
-                    // (
-                        server_args.tp_size
-                        // server_args.moe_dp_size
-                        // server_args.ep_size
-                    )
+                    // (server_args.tp_size // server_args.moe_dp_size // view.ep_size)
                 )
 
                 with self.env_lock, maybe_reindex_device_id(gpu_id) as gpu_id:

--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -82,8 +82,10 @@ def should_use_zmq(server_args) -> bool:
     the SHM file on node 0, so we fall back to zmq transport.  The env var
     ``SGLANG_LOAD_SNAPSHOT_USE_ZMQ`` forces zmq mode for testing.
     """
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     return (
-        server_args.enable_dp_attention and server_args.nnodes > 1
+        resolved_view(server_args).enable_dp_attention and server_args.nnodes > 1
     ) or envs.SGLANG_LOAD_SNAPSHOT_USE_ZMQ.get()
 
 

--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -74,7 +74,7 @@ class PrefillDelayer:
             f"queue_trigger_enabled={self._queue_trigger_enabled}"
         )
         self.dp_size = dp_size
-        self.enable_dp_attention = server_args.enable_dp_attention
+        self.enable_dp_attention = get_flags().enable_dp_attention
         dp_size_dim = dp_size if self.enable_dp_attention else 1
 
         # Mirror scheduler_dp_attn_mixin's NCCL all-gather path: when the

--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, NamedTuple, Optional
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import get_bool_env_var
 
 if TYPE_CHECKING:
@@ -80,7 +81,7 @@ class PrefillDelayer:
         # env flag is on (or overlap scheduling is disabled), ride the NCCL
         # device group on `device` instead of gloo on CPU.
         use_nccl = (
-            server_args.disable_overlap_schedule
+            get_flags().disable_overlap_schedule
             or envs.SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH.get()
         )
         if use_nccl:
@@ -108,7 +109,7 @@ class PrefillDelayer:
         self.skip_first_delayer = True
 
         assert (
-            not server_args.disable_overlap_schedule
+            not get_flags().disable_overlap_schedule
         ), "To use PrefillDelayer, disable_overlap_schedule must be False."
 
     def _negotiate_should_allow_prefill(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.runtime_context import (
+    mamba_extra_buffer_enabled,
+    mamba_extra_buffer_lazy_enabled,
+)
 from sglang.srt.utils.common import (
     Range,
     ceil_align,
@@ -2143,7 +2147,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 req.already_computed = seq_len
             req.is_retracted = False
 
-            if get_global_server_args().enable_mamba_extra_buffer():
+            if mamba_extra_buffer_enabled():
                 track_entry = self._mamba_radix_cache_v2_req_prepare_for_extend(req)
                 mamba_track_mask_cpu.append(track_entry.track_mask)
                 mamba_track_indices_cpu.append(track_entry.track_index)
@@ -2248,7 +2252,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_logprob_start_lens = extend_logprob_start_lens
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
 
-        if get_global_server_args().enable_mamba_extra_buffer():
+        if mamba_extra_buffer_enabled():
             self.mamba_track_indices = torch.tensor(
                 mamba_track_indices_cpu,
                 dtype=torch.int64,
@@ -2333,7 +2337,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # In lazy mode, skip the swap — the second ping-pong slot is not
             # allocated yet; it will be allocated on demand at the track boundary
             # in mamba_lazy_prealloc_at_boundary during prepare_for_decode.
-            if not get_global_server_args().enable_mamba_extra_buffer_lazy():
+            if not mamba_extra_buffer_lazy_enabled():
                 req.mamba_next_track_idx = (
                     self.req_to_token_pool.get_mamba_ping_pong_other_idx(
                         req.mamba_next_track_idx
@@ -2673,7 +2677,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 self.req_pool_indices_cpu,
             )
 
-        if get_global_server_args().enable_mamba_extra_buffer():
+        if mamba_extra_buffer_enabled():
             mamba_track_interval = get_global_server_args().mamba_track_interval
 
             if len(self.reqs) == 0:
@@ -2681,7 +2685,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     (0,), dtype=torch.int64, device=self.device
                 )
             else:
-                if get_global_server_args().enable_mamba_extra_buffer_lazy():
+                if mamba_extra_buffer_lazy_enabled():
                     self.mamba_lazy_prealloc_at_boundary(mamba_track_interval)
                 set_mamba_track_indices_from_reqs(self)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1352,8 +1352,10 @@ class Scheduler(
             "flashinfer": ("SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE", 4096),
             "triton": ("SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE", 4096),
         }
+        from sglang.srt.runtime_context import get_flags
+
         env_var, default_size = backend_sizes.get(
-            self.server_args.attention_backend, (None, None)
+            get_flags().attn.backend, (None, None)
         )
         self.truncation_align_size = (
             get_int_env_var(env_var, default_size) if env_var else None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -238,6 +238,7 @@ from sglang.srt.observability.trace import process_tracing_init, trace_set_threa
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.platforms import current_platform
 from sglang.srt.plugins import load_plugins
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import PortArgs, ServerArgs, get_global_server_args
 from sglang.srt.session.session_controller import SessionController
@@ -361,14 +362,16 @@ class Scheduler(
         self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
         self.enable_hisparse = server_args.enable_hisparse
 
-        # Distributed rank info
+        # Distributed rank info (pre-publish: read the resolved parallel
+        # shape through the view)
+        _view = resolved_view(server_args)
         attn_tp_rank, attn_tp_size, attn_dp_rank, attn_dp_size = (
             compute_dp_attention_world_info(
-                server_args.enable_dp_attention,
+                _view.enable_dp_attention,
                 tp_rank,
                 server_args.tp_size,
                 server_args.dp_size,
-                server_args.attn_cp_size,
+                _view.attn_cp_size,
             )
         )
         self.ps = ParallelState(
@@ -381,11 +384,11 @@ class Scheduler(
             attn_tp_rank=attn_tp_rank,
             attn_tp_size=attn_tp_size,
             attn_cp_rank=attn_cp_rank,
-            attn_cp_size=server_args.attn_cp_size,
+            attn_cp_size=_view.attn_cp_size,
             attn_dp_rank=attn_dp_rank,
             attn_dp_size=attn_dp_size,
             moe_ep_rank=moe_ep_rank,
-            moe_ep_size=server_args.ep_size,
+            moe_ep_size=_view.ep_size,
             moe_dp_rank=moe_dp_rank,
             moe_dp_size=server_args.moe_dp_size,
             gpu_id=gpu_id,
@@ -473,7 +476,7 @@ class Scheduler(
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
                 tp_group=(
                     self.attn_tp_cpu_group
-                    if self.server_args.enable_dp_attention
+                    if get_flags().enable_dp_attention
                     else self.tp_cpu_group
                 ),
                 tree_cache=self.tree_cache,
@@ -918,9 +921,7 @@ class Scheduler(
         # Use the CPU (gloo) group to broadcast VLM Python objects and avoid CUDA
         # stream/device coupling (#11910).
         self.dp_tp_group = (
-            self.attn_tp_group
-            if self.server_args.enable_dp_attention
-            else self.tp_group
+            self.attn_tp_group if get_flags().enable_dp_attention else self.tp_group
         )
         self.dp_tp_cpu_group = self.dp_tp_group.cpu_group
 
@@ -1346,8 +1347,6 @@ class Scheduler(
             "flashinfer": ("SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE", 4096),
             "triton": ("SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE", 4096),
         }
-        from sglang.srt.runtime_context import get_flags
-
         env_var, default_size = backend_sizes.get(
             get_flags().attn.backend, (None, None)
         )
@@ -3382,7 +3381,7 @@ class Scheduler(
 
     def _maybe_report_active_ranks(self) -> None:
         if not (
-            self.server_args.enable_dp_attention
+            get_flags().enable_dp_attention
             and self.server_args.elastic_ep_backend is not None
         ):
             return
@@ -4231,13 +4230,16 @@ def configure_scheduler_process(
         prefix += f" DP{dp_rank}"
     if server_args.pp_size > 1:
         prefix += f" PP{pp_rank}"
-    if server_args.attn_cp_size > 1:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    _view = resolved_view(server_args)
+    if _view.attn_cp_size > 1:
         prefix += f" ATTN_CP{attn_cp_rank}"
     if server_args.moe_dp_size > 1:
         prefix += f" MOE_DP{moe_dp_rank}"
     if server_args.tp_size > 1:
         prefix += f" TP{tp_rank}"
-    if server_args.ep_size > 1:
+    if _view.ep_size > 1:
         prefix += f" EP{moe_ep_rank}"
 
     # Config the process

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -348,7 +348,9 @@ class Scheduler(
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-        self.page_size = server_args.page_size
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.page_size = resolved_view(server_args).page_size
         self.enable_hierarchical_cache = server_args.enable_hierarchical_cache
         self.enable_hicache_storage = server_args.hicache_storage_backend is not None
         self.enable_decode_hicache = (
@@ -585,15 +587,6 @@ class Scheduler(
                 if self.server_args.dllm_algorithm is not None
                 else None
             )
-            if self.dllm_config:
-                if self.dllm_config.block_size < self.page_size:
-                    logger.warning(
-                        "WARNING: "
-                        f"The page size {self.page_size} should not be larger than dllm block size {self.dllm_config.block_size}."
-                        f"Page size now falls back to {self.dllm_config.block_size}"
-                    )
-                    self.page_size = self.dllm_config.block_size
-                    self.server_args.page_size = self.dllm_config.block_size
 
     def init_metrics_collector(
         self, tp_rank: int, pp_rank: int, dp_rank: Optional[int]

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -340,16 +340,17 @@ class Scheduler(
         self.enable_lora = server_args.enable_lora
         self.enable_lora_overlap_loading = server_args.enable_lora_overlap_loading
         self.max_loras_per_batch = server_args.max_loras_per_batch
-        self.enable_overlap = not server_args.disable_overlap_schedule and not use_mlx()
-        self.enable_overlap_mlx = not server_args.disable_overlap_schedule and use_mlx()
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        _overlap_disabled = resolved_view(server_args).disable_overlap_schedule
+        self.enable_overlap = not _overlap_disabled and not use_mlx()
+        self.enable_overlap_mlx = not _overlap_disabled and use_mlx()
         self.enable_pdmux = server_args.enable_pdmux
         self.skip_tokenizer_init = server_args.skip_tokenizer_init
         self.stream_interval = server_args.stream_interval
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-        from sglang.srt.arg_groups.overrides import resolved_view
-
         self.page_size = resolved_view(server_args).page_size
         self.enable_hierarchical_cache = server_args.enable_hierarchical_cache
         self.enable_hicache_storage = server_args.hicache_storage_backend is not None

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -25,6 +25,7 @@ from sglang.srt.mem_cache.common import (
     maybe_cache_unfinished_req,
     release_kv_cache,
 )
+from sglang.srt.runtime_context import mamba_extra_buffer_lazy_enabled
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.state_capturer.routed_experts import get_global_experts_capturer
@@ -848,7 +849,7 @@ class SchedulerBatchResultProcessor:
                     prepare_release(req)
                 is_insert = (
                     req.mamba_lazy_is_insert
-                    if get_global_server_args().enable_mamba_extra_buffer_lazy()
+                    if mamba_extra_buffer_lazy_enabled()
                     else True
                 )
                 release_kv_cache(req, self.tree_cache, is_insert=is_insert)
@@ -883,7 +884,7 @@ class SchedulerBatchResultProcessor:
         if req.mamba_ping_pong_track_buffer is None:
             return
 
-        lazy = get_global_server_args().enable_mamba_extra_buffer_lazy()
+        lazy = mamba_extra_buffer_lazy_enabled()
         at_boundary, track_seqlen = self._mamba_check_track_boundary(
             req, batch, result, i
         )

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -17,6 +17,7 @@ from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.model_executor.cuda_graph_config import cuda_graph_fully_disabled
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.metrics_collector import DPCooperationInfo
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils.common import require_mlp_tp_gather
@@ -279,7 +280,7 @@ class SchedulerDPAttnAdapter:
             get_idle_batch=self.get_idle_batch,
             disable_cuda_graph=cuda_graph_fully_disabled(),
             require_mlp_tp_gather=require_mlp_tp_gather(self.server_args),
-            disable_overlap_schedule=self.server_args.disable_overlap_schedule,
+            disable_overlap_schedule=get_flags().disable_overlap_schedule,
             offload_tags=self.offload_tags,
         )
 

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -26,6 +26,7 @@ from sglang.srt.managers.mm_utils import (
     has_shm_features,
     unwrap_shm_features,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
@@ -139,7 +140,7 @@ class SchedulerRequestReceiver:
         return recv_reqs
 
     def _broadcast_reqs_across_ranks(self, recv_reqs: Optional[List]) -> List:
-        if self.server_args.enable_dp_attention:
+        if get_flags().enable_dp_attention:
             if self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0:
                 work_reqs, control_reqs = self._split_work_and_control_reqs(recv_reqs)
             else:
@@ -242,7 +243,7 @@ class SchedulerRequestReceiver:
                 # peer ranks may still be unpickling ShmPointerMMData
                 # (-> shm_open).  Synchronize the same CPU groups that carried
                 # SHM-backed work requests before materialize() unlinks them.
-                if self.server_args.enable_dp_attention:
+                if get_flags().enable_dp_attention:
                     if self.ps.attn_tp_size > 1:
                         barrier(group=self.attn_tp_cpu_group)
                     if self.ps.attn_cp_size > 1:

--- a/python/sglang/srt/managers/scheduler_recv_skipper.py
+++ b/python/sglang/srt/managers/scheduler_recv_skipper.py
@@ -12,7 +12,9 @@ class SchedulerRecvSkipper:
 
     def __init__(self, server_args: ServerArgs):
         # Can be supported if needed, but may need e.g. `global_forward_mode`
-        assert not server_args.enable_dp_attention
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        assert not resolved_view(server_args).enable_dp_attention
         self._counter = 0
         self._threshold = server_args.scheduler_recv_interval
         # All can be tuned if needed

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -127,6 +127,13 @@ class TokenizerControlMixin:
     FanOutCommunicator, as opposed to data-plane inference requests multiplexed by rid.
     """
 
+    def _dp_attention_enabled(self) -> bool:
+        # Tokenizer process: no publish here; read the resolved value from
+        # the declaration stash carried by the instance.
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        return resolved_view(self.server_args).enable_dp_attention
+
     def init_communicators(self: TokenizerManager, server_args: ServerArgs):
         dispatch_pairs = []
         for spec in _COMMUNICATOR_SPECS:
@@ -373,7 +380,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for update weights from distributed"
 
         results = await self.init_weights_update_group_communicator(obj)
@@ -386,7 +393,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for destroy parameter update group"
 
         results = await self.destroy_weights_update_group_communicator(obj)
@@ -399,7 +406,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for update weights from distributed"
 
         if obj.abort_all_requests:
@@ -457,7 +464,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for update weights from tensor"
 
         if obj.abort_all_requests:
@@ -493,7 +500,7 @@ class TokenizerControlMixin:
         try:
             # For now, we only support single data parallel instance
             assert (
-                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+                self.server_args.dp_size == 1 or self._dp_attention_enabled()
             ), "dp_size must be 1 or dp attention must be enabled for update weights from IPC"
             logger.info("Starting IPC weight update")
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1320,10 +1320,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         - Or, if no request has text or multimodal input (all use pre-tokenized input_ids or input_embeds), batch the requests without tokenization.
         - Batch tokenization does not support DP attention yet, and it will make everything goes to the first rank currently
         """
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         return batch_size > 0 and (
             self.server_args.enable_tokenizer_batch_encode
             or (
-                (not self.server_args.enable_dp_attention)
+                (not resolved_view(self.server_args).enable_dp_attention)
                 and (not self._batch_has_text(batch_size, requests))
             )
         )

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -315,7 +315,9 @@ class TpModelWorker(BaseTpWorker):
         )[0]
         set_random_seed(self.random_seed)
 
-        self.enable_overlap = not server_args.disable_overlap_schedule
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.enable_overlap = not resolved_view(server_args).disable_overlap_schedule
         self.enable_spec = server_args.speculative_algorithm is not None
         self.hicache_layer_transfer_counter = None
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -243,10 +243,12 @@ class TpModelWorker(BaseTpWorker):
         is_multi_layer_eagle: bool = False,
         context_length: Optional[int] = None,
     ):
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         # Parse args
         self.server_args = server_args
         self.tp_size = server_args.tp_size
-        self.ep_size = server_args.ep_size
+        self.ep_size = resolved_view(server_args).ep_size
         self.pp_size = server_args.pp_size
         self.tp_rank = tp_rank
         self.moe_ep_rank = moe_ep_rank
@@ -314,8 +316,6 @@ class TpModelWorker(BaseTpWorker):
             src=self.world_group.ranks[0],
         )[0]
         set_random_seed(self.random_seed)
-
-        from sglang.srt.arg_groups.overrides import resolved_view
 
         self.enable_overlap = not resolved_view(server_args).disable_overlap_schedule
         self.enable_spec = server_args.speculative_algorithm is not None

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -222,8 +222,10 @@ def get_alloc_len_per_decode(server_args: Optional[ServerArgs] = None) -> int:
     # Spec decoding allocates max(topk * num_steps, num_draft_tokens) per decode step.
     spec_steps = server_args.speculative_num_steps or 1
     spec_topk = server_args.speculative_eagle_topk or 1
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     spec_tokens = server_args.max_speculative_num_draft_tokens
-    page_size = server_args.page_size
+    page_size = resolved_view(server_args).page_size
 
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
@@ -255,11 +257,13 @@ def get_req_to_token_extra_context_len(server_args: ServerArgs) -> int:
     Sized to hold the decode over-allocation; the spec v2 page>1 topk>1 holey
     draft footprint can outgrow the default num_draft_tokens headroom.
     """
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     # FIXME(lsyin): temporary fix for the context length issue under spec decoding
     extra = 4 + (server_args.max_speculative_num_draft_tokens or 0)
     if (
         server_args.speculative_algorithm is not None
-        and server_args.page_size > 1
+        and (resolved_view(server_args).page_size or 1) > 1
         and (server_args.speculative_eagle_topk or 1) > 1
     ):
         extra = max(extra, get_alloc_reserve_per_decode(server_args))
@@ -659,7 +663,7 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     start_p, end_p = req.pop_overallocated_kv_cache()
 
     global_server_args = get_global_server_args()
-    page_size = global_server_args.page_size
+    page_size = get_flags().page_size
     spec_algo = global_server_args.speculative_algorithm
 
     # strip_thinking_cache intentionally reports output tokens as overallocated

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -30,6 +30,10 @@ from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.registry import TreeCacheBuildContext, create_tree_cache
 from sglang.srt.model_loader.utils import get_resolved_model_impl
+from sglang.srt.runtime_context import (
+    mamba_extra_buffer_enabled,
+    mamba_extra_buffer_lazy_enabled,
+)
 
 if TYPE_CHECKING:
 
@@ -219,8 +223,8 @@ def build_kv_cache(
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,
         enable_session_radix_cache=server_args.enable_session_radix_cache,
-        enable_mamba_extra_buffer=server_args.enable_mamba_extra_buffer(),
-        enable_mamba_extra_buffer_lazy=server_args.enable_mamba_extra_buffer_lazy(),
+        enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
+        enable_mamba_extra_buffer_lazy=mamba_extra_buffer_lazy_enabled(),
         pp_rank=ps.pp_rank,
         pp_size=ps.pp_size,
         chunked_prefill_size=effective_chunked_prefill_size,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -128,6 +128,12 @@ def maybe_register_hicache_draft(
     tree_cache.cache_controller.set_draft_kv_pool(pool, draft_host_pool)
 
 
+def _resolved_view(server_args):
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return resolved_view(server_args)
+
+
 def build_kv_cache(
     *,
     server_args: ServerArgs,
@@ -216,7 +222,9 @@ def build_kv_cache(
         ),
         is_eagle=spec_algorithm.is_eagle(),
         tp_cache_group=(
-            attn_tp_cpu_group if server_args.enable_dp_attention else tp_cpu_group
+            attn_tp_cpu_group
+            if _resolved_view(server_args).enable_dp_attention
+            else tp_cpu_group
         ),
         attn_cp_cache_group=attn_cp_cpu_group,
         attn_tp_cache_group=attn_tp_cpu_group,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -60,7 +60,9 @@ def get_draft_kv_pool(
         return None
 
     # V2 workers nest the draft runner under `.draft_worker`.
-    if server_args.enable_multi_layer_eagle:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).enable_multi_layer_eagle:
         draft_runner = draft_worker.draft_worker.draft_runner_list[0]
     else:
         draft_runner = draft_worker.draft_worker.draft_runner

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -49,7 +49,7 @@ from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     ForwardBatchDeepSeekMHAMixin,
 )
 from sglang.srt.model_executor.triton_ops.position import compute_position_triton
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     is_cuda,
@@ -830,7 +830,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 ret.extend_prefix_lens = extend_prefix_lens
             ret.extend_num_tokens = batch.extend_num_tokens
             positions, ret.extend_start_loc = compute_position(
-                model_runner.server_args.attention_backend,
+                get_flags().attn.backend,
                 ret.extend_prefix_lens,
                 ret.extend_seq_lens,
                 ret.extend_num_tokens,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1429,7 +1429,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 logger.info(
                     "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
                 )
-                self.server_args.dtype = "float16"
+                from sglang.srt.arg_groups.overrides import (
+                    declare_load_time_override,
+                )
+
+                declare_load_time_override(
+                    "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
+                )
                 self.model_config.dtype = torch.float16
                 if torch.cuda.get_device_capability()[1] < 5:
                     raise RuntimeError("SGLang only supports sm75 and above.")
@@ -1597,13 +1603,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             getattr(self.model, "quant_config", None), "quantized_layers", None
         )
         if (
-            self.server_args.quantization is not None
+            get_flags().quantization is not None
             and isinstance(quantized_layers, tuple)
             and len(quantized_layers) == 2
         ):
             layer_types, quantized_layers_count = quantized_layers
             logger.info(
-                f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
+                f"Online {get_flags().quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
             )
 
         if self.server_args.debug_tensor_dump_output_folder is not None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2437,10 +2437,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         return result[1] if result else None
 
     def _record_kv_cache_dtype(self, resolved: str) -> None:
-        # Load-time resolution transition: the weight-resolved kv-cache dtype
-        # is declared into the flags tier; the dual-apply inside the helper
-        # replaces the legacy in-place write. Mock runners whose server_args
-        # is not the published object keep the plain write.
+        # The weight-resolved kv-cache dtype is declared into the flags
+        # tier. Mock runners whose server_args is not the published object
+        # keep the plain write (their readers go through the runner-local
+        # view).
         from sglang.srt.runtime_context import get_context
 
         if get_context()._server_args is self.server_args:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -384,11 +384,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.moe_ep_rank = moe_ep_rank
         self.moe_ep_size = moe_ep_size
         self.dp_rank = dp_rank
-        self.dp_size = server_args.dp_size if server_args.enable_dp_attention else 1
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        _view = resolved_view(server_args)
+        self.dp_size = server_args.dp_size if _view.enable_dp_attention else 1
         self.pp_rank = pp_rank
         self.pp_size = pp_size
         self.attn_cp_rank = attn_cp_rank
-        self.attn_cp_size = server_args.attn_cp_size
+        self.attn_cp_size = _view.attn_cp_size
         self.moe_dp_rank = moe_dp_rank
         self.moe_dp_size = server_args.moe_dp_size
         self.model_config = model_config
@@ -875,7 +878,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 device=self.device,
                 tp_group=(
                     self.attention_tp_group.cpu_group
-                    if self.server_args.enable_dp_attention
+                    if get_flags().enable_dp_attention
                     else self.tp_group.cpu_group
                 ),
                 host_to_device_ratio=hisparse_cfg.host_to_device_ratio,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1529,7 +1529,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             pyt_hooks = PytHooks()
             pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        if self.server_args.kv_cache_dtype == "fp8_e4m3":
+        # Same runner-local read as configure_kv_cache_dtype: the scale file
+        # must follow this runner's own kv-cache dtype, not the process-global
+        # flags (which may be default or another runner's for the unpublished
+        # fallback case _record_kv_cache_dtype supports).
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if resolved_view(self.server_args).kv_cache_dtype == "fp8_e4m3":
             if self.server_args.quantization_param_path is not None:
                 if callable(getattr(self.model, "load_kv_cache_scales", None)):
                     self.model.load_kv_cache_scales(
@@ -2444,7 +2450,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.server_args.kv_cache_dtype = resolved
 
     def configure_kv_cache_dtype(self):
-        if self.server_args.kv_cache_dtype == "auto":
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        # Read through the runner's own server_args: equal to the published
+        # leaf for the published runner, and honoring runner-local settings
+        # for runners whose server_args was never published (the case
+        # _record_kv_cache_dtype's fallback supports).
+        kv_cache_dtype = resolved_view(self.server_args).kv_cache_dtype
+        if kv_cache_dtype == "auto":
             quant_config = getattr(self.model, "quant_config", None)
             kv_cache_quant_algo = getattr(quant_config, "kv_cache_quant_algo", None)
             if (
@@ -2457,19 +2470,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
             else:
                 self.kv_cache_dtype = self.dtype
-        elif self.server_args.kv_cache_dtype == "fp8_e5m2":
+        elif kv_cache_dtype == "fp8_e5m2":
             if _is_hip:  # Using natively supported format
                 self.kv_cache_dtype = fp8_dtype
             else:
                 self.kv_cache_dtype = torch.float8_e5m2
-        elif self.server_args.kv_cache_dtype == "fp8_e4m3":
+        elif kv_cache_dtype == "fp8_e4m3":
             if _is_hip:  # Using natively supported format
                 self.kv_cache_dtype = fp8_dtype
             else:
                 self.kv_cache_dtype = torch.float8_e4m3fn
-        elif self.server_args.kv_cache_dtype in ("bf16", "bfloat16"):
+        elif kv_cache_dtype in ("bf16", "bfloat16"):
             self.kv_cache_dtype = torch.bfloat16
-        elif self.server_args.kv_cache_dtype == "fp4_e2m1":
+        elif kv_cache_dtype == "fp4_e2m1":
             if hasattr(torch, "float4_e2m1fn_x2"):
                 self.kv_cache_dtype = torch.float4_e2m1fn_x2
                 logger.warning(f"FP4 (E2M1) KV Cache might lead to a accuracy drop!")
@@ -2479,9 +2492,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
                 self.kv_cache_dtype = self.dtype
         else:
-            raise ValueError(
-                f"Unsupported kv_cache_dtype: {self.server_args.kv_cache_dtype}."
-            )
+            raise ValueError(f"Unsupported kv_cache_dtype: {kv_cache_dtype}.")
 
     def init_cublas(self):
         """We need to run a small matmul to init cublas. Otherwise, it will raise some errors later."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1147,14 +1147,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # bidirectional-attention forcing and silently produce junk output.
         is_prefix_lm_recurrent = is_hrm_text and getattr(hf_config, "prefix_lm", True)
         if is_prefix_lm_recurrent:
-            if server_args.attention_backend not in (None, "triton"):
-                logger.warning(
-                    f"Overriding --attention-backend "
-                    f"{server_args.attention_backend!r} -> 'triton': only the "
-                    "Triton backend supports HRM-Text's bidirectional prefix "
-                    "attention."
-                )
-            server_args.attention_backend = "triton"
+            from sglang.srt.arg_groups.overrides import (
+                _hrm_text_attention_force,
+                run_post_process_pass,
+            )
+
+            run_post_process_pass(server_args, _hrm_text_attention_force)
             server_args.chunked_prefill_size = -1
             server_args.disable_radix_cache = True
             server_args.disable_cuda_graph = True
@@ -1173,22 +1171,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     f"{self.model_config.hf_config.model_type}"
                 )
 
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if (
             not self.use_mla_backend
-            or server_args.attention_backend
+            or resolved_view(server_args).attention_backend
             not in CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS
         ):
             server_args.disable_chunked_prefix_cache = True
 
         if not server_args.disable_chunked_prefix_cache:
             log_info_on_rank0(logger, "Chunked prefix cache is turned on.")
-
-        # The imperative adjustments above may overwrite fields the resolution passes
-        # already declared (HRM-Text forces attention_backend); redeclare the
-        # adjusted values so publish parity holds.
-        from sglang.srt.arg_groups.overrides import refresh_declared_fields
-
-        refresh_declared_fields(server_args, ("attention_backend",))
 
     def check_quantized_moe_compatibility(self):
         if (
@@ -2571,7 +2564,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
         else:
             attn_backend = self._get_attention_backend_from_str(
-                self.server_args.attention_backend,
+                get_flags().attn.backend,
                 init_new_workspace=init_new_workspace,
             )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -180,7 +180,7 @@ from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
 from sglang.srt.model_loader.utils import set_default_torch_dtype
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.platforms import current_platform
-from sglang.srt.runtime_context import get_flags
+from sglang.srt.runtime_context import get_flags, resolved_attention_backends
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import (
     ServerArgs,
@@ -2542,7 +2542,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         (
             self.prefill_attention_backend_str,
             self.decode_attention_backend_str,
-        ) = self.server_args.get_attention_backends()
+        ) = resolved_attention_backends()
 
         if self.decode_attention_backend_str != self.prefill_attention_backend_str:
             from sglang.srt.layers.attention.hybrid_attn_backend import (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -404,7 +404,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-        self.page_size = server_args.page_size
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.page_size = resolved_view(server_args).page_size
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.is_hybrid_swa = model_config.is_hybrid_swa

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -997,7 +997,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             # would overwrite the target's process-global one.
             return
 
-        if not self.server_args.disable_shared_experts_fusion and hasattr(
+        if not get_flags().disable_shared_experts_fusion and hasattr(
             self.model, "num_fused_shared_experts"
         ):
             num_fused_shared_experts = self.model.num_fused_shared_experts

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1301,7 +1301,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 local_rank=self.gpu_id,
                 distributed_init_method=dist_init_method,
                 timeout=self.server_args.dist_timeout,
-                moe_a2a_backend=self.server_args.moe_a2a_backend,
+                moe_a2a_backend=get_flags().moe_a2a_backend,
                 recovered_rank=self.server_args.elastic_ep_rejoin,
             )
             initialize_model_parallel(
@@ -3063,7 +3063,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
         output.expert_distribution_metrics = recorder_outputs.get("metrics")
 
-        no_copy_to_cpu = not self.server_args.disable_overlap_schedule
+        no_copy_to_cpu = not get_flags().disable_overlap_schedule
         if (
             not self.is_draft_worker
             and (experts_capturer := get_global_experts_capturer()) is not None

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -50,6 +50,7 @@ from sglang.srt.mem_cache.memory_pool import (
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.platforms import current_platform
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_float4_e2m1fn_x2,
@@ -258,16 +259,16 @@ class ModelRunnerKVCacheMixin:
         # since it is not compatible for trtllm and other mla attn backend due to the different
         # kv cache layout.
         if (
-            self.server_args.dsa_prefill_backend == "trtllm"
-            or self.server_args.dsa_decode_backend == "trtllm"
+            get_flags().dsa_prefill_backend == "trtllm"
+            or get_flags().dsa_decode_backend == "trtllm"
         ):
             return kv_cache_dim
 
         # On HIP, TileLang and AITER DSA kernels consume the raw MLA KV layout:
         # nope(512 fp8) + rope(64 fp8), without extra per-block scales.
         if _is_hip and (
-            self.server_args.dsa_prefill_backend in ("tilelang", "aiter")
-            or self.server_args.dsa_decode_backend in ("tilelang", "aiter")
+            get_flags().dsa_prefill_backend in ("tilelang", "aiter")
+            or get_flags().dsa_decode_backend in ("tilelang", "aiter")
         ):
             return kv_cache_dim
 

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -156,14 +156,14 @@ class ModelRunnerKVCacheMixin:
         if server_args.max_mamba_cache_size is not None:
             # Use explicitly set max_mamba_cache_size
             server_args.max_mamba_cache_size = server_args.max_mamba_cache_size // (
-                server_args.dp_size if server_args.enable_dp_attention else 1
+                server_args.dp_size if get_flags().enable_dp_attention else 1
             )
             # Reserve intermediate memory based on capped max_num_reqs
             if has_spec_dec:
                 ratio = self._calculate_mamba_ratio()
                 capped_reqs = min(
                     server_args.max_running_requests
-                    // (self.dp_size if server_args.enable_dp_attention else 1),
+                    // (self.dp_size if get_flags().enable_dp_attention else 1),
                     server_args.max_mamba_cache_size // ratio,
                 )
                 intermediate_size = (
@@ -178,7 +178,7 @@ class ModelRunnerKVCacheMixin:
         ):
             # Use explicitly set max_running_requests when radix cache is disabled
             server_args.max_mamba_cache_size = server_args.max_running_requests // (
-                server_args.dp_size if server_args.enable_dp_attention else 1
+                server_args.dp_size if get_flags().enable_dp_attention else 1
             )
             # Reserve intermediate memory based on capped max_num_reqs
             if has_spec_dec:
@@ -216,7 +216,7 @@ class ModelRunnerKVCacheMixin:
                 # so the return value only has main_state subtracted from total
                 capped_reqs = min(
                     server_args.max_running_requests
-                    // (self.dp_size if server_args.enable_dp_attention else 1),
+                    // (self.dp_size if get_flags().enable_dp_attention else 1),
                     server_args.max_mamba_cache_size // ratio,
                 )
                 intermediate_size = per_req * capped_reqs * D

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -330,9 +330,7 @@ class ModelRunnerKVCacheMixin:
             unsupported_pool_family = "DeepSeekV4TokenToKVPool"
         elif current_platform.is_out_of_tree() and not self.mambaish_config:
             unsupported_pool_family = "out-of-tree platform KV pool"
-        elif (
-            self.server_args.attention_backend == "ascend" and not self.mambaish_config
-        ):
+        elif get_flags().attn.backend == "ascend" and not self.mambaish_config:
             unsupported_pool_family = "NPU/Ascend KV pool"
         elif self.use_mla_backend and is_dsa_model:
             unsupported_pool_family = "DSA/MLA KV pool"
@@ -772,9 +770,7 @@ class ModelRunnerKVCacheMixin:
                     start_layer=self.start_layer,
                     end_layer=self.end_layer,
                 )
-        elif (
-            self.server_args.attention_backend == "ascend" and not self.mambaish_config
-        ):
+        elif get_flags().attn.backend == "ascend" and not self.mambaish_config:
             if self.is_hybrid_swa:
                 from sglang.srt.hardware_backend.npu.memory_pool_npu import (
                     NPUMHATokenToKVPool,
@@ -1059,7 +1055,7 @@ class ModelRunnerKVCacheMixin:
                     need_sort=need_sort,
                 )
             elif _is_npu and (
-                self.server_args.attention_backend == "ascend"
+                get_flags().attn.backend == "ascend"
                 or is_dsv4_model
                 or self.hybrid_gdn_config is not None
             ):

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -50,7 +50,11 @@ from sglang.srt.mem_cache.memory_pool import (
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.platforms import current_platform
-from sglang.srt.runtime_context import get_flags
+from sglang.srt.runtime_context import (
+    get_flags,
+    mamba_extra_buffer_enabled,
+    mamba_extra_buffer_lazy_enabled,
+)
 from sglang.srt.utils.common import (
     get_available_gpu_memory,
     is_float4_e2m1fn_x2,
@@ -296,17 +300,17 @@ class ModelRunnerKVCacheMixin:
             return 1
 
         additional_ratio = 0
-        if self.server_args.enable_mamba_extra_buffer():
+        if mamba_extra_buffer_enabled():
             # ping-pong buffer size is 2 when overlap schedule is on, 1 otherwise.
             # Lazy mode saves 1 slot (2 → 1) for overlap; non-overlap already uses 1.
             if not self.server_args.disable_overlap_schedule:
-                if self.server_args.enable_mamba_extra_buffer_lazy():
+                if mamba_extra_buffer_lazy_enabled():
                     additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP_LAZY
                 else:
                     additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP
             else:
                 assert (
-                    not self.server_args.enable_mamba_extra_buffer_lazy()
+                    not mamba_extra_buffer_lazy_enabled()
                 ), "Lazy extra buffer requires overlap schedule (--disable-overlap-schedule is incompatible)"
                 additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP
 
@@ -400,7 +404,7 @@ class ModelRunnerKVCacheMixin:
             max_mamba_cache_size=self.server_args.max_mamba_cache_size,
             max_num_reqs=max_num_reqs,
             enable_memory_saver=self.server_args.enable_memory_saver,
-            enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+            enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
             speculative_num_draft_tokens=self.server_args.speculative_num_draft_tokens,
             disable_overlap_schedule=self.server_args.disable_overlap_schedule,
             need_sort=self.server_args.disaggregation_mode in ("decode", "prefill"),
@@ -559,7 +563,7 @@ class ModelRunnerKVCacheMixin:
                         ),
                         speculative_num_draft_tokens=max_spec_draft_tokens,
                         speculative_eagle_topk=self.server_args.speculative_eagle_topk,
-                        enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+                        enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
                         pre_alloc_size=pre_alloc_size,
                         enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
                         mamba_size=self.server_args.max_mamba_cache_size,
@@ -591,8 +595,8 @@ class ModelRunnerKVCacheMixin:
                             if self.start_layer <= i < self.end_layer
                         ]
                     ),
-                    enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
-                    enable_mamba_extra_buffer_lazy=self.server_args.enable_mamba_extra_buffer_lazy(),
+                    enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
+                    enable_mamba_extra_buffer_lazy=mamba_extra_buffer_lazy_enabled(),
                     speculative_num_draft_tokens=max_spec_draft_tokens,
                     speculative_eagle_topk=self.server_args.speculative_eagle_topk,
                     enable_overlap_schedule=not self.server_args.disable_overlap_schedule,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -303,7 +303,7 @@ class ModelRunnerKVCacheMixin:
         if mamba_extra_buffer_enabled():
             # ping-pong buffer size is 2 when overlap schedule is on, 1 otherwise.
             # Lazy mode saves 1 slot (2 → 1) for overlap; non-overlap already uses 1.
-            if not self.server_args.disable_overlap_schedule:
+            if not get_flags().disable_overlap_schedule:
                 if mamba_extra_buffer_lazy_enabled():
                     additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP_LAZY
                 else:
@@ -404,7 +404,7 @@ class ModelRunnerKVCacheMixin:
             enable_memory_saver=self.server_args.enable_memory_saver,
             enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
             speculative_num_draft_tokens=self.server_args.speculative_num_draft_tokens,
-            disable_overlap_schedule=self.server_args.disable_overlap_schedule,
+            disable_overlap_schedule=get_flags().disable_overlap_schedule,
             need_sort=self.server_args.disaggregation_mode in ("decode", "prefill"),
             mamba_full_memory_ratio=self.server_args.mamba_full_memory_ratio,
             # Overlap mode: the allocator's `free` drops a wait_stream(forward_stream)
@@ -563,7 +563,7 @@ class ModelRunnerKVCacheMixin:
                         speculative_eagle_topk=self.server_args.speculative_eagle_topk,
                         enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
                         pre_alloc_size=pre_alloc_size,
-                        enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
+                        enable_overlap_schedule=not get_flags().disable_overlap_schedule,
                         mamba_size=self.server_args.max_mamba_cache_size,
                         start_layer=self.start_layer,
                     )
@@ -597,7 +597,7 @@ class ModelRunnerKVCacheMixin:
                     enable_mamba_extra_buffer_lazy=mamba_extra_buffer_lazy_enabled(),
                     speculative_num_draft_tokens=max_spec_draft_tokens,
                     speculative_eagle_topk=self.server_args.speculative_eagle_topk,
-                    enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
+                    enable_overlap_schedule=not get_flags().disable_overlap_schedule,
                     start_layer=self.start_layer,
                     enable_linear_replayssm=self.server_args.enable_linear_replayssm,
                     linear_replayssm_cache_len=self.server_args.linear_replayssm_cache_len,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -1302,7 +1302,7 @@ class ModelRunnerKVCacheMixin:
         )
 
         available_bytes = self._profile_available_bytes(pre_model_load_memory)
-        page_size = self.server_args.page_size
+        page_size = get_flags().page_size
 
         configurator = create_memory_pool_configurator(self)
         config = configurator.calculate_pool_sizes(available_bytes, page_size)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -33,6 +33,7 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.mem_cache.common import get_alloc_len_per_decode
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils.common import (
     ceil_align,
     ceil_div,
@@ -300,7 +301,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
             self._swa_layers_num > 0
         ), "Hybrid SWA model must have at least one SWA layer"
 
-        self._swa_full_tokens_ratio = mr.server_args.swa_full_tokens_ratio
+        self._swa_full_tokens_ratio = get_flags().swa_full_tokens_ratio
 
         # Full layer per-token memory (bytes)
         self._full_per_token = (
@@ -533,7 +534,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 f"local={len(self.compression_ratios)}/{len(cfg.compress_ratios)}"
             )
         self.swa_page_size = cfg.window_size
-        self.swa_ratio = mr.server_args.swa_full_tokens_ratio
+        self.swa_ratio = get_flags().swa_full_tokens_ratio
         self.is_speculative = mr.server_args.speculative_algorithm is not None
         self.online_c128_mtp_max_draft_tokens = (
             mr.server_args.max_speculative_num_draft_tokens or 0

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -423,9 +423,11 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
         Padding to make sure eviction point is page-aligned.
         """
         trailing_tokens = window + eviction_interval * draft_tokens + page_size
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if sa.speculative_algorithm is None:
             decode_alloc = page_size
-        elif sa.disable_overlap_schedule:
+        elif resolved_view(sa).disable_overlap_schedule:
             # spec-v1: new_tokens_required_next_decode per request.
             decode_alloc = spec_decode_alloc_len_per_request(sa)
         else:
@@ -441,7 +443,7 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
                 + (window + page_size) * sa.disaggregation_decode_extra_slots
             )
         else:
-            chunks_in_flight = 1 if sa.disable_overlap_schedule else 2
+            chunks_in_flight = 1 if resolved_view(sa).disable_overlap_schedule else 2
             self._swa_cap = (
                 per_request * num_reqs
                 + chunks_in_flight * sa.chunked_prefill_size

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -239,7 +239,7 @@ class BaseRunner(ABC):
         with custom_all_reduce.register_graph_buffers).
         """
         mr = self.model_runner
-        if mr.server_args.flashinfer_allreduce_fusion_backend is None:
+        if get_flags().flashinfer_allreduce_fusion_backend is None:
             return
 
         from sglang.srt.layers.communicator import FUSE_ALLREDUCE_MAX_BATCH_SIZE

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -93,7 +93,7 @@ from sglang.srt.model_executor.runner_utils.deepep_adapter import (
     DeepEPCudaGraphRunnerAdapter,
 )
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
-from sglang.srt.runtime_context import get_flags
+from sglang.srt.runtime_context import get_flags, mamba_extra_buffer_enabled
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
@@ -298,8 +298,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
 
         enable_mamba_track = (
-            self.model_runner.server_args.enable_mamba_extra_buffer()
-            and self.model_runner.spec_algorithm.is_none()
+            mamba_extra_buffer_enabled() and self.model_runner.spec_algorithm.is_none()
         )
 
         if self.require_gathered_buffer:

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -49,6 +49,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     enable_tc_piecewise_cuda_graph,
     set_tc_piecewise_forward_context,
 )
+from sglang.srt.runtime_context import mamba_extra_buffer_enabled
 from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import ceil_align, require_mlp_sync
 
@@ -122,7 +123,7 @@ class EagerRunner(BaseRunner):
             max_num_token=max_num_token,
             cache_loc_dtype=torch.int64,
             enable_mamba_track=(
-                sa.enable_mamba_extra_buffer() and mr.spec_algorithm.is_none()
+                mamba_extra_buffer_enabled() and mr.spec_algorithm.is_none()
             ),
             is_encoder_decoder=is_encoder_decoder,
             encoder_len_fill_value=(

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -49,7 +49,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     enable_tc_piecewise_cuda_graph,
     set_tc_piecewise_forward_context,
 )
-from sglang.srt.runtime_context import mamba_extra_buffer_enabled
+from sglang.srt.runtime_context import get_flags, mamba_extra_buffer_enabled
 from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import ceil_align, require_mlp_sync
 
@@ -79,7 +79,7 @@ class EagerRunner(BaseRunner):
                     num_draft_tokens,
                     (
                         2 * (sa.speculative_num_steps or 0)
-                        if sa.enable_multi_layer_eagle
+                        if get_flags().enable_multi_layer_eagle
                         else 0
                     ),
                 )

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -124,7 +124,7 @@ def flashinfer_autotune_cache_path(model_runner: ModelRunner) -> Path:
     model_key_parts = [
         str(server_args.model_path),
         str(mr.dtype),
-        str(server_args.quantization),
+        str(get_flags().quantization),
         str(get_flags().moe.runner_backend),
         str(mr.tp_size),
         str(mr.pp_size),

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_flags
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
@@ -47,12 +48,12 @@ def should_run_flashinfer_autotune(
     # Read server_args directly to avoid depending on initialize_moe_config()
     # having already populated the MoE backend globals.
     if (
-        mr.server_args.moe_runner_backend == "flashinfer_cutedsl"
-        and mr.server_args.moe_a2a_backend == "deepep"
+        get_flags().moe.runner_backend == "flashinfer_cutedsl"
+        and get_flags().moe_a2a_backend == "deepep"
     ):
         return False
 
-    backend_str = mr.server_args.moe_runner_backend
+    backend_str = get_flags().moe.runner_backend
 
     # TODO smor- support other cases for flashinfer autotune, such as, mamba backend
 
@@ -124,7 +125,7 @@ def flashinfer_autotune_cache_path(model_runner: ModelRunner) -> Path:
         str(server_args.model_path),
         str(mr.dtype),
         str(server_args.quantization),
-        str(server_args.moe_runner_backend),
+        str(get_flags().moe.runner_backend),
         str(mr.tp_size),
         str(mr.pp_size),
         str(mr.dp_size),

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -80,6 +80,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
 from sglang.srt.model_executor.runner_utils.buffers import (
     PrefillInputBuffers,
 )
+from sglang.srt.runtime_context import mamba_extra_buffer_enabled
 from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidden_dim
 from sglang.srt.utils import (
     get_available_gpu_memory,
@@ -340,7 +341,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
     def _is_mamba_track_enabled(self) -> bool:
         return (
-            self.model_runner.server_args.enable_mamba_extra_buffer()
+            mamba_extra_buffer_enabled()
             and not self.model_runner.server_args.disable_radix_cache
             and self.model_runner.spec_algorithm.is_none()
         )

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -28,6 +28,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import BumpAllocator, get_bool_env_var, next_power_of_2
 
@@ -270,8 +271,8 @@ class DeepseekMHAForwardMixin:
                 self.use_dsa
                 and self.kv_cache_dtype == "fp8_e4m3"
                 and (
-                    not get_global_server_args().dsa_decode_backend == "trtllm"
-                    or not get_global_server_args().dsa_prefill_backend == "trtllm"
+                    not get_flags().dsa_decode_backend == "trtllm"
+                    or not get_flags().dsa_prefill_backend == "trtllm"
                 )
             ):
                 # FP8 path: dequantize DSA-specific FP8 format to BF16

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -64,6 +64,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.state_capturer.indexer_topk import (
     maybe_capture_indexer_topk,
@@ -985,8 +986,8 @@ class DeepseekMLAForwardMixin:
         """
         if self.current_attention_backend in ("dsa", "nsa"):
             return (
-                get_global_server_args().dsa_decode_backend == "trtllm"
-                or get_global_server_args().dsa_prefill_backend == "trtllm"
+                get_flags().dsa_decode_backend == "trtllm"
+                or get_flags().dsa_prefill_backend == "trtllm"
             ) and get_attn_backend().kv_cache_dtype == torch.float8_e4m3fn
 
         return (
@@ -1008,8 +1009,8 @@ class DeepseekMLAForwardMixin:
             _use_aiter_gfx95
             and self.current_attention_backend in ("dsa", "nsa")
             and (
-                server_args.dsa_decode_backend == "tilelang"
-                or server_args.dsa_prefill_backend == "tilelang"
+                get_flags().dsa_decode_backend == "tilelang"
+                or get_flags().dsa_prefill_backend == "tilelang"
             )
         )
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -175,7 +175,11 @@ from sglang.srt.models.deepseek_common.utils import (
     _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
-from sglang.srt.runtime_context import get_flags, get_parallel
+from sglang.srt.runtime_context import (
+    get_flags,
+    get_parallel,
+    resolved_attention_backends,
+)
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
@@ -1791,7 +1795,7 @@ class DeepseekV2AttentionMLA(
         # name stamped per-runner on the backend object, else resolve from server args.
         backend = get_attn_backend()
         server_args = get_global_server_args()
-        default_prefill_str, default_decode_str = server_args.get_attention_backends()
+        default_prefill_str, default_decode_str = resolved_attention_backends()
         prefill_backend_str = (
             backend.prefill_attention_backend_str or default_prefill_str
         )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1597,7 +1597,7 @@ class DeepseekV2AttentionMLA(
         self.scaling = self.qk_head_dim**-0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
-        self.kv_cache_dtype = get_global_server_args().kv_cache_dtype
+        self.kv_cache_dtype = get_flags().kv_cache_dtype
 
         # NOTE modification to rope_scaling must be done early enough, b/c e.g. Indexer needs it
         if rope_scaling:

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -464,7 +464,7 @@ class SarvamMoEMLAAttention(nn.Module):
         self.scaling = self.qk_head_dim**-0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
-        self.kv_cache_dtype = get_global_server_args().kv_cache_dtype
+        self.kv_cache_dtype = get_flags().kv_cache_dtype
 
         self._server_args = None
         self.current_attention_backend = None

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -60,7 +60,11 @@ from sglang.srt.models.bailing_moe import BailingMoEForCausalLM
 from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha import (
     DeepseekMHAForwardMixin,
 )
-from sglang.srt.runtime_context import get_flags, get_parallel
+from sglang.srt.runtime_context import (
+    get_flags,
+    get_parallel,
+    resolved_attention_backends,
+)
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     BumpAllocator,
@@ -152,10 +156,11 @@ for backend in CONCAT_ROPE_BACKENDS:
 
 def get_attn_forward_method(server_args, forward_batch) -> AttnForwardMethod:
     is_decode = forward_batch.forward_mode.is_decode_or_idle()
+    prefill_backend, decode_backend = resolved_attention_backends()
     if is_decode:
-        backend = server_args.decode_attention_backend or server_args.attention_backend
+        backend = decode_backend
     else:
-        backend = server_args.prefill_attention_backend or server_args.attention_backend
+        backend = prefill_backend
         if (
             forward_batch.forward_mode.is_extend_without_speculative()
             and backend == "fa3"
@@ -621,18 +626,11 @@ class SarvamMoEMLAAttention(nn.Module):
         return k
 
     def _set_current_attention_backend(self, forward_batch: ForwardBatch) -> None:
-        if self._server_args is None:
-            self._server_args = get_global_server_args()
+        prefill_backend, decode_backend = resolved_attention_backends()
         if forward_batch.forward_mode.is_decode_or_idle():
-            self.current_attention_backend = (
-                self._server_args.decode_attention_backend
-                or self._server_args.attention_backend
-            )
+            self.current_attention_backend = decode_backend
         else:
-            self.current_attention_backend = (
-                self._server_args.prefill_attention_backend
-                or self._server_args.attention_backend
-            )
+            self.current_attention_backend = prefill_backend
 
     def _maybe_fp8_bmm(
         self,

--- a/python/sglang/srt/ray/data_parallel_controller.py
+++ b/python/sglang/srt/ray/data_parallel_controller.py
@@ -150,13 +150,16 @@ class RayDataParallelController(DataParallelController):
                             tp_rank % tp_per_node
                         )
 
-                        if server_args.enable_dp_attention:
+                        from sglang.srt.arg_groups.overrides import resolved_view
+
+                        view = resolved_view(server_args)
+                        if view.enable_dp_attention:
                             _, _, actual_dp_rank, _ = compute_dp_attention_world_info(
-                                server_args.enable_dp_attention,
+                                view.enable_dp_attention,
                                 tp_rank,
                                 server_args.tp_size,
                                 server_args.dp_size,
-                                server_args.attn_cp_size,
+                                view.attn_cp_size,
                             )
                             rank_port_args = PortArgs.init_new(
                                 server_args, actual_dp_rank, worker_ports
@@ -221,13 +224,16 @@ class RayDataParallelController(DataParallelController):
 
                 bundle_idx = bundle_indices[global_rank]
 
-                if server_args.enable_dp_attention:
+                from sglang.srt.arg_groups.overrides import resolved_view
+
+                view = resolved_view(server_args)
+                if view.enable_dp_attention:
                     _, _, actual_dp_rank, _ = compute_dp_attention_world_info(
-                        server_args.enable_dp_attention,
+                        view.enable_dp_attention,
                         tp_rank,
                         server_args.tp_size,
                         server_args.dp_size,
-                        server_args.attn_cp_size,
+                        view.attn_cp_size,
                     )
                     rank_port_args = PortArgs.init_new(
                         server_args, actual_dp_rank, worker_ports

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -107,7 +107,9 @@ def _compute_world_size(server_args: ServerArgs) -> int:
 
     Normal: dp_size * tp_size * pp_size; DP attention: tp_size * pp_size.
     """
-    if server_args.enable_dp_attention:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).enable_dp_attention:
         return server_args.tp_size * server_args.pp_size
     return server_args.dp_size * server_args.tp_size * server_args.pp_size
 
@@ -265,7 +267,9 @@ class RayEngine(Engine):
                 placement_group as create_placement_group,
             )
 
-            if server_args.enable_dp_attention:
+            from sglang.srt.arg_groups.overrides import resolved_view
+
+            if resolved_view(server_args).enable_dp_attention:
                 total_gpus = server_args.tp_size * server_args.pp_size
             else:
                 total_gpus = (
@@ -438,11 +442,13 @@ class RayEngine(Engine):
         rank0_node_ip: str,
     ) -> RaySchedulerInitResult:
         """Launch DP schedulers via RayDataParallelController."""
+        from sglang.srt.arg_groups.overrides import resolved_view
         from sglang.srt.ray.data_parallel_controller import (
             RayDataParallelController,
         )
 
-        if server_args.enable_dp_attention:
+        enable_dp_attention = resolved_view(server_args).enable_dp_attention
+        if enable_dp_attention:
             # DP attention folds DP into TP — total GPUs = tp_size * pp_size
             total_gpus = server_args.tp_size * server_args.pp_size
         else:
@@ -452,7 +458,7 @@ class RayEngine(Engine):
             f"Ray DP cluster: {server_args.nnodes} nodes, "
             f"{gpus_per_node} GPUs/node, dp_size={server_args.dp_size}, "
             f"tp_size={server_args.tp_size}, pp_size={server_args.pp_size}, "
-            f"enable_dp_attention={server_args.enable_dp_attention}"
+            f"enable_dp_attention={enable_dp_attention}"
         )
 
         # Set dist_init_addr on server_args so PortArgs.init_new() can compute

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -448,10 +448,8 @@ class RuntimeContext:
         load-time stages) and
         atomically re-resolve the flags tier.
 
-        Target-worker only, and only before ``freeze_flags()``. During the
-        dual-apply transition the call sites keep their imperative
-        ``server_args`` writes; the recorded declarations must match them —
-        parity is re-asserted on every declared field. On failure the
+        Target-worker only, and only before ``freeze_flags()``. The
+        declarations never touch ``server_args``; on a failed re-resolve the
         recorded entries are rolled back and the previous flags stay
         installed.
         """
@@ -501,10 +499,7 @@ class RuntimeContext:
                 return
             declarations = ()
         declarations = list(declarations or ()) + self._runtime_overrides
-        from sglang.srt.arg_groups.overrides import (
-            apply_model_overrides,
-            assert_flag_parity,
-        )
+        from sglang.srt.arg_groups.overrides import apply_model_overrides
 
         # Resolve into a fresh container and only install it once everything
         # passed: a failed resolution (gate validation or the parity assert)
@@ -513,13 +508,6 @@ class RuntimeContext:
         # reset_context()).
         flags = Flags()
         apply_model_overrides(flags, server_args, declarations)
-        # Transition-period drift guard: dual-apply keeps the declared fields
-        # on server_args byte-identical to the resolved flag leaves.
-        assert_flag_parity(
-            flags,
-            server_args,
-            {field for _source, decl in declarations for field in decl},
-        )
         # The capture tier is not part of the static resolution: carry it
         # across re-resolves so runtime-stage recording cannot clobber a
         # capture-time write (set_server_args re-seeds it per lifecycle).

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -547,6 +547,36 @@ def get_flags() -> Flags:
     return _CONTEXT.flags
 
 
+def mamba_extra_buffer_enabled() -> bool:
+    """Resolved-semantics helper: whether the hybrid-mamba radix cache runs
+    the extra-buffer strategy (pristine radix switch + resolved strategy)."""
+    return (
+        get_server_args().disable_radix_cache is False
+        and get_flags().mamba_radix_cache_strategy
+        in (
+            "extra_buffer",
+            "extra_buffer_lazy",
+        )
+    )
+
+
+def mamba_extra_buffer_lazy_enabled() -> bool:
+    return (
+        get_server_args().disable_radix_cache is False
+        and get_flags().mamba_radix_cache_strategy == "extra_buffer_lazy"
+    )
+
+
+def resolved_attention_backends() -> tuple:
+    """Resolved (prefill, decode) attention backends from the flags tier
+    (split leaves fall back to the base backend leaf)."""
+    attn = get_flags().attn
+    return (
+        attn.prefill_backend if attn.prefill_backend else attn.backend,
+        attn.decode_backend if attn.decode_backend else attn.backend,
+    )
+
+
 def reset_context() -> None:
     """Clear the context-owned store (unit-test teardown): drop the published
     ``server_args`` and install a fresh, unfrozen ``Flags``.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4852,10 +4852,12 @@ class ServerArgs:
                 f"DP attention is enabled. The chunked prefill size is adjusted to {self.chunked_prefill_size} to avoid MoE kernel issues. "
             )
 
-        if self.enable_dp_lm_head:
-            assert (
-                self.enable_dp_attention
-            ), "Please enable dp attention when setting enable_dp_lm_head. "
+        # The dp-lm-head validation moved to the resolution pipeline
+        # (arg_groups/overrides.py: _dp_lm_head_validation), invoked here at
+        # its legacy slot.
+        from sglang.srt.arg_groups.overrides import _dp_lm_head_validation
+
+        run_post_process_pass(self, _dp_lm_head_validation)
 
     def _handle_moe_kernel_config(self):
         # The quantization-driven runner resolutions moved to the pipeline

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -69,7 +69,6 @@ from sglang.srt.utils.common import (
     get_int_env_var,
     get_quantization_config,
     human_readable_int,
-    is_blackwell_supported,
     is_cpu,
     is_cuda,
     is_flashinfer_available,
@@ -4340,33 +4339,12 @@ class ServerArgs:
         # fallback stay below.
         run_post_process_pass(self, _mla_backend_page_constraints)
 
-        if (
-            self.attention_backend == "trtllm_mla"
-            or self.decode_attention_backend == "trtllm_mla"
-        ):
-            if not is_blackwell_supported():
-                raise ValueError(
-                    "TRTLLM MLA backend is only supported on Blackwell GPUs (SM100/SM12x). Please use a different backend."
-                )
+        # The TRT-LLM / tokenspeed MLA kv-dtype validations moved to the
+        # resolution pipeline (arg_groups/overrides.py:
+        # _mla_kv_cache_dtype_checks), invoked here at their legacy slot.
+        from sglang.srt.arg_groups.overrides import _mla_kv_cache_dtype_checks
 
-            if self.kv_cache_dtype not in ["fp8_e4m3", "fp4_e2m1", "bf16", "auto"]:
-                raise ValueError(
-                    "TensorRT-LLM MLA backend only supports kv-cache-dtype of fp8_e4m3, fp4_e2m1, bf16, or auto."
-                )
-
-        if (
-            self.attention_backend == "tokenspeed_mla"
-            or self.decode_attention_backend == "tokenspeed_mla"
-        ):
-            if not is_blackwell_supported():
-                raise ValueError(
-                    "tokenspeed_mla backend is only supported on Blackwell GPUs (SM100/SM12x)."
-                )
-            if self.kv_cache_dtype not in ["fp8_e4m3"]:
-                raise ValueError(
-                    "tokenspeed_mla backend requires kv-cache-dtype=fp8_e4m3, "
-                    f"got {self.kv_cache_dtype}."
-                )
+        run_post_process_pass(self, _mla_kv_cache_dtype_checks)
 
         # The CuteDSL MLA validation + prefill fill moved to the resolution
         # pipeline (arg_groups/overrides.py: _cutedsl_prefill_backend_fill),
@@ -6591,9 +6569,14 @@ class ServerArgs:
                 )
 
         # Check hisparse
-        from sglang.srt.arg_groups.hisparse_hook import validate_hisparse
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _hisparse_validation), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _hisparse_validation,
+            run_post_process_pass,
+        )
 
-        validate_hisparse(self)
+        run_post_process_pass(self, _hisparse_validation)
 
         assert (
             self.schedule_conservativeness >= 0

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4254,14 +4254,18 @@ class ServerArgs:
 
         if not use_mla_backend:
             # MHA architecture
-            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(self):
+            from sglang.srt.arg_groups.overrides import resolved_view
+
+            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(
+                resolved_view(self)
+            ):
                 # Note: flashinfer 0.6.1 caused performance regression on Hopper attention kernel
                 # Before the kernel is fixed, we choose fa3 as the default backend on Hopper MHA
                 # ref: https://github.com/sgl-project/sglang/issues/17411
                 return "fa3"
             elif (
                 is_sm100_supported()
-                and is_no_spec_infer_or_topk_one(self)
+                and is_no_spec_infer_or_topk_one(resolved_view(self))
                 and (
                     self.speculative_algorithm is None
                     or self.speculative_eagle_topk is not None
@@ -5890,12 +5894,16 @@ class ServerArgs:
         run_post_process_pass(self, _dllm_attention_backend)
         run_post_process_pass(self, _dllm_overlap_disable)
 
-        if not self.disable_radix_cache:
-            # The page_size adjustment moved to the resolution pipeline
-            # (arg_groups/overrides.py: _dllm_page_size).
-            from sglang.srt.arg_groups.overrides import _dllm_page_size
+        # The page-size alignment + block-size cap for dllm moved to the
+        # resolution pipeline (arg_groups/overrides.py: _dllm_page_size).
+        # Invoked outside the radix gate: the alignment fill keeps its radix
+        # gate inside the pass, the block-size cap applies regardless (it
+        # replaces the unconditional scheduler-init fallback).
+        from sglang.srt.arg_groups.overrides import _dllm_page_size
 
-            run_post_process_pass(self, _dllm_page_size)
+        run_post_process_pass(self, _dllm_page_size)
+
+        if not self.disable_radix_cache:
             if self.enable_hierarchical_cache:
                 logger.warning(
                     "Hierarchical cache is disabled because of using diffusion LLM inference"
@@ -6425,12 +6433,15 @@ class ServerArgs:
         # (or mamba_chunk_size if it is defined in the model's config) and page_size.
         # It is used to determine the caching point in a sequence during prefill.
         if not hasattr(self, "_mamba_cache_chunk_size"):
+            from sglang.srt.arg_groups.overrides import resolved_view
+
             hf_config = self.get_model_config().hf_config
             chunk_size = getattr(hf_config, "mamba_chunk_size", FLA_CHUNK_SIZE)
+            page_size = resolved_view(self).page_size
             assert (
-                max(chunk_size, self.page_size) % min(chunk_size, self.page_size) == 0
-            ), f"For SSM models, either chunk_size or page_size must be divisible by the other, got {chunk_size=}, {self.page_size=}"
-            self._mamba_cache_chunk_size = max(chunk_size, self.page_size)
+                max(chunk_size, page_size) % min(chunk_size, page_size) == 0
+            ), f"For SSM models, either chunk_size or page_size must be divisible by the other, got {chunk_size=}, {page_size=}"
+            self._mamba_cache_chunk_size = max(chunk_size, page_size)
         return self._mamba_cache_chunk_size
 
     def _check_two_batch_overlap(self):
@@ -6509,8 +6520,10 @@ class ServerArgs:
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).
         # Skip validation if disaggregation mode is decode.
         if self.chunked_prefill_size > 0 and self.disaggregation_mode != "decode":
+            from sglang.srt.arg_groups.overrides import resolved_view
+
             assert (
-                self.chunked_prefill_size % self.page_size == 0
+                self.chunked_prefill_size % resolved_view(self).page_size == 0
             ), "chunked_prefill_size must be divisible by page_size"
 
         # Check pdmux
@@ -6962,10 +6975,11 @@ class ServerArgs:
         """
         # Lazy import so loading server_args doesn't pull in
         # disaggregation / msgspec / zmq at module top level.
+        from sglang.srt.arg_groups.overrides import resolved_view
         from sglang.srt.disaggregation.kv_events import KVEventsConfig
 
         raw = self.kv_events_config
-        page_size = self.page_size
+        page_size = resolved_view(self).page_size
         if not raw or page_size is None or page_size <= 0:
             return None
         try:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3231,6 +3231,8 @@ class ServerArgs:
             self._disable_breakable_cudagraph_if_incompatible()
 
     def _disable_tc_piecewise_cudagraph_if_incompatible(self):
+        from sglang.srt.arg_groups.overrides import resolved_view as _resolved_view
+
         """TcPiecewise (torch.compile + piecewise) is incompatible with
         these configurations. Most are torch.compile / dynamo limitations.
         """
@@ -3252,7 +3254,10 @@ class ServerArgs:
                 lambda: current_platform.is_out_of_tree()
                 and not current_platform.support_piecewise_cuda_graph(),
             ),
-            ("MoE A2A backend", lambda: self.moe_a2a_backend != "none"),
+            (
+                "MoE A2A backend",
+                lambda: _resolved_view(self).moe_a2a_backend != "none",
+            ),
             ("LoRA", lambda: bool(self.lora_paths) or self.enable_lora),
             (
                 "multimodal model",
@@ -3293,6 +3298,8 @@ class ServerArgs:
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
     def _disable_breakable_cudagraph_if_incompatible(self):
+        from sglang.srt.arg_groups.overrides import resolved_view as _resolved_view
+
         """Breakable (segmented capture, no torch.compile). Breakable enforces
         memory-saver rejection in its own __init__; config-time rules can be
         added here as they're discovered.
@@ -3313,7 +3320,10 @@ class ServerArgs:
             # BCG capture + LoRA adapter weights exceed host RAM headroom.
             ("LoRA", lambda: bool(self.lora_paths) or bool(self.enable_lora)),
             # BCG bucket sizes exceed FlashInfer MoE A2A's dispatch cap.
-            ("MoE A2A backend", lambda: self.moe_a2a_backend != "none"),
+            (
+                "MoE A2A backend",
+                lambda: _resolved_view(self).moe_a2a_backend != "none",
+            ),
             # DP-attn × BCG capture/replay not yet validated.
             ("DP attention", lambda: self.enable_dp_attention),
             # Multimodal prefill replay faults under BCG.
@@ -3604,10 +3614,12 @@ class ServerArgs:
 
             # DeepEP all-to-all buffers captured in the decode graph are real
             # extra allocations, so reserve them on top of the floor.
+            from sglang.srt.arg_groups.overrides import resolved_view
+
             if (
                 self.disaggregation_mode != "prefill"
                 and decode_cuda_graph_config.backend != Backend.DISABLED
-                and self.moe_a2a_backend == "deepep"
+                and resolved_view(self).moe_a2a_backend == "deepep"
             ):
                 reserved_mem += 2 * 1024
 
@@ -3973,7 +3985,7 @@ class ServerArgs:
             # The moe_runner_backend selection moved to the override registry
             # (arg_groups/overrides.py: _gpt_oss_overrides).
 
-            if self.moe_runner_backend == "triton_kernel":
+            if resolved_view(self).moe_runner_backend == "triton_kernel":
                 assert (
                     self.ep_size == 1
                 ), "Triton kernel MoE is only supported when ep_size == 1"
@@ -4839,12 +4851,15 @@ class ServerArgs:
         from sglang.srt.arg_groups.overrides import (
             _cutlass_moe_env_override,
             _moe_runner_backend_quant_constraints,
+            _moe_runner_fusion_disable,
+            resolved_view,
             run_post_process_pass,
         )
 
         run_post_process_pass(self, _moe_runner_backend_quant_constraints)
 
-        if self.moe_runner_backend == "flashinfer_cutlass":
+        view = resolved_view(self)
+        if view.moe_runner_backend == "flashinfer_cutlass":
             assert self.quantization in [
                 "modelopt_fp4",
                 "modelopt_fp8",
@@ -4856,7 +4871,7 @@ class ServerArgs:
                 self.tp_size,
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
 
-        if self.moe_runner_backend == "flashinfer_cutedsl":
+        if view.moe_runner_backend == "flashinfer_cutedsl":
             assert (
                 self.quantization in ["modelopt_fp4"]
                 or self.get_model_config().nvfp4_moe_meta is not None
@@ -4865,20 +4880,16 @@ class ServerArgs:
                 1,
                 self.tp_size,
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
-            assert self.moe_a2a_backend in [
+            assert view.moe_a2a_backend in [
                 "none",
                 "deepep",
                 "flashinfer",
             ], (
                 f"flashinfer_cutedsl supports moe_a2a_backend='none', 'deepep', or 'flashinfer', "
-                f"got '{self.moe_a2a_backend}'."
-            )
-            self.disable_shared_experts_fusion = True
-            logger.warning(
-                "FlashInfer CuteDSL MoE is enabled. --disable-shared-experts-fusion is automatically set."
+                f"got '{view.moe_a2a_backend}'."
             )
 
-        if self.moe_runner_backend in ["flashinfer_trtllm", "experimental_sgl_trtllm"]:
+        if view.moe_runner_backend in ["flashinfer_trtllm", "experimental_sgl_trtllm"]:
             assert self.quantization in [
                 "modelopt_fp4",
                 "nvfp4_online",
@@ -4889,12 +4900,8 @@ class ServerArgs:
                 "compressed-tensors",
                 None,
             ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'nvfp4_online', 'fp8', 'modelopt_fp8', 'modelopt_mixed', 'compressed-tensors', or bfloat16 (None)."
-            self.disable_shared_experts_fusion = True
-            logger.warning(
-                "FlashInfer TRTLLM MoE is enabled. --disable-shared-experts-fusion is automatically set."
-            )
 
-        if self.moe_runner_backend == "flashinfer_trtllm_routed":
+        if view.moe_runner_backend == "flashinfer_trtllm_routed":
             assert self.quantization in [
                 "fp8",
                 "mxfp8",
@@ -4902,17 +4909,20 @@ class ServerArgs:
                 "nvfp4_online",
                 None,
             ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM routed MOE supports only: 'fp8', 'mxfp8', 'modelopt_fp4', 'nvfp4_online', or bfloat16 (None)."
-            self.disable_shared_experts_fusion = True
-            logger.warning(
-                "FlashInfer TRTLLM routed MoE is enabled. --disable-shared-experts-fusion is automatically set."
-            )
+
+        # The runner-driven shared-experts fusion disables moved to the
+        # pipeline (arg_groups/overrides.py: _moe_runner_fusion_disable),
+        # invoked here at the legacy write slots.
+        run_post_process_pass(self, _moe_runner_fusion_disable)
 
         # The deprecated SGLANG_CUTLASS_MOE override moved to the pipeline
         # (arg_groups/overrides.py: _cutlass_moe_env_override). It sits after
         # the fusion blocks above on purpose: they must observe the
         # pre-override runner value, exactly as they did imperatively.
         run_post_process_pass(self, _cutlass_moe_env_override)
-        if self.moe_runner_backend == "cutlass" and self.quantization in [
+        if resolved_view(
+            self
+        ).moe_runner_backend == "cutlass" and self.quantization in [
             "fp8",
             "mxfp8",
         ]:
@@ -4959,9 +4969,12 @@ class ServerArgs:
         """Fail fast if the FlashInfer A2A dispatcher workspace cannot cover the
         largest CuteDSL MoE forward. Runs after speculative decoding is resolved
         so cutedsl_moe_max_num_tokens() sees the final num_tokens_per_bs."""
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        view = resolved_view(self)
         if not (
-            self.moe_a2a_backend == "flashinfer"
-            and self.moe_runner_backend == "flashinfer_cutedsl"
+            view.moe_a2a_backend == "flashinfer"
+            and view.moe_runner_backend == "flashinfer_cutedsl"
             and self.max_prefill_tokens > 0
             and self.disaggregation_mode != "decode"
         ):
@@ -4998,13 +5011,21 @@ class ServerArgs:
         from sglang.srt.arg_groups.overrides import (
             _a2a_backend_overrides,
             _a2a_ep_size,
+            _a2a_fusion_adjustments,
+            resolved_view,
             run_post_process_pass,
         )
 
         run_post_process_pass(self, _a2a_backend_overrides)
         run_post_process_pass(self, _a2a_ep_size)
 
-        if self.moe_a2a_backend == "megamoe":
+        # The a2a-driven shared-experts fusion adjustments moved to the
+        # pipeline (arg_groups/overrides.py: _a2a_fusion_adjustments),
+        # invoked here at the legacy write slots.
+        run_post_process_pass(self, _a2a_fusion_adjustments)
+
+        a2a_backend = resolved_view(self).moe_a2a_backend
+        if a2a_backend == "megamoe":
             if not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set():
                 envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
             logger.info(
@@ -5012,7 +5033,7 @@ class ServerArgs:
                 f"to be the same as the tensor parallel size[{self.tp_size}]."
             )
 
-        if self.moe_a2a_backend == "deepep":
+        if a2a_backend == "deepep":
             if self.deepep_mode == "normal":
                 logger.warning("Cuda graph is disabled because deepep_mode=`normal`")
                 self.cuda_graph_config.decode.backend = Backend.DISABLED
@@ -5021,27 +5042,22 @@ class ServerArgs:
                 f"DeepEP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
             if self.enable_deepep_waterfill:
-                if self.disable_shared_experts_fusion:
-                    logger.warning(
-                        "disable_shared_experts_fusion is overridden to False because DeepEP Waterfill requires shared expert fusion."
-                    )
-                    self.disable_shared_experts_fusion = False
                 self.enforce_shared_experts_fusion = True
                 logger.info(
                     "DeepEP Waterfill is enabled. Shared expert will be dispatched through DeepEP for load balancing."
                 )
 
-        if self.moe_a2a_backend == "mooncake":
+        if a2a_backend == "mooncake":
             logger.warning(
                 f"Mooncake MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
 
-        if self.moe_a2a_backend == "nixl":
+        if a2a_backend == "nixl":
             logger.warning(
                 f"Nixl MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
 
-        if self.moe_a2a_backend == "ascend_fuseep":
+        if a2a_backend == "ascend_fuseep":
             logger.warning(
                 f"Ascend fused EP MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
@@ -5054,16 +5070,12 @@ class ServerArgs:
                 assert (
                     self.quantization == "modelslim"
                 ), "When fuse_mode is set to 2, the NPU supports only ModelSlim quantization."
-        if self.moe_a2a_backend == "flashinfer":
+        if a2a_backend == "flashinfer":
             assert (
                 self.enable_dp_attention and self.dp_size == self.tp_size
             ), "Flashinfer MoE A2A is only supported with dp_size == tp_size and --enable-dp-attention"
             logger.warning(
                 f"Flashinfer MoE A2A is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
-            )
-            self.disable_shared_experts_fusion = True
-            logger.warning(
-                "Flashinfer MoE A2A is enabled. --disable-shared-experts-fusion is automatically set."
             )
             if self.deepep_mode != "auto":
                 logger.warning("--deepep-mode is ignored for Flashinfer MoE A2A")
@@ -5075,13 +5087,13 @@ class ServerArgs:
                 logger.warning(
                     "SGLANG_MOE_NVFP4_DISPATCH is set to True for Flashinfer MoE A2A"
                 )
-            assert self.moe_runner_backend in [
+            assert resolved_view(self).moe_runner_backend in [
                 "flashinfer_cutlass",
                 "flashinfer_cutedsl",
                 "flashinfer_trtllm_routed",
             ], "Flashinfer MoE A2A is only supported with flashinfer_cutlass, flashinfer_cutedsl or flashinfer_trtllm_routed moe runner backend"
 
-        if self.moe_a2a_backend == "mori":
+        if a2a_backend == "mori":
             if self.deepep_mode == "auto":
                 self.deepep_mode = "normal"
                 logger.warning("auto set deepep_mode=`normal` for MORI EP")
@@ -6449,9 +6461,11 @@ class ServerArgs:
         # DP TP-MoE path (overlapping the DP all_gatherv / reduce_scatterv with
         # the other ubatch's compute), which requires DP attention. Enabling it
         # there needs no extra opt-in env flag.
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if (
             self.enable_two_batch_overlap
-            and self.moe_a2a_backend == "none"
+            and resolved_view(self).moe_a2a_backend == "none"
             and not self.enable_dp_attention
         ):
             raise ValueError(
@@ -6482,8 +6496,11 @@ class ServerArgs:
         )
 
         if self.pp_size > 1:
+            from sglang.srt.arg_groups.overrides import resolved_view
+
             assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
+                resolved_view(self).disable_overlap_schedule
+                and self.speculative_algorithm is None
             ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
 
         assert not (
@@ -6537,9 +6554,13 @@ class ServerArgs:
             assert (
                 self.disaggregation_mode == "null"
             ), "PD-Multiplexing is not compatible with disaggregation mode."
-            assert (
-                self.disable_overlap_schedule
-            ), "PD-Multiplexing is not compatible with overlap schedule."
+            from sglang.srt.arg_groups.overrides import resolved_view
+
+            assert resolved_view(
+                self
+            ).disable_overlap_schedule, (
+                "PD-Multiplexing is not compatible with overlap schedule."
+            )
 
             # NOTE: CUDA Green Context may encounter potential issues with CudaGraph on torch 2.7.x – 2.8.x, leading to performance degradation.
             import torch

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3763,6 +3763,7 @@ class ServerArgs:
         from sglang.srt.arg_groups.overrides import (
             apply_declarations_to_server_args,
             collect_model_override_declarations,
+            resolved_view,
         )
 
         self._resolved_overrides = collect_model_override_declarations(
@@ -4032,14 +4033,15 @@ class ServerArgs:
         ):
             # Attention backend auto-select moved to the override registry
             # (arg_groups/overrides.py: _llama4_overrides).
-            assert self.attention_backend in {
+            attention_backend = resolved_view(self).attention_backend
+            assert attention_backend in {
                 "fa3",
                 "aiter",
                 "triton",
                 "ascend",
                 "trtllm_mha",
                 "intel_xpu",
-            }, f"fa3, aiter, triton, ascend, trtllm_mha or intel_xpu is required for Llama4 model but got {self.attention_backend}"
+            }, f"fa3, aiter, triton, ascend, trtllm_mha or intel_xpu is required for Llama4 model but got {attention_backend}"
             # The moe_runner_backend selection moved to the override registry
             # (arg_groups/overrides.py: _llama4_overrides).
         # Gemma2/Gemma3 (disable_hybrid_swa_memory) moved to the override registry
@@ -4073,9 +4075,10 @@ class ServerArgs:
                 # (arg_groups/overrides.py: _exaone_overrides).
                 # https://docs.sglang.ai/advanced_features/attention_backend.html
                 accepted_backends = ["fa3", "triton", "trtllm_mha"]
+                attention_backend = resolved_view(self).attention_backend
                 assert (
-                    self.attention_backend in accepted_backends
-                ), f"One of the attention backends in {accepted_backends} is required for {model_arch}, but got {self.attention_backend}"
+                    attention_backend in accepted_backends
+                ), f"One of the attention backends in {accepted_backends} is required for {model_arch}, but got {attention_backend}"
         elif model_arch in ["Olmo2ForCausalLM"]:
             # disable_hybrid_swa_memory + attention backend selection moved to
             # the override registry (arg_groups/overrides.py: _olmo2_overrides).
@@ -4083,18 +4086,19 @@ class ServerArgs:
             # Flashinfer appears to degrade performance when sliding window attention
             # is used for the Olmo2 architecture. Olmo2 does not use sliding window attention
             # but Olmo3 does.
+            attention_backend = resolved_view(self).attention_backend
             assert (
-                self.attention_backend != "flashinfer"
+                attention_backend != "flashinfer"
             ), "FlashInfer backend can significantly degrade the performance of Olmo3 models."
 
             logger.info(
-                f"Using {self.attention_backend} as attention backend for {model_arch}."
+                f"Using {attention_backend} as attention backend for {model_arch}."
             )
         elif model_arch in ["NemotronHForCausalLM", "NemotronHPuzzleForCausalLM"]:
             # Quantization / MoE runner / attention backend defaults moved to
             # the override registry (arg_groups/overrides.py:
             # _nemotron_h_overrides).
-            assert self.attention_backend != "triton", (
+            assert resolved_view(self).attention_backend != "triton", (
                 "NemotronHForCausalLM does not support triton attention backend,"
                 "as the first layer might not be an attention layer"
             )
@@ -4121,7 +4125,7 @@ class ServerArgs:
         elif model_arch in ["Lfm2ForCausalLM"]:
             # Attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _lfm2_overrides).
-            assert self.attention_backend != "triton", (
+            assert resolved_view(self).attention_backend != "triton", (
                 f"{model_arch} does not support triton attention backend, "
                 "as the first layer might not be an attention layer"
             )
@@ -4305,6 +4309,7 @@ class ServerArgs:
             _fa4_page_constraint,
             _intel_xpu_page_constraint,
             _mla_backend_page_constraints,
+            resolved_view,
             run_post_process_pass,
         )
 
@@ -4312,14 +4317,15 @@ class ServerArgs:
         run_post_process_pass(self, _attention_backend_default)
 
         # Torch native and flex attention backends
-        if self.attention_backend == "torch_native":
+        attention_backend = resolved_view(self).attention_backend
+        if attention_backend == "torch_native":
             logger.warning(
                 "Cuda graph is disabled because of using torch native attention backend"
             )
             self.cuda_graph_config.decode.backend = Backend.DISABLED
             self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
-        if self.attention_backend == "flex_attention":
+        if attention_backend == "flex_attention":
             logger.warning(
                 "Cuda graph is disabled because of using torch Flex Attention backend"
             )
@@ -4378,7 +4384,7 @@ class ServerArgs:
         run_post_process_pass(self, _fa4_page_constraint)
 
         # AMD platforms backends
-        if self.attention_backend == "aiter":
+        if resolved_view(self).attention_backend == "aiter":
             if model_config.context_len > 8192:
                 self.mem_fraction_static *= 0.85
 
@@ -4395,7 +4401,7 @@ class ServerArgs:
 
         # Dual chunk flash attention backend
         run_post_process_pass(self, _attention_backend_dual_chunk)
-        if self.attention_backend == "dual_chunk_flash_attn":
+        if resolved_view(self).attention_backend == "dual_chunk_flash_attn":
             logger.warning(
                 "Mixed chunk and radix cache are disabled when using dual-chunk flash attention backend"
             )
@@ -4404,11 +4410,14 @@ class ServerArgs:
 
     def _handle_kv4_compatibility(self):
         """Check FP4 KV cache compatibility with the attention backend"""
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if self.kv_cache_dtype != "fp4_e2m1":
             return
 
         use_mla_backend = self.use_mla_backend()
         prefill_backend, decode_backend = self._resolved_attention_backends()
+        attention_backend = resolved_view(self).attention_backend
 
         if is_cuda():
             if (
@@ -4449,11 +4458,9 @@ class ServerArgs:
                             "trtllm_mla",
                             "flashmla",
                         ]
-                        assert (
-                            self.attention_backend in KV4_ATTENTION_MLA_BACKEND_CHOICES
-                        ), (
+                        assert attention_backend in KV4_ATTENTION_MLA_BACKEND_CHOICES, (
                             f"KV4 MLA expects attention_backend to be one of "
-                            f"{KV4_ATTENTION_MLA_BACKEND_CHOICES}, but got {self.attention_backend}"
+                            f"{KV4_ATTENTION_MLA_BACKEND_CHOICES}, but got {attention_backend}"
                         )
                     else:  # !FA4 + MHA
                         KV4_ATTENTION_MHA_BACKEND_CHOICES = [
@@ -4462,11 +4469,9 @@ class ServerArgs:
                             "flex_attention",
                             "trtllm_mha",
                         ]
-                        assert (
-                            self.attention_backend in KV4_ATTENTION_MHA_BACKEND_CHOICES
-                        ), (
+                        assert attention_backend in KV4_ATTENTION_MHA_BACKEND_CHOICES, (
                             f"KV4 MHA expects attention_backend to be one of "
-                            f"{KV4_ATTENTION_MHA_BACKEND_CHOICES}, but got {self.attention_backend}"
+                            f"{KV4_ATTENTION_MHA_BACKEND_CHOICES}, but got {attention_backend}"
                         )
         else:
             raise RuntimeError("KV4 is not tested on non-CUDA platforms.")
@@ -5228,14 +5233,16 @@ class ServerArgs:
         Must run after _handle_attention_backend_compatibility() (which fills
         the default attention_backend if unset) and _handle_multi_item_scoring()
         (which may further mutate it). The assertion below guards against
-        accidental call-site reordering: if attention_backend is still None,
-        backends haven't settled yet and get_attention_backends() would return
-        a stale (None, None).
+        accidental call-site reordering: if the resolved attention_backend is
+        still None, backends haven't settled yet and the resolved (prefill,
+        decode) pair would be a stale (None, None).
         """
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if not self.prefill_only_disable_kv_cache:
             return
 
-        assert self.attention_backend is not None, (
+        assert resolved_view(self).attention_backend is not None, (
             "_handle_prefill_only_disable_kv_cache must run after "
             "_handle_attention_backend_compatibility() so the prefill backend is resolved."
         )
@@ -5733,6 +5740,7 @@ class ServerArgs:
             from sglang.srt.arg_groups.overrides import (
                 _deterministic_attention_backend,
                 _deterministic_sampling_backend,
+                resolved_view,
                 run_post_process_pass,
             )
 
@@ -5756,20 +5764,18 @@ class ServerArgs:
             # Check attention backend
             run_post_process_pass(self, _deterministic_attention_backend)
 
+            attention_backend = resolved_view(self).attention_backend
             if is_deepseek_model:
-                if self.attention_backend not in ["fa3", "triton"]:
+                if attention_backend not in ["fa3", "triton"]:
                     raise ValueError(
-                        f"Currently only {RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND} attention backends are supported for deterministic inference with DeepSeek models. But you're using {self.attention_backend}."
+                        f"Currently only {RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND} attention backends are supported for deterministic inference with DeepSeek models. But you're using {attention_backend}."
                     )
 
-            if (
-                self.attention_backend
-                not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND
-            ):
+            if attention_backend not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND:
                 # Currently, only certain backends support radix cache. Support for other backends is in progress
                 self.disable_radix_cache = True
                 logger.warning(
-                    f"Currently radix cache is not compatible with {self.attention_backend} attention backend for deterministic inference. It will be supported in the future."
+                    f"Currently radix cache is not compatible with {attention_backend} attention backend for deterministic inference. It will be supported in the future."
                 )
 
             # Check TP size

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3776,21 +3776,20 @@ class ServerArgs:
             self._handle_mamba_radix_cache(model_arch=model_arch)
 
         # Collect the declarative model overrides (registry) on the
-        # pristine config and stash them for publish-time flags resolution.
-        # Transition dual-apply: the same declarations are applied to
-        # server_args right here, byte-identical to the imperative arch
-        # branches this dispatch gradually replaces (dual-apply is retired
-        # per field once that field's readers migrate to the flags tier).
+        # pristine config and stash them for publish-time flags resolution;
+        # server_args is never mutated — mid-resolution readers see the
+        # declared values through resolved_view, runtime readers through the
+        # flags tier.
         from sglang.srt.arg_groups.overrides import (
-            apply_declarations_to_server_args,
             collect_model_override_declarations,
             resolved_view,
+            validate_declarations,
         )
 
         self._resolved_overrides = collect_model_override_declarations(
             model_arch, self, hf_config
         )
-        apply_declarations_to_server_args(self, self._resolved_overrides)
+        validate_declarations(self, self._resolved_overrides)
 
         if model_arch in [
             "DeepseekV4ForCausalLM",
@@ -6389,16 +6388,15 @@ class ServerArgs:
         return self.model_config
 
     def _resolved(self):
-        """Read-only view of the resolving configuration: dual-apply-retired
-        fields resolve from the declaration stash."""
+        """Read-only view of the resolving configuration: declared fields
+        resolve from the declaration stash."""
         from sglang.srt.arg_groups.overrides import resolved_view
 
         return resolved_view(self)
 
     def _resolved_attention_backends(self):
         """Mid-resolution (prefill, decode) backends: reads through the pass
-        view so dual-apply-retired fields resolve from the declaration
-        stash."""
+        view so declared fields resolve from the declaration stash."""
         from sglang.srt.arg_groups.overrides import (
             attention_backends_of,
             resolved_view,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3242,7 +3242,7 @@ class ServerArgs:
                 "model-arch blacklist",
                 lambda: self.get_model_config().is_piecewise_cuda_graph_disabled_model,
             ),
-            ("DP attention", lambda: self.enable_dp_attention),
+            ("DP attention", lambda: self._resolved().enable_dp_attention),
             ("full torch.compile mode", lambda: self.enable_torch_compile),
             ("pipeline parallelism (pp_size > 1)", lambda: self.pp_size > 1),
             (
@@ -3286,7 +3286,10 @@ class ServerArgs:
                 lambda: self.enable_eplb
                 or self.expert_distribution_recorder_mode is not None,
             ),
-            ("context parallel (attn_cp_size > 1)", lambda: self.attn_cp_size > 1),
+            (
+                "context parallel (attn_cp_size > 1)",
+                lambda: self._resolved().attn_cp_size > 1,
+            ),
             ("CUDA graph debug mode", lambda: self.debug_cuda_graph),
             (
                 "DSA prefill context parallelism",
@@ -3316,7 +3319,10 @@ class ServerArgs:
                 lambda: is_deepseek_v4(self.get_model_config().hf_config),
             ),
             # CP all_gather replay size mismatch under BCG.
-            ("context parallel (attn_cp_size > 1)", lambda: self.attn_cp_size > 1),
+            (
+                "context parallel (attn_cp_size > 1)",
+                lambda: self._resolved().attn_cp_size > 1,
+            ),
             # BCG capture + LoRA adapter weights exceed host RAM headroom.
             ("LoRA", lambda: bool(self.lora_paths) or bool(self.enable_lora)),
             # BCG bucket sizes exceed FlashInfer MoE A2A's dispatch cap.
@@ -3325,7 +3331,7 @@ class ServerArgs:
                 lambda: _resolved_view(self).moe_a2a_backend != "none",
             ),
             # DP-attn × BCG capture/replay not yet validated.
-            ("DP attention", lambda: self.enable_dp_attention),
+            ("DP attention", lambda: self._resolved().enable_dp_attention),
             # Multimodal prefill replay faults under BCG.
             ("multimodal model", lambda: self.get_model_config().is_multimodal),
         ]
@@ -3587,7 +3593,10 @@ class ServerArgs:
             # Some adjustments for large parallel size
             reserved_mem += self.tp_size * self.pp_size / 8 * 1024
 
-            if self.enable_dp_attention and self.disaggregation_mode != "prefill":
+            if (
+                self._resolved().enable_dp_attention
+                and self.disaggregation_mode != "prefill"
+            ):
                 # DP attention needs more padding for some operations
                 reserved_mem += decode_cuda_graph_config.max_bs * self.dp_size * 3
 
@@ -3890,7 +3899,7 @@ class ServerArgs:
 
             run_post_process_pass(self, _deepseek_moe_quant_resolution)
             if is_hip():
-                if not self.enable_dp_attention and self.nnodes == 1:
+                if not self._resolved().enable_dp_attention and self.nnodes == 1:
                     # TODO (Hubert): Put this back later
                     # self.enable_aiter_allreduce_fusion = True
                     logger.info(
@@ -3972,7 +3981,11 @@ class ServerArgs:
 
             quant_method = get_quantization_config(hf_config)
             is_mxfp4_quant_format = quant_method == "mxfp4"
-            if not self.enable_dp_attention and self.nnodes == 1 and is_hip():
+            if (
+                not self._resolved().enable_dp_attention
+                and self.nnodes == 1
+                and is_hip()
+            ):
                 # TODO (Hubert): Put this back later
                 # self.enable_aiter_allreduce_fusion = True
                 logger.info("Enable Aiter AllReduce Fusion for GptOssForCausalLM")
@@ -3989,7 +4002,7 @@ class ServerArgs:
 
             if resolved_view(self).moe_runner_backend == "triton_kernel":
                 assert (
-                    self.ep_size == 1
+                    self._resolved().ep_size == 1
                 ), "Triton kernel MoE is only supported when ep_size == 1"
 
         elif model_arch in ("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM"):
@@ -3997,9 +4010,10 @@ class ServerArgs:
                 expected_attn_tp_size = get_mimo_v2_fused_qkv_expected_tp_size(
                     hf_config
                 )
-                attn_dp_size = self.dp_size if self.enable_dp_attention else 1
+                view = self._resolved()
+                attn_dp_size = self.dp_size if view.enable_dp_attention else 1
                 effective_attn_tp_size = (
-                    self.tp_size // attn_dp_size // self.attn_cp_size
+                    self.tp_size // attn_dp_size // view.attn_cp_size
                 )
                 if (
                     expected_attn_tp_size is not None
@@ -4012,8 +4026,8 @@ class ServerArgs:
                         f"TP={expected_attn_tp_size}-interleaved; got "
                         f"{effective_attn_tp_size} "
                         f"(tp_size={self.tp_size}, dp_size={self.dp_size}, "
-                        f"enable_dp_attention={self.enable_dp_attention}, "
-                        f"attn_cp_size={self.attn_cp_size}). "
+                        f"enable_dp_attention={view.enable_dp_attention}, "
+                        f"attn_cp_size={view.attn_cp_size}). "
                         "Set --tp, --dp, --enable-dp-attention, and "
                         "--attention-context-parallel-size so the effective "
                         f"attention TP size is {expected_attn_tp_size}."
@@ -4780,13 +4794,14 @@ class ServerArgs:
                 "(DeepSeek V3/R1, Kimi K2.5) or MHA/GQA-based models."
             )
 
-        if self.attn_cp_size > 1:
+        view = self._resolved()
+        if view.attn_cp_size > 1:
             # The tp_size is the world size, not the real tensor parallel size
             assert (
-                self.tp_size % self.attn_cp_size == 0
+                self.tp_size % view.attn_cp_size == 0
             ), "tp_size must be divisible by attn_cp_size"
             assert (
-                self.tp_size % (self.dp_size * self.attn_cp_size) == 0
+                self.tp_size % (self.dp_size * view.attn_cp_size) == 0
             ), "tp_size must be divisible by dp_size * attn_cp_size"
 
             assert (
@@ -4799,20 +4814,20 @@ class ServerArgs:
                 self.tp_size % self.moe_dp_size == 0
             ), "tp_size must be divisible by moe_dp_size"
             assert (
-                self.ep_size * self.moe_dp_size <= self.tp_size
+                view.ep_size * self.moe_dp_size <= self.tp_size
             ), "ep_size * moe_dp_size must be less than or equal to tp_size"
             assert self.pp_size == 1, "PP is not supported with context parallelism"
 
-            if self.ep_size > 1:
+            if view.ep_size > 1:
                 assert (
-                    self.ep_size * self.moe_dp_size == self.tp_size
+                    view.ep_size * self.moe_dp_size == self.tp_size
                 ), "ep_size * moe_dp_size must be equal to tp_size"
 
             assert (
                 not self.enable_aiter_allreduce_fusion
             ), "Aiter allreduce fusion is not supported with context parallelism"
 
-        if self.attn_cp_size != self.moe_dp_size:
+        if view.attn_cp_size != self.moe_dp_size:
             assert (
                 self.moe_dp_size == 1
             ), "attn_cp_size != moe_dp_size is only supported when moe_dp_size == 1"
@@ -4831,7 +4846,7 @@ class ServerArgs:
 
         run_post_process_pass(self, _data_parallelism_defaults)
 
-        if self.enable_dp_attention:
+        if self._resolved().enable_dp_attention:
             self.schedule_conservativeness = self.schedule_conservativeness * 0.3
             assert self.tp_size % self.dp_size == 0
             self.chunked_prefill_size = self.chunked_prefill_size // self.dp_size
@@ -4868,7 +4883,7 @@ class ServerArgs:
                 "modelopt_mixed",
                 None,
             ], f"Invalid quantization '{view.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
-            assert self.ep_size in [
+            assert view.ep_size in [
                 1,
                 self.tp_size,
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
@@ -4878,7 +4893,7 @@ class ServerArgs:
                 view.quantization in ["modelopt_fp4"]
                 or self.get_model_config().nvfp4_moe_meta is not None
             ), f"Invalid quantization '{view.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4' or hybrid NVFP4 models."
-            assert self.ep_size in [
+            assert view.ep_size in [
                 1,
                 self.tp_size,
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
@@ -4929,7 +4944,7 @@ class ServerArgs:
             "mxfp8",
         ]:
             assert (
-                self.ep_size == 1
+                resolved_view(self).ep_size == 1
             ), "FP8/MXFP8 Cutlass MoE is only supported with ep_size == 1"
 
     def cutedsl_moe_max_num_tokens(self) -> int:
@@ -4985,9 +5000,9 @@ class ServerArgs:
         max_dispatch_tokens_per_rank = get_int_env_var(
             "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 1024
         )
-        max_cutedsl_tokens = max_dispatch_tokens_per_rank * self.ep_size
+        max_cutedsl_tokens = max_dispatch_tokens_per_rank * view.ep_size
         if max_cutedsl_tokens < required_tokens:
-            required_per_rank = (required_tokens + self.ep_size - 1) // self.ep_size
+            required_per_rank = (required_tokens + view.ep_size - 1) // view.ep_size
             raise ValueError(
                 "FlashInfer MoE A2A with flashinfer_cutedsl requires "
                 "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK * "
@@ -4997,7 +5012,7 @@ class ServerArgs:
                 "`ValueError: num_tokens (...) exceeds max_num_tokens (...)`. "
                 "Current values: "
                 f"SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK="
-                f"{max_dispatch_tokens_per_rank}, ep_size={self.ep_size}, "
+                f"{max_dispatch_tokens_per_rank}, ep_size={view.ep_size}, "
                 f"capacity={max_cutedsl_tokens}, required={required_tokens}. "
                 f"Set `export "
                 f"SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK="
@@ -5074,7 +5089,7 @@ class ServerArgs:
                 ), "When fuse_mode is set to 2, the NPU supports only ModelSlim quantization."
         if a2a_backend == "flashinfer":
             assert (
-                self.enable_dp_attention and self.dp_size == self.tp_size
+                resolved_view(self).enable_dp_attention and self.dp_size == self.tp_size
             ), "Flashinfer MoE A2A is only supported with dp_size == tp_size and --enable-dp-attention"
             logger.warning(
                 f"Flashinfer MoE A2A is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
@@ -5132,7 +5147,7 @@ class ServerArgs:
             self.ep_dispatch_algorithm = "static"
 
         if self.enable_eplb:
-            assert self.ep_size > 1
+            assert self._resolved().ep_size > 1
 
     def _handle_elastic_ep(self):
         if self.elastic_ep_backend is not None:
@@ -5224,7 +5239,7 @@ class ServerArgs:
         # Context-parallel prefill stages K/V through cp_allgather_and_save_kv_cache,
         # which writes to the pool via set_kv_buffer. NoOpMHATokenToKVPool intentionally
         # raises on writes, so the engine would boot fine but fail on the first request.
-        if self.attn_cp_size > 1:
+        if self._resolved().attn_cp_size > 1:
             raise ValueError(
                 "--prefill-only-disable-kv-cache is incompatible with --attn-cp-size > 1: "
                 "the context-parallel attention path writes K/V to the pool via set_kv_buffer, "
@@ -6373,6 +6388,13 @@ class ServerArgs:
         self.model_config = ModelConfig.from_server_args(self)
         return self.model_config
 
+    def _resolved(self):
+        """Read-only view of the resolving configuration: dual-apply-retired
+        fields resolve from the declaration stash."""
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        return resolved_view(self)
+
     def _resolved_attention_backends(self):
         """Mid-resolution (prefill, decode) backends: reads through the pass
         view so dual-apply-retired fields resolve from the declaration
@@ -6465,10 +6487,11 @@ class ServerArgs:
         # there needs no extra opt-in env flag.
         from sglang.srt.arg_groups.overrides import resolved_view
 
+        view = resolved_view(self)
         if (
             self.enable_two_batch_overlap
-            and resolved_view(self).moe_a2a_backend == "none"
-            and not self.enable_dp_attention
+            and view.moe_a2a_backend == "none"
+            and not view.enable_dp_attention
         ):
             raise ValueError(
                 "When enabling two batch overlap without an EP a2a backend "
@@ -6506,7 +6529,9 @@ class ServerArgs:
             ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
 
         assert not (
-            self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention
+            self.dp_size > 1
+            and self.nnodes != 1
+            and not self._resolved().enable_dp_attention
         ), "multi-node data parallel is not supported unless dp attention!"
 
         assert self.base_gpu_id >= 0, "base_gpu_id must be non-negative"
@@ -7173,7 +7198,9 @@ class PortArgs:
                 rank=int(server_args.decoupled_spec_rank),
             )
 
-        if not server_args.enable_dp_attention:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if not resolved_view(server_args).enable_dp_attention:
             # Normal case, use IPC within a single node
             return PortArgs(
                 tokenizer_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3267,7 +3267,7 @@ class ServerArgs:
             (
                 "GGUF quantization",
                 lambda: self.load_format == "gguf"
-                or self.quantization == "gguf"
+                or _resolved_view(self).quantization == "gguf"
                 or check_gguf_file(self.model_path),
             ),
             ("DLLM (diffusion LLM)", lambda: self.dllm_algorithm is not None),
@@ -3853,7 +3853,9 @@ class ServerArgs:
                     import torch
 
                     major, _ = torch.cuda.get_device_capability()
-                    self._set_default_dsa_kv_cache_dtype(major, self.quantization)
+                    self._set_default_dsa_kv_cache_dtype(
+                        major, resolved_view(self).quantization
+                    )
                     self._set_default_dsa_backends(self.kv_cache_dtype, major)
 
                 if self.enable_prefill_cp:
@@ -4860,12 +4862,12 @@ class ServerArgs:
 
         view = resolved_view(self)
         if view.moe_runner_backend == "flashinfer_cutlass":
-            assert self.quantization in [
+            assert view.quantization in [
                 "modelopt_fp4",
                 "modelopt_fp8",
                 "modelopt_mixed",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
             assert self.ep_size in [
                 1,
                 self.tp_size,
@@ -4873,9 +4875,9 @@ class ServerArgs:
 
         if view.moe_runner_backend == "flashinfer_cutedsl":
             assert (
-                self.quantization in ["modelopt_fp4"]
+                view.quantization in ["modelopt_fp4"]
                 or self.get_model_config().nvfp4_moe_meta is not None
-            ), f"Invalid quantization '{self.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4' or hybrid NVFP4 models."
+            ), f"Invalid quantization '{view.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4' or hybrid NVFP4 models."
             assert self.ep_size in [
                 1,
                 self.tp_size,
@@ -4890,7 +4892,7 @@ class ServerArgs:
             )
 
         if view.moe_runner_backend in ["flashinfer_trtllm", "experimental_sgl_trtllm"]:
-            assert self.quantization in [
+            assert view.quantization in [
                 "modelopt_fp4",
                 "nvfp4_online",
                 "fp8",
@@ -4899,16 +4901,16 @@ class ServerArgs:
                 "modelopt_mixed",
                 "compressed-tensors",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'nvfp4_online', 'fp8', 'modelopt_fp8', 'modelopt_mixed', 'compressed-tensors', or bfloat16 (None)."
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'nvfp4_online', 'fp8', 'modelopt_fp8', 'modelopt_mixed', 'compressed-tensors', or bfloat16 (None)."
 
         if view.moe_runner_backend == "flashinfer_trtllm_routed":
-            assert self.quantization in [
+            assert view.quantization in [
                 "fp8",
                 "mxfp8",
                 "modelopt_fp4",
                 "nvfp4_online",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM routed MOE supports only: 'fp8', 'mxfp8', 'modelopt_fp4', 'nvfp4_online', or bfloat16 (None)."
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer TRTLLM routed MOE supports only: 'fp8', 'mxfp8', 'modelopt_fp4', 'nvfp4_online', or bfloat16 (None)."
 
         # The runner-driven shared-experts fusion disables moved to the
         # pipeline (arg_groups/overrides.py: _moe_runner_fusion_disable),
@@ -4920,9 +4922,9 @@ class ServerArgs:
         # the fusion blocks above on purpose: they must observe the
         # pre-override runner value, exactly as they did imperatively.
         run_post_process_pass(self, _cutlass_moe_env_override)
-        if resolved_view(
+        if resolved_view(self).moe_runner_backend == "cutlass" and resolved_view(
             self
-        ).moe_runner_backend == "cutlass" and self.quantization in [
+        ).quantization in [
             "fp8",
             "mxfp8",
         ]:
@@ -5068,7 +5070,7 @@ class ServerArgs:
                 )
             elif fuse_mode == 2:
                 assert (
-                    self.quantization == "modelslim"
+                    resolved_view(self).quantization == "modelslim"
                 ), "When fuse_mode is set to 2, the NPU supports only ModelSlim quantization."
         if a2a_backend == "flashinfer":
             assert (
@@ -5080,7 +5082,7 @@ class ServerArgs:
             if self.deepep_mode != "auto":
                 logger.warning("--deepep-mode is ignored for Flashinfer MoE A2A")
             if not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set() and (
-                self.quantization == "modelopt_fp4"
+                resolved_view(self).quantization == "modelopt_fp4"
                 or self.get_model_config().nvfp4_moe_meta is not None
             ):
                 envs.SGLANG_MOE_NVFP4_DISPATCH.set(True)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3345,7 +3345,7 @@ class ServerArgs:
             not in self.get_model_config().hf_config.architectures
         ):
             return
-        prefill_attention_backend, _ = self.get_attention_backends()
+        prefill_attention_backend, _ = self._resolved_attention_backends()
         if prefill_attention_backend != "trtllm_mla":
             return
         logger.warning(
@@ -3392,7 +3392,7 @@ class ServerArgs:
             logger.warning("Chunked prefill is disabled because --enable-mis is set.")
             self.chunked_prefill_size = -1
 
-        prefill_backend, decode_backend = self.get_attention_backends()
+        prefill_backend, decode_backend = self._resolved_attention_backends()
         assert prefill_backend == "flashinfer" and decode_backend == "flashinfer", (
             "Multi-item scoring requires flashinfer attention backend for custom attention mask support. "
             f"Please set --attention-backend flashinfer when using --enable-mis. "
@@ -3943,7 +3943,9 @@ class ServerArgs:
                 "intel_xpu",
                 "aiter",
             ]
-            prefill_attn_backend, decode_attn_backend = self.get_attention_backends()
+            prefill_attn_backend, decode_attn_backend = (
+                self._resolved_attention_backends()
+            )
             assert (
                 prefill_attn_backend in supported_backends
                 and decode_attn_backend in supported_backends
@@ -4049,7 +4051,7 @@ class ServerArgs:
         ):
             # Default attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _gemma4_overrides).
-            prefill_backend, decode_backend = self.get_attention_backends()
+            prefill_backend, decode_backend = self._resolved_attention_backends()
             accepted_backends = ("trtllm_mha", "triton", "ascend", "intel_xpu")
             assert (
                 prefill_backend in accepted_backends
@@ -4164,29 +4166,31 @@ class ServerArgs:
 
         return supports_mamba_cache_extra_buffer(self, model_arch)
 
-    def _validate_mamba_no_buffer(self, model_arch: str):
-        assert self.page_size in (1, None), "no_buffer only supports page_size=1."
+    def _validate_mamba_no_buffer(self, view, model_arch: str):
+        assert view.page_size in (1, None), "no_buffer only supports page_size=1."
         assert (
-            self.disable_overlap_schedule
+            view.disable_overlap_schedule
         ), "no_buffer do not support overlap schedule. Try to set disable_overlap_schedule=True."
         assert (
-            self.attention_backend != "trtllm_mha"
+            view.attention_backend != "trtllm_mha"
         ), "no_buffer do not support trtllm_mha attention backend."
 
-    def _validate_mamba_extra_buffer(self, model_arch: str):
-        assert self._support_mamba_cache_extra_buffer(
-            model_arch
+    def _validate_mamba_extra_buffer(self, view, model_arch: str):
+        from sglang.srt.arg_groups.overrides import supports_mamba_cache_extra_buffer
+
+        assert supports_mamba_cache_extra_buffer(
+            view, model_arch
         ), f"extra_buffer is not supported for {model_arch}; use no_buffer."
         assert (
             is_cuda() or is_musa() or is_npu()
         ), "extra_buffer needs CUDA/MUSA/NPU (FLA)."
-        if self.speculative_num_draft_tokens is not None:
+        if view.speculative_num_draft_tokens is not None:
             assert (
-                not self.enable_mamba_extra_buffer_lazy()
+                view.mamba_radix_cache_strategy != "extra_buffer_lazy"
             ), "extra_buffer_lazy unsupported with spec."
-            assert self.mamba_track_interval >= self.speculative_num_draft_tokens
-        if self.page_size is not None:
-            assert self.mamba_track_interval % self.page_size == 0
+            assert view.mamba_track_interval >= view.speculative_num_draft_tokens
+        if view.page_size is not None:
+            assert view.mamba_track_interval % view.page_size == 0
             assert self.mamba_cache_chunk_size is not None
 
     def _handle_mamba_radix_cache(self, model_arch: str):
@@ -4195,17 +4199,20 @@ class ServerArgs:
         # slot; this handler keeps the validation.
         from sglang.srt.arg_groups.overrides import (
             _mamba_radix_cache_resolution,
+            mamba_extra_buffer_of,
+            resolved_view,
             run_post_process_pass,
         )
 
         run_post_process_pass(self, _mamba_radix_cache_resolution)
-        if not self.uses_mamba_radix_cache:
+        view = resolved_view(self)
+        if not view.uses_mamba_radix_cache:
             return
 
-        if self.enable_mamba_extra_buffer():
-            self._validate_mamba_extra_buffer(model_arch)
+        if mamba_extra_buffer_of(view):
+            self._validate_mamba_extra_buffer(view, model_arch)
         else:
-            self._validate_mamba_no_buffer(model_arch)
+            self._validate_mamba_no_buffer(view, model_arch)
 
     def _handle_sampling_backend(self):
         # Moved to the resolution pipeline (arg_groups/overrides.py:
@@ -4353,28 +4360,12 @@ class ServerArgs:
 
         run_post_process_pass(self, _cutedsl_prefill_backend_fill)
 
-        if (
-            self.attention_backend == "trtllm_mha"
-            or self.decode_attention_backend == "trtllm_mha"
-            or self.prefill_attention_backend == "trtllm_mha"
-        ):
-            # Check prefill backend
-            prefill_backend = (
-                self.prefill_attention_backend
-                if self.prefill_attention_backend is not None
-                else self.attention_backend
-            )
+        prefill_backend, decode_backend = self._resolved_attention_backends()
+        if "trtllm_mha" in (prefill_backend, decode_backend):
             if prefill_backend == "trtllm_mha" and not is_sm100_supported():
                 raise ValueError(
                     "TRTLLM MHA backend for prefill is only supported on Blackwell GPUs (SM100). Please use a different prefill backend."
                 )
-
-            # Check decode backend
-            decode_backend = (
-                self.decode_attention_backend
-                if self.decode_attention_backend is not None
-                else self.attention_backend
-            )
             if decode_backend == "trtllm_mha" and not (
                 is_sm90_supported() or is_sm100_supported() or is_sm120_supported()
             ):
@@ -4394,7 +4385,7 @@ class ServerArgs:
         # Other platforms backends
         run_post_process_pass(self, _attention_backend_platform_fallbacks)
 
-        prefill_backend, decode_backend = self.get_attention_backends()
+        prefill_backend, decode_backend = self._resolved_attention_backends()
         if self.use_mla_backend() and prefill_backend == "intel_xpu":
             raise ValueError(
                 "intel_xpu backend is only supported on decode for MLA models, please set --decode-attention-backend to intel_xpu and do not set --attention-backend or --prefill-attention-backend to intel_xpu for prefill instead use triton."
@@ -4417,35 +4408,28 @@ class ServerArgs:
             return
 
         use_mla_backend = self.use_mla_backend()
-        # self.attention_backend didn't overwrite self.prefill/decode_attention_backend yet
-        self.prefill_attention_backend_str, self.decode_attention_backend_str = (
-            self.get_attention_backends()
-        )
+        prefill_backend, decode_backend = self._resolved_attention_backends()
 
         if is_cuda():
             if (
-                self.prefill_attention_backend_str != self.decode_attention_backend_str
-                and self.prefill_attention_backend_str != "fa4"
+                prefill_backend != decode_backend and prefill_backend != "fa4"
             ):  # Take care of prefill=fa4 later
                 logger.warning(
-                    f"Attention: Using KV4 with PREFILL = {self.prefill_attention_backend_str} "
-                    f"and DECODE = {self.decode_attention_backend_str}. "
+                    f"Attention: Using KV4 with PREFILL = {prefill_backend} "
+                    f"and DECODE = {decode_backend}. "
                     f"Compatibility issues are unlikely, but may occur in rare edge cases."
                 )
             else:
-                if self.prefill_attention_backend_str == "fa4":
+                if prefill_backend == "fa4":
                     if use_mla_backend:  # FA4 + MLA
                         KV4_FA4_MLA_BACKEND_CHOICES = [
                             "cutlass_mla",
                             "flashinfer",
                             "trtllm_mla",
                         ]
-                        assert (
-                            self.decode_attention_backend_str
-                            in KV4_FA4_MLA_BACKEND_CHOICES
-                        ), (
+                        assert decode_backend in KV4_FA4_MLA_BACKEND_CHOICES, (
                             f"KV4 FA4 MLA expects decode_attention_backend to be one of "
-                            f"{KV4_FA4_MLA_BACKEND_CHOICES}, but got {self.decode_attention_backend_str}"
+                            f"{KV4_FA4_MLA_BACKEND_CHOICES}, but got {decode_backend}"
                         )
                     else:  # FA4 + MHA
                         KV4_FA4_MHA_BACKEND_CHOICES = [
@@ -4453,12 +4437,9 @@ class ServerArgs:
                             "torch_native",
                             "flex_attention",
                         ]
-                        assert (
-                            self.decode_attention_backend_str
-                            in KV4_FA4_MHA_BACKEND_CHOICES
-                        ), (
+                        assert decode_backend in KV4_FA4_MHA_BACKEND_CHOICES, (
                             f"KV4 FA4 MHA expects decode_attention_backend to be one of "
-                            f"{KV4_FA4_MHA_BACKEND_CHOICES}, but got {self.decode_attention_backend_str}"
+                            f"{KV4_FA4_MHA_BACKEND_CHOICES}, but got {decode_backend}"
                         )
                 else:
                     if use_mla_backend:  # !FA4 + MLA
@@ -4676,7 +4657,12 @@ class ServerArgs:
                     "linear-attn decode backend, got "
                     f"--linear-attn-decode-backend={decode!r}."
                 )
-            if self.enable_mamba_extra_buffer():
+            from sglang.srt.arg_groups.overrides import (
+                mamba_extra_buffer_of,
+                resolved_view,
+            )
+
+            if mamba_extra_buffer_of(resolved_view(self)):
                 raise ValueError(
                     "--enable-linear-replayssm requires --mamba-scheduler-strategy "
                     "no_buffer (the default); the extra_buffer ping-pong "
@@ -5254,7 +5240,7 @@ class ServerArgs:
             "_handle_attention_backend_compatibility() so the prefill backend is resolved."
         )
 
-        prefill_backend, _ = self.get_attention_backends()
+        prefill_backend, _ = self._resolved_attention_backends()
         if prefill_backend not in ("fa3", "fa4"):
             raise ValueError(
                 "--prefill-only-disable-kv-cache currently requires the FA prefill backend "
@@ -5849,11 +5835,7 @@ class ServerArgs:
             return
         # Only the Triton attention kernels read the strided 4-D envelope K/V
         # views; FA3 / FlashInfer do not.
-        backends = {
-            self.attention_backend,
-            self.prefill_attention_backend,
-            self.decode_attention_backend,
-        }
+        backends = set(self._resolved_attention_backends())
         backends.discard(None)
         assert backends <= {"triton"}, (
             "--enable-page-major-kv-layout requires the Triton attention backend "
@@ -5957,6 +5939,8 @@ class ServerArgs:
             )
 
     def _handle_other_validations(self):
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         # Handle optimistic prefill validation
         if (
             self.optimistic_prefill_retries > 0
@@ -5968,7 +5952,7 @@ class ServerArgs:
             elif self.enable_hierarchical_cache:
                 logger.warning("Optimistic prefill does not support hierarchical cache")
                 self.optimistic_prefill_retries = 0
-            elif getattr(self, "uses_mamba_radix_cache", False):
+            elif resolved_view(self).uses_mamba_radix_cache:
                 logger.warning(
                     "Optimistic prefill does not support models that use "
                     "mamba radix cache."
@@ -6360,6 +6344,17 @@ class ServerArgs:
             return self.model_config
         self.model_config = ModelConfig.from_server_args(self)
         return self.model_config
+
+    def _resolved_attention_backends(self):
+        """Mid-resolution (prefill, decode) backends: reads through the pass
+        view so dual-apply-retired fields resolve from the declaration
+        stash."""
+        from sglang.srt.arg_groups.overrides import (
+            attention_backends_of,
+            resolved_view,
+        )
+
+        return attention_backends_of(resolved_view(self))
 
     def get_attention_backends(self):
         prefill_attention_backend_str = (

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -49,6 +49,8 @@ DEFAULT_ADAPTIVE_CONFIG: dict[str, dict] = {
 
 def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
     """Return why adaptive spec cannot run under the given server args, or None if supported."""
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     if server_args.speculative_algorithm not in ("EAGLE", "EAGLE3"):
         return (
             f"speculative_algorithm={server_args.speculative_algorithm} "
@@ -62,13 +64,11 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             f"speculative_eagle_topk={server_args.speculative_eagle_topk} "
             "(only topk=1 is supported)"
         )
-    if server_args.enable_dp_attention:
+    if resolved_view(server_args).enable_dp_attention:
         return (
             "enable_dp_attention=True is not supported "
             "(adaptive tier decisions are not synchronized across DP ranks)"
         )
-    from sglang.srt.arg_groups.overrides import resolved_view
-
     if resolved_view(server_args).enable_multi_layer_eagle:
         return (
             "enable_multi_layer_eagle=True is not supported "

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -67,7 +67,9 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             "enable_dp_attention=True is not supported "
             "(adaptive tier decisions are not synchronized across DP ranks)"
         )
-    if server_args.enable_multi_layer_eagle:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).enable_multi_layer_eagle:
         return (
             "enable_multi_layer_eagle=True is not supported "
             "(MultiLayerEagleWorkerV2 does not implement adaptive)"

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -14,6 +14,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     compute_position,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
@@ -1278,7 +1279,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                     "DFLASH prefill expected out_cache_loc, but got None."
                 )
             positions, _ = compute_position(
-                self.model_runner.server_args.attention_backend,
+                get_flags().attn.backend,
                 draft_seq_lens,
                 ctx_lens,
                 int(sum(batch.extend_lens)),

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -118,7 +118,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.nccl_port = nccl_port
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         # Normalized in arg_groups.speculative_hook.handle_speculative_decoding.
         self.draft_window_size: Optional[int] = (
             server_args.speculative_draft_window_size

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -23,13 +23,14 @@ class DraftBackendFactory:
     def _create_backend(
         self, backend_name: str, backend_map: dict, error_template: str
     ):
-        backend_type = (
-            self.draft_attn_backend
-            if self.draft_attn_backend
-            else getattr(self.server_args, backend_name)
+        from sglang.srt.runtime_context import resolved_attention_backends
+
+        prefill_backend, decode_backend = resolved_attention_backends()
+        backend_type = self.draft_attn_backend or (
+            decode_backend
+            if backend_name == "decode_attention_backend"
+            else prefill_backend
         )
-        if backend_type is None:
-            backend_type = self.server_args.attention_backend
 
         if backend_type not in backend_map:
             raise ValueError(error_template.format(backend_type=backend_type))

--- a/python/sglang/srt/speculative/eagle_disaggregation.py
+++ b/python/sglang/srt/speculative/eagle_disaggregation.py
@@ -6,6 +6,7 @@ import torch
 
 from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.speculative.eagle_info import EagleDraftInput
 
 if TYPE_CHECKING:
@@ -21,7 +22,7 @@ def build_eagle_disagg_draft_input(
     future_map: FutureMap,
 ) -> EagleDraftInput:
     num_states = server_args.speculative_eagle_topk
-    if server_args.enable_multi_layer_eagle:
+    if get_flags().enable_multi_layer_eagle:
         num_states *= server_args.speculative_num_steps
 
     topk_p = torch.stack(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -170,7 +170,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self._rebuild_topk1_chain_buffers()
 
         # Load draft model weights only.
-        if server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
+        if get_flags().enable_dp_attention and self.speculative_algorithm.is_eagle3():
             ctx = draft_tp_context(get_attention_tp_group())
         else:
             ctx = empty_context()
@@ -203,7 +203,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             and self.topk == 1
         )
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -46,6 +46,7 @@ from sglang.srt.model_executor.runner import (
     DecodeCudaGraphRunner,
     get_batch_sizes_to_capture,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -985,7 +986,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -40,7 +40,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.runtime_context import resolved_attention_backends
+from sglang.srt.runtime_context import get_flags, resolved_attention_backends
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import EagleDraftWorkerBase
 from sglang.srt.speculative.eagle_utils import (
@@ -105,7 +105,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self.target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
@@ -667,7 +667,7 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -155,7 +155,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         self.kv_context: Optional[FrozenKVMTPContext] = None
 
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
 
         self.draft_attn_backend = None

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -40,6 +40,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
+from sglang.srt.runtime_context import resolved_attention_backends
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import EagleDraftWorkerBase
 from sglang.srt.speculative.eagle_utils import (
@@ -228,8 +229,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
     def _resolve_draft_backend_type(self) -> str:
         return (
             self.server_args.speculative_draft_attention_backend
-            or self.server_args.decode_attention_backend
-            or self.server_args.attention_backend
+            or resolved_attention_backends()[1]
         )
 
     def _init_draft_attn_backend(self):

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -40,6 +40,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
@@ -632,7 +633,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -165,7 +165,7 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         draft_arch = self.draft_worker.model_config.hf_config.architectures[0]
         self.chain_mtp_hidden_states = draft_arch in ["Step3p5MTP"]
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -57,7 +57,7 @@ class NGRAMWorker(BaseSpecWorker):
         target_worker: TpModelWorker,
     ):
         self.server_args = server_args
-        self.enable_overlap = not server_args.disable_overlap_schedule
+        self.enable_overlap = not get_flags().disable_overlap_schedule
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self.tp_rank = tp_rank

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -11,6 +11,7 @@ from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
@@ -60,7 +61,7 @@ class NGRAMWorker(BaseSpecWorker):
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self.tp_rank = tp_rank
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.draft_token_num: int = server_args.speculative_num_draft_tokens
         self.max_trie_depth: int = server_args.speculative_ngram_max_trie_depth
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -215,7 +215,9 @@ class SpeculativeAlgorithm(Enum):
 
         # EAGLE / EAGLE3 / STANDALONE / MULTI_LAYER always use the V2 worker,
         # even with overlap disabled (scheduler drives it synchronously).
-        if self.is_eagle() and server_args.enable_multi_layer_eagle:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if self.is_eagle() and resolved_view(server_args).enable_multi_layer_eagle:
             from sglang.srt.speculative.multi_layer_eagle_worker_v2 import (
                 MultiLayerEagleWorkerV2,
             )

--- a/python/sglang/srt/speculative/spec_registry.py
+++ b/python/sglang/srt/speculative/spec_registry.py
@@ -93,7 +93,12 @@ class CustomSpecAlgo:
         pass
 
     def create_worker(self, server_args: ServerArgs) -> Type:
-        if not server_args.disable_overlap_schedule and not self.supports_overlap:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if (
+            not resolved_view(server_args).disable_overlap_schedule
+            and not self.supports_overlap
+        ):
             raise ValueError(
                 f"Speculative algorithm {self.name} does not support overlap scheduling."
             )

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -15,6 +15,7 @@ from sglang.srt.distributed.parallel_state import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import set_mamba_track_indices_from_reqs
+from sglang.srt.runtime_context import mamba_extra_buffer_enabled
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.triton_ops.cache_locs import (
     align_evict_mask_to_page_size as align_evict_mask_to_page_size,
@@ -588,7 +589,7 @@ def prepare_mamba_track_for_verify(batch: ScheduleBatch) -> None:
     tracking during TARGET_VERIFY; tracking is done in
     commit_mamba_states_after_verify instead.
     """
-    if not get_global_server_args().enable_mamba_extra_buffer():
+    if not mamba_extra_buffer_enabled():
         return
     set_mamba_track_indices_from_reqs(batch)
     batch.mamba_track_mask = None

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -188,7 +188,9 @@ def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:
     # TODO(lsyin): also skip when step == 1.
     if server_args.speculative_algorithm in ("STANDALONE", "DFLASH"):
         return False
-    return not server_args.enable_multi_layer_eagle
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return not resolved_view(server_args).enable_multi_layer_eagle
 
 
 @torch.compile(dynamic=True, disable=_is_npu or _is_xpu)

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -101,7 +101,7 @@ class StandaloneDraftWorker(EagleDraftWorker):
         # Alias for better readability
         self.draft_runner = self.draft_worker.model_runner
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -7,6 +7,7 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -172,7 +173,7 @@ class StandaloneWorkerV2(EAGLEWorkerV2):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3459,7 +3459,7 @@ def require_mlp_tp_gather(server_args: ServerArgs):
         view = resolved_view(server_args)
         assert server_args.dp_size > 1, "dp_size must be greater than 1"
         if (
-            server_args.moe_dense_tp_size is None
+            view.moe_dense_tp_size is None
         ):  # TODO(ch-wan): some MoE models do not have dense layers
             return True
         elif not view.enable_dp_lm_head:
@@ -3467,10 +3467,7 @@ def require_mlp_tp_gather(server_args: ServerArgs):
         elif get_moe_a2a_backend().is_none():
             return True
         else:
-            return (
-                server_args.moe_dense_tp_size
-                > server_args.tp_size // server_args.dp_size
-            )
+            return view.moe_dense_tp_size > server_args.tp_size // server_args.dp_size
     else:
         return False
 
@@ -3486,9 +3483,13 @@ def require_attn_tp_gather(server_args: ServerArgs):
     if server_args.disable_attn_tp_gather:
         return False
 
+    from sglang.srt.arg_groups.overrides import resolved_view
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
-    if not get_moe_a2a_backend().is_none() or server_args.moe_dense_tp_size is not None:
+    if (
+        not get_moe_a2a_backend().is_none()
+        or resolved_view(server_args).moe_dense_tp_size is not None
+    ):
         if server_args.enable_dp_attention:
             return server_args.dp_size < server_args.tp_size
         else:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3734,7 +3734,9 @@ def spec_decode_alloc_len_per_request(server_args) -> int:
     """Per-request KV tokens a (spec-v1) decode step allocates: the draft-decode
     topk*num_steps peak vs. the verify num_draft_tokens, page-aligned.
     """
-    page_size = server_args.page_size
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    page_size = resolved_view(server_args).page_size
     len_per_topk = server_args.speculative_num_steps or 1
     spec_topk = server_args.speculative_eagle_topk or 1
     spec_tokens = server_args.speculative_num_draft_tokens or 1

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3448,15 +3448,14 @@ def require_mlp_tp_gather(server_args: ServerArgs):
     """
     Check if the input of MLP is obtained by all-gather rather than all-reduce. This only happens when each MLP TP group contains multiple attention DP groups.
     """
+    from sglang.srt.arg_groups.overrides import resolved_view
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
-    if server_args.enable_dp_attention:
-        from sglang.srt.arg_groups.overrides import resolved_view
-
-        # Callable pre-publish (Scheduler.init_moe_gemm_config computes
-        # require_mlp_sync before the model worker publishes the flags
-        # tier): read the resolved value through the view.
-        view = resolved_view(server_args)
+    # Callable pre-publish (Scheduler.init_moe_gemm_config computes
+    # require_mlp_sync before the model worker publishes the flags
+    # tier): read the resolved values through the view.
+    view = resolved_view(server_args)
+    if view.enable_dp_attention:
         assert server_args.dp_size > 1, "dp_size must be greater than 1"
         if (
             view.moe_dense_tp_size is None
@@ -3490,7 +3489,7 @@ def require_attn_tp_gather(server_args: ServerArgs):
         not get_moe_a2a_backend().is_none()
         or resolved_view(server_args).moe_dense_tp_size is not None
     ):
-        if server_args.enable_dp_attention:
+        if resolved_view(server_args).enable_dp_attention:
             return server_args.dp_size < server_args.tp_size
         else:
             return True
@@ -3503,7 +3502,11 @@ def require_gathered_buffer(server_args: ServerArgs):
 
 
 def require_mlp_sync(server_args: ServerArgs):
-    return server_args.enable_dp_attention or require_gathered_buffer(server_args)
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return resolved_view(server_args).enable_dp_attention or require_gathered_buffer(
+        server_args
+    )
 
 
 def find_local_repo_dir(repo_id: str, revision: Optional[str] = None) -> Optional[str]:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3451,12 +3451,18 @@ def require_mlp_tp_gather(server_args: ServerArgs):
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
     if server_args.enable_dp_attention:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        # Callable pre-publish (Scheduler.init_moe_gemm_config computes
+        # require_mlp_sync before the model worker publishes the flags
+        # tier): read the resolved value through the view.
+        view = resolved_view(server_args)
         assert server_args.dp_size > 1, "dp_size must be greater than 1"
         if (
             server_args.moe_dense_tp_size is None
         ):  # TODO(ch-wan): some MoE models do not have dense layers
             return True
-        elif not server_args.enable_dp_lm_head:
+        elif not view.enable_dp_lm_head:
             return True
         elif get_moe_a2a_backend().is_none():
             return True

--- a/test/registered/mock_model/test_self_unit_install.py
+++ b/test/registered/mock_model/test_self_unit_install.py
@@ -17,6 +17,10 @@ register_amd_ci(est_time=60, suite="extra-a-test-1-gpu-small-amd")
 
 
 def _make_server_args(*, sampling_backend: str) -> SimpleNamespace:
+    # The install gate reads the resolved backend from the flags tier.
+    from sglang.srt.runtime_context import get_flags
+
+    get_flags().sampling_backend = sampling_backend
     return SimpleNamespace(sampling_backend=sampling_backend)
 
 

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -102,6 +102,10 @@ def _make_model_runner(
 
     sa = SimpleNamespace()
     sa.swa_full_tokens_ratio = swa_full_tokens_ratio
+    # The configurator reads the resolved ratio from the flags tier.
+    from sglang.srt.runtime_context import get_flags
+
+    get_flags().swa_full_tokens_ratio = swa_full_tokens_ratio
     sa.page_size = page_size
     sa.disable_radix_cache = disable_radix_cache
     sa.chunked_prefill_size = chunked_prefill_size

--- a/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
+++ b/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
@@ -42,8 +42,8 @@ class TestDeepseekV4SharedExpertFusionPolicy(unittest.TestCase):
 
         self.assertEqual(model.num_fused_shared_experts, 0)
         self.assertTrue(get_flags().disable_shared_experts_fusion)
-        # dual-apply transition: the published config carries the value too
-        self.assertTrue(server_args.disable_shared_experts_fusion)
+        # dual-apply retired: the published config keeps the pristine input
+        self.assertFalse(server_args.disable_shared_experts_fusion)
 
     def test_enables_shared_fusion_when_enforced(self):
         server_args = self._publish(enforce=True)

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1125,7 +1125,11 @@ class TestDeepEPWaterfillArgs(CustomTestCase):
         # dummy-model path short-circuits __post_init__; invoke the handler directly.
         server_args._handle_a2a_moe()
 
-        self.assertFalse(server_args.disable_shared_experts_fusion)
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        # dual-apply retired: the fields stay pristine, the declarations win
+        self.assertTrue(server_args.disable_shared_experts_fusion)
+        self.assertFalse(resolved_view(server_args).disable_shared_experts_fusion)
         self.assertTrue(server_args.enforce_shared_experts_fusion)
 
     def test_waterfill_overrides_moe_a2a_backend_to_deepep(self):
@@ -1137,7 +1141,10 @@ class TestDeepEPWaterfillArgs(CustomTestCase):
         # dummy-model path short-circuits __post_init__; invoke the handler directly.
         server_args._handle_a2a_moe()
 
-        self.assertEqual(server_args.moe_a2a_backend, "deepep")
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.assertEqual(server_args.moe_a2a_backend, "none")  # pristine
+        self.assertEqual(resolved_view(server_args).moe_a2a_backend, "deepep")
         self.assertTrue(server_args.enforce_shared_experts_fusion)
 
     def test_waterfill_supports_deepep_low_latency_mode(self):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -354,7 +354,10 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
 
         args._handle_attention_backend_compatibility()
 
-        self.assertEqual(args.page_size, 128)
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.assertEqual(args.page_size, 1)  # dual-apply retired: pristine
+        self.assertEqual(resolved_view(args).page_size, 128)
 
     @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=True)
     @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
@@ -364,7 +367,10 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
 
         args._handle_attention_backend_compatibility()
 
-        self.assertEqual(args.page_size, 128)
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.assertEqual(args.page_size, 1)  # dual-apply retired: pristine
+        self.assertEqual(resolved_view(args).page_size, 128)
 
 
 class TestContextParallelServerArgs(CustomTestCase):

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -25,7 +25,7 @@ _SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
 # Baselines counted over python/sglang/srt/**/*.py, including each function's
 # own def line. Ratchet: decrease-only.
 _RATCHETS = [
-    ("get_global_server_args", r"\bget_global_server_args\s*\(", 280),
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 279),
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -25,7 +25,7 @@ _SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
 # Baselines counted over python/sglang/srt/**/*.py, including each function's
 # own def line. Ratchet: decrease-only.
 _RATCHETS = [
-    ("get_global_server_args", r"\bget_global_server_args\s*\(", 270),
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 261),
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -25,7 +25,7 @@ _SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
 # Baselines counted over python/sglang/srt/**/*.py, including each function's
 # own def line. Ratchet: decrease-only.
 _RATCHETS = [
-    ("get_global_server_args", r"\bget_global_server_args\s*\(", 279),
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 276),
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",

--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -25,7 +25,7 @@ _SRT_ROOT = Path(next(iter(sglang.srt.__path__)))
 # Baselines counted over python/sglang/srt/**/*.py, including each function's
 # own def line. Ratchet: decrease-only.
 _RATCHETS = [
-    ("get_global_server_args", r"\bget_global_server_args\s*\(", 276),
+    ("get_global_server_args", r"\bget_global_server_args\s*\(", 270),
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -415,7 +415,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_mistral_large3_forces_bfloat16(self):
         sa = self._construct("MistralLarge3ForCausalLM", "mistral")
-        self.assertEqual(sa.dtype, "bfloat16")  # dual-apply == legacy write
+        self.assertEqual(sa.dtype, "auto")  # dual-apply retired: pristine
         self.assertIn(
             ("MODEL_OVERRIDES['MistralLarge3ForCausalLM']", {"dtype": "bfloat16"}),
             sa._resolved_overrides,
@@ -424,15 +424,15 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_pixtral_forces_bfloat16(self):
         sa = self._construct("PixtralForConditionalGeneration", "pixtral")
-        self.assertEqual(sa.dtype, "bfloat16")
+        self.assertEqual(sa.dtype, "auto")  # pristine
         self.assertEqual(self._publish(sa).dtype, "bfloat16")
 
     def test_user_requested_dtype_is_still_overridden(self):
         # Legacy fidelity: the arch branch overwrote dtype unconditionally,
-        # so the declaration must too. The pristine request survives only on
-        # provenance (and, post-V3, as the un-overridden server_args field).
+        # so the declaration must too. The pristine request survives on the
+        # field; the leaf carries the override.
         sa = self._construct("MistralLarge3ForCausalLM", "mistral", dtype="float16")
-        self.assertEqual(sa.dtype, "bfloat16")
+        self.assertEqual(sa.dtype, "float16")  # pristine user request
         self.assertEqual(self._publish(sa).dtype, "bfloat16")
 
     def test_control_arch_keeps_pristine_dtype(self):
@@ -491,16 +491,16 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             config_extra=config_extra,
             enable_hierarchical_cache=True,
         )
-        # dual-apply retired: the field stays pristine
+        # dual-apply retired: the fields stay pristine
         self.assertEqual(sa.swa_full_tokens_ratio, 0.8)
-        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertFalse(sa.disable_hybrid_swa_memory)
         flags = self._publish(sa)
         self.assertEqual(flags.swa_full_tokens_ratio, 1.0)
         self.assertTrue(flags.disable_hybrid_swa_memory)
 
     def test_gemma2_disables_hybrid_swa_memory(self):
         sa = self._construct("Gemma2ForCausalLM", "llama")
-        self.assertTrue(sa.disable_hybrid_swa_memory)  # dual-apply == legacy
+        self.assertFalse(sa.disable_hybrid_swa_memory)  # pristine
         self.assertIn(
             ("_gemma2_gemma3_overrides", {"disable_hybrid_swa_memory": True}),
             sa._resolved_overrides,
@@ -509,7 +509,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_olmo2_disables_hybrid_swa_memory(self):
         sa = self._construct("Olmo2ForCausalLM", "llama")
-        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertFalse(sa.disable_hybrid_swa_memory)  # pristine
         self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
 
     def test_exaone_conditional_on_sliding_window_pattern(self):
@@ -520,7 +520,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             config_extra={"sliding_window_pattern": "LLLG"},
             attention_backend="fa3",
         )
-        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertFalse(sa.disable_hybrid_swa_memory)  # pristine
         self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
 
     def test_exaone_without_pattern_declares_nothing(self):
@@ -543,7 +543,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "llama",
             config_extra={"quantization_config": {"quant_method": "mxfp4"}},
         )
-        self.assertEqual(sa.dtype, "bfloat16")  # dual-apply == legacy
+        self.assertEqual(sa.dtype, "auto")  # dual-apply retired: pristine
         self.assertEqual(self._publish(sa).dtype, "bfloat16")
 
     def test_gpt_oss_without_mxfp4_keeps_pristine_dtype(self):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -632,8 +632,10 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_dllm_forces_flashinfer_with_cuda_graph(self):
         # CUDA path: cuda graph enabled by default -> dllm forces flashinfer.
+        # A real dllm arch: the page pass now runs regardless of the radix
+        # switch and builds DllmConfig for it.
         sa = self._construct(
-            "LlamaForCausalLM",
+            "SDARForCausalLM",
             "llama",
             dllm_algorithm="LowConfidence",
             disable_radix_cache=True,
@@ -809,9 +811,17 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             return_value=SimpleNamespace(block_size=32),
         ):
             self.assertEqual(_view() and _dllm_page_size(_view()), {"page_size": 32})
-            self.assertEqual(_dllm_page_size(_view(page_size=64)), {})  # aligned
+            # aligned but larger than the block: the scheduler-init fallback
+            # (folded into this pass) still caps the page at the block size
+            self.assertEqual(_dllm_page_size(_view(page_size=64)), {"page_size": 32})
+            self.assertEqual(_dllm_page_size(_view(page_size=32)), {})  # equal
+            # radix disabled skips the alignment fill but keeps the cap
+            self.assertEqual(_dllm_page_size(_view(disable_radix_cache=True)), {})
+            self.assertEqual(
+                _dllm_page_size(_view(disable_radix_cache=True, page_size=64)),
+                {"page_size": 32},
+            )
         self.assertEqual(_dllm_page_size(_view(dllm_algorithm=None)), {})
-        self.assertEqual(_dllm_page_size(_view(disable_radix_cache=True)), {})
 
     def test_dual_apply_retired_field_mechanics(self):
         from sglang.srt.arg_groups.overrides import run_post_process_pass
@@ -846,8 +856,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             overrides_module, "DUAL_APPLY_RETIRED", frozenset({"page_size"})
         ):
             assert_flag_parity(flags, args, {"page_size"})  # no raise
-        with self.assertRaises(AssertionError):
-            assert_flag_parity(flags, args, {"page_size"})
+        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset()):
+            with self.assertRaises(AssertionError):
+                assert_flag_parity(flags, args, {"page_size"})
 
     def test_initialize_moe_config_reads_resolving_state_prepublish(self):
         # Scheduler.init_moe_gemm_config runs before the model worker
@@ -1604,9 +1615,12 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_page_size_leaf_materializes_end_state(self):
         sa = self._construct("LlamaForCausalLM", "llama")
-        declared = {f for _s, d in sa._resolved_overrides for f in d}
-        self.assertIn("page_size", declared)  # default fill declared
-        self.assertEqual(self._publish(sa).page_size, sa.page_size)
+        declared_values = [
+            d["page_size"] for _s, d in sa._resolved_overrides if "page_size" in d
+        ]
+        self.assertTrue(declared_values)  # default fill declared
+        self.assertIsNone(sa.page_size)  # pristine default
+        self.assertEqual(self._publish(sa).page_size, declared_values[-1])
 
     def test_qwen3_5_hybrid_coupled_declaration(self):
         from sglang.srt.arg_groups.overrides import _qwen3_5_hybrid_overrides

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -19,11 +19,10 @@ from sglang.srt.arg_groups import overrides as overrides_module
 from sglang.srt.arg_groups.arg_utils import A, Arg, resolvable_fields
 from sglang.srt.arg_groups.overrides import (
     OverrideRecord,
-    apply_declarations_to_server_args,
     apply_model_overrides,
-    assert_flag_parity,
     collect_model_override_declarations,
     register_model_override,
+    validate_declarations,
 )
 from sglang.srt.runtime_context import (
     _StaticFlags,
@@ -207,7 +206,7 @@ class TestResolvedViewAndPasses(CustomTestCase):
         self.assertEqual(view.a, 10)
         self.assertEqual(view.b, 2)
 
-    def test_run_pass_appends_stash_and_dual_applies(self):
+    def test_run_pass_appends_stash_and_stays_pristine(self):
         from sglang.srt.arg_groups.overrides import run_post_process_pass
 
         live = SimpleNamespace(x=None, _resolved_overrides=[])
@@ -216,11 +215,12 @@ class TestResolvedViewAndPasses(CustomTestCase):
             return {"x": "filled"} if view.x is None else {}
 
         run_post_process_pass(live, _fill_x)
-        self.assertEqual(live.x, "filled")  # dual-applied in place
+        self.assertIsNone(live.x)  # never applied in place
         self.assertEqual(
             live._resolved_overrides, [(_fill_x.__qualname__, {"x": "filled"})]
         )
-        run_post_process_pass(live, _fill_x)  # now a no-op
+        # the next invocation sees the declared value through the overlay
+        run_post_process_pass(live, _fill_x)
         self.assertEqual(len(live._resolved_overrides), 1)
 
     def test_run_pass_rejects_non_dict(self):
@@ -823,7 +823,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             )
         self.assertEqual(_dllm_page_size(_view(dllm_algorithm=None)), {})
 
-    def test_dual_apply_retired_field_mechanics(self):
+    def test_declaration_overlay_mechanics(self):
         from sglang.srt.arg_groups.overrides import run_post_process_pass
 
         live = SimpleNamespace(x="user", y=None, _resolved_overrides=[])
@@ -834,31 +834,18 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         def _read_x(view):
             return {"y": view.x}
 
-        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset({"x"})):
-            run_post_process_pass(live, _resolve_x)
-            # declaration recorded, but server_args stays pristine
-            self.assertEqual(
-                live._resolved_overrides, [(_resolve_x.__qualname__, {"x": "resolved"})]
-            )
-            self.assertEqual(live.x, "user")
-            # a later pass sees the resolved value through the view overlay
-            run_post_process_pass(live, _read_x)
-            self.assertEqual(live.y, "resolved")
-
-    def test_parity_skips_retired_fields(self):
-        from sglang.srt.arg_groups.overrides import assert_flag_parity
-        from sglang.srt.runtime_context import Flags
-
-        flags = Flags()
-        flags.page_size = 64
-        args = SimpleNamespace(page_size=1)  # pristine differs from the leaf
-        with patch.object(
-            overrides_module, "DUAL_APPLY_RETIRED", frozenset({"page_size"})
-        ):
-            assert_flag_parity(flags, args, {"page_size"})  # no raise
-        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset()):
-            with self.assertRaises(AssertionError):
-                assert_flag_parity(flags, args, {"page_size"})
+        run_post_process_pass(live, _resolve_x)
+        # declaration recorded, but server_args stays pristine
+        self.assertEqual(
+            live._resolved_overrides, [(_resolve_x.__qualname__, {"x": "resolved"})]
+        )
+        self.assertEqual(live.x, "user")
+        # a later pass sees the resolved value through the view overlay
+        run_post_process_pass(live, _read_x)
+        self.assertEqual(
+            live._resolved_overrides[-1], (_read_x.__qualname__, {"y": "resolved"})
+        )
+        self.assertIsNone(live.y)  # never applied in place
 
     def test_initialize_moe_config_reads_resolving_state_prepublish(self):
         # Scheduler.init_moe_gemm_config runs before the model worker
@@ -2194,22 +2181,22 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self.assertEqual(_step3p_overrides(_args(), None), {})
 
 
-class TestDualApplyParity(CustomTestCase):
-    def test_dual_apply_replays_and_parity_holds(self):
+class TestDeclarationValidation(CustomTestCase):
+    def test_declarations_never_mutate_server_args(self):
         flags, args = _FakeFlags(), _FakeArgs()
         declarations = [("src", {"resolved_by_model": "dsv4", "also_resolved": 7})]
         apply_model_overrides(flags, args, declarations)
-        apply_declarations_to_server_args(args, declarations)
-        self.assertEqual(args.resolved_by_model, "dsv4")
-        self.assertEqual(args.also_resolved, 7)
-        assert_flag_parity(flags, args, ["resolved_by_model", "also_resolved"])
+        validate_declarations(args, declarations)
+        # the leaves carry the declared values; the fields stay pristine
+        self.assertEqual(flags.resolved_by_model, "dsv4")
+        self.assertEqual(flags.also_resolved, 7)
+        self.assertEqual(args.resolved_by_model, _FakeArgs.resolved_by_model)
+        self.assertEqual(args.also_resolved, _FakeArgs.also_resolved)
 
-    def test_parity_detects_drift(self):
-        flags, args = _FakeFlags(), _FakeArgs()
-        apply_model_overrides(flags, args, [("src", {"resolved_by_model": "x"})])
-        # dual-apply skipped -> server_args still pristine -> drift is caught
-        with self.assertRaises(AssertionError):
-            assert_flag_parity(flags, args, ["resolved_by_model"])
+    def test_validation_rejects_unknown_fields(self):
+        args = _FakeArgs()
+        with self.assertRaises(ValueError):
+            validate_declarations(args, [("src", {"nope": 1})])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -446,7 +446,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_minimax_m2_enables_tf32_matmul(self):
         sa = self._construct("MiniMaxM2ForCausalLM", "llama")
-        self.assertTrue(sa.enable_tf32_matmul)  # dual-apply == legacy write
+        self.assertFalse(sa.enable_tf32_matmul)  # dual-apply retired: pristine
         self.assertIn(
             ("_minimax_m2_overrides", {"enable_tf32_matmul": True}),
             sa._resolved_overrides,

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -569,7 +569,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
         sa = self._construct("LlamaForCausalLM", "llama")
         expected = "flashinfer" if is_flashinfer_available() else "pytorch"
-        self.assertEqual(sa.sampling_backend, expected)
+        self.assertIsNone(sa.sampling_backend)  # dual-apply retired: pristine
         self.assertIn(
             ("_sampling_backend_default", {"sampling_backend": expected}),
             sa._resolved_overrides,
@@ -587,8 +587,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "LlamaForCausalLM", "llama", enable_deterministic_inference=True
         )
         # two pass writers chain: default fill, then the deterministic force —
-        # last writer wins on the flags leaf and parity holds end-to-end.
-        self.assertEqual(sa.sampling_backend, "pytorch")
+        # last writer wins on the flags leaf; the server_args field stays
+        # pristine (dual-apply retired).
+        self.assertIsNone(sa.sampling_backend)
         flags = self._publish(sa)
         self.assertEqual(flags.sampling_backend, "pytorch")
         # the deterministic attention fill declared a compatible backend and

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -587,21 +587,21 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "LlamaForCausalLM", "llama", enable_deterministic_inference=True
         )
         # two pass writers chain: default fill, then the deterministic force —
-        # last writer wins on the flags leaf; the server_args field stays
+        # last writer wins on the flags leaf; the server_args fields stay
         # pristine (dual-apply retired).
         self.assertIsNone(sa.sampling_backend)
+        self.assertIsNone(sa.attention_backend)
         flags = self._publish(sa)
         self.assertEqual(flags.sampling_backend, "pytorch")
         # the deterministic attention fill declared a compatible backend and
         # the compatibility default-fill then had nothing to do
-        self.assertIn(
-            (
-                "_deterministic_attention_backend",
-                {"attention_backend": sa.attention_backend},
-            ),
-            sa._resolved_overrides,
-        )
-        self.assertEqual(flags.attn.backend, sa.attention_backend)
+        deterministic_fills = [
+            decl["attention_backend"]
+            for source, decl in sa._resolved_overrides
+            if source == "_deterministic_attention_backend"
+        ]
+        self.assertEqual(len(deterministic_fills), 1)
+        self.assertEqual(flags.attn.backend, deterministic_fills[0])
 
     def test_deterministic_incompatible_backend_raises(self):
         from sglang.srt.arg_groups.overrides import (
@@ -638,7 +638,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             dllm_algorithm="LowConfidence",
             disable_radix_cache=True,
         )
-        self.assertEqual(sa.attention_backend, "flashinfer")
+        self.assertIsNone(sa.attention_backend)  # dual-apply retired: pristine
         self.assertIn(
             ("_dllm_attention_backend", {"attention_backend": "flashinfer"}),
             sa._resolved_overrides,
@@ -648,25 +648,35 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_attention_backend_leaf_materializes_end_state(self):
         # The default-fill pass declares the platform-selected backend; the
-        # leaf must equal the final server_args value (publish parity).
+        # leaf must equal the last declared value while the server_args field
+        # stays pristine (dual-apply retired).
         sa = self._construct("LlamaForCausalLM", "llama")
-        declared = {f for _s, d in sa._resolved_overrides for f in d}
-        self.assertIn("attention_backend", declared)  # default fill declared
-        self.assertEqual(self._publish(sa).attn.backend, sa.attention_backend)
+        declared_values = [
+            d["attention_backend"]
+            for _s, d in sa._resolved_overrides
+            if "attention_backend" in d
+        ]
+        self.assertTrue(declared_values)  # default fill declared
+        self.assertIsNone(sa.attention_backend)
+        self.assertEqual(self._publish(sa).attn.backend, declared_values[-1])
 
-    def test_runner_side_adjustment_can_refresh_declaration(self):
-        from sglang.srt.arg_groups.overrides import refresh_declared_fields
+    def test_runner_side_adjustment_declares_at_its_slot(self):
+        from sglang.srt.arg_groups.overrides import (
+            _hrm_text_attention_force,
+            run_post_process_pass,
+        )
 
+        # Runner-side adjustment between collection and publish (HRM-Text
+        # forces attention_backend) declares through the pass slot: last
+        # writer on the stash wins the leaf, the field stays pristine.
         sa = self._construct("LlamaForCausalLM", "llama")
-        declared = {f for _s, d in sa._resolved_overrides for f in d}
-        self.assertIn("attention_backend", declared)
-        # Simulate a legacy runner-side overwrite between collection and publish
-        # (model_specific_adjustment forces attention_backend for HRM-Text).
-        sa.attention_backend = "fa3" if sa.attention_backend != "fa3" else "triton"
-        with self.assertRaises(AssertionError):
-            self._publish(sa)  # stale declaration breaks parity
-        refresh_declared_fields(sa, ("attention_backend",))
-        self.assertEqual(self._publish(sa).attn.backend, sa.attention_backend)
+        run_post_process_pass(sa, _hrm_text_attention_force)
+        self.assertIsNone(sa.attention_backend)
+        self.assertIn(
+            ("_hrm_text_attention_force", {"attention_backend": "triton"}),
+            sa._resolved_overrides,
+        )
+        self.assertEqual(self._publish(sa).attn.backend, "triton")
 
     def test_attention_backend_user_choice_declares_nothing_extra(self):
         sa = self._construct("LlamaForCausalLM", "llama", attention_backend="triton")

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -802,6 +802,42 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self.assertEqual(_dllm_page_size(_view(dllm_algorithm=None)), {})
         self.assertEqual(_dllm_page_size(_view(disable_radix_cache=True)), {})
 
+    def test_dual_apply_retired_field_mechanics(self):
+        from sglang.srt.arg_groups.overrides import run_post_process_pass
+
+        live = SimpleNamespace(x="user", y=None, _resolved_overrides=[])
+
+        def _resolve_x(view):
+            return {"x": "resolved"} if view.x == "user" else {}
+
+        def _read_x(view):
+            return {"y": view.x}
+
+        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset({"x"})):
+            run_post_process_pass(live, _resolve_x)
+            # declaration recorded, but server_args stays pristine
+            self.assertEqual(
+                live._resolved_overrides, [(_resolve_x.__qualname__, {"x": "resolved"})]
+            )
+            self.assertEqual(live.x, "user")
+            # a later pass sees the resolved value through the view overlay
+            run_post_process_pass(live, _read_x)
+            self.assertEqual(live.y, "resolved")
+
+    def test_parity_skips_retired_fields(self):
+        from sglang.srt.arg_groups.overrides import assert_flag_parity
+        from sglang.srt.runtime_context import Flags
+
+        flags = Flags()
+        flags.page_size = 64
+        args = SimpleNamespace(page_size=1)  # pristine differs from the leaf
+        with patch.object(
+            overrides_module, "DUAL_APPLY_RETIRED", frozenset({"page_size"})
+        ):
+            assert_flag_parity(flags, args, {"page_size"})  # no raise
+        with self.assertRaises(AssertionError):
+            assert_flag_parity(flags, args, {"page_size"})
+
     def test_overlap_disable_passes(self):
         from sglang.srt.arg_groups.overrides import (
             ResolvedView,

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1607,7 +1607,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 _get_default_attn_backend=lambda **_: default_backend,
                 use_mla_backend=lambda: False,
                 get_model_config=lambda: None,
-                enable_mamba_extra_buffer=lambda: False,
+                mamba_radix_cache_strategy="auto",
                 disable_radix_cache=False,
                 speculative_algorithm=None,
             )
@@ -1633,6 +1633,24 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     _args("trtllm_mha", attention_backend="fa3"), None
                 ),
                 {},
+            )
+            # the mamba pass ran before this dispatch and stashed the
+            # extra-buffer strategy: the callable must see it through the
+            # view (SM100 hybrid keeps trtllm_mha + page 64)
+            self.assertEqual(
+                _qwen3_5_hybrid_overrides(
+                    _args(
+                        "trtllm_mha",
+                        _resolved_overrides=[
+                            (
+                                "_mamba_radix_cache_declarations",
+                                {"mamba_radix_cache_strategy": "extra_buffer"},
+                            )
+                        ],
+                    ),
+                    None,
+                ),
+                {"attention_backend": "trtllm_mha", "page_size": 64},
             )
         with patch.object(overrides_module, "is_sm100_supported", return_value=False):
             self.assertEqual(_qwen3_5_hybrid_overrides(_args("fa3"), None), {})
@@ -1801,7 +1819,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self.assertEqual(
             _intel_xpu_page_constraint(
                 _view(
-                    get_attention_backends=lambda: (None, "intel_xpu"),
+                    decode_attention_backend="intel_xpu",
                     use_mla_backend=lambda: False,
                 )
             ),
@@ -1810,7 +1828,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self.assertEqual(
             _intel_xpu_page_constraint(
                 _view(
-                    get_attention_backends=lambda: (None, "intel_xpu"),
+                    decode_attention_backend="intel_xpu",
                     use_mla_backend=lambda: True,
                     page_size=16,  # MLA decode accepts 16
                 )

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -491,8 +491,8 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             config_extra=config_extra,
             enable_hierarchical_cache=True,
         )
-        # dual-apply == legacy writes
-        self.assertEqual(sa.swa_full_tokens_ratio, 1.0)
+        # dual-apply retired: the field stays pristine
+        self.assertEqual(sa.swa_full_tokens_ratio, 0.8)
         self.assertTrue(sa.disable_hybrid_swa_memory)
         flags = self._publish(sa)
         self.assertEqual(flags.swa_full_tokens_ratio, 1.0)
@@ -838,6 +838,32 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             assert_flag_parity(flags, args, {"page_size"})  # no raise
         with self.assertRaises(AssertionError):
             assert_flag_parity(flags, args, {"page_size"})
+
+    def test_initialize_moe_config_reads_resolving_state_prepublish(self):
+        # Scheduler.init_moe_gemm_config runs before the model worker
+        # publishes the flags tier: initialize_moe_config must read the
+        # declaration stash through the view, not the (still default)
+        # process-global flags.
+        import sglang.srt.layers.moe.utils as moe_utils
+        from sglang.srt.runtime_context import reset_context
+
+        sa = self._construct("LlamaForCausalLM", "llama")
+        sa._resolved_overrides.append(
+            ("test.declared", {"speculative_moe_runner_backend": "triton"})
+        )
+        reset_context()  # no publish: global flags stay default
+        try:
+            moe_utils.initialize_moe_config(sa)
+            self.assertEqual(
+                moe_utils.SPECULATIVE_MOE_RUNNER_BACKEND,
+                moe_utils.MoeRunnerBackend("triton"),
+            )
+        finally:
+            reset_context()
+            moe_utils.SPECULATIVE_MOE_RUNNER_BACKEND = None
+            moe_utils.MOE_A2A_BACKEND = None
+            moe_utils.MOE_RUNNER_BACKEND = None
+            moe_utils.SPECULATIVE_MOE_A2A_BACKEND = None
 
     def test_overlap_disable_passes(self):
         from sglang.srt.arg_groups.overrides import (

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -415,6 +415,20 @@ class TestRuntimeResolutionStages(_IsolatedServerArgs):
         finally:
             reset_context()
 
+    def test_retired_field_stays_pristine_through_publish(self):
+        # enable_dp_lm_head is dual-apply-retired: a declaration reaches the
+        # flag leaf while the server_args field keeps the user input.
+        @dataclasses.dataclass
+        class _Args:
+            enable_dp_lm_head: A[bool, Arg(help="d", resolvable=True)] = True
+            _resolved_overrides: list = dataclasses.field(default_factory=list)
+
+        args = _Args()
+        args._resolved_overrides = [("dp", {"enable_dp_lm_head": False})]
+        get_context().set_server_args(args)
+        self.assertTrue(args.enable_dp_lm_head)  # pristine, not dual-applied
+        self.assertFalse(get_flags().enable_dp_lm_head)  # resolved leaf
+
     def test_bare_dataclass_publish_skips_materialization(self):
         # object.__new__(ServerArgs) fixtures (no __init__, no field values)
         # must publish without touching the flags tier — dataclass defaults

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -340,11 +340,15 @@ class TestRuntimeResolutionStages(_IsolatedServerArgs):
         self.assertEqual(get_flags().page_size, 64)  # earlier stage survives
 
     def test_record_parity_failure_rolls_back(self):
+        import sglang.srt.arg_groups.overrides as overrides_module
+
         self._publish(page_size=1)
         flags_before = get_flags()
-        with self.assertRaises(AssertionError):
-            # declared value diverges from the live server_args (no dual-apply)
-            get_context().record_runtime_overrides([("bad", {"page_size": 64})])
+        # pin an empty retired set so parity still compares page_size
+        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset()):
+            with self.assertRaises(AssertionError):
+                # declared value diverges from the live server_args (no dual-apply)
+                get_context().record_runtime_overrides([("bad", {"page_size": 64})])
         self.assertIs(get_flags(), flags_before)  # previous flags intact
         self.assertEqual(get_context()._runtime_overrides, [])  # rolled back
 
@@ -366,12 +370,14 @@ class TestRuntimeResolutionStages(_IsolatedServerArgs):
         finally:
             reset_context()
 
-    def test_declare_load_time_override_dual_applies_and_records(self):
+    def test_declare_load_time_override_records_and_resolves(self):
         from sglang.srt.arg_groups.overrides import declare_load_time_override
 
         args = self._publish(page_size=1)
         declare_load_time_override("model.load_time", {"page_size": 64})
-        self.assertEqual(args.page_size, 64)  # dual-applied onto server_args
+        # dual-apply is retired for page_size: the field stays pristine and
+        # the leaf alone carries the load-time value
+        self.assertEqual(args.page_size, 1)
         self.assertEqual(get_flags().page_size, 64)  # resolved into the leaf
         self.assertEqual(
             get_context()._runtime_overrides,

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -339,19 +339,6 @@ class TestRuntimeResolutionStages(_IsolatedServerArgs):
         self.assertEqual(get_flags().sampling_backend, "pytorch")
         self.assertEqual(get_flags().page_size, 64)  # earlier stage survives
 
-    def test_record_parity_failure_rolls_back(self):
-        import sglang.srt.arg_groups.overrides as overrides_module
-
-        self._publish(page_size=1)
-        flags_before = get_flags()
-        # pin an empty retired set so parity still compares page_size
-        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset()):
-            with self.assertRaises(AssertionError):
-                # declared value diverges from the live server_args (no dual-apply)
-                get_context().record_runtime_overrides([("bad", {"page_size": 64})])
-        self.assertIs(get_flags(), flags_before)  # previous flags intact
-        self.assertEqual(get_context()._runtime_overrides, [])  # rolled back
-
     def test_record_whitelist_violation_rolls_back(self):
         self._publish()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Full-stack review PR for the dual-apply retirement series (continues #30063–#30077 and #30137). This PR carries the complete diff of all 11 stack units plus a placeholder file and runs full CI — **review and CI only, do not merge as-is**: merging happens through the individual stack PRs below, or, if this PR is used as the squash vehicle for the whole series (as was done for #30137), drop the placeholder commit first.

| # | PR | Unit |
|---|----|------|
| 1 | #30228 | Add per-field dual-apply retirement and retire enable_dp_lm_head |
| 2 | #30229 | Retire eight single-cohort dual-applies |
| 3 | #30230 | Retire the kv-cache dtype and DSA split-backend dual-applies |
| 4 | #30231 | Retire the attention split-backend and mamba radix cache dual-applies |
| 5 | #30282 | Retire the attention_backend dual-apply |
| 6 | #30283 | Retire the page_size dual-apply |
| 7 | #30284 | Retire the MoE backend and overlap-schedule dual-applies |
| 8 | #30285 | Retire the dtype, quantization and hybrid-SWA dual-applies |
| 9 | #30286 | Retire the enable_multi_layer_eagle dual-apply |
| 10 | #30287 | Retire the launcher-trio dual-applies |
| 11 | #30288 | Dismantle the dual-apply transition machinery |

Summary of the series: the transition dual-apply — which replayed pipeline declarations onto `server_args` byte-identically while readers migrated — retires per field and then comes out entirely. A field retires once every reader of its resolved value goes through the flags tier (post-publish), a pass view (mid-resolution), or `resolved_view` over the instance-carried declaration stash (launcher-side and pre-publish reads — the stash pickles with the instance, so views are valid in any process). All 28 whitelisted fields retire across the series; the final unit removes the replay loop, the parity assert and the retirement set itself.

End state: `server_args` carries pristine user input; the declaration stash rides the instance across processes; the flags tier alone materializes resolved values at publish. Legacy-getter ratchet 280 → 261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28820599660](https://github.com/sgl-project/sglang/actions/runs/28820599660)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28820599507](https://github.com/sgl-project/sglang/actions/runs/28820599507)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->