### PR TITLE
fix(docker): install distro and missing runtime Python deps in the runtime image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -564,6 +564,21 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     termplotlib \
     "runai-model-streamer[s3,gcs,azure]>=0.15.7"
 
+# Runtime deps satisfied only by the base image's apt Python (distro is a
+# declared sglang dep; cryptography/pyjwt/pyparsing are transitive). pip sees
+# the system copies under /usr/lib/python3/dist-packages as already-satisfied
+# and skips them, so they never land in /usr/local/lib/.../dist-packages — the
+# only tree the slim runtime stage COPYs. That leaves them missing at launch
+# (ModuleNotFoundError: distro). --ignore-installed forces a pip copy into
+# /usr/local so the runtime COPY carries them; -c constraints.txt keeps builds
+# reproducible. See https://github.com/sgl-project/sglang/issues/29650
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --ignore-installed -c /sgl-workspace/constraints.txt \
+    cryptography \
+    distro \
+    pyjwt \
+    pyparsing
+
 # Optional ai-dynamo nightly for Dynamo + SGLang integration testing. Gated by
 # INSTALL_DYNAMO so it lands only in the dev image (release-docker-dev.yml sets
 # it), not the version-tagged release/runtime images. Empty DYNAMO_VERSION


### PR DESCRIPTION
## Motivation

Launching `sglang.launch_server` in the `latest-runtime` Docker image fails with `ModuleNotFoundError: No module named 'distro'` (#29650).

Root cause: `distro` (a declared sglang runtime dependency in `python/pyproject.toml`) and a few transitive runtime deps — `cryptography`, `pyjwt`, `pyparsing` — are provided by the base image's **apt** Python under `/usr/lib/python3/dist-packages`. When the sglang wheel is installed, pip sees those system copies as already-satisfied and never installs them into `/usr/local/lib/python3.12/dist-packages`. The slim `runtime` stage is assembled from a fresh CUDA base and only copies `/usr/local/lib/python3.12/dist-packages` from `framework_final`, so these packages are absent at launch.

## Modifications

- `docker/Dockerfile`: in the `framework` builder stage, install `cryptography`, `distro`, `pyjwt`, and `pyparsing` with `pip install --ignore-installed -c /sgl-workspace/constraints.txt`.

Design notes:

- `--ignore-installed` forces pip to place the packages into `/usr/local/lib/python3.12/dist-packages` even though the base-image system copies exist, so the existing `COPY --from=framework_final .../dist-packages` step carries them into the runtime image.
- `-c constraints.txt` pins the resolved versions (from the earlier `pip freeze`) for build-to-build reproducibility.
- The install lives in a builder stage, so the `runtime` stage stays copy-only and safe in air-gapped / private-mirror environments.

This covers the complete set of runtime deps left behind by the multi-stage copy, fully closing #29650 rather than patching only `distro`.

## Accuracy Tests

N/A — Dockerfile-only change with no impact on model outputs.

## Speed Tests and Profiling

N/A — no runtime code path is affected.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-fixing-docstrings).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/accuracy_results.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and want to complete a review, please take up review this PR instead of approving it directly.
- [ ] For reviewers: If you haven't made any contributions to this PR and want to complete a review, click the button in the [Reviewers section](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-review-process) to move it to the "Approved" state.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28783164477](https://github.com/chethanuk/sglang/actions/runs/28783164477)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28783164331](https://github.com/chethanuk/sglang/actions/runs/28783164331)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---
_Related: #29743 targets the same runtime-deps gap. This is an independent implementation arriving at the same `--ignore-installed -c constraints.txt` fix for the four system-provided deps. Happy to close in favor of #29743 if preferred._
