### PR TITLE
[BugFix] Honor a stop inside a multi-token step that crosses max_new_tokens

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1482,13 +1482,6 @@ class Req(ReqDllmMixin):
             self.to_finish = None
             return
 
-        if len(self.output_ids) >= self.sampling_params.max_new_tokens:
-            self.finished_reason = FINISH_LENGTH(
-                length=self.sampling_params.max_new_tokens
-            )
-            self.finished_len = self.sampling_params.max_new_tokens
-            return
-
         new_accepted_tokens = self.output_ids[-new_accepted_len:]
 
         # Sanitize out-of-range / NaN token ids before any decode.
@@ -1498,12 +1491,34 @@ class Req(ReqDllmMixin):
         # Stop string beats EOS/stop-token matched in the same step (speculative
         # decoding can accept >1 token): token-based would trim only the last
         # token and leak the stop string.
-        if self._check_str_based_finish(new_accepted_len):
+        stop_matched = self._check_str_based_finish(
+            new_accepted_len
+        ) or self._check_token_based_finish(new_accepted_tokens)
+
+        # The length limit is checked AFTER the stop checks and clamped to the
+        # earlier cut. A single multi-token step (speculative / dllm) can accept
+        # a run that both contains a stop token/string and crosses
+        # max_new_tokens; checking length first (or without clamping) would mask
+        # the stop inside the run -- finish_reason would wrongly be 'length' and
+        # the tokens after the stop would leak to the user. A stop landing within
+        # the token budget wins; a stop past the budget (or no stop at all) means
+        # the request is length-limited.
+        max_new_tokens = self.sampling_params.max_new_tokens
+        if (
+            stop_matched
+            and self.finished_len is not None
+            and self.finished_len <= max_new_tokens
+        ):
             return
 
-        if self._check_token_based_finish(new_accepted_tokens):
+        if len(self.output_ids) >= max_new_tokens:
+            self.finished_reason = FINISH_LENGTH(length=max_new_tokens)
+            self.finished_len = max_new_tokens
             return
 
+        # Grammar termination is checked after the stop scans (#31738: a stop
+        # matched in the same step wins) and after the length limit (an
+        # over-budget run finishes as 'length', matching the pre-existing order).
         if self.grammar is not None and self.grammar.is_terminated():
             self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
             return

--- a/test/registered/unit/managers/test_stop_str_speculative.py
+++ b/test/registered/unit/managers/test_stop_str_speculative.py
@@ -16,6 +16,7 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -158,7 +159,7 @@ class TestStopStrSpeculative(unittest.TestCase):
         self.assertIsNone(req.finished_len)
 
 
