### PR TITLE
[DSV4] Split mixed-chunk attention: route decode tokens to the fp8 paged MLA kernel

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -845,6 +845,7 @@ class Envs:
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)
     SGLANG_OPT_FLASHMLA_SPARSE_PREFILL = EnvBool(True)
+    SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN = EnvBool(True)
 
     # SWA radix cache
     # TODO(DSV4): @ispobock this has bug on main branch when retract

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1122,6 +1122,7 @@ class Envs:
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)
     SGLANG_OPT_FLASHMLA_SPARSE_PREFILL = EnvBool(True)
+    SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN = EnvBool(True)
 
     # SWA radix cache
     # TODO(DSV4): @ispobock this has bug on main branch when retract

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -62,6 +62,9 @@ if TYPE_CHECKING:
 _is_sm120 = is_sm120_supported()
 _is_xpu = is_xpu()
 
+if not _is_sm120 and not _is_xpu:
+    from sgl_kernel.flash_mla import flash_mla_with_kvcache
+
 logger = logging.getLogger(__name__)
 
 SWA_WINDOW = 128
@@ -368,6 +371,9 @@ class DSV4Metadata:
     # reused across every layer in the chunk. Reset to ``None`` when graph
     # metadata is refreshed so replay rebuilds it from the live batch.
     sparse_prefill_cache: Optional[SparsePrefillChunkCache] = None
+    # Set by init_forward_metadata for mixed batches when the split path is
+    # enabled; None otherwise.
+    mixed_decode_tail_len: Optional[int] = None
 
     @property
     def core_metadata(self) -> DSV4AttnMetadata:
@@ -381,6 +387,7 @@ class DSV4Metadata:
             self.c128_compress_metadata, src=other.c128_compress_metadata
         )
         self.sparse_prefill_cache = None
+        self.mixed_decode_tail_len = None
 
     def refresh_for_breakable_cuda_graph_replay_(self, static_metadata: DSV4Metadata):
         self.core_attn_metadata.refresh_for_breakable_cuda_graph_replay_(
@@ -400,6 +407,7 @@ class DSV4Metadata:
                 src=static_metadata.c128_compress_metadata,
             )
         self.sparse_prefill_cache = None
+        self.mixed_decode_tail_len = None
 
 
 @dataclass
