### PR TITLE
[refactor] Retire the dtype, quantization and hybrid-SWA dual-applies (stack 8/11)

### DIFF
--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -554,7 +554,7 @@ class _MlxBenchRunner:
             trust_remote_code=server_args.trust_remote_code,
             disable_radix_cache=True,
             mem_fraction_static=server_args.mem_fraction_static,
-            quantization=server_args.quantization,
+            quantization=get_flags().quantization,
         )
         if server_args.max_total_tokens is not None:
             init_kwargs["pool_size"] = server_args.max_total_tokens

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2182,6 +2182,17 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # the spec registry read the leaf; the pp / pdmux asserts read
         # views; the mps early disable is pre-resolution input synthesis.
         "disable_overlap_schedule",
+        # Every ModelConfig construction (mid-resolution cached, scheduler
+        # post-publish, launcher-side) captures these through the view in
+        # from_server_args — which also removes the timing skew between the
+        # pre- and post-declaration constructions; the sm<80 float16 force
+        # is a load-time declaration; MoE / DSA / gguf mid-resolution reads
+        # go through views; the runtime quantization readers are on the
+        # tier; the unquant normalization and the draft-quantization copy
+        # run pre-declaration on pristine input.
+        "dtype",
+        "quantization",
+        "disable_hybrid_swa_memory",
     }
 )
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -486,10 +486,17 @@ class ModelConfig:
         context_length: Optional[int] = None,
         **kwargs,
     ):
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        # dtype / quantization / disable_hybrid_swa_memory are pipeline-
+        # resolved: read them through the view so every construction —
+        # mid-resolution, scheduler-process post-publish, or launcher-side —
+        # captures the declared values (dual-apply retired).
+        view = resolved_view(server_args)
         quantization = (
             server_args.speculative_draft_model_quantization
             if is_draft_model
-            else server_args.quantization
+            else view.quantization
         )
         override_config_file = (
             server_args.decrypted_draft_config_file
@@ -508,7 +515,7 @@ class ModelConfig:
             model_override_args=server_args.json_model_override_args,
             is_embedding=server_args.is_embedding,
             enable_multimodal=server_args.enable_multimodal,
-            dtype=server_args.dtype,
+            dtype=view.dtype,
             quantization=quantization,
             model_impl=server_args.model_impl,
             sampling_defaults=server_args.sampling_defaults,
@@ -518,7 +525,7 @@ class ModelConfig:
             language_only=server_args.language_only,
             encoder_only=server_args.encoder_only,
             is_draft_model=is_draft_model,
-            disable_hybrid_swa_memory=server_args.disable_hybrid_swa_memory,
+            disable_hybrid_swa_memory=view.disable_hybrid_swa_memory,
             model_config_parser=server_args.model_config_parser,
             **kwargs,
         )

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -18,6 +18,7 @@ from typing import Optional, Union
 import mlx.core as mx
 import torch
 
+from sglang.srt.arg_groups.overrides import resolved_view
 from sglang.srt.hardware_backend.mlx.model_runner import (
     MlxPendingDecode,
     MlxPendingExtend,
@@ -53,7 +54,7 @@ class MlxTpModelWorker(TpModelWorker):
             trust_remote_code=self.server_args.trust_remote_code,
             disable_radix_cache=self.server_args.disable_radix_cache,
             mem_fraction_static=self.server_args.mem_fraction_static,
-            quantization=self.server_args.quantization,
+            quantization=resolved_view(self.server_args).quantization,
         )
         if self.server_args.max_total_tokens is not None:
             init_kwargs["pool_size"] = self.server_args.max_total_tokens

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -301,7 +301,7 @@ def initialize_moe_config(server_args: ServerArgs):
     DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = (
         server_args.disable_flashinfer_cutlass_moe_fp4_allgather
     )
