### PR TITLE
[NPU]Add support --pre-warm-nccl

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1328,7 +1328,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             if is_npu():
                 register_sgl_tp_rank(self.gpu_id)
 
-            # Pre-warm NCCL/RCCL to eliminate cold-start latency in first request
+            # Pre-warm NCCL/RCCL/HCCL to eliminate cold-start latency in first request
             # Controlled by --pre-warm-nccl flag (default: enabled on AMD GPUs)
             if self.server_args.pre_warm_nccl and (
                 self.tp_size > 1 or self.pp_size > 1 or self.moe_ep_size > 1
@@ -1336,14 +1336,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 warmup_start = time.perf_counter()
                 tp_group_handle = get_tp_group().device_group
 
-                # Single warmup all_reduce to initialize NCCL/RCCL communicator
+                # Single warmup all_reduce to initialize NCCL/RCCL/HCCL communicator
                 warmup_tensor = torch.zeros(1, device=torch.cuda.current_device())
                 dist.all_reduce(warmup_tensor, group=tp_group_handle)
                 current_platform.synchronize()
 
                 warmup_elapsed = time.perf_counter() - warmup_start
                 logger.info(
-                    f"NCCL/RCCL warmup completed in {warmup_elapsed:.3f}s "
+                    f"NCCL/RCCL/HCCL warmup completed in {warmup_elapsed:.3f}s "
                     f"(tp_size={self.tp_size}, pp_size={self.pp_size}, ep_size={self.moe_ep_size})"
                 )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4528,10 +4528,10 @@ class ServerArgs:
             self.triton_attention_num_kv_splits = 16
 
     def _handle_nccl_pre_warm(self):
-        # pre_warm_nccl is only used with CUDA or HIP hardware or Ascend hardware
+        # pre_warm_nccl is only used with CUDA or HIP hardware or NPU hardware
         if self.pre_warm_nccl and not (is_cuda() or is_hip() or is_npu()):
             logger.warning(
-                "pre_warm_nccl is only applicable for CUDA or HIP hardware or Ascend hardware. "
+                "pre_warm_nccl is only applicable for CUDA or HIP hardware or NPU hardware. "
                 "Ignoring pre_warm_nccl setting on current hardware."
             )
             self.pre_warm_nccl = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4528,10 +4528,10 @@ class ServerArgs:
             self.triton_attention_num_kv_splits = 16
 
     def _handle_nccl_pre_warm(self):
-        # pre_warm_nccl is only used with CUDA or HIP hardware
-        if self.pre_warm_nccl and not (is_cuda() or is_hip()):
+        # pre_warm_nccl is only used with CUDA or HIP hardware or Ascend hardware
+        if self.pre_warm_nccl and not (is_cuda() or is_hip() or is_npu()):
             logger.warning(
-                "pre_warm_nccl is only applicable for CUDA or HIP hardware. "
+                "pre_warm_nccl is only applicable for CUDA or HIP hardware or Ascend hardware. "
                 "Ignoring pre_warm_nccl setting on current hardware."
             )
             self.pre_warm_nccl = False


### PR DESCRIPTION
> Motivation



> ## Motivation
> When using multi-GPU tensor parallelism (TP > 1), the first collective communication operation triggers HCCL communicator initialization, causing **severe P99 TTFT degradation** for the first 2-3 requests.
> 
> This PR implements **HCCL pre-warming** during server startup to eliminate cold-start latency.

> **Measured Impact on Ascend A3**:
> 
> * **P99 TTFT improvement**: 61.4% (4197.49ms → 1620.13ms)
> 
> ## Accuracy Tests
> **No accuracy impact** - latency optimization only, does not affect model outputs.
> 
> Validated with GSM8K (100 questions):
> 
> * Without pre-warm: 93.0%
> * With pre-warm: 92.0%
> 
> ## Benchmarking
> ### Test Environment
> * **Platform**: Ascend A3
> * **Model**: Qwen3-30B-A3B
> * **Configuration**: TP=4, random-input-len=3500,  random-output-len=1500
> 
### Results
**Without pre-warm**
<img width="547" height="711" alt="1" src="https://github.com/user-attachments/assets/035d864d-a029-4f7e-b8a4-8f939302f268" />

**With pre-warm**  
<img width="566" height="703" alt="2" src="https://github.com/user-attachments/assets/716b69b8-8697-4075-8851-77a48d4015f8" />


































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28836831631](https://github.com/sgl-project/sglang/actions/runs/28836831631)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28836831571](https://github.com/sgl-project/sglang/actions/runs/28836831571)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->