### PR TITLE
[PD][NIXL] Handle decode abort notifications

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2319,6 +2319,42 @@ class NixlKVManager(CommonKVManager):
                         handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
                     continue
 
+                # Decode-side abort notification: mark room as failed
+                if waiting_req_bytes[0] == b"ABORT":
+                    try:
+                        room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
+                        decode_ip = waiting_req_bytes[2].decode("ascii")
+                        decode_port = int(waiting_req_bytes[3].decode("ascii"))
+                    except (IndexError, UnicodeDecodeError, ValueError):
+                        logger.warning("Ignoring malformed ABORT notification")
+                        continue
+
+                    status = self.request_status.get(room_to_be_aborted)
+                    if status not in (None, KVPoll.Failed, KVPoll.Success):
+                        self.record_failure(
+                            room_to_be_aborted,
+                            f"Request {room_to_be_aborted} was aborted by decode.",
+                        )
+                        self.update_status(room_to_be_aborted, KVPoll.Failed)
+                        logger.debug(
+                            "Received abort notification for room %s from %s:%s, "
+                            "marked as Failed",
+                            room_to_be_aborted,
+                            decode_ip,
+                            decode_port,
+                        )
+                    else:
+                        logger.debug(
+                            "Received abort notification for room %s from %s:%s, "
+                            "ignoring (already terminal or unknown)",
+                            room_to_be_aborted,
+                            decode_ip,
+                            decode_port,
+                        )
+                    # NIXL has no decode-side ABORT_ACK handler, so abort
+                    # notification remains fire-and-forget.
+                    continue
+
                 assert (
                     waiting_req_bytes[0] == GUARD
                 ), f"First message should be {GUARD}. Foreign traffic?"

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -330,6 +330,72 @@ class TestNixlKVSenderChunkPolicy(CustomTestCase):
         self.assertTrue(sender.should_send_kv_chunk(3, last_chunk=False))
 
 
+class TestNixlBootstrapMessages(CustomTestCase):
+    def _make_manager(self, request_status):
+        mgr = object.__new__(NixlKVManager)
+        mgr.request_status = request_status
+        mgr.record_failure = MagicMock()
+        mgr.update_status = MagicMock()
+        return mgr
+
+    def _run_bootstrap_message(self, mgr, message):
+        mgr.server_socket = MagicMock()
+        mgr.server_socket.recv_multipart.side_effect = [message, StopIteration]
+
+        with patch(
+            "sglang.srt.disaggregation.nixl.conn.threading.Thread"
+        ) as mock_thread:
+            mgr._start_bootstrap_thread()
+
+        bootstrap_target = mock_thread.call_args.kwargs["target"]
+        with self.assertRaises(StopIteration):
+            bootstrap_target()
+
+    def test_abort_marks_active_room_failed(self):
+        for status in (
+            KVPoll.Bootstrapping,
+            KVPoll.WaitingForInput,
+            KVPoll.Transferring,
+        ):
+            with self.subTest(status=status):
+                mgr = self._make_manager({7: status})
+
+                self._run_bootstrap_message(
+                    mgr, [b"ABORT", b"7", b"127.0.0.1", b"12345"]
+                )
+
+                mgr.record_failure.assert_called_once_with(
+                    7, "Request 7 was aborted by decode."
+                )
+                mgr.update_status.assert_called_once_with(7, KVPoll.Failed)
+
+    def test_abort_ignores_terminal_or_unknown_room(self):
+        for request_status in ({7: KVPoll.Failed}, {7: KVPoll.Success}, {}):
+            with self.subTest(request_status=request_status):
+                mgr = self._make_manager(request_status)
+
+                self._run_bootstrap_message(
+                    mgr, [b"ABORT", b"7", b"127.0.0.1", b"12345"]
+                )
+
+                mgr.record_failure.assert_not_called()
+                mgr.update_status.assert_not_called()
+
+    def test_malformed_abort_is_ignored(self):
+        for message in (
+            [b"ABORT"],
+            [b"ABORT", b"not-a-room", b"127.0.0.1", b"12345"],
+            [b"ABORT", b"7", b"127.0.0.1", b"not-a-port"],
+        ):
+            with self.subTest(message=message):
+                mgr = self._make_manager({7: KVPoll.WaitingForInput})
+
+                self._run_bootstrap_message(mgr, message)
+
+                mgr.record_failure.assert_not_called()
+                mgr.update_status.assert_not_called()
+
+
 class TestNixlNotifications(CustomTestCase):
     def _make_manager(self, messages, required=None):
         mgr = object.__new__(NixlKVManager)


### PR DESCRIPTION
## Motivation

`CommonKVReceiver` sends an `ABORT` control message when a decode request is cancelled or times out. The NIXL prefill bootstrap loop previously treated that message as foreign traffic and exited on its guard assertion, preventing subsequent bootstrap traffic from being processed.

## Changes

- validate and handle decode-side `ABORT` notifications in the NIXL bootstrap loop
- mark active rooms as failed while leaving terminal or unknown rooms unchanged
- cover active, terminal, unknown, and malformed notifications

## Related work

#30352 covers the same abort path and adds sticky failed-state handling. Synchronized transfer-worker cleanup and prefill failure propagation are handled separately by #30329.
