### PR TITLE
[Fix] Avoid chunked-prefill slot double-count that pins the running batch below `max_running_requests`

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2730,9 +2730,16 @@ class Scheduler(
 
         return ret
 
-    def get_num_allocatable_reqs(self, running_bs):
+    def get_num_allocatable_reqs(self, running_bs, chunked_req_in_flight=False):
         res = get_global_server_args().pp_max_micro_batch_size - running_bs
-        res = min(res, self.req_to_token_pool.available_size())
+        # An in-flight chunked prefill already holds a req_to_token_pool slot
+        # (deducted from available_size()) and is re-counted in the adder's
+        # can_run_list by add_chunked_req, so add that held slot back here to
+        # avoid declaring the batch full one request early.
+        res = min(
+            res,
+            self.req_to_token_pool.available_size() + int(chunked_req_in_flight),
+        )
         return res
 
     def get_new_batch_prefill(self) -> Optional[ScheduleBatch]:
@@ -2837,6 +2844,10 @@ class Scheduler(
             waiting_queue_len=len(self.waiting_queue),
         )
 
+        # add_chunked_req returns None on the final chunk, so capture whether a
+        # chunk is in flight (holding a req_to_token_pool slot) before the call;
+        # the batch-full check below compensates for that already-held slot.
+        chunked_req_holds_slot = self.chunked_req is not None
         if self.chunked_req is not None:
             self.chunked_req.init_next_round_input()
             self.chunked_req = adder.add_chunked_req(self.chunked_req)
@@ -2863,7 +2874,9 @@ class Scheduler(
                 continue
 
             running_bs = len(self.running_batch.reqs)
-            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
+            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(
+                running_bs, chunked_req_in_flight=chunked_req_holds_slot
+            ):
                 self.running_batch.batch_is_full = True
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 # In prefill mode, prealloc queue and transfer queue can also take memory,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3232,7 +3232,7 @@ class Scheduler(
 
         return NextBatchPlan(batch_to_run=ret, running_batch=running_batch)
 
-    def get_num_allocatable_reqs(self, running_bs, chunked_req_in_flight=False):
+    def get_num_allocatable_reqs(self, running_bs, chunked_req_in_batch=False):
         res = get_parallel().pp_max_micro_batch_size - running_bs
         # An in-flight chunked prefill already holds a req_to_token_pool slot
         # (deducted from available_size()) and is re-counted in the adder's
@@ -3240,7 +3240,7 @@ class Scheduler(
         # avoid declaring the batch full one request early.
         res = min(
             res,
-            self.req_to_token_pool.available_size() + int(chunked_req_in_flight),
+            self.req_to_token_pool.available_size() + int(chunked_req_in_batch),
         )
         return res
 
@@ -3363,13 +3363,17 @@ class Scheduler(
             prefill_tile_block_m=prefill_tile_block_m,
         )
 
-        # add_chunked_req returns None on the final chunk, so capture whether a
-        # chunk is in flight (holding a req_to_token_pool slot) before the call;
-        # the batch-full check below compensates for that already-held slot.
-        chunked_req_holds_slot = self.chunked_req is not None
-        if self.chunked_req is not None:
-            self.chunked_req.init_next_round_input()
-            self.chunked_req = adder.add_chunked_req(self.chunked_req)
+        chunked_req = self.chunked_req
+        if chunked_req is not None:
+            chunked_req.init_next_round_input()
+            self.chunked_req = adder.add_chunked_req(chunked_req)
+
+        # Only compensate the pool term when the already-allocated chunk is
+        # counted in this batch. Hybrid-SWA may park it without appending it,
+        # while a final chunk is appended even though add_chunked_req returns None.
+        chunked_req_in_batch = chunked_req is not None and any(
+            req is chunked_req for req in adder.can_run_list
+        )
 
         if self.enable_lora:
             running_loras = {
@@ -3394,13 +3398,15 @@ class Scheduler(
 
             running_bs = len(running_batch.reqs)
             if len(adder.can_run_list) >= self.get_num_allocatable_reqs(
-                running_bs, chunked_req_in_flight=chunked_req_holds_slot
+                running_bs, chunked_req_in_batch=chunked_req_in_batch
             ):
                 running_batch.batch_is_full = True
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 # In prefill mode, prealloc queue and transfer queue can also take memory,
                 # so we need to check if the available size for the actual available size.
-                if len(adder.can_run_list) >= self.req_to_token_pool.available_size():
+                if len(adder.can_run_list) >= (
+                    self.req_to_token_pool.available_size() + int(chunked_req_in_batch)
+                ):
                     running_batch.batch_is_full = True
 
             if running_batch.batch_is_full:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3232,9 +3232,16 @@ class Scheduler(
 
         return NextBatchPlan(batch_to_run=ret, running_batch=running_batch)
 
-    def get_num_allocatable_reqs(self, running_bs):
+    def get_num_allocatable_reqs(self, running_bs, chunked_req_in_flight=False):
         res = get_parallel().pp_max_micro_batch_size - running_bs
-        res = min(res, self.req_to_token_pool.available_size())
+        # An in-flight chunked prefill already holds a req_to_token_pool slot
+        # (deducted from available_size()) and is re-counted in the adder's
+        # can_run_list by add_chunked_req, so add that held slot back here to
+        # avoid declaring the batch full one request early.
+        res = min(
+            res,
+            self.req_to_token_pool.available_size() + int(chunked_req_in_flight),
+        )
         return res
 
     def get_new_batch_prefill(self, running_batch: ScheduleBatch) -> NextBatchPlan:
@@ -3356,6 +3363,10 @@ class Scheduler(
             prefill_tile_block_m=prefill_tile_block_m,
         )
 
+        # add_chunked_req returns None on the final chunk, so capture whether a
+        # chunk is in flight (holding a req_to_token_pool slot) before the call;
+        # the batch-full check below compensates for that already-held slot.
+        chunked_req_holds_slot = self.chunked_req is not None
         if self.chunked_req is not None:
             self.chunked_req.init_next_round_input()
             self.chunked_req = adder.add_chunked_req(self.chunked_req)
@@ -3382,7 +3393,9 @@ class Scheduler(
                 continue
 
             running_bs = len(running_batch.reqs)
-            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
+            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(
+                running_bs, chunked_req_in_flight=chunked_req_holds_slot
+            ):
                 running_batch.batch_is_full = True
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 # In prefill mode, prealloc queue and transfer queue can also take memory,

--- a/test/registered/unit/managers/test_get_new_batch_prefill_chunked_slot.py
+++ b/test/registered/unit/managers/test_get_new_batch_prefill_chunked_slot.py
@@ -1,0 +1,216 @@
+"""Behavioral regression test for the chunked-prefill slot double-count in
+``Scheduler._get_new_batch_prefill_raw``.
+
+An in-flight chunked prefill already holds its ``req_to_token_pool`` slot (that
+slot is deducted from ``available_size()``) AND is re-appended to the adder's
+``can_run_list`` by ``add_chunked_req``. The admission gate
+
+    num_allocatable = min(
+        pp_max_micro_batch_size - running_bs,
+        available_size() + int(chunked_req_holds_slot),
+    )
+    if len(can_run_list) >= num_allocatable:
+        batch_is_full = True
+
+must add that already-held slot back (the ``+ int(chunked_req_holds_slot)``
+term). Without it the batch is declared full one request early, and because
+``batch_is_full`` is sticky (reset only when a request finishes) the rank parks
+at ``max_running_requests - 1`` with requests still queued -- the DP-attention
+"caps at 15 instead of 16" symptom.
+
+Rather than re-assert the arithmetic, these tests drive the real
+``_get_new_batch_prefill_raw`` and check the observable outcome: is the queued
+request actually *issued* (moved out of the waiting queue into the prefill
+batch) or left parked? The admission gate lives in the method itself and only
+reads ``can_run_list`` plus the result of ``add_one_req``, so a faithful fake
+``PrefillAdder`` (add_chunked_req re-appends the in-flight chunk; add_one_req
+always admits -- there is token budget, only the slot/ceiling gate limits us)
+leaves the real gate under test. ``available_size()`` is held constant because
+the real ``add_one_req`` allocates no ``req_to_token_pool`` slot -- those are
+allocated later in ``prepare_for_extend`` -- so free-slot count does not change
+across the admit loop.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.managers.schedule_policy import AddReqResult
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class _FakeAdder:
+    """Minimal stand-in for ``PrefillAdder``.
+
+    The admission gate under test lives in ``_get_new_batch_prefill_raw`` itself
+    and only reads ``can_run_list`` and the return of ``add_one_req``. This fake
+    models exactly that: ``add_chunked_req`` re-appends the in-flight chunk
+    (whose pool slot is already held from a previous pass), and ``add_one_req``
+    always admits -- in these scenarios there is always token budget, so only the
+    slot/ceiling gate can limit admission.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.can_run_list = []
+        self.preempt_list = []
+        self.new_chunked_req = None
+
+    def add_chunked_req(self, req):
+        self.can_run_list.append(req)
+        return req  # truncated=True: still chunking, not the final chunk
+
+    def add_one_req(self, req, has_chunked_req=False, truncation_align_size=None):
+        self.can_run_list.append(req)
+        return AddReqResult.CONTINUE
+
+
+def _make_scheduler(*, ceiling, running_bs, pool_avail, chunked_req, waiting_queue):
+    """A ``Scheduler`` skeleton carrying only the attributes
+    ``_get_new_batch_prefill_raw`` reads on the path exercised here."""
+    s = Scheduler.__new__(Scheduler)
+    # _run_prefill patches get_global_server_args() to return this, so the
+    # ceiling term of the gate reads pp_max_micro_batch_size == ceiling.
+    s._server_args_stub = SimpleNamespace(pp_max_micro_batch_size=ceiling)
+    s.grammar_manager = MagicMock()
+    s.grammar_manager.has_waiting_grammars.return_value = False
+    s.enable_hierarchical_cache = False
+    s.enable_priority_preemption = False
+    s.is_hybrid_swa = False
+    s.spec_algorithm = MagicMock()
+    s.min_free_slots_delayer = None  # skip the free-slots prefill delay
+    s.policy = MagicMock()
+    s.chunked_prefill_size = 8192
+    s.enable_dynamic_chunking = False
+    s.page_size = 1
+    s.tree_cache = MagicMock()
+    s.token_to_kv_pool_allocator = MagicMock()
+    s.new_token_ratio_tracker = SimpleNamespace(current=0.0)
+    s.max_prefill_tokens = 1 << 20
+    s.is_mixed_chunk = False
+    s.priority_scheduling_preemption_threshold = 0
+    s.max_prefill_bs = 0
+    s.max_running_requests = ceiling
+    s.server_args = SimpleNamespace(prefill_max_requests=None)
+    s.prefill_delayer = None
+    s.dllm_config = None
+    s.enable_lora = False
+    s.disaggregation_mode = None  # != DisaggregationMode.PREFILL
+    s.truncation_align_size = None
+    s.enable_hicache_storage = False
+    s.enable_priority_scheduling = False
+    s.load_inquirer = MagicMock()
+    s.model_config = MagicMock()
+    s.enable_overlap = False
+    s.tp_worker = SimpleNamespace(model_runner=SimpleNamespace(prefill_aware_swa=False))
+    # A pool with no ``mamba_allocator`` attr, so getattr(..., None) short-circuits.
+    s.req_to_token_pool = SimpleNamespace(available_size=lambda: pool_avail)
+    s.running_batch = SimpleNamespace(
+        reqs=list(range(running_bs)),
+        batch_is_full=False,
+        return_logprob=False,
+        is_empty=lambda: running_bs == 0,
+    )
+    s.chunked_req = chunked_req
+    s.waiting_queue = list(waiting_queue)
+    return s
+
+
+def _run_prefill(s):
+    """Drive the real gate; stub only the batch-construction tail (real KV pools
+    / CUDA) and the ``PrefillAdder`` factory, capturing the adder instance so the
+    resulting ``can_run_list`` can be inspected."""
+    created = []
+
+    def _factory(*args, **kwargs):
+        adder = _FakeAdder()
+        created.append(adder)
+        return adder
+
+    with patch(
+        "sglang.srt.managers.scheduler.PrefillAdder", side_effect=_factory
+    ), patch("sglang.srt.managers.scheduler.ScheduleBatch"), patch(
+        "sglang.srt.managers.scheduler.PrefillStats"
+    ), patch(
+        "sglang.srt.managers.scheduler.get_global_server_args",
+        return_value=s._server_args_stub,
+    ):
+        batch = Scheduler._get_new_batch_prefill_raw(
+            s, prefill_delayer_single_pass=None
+        )
+    return batch, created[0]
+
+
+class TestGetNewBatchPrefillChunkedSlot(CustomTestCase):
+    def test_chunked_slot_added_back_so_queued_req_is_issued(self):
+        # Live-trace scenario: ceiling 16, 14 decoding, a chunk in flight holding
+        # the 15th slot, exactly one free req_to_token_pool slot, one queued req.
+        #   buggy: min(16-14, 1)     = 1 -> can_run_list 1 >= 1 -> FULL, parked at 15
+        #   fixed: min(16-14, 1 + 1) = 2 -> can_run_list 1 <  2 -> issue queued -> 16
+        q = MagicMock(name="queued")
+        chunk = MagicMock(name="chunked")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=14,
+            pool_avail=1,
+            chunked_req=chunk,
+            waiting_queue=[q],
+        )
+
+        batch, adder = _run_prefill(s)
+
+        self.assertIn(q, adder.can_run_list)  # the queued request was issued
+        self.assertEqual(adder.can_run_list, [chunk, q])
+        self.assertEqual(s.waiting_queue, [])  # ... and dequeued
+        self.assertFalse(s.running_batch.batch_is_full)
+        self.assertIsNotNone(batch)
+
+    def test_ceiling_term_still_caps_total_no_over_admit(self):
+        # The +1 compensation must not over-admit past the ceiling. At running_bs
+        # 15 with a chunk in flight, 15 decoding + 1 chunk already == 16 == ceiling,
+        # so the queued req must be refused even though the pool has spare slots.
+        q = MagicMock(name="queued")
+        chunk = MagicMock(name="chunked")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=15,
+            pool_avail=8,
+            chunked_req=chunk,
+            waiting_queue=[q],
+        )
+
+        _, adder = _run_prefill(s)
+
+        self.assertNotIn(q, adder.can_run_list)
+        self.assertEqual(adder.can_run_list, [chunk])
+        self.assertEqual(s.waiting_queue, [q])  # left queued
+        self.assertTrue(s.running_batch.batch_is_full)
+
+    def test_no_chunk_in_flight_is_unchanged_legacy_behavior(self):
+        # No chunk -> no compensation (+0). With one free slot and ceiling room
+        # for two, exactly one new req is admitted (legacy min(16-14, 1) == 1);
+        # the second is left queued. Confirms the fix is scoped to the chunk case.
+        q1 = MagicMock(name="q1")
+        q2 = MagicMock(name="q2")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=14,
+            pool_avail=1,
+            chunked_req=None,
+            waiting_queue=[q1, q2],
+        )
+
+        _, adder = _run_prefill(s)
+
+        self.assertEqual(adder.can_run_list, [q1])
+        self.assertEqual(s.waiting_queue, [q2])
+        self.assertTrue(s.running_batch.batch_is_full)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_get_new_batch_prefill_chunked_slot.py
+++ b/test/registered/unit/managers/test_get_new_batch_prefill_chunked_slot.py
@@ -7,12 +7,12 @@ slot is deducted from ``available_size()``) AND is re-appended to the adder's
 
     num_allocatable = min(
         pp_max_micro_batch_size - running_bs,
-        available_size() + int(chunked_req_holds_slot),
+        available_size() + int(chunked_req_in_batch),
     )
     if len(can_run_list) >= num_allocatable:
         batch_is_full = True
 
-must add that already-held slot back (the ``+ int(chunked_req_holds_slot)``
+must add that already-held slot back (the ``+ int(chunked_req_in_batch)``
 term). Without it the batch is declared full one request early, and because
 ``batch_is_full`` is sticky (reset only when a request finishes) the rank parks
 at ``max_running_requests - 1`` with requests still queued -- the DP-attention
@@ -35,6 +35,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.schedule_policy import AddReqResult
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.runtime_context import get_context
@@ -57,21 +58,34 @@ class _FakeAdder:
     slot/ceiling gate can limit admission.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *, schedule_chunk=True, chunk_continues=True):
         self.can_run_list = []
         self.preempt_list = []
         self.new_chunked_req = None
+        self.schedule_chunk = schedule_chunk
+        self.chunk_continues = chunk_continues
 
     def add_chunked_req(self, req):
-        self.can_run_list.append(req)
-        return req  # truncated=True: still chunking, not the final chunk
+        if self.schedule_chunk:
+            self.can_run_list.append(req)
+        return req if self.chunk_continues else None
 
     def add_one_req(self, req, has_chunked_req=False, truncation_align_size=None):
         self.can_run_list.append(req)
         return AddReqResult.CONTINUE
 
 
-def _make_scheduler(*, ceiling, running_bs, pool_avail, chunked_req, waiting_queue):
+def _make_scheduler(
+    *,
+    ceiling,
+    running_bs,
+    pool_avail,
+    chunked_req,
+    waiting_queue,
+    disaggregation_mode=None,
+    schedule_chunk=True,
+    chunk_continues=True,
+):
     """A ``Scheduler`` skeleton carrying only the attributes
     ``_get_new_batch_prefill_raw`` reads on the path exercised here."""
     s = Scheduler.__new__(Scheduler)
@@ -102,7 +116,7 @@ def _make_scheduler(*, ceiling, running_bs, pool_avail, chunked_req, waiting_que
     s.prefill_delayer = None
     s.dllm_config = None
     s.enable_lora = False
-    s.disaggregation_mode = None  # != DisaggregationMode.PREFILL
+    s.disaggregation_mode = disaggregation_mode
     s.truncation_align_size = None
     s.enable_hicache_storage = False
     s.enable_priority_scheduling = False
@@ -126,6 +140,8 @@ def _make_scheduler(*, ceiling, running_bs, pool_avail, chunked_req, waiting_que
     )
     s.chunked_req = chunked_req
     s.waiting_queue = list(waiting_queue)
+    s._test_schedule_chunk = schedule_chunk
+    s._test_chunk_continues = chunk_continues
     return s
 
 
@@ -136,7 +152,10 @@ def _run_prefill(s):
     created = []
 
     def _factory(*args, **kwargs):
-        adder = _FakeAdder()
+        adder = _FakeAdder(
+            schedule_chunk=s._test_schedule_chunk,
+            chunk_continues=s._test_chunk_continues,
+        )
         created.append(adder)
         return adder
 
@@ -212,6 +231,60 @@ class TestGetNewBatchPrefillChunkedSlot(CustomTestCase):
             pool_avail=1,
             chunked_req=None,
             waiting_queue=[q1, q2],
+        )
+
+        _, adder = _run_prefill(s)
+
+        self.assertEqual(adder.can_run_list, [q1])
+        self.assertEqual(s.waiting_queue, [q2])
+        self.assertTrue(s.running_batch.batch_is_full)
+
+    def test_pd_prefill_pool_gate_also_adds_back_chunked_slot(self):
+        q = MagicMock(name="queued")
+        chunk = MagicMock(name="chunked")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=14,
+            pool_avail=1,
+            chunked_req=chunk,
+            waiting_queue=[q],
+            disaggregation_mode=DisaggregationMode.PREFILL,
+        )
+
+        _, adder = _run_prefill(s)
+
+        self.assertEqual(adder.can_run_list, [chunk, q])
+        self.assertEqual(s.waiting_queue, [])
+        self.assertFalse(s.running_batch.batch_is_full)
+
+    def test_final_chunk_still_receives_held_slot_credit(self):
+        q = MagicMock(name="queued")
+        chunk = MagicMock(name="final_chunk")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=14,
+            pool_avail=1,
+            chunked_req=chunk,
+            waiting_queue=[q],
+            chunk_continues=False,
+        )
+
+        _, adder = _run_prefill(s)
+
+        self.assertEqual(adder.can_run_list, [chunk, q])
+        self.assertIsNone(s.chunked_req)
+
+    def test_parked_chunk_does_not_receive_slot_credit(self):
+        q1 = MagicMock(name="q1")
+        q2 = MagicMock(name="q2")
+        chunk = MagicMock(name="parked_hybrid_swa_chunk")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=14,
+            pool_avail=1,
+            chunked_req=chunk,
+            waiting_queue=[q1, q2],
+            schedule_chunk=False,
         )
 
         _, adder = _run_prefill(s)

