### PR TITLE
fix(llama): only remap weight_scale_inv for per-tensor FP8 loading

### DIFF
--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -640,8 +640,15 @@ class LlamaForCausalLM(nn.Module):
         for name, loaded_weight in weights:
             if name.endswith(".activation_scale"):
                 name = name.replace(".activation_scale", ".input_scale")
-            if name.endswith(".weight_scale_inv"):
-                name = name.replace(".weight_scale_inv", ".weight_scale")
+            # Per-tensor FP8 checkpoints may use weight_scale_inv while the
+            # model param is weight_scale. Block FP8 keeps weight_scale_inv.
+            if name.endswith(".weight_scale_inv") and self.quant_config is not None:
+                use_mxfp8 = bool(getattr(self.quant_config, "use_mxfp8", False))
+                weight_block_size = getattr(
+                    self.quant_config, "weight_block_size", None
+                )
+                if not use_mxfp8 and weight_block_size is None:
+                    name = name.replace(".weight_scale_inv", ".weight_scale")
 
             layer_id = get_layer_id(name)
             if (


### PR DESCRIPTION
Block FP8 checkpoints store weight_scale_inv and Fp8Config registers the same param name. The unconditional remap added in #14251 broke loading; align with transformers.py by gating remap on weight_block_size is None.

## Motivation

In #14251 (ministral3), LlamaForCausalLM.load_weights added an unconditional remap from weight_scale_inv to weight_scale. That is correct for per-tensor FP8 checkpoints (e.g. Ministral-3), where the checkpoint may use weight_scale_inv but the model parameter is weight_scale.

For block-wise FP8 (Fp8Config with weight_block_size, e.g. [128, 128]), sglang registers weight_scale_inv and checkpoints also store weight_scale_inv. The unconditional remap breaks loading with warnings such as:

> Parameter model.layers.31.self_attn.qkv_proj.weight_scale not found in params_dict

transformers.py already gates this remap correctly (#19163): only remap when weight_block_size is None and not MXFP8. This PR aligns llama.py with that behavior.

Reproduced with: custom block FP8 Llama-2-7B (quant_method: fp8, weight_block_size: [128, 128]), checkpoint with 168 *.weight_scale_inv keys and 0 *.weight_scale keys.

## Modifications

- python/sglang/srt/models/llama.py: only remap weight_scale_inv → weight_scale when quant_config is set, use_mxfp8 is false, and weight_block_size is None.
- Added a short comment explaining per-tensor vs block FP8 naming.

No changes to forward pass, kernels, or quantization math.

## Accuracy Tests

N/A — this change only affects weight loading key remapping, not inference or model outputs. Verified by loading a block FP8 Llama model without weight_scale not found in params_dict warnings.

## Speed Tests and Profiling

N/A — no impact on inference speed or runtime behavior after weights are loaded.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28839936471](https://github.com/sgl-project/sglang/actions/runs/28839936471)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28839936398](https://github.com/sgl-project/sglang/actions/runs/28839936398)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->