### PR TITLE
ci: run jit-kernel tests on scheduled full runs

### DIFF
--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -39,9 +39,9 @@ env:
 
 jobs:
   jit-kernel-unit-test:
-    if: |
-      github.event_name != 'schedule' &&
-      inputs.test_parallel_dispatch != 'true'
+    # Runs whenever call-jit-kernel-tests dispatches this workflow. That caller is the
+    # single gate (PR jit_kernel changes, or scheduled/parallel-dispatch full runs), so
+    # the sub-jobs no longer re-exclude schedule/parallel-dispatch here.
     runs-on: 1-gpu-h100
     timeout-minutes: 240
     steps:
@@ -79,9 +79,9 @@ jobs:
           python3 run_suite.py --hw cuda --suite base-b-kernel-unit-test-1-gpu-large
 
   jit-kernel-multigpu-unit-test:
-    if: |
-      github.event_name != 'schedule' &&
-      inputs.test_parallel_dispatch != 'true'
+    # Runs whenever call-jit-kernel-tests dispatches this workflow. That caller is the
+    # single gate (PR jit_kernel changes, or scheduled/parallel-dispatch full runs), so
+    # the sub-jobs no longer re-exclude schedule/parallel-dispatch here.
     runs-on: 8-gpu-h200
     timeout-minutes: 240
     steps:
@@ -117,9 +117,9 @@ jobs:
           python3 run_suite.py --hw cuda --suite base-b-kernel-unit-test-8-gpu-h200
 
   jit-kernel-benchmark-test:
-    if: |
-      github.event_name != 'schedule' &&
-      inputs.test_parallel_dispatch != 'true'
+    # Runs whenever call-jit-kernel-tests dispatches this workflow. That caller is the
+    # single gate (PR jit_kernel changes, or scheduled/parallel-dispatch full runs), so
+    # the sub-jobs no longer re-exclude schedule/parallel-dispatch here.
     runs-on: 1-gpu-h100
     timeout-minutes: 240
     steps:
@@ -157,9 +157,9 @@ jobs:
           python3 run_suite.py --hw cuda --suite base-b-kernel-benchmark-test-1-gpu-large
 
   jit-kernel-b200-test:
-    if: |
-      github.event_name != 'schedule' &&
-      inputs.test_parallel_dispatch != 'true'
+    # Runs whenever call-jit-kernel-tests dispatches this workflow. That caller is the
+    # single gate (PR jit_kernel changes, or scheduled/parallel-dispatch full runs), so
+    # the sub-jobs no longer re-exclude schedule/parallel-dispatch here.
     runs-on: ${{ fromJson(inputs.runs_on_map)[inputs.runner_config] }}
     timeout-minutes: 240
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -225,18 +225,22 @@ jobs:
 
   call-jit-kernel-tests:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    # Run on scheduled/parallel-dispatch runs (same pattern as the base-* stages) so the
+    # jit_kernel suite is exercised on main 3x daily, not only on PRs that touch jit_kernel/**.
+    # check-changes already forces jit_kernel='true' on scheduled runs (run_all_tests).
     if: |
       always() &&
-      !failure() && !cancelled() &&
-      github.event_name != 'schedule' &&
-      inputs.test_parallel_dispatch != true &&
+      ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == true) || (!failure() && !cancelled())) &&
       needs.check-changes.outputs.jit_kernel == 'true'
     uses: ./.github/workflows/pr-test-jit-kernel.yml
     with:
       runner_config: 4-gpu-b200
       runs_on_map: ${{ needs.check-changes.outputs.runs_on_map }}
       jit_kernel: ${{ needs.check-changes.outputs.jit_kernel }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
+      # On scheduled/parallel-dispatch runs sgl-kernel-build-wheels is skipped, so the wheel
+      # artifact does not exist. Force sgl_kernel='false' there so the jit-kernel jobs skip the
+      # wheel download and run against the released/pinned sgl-kernel instead of a fresh build.
+      sgl_kernel: ${{ (github.event_name == 'schedule' || inputs.test_parallel_dispatch == true) && 'false' || needs.check-changes.outputs.sgl_kernel }}
       git_ref: ${{ inputs.git_ref || '' }}
       test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
       skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}


### PR DESCRIPTION
## Motivation

The jit-kernel suite (`pr-test-jit-kernel.yml`) only ran on PRs that touch `python/sglang/jit_kernel/**`. The 3x-daily scheduled full run skipped it via an explicit `github.event_name != 'schedule'` guard on `call-jit-kernel-tests`, so regressions on `main` from unrelated changes went uncaught until a jit_kernel PR happened to run.

## Change

Gate `call-jit-kernel-tests` the same way as the `base-*` stages so it runs on scheduled / parallel-dispatch runs (`check-changes` already forces `jit_kernel='true'` on scheduled runs via `run_all_tests`).

On scheduled / parallel-dispatch runs `sgl-kernel-build-wheels` is skipped, so the wheel artifact the jit-kernel jobs download (`if: inputs.sgl_kernel == 'true'`) does not exist and they would fail. To avoid that, force `sgl_kernel='false'` for the jit-kernel call on those runs, so the jobs skip the wheel download and test against the released/pinned sgl-kernel instead of a fresh build. This keeps the scheduled run from also triggering the 20-30 min wheel build.

## Effect

- Adds the jit-kernel jobs (`1-gpu-h100`, `8-gpu-h200`, `4-gpu-b200`) to every scheduled full run; jit-kernel failures now surface in the scheduled `pr-test-finish` gate.
- PR behavior is unchanged (still runs only when `jit_kernel/**` changes).

## Validation

Triggered a `workflow_dispatch` with `test_parallel_dispatch=true` + `run_all_tests=true` (the built-in scheduled-run simulation) on this branch to confirm `call-jit-kernel-tests` dispatches and passes on the scheduled path.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28828864531](https://github.com/sgl-project/sglang/actions/runs/28828864531)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28828864450](https://github.com/sgl-project/sglang/actions/runs/28828864450)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->