### PR TITLE
ci(deepep): purge stale deep_ep eggs before rebuild

### DIFF
--- a/scripts/ci/cuda/ci_install_deepep.sh
+++ b/scripts/ci/cuda/ci_install_deepep.sh
@@ -24,6 +24,13 @@ export GDRCOPY_HOME=/usr/src/gdrdrv-2.5.1/
 export CUDA_HOME=/usr/local/cuda
 
 GRACE_BLACKWELL=${GRACE_BLACKWELL:-0}
+# Pinned DeepEP commit. Used both for the version-shadow check below and the
+# `git checkout` further down — keep them in sync via this single variable.
+if [ "$GRACE_BLACKWELL" = "1" ]; then
+    DEEPEP_COMMIT=d28bd676c2120573c9f1425f0c16c39faa4117e6
+else
+    DEEPEP_COMMIT=9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee
+fi
 # Detect architecture
 ARCH=$(uname -m)
 if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "aarch64" ]; then
@@ -49,14 +56,10 @@ for base in {sysconfig.get_paths()["purelib"], sysconfig.get_paths()["platlib"]}
     pth = os.path.join(base, "easy-install.pth")
     if os.path.exists(pth):
         lines = open(pth).read().splitlines()
-        kept, seen = [], set()
-        for line in lines:
-            if "deep_ep" in line:  # drop every deep_ep egg entry; reinstall re-adds the right one
-                continue
-            if line not in seen:
-                seen.add(line)
-                kept.append(line)
-        if kept != lines:
+        # Drop only deep_ep egg entries; leave every other line (including any
+        # unrelated duplicates) byte-for-byte intact.
+        kept = [line for line in lines if "deep_ep" not in line]
+        if len(kept) != len(lines):  # only rewrite if a deep_ep entry was actually dropped
             open(pth, "w").write("\n".join(kept) + ("\n" if kept else ""))
             print(f"cleaned deep_ep entries from {pth}")
 PYCLEAN
@@ -66,12 +69,13 @@ if [ "${FORCE_REBUILD_DEEPEP:-0}" = "1" ]; then
     echo "FORCE_REBUILD_DEEPEP=1; uninstalling any cached deep_ep before rebuild."
     ${PIP_UNINSTALL_CMD:-pip uninstall -y} deep_ep ${PIP_UNINSTALL_SUFFIX:-} || true
     purge_deep_ep_eggs
-elif python3 -c "import deep_ep" >/dev/null 2>&1; then
-    echo "deep_ep is already installed or importable. Skipping installation."
+elif python3 -c "import deep_ep, sys; sys.exit(0 if '${DEEPEP_COMMIT:0:7}' in getattr(deep_ep, '__version__', '') else 1)" >/dev/null 2>&1; then
+    echo "deep_ep (pinned ${DEEPEP_COMMIT:0:7}) already installed and importable. Skipping installation."
     exit 0
 else
-    # deep_ep is present but not importable (a stale/incompatible egg from another PR on a
-    # shared runner is shadowing a good build) — purge eggs so the reinstall below is clean.
+    # deep_ep is missing, not importable, OR a wrong-version egg from another PR on a shared
+    # runner is shadowing the pinned build (imports fine but != pinned commit) — purge eggs so
+    # the reinstall below is clean.
     purge_deep_ep_eggs
 fi
 
@@ -138,13 +142,13 @@ if [ "$GRACE_BLACKWELL" = "1" ]; then
     GRACE_BLACKWELL_DEEPEP_BRANCH=hybrid-ep
     git clone https://github.com/deepseek-ai/DeepEP.git -b ${GRACE_BLACKWELL_DEEPEP_BRANCH} ${DEEPEP_DIR} && \
     pushd ${DEEPEP_DIR} && \
-    git checkout d28bd676c2120573c9f1425f0c16c39faa4117e6 && \
+    git checkout ${DEEPEP_COMMIT} && \
     sed -i 's/#define NUM_CPU_TIMEOUT_SECS 100/#define NUM_CPU_TIMEOUT_SECS 1000/' csrc/kernels/configs.cuh && \
     popd
 else
     git clone https://github.com/deepseek-ai/DeepEP.git ${DEEPEP_DIR} && \
     pushd ${DEEPEP_DIR} && \
-    git checkout 9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee && \
+    git checkout ${DEEPEP_COMMIT} && \
     popd
 fi
 

--- a/scripts/ci/cuda/ci_install_deepep.sh
+++ b/scripts/ci/cuda/ci_install_deepep.sh
@@ -38,27 +38,45 @@ if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "aarch64" ]; then
     exit 1
 fi
 
