### PR TITLE
[DSA] Add NeoX RoPE branch to indexer fused kernels; re-enable fusion for DeepSeek-V3.2

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v32/indexer_k.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v32/indexer_k.cuh
@@ -47,6 +47,45 @@ load_rope_first_cos_sin(const float* __restrict__ cos_sin_cache, int32_t lane_id
   return freq;
 }
 
+// NeoX (non-interleaved) freq load. The cache row layout is the same halves
+// layout [cos_0..cos_31, sin_0..sin_31]; only the element pairing differs:
+// NeoX pairs element e with e ^ (kRopeDim/2), both using freq index
+// e & (kRopeDim/2 - 1). Lane L owns elements [4L, 4L+4), so it needs 4
+// contiguous cos and 4 contiguous sin values (one 16B load each).
+template <int64_t kRopeDim>
+SGL_DEVICE void load_rope_first_cos_sin_neox(
+    const float* __restrict__ cos_sin_cache,
+    int32_t lane_id,
+    device::AlignedVector<float, 4>& cos4,
+    device::AlignedVector<float, 4>& sin4) {
+  constexpr int64_t kHalfRopeDim = kRopeDim / 2;
+  const int32_t freq0 = (lane_id * 4) & (kHalfRopeDim - 1);
+  cos4.load(cos_sin_cache + freq0);
+  sin4.load(cos_sin_cache + kHalfRopeDim + freq0);
+}
+
+// NeoX rotation for the rope lanes of a warp where lane L holds the 4-elem
+// pack [4L, 4L+4) of a kRopeDim-wide rope region spanning lanes
+// [0, kRopeSize). Element e pairs with e ^ (kRopeDim/2), i.e. the partner
+// pack lives at lane L ^ (kRopeSize/2) with the same intra-pack index. Must
+// be called by ALL lanes [0, kRopeSize) (they converge on the shuffle).
+template <uint32_t kRopeSize>
+SGL_DEVICE void rope_rotate_neox(
+    device::AlignedVector<float, 4>& data,
+    const device::AlignedVector<float, 4>& cos4,
+    const device::AlignedVector<float, 4>& sin4,
+    int32_t lane_id) {
+  constexpr uint32_t kHalfLaneMask = kRopeSize / 2;
+  constexpr uint32_t kActiveMask = (1u << kRopeSize) - 1;
+  const bool is_first_half = lane_id < kHalfLaneMask;
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    float other = __shfl_xor_sync(kActiveMask, data[i], kHalfLaneMask);
+    other = is_first_half ? -other : other;
+    data[i] = data[i] * cos4[i] + other * sin4[i];
+  }
+}
+
 // Indexer K: LayerNorm + RoPE -> bf16.
 struct FusedKIndexerNormRopeParams {
   const void* __restrict__ k_input;         // (B, 128) DType
@@ -61,7 +100,7 @@ struct FusedKIndexerNormRopeParams {
   float eps;
 };
 
-template <typename DType, typename PosT, bool kUsePDL>
+template <typename DType, typename PosT, bool kUsePDL, bool kIsNeox>
 K_INDEXER_KERNEL void fused_k_indexer_norm_rope(const __grid_constant__ FusedKIndexerNormRopeParams params) {
   using namespace device;
 
@@ -88,7 +127,7 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope(const __grid_constant__ FusedKIn
   const auto cos_sin_cache = params.cos_sin_cache + position * kRopeDim;
 
   PDLWaitPrimary<kUsePDL>();
-  Float4 data, freq, gamma, beta;
+  Float4 data, freq, freq2, gamma, beta;
 
   // part 1: LayerNorm
   {
@@ -96,7 +135,13 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope(const __grid_constant__ FusedKIn
     input_vec.load(input_ptr, lane_id);
     gamma.load(params.weight, lane_id);
     beta.load(params.bias, lane_id);
-    if (is_rope_lane) freq = load_rope_first_cos_sin<kRopeDim>(cos_sin_cache, lane_id);
+    if (is_rope_lane) {
+      if constexpr (kIsNeox) {
+        load_rope_first_cos_sin_neox<kRopeDim>(cos_sin_cache, lane_id, freq, freq2);
+      } else {
+        freq = load_rope_first_cos_sin<kRopeDim>(cos_sin_cache, lane_id);
+      }
+    }
 
     float sum = 0.0f;
 #pragma unroll
@@ -122,18 +167,22 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope(const __grid_constant__ FusedKIn
 
   // part 2: rope on rope lanes
   if (is_rope_lane) {
-    const auto x_real = data[0];
-    const auto x_imag = data[1];
-    const auto y_real = data[2];
-    const auto y_imag = data[3];
-    const auto fxr = freq[0];
-    const auto fxi = freq[1];
-    const auto fyr = freq[2];
-    const auto fyi = freq[3];
-    data[0] = x_real * fxr - x_imag * fxi;
-    data[1] = x_real * fxi + x_imag * fxr;
-    data[2] = y_real * fyr - y_imag * fyi;
-    data[3] = y_real * fyi + y_imag * fyr;
+    if constexpr (kIsNeox) {
+      rope_rotate_neox<kRopeSize>(data, freq, freq2, lane_id);
+    } else {
+      const auto x_real = data[0];
+      const auto x_imag = data[1];
+      const auto y_real = data[2];
+      const auto y_imag = data[3];
+      const auto fxr = freq[0];
+      const auto fxi = freq[1];
+      const auto fyr = freq[2];
+      const auto fyi = freq[3];
+      data[0] = x_real * fxr - x_imag * fxi;
+      data[1] = x_real * fxi + x_imag * fxr;
+      data[2] = y_real * fyr - y_imag * fyi;
+      data[3] = y_real * fyi + y_imag * fyr;
+    }
   }
 
   PDLTriggerSecondary<kUsePDL>();
@@ -148,10 +197,10 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope(const __grid_constant__ FusedKIn
   }
 }
 
-template <typename DType, bool kUsePDL>
+template <typename DType, bool kUsePDL, bool kIsNeox>
 struct FusedKIndexerNormRopeKernel {
   template <typename PosT>
-  static constexpr auto kernel = fused_k_indexer_norm_rope<DType, PosT, kUsePDL>;
+  static constexpr auto kernel = fused_k_indexer_norm_rope<DType, PosT, kUsePDL, kIsNeox>;
 
   static void forward(
       const tvm::ffi::TensorView k_input,
@@ -237,7 +286,7 @@ struct FusedKIndexerNormRopeStoreParams {
   float eps;
 };
 
-template <typename DType, typename PosT, bool kUsePDL, int32_t kPageBits>
+template <typename DType, typename PosT, bool kUsePDL, int32_t kPageBits, bool kIsNeox>
 K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ FusedKIndexerNormRopeStoreParams params) {
   using namespace device;
 
@@ -266,7 +315,7 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
   const auto cos_sin_cache = params.cos_sin_cache + position * kRopeDim;
 
   PDLWaitPrimary<kUsePDL>();
-  Float4 data, freq, gamma, beta;
+  Float4 data, freq, freq2, gamma, beta;
 
   // part 1: LayerNorm
   {
@@ -274,7 +323,13 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
     input_vec.load(input_ptr, lane_id);
     gamma.load(params.weight, lane_id);
     beta.load(params.bias, lane_id);
-    if (is_rope_lane) freq = load_rope_first_cos_sin<kRopeDim>(cos_sin_cache, lane_id);
+    if (is_rope_lane) {
+      if constexpr (kIsNeox) {
+        load_rope_first_cos_sin_neox<kRopeDim>(cos_sin_cache, lane_id, freq, freq2);
+      } else {
+        freq = load_rope_first_cos_sin<kRopeDim>(cos_sin_cache, lane_id);
+      }
+    }
 
     float sum = 0.0f;
 #pragma unroll
@@ -300,18 +355,22 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
 
   // part 2: rope on rope lanes
   if (is_rope_lane) {
-    const auto x_real = data[0];
-    const auto x_imag = data[1];
-    const auto y_real = data[2];
-    const auto y_imag = data[3];
-    const auto fxr = freq[0];
-    const auto fxi = freq[1];
-    const auto fyr = freq[2];
-    const auto fyi = freq[3];
-    data[0] = x_real * fxr - x_imag * fxi;
-    data[1] = x_real * fxi + x_imag * fxr;
-    data[2] = y_real * fyr - y_imag * fyi;
-    data[3] = y_real * fyi + y_imag * fyr;
+    if constexpr (kIsNeox) {
+      rope_rotate_neox<kRopeSize>(data, freq, freq2, lane_id);
+    } else {
+      const auto x_real = data[0];
+      const auto x_imag = data[1];
+      const auto y_real = data[2];
+      const auto y_imag = data[3];
+      const auto fxr = freq[0];
+      const auto fxi = freq[1];
+      const auto fyr = freq[2];
+      const auto fyi = freq[3];
+      data[0] = x_real * fxr - x_imag * fxi;
+      data[1] = x_real * fxi + x_imag * fxr;
+      data[2] = y_real * fyr - y_imag * fyi;
+      data[3] = y_real * fyi + y_imag * fyr;
+    }
   }
 
   PDLTriggerSecondary<kUsePDL>();
@@ -344,14 +403,14 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
   if (lane_id == 0) *reinterpret_cast<float*>(scale_ptr) = scale;
 }
 
-template <typename DType, bool kUsePDL, uint32_t kPageSize>
+template <typename DType, bool kUsePDL, uint32_t kPageSize, bool kIsNeox>
 struct FusedKIndexerNormRopeStoreKernel {
   static constexpr int32_t kPageBits = std::countr_zero(kPageSize);
   static constexpr int64_t kPageBytes = 132ll * kPageSize;
   static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
 
   template <typename PosT>
-  static constexpr auto kernel = fused_k_indexer_norm_rope_store<DType, PosT, kUsePDL, kPageBits>;
+  static constexpr auto kernel = fused_k_indexer_norm_rope_store<DType, PosT, kUsePDL, kPageBits, kIsNeox>;
 
   static void forward(
       const tvm::ffi::TensorView k_input,

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/main_norm_rope.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/main_norm_rope.cuh
@@ -60,6 +60,45 @@ load_rope_first_cos_sin(const float* __restrict__ cos_sin_cache, int32_t lane_id
   return freq;
 }
 
+// NeoX (non-interleaved) freq load. The cache row layout is the same halves
+// layout [cos_0..cos_31, sin_0..sin_31]; only the element pairing differs:
+// NeoX pairs element e with e ^ (kRopeDim/2), both using freq index
+// e & (kRopeDim/2 - 1). Lane L owns elements [4L, 4L+4), so it needs 4
+// contiguous cos and 4 contiguous sin values (one 16B load each).
+template <int64_t kRopeDim>
+SGL_DEVICE void load_rope_first_cos_sin_neox(
+    const float* __restrict__ cos_sin_cache,
+    int32_t lane_id,
+    device::AlignedVector<float, 4>& cos4,
+    device::AlignedVector<float, 4>& sin4) {
+  constexpr int64_t kHalfRopeDim = kRopeDim / 2;
+  const int32_t freq0 = (lane_id * 4) & (kHalfRopeDim - 1);
+  cos4.load(cos_sin_cache + freq0);
+  sin4.load(cos_sin_cache + kHalfRopeDim + freq0);
+}
+
+// NeoX rotation for the rope lanes of a warp where lane L holds the 4-elem
+// pack [4L, 4L+4) of a kRopeDim-wide rope region spanning lanes
+// [0, kRopeSize). Element e pairs with e ^ (kRopeDim/2), i.e. the partner
+// pack lives at lane L ^ (kRopeSize/2) with the same intra-pack index. Must
+// be called by ALL lanes [0, kRopeSize) (they converge on the shuffle).
+template <uint32_t kRopeSize>
+SGL_DEVICE void rope_rotate_neox(
+    device::AlignedVector<float, 4>& data,
+    const device::AlignedVector<float, 4>& cos4,
+    const device::AlignedVector<float, 4>& sin4,
+    int32_t lane_id) {
+  constexpr uint32_t kHalfLaneMask = kRopeSize / 2;
+  constexpr uint32_t kActiveMask = (1u << kRopeSize) - 1;
+  const bool is_first_half = lane_id < kHalfLaneMask;
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    float other = __shfl_xor_sync(kActiveMask, data[i], kHalfLaneMask);
+    other = is_first_half ? -other : other;
+    data[i] = data[i] * cos4[i] + other * sin4[i];
+  }
+}
+
 // ============================================================================
 // Q kernel: warp-per-(token, head) rmsnorm-self + RoPE + write to q_out.
 // ============================================================================
@@ -448,7 +487,13 @@ struct FusedQIndexerRopeHadamardQuantParams {
   uint32_t num_heads;
 };
 
-template <typename DType, typename PosT, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true>
+template <
+    typename DType,
+    typename PosT,
+    bool kUsePDL,
+    bool kRopeFirst = false,
+    bool kHadamard = true,
+    bool kIsNeox = false>
 Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQIndexerRopeHadamardQuantParams params) {
   using namespace device;
 
@@ -459,6 +504,10 @@ Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQ
   static_assert(kHeadDim == kWarpThreads * kVecSize);
   static_assert(kRopeDim == kWarpThreads * 2);
   static_assert(kRopeSize <= kWarpThreads);
+  // NeoX rotation is only wired for the rope-first (V3.2 indexer) layout,
+  // where the rope lanes are the low lanes [0, kRopeSize) that the
+  // shuffle-based half-swap in rope_rotate_neox assumes.
+  static_assert(!kIsNeox || kRopeFirst, "kIsNeox requires kRopeFirst");
 
   using Storage = AlignedVector<DType, kVecSize>;
   using Float4 = AlignedVector<float, kVecSize>;
@@ -485,7 +534,7 @@ Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQ
   // is known (part 4).
 
   PDLWaitPrimary<kUsePDL>();
-  Float4 data, freq;
+  Float4 data, freq, freq2;
   const uint32_t head_id = work_id - batch_id * params.num_heads;
   const auto weight_val =
       cast<float>(static_cast<const DType*>(params.weight)[batch_id * params.weight_stride_batch + head_id]);
@@ -495,7 +544,9 @@ Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQ
     Storage input_vec;
     input_vec.load(input_ptr, lane_id);
     if (is_rope_lane) {
-      if constexpr (kRopeFirst) {
+      if constexpr (kIsNeox) {
+        load_rope_first_cos_sin_neox<kRopeDim>(rope_cache, lane_id, freq, freq2);
+      } else if constexpr (kRopeFirst) {
         freq = load_rope_first_cos_sin<kRopeDim>(rope_cache, lane_id);
       } else {
         freq.load(rope_cache, lane_id - (kWarpThreads - kRopeSize));
@@ -507,20 +558,25 @@ Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQ
     }
   }
 
-  // part 2: rope on rope lanes only (4 elems / lane = 2 (real, imag) pairs).
+  // part 2: rope on rope lanes only (4 elems / lane; NeoX pairs across lanes,
+  // interleave pairs 2 local (real, imag) pairs).
   if (is_rope_lane) {
-    const auto x_real = data[0];
-    const auto x_imag = data[1];
-    const auto y_real = data[2];
-    const auto y_imag = data[3];
-    const auto fxr = freq[0];
-    const auto fxi = freq[1];
-    const auto fyr = freq[2];
-    const auto fyi = freq[3];
-    data[0] = x_real * fxr - x_imag * fxi;
-    data[1] = x_real * fxi + x_imag * fxr;
-    data[2] = y_real * fyr - y_imag * fyi;
-    data[3] = y_real * fyi + y_imag * fyr;
+    if constexpr (kIsNeox) {
+      rope_rotate_neox<kRopeSize>(data, freq, freq2, lane_id);
+    } else {
+      const auto x_real = data[0];
+      const auto x_imag = data[1];
+      const auto y_real = data[2];
+      const auto y_imag = data[3];
+      const auto fxr = freq[0];
+      const auto fxi = freq[1];
+      const auto fyr = freq[2];
+      const auto fyi = freq[3];
+      data[0] = x_real * fxr - x_imag * fxi;
+      data[1] = x_real * fxi + x_imag * fxr;
+      data[2] = y_real * fyr - y_imag * fyi;
+      data[3] = y_real * fyi + y_imag * fyr;
+    }
   }
 
   PDLTriggerSecondary<kUsePDL>();
@@ -579,10 +635,11 @@ Q_KERNEL void fused_q_indexer_rope_hadamard_quant(const __grid_constant__ FusedQ
   }
 }
 
-template <typename DType, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true>
+template <typename DType, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true, bool kIsNeox = false>
 struct FusedQIndexerRopeHadamardQuantKernel {
   template <typename PosT>
-  static constexpr auto kernel = fused_q_indexer_rope_hadamard_quant<DType, PosT, kUsePDL, kRopeFirst, kHadamard>;
+  static constexpr auto kernel =
+      fused_q_indexer_rope_hadamard_quant<DType, PosT, kUsePDL, kRopeFirst, kHadamard, kIsNeox>;
 
   static void forward(
       const tvm::ffi::TensorView q_input,

--- a/python/sglang/jit_kernel/dsv32/elementwise.py
+++ b/python/sglang/jit_kernel/dsv32/elementwise.py
@@ -13,10 +13,10 @@ _CUDA_FILE = "deepseek_v32/indexer_k.cuh"
 
 
 @cache_once
-def _jit_k_indexer_norm_rope_module(dtype: torch.dtype):
-    args = make_cpp_args(dtype, is_arch_support_pdl())
+def _jit_k_indexer_norm_rope_module(dtype: torch.dtype, is_neox: bool):
+    args = make_cpp_args(dtype, is_arch_support_pdl(), is_neox)
     return load_jit(
-        "dpsk_v32_k_indexer_norm_rope",
+        f"dpsk_v32_k_indexer_norm_rope{'_neox' if is_neox else ''}",
         *args,
         cuda_files=[_CUDA_FILE],
         cuda_wrappers=[
@@ -26,10 +26,12 @@ def _jit_k_indexer_norm_rope_module(dtype: torch.dtype):
 
 
 @cache_once
-def _jit_k_indexer_norm_rope_store_module(dtype: torch.dtype, page_size: int):
-    args = make_cpp_args(dtype, is_arch_support_pdl(), page_size)
+def _jit_k_indexer_norm_rope_store_module(
+    dtype: torch.dtype, page_size: int, is_neox: bool
+):
+    args = make_cpp_args(dtype, is_arch_support_pdl(), page_size, is_neox)
     return load_jit(
-        f"dpsk_v32_k_indexer_norm_rope_store_p{page_size}",
+        f"dpsk_v32_k_indexer_norm_rope_store_p{page_size}{'_neox' if is_neox else ''}",
         *args,
         cuda_files=[_CUDA_FILE],
         cuda_wrappers=[
@@ -45,11 +47,18 @@ def fused_k_indexer_norm_rope(
     eps: float,
     cos_sin_cache: torch.Tensor,
     positions: torch.Tensor,
+    *,
+    is_neox: bool = False,
 ) -> torch.Tensor:
-    """V3.2 indexer K: LayerNorm + RoPE on leading dims -> bf16. CUDA only."""
+    """V3.2 indexer K: LayerNorm + RoPE on leading dims -> bf16. CUDA only.
+
+    is_neox selects the RoPE convention: True pairs dim i with i + rope_dim/2
+    (NeoX, DeepSeek-V3.2), False pairs (2i, 2i+1) (interleave/GPT-J, GLM-5.x).
+    The cos_sin_cache halves layout [cos..., sin...] is the same for both.
+    """
     # k_input may be a non-contiguous wk slice; output is always contiguous.
     k_out = torch.empty(k_input.shape, dtype=k_input.dtype, device=k_input.device)
-    module = _jit_k_indexer_norm_rope_module(k_input.dtype)
+    module = _jit_k_indexer_norm_rope_module(k_input.dtype, is_neox)
     module.forward(
         k_input,
         k_out,
@@ -72,12 +81,17 @@ def fused_k_indexer_norm_rope_store(
     cos_sin_cache: torch.Tensor,
     positions: torch.Tensor,
     page_size: int,
+    *,
+    is_neox: bool = False,
 ) -> None:
     """V3.2 indexer K + fused store: LayerNorm + RoPE on leading dims + fp8
-    act-quant + paged index-k cache write, in one launch. CUDA only."""
+    act-quant + paged index-k cache write, in one launch. CUDA only.
+
+    See fused_k_indexer_norm_rope for the is_neox convention.
+    """
     if not out_cache_loc.is_contiguous():
         out_cache_loc = out_cache_loc.contiguous()
-    module = _jit_k_indexer_norm_rope_store_module(k_input.dtype, page_size)
+    module = _jit_k_indexer_norm_rope_store_module(k_input.dtype, page_size, is_neox)
     module.forward(
         k_input,
         cache,

--- a/python/sglang/jit_kernel/dsv4/elementwise.py
+++ b/python/sglang/jit_kernel/dsv4/elementwise.py
@@ -79,12 +79,13 @@ def _jit_main_q_indexer_rope_hadamard_quant_module(dtype: torch.dtype):
 
 
 # V3.2 lays q out as [rope | nope] (V4 is [nope | rope]) -> kRopeFirst=true, and
-# drops the Hadamard rotation (kHadamard=false).
+# drops the Hadamard rotation (kHadamard=false). is_neox selects the RoPE
+# convention (kIsNeox): NeoX for DeepSeek-V3.2, interleave for GLM-5.x.
 @cache_once
-def _jit_main_q_indexer_rope_first_quant_module(dtype: torch.dtype):
-    args = make_cpp_args(dtype, is_arch_support_pdl(), True, False)
+def _jit_main_q_indexer_rope_first_quant_module(dtype: torch.dtype, is_neox: bool):
+    args = make_cpp_args(dtype, is_arch_support_pdl(), True, False, is_neox)
     return load_jit(
-        make_name("main_q_indexer_rope_first_quant"),
+        make_name(f"main_q_indexer_rope_first_quant{'_neox' if is_neox else ''}"),
         *args,
         cuda_files=["deepseek_v4/main_norm_rope.cuh"],
         cuda_wrappers=[
@@ -191,13 +192,20 @@ def fused_q_indexer_rope_first_quant(
     weight_scale: float,
     cos_sin_cache: torch.Tensor,
     positions: torch.Tensor,
+    *,
+    is_neox: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """DeepSeek-V3.2 only. Indexer Q: RoPE on the leading dims + fp8 act-quant. CUDA only."""
+    """DSA indexer Q: RoPE on the leading dims + fp8 act-quant. CUDA only.
+
+    is_neox selects the RoPE convention: True pairs dim i with i + rope_dim/2
+    (NeoX, DeepSeek-V3.2), False pairs (2i, 2i+1) (interleave/GPT-J, GLM-5.x).
+    The cos_sin_cache halves layout [cos..., sin...] is the same for both.
+    """
     q_fp8 = torch.empty(q_input.shape, dtype=torch.float8_e4m3fn, device=q_input.device)
     weights_out = torch.empty(
         (*q_input.shape[:-1], 1), dtype=torch.float32, device=q_input.device
     )
-    module = _jit_main_q_indexer_rope_first_quant_module(q_input.dtype)
+    module = _jit_main_q_indexer_rope_first_quant_module(q_input.dtype, is_neox)
     module.forward(
         q_input,
         q_fp8,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -363,10 +363,9 @@ class Indexer(MultiPlatformOp):
         self.index_topk = index_topk
         self.q_lora_rank = q_lora_rank
         self.layer_id = layer_id
+        self.is_neox_style = is_neox_style
         self.use_dsa_indexer_fusion = (
-            _is_cuda
-            and not envs.SGLANG_DISABLE_DSA_INDEXER_FUSION.get()
-            and not is_neox_style
+            _is_cuda and not envs.SGLANG_DISABLE_DSA_INDEXER_FUSION.get()
         )
         self.alt_stream = alt_stream
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
@@ -659,6 +658,7 @@ class Indexer(MultiPlatformOp):
                 self._indexer_cos_sin_cache,
                 positions,
                 page_size,
+                is_neox=self.is_neox_style,
             )
             return
 
@@ -670,6 +670,7 @@ class Indexer(MultiPlatformOp):
             self.k_norm.variance_epsilon,
             self._indexer_cos_sin_cache,
             positions,
+            is_neox=self.is_neox_style,
         )
         self._store_index_k_cache(
             forward_batch=forward_batch,
@@ -722,6 +723,7 @@ class Indexer(MultiPlatformOp):
                 q_scale_gate,
                 self._indexer_cos_sin_cache,
                 positions,
+                is_neox=self.is_neox_style,
             )
 
         # Two overlap stages: wq_b GEMM (alt) || wk_weights_proj GEMM (current),
@@ -749,6 +751,7 @@ class Indexer(MultiPlatformOp):
             q_scale_gate,
             self._indexer_cos_sin_cache,
             positions,
+            is_neox=self.is_neox_style,
         )
         with torch.cuda.stream(self.alt_stream):
             self._fused_k_prepare_and_store(

--- a/test/registered/jit/test_dsv32_indexer_fusion.py
+++ b/test/registered/jit/test_dsv32_indexer_fusion.py
@@ -71,10 +71,27 @@ def _rope_first(x, cos_p, sin_p):
     return x
 
 
+def _rope_first_neox(x, cos_p, sin_p):
+    """NeoX rope on the leading ROPE_DIM dims: dim i pairs with i + HALF."""
+    x = x.clone()
+    x1 = x[..., 0:HALF].clone()
+    x2 = x[..., HALF:ROPE_DIM].clone()
+    x[..., 0:HALF] = x1 * cos_p - x2 * sin_p
+    x[..., HALF:ROPE_DIM] = x2 * cos_p + x1 * sin_p
+    return x
+
+
+def _rope_ref(x, cos_p, sin_p, is_neox):
+    return (
+        _rope_first_neox(x, cos_p, sin_p) if is_neox else _rope_first(x, cos_p, sin_p)
+    )
+
+
 # ----------------------------------------------------------------------------
 # K kernel (-> bf16): LayerNorm + rope-first
 # ----------------------------------------------------------------------------
-def test_k_norm_rope_matches_reference():
+@pytest.mark.parametrize("is_neox", [False, True])
+def test_k_norm_rope_matches_reference(is_neox):
     _skip_if_unavailable()
     dev = "cuda"
     B = 37
@@ -83,14 +100,16 @@ def test_k_norm_rope_matches_reference():
     weight = torch.randn(HEAD_DIM, dtype=torch.float32, device=dev)
     bias = torch.randn(HEAD_DIM, dtype=torch.float32, device=dev)
 
-    out = fused_k_indexer_norm_rope(key, weight, bias, EPS, cos_sin_cache, positions)
+    out = fused_k_indexer_norm_rope(
+        key, weight, bias, EPS, cos_sin_cache, positions, is_neox=is_neox
+    )
     torch.cuda.synchronize()
 
     normed = torch.nn.functional.layer_norm(
         key.float(), (HEAD_DIM,), weight=weight, bias=bias, eps=EPS
     )
     cp, sp = cos[positions.long()], sin[positions.long()]
-    ref = _rope_first(normed, cp, sp)
+    ref = _rope_ref(normed, cp, sp, is_neox)
 
     torch.testing.assert_close(out.float(), ref, atol=0.06, rtol=0.0)
 
@@ -100,7 +119,8 @@ def test_k_norm_rope_matches_reference():
 # Also covers the strided (non-contiguous wk slice) no-copy input path.
 # ----------------------------------------------------------------------------
 @pytest.mark.parametrize("strided", [False, True])
-def test_k_store_matches_unfused(strided):
+@pytest.mark.parametrize("is_neox", [False, True])
+def test_k_store_matches_unfused(strided, is_neox):
     _skip_if_unavailable()
     if not can_use_dsa_fused_store(torch.bfloat16, torch.int64, PAGE_SIZE):
         pytest.skip("fused store JIT unavailable")
@@ -126,12 +146,21 @@ def test_k_store_matches_unfused(strided):
     buf_fused = torch.zeros_like(buf_ref)
 
     key_bf16 = fused_k_indexer_norm_rope(
-        key, weight, bias, EPS, cos_sin_cache, positions
+        key, weight, bias, EPS, cos_sin_cache, positions, is_neox=is_neox
     )
     fused_store_index_k_cache(key_bf16, buf_ref, loc, PAGE_SIZE)
 
     fused_k_indexer_norm_rope_store(
-        key, buf_fused, loc, weight, bias, EPS, cos_sin_cache, positions, PAGE_SIZE
+        key,
+        buf_fused,
+        loc,
+        weight,
+        bias,
+        EPS,
+        cos_sin_cache,
+        positions,
+        PAGE_SIZE,
+        is_neox=is_neox,
     )
     torch.cuda.synchronize()
 
@@ -142,7 +171,8 @@ def test_k_store_matches_unfused(strided):
 # Q kernel: rope-first + fp8 quant + head-gate fold
 # ----------------------------------------------------------------------------
 @pytest.mark.parametrize("pos_dtype", [torch.int32, torch.int64])
-def test_q_rope_quant_matches_reference(pos_dtype):
+@pytest.mark.parametrize("is_neox", [False, True])
+def test_q_rope_quant_matches_reference(pos_dtype, is_neox):
     _skip_if_unavailable()
     dev = "cuda"
     B, n_heads = 37, 64
@@ -152,13 +182,13 @@ def test_q_rope_quant_matches_reference(pos_dtype):
     weight_scale = 0.137
 
     q_fp8, weights_out = fused_q_indexer_rope_first_quant(
-        q, weight, weight_scale, cos_sin_cache, positions
+        q, weight, weight_scale, cos_sin_cache, positions, is_neox=is_neox
     )
     torch.cuda.synchronize()
 
     cp = cos[positions.long()][:, None, :]
     sp = sin[positions.long()][:, None, :]
-    ref = _rope_first(q.float(), cp, sp)  # [B, n_heads, 128]
+    ref = _rope_ref(q.float(), cp, sp, is_neox)  # [B, n_heads, 128]
     amax = ref.abs().amax(dim=-1, keepdim=True)
     scale = torch.clamp(amax, min=1e-4) / FP8_MAX
 
@@ -200,6 +230,79 @@ def test_q_strided_weight_matches_contiguous():
     torch.cuda.synchronize()
     assert torch.equal(a_fp8, b_fp8)
     assert torch.equal(a_w, b_w)
+
+
+# ----------------------------------------------------------------------------
+# NeoX top-k checksum: the fused kernels' selected indices must match the
+# rotary_emb-based eager reference under is_neox_style=True. This is the guard
+# for the DeepSeek-V3.2 accuracy regression: an interleave-only rotation
+# corrupts the indexer scores and collapses the top-k overlap to ~1/3.
+# ----------------------------------------------------------------------------
+def test_neox_topk_matches_rotary_emb_reference():
+    _skip_if_unavailable()
+    from sglang.srt.layers.rotary_embedding.utils import apply_rotary_emb
+
+    dev = "cuda"
+    B, n_heads, n_keys, topk = 64, 4, 512, 64
+    g = torch.Generator(device=dev).manual_seed(7)
+    # Real rope frequencies (not random cos/sin): convention bugs shear real
+    # rotations; random tables can mask the pairing structure.
+    inv_freq = 1.0 / (
+        10000.0 ** (torch.arange(0, ROPE_DIM, 2, dtype=torch.float) / ROPE_DIM)
+    )
+    t = torch.arange(MAX_POS, dtype=torch.float)
+    freqs = torch.einsum("i,j->ij", t, inv_freq)
+    cos_sin_cache = torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(dev)
+
+    def eager_neox(x, positions):
+        cos, sin = cos_sin_cache.index_select(0, positions).chunk(2, dim=-1)
+        x_rot = x[..., :ROPE_DIM].float()
+        squeeze = x_rot.dim() == 2
+        if squeeze:
+            x_rot = x_rot.unsqueeze(1)
+        out = apply_rotary_emb(x_rot, cos, sin, True)
+        if squeeze:
+            out = out.squeeze(1)
+        return torch.cat((out, x[..., ROPE_DIM:].float()), dim=-1)
+
+    q = torch.randn(B, n_heads, HEAD_DIM, dtype=torch.bfloat16, device=dev, generator=g)
+    w = torch.ones(B, n_heads, dtype=torch.bfloat16, device=dev)
+    q_pos = torch.randint(1, MAX_POS, (B,), dtype=torch.int64, device=dev, generator=g)
+    keys = torch.randn(n_keys, HEAD_DIM, dtype=torch.bfloat16, device=dev, generator=g)
+    k_pos = torch.arange(n_keys, dtype=torch.int64, device=dev)
+    k_weight = torch.randn(HEAD_DIM, dtype=torch.float32, device=dev, generator=g)
+    k_bias = torch.randn(HEAD_DIM, dtype=torch.float32, device=dev, generator=g)
+
+    # Fused path (dequantized q so both sides rank in the same scale).
+    q_fp8, weights_out = fused_q_indexer_rope_first_quant(
+        q, w, 1.0, cos_sin_cache, q_pos, is_neox=True
+    )
+    q_fused = (q_fp8.float() * weights_out.view(B, n_heads, 1))[:, 0, :]
+    k_fused = fused_k_indexer_norm_rope(
+        keys, k_weight, k_bias, EPS, cos_sin_cache, k_pos, is_neox=True
+    ).float()
+
+    # Eager reference: LayerNorm + apply_rotary_emb(is_neox_style=True), the
+    # same math the non-fused indexer path executes via self.rotary_emb.
+    normed = torch.nn.functional.layer_norm(
+        keys.float(), (HEAD_DIM,), weight=k_weight, bias=k_bias, eps=EPS
+    )
+    k_eager = eager_neox(normed, k_pos)
+    q_eager = eager_neox(q, q_pos)[:, 0, :]
+
+    top_fused = (q_fused @ k_fused.T).topk(topk, dim=-1).indices
+    top_eager = (q_eager @ k_eager.T).topk(topk, dim=-1).indices
+    overlaps = torch.tensor(
+        [
+            len(set(top_fused[i].tolist()) & set(top_eager[i].tolist()))
+            for i in range(B)
+        ],
+        dtype=torch.float,
+    )
+    # fp8 quantization of q can flip near-tied boundary picks; a convention
+    # bug collapses overlap to ~topk/3, so these bounds have a wide margin.
+    assert overlaps.min() >= topk - 8, f"min overlap {overlaps.min()}/{topk}"
+    assert overlaps.mean() >= topk - 4, f"mean overlap {overlaps.mean()}/{topk}"
 
 
 def test_indexer_uses_replaced_rope_cache_for_fused_kernels():


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

- The DSA lightning-indexer Q/K kernel fusion (#27705, ~+10% single-stream on B300) is disabled for `is_neox_style=True` models (DeepSeek-V3.2 family).
- #30088 measured the V3.2 GSM8K regression with fusion on (0.955 off vs 0.931 on); #30111 root-caused it to the fused kernels hardcoding interleave/GPT-J RoPE and parked NeoX models on the slow split path via `and not is_neox_style` in the fusion gate.
- This PR fixes the kernels instead of skipping them, so DeepSeek-V3.2 gets the same fused-path speedup GLM-5.x already has.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. Add a compile-time `kIsNeox` branch to both indexer fused kernels — `csrc/deepseek_v32/indexer_k.cuh` (`fused_k_indexer_norm_rope[_store]`) and `csrc/deepseek_v4/main_norm_rope.cuh` (`fused_q_indexer_rope_hadamard_quant`, `kRopeFirst=true` path):
   - NeoX pairs dim `i` with `i + rope_dim/2` (interleave pairs `(2i, 2i+1)`).
   - Freq load: each rope lane loads 4 contiguous cos + 4 contiguous sin values. The `cos_sin_cache` halves layout `[cos..., sin...]` is identical between the two conventions — only the element pairing differs.
   - Rotation: one `__shfl_xor_sync` half-swap across the 16 rope lanes (partner pack at `lane ^ 8`), mirroring the `is_neox` handling in `fused_qknorm_rope.cuh`.
   - `static_assert(!kIsNeox || kRopeFirst)` keeps the V4 (`kRopeFirst=false`) layout unreachable.
2. Plumb `is_neox` through the JIT wrappers (`dsv32/elementwise.py`, `dsv4/elementwise.py`; the new template arg is part of the module cache key) and pass `self.is_neox_style` at all four fused call sites in `dsa_indexer.py`.
3. Drop `and not is_neox_style` from the `use_dsa_indexer_fusion` gate. `SGLANG_DISABLE_DSA_INDEXER_FUSION` stays as the kill-switch.
4. Tests:
   - Parametrize `test/registered/jit/test_dsv32_indexer_fusion.py` over `is_neox`.
   - Add `test_neox_topk_matches_rotary_emb_reference` — fused-vs-eager NeoX top-k checksum against `apply_rotary_emb` (the split-path reference). The interleave-only rotation scores ~topk/3 overlap; the test requires ≥ topk−8 per row, so it would have caught #27705's NeoX incompatibility.

Not changed:

- The non-fused split path.
- The Hadamard behavior (`kHadamard` stays dropped for the rope-first path).
- Index-share / `skip_topk` logic.
- The DeepSeek-V4 native indexer.
- Interleave (GLM-5.x) kernel outputs: bit-identical to main (seeded K/Q/weights outputs compared across checkouts).

Root-cause evidence on hardware (DeepSeek-V3.2 FP8, tp4 ep4, B300; per-layer top-k sets over all 61 layers for a fixed 3649-token prompt, last 64 tokens):

| comparison | mean top-k overlap | min |
|---|---|---|
| fusion-ON (buggy: main + gate clause removed) vs fusion-OFF | 0.634 | 0.549 |
| fusion-ON (this PR) vs fusion-OFF | 0.944 | 0.904 |
| GLM-5.2 fusion-ON vs fusion-OFF (isolates the Hadamard drop) | 0.906 | 0.777 |

- The buggy rotation replaces ~37% of every layer's selected KV positions; this PR moves the fused path to within fp8-quant noise of the split path.
- The GLM row is the Hadamard-hypothesis control: GLM's fused path drops the Hadamard rotation its split path applies, producing the same class of fp8-quant-level top-k perturbation — with zero GSM8K movement (below).
- Conclusion: the 0.634-overlap rotation corruption is what costs accuracy, not the Hadamard drop or the fp8 quant.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

GSM8K full set, `python3 -m sglang.test.few_shot_gsm8k --num-questions 1319 --num-shots 20`, `/flush_cache` between runs, B300 ×4, `--tp 4 --ep 4`:

```
deepseek-ai/DeepSeek-V3.2, fusion OFF (SGLANG_DISABLE_DSA_INDEXER_FUSION=1):
Accuracy: 0.958   Accuracy: 0.955   Accuracy: 0.952   Accuracy: 0.959   Accuracy: 0.956   mean 0.956

deepseek-ai/DeepSeek-V3.2, fusion ON with main's interleave-only kernels (gate clause removed, no kernel fix):
Accuracy: 0.953   Accuracy: 0.953   Accuracy: 0.946   Accuracy: 0.951   Accuracy: 0.948   mean 0.950

deepseek-ai/DeepSeek-V3.2, fusion ON with this PR:
Accuracy: 0.954   Accuracy: 0.956   Accuracy: 0.958   Accuracy: 0.955   Accuracy: 0.957   mean 0.956
```

- Buggy-ON distribution sits entirely at/below the OFF minimum; this PR restores exact parity.
- On this release-V3.2 checkpoint / B300 the buggy gap is ~0.6pt vs the 2.4pt #30088 measured on V3.2-Exp / 8×H200 — same sign, same mechanism.

Control — GLM-5.2 (non-NeoX, must not regress), `nvidia/GLM-5.2-NVFP4`, tp4 ep4:

```
fusion ON, this PR : Accuracy: 0.942   Accuracy: 0.942   Accuracy: 0.947   mean 0.944
fusion ON, main    : Accuracy: 0.945   Accuracy: 0.942   Accuracy: 0.943   mean 0.943
fusion OFF         : Accuracy: 0.945   Accuracy: 0.945   Accuracy: 0.945   mean 0.945
```

NVFP4 target variant — `nvidia/DeepSeek-V3.2-NVFP4` (indexer excluded from quantization), tp4 ep4:

```
fusion OFF         : Accuracy: 0.954   Accuracy: 0.955   Accuracy: 0.958   mean 0.956
fusion ON, this PR : Accuracy: 0.958   Accuracy: 0.956   Accuracy: 0.955   mean 0.956
```

AIME25 (harder signal) — `deepseek-ai/DeepSeek-V3.2`, tp4 ep4, B300; before = fusion OFF, after = fusion ON (this PR), run simultaneously on separate 4-GPU halves of the same node:

```
sgl-eval run aime25 \
    --base-url http://localhost:30300/v1 \
    --n-repeats 8 \
    --max-tokens 65536 \
    --temperature 1.0 \
    --top-p 0.95 \
    --num-threads 128
```

Before (fusion OFF):

```
Run directory: /root/.sgl_eval/sgl_eval_aime25_20260707-053838
aime25 rep 1/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=90.00%]
aime25 rep 2/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=86.67%]
aime25 rep 3/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=90.00%]
aime25 rep 4/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=90.00%]
aime25 rep 5/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=86.67%]
aime25 rep 6/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=90.00%]
aime25 rep 7/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=90.00%]
aime25 rep 8/8: 100%|██████████| 30/30 [33:50<00:00, 67.69s/it, acc=93.33%]
aime25 overall: 100%|██████████| 240/240 [33:50<00:00,  8.46s/it, acc=89.58%]
== aime25 ==
30 examples x 8 repeats  |  2030.7s  |  1794 tok/s  |  3.6M tokens

* pass@1[avg-of-8]  =  89.58% +/- 2.14% (SEM 0.76%)
  pass@8            =  96.67%
  majority@8        =  93.33%
  no_answer         =  0.42%
```

After (fusion ON, this PR):

```
Run directory: /root/.sgl_eval/sgl_eval_aime25_20260707-053841
aime25 rep 1/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=93.33%]
aime25 rep 2/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=86.67%]
aime25 rep 3/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=86.67%]
aime25 rep 4/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=93.33%]
aime25 rep 5/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=90.00%]
aime25 rep 6/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=90.00%]
aime25 rep 7/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=90.00%]
aime25 rep 8/8: 100%|██████████| 30/30 [31:52<00:00, 63.74s/it, acc=90.00%]
aime25 overall: 100%|██████████| 240/240 [31:52<00:00,  7.97s/it, acc=90.00%]
== aime25 ==
30 examples x 8 repeats  |  1912.3s  |  1949 tok/s  |  3.7M tokens

* pass@1[avg-of-8]  =  90.00% +/- 2.52% (SEM 0.89%)
  pass@8            =  93.33%
  majority@8        =  93.33%
  no_answer         =  1.25%
```

- pass@1 parity within noise (89.58% vs 90.00%, SEM ~0.8-0.9%).
- The fused arm also finished ~6% faster wall-clock (1912 s vs 2031 s) at higher throughput (1949 vs 1794 tok/s), consistent with the bench numbers below.

Unit tests:

```
python3 -m pytest test/registered/jit/test_dsv32_indexer_fusion.py -q
13 passed, 21 warnings in 14.19s

python3 -m pytest test/registered/jit/deepseek_v4/test_fp4_indexer.py -q   # shared main_norm_rope.cuh, V4 path
12 passed, 7 warnings in 40.91s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

```
python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 \
    --trust-remote-code --tp 4 --ep 4
python3 -m sglang.benchmark.one_batch_server --base-url http://127.0.0.1:30400 \
    --model-path deepseek-ai/DeepSeek-V3.2 --trust-remote-code \
    --batch-size 1 --input-len 1 --output-len 512        # and 128 / 1024 / 512
```

DeepSeek-V3.2 FP8, B300 ×4, tp4 ep4, fusion OFF vs fusion ON (this PR):

| shape | fusion OFF | fusion ON (this PR) | delta |
|---|---|---|---|
| BS=1, in=1, out=512 (output tok/s) | 102.84 | 119.45 | **+16.2%** |
| BS=128, in=1024, out=512 (output tok/s) | 3617.47 | 3775.05 | **+4.4%** |

- GSM8K wall-clock reflects the same: fusion-OFF runs averaged ~109.6 s vs ~98.7 s fused (−10%).

nvidia/DeepSeek-V3.2-NVFP4, same shapes:

| shape | fusion OFF | fusion ON (this PR) | delta |
|---|---|---|---|
| BS=1, in=1, out=512 (output tok/s) | 138.36 | 156.39 | **+13.0%** |
| BS=128, in=1024, out=512 (output tok/s) | 5620.88 | 5935.66 | **+5.6%** |

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Refs: #27705 #29576 #29613 #30025 #30018 #30088 #30111



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28843207914](https://github.com/sgl-project/sglang/actions/runs/28843207914)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28843207839](https://github.com/sgl-project/sglang/actions/runs/28843207839)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->