### PR TITLE
[Bugfix] Auto-disable shared-expert fusion for ModelOpt/NVFP4 checkpoints

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2781,6 +2781,18 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             )
         elif self.quant_config and self.quant_config.get_name() == "w4afp8":
             disable_reason = "Deepseek V3/R1 W4AFP8 model uses different quant method for routed experts and shared experts."
+        elif (
+            self.quant_config
+            and self.quant_config.get_name() == "modelopt_fp4"
+            and any(
+                "shared_experts" in e
+                for e in (getattr(self.quant_config, "exclude_modules", None) or [])
+            )
+        ):
+            disable_reason = (
+                "ModelOpt/NVFP4 checkpoint excludes shared experts from quantization; "
+                "fusing the unquantized shared expert into the NVFP4 MoE loader is unsafe."
+            )
 
         if disable_reason is not None:
             from sglang.srt.arg_groups.overrides import declare_load_time_override

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -1213,6 +1213,18 @@ class Glm4MoeForCausalLM(nn.Module):
             disable_reason = "GLM-4.5 cannot use shared experts fusion optimization under deepep expert parallelism."
         elif self.quant_config and self.quant_config.get_name() == "w4afp8":
             disable_reason = "GLM-4.5 W4AFP8 model uses different quant method for routed experts and shared experts."
+        elif (
+            self.quant_config
+            and self.quant_config.get_name() == "modelopt_fp4"
+            and any(
+                "shared_experts" in e
+                for e in (getattr(self.quant_config, "exclude_modules", None) or [])
+            )
+        ):
+            disable_reason = (
+                "ModelOpt/NVFP4 checkpoint excludes shared experts from quantization; "
+                "fusing the unquantized shared expert into the NVFP4 MoE loader is unsafe."
+            )
 
         if disable_reason is not None:
             from sglang.srt.arg_groups.overrides import declare_load_time_override


### PR DESCRIPTION
## Motivation

GLM-5.2-NVFP4 ships with routed experts quantized to NVFP4 but the **shared expert left unquantized (BF16)** — it is listed in the checkpoint's quant ignore / `exclude_modules`. With shared-expert fusion enabled, SGLang remaps the unquantized shared expert into the NVFP4 MoE loader's packed FP4 expert slot, corrupting buffer/size and causing an **illegal memory access in the MoE act kernel (`silu_and_mul`) during warmup**:

```
python/sglang/srt/models/deepseek_v2.py:420 self.act_fn(gate_up)
  -> silu_and_mul -> activation.cuh:187
  -> CUDA error: an illegal memory access was encountered
```

Reported in #29562. Bisected to the 07-04 config-resolution pipeline refactor (#30063–#30077, 15-PR stack), which turned the latent mismatch into a hard crash on recent `dev-cu13` nightlies: the 07-03 nightly (`75cdaf43`) boots clean, the 07-06 nightly (`8673e85e`) crashes during warmup. `activation.cuh` / `jit_kernel/activation.py` / `sgl-kernel` elementwise headers have zero diff in the regression window, so the kernel itself is unchanged — the crash is upstream feeding it a wrong buffer.

## Modifications

Add a disable branch to both `Glm4MoeForCausalLM.determine_num_fused_shared_experts` (`python/sglang/srt/models/glm4_moe.py`) and `DeepseekV2ForCausalLM.determine_num_fused_shared_experts` (`python/sglang/srt/models/deepseek_v2.py`). The new branch fires when:

- `quant_config.get_name() == "modelopt_fp4"`, **and**
- the shared experts appear in `exclude_modules` (i.e. the shared expert is not quantized).

```python
elif (
    self.quant_config
    and self.quant_config.get_name() == "modelopt_fp4"
    and any(
        "shared_experts" in e
        for e in (getattr(self.quant_config, "exclude_modules", None) or [])
    )
):
    disable_reason = (
        "ModelOpt/NVFP4 checkpoint excludes shared experts from quantization; "
        "fusing the unquantized shared expert into the NVFP4 MoE loader is unsafe."
    )
```

The check mirrors the existing `w4afp8` guard and uses `getattr(..., "exclude_modules", None) or []` so it is a no-op for quant configs that lack the attribute. The `any("shared_experts" in e for e in ...)` pattern matches the one used in #22618 for `linear_attn`.

### Safety

- DeepSeek-R1 NVFP4 (whose shared expert **is** quantized) is **unaffected** — `shared_experts` is not in its `exclude_modules`, so fusion stays enabled.
- Only checkpoints that explicitly exclude `shared_experts` from quantization (the GLM-5.2-NVFP4 case) hit the new branch.

## Accuracy Tests

This PR does not change model numerics for any path that was previously working: it only auto-disables a fusion that was unsafe for NVFP4 checkpoints whose shared expert is unquantized. For GLM-5.2-NVFP4 the previously-working behavior is preserved by running the shared expert as a separate (unfused) BF16 MLP, identical to passing `--disable-shared-experts-fusion`.

Sanity check (no quantized-output regression):
```
# Launch a server (with this PR, no --disable-shared-experts-fusion needed)
python3 -m sglang.launch_server \
  --model-path nvidia/GLM-5.2-NVFP4 \
  --tensor-parallel-size 8 \
  --quantization modelopt_fp4 \
  --trust-remote-code \
  --reasoning-parser glm45 --tool-call-parser glm47

python3 -m sglang.test.few_shot_gsm8k --num-questions 200
```

## Speed Tests and Profiling

No speed impact. The PR disables a fusion that was already crashing on affected checkpoints, so the only path that changes (GLM-5.2-NVFP4) goes from "crash" to "runs with shared expert unfused" — the same performance profile as the documented `--disable-shared-experts-fusion` workaround. All other models (DeepSeek-R1 NVFP4, FP8, BF16) take the same code path as before.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

> Note: pre-commit run and a focused unit test under `test/registered/unit/` are planned in a follow-up commit. Both modified files pass `python3 -m py_compile`. Reproduced on 8×B200 with `nvidia/GLM-5.2-NVFP4`, `--quantization modelopt_fp4`, EAGLE MTP, hierarchical cache: pre-fix warmup crash; with `--disable-shared-experts-fusion` (the behavior this PR automates) the server boots clean.

## Reproduction

- **Workstation:** 8× B200, TP=8
- **Image (pre-fix, crashes):** `lmsysorg/sglang:dev-cu13` @ commit `8673e85e` (2026-07-06 nightly)
- **Image (working):** `lmsysorg/sglang:dev-cu13` @ commit `75cdaf43` (2026-07-03 nightly), also `lmsysorg/sglang@sha256:6398424a820f7846b714423c1a6ca38ee07304a685d8c8eac295602ff34f2248`
- **Workaround before this PR:** `--disable-shared-experts-fusion`, or pin the pre-regression image above.

Ref: #29562




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28805694979](https://github.com/sgl-project/sglang/actions/runs/28805694979)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28805696104](https://github.com/sgl-project/sglang/actions/runs/28805696104)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->