### PR TITLE
[AMD] Register 5 CI-verified 1-GPU kernel/attention unit tests for AMD PR CI

### DIFF
--- a/test/registered/attention/test_gdn_noncontiguous_stride.py
+++ b/test/registered/attention/test_gdn_noncontiguous_stride.py
@@ -12,9 +12,10 @@ from sglang.srt.layers.attention.fla.fused_gdn_gating import fused_gdn_gating
 from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
     fused_sigmoid_gating_delta_rule_update,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=7, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=7, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 def _make_noncontiguous_ab(batch, num_heads, dtype=torch.bfloat16, device="cuda"):

--- a/test/registered/attention/test_kda_kernels.py
+++ b/test/registered/attention/test_kda_kernels.py
@@ -15,9 +15,10 @@ from sglang.srt.layers.attention.fla.kda import (
     kda_gate_chunk_cumsum,
 )
 from sglang.srt.utils.common import get_device
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=12, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=12, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 @unittest.skipIf(

--- a/test/registered/attention/test_trtllm_mha_page_table.py
+++ b/test/registered/attention/test_trtllm_mha_page_table.py
@@ -21,11 +21,12 @@ import torch
 from sglang.srt.layers.attention.triton_ops.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 # Triton kernel unit test for the trtllm_mha device-side page-table build.
 register_cuda_ci(est_time=14, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=14, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _build_page_table_reference(

--- a/test/registered/kernels/test_dsa_metadata.py
+++ b/test/registered/kernels/test_dsa_metadata.py
@@ -7,10 +7,11 @@ from sglang.srt.layers.attention.triton_ops.dsa_metadata import (
     fused_dsa_draft_extend_metadata,
     fused_dsa_target_verify_metadata,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=15, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 def _cu_seqlens(seqlens: torch.Tensor) -> torch.Tensor:

--- a/test/registered/unit/mem_cache/test_unified_mamba_views.py
+++ b/test/registered/unit/mem_cache/test_unified_mamba_views.py
@@ -46,12 +46,13 @@ import unittest
 
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 _HAS_CUDA = torch.cuda.is_available()
 _DEV = "cuda" if _HAS_CUDA else "cpu"
 
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _make_pool(


### PR DESCRIPTION
## Motivation

Extends AMD per-commit (PR-tier) test coverage tracked on the ROCm CI
dashboard. All 5 tests already run on NVIDIA per-commit CI (`base-b` 1-GPU) and
are hardware-agnostic (Triton kernels / plain-torch), so the standard
`register_amd_ci(...)` 2-line edit is sufficient — no ROCm-specific code changes.

## Modifications

`register_amd_ci(...)` added next to the existing `register_cuda_ci(...)`
(CUDA `base-b` → AMD `stage-b`):

| File | AMD suite | est | What it covers |
|---|---|---|---|
| [kernels/test_dsa_metadata.py](https://github.com/sgl-project/sglang/blob/main/test/registered/kernels/test_dsa_metadata.py) | `stage-b-test-1-gpu-large-amd` | 15 | Triton DSA metadata kernels (`fused_dsa_*_metadata`) + torch reference |
| [unit/mem_cache/test_unified_mamba_views.py](https://github.com/sgl-project/sglang/blob/main/test/registered/unit/mem_cache/test_unified_mamba_views.py) | `stage-b-test-1-gpu-small-amd` | 30 | Plain-torch view/stride round-trip for `UnifiedKVPool._build_mamba_views` |
| [attention/test_trtllm_mha_page_table.py](https://github.com/sgl-project/sglang/blob/main/test/registered/attention/test_trtllm_mha_page_table.py) | `stage-b-test-1-gpu-small-amd` | 14 | Triton device-side page-table build + torch reference |
| [attention/test_gdn_noncontiguous_stride.py](https://github.com/sgl-project/sglang/blob/main/test/registered/attention/test_gdn_noncontiguous_stride.py) | `stage-b-test-1-gpu-large-amd` | 7 | FLA gated-delta-net Triton kernels (non-contiguous stride) |
| [attention/test_kda_kernels.py](https://github.com/sgl-project/sglang/blob/main/test/registered/attention/test_kda_kernels.py) | `stage-b-test-1-gpu-large-amd` | 12 | KDA (Kimi delta attention) FLA Triton kernels |

## Test plan — verified on BOTH AMD lanes

| File | rocm700 (MI325, `pr-test-amd`) | rocm720 (ROCm 7.2.0, `pr-test-amd-rocm720`) |
|---|---|---|
| `test_dsa_metadata.py` | ✅ 7s | ✅ 8s |
| `test_unified_mamba_views.py` | ✅ 15s | ✅ 10s |
| `test_trtllm_mha_page_table.py` | ✅ 6s | ✅ 7s |
| `test_gdn_noncontiguous_stride.py` | ✅ 6s | ✅ 6s |
| `test_kda_kernels.py` | ✅ 22s | ✅ 21s |

- rocm700: small https://github.com/sgl-project/sglang/actions/runs/28832853806 · large https://github.com/sgl-project/sglang/actions/runs/28832854912
- rocm720: small https://github.com/sgl-project/sglang/actions/runs/28894526254 (`success`) · large https://github.com/sgl-project/sglang/actions/runs/28894528135

Run-level failures on the `*-large-amd` suites are pre-existing, unrelated
partition-mates (fail-fast); every file in this PR passed on both lanes.

- [x] AMD CI passes on the registered files — **rocm700 + rocm720**
- [x] NVIDIA CI green (registration-only change; PR merged)