### PR TITLE
[refactor] Retire the page_size dual-apply (stack 6/11)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1956,14 +1956,23 @@ def _dllm_overlap_disable(view: Any) -> dict:
 
 @register_post_process
 def _dllm_page_size(view: Any) -> dict:
-    if view.dllm_algorithm is None or view.disable_radix_cache:
+    if view.dllm_algorithm is None:
         return {}
     from sglang.srt.dllm.config import DllmConfig
 
     config = DllmConfig.from_server_args(view)
-    if view.page_size % config.block_size != 0:
+    if not view.disable_radix_cache and view.page_size % config.block_size != 0:
         logger.warning(
             f"Setting page size to {config.block_size} for diffusion LLM inference"
+        )
+        return {"page_size": config.block_size}
+    if view.page_size > config.block_size:
+        # Legacy scheduler-init fallback, folded into the pass: the page
+        # size must not exceed the dllm block size.
+        logger.warning(
+            "WARNING: "
+            f"The page size {view.page_size} should not be larger than dllm block size {config.block_size}."
+            f"Page size now falls back to {config.block_size}"
         )
         return {"page_size": config.block_size}
     return {}
@@ -2109,6 +2118,14 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # declaration; the engine flashinfer preflight and the registry
         # dispatch callables read the pristine input by design.
         "attention_backend",
+        # KV sizing, workers and attention backends read the leaf; the
+        # scheduler / ModelRunner pre-publish captures, the
+        # mamba_cache_chunk_size property, the chunked-prefill divisibility
+        # check, the kv-events describe (launcher-side) and the
+        # default-backend spec gate read the view; the dllm scheduler-init
+        # page fallback is folded into the _dllm_page_size pass; the npu
+        # early default is pre-resolution input synthesis.
+        "page_size",
     }
 )
 

