### PR TITLE
[Fix] Declare think_excluded_tokens for Hunyuan so strict-thinking budgets arm

### DIFF
--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -26,6 +26,7 @@ _HUNYUAN_TOKEN_NAMES = (
     "arg_key",
     "arg_value",
     "think",
+    "answer",
 )
 
 _HUNYUAN_TOKEN_RE = re.compile(

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -545,14 +545,39 @@ class HunyuanDetector(BaseReasoningFormatDetector):
         previous_content: str = "",
         tokenizer=None,
     ):
+        def _close(open_tok: str) -> str:
+            return "</" + open_tok[1:] if open_tok.startswith("<") else open_tok
+
         t = resolve_hunyuan_tokens(tokenizer)
         think_open = t["think"]
-        think_close = (
-            "</" + think_open[1:] if think_open.startswith("<") else think_open
-        )
+        think_close = _close(think_open)
+        answer_open = t["answer"]
+
+        think_excluded_tokens = None
+        if tokenizer is not None:
+            try:
+                vocab = tokenizer.get_vocab()
+            except Exception:
+                vocab = None
+            if isinstance(vocab, dict):
+                candidates = [
+                    getattr(tokenizer, "eos_token", None),
+                    answer_open,
+                    _close(answer_open),
+                    think_open,
+                ]
+                # The grammar backend excludes every id a string encodes to,
+                # so only single vocab entries are safe to exclude.
+                think_excluded_tokens = [
+                    tok
+                    for tok in dict.fromkeys(candidates)
+                    if isinstance(tok, str) and tok in vocab
+                ] or None
+
         super().__init__(
             think_open,
             think_close,
+            think_excluded_tokens=think_excluded_tokens,
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
             tool_start_token=t["tool_calls"],

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -520,6 +520,30 @@ class TestGlm45Detector(CustomTestCase):
         self.assertEqual(result.normal_text, "<tool_call>tool call")
 
 
+_HY3_VOCAB = {
+    "<｜hy_eos:opensource｜>": 120025,
+    "<think:opensource>": 120029,
+    "</think:opensource>": 120030,
+    "<answer>": 120031,
+    "</answer>": 120032,
+}
+
+
+class _FakeHy3Tokenizer:
+    """Minimal stand-in for the shipping Hy3 tokenizer (suffixed specials)."""
+
+    eos_token = "<｜hy_eos:opensource｜>"
+
+    def __init__(self, vocab):
+        self._vocab = dict(vocab)
+
+    def get_vocab(self):
+        return dict(self._vocab)
+
+    def convert_tokens_to_ids(self, token):
+        return self._vocab.get(token)
+
+
 class TestHunyuanDetector(CustomTestCase):
     """Test cases for Hunyuan detector with tool interruption support."""
 
@@ -611,6 +635,43 @@ class TestHunyuanDetector(CustomTestCase):
 
         self.assertEqual(all_reasoning, "reasoning")
         self.assertIn("<tool_calls>", all_normal)
+
+    def test_suffixed_think_tokens_resolve_from_tokenizer(self):
+        """Suffixed think tags resolve from the tokenizer vocab."""
+        detector = HunyuanDetector(tokenizer=_FakeHy3Tokenizer(_HY3_VOCAB))
+        self.assertEqual(detector.think_start_token, "<think:opensource>")
+        self.assertEqual(detector.think_end_token, "</think:opensource>")
+
+        text = "<think:opensource>Let me think</think:opensource>The answer is 42."
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "Let me think")
+        self.assertEqual(result.normal_text, "The answer is 42.")
+
+    def test_think_excluded_tokens_from_tokenizer(self):
+        """With a tokenizer, the single-token specials are excluded."""
+        detector = HunyuanDetector(tokenizer=_FakeHy3Tokenizer(_HY3_VOCAB))
+        self.assertEqual(
+            detector.think_excluded_tokens,
+            [
+                "<｜hy_eos:opensource｜>",
+                "<answer>",
+                "</answer>",
+                "<think:opensource>",
+            ],
+        )
+
+    def test_no_tokenizer_declares_no_excluded_tokens(self):
+        """Without a tokenizer, no tokens are declared for exclusion."""
+        self.assertIsNone(self.detector.think_excluded_tokens)
+
+    def test_vocab_without_answer_specials_omits_them(self):
+        """Answer specials absent from the vocab are omitted, without error."""
+        vocab = {k: v for k, v in _HY3_VOCAB.items() if "answer" not in k}
+        detector = HunyuanDetector(tokenizer=_FakeHy3Tokenizer(vocab))
+        self.assertEqual(
+            detector.think_excluded_tokens,
+            ["<｜hy_eos:opensource｜>", "<think:opensource>"],
+        )
 
 
 class TestNemotron3Detector(CustomTestCase):


### PR DESCRIPTION
## Motivation

`--enable-strict-thinking` thinking budgets (`custom_params.thinking_budget`) are silently inert for Hunyuan models: `ReasonerGrammarBackend` only arms `enable_token_filter` when the reasoning detector declares `think_excluded_tokens`, and `HunyuanDetector` declares none (Qwen3, KimiK2, and GLM-4.5 detectors all do).

Verified live on `tencent/Hy3-FP8`: budget 100 → 741–873 reasoning tokens (unbounded). With this fix: budget 100 → 101, budget 400 → 401 — the documented force-close behavior.

## Modifications

- `"answer"` joins `_HUNYUAN_TOKEN_NAMES` so `<answer>` / `<answer:...>` resolve from the vocabulary like the other Hunyuan specials (the runtime-resolution pattern from #29920).
- With a tokenizer present, `HunyuanDetector` declares `think_excluded_tokens` = `[eos, <answer>, </answer>, think-open]`, filtered to strings that are actual vocabulary entries. The vocabulary gate matters: the grammar backend excludes every id a declared string encodes to, so a multi-token string would ban ordinary text tokens during thinking. Without a tokenizer, behavior is unchanged (no declaration).
- No changes to `reasoner_grammar_backend.py` or `server_args.py` — the consumer arms automatically once the detector declares the tokens.
- Tests: `TestHunyuanDetector` gains a fake Hy3 tokenizer and four cases — suffixed-tag resolution end-to-end (previously zero coverage of the #29920 path anywhere in `test/`), the exact excluded set, the no-tokenizer case, and an answer-less vocabulary omitting the pair without error. 128/128 pass; the new tests fail against the unfixed source.

## Accuracy Tests

No effect on default serving — the excluded-token list is only consulted under `--enable-strict-thinking`. Unit tests: 128/128 pass (124 pre-existing, 4 new).

## Speed Tests and Profiling

Not applicable (no hot-path changes).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28840170855](https://github.com/sgl-project/sglang/actions/runs/28840170855)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28840170750](https://github.com/sgl-project/sglang/actions/runs/28840170750)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->