### PR TITLE
[server] Widen streaming-kickstart to preserve HTTPException status

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -224,6 +224,38 @@ class OpenAIServingBase(ABC):
         )
         return ORJSONResponse(content=error.model_dump(), status_code=status_code)
 
+    def create_error_response_for_stream_kickstart(
+        self, exc: Exception
+    ) -> ORJSONResponse:
+        """Map a pre-first-chunk exception to a real HTTP error response.
+
+        Called from the streaming kickstart (in ``serving_chat`` /
+        ``serving_completions``) after ``await generator.__anext__()``
+        raises. Because headers haven't been sent yet we can still return
+        a proper HTTP status instead of a 200 with an SSE-body error
+        payload. Once the first chunk has been yielded, mid-stream errors
+        must go through ``create_streaming_error_response`` instead.
+
+        Mapping:
+        - ``HTTPException`` — preserve ``status_code`` and ``detail``. Lets
+          the engine surface 429 / 503 / 504 with their real status.
+        - ``ValueError`` — 400 (unchanged from prior behavior).
+        - Any other exception — 500 InternalServerError.
+        """
+        if isinstance(exc, HTTPException):
+            return self.create_error_response(
+                message=str(exc.detail),
+                err_type=exc.__class__.__name__,
+                status_code=exc.status_code,
+            )
+        if isinstance(exc, ValueError):
+            return self.create_error_response(str(exc))
+        return self.create_error_response(
+            message=str(exc),
+            err_type="InternalServerError",
+            status_code=500,
+        )
+
     def create_streaming_error_response(
         self,
         message: str,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1000,13 +1000,14 @@ class OpenAIServingChat(OpenAIServingBase):
         """Handle streaming chat completion request"""
         generator = self._generate_chat_stream(adapted_request, request, raw_request)
 
-        # Kick-start the generator to trigger validation before HTTP 200 is sent.
-        # If validation fails (e.g., context length exceeded), we can still return
-        # a proper HTTP 400 error response instead of streaming it as SSE payload.
+        # Kick-start the generator so validation / rate-limit / capacity errors
+        # raised BEFORE the first token get a real HTTP status instead of a 200
+        # + SSE-body error payload. Widened from ValueError-only so the engine
+        # can surface HTTPException(status_code=429/503/etc.) as its real status.
         try:
             first_chunk = await generator.__anext__()
-        except ValueError as e:
-            return self.create_error_response(str(e))
+        except Exception as e:
+            return self.create_error_response_for_stream_kickstart(e)
 
         async def prepend_first_chunk():
             yield first_chunk

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1000,10 +1000,8 @@ class OpenAIServingChat(OpenAIServingBase):
         """Handle streaming chat completion request"""
         generator = self._generate_chat_stream(adapted_request, request, raw_request)
 
-        # Kick-start the generator so validation / rate-limit / capacity errors
-        # raised BEFORE the first token get a real HTTP status instead of a 200
-        # + SSE-body error payload. Widened from ValueError-only so the engine
-        # can surface HTTPException(status_code=429/503/etc.) as its real status.
+        # Kick-start so a pre-first-chunk error gets a real HTTP status instead
+        # of a 200 + SSE-body error payload. See docstring on the helper.
         try:
             first_chunk = await generator.__anext__()
         except Exception as e:

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -195,11 +195,14 @@ class OpenAIServingCompletion(OpenAIServingBase):
             adapted_request, request, raw_request
         )
 
-        # Kick-start the generator to trigger validation before HTTP 200 is sent.
+        # Kick-start the generator so validation / rate-limit / capacity errors
+        # raised BEFORE the first token get a real HTTP status instead of a 200
+        # + SSE-body error payload. Widened from ValueError-only so the engine
+        # can surface HTTPException(status_code=429/503/etc.) as its real status.
         try:
             first_chunk = await generator.__anext__()
-        except ValueError as e:
-            return self.create_error_response(str(e))
+        except Exception as e:
+            return self.create_error_response_for_stream_kickstart(e)
 
         async def prepend_first_chunk():
             yield first_chunk

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -195,10 +195,8 @@ class OpenAIServingCompletion(OpenAIServingBase):
             adapted_request, request, raw_request
         )
 
-        # Kick-start the generator so validation / rate-limit / capacity errors
-        # raised BEFORE the first token get a real HTTP status instead of a 200
-        # + SSE-body error payload. Widened from ValueError-only so the engine
-        # can surface HTTPException(status_code=429/503/etc.) as its real status.
+        # Kick-start so a pre-first-chunk error gets a real HTTP status instead
+        # of a 200 + SSE-body error payload. See docstring on the helper.
         try:
             first_chunk = await generator.__anext__()
         except Exception as e:

--- a/test/registered/unit/utils/test_stream_kickstart_error_mapping.py
+++ b/test/registered/unit/utils/test_stream_kickstart_error_mapping.py
@@ -69,6 +69,16 @@ class TestStreamKickstartErrorMapping(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 500)
 
