### PR TITLE
[HiSparse] Quest runtime integration (Part 1 of 4)

### DIFF
--- a/python/sglang/srt/arg_groups/hisparse_hook.py
+++ b/python/sglang/srt/arg_groups/hisparse_hook.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
 import logging
+from importlib import import_module
+from importlib.util import find_spec
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -14,12 +18,111 @@ HISPARSE_CUDA_DSA_BACKENDS_BY_DTYPE = {
 }
 HISPARSE_ROCM_DSA_BACKENDS = {"tilelang", "aiter"}
 HISPARSE_KV_CACHE_DTYPES = ("bfloat16", "fp8_e4m3")
+RUNTIME_SPARSE_BACKENDS_BY_ALGORITHM = {
+    "quest": {"fa3", "flashattention"},
+}
+RUNTIME_SPARSE_ALGORITHMS = set(RUNTIME_SPARSE_BACKENDS_BY_ALGORITHM)
+RUNTIME_SPARSE_ATTENTION_BACKEND_ALIASES = {"flashattention": "fa3"}
+RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER = "sglang.srt.mem_cache.sparsity.cuda_graph_support"
+
+
+def _load_hisparse_config(server_args: ServerArgs) -> dict:
+    if not server_args.hisparse_config:
+        return {}
+    try:
+        config = json.loads(server_args.hisparse_config)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to parse hisparse_config: {e}") from e
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"hisparse_config must be a JSON object, got {type(config).__name__}."
+        )
+    return config
+
+
+def get_hisparse_algorithm(server_args: ServerArgs) -> str | None:
+    algorithm = _load_hisparse_config(server_args).get("algorithm")
+    return algorithm.strip().lower() if isinstance(algorithm, str) else None
+
+
+def get_hisparse_backend(server_args: ServerArgs) -> str | None:
+    backend = _load_hisparse_config(server_args).get("backend")
+    return backend.strip().lower() if isinstance(backend, str) else None
+
+
+def get_hisparse_page_size(server_args: ServerArgs):
+    return _load_hisparse_config(server_args).get("page_size")
+
+
+def get_hisparse_attention_backend(server_args: ServerArgs) -> str | None:
+    backend = get_hisparse_backend(server_args)
+    if backend is None:
+        return None
+    return RUNTIME_SPARSE_ATTENTION_BACKEND_ALIASES.get(backend, backend)
+
+
+def get_runtime_sparse_backends(server_args: ServerArgs) -> set[str]:
+    algorithm = get_hisparse_algorithm(server_args)
+    return RUNTIME_SPARSE_BACKENDS_BY_ALGORITHM.get(algorithm, set())
+
+
+def use_runtime_sparse_attention(server_args: ServerArgs) -> bool:
+    return (
+        server_args.enable_hisparse
+        and get_hisparse_algorithm(server_args) in RUNTIME_SPARSE_ALGORITHMS
+    )
+
+
+def use_runtime_sparse_cuda_graph(server_args: ServerArgs) -> bool:
+    if not use_runtime_sparse_attention(server_args):
+        return False
+    try:
+        provider_spec = find_spec(RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER)
+    except ModuleNotFoundError as exc:
+        if not RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER.startswith(f"{exc.name}."):
+            raise
+        return False
+    if provider_spec is None:
+        return False
+
+    import torch
+
+    from sglang.srt.mem_cache.sparsity.factory import (
+        _create_sparse_algorithm,
+        parse_runtime_sparse_config,
+    )
+
+    config = parse_runtime_sparse_config(server_args)
+    device = torch.device("cuda")
+    algorithm = _create_sparse_algorithm(config, device)
+    provider_module = import_module(RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER)
+    preflight = getattr(provider_module, "is_runtime_sparse_cuda_graph_available", None)
+    if not callable(preflight):
+        raise RuntimeError(
+            f"{RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER} must define "
+            "is_runtime_sparse_cuda_graph_available(coordinator)"
+        )
+    return bool(
+        preflight(
+            SimpleNamespace(
+                config=config,
+                algorithm=algorithm,
+                device=device,
+            )
+        )
+    )
 
 
 def _is_hip() -> bool:
     from sglang.srt.server_args import is_hip
 
     return is_hip()
+
+
+def _is_cuda() -> bool:
+    from sglang.srt.server_args import is_cuda
+
+    return is_cuda()
 
 
 def _hisparse_default_backend(kv_cache_dtype: str) -> str:
@@ -83,6 +186,114 @@ def validate_hisparse(server_args: ServerArgs) -> None:
     if not server_args.enable_hisparse:
         return
 
+    if use_runtime_sparse_attention(server_args):
+        from sglang.srt.arg_groups.overrides import attention_backends_of
+        from sglang.srt.configs.hybrid_arch import mambaish_config
+        from sglang.srt.configs.model_config import AttentionArch
+        from sglang.srt.environ import envs
+        from sglang.srt.mem_cache.sparsity import parse_runtime_sparse_config
+        from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+
+        config = parse_runtime_sparse_config(server_args)
+        subject = f"Sparse attention algorithm {config.algorithm!r}"
+        supported_backends = get_runtime_sparse_backends(server_args)
+        if _is_hip():
+            raise ValueError(
+                f"{subject} does not yet support ROCm; Quest requires CUDA FA3."
+            )
+        if not _is_cuda():
+            raise ValueError(f"{subject} currently requires the NVIDIA CUDA FA3 path.")
+        if envs.SGLANG_USE_HND_KVCACHE.get():
+            raise ValueError(
+                f"{subject} does not support HND KV-cache layout; use NHD layout."
+            )
+        if config.backend not in supported_backends:
+            raise ValueError(
+                f"{subject} supports backend values {sorted(supported_backends)}, "
+                f"but got {config.backend!r}."
+            )
+        if not server_args.disable_radix_cache:
+            raise ValueError(f"{subject} currently requires --disable-radix-cache.")
+        prefill_backend, decode_backend = attention_backends_of(server_args)
+        if any(
+            backend not in supported_backends
+            for backend in (prefill_backend, decode_backend)
+        ):
+            raise ValueError(
+                f"{subject} requires FA3 for prefill and decode, but got "
+                f"prefill={prefill_backend}, decode={decode_backend}."
+            )
+        unsupported_options = (
+            (server_args.speculative_algorithm is not None, "speculative decoding"),
+            (server_args.dllm_algorithm is not None, "diffusion LLM inference"),
+            (server_args.enable_pdmux, "PD multiplexing"),
+            (server_args.disaggregation_mode != "null", "PD disaggregation"),
+            (server_args.enable_two_batch_overlap, "two-batch overlap"),
+            (server_args.enable_mixed_chunk, "mixed chunked prefill"),
+            (server_args.enable_torch_compile, "torch.compile"),
+            (server_args.enable_dp_attention, "DP attention"),
+            (server_args.enable_prefill_cp, "prefill context parallelism"),
+            (server_args.attn_cp_size > 1, "attention context parallelism"),
+            (server_args.dcp_size > 1, "decode context parallelism"),
+        )
+        for enabled, label in unsupported_options:
+            if enabled:
+                raise ValueError(f"{subject} does not yet support {label}.")
+
+        model_config = server_args.get_model_config()
+        if model_config.attention_arch != AttentionArch.MHA:
+            raise ValueError(
+                f"{subject} currently supports standard MHA/GQA models only."
+            )
+        if model_config.is_encoder_decoder:
+            raise ValueError(f"{subject} does not support encoder-decoder models.")
+        if model_config.is_multimodal:
+            raise ValueError(f"{subject} does not support multimodal models.")
+        if not model_config.is_generation:
+            raise ValueError(f"{subject} is only supported for generation models.")
+        if model_config.num_attention_layers != model_config.num_hidden_layers:
+            raise ValueError(
+                f"{subject} requires one attention layer per hidden layer."
+            )
+        sliding_window_size = model_config.sliding_window_size
+        has_sliding_window = isinstance(sliding_window_size, (int, float)) and (
+            sliding_window_size > -1
+        )
+        if (
+            model_config.is_hybrid_swa
+            or has_sliding_window
+            or model_config.attention_chunk_size is not None
+        ):
+            raise ValueError(f"{subject} does not support sliding/local attention.")
+        if mambaish_config(model_config) is not None:
+            raise ValueError(f"{subject} does not support hybrid linear attention.")
+        num_kv_shared_layers = getattr(
+            model_config.hf_text_config, "num_kv_shared_layers", 0
+        )
+        if (
+            isinstance(num_kv_shared_layers, int)
+            and not isinstance(num_kv_shared_layers, bool)
+            and num_kv_shared_layers > 0
+        ):
+            raise ValueError(f"{subject} does not support cross-layer KV sharing.")
+
+        graph_available = use_runtime_sparse_cuda_graph(server_args)
+        locked = getattr(server_args, "_cuda_graph_config_locked", set())
+        for phase, phase_config in (
+            (Phase.DECODE, server_args.cuda_graph_config.decode),
+            (Phase.PREFILL, server_args.cuda_graph_config.prefill),
+        ):
+            graph_supported = phase == Phase.DECODE and graph_available
+            if (
+                not graph_supported
+                and (phase, "backend") in locked
+                and phase_config.backend != Backend.DISABLED
+            ):
+                raise ValueError(
+                    f"{subject} requires {phase.value} CUDA graph to be disabled."
+                )
+        return
+
     from sglang.srt.configs.model_config import (
         is_deepseek_dsa,
         is_deepseek_v4,
@@ -135,3 +346,20 @@ def validate_hisparse(server_args: ServerArgs) -> None:
         ("dsa_decode_backend", "decode"),
     ]:
         validate_hisparse_dsa_backend(server_args, attr, label)
