### PR TITLE
[refactor] Retire the launcher-trio dual-applies (stack 10/11)

### DIFF
--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -298,7 +298,12 @@ class BenchArgs:
 def load_model(server_args, port_args, gpu_id, tp_rank):
     suppress_other_loggers()
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
-    moe_ep_rank = tp_rank // (server_args.tp_size // server_args.ep_size)
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # Pre-publish (the ModelRunner below performs the publish): read the
+    # resolved ep_size through the view.
+    ep_size = resolved_view(server_args).ep_size
+    moe_ep_rank = tp_rank // (server_args.tp_size // ep_size)
 
     model_config = ModelConfig.from_server_args(server_args)
     runner_kwargs = dict(
@@ -308,7 +313,7 @@ def load_model(server_args, port_args, gpu_id, tp_rank):
         tp_rank=tp_rank,
         tp_size=server_args.tp_size,
         moe_ep_rank=moe_ep_rank,
-        moe_ep_size=server_args.ep_size,
+        moe_ep_size=ep_size,
         pp_rank=0,
         pp_size=1,
         nccl_port=port_args.nccl_port,

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2198,6 +2198,14 @@ DUAL_APPLY_RETIRED: frozenset = frozenset(
         # builder and the eager runner read the leaf; the two dispatch
         # declarers (MiMoV2, Step3p5/3p7) read the pristine input.
         "enable_multi_layer_eagle",
+        # The launcher / tokenizer / ray-controller processes (where no
+        # publish exists) and the pre-publish scheduler/runner captures read
+        # views over the instance-carried declaration stash; scheduler-
+        # process runtime readers are on the leaves; the __post_init__
+        # validation chains read views at their slots.
+        "enable_dp_attention",
+        "ep_size",
+        "attn_cp_size",
     }
 )
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -15,6 +15,7 @@ import torch.distributed as dist
 import zmq
 from aiohttp import web
 
