### PR TITLE
[Feature] Add hits-per-token (HPT) size-aware radix-cache eviction policy

### DIFF
--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -63,3 +63,26 @@ class SLRUStrategy(EvictionStrategy):
 
         is_protected = 1 if node.hit_count >= self.protected_threshold else 0
         return (is_protected, node.last_access_time)
+
+
+class HitsPerTokenStrategy(EvictionStrategy):
+    """Hits-per-token (HPT): size-aware frequency eviction.
+
+    ``priority = (hit_count + 1) / size``  (smaller value is evicted first)
+
+    LRU/LFU/SLRU rank nodes by recency and/or frequency only. HPT additionally
+    accounts for a node's *size* (its KV length in tokens): among prefixes with
+    comparable reuse it evicts the largest first, freeing more KV per eviction and
+    retaining more small, frequently-reused prefixes. The score is the node's reuse
+    count per KV token it occupies. On workloads with heterogeneous prefix sizes and
+    deep prefix reuse under KV pressure this raises the radix-cache hit rate (and,
+    when prefill is a meaningful share of the work, end-to-end throughput).
+
+    Related to the classic Greedy-Dual-Size-Frequency (GDSF) family, but simpler:
+    it is the bare frequency-over-size ratio, with no aging/inflation clock and no
+    cost term.
+    """
+
+    def get_priority(self, node: TreeNode) -> float:
+        size = len(node.value) if node.value is not None else 1
+        return (node.hit_count + 1) / max(size, 1)

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -21,6 +21,7 @@ from sglang.srt.mem_cache.evict_policy import (
     EvictionStrategy,
     FIFOStrategy,
     FILOStrategy,
+    HitsPerTokenStrategy,
     LFUStrategy,
     LRUStrategy,
     MRUStrategy,
@@ -60,6 +61,7 @@ _EVICTION_POLICY_FACTORIES: dict[str, Callable[[], EvictionStrategy]] = {
     "filo": FILOStrategy,
     "priority": PriorityStrategy,
     "slru": SLRUStrategy,
+    "hpt": HitsPerTokenStrategy,
 }
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -266,7 +266,7 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
     "marlin",
 ]
 
-RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
+RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority", "hpt"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
 


### PR DESCRIPTION
# [Feature] Add hits-per-token (HPT) size-aware radix-cache eviction policy