+
+
+def apply_runtime_sparse_eager_defaults(server_args: ServerArgs) -> None:
+    """Keep unsupported Quest phases eager without constraining merge order."""
+    if not use_runtime_sparse_attention(server_args):
+        return
+
+    from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+
+    locked = getattr(server_args, "_cuda_graph_config_locked", set())
+    graph_available = use_runtime_sparse_cuda_graph(server_args)
+    phases = [(Phase.PREFILL, server_args.cuda_graph_config.prefill)]
+    if not graph_available:
+        phases.append((Phase.DECODE, server_args.cuda_graph_config.decode))
+    for phase, phase_config in phases:
+        if (phase, "backend") not in locked:
+            phase_config.backend = Backend.DISABLED

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1295,7 +1295,13 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
     declared: Dict[str, Any] = {}
 
     if view.enable_hisparse:
-        from sglang.srt.arg_groups.hisparse_hook import _hisparse_default_backend
+        from sglang.srt.arg_groups.hisparse_hook import (
+            _hisparse_default_backend,
+            use_runtime_sparse_attention,
+        )
+
+        if use_runtime_sparse_attention(view):
+            return {}
 
         backend = _hisparse_default_backend(kv_cache_dtype)
         if not user_set_prefill:
@@ -1691,6 +1697,15 @@ def _attention_backend_default(view: Any) -> dict:
         view.prefill_attention_backend == view.decode_attention_backend
     ):  # override the default attention backend
         return {"attention_backend": view.prefill_attention_backend}
