### PR TITLE
[Feature] Per-request disable_speculative_decoding sampling param (API plumbing, RFC)

### DIFF
--- a/docs_new/docs/basic_usage/sampling_params.mdx
+++ b/docs_new/docs/basic_usage/sampling_params.mdx
@@ -314,6 +314,11 @@ Please refer to our dedicated guide on [constrained decoding](../advanced_featur
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Don't trim stop words or EOS token from the generated text.</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>disable_speculative_decoding</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`bool = False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Experimental (RFC #30263): request-level opt-out of speculative decoding. The parameter is accepted and carried per request, but worker-side enforcement is still being designed in RFC #30263 and is not active yet. Always a no-op when the server runs no speculative decoding.</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>custom_params</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`Optional[List[Optional[Dict[str, Any]]]] = None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Used when employing `CustomLogitProcessor`. For usage, see below.</td>

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -354,6 +354,10 @@ class CompletionRequest(BaseModel):
     stop_regex: Optional[Union[str, List[str]]] = None
     no_stop_trim: bool = False
     ignore_eos: bool = False
+    # SGLang extension (RFC #30263): request-level opt-out of speculative
+    # decoding. Currently plumbed but not yet enforced by the speculative
+    # workers. Always a no-op when the server runs no speculative decoding.
+    disable_speculative_decoding: bool = False
     skip_special_tokens: bool = True
     lora_path: Optional[Union[List[Optional[str]], Optional[str]]] = None
     session_id: Optional[str] = None
@@ -726,6 +730,10 @@ class ChatCompletionRequest(BaseModel):
     stop_regex: Optional[Union[str, List[str]]] = None
     no_stop_trim: bool = False
     ignore_eos: bool = False
+    # SGLang extension (RFC #30263): request-level opt-out of speculative
+    # decoding. Currently plumbed but not yet enforced by the speculative
+    # workers. Always a no-op when the server runs no speculative decoding.
+    disable_speculative_decoding: bool = False
     continue_final_message: bool = False
     skip_special_tokens: bool = True
     lora_path: Optional[Union[List[Optional[str]], Optional[str]]] = None
@@ -913,6 +921,7 @@ class ChatCompletionRequest(BaseModel):
             "n": self.n,
             "no_stop_trim": self.no_stop_trim,
             "ignore_eos": self.ignore_eos,
+            "disable_speculative_decoding": self.disable_speculative_decoding,
             "skip_special_tokens": self.skip_special_tokens,
             "logit_bias": self.logit_bias,
             "custom_params": self.custom_params,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -158,6 +158,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             "n": request.n,
             "no_stop_trim": request.no_stop_trim,
             "ignore_eos": request.ignore_eos,
+            "disable_speculative_decoding": request.disable_speculative_decoding,
             "skip_special_tokens": request.skip_special_tokens,
             "logit_bias": request.logit_bias,
             "custom_params": request.custom_params,

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -111,6 +111,15 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
     stream_interval: Optional[int] = None
     logit_bias: Optional[Dict[str, float]] = None
     sampling_seed: Optional[int] = None
+    # Request-level opt-out of speculative decoding (RFC #30263). When True,
+    # this request asks the server to skip the draft/verify path and produce
+    # its output with the target model alone. This field is currently plumbed
+    # end-to-end (API -> SamplingParams -> IPC -> Req) but NOT yet enforced by
+    # the speculative workers: correct enforcement requires switching to a
+    # num_steps=0 runtime state (CUDA graph runner + attention backend), which
+    # is being designed in RFC #30263. Always a no-op when the server has no
+    # speculative decoding configured.
+    disable_speculative_decoding: bool = False
 
     # --- Internal fields (populated by __post_init__ or normalize(), not API-facing) ---
     stop_strs: Optional[Union[str, List[str]]] = None  # from stop
@@ -163,6 +172,11 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
         )
         self.no_stop_trim = (
             self.no_stop_trim if self.no_stop_trim is not None else False
+        )
+        self.disable_speculative_decoding = (
+            self.disable_speculative_decoding
+            if self.disable_speculative_decoding is not None
+            else False
         )
 
         # Process some special cases

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -520,5 +520,51 @@ class TestRegexMaxLength(CustomTestCase):
         self.assertGreaterEqual(result, MAX_LEN)
 
 
