### PR TITLE
[refactor] Retire the attention_backend dual-apply (stack 5/11)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2102,6 +2102,13 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # reset writes the pristine default.
         "uses_mamba_radix_cache",
         "mamba_radix_cache_strategy",
+        # Runtime readers are on the mapped leaf (flags.attn.backend) or
+        # resolved_attention_backends(); every mid-resolution consumer reads
+        # a pass view; the hpu/cpu/npu early defaults are pre-resolution
+        # input synthesis; the HRM-Text runner force is a load-time
+        # declaration; the engine flashinfer preflight and the registry
+        # dispatch callables read the pristine input by design.
+        "attention_backend",
     }
 )
 
@@ -2141,25 +2148,18 @@ def apply_declarations_to_server_args(
             setattr(server_args, field, value)
 
 
-def refresh_declared_fields(server_args: Any, fields: Iterable[str]) -> None:
-    """Transition helper for legacy code that overwrites a resolved field
-    AFTER the override collection in ``__post_init__`` (e.g.
-    ``ModelRunner.model_specific_adjustment`` forcing ``attention_backend``
-    for HRM-Text). Redeclares the live value so publish parity holds and the
-    flags tier materializes the adjusted end state.
-    """
-    _missing = object()
-    declarations = server_args._resolved_overrides
-    for field in fields:
-        effective = _missing
-        for _source, decl in declarations:
-            if field in decl:
-                effective = decl[field]
-        if effective is _missing:
-            continue
-        live = getattr(server_args, field)
-        if effective != live:
-            declarations.append((f"runtime_adjustment[{field}]", {field: live}))
+def _hrm_text_attention_force(view: Any) -> dict:
+    """HRM-Text's bidirectional prefix attention only works on the Triton
+    backend. Invoked from ModelRunner.model_specific_adjustment (pre-publish,
+    once the architecture is known) at the legacy overwrite's slot."""
+    if view.attention_backend not in (None, "triton"):
+        logger.warning(
+            f"Overriding --attention-backend "
+            f"{view.attention_backend!r} -> 'triton': only the "
+            "Triton backend supports HRM-Text's bidirectional prefix "
+            "attention."
+        )
+    return {"attention_backend": "triton"}
 
 
 def assert_flag_parity(

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -290,16 +290,19 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
         initialize_linear_attn_config(runner.server_args)
         hybrid_backend_cls = HybridLinearAttnBackend
         if runner.hybrid_gdn_config is not None:
+            from sglang.srt.runtime_context import get_flags
+
+            attention_backend = get_flags().attn.backend
             if is_blackwell():
-                assert (
-                    runner.server_args.attention_backend == "triton"
-                    or runner.server_args.attention_backend == "trtllm_mha"
-                    or runner.server_args.attention_backend == "fa4"
-                    or runner.server_args.attention_backend == "flashinfer"
+                assert attention_backend in (
+                    "triton",
+                    "trtllm_mha",
+                    "fa4",
+                    "flashinfer",
                 ), "triton, trtllm_mha, fa4, or flashinfer backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend to specify the backend."
             if is_npu():
                 assert (
-                    runner.server_args.attention_backend == "ascend"
+                    attention_backend == "ascend"
                 ), "ascend backend is the only supported backend on NPU for hybrid GDN models, use --attention-backend ascend to specify the backend."
             logger.info(f"Using hybrid linear attention backend for hybrid GDN models.")
             linear_attn_backend = GDNAttnBackend(runner)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1352,8 +1352,10 @@ class Scheduler(
             "flashinfer": ("SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE", 4096),
             "triton": ("SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE", 4096),
         }
+        from sglang.srt.runtime_context import get_flags
+
         env_var, default_size = backend_sizes.get(
-            self.server_args.attention_backend, (None, None)
+            get_flags().attn.backend, (None, None)
         )
         self.truncation_align_size = (
             get_int_env_var(env_var, default_size) if env_var else None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -49,7 +49,7 @@ from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     ForwardBatchDeepSeekMHAMixin,
 )
 from sglang.srt.model_executor.triton_ops.position import compute_position_triton
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     is_cuda,
@@ -830,7 +830,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 ret.extend_prefix_lens = extend_prefix_lens
             ret.extend_num_tokens = batch.extend_num_tokens
             positions, ret.extend_start_loc = compute_position(
-                model_runner.server_args.attention_backend,
+                get_flags().attn.backend,
                 ret.extend_prefix_lens,
                 ret.extend_seq_lens,
                 ret.extend_num_tokens,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1147,14 +1147,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # bidirectional-attention forcing and silently produce junk output.
         is_prefix_lm_recurrent = is_hrm_text and getattr(hf_config, "prefix_lm", True)
         if is_prefix_lm_recurrent:
-            if server_args.attention_backend not in (None, "triton"):
-                logger.warning(
-                    f"Overriding --attention-backend "
-                    f"{server_args.attention_backend!r} -> 'triton': only the "
-                    "Triton backend supports HRM-Text's bidirectional prefix "
-                    "attention."
-                )
-            server_args.attention_backend = "triton"
+            from sglang.srt.arg_groups.overrides import (
+                _hrm_text_attention_force,
+                run_post_process_pass,
+            )
+
+            run_post_process_pass(server_args, _hrm_text_attention_force)
             server_args.chunked_prefill_size = -1
             server_args.disable_radix_cache = True
             server_args.disable_cuda_graph = True
@@ -1173,22 +1171,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     f"{self.model_config.hf_config.model_type}"
                 )
 
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if (
             not self.use_mla_backend
-            or server_args.attention_backend
+            or resolved_view(server_args).attention_backend
             not in CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS
         ):
             server_args.disable_chunked_prefix_cache = True
 
         if not server_args.disable_chunked_prefix_cache:
             log_info_on_rank0(logger, "Chunked prefix cache is turned on.")
-
-        # The imperative adjustments above may overwrite fields the resolution passes
-        # already declared (HRM-Text forces attention_backend); redeclare the
-        # adjusted values so publish parity holds.
-        from sglang.srt.arg_groups.overrides import refresh_declared_fields
-
-        refresh_declared_fields(server_args, ("attention_backend",))
 
     def check_quantized_moe_compatibility(self):
         if (
@@ -2571,7 +2564,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
         else:
             attn_backend = self._get_attention_backend_from_str(
-                self.server_args.attention_backend,
+                get_flags().attn.backend,
                 init_new_workspace=init_new_workspace,
             )
 

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -330,9 +330,7 @@ class ModelRunnerKVCacheMixin:
             unsupported_pool_family = "DeepSeekV4TokenToKVPool"
         elif current_platform.is_out_of_tree() and not self.mambaish_config:
             unsupported_pool_family = "out-of-tree platform KV pool"
-        elif (
-            self.server_args.attention_backend == "ascend" and not self.mambaish_config
-        ):
+        elif get_flags().attn.backend == "ascend" and not self.mambaish_config:
             unsupported_pool_family = "NPU/Ascend KV pool"
         elif self.use_mla_backend and is_dsa_model:
             unsupported_pool_family = "DSA/MLA KV pool"
@@ -772,9 +770,7 @@ class ModelRunnerKVCacheMixin:
                     start_layer=self.start_layer,
                     end_layer=self.end_layer,
                 )
-        elif (
-            self.server_args.attention_backend == "ascend" and not self.mambaish_config
-        ):
+        elif get_flags().attn.backend == "ascend" and not self.mambaish_config:
             if self.is_hybrid_swa:
                 from sglang.srt.hardware_backend.npu.memory_pool_npu import (
                     NPUMHATokenToKVPool,
@@ -1059,7 +1055,7 @@ class ModelRunnerKVCacheMixin:
                     need_sort=need_sort,
                 )
             elif _is_npu and (
-                self.server_args.attention_backend == "ascend"
+                get_flags().attn.backend == "ascend"
                 or is_dsv4_model
                 or self.hybrid_gdn_config is not None
             ):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3763,6 +3763,7 @@ class ServerArgs:
         from sglang.srt.arg_groups.overrides import (
             apply_declarations_to_server_args,
             collect_model_override_declarations,
+            resolved_view,
         )
 
         self._resolved_overrides = collect_model_override_declarations(
@@ -4032,14 +4033,15 @@ class ServerArgs:
         ):
             # Attention backend auto-select moved to the override registry
             # (arg_groups/overrides.py: _llama4_overrides).
-            assert self.attention_backend in {
+            attention_backend = resolved_view(self).attention_backend
+            assert attention_backend in {
                 "fa3",
                 "aiter",
                 "triton",
                 "ascend",
                 "trtllm_mha",
                 "intel_xpu",
-            }, f"fa3, aiter, triton, ascend, trtllm_mha or intel_xpu is required for Llama4 model but got {self.attention_backend}"
+            }, f"fa3, aiter, triton, ascend, trtllm_mha or intel_xpu is required for Llama4 model but got {attention_backend}"
             # The moe_runner_backend selection moved to the override registry
             # (arg_groups/overrides.py: _llama4_overrides).
         # Gemma2/Gemma3 (disable_hybrid_swa_memory) moved to the override registry
@@ -4073,9 +4075,10 @@ class ServerArgs:
                 # (arg_groups/overrides.py: _exaone_overrides).
                 # https://docs.sglang.ai/advanced_features/attention_backend.html
                 accepted_backends = ["fa3", "triton", "trtllm_mha"]
+                attention_backend = resolved_view(self).attention_backend
                 assert (
-                    self.attention_backend in accepted_backends
-                ), f"One of the attention backends in {accepted_backends} is required for {model_arch}, but got {self.attention_backend}"
+                    attention_backend in accepted_backends
+                ), f"One of the attention backends in {accepted_backends} is required for {model_arch}, but got {attention_backend}"
         elif model_arch in ["Olmo2ForCausalLM"]:
             # disable_hybrid_swa_memory + attention backend selection moved to
             # the override registry (arg_groups/overrides.py: _olmo2_overrides).
@@ -4083,18 +4086,19 @@ class ServerArgs:
             # Flashinfer appears to degrade performance when sliding window attention
             # is used for the Olmo2 architecture. Olmo2 does not use sliding window attention
             # but Olmo3 does.
+            attention_backend = resolved_view(self).attention_backend
             assert (
-                self.attention_backend != "flashinfer"
+                attention_backend != "flashinfer"
             ), "FlashInfer backend can significantly degrade the performance of Olmo3 models."
 
             logger.info(
-                f"Using {self.attention_backend} as attention backend for {model_arch}."
+                f"Using {attention_backend} as attention backend for {model_arch}."
             )
         elif model_arch in ["NemotronHForCausalLM", "NemotronHPuzzleForCausalLM"]:
             # Quantization / MoE runner / attention backend defaults moved to
             # the override registry (arg_groups/overrides.py:
             # _nemotron_h_overrides).
-            assert self.attention_backend != "triton", (
+            assert resolved_view(self).attention_backend != "triton", (
                 "NemotronHForCausalLM does not support triton attention backend,"
                 "as the first layer might not be an attention layer"
             )
@@ -4121,7 +4125,7 @@ class ServerArgs:
         elif model_arch in ["Lfm2ForCausalLM"]:
             # Attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _lfm2_overrides).
-            assert self.attention_backend != "triton", (
+            assert resolved_view(self).attention_backend != "triton", (
                 f"{model_arch} does not support triton attention backend, "
                 "as the first layer might not be an attention layer"
             )
@@ -4305,6 +4309,7 @@ class ServerArgs:
             _fa4_page_constraint,
             _intel_xpu_page_constraint,
             _mla_backend_page_constraints,
+            resolved_view,
             run_post_process_pass,
         )
 
@@ -4312,14 +4317,15 @@ class ServerArgs:
         run_post_process_pass(self, _attention_backend_default)
 
         # Torch native and flex attention backends
-        if self.attention_backend == "torch_native":
+        attention_backend = resolved_view(self).attention_backend
+        if attention_backend == "torch_native":
             logger.warning(
                 "Cuda graph is disabled because of using torch native attention backend"
             )
             self.cuda_graph_config.decode.backend = Backend.DISABLED
             self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
-        if self.attention_backend == "flex_attention":
+        if attention_backend == "flex_attention":
             logger.warning(
                 "Cuda graph is disabled because of using torch Flex Attention backend"
             )
@@ -4378,7 +4384,7 @@ class ServerArgs:
         run_post_process_pass(self, _fa4_page_constraint)
 
         # AMD platforms backends
-        if self.attention_backend == "aiter":
+        if resolved_view(self).attention_backend == "aiter":
             if model_config.context_len > 8192:
                 self.mem_fraction_static *= 0.85
 
@@ -4395,7 +4401,7 @@ class ServerArgs:
 
         # Dual chunk flash attention backend
         run_post_process_pass(self, _attention_backend_dual_chunk)
-        if self.attention_backend == "dual_chunk_flash_attn":
+        if resolved_view(self).attention_backend == "dual_chunk_flash_attn":
             logger.warning(
                 "Mixed chunk and radix cache are disabled when using dual-chunk flash attention backend"
             )
@@ -4404,11 +4410,14 @@ class ServerArgs:
 
     def _handle_kv4_compatibility(self):
         """Check FP4 KV cache compatibility with the attention backend"""
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if self.kv_cache_dtype != "fp4_e2m1":
             return
 
         use_mla_backend = self.use_mla_backend()
         prefill_backend, decode_backend = self._resolved_attention_backends()
+        attention_backend = resolved_view(self).attention_backend
 
         if is_cuda():
             if (
@@ -4449,11 +4458,9 @@ class ServerArgs:
                             "trtllm_mla",
                             "flashmla",
                         ]
-                        assert (
-                            self.attention_backend in KV4_ATTENTION_MLA_BACKEND_CHOICES
-                        ), (
+                        assert attention_backend in KV4_ATTENTION_MLA_BACKEND_CHOICES, (
                             f"KV4 MLA expects attention_backend to be one of "
-                            f"{KV4_ATTENTION_MLA_BACKEND_CHOICES}, but got {self.attention_backend}"
+                            f"{KV4_ATTENTION_MLA_BACKEND_CHOICES}, but got {attention_backend}"
                         )
                     else:  # !FA4 + MHA
                         KV4_ATTENTION_MHA_BACKEND_CHOICES = [
@@ -4462,11 +4469,9 @@ class ServerArgs:
                             "flex_attention",
                             "trtllm_mha",
                         ]
-                        assert (
-                            self.attention_backend in KV4_ATTENTION_MHA_BACKEND_CHOICES
-                        ), (
+                        assert attention_backend in KV4_ATTENTION_MHA_BACKEND_CHOICES, (
                             f"KV4 MHA expects attention_backend to be one of "
-                            f"{KV4_ATTENTION_MHA_BACKEND_CHOICES}, but got {self.attention_backend}"
+                            f"{KV4_ATTENTION_MHA_BACKEND_CHOICES}, but got {attention_backend}"
                         )
         else:
             raise RuntimeError("KV4 is not tested on non-CUDA platforms.")
@@ -5228,14 +5233,16 @@ class ServerArgs:
         Must run after _handle_attention_backend_compatibility() (which fills
         the default attention_backend if unset) and _handle_multi_item_scoring()
         (which may further mutate it). The assertion below guards against
-        accidental call-site reordering: if attention_backend is still None,
-        backends haven't settled yet and get_attention_backends() would return
-        a stale (None, None).
+        accidental call-site reordering: if the resolved attention_backend is
+        still None, backends haven't settled yet and the resolved (prefill,
+        decode) pair would be a stale (None, None).
         """
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         if not self.prefill_only_disable_kv_cache:
             return
 
-        assert self.attention_backend is not None, (
+        assert resolved_view(self).attention_backend is not None, (
             "_handle_prefill_only_disable_kv_cache must run after "
             "_handle_attention_backend_compatibility() so the prefill backend is resolved."
         )
@@ -5733,6 +5740,7 @@ class ServerArgs:
             from sglang.srt.arg_groups.overrides import (
                 _deterministic_attention_backend,
                 _deterministic_sampling_backend,
+                resolved_view,
                 run_post_process_pass,
             )
 
@@ -5756,20 +5764,18 @@ class ServerArgs:
             # Check attention backend
             run_post_process_pass(self, _deterministic_attention_backend)
 
+            attention_backend = resolved_view(self).attention_backend
             if is_deepseek_model:
-                if self.attention_backend not in ["fa3", "triton"]:
+                if attention_backend not in ["fa3", "triton"]:
                     raise ValueError(
-                        f"Currently only {RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND} attention backends are supported for deterministic inference with DeepSeek models. But you're using {self.attention_backend}."
+                        f"Currently only {RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND} attention backends are supported for deterministic inference with DeepSeek models. But you're using {attention_backend}."
                     )
 
-            if (
-                self.attention_backend
-                not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND
-            ):
+            if attention_backend not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND:
                 # Currently, only certain backends support radix cache. Support for other backends is in progress
                 self.disable_radix_cache = True
                 logger.warning(
-                    f"Currently radix cache is not compatible with {self.attention_backend} attention backend for deterministic inference. It will be supported in the future."
+                    f"Currently radix cache is not compatible with {attention_backend} attention backend for deterministic inference. It will be supported in the future."
                 )
 
             # Check TP size

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -14,6 +14,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     compute_position,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
@@ -1278,7 +1279,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                     "DFLASH prefill expected out_cache_loc, but got None."
                 )
             positions, _ = compute_position(
-                self.model_runner.server_args.attention_backend,
+                get_flags().attn.backend,
                 draft_seq_lens,
                 ctx_lens,
                 int(sum(batch.extend_lens)),

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -587,21 +587,21 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "LlamaForCausalLM", "llama", enable_deterministic_inference=True
         )
         # two pass writers chain: default fill, then the deterministic force —
-        # last writer wins on the flags leaf; the server_args field stays
+        # last writer wins on the flags leaf; the server_args fields stay
         # pristine (dual-apply retired).
         self.assertIsNone(sa.sampling_backend)
+        self.assertIsNone(sa.attention_backend)
         flags = self._publish(sa)
         self.assertEqual(flags.sampling_backend, "pytorch")
         # the deterministic attention fill declared a compatible backend and
         # the compatibility default-fill then had nothing to do
-        self.assertIn(
-            (
-                "_deterministic_attention_backend",
-                {"attention_backend": sa.attention_backend},
-            ),
-            sa._resolved_overrides,
-        )
-        self.assertEqual(flags.attn.backend, sa.attention_backend)
+        deterministic_fills = [
+            decl["attention_backend"]
+            for source, decl in sa._resolved_overrides
+            if source == "_deterministic_attention_backend"
+        ]
+        self.assertEqual(len(deterministic_fills), 1)
+        self.assertEqual(flags.attn.backend, deterministic_fills[0])
 
     def test_deterministic_incompatible_backend_raises(self):
         from sglang.srt.arg_groups.overrides import (
@@ -638,7 +638,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             dllm_algorithm="LowConfidence",
             disable_radix_cache=True,
         )
-        self.assertEqual(sa.attention_backend, "flashinfer")
+        self.assertIsNone(sa.attention_backend)  # dual-apply retired: pristine
         self.assertIn(
             ("_dllm_attention_backend", {"attention_backend": "flashinfer"}),
             sa._resolved_overrides,
@@ -648,25 +648,35 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_attention_backend_leaf_materializes_end_state(self):
         # The default-fill pass declares the platform-selected backend; the
-        # leaf must equal the final server_args value (publish parity).
+        # leaf must equal the last declared value while the server_args field
+        # stays pristine (dual-apply retired).
         sa = self._construct("LlamaForCausalLM", "llama")
-        declared = {f for _s, d in sa._resolved_overrides for f in d}
-        self.assertIn("attention_backend", declared)  # default fill declared
-        self.assertEqual(self._publish(sa).attn.backend, sa.attention_backend)
+        declared_values = [
+            d["attention_backend"]
+            for _s, d in sa._resolved_overrides
+            if "attention_backend" in d
+        ]
+        self.assertTrue(declared_values)  # default fill declared
+        self.assertIsNone(sa.attention_backend)
+        self.assertEqual(self._publish(sa).attn.backend, declared_values[-1])
 
-    def test_runner_side_adjustment_can_refresh_declaration(self):
-        from sglang.srt.arg_groups.overrides import refresh_declared_fields
+    def test_runner_side_adjustment_declares_at_its_slot(self):
+        from sglang.srt.arg_groups.overrides import (
+            _hrm_text_attention_force,
+            run_post_process_pass,
+        )
 
+        # Runner-side adjustment between collection and publish (HRM-Text
+        # forces attention_backend) declares through the pass slot: last
+        # writer on the stash wins the leaf, the field stays pristine.
         sa = self._construct("LlamaForCausalLM", "llama")
-        declared = {f for _s, d in sa._resolved_overrides for f in d}
-        self.assertIn("attention_backend", declared)
-        # Simulate a legacy runner-side overwrite between collection and publish
-        # (model_specific_adjustment forces attention_backend for HRM-Text).
-        sa.attention_backend = "fa3" if sa.attention_backend != "fa3" else "triton"
-        with self.assertRaises(AssertionError):
-            self._publish(sa)  # stale declaration breaks parity
-        refresh_declared_fields(sa, ("attention_backend",))
-        self.assertEqual(self._publish(sa).attn.backend, sa.attention_backend)
+        run_post_process_pass(sa, _hrm_text_attention_force)
+        self.assertIsNone(sa.attention_backend)
+        self.assertIn(
+            ("_hrm_text_attention_force", {"attention_backend": "triton"}),
+            sa._resolved_overrides,
+        )
+        self.assertEqual(self._publish(sa).attn.backend, "triton")
 
     def test_attention_backend_user_choice_declares_nothing_extra(self):
         sa = self._construct("LlamaForCausalLM", "llama", attention_backend="triton")


### PR DESCRIPTION
Unit 5 of the dual-apply retirement stack (continues #30228–#30231; the series grows to 11 units, ending with the removal of the transition machinery itself). Based on #30231.

The base attention backend joins the split pair on the flags tier: `server_args.attention_backend` returns to pristine user input, and `flags.attn.backend` alone carries the resolved value.

Post-publish readers move to the tier: the ModelRunner backend construction, the chunked-prefix-cache gate, the attention registry's hybrid-GDN platform asserts, the scheduler truncation-align sizing, the extend-position computation (forward_batch_info and the DFLASH worker) and the kv-cache mixin's ascend checks. Mid-resolution readers go through pass views: the arch-specific backend asserts, the interleaved compatibility-handler reads, the kv4 base-backend choices, the prefill-only settledness assert and the deterministic-inference checks.

The HRM-Text runner-side force becomes the `_hrm_text_attention_force` pass at its legacy slot (pre-publish: `model_specific_adjustment` runs just before the scheduler-process publish), which obsoletes `refresh_declared_fields` — removed with its sole client. The hpu/cpu/npu early defaults stay as pre-resolution input synthesis; the engine flashinfer preflight and the registry dispatch callables keep reading the pristine input by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28820083453](https://github.com/sgl-project/sglang/actions/runs/28820083453)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28820083416](https://github.com/sgl-project/sglang/actions/runs/28820083416)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->