--- a/test/registered/unit/managers/test_get_new_batch_prefill_chunked_slot.py
+++ b/test/registered/unit/managers/test_get_new_batch_prefill_chunked_slot.py
@@ -1,0 +1,225 @@
+"""Behavioral regression test for the chunked-prefill slot double-count in
+``Scheduler._get_new_batch_prefill_raw``.
+
+An in-flight chunked prefill already holds its ``req_to_token_pool`` slot (that
+slot is deducted from ``available_size()``) AND is re-appended to the adder's
+``can_run_list`` by ``add_chunked_req``. The admission gate
+
+    num_allocatable = min(
+        pp_max_micro_batch_size - running_bs,
+        available_size() + int(chunked_req_holds_slot),
+    )
+    if len(can_run_list) >= num_allocatable:
+        batch_is_full = True
+
+must add that already-held slot back (the ``+ int(chunked_req_holds_slot)``
+term). Without it the batch is declared full one request early, and because
+``batch_is_full`` is sticky (reset only when a request finishes) the rank parks
+at ``max_running_requests - 1`` with requests still queued -- the DP-attention
+"caps at 15 instead of 16" symptom.
+
+Rather than re-assert the arithmetic, these tests drive the real
+``_get_new_batch_prefill_raw`` and check the observable outcome: is the queued
+request actually *issued* (moved out of the waiting queue into the prefill
+batch) or left parked? The admission gate lives in the method itself and only
+reads ``can_run_list`` plus the result of ``add_one_req``, so a faithful fake
+``PrefillAdder`` (add_chunked_req re-appends the in-flight chunk; add_one_req
+always admits -- there is token budget, only the slot/ceiling gate limits us)
+leaves the real gate under test. ``available_size()`` is held constant because
+the real ``add_one_req`` allocates no ``req_to_token_pool`` slot -- those are
+allocated later in ``prepare_for_extend`` -- so free-slot count does not change
+across the admit loop.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.managers.schedule_policy import AddReqResult
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class _FakeAdder:
+    """Minimal stand-in for ``PrefillAdder``.
+
+    The admission gate under test lives in ``_get_new_batch_prefill_raw`` itself
+    and only reads ``can_run_list`` and the return of ``add_one_req``. This fake
+    models exactly that: ``add_chunked_req`` re-appends the in-flight chunk
+    (whose pool slot is already held from a previous pass), and ``add_one_req``
+    always admits -- in these scenarios there is always token budget, so only the
+    slot/ceiling gate can limit admission.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.can_run_list = []
+        self.preempt_list = []
+        self.new_chunked_req = None
+
+    def add_chunked_req(self, req):
+        self.can_run_list.append(req)
+        return req  # truncated=True: still chunking, not the final chunk
+
+    def add_one_req(self, req, has_chunked_req=False, truncation_align_size=None):
+        self.can_run_list.append(req)
+        return AddReqResult.CONTINUE
+
+
+def _make_scheduler(*, ceiling, running_bs, pool_avail, chunked_req, waiting_queue):
+    """A ``Scheduler`` skeleton carrying only the attributes
+    ``_get_new_batch_prefill_raw`` reads on the path exercised here."""
+    s = Scheduler.__new__(Scheduler)
+    # _run_prefill publishes a context carrying this, so the ceiling term of
+    # the gate reads get_parallel().pp_max_micro_batch_size == ceiling.
+    s._test_ceiling = ceiling
+    s.grammar_manager = MagicMock()
+    s.grammar_manager.has_waiting_grammars.return_value = False
+    s.enable_hierarchical_cache = False
+    s.enable_priority_preemption = False
+    s.is_hybrid_swa = False
+    s.spec_algorithm = MagicMock()
+    s.min_free_slots_delayer = None  # skip the free-slots prefill delay
+    s.policy = MagicMock()
+    s.chunked_prefill_size = 8192
+    s.enable_dynamic_chunking = False
+    s.page_size = 1
+    s.tree_cache = MagicMock()
+    s.token_to_kv_pool_allocator = MagicMock()
+    s.new_token_ratio_tracker = SimpleNamespace(current=0.0)
+    s.max_prefill_tokens = 1 << 20
+    s.is_mixed_chunk = False
+    s.priority_scheduling_preemption_threshold = 0
+    s.max_prefill_bs = 0
+    s.max_running_requests = ceiling
+    # Only ever passed along (to preempt_to_schedule), never read on this path.
+    s.server_args = MagicMock()
+    s.prefill_delayer = None
+    s.dllm_config = None
+    s.enable_lora = False
+    s.disaggregation_mode = None  # != DisaggregationMode.PREFILL
+    s.truncation_align_size = None
+    s.enable_hicache_storage = False
+    s.enable_priority_scheduling = False
+    s.load_inquirer = MagicMock()
+    s.model_config = MagicMock()
+    s.enable_overlap = False
+    # A model runner with no ``extend_attention_block_m`` on its backend, so the
+    # adder's tile budget takes the non-Triton fallback.
+    s.tp_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            prefill_aware_swa=False, attn_backend=SimpleNamespace()
+        )
+    )
+    # A pool with no ``mamba_allocator`` attr, so getattr(..., None) short-circuits.
+    s.req_to_token_pool = SimpleNamespace(available_size=lambda: pool_avail)
+    s.running_batch = SimpleNamespace(
+        reqs=list(range(running_bs)),
+        batch_is_full=False,
+        return_logprob=False,
+        is_empty=lambda: running_bs == 0,
+    )
+    s.chunked_req = chunked_req
+    s.waiting_queue = list(waiting_queue)
+    return s
+
+
+def _run_prefill(s):
+    """Drive the real gate; stub only the batch-construction tail (real KV pools
+    / CUDA) and the ``PrefillAdder`` factory, capturing the adder instance so the
+    resulting ``can_run_list`` can be inspected."""
+    created = []
+
+    def _factory(*args, **kwargs):
+        adder = _FakeAdder()
+        created.append(adder)
+        return adder
+
+    with get_context().override_server_args(
+        pp_max_micro_batch_size=s._test_ceiling
+    ), patch("sglang.srt.managers.scheduler.PrefillAdder", side_effect=_factory), patch(
+        "sglang.srt.managers.scheduler.ScheduleBatch"
+    ), patch(
+        "sglang.srt.managers.scheduler.PrefillStats"
+    ):
+        batch, _ = Scheduler._get_new_batch_prefill_raw(
+            s,
+            prefill_delayer_single_pass=None,
+            running_batch=s.running_batch,
+        )
+    return batch, created[0]
+
+
+class TestGetNewBatchPrefillChunkedSlot(CustomTestCase):
+    def test_chunked_slot_added_back_so_queued_req_is_issued(self):
+        # Live-trace scenario: ceiling 16, 14 decoding, a chunk in flight holding
+        # the 15th slot, exactly one free req_to_token_pool slot, one queued req.
+        #   buggy: min(16-14, 1)     = 1 -> can_run_list 1 >= 1 -> FULL, parked at 15
+        #   fixed: min(16-14, 1 + 1) = 2 -> can_run_list 1 <  2 -> issue queued -> 16
+        q = MagicMock(name="queued")
+        chunk = MagicMock(name="chunked")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=14,
+            pool_avail=1,
+            chunked_req=chunk,
+            waiting_queue=[q],
+        )
+
+        batch, adder = _run_prefill(s)
+
+        self.assertIn(q, adder.can_run_list)  # the queued request was issued
+        self.assertEqual(adder.can_run_list, [chunk, q])
+        self.assertEqual(s.waiting_queue, [])  # ... and dequeued
+        self.assertFalse(s.running_batch.batch_is_full)
+        self.assertIsNotNone(batch)
+
+    def test_ceiling_term_still_caps_total_no_over_admit(self):
+        # The +1 compensation must not over-admit past the ceiling. At running_bs
+        # 15 with a chunk in flight, 15 decoding + 1 chunk already == 16 == ceiling,
+        # so the queued req must be refused even though the pool has spare slots.
+        q = MagicMock(name="queued")
+        chunk = MagicMock(name="chunked")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=15,
+            pool_avail=8,
+            chunked_req=chunk,
+            waiting_queue=[q],
+        )
+
+        _, adder = _run_prefill(s)
+
+        self.assertNotIn(q, adder.can_run_list)
+        self.assertEqual(adder.can_run_list, [chunk])
+        self.assertEqual(s.waiting_queue, [q])  # left queued
+        self.assertTrue(s.running_batch.batch_is_full)
+
+    def test_no_chunk_in_flight_is_unchanged_legacy_behavior(self):
+        # No chunk -> no compensation (+0). With one free slot and ceiling room
+        # for two, exactly one new req is admitted (legacy min(16-14, 1) == 1);
+        # the second is left queued. Confirms the fix is scoped to the chunk case.
+        q1 = MagicMock(name="q1")
+        q2 = MagicMock(name="q2")
+        s = _make_scheduler(
+            ceiling=16,
+            running_bs=14,
+            pool_avail=1,
+            chunked_req=None,
+            waiting_queue=[q1, q2],
+        )
+
+        _, adder = _run_prefill(s)
+
+        self.assertEqual(adder.can_run_list, [q1])
+        self.assertEqual(s.waiting_queue, [q2])
+        self.assertTrue(s.running_batch.batch_is_full)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #38118

