### PR TITLE
fuse fragment ops to reduce host-bubble

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -264,15 +264,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         return self.forward_metadata.page_table
 
     @staticmethod
-    def _fill_cu_seqlens_k(metadata: TRTLLMMHAMetadata):
-        torch.cumsum(
-            metadata.cache_seqlens_int32,
-            dim=0,
-            dtype=torch.int32,
-            out=metadata.cu_seqlens_k[1:],
-        )
-
-    @staticmethod
     def _get_scalar_scale(
         layer: RadixAttention,
         float_attr: str,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -264,6 +264,15 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         return self.forward_metadata.page_table
 
     @staticmethod
+    def _fill_cu_seqlens_k(metadata: TRTLLMMHAMetadata):
+        torch.cumsum(
+            metadata.cache_seqlens_int32,
+            dim=0,
+            dtype=torch.int32,
+            out=metadata.cu_seqlens_k[1:],
+        )
+
+    @staticmethod
     def _get_scalar_scale(
         layer: RadixAttention,
         float_attr: str,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1570,20 +1570,10 @@ class _MambaRadixCacheV2TrackEntry(NamedTuple):
 def set_mamba_track_indices_from_reqs(batch):
     """Build mamba_track_indices from req objects (authoritative source)."""
     req_to_token_pool = batch.req_to_token_pool
-    all_buffers = req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
-        batch.req_pool_indices
-    ]  # (bs, ping_pong_size), int64, on device
-    idx = (
-        torch.tensor(
-            [req.mamba_next_track_idx for req in batch.reqs],
-            dtype=torch.int64,
-            pin_memory=True,
-        )
-        .unsqueeze(1)
-        .to(device=all_buffers.device, non_blocking=True)
-    )
     batch.mamba_track_indices = (
-        torch.gather(all_buffers, 1, idx).squeeze(1).to(torch.int64)
+        req_to_token_pool.req_index_to_active_mamba_track_slot_mapping[
+            batch.req_pool_indices
+        ]
     )
 
 
@@ -2334,10 +2324,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # allocated yet; it will be allocated on demand at the track boundary
             # in mamba_lazy_prealloc_at_boundary during prepare_for_decode.
             if not get_global_server_args().enable_mamba_extra_buffer_lazy():
-                req.mamba_next_track_idx = (
+                self.req_to_token_pool.set_mamba_next_track_idx(
+                    req,
                     self.req_to_token_pool.get_mamba_ping_pong_other_idx(
                         req.mamba_next_track_idx
-                    )
+                    ),
                 )
             if req.mamba_branching_seqlen is not None:
                 # track branching point in this forward if the branching point
@@ -2592,7 +2583,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     new_slot = pool.mamba_allocator.alloc(1)
             if new_slot is not None:
                 pool.set_mamba_ping_pong_slot(req, other_idx, new_slot[0])
-                req.mamba_next_track_idx = other_idx
+                pool.set_mamba_next_track_idx(req, other_idx)
 
     def cumulate_penalty_output_tokens(self):
         # Under overlap batch.input_ids is just a placeholder here -- the

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -895,10 +895,11 @@ class SchedulerBatchResultProcessor:
         if lazy:
             self.mamba_lazy_post_decode_at_boundary(req, batch)
         else:
-            req.mamba_next_track_idx = (
+            batch.req_to_token_pool.set_mamba_next_track_idx(
+                req,
                 batch.req_to_token_pool.get_mamba_ping_pong_other_idx(
                     req.mamba_next_track_idx
-                )
+                ),
             )
 
     def _mamba_check_track_boundary(self, req, batch, result, i):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -924,6 +924,9 @@ class HybridReqToTokenPool(ReqToTokenPool):
                     device=self.device,
                 )
             )
+            self.req_index_to_active_mamba_track_slot_mapping: torch.Tensor = (
+                torch.zeros(req_pool_size, dtype=torch.int64, device=self.device)
+            )
 
     def register_layer_transfer_counter(self, layer_transfer_counter: LayerDoneCounter):
         self.layer_transfer_counter = layer_transfer_counter