## Summary
Adds an **opt-in, size-aware frequency** RadixAttention eviction policy, selectable with
`--radix-eviction-policy hpt`. It slots into the existing `EvictionStrategy` framework exactly like
`slru` (#18843) — ~20 LOC across three files, **no change to default behavior** (`lru` stays default).

On workloads with heterogeneous prefix sizes under KV pressure, HPT delivers **vs `lru`** (3-run medians):
- **Throughput: up to +15%** (mixed heterogeneous traffic; +13.6–15.1% ± 1.5%).
- **End-to-end latency: −54% median** at the saturation knee, **−8.7% just below it** — on SGLang's *own* `generated-shared-prefix` benchmark.
- **Radix cache hit-rate: 0.2% → 18%** on mixed traffic (and 1.7%→13% / 5.4%→10% on deep multi-turn).

It is a **bit-identical no-op** when the pool isn't pressured, and is regime-dependent (LRU stays best for recency/popularity traffic — details below).

## Motivation
Every current radix-cache eviction policy ranks nodes by **recency and/or frequency** only
(`lru`, `lfu`, `fifo`, `mru`, `filo`, `priority`, `slru`). **None accounts for a node's size** — we
checked the full sglang PR history (~6000 PRs); no size-aware radix eviction policy exists.

Under KV pressure, size matters: evicting one large, rarely-reused prefix frees the room that many
small, frequently-reused prefixes occupy. HPT scores each node by its **reuse count per KV token** it
holds:

```
priority = (hit_count + 1) / size          # size = node KV length in tokens; smaller value evicted first
```

A large cold prefix (`hit=0, size=1000 → 0.001`) is evicted before a small hot one
(`hit=5, size=10 → 0.6`), so the cache retains more high-value tokens per byte. This is the classic
Greedy-Dual-Size-Frequency (GDSF) family reduced to its essential term — the bare frequency-over-size
ratio, **no aging clock and no cost term** (hence "hits-per-token", not "GDSF").

## What this adds
- `HitsPerTokenStrategy` in `mem_cache/evict_policy.py` (mirrors the other strategies; guards `value is None`).
- Registration in the `mem_cache/utils.py` eviction-policy factory.
- `"hpt"` added to `RADIX_EVICTION_POLICY_CHOICES` in `server_args.py`.

## Evidence
Benchmarks on **Mistral-7B-Instruct-v0.3, 1× H100**, the natural HBM-sized KV pool
(`max_total_num_tokens ≈ 546k`), streaming, concurrency 64. **All figures are 3-run
medians/means** (single runs are noisy under concurrency; only reproducible numbers reported).

### 1. Latency under load — on SGLang's *own* `generated-shared-prefix` benchmark (headline)
Using the in-tree `bench_serving generated-shared-prefix` workload (heterogeneous shared-prefix
lengths) at fixed request-rates around the ~22 req/s saturation knee. `hpt` vs `lru`, 3-run medians:

| request rate | median TTFT Δ | median E2E Δ | note |
|---|---|---|---|
| 18 req/s | −5.4% | −5.3% | below knee — modest |
| 20 req/s | **−8.0%** | **−8.7%** | approaching knee — solid |
| **22 req/s (knee)** | **−48.4%** | **−54.2%** | LRU collapses (E2E 1268 ms), HPT holds (580 ms) |

```
median E2E latency vs load          LRU ██  HPT ▓▓
 22 req/s (knee)  LRU ██████████████████████████ 1268 ms
                  HPT ▓▓▓▓▓▓▓▓▓▓▓▓ 580 ms        (−54%)
 20 req/s         LRU ████▏                       (HPT −8.7%)
 18 req/s         LRU ███▉                        (HPT −5.3%)
```
At the saturation knee LRU's latency blows up superlinearly (poor cache → recompute → queue
explosion) while HPT's higher hit-rate delays the blowup — exactly the operating point serving
systems target. *(Medians only: P99 showed no reliable effect across runs — not claimed.)*

### 2. Throughput on size-heterogeneous traffic
When small frequently-reused prefixes (chat) share a server with large rarely-reused ones
(RAG / long-context) under a pressured pool:

Higher throughput and hit-rate are better; all deltas are **HPT relative to LRU** (positive = HPT wins).

| workload regime | cache hit-rate: LRU → HPT | throughput gain: HPT over LRU |
|---|---|---|
| **Mixed** (small-deep chat + large-shallow long-context) | 0.2% → **18%** | **+13.6 to +15.1% ± 1.5%** |
| Deep multi-turn, moderate pressure | 1.7% → 13% | **+6.3% ± 1.4%** |
| Deep multi-turn, heavy pressure | 5.4% → 10% | **+3.5% ± 1.5%** |

### 3. Size is the essential lever (ablation)
On the mixed regime, size-aware scoring variants cluster at **+11.9–14.5%** throughput; a size-blind
**recency+frequency** policy on the same workload gives only **+1.9%** (hit-rate stays flat). The gain
comes from the size term, not from frequency alone.

### 4. Holds at scale
With load scaled ∝ GPUs (pressure held), the mixed-traffic win persists at tensor-parallel 4:
**+11.1%** throughput (hit-rate 0.06 → 0.25). It decays only when the pool comfortably outgrows the
working set (no eviction → no-op).

## Reproduce
The **latency result (§1) uses only stock sglang tooling** (`bench_serving generated-shared-prefix`),
so it's independently reproducible. On 1× H100 with Mistral-7B-Instruct-v0.3:

