### PR TITLE
[PD][NIXL] Propagate prefill transfer failures

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import errno
 import json
 import logging
 import struct
@@ -58,6 +59,7 @@ logger = logging.getLogger(__name__)
 
 GUARD = "NixlMsgGuard".encode("ascii")
 TRANSFER_FAILED = b"TRANSFER_FAILED"
+DECODE_CONTROL_RECV_RETRY_DELAY = 0.1
 KV_MEM_KINDS = {"VRAM", "DRAM"}
 
 
@@ -481,6 +483,7 @@ class NixlKVManager(CommonKVManager):
             self.transfer_statuses: Dict[int, TransferStatus] = defaultdict(
                 TransferStatus
             )
+            self.propagated_failure_rooms: Set[int] = set()
             self._transfer_failure_lock = threading.Lock()
             self._staging_handler = None
             self._chunk_writer_counts: dict = defaultdict(lambda: defaultdict(list))
@@ -573,9 +576,16 @@ class NixlKVManager(CommonKVManager):
             while True:
                 try:
                     msg = self.server_socket.recv_multipart()
-                except (zmq.ContextTerminated, zmq.ZMQError):
-                    logger.debug("Decode control thread stopped")
-                    return
+                except zmq.ZMQError as e:
+                    if e.errno in (zmq.ETERM, zmq.ENOTSOCK):
+                        logger.debug("Decode control thread stopped")
+                        return
+                    if e.errno not in (zmq.EAGAIN, errno.EINTR):
+                        logger.exception("Decode control thread stopped unexpectedly")
+                        return
+                    logger.exception("Decode control receive failed")
+                    time.sleep(DECODE_CONTROL_RECV_RETRY_DELAY)
+                    continue
                 try:
                     if msg[0] == b"STAGING_REQ":
                         if self.enable_staging:
@@ -595,6 +605,11 @@ class NixlKVManager(CommonKVManager):
 
         threading.Thread(target=decode_control_thread, daemon=True).start()
 
+    def _record_propagated_failure(self, room: int, reason: str) -> None:
+        with self.failure_lock:
+            self.failure_records[room] = reason
+            self.propagated_failure_rooms.add(room)
+
     def _handle_transfer_failure(self, msg: List[bytes]) -> None:
         """Mark an active decode room failed from a prefill notification."""
         try:
@@ -612,7 +627,7 @@ class NixlKVManager(CommonKVManager):
                 )
                 return
 
-            self.record_failure(room, reason)
+            self._record_propagated_failure(room, reason)
             self.update_status(room, KVPoll.Failed)
         logger.debug("Prefill reported transfer failure for room %s: %s", room, reason)
 
@@ -2811,6 +2826,9 @@ class NixlKVReceiver(CommonKVReceiver):
         with self.kv_mgr._transfer_failure_lock:
             super().clear()
             self.kv_mgr.transfer_statuses.pop(self.bootstrap_room, None)
+            with self.kv_mgr.failure_lock:
+                self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
+                self.kv_mgr.propagated_failure_rooms.discard(self.bootstrap_room)
             rooms = self.kv_mgr.addr_to_rooms_tracker.get(self.bootstrap_addr)
             if rooms is not None:
                 rooms.discard(self.bootstrap_room)
@@ -2890,8 +2908,12 @@ class NixlKVReceiver(CommonKVReceiver):
     def failure_exception(self):
         with self.kv_mgr.failure_lock:
             failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
-        is_propagated = failure_reason is None
-        if is_propagated:
+            is_propagated = (
+                failure_reason is None
+                or self.bootstrap_room in self.kv_mgr.propagated_failure_rooms
+            )
+            self.kv_mgr.propagated_failure_rooms.discard(self.bootstrap_room)
+        if failure_reason is None:
             failure_reason = "NIXL KVReceiver Exception"
         raise KVTransferError(
             self.bootstrap_room, failure_reason, is_from_another_rank=is_propagated

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -8,10 +8,12 @@ import threading
 import time
 import uuid
 from collections import defaultdict
+from queue import Empty, Queue
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 import numpy.typing as npt
+import zmq
 
 if TYPE_CHECKING:
     from sglang.srt.disaggregation.common.staging_handler import StagingTransferInfo
@@ -35,6 +37,7 @@ from sglang.srt.disaggregation.common.utils import (
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils.network import NetworkAddress
 
 try:
     from nixl._bindings import (
@@ -54,6 +57,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 GUARD = "NixlMsgGuard".encode("ascii")
+TRANSFER_FAILED = b"TRANSFER_FAILED"
 KV_MEM_KINDS = {"VRAM", "DRAM"}
 
 
@@ -182,6 +186,16 @@ class TransferInfo:
                 int(msg[8].decode("ascii")) if len(msg) > 8 and msg[8] != b"" else None
             ),  # hacky just add it into the message that will be sent
         )
+
+
+@dataclasses.dataclass
+class _PendingFailureNotification:
+    reason: str
+    deadline: float
+    expected_agents: int = 0
+    seen_agents: Set[str] = dataclasses.field(default_factory=set)
+    queued_endpoints: Set[Tuple[str, int]] = dataclasses.field(default_factory=set)
+    pending_batches: int = 0
 
 
 @dataclasses.dataclass
@@ -433,6 +447,18 @@ class NixlKVManager(CommonKVManager):
                 FastQueue() for _ in range(transfer_queue_size)
             ]
             self.exceptions: Dict[int, Exception] = {}