@@ -1096,6 +1104,15 @@ class DeepseekV4AttnBackend(
             return
 
         self.forward_metadata = self._build_forward_metadata(forward_batch)
+        if (
+            envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
+            and forward_batch.forward_mode.is_mixed()
+            and not _is_sm120
+            and not _is_xpu
+        ):
+            self.forward_metadata.mixed_decode_tail_len = (
+                forward_batch.num_mixed_decode_tokens
+            )
         self.init_forward_metadata_in_graph(forward_batch)
 
     def _build_forward_metadata(
@@ -1406,6 +1423,31 @@ class DeepseekV4AttnBackend(
                 q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                 or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
             ):
+                if (
+                    envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
+                    and forward_batch.forward_mode.is_mixed()
+                    and not _is_sm120
+                    and not _is_xpu
+                ):
+                    num_tail = metadata.mixed_decode_tail_len
+                    if num_tail is not None and 0 < num_tail < q.shape[0]:
+                        return self._forward_mixed_split(
+                            q=q,
+                            layer_id=layer_id,
+                            compress_ratio=compress_ratio,
+                            forward_batch=forward_batch,
+                            token_to_kv_pool=token_to_kv_pool,
+                            core_attn_metadata=core_attn_metadata,
+                            attn_sink=attn_sink,
+                            num_tail=num_tail,
+                            swa_k_cache=swa_k_cache,
+                            swa_page_indices=swa_page_indices,
+                            swa_topk_lengths=swa_topk_lengths,
+                            extra_k_cache=extra_k_cache,
+                            extra_indices=extra_indices,
+                            extra_topk_lengths=extra_topk_lengths,
+                            flashmla_metadata=flashmla_metadata,
+                        )
                 return self._forward_prefill_sparse(
                     q=q,
                     layer_id=layer_id,
@@ -1460,6 +1502,81 @@ class DeepseekV4AttnBackend(
             return o
 
         raise NotImplementedError("ragged attention")
+
+    def _forward_mixed_split(
+        self,
+        q: torch.Tensor,
+        layer_id: int,
+        compress_ratio: Literal[0, 4, 128],
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: DeepSeekV4TokenToKVPool,
+        core_attn_metadata: DSV4AttnMetadata,
+        attn_sink: torch.Tensor,
+        num_tail: int,
+        swa_k_cache: torch.Tensor,
+        swa_page_indices: torch.Tensor,
+        swa_topk_lengths: torch.Tensor,
+        extra_k_cache: Optional[torch.Tensor],
+        extra_indices: Optional[torch.Tensor],
+        extra_topk_lengths: Optional[torch.Tensor],
+        flashmla_metadata,
+    ) -> torch.Tensor:
+        """Split a mixed-chunk batch at the prefill/decode boundary so the
+        decode tail reads the fp8 KV cache directly instead of paying the
+        per-layer bf16 dequant of the sparse-prefill workspace path."""
+        num_head = q.shape[0] - num_tail
+        metadata = self.forward_metadata
+        if metadata.sparse_prefill_cache is None:
+            seq_lens_cpu = forward_batch.seq_lens_cpu
+            assert seq_lens_cpu is not None
+            num_head_reqs = int(forward_batch.seq_lens.shape[0]) - num_tail
+            metadata.sparse_prefill_cache = SparsePrefillChunkCache.build(
+                seq_lens=forward_batch.seq_lens[:num_head_reqs].to(torch.int32),
+                extend_seq_lens=forward_batch.extend_seq_lens[:num_head_reqs].to(
+                    torch.int32
+                ),
+                req_pool_indices=forward_batch.req_pool_indices[:num_head_reqs].to(
+                    torch.int32
+                ),
+                req_to_token=self.req_to_token,
+                full_to_swa=token_to_kv_pool.full_to_swa_index_mapping,
+                swa_window_size=SWA_WINDOW,
+                swa_page_size=token_to_kv_pool.swa_window_size,
+                num_qo_tokens=num_head,
+                max_seq_len=int(seq_lens_cpu[:num_head_reqs].max().item()),
+            )
+        o_head = self._forward_prefill_sparse(
+            q=q[:num_head],
+            layer_id=layer_id,
+            compress_ratio=compress_ratio,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+            core_attn_metadata=core_attn_metadata,
+            attn_sink=attn_sink,
+        )
+        o_tail = flash_mla_with_kvcache(
+            q=q[num_head:],
+            k_cache=swa_k_cache,
+            head_dim_v=self.head_dim_v,
+            block_table=None,
+            cache_seqlens=None,
+            tile_scheduler_metadata=flashmla_metadata,
+            softmax_scale=self.softmax_scale,
+            is_fp8_kvcache=True,
+            indices=swa_page_indices[num_head:],
+            topk_length=swa_topk_lengths[num_head:],
+            attn_sink=attn_sink,
+            extra_k_cache=extra_k_cache,
+            extra_indices_in_kvcache=(
+                extra_indices[num_head:] if extra_indices is not None else None
+            ),
+            extra_topk_length=(
+                extra_topk_lengths[num_head:]
+                if extra_topk_lengths is not None
+                else None
+            ),
+        )[0].squeeze(1)
+        return torch.cat([o_head, o_tail], dim=0)
 
     def _forward_prefill_sparse(
         self,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -88,6 +88,9 @@ _is_sm120 = is_sm120_supported()
 _is_cuda = is_cuda()
 _is_xpu = is_xpu()
 
+if not _is_sm120 and not _is_xpu:
+    from sgl_kernel.flash_mla import flash_mla_with_kvcache
+
 logger = logging.getLogger(__name__)
 
 SWA_WINDOW = 128
@@ -405,6 +408,9 @@ class DSV4Metadata:
     # reused across every layer in the chunk. Reset to ``None`` when graph
     # metadata is refreshed so replay rebuilds it from the live batch.
     sparse_prefill_cache: Optional[SparsePrefillChunkCache] = None
+    # Set by init_forward_metadata for mixed batches when the split path is
+    # enabled; None otherwise.
+    mixed_decode_tail_len: Optional[int] = None
 
     @property
     def core_metadata(self) -> DSV4AttnMetadata:
@@ -418,6 +424,7 @@ class DSV4Metadata:
             self.c128_compress_metadata, src=other.c128_compress_metadata
         )
         self.sparse_prefill_cache = None
+        self.mixed_decode_tail_len = None
 
     def refresh_for_breakable_cuda_graph_replay_(self, static_metadata: DSV4Metadata):
         self.core_attn_metadata.refresh_for_breakable_cuda_graph_replay_(
@@ -437,6 +444,7 @@ class DSV4Metadata:
                 src=static_metadata.c128_compress_metadata,
             )
         self.sparse_prefill_cache = None
+        self.mixed_decode_tail_len = None
 
 
 @dataclass
@@ -1386,6 +1394,15 @@ class DeepseekV4AttnBackend(
             return
 
         self.forward_metadata = self._build_forward_metadata(forward_batch)
+        if (
+            envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
+            and forward_batch.forward_mode.is_mixed()
+            and not _is_sm120
+            and not _is_xpu
+        ):
+            self.forward_metadata.mixed_decode_tail_len = (
+                forward_batch.num_mixed_decode_tokens
+            )
         self.init_forward_metadata_in_graph(forward_batch)
 
     def _build_forward_metadata(
@@ -1739,6 +1756,31 @@ class DeepseekV4AttnBackend(
                     or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
                 )
             ):
+                if (
+                    envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
+                    and forward_batch.forward_mode.is_mixed()
+                    and not _is_sm120
+                    and not _is_xpu
+                ):
+                    num_tail = metadata.mixed_decode_tail_len
+                    if num_tail is not None and 0 < num_tail < q.shape[0]:
+                        return self._forward_mixed_split(
+                            q=q,
+                            layer_id=layer_id,
+                            compress_ratio=compress_ratio,
+                            forward_batch=forward_batch,
+                            token_to_kv_pool=token_to_kv_pool,
+                            core_attn_metadata=core_attn_metadata,
+                            attn_sink=attn_sink,
+                            num_tail=num_tail,
+                            swa_k_cache=swa_k_cache,
+                            swa_page_indices=swa_page_indices,
+                            swa_topk_lengths=swa_topk_lengths,
+                            extra_k_cache=extra_k_cache,
+                            extra_indices=extra_indices,
+                            extra_topk_lengths=extra_topk_lengths,
+                            flashmla_metadata=flashmla_metadata,
+                        )
                 return self._forward_prefill_sparse(
                     q=q,
                     layer_id=layer_id,
@@ -1793,6 +1835,81 @@ class DeepseekV4AttnBackend(
             return o
 
         raise NotImplementedError("ragged attention")
+
+    def _forward_mixed_split(
+        self,
+        q: torch.Tensor,
+        layer_id: int,
+        compress_ratio: Literal[0, 4, 128],
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: DeepSeekV4TokenToKVPool,
+        core_attn_metadata: DSV4AttnMetadata,
+        attn_sink: torch.Tensor,
+        num_tail: int,
+        swa_k_cache: torch.Tensor,
+        swa_page_indices: torch.Tensor,
+        swa_topk_lengths: torch.Tensor,
+        extra_k_cache: Optional[torch.Tensor],
+        extra_indices: Optional[torch.Tensor],
+        extra_topk_lengths: Optional[torch.Tensor],
+        flashmla_metadata,
+    ) -> torch.Tensor:
+        """Split a mixed-chunk batch at the prefill/decode boundary so the
+        decode tail reads the fp8 KV cache directly instead of paying the
+        per-layer bf16 dequant of the sparse-prefill workspace path."""
+        num_head = q.shape[0] - num_tail
+        metadata = self.forward_metadata
+        if metadata.sparse_prefill_cache is None:
+            seq_lens_cpu = forward_batch.seq_lens_cpu
+            assert seq_lens_cpu is not None
+            num_head_reqs = int(forward_batch.seq_lens.shape[0]) - num_tail
+            metadata.sparse_prefill_cache = SparsePrefillChunkCache.build(
+                seq_lens=forward_batch.seq_lens[:num_head_reqs].to(torch.int32),
+                extend_seq_lens=forward_batch.extend_seq_lens[:num_head_reqs].to(
+                    torch.int32
+                ),
+                req_pool_indices=forward_batch.req_pool_indices[:num_head_reqs].to(
+                    torch.int32
+                ),
+                req_to_token=self.req_to_token,
+                full_to_swa=token_to_kv_pool.full_to_swa_index_mapping,
+                swa_window_size=SWA_WINDOW,
+                swa_page_size=token_to_kv_pool.swa_window_size,
+                num_qo_tokens=num_head,
+                max_seq_len=int(seq_lens_cpu[:num_head_reqs].max().item()),
+            )
+        o_head = self._forward_prefill_sparse(
+            q=q[:num_head],
+            layer_id=layer_id,
+            compress_ratio=compress_ratio,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+            core_attn_metadata=core_attn_metadata,
+            attn_sink=attn_sink,
+        )
+        o_tail = flash_mla_with_kvcache(
+            q=q[num_head:],
+            k_cache=swa_k_cache,
+            head_dim_v=self.head_dim_v,
+            block_table=None,
+            cache_seqlens=None,
+            tile_scheduler_metadata=flashmla_metadata,
+            softmax_scale=self.softmax_scale,
+            is_fp8_kvcache=True,
+            indices=swa_page_indices[num_head:],
+            topk_length=swa_topk_lengths[num_head:],
+            attn_sink=attn_sink,
+            extra_k_cache=extra_k_cache,
+            extra_indices_in_kvcache=(
+                extra_indices[num_head:] if extra_indices is not None else None
+            ),
+            extra_topk_length=(
+                extra_topk_lengths[num_head:]
+                if extra_topk_lengths is not None
+                else None
+            ),
+        )[0].squeeze(1)
+        return torch.cat([o_head, o_tail], dim=0)
 
     def _forward_prefill_sparse(
         self,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1736,6 +1736,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # Staging consumed by resolve_forward_inputs (prefill H2D / mixed gather).
     prefill_input_ids_cpu: Optional[torch.Tensor] = None
     mix_running_indices: Optional[torch.Tensor] = None
+    # Set by mix_with_running: number of decode tokens appended after the
+    # prefill tokens (one per running request).
+    num_mixed_decode_tokens: Optional[int] = None
     input_embeds: torch.Tensor = None  # shape: [b, hidden_size], float32
 
     # Token replacement embeddings and absolute positions (optional).
@@ -2402,6 +2405,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # Decode tokens of the running portion live in future_map.output_tokens_buf.
         self.input_ids = None
         self.mix_running_indices = running_batch.req_pool_indices
+        self.num_mixed_decode_tokens = running_bs
         out_cache_loc = torch.cat([self.out_cache_loc, running_batch.out_cache_loc])
 
         self.merge_batch(running_batch)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2060,6 +2060,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # Staging consumed by resolve_forward_inputs (prefill H2D / mixed gather).
     prefill_input_ids_cpu: Optional[torch.Tensor] = None
     mix_running_indices: Optional[torch.Tensor] = None
+    # Set by mix_with_running: number of decode tokens appended after the
+    # prefill tokens (one per running request).
+    num_mixed_decode_tokens: Optional[int] = None
     input_embeds: torch.Tensor = None  # shape: [b, hidden_size], float32
 
     # Token replacement embeddings and absolute positions (optional).
@@ -2748,6 +2751,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # Decode tokens of the running portion live in future_map.output_tokens_buf.
         self.input_ids = None
         self.mix_running_indices = running_batch.req_pool_indices
+        self.num_mixed_decode_tokens = running_bs
         out_cache_loc = torch.cat([self.out_cache_loc, running_batch.out_cache_loc])
 
         self.merge_batch(running_batch)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -447,6 +447,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     extend_seq_lens_cpu: Optional[List[int]] = None
     extend_logprob_start_lens_cpu: Optional[List[int]] = None
     extend_input_logprob_token_ids_gpu: Optional[torch.Tensor] = None
+    # Mixed-chunk: number of decode tokens at the batch tail (from
+    # ScheduleBatch.mix_with_running); None for non-mixed batches.
+    num_mixed_decode_tokens: Optional[int] = None
 
     # For DP attention (MLP sync sizes)
     original_global_num_tokens_cpu: Optional[List[int]] = None
@@ -702,6 +705,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Scalar config / flags
             return_logprob=batch.return_logprob,
             is_extend_in_batch=batch.is_extend_in_batch,
+            num_mixed_decode_tokens=batch.num_mixed_decode_tokens,
             all_extend_in_batch=batch.all_extend_in_batch,
             can_run_dp_cuda_graph=batch.can_run_dp_cuda_graph,
             can_run_dp_breakable_cuda_graph=batch.can_run_dp_breakable_cuda_graph,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -536,6 +536,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     extend_seq_lens_cpu: Optional[List[int]] = None
     extend_logprob_start_lens_cpu: Optional[List[int]] = None
     extend_input_logprob_token_ids_gpu: Optional[torch.Tensor] = None
+    # Mixed-chunk: number of decode tokens at the batch tail (from
+    # ScheduleBatch.mix_with_running); None for non-mixed batches.
+    num_mixed_decode_tokens: Optional[int] = None
 
     # For DP attention (MLP sync sizes)
     original_global_num_tokens_cpu: Optional[List[int]] = None
@@ -818,6 +821,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Scalar config / flags
             return_logprob=batch.return_logprob,
             is_extend_in_batch=batch.is_extend_in_batch,
+            num_mixed_decode_tokens=batch.num_mixed_decode_tokens,
             can_run_dp_cuda_graph=batch.can_run_dp_cuda_graph,
             can_run_dp_breakable_cuda_graph=batch.can_run_dp_breakable_cuda_graph,
             global_forward_mode=batch.global_forward_mode,


### PR DESCRIPTION
## Motivation

With `--enable-mixed-chunk`, every step in the high-concurrency steady state is a mixed batch (prefill chunk + one decode token per running request), and all tokens go through the bf16 sparse-prefill workspace path. This forces two `_dequantize_k_cache_paged` calls per layer covering every running request's SWA window (~16.9 ms/step at conc 2048 on 8xB300), and the fp8-native decode kernel is never used in steady state.

## Modification

`mix_with_running` appends decode requests after prefill requests (one token each), so decode tokens are the contiguous tail of the batch. Split at that boundary:

- decode tail -> fp8-native `flash_mla_with_kvcache` (row-sliced topk indices, no dequant);
- prefill head -> existing bf16 sparse path, with `SparsePrefillChunkCache` built over the prefill requests only, shrinking the dequant workspace.

Controlled by `SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN` (default on; set to 0 to fall back to the previous behavior).

## Results

8xB300, DeepSeek-V4-Pro FP4, 8k1k, conc 2048 (megamoe + dp-attention + mixed-chunk), radix cache enabled with forced misses, num_prompts = 6x conc, warmup = 2x conc. Back-to-back A/B on the same machine with byte-identical launch commands; the only variable is this commit (feature default-on for the comparison):

| | Without this commit | With this commit | Delta |
|---|---:|---:|---:|
| Output throughput (tok/s) | 8983.25 | **9828.27** | **+9.4%** |
| Median TPOT (ms) | 196.25 | 177.20 | -9.7% |
| P99 TPOT (ms) | 196.89 | 178.37 | -9.4% |
| Median TTFT (ms) | 26925 | 24517 | -8.9% |
| Successful requests | 12288/12288 | 12288/12288 | — |

GSM8K under concurrency (mixed steps active): 0.970 with the flag vs 0.980 without, within noise (n=200).

## TODO (draft)

- Done: `num_mixed_decode_tokens` is recorded by `mix_with_running` and plumbed through `ForwardBatch`. A temporary cross-check assert against a tail-scan of `extend_seq_lens` ran clean over 16k requests (~4.7k mixed steps) and has been removed.
- Full GSM8K (1319) + a long-context eval; conc 1024 regression check.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31791518956](https://github.com/sgl-project/sglang/actions/runs/31791518956)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31791518814](https://github.com/sgl-project/sglang/actions/runs/31791518814)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->






