### PR TITLE
[XPU] Enable breakable prefill CUDA graph on XPU

### DIFF
--- a/docs_new/docs/hardware-platforms/xpu.mdx
+++ b/docs_new/docs/hardware-platforms/xpu.mdx
@@ -149,6 +149,7 @@ SGLang enables XPU graph capture to reduce per-step kernel-launch overhead.
 |---|---|---|---|
 | Decode | `full` | One `torch.xpu.XPUGraph` per batch size, captured on startup | **Off** (opt-in) |
 | Prefill | `tc_piecewise` | `torch.compile` + XPU graph, one graph segment per token-length bucket | **Off** (opt-in) |
+| Prefill | `breakable` | Segmented `torch.xpu.XPUGraph` capture/replay (no `torch.compile`); eager break points at attention / MoE boundaries | **Off** (opt-in) |
 
 ### Enable Decode Graph
 
@@ -184,6 +185,27 @@ You can also configure both phases together with a single `--cuda-graph-config` 
 python -m sglang.launch_server --model-path <MODEL> --device xpu \
     --cuda-graph-config '{"decode":{"backend":"full"},"prefill":{"backend":"tc_piecewise","tc_compiler":"eager"}}'
 ```
+
+### Enable Breakable Prefill Graph
+
+The `breakable` prefill backend captures the transformer stack as a series of
+real `torch.xpu.XPUGraph` **segments** separated by eager break points (at
+attention / MoE boundaries); attention metadata is recomputed at replay outside
+the captured segments. Unlike `tc_piecewise`, it does **not** use `torch.compile`.
+It is **opt-in** and enabled explicitly:
+
+```bash
+python -m sglang.launch_server --model-path <MODEL> --device xpu \
+    --cuda-graph-backend-prefill breakable
+```
+
+> **Note:** Executable-graph dedup is CUDA-only (it introspects the raw graph
+> via `cuda-python`), so XPU always takes the plain segmented path. Without
+> dedup, breakable retains roughly `num_shapes × (num_layers + 1)` distinct
+> `XPUGraph` segments for the runner's lifetime, which increases memory use for
+> larger models or higher `max_bs`. On memory-constrained runs, lower
+> `--mem-fraction-static` and/or cap `--cuda-graph-bs-prefill` to reduce the
+> number of captured shapes.
 
 ### Enable torch.compile for Decode
 
@@ -246,7 +268,7 @@ python -m sglang.launch_server \
 | Argument | XPU allowed values | Default | Description |
 |---|---|---|---|
 | `--cuda-graph-backend-decode` | `full`, `disabled` | `disabled` | Backend for the decode phase. Only `full` is supported on XPU. Set to `full` to enable. |
-| `--cuda-graph-backend-prefill` | `tc_piecewise`, `disabled` | `disabled`* | Backend for the prefill phase. Must be set to `tc_piecewise` explicitly to enable. |
+| `--cuda-graph-backend-prefill` | `tc_piecewise`, `breakable`, `disabled` | `disabled`* | Backend for the prefill phase. Set to `tc_piecewise` or `breakable` explicitly to enable. |
 | `--cuda-graph-tc-compiler` | `eager`, `inductor` | `eager` | Compiler for `tc_piecewise` prefill subgraphs. `inductor` produces more optimized code but has longer startup. |
 | `--cuda-graph-bs-prefill` | list of ints | auto | Explicit token-length buckets to capture for prefill. |
 | `--cuda-graph-bs-decode` | list of ints | auto | Explicit batch sizes to capture for decode. |
@@ -265,7 +287,6 @@ via `--cuda-graph-backend-prefill` or `--cuda-graph-config`.
 |---|---|
 | Memory saver (`--enable-memory-saver`) | Not yet supported |
 | Two-batch overlap (`--enable-two-batch-overlap`) | Not yet supported |
-| Breakable CUDA graph | Not yet supported |
 | Speculative decoding | Not yet implemented |
 
 ## Prefill-Decode (P/D) Disaggregation on Intel XPU [Experimental]

--- a/docs_new/docs/hardware-platforms/xpu.mdx
+++ b/docs_new/docs/hardware-platforms/xpu.mdx
@@ -162,8 +162,13 @@ python -m sglang.launch_server --model-path <MODEL> --device xpu \
 
 ### Enable Prefill Graph
 
-Prefill graph capture is **opt-in** on XPU and requires `torch.compile`
-and must be enabled explicitly:
+Prefill graph capture is **opt-in** on XPU and must be enabled explicitly.
+Two backends are available: `tc_piecewise` and `breakable`.
+
+#### tc_piecewise
+
+Uses `torch.compile` plus an XPU graph, one graph segment per token-length
+bucket:
 
 ```bash
 python -m sglang.launch_server --model-path <MODEL> --device xpu \
