### PR TITLE
[refactor] Retire the enable_multi_layer_eagle dual-apply (stack 9/11)

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2193,6 +2193,11 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         "dtype",
         "quantization",
         "disable_hybrid_swa_memory",
+        # ModelConfig captures through the view; the spec hook / adaptive
+        # gates and the worker-shape helpers read views; the disagg draft
+        # builder and the eager runner read the leaf; the two dispatch
+        # declarers (MiMoV2, Step3p5/3p7) read the pristine input.
+        "enable_multi_layer_eagle",
     }
 )
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -424,7 +424,9 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
                 "--enable-deterministic-inference; the sampling kernel draws "
                 "coins from the global RNG and is not batch-invariant."
             )
-        if server_args.enable_multi_layer_eagle:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if resolved_view(server_args).enable_multi_layer_eagle:
             raise NotImplementedError(
                 "--speculative-use-rejection-sampling is not supported with "
                 "multi-layer EAGLE (--enable-multi-layer-eagle)."

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -521,7 +521,7 @@ class ModelConfig:
             sampling_defaults=server_args.sampling_defaults,
             quantize_and_serve=server_args.quantize_and_serve,
             override_config_file=override_config_file,
-            is_multi_layer_eagle=server_args.enable_multi_layer_eagle,
+            is_multi_layer_eagle=view.enable_multi_layer_eagle,
             language_only=server_args.language_only,
             encoder_only=server_args.encoder_only,
             is_draft_model=is_draft_model,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -60,7 +60,9 @@ def get_draft_kv_pool(
         return None
 
     # V2 workers nest the draft runner under `.draft_worker`.
-    if server_args.enable_multi_layer_eagle:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).enable_multi_layer_eagle:
         draft_runner = draft_worker.draft_worker.draft_runner_list[0]
     else:
         draft_runner = draft_worker.draft_worker.draft_runner

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -49,7 +49,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     enable_tc_piecewise_cuda_graph,
     set_tc_piecewise_forward_context,
 )
-from sglang.srt.runtime_context import mamba_extra_buffer_enabled
+from sglang.srt.runtime_context import get_flags, mamba_extra_buffer_enabled
 from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import ceil_align, require_mlp_sync
 
@@ -79,7 +79,7 @@ class EagerRunner(BaseRunner):
                     num_draft_tokens,
                     (
                         2 * (sa.speculative_num_steps or 0)
-                        if sa.enable_multi_layer_eagle
+                        if get_flags().enable_multi_layer_eagle
                         else 0
                     ),
                 )

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -67,7 +67,9 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             "enable_dp_attention=True is not supported "
             "(adaptive tier decisions are not synchronized across DP ranks)"
         )
-    if server_args.enable_multi_layer_eagle:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).enable_multi_layer_eagle:
         return (
             "enable_multi_layer_eagle=True is not supported "
             "(MultiLayerEagleWorkerV2 does not implement adaptive)"

--- a/python/sglang/srt/speculative/eagle_disaggregation.py
+++ b/python/sglang/srt/speculative/eagle_disaggregation.py
@@ -6,6 +6,7 @@ import torch
 
 from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.speculative.eagle_info import EagleDraftInput
 
 if TYPE_CHECKING:
@@ -21,7 +22,7 @@ def build_eagle_disagg_draft_input(
     future_map: FutureMap,
 ) -> EagleDraftInput:
     num_states = server_args.speculative_eagle_topk
-    if server_args.enable_multi_layer_eagle:
+    if get_flags().enable_multi_layer_eagle:
         num_states *= server_args.speculative_num_steps
 
     topk_p = torch.stack(

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -215,7 +215,9 @@ class SpeculativeAlgorithm(Enum):
 
         # EAGLE / EAGLE3 / STANDALONE / MULTI_LAYER always use the V2 worker,
         # even with overlap disabled (scheduler drives it synchronously).
-        if self.is_eagle() and server_args.enable_multi_layer_eagle:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if self.is_eagle() and resolved_view(server_args).enable_multi_layer_eagle:
             from sglang.srt.speculative.multi_layer_eagle_worker_v2 import (
                 MultiLayerEagleWorkerV2,
             )

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -188,7 +188,9 @@ def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:
     # TODO(lsyin): also skip when step == 1.
     if server_args.speculative_algorithm in ("STANDALONE", "DFLASH"):
         return False
-    return not server_args.enable_multi_layer_eagle
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return not resolved_view(server_args).enable_multi_layer_eagle
 
 
 @torch.compile(dynamic=True, disable=_is_npu or _is_xpu)


### PR DESCRIPTION
Unit 9 of the dual-apply retirement stack. Based on the stack PR before it.

The last model-declared field outside the launcher set: MiMoV2 and Step3p5/3p7 declare it at dispatch when EAGLE is selected. ModelConfig captures it through the view; the spec-hook rejection-sampling gate and the adaptive-spec gate read views mid-resolution; the worker-shape helpers (spec_info worker selection, spec_need_hidden_states, the draft-KV pool lookup) read views through their server_args parameter; the per-batch disagg draft builder and the eager-runner sizing read the leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28820587697](https://github.com/sgl-project/sglang/actions/runs/28820587697)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28820587464](https://github.com/sgl-project/sglang/actions/runs/28820587464)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->