+    if view.is_attention_backend_not_set():
+        from sglang.srt.arg_groups.hisparse_hook import (
+            get_hisparse_attention_backend,
+            use_runtime_sparse_attention,
+        )
+
+        if use_runtime_sparse_attention(view):
+            if sparse_backend := get_hisparse_attention_backend(view):
+                return {"attention_backend": sparse_backend}
     if view.attention_backend is None:
         backend = view._get_default_attn_backend(
             view.use_mla_backend(), view.get_model_config()
@@ -1951,6 +1966,29 @@ def _attention_backend_dual_chunk(view: Any) -> dict:
 def _page_size_default(view: Any) -> dict:
     if view.page_size is not None:
         return {}
+
+    from sglang.srt.arg_groups.hisparse_hook import (
+        get_hisparse_page_size,
+        use_runtime_sparse_attention,
+    )
+
+    if use_runtime_sparse_attention(view):
+        sparse_page_size = get_hisparse_page_size(view)
+        if sparse_page_size is not None:
+            if (
+                not isinstance(sparse_page_size, int)
+                or isinstance(sparse_page_size, bool)
+                or sparse_page_size <= 0
+            ):
+                raise ValueError(
+                    "Sparse runtime config page_size must be a positive integer, "
+                    f"got {sparse_page_size!r}."
+                )
+            logger.info(
+                "Using page_size=%d from --hisparse-config for Quest.",
+                sparse_page_size,
+            )
+            return {"page_size": sparse_page_size}
 
     # SHUFFLE 5D vectorized KV layout (aiter backend + pa_decode_gluon)
     # is tuned for and prefers page_size=64 — making it the default

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -48,7 +48,13 @@ from sglang.kernels.ops.attention.flash_attention import (
 
 
 def _should_disable_scheduler_metadata_precompute(server_args) -> bool:
-    return bool(server_args.enable_prefill_cp or server_args.enable_dp_attention)
+    from sglang.srt.arg_groups.hisparse_hook import use_runtime_sparse_attention
+
+    return bool(
+        server_args.enable_prefill_cp
+        or server_args.enable_dp_attention
+        or use_runtime_sparse_attention(server_args)
+    )
 
 
 @dataclass

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -24,7 +24,10 @@ import torch
 from torch import nn
 
 from sglang.srt.compilation.compilation_config import register_split_op
-from sglang.srt.model_executor.forward_context import get_attn_backend
+from sglang.srt.model_executor.forward_context import (
+    get_attn_backend,
+    get_forward_context,
+)
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
     is_in_breakable_cuda_graph,
@@ -269,15 +272,109 @@ class RadixAttention(nn.Module):
                 return output.view(-1, self.tp_q_head_num, self.v_head_dim), lse
             return output
         else:
-            return get_attn_backend().forward(
-                q,
-                k,
-                v,
+            context = get_forward_context()
+            attn_backend = context.attn_backend
+            runtime_sparse_coordinator = context.runtime_sparse_coordinator
+            if _should_use_runtime_sparse_attention(
                 self,
                 forward_batch,
+                k,
                 save_kv_cache,
-                **kwargs,
+                runtime_sparse_coordinator,
+            ):
+                return sparse_attention_forward(
+                    q, k, v, self, forward_batch, save_kv_cache, **kwargs
+                )
+            return _dense_attention_forward(
+                attn_backend, q, k, v, self, forward_batch, save_kv_cache, **kwargs
             )
+
+
+def _should_use_runtime_sparse_attention(
+    layer: RadixAttention,
+    forward_batch: ForwardBatch,
+    key: Optional[torch.Tensor],
+    save_kv_cache: bool,
+    runtime_sparse_coordinator,
+) -> bool:
+    if runtime_sparse_coordinator is None:
+        return False
+    if (
+        not save_kv_cache
+        or key is None
+        or layer.is_cross_attention
+        or layer.attn_type != AttentionType.DECODER
+        or get_tc_piecewise_forward_context() is not None
+        or forward_batch.req_pool_indices is None
+        or forward_batch.seq_lens is None
+    ):
+        return False
+    return forward_batch.forward_mode.is_decode() or (
+        forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+        and not forward_batch.forward_mode.is_mixed()
+        and not forward_batch.forward_mode.is_split_prefill()
+    )
+
+
+def _dense_attention_forward(
+    attn_backend,
+    q: torch.Tensor,
+    k: Optional[torch.Tensor],
+    v: Optional[torch.Tensor],
+    layer: RadixAttention,
+    forward_batch: ForwardBatch,
+    save_kv_cache: bool,
+    **kwargs,
+) -> torch.Tensor:
+    return attn_backend.forward(q, k, v, layer, forward_batch, save_kv_cache, **kwargs)
+
+
+def sparse_attention_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    layer: RadixAttention,
+    forward_batch: ForwardBatch,
+    save_kv_cache: bool,
+    **kwargs,
+) -> torch.Tensor:
+    context = get_forward_context()
+    attn_backend = context.attn_backend
+    coordinator = context.runtime_sparse_coordinator
+
+    if forward_batch.forward_mode.is_decode():
+        sparse_attention_begin(q, k, v, layer, forward_batch, **kwargs)
+
+    output = _dense_attention_forward(
+        attn_backend, q, k, v, layer, forward_batch, save_kv_cache, **kwargs
+    )
+    coordinator.attention_end(output, layer, forward_batch)
+    return output
+
+
+def sparse_attention_begin(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    layer: RadixAttention,
+    forward_batch: ForwardBatch,
+    **kwargs,
+) -> None:
+    context = get_forward_context()
+    attn_backend = context.attn_backend
+    coordinator = context.runtime_sparse_coordinator
+    current_metadata = getattr(attn_backend, "forward_metadata", None)
+    new_metadata = coordinator.attention_begin(
+        q,
+        k,
+        v,
+        layer,
+        forward_batch,
+        current_metadata,
+        **kwargs,
+    )
+    if new_metadata is not None:
+        attn_backend.forward_metadata = new_metadata
 
 
 def _unified_attention_with_output_impl(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -41,6 +41,7 @@ from torch.distributed import barrier
 from sglang.kernels.ops.mamba.triton_ops import (
     initialize_mamba_selective_state_update_backend,
 )
+from sglang.srt.arg_groups.hisparse_hook import use_runtime_sparse_attention
 from sglang.srt.configs.model_config import ModelConfig, ModelImpl, is_minimax_sparse
 from sglang.srt.constrained.grammar_manager import GrammarManager
 from sglang.srt.debug_utils.pr_fix_toggle import maybe_revert_pr_fix
@@ -385,7 +386,10 @@ class Scheduler(
         )
         self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
         self.max_new_tokens_limit = envs.SGLANG_MAX_NEW_TOKENS_LIMIT.get()
-        self.enable_hisparse = server_args.enable_hisparse
+        self.enable_hisparse = (
+            server_args.enable_hisparse
+            and not use_runtime_sparse_attention(server_args)
+        )
         self.enable_dp_attention = server_args.enable_dp_attention
         self.enable_unified_memory = server_args.enable_unified_memory
 

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -92,7 +92,7 @@ class SchedulerBatchResultProcessor:
             req.update_finish_state()
             if req.finished():
                 req.time_stats.set_quick_finish_time()
-                if self.server_args.enable_hisparse:
+                if self.hisparse_coordinator is not None:
                     self.hisparse_coordinator.request_finished(req)
                 release_kv_cache(req, self.tree_cache)
 
@@ -243,7 +243,7 @@ class SchedulerBatchResultProcessor:
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
-                        if self.server_args.enable_hisparse:
+                        if self.hisparse_coordinator is not None:
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
                     self._maybe_collect_customized_info(i, req, logits_output)
@@ -964,7 +964,7 @@ class SchedulerBatchResultProcessor:
                 if not self.decode_offload_manager.offload_kv_cache(req):
                     self.decode_offload_manager.finalize_release_on_finish(req)
             else:
-                if self.server_args.enable_hisparse:
+                if self.hisparse_coordinator is not None:
                     self.hisparse_coordinator.request_finished(req)
                 prepare_release = getattr(
                     self.model_worker, "prepare_for_kv_cache_release", None

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import msgspec
 import torch
 
+from sglang.srt.arg_groups.hisparse_hook import use_runtime_sparse_attention
 from sglang.srt.configs.hybrid_arch import hybrid_gdn_config, mambaish_config
 from sglang.srt.configs.model_config import (
     ModelConfig,
@@ -1446,7 +1447,10 @@ class KVCacheConfigurator:
                         need_sort=need_sort,
                     )
                 else:
-                    if self.server_args.enable_hisparse:
+                    if (
+                        self.server_args.enable_hisparse
+                        and not use_runtime_sparse_attention(self.server_args)
+                    ):
                         from sglang.srt.mem_cache.sparsity import (
                             parse_hisparse_config,
                         )

--- a/python/sglang/srt/mem_cache/sparsity/__init__.py
+++ b/python/sglang/srt/mem_cache/sparsity/__init__.py
@@ -10,6 +10,7 @@ from sglang.srt.mem_cache.sparsity.factory import (
     create_sparse_coordinator,
     get_sparse_coordinator,
     parse_hisparse_config,
+    parse_runtime_sparse_config,
     register_sparse_coordinator,
 )
 
@@ -25,5 +26,6 @@ __all__ = [
     "create_sparse_coordinator",
     "get_sparse_coordinator",
     "parse_hisparse_config",
+    "parse_runtime_sparse_config",
     "register_sparse_coordinator",
 ]

--- a/python/sglang/srt/mem_cache/sparsity/algorithms/base_algorithm.py
+++ b/python/sglang/srt/mem_cache/sparsity/algorithms/base_algorithm.py
@@ -198,11 +198,25 @@ class BaseSparseAlgorithmImpl(BaseSparseAlgorithm):
         if not forward_batch.forward_mode.is_extend():
             return
 
+        if getattr(forward_batch, "extend_prefix_lens", None) is not None:
+            new_req_mask = forward_batch.extend_prefix_lens == 0
+            if new_req_mask.any():
+                new_req_indices = req_pool_indices[new_req_mask]
+                self.states.repr_constructed[new_req_indices] = False
+                self.states.prompt_lens[new_req_indices] = 0
+                self.states.last_constructed_page[new_req_indices] = 0
+
+        prompt_lens = self.states.prompt_lens[req_pool_indices]
+        self.states.prompt_lens[req_pool_indices] = torch.maximum(prompt_lens, seq_lens)
+
         num_pages = seq_lens // self.page_size
-        valid_mask = (
-            ~self.states.repr_constructed[req_pool_indices]
-            & (seq_lens >= self.states.prompt_lens[req_pool_indices])
-            & (num_pages > 0)
+        start_page = torch.where(
+            self.states.repr_constructed[req_pool_indices],
+            self.states.last_constructed_page[req_pool_indices],
+            torch.zeros_like(num_pages),
+        )
+        valid_mask = (seq_lens >= self.states.prompt_lens[req_pool_indices]) & (
+            num_pages > start_page
         )
 
         if not valid_mask.any():
@@ -213,7 +227,7 @@ class BaseSparseAlgorithmImpl(BaseSparseAlgorithm):
             layer_id,
             req_pool_indices[valid_mask],
             seq_lens[valid_mask],
-            0,
+            start_page[valid_mask],
             num_pages[valid_mask],
             k_buffer,
         )

--- a/python/sglang/srt/mem_cache/sparsity/backend/backend_adaptor.py
+++ b/python/sglang/srt/mem_cache/sparsity/backend/backend_adaptor.py
@@ -1,5 +1,8 @@
 import logging
 from abc import ABC, abstractmethod
+from functools import lru_cache
+from importlib import import_module
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
@@ -9,9 +12,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_QUEST_METADATA_KERNEL_MODULE = (
+    "sglang.srt.mem_cache.sparsity.kernels.quest_flashattention_metadata"
+)
+
+
+@lru_cache(maxsize=1)
+def _load_quest_metadata_kernel():
+    try:
+        module_spec = find_spec(_QUEST_METADATA_KERNEL_MODULE)
+    except ModuleNotFoundError as exc:
+        if not _QUEST_METADATA_KERNEL_MODULE.startswith(f"{exc.name}."):
+            raise
+        return None
+    if module_spec is None:
+        return None
+    return import_module(_QUEST_METADATA_KERNEL_MODULE)
+
 
 class BackendAdaptor(ABC):
     """Base class for attention backend adaptors."""
+
+    supports_prepared_metadata = False
 
     def __init__(self, device: torch.device):
         self.device = device
@@ -79,13 +101,36 @@ class DSABackendAdaptor(BackendAdaptor):
 class FlashAttentionAdaptor(BackendAdaptor):
     """Adaptor for FlashAttention backend."""
 
+    supports_prepared_metadata = True
+
+    def __init__(self, device: torch.device):
+        super().__init__(device)
+        self._metadata_prepared = False
+        self._max_selected = None
+
+    def _reset_forward_state(self) -> None:
+        self._metadata_prepared = False
+        self._max_selected = None
+
     def save_original_metadata(self, metadata: Any) -> None:
+        self._reset_forward_state()
+        required_attrs = (
+            "page_table",
+            "cache_seqlens_int32",
+            "cu_seqlens_k",
+            "max_seq_len_k",
+        )
+        if metadata is None or not all(
+            hasattr(metadata, attr) for attr in required_attrs
+        ):
+            self._original_metadata = None
+            return
         self._original_metadata = {
-            "page_table": metadata.page_table.clone(),
             "cache_seqlens_int32": metadata.cache_seqlens_int32.clone(),
-            "cu_seqlens_k": metadata.cu_seqlens_k.clone(),
             "max_seq_len_k": metadata.max_seq_len_k,
         }
+        if hasattr(metadata, "scheduler_metadata"):
+            metadata.scheduler_metadata = None
 
     def adapt_for_attn_metadata(
         self,
@@ -110,13 +155,50 @@ class FlashAttentionAdaptor(BackendAdaptor):
         if self._original_metadata is None:
             return current_metadata
 
-        if not sparse_mask.any():
+        max_selected = selected_indices.shape[1]
+        if not self._metadata_prepared:
+            self._max_selected = max_selected
+            current_metadata.max_seq_len_k = max(
+                self._original_metadata["max_seq_len_k"],
+                max_selected * page_size,
+            )
+            self._metadata_prepared = True
+        elif max_selected != self._max_selected:
+            raise ValueError("Sparse selection width changed within one forward")
+
+        if kwargs.get("metadata_prepared", False):
             return current_metadata
 
-        current_metadata.page_table.copy_(self._original_metadata["page_table"])
-        current_metadata.cache_seqlens_int32.copy_(
-            self._original_metadata["cache_seqlens_int32"]
+        kernel_module = _load_quest_metadata_kernel()
+        use_metadata_kernel = kernel_module is not None and all(
+            tensor.is_cuda
+            for tensor in (
+                selected_indices,
+                valid_lengths,
+                sparse_mask,
+                forward_batch.seq_lens,
+                forward_batch.req_pool_indices,
+                req_to_token,
+                current_metadata.page_table,
+                current_metadata.cache_seqlens_int32,
+                current_metadata.cu_seqlens_k,
+            )
         )
+        if use_metadata_kernel:
+            kernel_module.quest_update_flashattention_metadata_(
+                selected_indices=selected_indices,
+                valid_lengths=valid_lengths,
+                sparse_mask=sparse_mask,
+                seq_lens=forward_batch.seq_lens,
+                req_pool_indices=forward_batch.req_pool_indices,
+                req_to_token=req_to_token,
+                page_table=current_metadata.page_table,
+                cache_seqlens_int32=current_metadata.cache_seqlens_int32,
+                cu_seqlens_k=current_metadata.cu_seqlens_k,
+                page_size=page_size,
+                update_lengths=True,
+            )
+            return current_metadata
 
         physical_pages = self._logical_to_physical_pages_batch(
             selected_indices,
@@ -125,32 +207,37 @@ class FlashAttentionAdaptor(BackendAdaptor):
             page_size,
         )
 
-        max_selected = physical_pages.shape[1]
+        active_sparse_mask = sparse_mask & (valid_lengths > 0)
         valid_mask = torch.arange(max_selected, device=physical_pages.device).unsqueeze(
             0
         ) < valid_lengths.unsqueeze(1)
-        update_mask = sparse_mask.unsqueeze(1) & valid_mask
-
-        current_metadata.page_table[:, :max_selected] = torch.where(
-            update_mask, physical_pages, current_metadata.page_table[:, :max_selected]
-        )
+        page_table_update_mask = active_sparse_mask.unsqueeze(1) & valid_mask
 
         seq_lens = forward_batch.seq_lens
         positions_in_page = (seq_lens - 1) % page_size
-        diff = page_size - positions_in_page - 1
-        sparse_seq_lens = (valid_lengths * page_size - diff).to(torch.int32)
-
-        current_metadata.cache_seqlens_int32 = torch.where(
-            sparse_mask, sparse_seq_lens, self._original_metadata["cache_seqlens_int32"]
+        sparse_seq_lens = (
+            valid_lengths * page_size - (page_size - positions_in_page - 1)
+        ).to(torch.int32)
+        current_metadata.cache_seqlens_int32.copy_(
+            torch.where(
+                active_sparse_mask,
+                sparse_seq_lens,
+                self._original_metadata["cache_seqlens_int32"],
+            )
         )
-
-        current_metadata.cu_seqlens_k = torch.nn.functional.pad(
+        current_metadata.cu_seqlens_k[0].zero_()
+        current_metadata.cu_seqlens_k[1:].copy_(
             torch.cumsum(
-                current_metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
-            ),
-            (1, 0),
+                current_metadata.cache_seqlens_int32,
+                dim=0,
+                dtype=torch.int32,
+            )
         )
-        current_metadata.max_seq_len_k = int(current_metadata.cache_seqlens_int32.max())
+
+        page_table = current_metadata.page_table[:, :max_selected]
+        page_table.copy_(
+            torch.where(page_table_update_mask, physical_pages, page_table)
+        )
         return current_metadata
 
     def _logical_to_physical_pages_batch(

--- a/python/sglang/srt/mem_cache/sparsity/core/sparse_coordinator.py
+++ b/python/sglang/srt/mem_cache/sparsity/core/sparse_coordinator.py
@@ -1,9 +1,12 @@
 import logging
 from dataclasses import dataclass, field
+from importlib import import_module
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
+from sglang.srt.arg_groups.hisparse_hook import RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER
 from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
 from sglang.srt.mem_cache.sparsity.algorithms.base_algorithm import BaseSparseAlgorithm
 from sglang.srt.mem_cache.sparsity.backend.backend_adaptor import BackendAdaptor
@@ -118,7 +121,7 @@ class SparseCoordinator:
         self.states = RequestTrackers(
             req_to_token_pool.req_to_token.shape[0],
             device,
-            end_layer - start_layer + 1,
+            end_layer - start_layer,
             self.config.min_sparse_prompt_len,
             self.req_to_token_pool.max_context_len,
         )
@@ -131,10 +134,30 @@ class SparseCoordinator:
             self.req_to_token_pool,
             self.states,
         )
+        self._forward_sparse_mask = None
+        self._cuda_graph_provider = self._load_cuda_graph_provider()
 
         logger.info(
             f"SparseCoordinator initialized with sparse algorithm={type(algorithm).__name__}"
         )
+
+    def _load_cuda_graph_provider(self):
+        try:
+            provider_spec = find_spec(RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER)
+        except ModuleNotFoundError as exc:
+            if not RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER.startswith(f"{exc.name}."):
+                raise
+            return None
+        if provider_spec is None:
+            return None
+        module = import_module(RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER)
+        factory = getattr(module, "create_cuda_graph_runtime_provider", None)
+        if not callable(factory):
+            raise RuntimeError(
+                f"{RUNTIME_SPARSE_CUDA_GRAPH_PROVIDER} must define "
+                "create_cuda_graph_runtime_provider(coordinator)"
+            )
+        return factory(self)
 
     def on_request_begin(self, req: "Req") -> None:
         """
@@ -165,9 +188,22 @@ class SparseCoordinator:
         Wait for pending KVCache offloading operations to complete before forward pass.
         Ensures memory consistency for subsequent sparse attention operations.
         """
-        # TODO: Implement forward begin handling
-        # - Check if there are pending offloading operations
-        pass
+        req_pool_indices = forward_batch.req_pool_indices
+        if req_pool_indices is None:
+            self._forward_sparse_mask = None
+            return
+        self._forward_sparse_mask = self._compute_sparse_mask(req_pool_indices)
+        begin_forward = getattr(self.algorithm, "begin_forward", None)
+        if begin_forward is not None:
+            begin_forward(
+                forward_batch=forward_batch,
+                req_pool_indices=req_pool_indices,
+                sparse_mask=self._forward_sparse_mask,
+                device=forward_batch.seq_lens.device,
+                fixed_capacity=getattr(
+                    forward_batch, "runtime_sparse_page_capacity", False
+                ),
+            )
 
     def forward_end(self, forward_batch: "ForwardBatch") -> None:
         """
@@ -175,9 +211,6 @@ class SparseCoordinator:
 
         Trigger async KVCache offloading operations.
         """
-        # TODO: Implement forward end handling
-        # - Identify tokens to offload
-        # - Trigger async offloading operations
         pass
 
     def attention_begin(
@@ -197,6 +230,7 @@ class SparseCoordinator:
         and adapt attention metadata for the attention backend.
         """
         if layer.layer_id == self.start_layer:
+            self.forward_begin(forward_batch)
             self.backend_adaptor.save_original_metadata(attn_metadata)
 
         return self._handle_sparse_retrieve(
@@ -243,18 +277,31 @@ class SparseCoordinator:
         **kwargs,
     ) -> Optional[torch.Tensor]:
         req_pool_indices = forward_batch.req_pool_indices
+        layer_id = layer.layer_id
         # Compute Topk
-        sparse_mask = self._compute_sparse_mask(req_pool_indices)
-        selected_indices, valid_lengths = self.algorithm.retrieve_topk(
+        sparse_mask = self._forward_sparse_mask
+        if sparse_mask is None:
+            sparse_mask = self._compute_sparse_mask(req_pool_indices)
+        retrieval_result = self.algorithm.retrieve_topk(
             queries=query,
-            layer_id=layer.layer_id,
+            layer_id=layer_id,
             req_pool_indices=req_pool_indices,
             sparse_mask=sparse_mask,
             forward_batch=forward_batch,
             attn_metadata=attn_metadata,
+            allow_prepared_metadata=self.backend_adaptor.supports_prepared_metadata,
             **kwargs,
         )
-
+        if len(retrieval_result) == 3:
+            selected_indices, valid_lengths, metadata_prepared = retrieval_result
+        elif len(retrieval_result) == 2:
+            selected_indices, valid_lengths = retrieval_result
+            metadata_prepared = False
+        else:
+            raise ValueError(
+                "Sparse retrieval must return (indices, lengths) or "
+                "(indices, lengths, metadata_prepared)"
+            )
         # Adapt Attention Metadata
         return self.backend_adaptor.adapt_for_attn_metadata(
             selected_indices=selected_indices,
@@ -264,13 +311,14 @@ class SparseCoordinator:
             forward_batch=forward_batch,
             req_to_token=self.req_to_token_pool.req_to_token,
             page_size=self.page_size,
-            layer_id=layer.layer_id,
+            layer_id=layer_id,
+            metadata_prepared=metadata_prepared,
         )
 
     def _compute_sparse_mask(self, req_pool_indices):
-        mask = (
-            self.states.prompt_lens[req_pool_indices]
-            >= self.config.min_sparse_prompt_len
+        min_sparse_prompt_len = self.config.min_sparse_prompt_len or 0
+        mask = self.states.repr_constructed[req_pool_indices] & (
+            self.states.prompt_lens[req_pool_indices] >= min_sparse_prompt_len
         )
 
         return mask

--- a/python/sglang/srt/mem_cache/sparsity/factory.py
+++ b/python/sglang/srt/mem_cache/sparsity/factory.py
@@ -58,7 +58,14 @@ def _create_backend_adaptor(
     raise ValueError(f"Unknown attention backend: {backend}")
 
 
-def _parse_sparse_config(server_args) -> SparseConfig:
+def _parse_sparse_config(
+    server_args,
+    *,
+    default_algorithm: Optional[str] = None,
+    default_backend: Optional[str] = None,
+    default_page_size: Optional[int] = None,
+    default_min_sparse_prompt_len: Optional[int] = None,
+) -> SparseConfig:
     """Parse hierarchical sparse config from JSON string.
 
     Required fields with defaults: top_k (2048), device_buffer_size (2*top_k),
@@ -72,6 +79,10 @@ def _parse_sparse_config(server_args) -> SparseConfig:
             extra_config = json.loads(extra_config_str)
         except json.JSONDecodeError as e:
             raise ValueError(f"Failed to parse hisparse_config: {e}") from e
+        if not isinstance(extra_config, dict):
+            raise ValueError(
+                f"hisparse_config must be a JSON object, got {type(extra_config).__name__}."
+            )
     else:
         extra_config = {}
 
@@ -93,10 +104,16 @@ def _parse_sparse_config(server_args) -> SparseConfig:
             f"swap_in_block_size ({swap_in_block_size}) must be in the range [1, 1024]"
         )
 
-    algorithm = extra_config.pop("algorithm", None)
-    backend = extra_config.pop("backend", None)
-    min_sparse_prompt_len = extra_config.pop("min_sparse_prompt_len", None)
-    page_size = extra_config.pop("page_size", None)
+    algorithm = extra_config.pop("algorithm", default_algorithm)
+    backend = extra_config.pop("backend", default_backend)
+    if isinstance(algorithm, str):
+        algorithm = algorithm.strip().lower()
+    if isinstance(backend, str):
+        backend = backend.strip().lower()
+    min_sparse_prompt_len = extra_config.pop(
+        "min_sparse_prompt_len", default_min_sparse_prompt_len
+    )
+    page_size = extra_config.pop("page_size", default_page_size)
 
     return SparseConfig(
         top_k=top_k,
@@ -116,6 +133,78 @@ def parse_hisparse_config(server_args) -> SparseConfig:
     return _parse_sparse_config(server_args)
 
 
+def parse_runtime_sparse_config(server_args) -> SparseConfig:
+    """Parse and validate the runtime Quest configuration."""
+    from sglang.srt.arg_groups.overrides import attention_backends_of
+
+    prefill_backend, decode_backend = attention_backends_of(server_args)
+    runtime_page_size = server_args.page_size
+    config = _parse_sparse_config(
+        server_args,
+        default_algorithm="quest",
+        default_backend=decode_backend or prefill_backend,
+        default_page_size=runtime_page_size,
+        default_min_sparse_prompt_len=0,
+    )
+    if not config.algorithm:
+        raise ValueError("Sparse runtime config requires an algorithm.")
+    if not config.backend:
+        raise ValueError("Sparse runtime config requires an attention backend.")
+    if not isinstance(config.page_size, int) or isinstance(config.page_size, bool):
+        raise ValueError(
+            f"Sparse runtime config page_size must be an integer, got {config.page_size!r}."
+        )
+    if config.page_size <= 0:
+        raise ValueError(
+            f"Sparse runtime config page_size must be positive, got {config.page_size}."
+        )
+    if runtime_page_size is not None and config.page_size != runtime_page_size:
+        raise ValueError(
+            "Sparse runtime config page_size must match the runtime KV cache "
+            f"--page-size ({runtime_page_size}), got {config.page_size}."
+        )
+    if config.min_sparse_prompt_len is not None and (
+        not isinstance(config.min_sparse_prompt_len, int)
+        or isinstance(config.min_sparse_prompt_len, bool)
+        or config.min_sparse_prompt_len < 0
+    ):
+        raise ValueError(
+            "Sparse runtime config min_sparse_prompt_len must be a non-negative "
+            f"integer, got {config.min_sparse_prompt_len!r}."
+        )
+
+    sparsity_ratio = config.sparse_extra_config.get("sparsity_ratio")
+    if sparsity_ratio is not None and (
+        not isinstance(sparsity_ratio, (int, float))
+        or isinstance(sparsity_ratio, bool)
+        or not 0 < sparsity_ratio <= 1
+    ):
+        raise ValueError(
+            "Sparse runtime config sparsity_ratio must be in the range (0, 1], "
+            f"got {sparsity_ratio!r}."
+        )
+    num_recent_pages = config.sparse_extra_config.get("num_recent_pages")
+    if num_recent_pages is not None and (
+        not isinstance(num_recent_pages, int)
+        or isinstance(num_recent_pages, bool)
+        or num_recent_pages <= 0
+    ):
+        raise ValueError(
+            "Sparse runtime config num_recent_pages must be a positive integer, "
+            f"got {num_recent_pages!r}."
+        )
+    enable_cuda_graph_retrieval = config.sparse_extra_config.get(
+        "enable_cuda_graph_retrieval", False
+    )
+    if not isinstance(enable_cuda_graph_retrieval, bool):
+        raise ValueError(
+            "Sparse runtime config enable_cuda_graph_retrieval must be a boolean, "
+            f"got {enable_cuda_graph_retrieval!r}."
+        )
+
+    return config
+
+
 def create_sparse_coordinator(
     device: torch.device,
     req_to_token_pool,
@@ -125,7 +214,7 @@ def create_sparse_coordinator(
     server_args,
     **kwargs,
 ) -> SparseCoordinator:
-    config = _parse_sparse_config(server_args)
+    config = parse_runtime_sparse_config(server_args)
     algorithm = _create_sparse_algorithm(config, device, **kwargs)
     backend_adaptor = _create_backend_adaptor(
         config.backend, device, algorithm, req_to_token_pool

--- a/python/sglang/srt/model_executor/forward_context.py
+++ b/python/sglang/srt/model_executor/forward_context.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
     from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+    from sglang.srt.mem_cache.sparsity.core.sparse_coordinator import SparseCoordinator
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,6 +39,7 @@ class ForwardContext:
     write time — use dataclasses.replace for per-call overrides."""
 
     attn_backend: AttentionBackend
+    runtime_sparse_coordinator: Optional[SparseCoordinator] = None
 
 
 _current: Optional[ForwardContext] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -25,6 +25,7 @@ from typing import Optional, Union
 import torch
 import torch.distributed as dist
 
+from sglang.srt.arg_groups.hisparse_hook import use_runtime_sparse_attention
 from sglang.srt.configs.load_config import LoadConfig
 from sglang.srt.configs.model_config import (
     AttentionArch,
@@ -292,7 +293,10 @@ class ModelRunner:
         self._pending_elastic_scale_update = None
         self.init_new_workspace = False
         self.draft_model_idx = draft_model_idx
-        self.enable_hisparse = server_args.enable_hisparse
+        self.enable_runtime_sparse_attention = use_runtime_sparse_attention(server_args)
+        self.enable_hisparse = (
+            server_args.enable_hisparse and not self.enable_runtime_sparse_attention
+        )
 
         self.init_remote_instance_weight_transporter()
 
@@ -372,6 +376,8 @@ class ModelRunner:
 
         # For hisparse (must be set before initialize() so CUDA graph capture can see it)
         self.hisparse_coordinator = None
+        self.runtime_sparse_coordinator = None
+        self.cuda_graph_runtime_extension = None
 
         # Load model weights and configure
         self.initialize()
@@ -771,6 +777,7 @@ class ModelRunner:
         self.init_ngram_embedding_manager()
 
         self.maybe_init_hisparse_coordinator()
+        self.maybe_init_runtime_sparse_coordinator()
 
         self.init_routed_experts_capturer()
         self.init_indexer_capturer()
@@ -800,6 +807,24 @@ class ModelRunner:
             ),
             host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
             swap_in_block_size=hisparse_cfg.swap_in_block_size,
+        )
+
+    def maybe_init_runtime_sparse_coordinator(self):
+        if not self.enable_runtime_sparse_attention:
+            return
+
+        from sglang.srt.mem_cache.sparsity import create_sparse_coordinator
+
+        self.runtime_sparse_coordinator = create_sparse_coordinator(
+            device=self.device,
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool=self.token_to_kv_pool,
+            start_layer=self.layer_info.start_layer,
+            end_layer=self.layer_info.end_layer,
+            server_args=self.server_args,
+        )
+        self.cuda_graph_runtime_extension = (
+            self.runtime_sparse_coordinator._cuda_graph_provider
         )
 
     def post_capture_resize_kv_pool(self):
@@ -1486,7 +1511,12 @@ class ModelRunner:
         if has_forward_context():
             ctx_mgr = contextlib.nullcontext()
         else:
-            ctx_mgr = forward_context(ForwardContext(attn_backend=self.attn_backend))
+            ctx_mgr = forward_context(
+                ForwardContext(
+                    attn_backend=self.attn_backend,
+                    runtime_sparse_coordinator=self.runtime_sparse_coordinator,
+                )
+            )
         with ctx_mgr:
             mode_check = (
                 forward_batch.forward_mode.is_cpu_graph

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
+from sglang.srt.arg_groups.hisparse_hook import get_hisparse_algorithm
 from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.configs.model_config import (
     get_dsa_index_head_dim,
@@ -142,6 +143,18 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             if has_kv_on_another_pp_stage
             else kvc.server_args.max_total_tokens or kvc.model_config.context_len
         )
+        self._runtime_sparse_representation_bytes_per_page = 0
+        if (
+            kvc.server_args.enable_hisparse
+            and get_hisparse_algorithm(kvc.server_args) == "quest"
+        ):
+            kv_heads = kvc.model_config.get_num_kv_heads(get_parallel().attn_tp_size)
+            local_layers = kvc.layer_info.end_layer - kvc.layer_info.start_layer
+            bounds_bytes = 4
+            valid_bytes = torch.empty((), dtype=torch.bool).element_size()
+            self._runtime_sparse_representation_bytes_per_page = local_layers * (
+                2 * kv_heads * kvc.model_config.head_dim * bounds_bytes + valid_bytes
+            )
 
         # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
         # Assumes draft and target share the same per-layer KV size (head_dim,
@@ -316,12 +329,23 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
-        max_total_num_tokens = (
-            available_bytes // self._cell_size
-            if self._cell_size
-            else self._zero_kv_max_tokens
-        )
-        max_total_num_tokens = max_total_num_tokens // page_size * page_size
+        representation_page_bytes = self._runtime_sparse_representation_bytes_per_page
+        if representation_page_bytes:
+            # KV pools allocate one extra padding page, and Quest mirrors it.
+            available_for_pages = max(0, available_bytes - representation_page_bytes)
+            combined_page_bytes = (
+                page_size * self._cell_size + representation_page_bytes
+            )
+            max_total_num_tokens = (
+                available_for_pages // combined_page_bytes * page_size
+            )
+        else:
+            max_total_num_tokens = (
+                available_bytes // self._cell_size
+                if self._cell_size
+                else self._zero_kv_max_tokens
+            )
+            max_total_num_tokens = max_total_num_tokens // page_size * page_size
         return MemoryPoolConfig(max_total_num_tokens=max_total_num_tokens)
 
     def calculate_pool_sizes_from_max_tokens(

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -607,7 +607,12 @@ class BaseRunner(ABC):
 
         torch.get_device_module(mr.device).synchronize()
         mr.tp_group.barrier()
-        with forward_context(ForwardContext(attn_backend=mr.attn_backend)):
+        with forward_context(
+            ForwardContext(
+                attn_backend=mr.attn_backend,
+                runtime_sparse_coordinator=mr.runtime_sparse_coordinator,
+            )
+        ):
             with torch.inference_mode(), run_ctx or empty_context():
                 run_once()
 

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -291,6 +291,18 @@ def enable_fused_set_kv_buffer(forward_batch: ForwardBatch):
     `.view(-> 4D NHD)` reshape, and let the rotary forward pass
     `flash_layout=False`. See `create_fused_set_kv_buffer_arg` below.
     """
+    from sglang.srt.model_executor.forward_context import (
+        get_forward_context,
+        has_forward_context,
+    )
+
+    if (
+        has_forward_context()
+        and get_forward_context().runtime_sparse_coordinator is not None
+    ):
+        # Quest updates page representations after RadixAttention writes KV.
+        return False
+
     pool = get_token_to_kv_pool()
     return (
         _is_cuda

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2642,7 +2642,15 @@ class ServerArgs:
     hisparse_config: A[
         Optional[str],
         Arg(
-            help='A dictionary in JSON string format for hierarchical sparse attention configuration. Example: \'{"top_k": 2048, "device_buffer_size": 4096, "host_to_device_ratio": 2}\'',
+            help=(
+                "A dictionary in JSON string format for hierarchical sparse "
+                "attention. Example: "
+                '\'{"top_k":2048,"device_buffer_size":4096}\'. For Quest '
+                "runtime attention use e.g. "
+                '\'{"algorithm":"quest","backend":"fa3","page_size":16,'
+                '"sparsity_ratio":0.5}\'. Quest page_size also sets the runtime '
+                "KV page size; an explicit --page-size must match it."
+            ),
             aliases=["--hierarchical-sparse-attention-extra-config"],
         ),
         NS("memory"),
@@ -4704,6 +4712,8 @@ class ServerArgs:
         """Whether the mem_fraction heuristic may skip the graph reserve; must be
         False for any config the runtime won't post-capture-size, else it gets an
         under-reserved fraction."""
+        from sglang.srt.arg_groups.hisparse_hook import use_runtime_sparse_attention
+
         # use_mla_backend is a method at args time but ModelRunner overwrites it
         # with a bool on global_server_args (see the FIXME there) -- handle both.
         use_mla = self.use_mla_backend
@@ -4716,6 +4726,7 @@ class ServerArgs:
             and not self.prefill_only_disable_kv_cache
             and not self.enable_memory_saver
             and envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is None
+            and not use_runtime_sparse_attention(self)
             # Accurate sizing assumes graph-covered execution (graphs retain the
             # activation workspace, so it is measured post-capture). An eager
             # phase would pay activations outside the measurement: DP attention
@@ -8443,6 +8454,12 @@ class ServerArgs:
         )
 
         run_post_process_pass(self, _hisparse_validation)
+
+        from sglang.srt.arg_groups.hisparse_hook import (
+            apply_runtime_sparse_eager_defaults,
+        )
+
+        apply_runtime_sparse_eager_defaults(self)
 
         assert (
             self.schedule_conservativeness >= 0

--- a/test/registered/unit/mem_cache/test_runtime_sparse_attention.py
+++ b/test/registered/unit/mem_cache/test_runtime_sparse_attention.py
@@ -1,0 +1,241 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.layers.radix_attention import (
+    AttentionType,
+    _should_use_runtime_sparse_attention,
+)
+from sglang.srt.mem_cache import kv_cache_configurator as configurator_module
+from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
+from sglang.srt.mem_cache.sparsity.backend.backend_adaptor import (
+    FlashAttentionAdaptor,
+)
+from sglang.srt.mem_cache.sparsity.core.sparse_coordinator import (
+    SparseConfig,
+    SparseCoordinator,
+)
+from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.srt.models.utils import enable_fused_set_kv_buffer
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestFlashAttentionAdaptor(unittest.TestCase):
+    def setUp(self):
+        self.adaptor = FlashAttentionAdaptor(torch.device("cpu"))
+        self.metadata = SimpleNamespace(
+            page_table=torch.tensor([[0, 2], [1, 3]], dtype=torch.int32),
+            cache_seqlens_int32=torch.tensor([7, 6], dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, 7, 13], dtype=torch.int32),
+            max_seq_len_k=7,
+            scheduler_metadata=torch.ones(1, dtype=torch.int32),
+        )
+        self.batch = SimpleNamespace(
+            req_pool_indices=torch.tensor([0, 1]),
+            seq_lens=torch.tensor([7, 6]),
+        )
+        self.req_to_token = torch.tensor(
+            [[0, 1, 2, 3, 8, 9, 10, 11], [4, 5, 6, 7, 12, 13, 14, 15]]
+        )
+
+    def _adapt(self, selected, lengths, *, layer_id=0, prepared=False):
+        return self.adaptor.adapt_for_attn_metadata(
+            selected_indices=torch.tensor(selected, dtype=torch.int32),
+            valid_lengths=torch.tensor(lengths, dtype=torch.int32),
+            sparse_mask=torch.tensor([True, False]),
+            current_metadata=self.metadata,
+            forward_batch=self.batch,
+            req_to_token=self.req_to_token,
+            page_size=4,
+            layer_id=layer_id,
+            metadata_prepared=prepared,
+        )
+
+    def test_mixed_batch_is_in_place_across_layers_and_forwards(self):
+        pointers = tuple(
+            tensor.data_ptr()
+            for tensor in (
+                self.metadata.page_table,
+                self.metadata.cache_seqlens_int32,
+                self.metadata.cu_seqlens_k,
+            )
+        )
+        self.adaptor.save_original_metadata(self.metadata)
+        self.assertIs(self._adapt([[0, 1], [0, 1]], [2, 2]), self.metadata)
+        self.assertEqual(self.metadata.page_table.tolist(), [[0, 2], [1, 3]])
+        self.assertEqual(self.metadata.cache_seqlens_int32.tolist(), [7, 6])
+        self.assertEqual(self.metadata.cu_seqlens_k.tolist(), [0, 7, 13])
+        self.assertEqual(
+            tuple(
+                tensor.data_ptr()
+                for tensor in (
+                    self.metadata.page_table,
+                    self.metadata.cache_seqlens_int32,
+                    self.metadata.cu_seqlens_k,
+                )
+            ),
+            pointers,
+        )
+
+        self._adapt([[1, -1], [0, -1]], [1, 1], layer_id=1)
+        self.assertEqual(self.metadata.page_table.tolist(), [[2, 2], [1, 3]])
+        self.assertEqual(self.metadata.cache_seqlens_int32.tolist(), [3, 6])
+        self.assertEqual(self.metadata.cu_seqlens_k.tolist(), [0, 3, 9])
+
+        self.metadata.page_table.copy_(torch.tensor([[0, 2], [1, 3]]))
+        self.metadata.cache_seqlens_int32.copy_(torch.tensor([7, 6]))
+        self.metadata.cu_seqlens_k.copy_(torch.tensor([0, 7, 13]))
+        self.adaptor.save_original_metadata(self.metadata)
+        self._adapt([[0, 1], [0, -1]], [2, 1])
+        self.assertEqual(self.metadata.cache_seqlens_int32.tolist(), [7, 6])
+        self.assertEqual(self.metadata.cu_seqlens_k.tolist(), [0, 7, 13])
+
+        self.metadata.page_table.copy_(torch.tensor([[8, 9], [6, 7]]))
+        self._adapt([[8, 9], [6, 7]], [2, 2], prepared=True)
+        self.assertEqual(self.metadata.page_table.tolist(), [[8, 9], [6, 7]])
+
+
+class TestRuntimeSparseBoundaries(unittest.TestCase):
+    @staticmethod
+    def _batch():
+        forward_mode = SimpleNamespace(
+            is_decode=Mock(return_value=True),
+            is_extend_or_draft_extend_or_mixed=Mock(return_value=False),
+            is_mixed=Mock(return_value=False),
+            is_split_prefill=Mock(return_value=False),
+        )
+        return SimpleNamespace(
+            req_pool_indices=torch.tensor([0]),
+            seq_lens=torch.tensor([16]),
+            forward_mode=forward_mode,
+        )
+
+    @patch(
+        "sglang.srt.layers.radix_attention.get_tc_piecewise_forward_context",
+        return_value=None,
+    )
+    def test_dense_fallback_boundaries(self, _mock_piecewise_context):
+        batch, key = self._batch(), torch.empty(1)
+        decoder = SimpleNamespace(
+            is_cross_attention=False, attn_type=AttentionType.DECODER
+        )
+        self.assertTrue(
+            _should_use_runtime_sparse_attention(decoder, batch, key, True, object())
+        )
+        cases = (
+            (decoder, key, True, None),
+            (decoder, key, False, object()),
+            (SimpleNamespace(is_cross_attention=True), key, True, object()),
+        )
+        for layer, candidate_key, save_kv, coordinator in cases:
+            with self.subTest(layer=layer, save_kv=save_kv):
+                self.assertFalse(
+                    _should_use_runtime_sparse_attention(
+                        layer, batch, candidate_key, save_kv, coordinator
+                    )
+                )
+
+    def test_kv_write_order_and_half_open_layer_range(self):
+        with forward_context(
+            ForwardContext(attn_backend=None, runtime_sparse_coordinator=object())
+        ):
+            self.assertFalse(enable_fused_set_kv_buffer(SimpleNamespace()))
+
+        algorithm = Mock()
+        coordinator = SparseCoordinator(
+            config=SparseConfig(page_size=16, min_sparse_prompt_len=0),
+            algorithm=algorithm,
+            backend_adaptor=Mock(),
+            req_to_token_pool=SimpleNamespace(
+                req_to_token=torch.zeros((2, 32), dtype=torch.int32),
+                max_context_len=32,
+            ),
+            token_to_kv_pool=Mock(),
+            start_layer=4,
+            end_layer=10,
+            device=torch.device("cpu"),
+        )
+        self.assertEqual(coordinator.states.num_layers, 6)
+        algorithm.initialize_representation_pool.assert_called_once()
+
+    def test_quest_uses_the_regular_paged_allocator(self):
+        configurator = object.__new__(KVCacheConfigurator)
+        configurator.server_args = SimpleNamespace(
+            disaggregation_mode="null",
+            enable_hisparse=True,
+            hisparse_config=json.dumps({"algorithm": "quest"}),
+            page_size=16,
+            dcp_size=1,
+        )
+        configurator.is_hybrid_swa = False
+        configurator.kv_cache_dtype = torch.bfloat16
+        configurator.device = "cpu"
+        expected = Mock()
+        with (
+            patch.object(
+                configurator_module.current_platform,
+                "is_out_of_tree",
+                return_value=False,
+            ),
+            patch.object(configurator_module, "_is_npu", False),
+            patch.object(
+                configurator_module,
+                "PagedTokenToKVPoolAllocator",
+                return_value=expected,
+            ) as paged,
+            patch.object(
+                configurator_module, "HiSparseTokenToKVPoolAllocator"
+            ) as hisparse,
+        ):
+            actual = configurator._build_token_to_kv_pool_allocator(
+                sizes=SimpleNamespace(
+                    max_total_num_tokens=64,
+                    full_max_total_num_tokens=None,
+                    swa_max_total_num_tokens=None,
+                ),
+                token_to_kv_pool=Mock(),
+                is_dsv4_model=False,
+                req_to_token_pool=SimpleNamespace(),
+                token_to_kv_pool_allocator=None,
+            )
+        self.assertIs(actual, expected)
+        paged.assert_called_once()
+        hisparse.assert_not_called()
+
+    def test_coordinator_accepts_two_and_three_item_retrieval_results(self):
+        coordinator = object.__new__(SparseCoordinator)
+        coordinator._forward_sparse_mask = torch.tensor([True])
+        coordinator.algorithm = Mock()
+        coordinator.backend_adaptor = Mock(supports_prepared_metadata=True)
+        coordinator.backend_adaptor.adapt_for_attn_metadata.return_value = "metadata"
+        coordinator.req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+        )
+        coordinator.page_size = 4
+
+        indices = torch.tensor([[3]], dtype=torch.int32)
+        lengths = torch.tensor([1], dtype=torch.int32)
+        for retrieval_result, prepared in (
+            ((indices, lengths), False),
+            ((indices, lengths, True), True),
+        ):
+            with self.subTest(prepared=prepared):
+                coordinator.algorithm.retrieve_topk.return_value = retrieval_result
+                result = coordinator._handle_sparse_retrieve(
+                    torch.empty((1, 1)),
+                    SimpleNamespace(layer_id=0),
+                    SimpleNamespace(req_pool_indices=torch.tensor([0])),
+                    "metadata",
+                )
+                self.assertEqual(result, "metadata")
+                self.assertEqual(
+                    coordinator.backend_adaptor.adapt_for_attn_metadata.call_args.kwargs[
+                        "metadata_prepared"
+                    ],
+                    prepared,
+                )

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -6,9 +6,12 @@ invariants hold (tokens * per_token_cost <= available_bytes).
 """
 
 import contextlib
+import json
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import torch
 
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.runtime_context import get_parallel
@@ -78,6 +81,7 @@ def _make_model_runner(
     disaggregation_mode="null",
     max_running_requests=None,
     disaggregation_decode_extra_slots=0,
+    enable_runtime_sparse_attention=False,
 ):
     """Create a mock ModelRunner with the fields configurators need."""
     mr = MagicMock()
@@ -114,7 +118,9 @@ def _make_model_runner(
     mc.linear_attn_registry_result = None
     mr.model_config = mc
 
-    mr.kv_cache_dtype = "fake_bf16"
+    mr.kv_cache_dtype = (
+        torch.bfloat16 if enable_runtime_sparse_attention else "fake_bf16"
+    )
 
     sa = SimpleNamespace()
     sa.swa_full_tokens_ratio = swa_full_tokens_ratio
@@ -134,6 +140,21 @@ def _make_model_runner(
     sa.disaggregation_decode_extra_slots = disaggregation_decode_extra_slots
     sa.enable_dsa_cache_layer_split = False
     sa.kv_cache_dtype = "auto"
+    sa.enable_hisparse = enable_runtime_sparse_attention
+    sa.hisparse_config = (
+        json.dumps(
+            {
+                "algorithm": "quest",
+                "backend": "fa3",
+                "page_size": page_size,
+            }
+        )
+        if enable_runtime_sparse_attention
+        else None
+    )
+    sa.prefill_attention_backend = None
+    sa.decode_attention_backend = None
+    sa.attention_backend = "fa3" if enable_runtime_sparse_attention else None
     mr.server_args = sa
 
     spec = MagicMock()
@@ -229,6 +250,40 @@ class TestDefaultConfigurator(unittest.TestCase):
         _, _, config = self._run(10_000_000)
         self.assertIsNone(config.full_max_total_num_tokens)
         self.assertIsNone(config.swa_max_total_num_tokens)
+
+    def test_runtime_quest_representation_memory_is_budgeted(self):
+        available = 10_000_000
+        page_size = 16
+        kvc, cfg, config = self._run(
+            available,
+            page_size=page_size,
+            enable_runtime_sparse_attention=True,
+        )
+        kv_bytes_per_token = _actual_memory_used(
+            kvc,
+            SimpleNamespace(max_total_num_tokens=1),
+        )
+        representation_bytes_per_page = kvc.layer_info.num_effective_layers * (
+            2 * kvc.model_config.get_num_kv_heads(1) * kvc.model_config.head_dim * 4 + 1
+        )
+        representation_pages = config.max_total_num_tokens // page_size + 1
+        used = (
+            config.max_total_num_tokens * kv_bytes_per_token
+            + representation_pages * representation_bytes_per_page
+        )
+        expected_pages = (available - representation_bytes_per_page) // (
+            page_size * kv_bytes_per_token + representation_bytes_per_page
+        )
+
+        self.assertEqual(
+            cfg._runtime_sparse_representation_bytes_per_page,
+            representation_bytes_per_page,
+        )
+        self.assertEqual(
+            config.max_total_num_tokens,
+            expected_pages * page_size,
+        )
+        self.assertLessEqual(used, available)
 
 
 class TestHybridSWAConfigurator(unittest.TestCase):

--- a/test/registered/unit/server_args/test_runtime_sparse_config.py
+++ b/test/registered/unit/server_args/test_runtime_sparse_config.py
@@ -1,0 +1,120 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.arg_groups.hisparse_hook import (
+    apply_runtime_sparse_eager_defaults,
+    use_runtime_sparse_cuda_graph,
+)
+from sglang.srt.mem_cache.sparsity import parse_runtime_sparse_config
+from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _args(config, *, page_size=16):
+    return SimpleNamespace(
+        enable_hisparse=True,
+        hisparse_config=json.dumps(config),
+        page_size=page_size,
+    )
+
+
+class TestRuntimeSparseConfig(unittest.TestCase):
+    def _parse(self, config, *, page_size=16):
+        with patch(
+            "sglang.srt.arg_groups.overrides.attention_backends_of",
+            return_value=("fa3", "fa3"),
+        ):
+            return parse_runtime_sparse_config(_args(config, page_size=page_size))
+
+    def test_parses_quest_runtime_options_and_rejects_page_mismatch(self):
+        config = self._parse(
+            {
+                "algorithm": "quest",
+                "backend": "fa3",
+                "page_size": 16,
+                "sparsity_ratio": 0.125,
+                "num_recent_pages": 4,
+            }
+        )
+        self.assertEqual(
+            (config.algorithm, config.backend, config.page_size),
+            ("quest", "fa3", 16),
+        )
+        self.assertEqual(config.sparse_extra_config["sparsity_ratio"], 0.125)
+        self.assertEqual(config.sparse_extra_config["num_recent_pages"], 4)
+
+        with self.assertRaisesRegex(ValueError, "page_size.*match"):
+            self._parse(
+                {"algorithm": "quest", "backend": "fa3", "page_size": 8},
+                page_size=16,
+            )
+
+    @patch(
+        "sglang.srt.arg_groups.hisparse_hook.use_runtime_sparse_attention",
+        return_value=True,
+    )
+    def test_graph_provider_controls_decode_while_prefill_remains_eager(
+        self, _mock_runtime
+    ):
+        for provider_ready, expected_decode in (
+            (False, Backend.DISABLED),
+            (True, Backend.BREAKABLE),
+        ):
+            with self.subTest(provider_ready=provider_ready), patch(
+                "sglang.srt.arg_groups.hisparse_hook.use_runtime_sparse_cuda_graph",
+                return_value=provider_ready,
+            ):
+                args = SimpleNamespace(
+                    cuda_graph_config=SimpleNamespace(
+                        prefill=SimpleNamespace(backend=Backend.BREAKABLE),
+                        decode=SimpleNamespace(backend=Backend.BREAKABLE),
+                    ),
+                    _cuda_graph_config_locked=set(),
+                )
+                apply_runtime_sparse_eager_defaults(args)
+                self.assertEqual(
+                    args.cuda_graph_config.prefill.backend, Backend.DISABLED
+                )
+                self.assertEqual(args.cuda_graph_config.decode.backend, expected_decode)
+
+    @patch(
+        "sglang.srt.arg_groups.hisparse_hook.use_runtime_sparse_attention",
+        return_value=True,
+    )
+    def test_missing_or_incapable_graph_provider_stays_eager(self, _mock_runtime):
+        args = _args(
+            {
+                "algorithm": "quest",
+                "backend": "fa3",
+                "page_size": 16,
+                "enable_cuda_graph_retrieval": True,
+            }
+        )
+        with patch("sglang.srt.arg_groups.hisparse_hook.find_spec", return_value=None):
+            self.assertFalse(use_runtime_sparse_cuda_graph(args))
+
+        provider = SimpleNamespace(
+            is_runtime_sparse_cuda_graph_available=lambda _coordinator: False
+        )
+        with (
+            patch(
+                "sglang.srt.arg_groups.overrides.attention_backends_of",
+                return_value=("fa3", "fa3"),
+            ),
+            patch(
+                "sglang.srt.arg_groups.hisparse_hook.find_spec", return_value=object()
+            ),
+            patch(
+                "sglang.srt.arg_groups.hisparse_hook.import_module",
+                return_value=provider,
+            ),
+            patch(
+                "sglang.srt.mem_cache.sparsity.factory._create_sparse_algorithm",
+                return_value=object(),
+            ),
+        ):
+            self.assertFalse(use_runtime_sparse_cuda_graph(args))


### PR DESCRIPTION
## Overview

This PR adds the correctness-first eager runtime that makes Quest sparse attention usable in SGLang serving. It owns configuration, memory accounting, request/coordinator lifecycle, the Dense-or-Quest attention boundary, and the portable FA3 metadata fallback.

The four PRs are independently based on `main` and do not require a controlled merge order. This PR exposes small optional hooks for later parts; when another part is absent or its capability check fails, runtime behavior remains on the existing Dense, PyTorch, or eager fallback.

| Part | Independent scope |
|---|---|
| Part 1, this PR ([#30277](https://github.com/sgl-project/sglang/pull/30277)) | Eager runtime integration, FA3 metadata fallback, and optional integration hooks |
| Part 2 ([#29666](https://github.com/sgl-project/sglang/pull/29666)) | Batched retrieval, host-sync reduction, and the full-page fast path |
| Part 3 ([#31790](https://github.com/sgl-project/sglang/pull/31790)) | Standalone score, page-update, finalize, and direct-FA metadata GPU kernels |
| Part 4 ([#31951](https://github.com/sgl-project/sglang/pull/31951)) | Standalone Breakable CUDA Graph provider and graph infrastructure |

## What this PR changes

At a high level, the request now follows one explicit runtime path:

```text
ServerArgs -> SparseConfig -> ModelRunner/SparseCoordinator
           -> Dense-or-Quest attention -> FA3 metadata -> FA3 attention
           -> per-layer Quest representation update
```

- Parse and validate the Quest runtime configuration before model startup.
- Include Quest representation memory in KV-cache sizing.
- Create and own `SparseCoordinator` through the model-runner and request lifecycle.
- Route eligible decoder layers through Quest retrieval while preserving Dense fallback for disabled, short, unsupported, or out-of-range cases.
- Recompute the active mask, valid page mask, `cache_seqlens`, and `cu_seqlens` for every layer, and update FA3 metadata in place.
- Disable fused KV prewrite while runtime Quest is active, so the current layer writes KV before its Quest representation is updated.
- Keep Quest prefill eager. Decode graph is retained only when an optional Part 4 provider exists and its real capability preflight succeeds.
- Expose small optional hooks for later providers: an algorithm `begin_forward` hook and a prepared-metadata retrieval result. When those hooks are absent, the normal two-value retrieval and portable path are unchanged.


## Baseline and historical evidence

| Archived stage | `8k-c8` Quest/Dense | `32k-c1` Quest/Dense | `32k-c4` Quest/Dense |
|---|---:|---:|---:|
| Original P0 functional baseline | 16.98% | 45.63% | 39.19% |
| Algorithm endpoint in the archived stacked order | 34.68% | 50.36% | 47.67% |
| Runtime endpoint in the archived stacked order | 33.34% | 47.64% | 46.24% |
| GPU-kernel endpoint in the archived stacked order | 45.99% | 55.83% | 55.15% |
| Breakable CUDA Graph endpoint in the archived stacked order | 95.53% | 87.52% | 84.75% |

These are archived supporting endpoint results. They came from the historical order P0 -> Algorithm -> Runtime -> GPU Kernels -> BCG; they are not isolated measurements of this independently based PR.

## Test Plan

- Run focused CPU tests for FA3 metadata, Dense fallback, runtime boundaries, and KV write order.
- Run runtime configuration/memory tests and changed-file checks.
- Run eager FA3 serving smoke and the fixed performance protocol.


## Test Result

```text
Focused runtime tests: 35 passed, 4 subtests passed
Split-diff source validation: passed
Qwen3-1.7B + FA3 eager serving: PASS
```


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30327034163](https://github.com/sgl-project/sglang/actions/runs/30327034163)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30327034124](https://github.com/sgl-project/sglang/actions/runs/30327034124)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->