### PR TITLE
Fix: use getattr for head_dim/sliding_window in DeepSeek V4 config

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -777,11 +777,15 @@ class ModelConfig:
             or "DeepseekV4ForCausalLMNextN" in self.hf_config.architectures
         ):
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
-            if hasattr(self.hf_config, 'head_dim'):
+            if hasattr(self.hf_config, "head_dim"):
                 self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
             else:
                 self.qk_nope_head_dim = self.hf_config.qk_nope_head_dim
-            self.window_size = getattr(self.hf_config, "sliding_window", getattr(self.hf_config, "window_size", None))
+            self.window_size = getattr(
+                self.hf_config,
+                "sliding_window",
+                getattr(self.hf_config, "window_size", None),
+            )
             self.head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
             self.v_head_dim = self.head_dim
             self.index_head_dim = self.hf_config.index_head_dim

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -777,8 +777,11 @@ class ModelConfig:
             or "DeepseekV4ForCausalLMNextN" in self.hf_config.architectures
         ):
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
-            self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
-            self.window_size = self.hf_config.sliding_window
+            if hasattr(self.hf_config, 'head_dim'):
+                self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
+            else:
+                self.qk_nope_head_dim = self.hf_config.qk_nope_head_dim
+            self.window_size = getattr(self.hf_config, "sliding_window", getattr(self.hf_config, "window_size", None))
             self.head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
             self.v_head_dim = self.head_dim
             self.index_head_dim = self.hf_config.index_head_dim

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -777,8 +777,8 @@ class ModelConfig:
             or "DeepseekV4ForCausalLMNextN" in self.hf_config.architectures
         ):
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
-            self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
-            self.window_size = self.hf_config.sliding_window
+            self.qk_nope_head_dim = getattr(self.hf_config, 'head_dim', self.hf_config.qk_nope_head_dim + self.qk_rope_head_dim) - self.qk_rope_head_dim
+            self.window_size = getattr(self.hf_config, 'sliding_window', self.hf_config.window_size)
             self.head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
             self.v_head_dim = self.head_dim
             self.index_head_dim = self.hf_config.index_head_dim

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -777,8 +777,8 @@ class ModelConfig:
             or "DeepseekV4ForCausalLMNextN" in self.hf_config.architectures
         ):
             self.qk_rope_head_dim = self.hf_config.qk_rope_head_dim
-            self.qk_nope_head_dim = getattr(self.hf_config, 'head_dim', self.hf_config.qk_nope_head_dim + self.qk_rope_head_dim) - self.qk_rope_head_dim
-            self.window_size = getattr(self.hf_config, 'sliding_window', self.hf_config.window_size)
+            self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
+            self.window_size = self.hf_config.sliding_window
             self.head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
             self.v_head_dim = self.head_dim
             self.index_head_dim = self.hf_config.index_head_dim


### PR DESCRIPTION
# Fix: Use getattr for head_dim/sliding_window in DeepSeek V4 config

## Problem

In `python/sglang/srt/configs/model_config.py:545-546`, when `SGLANG_DSV4_MODE == "2604"`, the code directly accesses `head_dim` and `sliding_window` on `hf_config`:

```python
self.qk_nope_head_dim = self.hf_config.head_dim - self.qk_rope_head_dim
self.window_size = self.hf_config.sliding_window
```

These fields are not guaranteed to exist in custom or GGUF-converted model configs. When missing, SGLang crashes with `AttributeError` at startup.

## Fix

Replace direct attribute access with `getattr` providing sensible fallbacks:

```python
self.qk_nope_head_dim = getattr(self.hf_config, 'head_dim',
    self.hf_config.qk_nope_head_dim + self.qk_rope_head_dim) - self.qk_rope_head_dim
self.window_size = getattr(self.hf_config, 'sliding_window',
    self.hf_config.window_size)
```

- If `head_dim` exists → identical to original behavior
- If `head_dim` missing → computes equivalent from `qk_nope_head_dim + qk_rope_head_dim`
- If `sliding_window` missing → falls back to `window_size` (already used in non-2604 mode)

## Impact

Enables GGUF and community-quantized DeepSeek V4 models to load without manual config patching. Safe for all existing models — zero behavioral change when fields are present.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28790060710](https://github.com/sgl-project/sglang/actions/runs/28790060710)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28790060635](https://github.com/sgl-project/sglang/actions/runs/28790060635)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->