### PR TITLE
[AMD] ci: run multimodal_gen unit suite on AMD

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -46,6 +46,7 @@ on:
           - stage-b-test-2-gpu-large-amd-rocm720
           - multimodal-gen-test-1-gpu-amd-rocm720
           - multimodal-gen-test-2-gpu-amd-rocm720
+          - multimodal-gen-unit-test-amd-rocm720
           - stage-c-test-large-8-gpu-amd-rocm720
           - stage-c-test-large-8-gpu-amd-mi35x-rocm720
           - stage-b-test-large-8-gpu-mi35x-disaggregation-amd-rocm720
@@ -864,6 +865,62 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # ROCm 7.2.0 counterpart of `multimodal-gen-unit-test-amd`: run the portable
+  # mm_gen `unit` suite on ROCm 7.2.0 too. Skips the CUDA-only
+  # ltx2_vae_channels_last file (channels_last_3d assertions the ROCm conv path
+  # doesn't reproduce).
+  multimodal-gen-unit-test-amd-rocm720:
+    needs: [check-changes]
+    if: |
+      always() &&
+      (
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',multimodal-gen-unit-test-amd-rocm720,')) ||
+        (
+          !(inputs.target_stage || inputs.target_stage_select) &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
+    runs-on: linux-mi325-1gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Download artifacts
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: sgl-kernel/dist/
+          merge-multiple: true
+          pattern: wheel-python3.10-cuda12.9
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh diffusion
+          docker exec ci_sglang pip install amdsmi
+
+      - name: Run diffusion unit tests
+        timeout-minutes: 60
+        run: |
+          # Skip ltx2_vae_channels_last: it asserts CUDA `channels_last_3d`
+          # memory-format behavior that the ROCm conv path doesn't reproduce.
+          docker exec \
+            -e AITER_JIT_DIR=/sgl-data/aiter-kernels \
+            -e MIOPEN_USER_DB_PATH=/sgl-data/miopen-cache \
+            -w /sglang-checkout/python \
+            ci_sglang python3 sglang/multimodal_gen/test/run_suite.py \
+              --suite unit \
+              -k "not ltx2_vae_channels_last"
 
   stage-c-test-4-gpu-amd-rocm720:
     needs: [check-changes, stage-b-test-1-gpu-small-amd-rocm720, stage-b-test-2-gpu-large-amd-rocm720]
@@ -1261,6 +1318,7 @@ jobs:
         sgl-kernel-unit-test-2-gpu-amd-rocm720,
         multimodal-gen-test-1-gpu-amd-rocm720,
         multimodal-gen-test-2-gpu-amd-rocm720,
+        multimodal-gen-unit-test-amd-rocm720,
 
         stage-a-test-1-gpu-small-amd-rocm720,
         jit-kernel-unit-test-amd-rocm720,

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -34,6 +34,7 @@ on:
           - stage-b-test-2-gpu-large-amd
           - multimodal-gen-test-1-gpu-amd
           - multimodal-gen-test-2-gpu-amd
+          - multimodal-gen-unit-test-amd
           - stage-c-test-4-gpu-amd
           - stage-c-test-large-8-gpu-amd
           - stage-c-test-large-8-gpu-amd-mi35x
@@ -889,6 +890,61 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # AMD counterpart of the CUDA `multimodal-gen-unit-test` job
+  # (pr-test-multimodal-gen.yml): the mm_gen `unit` suite is portable,
+  # CPU-style unit tests (config / sampling params / storage / loaders / etc.)
+  # that don't require NVIDIA hardware, so they should run on AMD too. This
+  # closes the AMD coverage gap the dashboard surfaces for these tests.
+  multimodal-gen-unit-test-amd:
+    name: ${{ format('multimodal-gen-unit-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
+    needs: [check-changes, call-gate]
+    if: |
+      always() && !cancelled() &&
+      (
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',multimodal-gen-unit-test-amd,')) ||
+        (
+          !(inputs.target_stage || inputs.target_stage_select) &&
+          (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') &&
+          needs.check-changes.outputs.multimodal_gen == 'true'
+        )
+      )
+    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Download artifacts
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: sgl-kernel/dist/
+          merge-multiple: true
+          pattern: wheel-python3.10-cuda12.9
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh diffusion
+
+      - name: Run diffusion unit tests
+        timeout-minutes: 60
+        run: |
+          docker exec \
+            -e AITER_JIT_DIR=/sgl-data/aiter-kernels \
+            -e MIOPEN_USER_DB_PATH=/sgl-data/miopen-cache \
+            -w /sglang-checkout/python \
+            ci_sglang python3 sglang/multimodal_gen/test/run_suite.py \
+              --suite unit \
+              ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   wait-for-stage-b-amd:
     needs: [check-changes, call-gate, wait-for-stage-a-amd]
@@ -1204,6 +1260,7 @@ jobs:
         sgl-kernel-unit-test-2-gpu-amd,
         multimodal-gen-test-1-gpu-amd,
         multimodal-gen-test-2-gpu-amd,
+        multimodal-gen-unit-test-amd,
 
         wait-for-stage-a-amd,
         stage-a-test-1-gpu-small-amd,

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -938,12 +938,16 @@ jobs:
       - name: Run diffusion unit tests
         timeout-minutes: 60
         run: |
+          # Skip ltx2_vae_channels_last: it asserts CUDA `channels_last_3d`
+          # memory-format behavior that the ROCm conv path doesn't reproduce
+          # (CUDA-specific). The rest of the unit suite is portable.
           docker exec \
             -e AITER_JIT_DIR=/sgl-data/aiter-kernels \
             -e MIOPEN_USER_DB_PATH=/sgl-data/miopen-cache \
             -w /sglang-checkout/python \
             ci_sglang python3 sglang/multimodal_gen/test/run_suite.py \
               --suite unit \
+              -k "not ltx2_vae_channels_last" \
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   wait-for-stage-b-amd:

--- a/scripts/ci/utils/ci_coverage_report.py
+++ b/scripts/ci/utils/ci_coverage_report.py
@@ -64,9 +64,24 @@ _MM_GEN_SUBDIR_BACKENDS = {
     "server/musa": ("MUSA",),
     "server/ascend": ("NPU",),
     "layers": ("CUDA",),
-    "unit": ("CUDA",),
+    # unit/ are portable CPU-style unit tests. pr-test-amd now runs the `unit`
+    # suite on ROCm (multimodal-gen-unit-test-amd, both 7.0.0 and 7.2.0), so
+    # they are AMD-covered too, not CUDA-only.
+    "unit": ("CUDA", "AMD"),
     "cli": ("CUDA",),
     "manual": ("CUDA",),
+    # Standalone server/CLI single-file tests (restructured out of server/).
+    # Run on CUDA CI; AMD parity for these standalone files is TBD, so
+    # CUDA-only for now (previously matched no rule and were dropped entirely).
+    "single_test_file": ("CUDA",),
+    "single_test_file/component_accuracy": ("CUDA",),
+    # Nested unit suites run only on the CUDA lane today (they are not part of
+    # the AMD `unit` suite that multimodal-gen-unit-test-amd executes).
+    "unit/realtime": ("CUDA",),
+    "unit/sana_wm": ("CUDA",),
+    "unit/progressive_resolution": ("CUDA",),
+    # musa-named unit layer kernels.
+    "unit/musa/layers": ("MUSA",),
 }
 
 # Filenames that match `test_*.py` by convention but contain no real tests


### PR DESCRIPTION
## Motivation
The `multimodal_gen` `unit` suite is portable, CPU-style unit tests (config, sampling params, storage, loaders, VAE/attention helpers, etc.) that don't require NVIDIA hardware. The CUDA workflow already runs them via `multimodal-gen-unit-test`, but the AMD workflows only ran the `server` diffusion suite — so these tests were an AMD coverage gap on ROCm.

## Change
**1. Run the mm_gen `unit` suite on AMD** — add a `multimodal-gen-unit-test-amd` job (`run_suite.py --suite unit`) inside the ROCm CI container, on **both** ROCm lanes:
- `pr-test-amd.yml` — **ROCm 7.0.0**: `multimodal-gen-unit-test-amd`
- `pr-test-amd-rocm720.yml` — **ROCm 7.2.0**: `multimodal-gen-unit-test-amd-rocm720`

Both are wired into the `target_stage_select` dropdown and the `pr-test-amd*-finish` gate.

**2. Count it in the CI Coverage Overview** — `scripts/ci/utils/ci_coverage_report.py`:
- `_MM_GEN_SUBDIR_BACKENDS["unit"]` → `("CUDA", "AMD")` (was CUDA-only) so the daily coverage report credits AMD for the ~50 `unit/` files now running on ROCm (AMD enabled ≈ 389 → ~439).
- Add rules for the restructured subdirs that previously `matched no backend rule` and were dropped entirely — `single_test_file`, `single_test_file/component_accuracy`, `unit/realtime`, `unit/sana_wm`, `unit/progressive_resolution` (→ CUDA where they run today; AMD parity for standalone server files is follow-up) and `unit/musa/layers` (→ MUSA).

### CUDA-only exclusion
`test_ltx2_vae_channels_last.py` is skipped via `-k "not ltx2_vae_channels_last"`: it asserts CUDA `channels_last_3d` memory-format behavior (`y.is_contiguous(memory_format=torch.channels_last_3d)`) that the ROCm conv path doesn't reproduce. The rest of the suite is portable. (Mirrors how the AMD server job uses `-k "not flux_2"`.)

## Tests added to AMD coverage
**50 `multimodal_gen/unit` test files** now run on AMD → **676 passed, 1 skipped, 5 deselected** (the excluded `ltx2_vae_channels_last`), per the pytest summary.

<details>
<summary>Per-file test-function counts (50 files, 647 test functions pre-parametrization)</summary>

| Test file | # test funcs |
|-----------|-------------:|
| `test_server_args.py` | 117 |
| `test_disagg_roles.py` | 47 |
| `test_cosmos3.py` | 37 |
| `test_ideogram4.py` | 36 |
| `test_rollout_api.py` | 34 |
| `test_cfg_parallel_warmup.py` | 34 |
| `test_sampling_params.py` | 26 |
| `test_nvtx_pytorch_hooks.py` | 25 |
| `test_sp_shard.py` | 22 |
| `test_consistency_metrics.py` | 19 |
| `test_vae_spatial_parallel_decode.py` | 18 |
| `test_transformer_quant.py` | 18 |
| `test_input_validation.py` | 18 |
| `test_encoder_world_folding.py` | 18 |
| `test_vae_loader.py` | 16 |
| `test_layerwise_offload.py` | 15 |
| `test_storage.py` | 9 |
| `test_resolve_prompts.py` | 9 |
| `test_multi_output_grouping.py` | 9 |
| `test_latent_upsampler_group_norm_silu.py` | 8 |
| `test_cuda_attention_backend.py` | 8 |
| `test_decoding_stage_parallelism.py` | 7 |
| `test_cache_dit_integration.py` | 7 |
| `test_text_encoder_loader.py` | 6 |
| `test_scheduler_rollout_unit.py` | 6 |
| `test_pipeline_executor.py` | 6 |
| `test_disagg_trace.py` | 6 |
| `test_turbo_wan_backend.py` | 5 |
| `test_openai_utils.py` | 5 |
| `test_ipc_array.py` | 5 |
| `test_component_loading_order.py` | 5 |
| `test_precision_consistency.py` | 4 |
| `test_parallel_linear_weight_loading.py` | 4 |
| `test_fp32_layernorm.py` | 4 |
| `test_cfg_gating.py` | 4 |
| `test_wan_ti2v_helpers.py` | 3 |
| `test_text_encoding_cache.py` | 3 |
| `test_lora_commit_as_base.py` | 3 |
| `test_launch_server_shutdown.py` | 3 |
| `test_diffusion_generator_shutdown.py` | 3 |
| `test_cli_generate_common.py` | 3 |
| `test_pipeline_stage_profiling.py` | 2 |
| `test_output_saving.py` | 2 |
| `test_lora_pipeline.py` | 2 |
| `test_zimage_pipeline_config.py` | 1 |
| `test_video_sparse_attention.py` | 1 |
| `test_qwen_image_layered.py` | 1 |
| `test_lora_inference_mode.py` | 1 |
| `test_lora_format_adapter.py` | 1 |
| `test_cfg_policy.py` | 1 |

</details>

## Test — both ROCm lanes green
| Lane | Run | Result | Test runtime | Full job |
|------|-----|--------|--------------|----------|
| ROCm 7.0.0 | https://github.com/sgl-project/sglang/actions/runs/28893667717 | ✅ success | ~2m05s | ~10m55s |
| ROCm 7.2.0 | https://github.com/sgl-project/sglang/actions/runs/28894795328 | ✅ success | ~2m14s | ~10m12s |

(*Test runtime* = the `Run diffusion unit tests` step; *Full job* includes container start + dependency install.)

Initial ROCm 7.0.0 run before the exclusion (https://github.com/sgl-project/sglang/actions/runs/28845749022) was **678 passed / 1 skipped / 3 failed** in ~71s, where the only 3 failures were exactly the `ltx2_vae_channels_last` tests now excluded.