-    MOE_QUANTIZATION = server_args.quantization
+    MOE_QUANTIZATION = view.quantization
 
 
 def get_moe_a2a_backend() -> MoeA2ABackend:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -19,6 +19,7 @@ from sglang.srt.utils.common import torch_release
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
+from sglang.srt.arg_groups.overrides import resolved_view
 from sglang.srt.layers.quantization.fp8_kernel import (
     fp8_dtype,
     fp8_max,
@@ -535,7 +536,7 @@ def initialize_fp8_gemm_config(server_args: ServerArgs) -> None:
 
     if (
         backend.is_auto()
-        and server_args.quantization == "mxfp8"
+        and resolved_view(server_args).quantization == "mxfp8"
         and _is_sm100_supported
         and is_flashinfer_available()
     ):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1429,7 +1429,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 logger.info(
                     "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
                 )
-                self.server_args.dtype = "float16"
+                from sglang.srt.arg_groups.overrides import (
+                    declare_load_time_override,
+                )
+
+                declare_load_time_override(
+                    "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
+                )
                 self.model_config.dtype = torch.float16
                 if torch.cuda.get_device_capability()[1] < 5:
                     raise RuntimeError("SGLang only supports sm75 and above.")
@@ -1597,13 +1603,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             getattr(self.model, "quant_config", None), "quantized_layers", None
         )
         if (
-            self.server_args.quantization is not None
+            get_flags().quantization is not None
             and isinstance(quantized_layers, tuple)
             and len(quantized_layers) == 2
         ):
             layer_types, quantized_layers_count = quantized_layers
             logger.info(
-                f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
+                f"Online {get_flags().quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
             )
 
         if self.server_args.debug_tensor_dump_output_folder is not None:

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -124,7 +124,7 @@ def flashinfer_autotune_cache_path(model_runner: ModelRunner) -> Path:
     model_key_parts = [
         str(server_args.model_path),
         str(mr.dtype),
-        str(server_args.quantization),
+        str(get_flags().quantization),
         str(get_flags().moe.runner_backend),
         str(mr.tp_size),
         str(mr.pp_size),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3267,7 +3267,7 @@ class ServerArgs:
             (
                 "GGUF quantization",
                 lambda: self.load_format == "gguf"
-                or self.quantization == "gguf"
+                or _resolved_view(self).quantization == "gguf"
                 or check_gguf_file(self.model_path),
             ),
             ("DLLM (diffusion LLM)", lambda: self.dllm_algorithm is not None),
@@ -3853,7 +3853,9 @@ class ServerArgs:
                     import torch
 
                     major, _ = torch.cuda.get_device_capability()
-                    self._set_default_dsa_kv_cache_dtype(major, self.quantization)
+                    self._set_default_dsa_kv_cache_dtype(
+                        major, resolved_view(self).quantization
+                    )
                     self._set_default_dsa_backends(self.kv_cache_dtype, major)
 
                 if self.enable_prefill_cp:
@@ -4860,12 +4862,12 @@ class ServerArgs:
 
         view = resolved_view(self)
         if view.moe_runner_backend == "flashinfer_cutlass":
-            assert self.quantization in [
+            assert view.quantization in [
                 "modelopt_fp4",
                 "modelopt_fp8",
                 "modelopt_mixed",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
             assert self.ep_size in [
                 1,
                 self.tp_size,
@@ -4873,9 +4875,9 @@ class ServerArgs:
 
         if view.moe_runner_backend == "flashinfer_cutedsl":
             assert (
-                self.quantization in ["modelopt_fp4"]
+                view.quantization in ["modelopt_fp4"]
                 or self.get_model_config().nvfp4_moe_meta is not None
-            ), f"Invalid quantization '{self.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4' or hybrid NVFP4 models."
+            ), f"Invalid quantization '{view.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4' or hybrid NVFP4 models."
             assert self.ep_size in [
                 1,
                 self.tp_size,
@@ -4890,7 +4892,7 @@ class ServerArgs:
             )
 
         if view.moe_runner_backend in ["flashinfer_trtllm", "experimental_sgl_trtllm"]:
-            assert self.quantization in [
+            assert view.quantization in [
                 "modelopt_fp4",
                 "nvfp4_online",
                 "fp8",
@@ -4899,16 +4901,16 @@ class ServerArgs:
                 "modelopt_mixed",
                 "compressed-tensors",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'nvfp4_online', 'fp8', 'modelopt_fp8', 'modelopt_mixed', 'compressed-tensors', or bfloat16 (None)."
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'nvfp4_online', 'fp8', 'modelopt_fp8', 'modelopt_mixed', 'compressed-tensors', or bfloat16 (None)."
 
         if view.moe_runner_backend == "flashinfer_trtllm_routed":
-            assert self.quantization in [
+            assert view.quantization in [
                 "fp8",
                 "mxfp8",
                 "modelopt_fp4",
                 "nvfp4_online",
                 None,
-            ], f"Invalid quantization '{self.quantization}'. \nFlashInfer TRTLLM routed MOE supports only: 'fp8', 'mxfp8', 'modelopt_fp4', 'nvfp4_online', or bfloat16 (None)."
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer TRTLLM routed MOE supports only: 'fp8', 'mxfp8', 'modelopt_fp4', 'nvfp4_online', or bfloat16 (None)."
 
         # The runner-driven shared-experts fusion disables moved to the
         # pipeline (arg_groups/overrides.py: _moe_runner_fusion_disable),
@@ -4920,9 +4922,9 @@ class ServerArgs:
         # the fusion blocks above on purpose: they must observe the
         # pre-override runner value, exactly as they did imperatively.
         run_post_process_pass(self, _cutlass_moe_env_override)
-        if resolved_view(
+        if resolved_view(self).moe_runner_backend == "cutlass" and resolved_view(
             self
-        ).moe_runner_backend == "cutlass" and self.quantization in [
+        ).quantization in [
             "fp8",
             "mxfp8",
         ]:
@@ -5068,7 +5070,7 @@ class ServerArgs:
                 )
             elif fuse_mode == 2:
                 assert (
-                    self.quantization == "modelslim"
+                    resolved_view(self).quantization == "modelslim"
                 ), "When fuse_mode is set to 2, the NPU supports only ModelSlim quantization."
         if a2a_backend == "flashinfer":
             assert (
@@ -5080,7 +5082,7 @@ class ServerArgs:
             if self.deepep_mode != "auto":
                 logger.warning("--deepep-mode is ignored for Flashinfer MoE A2A")
             if not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set() and (
-                self.quantization == "modelopt_fp4"
+                resolved_view(self).quantization == "modelopt_fp4"
                 or self.get_model_config().nvfp4_moe_meta is not None
             ):
                 envs.SGLANG_MOE_NVFP4_DISPATCH.set(True)

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -415,7 +415,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_mistral_large3_forces_bfloat16(self):
         sa = self._construct("MistralLarge3ForCausalLM", "mistral")
-        self.assertEqual(sa.dtype, "bfloat16")  # dual-apply == legacy write
+        self.assertEqual(sa.dtype, "auto")  # dual-apply retired: pristine
         self.assertIn(
             ("MODEL_OVERRIDES['MistralLarge3ForCausalLM']", {"dtype": "bfloat16"}),
             sa._resolved_overrides,
@@ -424,15 +424,15 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_pixtral_forces_bfloat16(self):
         sa = self._construct("PixtralForConditionalGeneration", "pixtral")
-        self.assertEqual(sa.dtype, "bfloat16")
+        self.assertEqual(sa.dtype, "auto")  # pristine
         self.assertEqual(self._publish(sa).dtype, "bfloat16")
 
     def test_user_requested_dtype_is_still_overridden(self):
         # Legacy fidelity: the arch branch overwrote dtype unconditionally,
-        # so the declaration must too. The pristine request survives only on
-        # provenance (and, post-V3, as the un-overridden server_args field).
+        # so the declaration must too. The pristine request survives on the
+        # field; the leaf carries the override.
         sa = self._construct("MistralLarge3ForCausalLM", "mistral", dtype="float16")
-        self.assertEqual(sa.dtype, "bfloat16")
+        self.assertEqual(sa.dtype, "float16")  # pristine user request
         self.assertEqual(self._publish(sa).dtype, "bfloat16")
 
     def test_control_arch_keeps_pristine_dtype(self):
@@ -491,16 +491,16 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             config_extra=config_extra,
             enable_hierarchical_cache=True,
         )
-        # dual-apply retired: the field stays pristine
+        # dual-apply retired: the fields stay pristine
         self.assertEqual(sa.swa_full_tokens_ratio, 0.8)
-        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertFalse(sa.disable_hybrid_swa_memory)
         flags = self._publish(sa)
         self.assertEqual(flags.swa_full_tokens_ratio, 1.0)
         self.assertTrue(flags.disable_hybrid_swa_memory)
 
     def test_gemma2_disables_hybrid_swa_memory(self):
         sa = self._construct("Gemma2ForCausalLM", "llama")
-        self.assertTrue(sa.disable_hybrid_swa_memory)  # dual-apply == legacy
+        self.assertFalse(sa.disable_hybrid_swa_memory)  # pristine
         self.assertIn(
             ("_gemma2_gemma3_overrides", {"disable_hybrid_swa_memory": True}),
             sa._resolved_overrides,
@@ -509,7 +509,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
     def test_olmo2_disables_hybrid_swa_memory(self):
         sa = self._construct("Olmo2ForCausalLM", "llama")
-        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertFalse(sa.disable_hybrid_swa_memory)  # pristine
         self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
 
     def test_exaone_conditional_on_sliding_window_pattern(self):
@@ -520,7 +520,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             config_extra={"sliding_window_pattern": "LLLG"},
             attention_backend="fa3",
         )
-        self.assertTrue(sa.disable_hybrid_swa_memory)
+        self.assertFalse(sa.disable_hybrid_swa_memory)  # pristine
         self.assertTrue(self._publish(sa).disable_hybrid_swa_memory)
 
     def test_exaone_without_pattern_declares_nothing(self):
@@ -543,7 +543,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "llama",
             config_extra={"quantization_config": {"quant_method": "mxfp4"}},
         )
-        self.assertEqual(sa.dtype, "bfloat16")  # dual-apply == legacy
+        self.assertEqual(sa.dtype, "auto")  # dual-apply retired: pristine
         self.assertEqual(self._publish(sa).dtype, "bfloat16")
 
     def test_gpt_oss_without_mxfp4_keeps_pristine_dtype(self):


### PR DESCRIPTION
Unit 8 of the dual-apply retirement stack. Based on #30284.

The last mixed-timing capture moves to the view: every `ModelConfig.from_server_args` construction — the mid-resolution cached instance, the scheduler-process post-publish constructions and the launcher-side tokenizer-manager construction — reads `dtype`, `quantization` and `disable_hybrid_swa_memory` through `resolved_view`, so each captures the declared values regardless of when and in which process it runs.

The ModelRunner sm<80 float16 fallback becomes a load-time declaration. Mid-resolution quantization reads go through views (the MoE kernel-config asserts, the cutlass gate, the ascend fuse-mode check, the FlashInfer nvfp4 dispatch gate, the DSA kv-cache-dtype default, the gguf cuda-graph compat rule); runtime quantization readers move to the tier. The unquant normalization and the draft-quantization copy run pre-declaration on pristine input and stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28820584740](https://github.com/sgl-project/sglang/actions/runs/28820584740)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28820584524](https://github.com/sgl-project/sglang/actions/runs/28820584524)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->