Start a server (once per policy — run with `lru`, then `hpt`):
```bash
python -m sglang.launch_server --model-path mistralai/Mistral-7B-Instruct-v0.3 \
  --port 30000 --radix-eviction-policy lru \
  --mem-fraction-static 0.85 --attention-backend triton
```
Drive it at controlled rates around the saturation knee (~22 req/s on this HW):
```bash
for rate in 18 20 22; do
  python -m sglang.bench_serving --backend sglang --host 127.0.0.1 --port 30000 \
    --dataset-name generated-shared-prefix \
    --gsp-num-groups 300 --gsp-prompts-per-group 20 \
    --gsp-system-prompt-len 4096 --gsp-range-ratio 0.15 \
    --gsp-question-len 128 --gsp-output-len 8 \
    --num-prompts 3000 --request-rate "$rate"
done
```
Repeat with `--radix-eviction-policy hpt` and compare median TTFT / E2E. The gain is small below the
knee and grows sharply at it; the **knee location is HW/model/pool-dependent — sweep rates to find
where LRU's latency turns up**. Numbers reported are 3-run medians (P99 was noisy — not claimed).

The **throughput numbers (§2–4)** use a **custom synthetic *mixed* workload** (small-deep chat + large-
shallow long-context interleaved) that is **not in the sglang tree** — that generator can be shared on
request / added as a benchmark script if useful. The generated-shared-prefix latency result above is the
stock-tooling, reviewer-reproducible anchor.

## When it helps / when it doesn't (honest regime map)
- **Helps** when both hold: (a) **prefix-size variance** in the traffic, and (b) the KV pool is
  **actually pressured** (evicting). The throughput gain also needs prefill to be a meaningful share
  of the batch (deep multi-turn / prefill-heavy) — that's when a higher hit-rate converts to speed.
- **No-op** at light load (pool never fills → no eviction; bit-identical to LRU).
- **Not better** on recency- or popularity-dominated traffic (plain chat, Zipfian reuse): LRU is
  near-optimal there and should stay the choice. This is why HPT ships **opt-in**, not as default.

## Scope & limitations
- **Opt-in only** — no default change; safe for existing deployments, no regression at light load.
- **Small median-TTFT cost** can appear under heavy load on recency-dominated traffic (size-aware
  eviction reorders more) — traded for the wins above; keep such workloads on `lru`.
- Benchmarks are single-model (Mistral-7B) / 1× H100; latency claims are **medians** (P99 not claimed).

## Relation to #23781 (WLFU)
Orthogonal. WLFU ranks by recency with a frequency-age penalty
(`last_access_time − α·log1p(hit_count)`); HPT ranks by size-normalized frequency (`(hit_count+1)/size`).
WLFU exploits *frequency-aging*; HPT exploits *size variance*. Different signals, different regimes —
composable (a size term can be folded into WLFU's recency form).

## Future work
A natural follow-up is an **adaptive** policy that self-selects among recency (LRU), frequency-aging
(WLFU) and size-aware (HPT) from live signals (pool pressure, reuse-depth, prefix-size variance) —
e.g. an ARC-style ghost-list mechanism — applying each where it pays. This PR lands the size-aware
building block.

## Test plan
- `--radix-eviction-policy hpt` registers and runs (factory returns `HitsPerTokenStrategy`; priority
  math verified — large-cold evicted before small-hot; `value is None` guarded).
- Correctness parity with `lru` (identical outputs; eviction changes *what's cached*, not results).
- Reproduce the latency result with stock tooling — see the **Reproduce** section above (server + `bench_serving generated-shared-prefix` at rates 18/20/22, `lru` vs `hpt`).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28825187577](https://github.com/sgl-project/sglang/actions/runs/28825187577)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28825187417](https://github.com/sgl-project/sglang/actions/runs/28825187417)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->