### PR TITLE
[AMD] Fix stale SWA ring buffer on radix prefix reuse for DeepSeek-V4 with unified_kv backend

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1168,6 +1168,14 @@ class Req(ReqDllmMixin):
         if tree_cache is not None:
             if cow_mamba is None:
                 cow_mamba = tree_cache.supports_mamba()
+            # unified_kv SWA lives in a per-request ring that is not content-stable
+            # and never cached in the radix tree, so a reused prefix carries stale
+            # SWA. Cap the match by the trailing sliding window so it is re-prefilled
+            # into this request's ring. No-op for other layouts (returns 0).
+            reprefill_tail = tree_cache.swa_reprefill_tail_tokens()
+            if reprefill_tail:
+                capped = max(0, input_len - reprefill_tail)
+                key_limit = capped if key_limit is None else min(key_limit, capped)
             match_result = tree_cache.match_prefix(
                 MatchPrefixParams(
                     key=RadixKey(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -99,9 +99,15 @@ def match_prefix_for_req(
     if token_ids is None:
         token_ids = req.origin_input_ids + req.output_ids
 
+    # unified_kv SWA lives in a per-request ring (not content-stable, never cached
+    # in the radix tree), so a reused prefix carries stale SWA. Cap the match by the
+    # trailing sliding window so it is re-prefilled. No-op for other layouts.
+    reprefill_tail = tree_cache.swa_reprefill_tail_tokens()
+    key_limit = max(0, len(token_ids) - reprefill_tail) if reprefill_tail else None
+
     match_result = tree_cache.match_prefix(
         MatchPrefixParams(
-            key=RadixKey(token_ids=token_ids, extra_key=req.extra_key),
+            key=RadixKey(token_ids=token_ids, extra_key=req.extra_key, limit=key_limit),
             cow_mamba=cow_mamba,
             req=req if include_req else None,
         )

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -328,6 +328,9 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def supports_swa(self) -> bool:
         return False
 
+    def swa_reprefill_tail_tokens(self) -> int:
+        return 0
+
     def supports_mamba(self) -> bool:
         return False
 

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -370,6 +370,27 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         ), "sliding_window_size must be set for SWARadixCache"
         return True
 
+    def swa_reprefill_tail_tokens(self) -> int:
+        """Tokens at the tail of a matched prefix that must NOT be reused.
+
+        The DeepSeek-V4 unified_kv layout keeps SWA in a per-request ring
+        (addressed by ``req_pool_idx * window + pos % window``), which is NOT
+        content-stable and is never stored in the radix tree. A reused prefix
+        therefore carries another request's stale SWA in the ring. Hold back the
+        trailing sliding window from the match so it gets re-prefilled into THIS
+        request's ring, making the decode window read freshly-written data.
+
+        No-op (0) for the index-addressed SWA pool, whose slots are
+        content-stable and safe to reuse.
+        """
+        from sglang.srt.layers.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_triton,
+        )
+
+        if self.sliding_window_size and is_unified_kv_triton():
+            return self.sliding_window_size
+        return 0
+
     def reset(self) -> None:
         self.root_node = TreeNode()
         self.root_node.key = []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The DeepSeek-V4 **unified_kv** backend under ROCm stores SWA KV in a **per-request ring buffer**, addressed by `req_pool_idx * window + pos % window`. Unlike the compressed/global KV, this ring is **not content-addressed and is never written into the radix tree**.

Radix prefix caching reuses matched prefix pages across requests. For the index-addressed compressed KV this is safe (content-stable). But the **SWA ring slots covering the reused-prefix region still hold whatever the previous occupant of that `req_pool` slot wrote** — i.e. stale SWA from an unrelated request.

When a request reuses a cached prefix and its decode sliding window (the trailing `window` = 128 tokens) reaches back into that reused-prefix region, the SWA path reads stale ring contents, leading to wrong attention output.

This affects **only** the unified_kv layout. The default index-addressed SWA pool (triton/tilelang backend) is content-stable and unaffected.

## Modifications

<!-- Detail the changes made in this pull request. -->
- `BasePrefixCache.swa_reprefill_tail_tokens() -> int`: new base method returning `0` (no-op for all layouts).
- `SWARadixCache.swa_reprefill_tail_tokens()`: override returning `sliding_window_size` **only** when the unified_kv_triton backend is active on HIP (`is_unified_kv_triton()`), else `0`.
- Scheduler prefix-match paths (`schedule_batch.py`, `schedule_policy.py`): cap the radix match length by `input_len - reprefill_tail`, so the trailing sliding window is **held back from prefix reuse and re-prefilled into this request's own ring**. The decode window therefore reads freshly-written data.

The scheduler cap is **generic** — it just calls `tree_cache.swa_reprefill_tail_tokens()`, so any cache implementing the method benefits, and it is a strict no-op for every other layout/backend (base returns `0`).

**Scope / activation:** the fix engages only when **all** of the following hold:
- `SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton` on HIP and the model has a sliding window.
- radix prefix caching is **enabled** (when disabled the cache is `ChunkCache`/`SWAChunkCache`, which inherits the base `0` — and with no prefix reuse there is no stale-ring read to fix);
- `--enable-hierarchical-cache` **off** and `SGLANG_ENABLE_UNIFIED_RADIX_TREE` **off** (these route to `UnifiedRadixCache`, owned by #29417) and the experimental C++ radix tree **off**;

In every other configuration `swa_reprefill_tail_tokens()` returns `0` and this is a complete no-op.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### GSM8K does not surface this bug (that's also why we didn't notice this bug before):
The root cause only manifests when several conditions hold at the same time. It's this conjunction that makes the bug so easy to miss:

1. Prefix reuse — a request's prefix is served from the radix cache (a real cache hit).
2. Short uncached tail — the tokens after the reused prefix number fewer than the sliding window W (tail < W), so during decode the sliding-window attention still needs keys/values that live inside the reused prefix.
3. Stale ring — the per-request SWA slots that the reused prefix maps to were, in the meantime, overwritten with different content by another request that recycled the same `req_pool` slot. The SWA ring is addressed by `req_pool_idx * W + pos % W` and is never stored in the radix tree, so it is not content-stable.

So GSM8K structurally cannot surface this bug: it breaks (2) and rarely meets (3). Empirically it's unchanged before/after (0.945–0.950, within run-to-run noise) — a no-regression guard, not a detector. 

### Determinism harness (the actual detector)
At `temperature=0`, prefix-cache reuse must not increase output divergence beyond the model's inherent non-determinism floor. We make this rigorous and self-calibrating: for each uncached tail length we send K=64 identical prompts and report how many fall outside the majority cluster.

- tail >= window (128): the decode window cannot reach the reused region → these rows are the non-determinism floor (in-run control).
- tail < window: the decode window reaches into the reused prefix → the stale-ring read is exposed.

#### Result (dsv4 Pro, unified_kv backend, TP8/DP8, --page-size 256, radix on, MTP):
tail | BEFORE (3rounds) | AFTER (3rounds)
-- | -- | --
16 | 0 / 0 / 0 | 0
32 | 4 / 6 / 17 | 0
64 | 0 / 0 / 0 | 1/0/0
96 | 0 / 0 / 0 | 0
127 | 2 / 1 / 0 | 0
160 / 220 | 0 | 0–1

**Conclusion:** Within tail<W, which specific tail fires is scheduling-dependent; tail=32 reproduces most reliably. The headline is not any single cell but: every tail<W row can exceed the ≥W floor BEFORE, and all return to the floor AFTER.

####  How to reproduce?
1) Launch server with dsv4 unified_kv  backend + radix cache enabled
```
export TRITON_CACHE_AUTOTUNING=1
export TRITON_CACHE_DIR=/sgl-workspace/.triton_cache/
export SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton

export SGLANG_OPT_FP4_MOE_K_ALIGN=128
export SGLANG_DSV4_INDEXER_K_CACHE_PRESHUFFLE=1

export SGLANG_DEFAULT_THINKING=1
export SGLANG_DSV4_REASONING_EFFORT=max
export SGLANG_OPT_DEEPGEMM_HC_PRENORM=false
export SGLANG_USE_AITER=1
export SGLANG_USE_ROCM700A=1
export SGLANG_OPT_USE_FUSED_COMPRESS=true
export SGLANG_OPT_FP8_WO_A_GEMM=false
export SGLANG_OPT_USE_JIT_INDEXER_METADATA=false
export SGLANG_OPT_USE_TOPK_V2=false
export SGLANG_OPT_USE_AITER_INDEXER=true
export SGLANG_OPT_USE_TILELANG_INDEXER=false
export SGLANG_OPT_USE_TILELANG_MHC_PRE=false
export SGLANG_OPT_USE_TILELANG_MHC_POST=false
export SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1
export SGLANG_OPT_USE_FUSED_COMPRESS_TRITON=true

export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false
export SGLANG_ROCM_USE_MULTI_STREAM=false

export AITER_BF16_FP8_MOE_BOUND=0
MODEL=/data/models/DeepSeek-V4-Pro
python3 -m sglang.launch_server \
    --model-path /data/models/DeepSeek-V4-Pro \
    --trust-remote-code \
    --swa-full-tokens-ratio 0.1 \
    --tp 8 \
    --dp 8 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-num-draft-tokens 4 \
    --speculative-eagle-topk 1 \
    --enable-dp-attention \
    --enable-cache-report \
    --attention-backend dsv4 \
    --max-running-request 1024 \
    --page-size 256 \
    --chunked-prefill-size 32768 \
    --mem-fraction-static 0.9 \
    --port 30001 \
    --disable-shared-experts-fusion \
    --tool-call-parser deepseekv4 \
    --reasoning-parser deepseek-v4 \
    --enable-prefill-delayer
```

2) The trigger is scheduling-dependent, **so the magnitude varies run-to-run; run the script several times**. 
`python3 swa_ring_determinism.py 30001 /path/to/DeepSeek-V4-Pro`

```
#!/usr/bin/env python3
# Deterministic reproduction for the DeepSeek-V4 unified_kv SWA-ring reuse bug.
#
# This harness is reference-free and self-calibrating:
#   * For each `tail`, send K identical prompts and report how many fall OUTSIDE
#     the majority output cluster (`off_majority`) and the number of distinct
#     outputs (`distinct`).
#   * `tail <  W` : the decode window reaches back into the REUSED prefix -> the
#     stale-ring read is exposed  (BUG-EXPOSED rows).
#   * `tail >= W` : the decode window cannot reach the reused region -> these rows
#     measure the inherent non-determinism FLOOR (in-run control).
#
# The churn filler MUST be >= W tokens: the SWA ring is addressed by
# `req_pool_idx * W + pos % W`, so a filler shorter than W only overwrites the
# first few slots and fails to pollute the window the reused prefix maps to.
#
import sys, requests, concurrent.futures as cf
from collections import Counter
from transformers import AutoTokenizer

PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 30001
MODEL = sys.argv[2] if len(sys.argv) > 2 else "/data/models/DeepSeek-V4-Pro"
BASE = f"http://127.0.0.1:{PORT}"
W = 128          # sliding window, hard-coded to 128
K = 64           # identical requests per tail

tok = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=True)
FILLER = ("The history of mathematics spans thousands of years and many cultures. "
          "Ancient civilizations developed counting, geometry, and astronomy. ")

def gen(prompt, mx=60):
    j = requests.post(f"{BASE}/generate", json={
        "text": prompt,
        "sampling_params": {"temperature": 0.0, "max_new_tokens": mx},
    }, timeout=600).json()
    return j["text"], j.get("meta_info", {}).get("cached_tokens", -1)

def build(tag, n):
    ids = tok(tag + " " + FILLER, add_special_tokens=False)["input_ids"]
    out = []
    while len(out) < n:
        out.extend(ids)
    return tok.decode(out[:n])

def churn(n=500):                       # distinct >=W-token requests recycle req_pool
    with cf.ThreadPoolExecutor(max_workers=32) as ex:   # slots and overwrite the ring
        list(ex.map(lambda i: gen(build(f"C{i}", 256), 1), range(n)))

def run(tail):
    P = build("FIXEDTAG", 512 + tail)   # distinctive prefix; uncached tail = `tail`
    gen(P); churn()                     # warm prefix into radix, then pollute ring slots
    with cf.ThreadPoolExecutor(max_workers=K) as ex:
        outs = [t for t, _ in ex.map(lambda i: gen(P), range(K))]
    c = Counter(outs)
    off_majority = K - c.most_common(1)[0][1]
    zone = "<W  (bug-exposed)" if tail < W else ">=W (floor/control)"
    print(f"tail={tail:3d} {zone:20s} distinct={len(c):2d}  off_majority={off_majority}/{K}")

if __name__ == "__main__":
    print(f"K={K} identical reqs per tail; temp=0; churn filler=256 (>=W)")
    for tail in [16, 32, 64, 96, 127, 160, 220]:
        run(tail)
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
The cap re-prefills the trailing sliding window (128) of an otherwise-cached prefix, rounded up to page granularity — i.e. bounded by window + page_size, a constant independent of context/prefix length.

Measured with `generated-shared-prefix` (shared system prompt = 2048, 64 groups × 16 prompts = 1024 req, output = 256, TP8/DP8, unified_kv, radix on, page-size 256, concurrency 64; steady-state of 3 runs; `--cache-report` on):
**Client:** `python3 -m sglang.bench_serving --port 30001 --dataset-name generated-shared-prefix --gsp-num-groups 64 --gsp-prompts-per-group 16 --gsp-system-prompt-len 2048 --gsp-question-len 64 --gsp-output-len 256 --max-concurrency 64 --cache-report`

**tail ≥ W (`question_len=128`) — cap is a no-op:**
| metric | BEFORE | AFTER |
|---|---|---|
| Total cached tokens | 2.09M | 2.09M (identical) |
| Output tok/s | 3200 | 3206 |
| Mean TTFT (ms) | 510 | 520 |
| Mean TPOT (ms) | 17.2 | 17.2 |

**tail < W (`question_len=64`) — cap active (this is the fix's worst case):**
| metric | BEFORE | AFTER | perf diff |
|---|---|---|---|
| Total cached tokens | ~2.09M | ~1.85M | −11.7% (≈1 page/hit re-prefilled) |
| Output tok/s | 3247 | 3188 | −1.8% |
| Mean TTFT (ms) | 494 | 525 | +31 ms |
| Mean TPOT (ms) | 17.12 | 17.35 | +1.3% |

The drop in cached tokens (2.09M → 1.85M) confirms the fix path is actually exercised; even so the throughput cost is ≤2% and TTFT +~30 ms. In real traffic only a fraction of requests have `tail < W`, so the aggregate overhead is smaller.

## Relationship with #29417 (HiCache for unified_kv)
This PR and #29417 are complementary and intentionally non-overlapping in ownership:
| | This PR | #29417 |
|---|---|---|
| Cache class | `SWARadixCache` (radix-only) | `UnifiedRadixCache` (HiCache host-offload) |
| Scope | unified_kv + radix, HiCache **off** | unified_kv + HiCache |
| SWA tail fix | `SWARadixCache` override | `UnifiedRadixCache` override (its own path) |

- `BasePrefixCache` returns `0`, so `UnifiedRadixCache` inherits a no-op here and gets its own override in #29417 — **no functional conflict**.
- Both PRs touch the same scheduler cap sites. Since the cap is generic (`tree_cache.swa_reprefill_tail_tokens()`), whichever merges first provides it; the other should drop its duplicate scheduler edit and keep only its cache-class override. @1am9trash 

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
5. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
6. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
7. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28841909733](https://github.com/sgl-project/sglang/actions/runs/28841909733)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28847534328](https://github.com/sgl-project/sglang/actions/runs/28847534328)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->