## Motivation

Under steady-state load the running batch plateaus exactly one request below
`--max-running-requests`. With DP attention this happens per rank, capping concurrency at
`max_running_requests // dp_size - 1`. On GLM-5-FP8 with DP attention (`dp_size=8`,
`--max-running-requests 128` → 16/rank) every rank plateaus at **15**, leaving one slot/rank
idle and making the `--max-running-requests += dp_size` over-provisioning workaround necessary.

Root cause: in `Scheduler._get_new_batch_prefill_raw`, an in-flight chunked prefill is
re-appended to the adder's `can_run_list` by `add_chunked_req`, while its `req_to_token_pool`
slot is already allocated (excluded from `available_size()`). The batch-full check

```python
if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):  # min(ceiling - running_bs, available_size())
    self.running_batch.batch_is_full = True
```

counts that chunked request on the left while its slot is already subtracted on the right, so it
declares the batch full one request early. `batch_is_full` is sticky (reset only when a request
finishes), so the rank parks one below the ceiling with requests still queued — observable as a
steady `#running-req: 15` with `#queue-req >= 1` on every DP rank (see the companion issue, and
the before/after server-log excerpts under Speed Tests below).

## Modifications

- `python/sglang/srt/managers/scheduler.py`
  - `get_num_allocatable_reqs` gains a `chunked_req_in_flight=False` kwarg; when set, the
    already-held slot is added back **inside** the `min`, so it only lifts the pool term and
    never over-admits past the `pp_max_micro_batch_size - running_bs` ceiling term. The default
    keeps all other call-sites (dflash delay check, early-return guard, dllm mixin) unchanged.
  - `_get_new_batch_prefill_raw` captures `chunked_req_holds_slot = self.chunked_req is not None`
    **before** `add_chunked_req` (which returns `None` on the final chunk) and passes it to the
    batch-full check.