-# deep_ep is installed via `python3 setup.py install`, i.e. as a setuptools *egg*.
-# `uv pip uninstall` / `pip uninstall` cannot remove eggs (they report "not installed"),
-# so old eggs pile up in easy-install.pth. On shared CI runners a different DeepEP version
-# left behind by another PR (e.g. a 2.0.0 build) then shadows the freshly-built pinned egg
-# and fails to import ("undefined symbol: ncclCommQueryProperties"), which sglang masks as
-# "DeepEP is not installed". Purge every deep_ep egg + its .pth entry so each (re)install
-# starts from a clean slate; the build below re-adds exactly the pinned version.
+# The default install path builds deep_ep via `python3 setup.py install`, i.e. as
+# a setuptools *egg*. `uv pip uninstall` / `pip uninstall` cannot remove eggs (they
+# report "not installed"), so old eggs pile up in easy-install.pth. On a shared CI
+# runner a different DeepEP version left behind by another PR (e.g. a 2.0.0 build)
+# then shadows the freshly-built pinned egg and fails to import ("undefined symbol:
+# ncclCommQueryProperties"), which sglang masks as "DeepEP is not installed". Purge
+# every deep_ep egg + its .pth entry so each (re)install starts clean; the build
+# below re-adds exactly the pinned version.
+#
+# (The Grace-Blackwell branch installs via `pip install .` → a dist-info, not an
+# egg; pip replaces a stale dist-info itself, so this egg purge is a no-op there.)
 purge_deep_ep_eggs() {
     python3 - <<'PYCLEAN'
-import glob, os, shutil, sysconfig
+import glob, os, re, shutil, sysconfig
+
+# Match the egg-name form (deep_ep-<ver>.egg), not a bare "deep_ep" substring, so
+# a co-installed package like deep_ep_utils-*.egg (underscore, not hyphen) — or a
+# path that merely contains "deep_ep" — keeps its easy-install.pth entry.
+egg_line = re.compile(r"deep_ep-[^/\s]*\.egg")
 
 for base in {sysconfig.get_paths()["purelib"], sysconfig.get_paths()["platlib"]}:
     for egg in glob.glob(os.path.join(base, "deep_ep-*.egg")):
-        shutil.rmtree(egg, ignore_errors=True)
-        print(f"purged stale deep_ep egg: {egg}")
+        # deep_ep ships a C extension, so its egg is normally an unpacked dir, but
+        # handle the zip-safe file form too: rmtree is a silent no-op on a file,
+        # which would leave a shadowing egg behind while still logging "purged".
+        try:
+            if os.path.isdir(egg):
+                shutil.rmtree(egg, ignore_errors=True)
+            else:
+                os.remove(egg)
+            print(f"purged stale deep_ep egg: {egg}")
+        except OSError as e:
+            print(f"could not purge {egg}: {e}")
     pth = os.path.join(base, "easy-install.pth")
     if os.path.exists(pth):
         lines = open(pth).read().splitlines()
         # Drop only deep_ep egg entries; leave every other line (including any
         # unrelated duplicates) byte-for-byte intact.
-        kept = [line for line in lines if "deep_ep" not in line]
+        kept = [line for line in lines if not egg_line.search(line)]
         if len(kept) != len(lines):  # only rewrite if a deep_ep entry was actually dropped
             open(pth, "w").write("\n".join(kept) + ("\n" if kept else ""))
             print(f"cleaned deep_ep entries from {pth}")
@@ -68,15 +86,23 @@ PYCLEAN
 if [ "${FORCE_REBUILD_DEEPEP:-0}" = "1" ]; then
     echo "FORCE_REBUILD_DEEPEP=1; uninstalling any cached deep_ep before rebuild."
     ${PIP_UNINSTALL_CMD:-pip uninstall -y} deep_ep ${PIP_UNINSTALL_SUFFIX:-} || true
-    purge_deep_ep_eggs
-elif python3 -c "import deep_ep, sys; sys.exit(0 if '${DEEPEP_COMMIT:0:7}' in getattr(deep_ep, '__version__', '') else 1)" >/dev/null 2>&1; then
+    purge_deep_ep_eggs || true
+elif python3 -c "
+import importlib.metadata as md, sys
+try:
+    import deep_ep  # must actually import — a right-version but broken egg rebuilds
+    v = md.version('deep_ep')
+except Exception:
+    sys.exit(1)
+sys.exit(0 if '${DEEPEP_COMMIT:0:7}' in v else 1)
+" >/dev/null 2>&1; then
     echo "deep_ep (pinned ${DEEPEP_COMMIT:0:7}) already installed and importable. Skipping installation."
     exit 0
 else
     # deep_ep is missing, not importable, OR a wrong-version egg from another PR on a shared
     # runner is shadowing the pinned build (imports fine but != pinned commit) — purge eggs so
     # the reinstall below is clean.
-    purge_deep_ep_eggs
+    purge_deep_ep_eggs || true
 fi
 
 # Install system dependencies

--- a/scripts/ci/cuda/ci_install_deepep.sh
+++ b/scripts/ci/cuda/ci_install_deepep.sh
@@ -31,12 +31,48 @@ if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "aarch64" ]; then
     exit 1
 fi
 