--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -75,7 +75,7 @@ patches:
       - match: |
           if (
               server_args.speculative_algorithm is not None
-              and server_args.page_size > 1
+              and (resolved_view(server_args).page_size or 1) > 1
               and (server_args.speculative_eagle_topk or 1) > 1
           ):
               extra = max(extra, get_alloc_reserve_per_decode(server_args))

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.memory_pool_host import (
     MLATokenToKVPoolHost,
     get_mha_host_pool_cls,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import ceil_align
 
@@ -44,7 +45,7 @@ class DecodeKVCacheOffloadManager:
     ) -> None:
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.server_args = server_args
         self.request_counter = 0
         self.tree_cache = tree_cache

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -72,6 +72,7 @@ from sglang.srt.layers.attention.utils import (
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import get_bool_env_var
 
 logger = logging.getLogger(__name__)
@@ -145,7 +146,7 @@ class AiterAttnBackend(AttentionBackend):
 
         self.input_dtype = model_runner.model_config.dtype
 
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
         self.extend_attention_fwd = torch.compiler.disable(extend_attention_fwd)
 
@@ -2795,7 +2796,7 @@ class AiterMultiStepDraftBackend:
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
     def common_template(
         self, forward_batch: ForwardBatch, kv_indices_buffer: torch.Tensor, call_fn: int

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -34,6 +34,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.speculative.spec_utils import (
@@ -968,7 +969,7 @@ class FlashInferMLAMultiStepDraftBackend:
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
     def common_template(
         self,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -27,7 +27,7 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.cuda_graph_config import cuda_graph_fully_disabled
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
     draft_kv_indices_used_len,
@@ -1817,7 +1817,7 @@ class TritonMultiStepDraftBackend:
         # Cached variables for generate_draft_decode_kv_indices
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]
-        self.page_size = model_runner.server_args.page_size
+        self.page_size = get_flags().page_size
 
     def common_template(
         self,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -348,7 +348,9 @@ class Scheduler(
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-        self.page_size = server_args.page_size
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.page_size = resolved_view(server_args).page_size
         self.enable_hierarchical_cache = server_args.enable_hierarchical_cache
         self.enable_hicache_storage = server_args.hicache_storage_backend is not None
         self.enable_decode_hicache = (
@@ -585,15 +587,6 @@ class Scheduler(
                 if self.server_args.dllm_algorithm is not None
                 else None
             )
-            if self.dllm_config:
-                if self.dllm_config.block_size < self.page_size:
-                    logger.warning(
-                        "WARNING: "
-                        f"The page size {self.page_size} should not be larger than dllm block size {self.dllm_config.block_size}."
-                        f"Page size now falls back to {self.dllm_config.block_size}"
-                    )
-                    self.page_size = self.dllm_config.block_size
-                    self.server_args.page_size = self.dllm_config.block_size
 
     def init_metrics_collector(
         self, tp_rank: int, pp_rank: int, dp_rank: Optional[int]

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -222,8 +222,10 @@ def get_alloc_len_per_decode(server_args: Optional[ServerArgs] = None) -> int:
     # Spec decoding allocates max(topk * num_steps, num_draft_tokens) per decode step.
     spec_steps = server_args.speculative_num_steps or 1
     spec_topk = server_args.speculative_eagle_topk or 1
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     spec_tokens = server_args.max_speculative_num_draft_tokens
-    page_size = server_args.page_size
+    page_size = resolved_view(server_args).page_size
 
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
@@ -255,11 +257,13 @@ def get_req_to_token_extra_context_len(server_args: ServerArgs) -> int:
     Sized to hold the decode over-allocation; the spec v2 page>1 topk>1 holey
     draft footprint can outgrow the default num_draft_tokens headroom.
     """
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     # FIXME(lsyin): temporary fix for the context length issue under spec decoding
     extra = 4 + (server_args.max_speculative_num_draft_tokens or 0)
     if (
         server_args.speculative_algorithm is not None
-        and server_args.page_size > 1
+        and (resolved_view(server_args).page_size or 1) > 1
         and (server_args.speculative_eagle_topk or 1) > 1
     ):
         extra = max(extra, get_alloc_reserve_per_decode(server_args))
@@ -659,7 +663,7 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     start_p, end_p = req.pop_overallocated_kv_cache()
 
     global_server_args = get_global_server_args()
-    page_size = global_server_args.page_size
+    page_size = get_flags().page_size
     spec_algo = global_server_args.speculative_algorithm
 
     # strip_thinking_cache intentionally reports output tokens as overallocated

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -404,7 +404,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-        self.page_size = server_args.page_size
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.page_size = resolved_view(server_args).page_size
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.is_hybrid_swa = model_config.is_hybrid_swa

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -1302,7 +1302,7 @@ class ModelRunnerKVCacheMixin:
         )
 
         available_bytes = self._profile_available_bytes(pre_model_load_memory)
-        page_size = self.server_args.page_size
+        page_size = get_flags().page_size
 
         configurator = create_memory_pool_configurator(self)
         config = configurator.calculate_pool_sizes(available_bytes, page_size)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4254,14 +4254,18 @@ class ServerArgs:
 
         if not use_mla_backend:
             # MHA architecture
-            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(self):
+            from sglang.srt.arg_groups.overrides import resolved_view
+
+            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(
+                resolved_view(self)
+            ):
                 # Note: flashinfer 0.6.1 caused performance regression on Hopper attention kernel
                 # Before the kernel is fixed, we choose fa3 as the default backend on Hopper MHA
                 # ref: https://github.com/sgl-project/sglang/issues/17411
                 return "fa3"
             elif (
                 is_sm100_supported()
-                and is_no_spec_infer_or_topk_one(self)
+                and is_no_spec_infer_or_topk_one(resolved_view(self))
                 and (
                     self.speculative_algorithm is None
                     or self.speculative_eagle_topk is not None
@@ -5890,12 +5894,16 @@ class ServerArgs:
         run_post_process_pass(self, _dllm_attention_backend)
         run_post_process_pass(self, _dllm_overlap_disable)
 
-        if not self.disable_radix_cache:
-            # The page_size adjustment moved to the resolution pipeline
-            # (arg_groups/overrides.py: _dllm_page_size).
-            from sglang.srt.arg_groups.overrides import _dllm_page_size
+        # The page-size alignment + block-size cap for dllm moved to the
+        # resolution pipeline (arg_groups/overrides.py: _dllm_page_size).
+        # Invoked outside the radix gate: the alignment fill keeps its radix
+        # gate inside the pass, the block-size cap applies regardless (it
+        # replaces the unconditional scheduler-init fallback).
+        from sglang.srt.arg_groups.overrides import _dllm_page_size
 
-            run_post_process_pass(self, _dllm_page_size)
+        run_post_process_pass(self, _dllm_page_size)
+
+        if not self.disable_radix_cache:
             if self.enable_hierarchical_cache:
                 logger.warning(
                     "Hierarchical cache is disabled because of using diffusion LLM inference"
@@ -6425,12 +6433,15 @@ class ServerArgs:
         # (or mamba_chunk_size if it is defined in the model's config) and page_size.
         # It is used to determine the caching point in a sequence during prefill.
         if not hasattr(self, "_mamba_cache_chunk_size"):
+            from sglang.srt.arg_groups.overrides import resolved_view
+
             hf_config = self.get_model_config().hf_config
             chunk_size = getattr(hf_config, "mamba_chunk_size", FLA_CHUNK_SIZE)
+            page_size = resolved_view(self).page_size
             assert (
-                max(chunk_size, self.page_size) % min(chunk_size, self.page_size) == 0
-            ), f"For SSM models, either chunk_size or page_size must be divisible by the other, got {chunk_size=}, {self.page_size=}"
-            self._mamba_cache_chunk_size = max(chunk_size, self.page_size)
+                max(chunk_size, page_size) % min(chunk_size, page_size) == 0
+            ), f"For SSM models, either chunk_size or page_size must be divisible by the other, got {chunk_size=}, {page_size=}"
+            self._mamba_cache_chunk_size = max(chunk_size, page_size)
         return self._mamba_cache_chunk_size
 
     def _check_two_batch_overlap(self):
@@ -6509,8 +6520,10 @@ class ServerArgs:
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).
         # Skip validation if disaggregation mode is decode.
         if self.chunked_prefill_size > 0 and self.disaggregation_mode != "decode":
+            from sglang.srt.arg_groups.overrides import resolved_view
+
             assert (
-                self.chunked_prefill_size % self.page_size == 0
+                self.chunked_prefill_size % resolved_view(self).page_size == 0
             ), "chunked_prefill_size must be divisible by page_size"
 
         # Check pdmux
@@ -6962,10 +6975,11 @@ class ServerArgs:
         """
         # Lazy import so loading server_args doesn't pull in
         # disaggregation / msgspec / zmq at module top level.
+        from sglang.srt.arg_groups.overrides import resolved_view
         from sglang.srt.disaggregation.kv_events import KVEventsConfig
 
         raw = self.kv_events_config
-        page_size = self.page_size
+        page_size = resolved_view(self).page_size
         if not raw or page_size is None or page_size <= 0:
             return None
         try:

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -118,7 +118,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.nccl_port = nccl_port
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         # Normalized in arg_groups.speculative_hook.handle_speculative_decoding.
         self.draft_window_size: Optional[int] = (
             server_args.speculative_draft_window_size

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -46,6 +46,7 @@ from sglang.srt.model_executor.runner import (
     DecodeCudaGraphRunner,
     get_batch_sizes_to_capture,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -985,7 +986,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -40,7 +40,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.runtime_context import resolved_attention_backends
+from sglang.srt.runtime_context import get_flags, resolved_attention_backends
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import EagleDraftWorkerBase
 from sglang.srt.speculative.eagle_utils import (
@@ -105,7 +105,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self.target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
@@ -667,7 +667,7 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -40,6 +40,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
@@ -632,7 +633,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -11,6 +11,7 @@ from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
@@ -60,7 +61,7 @@ class NGRAMWorker(BaseSpecWorker):
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self.tp_rank = tp_rank
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.draft_token_num: int = server_args.speculative_num_draft_tokens
         self.max_trie_depth: int = server_args.speculative_ngram_max_trie_depth
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -7,6 +7,7 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -172,7 +173,7 @@ class StandaloneWorkerV2(EAGLEWorkerV2):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_flags().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3734,7 +3734,9 @@ def spec_decode_alloc_len_per_request(server_args) -> int:
     """Per-request KV tokens a (spec-v1) decode step allocates: the draft-decode
     topk*num_steps peak vs. the verify num_draft_tokens, page-aligned.
     """
-    page_size = server_args.page_size
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    page_size = resolved_view(server_args).page_size
     len_per_topk = server_args.speculative_num_steps or 1
     spec_topk = server_args.speculative_eagle_topk or 1
     spec_tokens = server_args.speculative_num_draft_tokens or 1

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -354,7 +354,10 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
 
         args._handle_attention_backend_compatibility()
 
-        self.assertEqual(args.page_size, 128)
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.assertEqual(args.page_size, 1)  # dual-apply retired: pristine
+        self.assertEqual(resolved_view(args).page_size, 128)
 
     @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=True)
     @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
@@ -364,7 +367,10 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
 
         args._handle_attention_backend_compatibility()
 
-        self.assertEqual(args.page_size, 128)
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        self.assertEqual(args.page_size, 1)  # dual-apply retired: pristine
+        self.assertEqual(resolved_view(args).page_size, 128)
 
 
 class TestContextParallelServerArgs(CustomTestCase):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -632,8 +632,10 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_dllm_forces_flashinfer_with_cuda_graph(self):
         # CUDA path: cuda graph enabled by default -> dllm forces flashinfer.
+        # A real dllm arch: the page pass now runs regardless of the radix
+        # switch and builds DllmConfig for it.
         sa = self._construct(
-            "LlamaForCausalLM",
+            "SDARForCausalLM",
             "llama",
             dllm_algorithm="LowConfidence",
             disable_radix_cache=True,
@@ -809,9 +811,17 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             return_value=SimpleNamespace(block_size=32),
         ):
             self.assertEqual(_view() and _dllm_page_size(_view()), {"page_size": 32})
-            self.assertEqual(_dllm_page_size(_view(page_size=64)), {})  # aligned
+            # aligned but larger than the block: the scheduler-init fallback
+            # (folded into this pass) still caps the page at the block size
+            self.assertEqual(_dllm_page_size(_view(page_size=64)), {"page_size": 32})
+            self.assertEqual(_dllm_page_size(_view(page_size=32)), {})  # equal
+            # radix disabled skips the alignment fill but keeps the cap
+            self.assertEqual(_dllm_page_size(_view(disable_radix_cache=True)), {})
+            self.assertEqual(
+                _dllm_page_size(_view(disable_radix_cache=True, page_size=64)),
+                {"page_size": 32},
+            )
         self.assertEqual(_dllm_page_size(_view(dllm_algorithm=None)), {})
-        self.assertEqual(_dllm_page_size(_view(disable_radix_cache=True)), {})
 
     def test_dual_apply_retired_field_mechanics(self):
         from sglang.srt.arg_groups.overrides import run_post_process_pass
@@ -846,8 +856,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             overrides_module, "DUAL_APPLY_RETIRED", frozenset({"page_size"})
         ):
             assert_flag_parity(flags, args, {"page_size"})  # no raise
-        with self.assertRaises(AssertionError):
-            assert_flag_parity(flags, args, {"page_size"})
+        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset()):
+            with self.assertRaises(AssertionError):
+                assert_flag_parity(flags, args, {"page_size"})
 
     def test_initialize_moe_config_reads_resolving_state_prepublish(self):
         # Scheduler.init_moe_gemm_config runs before the model worker
@@ -1604,9 +1615,12 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_page_size_leaf_materializes_end_state(self):
         sa = self._construct("LlamaForCausalLM", "llama")
-        declared = {f for _s, d in sa._resolved_overrides for f in d}
-        self.assertIn("page_size", declared)  # default fill declared
-        self.assertEqual(self._publish(sa).page_size, sa.page_size)
+        declared_values = [
+            d["page_size"] for _s, d in sa._resolved_overrides if "page_size" in d
+        ]
+        self.assertTrue(declared_values)  # default fill declared
+        self.assertIsNone(sa.page_size)  # pristine default
+        self.assertEqual(self._publish(sa).page_size, declared_values[-1])
 
     def test_qwen3_5_hybrid_coupled_declaration(self):
         from sglang.srt.arg_groups.overrides import _qwen3_5_hybrid_overrides

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -340,11 +340,15 @@ class TestRuntimeResolutionStages(_IsolatedServerArgs):
         self.assertEqual(get_flags().page_size, 64)  # earlier stage survives
 
     def test_record_parity_failure_rolls_back(self):
+        import sglang.srt.arg_groups.overrides as overrides_module
+
         self._publish(page_size=1)
         flags_before = get_flags()
-        with self.assertRaises(AssertionError):
-            # declared value diverges from the live server_args (no dual-apply)
-            get_context().record_runtime_overrides([("bad", {"page_size": 64})])
+        # pin an empty retired set so parity still compares page_size
+        with patch.object(overrides_module, "DUAL_APPLY_RETIRED", frozenset()):
+            with self.assertRaises(AssertionError):
+                # declared value diverges from the live server_args (no dual-apply)
+                get_context().record_runtime_overrides([("bad", {"page_size": 64})])
         self.assertIs(get_flags(), flags_before)  # previous flags intact
         self.assertEqual(get_context()._runtime_overrides, [])  # rolled back
 
@@ -366,12 +370,14 @@ class TestRuntimeResolutionStages(_IsolatedServerArgs):
         finally:
             reset_context()
 
-    def test_declare_load_time_override_dual_applies_and_records(self):
+    def test_declare_load_time_override_records_and_resolves(self):
         from sglang.srt.arg_groups.overrides import declare_load_time_override
 
         args = self._publish(page_size=1)
         declare_load_time_override("model.load_time", {"page_size": 64})
-        self.assertEqual(args.page_size, 64)  # dual-applied onto server_args
+        # dual-apply is retired for page_size: the field stays pristine and
+        # the leaf alone carries the load-time value
+        self.assertEqual(args.page_size, 1)
         self.assertEqual(get_flags().page_size, 64)  # resolved into the leaf
         self.assertEqual(
             get_context()._runtime_overrides,


### PR DESCRIPTION
Unit 6 of the dual-apply retirement stack. Based on #30282.

`server_args.page_size` returns to pristine user input; `flags.page_size` alone carries the resolved value.

Post-publish readers move to the tier (speculative workers' page captures, the decode-offload manager, the pool-sizing mixin, the flashinfer-MLA / aiter / triton backend captures); the KV sizing helpers read the view through their `server_args` parameter — behavior-identical on published instances, and direct-call fixtures that never publish keep working. The scheduler and ModelRunner captures run before the scheduler-process publish and read views, as do the `mamba_cache_chunk_size` property, the chunked-prefill divisibility check, the kv-events describe (which runs in the launcher process) and the default-backend spec/page gate.

The scheduler-init dllm page fallback (page must not exceed the dllm block size) folds into the `_dllm_page_size` pass at its resolution slot. The pr-fix-toggle patch template is updated to keep matching the rewritten source. The npu early default stays as pre-resolution input synthesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28820578316](https://github.com/sgl-project/sglang/actions/runs/28820578316)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28820578140](https://github.com/sgl-project/sglang/actions/runs/28820578140)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->