- `test/registered/unit/managers/test_get_new_batch_prefill_chunked_slot.py` (new, CPU): drives
  the real `_get_new_batch_prefill_raw` on a `Scheduler.__new__` skeleton with a faithful fake
  `PrefillAdder`, asserting the observable outcome — is the queued request issued (moved from the
  waiting queue into the prefill batch) or parked. Three scenarios: (1) chunk in flight + one
  free slot at ceiling−1 → queued req **issued** (this scenario **fails on the pre-fix code**);
  (2) at the ceiling → still capped, no over-admit; (3) no chunk → legacy behavior unchanged.

Net diff: `scheduler.py` +16/−3 plus the new test.

## Accuracy Tests

No model-output path changes — this only affects *when* a queued request is admitted to a
prefill batch, not how any request is computed. Existing scheduler/accuracy tests continue to
apply; the batch that is eventually built is identical, only its timing (one iteration earlier)
differs.

## Speed Tests and Profiling

Measured on `main` (8×B200), only `scheduler.py` toggled between baseline and fix. **The server
args are identical for both runs** and identical to the reproduction in the companion issue
(`--model-path` was a local stage of `zai-org/GLM-5-FP8`):

```bash
SGLANG_DP_USE_GATHERV=1 python3 -m sglang.launch_server \
  --model-path zai-org/GLM-5-FP8 \
  --host 0.0.0.0 --port 8891 \
  --trust-remote-code \
  --tensor-parallel-size=8 \
  --enable-dp-attention \
  --data-parallel-size 8 \
  --expert-parallel-size 1 \
  --load-balance-method round_robin \
  --enable-prefill-delayer \
  --tool-call-parser glm47 \
  --reasoning-parser glm45 \
  --kv-cache-dtype fp8_e4m3 \
  --quantization fp8 \
  --attention-backend nsa \
  --nsa-decode-backend trtllm \
  --nsa-prefill-backend trtllm \
  --moe-runner-backend flashinfer_trtllm \
  --cuda-graph-max-bs 128 \
  --max-running-requests 128 \
  --mem-fraction-static 0.85 \
  --chunked-prefill-size 32768 \
  --max-prefill-tokens 32768 \
  --enable-flashinfer-allreduce-fusion \
  --disable-radix-cache \
  --stream-interval 30 \
  --model-loader-extra-config '{"enable_multithread_load": true}'
```