+    def test_stop_async_iteration_maps_to_500(self):
+        # Edge case: generator terminates without yielding anything. Old
+        # narrow ``except ValueError`` let this bubble to FastAPI's default
+        # 500. ``except Exception`` catches it too (StopAsyncIteration is
+        # Exception-derived), and we return the same 500 status with a
+        # structured body — strict improvement, not a regression.
+        serving = self._make_serving()
+        resp = serving.create_error_response_for_stream_kickstart(StopAsyncIteration())
+        self.assertEqual(resp.status_code, 500)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/utils/test_stream_kickstart_error_mapping.py
+++ b/test/registered/unit/utils/test_stream_kickstart_error_mapping.py
@@ -1,0 +1,74 @@
+"""Unit tests for the streaming-kickstart exception → HTTP status mapping.
+
+Covers create_error_response_for_stream_kickstart(): the helper that maps
+a pre-first-chunk exception to a proper HTTP status code so streaming
+endpoints don't emit an SSE-body error under a HTTP 200 header when the
+engine wants to signal 503 / 429 / etc.
+
+Usage:
+    python3 -m pytest test/registered/unit/utils/test_stream_kickstart_error_mapping.py -v
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import HTTPException
+
+from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _TestServing(OpenAIServingBase):
+    # OpenAIServingBase is abstract; stub the two required methods so we
+    # can instantiate it for testing the error-mapping helper.
+    def _convert_to_internal_request(self, request):
+        raise NotImplementedError
+
+    def _request_id_prefix(self):
+        return "test"
+
+
+class TestStreamKickstartErrorMapping(unittest.TestCase):
+    def _make_serving(self):
+        return _TestServing(MagicMock())
+
+    def test_value_error_maps_to_400(self):
+        # Existing behavior: ValueError → HTTP 400 (backward compat with
+        # the narrow kickstart that only handled ValueError).
+        serving = self._make_serving()
+        resp = serving.create_error_response_for_stream_kickstart(
+            ValueError("bad prompt shape")
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_http_exception_preserves_status_code_503(self):
+        # The whole point: engine raises HTTPException(503) pre-first-chunk,
+        # we return a real HTTP 503 instead of a 200 + SSE-body error.
+        serving = self._make_serving()
+        resp = serving.create_error_response_for_stream_kickstart(
+            HTTPException(status_code=503, detail="engine overloaded")
+        )
+        self.assertEqual(resp.status_code, 503)
+
+    def test_http_exception_preserves_429(self):
+        # Rate limiting is another common pre-first-chunk case.
+        serving = self._make_serving()
+        resp = serving.create_error_response_for_stream_kickstart(
+            HTTPException(status_code=429, detail="rate limit exceeded")
+        )
+        self.assertEqual(resp.status_code, 429)
+
+    def test_generic_exception_falls_back_to_500(self):
+        # Anything we didn't anticipate should still be a real HTTP error,
+        # not silently become an SSE-body message under HTTP 200.
+        serving = self._make_serving()
+        resp = serving.create_error_response_for_stream_kickstart(
+            RuntimeError("unexpected engine state")
+        )
+        self.assertEqual(resp.status_code, 500)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Pre-first-chunk errors in `/v1/chat/completions` and `/v1/completions` now surface with their real HTTP status code instead of falling into a `200 OK` + SSE-body error payload.

## Motivation

The pre-first-chunk kickstart in `serving_chat.py` / `serving_completions.py` currently catches only `ValueError`:

```python
try:
    first_chunk = await generator.__anext__()
except ValueError as e:
    return self.create_error_response(str(e))    # → HTTP 400
```

Any other engine-side pre-stream error (rate limit, capacity, disaggregation encoder returning 503, etc.) doesn't match `ValueError`, so it either falls through to FastAPI's default 500 handler or — if the exception is caught deeper in the generator — gets turned into a `data: {...}` SSE frame emitted under a HTTP 200 header. That is the origin of "the engine emitted the 503 directly into its own SSE body": headers are already committed to `text/event-stream`, so nothing downstream can turn the response back into a real HTTP error.

## Fix

Catch `Exception` in the kickstart and route through a shared helper `create_error_response_for_stream_kickstart()` on `OpenAIServingBase`:

| Exception type | Response status |
|---|---|
| `HTTPException(status_code=N)` | Preserves `N` (429, 503, 504, ...) with `detail` as message |
| `ValueError` | 400 (**unchanged from prior behavior**) |
| Any other `Exception` | 500 InternalServerError |

Mid-stream errors (once `stream_started=True`) are **unchanged**: those must stay as SSE-body errors because the `200 OK` header is already on the wire and the socket is committed to `text/event-stream`.

## Backward compatibility

- Existing `ValueError → 400` mapping is preserved (regression-guard test added).
- Any pre-first-chunk exception that previously bubbled to FastAPI's default 500 handler now goes through our helper and gets a clean OpenAI-shaped error body with the same 500 status. Structured error response instead of raw stack trace — no behavior loss.

## Test plan
- [x] `pytest test/registered/unit/utils/test_stream_kickstart_error_mapping.py` — 4 passed
  - `ValueError → 400` (backward-compat regression guard)
  - `HTTPException(503) → 503`
  - `HTTPException(429) → 429`
  - `RuntimeError → 500`
- [x] Pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28844320792](https://github.com/sgl-project/sglang/actions/runs/28844320792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28844320704](https://github.com/sgl-project/sglang/actions/runs/28844320704)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->