### PR TITLE
fix(srt): guard videos_kwargs key removal in processor fallback

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/modules/qwen_vl_processor.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/qwen_vl_processor.py
@@ -29,7 +29,7 @@ def transform_patches_to_flatten(
     patch_size: int,
     merge_size: int,
 ) -> torch.Tensor:
-    patches = patches.view(
+    patches = patches.reshape(
         batch_size * grid_t,
         temporal_patch_size * channel,
         grid_h // merge_size,

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -491,7 +491,6 @@ class BaseMultimodalProcessor(ABC):
                 return_tensors="pt",
                 **kwargs,
             )
-
         if not self.server_args.keep_mm_feature_on_device:
             # move feature tensors to cpu
             for feature_name in self.FEATURE_NAMES:

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -471,8 +471,9 @@ class BaseMultimodalProcessor(ABC):
                 **kwargs,
             )
         except (TypeError, ValueError) as e:
-            logger.warning(f"Processor call failed with video kwargs, retrying without video-specific params: {e}")
-
+            logger.warning(
+                f"Processor call failed with video kwargs, retrying without video-specific params: {e}"
+            )
             sglang_video_keys = (
                 "fps",
                 "max_pixels",
@@ -481,7 +482,7 @@ class BaseMultimodalProcessor(ABC):
                 "max_frames",
                 "min_frames",
                 "resized_height",
-                "resized_width"
+                "resized_width",
             )
             for k in sglang_video_keys:
                 kwargs["videos_kwargs"].pop(k, None)

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -484,8 +484,10 @@ class BaseMultimodalProcessor(ABC):
                 "resized_height",
                 "resized_width",
             )
-            for k in sglang_video_keys:
-                kwargs["videos_kwargs"].pop(k, None)
+            # Guard: only strip if videos_kwargs exists and is a dict
+            if "videos_kwargs" in kwargs and isinstance(kwargs["videos_kwargs"], dict):
+                for k in sglang_video_keys:
+                    kwargs["videos_kwargs"].pop(k, None)
             result = processor.__call__(
                 text=[input_text],
                 padding=True,

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -483,16 +483,15 @@ class BaseMultimodalProcessor(ABC):
                 "resized_height",
                 "resized_width"
             )
-            hf_video_kwargs = {}
-            for k, v in kwargs.items():
-                if k not in sglang_video_keys:
-                    hf_video_kwargs[k] = v
+            for k in sglang_video_keys:
+                kwargs["videos_kwargs"].pop(k, None)
             result = processor.__call__(
                 text=[input_text],
                 padding=True,
                 return_tensors="pt",
-                **hf_video_kwargs,
+                **kwargs,
             )
+
         if not self.server_args.keep_mm_feature_on_device:
             # move feature tensors to cpu
             for feature_name in self.FEATURE_NAMES:

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -483,11 +483,10 @@ class BaseMultimodalProcessor(ABC):
                 "resized_height",
                 "resized_width"
             )
-            hf_video_kwargs = {
-                k: v
-                for k, v in kwargs
-                if k not in sglang_video_keys
-            }
+            hf_video_kwargs = {}
+            for k, v in kwargs.items():
+                if k not in sglang_video_keys:
+                    hf_video_kwargs[k] = v
             result = processor.__call__(
                 text=[input_text],
                 padding=True,

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -463,13 +463,37 @@ class BaseMultimodalProcessor(ABC):
 
                 npu_apply_glm46v_image_preprocess_patch()
                 kwargs["device"] = "npu"
+        try:
+            result = processor.__call__(
+                text=[input_text],
+                padding=True,
+                return_tensors="pt",
+                **kwargs,
+            )
+        except (TypeError, ValueError) as e:
+            logger.warning(f"Processor call failed with video kwargs, retrying without video-specific params: {e}")
 
-        result = processor.__call__(
-            text=[input_text],
-            padding=True,
-            return_tensors="pt",
-            **kwargs,
-        )
+            sglang_video_keys = (
+                "fps",
+                "max_pixels",
+                "min_pixels",
+                "total_pixels",
+                "max_frames",
+                "min_frames",
+                "resized_height",
+                "resized_width"
+            )
+            hf_video_kwargs = {
+                k: v
+                for k, v in kwargs
+                if k not in sglang_video_keys
+            }
+            result = processor.__call__(
+                text=[input_text],
+                padding=True,
+                return_tensors="pt",
+                **hf_video_kwargs,
+            )
         if not self.server_args.keep_mm_feature_on_device:
             # move feature tensors to cpu
             for feature_name in self.FEATURE_NAMES:


### PR DESCRIPTION
Safer fallback for video processor: only strips sglang video keys if videos_kwargs exists and is a dict. Prevents KeyError when transformers typed-dict rejects unexpected args (see PR #30260).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28795278401](https://github.com/sgl-project/sglang/actions/runs/28795278401)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28795276580](https://github.com/sgl-project/sglang/actions/runs/28795276580)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->