Client — InferenceX `bench_serving` (`SemiAnalysisAI/InferenceX : utils/bench_serving`), random
dataset input 8192 / output 1024, `--num-prompts 128 --max-concurrency 128 --request-rate inf
--ignore-eos`, seed 0 (deterministic — identical workload for both runs).

Direct effect — steady-state per-rank `#running-req`:

| | steady per-rank `#running-req` | output tok/s | benchmark duration | mean TTFT | mean TPOT |
|---|:--|---:|---:|---:|---:|
| baseline (`main`) | all 8 ranks pinned at **15** | 1793 | 65.3 s | 12942 ms | 39.1 ms |
| `main` + fix | all 8 ranks reach **16** | **2299** | **50.9 s** | 11405 ms | 40.3 ms |

Identical deterministic workload (117 113 output tokens in both, seed 0). The concurrency fix is
unambiguous: every rank moves from a hard 15-pin to 16. Here that also gives **+28% output
throughput / −22% duration** — large because a single 128-request wave otherwise defers the 16th
request per rank into a *second* decode round, whereas the fix runs all 16 in one round. Under
sustained (queued) load the effect is the steady-state concurrency ratio (16/15) rather than the
whole deferred-tail, i.e. a smaller but continuous gain.

Matched before/after server-log excerpts (same steady window, one decode step across all 8 ranks):