@@ -971,6 +974,15 @@ class HybridReqToTokenPool(ReqToTokenPool):
             ping_pong_tensor = torch.stack(mamba_ping_pong_track_buffers)
             self.req_index_to_mamba_ping_pong_track_buffer_mapping[select_index] = (
                 ping_pong_tensor
+            )
+            active_track_slots = torch.stack(
+                [
+                    req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx]
+                    for req in reqs
+                ]
+            )
+            self.req_index_to_active_mamba_track_slot_mapping[select_index] = (
+                active_track_slots
             )
         return select_index
 
@@ -1042,6 +1054,14 @@ class HybridReqToTokenPool(ReqToTokenPool):
         req.mamba_ping_pong_track_buffer = buf
         req.mamba_next_track_idx = 0
 
+    def set_mamba_next_track_idx(self, req: Req, idx: int):
+        """Update the active ping-pong index and the pre-resolved device mapping."""
+        req.mamba_next_track_idx = idx
+        if req.mamba_ping_pong_track_buffer is not None:
+            self.req_index_to_active_mamba_track_slot_mapping[req.req_pool_idx] = (
+                req.mamba_ping_pong_track_buffer[idx]
+            )
+
     def set_mamba_ping_pong_slot(self, req: Req, idx: int, value):
         """Update a ping-pong slot value and sync the device-side mapping.
 
@@ -1053,6 +1073,10 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.req_index_to_mamba_ping_pong_track_buffer_mapping[req.req_pool_idx] = (
             req.mamba_ping_pong_track_buffer
         )
+        if idx == req.mamba_next_track_idx:
+            self.req_index_to_active_mamba_track_slot_mapping[req.req_pool_idx] = (
+                req.mamba_ping_pong_track_buffer[idx]
+            )
 
     def donate_mamba_ping_pong_slot(
         self, req: Req, new_slot: torch.Tensor
@@ -1129,6 +1153,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
             # tensor on the req side while the new pool slot leaks).
             req.mamba_ping_pong_track_buffer = None
             req.mamba_next_track_idx = None
+            self.req_index_to_active_mamba_track_slot_mapping[req.req_pool_idx] = 0
 
     def clear(self):
         logger.info("Reset HybridReqToTokenPool")
@@ -1143,6 +1168,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.req_index_to_mamba_index_mapping.zero_()
         if self.enable_mamba_extra_buffer:
             self.req_index_to_mamba_ping_pong_track_buffer_mapping.zero_()
+            self.req_index_to_active_mamba_track_slot_mapping.zero_()
 
 
 @dataclass

--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -34,11 +34,130 @@ import torch
 
 from sglang.srt.model_executor.input_buffers import share_input_buffer
 
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
 _has_foreach_copy = hasattr(torch, "_foreach_copy_")
+_has_triton = triton is not None
+
+if _has_triton:
+
+    @triton.jit
+    def _fused_copy_8_kernel(
+        dst0,
+        src0,
+        n0,
+        dst1,
+        src1,
+        n1,
+        dst2,
+        src2,
+        n2,
+        dst3,
+        src3,
+        n3,
+        dst4,
+        src4,
+        n4,
+        dst5,
+        src5,
+        n5,
+        dst6,
+        src6,
+        n6,
+        dst7,
+        src7,
+        n7,
+        BLOCK: tl.constexpr,
+    ):
+        slot = tl.program_id(0)
+        block = tl.program_id(1)
+        offs = block * BLOCK + tl.arange(0, BLOCK)
+        if slot == 0:
+            mask = offs < n0
+            tl.store(dst0 + offs, tl.load(src0 + offs, mask=mask), mask=mask)
+        elif slot == 1:
+            mask = offs < n1
+            tl.store(dst1 + offs, tl.load(src1 + offs, mask=mask), mask=mask)
+        elif slot == 2:
+            mask = offs < n2
+            tl.store(dst2 + offs, tl.load(src2 + offs, mask=mask), mask=mask)
+        elif slot == 3:
+            mask = offs < n3
+            tl.store(dst3 + offs, tl.load(src3 + offs, mask=mask), mask=mask)
+        elif slot == 4:
+            mask = offs < n4
+            tl.store(dst4 + offs, tl.load(src4 + offs, mask=mask), mask=mask)
+        elif slot == 5:
+            mask = offs < n5
+            tl.store(dst5 + offs, tl.load(src5 + offs, mask=mask), mask=mask)
+        elif slot == 6:
+            mask = offs < n6
+            tl.store(dst6 + offs, tl.load(src6 + offs, mask=mask), mask=mask)
+        elif slot == 7:
+            mask = offs < n7
+            tl.store(dst7 + offs, tl.load(src7 + offs, mask=mask), mask=mask)
+
+
+def _can_fuse_copy(dst: torch.Tensor, src: torch.Tensor) -> bool:
+    return (
+        _has_triton
+        and dst.device.type == "cuda"
+        and src.device.type == "cuda"
+        and dst.device == src.device
+        and dst.dtype == src.dtype
+        and dst.numel() == src.numel()
+        and dst.is_contiguous()
+        and src.is_contiguous()
+        and not torch.cuda.is_current_stream_capturing()
+    )
+
+
+def _fused_copy_chunks_(dsts: List[torch.Tensor], srcs: List[torch.Tensor]) -> None:
+    block = 256
+    for start in range(0, len(dsts), 8):
+        chunk_dsts = dsts[start : start + 8]
+        chunk_srcs = srcs[start : start + 8]
+        num_slots = len(chunk_dsts)
+        max_n = max(dst.numel() for dst in chunk_dsts)
+        padded_dsts = chunk_dsts + [chunk_dsts[0]] * (8 - num_slots)
+        padded_srcs = chunk_srcs + [chunk_srcs[0]] * (8 - num_slots)
+        ns = [dst.numel() for dst in chunk_dsts] + [0] * (8 - num_slots)
+        _fused_copy_8_kernel[(num_slots, triton.cdiv(max_n, block))](
+            padded_dsts[0],
+            padded_srcs[0],
+            ns[0],
+            padded_dsts[1],
+            padded_srcs[1],
+            ns[1],
+            padded_dsts[2],
+            padded_srcs[2],
+            ns[2],
+            padded_dsts[3],
+            padded_srcs[3],
+            ns[3],
+            padded_dsts[4],
+            padded_srcs[4],
+            ns[4],
+            padded_dsts[5],
+            padded_srcs[5],
+            ns[5],
+            padded_dsts[6],
+            padded_srcs[6],
+            ns[6],
+            padded_dsts[7],
+            padded_srcs[7],
+            ns[7],
+            BLOCK=block,
+        )
 
 
 def _grouped_foreach_copy_(dsts: List[torch.Tensor], srcs: List[torch.Tensor]) -> None:
@@ -48,10 +167,30 @@ def _grouped_foreach_copy_(dsts: List[torch.Tensor], srcs: List[torch.Tensor]) -
     def _foreach_copy(
         group_dsts: List[torch.Tensor], group_srcs: List[torch.Tensor]
     ) -> None:
+        fused_dsts: List[torch.Tensor] = []
+        fused_srcs: List[torch.Tensor] = []
+        fallback_dsts: List[torch.Tensor] = []
+        fallback_srcs: List[torch.Tensor] = []
+        for dst, src in zip(group_dsts, group_srcs):
+            if _can_fuse_copy(dst, src):
+                fused_dsts.append(dst)
+                fused_srcs.append(src)
+            else:
+                fallback_dsts.append(dst)
+                fallback_srcs.append(src)
+
+        if len(fused_dsts) >= 2:
+            _fused_copy_chunks_(fused_dsts, fused_srcs)
+        elif len(fused_dsts) == 1:
+            fallback_dsts.extend(fused_dsts)
+            fallback_srcs.extend(fused_srcs)
+
+        if not fallback_dsts:
+            return
         if _has_foreach_copy:
-            torch._foreach_copy_(group_dsts, group_srcs)
+            torch._foreach_copy_(fallback_dsts, fallback_srcs)
         else:
-            for dst, src in zip(group_dsts, group_srcs):
+            for dst, src in zip(fallback_dsts, fallback_srcs):
                 dst.copy_(src)
 
     groups: Dict[Tuple[torch.dtype, torch.dtype], Tuple[List, List]] = {}

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -539,6 +539,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # (runtime refs were removed from this dataclass on purpose).
     forward_metadata_planned_bs: Optional[int] = None
     forward_metadata_planned_num_tokens: Optional[int] = None
+    cuda_graph_batch_loaded_runner_id: Optional[int] = None
+    cuda_graph_batch_loaded_raw_bs: Optional[int] = None
+    cuda_graph_batch_loaded_padded_bs: Optional[int] = None
+    cuda_graph_batch_loaded_raw_num_tokens: Optional[int] = None
+    cuda_graph_batch_loaded_padded_num_tokens: Optional[int] = None
     # Whether the forward path may re-plan this batch when its shapes no
     # longer match the plan record. Only mark sites where the forward
     # path's own init_forward_metadata is equivalent to the pre-plan
@@ -563,6 +568,36 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             self.input_ids.shape[0] if self.input_ids is not None else 0
         )
         self.forward_metadata_replan_equivalent = replan_equivalent
+
+    def mark_cuda_graph_batch_loaded(
+        self,
+        *,
+        runner_id: int,
+        raw_bs: int,
+        padded_bs: int,
+        raw_num_tokens: int,
+        padded_num_tokens: int,
+    ) -> None:
+        self.cuda_graph_batch_loaded_runner_id = runner_id
+        self.cuda_graph_batch_loaded_raw_bs = raw_bs
+        self.cuda_graph_batch_loaded_padded_bs = padded_bs
+        self.cuda_graph_batch_loaded_raw_num_tokens = raw_num_tokens
+        self.cuda_graph_batch_loaded_padded_num_tokens = padded_num_tokens
+
+    def is_cuda_graph_batch_loaded(
+        self,
+        *,
+        runner_id: int,
+        raw_bs: int,
+        raw_num_tokens: int,
+    ) -> bool:
+        return (
+            self.cuda_graph_batch_loaded_runner_id == runner_id
+            and self.cuda_graph_batch_loaded_raw_bs == raw_bs
+            and self.cuda_graph_batch_loaded_raw_num_tokens == raw_num_tokens
+            and self.cuda_graph_batch_loaded_padded_bs is not None
+            and self.cuda_graph_batch_loaded_padded_num_tokens is not None
+        )
 
     def needs_forward_metadata_init(self) -> bool:
         """Single judgment point for whether the forward path must plan.

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -914,8 +914,39 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if not forward_batch.needs_forward_metadata_init():
             # Pre-planned (plan-stream load_batch already ran).
             # In speculative decoding, these two fields are still needed.
