### PR TITLE
fix: keep auto-derived SGLANG_GRPC_PORT in range for high --port

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2968,9 +2968,17 @@ class ServerArgs:
         self.enable_grpc = envs.SGLANG_ENABLE_GRPC.get()
 
         grpc_port_env = envs.SGLANG_GRPC_PORT.get()
-        self.grpc_port = (
-            grpc_port_env if grpc_port_env is not None else self.port + 10000
-        )
+        if grpc_port_env is not None:
+            # Explicit user-provided port; validated by the range check below.
+            self.grpc_port = grpc_port_env
+        else:
+            # Auto-derive from --port. Use +10000, but fall back to -10000 when
+            # that would exceed 65535 so a high --port never crashes startup.
+            # port + 10000 > 65535 implies port > 55535, so port - 10000 > 45535
+            # stays in range and still differs from --port. See issue #29416.
+            self.grpc_port = (
+                self.port + 10000 if self.port <= 55535 else self.port - 10000
+            )
 
         if not (1 <= self.grpc_port <= 65535):
             raise ValueError(

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.environ import envs
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -1410,6 +1411,61 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
     def test_tbo_disabled_is_noop(self):
         args = self._args(enable_two_batch_overlap=False, enable_dp_attention=False)
         args._check_two_batch_overlap()
+
+
+class TestGrpcPortDerivation(CustomTestCase):
+    """gRPC port handling in _handle_deprecated_args (issue #29416)."""
+
+    def test_auto_derived_grpc_port(self):
+        # (port, expected grpc_port) — auto-derived branch (no SGLANG_GRPC_PORT).
+        # port <= 55535 -> port + 10000; higher ports fall back to port - 10000
+        # so the result stays in range and always differs from --port.
+        cases = [
+            (30000, 40000),  # normal: port + 10000
+            (55535, 65535),  # boundary: exactly 65535 via +10000
+            (60000, 50000),  # high port falls back to port - 10000
+            (65438, 55438),  # reporter's repro (was 75438 -> ValueError)
+            (65535, 55535),  # max port, no crash, differs from --port
+        ]
+        for port, expected in cases:
+            with self.subTest(port=port):
+                # Pin SGLANG_ENABLE_GRPC too so the test is hermetic: a runner
+                # with SGLANG_ENABLE_GRPC=1 must not change port derivation.
+                with envs.SGLANG_GRPC_PORT.override(
+                    None
+                ), envs.SGLANG_ENABLE_GRPC.override(False):
+                    server_args = ServerArgs(model_path="dummy", port=port)
+                    # __post_init__ returns early for dummy models before
+                    # _handle_deprecated_args() runs, so invoke it explicitly.
+                    server_args._handle_deprecated_args()
+                self.assertEqual(server_args.grpc_port, expected)
+                self.assertTrue(1 <= server_args.grpc_port <= 65535)
+                # Derived port must never collide with --port (see the
+                # grpc_port == port validation elsewhere in ServerArgs).
+                self.assertNotEqual(server_args.grpc_port, server_args.port)
+
+    def test_explicit_grpc_port_in_range_is_used(self):
+        with envs.SGLANG_GRPC_PORT.override(50000), envs.SGLANG_ENABLE_GRPC.override(
+            False
+        ):
+            server_args = ServerArgs(model_path="dummy", port=60000)
+            server_args._handle_deprecated_args()
+        # Explicit value wins; not derived from port.
+        self.assertEqual(server_args.grpc_port, 50000)
+
+    def test_explicit_grpc_port_out_of_range_still_raises(self):
+        # An explicit user-provided out-of-range port must NOT be silently
+        # clamped — it stays a loud error.
+        for bad_port in (70000, 0):
+            with self.subTest(grpc_port=bad_port):
+                with envs.SGLANG_GRPC_PORT.override(
+                    bad_port
+                ), envs.SGLANG_ENABLE_GRPC.override(False):
+                    server_args = ServerArgs(model_path="dummy", port=30000)
+                    # The out-of-range check lives in _handle_deprecated_args(),
+                    # which __post_init__ skips for dummy models.
+                    with self.assertRaises(ValueError):
+                        server_args._handle_deprecated_args()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #29416.

The native gRPC port is auto-derived as `--port + 10000` when `SGLANG_GRPC_PORT`
is not set. For a high `--port` (anything above `55535`), that derived value
exceeds the maximum TCP port `65535`, and startup aborted with:

```
ValueError: SGLANG_GRPC_PORT (75438) must be between 1 and 65535
```

A user simply choosing a high HTTP `--port` (e.g. `65438`) should not crash the
server over an *auto-derived* gRPC port they never asked for.

## Overview

```mermaid
flowchart TD
    A["_handle_deprecated_args()"] --> B{"SGLANG_GRPC_PORT set?"}
    B -- "Yes (explicit)" --> E["grpc_port = value"]
    B -- "No (auto-derive)" --> C{"--port &le; 55535?"}
    C -- Yes --> F["grpc_port = --port + 10000"]
    C -- No --> G["grpc_port = --port - 10000"]
    E --> H{"1 &le; grpc_port &le; 65535?"}
    F --> H
    G --> H
    H -- No --> I["raise ValueError"]
    H -- Yes --> J["use grpc_port"]
```

## Modifications

- `python/sglang/srt/server_args.py` — in `_handle_deprecated_args`, when the
  gRPC port is auto-derived from `--port`, keep `--port + 10000` but fall back to
  `--port - 10000` when `+10000` would overflow `65535`. Because
  `--port + 10000 > 65535` implies `--port > 55535`, the fallback
  `--port - 10000 > 45535` always lands in `[1, 65535]` **and** still differs
  from `--port`. This holds for every `--port` in `[1, 65535]`, so the derived
  gRPC port never overflows and never collides with the HTTP port. An explicitly
  set `SGLANG_GRPC_PORT` is untouched and still validated by the existing range
  check (out-of-range values still raise loudly).
- `test/registered/unit/server_args/test_server_args.py` — add
  `TestGrpcPortDerivation` covering the derive/fallback branch (result stays in
  range and differs from `--port`, including the `55535` boundary and the
  reporter's repro), the explicit-in-range path, and the explicit out-of-range
  error path. The tests call `_handle_deprecated_args()` directly (because
  `ServerArgs(model_path="dummy")` returns early in `__post_init__` before it
  runs) and pin `SGLANG_ENABLE_GRPC` so derivation stays hermetic regardless of
  the runner's environment.

## Accuracy Tests

N/A — startup argument validation only; no effect on model outputs.

## Speed Tests and Profiling

N/A — one-time startup path; no impact on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28783066065](https://github.com/chethanuk/sglang/actions/runs/28783066065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28783065412](https://github.com/chethanuk/sglang/actions/runs/28783065412)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---
_Related: an independent parallel effort in #29517 targets the same issue. This PR adopts the same range-preserving derivation and adds tests asserting the derived gRPC port stays in `[1,65535]` and never collides with `--port`. Maintainers can pick either; happy to close if #29517 is preferred._