```
# baseline (main): every DP rank pinned at 15, a request waiting (#queue-req: 1)
[19:37:28 DP0 TP0] Decode batch, #running-req: 15, #token: 110848, #queue-req: 1
[19:37:28 DP1 TP1] Decode batch, #running-req: 15, #token: 111488, #queue-req: 1
[19:37:28 DP2 TP2] Decode batch, #running-req: 15, #token: 112576, #queue-req: 1
[19:37:28 DP3 TP3] Decode batch, #running-req: 15, #token: 112320, #queue-req: 1
[19:37:28 DP4 TP4] Decode batch, #running-req: 15, #token: 110336, #queue-req: 1
[19:37:28 DP5 TP5] Decode batch, #running-req: 15, #token: 108672, #queue-req: 1
[19:37:28 DP6 TP6] Decode batch, #running-req: 15, #token: 109440, #queue-req: 1
[19:37:28 DP7 TP7] Decode batch, #running-req: 15, #token: 109632, #queue-req: 1

# main + fix: every DP rank reaches 16, queue drained (#queue-req: 0)
[19:41:30 DP0 TP0] Decode batch, #running-req: 16, #token: 118656, #queue-req: 0
[19:41:30 DP1 TP1] Decode batch, #running-req: 16, #token: 120704, #queue-req: 0
[19:41:30 DP2 TP2] Decode batch, #running-req: 16, #token: 116480, #queue-req: 0
[19:41:30 DP3 TP3] Decode batch, #running-req: 16, #token: 117952, #queue-req: 0
[19:41:30 DP4 TP4] Decode batch, #running-req: 16, #token: 116352, #queue-req: 0
[19:41:30 DP5 TP5] Decode batch, #running-req: 16, #token: 116288, #queue-req: 0
[19:41:30 DP6 TP6] Decode batch, #running-req: 16, #token: 120640, #queue-req: 0
[19:41:30 DP7 TP7] Decode batch, #running-req: 16, #token: 119552, #queue-req: 0
```

## Checklist

- [x] Format your code according to Format code with pre-commit. (all hooks pass on both files)
- [x] Add unit tests. (`test_get_new_batch_prefill_chunked_slot.py`, CPU; verified to fail on the
  pre-fix code so it is a real regression guard)
- [ ] Update documentation. (n/a — no user-facing API/flag change)
- [x] Provide accuracy and speed benchmark results. (above)
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32933008060](https://github.com/sgl-project/sglang/actions/runs/32933008060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32933007734](https://github.com/sgl-project/sglang/actions/runs/32933007734)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32933008104](https://github.com/sgl-project/sglang/actions/runs/32933008104)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->