### PR TITLE
[DeepSeek V4] Fix stale override wording in ROCm FlashMLA sparse-prefill disable

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -26,13 +26,13 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
 
     # FlashMLA sparse prefill (SGLANG_OPT_FLASHMLA_SPARSE_PREFILL, default on)
     # currently returns incorrect output for DeepSeek-V4-Flash on ROCm/HIP
-    # (MI355X), which breaks the disaggregation nightly. Keep the previous
-    # (dense prefill) behavior on ROCm until the sparse kernel is validated
-    # there;
+    # (MI355X), which breaks the disaggregation nightly. Force the previous
+    # (dense prefill) behavior on ROCm until the sparse prefill kernel is
+    # validated there.
     if is_hip():
         logger.warning(
-            "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL by default on ROCm/HIP "
-            f"for {model_arch}; set it explicitly to override."
+            "Disabling SGLANG_OPT_FLASHMLA_SPARSE_PREFILL on ROCm/HIP "
+            f"for {model_arch} until the sparse prefill kernel is validated there."
         )
         envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
 


### PR DESCRIPTION
## Motivation

#30237 made the ROCm/HIP disable of `SGLANG_OPT_FLASHMLA_SPARSE_PREFILL` unconditional (dropped the `is_set()` check), which is correct — but the warning message and preceding comment still say the env var can be *set explicitly to override*, which is no longer true. This was also raised by the gemini review bot on #30237.

## Modifications

`python/sglang/srt/arg_groups/deepseek_v4_hook.py`: update the comment and `logger.warning` text to reflect that the flag is unconditionally disabled on ROCm/HIP until the sparse prefill kernel is validated there. No behavior change.

## Accuracy Tests

Comment/log-string only; no functional change.

## Checklist

- [x] Docs/log-string only, no behavior change.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28817248929](https://github.com/sgl-project/sglang/actions/runs/28817248929)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28817248875](https://github.com/sgl-project/sglang/actions/runs/28817248875)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->