### PR TITLE
docs: add Top-n-sigma custom logit processor example

### DIFF
--- a/examples/runtime/custom_logit_processor/test_top_n_sigma.py
+++ b/examples/runtime/custom_logit_processor/test_top_n_sigma.py
@@ -1,0 +1,110 @@
+"""Unit tests for the Top-nσ custom logit processor example.
+
+Loads ``top_n_sigma.py`` from this directory via importlib so the real example
+code is exercised (not a copy). No server, no model loading. Run with ``pytest``.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+_EXAMPLE_PATH = Path(__file__).resolve().parent / "top_n_sigma.py"
+NEG = float("-inf")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("top_n_sigma_example", _EXAMPLE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestTopNSigmaExample(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        module = _load_example()
+        cls.processor = module.TopNSigmaLogitProcessor()
+
+    def _run(self, logits, params):
+        return self.processor(logits.clone(), params)
+
+    def test_argmax_invariant_and_masks(self):
+        torch.manual_seed(0)
+        logits = torch.randn(2, 1000)
+        top = logits.argmax(dim=-1)
+        out = self._run(logits, [{"top_n_sigma": 1.0}, {"top_n_sigma": 1.0}])
+        self.assertTrue(torch.equal(top, out.argmax(dim=-1)))
+        self.assertTrue((out == NEG).any())
+        for i in range(2):
+            self.assertTrue(out[i, top[i]].isfinite())
+
+    def test_threshold_is_max_minus_n_std(self):
+        # All-finite row: threshold uses the unbiased (ddof=1) std of the row.
+        row = torch.tensor([[10.0, 9.0, 0.0, -5.0]])
+        out = self._run(row, [{"top_n_sigma": 0.5}])
+        thr = 10.0 - 0.5 * float(row.std(dim=-1))
+        self.assertTrue(torch.equal(row[0] < thr, out[0] == NEG))
+
+    def test_std_zero_is_skipped(self):
+        row = torch.full((1, 5), 2.0)
+        self.assertTrue(torch.equal(self._run(row, [{"top_n_sigma": 1.0}]), row))
+
+    def test_inf_masked_tokens_still_truncate(self):
+        # Differentiator vs. an all-finite guard: a row carrying -inf (vocab
+        # padding / grammar masks) is NOT skipped. max/std are taken over the
+        # finite logits only; the row is still truncated and the pre-existing
+        # -inf stays masked.
+        row = torch.tensor([[10.0, 9.0, 1.0, NEG]])
+        out = self._run(row, [{"top_n_sigma": 1.0}])
+        self.assertFalse(torch.equal(out, row))  # active, not passed through
+        self.assertTrue(out[0, 0].isfinite() and out[0, 1].isfinite())
+        self.assertTrue((out[0, 2] == NEG) and (out[0, 3] == NEG))
+        self.assertTrue(out[0].argmax() == row[0, :3].argmax())  # argmax kept
+
+    def test_single_finite_logit_is_skipped(self):
+        # Only one finite logit -> std undefined -> row left unchanged.
+        row = torch.tensor([[5.0, NEG, NEG, NEG]])
+        self.assertTrue(torch.equal(self._run(row, [{"top_n_sigma": 1.0}]), row))
+
+    def test_invalid_params_are_skipped(self):
+        base = torch.randn(1, 50)
+        for bad in (
+            {"top_n_sigma": 0},
+            {"top_n_sigma": -1.0},
+            {"top_n_sigma": None},
+            {"top_n_sigma": "x"},
+            {"top_n_sigma": True},  # bool is an int subclass -> must be rejected
+            {},
+            None,
+        ):
+            with self.subTest(bad=bad):
+                self.assertTrue(torch.equal(self._run(base, [bad]), base))
+
+    def test_empty_param_list_unchanged(self):
+        base = torch.randn(1, 50)
+        self.assertTrue(torch.equal(self._run(base, []), base))
+        self.assertTrue(torch.equal(self._run(base, None), base))
+
+    def test_mixed_n_per_row(self):
+        torch.manual_seed(1)
+        batch = torch.randn(2, 200)
+        out = self._run(batch, [{"top_n_sigma": 1.0}, {"top_n_sigma": 0}])
+        self.assertTrue((out[0] == NEG).any())  # row 0 truncated
+        self.assertTrue(torch.equal(out[1], batch[1]))  # row 1 untouched
+
+    def test_input_not_mutated(self):
+        # Docstring promise: the input tensor is left unmodified; a new tensor
+        # is returned. Pass ``base`` directly (not via _run's clone) to check.
+        base = torch.randn(1, 100)
+        original = base.clone()
+        out = self.processor(base, [{"top_n_sigma": 1.0}])
+        self.assertTrue(torch.equal(base, original))  # input untouched
+        self.assertFalse(torch.equal(out, base))  # something was masked
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/runtime/custom_logit_processor/top_n_sigma.py
+++ b/examples/runtime/custom_logit_processor/top_n_sigma.py
@@ -1,0 +1,241 @@
+"""
+Top-nσ custom logit processor example.
+
+Top-nσ ("Top-nσ: Not All Logits Are You Need", Tang et al., ACL 2025;
+https://arxiv.org/abs/2411.07641) is a logit-space dynamic truncation method:
+
+    threshold = max_logit - n * std_logit
+    logits[logits < threshold] = -inf   # then sample as usual
+
+Unlike SGLang's built-in ``top_k`` / ``top_p`` / ``min_p`` (which all filter in
+*probability* space, after softmax), Top-nσ filters in *logit* space, before
+softmax. The std-based threshold is dual-adaptive: it adapts both how many and
+how loosely candidates survive, and because it never removes the argmax token
+(threshold < max_logit whenever n > 0 and std > 0) greedy decoding is unaffected.
+
+This file is a self-contained example of the SGLang custom logit processor
+framework -- no framework changes. The processor is injected per request via the
+``custom_logit_processor`` field, gated by ``--enable-custom-logit-processor``.
+
+Usage:
+    # 1. Launch a server with the custom logit processor gate enabled:
+    python -m sglang.launch_server \
+        --model-path meta-llama/Meta-Llama-3-8B-Instruct \
+        --port 30000 \
+        --enable-custom-logit-processor
+
+    # 2. Run the client demo (raw /generate + OpenAI chat.completions):
+    python examples/runtime/custom_logit_processor/top_n_sigma.py
+
+    # 3. Validate the truncation math without a server (needs torch only):
+    python examples/runtime/custom_logit_processor/top_n_sigma.py --self-check
+
+    # 4. Or run the companion pytest (imports this file, no server):
+    pytest examples/runtime/custom_logit_processor/test_top_n_sigma.py
+"""
+
+import argparse
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
+
+# Per-request key read from ``sampling_params.custom_params``.
+PARAM_KEY = "top_n_sigma"
+
+
+def apply_top_n_sigma(logits: torch.Tensor, n_values: torch.Tensor) -> torch.Tensor:
+    """Vectorized Top-nσ truncation over a batch of logits.
+
+    Args:
+        logits: ``[batch, vocab]`` logits. The input is left unmodified; a new
+            tensor is returned -- callers must use the return value.
+        n_values: ``[batch]`` per-row nσ value. Rows whose value is ``<= 0`` or
+            ``NaN`` are skipped (left unchanged).
+
+    Rules (all vectorized, no per-row Python loop):
+        * max/std are computed over the *finite* logits only. Real LLM logits
+          routinely carry ``-inf`` (vocab padding, disallowed tokens, grammar
+          constraints); reducing over them would drag std/max to ``-inf`` and,
+          under an all-finite guard, skip the processor for nearly every request.
+        * A row is filtered only when it has a valid ``n`` (> 0), at least two
+          finite logits, and non-zero finite std -- otherwise it passes through
+          untouched. (>= 2 finite logits are needed for an unbiased std.)
+        * Argmax-invariant: ``threshold < max_logit`` for every filtered row, so
+          the top-1 token always survives; already-``-inf`` tokens stay masked.
+    """
+    # Active rows: a positive, finite n and at least one finite logit.
+    finite = torch.isfinite(logits)
+    active = torch.isfinite(n_values) & (n_values > 0)
+    active &= finite.any(dim=-1)
+    if not bool(active.any()):
+        return logits
+
+    # max over finite logits (non-finite -> -inf so they never win the max).
+    neg_inf = torch.tensor(float("-inf"), device=logits.device, dtype=logits.dtype)
+    max_logit = torch.where(finite, logits, neg_inf).max(dim=-1, keepdim=True).values
+
+    # Unbiased (ddof=1) std over finite logits only, computed manually: torch has
+    # no ``nanstd``/``nanmax``, so mask non-finite out of the mean/variance sums.
+    zero = torch.zeros((), device=logits.device, dtype=logits.dtype)
+    n_finite = finite.sum(dim=-1, keepdim=True)  # [batch, 1]
+    mean = torch.where(finite, logits, zero).sum(dim=-1, keepdim=True) / n_finite.clamp(
+        min=1
+    )
+    var = torch.where(finite, (logits - mean) ** 2, zero).sum(
+        dim=-1, keepdim=True
+    ) / (n_finite - 1).clamp(min=1)
+    std_logit = var.sqrt()  # [batch, 1]
+    # Need >= 2 finite logits for a defined std, and non-zero std to truncate.
+    active &= (n_finite.squeeze(-1) >= 2) & (std_logit.squeeze(-1) > 0)
+    if not bool(active.any()):
+        return logits
+
+    threshold = max_logit - n_values.unsqueeze(-1) * std_logit  # [batch, 1]
+    mask = (logits < threshold) & active.unsqueeze(-1)
+    return logits.masked_fill(mask, float("-inf"))
+
+
+class TopNSigmaLogitProcessor(CustomLogitProcessor):
+    """Top-nσ logit-space truncation, applied per request.
+
+    Reads ``custom_params={"top_n_sigma": n}`` for each request in the batch.
+    Requests without a positive numeric ``top_n_sigma`` are left unchanged, so
+    the same processor can be attached to a mixed batch safely.
+    """
+
+    def __call__(
+        self,
+        logits: torch.Tensor,
+        custom_param_list: Optional[List[Dict[str, Any]]] = None,
+    ) -> torch.Tensor:
+        if not custom_param_list:
+            return logits
+
+        # Build the per-row n vector; NaN marks "skip this row".
+        n_values = torch.full(
+            (logits.shape[0],), float("nan"), device=logits.device, dtype=logits.dtype
+        )
+        for i, params in enumerate(custom_param_list):
+            if not params:
+                continue
+            n = params.get(PARAM_KEY)
+            # Reject None, non-numeric, and bool (bool is an int subclass).
+            if isinstance(n, bool) or not isinstance(n, (int, float)):
+                continue
+            n_values[i] = float(n)
+
+        return apply_top_n_sigma(logits, n_values)
+
+
+def run_generate_example(base_url: str = "http://localhost:30000") -> None:
+    """Raw ``/generate`` request using the processor."""
+    import requests
+
+    response = requests.post(
+        f"{base_url}/generate",
+        json={
+            "text": "The capital of France is",
+            "custom_logit_processor": TopNSigmaLogitProcessor.to_str(),
+            "sampling_params": {
+                "temperature": 1.0,
+                "max_new_tokens": 32,
+                # n = 1.0 keeps tokens within 1 std of the peak logit.
+                "custom_params": {PARAM_KEY: 1.0},
+            },
+        },
+        timeout=60,
+    )
+    print("[/generate]", response.json())
+
+
+def run_openai_example(base_url: str = "http://127.0.0.1:30000/v1") -> None:
+    """OpenAI-compatible chat.completions, with and without the processor.
+
+    ``model="default"`` targets whichever model the server was launched with,
+    so the example is not tied to a specific checkpoint.
+    """
+    import openai
+
+    client = openai.Client(base_url=base_url, api_key="None")
+    messages = [{"role": "user", "content": "List 3 countries and their capitals."}]
+
+    filtered = client.chat.completions.create(
+        model="default",
+        messages=messages,
+        temperature=1.0,
+        max_tokens=32,
+        extra_body={
+            "custom_logit_processor": TopNSigmaLogitProcessor.to_str(),
+            "custom_params": {PARAM_KEY: 1.0},
+        },
+    )
+    print("[openai top_n_sigma=1.0]", filtered.choices[0].message.content)
+
+    # Baseline: omit the processor to fall back to standard sampling.
+    plain = client.chat.completions.create(
+        model="default", messages=messages, temperature=1.0, max_tokens=32
+    )
+    print("[openai baseline]", plain.choices[0].message.content)
+
+
+def self_check() -> None:
+    """Assert the truncation math on a known input (needs torch, no server)."""
+    # Row 0: n=1.0 -> keep tokens >= mean-ish threshold; Row 1: n=-1 -> untouched.
+    logits = torch.tensor([[10.0, 9.0, 1.0, 0.0], [10.0, 9.0, 1.0, 0.0]])
+    n_values = torch.tensor([1.0, -1.0])
+    out = apply_top_n_sigma(logits.clone(), n_values)
+
+    std = logits[0].std()
+    threshold = logits[0].max() - 1.0 * std
+    expected_keep = logits[0] >= threshold
+    assert torch.isinf(out[0][~expected_keep]).all(), out[0]
+    assert torch.isfinite(out[0][expected_keep]).all(), out[0]
+    # Argmax-invariant: the top-1 token is always kept.
+    assert torch.isfinite(out[0, logits[0].argmax()]), out[0]
+    # Non-positive n leaves the row untouched.
+    assert torch.equal(out[1], logits[1]), out[1]
+
+    # std == 0 guard: all-equal logits pass through unchanged.
+    flat = torch.zeros(1, 5)
+    assert torch.equal(apply_top_n_sigma(flat.clone(), torch.tensor([2.0])), flat)
+
+    # -inf logits are handled (max/std over finite only), NOT skipped: the row
+    # is still truncated and the pre-existing -inf stays masked.
+    logits_with_inf = torch.tensor([[10.0, 9.0, 1.0, float("-inf")]])
+    out_inf = apply_top_n_sigma(logits_with_inf.clone(), torch.tensor([1.0]))
+    expected_keep_inf = torch.tensor([True, True, False, False])
+    assert torch.isinf(out_inf[0][~expected_keep_inf]).all(), out_inf
+    assert torch.isfinite(out_inf[0][expected_keep_inf]).all(), out_inf
+    # The processor stays ACTIVE with -inf masked tokens present -- it truncates
+    # rather than being disabled/passed through (regression guard for the
+    # all-finite reduction bug that would drag std/max to -inf and skip the row).
+    assert not torch.equal(out_inf, logits_with_inf), out_inf
+
+    # Single finite logit (rest -inf): std undefined -> row left unchanged.
+    one_finite = torch.tensor([[5.0, float("-inf"), float("-inf"), float("-inf")]])
+    assert torch.equal(apply_top_n_sigma(one_finite.clone(), torch.tensor([1.0])), one_finite)
+    print("self-check passed")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help="Validate the truncation math locally (no server needed).",
+    )
+    parser.add_argument(
+        "--skip-openai",
+        action="store_true",
+        help="Only run the raw /generate example.",
+    )
+    args = parser.parse_args()
+
+    if args.self_check:
+        self_check()
+    else:
+        run_generate_example()
+        if not args.skip_openai:
+            run_openai_example()


### PR DESCRIPTION
## Motivation

Addresses #29397. SGLang's built-in truncation samplers (`top_k`, `top_p`, `min_p`) all
filter in *probability* space, after softmax. Top-nσ ("Top-nσ: Not All Logits Are You
Need", Tang et al., ACL 2025; https://arxiv.org/abs/2411.07641) instead truncates in
*logit* space, before softmax:

```
threshold = max_logit - n * std_logit
logits[logits < threshold] = -inf   # then sample as usual
```

The std-based threshold is dual-adaptive (it adapts both how many and how loosely
candidates survive) and is argmax-invariant, so greedy decoding is unaffected. There was
no runnable example showing how to implement this on top of the `CustomLogitProcessor`
framework; this PR adds one, together with a companion unit test.

## Modifications

Purely additive — no framework code is touched.

- `examples/runtime/custom_logit_processor/top_n_sigma.py`
  - `apply_top_n_sigma(logits, n_values)`: a pure, fully vectorized truncation over a
    batch (no per-row Python loop). `max`/`std` are computed over the *finite* logits
    only, since real LLM logits routinely carry `-inf` (vocab padding, disallowed tokens,
    grammar constraints) — reducing over them would drag `std`/`max` to `-inf` and, under a
    naive all-finite guard, silently skip the processor for nearly every request. Rows are
    left untouched when `n <= 0`/`NaN`, when there are fewer than two finite logits (std
    undefined), or when std is zero. std is unbiased (ddof=1).
  - `TopNSigmaLogitProcessor(CustomLogitProcessor)`: reads a per-request
    `custom_params={"top_n_sigma": n}`, so the same processor can be attached to a mixed
    batch safely (requests without a positive numeric value pass through unchanged).
  - Client demos for both the raw `/generate` endpoint (with an explicit request timeout)
    and the OpenAI-compatible `chat.completions` API (`extra_body`, `model="default"`),
    including a processor-vs-baseline comparison. Both require the server to be launched
    with `--enable-custom-logit-processor`.
  - A `--self-check` mode that validates the truncation math locally (no server).
- `examples/runtime/custom_logit_processor/test_top_n_sigma.py`
  - A companion `pytest` (`CustomTestCase`) that imports the example via `importlib` (the
    real code is tested, not a copy) and covers the full edge-case matrix: argmax-
    invariance, exact `max - n*std` threshold, `std == 0`, `-inf`-masked tokens still
    truncating (rather than being skipped), single-finite-logit, invalid/`bool`/`None`
    params, empty param list, mixed per-row `n`, and input non-mutation.

## Accuracy Tests

N/A — documentation/example-only change; no model accuracy is affected. The pure
`apply_top_n_sigma` math was validated locally via the embedded `--self-check` assertions
and a torch-free numpy replica reproducing the same branching (argmax-invariance, the
`n <= 0` / `std == 0` / non-finite guards, and monotonicity of kept-token count in `n`).
`python -m py_compile` passes on both files. torch/GPU and a running server were
unavailable in the authoring environment, so the `pytest` run and the end-to-end server
run are left as follow-up.

## Speed Tests and Profiling

N/A — no runtime/kernel path is changed; this adds example + test files only.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-tests).
- [ ] Update documentation / docstrings / example tutorials as appropriate, especially if the change is user facing.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, following the [guidelines](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) if applicable.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28783160534](https://github.com/chethanuk/sglang/actions/runs/28783160534)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28783160247](https://github.com/chethanuk/sglang/actions/runs/28783160247)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---
_Related: #29398 also adds a Top-nσ example. This PR differs by keeping the processor active when a row already contains `-inf` (grammar/vocab masks) instead of skipping it, ships a companion pytest covering that case, and uses a portable `model="default"`. Happy to consolidate with #29398 if maintainers prefer._
