### PR TITLE
Fix DSV4 prefill large Triton recompilation idle across context lengths

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
@@ -5,9 +5,7 @@ import triton
 import triton.language as tl
 
 
-# The C128 capacity follows the live metadata extent. Keep it runtime so exact
-# context lengths do not create distinct kernel specializations.
-@triton.jit(do_not_specialize=["c128_capacity"])
+@triton.jit(do_not_specialize=["bs", "c128_cur_max_seq_len"])
 def _init_compressed_attn_metadata_kernel(
     seq_lens_ptr,
     positions_ptr,
@@ -24,7 +22,7 @@ def _init_compressed_attn_metadata_kernel(
     c128_page_indices_ptr,
     bs,
     max_pages,
-    c128_capacity,
+    c128_cur_max_seq_len,
     c128_page_size: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     COMPUTE_PAGE_INDICES: tl.constexpr,
@@ -60,10 +58,10 @@ def _init_compressed_attn_metadata_kernel(
     tl.store(c128_seq_lens_clamp1_ptr + batch_id, c128_seq_lens_clamp1)
 
     if COMPUTE_PAGE_INDICES:
-        page_indices_base = batch_id * c128_capacity
-        for block_start in tl.range(0, c128_capacity, BLOCK_SIZE):
+        page_indices_base = batch_id * c128_cur_max_seq_len
+        for block_start in tl.range(0, c128_cur_max_seq_len, BLOCK_SIZE):
             offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < c128_capacity
+            mask = offsets < c128_cur_max_seq_len
 
             page_idx = offsets // c128_page_size
             offset_in_page = offsets % c128_page_size
@@ -122,18 +120,20 @@ def _init_compressed_attn_metadata_triton(
         assert (
             page_table is not None
         ), "page_table required when compute_page_indices=True"
-        assert page_size > 0, "page_size required when compute_page_indices=True"
+        assert (
+            page_size >= 128 and page_size % 128 == 0
+        ), "page_size must be a multiple of 128 when compute_page_indices=True"
         max_pages = page_table.shape[1]
         c128_page_size = page_size // 128
-        c128_capacity = c128_page_size * max_pages
+        c128_cur_max_seq_len = c128_page_size * max_pages
         c128_page_indices = torch.empty(
-            bs, c128_capacity, dtype=torch.int32, device=device
+            bs, c128_cur_max_seq_len, dtype=torch.int32, device=device
         )
         BLOCK_SIZE = triton.next_power_of_2(max(c128_page_size, 64))
     else:
         max_pages = 0
         c128_page_size = 1
-        c128_capacity = 0
+        c128_cur_max_seq_len = 0
         c128_page_indices = None
         BLOCK_SIZE = 64
         if page_table is None:
@@ -160,7 +160,7 @@ def _init_compressed_attn_metadata_triton(
         ),
         bs,
         max_pages,
-        c128_capacity,
+        c128_cur_max_seq_len,
         c128_page_size,
         BLOCK_SIZE,
         compute_page_indices,

--- a/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
@@ -5,7 +5,9 @@ import triton
 import triton.language as tl
 
 
-@triton.jit
+# The C128 capacity follows the live metadata extent. Keep it runtime so exact
+# context lengths do not create distinct kernel specializations.
+@triton.jit(do_not_specialize=["c128_capacity"])
 def _init_compressed_attn_metadata_kernel(
     seq_lens_ptr,
     positions_ptr,
@@ -22,8 +24,7 @@ def _init_compressed_attn_metadata_kernel(
     c128_page_indices_ptr,
     bs,
     max_pages,
-    page_size: tl.constexpr,
-    c128_max_seq_len: tl.constexpr,
+    c128_capacity,
     c128_page_size: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     COMPUTE_PAGE_INDICES: tl.constexpr,
@@ -59,10 +60,10 @@ def _init_compressed_attn_metadata_kernel(
     tl.store(c128_seq_lens_clamp1_ptr + batch_id, c128_seq_lens_clamp1)
 
     if COMPUTE_PAGE_INDICES:
-        page_indices_base = batch_id * c128_max_seq_len
-        for block_start in range(0, c128_max_seq_len, BLOCK_SIZE):
+        page_indices_base = batch_id * c128_capacity
+        for block_start in tl.range(0, c128_capacity, BLOCK_SIZE):
             offsets = block_start + tl.arange(0, BLOCK_SIZE)
-            mask = offsets < c128_max_seq_len
+            mask = offsets < c128_capacity
 
             page_idx = offsets // c128_page_size
             offset_in_page = offsets % c128_page_size
@@ -124,15 +125,15 @@ def _init_compressed_attn_metadata_triton(
         assert page_size > 0, "page_size required when compute_page_indices=True"
         max_pages = page_table.shape[1]
         c128_page_size = page_size // 128
-        c128_max_seq_len = c128_page_size * max_pages
+        c128_capacity = c128_page_size * max_pages
         c128_page_indices = torch.empty(
-            bs, c128_max_seq_len, dtype=torch.int32, device=device
+            bs, c128_capacity, dtype=torch.int32, device=device
         )
         BLOCK_SIZE = triton.next_power_of_2(max(c128_page_size, 64))
     else:
         max_pages = 0
         c128_page_size = 1
-        c128_max_seq_len = 0
+        c128_capacity = 0
         c128_page_indices = None
         BLOCK_SIZE = 64
         if page_table is None:
@@ -159,8 +160,7 @@ def _init_compressed_attn_metadata_triton(
         ),
         bs,
         max_pages,
-        page_size if page_size > 0 else 128,
-        c128_max_seq_len,
+        c128_capacity,
         c128_page_size,
         BLOCK_SIZE,
         compute_page_indices,

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -135,7 +135,7 @@ def combine_topk_swa_indices(
     assert gather_lens.dtype == torch.int32
     assert compressed_base.dtype == torch.int32
     assert swa_base.dtype == torch.int32
-    assert compress_ratio >= 1, "COMPRESS_RATIO must be >= 1 (use TOP_K=0 for SWA-only)"
+    assert compress_ratio >= 1, "compress_ratio must be >= 1 (use topk=0 for SWA-only)"
 
     num_tokens = topk_indices.shape[0]
     num_reqs = seq_lens.shape[0]
@@ -172,7 +172,7 @@ def combine_topk_swa_indices(
         gather_lens,
         compressed_base,
         swa_base,
-        TOP_K=topk,
+        top_k=topk,
         COMPRESS_RATIO=compress_ratio,
         WINDOW_SIZE=window_size,
         PADDED_TOP_K=triton.next_power_of_2(topk_indices.shape[-1]),
@@ -279,7 +279,9 @@ def _build_swa_token_ids_kernel(
         tl.store(out_ptr + out_off + i, swa_id)
 
 
-@triton.jit
+# The configured top-k follows the live compressed extent. Keep its exact
+# value runtime while retaining stride-alignment and padded-width specialization.
+@triton.jit(do_not_specialize=["top_k"])
 def _combine_topk_swa_indices_kernel(
     combined_indices_ptr,
     combined_indices_stride,
@@ -291,7 +293,7 @@ def _combine_topk_swa_indices_kernel(
     gather_lens_ptr,
     compressed_base_ptr,
     swa_base_ptr,
-    TOP_K: tl.constexpr,
+    top_k,
     COMPRESS_RATIO: tl.constexpr,
     WINDOW_SIZE: tl.constexpr,
     PADDED_TOP_K: tl.constexpr,
@@ -321,8 +323,8 @@ def _combine_topk_swa_indices_kernel(
         pos = start_pos + token_idx_in_query
         # Both the C4 indexer and the C128 metadata builder emit
         # min((pos+1)//compress_ratio, topk_tokens) valid entries. Caller
-        # passes TOP_K=0 for SWA-only layers to zero this out.
-        topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, TOP_K)
+        # passes top_k=0 for SWA-only layers to zero this out.
+        topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, top_k)
         swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
 
         combined_row = token_idx.to(tl.int64) * combined_indices_stride

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -136,6 +136,9 @@ def combine_topk_swa_indices(
     assert compressed_base.dtype == torch.int32
     assert swa_base.dtype == torch.int32
     assert compress_ratio >= 1, "compress_ratio must be >= 1 (use topk=0 for SWA-only)"
+    assert (
+        topk_indices.shape[-1] >= topk
+    ), f"topk_indices width {topk_indices.shape[-1]} must be >= topk {topk}"
 
     num_tokens = topk_indices.shape[0]
     num_reqs = seq_lens.shape[0]
@@ -279,8 +282,6 @@ def _build_swa_token_ids_kernel(
         tl.store(out_ptr + out_off + i, swa_id)
 
 
-# The configured top-k follows the live compressed extent. Keep its exact
-# value runtime while retaining stride-alignment and padded-width specialization.
 @triton.jit(do_not_specialize=["top_k"])
 def _combine_topk_swa_indices_kernel(
     combined_indices_ptr,


### PR DESCRIPTION
## Motivation

DeepSeek-V4 sparse prefill derives the C128 metadata capacity and sparse-index combiner top-k from the live context length. Both values were passed to Triton as `tl.constexpr`, so changing an exact context length generated a new kernel specialization. These synchronous JIT compilations introduce huge stalling.

## Modifications

- Pass the exact C128 metadata capacity as a runtime scalar and iterate over it with a masked `tl.range`.
- Pass the sparse combiner's exact `top_k` as a runtime scalar.
- Remove the unused private metadata-kernel `page_size` argument.

## Speed Tests and Profiling

AgentX benchmark concurrency 384 shows great perf improvement.

| Metric | Baseline | This PR | Delta |
|---|---:|---:|---:|
| Mean TTFT | 32.682 s | 20.836 s | -36.25% |
| Output throughput | 10,423.36 tok/s | 13,211.38 tok/s | +26.75% |
| Input throughput | 1,444,106.37 tok/s | 1,771,722.55 tok/s | +22.69% |
| Request throughput | 10.67 req/s | 13.74 req/s | +28.74% |
| Mean ITL | 14.300 ms | 15.670 ms | +9.58% |

The kernel perf won't regress by reduced specialization:

Direct steady-state kernel benchmarks on the same GB300 allocation (`warmup=100`, `rep=500`) found no meaningful regression:

| Kernel | Shape | Baseline | This PR | Delta |
|---|---|---:|---:|---:|
| C128 metadata | `bs=4096`, `max_pages=2048` | 0.0711253 ms | 0.0703080 ms | -1.15% |
| Sparse combiner | `num_tokens=4096`, `top_k=4084` | 0.0607069 ms | 0.0610846 ms | +0.62% |

An additional same-GPU, alternating metadata sweep at `max_pages=512` also found no meaningful regression:

| Batch size | Baseline | This PR | Delta |
|---:|---:|---:|---:|
| 1 | 32.256 µs | 29.600 µs | -8.23% |
| 32 | 29.088 µs | 29.552 µs | +1.60% |
| 256 | 32.560 µs | 30.416 µs | -6.58% |

## Accuracy Tests

A full 5-shot GSM8K evaluation on the patched version achieved 1,274/1,319 strict-match accuracy (96.59%)































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28846608165](https://github.com/sgl-project/sglang/actions/runs/28846608165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28846608089](https://github.com/sgl-project/sglang/actions/runs/28846608089)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