+# deep_ep is installed via `python3 setup.py install`, i.e. as a setuptools *egg*.
+# `uv pip uninstall` / `pip uninstall` cannot remove eggs (they report "not installed"),
+# so old eggs pile up in easy-install.pth. On shared CI runners a different DeepEP version
+# left behind by another PR (e.g. a 2.0.0 build) then shadows the freshly-built pinned egg
+# and fails to import ("undefined symbol: ncclCommQueryProperties"), which sglang masks as
+# "DeepEP is not installed". Purge every deep_ep egg + its .pth entry so each (re)install
+# starts from a clean slate; the build below re-adds exactly the pinned version.
+purge_deep_ep_eggs() {
+    python3 - <<'PYCLEAN'
+import glob, os, shutil, sysconfig
+
+for base in {sysconfig.get_paths()["purelib"], sysconfig.get_paths()["platlib"]}:
+    for egg in glob.glob(os.path.join(base, "deep_ep-*.egg")):
+        shutil.rmtree(egg, ignore_errors=True)
+        print(f"purged stale deep_ep egg: {egg}")
+    pth = os.path.join(base, "easy-install.pth")
+    if os.path.exists(pth):
+        lines = open(pth).read().splitlines()
+        kept, seen = [], set()
+        for line in lines:
+            if "deep_ep" in line:  # drop every deep_ep egg entry; reinstall re-adds the right one
+                continue
+            if line not in seen:
+                seen.add(line)
+                kept.append(line)
+        if kept != lines:
+            open(pth, "w").write("\n".join(kept) + ("\n" if kept else ""))
+            print(f"cleaned deep_ep entries from {pth}")
+PYCLEAN
+}
+
 if [ "${FORCE_REBUILD_DEEPEP:-0}" = "1" ]; then
     echo "FORCE_REBUILD_DEEPEP=1; uninstalling any cached deep_ep before rebuild."
     ${PIP_UNINSTALL_CMD:-pip uninstall -y} deep_ep ${PIP_UNINSTALL_SUFFIX:-} || true
+    purge_deep_ep_eggs
 elif python3 -c "import deep_ep" >/dev/null 2>&1; then
     echo "deep_ep is already installed or importable. Skipping installation."
     exit 0
+else
+    # deep_ep is present but not importable (a stale/incompatible egg from another PR on a
+    # shared runner is shadowing a good build) — purge eggs so the reinstall below is clean.
+    purge_deep_ep_eggs
 fi
 
 # Install system dependencies


### PR DESCRIPTION
## Motivation

The `deepep` CI jobs (e.g. `base-c-test-deepep-4-gpu-h100`) intermittently fail with `ImportError: DeepEP is not installed` even though the log clearly shows deep_ep building and installing successfully in the same job.

Root cause: deep_ep is installed via `python3 setup.py install`, i.e. as a setuptools **egg**. `uv pip uninstall` / `pip uninstall` cannot remove eggs (they report "not installed" / "No packages to uninstall"), so old eggs accumulate in `easy-install.pth`. On a shared CI runner, a different DeepEP version installed by another PR can persist and, because it sorts ahead in `easy-install.pth`, **shadow** the freshly-built pinned egg.

Observed on a novita h100 runner: a leftover `deep_ep-2.0.0` egg shadowed the pinned `deep_ep-1.2.1`, and its extension fails to load against the runtime NCCL (`undefined symbol: ncclCommQueryProperties`). The real `ImportError` is then caught by sglang's DeepEP import guard and surfaced as the misleading "DeepEP is not installed", so the test dies despite a successful build. b200/h200 runners were unaffected because their containers never received the stale egg.

## Change

Purge every `deep_ep-*.egg` and its `easy-install.pth` entry before each (re)build in `ci_install_deepep.sh`, so a stale/incompatible DeepEP version can no longer shadow the freshly-built pinned one. Also purge on the "present but not importable" path so an already-poisoned runner self-heals on its next deepep job.

## Test

Unit-tested the purge against a reproduction of the poisoned runner state (broken `2.0.0` egg listed first + a duplicate `1.2.1` entry + an unrelated egg): both deep_ep eggs and their `.pth` entries are removed, the unrelated egg/entry is preserved, and the duplicate is collapsed. `bash -n` clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29067106054](https://github.com/sgl-project/sglang/actions/runs/29067106054)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29067105846](https://github.com/sgl-project/sglang/actions/runs/29067105846)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->