@@ -179,33 +184,22 @@ python -m sglang.launch_server --model-path <MODEL> --device xpu \
     --cuda-graph-tc-compiler inductor
 ```
 
-You can also configure both phases together with a single `--cuda-graph-config` JSON argument:
+#### breakable
 
-```bash
-python -m sglang.launch_server --model-path <MODEL> --device xpu \
-    --cuda-graph-config '{"decode":{"backend":"full"},"prefill":{"backend":"tc_piecewise","tc_compiler":"eager"}}'
-```
-
-### Enable Breakable Prefill Graph
-
-The `breakable` prefill backend captures the transformer stack as a series of
-real `torch.xpu.XPUGraph` **segments** separated by eager break points (at
-attention / MoE boundaries); attention metadata is recomputed at replay outside
-the captured segments. Unlike `tc_piecewise`, it does **not** use `torch.compile`.
-It is **opt-in** and enabled explicitly:
+Captures the transformer stack as segmented `XPUGraph`s with eager break points
+at attention / MoE boundaries, without `torch.compile`:
 
 ```bash
 python -m sglang.launch_server --model-path <MODEL> --device xpu \
     --cuda-graph-backend-prefill breakable
 ```
 
-> **Note:** Executable-graph dedup is CUDA-only (it introspects the raw graph
-> via `cuda-python`), so XPU always takes the plain segmented path. Without
-> dedup, breakable retains roughly `num_shapes × (num_layers + 1)` distinct
-> `XPUGraph` segments for the runner's lifetime, which increases memory use for
-> larger models or higher `max_bs`. On memory-constrained runs, lower
-> `--mem-fraction-static` and/or cap `--cuda-graph-bs-prefill` to reduce the
-> number of captured shapes.
+You can also configure both phases together with a single `--cuda-graph-config` JSON argument:
+
+```bash
+python -m sglang.launch_server --model-path <MODEL> --device xpu \
+    --cuda-graph-config '{"decode":{"backend":"full"},"prefill":{"backend":"tc_piecewise","tc_compiler":"eager"}}'
+```
 
 ### Enable torch.compile for Decode
 

--- a/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph.py
+++ b/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph.py
@@ -43,7 +43,6 @@ logger = logging.getLogger(__name__)
 
 _is_xpu = is_xpu()
 
-
 __all__ = [
     "eager_on_graph",
     "BreakableCUDAGraph",

--- a/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph.py
+++ b/python/sglang/srt/model_executor/runner_backend_utils/breakable_cuda_graph/breakable_cuda_graph.py
@@ -37,9 +37,12 @@ except ImportError:
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.cuda_utils import (
     checkCudaErrors,
 )
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import get_device_module, is_hip, is_xpu
 
 logger = logging.getLogger(__name__)
+
+_is_xpu = is_xpu()
+
 
 __all__ = [
     "eager_on_graph",
@@ -63,18 +66,18 @@ def _check_cuda_bindings():
 _current_capture_var: ContextVar["BreakableCUDAGraphCapture | None"] = ContextVar(
     "current_capture", default=None
 )
-_current_stream_var: ContextVar[torch.cuda.Stream | None] = ContextVar(
+_current_stream_var: ContextVar[torch.Stream | None] = ContextVar(
     "current_stream", default=None
 )
-_forked_streams_var: ContextVar[set[torch.cuda.Stream] | None] = ContextVar(
+_forked_streams_var: ContextVar[set[torch.Stream] | None] = ContextVar(
     "forked_streams", default=None
 )
 
 
-def get_current_stream(device: torch.device | None = None) -> torch.cuda.Stream:
+def get_current_stream(device: torch.device | None = None) -> torch.Stream:
     stream = _current_stream_var.get()
     if stream is None:
-        return torch.cuda.current_stream(device)
+        return get_device_module().current_stream(device)
     return stream
 
 
@@ -84,14 +87,14 @@ def _capture_status(stream_ptr: int) -> "rt.cudaStreamCaptureStatus":
     return status
 
 
-def _is_stream_capturing(stream: torch.cuda.Stream) -> bool:
-    # On ROCm/HIP, cuda-python is unavailable, so use the portable torch API
-    # (which maps to the HIP runtime). On NVIDIA, keep querying the CUDA runtime
-    # directly via cuda-python: torch.cuda.is_current_stream_capturing() has
-    # proven unreliable there, so we preserve the original behavior.
-    if is_hip():
-        with torch.cuda.stream(stream):
-            return torch.cuda.is_current_stream_capturing()
+def _is_stream_capturing(stream: torch.Stream) -> bool:
+    # On ROCm/HIP and XPU, cuda-python is unavailable, so use the portable torch
+    # API (which maps to the HIP / XPU runtime). On NVIDIA, keep querying the
+    # CUDA runtime directly via cuda-python: torch.cuda.is_current_stream_capturing()
+    # has proven unreliable there, so we preserve the original behavior.
+    if is_hip() or _is_xpu:
+        with get_device_module().stream(stream):
+            return get_device_module().is_current_stream_capturing()
     return (
         _capture_status(stream.cuda_stream)
         == rt.cudaStreamCaptureStatus.cudaStreamCaptureStatusActive
@@ -107,7 +110,7 @@ _hook_lock = threading.Lock()
 _hook_refcount = 0
 
 
-def _hooked_wait_stream(self: torch.cuda.Stream, other: torch.cuda.Stream):
+def _hooked_wait_stream(self: torch.Stream, other: torch.Stream):
     assert _original_wait_stream is not None
     forked = _forked_streams_var.get()
     if forked is None:
@@ -118,9 +121,9 @@ def _hooked_wait_stream(self: torch.cuda.Stream, other: torch.cuda.Stream):
         _original_wait_stream(self, other)
         return
 
-    cap_ptr = capturing.cuda_stream
-    is_self_cap = self is capturing or self.cuda_stream == cap_ptr
-    is_other_cap = other is capturing or other.cuda_stream == cap_ptr
+    cap_id = capturing.stream_id
+    is_self_cap = self is capturing or self.stream_id == cap_id
+    is_other_cap = other is capturing or other.stream_id == cap_id
 
     if is_self_cap and not is_other_cap:
         if not _is_stream_capturing(other):
@@ -138,8 +141,8 @@ def _install_wait_stream_hook():
     global _original_wait_stream, _hook_refcount
     with _hook_lock:
         if _hook_refcount == 0:
-            _original_wait_stream = torch.cuda.Stream.wait_stream
-            torch.cuda.Stream.wait_stream = _hooked_wait_stream  # type: ignore[assignment]
+            _original_wait_stream = get_device_module().Stream.wait_stream
+            get_device_module().Stream.wait_stream = _hooked_wait_stream  # type: ignore[assignment]
         _hook_refcount += 1
 
 
@@ -149,7 +152,7 @@ def _uninstall_wait_stream_hook():
         _hook_refcount -= 1
         if _hook_refcount == 0:
             assert _original_wait_stream is not None, "wait_stream hook not installed"
-            torch.cuda.Stream.wait_stream = _original_wait_stream  # type: ignore[assignment]
+            get_device_module().Stream.wait_stream = _original_wait_stream  # type: ignore[assignment]
             _original_wait_stream = None
 
 
@@ -270,7 +273,7 @@ class BreakableCUDAGraph:
         self._deduped_cuda_graph = deduped_cuda_graph
 
     def replay(self) -> None:
-        stream = torch.cuda.current_stream()
+        stream = get_device_module().current_stream()
         token = _current_stream_var.set(stream)
         try:
             for i, seg in enumerate(self._segments):
@@ -280,9 +283,7 @@ class BreakableCUDAGraph:
         finally:
             _current_stream_var.reset(token)
 
-    def _append_segment(
-        self, graph: torch.cuda.CUDAGraph, needs_instantiate: bool
-    ) -> None:
+    def _append_segment(self, graph, needs_instantiate: bool) -> None:
         if self._deduped_cuda_graph is not None:
             self._segments.append(self._deduped_cuda_graph.register(graph))
             return
@@ -306,7 +307,7 @@ class BreakableCUDAGraphCapture:
         self,
         cuda_graph: BreakableCUDAGraph,
         pool=None,
-        stream: torch.cuda.Stream | None = None,
+        stream: torch.Stream | None = None,
         capture_error_mode: str = "global",
     ):
         assert isinstance(
@@ -320,17 +321,17 @@ class BreakableCUDAGraphCapture:
         self._capture_token = None
         self._stream_token = None
         self._forked_token = None
-        self._current_graph: torch.cuda.CUDAGraph | None = None
+        self._current_graph = None
         self._current_graph_needs_instantiate = False
 
     def __enter__(self):
         _install_wait_stream_hook()
         if self._stream is not None:
-            self._stream_ctx = torch.cuda.stream(self._stream)
+            self._stream_ctx = get_device_module().stream(self._stream)
             self._stream_ctx.__enter__()
         self._capture_token = _current_capture_var.set(self)
         self._stream_token = _current_stream_var.set(
-            self._stream or torch.cuda.current_stream()
+            self._stream or get_device_module().current_stream()
         )
         self._forked_token = _forked_streams_var.set(set())
         self._begin_new_segment()
@@ -350,20 +351,27 @@ class BreakableCUDAGraphCapture:
         return False
 
     def _begin_new_segment(self) -> None:
+        graph_cls = torch.xpu.XPUGraph if _is_xpu else torch.cuda.CUDAGraph
         # keep_graph retains the raw graph for dedup; skip it on the plain path.
+        # Dedup is CUDA-only (it introspects the raw graph via cuda-python), so
+        # XPU always takes the plain path below.
         if self.cuda_graph._deduped_cuda_graph is not None:
             try:
-                graph = torch.cuda.CUDAGraph(keep_graph=True)
+                graph = graph_cls(keep_graph=True)
                 self._current_graph_needs_instantiate = True
             except TypeError:
-                graph = torch.cuda.CUDAGraph()
+                graph = graph_cls()
                 self._current_graph_needs_instantiate = False
         else:
-            graph = torch.cuda.CUDAGraph()
+            graph = graph_cls()
             self._current_graph_needs_instantiate = False
-        graph.capture_begin(
-            pool=self._pool, capture_error_mode=self._capture_error_mode
-        )
+        if _is_xpu:
+            # torch.xpu.XPUGraph.capture_begin takes only an optional pool.
+            graph.capture_begin(pool=self._pool)
+        else:
+            graph.capture_begin(
+                pool=self._pool, capture_error_mode=self._capture_error_mode
+            )
         self._current_graph = graph
 
     def _end_current_segment(self) -> None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3457,16 +3457,6 @@ class ServerArgs:
                 )
                 self.cuda_graph_config.decode.backend = Backend.DISABLED
 
-            if self.cuda_graph_config.prefill.backend not in (
-                Backend.DISABLED,
-                Backend.TC_PIECEWISE,
-            ):
-                logger.warning(
-                    "XPU platform currently only supports prefill tc_piecewise CUDA graph; "
-                    "disabling unsupported prefill backend."
-                )
-                self.cuda_graph_config.prefill.backend = Backend.DISABLED
-
     # ------------------------------------------------------------------
     # CUDA graph configuration resolution
     # ------------------------------------------------------------------

--- a/test/registered/cuda_graph/breakable/test_breakable_cuda_graph.py
+++ b/test/registered/cuda_graph/breakable/test_breakable_cuda_graph.py
@@ -11,8 +11,12 @@ import unittest
 
 import torch
 
-from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.srt.utils import get_device, get_device_module, kill_process_tree
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cuda_ci,
+    register_xpu_ci,
+)
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -25,6 +29,7 @@ from sglang.test.test_utils import (
 # CI Registration — large suite to fit the integration test's server startup.
 register_cuda_ci(est_time=79, stage="base-b", runner_config="1-gpu-large")
 register_amd_ci(est_time=200, suite="stage-c-test-large-8-gpu-amd-mi35x")
+register_xpu_ci(est_time=79, suite="stage-a-test-1-gpu-xpu")
 
 
 class TestBreakableCUDAGraphBasic(CustomTestCase):
@@ -32,8 +37,8 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest("CUDA not available")
+        if not get_device_module().is_available():
+            raise unittest.SkipTest(f"{get_device()} not available")
 
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
             BreakableCUDAGraph,
@@ -44,7 +49,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         cls.BreakableCUDAGraph = BreakableCUDAGraph
         cls.BreakableCUDAGraphCapture = BreakableCUDAGraphCapture
         cls.eager_on_graph = staticmethod(eager_on_graph)
-        cls.device = torch.device("cuda:0")
+        cls.device = torch.device(f"{get_device()}:0")
 
     def test_no_break_capture_replay(self):
         """Capture and replay without any graph breaks should work like normal CUDA graph."""
@@ -52,14 +57,14 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         y = torch.zeros(4, device=self.device)
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             y.copy_(x + 1.0)
 
         # Replay with new input
         x.fill_(5.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 6.0, device=self.device)))
 
     def test_single_break(self):
@@ -73,7 +78,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 2.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             intermediate.copy_(x + 1.0)
             broken = eager_op(intermediate)
@@ -82,7 +87,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         # Replay with new input
         x.fill_(10.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         # x=10 -> intermediate=11 -> eager: 11*2=22 -> y=22+3=25
         self.assertTrue(torch.allclose(y, torch.full((4,), 25.0, device=self.device)))
 
@@ -100,7 +105,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 2.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t1 = x + 1.0  # graph segment 1
             t2 = add_one(t1)  # break 1: eager
@@ -111,7 +116,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         # Replay: x=5 -> +1=6 -> add_one=7 -> +1=8 -> double=16
         x.fill_(5.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 16.0, device=self.device)))
 
     def test_eager_on_graph_disabled(self):
@@ -151,7 +156,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 3.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t = x + 1.0
             t2 = scale(t)
@@ -159,13 +164,13 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
 
         # First replay: x=0 -> 0+1=1 -> 1*3=3
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 3.0, device=self.device)))
 
         # Second replay: x=10 -> 10+1=11 -> 11*3=33
         x.fill_(10.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 33.0, device=self.device)))
 
     def test_eager_output_is_held_strongly_for_replay_bridge(self):
@@ -196,15 +201,15 @@ class TestCopyOutput(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest("CUDA not available")
+        if not get_device_module().is_available():
+            raise unittest.SkipTest(f"{get_device()} not available")
 
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
             _copy_output,
         )
 
         cls._copy_output = staticmethod(_copy_output)
-        cls.device = torch.device("cuda:0")
+        cls.device = torch.device(f"{get_device()}:0")
 
     def test_tensor_copy(self):
         dst = torch.zeros(4, device=self.device)
@@ -254,8 +259,8 @@ class TestBreakGraphHelper(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest("CUDA not available")
+        if not get_device_module().is_available():
+            raise unittest.SkipTest(f"{get_device()} not available")
 
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
             BreakableCUDAGraph,
@@ -266,7 +271,7 @@ class TestBreakGraphHelper(CustomTestCase):
         cls.BreakableCUDAGraph = BreakableCUDAGraph
         cls.BreakableCUDAGraphCapture = BreakableCUDAGraphCapture
         cls.break_graph = staticmethod(break_graph)
-        cls.device = torch.device("cuda:0")
+        cls.device = torch.device(f"{get_device()}:0")
 
     def test_break_graph_inserts_segment(self):
         """break_graph() should insert a graph break even though it does nothing."""
@@ -274,7 +279,7 @@ class TestBreakGraphHelper(CustomTestCase):
         y = torch.zeros(4, device=self.device)
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t = x + 1.0
             self.break_graph()
@@ -282,7 +287,7 @@ class TestBreakGraphHelper(CustomTestCase):
 
         x.fill_(10.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         # x=10 -> +1=11 -> break -> +2=13
         self.assertTrue(torch.allclose(y, torch.full((4,), 13.0, device=self.device)))
 

--- a/test/registered/cuda_graph/breakable/test_breakable_cuda_graph.py
+++ b/test/registered/cuda_graph/breakable/test_breakable_cuda_graph.py
@@ -183,7 +183,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 3.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t = x + 1.0
             broken = scale(t)

--- a/test/registered/xpu/test_breakable_cuda_graph.py
+++ b/test/registered/xpu/test_breakable_cuda_graph.py
@@ -1,30 +1,41 @@
-"""Tests for the breakable CUDA graph (BCG) runner.
+"""Tests for the breakable CUDA graph (BCG) runner on XPU.
 
 Two test classes:
 - TestBreakableCUDAGraphBasic / TestCopyOutput / TestBreakGraphHelper:
   unit tests for the core capture / replay mechanism (simple tensor ops).
-- TestBreakableCudaGraph: integration test — spin up Qwen3-8B with
-  --enable-breakable-cuda-graph and check mgsm_en accuracy.
+- TestXPUBreakableGraph: integration test — run a small Qwen model with the
+  breakable prefill CUDA graph backend via a single bench_one_batch invocation.
 """
 
 import unittest
 
 import torch
 
-from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
-from sglang.test.run_eval import run_eval
+from sglang.srt.utils import get_device, get_device_module
+from sglang.test.ci.ci_register import register_xpu_ci
 from sglang.test.test_utils import (
-    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-    DEFAULT_URL_FOR_TEST,
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
     CustomTestCase,
-    SimpleNamespace,
-    popen_launch_server,
+    is_in_ci,
+    run_bench_one_batch,
 )
 
-# CI Registration — large suite to fit the integration test's server startup.
-register_cuda_ci(est_time=79, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=200, suite="stage-c-test-large-8-gpu-amd-mi35x")
+register_xpu_ci(est_time=600, suite="stage-b-test-1-gpu-xpu")
+
+_COMMON_ARGS = [
+    "--device",
+    "xpu",
+    "--attention-backend",
+    "triton",
+    "--disable-radix-cache",
+    "--mem-fraction-static",
+    "0.6",
+    "--batch-size",
+    "1",
+]
+
+_CI_IO_ARGS = ["--input", "64", "--output", "4"]
+_FULL_IO_ARGS = ["--input", "128", "--output", "16"]
 
 
 class TestBreakableCUDAGraphBasic(CustomTestCase):
@@ -32,8 +43,8 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest("CUDA not available")
+        if not get_device_module().is_available():
+            raise unittest.SkipTest(f"{get_device()} not available")
 
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
             BreakableCUDAGraph,
@@ -44,7 +55,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         cls.BreakableCUDAGraph = BreakableCUDAGraph
         cls.BreakableCUDAGraphCapture = BreakableCUDAGraphCapture
         cls.eager_on_graph = staticmethod(eager_on_graph)
-        cls.device = torch.device("cuda:0")
+        cls.device = torch.device(f"{get_device()}:0")
 
     def test_no_break_capture_replay(self):
         """Capture and replay without any graph breaks should work like normal CUDA graph."""
@@ -52,14 +63,14 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         y = torch.zeros(4, device=self.device)
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             y.copy_(x + 1.0)
 
         # Replay with new input
         x.fill_(5.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 6.0, device=self.device)))
 
     def test_single_break(self):
@@ -73,7 +84,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 2.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             intermediate.copy_(x + 1.0)
             broken = eager_op(intermediate)
@@ -82,7 +93,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         # Replay with new input
         x.fill_(10.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         # x=10 -> intermediate=11 -> eager: 11*2=22 -> y=22+3=25
         self.assertTrue(torch.allclose(y, torch.full((4,), 25.0, device=self.device)))
 
@@ -100,7 +111,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 2.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t1 = x + 1.0  # graph segment 1
             t2 = add_one(t1)  # break 1: eager
@@ -111,7 +122,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
         # Replay: x=5 -> +1=6 -> add_one=7 -> +1=8 -> double=16
         x.fill_(5.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 16.0, device=self.device)))
 
     def test_eager_on_graph_disabled(self):
@@ -151,7 +162,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 3.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t = x + 1.0
             t2 = scale(t)
@@ -159,13 +170,13 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
 
         # First replay: x=0 -> 0+1=1 -> 1*3=3
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 3.0, device=self.device)))
 
         # Second replay: x=10 -> 10+1=11 -> 11*3=33
         x.fill_(10.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         self.assertTrue(torch.allclose(y, torch.full((4,), 33.0, device=self.device)))
 
     def test_eager_output_is_held_strongly_for_replay_bridge(self):
@@ -178,7 +189,7 @@ class TestBreakableCUDAGraphBasic(CustomTestCase):
             return src * 3.0
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t = x + 1.0
             broken = scale(t)
@@ -196,15 +207,15 @@ class TestCopyOutput(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest("CUDA not available")
+        if not get_device_module().is_available():
+            raise unittest.SkipTest(f"{get_device()} not available")
 
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
             _copy_output,
         )
 
         cls._copy_output = staticmethod(_copy_output)
-        cls.device = torch.device("cuda:0")
+        cls.device = torch.device(f"{get_device()}:0")
 
     def test_tensor_copy(self):
         dst = torch.zeros(4, device=self.device)
@@ -254,8 +265,8 @@ class TestBreakGraphHelper(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest("CUDA not available")
+        if not get_device_module().is_available():
+            raise unittest.SkipTest(f"{get_device()} not available")
 
         from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
             BreakableCUDAGraph,
@@ -266,7 +277,7 @@ class TestBreakGraphHelper(CustomTestCase):
         cls.BreakableCUDAGraph = BreakableCUDAGraph
         cls.BreakableCUDAGraphCapture = BreakableCUDAGraphCapture
         cls.break_graph = staticmethod(break_graph)
-        cls.device = torch.device("cuda:0")
+        cls.device = torch.device(f"{get_device()}:0")
 
     def test_break_graph_inserts_segment(self):
         """break_graph() should insert a graph break even though it does nothing."""
@@ -274,7 +285,7 @@ class TestBreakGraphHelper(CustomTestCase):
         y = torch.zeros(4, device=self.device)
 
         graph = self.BreakableCUDAGraph()
-        stream = torch.cuda.Stream(self.device)
+        stream = get_device_module().Stream(self.device)
         with self.BreakableCUDAGraphCapture(graph, stream=stream):
             t = x + 1.0
             self.break_graph()
@@ -282,45 +293,46 @@ class TestBreakGraphHelper(CustomTestCase):
 
         x.fill_(10.0)
         graph.replay()
-        torch.cuda.synchronize()
+        get_device_module().synchronize()
         # x=10 -> +1=11 -> break -> +2=13
         self.assertTrue(torch.allclose(y, torch.full((4,), 13.0, device=self.device)))
 
 
-class TestBreakableCudaGraph(CustomTestCase):
-    """Integration: Qwen3-8B with --enable-breakable-cuda-graph on mgsm_en."""
+class TestXPUBreakableGraph(CustomTestCase):
+    """Integration: breakable prefill CUDA graph on XPU via bench_one_batch.
 
-    @classmethod
-    def setUpClass(cls):
-        cls.model = "Qwen/Qwen3-8B"
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--cuda-graph-backend-prefill=breakable",
-            ],
+    The prefill graph shapes are pinned with --cuda-graph-bs-prefill; capturing
+    the full default shape range exhausts the level-zero backend on the current
+    XPU stack, so a small explicit set keeps capture within device limits.
+    """
+
+    def test_breakable_graph_runs(self):
+        args = [
+            *_COMMON_ARGS,
+            "--cuda-graph-config",
+            '{"prefill":{"backend":"breakable"}}',
+            "--cuda-graph-bs-prefill",
+            "64",
+            "128",
+        ]
+        if is_in_ci():
+            args += _CI_IO_ARGS
+        else:
+            args += _FULL_IO_ARGS
+
+        prefill_latency, decode_throughput, _ = run_bench_one_batch(
+            DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN, args
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-    def test_gsm8k_accuracy(self):
-        args = SimpleNamespace(
-            base_url=self.base_url,
-            model=self.model,
-            eval_name="mgsm_en",
-            num_examples=1319,
-            num_threads=1024,
+        self.assertGreater(
+            prefill_latency,
+            0,
+            "prefill latency must be > 0 with breakable XPU prefill graph",
         )
-
-        metrics = run_eval(args)
-        score = metrics["score"]
-        print(f"mgsm_en accuracy with breakable CUDA graph: {score:.3f}")
-
-        self.assertGreaterEqual(score, 0.80)
+        self.assertGreater(
+            decode_throughput,
+            0,
+            "decode throughput must be > 0 with breakable XPU prefill graph",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make the breakable-CUDA-graph primitives device-agnostic so the segmented capture/replay path runs on Intel XPU (torch.xpu.XPUGraph) as well as CUDA/HIP, allow the breakable prefill backend on XPU, and run the tests on all three backends.

- breakable_cuda_graph.py: route CUDAGraph/Stream/current_stream, the wait_stream hook, stream-capture status, and capture_begin through torch.get_device_module() (via get_device_module()) instead of a hardcoded torch.cuda. XPU uses the portable is_current_stream_capturing() (as HIP does; cuda-python is NVIDIA-only) and capture_begin(pool=...) without capture_error_mode. Stream identity is compared via the base torch.Stream.stream_id (present on CUDA and XPU), and stream type hints use torch.Stream. The CUDA dedup path is untouched and inert on XPU (no cuda.bindings).
- server_args._handle_xpu_backends: drop the prefill-backend restriction that forced non-tc_piecewise backends to DISABLED, so BREAKABLE prefill is allowed on XPU.
- test_breakable_cuda_graph.py: replace hardcoded torch.cuda / "cuda:0" with get_device_module() and get_device() so the unit tests and the mgsm_en integration test run on CUDA/HIP and XPU, and register the suite on the XPU CI runner.





























































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29549797217](https://github.com/sgl-project/sglang/actions/runs/29549797217)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29549797095](https://github.com/sgl-project/sglang/actions/runs/29549797095)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->