### PR TITLE
[AMD] Enable dense-MHA prefill threshold on gfx950 for DSA

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2673,11 +2673,21 @@ class DeepseekSparseAttnBackend(
             sum_seq_lens = sum(forward_batch.seq_lens_cpu)
             device_sm = get_device_sm()
 
-            # Requirements: H200/B200, short sequences, supported dtype, fits in chunk
+            # Hardware that has a dense varlen MHA prefill kernel wired into
+            # _forward_standard_mha: NVIDIA SM90 (FA3) / SM100 (flashinfer trtllm),
+            # and AMD gfx950 (aiter flash_attn_varlen_func, imported on HIP above).
+            mha_prefill_hw_ok = (
+                device_sm == 90
+                or (device_sm >= 100 and device_sm < 110)
+                or (_is_hip and device_sm == 95)
+            )
+
+            # Requirements: supported HW, short sequences, supported dtype, fits in chunk.
+            # gfx950 prefix-continuation reads the latent back from the fp8 KV cache;
+            # the HIP raw 576B layout (no per-tile scales) is handled by
+            # dequantize_k_cache_paged's dim_quant==576 branch.
             self.use_mha = (
-                (
-                    device_sm == 90 or (device_sm >= 100 and device_sm < 110)
-                )  # SM90/SM100 only
+                mha_prefill_hw_ok
                 and max_kv_len
                 <= envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()  # Short enough for MHA
                 and self.token_to_kv_pool.dtype in [torch.bfloat16, torch.float8_e4m3fn]


### PR DESCRIPTION
## Motivation

The DSA dense one-shot MHA prefill (`_forward_standard_mha`), gated by `SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD`, was hard-gated to NVIDIA SM90/SM100, so AMD gfx950 (MI350/MI355) always fell back to the slower sparse path. This PR flips the hardware gate to enable it on gfx950.

Two regimes:
- **`context ≤ 2048` (default): exact + free.** Sparse top-k selects *all* keys, so dense MHA is mathematically identical while skipping the indexer GEMM + top-k. On gfx950 the indexer (`_gluon_fp8_mqa_logits`, 1 warp/query) is a real bottleneck, so this is a pure speed win.
- **Above 2048: approximation, bounded.** Dense is faster at all contexts, but on a hard 10-needle recall test its accuracy drops below sparse past a **model-dependent** length, and it uses more KV memory. Raising the threshold is a per-use-case opt-in. No-op above the threshold; NVIDIA paths untouched.

## Modifications

- **`dsa_backend.py`** — add gfx950 to the dense-MHA gate (`_is_hip and device_sm == 95`) alongside NVIDIA SM90/SM100; uses aiter `flash_attn_varlen_func` (per-model head dims). No-op above the threshold; NVIDIA behavior unchanged.

**Dependency:** requires the support PR (#30257 - `amd-dsa-mha-prefill-support`), which adds the gfx950 dense-MHA kernels/paths (HIP 576B dequant, `MHA_ONE_SHOT` reload fix, indexer skip) and CI coverage. Merge that PR first. 

## Accuracy (TP8 / 8×MI350X, `dsa`, `kv-cache fp8_e4m3`, real weights)

Dense = threshold raised (`use_mha=True`, kernel-verified); sparse = threshold 0.

**Easy retrieval — dense matches sparse (GLM-5.1):** GSM8K 0.965 vs 0.960; NIAH single/multi + KV @10k/30k/60k = **100% (sparse and dense)**.

**Hard 10-needle recall — reveals the ceiling.** 10 animal "needles" hidden in a long word-list haystack; recall = needles found / 10, greedy/no-thinking, 1 prompt × 10 needle-sets per length (mean shown).

| input | 5.1 dense | 5.1 sparse | 5.2 dense | 5.2 sparse |
| ----- | --------- | ---------- | --------- | ---------- |
| 10k   | 87%       | 82%        | 100%      | 100%       |
| 20k   | 88%       | 93%        | 98%       | 97%        |
| 30k   | 88%       | 86%        | 97%       | 99%        |
| 40k   | 80%       | 92%        | 94%       | 96%        |
| 50k   | **59%**   | 89%        | 87%       | 99%        |
| 60k   | 50%       | 90%        | 75%       | 96%        |
| 70k   | 41%       | 91%        | 81%       | 98%        |
| 80k   | 44%       | 84%        | 64%       | 90%        |

Sparse holds ~85–99% throughout (top-k denoises). Dense tracks sparse up to a **model-dependent** context then degrades: **GLM-5.1 ≈ sparse to ~30k**, **GLM-5.2 to ~50k**.

## Recommended threshold (`SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD`)

| Use case                                   | Threshold                                                |
| ------------------------------------------ | -------------------------------------------------------- |
| Correctness-critical / any model (default) | **2048** (exact)                                         |
| GLM-5.1, throughput-focused                | up to **~30k** (~88%, ≈ sparse)                          |
| GLM-5.2, throughput-focused                | up to **~50k** (≥87%, ≈ sparse)                          |
| DeepSeek-V3.2                              | **2048** — enabled but not accuracy-tested in this sweep |

## Speed (GLM-5.1-FP8, TP8/MI350X, apple-to-apple, only threshold differs)

Dense is faster at every measured shape — **TTFT −29% to −48%, total throughput +7% to +36%**; decode (TPOT) comparable (decode is always sparse). Examples:

| ISL/OSL   | conc | total tok/s (sparse→dense) | TTFT ms (sparse→dense)   |
| --------- | ---- | -------------------------- | ------------------------ |
| 2048/200  | 8    | 3315 → **3554** (+7%)      | 273 → **193** (−29%)     |
| 8192/1024 | 64   | 8276 → **10802** (+31%)    | 8258 → **4255** (−48%)   |
| 60000/200 | 16   | 9994 → **13615** (+36%)    | 30984 → **22004** (−29%) |

Full sweep (ISL 10k–180k × conc 1–32): dense wins at every point, +8% to +59%, largest at short/medium context and high concurrency.

**Operational note:** dense materializes the full KV, so at long context under sustained mixed load (high `--mem-fraction-static`) it can fragment the HIP allocator. Together with the accuracy ceiling, this is why the default stays conservative and raising it is an opt-in.

## Checklist
- [x] Format code with pre-commit
- [x] Follow the SGLang code style guidance
- [x] Accuracy and speed benchmarks (above)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28789032490](https://github.com/sgl-project/sglang/actions/runs/28789032490)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28789032254](https://github.com/sgl-project/sglang/actions/runs/28789032254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->