### PR TITLE
Fix LTX2 RoPE JIT kernel CI

### DIFF
--- a/python/sglang/jit_kernel/csrc/diffusion/ltx2_qknorm_split_rope.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/ltx2_qknorm_split_rope.cuh
@@ -3,9 +3,8 @@
 // Developed with MIT HAN Lab Kernel Design Agents:
 // https://github.com/mit-han-lab/kernel-design-agents
 //
-// This mirrors the LTX2 eager oracle:
-//   torch.nn.RMSNorm(input) returns fp32 under bf16 autocast, then split RoPE
-//   runs in fp32 and rounds once to bf16 at the final attention input.
+// This mirrors the LTX2 eager oracle: RMSNorm and split RoPE both run in
+// fp32, rounding to bf16 only once at the final attention input.
 
 #pragma once
 

--- a/test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py
+++ b/test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 from sglang.jit_kernel.diffusion.ltx2_qknorm_split_rope import (
     can_use_ltx2_qknorm_split_rope_cuda,
@@ -72,17 +73,12 @@ def _reference(
     k_weight: torch.Tensor,
     eps: float,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    q_norm = torch.nn.RMSNorm(q.shape[-1], eps=eps, device="cuda").to(
-        dtype=torch.bfloat16
-    )
-    k_norm = torch.nn.RMSNorm(k.shape[-1], eps=eps, device="cuda").to(
-        dtype=torch.bfloat16
-    )
-    q_norm.weight.data.copy_(q_weight)
-    k_norm.weight.data.copy_(k_weight)
-    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
-        q_ref = _apply_split_rotary_ref(q_norm(q), q_cos, q_sin)
-        k_ref = _apply_split_rotary_ref(k_norm(k), k_cos, k_sin)
+    # rms_norm isn't autocast fp32-preserving, so feed fp32 inputs directly
+    # to keep the normalized value unrounded until the final RoPE output.
+    q_norm = F.rms_norm(q.float(), (q.shape[-1],), q_weight.float(), eps)
+    k_norm = F.rms_norm(k.float(), (k.shape[-1],), k_weight.float(), eps)
+    q_ref = _apply_split_rotary_ref(q_norm, q_cos, q_sin)
+    k_ref = _apply_split_rotary_ref(k_norm, k_cos, k_sin)
     return q_ref.to(dtype=torch.bfloat16), k_ref.to(dtype=torch.bfloat16)
 
 


### PR DESCRIPTION
```
python test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /sgl-workspace/sglang/test
configfile: pytest.ini
plugins: anyio-4.14.1, typeguard-4.5.2
collected 5 items                                                                                                                                                                                               

test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py::test_ltx2_qknorm_split_rope_matches_torch_exactly[1-3-3-32-128] PASSED
test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py::test_ltx2_qknorm_split_rope_matches_torch_exactly[1-5-2-32-64] PASSED
test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py::test_ltx2_qknorm_split_rope_matches_torch_exactly[2-4-3-32-64] PASSED
test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py::test_ltx2_qknorm_split_rope_rejects_unsupported_inputs PASSED
test/registered/jit/diffusion/test_ltx2_qknorm_split_rope.py::test_ltx2_qknorm_split_rope_custom_op_torch_compile_fullgraph PASSED

=============================================================================================== warnings summary ================================================================================================
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1309
../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1309
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1309: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; anyio
    self._mark_plugins_for_rewrite(hook, disable_autoload)

../../usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1434
  /usr/local/lib/python3.12/dist-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

registered/jit/diffusion/test_ltx2_qknorm_split_rope.py: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== 5 passed, 17 warnings in 1.40s =========================================================================================
```


Observed in https://github.com/sgl-project/sglang/actions/runs/28798849023/job/85396541208?pr=29690, https://github.com/sgl-project/sglang/actions/runs/28768180627/job/85296541953?pr=30117











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28806860654](https://github.com/sgl-project/sglang/actions/runs/28806860654)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28806860424](https://github.com/sgl-project/sglang/actions/runs/28806860424)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->