+class TestSamplingParamsDisableSpeculativeDecoding(CustomTestCase):
+    """Covers the per-request speculative-decoding opt-out flag (API plumbing)."""
+
+    def test_default_is_false(self):
+        """By default a request does not opt out of speculative decoding."""
+        self.assertFalse(SamplingParams().disable_speculative_decoding)
+
+    def test_explicit_true_preserved(self):
+        """An explicit opt-out is kept as-is."""
+        sp = SamplingParams(disable_speculative_decoding=True)
+        self.assertTrue(sp.disable_speculative_decoding)
+
+    def test_none_falls_back_to_false(self):
+        """/generate callers may send an explicit null; __post_init__ normalizes it."""
+        sp = SamplingParams(disable_speculative_decoding=None)
+        self.assertFalse(sp.disable_speculative_decoding)
+
+    def test_default_omitted_from_wire(self):
+        """omit_defaults=True: the default False must not bloat the msgpack IPC payload."""
+        encoded = msgspec.msgpack.encode(SamplingParams())
+        self.assertNotIn(
+            "disable_speculative_decoding", msgspec.msgpack.decode(encoded)
+        )
+
+    def test_msgpack_round_trip_preserves_opt_out(self):
+        """The flag must survive msgpack encode/decode of a bare struct."""
+        decoder = msgspec.msgpack.Decoder(SamplingParams)
+        rebuilt = decoder.decode(
+            msgspec.msgpack.Encoder().encode(
+                SamplingParams(disable_speculative_decoding=True)
+            )
+        )
+        self.assertTrue(rebuilt.disable_speculative_decoding)
+
+    def test_normalized_round_trip_preserves_opt_out(self):
+        """Mirror the real tokenizer -> scheduler IPC: normalize() first, then
+        encode/decode. The decode-side __post_init__ early-returns for normalized
+        structs, so this covers the path the bare round-trip above does not."""
+        sp = SamplingParams(disable_speculative_decoding=True)
+        sp.normalize(tokenizer=None)
+        decoder = msgspec.msgpack.Decoder(SamplingParams)
+        rebuilt = decoder.decode(msgspec.msgpack.Encoder().encode(sp))
+        self.assertTrue(rebuilt.is_normalized)
+        self.assertTrue(rebuilt.disable_speculative_decoding)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

## Motivation

Speculative decoding in SGLang is fixed at server startup (`--speculative-*`) — every request on an SD-enabled server is speculated. But a draft model's acceptance rate is workload-dependent, and SD can reduce goodput at high batch size (verification cost scales with `batch_size × draft_length`). Operators can already *measure* per-request acceptance via `meta_info` (`spec_verify_ct`, `spec_accept_rate`, `spec_accept_length`) but have no per-request knob to *act* on it.

RFC / design discussion: #30263 (follow-up to #9319).

**Scope of this draft PR: API plumbing only.** It adds and threads the per-request `disable_speculative_decoding` flag end-to-end, but deliberately does **not** wire worker-side enforcement. Marked as GitHub Draft and not intended to merge until the RFC settles the naming/shape question — the field, docs row, and tests get renamed or reshaped per that outcome. As analyzed in the RFC, the "obvious" enforcement — reusing the `speculative_num_steps == 0` trivial-verify path in `EAGLEWorkerV2` — is only valid after `apply_runtime_state()` has switched to a steps-0 runtime state (target CUDA-graph runner re-captured at 1 token/req + matching attention backend); taking that branch under a static `K > 0` state breaks the `num_tokens_per_req == draft_token_num` invariant (shape-mismatch crash on the CUDA-graph path, miscomputed TARGET_VERIFY attention metadata on the eager path). Enforcement therefore needs a runtime-state swap (or scheduler-level batch grouping), which I'd like to settle in the RFC before implementing. Until then the flag is accepted, carried per request, and documented as experimental/not yet enforced.

## Modifications

- `SamplingParams.disable_speculative_decoding: bool = False` (msgspec Struct; `None` → `False` normalization consistent with sibling bools; `omit_defaults` keeps it off the IPC wire when default).
- Exposed on OpenAI `CompletionRequest` / `ChatCompletionRequest` and threaded through their sampling-param dicts; carried on the native `/generate` `sampling_params` automatically and survives the tokenizer → scheduler msgpack IPC into `Req.sampling_params`.
- Docs row in `docs_new/docs/basic_usage/sampling_params.mdx`, explicitly marked experimental / not yet enforced.
- CPU-only unit tests (`test/registered/unit/sampling/test_sampling_params.py::TestSamplingParamsDisableSpeculativeDecoding`): default, explicit opt-out, `None` normalization, wire omission of the default, bare round-trip, and a normalized round-trip mirroring the real tokenizer → scheduler IPC (decode-side `__post_init__` early-return path).

No behavior change for any existing configuration: the flag is normalized and carried per request, but no scheduler or worker logic consumes it yet.

Usage (once enforcement lands):

```python
client.completions.create(
    model=..., prompt=...,
    extra_body={"disable_speculative_decoding": True},
)
```

## Accuracy Tests

Not applicable — no model-forward or kernel changes; the flag is plumbing-only in this PR and nothing consumes it. CPU unit tests cover the API/serialization surface.

## Speed Tests and Profiling

Not applicable — no hot-path behavior change. (The one hot-path candidate — a per-iteration batch scan in the worker — was deliberately excluded along with enforcement.)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — N/A for plumbing-only; will accompany the enforcement PR.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28792968134](https://github.com/sgl-project/sglang/actions/runs/28792968134)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28792967792](https://github.com/sgl-project/sglang/actions/runs/28792967792)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->