### PR TITLE
[Fix] Redact api_key/admin_api_key/ssl_keyfile_password from server info endpoints

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1001,7 +1001,7 @@ class Engine(EngineScoreMixin, EngineBase):
         )
         return msgspec_to_builtins(
             {
-                **dataclasses.asdict(self.tokenizer_manager.server_args),
+                **self.tokenizer_manager.server_args.redacted_asdict(),
                 **self._scheduler_init_result.scheduler_infos[0],
                 "internal_states": internal_states,
                 "version": __version__,

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -7,7 +7,6 @@ TokenizerManager's event loop.
 """
 
 import asyncio
-import dataclasses
 import json
 import logging
 from types import SimpleNamespace
@@ -385,7 +384,7 @@ class RuntimeHandle:
         return json.dumps(result, default=str)
 
     def get_server_info(self) -> str:
-        result: Dict[str, Any] = dataclasses.asdict(self.server_args)
+        result: Dict[str, Any] = self.server_args.redacted_asdict()
         result.update(self.scheduler_info)
         return json.dumps(msgspec_to_builtins(result), default=str)
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -715,7 +715,7 @@ async def server_info():
     # server_args.model_config is not serializable but should be excluded by asdict.
     return msgspec_to_builtins(
         {
-            **dataclasses.asdict(server_args),
+            **server_args.redacted_asdict(),
             **_global_state.scheduler_info,
             "internal_states": internal_states,
             "version": __version__,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7089,6 +7089,23 @@ class ServerArgs:
             "dp_size": self.dp_size,
         }
 
+    # Fields whose values are secrets and must never leave the process via
+    # introspection surfaces (/server_info, gRPC GetServerInfo, etc.).
+    SENSITIVE_FIELDS = ("api_key", "admin_api_key", "ssl_keyfile_password")
+
+    def redacted_asdict(self) -> Dict[str, Any]:
+        """Like ``dataclasses.asdict(self)`` but with secret fields masked.
+
+        Keys stay present (so consumers can still detect whether e.g. an
+        API key is configured), but any set value is replaced with
+        ``"****"``. Unset (``None``) values are left as ``None``.
+        """
+        d = dataclasses.asdict(self)
+        for key in self.SENSITIVE_FIELDS:
+            if d.get(key) is not None:
+                d[key] = "****"
+        return d
+
 
 # NOTE: The process-wide ServerArgs is owned by the runtime context
 # (sglang.srt.runtime_context). The two functions below are LEGACY shims kept

--- a/test/registered/unit/entrypoints/test_server_info.py
+++ b/test/registered/unit/entrypoints/test_server_info.py
@@ -321,5 +321,51 @@ class TestServerInfoExistingFieldsPreserved(CustomTestCase):
         json.dumps(info)
 
 
+class TestServerInfoSecretsRedacted(CustomTestCase):
+    """`/server_info` must never leak secrets from ServerArgs.
+
+    Regression tests for the credential-exposure report: the handler
+    used to spread `dataclasses.asdict(server_args)` into the response,
+    which exposed `api_key`, `admin_api_key`, and
+    `ssl_keyfile_password` verbatim — e.g. an anonymous caller could
+    read `admin_api_key` when only `--admin-api-key` was set.
+    """
+
+    def test_secret_fields_are_masked_when_set(self):
+        args = ServerArgs(
+            model_path="dummy",
+            api_key="user-secret-key",
+            admin_api_key="admin-secret-key",
+            ssl_keyfile_password="ssl-secret",
+        )
+
+        info = _call_server_info_with(args)
+
+        for field in ServerArgs.SENSITIVE_FIELDS:
+            self.assertEqual(info[field], "****", f"{field} leaked to /server_info")
+        serialized = json.dumps(info)
+        self.assertNotIn("user-secret-key", serialized)
+        self.assertNotIn("admin-secret-key", serialized)
+        self.assertNotIn("ssl-secret", serialized)
+
+    def test_unset_secret_fields_stay_none(self):
+        # Consumers can still distinguish "not configured" (None) from
+        # "configured" ("****").
+        args = ServerArgs(model_path="dummy")
+
+        info = _call_server_info_with(args)
+
+        for field in ServerArgs.SENSITIVE_FIELDS:
+            self.assertIn(field, info)
+            self.assertIsNone(info[field])
+
+    def test_redacted_asdict_does_not_mutate_server_args(self):
+        args = ServerArgs(model_path="dummy", api_key="user-secret-key")
+
+        args.redacted_asdict()
+
+        self.assertEqual(args.api_key, "user-secret-key")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #30166 (reported earlier as GHSA-4qvj-c8fp-873j).

The `/server_info` (and deprecated `/get_server_info`) HTTP endpoint, the gRPC bridge `get_server_info`, and `Engine.get_server_info()` all serialize the full `ServerArgs` dataclass via `dataclasses.asdict()`. This exposes `api_key`, `admin_api_key`, and `ssl_keyfile_password` verbatim to callers:

- With both `--api-key` and `--admin-api-key` set, a caller holding the lower-privilege `api_key` can read the `admin_api_key` (and vice versa).
- With only `--admin-api-key` set, `/server_info` is reachable anonymously (defaults to `AuthLevel.NORMAL`), so the admin key leaks to unauthenticated callers.

## Modifications

- `python/sglang/srt/server_args.py`: add `ServerArgs.SENSITIVE_FIELDS = ("api_key", "admin_api_key", "ssl_keyfile_password")` and `ServerArgs.redacted_asdict()`, which masks set secret values with `"****"`. Keys stay present and unset values stay `None`, so consumers can still detect whether a key is configured — the response shape is fully backward compatible.
- `python/sglang/srt/entrypoints/http_server.py`: `/server_info` uses `redacted_asdict()`.
- `python/sglang/srt/entrypoints/grpc_bridge.py`: gRPC `get_server_info` uses `redacted_asdict()`; dropped the now-unused `dataclasses` import.
- `python/sglang/srt/entrypoints/engine.py`: `Engine.get_server_info()` uses `redacted_asdict()`.

These are all `asdict(ServerArgs)` serialization sites in `python/sglang/srt` (verified by grep); the remaining `asdict` calls operate on unrelated dataclasses.

## Accuracy Tests

Not applicable (no model-forward changes).

## Speed Tests and Profiling

Not applicable (introspection endpoints only).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests): added `TestServerInfoSecretsRedacted` (secrets masked and absent from serialized JSON; unset secrets stay `None`; `redacted_asdict()` does not mutate the instance) to `test/registered/unit/entrypoints/test_server_info.py`. Full file passes locally: 17 passed (including the pre-existing backward-compat guard `test_every_server_args_field_appears_in_response`).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28843512294](https://github.com/sgl-project/sglang/actions/runs/28843512294)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28843512203](https://github.com/sgl-project/sglang/actions/runs/28843512203)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->