+from sglang.srt.arg_groups.overrides import resolved_view
 from sglang.srt.disaggregation.base.conn import (
     BaseKVBootstrapServer,
     BaseKVManager,
@@ -132,7 +133,7 @@ class CommonKVManager(BaseKVManager):
         self.attn_dp_size = get_attention_dp_size()
         self.attn_dp_rank = get_attention_dp_rank()
         self.system_dp_size = (
-            1 if server_args.enable_dp_attention else server_args.dp_size
+            1 if resolved_view(server_args).enable_dp_attention else server_args.dp_size
         )
         self.system_dp_rank = (
             self.kv_args.system_dp_rank if self.kv_args.system_dp_rank else 0

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1436,17 +1436,22 @@ def _compute_parallelism_ranks(
     server_args: ServerArgs, tp_rank: int
 ) -> Tuple[int, int, int]:
     """Compute attention-CP, MoE-DP, and MoE-EP ranks for a TP rank."""
-    attn_dp_size = server_args.dp_size if server_args.enable_dp_attention else 1
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    # Launcher process: no publish exists here; the resolved parallel shape
+    # lives on the declaration stash carried by the instance.
+    view = resolved_view(server_args)
+    attn_dp_size = server_args.dp_size if view.enable_dp_attention else 1
 
     # Parallelism hierarchy (outermost to innermost):
     # - Attention: Global(TP) -> DP -> ATTN_CP -> ATTN_TP (innermost)
     # - MoE: Global(TP) -> MOE_DP -> EP -> MOE_TP (innermost)
-    attn_tp_size = server_args.tp_size // attn_dp_size // server_args.attn_cp_size
-    attn_cp_rank = (tp_rank // attn_tp_size) % server_args.attn_cp_size
+    attn_tp_size = server_args.tp_size // attn_dp_size // view.attn_cp_size
+    attn_cp_rank = (tp_rank // attn_tp_size) % view.attn_cp_size
     moe_dp_rank = tp_rank // (server_args.tp_size // server_args.moe_dp_size)
     moe_ep_rank = (
         tp_rank
         % (server_args.tp_size // server_args.moe_dp_size)
-        // (server_args.tp_size // server_args.moe_dp_size // server_args.ep_size)
+        // (server_args.tp_size // server_args.moe_dp_size // view.ep_size)
     )
     return attn_cp_rank, moe_dp_rank, moe_ep_rank

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -199,7 +199,9 @@ class ExpertLocationMetadata:
             model_config_for_expert_location.num_logical_experts
             + server_args.ep_num_redundant_experts
         )
-        ep_size = server_args.ep_size
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        ep_size = resolved_view(server_args).ep_size
         assert num_physical_experts % ep_size == 0
         num_local_physical_experts = num_physical_experts // ep_size
 
@@ -391,7 +393,9 @@ def _compute_logical_to_all_physical_map(
 
     # Replace by the physical expert on local GPU or node if possible
     if moe_ep_rank is not None:
-        num_gpus_per_node = server_args.ep_size // server_args.nnodes
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        num_gpus_per_node = resolved_view(server_args).ep_size // server_args.nnodes
         num_local_gpu_physical_experts = num_physical_experts // ep_size
         num_local_node_physical_experts = (
             num_local_gpu_physical_experts * num_gpus_per_node
@@ -448,7 +452,9 @@ def compute_logical_to_rank_dispatch_physical_map(
     logical_to_all_physical_map = logical_to_all_physical_map.cpu()
 
     num_local_gpu_physical_experts = num_physical_experts // ep_size
-    num_gpus_per_node = server_args.ep_size // server_args.nnodes
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    num_gpus_per_node = resolved_view(server_args).ep_size // server_args.nnodes
     num_local_node_physical_experts = num_local_gpu_physical_experts * num_gpus_per_node
     num_layers, num_logical_experts, _ = logical_to_all_physical_map.shape
     dtype = logical_to_all_physical_map.dtype

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -287,10 +287,10 @@ def initialize_dp_attention(
     _DP_MAX_LEN_WITH_IDLE = (
         getattr(model_config.hf_config, "hybrid_override_pattern", None) is not None
     )
-    enable_dp_attention = server_args.enable_dp_attention
+    enable_dp_attention = get_flags().enable_dp_attention
     dp_size = server_args.dp_size
     moe_dense_tp_size = get_flags().moe_dense_tp_size
-    attn_cp_size = server_args.attn_cp_size
+    attn_cp_size = get_flags().attn_cp_size
 
     _ENABLE_DP_ATTENTION_FLAG = enable_dp_attention
 
@@ -836,7 +836,9 @@ def is_enable_moe_cp_allgather() -> bool:
     from sglang.srt.server_args import get_global_server_args
 
     sa = get_global_server_args()
-    return sa.attn_cp_size > sa.moe_dp_size
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return resolved_view(sa).attn_cp_size > sa.moe_dp_size
 
 
 def moe_cp_all_gather_into_tensor(output: torch.Tensor, input: torch.Tensor):

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -181,7 +181,9 @@ class DataParallelController:
         self.workers: List[zmq.Socket] = [None] * server_args.dp_size
         self.status: List[bool] = [True] * server_args.dp_size
 
-        if server_args.enable_dp_attention:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if resolved_view(server_args).enable_dp_attention:
             self.launch_dp_attention_schedulers(server_args, port_args)
             # When local control broadcast is enabled, send control messages to
             # every DP group leader (attn_tp_rank=0) so each leader broadcasts
@@ -492,7 +494,9 @@ class DataParallelController:
         dp_rank: Optional[int],
         worker_ports: Optional[List[int]] = None,
     ):
-        if not server_args.enable_dp_attention:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if not resolved_view(server_args).enable_dp_attention:
             logger.info(f"Launch DP{dp_rank} starting at GPU #{base_gpu_id}.")
 
         memory_saver_adapter = TorchMemorySaverAdapter.create(
@@ -517,18 +521,21 @@ class DataParallelController:
 
         attn_cp_rank = 0
         moe_dp_rank = 0
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        view = resolved_view(server_args)
         for pp_rank in pp_rank_range:
             for tp_rank in tp_rank_range:
                 rank_port_args = port_args
 
-                if server_args.enable_dp_attention:
+                if view.enable_dp_attention:
                     # dp attention has different sharding logic
                     _, _, dp_rank, _ = compute_dp_attention_world_info(
-                        server_args.enable_dp_attention,
+                        view.enable_dp_attention,
                         tp_rank,
                         server_args.tp_size,
                         server_args.dp_size,
-                        server_args.attn_cp_size,
+                        view.attn_cp_size,
                     )
                     # compute zmq ports for this dp rank
                     rank_port_args = PortArgs.init_new(
@@ -546,28 +553,20 @@ class DataParallelController:
                     + ((pp_rank % pp_size_per_node) * tp_size_per_node)
                     + (tp_rank % tp_size_per_node) * server_args.gpu_id_step
                 )
-                attn_dp_size = (
-                    server_args.dp_size if server_args.enable_dp_attention else 1
-                )
+                attn_dp_size = server_args.dp_size if view.enable_dp_attention else 1
 
                 # Parallelism hierarchy (outermost to innermost):
                 # - Attention: Global(TP) -> DP -> ATTN_CP -> ATTN_TP (innermost)
                 # - MoE: Global(TP) -> MOE_DP -> EP -> MOE_TP (innermost)
-                attn_tp_size = (
-                    server_args.tp_size // attn_dp_size // server_args.attn_cp_size
-                )
-                attn_cp_rank = (tp_rank // attn_tp_size) % server_args.attn_cp_size
+                attn_tp_size = server_args.tp_size // attn_dp_size // view.attn_cp_size
+                attn_cp_rank = (tp_rank // attn_tp_size) % view.attn_cp_size
                 moe_dp_rank = tp_rank // (
                     server_args.tp_size // server_args.moe_dp_size
                 )
                 moe_ep_rank = (
                     tp_rank
                     % (server_args.tp_size // server_args.moe_dp_size)
-                    // (
-                        server_args.tp_size
-                        // server_args.moe_dp_size
-                        // server_args.ep_size
-                    )
+                    // (server_args.tp_size // server_args.moe_dp_size // view.ep_size)
                 )
 
                 with self.env_lock, maybe_reindex_device_id(gpu_id) as gpu_id:

--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -82,8 +82,10 @@ def should_use_zmq(server_args) -> bool:
     the SHM file on node 0, so we fall back to zmq transport.  The env var
     ``SGLANG_LOAD_SNAPSHOT_USE_ZMQ`` forces zmq mode for testing.
     """
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     return (
-        server_args.enable_dp_attention and server_args.nnodes > 1
+        resolved_view(server_args).enable_dp_attention and server_args.nnodes > 1
     ) or envs.SGLANG_LOAD_SNAPSHOT_USE_ZMQ.get()
 
 

--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -74,7 +74,7 @@ class PrefillDelayer:
             f"queue_trigger_enabled={self._queue_trigger_enabled}"
         )
         self.dp_size = dp_size
-        self.enable_dp_attention = server_args.enable_dp_attention
+        self.enable_dp_attention = get_flags().enable_dp_attention
         dp_size_dim = dp_size if self.enable_dp_attention else 1
 
         # Mirror scheduler_dp_attn_mixin's NCCL all-gather path: when the

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -238,6 +238,7 @@ from sglang.srt.observability.trace import process_tracing_init, trace_set_threa
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.platforms import current_platform
 from sglang.srt.plugins import load_plugins
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import PortArgs, ServerArgs, get_global_server_args
 from sglang.srt.session.session_controller import SessionController
@@ -361,14 +362,16 @@ class Scheduler(
         self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
         self.enable_hisparse = server_args.enable_hisparse
 
-        # Distributed rank info
+        # Distributed rank info (pre-publish: read the resolved parallel
+        # shape through the view)
+        _view = resolved_view(server_args)
         attn_tp_rank, attn_tp_size, attn_dp_rank, attn_dp_size = (
             compute_dp_attention_world_info(
-                server_args.enable_dp_attention,
+                _view.enable_dp_attention,
                 tp_rank,
                 server_args.tp_size,
                 server_args.dp_size,
-                server_args.attn_cp_size,
+                _view.attn_cp_size,
             )
         )
         self.ps = ParallelState(
@@ -381,11 +384,11 @@ class Scheduler(
             attn_tp_rank=attn_tp_rank,
             attn_tp_size=attn_tp_size,
             attn_cp_rank=attn_cp_rank,
-            attn_cp_size=server_args.attn_cp_size,
+            attn_cp_size=_view.attn_cp_size,
             attn_dp_rank=attn_dp_rank,
             attn_dp_size=attn_dp_size,
             moe_ep_rank=moe_ep_rank,
-            moe_ep_size=server_args.ep_size,
+            moe_ep_size=_view.ep_size,
             moe_dp_rank=moe_dp_rank,
             moe_dp_size=server_args.moe_dp_size,
             gpu_id=gpu_id,
@@ -473,7 +476,7 @@ class Scheduler(
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
                 tp_group=(
                     self.attn_tp_cpu_group
-                    if self.server_args.enable_dp_attention
+                    if get_flags().enable_dp_attention
                     else self.tp_cpu_group
                 ),
                 tree_cache=self.tree_cache,
@@ -918,9 +921,7 @@ class Scheduler(
         # Use the CPU (gloo) group to broadcast VLM Python objects and avoid CUDA
         # stream/device coupling (#11910).
         self.dp_tp_group = (
-            self.attn_tp_group
-            if self.server_args.enable_dp_attention
-            else self.tp_group
+            self.attn_tp_group if get_flags().enable_dp_attention else self.tp_group
         )
         self.dp_tp_cpu_group = self.dp_tp_group.cpu_group
 
@@ -1346,8 +1347,6 @@ class Scheduler(
             "flashinfer": ("SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE", 4096),
             "triton": ("SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE", 4096),
         }
-        from sglang.srt.runtime_context import get_flags
-
         env_var, default_size = backend_sizes.get(
             get_flags().attn.backend, (None, None)
         )
@@ -3382,7 +3381,7 @@ class Scheduler(
 
     def _maybe_report_active_ranks(self) -> None:
         if not (
-            self.server_args.enable_dp_attention
+            get_flags().enable_dp_attention
             and self.server_args.elastic_ep_backend is not None
         ):
             return
@@ -4231,13 +4230,16 @@ def configure_scheduler_process(
         prefix += f" DP{dp_rank}"
     if server_args.pp_size > 1:
         prefix += f" PP{pp_rank}"
-    if server_args.attn_cp_size > 1:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    _view = resolved_view(server_args)
+    if _view.attn_cp_size > 1:
         prefix += f" ATTN_CP{attn_cp_rank}"
     if server_args.moe_dp_size > 1:
         prefix += f" MOE_DP{moe_dp_rank}"
     if server_args.tp_size > 1:
         prefix += f" TP{tp_rank}"
-    if server_args.ep_size > 1:
+    if _view.ep_size > 1:
         prefix += f" EP{moe_ep_rank}"
 
     # Config the process

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -26,6 +26,7 @@ from sglang.srt.managers.mm_utils import (
     has_shm_features,
     unwrap_shm_features,
 )
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
@@ -139,7 +140,7 @@ class SchedulerRequestReceiver:
         return recv_reqs
 
     def _broadcast_reqs_across_ranks(self, recv_reqs: Optional[List]) -> List:
-        if self.server_args.enable_dp_attention:
+        if get_flags().enable_dp_attention:
             if self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0:
                 work_reqs, control_reqs = self._split_work_and_control_reqs(recv_reqs)
             else:
@@ -242,7 +243,7 @@ class SchedulerRequestReceiver:
                 # peer ranks may still be unpickling ShmPointerMMData
                 # (-> shm_open).  Synchronize the same CPU groups that carried
                 # SHM-backed work requests before materialize() unlinks them.
-                if self.server_args.enable_dp_attention:
+                if get_flags().enable_dp_attention:
                     if self.ps.attn_tp_size > 1:
                         barrier(group=self.attn_tp_cpu_group)
                     if self.ps.attn_cp_size > 1:

--- a/python/sglang/srt/managers/scheduler_recv_skipper.py
+++ b/python/sglang/srt/managers/scheduler_recv_skipper.py
@@ -12,7 +12,9 @@ class SchedulerRecvSkipper:
 
     def __init__(self, server_args: ServerArgs):
         # Can be supported if needed, but may need e.g. `global_forward_mode`
-        assert not server_args.enable_dp_attention
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        assert not resolved_view(server_args).enable_dp_attention
         self._counter = 0
         self._threshold = server_args.scheduler_recv_interval
         # All can be tuned if needed

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -127,6 +127,13 @@ class TokenizerControlMixin:
     FanOutCommunicator, as opposed to data-plane inference requests multiplexed by rid.
     """
 
+    def _dp_attention_enabled(self) -> bool:
+        # Tokenizer process: no publish here; read the resolved value from
+        # the declaration stash carried by the instance.
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        return resolved_view(self.server_args).enable_dp_attention
+
     def init_communicators(self: TokenizerManager, server_args: ServerArgs):
         dispatch_pairs = []
         for spec in _COMMUNICATOR_SPECS:
@@ -373,7 +380,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for update weights from distributed"
 
         results = await self.init_weights_update_group_communicator(obj)
@@ -386,7 +393,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for destroy parameter update group"
 
         results = await self.destroy_weights_update_group_communicator(obj)
@@ -399,7 +406,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for update weights from distributed"
 
         if obj.abort_all_requests:
@@ -457,7 +464,7 @@ class TokenizerControlMixin:
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
         assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            self.server_args.dp_size == 1 or self._dp_attention_enabled()
         ), "dp_size must be 1 or dp attention must be enabled for update weights from tensor"
 
         if obj.abort_all_requests:
@@ -493,7 +500,7 @@ class TokenizerControlMixin:
         try:
             # For now, we only support single data parallel instance
             assert (
-                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+                self.server_args.dp_size == 1 or self._dp_attention_enabled()
             ), "dp_size must be 1 or dp attention must be enabled for update weights from IPC"
             logger.info("Starting IPC weight update")
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1320,10 +1320,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         - Or, if no request has text or multimodal input (all use pre-tokenized input_ids or input_embeds), batch the requests without tokenization.
         - Batch tokenization does not support DP attention yet, and it will make everything goes to the first rank currently
         """
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         return batch_size > 0 and (
             self.server_args.enable_tokenizer_batch_encode
             or (
-                (not self.server_args.enable_dp_attention)
+                (not resolved_view(self.server_args).enable_dp_attention)
                 and (not self._batch_has_text(batch_size, requests))
             )
         )

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -243,10 +243,12 @@ class TpModelWorker(BaseTpWorker):
         is_multi_layer_eagle: bool = False,
         context_length: Optional[int] = None,
     ):
+        from sglang.srt.arg_groups.overrides import resolved_view
+
         # Parse args
         self.server_args = server_args
         self.tp_size = server_args.tp_size
-        self.ep_size = server_args.ep_size
+        self.ep_size = resolved_view(server_args).ep_size
         self.pp_size = server_args.pp_size
         self.tp_rank = tp_rank
         self.moe_ep_rank = moe_ep_rank
@@ -314,8 +316,6 @@ class TpModelWorker(BaseTpWorker):
             src=self.world_group.ranks[0],
         )[0]
         set_random_seed(self.random_seed)
-
-        from sglang.srt.arg_groups.overrides import resolved_view
 
         self.enable_overlap = not resolved_view(server_args).disable_overlap_schedule
         self.enable_spec = server_args.speculative_algorithm is not None

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -128,6 +128,12 @@ def maybe_register_hicache_draft(
     tree_cache.cache_controller.set_draft_kv_pool(pool, draft_host_pool)
 
 
+def _resolved_view(server_args):
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return resolved_view(server_args)
+
+
 def build_kv_cache(
     *,
     server_args: ServerArgs,
@@ -216,7 +222,9 @@ def build_kv_cache(
         ),
         is_eagle=spec_algorithm.is_eagle(),
         tp_cache_group=(
-            attn_tp_cpu_group if server_args.enable_dp_attention else tp_cpu_group
+            attn_tp_cpu_group
+            if _resolved_view(server_args).enable_dp_attention
+            else tp_cpu_group
         ),
         attn_cp_cache_group=attn_cp_cpu_group,
         attn_tp_cache_group=attn_tp_cpu_group,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -384,11 +384,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.moe_ep_rank = moe_ep_rank
         self.moe_ep_size = moe_ep_size
         self.dp_rank = dp_rank
-        self.dp_size = server_args.dp_size if server_args.enable_dp_attention else 1
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        _view = resolved_view(server_args)
+        self.dp_size = server_args.dp_size if _view.enable_dp_attention else 1
         self.pp_rank = pp_rank
         self.pp_size = pp_size
         self.attn_cp_rank = attn_cp_rank
-        self.attn_cp_size = server_args.attn_cp_size
+        self.attn_cp_size = _view.attn_cp_size
         self.moe_dp_rank = moe_dp_rank
         self.moe_dp_size = server_args.moe_dp_size
         self.model_config = model_config
@@ -875,7 +878,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 device=self.device,
                 tp_group=(
                     self.attention_tp_group.cpu_group
-                    if self.server_args.enable_dp_attention
+                    if get_flags().enable_dp_attention
                     else self.tp_group.cpu_group
                 ),
                 host_to_device_ratio=hisparse_cfg.host_to_device_ratio,

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -156,14 +156,14 @@ class ModelRunnerKVCacheMixin:
         if server_args.max_mamba_cache_size is not None:
             # Use explicitly set max_mamba_cache_size
             server_args.max_mamba_cache_size = server_args.max_mamba_cache_size // (
-                server_args.dp_size if server_args.enable_dp_attention else 1
+                server_args.dp_size if get_flags().enable_dp_attention else 1
             )
             # Reserve intermediate memory based on capped max_num_reqs
             if has_spec_dec:
                 ratio = self._calculate_mamba_ratio()
                 capped_reqs = min(
                     server_args.max_running_requests
-                    // (self.dp_size if server_args.enable_dp_attention else 1),
+                    // (self.dp_size if get_flags().enable_dp_attention else 1),
                     server_args.max_mamba_cache_size // ratio,
                 )
                 intermediate_size = (
@@ -178,7 +178,7 @@ class ModelRunnerKVCacheMixin:
         ):
             # Use explicitly set max_running_requests when radix cache is disabled
             server_args.max_mamba_cache_size = server_args.max_running_requests // (
-                server_args.dp_size if server_args.enable_dp_attention else 1
+                server_args.dp_size if get_flags().enable_dp_attention else 1
             )
             # Reserve intermediate memory based on capped max_num_reqs
             if has_spec_dec:
@@ -216,7 +216,7 @@ class ModelRunnerKVCacheMixin:
                 # so the return value only has main_state subtracted from total
                 capped_reqs = min(
                     server_args.max_running_requests
-                    // (self.dp_size if server_args.enable_dp_attention else 1),
+                    // (self.dp_size if get_flags().enable_dp_attention else 1),
                     server_args.max_mamba_cache_size // ratio,
                 )
                 intermediate_size = per_req * capped_reqs * D

--- a/python/sglang/srt/ray/data_parallel_controller.py
+++ b/python/sglang/srt/ray/data_parallel_controller.py
@@ -150,13 +150,16 @@ class RayDataParallelController(DataParallelController):
                             tp_rank % tp_per_node
                         )
 
-                        if server_args.enable_dp_attention:
+                        from sglang.srt.arg_groups.overrides import resolved_view
+
+                        view = resolved_view(server_args)
+                        if view.enable_dp_attention:
                             _, _, actual_dp_rank, _ = compute_dp_attention_world_info(
-                                server_args.enable_dp_attention,
+                                view.enable_dp_attention,
                                 tp_rank,
                                 server_args.tp_size,
                                 server_args.dp_size,
-                                server_args.attn_cp_size,
+                                view.attn_cp_size,
                             )
                             rank_port_args = PortArgs.init_new(
                                 server_args, actual_dp_rank, worker_ports
@@ -221,13 +224,16 @@ class RayDataParallelController(DataParallelController):
 
                 bundle_idx = bundle_indices[global_rank]
 
-                if server_args.enable_dp_attention:
+                from sglang.srt.arg_groups.overrides import resolved_view
+
+                view = resolved_view(server_args)
+                if view.enable_dp_attention:
                     _, _, actual_dp_rank, _ = compute_dp_attention_world_info(
-                        server_args.enable_dp_attention,
+                        view.enable_dp_attention,
                         tp_rank,
                         server_args.tp_size,
                         server_args.dp_size,
-                        server_args.attn_cp_size,
+                        view.attn_cp_size,
                     )
                     rank_port_args = PortArgs.init_new(
                         server_args, actual_dp_rank, worker_ports

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -107,7 +107,9 @@ def _compute_world_size(server_args: ServerArgs) -> int:
 
     Normal: dp_size * tp_size * pp_size; DP attention: tp_size * pp_size.
     """
-    if server_args.enable_dp_attention:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    if resolved_view(server_args).enable_dp_attention:
         return server_args.tp_size * server_args.pp_size
     return server_args.dp_size * server_args.tp_size * server_args.pp_size
 
@@ -265,7 +267,9 @@ class RayEngine(Engine):
                 placement_group as create_placement_group,
             )
 
-            if server_args.enable_dp_attention:
+            from sglang.srt.arg_groups.overrides import resolved_view
+
+            if resolved_view(server_args).enable_dp_attention:
                 total_gpus = server_args.tp_size * server_args.pp_size
             else:
                 total_gpus = (
@@ -438,11 +442,13 @@ class RayEngine(Engine):
         rank0_node_ip: str,
     ) -> RaySchedulerInitResult:
         """Launch DP schedulers via RayDataParallelController."""
+        from sglang.srt.arg_groups.overrides import resolved_view
         from sglang.srt.ray.data_parallel_controller import (
             RayDataParallelController,
         )
 
-        if server_args.enable_dp_attention:
+        enable_dp_attention = resolved_view(server_args).enable_dp_attention
+        if enable_dp_attention:
             # DP attention folds DP into TP — total GPUs = tp_size * pp_size
             total_gpus = server_args.tp_size * server_args.pp_size
         else:
@@ -452,7 +458,7 @@ class RayEngine(Engine):
             f"Ray DP cluster: {server_args.nnodes} nodes, "
             f"{gpus_per_node} GPUs/node, dp_size={server_args.dp_size}, "
             f"tp_size={server_args.tp_size}, pp_size={server_args.pp_size}, "
-            f"enable_dp_attention={server_args.enable_dp_attention}"
+            f"enable_dp_attention={enable_dp_attention}"
         )
 
         # Set dist_init_addr on server_args so PortArgs.init_new() can compute

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3242,7 +3242,7 @@ class ServerArgs:
                 "model-arch blacklist",
                 lambda: self.get_model_config().is_piecewise_cuda_graph_disabled_model,
             ),
-            ("DP attention", lambda: self.enable_dp_attention),
+            ("DP attention", lambda: self._resolved().enable_dp_attention),
             ("full torch.compile mode", lambda: self.enable_torch_compile),
             ("pipeline parallelism (pp_size > 1)", lambda: self.pp_size > 1),
             (
@@ -3286,7 +3286,10 @@ class ServerArgs:
                 lambda: self.enable_eplb
                 or self.expert_distribution_recorder_mode is not None,
             ),
-            ("context parallel (attn_cp_size > 1)", lambda: self.attn_cp_size > 1),
+            (
+                "context parallel (attn_cp_size > 1)",
+                lambda: self._resolved().attn_cp_size > 1,
+            ),
             ("CUDA graph debug mode", lambda: self.debug_cuda_graph),
             (
                 "DSA prefill context parallelism",
@@ -3316,7 +3319,10 @@ class ServerArgs:
                 lambda: is_deepseek_v4(self.get_model_config().hf_config),
             ),
             # CP all_gather replay size mismatch under BCG.
-            ("context parallel (attn_cp_size > 1)", lambda: self.attn_cp_size > 1),
+            (
+                "context parallel (attn_cp_size > 1)",
+                lambda: self._resolved().attn_cp_size > 1,
+            ),
             # BCG capture + LoRA adapter weights exceed host RAM headroom.
             ("LoRA", lambda: bool(self.lora_paths) or bool(self.enable_lora)),
             # BCG bucket sizes exceed FlashInfer MoE A2A's dispatch cap.
@@ -3325,7 +3331,7 @@ class ServerArgs:
                 lambda: _resolved_view(self).moe_a2a_backend != "none",
             ),
             # DP-attn × BCG capture/replay not yet validated.
-            ("DP attention", lambda: self.enable_dp_attention),
+            ("DP attention", lambda: self._resolved().enable_dp_attention),
             # Multimodal prefill replay faults under BCG.
             ("multimodal model", lambda: self.get_model_config().is_multimodal),
         ]
@@ -3587,7 +3593,10 @@ class ServerArgs:
             # Some adjustments for large parallel size
             reserved_mem += self.tp_size * self.pp_size / 8 * 1024
 
-            if self.enable_dp_attention and self.disaggregation_mode != "prefill":
+            if (
+                self._resolved().enable_dp_attention
+                and self.disaggregation_mode != "prefill"
+            ):
                 # DP attention needs more padding for some operations
                 reserved_mem += decode_cuda_graph_config.max_bs * self.dp_size * 3
 
@@ -3890,7 +3899,7 @@ class ServerArgs:
 
             run_post_process_pass(self, _deepseek_moe_quant_resolution)
             if is_hip():
-                if not self.enable_dp_attention and self.nnodes == 1:
+                if not self._resolved().enable_dp_attention and self.nnodes == 1:
                     # TODO (Hubert): Put this back later
                     # self.enable_aiter_allreduce_fusion = True
                     logger.info(
@@ -3972,7 +3981,11 @@ class ServerArgs:
 
             quant_method = get_quantization_config(hf_config)
             is_mxfp4_quant_format = quant_method == "mxfp4"
-            if not self.enable_dp_attention and self.nnodes == 1 and is_hip():
+            if (
+                not self._resolved().enable_dp_attention
+                and self.nnodes == 1
+                and is_hip()
+            ):
                 # TODO (Hubert): Put this back later
                 # self.enable_aiter_allreduce_fusion = True
                 logger.info("Enable Aiter AllReduce Fusion for GptOssForCausalLM")
@@ -3989,7 +4002,7 @@ class ServerArgs:
 
             if resolved_view(self).moe_runner_backend == "triton_kernel":
                 assert (
-                    self.ep_size == 1
+                    self._resolved().ep_size == 1
                 ), "Triton kernel MoE is only supported when ep_size == 1"
 
         elif model_arch in ("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM"):
@@ -3997,9 +4010,10 @@ class ServerArgs:
                 expected_attn_tp_size = get_mimo_v2_fused_qkv_expected_tp_size(
                     hf_config
                 )
-                attn_dp_size = self.dp_size if self.enable_dp_attention else 1
+                view = self._resolved()
+                attn_dp_size = self.dp_size if view.enable_dp_attention else 1
                 effective_attn_tp_size = (
-                    self.tp_size // attn_dp_size // self.attn_cp_size
+                    self.tp_size // attn_dp_size // view.attn_cp_size
                 )
                 if (
                     expected_attn_tp_size is not None
@@ -4012,8 +4026,8 @@ class ServerArgs:
                         f"TP={expected_attn_tp_size}-interleaved; got "
                         f"{effective_attn_tp_size} "
                         f"(tp_size={self.tp_size}, dp_size={self.dp_size}, "
-                        f"enable_dp_attention={self.enable_dp_attention}, "
-                        f"attn_cp_size={self.attn_cp_size}). "
+                        f"enable_dp_attention={view.enable_dp_attention}, "
+                        f"attn_cp_size={view.attn_cp_size}). "
                         "Set --tp, --dp, --enable-dp-attention, and "
                         "--attention-context-parallel-size so the effective "
                         f"attention TP size is {expected_attn_tp_size}."
@@ -4780,13 +4794,14 @@ class ServerArgs:
                 "(DeepSeek V3/R1, Kimi K2.5) or MHA/GQA-based models."
             )
 
-        if self.attn_cp_size > 1:
+        view = self._resolved()
+        if view.attn_cp_size > 1:
             # The tp_size is the world size, not the real tensor parallel size
             assert (
-                self.tp_size % self.attn_cp_size == 0
+                self.tp_size % view.attn_cp_size == 0
             ), "tp_size must be divisible by attn_cp_size"
             assert (
-                self.tp_size % (self.dp_size * self.attn_cp_size) == 0
+                self.tp_size % (self.dp_size * view.attn_cp_size) == 0
             ), "tp_size must be divisible by dp_size * attn_cp_size"
 
             assert (
@@ -4799,20 +4814,20 @@ class ServerArgs:
                 self.tp_size % self.moe_dp_size == 0
             ), "tp_size must be divisible by moe_dp_size"
             assert (
-                self.ep_size * self.moe_dp_size <= self.tp_size
+                view.ep_size * self.moe_dp_size <= self.tp_size
             ), "ep_size * moe_dp_size must be less than or equal to tp_size"
             assert self.pp_size == 1, "PP is not supported with context parallelism"
 
-            if self.ep_size > 1:
+            if view.ep_size > 1:
                 assert (
-                    self.ep_size * self.moe_dp_size == self.tp_size
+                    view.ep_size * self.moe_dp_size == self.tp_size
                 ), "ep_size * moe_dp_size must be equal to tp_size"
 
             assert (
                 not self.enable_aiter_allreduce_fusion
             ), "Aiter allreduce fusion is not supported with context parallelism"
 
-        if self.attn_cp_size != self.moe_dp_size:
+        if view.attn_cp_size != self.moe_dp_size:
             assert (
                 self.moe_dp_size == 1
             ), "attn_cp_size != moe_dp_size is only supported when moe_dp_size == 1"
@@ -4831,7 +4846,7 @@ class ServerArgs:
 
         run_post_process_pass(self, _data_parallelism_defaults)
 
-        if self.enable_dp_attention:
+        if self._resolved().enable_dp_attention:
             self.schedule_conservativeness = self.schedule_conservativeness * 0.3
             assert self.tp_size % self.dp_size == 0
             self.chunked_prefill_size = self.chunked_prefill_size // self.dp_size
@@ -4868,7 +4883,7 @@ class ServerArgs:
                 "modelopt_mixed",
                 None,
             ], f"Invalid quantization '{view.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
-            assert self.ep_size in [
+            assert view.ep_size in [
                 1,
                 self.tp_size,
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
@@ -4878,7 +4893,7 @@ class ServerArgs:
                 view.quantization in ["modelopt_fp4"]
                 or self.get_model_config().nvfp4_moe_meta is not None
             ), f"Invalid quantization '{view.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4' or hybrid NVFP4 models."
-            assert self.ep_size in [
+            assert view.ep_size in [
                 1,
                 self.tp_size,
             ], "The expert parallel size must be 1 or the same as the tensor parallel size"
@@ -4929,7 +4944,7 @@ class ServerArgs:
             "mxfp8",
         ]:
             assert (
-                self.ep_size == 1
+                resolved_view(self).ep_size == 1
             ), "FP8/MXFP8 Cutlass MoE is only supported with ep_size == 1"
 
     def cutedsl_moe_max_num_tokens(self) -> int:
@@ -4985,9 +5000,9 @@ class ServerArgs:
         max_dispatch_tokens_per_rank = get_int_env_var(
             "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 1024
         )
-        max_cutedsl_tokens = max_dispatch_tokens_per_rank * self.ep_size
+        max_cutedsl_tokens = max_dispatch_tokens_per_rank * view.ep_size
         if max_cutedsl_tokens < required_tokens:
-            required_per_rank = (required_tokens + self.ep_size - 1) // self.ep_size
+            required_per_rank = (required_tokens + view.ep_size - 1) // view.ep_size
             raise ValueError(
                 "FlashInfer MoE A2A with flashinfer_cutedsl requires "
                 "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK * "
@@ -4997,7 +5012,7 @@ class ServerArgs:
                 "`ValueError: num_tokens (...) exceeds max_num_tokens (...)`. "
                 "Current values: "
                 f"SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK="
-                f"{max_dispatch_tokens_per_rank}, ep_size={self.ep_size}, "
+                f"{max_dispatch_tokens_per_rank}, ep_size={view.ep_size}, "
                 f"capacity={max_cutedsl_tokens}, required={required_tokens}. "
                 f"Set `export "
                 f"SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK="
@@ -5074,7 +5089,7 @@ class ServerArgs:
                 ), "When fuse_mode is set to 2, the NPU supports only ModelSlim quantization."
         if a2a_backend == "flashinfer":
             assert (
-                self.enable_dp_attention and self.dp_size == self.tp_size
+                resolved_view(self).enable_dp_attention and self.dp_size == self.tp_size
             ), "Flashinfer MoE A2A is only supported with dp_size == tp_size and --enable-dp-attention"
             logger.warning(
                 f"Flashinfer MoE A2A is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
@@ -5132,7 +5147,7 @@ class ServerArgs:
             self.ep_dispatch_algorithm = "static"
 
         if self.enable_eplb:
-            assert self.ep_size > 1
+            assert self._resolved().ep_size > 1
 
     def _handle_elastic_ep(self):
         if self.elastic_ep_backend is not None:
@@ -5224,7 +5239,7 @@ class ServerArgs:
         # Context-parallel prefill stages K/V through cp_allgather_and_save_kv_cache,
         # which writes to the pool via set_kv_buffer. NoOpMHATokenToKVPool intentionally
         # raises on writes, so the engine would boot fine but fail on the first request.
-        if self.attn_cp_size > 1:
+        if self._resolved().attn_cp_size > 1:
             raise ValueError(
                 "--prefill-only-disable-kv-cache is incompatible with --attn-cp-size > 1: "
                 "the context-parallel attention path writes K/V to the pool via set_kv_buffer, "
@@ -6373,6 +6388,13 @@ class ServerArgs:
         self.model_config = ModelConfig.from_server_args(self)
         return self.model_config
 
+    def _resolved(self):
+        """Read-only view of the resolving configuration: dual-apply-retired
+        fields resolve from the declaration stash."""
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        return resolved_view(self)
+
     def _resolved_attention_backends(self):
         """Mid-resolution (prefill, decode) backends: reads through the pass
         view so dual-apply-retired fields resolve from the declaration
@@ -6465,10 +6487,11 @@ class ServerArgs:
         # there needs no extra opt-in env flag.
         from sglang.srt.arg_groups.overrides import resolved_view
 
+        view = resolved_view(self)
         if (
             self.enable_two_batch_overlap
-            and resolved_view(self).moe_a2a_backend == "none"
-            and not self.enable_dp_attention
+            and view.moe_a2a_backend == "none"
+            and not view.enable_dp_attention
         ):
             raise ValueError(
                 "When enabling two batch overlap without an EP a2a backend "
@@ -6506,7 +6529,9 @@ class ServerArgs:
             ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
 
         assert not (
-            self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention
+            self.dp_size > 1
+            and self.nnodes != 1
+            and not self._resolved().enable_dp_attention
         ), "multi-node data parallel is not supported unless dp attention!"
 
         assert self.base_gpu_id >= 0, "base_gpu_id must be non-negative"
@@ -7173,7 +7198,9 @@ class PortArgs:
                 rank=int(server_args.decoupled_spec_rank),
             )
 
-        if not server_args.enable_dp_attention:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        if not resolved_view(server_args).enable_dp_attention:
             # Normal case, use IPC within a single node
             return PortArgs(
                 tokenizer_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -49,6 +49,8 @@ DEFAULT_ADAPTIVE_CONFIG: dict[str, dict] = {
 
 def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
     """Return why adaptive spec cannot run under the given server args, or None if supported."""
+    from sglang.srt.arg_groups.overrides import resolved_view
+
     if server_args.speculative_algorithm not in ("EAGLE", "EAGLE3"):
         return (
             f"speculative_algorithm={server_args.speculative_algorithm} "
@@ -62,13 +64,11 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             f"speculative_eagle_topk={server_args.speculative_eagle_topk} "
             "(only topk=1 is supported)"
         )
-    if server_args.enable_dp_attention:
+    if resolved_view(server_args).enable_dp_attention:
         return (
             "enable_dp_attention=True is not supported "
             "(adaptive tier decisions are not synchronized across DP ranks)"
         )
-    from sglang.srt.arg_groups.overrides import resolved_view
-
     if resolved_view(server_args).enable_multi_layer_eagle:
         return (
             "enable_multi_layer_eagle=True is not supported "

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -170,7 +170,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self._rebuild_topk1_chain_buffers()
 
         # Load draft model weights only.
-        if server_args.enable_dp_attention and self.speculative_algorithm.is_eagle3():
+        if get_flags().enable_dp_attention and self.speculative_algorithm.is_eagle3():
             ctx = draft_tp_context(get_attention_tp_group())
         else:
             ctx = empty_context()
@@ -203,7 +203,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             and self.topk == 1
         )
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -155,7 +155,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         self.kv_context: Optional[FrozenKVMTPContext] = None
 
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
 
         self.draft_attn_backend = None

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -165,7 +165,7 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         draft_arch = self.draft_worker.model_config.hf_config.architectures[0]
         self.chain_mtp_hidden_states = draft_arch in ["Step3p5MTP"]
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -101,7 +101,7 @@ class StandaloneDraftWorker(EagleDraftWorker):
         # Alias for better readability
         self.draft_runner = self.draft_worker.model_runner
         self.draft_tp_context = (
-            draft_tp_context if server_args.enable_dp_attention else empty_context
+            draft_tp_context if get_flags().enable_dp_attention else empty_context
         )
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3448,15 +3448,14 @@ def require_mlp_tp_gather(server_args: ServerArgs):
     """
     Check if the input of MLP is obtained by all-gather rather than all-reduce. This only happens when each MLP TP group contains multiple attention DP groups.
     """
+    from sglang.srt.arg_groups.overrides import resolved_view
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
-    if server_args.enable_dp_attention:
-        from sglang.srt.arg_groups.overrides import resolved_view
-
-        # Callable pre-publish (Scheduler.init_moe_gemm_config computes
-        # require_mlp_sync before the model worker publishes the flags
-        # tier): read the resolved value through the view.
-        view = resolved_view(server_args)
+    # Callable pre-publish (Scheduler.init_moe_gemm_config computes
+    # require_mlp_sync before the model worker publishes the flags
+    # tier): read the resolved values through the view.
+    view = resolved_view(server_args)
+    if view.enable_dp_attention:
         assert server_args.dp_size > 1, "dp_size must be greater than 1"
         if (
             view.moe_dense_tp_size is None
@@ -3490,7 +3489,7 @@ def require_attn_tp_gather(server_args: ServerArgs):
         not get_moe_a2a_backend().is_none()
         or resolved_view(server_args).moe_dense_tp_size is not None
     ):
-        if server_args.enable_dp_attention:
+        if resolved_view(server_args).enable_dp_attention:
             return server_args.dp_size < server_args.tp_size
         else:
             return True
@@ -3503,7 +3502,11 @@ def require_gathered_buffer(server_args: ServerArgs):
 
 
 def require_mlp_sync(server_args: ServerArgs):
-    return server_args.enable_dp_attention or require_gathered_buffer(server_args)
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return resolved_view(server_args).enable_dp_attention or require_gathered_buffer(
+        server_args
+    )
 
 
 def find_local_repo_dir(repo_id: str, revision: Optional[str] = None) -> Optional[str]:


### PR DESCRIPTION
Unit 10 of the dual-apply retirement stack. Based on #30286.

`enable_dp_attention`, `ep_size` and `attn_cp_size` — the last three dual-applied fields — return to pristine user input. Their blocker was the launcher-family processes (engine entrypoint, data-parallel controllers, ray engine, tokenizer manager), which read resolved values where no publish exists; `resolved_view` over the instance-carried declaration stash solves this uniformly, so process-spawn sizing, PortArgs endpoint selection, dp-attention world-info computation and the tokenizer control gates all read views.

Pre-publish captures in the scheduler process read views as well; scheduler-process runtime readers read the leaves; the `__post_init__` validation chains read views through the new `ServerArgs._resolved()` helper; the eplb expert-location helpers and `require_*` family read views through their `server_args` parameter.

With 28 of 28 whitelisted fields retired, the transition dual-apply no longer writes anything; the machinery is dismantled in the next unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28820592236](https://github.com/sgl-project/sglang/actions/runs/28820592236)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28820591566](https://github.com/sgl-project/sglang/actions/runs/28820591566)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->