-            self.buffers.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
-            self.buffers.positions[: self.raw_num_token].copy_(forward_batch.positions)
+            raw_bs = forward_batch.batch_size
+            raw_num_token = raw_bs * self.num_tokens_per_bs
+            self.raw_bs = raw_bs
+            self.raw_num_token = raw_num_token
+
+            if self.require_mlp_tp_gather:
+                max_num_tokens = max(forward_batch.global_num_tokens_cpu)
+                max_batch_size = (
+                    max_num_tokens / self.num_tokens_per_bs
+                    if self.model_runner.spec_algorithm.is_eagle()
+                    or self.model_runner.spec_algorithm.is_standalone()
+                    or self.model_runner.spec_algorithm.is_dflash()
+                    else max_num_tokens
+                )
+                default_bs = self._pad_to_bucket(int(max_batch_size), self.capture_bs)
+            else:
+                default_bs = self._pad_to_bucket(raw_bs, self.capture_bs)
+
+            can_skip_input_copy = (
+                not torch.cuda.is_current_stream_capturing()
+                and forward_batch.is_cuda_graph_batch_loaded(
+                    runner_id=id(self),
+                    raw_bs=raw_bs,
+                    raw_num_tokens=raw_num_token,
+                )
+            )
+            if can_skip_input_copy:
+                self.bs = forward_batch.cuda_graph_batch_loaded_padded_bs
+            else:
+                self.bs = default_bs
+                self.buffers.input_ids[:raw_num_token].copy_(forward_batch.input_ids)
+                self.buffers.positions[:raw_num_token].copy_(forward_batch.positions)
+
             if (
                 self.model_runner.spec_algorithm.is_dflash()
                 and self.model_runner.is_draft_worker
@@ -996,6 +1027,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         self.raw_bs = raw_bs
         self.raw_num_token = raw_num_token
         self.bs = bs
+        forward_batch.mark_cuda_graph_batch_loaded(
+            runner_id=id(self),
+            raw_bs=raw_bs,
+            padded_bs=bs,
+            raw_num_tokens=raw_num_token,
+            padded_num_tokens=bs * self.num_tokens_per_bs,
+        )
 
         if self.model_runner.hisparse_coordinator is not None:
             self.model_runner.hisparse_coordinator.num_real_reqs.fill_(raw_bs)


### PR DESCRIPTION
## Motivation

Fuse fragment ops to reduce host-bubble

## Modifications

- Skipping duplicate CUDA graph `load_batch` input copies when the same `ForwardBatch` has already been loaded for the same graph runner and shape.
- Fusing eligible CUDA graph buffer copies through a Triton copy kernel, with fallback to existing foreach/copy behavior.
- Pre-resolving active Mamba track slots in the req-to-token pool so decode can avoid per-step gather/index construction.
 
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

baseline commit: 80decc78ec

Serve Qwen3.5-397B-A17B-NVFP4 :

```
  sglang serve \
    --model-path /tmp/Qwen3.5-397B-A17B-NVFP4 \
    --tp-size 4 \
    --context-length 80000 \
    --max-running-requests 2048 \
    --mem-fraction-static 0.9 \
    --trust-remote-code \
    --attention-backend trtllm_mha \
    --moe-runner-backend flashinfer_trtllm \
    --quantization modelopt_fp4 \
    --kv-cache-dtype fp8_e4m3 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --speculative-draft-model-path /mnt/workspace/yancey.yx/ckps/Qwen3.5-397B-A17B-NVFP4 \
    --mamba-scheduler-strategy extra_buffer \
    --enable-cache-report \
    --weight-loader-prefetch-checkpoints \
    --host 127.0.0.1 \
    --port 8000
```

evalscope perf:

``` bash
  evalscope perf \
    --model nvidia/Qwen3.5-397B-A17B-NVFP4 \
    --url http://localhost:8000/v1/chat/completions \
    --api openai \
    --dataset swe_smith \
    --dataset-path /tmp/agentic_dataset.json \
    --max-tokens 500 \
    --multi-turn \
    --number 4 8 8 16 \
    --parallel 1 2 4 8 \
    --outputs-dir "$RUN_DIR/evalscope" \
    --extra-args '{"ignore_eos": true}' \
    --no-timestamp
```

| Case | C=1 Decode TPS | C=2 Decode TPS | C=4 Decode TPS | C=8 Decode TPS |
|---|---:|---:|---:|---:|
| Baseline | 512.41 | 461.75 | 278.01 | 148.60 |
| Host-bubble fix | 526.59 | 460.41 | 329.69 | 219.86 |
| Benefit | +2.77% | -0.29% | +18.59% | +47.96% |















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28841573094](https://github.com/sgl-project/sglang/actions/runs/28841573094)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28841572991](https://github.com/sgl-project/sglang/actions/runs/28841572991)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->