### PR TITLE
Fix rejected prefills entering disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -117,7 +117,7 @@ class PrefillBootstrapQueue:
         gpu_id: int,
         bootstrap_port: int,
         gloo_group: ProcessGroup,
-        max_total_num_tokens: int,
+        max_req_input_len: int,
         scheduler: Scheduler,
         pp_rank: int,
         pp_size: int,
@@ -137,9 +137,7 @@ class PrefillBootstrapQueue:
         self.queue: List[Req] = []
         self.gloo_group = gloo_group
         self.scheduler = scheduler
-        self.max_total_num_tokens = (
-            self.scheduler.tp_worker.model_runner.max_token_pool_size
-        )
+        self.max_req_input_len = max_req_input_len
         self.transfer_backend = transfer_backend
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get() and self.is_mla_backend:
             raise RuntimeError(
@@ -283,6 +281,18 @@ class PrefillBootstrapQueue:
         return True
 
     def add(self, req: Req, num_kv_heads: int) -> None:
+        if is_aborted(req):
+            abort_reason = (
+                req.to_finish
+                if isinstance(req.to_finish, FINISH_ABORT)
+                else req.finished_reason
+            )
+            req.time_stats.trace_ctx.abort(abort_info={"reason": abort_reason.message})
+            req.finished_reason = abort_reason
+            req.to_finish = None
+            self.scheduler.output_streamer.stream_output([req], req.return_logprob)
+            return
+
         if not self.create_sender(req, num_kv_heads):
             return
         self.queue.append(req)
@@ -292,8 +302,8 @@ class PrefillBootstrapQueue:
             self.add(req, num_kv_heads)
 
     def _check_if_req_exceed_kv_capacity(self, req: Req) -> bool:
-        if len(req.origin_input_ids) > self.max_total_num_tokens:
-            message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} > {self.max_total_num_tokens}"
+        if len(req.origin_input_ids) >= self.max_req_input_len:
+            message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} >= {self.max_req_input_len}"
             logger.error(message)
             req.time_stats.trace_ctx.abort(abort_info={"reason": message})
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1221,7 +1221,7 @@ class Scheduler(
                 gpu_id=self.ps.gpu_id,
                 bootstrap_port=self.server_args.disaggregation_bootstrap_port,
                 gloo_group=self.attn_tp_cpu_group,
-                max_total_num_tokens=self.max_total_num_tokens,
+                max_req_input_len=self.max_req_input_len,
                 scheduler=self,
                 pp_rank=self.ps.pp_rank,
                 pp_size=self.ps.pp_size,

--- a/test/registered/unit/disaggregation/test_prefill_capacity.py
+++ b/test/registered/unit/disaggregation/test_prefill_capacity.py
@@ -1,0 +1,75 @@
+import unittest
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue
+from sglang.srt.disaggregation.utils import TransferBackend
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestPrefillCapacity(CustomTestCase):
+    @patch.object(PrefillBootstrapQueue, "_init_kv_manager")
+    @patch("sglang.srt.disaggregation.prefill.prepare_abort")
+    def test_rejects_against_scheduler_input_limit(
+        self, mock_prepare_abort, mock_init_kv_manager
+    ):
+        scheduler = MagicMock()
+
+        queue = PrefillBootstrapQueue(
+            token_to_kv_pool=MagicMock(),
+            draft_token_to_kv_pool=None,
+            req_to_metadata_buffer_idx_allocator=MagicMock(),
+            metadata_buffers=MagicMock(),
+            tp_rank=0,
+            tp_size=1,
+            gpu_id=0,
+            bootstrap_port=12345,
+            gloo_group=MagicMock(),
+            max_req_input_len=1024,
+            scheduler=scheduler,
+            pp_rank=0,
+            pp_size=1,
+            transfer_backend=TransferBackend.NIXL,
+        )
+
+        self.assertEqual(queue.max_req_input_len, 1024)
+
+        req = MagicMock()
+        req.rid = "at-input-limit"
+        req.origin_input_ids = [0] * 1024
+        req.return_logprob = False
+
+        self.assertTrue(queue._check_if_req_exceed_kv_capacity(req))
+        mock_prepare_abort.assert_called_once()
+        scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+
+        scheduler.output_streamer.reset_mock()
+        aborted_req = MagicMock()
+        aborted_req.rid = "already-aborted"
+        aborted_req.origin_input_ids = [0]
+        aborted_req.return_logprob = False
+        aborted_req.to_finish = FINISH_ABORT(
+            "Input length exceeds the scheduler limit",
+            HTTPStatus.BAD_REQUEST,
+            "BadRequestError",
+        )
+        aborted_req.finished_reason = None
+        queue.create_sender = MagicMock()
+
+        queue.add(aborted_req, num_kv_heads=1)
+
+        queue.create_sender.assert_not_called()
+        self.assertEqual(queue.queue, [])
+        self.assertIsNone(aborted_req.to_finish)
+        self.assertIsInstance(aborted_req.finished_reason, FINISH_ABORT)
+        scheduler.output_streamer.stream_output.assert_called_once_with(
+            [aborted_req], False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Oversized prefills are rejected using the scheduler's `max_req_input_len`. That rejection replaces the input IDs with a one-token placeholder before disaggregation bootstrap runs. Bootstrap previously checked the larger KV-pool capacity and could start a transfer for the already-rejected request, leaving decode waiting for a transfer that could not complete.

## Changes

- use `max_req_input_len` for prefill bootstrap admission
- complete requests already marked `FINISH_ABORT` before creating a sender
- cover the input-limit boundary and already-aborted path