-class TestFinishLengthVsStopSpeculative(unittest.TestCase):
+class TestFinishLengthVsStopSpeculative(CustomTestCase):
     """A stop token/string inside a multi-token accepted run that crosses
     max_new_tokens must be honored (correct finish_reason + trim at the stop),
     not masked by the length limit. Guards the ordering/clamping between the

--- a/test/registered/unit/managers/test_stop_str_speculative.py
+++ b/test/registered/unit/managers/test_stop_str_speculative.py
@@ -8,7 +8,12 @@ a fake tokenizer; pure CPU. Each test guards a distinct branch of
 import unittest
 from array import array
 
-from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_batch import (
+    FINISH_LENGTH,
+    FINISH_MATCHED_STR,
+    FINISH_MATCHED_TOKEN,
+    Req,
+)
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -50,8 +55,14 @@ class _MockTokenizerForNormalize:
         return list(range(len(s)))  # One "token" per character
 
 
-def _make_req(output_ids, stop=None, stop_regex=None, eos_token_ids=frozenset()):
-    sp = SamplingParams(max_new_tokens=1000, stop=stop, stop_regex=stop_regex)
+def _make_req(
+    output_ids,
+    stop=None,
+    stop_regex=None,
+    eos_token_ids=frozenset(),
+    max_new_tokens=1000,
+):
+    sp = SamplingParams(max_new_tokens=max_new_tokens, stop=stop, stop_regex=stop_regex)
     sp.normalize(tokenizer=_MockTokenizerForNormalize())  # char-based stop_str_max_len
     req = Req(
         rid="t",
@@ -145,6 +156,80 @@ class TestStopStrSpeculative(unittest.TestCase):
         req.update_finish_state(new_accepted_len=3)
         self.assertTrue(req.finished())
         self.assertIsNone(req.finished_len)
+
+
+class TestFinishLengthVsStopSpeculative(unittest.TestCase):
+    """A stop token/string inside a multi-token accepted run that crosses
+    max_new_tokens must be honored (correct finish_reason + trim at the stop),
+    not masked by the length limit. Guards the ordering/clamping between the
+    length check and the stop checks in `update_finish_state`.
+
+    Setup for all: max_new_tokens=10, output_ids has 11 tokens (an accepted run
+    of 3 crossed the budget), new_accepted_len=3 -> the run is indices 8,9,10.
+    """
+
+    def test_eos_within_budget_beats_length(self):
+        # EOS at index 8 (finished_len 9 <= 10): the stop token wins over length,
+        # and the token leaked after it (index 9) is trimmed.
+        req = _make_req(
+            [10, 11, 12, 13, 14, 15, 16, 17, EOS_ID, 20, 21],
+            eos_token_ids={EOS_ID},
+            max_new_tokens=10,
+        )
+        req.update_finish_state(new_accepted_len=3)
+        self.assertTrue(req.finished())
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+        self.assertEqual(req.finished_reason.matched, EOS_ID)
+        self.assertEqual(req.finished_len, 9)
+
+    def test_eos_at_budget_boundary_is_stop_not_length(self):
+        # EOS at index 9 -> finished_len 10 == the length cap. finished_len is the
+        # same either way, but the reason must be 'stop', not 'length'.
+        req = _make_req(
+            [10, 11, 12, 13, 14, 15, 16, 17, 20, EOS_ID, 21],
+            eos_token_ids={EOS_ID},
+            max_new_tokens=10,
+        )
+        req.update_finish_state(new_accepted_len=3)
+        self.assertTrue(req.finished())
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+        self.assertEqual(req.finished_len, 10)
+
+    def test_eos_past_budget_is_length_limited(self):
+        # EOS at index 10, past the budget: no stop within budget, so the request
+        # is length-limited and trimmed to max_new_tokens (no leak).
+        req = _make_req(
+            [10, 11, 12, 13, 14, 15, 16, 17, 18, 20, EOS_ID],
+            eos_token_ids={EOS_ID},
+            max_new_tokens=10,
+        )
+        req.update_finish_state(new_accepted_len=3)
+        self.assertTrue(req.finished())
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 10)
+
+    def test_stop_str_within_budget_beats_length(self):
+        # A stop string inside the over-budget run is honored, not masked by the
+        # length cap. Stop lands within budget so its reason wins.
+        req = _make_req(
+            [10, 11, 12, 13, 14, 15, 16, 17, STOP_ID, 20, 21],
+            stop=["STOP"],
+            max_new_tokens=10,
+        )
+        req.update_finish_state(new_accepted_len=3)
+        self.assertTrue(req.finished())
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_STR)
+        self.assertEqual(req.finished_reason.matched, "STOP")
+        self.assertIsNotNone(req.finished_len)
+        self.assertLessEqual(req.finished_len, 10)
+
+    def test_no_stop_over_budget_is_length(self):
+        # Baseline (unchanged): no stop in the run -> FINISH_LENGTH at the cap.
+        req = _make_req(list(range(10, 21)), max_new_tokens=10)
+        req.update_finish_state(new_accepted_len=3)
+        self.assertTrue(req.finished())
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`Req.update_finish_state` checked the `max_new_tokens` length limit and returned `FINISH_LENGTH` **before** the stop-string / stop-token checks.

With speculative or dllm decoding, a single step commits a whole accepted run at once (the caller `extend`s `output_ids` by the full run, then calls `update_finish_state(new_accepted_len)`). So one step can **both** contain a stop (EOS / stop token / stop string) **and** push the request past `max_new_tokens`. When that happens, the early length return masked the stop:

- `finish_reason` was wrongly `'length'` instead of `'stop'`, and
- tokens accepted **after** the stop leaked to the user, because `output_ids_through_stop` trims at `finished_len` (= the length cap) instead of at the stop.

### Concrete failure
`max_new_tokens=10`, `output_ids` has 8 tokens, a step accepts the run `[EOS, t, t']` → `len(output_ids)=11 ≥ 10`, so `FINISH_LENGTH` fires first with `finished_len=10`. The EOS is at index 8, so the correct result is `FINISH_MATCHED_TOKEN` with `finished_len=9`. The user instead receives one token past EOS and `finish_reason='length'` — wrong OpenAI-API semantics plus a leak.

`_check_token_based_finish` already scans the whole accepted run and computes the right cut for a mid-run EOS — it was simply unreachable once the run crossed the length boundary. This is the same class of ordering bug the team already fixed one layer down (stop-string vs stop-token, #28802); the length check above both had the same hazard.

## Modifications

In `update_finish_state`, run the stop checks first and check the length limit afterwards, **clamped to the earlier cut**:

- A stop landing **within** the `max_new_tokens` budget wins → correct `finish_reason` + trim at the stop.
- A stop landing **past** the budget, or no stop at all → the request is length-limited (`FINISH_LENGTH` at the cap).

This is deliberately **not** a blind reorder: an EOS past the budget must still finish as `'length'`, so the length check takes the minimum of the stop cut and the length cap. Behavior is unchanged for every request that does not cross the budget within a single step.

Note: because the length check now runs last, the grammar-termination and NaN/vocab-boundary checks now precede it (they were after). This is intentional — a definite stop within the step is honored, and length is the fallback.

## Accuracy Tests

Added regression tests to `test/registered/unit/managers/test_stop_str_speculative.py` (pure CPU, drives the real `update_finish_state` with a fake tokenizer, no model load):

- EOS within budget → `FINISH_MATCHED_TOKEN`, trimmed at the stop (previously `'length'` + leaked token)
- EOS exactly at the budget boundary → reason is `'stop'`, not `'length'`
- EOS past the budget → `FINISH_LENGTH` (guard)
- stop string within budget → string reason wins (guard for the string path)
- no stop over budget → `FINISH_LENGTH` (baseline)

Verified the three within-budget tests fail on the pre-fix code and pass after; the existing tests in the file continue to pass.

## Speed Tests and Profiling

No performance impact: this is a control-flow reorder inside a CPU-side bookkeeping method; no extra work on the hot path.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation — N/A (no user-facing surface change).
- [x] Accuracy verified via the regression tests above. Standard GSM8K / speed benchmarks are not applicable to a finish-state ordering fix.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29835352573](https://github.com/sgl-project/sglang/actions/runs/29835352573)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29835352426](https://github.com/sgl-project/sglang/actions/runs/29835352426)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->