+            self._transfer_info_lock = threading.Lock()
+            self._failure_notification_lock = threading.Lock()
+            self._pending_failure_notifications: Dict[
+                int, _PendingFailureNotification
+            ] = {}
+            self._failure_notification_queue: Queue[
+                Tuple[int, str, List[Tuple[str, int]]]
+            ] = Queue()
+            threading.Thread(
+                target=self._failure_notification_worker,
+                daemon=True,
+            ).start()
             # Mirror mooncake: one staging buffer per worker queue, all
             # built before workers spawn so each worker owns a private
             # buffer (no cross-worker contention on the staging ring).
@@ -455,11 +481,13 @@ class NixlKVManager(CommonKVManager):
             self.transfer_statuses: Dict[int, TransferStatus] = defaultdict(
                 TransferStatus
             )
+            self._transfer_failure_lock = threading.Lock()
+            self._staging_handler = None
+            self._chunk_writer_counts: dict = defaultdict(lambda: defaultdict(list))
             if self.enable_staging:
                 self._init_staging_decode_ctx()
-                self._staging_handler = None
-                self._chunk_writer_counts: dict = defaultdict(lambda: defaultdict(list))
-                self._start_decode_staging_thread()
+            # TRANSFER_FAILED uses this thread even when staging is disabled.
+            self._start_decode_control_thread()
             self._start_heartbeat_checker_thread()
         else:
             raise ValueError(
@@ -538,21 +566,55 @@ class NixlKVManager(CommonKVManager):
 
         return is_watermark_ready(self._staging_ctx, agent_name, alloc_round, alloc_end)
 
-    def _start_decode_staging_thread(self):
-        """Start a thread on the decode side to recv STAGING_REQ from prefill via ZMQ."""
+    def _start_decode_control_thread(self):
+        """Receive control messages from prefill via ZMQ."""
 
-        def decode_staging_thread():
+        def decode_control_thread():
             while True:
-                msg = self.server_socket.recv_multipart()
-                if msg[0] == b"STAGING_REQ":
-                    self._handle_staging_req(msg)
-                    continue
-                logger.warning(
-                    "decode_staging_thread: unexpected message tag %s",
-                    msg[0][:20],
-                )
+                try:
+                    msg = self.server_socket.recv_multipart()
+                except (zmq.ContextTerminated, zmq.ZMQError):
+                    logger.debug("Decode control thread stopped")
+                    return
+                try:
+                    if msg[0] == b"STAGING_REQ":
+                        if self.enable_staging:
+                            self._handle_staging_req(msg)
+                        else:
+                            logger.warning("Ignoring STAGING_REQ: staging is disabled")
+                        continue
+                    if msg[0] == TRANSFER_FAILED:
+                        self._handle_transfer_failure(msg)
+                        continue
+                    logger.warning(
+                        "decode_control_thread: unexpected message tag %s",
+                        msg[0][:20],
+                    )
+                except Exception:
+                    logger.exception("Decode control message handling failed")
 
-        threading.Thread(target=decode_staging_thread, daemon=True).start()
+        threading.Thread(target=decode_control_thread, daemon=True).start()
+
+    def _handle_transfer_failure(self, msg: List[bytes]) -> None:
+        """Mark an active decode room failed from a prefill notification."""
+        try:
+            room = int(msg[1].decode("ascii"))
+            reason = msg[2].decode("utf-8") or "Prefill signaled transfer failure"
+        except (IndexError, UnicodeDecodeError, ValueError):
+            logger.warning("Ignoring malformed TRANSFER_FAILED notification")
+            return
+
+        with self._transfer_failure_lock:
+            status = self.request_status.get(room)
+            if status not in (KVPoll.WaitingForInput, KVPoll.Transferring):
+                logger.debug(
+                    "Ignoring TRANSFER_FAILED for terminal or unknown room %s", room
+                )
+                return
+
+            self.record_failure(room, reason)
+            self.update_status(room, KVPoll.Failed)
+        logger.debug("Prefill reported transfer failure for room %s: %s", room, reason)
 
     def _handle_staging_req(self, msg):
         from sglang.srt.disaggregation.common.staging_handler import (
@@ -601,7 +663,8 @@ class NixlKVManager(CommonKVManager):
         if room in self._staging_ctx.prefetched_rooms:
             return
 
-        room_infos = self.transfer_infos.get(room, {})
+        with self._transfer_info_lock:
+            room_infos = self.transfer_infos.get(room, {}).copy()
         needs_staging = any(
             not tinfo.is_dummy()
             and tinfo.agent_name in self.decode_kv_args_table
@@ -620,7 +683,7 @@ class NixlKVManager(CommonKVManager):
 
         prefetch_staging_reqs(
             room,
-            self.transfer_infos,
+            {room: room_infos},
             self.kv_buffer_tensors,
             self.server_args.chunked_prefill_size,
             self._staging_ctx.prefetch_requested,
@@ -630,6 +693,141 @@ class NixlKVManager(CommonKVManager):
 
     def check_status(self, bootstrap_room: int):
         return self.request_status.get(bootstrap_room, KVPoll.WaitingForInput)
+
+    def notify_decode_transfer_failure(
+        self, bootstrap_room: int, failure_reason: str
+    ) -> None:
+        """Queue a best-effort failure notification without blocking the scheduler."""
+        failure_reason = failure_reason or "Prefill signaled transfer failure"
+        with self._transfer_info_lock:
+            room_infos = self.transfer_infos.get(bootstrap_room, {}).copy()
+            with self._failure_notification_lock:
+                # Preserve the first reason because some endpoints may be queued
+                # before later failure paths report a different reason.
+                pending = self._pending_failure_notifications.setdefault(
+                    bootstrap_room,
+                    _PendingFailureNotification(
+                        reason=failure_reason,
+                        deadline=time.monotonic() + self.bootstrap_timeout,
+                    ),
+                )
+                endpoints = []
+                for agent_name, info in room_infos.items():
+                    pending.expected_agents = max(
+                        pending.expected_agents, info.required_dst_info_num
+                    )
+                    pending.seen_agents.add(agent_name)
+                    endpoint = (info.endpoint, info.dst_port)
+                    if endpoint not in pending.queued_endpoints:
+                        pending.queued_endpoints.add(endpoint)
+                        endpoints.append(endpoint)
+                self._queue_failure_notification_locked(
+                    bootstrap_room, pending.reason, endpoints
+                )
+
+    def _queue_failure_notification_locked(
+        self,
+        bootstrap_room: int,
+        failure_reason: str,
+        endpoints: List[Tuple[str, int]],
+    ) -> None:
+        if endpoints:
+            pending = self._pending_failure_notifications[bootstrap_room]
+            pending.pending_batches += 1
+            self._failure_notification_queue.put_nowait(
+                (bootstrap_room, failure_reason, sorted(endpoints))
+            )
+
+    def _capture_failed_room_registration(
+        self, bootstrap_room: int, agent_name: str, transfer_info: TransferInfo
+    ) -> bool:
+        """Capture a late decode endpoint after the prefill request has failed."""
+        with self._failure_notification_lock:
+            pending = self._pending_failure_notifications.get(bootstrap_room)
+            if pending is None:
+                return False
+            pending.expected_agents = max(
+                pending.expected_agents, transfer_info.required_dst_info_num
+            )
+            pending.seen_agents.add(agent_name)
+            endpoint = (transfer_info.endpoint, transfer_info.dst_port)
+            endpoints = []
+            if endpoint not in pending.queued_endpoints:
+                pending.queued_endpoints.add(endpoint)
+                endpoints.append(endpoint)
+            self._queue_failure_notification_locked(
+                bootstrap_room, pending.reason, endpoints
+            )
+            return True
+
+    def _prune_pending_failure_notifications(self) -> None:
+        now = time.monotonic()
+        with self._failure_notification_lock:
+            expired = [
+                (room, pending)
+                for room, pending in self._pending_failure_notifications.items()
+                if pending.deadline <= now
+            ]
+            for room, _ in expired:
+                self._pending_failure_notifications.pop(room, None)
+        for room, pending in expired:
+            if (
+                pending.expected_agents
+                and len(pending.seen_agents) >= pending.expected_agents
+            ):
+                logger.debug("Expired TRANSFER_FAILED tombstone for room %s", room)
+            else:
+                logger.warning(
+                    "Expired TRANSFER_FAILED tombstone for room %s after seeing "
+                    "%s of %s decode registrations",
+                    room,
+                    len(pending.seen_agents),
+                    pending.expected_agents,
+                )
+
+    def _failure_notification_worker(self) -> None:
+        while True:
+            try:
+                bootstrap_room, failure_reason, endpoints = (
+                    self._failure_notification_queue.get(timeout=1)
+                )
+            except Empty:
+                self._prune_pending_failure_notifications()
+                continue
+
+            payload = [
+                TRANSFER_FAILED,
+                str(bootstrap_room).encode("ascii"),
+                failure_reason.encode("utf-8"),
+            ]
+            try:
+                for endpoint, dst_port in endpoints:
+                    try:
+                        na = NetworkAddress(endpoint, dst_port)
+                        self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
+                            payload, flags=zmq.NOBLOCK
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to notify decode endpoint %s:%s that room %s failed",
+                            endpoint,
+                            dst_port,
+                            bootstrap_room,
+                        )
+            finally:
+                with self._failure_notification_lock:
+                    pending = self._pending_failure_notifications.get(bootstrap_room)
+                    if pending is not None:
+                        pending.pending_batches -= 1
+                    if (
+                        pending is not None
+                        and pending.expected_agents
+                        and len(pending.seen_agents) >= pending.expected_agents
+                        and pending.pending_batches == 0
+                    ):
+                        self._pending_failure_notifications.pop(bootstrap_room, None)
+                self._failure_notification_queue.task_done()
+                self._prune_pending_failure_notifications()
 
     def _prep_equal_tp_dlist(
         self,
@@ -1008,7 +1206,11 @@ class NixlKVManager(CommonKVManager):
                 if self.check_status(room) == KVPoll.Failed:
                     continue
 
-                assert room in self.transfer_infos
+                with self._transfer_info_lock:
+                    room_infos = self.transfer_infos.get(room)
+                    if room_infos is None:
+                        continue
+                    reqs_to_be_processed = list(room_infos.values())
 
                 # Lazily build a per-worker staging strategy bound to this
                 # worker's private staging buffer (matches mooncake).
@@ -1020,8 +1222,6 @@ class NixlKVManager(CommonKVManager):
                     staging_strategy = self._try_create_staging_strategy(staging_buffer)
 
                 self.update_status(room, KVPoll.Transferring)
-
-                reqs_to_be_processed = list(self.transfer_infos[room].values())
 
                 # Set when staging allocation/watermark is not yet ready and
                 # the chunk has been re-enqueued. We then break out of the
@@ -1199,7 +1399,8 @@ class NixlKVManager(CommonKVManager):
                     self.update_status(room, KVPoll.Success)
                     # Drop per-room state on Success (parity with mooncake
                     # transfer_worker; staging prefetch sets are NIXL-only).
-                    self.transfer_infos.pop(room, None)
+                    with self._transfer_info_lock:
+                        self.transfer_infos.pop(room, None)
                     self.req_to_decode_prefix_len.pop(room, None)
                     if self.enable_staging and self._staging_ctx is not None:
                         self._staging_ctx.prefetched_rooms.discard(room)
@@ -2342,7 +2543,8 @@ class NixlKVManager(CommonKVManager):
                             handle_staging_rsp,
                         )
 
-                        handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
+                        with self._transfer_info_lock:
+                            handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
                     continue
 
                 assert (
@@ -2359,24 +2561,30 @@ class NixlKVManager(CommonKVManager):
                     logger.debug(f"Register KVArgs from {agent_name} successfully")
                     continue
                 room = int(room)
-                if room not in self.transfer_infos:
-                    self.transfer_infos[room] = {}
-                self.transfer_infos[room][agent_name] = TransferInfo.from_zmq(
-                    waiting_req_bytes
-                )
-                required_dst_info_num = self.transfer_infos[room][
-                    agent_name
-                ].required_dst_info_num
-                logger.debug(f"got info {room=} {agent_name=} {required_dst_info_num=}")
-                if len(self.transfer_infos[room]) == required_dst_info_num:
-                    self.req_to_decode_prefix_len[room] = next(
-                        (
-                            info.decode_prefix_len
-                            for info in self.transfer_infos[room].values()
-                            if info.decode_prefix_len is not None
-                        ),
-                        0,
+                transfer_info = TransferInfo.from_zmq(waiting_req_bytes)
+                with self._transfer_info_lock:
+                    required_dst_info_num = transfer_info.required_dst_info_num
+                    failed_room = self._capture_failed_room_registration(
+                        room, agent_name, transfer_info
                     )
+                    if not failed_room:
+                        room_infos = self.transfer_infos.setdefault(room, {})
+                        room_infos[agent_name] = transfer_info
+                        registration_complete = len(room_infos) == required_dst_info_num
+                        if registration_complete:
+                            self.req_to_decode_prefix_len[room] = next(
+                                (
+                                    info.decode_prefix_len
+                                    for info in room_infos.values()
+                                    if info.decode_prefix_len is not None
+                                ),
+                                0,
+                            )
+                logger.debug(f"got info {room=} {agent_name=} {required_dst_info_num=}")
+                if failed_room:
+                    logger.debug("Captured late registration for failed room %s", room)
+                    continue
+                if registration_complete:
                     logger.debug(f"{room=} is bootstrapped")
                     self.update_status(room, KVPoll.WaitingForInput)
 
@@ -2447,11 +2655,9 @@ class NixlKVSender(CommonKVSender):
         return status
 
     def clear(self) -> None:
-        super().clear()
-        if (
-            getattr(self.kv_mgr, "enable_staging", False)
-            and getattr(self.kv_mgr, "_staging_ctx", None) is not None
-        ):
+        with self.kv_mgr._transfer_info_lock:
+            super().clear()
+        if self.kv_mgr.enable_staging and self.kv_mgr._staging_ctx is not None:
             self.kv_mgr._staging_ctx.prefetched_rooms.discard(self.bootstrap_room)
             self.kv_mgr._staging_ctx.prefetch_requested = {
                 key
@@ -2463,6 +2669,13 @@ class NixlKVSender(CommonKVSender):
         exc = self.kv_mgr.exceptions.pop(self.bootstrap_room, None)
         with self.kv_mgr.failure_lock:
             failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
+
+        notification_reason = failure_reason
+        if notification_reason is None and exc is not None:
+            notification_reason = str(exc)
+        self.kv_mgr.notify_decode_transfer_failure(
+            self.bootstrap_room, notification_reason or "NIXL KV transfer failed"
+        )
 
         if self.conclude_state is None:
             self.conclude_state = KVPoll.Failed
@@ -2478,6 +2691,13 @@ class NixlKVSender(CommonKVSender):
             raise KVTransferError(self.bootstrap_room, failure_reason)
         raise KVTransferError(
             self.bootstrap_room, "NIXL KVSender Exception", is_from_another_rank=True
+        )
+
+    def abort(self):
+        super().abort()
+        self._send_failed = True
+        self.kv_mgr.notify_decode_transfer_failure(
+            self.bootstrap_room, "Aborted by AbortReq."
         )
 
 
@@ -2574,13 +2794,30 @@ class NixlKVReceiver(CommonKVReceiver):
 
         self.kv_mgr.update_transfer_status()
         if self.kv_mgr.check_transfer_done(self.bootstrap_room):  # type: ignore
-            self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].discard(
-                self.bootstrap_room
-            )
-            self.conclude_state = KVPoll.Success
-            del self.kv_mgr.transfer_statuses[self.bootstrap_room]
-            return self.conclude_state  # type: ignore
+            with self.kv_mgr._transfer_failure_lock:
+                if self.kv_mgr.check_status(self.bootstrap_room) == KVPoll.Failed:
+                    self.conclude_state = KVPoll.Failed
+                else:
+                    self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
+                    self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].discard(
+                        self.bootstrap_room
+                    )
+                    self.conclude_state = KVPoll.Success
+                    del self.kv_mgr.transfer_statuses[self.bootstrap_room]
+                return self.conclude_state  # type: ignore
         return KVPoll.WaitingForInput  # type: ignore
+
+    def clear(self) -> None:
+        with self.kv_mgr._transfer_failure_lock:
+            super().clear()
+            self.kv_mgr.transfer_statuses.pop(self.bootstrap_room, None)
+            rooms = self.kv_mgr.addr_to_rooms_tracker.get(self.bootstrap_addr)
+            if rooms is not None:
+                rooms.discard(self.bootstrap_room)
+            if self.kv_mgr.enable_staging:
+                self.kv_mgr._staging_ctx.room_receivers.pop(self.bootstrap_room, None)
+                self.kv_mgr._staging_ctx.room_bootstrap.pop(self.bootstrap_room, None)
+                self.kv_mgr._chunk_writer_counts.pop(self.bootstrap_room, None)
 
     def _register_kv_args(self):
         for bootstrap_info in self.bootstrap_infos:

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -12,9 +12,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import zmq
 
 from sglang.srt.disaggregation.base.conn import KVPoll
-from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.common.conn import CommonKVManager, KVTransferError
 from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
 from sglang.srt.disaggregation.common.utils import pack_int_lists
 from sglang.srt.disaggregation.nixl.conn import (
@@ -343,6 +344,7 @@ class TestNixlFailurePropagation(CustomTestCase):
             mgr, CommonKVManager
         )
         mgr.update_status = CommonKVManager.update_status.__get__(mgr, CommonKVManager)
+        mgr.propagated_failure_rooms = set()
         mgr._transfer_failure_lock = threading.Lock()
         return mgr
 
@@ -360,6 +362,7 @@ class TestNixlFailurePropagation(CustomTestCase):
 
                 self.assertEqual(mgr.request_status[7], KVPoll.Failed)
                 self.assertEqual(mgr.failure_records[7], "state index length mismatch")
+                self.assertEqual(mgr.propagated_failure_rooms, {7})
 
     def test_transfer_failure_is_idempotent_for_terminal_or_unknown_room(self):
         for request_status in ({7: KVPoll.Failed}, {7: KVPoll.Success}, {}):
@@ -372,6 +375,7 @@ class TestNixlFailurePropagation(CustomTestCase):
 
                 self.assertEqual(mgr.request_status, request_status)
                 self.assertEqual(mgr.failure_records, {})
+                self.assertEqual(mgr.propagated_failure_rooms, set())
 
     def test_transfer_failure_uses_default_reason_when_empty(self):
         mgr = self._make_decode_manager({7: KVPoll.WaitingForInput})
@@ -380,6 +384,7 @@ class TestNixlFailurePropagation(CustomTestCase):
 
         self.assertEqual(mgr.request_status[7], KVPoll.Failed)
         self.assertEqual(mgr.failure_records[7], "Prefill signaled transfer failure")
+        self.assertEqual(mgr.propagated_failure_rooms, {7})
 
     def test_malformed_transfer_failure_is_ignored(self):
         mgr = self._make_decode_manager({7: KVPoll.WaitingForInput})
@@ -394,6 +399,61 @@ class TestNixlFailurePropagation(CustomTestCase):
 
         self.assertEqual(mgr.request_status[7], KVPoll.WaitingForInput)
         self.assertEqual(mgr.failure_records, {})
+        self.assertEqual(mgr.propagated_failure_rooms, set())
+
+    def test_decode_control_thread_retries_transient_receive_error(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.server_socket = MagicMock()
+        mgr.server_socket.recv_multipart.side_effect = [
+            zmq.ZMQError(zmq.EAGAIN),
+            zmq.ZMQError(zmq.ETERM),
+        ]
+
+        with (
+            patch("sglang.srt.disaggregation.nixl.conn.threading.Thread") as thread,
+            patch("sglang.srt.disaggregation.nixl.conn.time.sleep") as sleep,
+        ):
+            mgr._start_decode_control_thread()
+            control_loop = thread.call_args.kwargs["target"]
+            control_loop()
+
+        thread.return_value.start.assert_called_once()
+        self.assertEqual(mgr.server_socket.recv_multipart.call_count, 2)
+        sleep.assert_called_once_with(0.1)
+
+    def test_decode_control_thread_stops_on_unexpected_receive_error(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.server_socket = MagicMock()
+        mgr.server_socket.recv_multipart.side_effect = zmq.ZMQError(zmq.EFAULT)
+
+        with (
+            patch("sglang.srt.disaggregation.nixl.conn.threading.Thread") as thread,
+            patch("sglang.srt.disaggregation.nixl.conn.time.sleep") as sleep,
+        ):
+            mgr._start_decode_control_thread()
+            control_loop = thread.call_args.kwargs["target"]
+            control_loop()
+
+        self.assertEqual(mgr.server_socket.recv_multipart.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_receiver_preserves_propagated_failure_reason(self):
+        mgr = self._make_decode_manager({7: KVPoll.Failed})
+        mgr.failure_records[7] = "state index length mismatch"
+        mgr.propagated_failure_rooms.add(7)
+        receiver = object.__new__(NixlKVReceiver)
+        receiver.kv_mgr = mgr
+        receiver.bootstrap_room = 7
+
+        with self.assertRaises(KVTransferError) as context:
+            receiver.failure_exception()
+
+        self.assertEqual(
+            context.exception.failure_reason, "state index length mismatch"
+        )
+        self.assertTrue(context.exception.is_from_another_rank)
+        self.assertNotIn(7, mgr.failure_records)
+        self.assertNotIn(7, mgr.propagated_failure_rooms)
 
     def _make_prefill_notification_manager(self, infos):
         mgr = object.__new__(NixlKVManager)
@@ -647,6 +707,9 @@ class TestNixlReceiverPoll(CustomTestCase):
         mgr.transfer_statuses = {}
         mgr.addr_to_rooms_tracker = defaultdict(set)
         mgr.addr_to_rooms_tracker["prefill:8998"].add(11)
+        mgr.failure_records = {}
+        mgr.failure_lock = threading.Lock()
+        mgr.propagated_failure_rooms = set()
         mgr._transfer_failure_lock = threading.Lock()
         mgr.enable_staging = False
 
@@ -732,11 +795,15 @@ class TestNixlReceiverPoll(CustomTestCase):
         mgr.required_prefill_response_num_table = {11: 1}
         mgr.prefill_response_tracker = {11: set()}
         mgr.transfer_statuses = {11: TransferStatus()}
+        mgr.failure_records = {11: "state index length mismatch"}
+        mgr.propagated_failure_rooms = {11}
 
         receiver.clear()
 
         self.assertNotIn(11, mgr.request_status)
         self.assertNotIn(11, mgr.transfer_statuses)
+        self.assertNotIn(11, mgr.failure_records)
+        self.assertNotIn(11, mgr.propagated_failure_rooms)
         self.assertEqual(mgr.addr_to_rooms_tracker["prefill:8998"], set())
 
     def test_clear_removes_staging_room_tracking(self):

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -3,9 +3,11 @@
 import struct
 import sys
 import threading
+import time
 import types
 import unittest
 from collections import defaultdict
+from queue import Empty, Queue
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +18,7 @@ from sglang.srt.disaggregation.common.conn import CommonKVManager
 from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
 from sglang.srt.disaggregation.common.utils import pack_int_lists
 from sglang.srt.disaggregation.nixl.conn import (
+    TRANSFER_FAILED,
     KVArgsRegisterInfo,
     NixlKVManager,
     NixlKVReceiver,
@@ -330,6 +333,254 @@ class TestNixlKVSenderChunkPolicy(CustomTestCase):
         self.assertTrue(sender.should_send_kv_chunk(3, last_chunk=False))
 
 
+class TestNixlFailurePropagation(CustomTestCase):
+    def _make_decode_manager(self, request_status):
+        mgr = object.__new__(NixlKVManager)
+        mgr.request_status = request_status
+        mgr.failure_records = {}
+        mgr.failure_lock = threading.Lock()
+        mgr.record_failure = CommonKVManager.record_failure.__get__(
+            mgr, CommonKVManager
+        )
+        mgr.update_status = CommonKVManager.update_status.__get__(mgr, CommonKVManager)
+        mgr._transfer_failure_lock = threading.Lock()
+        return mgr
+
+    def test_transfer_failure_marks_active_decode_room_failed(self):
+        for status in (
+            KVPoll.WaitingForInput,
+            KVPoll.Transferring,
+        ):
+            with self.subTest(status=status):
+                mgr = self._make_decode_manager({7: status})
+
+                mgr._handle_transfer_failure(
+                    [TRANSFER_FAILED, b"7", b"state index length mismatch"]
+                )
+
+                self.assertEqual(mgr.request_status[7], KVPoll.Failed)
+                self.assertEqual(mgr.failure_records[7], "state index length mismatch")
+
+    def test_transfer_failure_is_idempotent_for_terminal_or_unknown_room(self):
+        for request_status in ({7: KVPoll.Failed}, {7: KVPoll.Success}, {}):
+            with self.subTest(request_status=request_status):
+                mgr = self._make_decode_manager(request_status.copy())
+
+                mgr._handle_transfer_failure(
+                    [TRANSFER_FAILED, b"7", b"state index length mismatch"]
+                )
+
+                self.assertEqual(mgr.request_status, request_status)
+                self.assertEqual(mgr.failure_records, {})
+
+    def test_transfer_failure_uses_default_reason_when_empty(self):
+        mgr = self._make_decode_manager({7: KVPoll.WaitingForInput})
+
+        mgr._handle_transfer_failure([TRANSFER_FAILED, b"7", b""])
+
+        self.assertEqual(mgr.request_status[7], KVPoll.Failed)
+        self.assertEqual(mgr.failure_records[7], "Prefill signaled transfer failure")
+
+    def test_malformed_transfer_failure_is_ignored(self):
+        mgr = self._make_decode_manager({7: KVPoll.WaitingForInput})
+
+        for message in (
+            [TRANSFER_FAILED],
+            [TRANSFER_FAILED, b"not-a-room", b"failure"],
+            [TRANSFER_FAILED, b"7", b"\xff"],
+        ):
+            with self.subTest(message=message):
+                mgr._handle_transfer_failure(message)
+
+        self.assertEqual(mgr.request_status[7], KVPoll.WaitingForInput)
+        self.assertEqual(mgr.failure_records, {})
+
+    def _make_prefill_notification_manager(self, infos):
+        mgr = object.__new__(NixlKVManager)
+        mgr.transfer_infos = {7: infos}
+        mgr._transfer_info_lock = threading.Lock()
+        mgr._failure_notification_lock = threading.Lock()
+        mgr._pending_failure_notifications = {}
+        mgr._failure_notification_queue = Queue()
+        mgr.bootstrap_timeout = 5
+        return mgr
+
+    def test_prefill_queues_each_decode_endpoint_once(self):
+        mgr = self._make_prefill_notification_manager(
+            {
+                "agent-0": SimpleNamespace(
+                    endpoint="127.0.0.1",
+                    dst_port=1000,
+                    required_dst_info_num=3,
+                ),
+                "agent-1": SimpleNamespace(
+                    endpoint="127.0.0.1",
+                    dst_port=1001,
+                    required_dst_info_num=3,
+                ),
+                "agent-1-duplicate": SimpleNamespace(
+                    endpoint="127.0.0.1",
+                    dst_port=1001,
+                    required_dst_info_num=3,
+                ),
+            }
+        )
+
+        mgr.notify_decode_transfer_failure(7, "state index length mismatch")
+        mgr.notify_decode_transfer_failure(7, "state index length mismatch")
+
+        self.assertEqual(
+            mgr._failure_notification_queue.get_nowait(),
+            (
+                7,
+                "state index length mismatch",
+                [("127.0.0.1", 1000), ("127.0.0.1", 1001)],
+            ),
+        )
+        with self.assertRaises(Empty):
+            mgr._failure_notification_queue.get_nowait()
+
+    def test_prefill_queues_late_endpoint_after_partial_registration(self):
+        def info(port):
+            return SimpleNamespace(
+                endpoint="127.0.0.1",
+                dst_port=port,
+                required_dst_info_num=3,
+            )
+
+        mgr = self._make_prefill_notification_manager(
+            {"agent-0": info(1000), "agent-1": info(1001)}
+        )
+
+        mgr.notify_decode_transfer_failure(7, "state index length mismatch")
+
+        self.assertEqual(
+            mgr._failure_notification_queue.get_nowait(),
+            (
+                7,
+                "state index length mismatch",
+                [("127.0.0.1", 1000), ("127.0.0.1", 1001)],
+            ),
+        )
+        self.assertIn(7, mgr._pending_failure_notifications)
+
+        with mgr._transfer_info_lock:
+            captured = mgr._capture_failed_room_registration(7, "agent-2", info(1002))
+
+        room, reason, endpoints = mgr._failure_notification_queue.get_nowait()
+        self.assertTrue(captured)
+        self.assertEqual(room, 7)
+        self.assertEqual(reason, "state index length mismatch")
+        self.assertEqual(endpoints, [("127.0.0.1", 1002)])
+        pending = mgr._pending_failure_notifications[7]
+        self.assertEqual(pending.seen_agents, {"agent-0", "agent-1", "agent-2"})
+
+    def test_failure_worker_sends_nonblocking_wire_message(self):
+        info = SimpleNamespace(
+            endpoint="127.0.0.1",
+            dst_port=1000,
+            required_dst_info_num=1,
+        )
+        mgr = self._make_prefill_notification_manager({"agent-0": info})
+        socket = MagicMock()
+        mgr._connect = MagicMock(return_value=socket)
+
+        mgr.notify_decode_transfer_failure(7, "state index length mismatch")
+        worker = threading.Thread(target=mgr._failure_notification_worker, daemon=True)
+        worker.start()
+
+        deadline = time.monotonic() + 2
+        while socket.send_multipart.call_count == 0 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        while 7 in mgr._pending_failure_notifications and time.monotonic() < deadline:
+            time.sleep(0.01)
+        socket.send_multipart.assert_called_once()
+        self.assertEqual(
+            socket.send_multipart.call_args.args[0],
+            [TRANSFER_FAILED, b"7", b"state index length mismatch"],
+        )
+        self.assertNotEqual(socket.send_multipart.call_args.kwargs["flags"], 0)
+        self.assertNotIn(7, mgr._pending_failure_notifications)
+
+    @patch("sglang.srt.disaggregation.nixl.conn.time.monotonic")
+    def test_pending_notification_expires_without_retaining_room_state(self, mock_time):
+        mock_time.side_effect = [10, 20]
+        mgr = self._make_prefill_notification_manager({})
+
+        mgr.notify_decode_transfer_failure(7, "bootstrap failed")
+        mgr._prune_pending_failure_notifications()
+
+        self.assertNotIn(7, mgr._pending_failure_notifications)
+
+    def test_sender_failure_notifies_decode_before_cleanup(self):
+        mgr = MagicMock()
+        mgr.exceptions = {7: RuntimeError("state index length mismatch")}
+        mgr.failure_records = {7: "state index length mismatch"}
+        mgr.failure_lock = threading.Lock()
+        sender = object.__new__(NixlKVSender)
+        sender.kv_mgr = mgr
+        sender.bootstrap_room = 7
+        sender.conclude_state = None
+        sender._send_failed = False
+        sender._send_error = None
+        sender.clear = MagicMock()
+        events = []
+        mgr.notify_decode_transfer_failure.side_effect = lambda *args: events.append(
+            "notify"
+        )
+        sender.clear.side_effect = lambda: events.append("clear")
+
+        with self.assertRaisesRegex(RuntimeError, "state index length mismatch"):
+            sender.failure_exception()
+
+        mgr.notify_decode_transfer_failure.assert_called_once_with(
+            7, "state index length mismatch"
+        )
+        sender.clear.assert_called_once()
+        self.assertEqual(events, ["notify", "clear"])
+
+    def test_sender_clear_releases_room_state_with_pending_notification(self):
+        mgr = self._make_prefill_notification_manager(
+            {
+                "agent-0": SimpleNamespace(
+                    endpoint="127.0.0.1",
+                    dst_port=1000,
+                    required_dst_info_num=2,
+                )
+            }
+        )
+        mgr.request_status = {7: KVPoll.Failed}
+        mgr.req_to_decode_prefix_len = {7: 4}
+        mgr.enable_staging = False
+        mgr.notify_decode_transfer_failure(7, "bootstrap failed")
+        sender = object.__new__(NixlKVSender)
+        sender.kv_mgr = mgr
+        sender.bootstrap_room = 7
+
+        sender.clear()
+
+        self.assertNotIn(7, mgr.request_status)
+        self.assertNotIn(7, mgr.req_to_decode_prefix_len)
+        self.assertNotIn(7, mgr.transfer_infos)
+        self.assertIn(7, mgr._pending_failure_notifications)
+
+    def test_sender_abort_notifies_decode(self):
+        mgr = MagicMock()
+        sender = object.__new__(NixlKVSender)
+        sender.kv_mgr = mgr
+        sender.bootstrap_room = 7
+        sender.conclude_state = None
+
+        sender.abort()
+
+        mgr.record_failure.assert_called_once_with(7, "Aborted by AbortReq.")
+        mgr.update_status.assert_called_once_with(7, KVPoll.Failed)
+        mgr.notify_decode_transfer_failure.assert_called_once_with(
+            7, "Aborted by AbortReq."
+        )
+        self.assertTrue(sender._send_failed)
+
+
 class TestNixlNotifications(CustomTestCase):
     def _make_manager(self, messages, required=None):
         mgr = object.__new__(NixlKVManager)
@@ -396,6 +647,8 @@ class TestNixlReceiverPoll(CustomTestCase):
         mgr.transfer_statuses = {}
         mgr.addr_to_rooms_tracker = defaultdict(set)
         mgr.addr_to_rooms_tracker["prefill:8998"].add(11)
+        mgr._transfer_failure_lock = threading.Lock()
+        mgr.enable_staging = False
 
         receiver = object.__new__(NixlKVReceiver)
         receiver.kv_mgr = mgr
@@ -456,6 +709,52 @@ class TestNixlReceiverPoll(CustomTestCase):
         self.assertNotIn(11, mgr.transfer_statuses)
         self.assertNotIn(11, mgr.addr_to_rooms_tracker["prefill:8998"])
         self.assertEqual(receiver.conclude_state, KVPoll.Success)
+        mgr.update_status.assert_called_once_with(11, KVPoll.Success)
+
+    @patch("sglang.srt.disaggregation.nixl.conn.time.time")
+    def test_transfer_failure_wins_race_with_local_completion(self, mock_time):
+        mock_time.return_value = 12.0
+        receiver, mgr = self._make_receiver(status=KVPoll.WaitingForInput)
+        receiver.started_transfer = True
+        receiver.init_time = 10.0
+        mgr.check_status.side_effect = [KVPoll.WaitingForInput, KVPoll.Failed]
+        mgr.check_transfer_done.return_value = True
+        mgr.transfer_statuses = {11: TransferStatus()}
+
+        self.assertEqual(receiver.poll(), KVPoll.Failed)
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+        self.assertIn(11, mgr.transfer_statuses)
+        mgr.update_status.assert_not_called()
+
+    def test_clear_removes_decode_transfer_tracking(self):
+        receiver, mgr = self._make_receiver()
+        mgr.request_status = {11: KVPoll.Failed}
+        mgr.required_prefill_response_num_table = {11: 1}
+        mgr.prefill_response_tracker = {11: set()}
+        mgr.transfer_statuses = {11: TransferStatus()}
+
+        receiver.clear()
+
+        self.assertNotIn(11, mgr.request_status)
+        self.assertNotIn(11, mgr.transfer_statuses)
+        self.assertEqual(mgr.addr_to_rooms_tracker["prefill:8998"], set())
+
+    def test_clear_removes_staging_room_tracking(self):
+        receiver, mgr = self._make_receiver()
+        mgr.request_status = {11: KVPoll.Failed}
+        mgr.required_prefill_response_num_table = {11: 1}
+        mgr.prefill_response_tracker = {11: set()}
+        mgr.enable_staging = True
+        mgr._staging_ctx = SimpleNamespace(
+            room_receivers={11: receiver}, room_bootstrap={11: [object()]}
+        )
+        mgr._chunk_writer_counts = {11: {0: [object()]}}
+
+        receiver.clear()
+
+        self.assertNotIn(11, mgr._staging_ctx.room_receivers)
+        self.assertNotIn(11, mgr._staging_ctx.room_bootstrap)
+        self.assertNotIn(11, mgr._chunk_writer_counts)
 
 
 class TestNixlNodeFailure(CustomTestCase):
@@ -528,6 +827,7 @@ class TestNixlStaging(CustomTestCase):
             kv_head_num=1,
         )
         mgr.server_args = SimpleNamespace(chunked_prefill_size=4)
+        mgr._transfer_info_lock = threading.Lock()
         return mgr
 
     def test_register_buffer_to_engine_groups_kv_memory_kinds_in_one_pass(self):


### PR DESCRIPTION
## Motivation

A NIXL transfer failure on prefill was recorded only on the prefill worker. Decode could remain in `WaitingForInput` until the fallback timeout, even though the transfer could no longer succeed. Failure delivery must also handle decode endpoints that register after prefill has already failed.

## Changes

- dispatch prefill transfer failures from a socket-owning control thread
- retain bounded per-room failure state for late decode registrations
- fail decode idempotently, preserve the remote reason, and clean transfer state without waiting for the fallback timeout
- recover from transient control-socket receive errors
