### PR TITLE
[Fix] Load HunyuanV3 NextN final_layernorm into the draft head's output norm

### DIFF
--- a/python/sglang/srt/models/hunyuan_v3_nextn.py
+++ b/python/sglang/srt/models/hunyuan_v3_nextn.py
@@ -186,6 +186,10 @@ class HYV3ForCausalLMNextN(nn.Module):
                 subname = name[len(nextn_prefix) :]
                 if any(subname.startswith(s) for s in spec_weight_names):
                     name = f"model.{subname}"
+                elif subname.startswith("final_layernorm"):
+                    # Released checkpoints store the draft head's output norm
+                    # as model.layers.<N>.final_layernorm.weight.
+                    name = "model.shared_head.norm.weight"
                 else:
                     name = f"model.decoder.{subname}"
             elif name == "model.shared_head.norm.weight":

--- a/test/registered/unit/models/test_hunyuan_v3_nextn_weight_loading.py
+++ b/test/registered/unit/models/test_hunyuan_v3_nextn_weight_loading.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for HYV3ForCausalLMNextN.load_weights.
+
+Regression test for the released Hy3 MTP checkpoint key
+``model.layers.<num_hidden_layers>.final_layernorm.weight``, which must load
+into the draft head's output norm (``model.shared_head.norm``) instead of
+being remapped to a nonexistent decoder parameter and silently dropped.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.models.hunyuan_v3_nextn import HYV3ForCausalLMNextN
+
+
+class _FakeParam:
+    def __init__(self):
+        self.loaded = None
+
+    def weight_loader(self, param, loaded_weight, *args, **kwargs):
+        self.loaded = (param, loaded_weight, args, kwargs)
+
+
+class TestHunyuanV3NextNWeightLoading(unittest.TestCase):
+    def _make_minimal_model(self, named_parameters=()):
+        model = object.__new__(HYV3ForCausalLMNextN)
+        model.config = SimpleNamespace(num_hidden_layers=80, num_experts=2)
+        model.named_parameters = lambda: iter(named_parameters)
+        return model
+
+    def test_final_layernorm_loads_into_shared_head_norm(self):
+        param = _FakeParam()
+        model = self._make_minimal_model([("model.shared_head.norm.weight", param)])
+        loaded_weight = torch.ones(1)
+
+        model.load_weights([("model.layers.80.final_layernorm.weight", loaded_weight)])
+
+        self.assertEqual(param.loaded, (param, loaded_weight, (), {}))
+
+    def test_spec_weights_map_to_model_prefix(self):
+        params = {
+            "model.enorm.weight": _FakeParam(),
+            "model.hnorm.weight": _FakeParam(),
+            "model.eh_proj.weight": _FakeParam(),
+        }
+        model = self._make_minimal_model(list(params.items()))
+        weights = [
+            ("model.layers.80.enorm.weight", torch.ones(1)),
+            ("model.layers.80.hnorm.weight", torch.ones(1)),
+            ("model.layers.80.eh_proj.weight", torch.ones(1)),
+        ]
+
+        model.load_weights(weights)
+
+        for name, param in params.items():
+            self.assertIsNotNone(param.loaded, f"{name} was not loaded")
+
+    def test_decoder_layer_weight_maps_to_decoder_prefix(self):
+        param = _FakeParam()
+        model = self._make_minimal_model(
+            [("model.decoder.input_layernorm.weight", param)]
+        )
+        loaded_weight = torch.ones(1)
+
+        model.load_weights([("model.layers.80.input_layernorm.weight", loaded_weight)])
+
+        self.assertEqual(param.loaded, (param, loaded_weight, (), {}))
+
+    def test_embed_tokens_and_lm_head_are_skipped(self):
+        params = {
+            "model.embed_tokens.weight": _FakeParam(),
+            "lm_head.weight": _FakeParam(),
+        }
+        model = self._make_minimal_model(list(params.items()))
+        weights = [
+            ("model.embed_tokens.weight", torch.ones(1)),
+            ("lm_head.weight", torch.ones(1)),
+        ]
+
+        model.load_weights(weights)
+
+        for name, param in params.items():
+            self.assertIsNone(param.loaded, f"{name} should have been skipped")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On released `tencent/Hy3` checkpoints, MTP speculative decoding is slower than plain decode. Root cause: the checkpoint stores the draft layer's output norm as `model.layers.80.final_layernorm.weight`, but `HYV3ForCausalLMNextN.load_weights` remaps every non-spec key under the NextN prefix to `model.decoder.<subname>`. `model.decoder.final_layernorm.weight` exists on no module, so the key is silently dropped by the `name not in params_dict` guard — and `shared_head.norm`, the RMSNorm applied immediately before the draft `lm_head`, only loads from a literal `model.shared_head.norm.weight` key that the released checkpoint does not contain. The draft head therefore runs a default-initialized output norm. The real tensor is materially non-identity (mean 1.16, range 0.81–1.23), so every draft logit is skewed and acceptance collapses.

## Modifications

- One `elif` in the NextN key remap routes `final_layernorm.*` to `model.shared_head.norm.weight`. The existing bare-key branch is kept for preview-era checkpoints.
- New unit test `test/registered/unit/models/test_hunyuan_v3_nextn_weight_loading.py` (CPU-only, mirrors the Nemotron-H exemplar) asserting the four mapping classes: `final_layernorm` → `shared_head.norm`, spec weights → `model.*`, decoder-layer keys → `model.decoder.*`, embed/lm_head skipped. The regression test fails against the unfixed source.

## Accuracy Tests

Output distribution is unchanged by construction — the fix touches only the draft model, and speculative verification is lossless. Unit tests: 4/4 pass.

## Speed Tests and Profiling

`tencent/Hy3-FP8`, TP4 on 4× RTX PRO 6000 Blackwell (SM120), SGLang 0.5.14, fp8 KV.

| Configuration | accept | decode tok/s (bs=1) |
|---|---|---|
| Plain decode (no speculation) | — | 81–86 |
| MTP before fix (EAGLE 2-1-3) | rate 0.575 | 54–56 (slower than plain) |
| MTP after fix (EAGLE 3-1-4) | length 2.3–2.6 | 87–89 (332 tok/s aggregate @ 8 streams) |

The dropped-tensor mechanism is configuration-independent.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29249862209](https://github.com/sgl-project/sglang/actions/runs/29249862209)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29249862255](https://github.com/sgl-project/sglang/actions/runs/29249862255)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->