### PR TITLE
fix(server_args): normalize log level before passing to uvicorn (uppercase like `WARN` silently hangs the HTTP server)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2630,6 +2630,33 @@ class ServerArgs:
         "The path of the JSON configuration file for msProbe. If specified, enables msProbe dump.",
     ] = None
 
+    # Levels every consumer accepts (stdlib logging, uvicorn, granian); their
+    # intersection, so uvicorn-only "trace" is excluded. Aliases cover names
+    # stdlib logging accepts but uvicorn/granian do not.
+    _VALID_LOG_LEVELS = ("critical", "error", "warning", "info", "debug")
+    _LOG_LEVEL_ALIASES = {"warn": "warning", "fatal": "critical"}
+
+    @classmethod
+    def _normalize_log_level(cls, level: Optional[str]) -> Optional[str]:
+        """Lowercase and alias-map a log level, rejecting unknown values.
+
+        Uppercase/alias values (e.g. WARN) otherwise reach uvicorn unnormalized
+        and raise KeyError before the HTTP socket binds.
+        """
+        if level is None:
+            return None
+        normalized = cls._LOG_LEVEL_ALIASES.get(level.lower(), level.lower())
+        if normalized not in cls._VALID_LOG_LEVELS:
+            raise ValueError(
+                f"Unsupported log level {level!r}. "
+                f"Valid levels are {', '.join(cls._VALID_LOG_LEVELS)}."
+            )
+        return normalized
+
+    def _handle_log_level_normalization(self):
+        self.log_level = self._normalize_log_level(self.log_level)
+        self.log_level_http = self._normalize_log_level(self.log_level_http)
+
     def __post_init__(self):
         """
         Orchestrates the handling of various server arguments, ensuring proper configuration and validation.
@@ -2659,6 +2686,9 @@ class ServerArgs:
         # direct handler invocations can rely on it even when
         # _handle_model_specific_adjustments never runs.
         self._resolved_overrides = []
+
+        # Normalize log levels before any consumer reads them.
+        self._handle_log_level_normalization()
 
         if self.model_path.lower() in ["none", "dummy"]:
             return

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1425,5 +1425,60 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestLogLevelNormalization(unittest.TestCase):
+    """ServerArgs normalizes log levels so uppercase/alias values do not reach
+    uvicorn unnormalized (which would KeyError before the HTTP socket binds)."""
+
+    def test_uppercase_is_lowercased(self):
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="INFO").log_level, "info"
+        )
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="Debug").log_level, "debug"
+        )
+
+    def test_warn_alias_maps_to_warning(self):
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="WARN").log_level, "warning"
+        )
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="warn").log_level, "warning"
+        )
+
+    def test_fatal_alias_maps_to_critical(self):
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="FATAL").log_level, "critical"
+        )
+
+    def test_valid_lowercase_unchanged(self):
+        for level in ("critical", "error", "warning", "info", "debug"):
+            self.assertEqual(
+                ServerArgs(model_path="dummy", log_level=level).log_level, level
+            )
+
+    def test_log_level_http_is_normalized(self):
+        args = ServerArgs(model_path="dummy", log_level="info", log_level_http="WARN")
+        self.assertEqual(args.log_level_http, "warning")
+
+    def test_log_level_http_none_is_preserved(self):
+        # None means "reuse --log-level", so it must not be coerced to a string.
+        self.assertIsNone(
+            ServerArgs(model_path="dummy", log_level="info").log_level_http
+        )
+
+    def test_unknown_level_raises(self):
+        # A genuinely unknown level fails fast instead of silently hanging the
+        # HTTP server later inside uvicorn.
+        for bad in ("verbose", "notset", "bogus"):
+            with self.assertRaises(ValueError):
+                ServerArgs(model_path="dummy", log_level=bad)
+
+    def test_trace_is_rejected(self):
+        # 'trace' is uvicorn-only; stdlib logging and granian have no TRACE, so it
+        # is not in the accepted intersection and must be rejected, not blessed.
+        with self.assertRaises(ValueError):
+            ServerArgs(model_path="dummy", log_level="trace")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

An uppercase or aliased `--log-level` / `--log-level-http` value such as `WARN` or `FATAL` currently makes the HTTP server hang: SGLang forwards the string unnormalized to uvicorn, and uvicorn raises `KeyError` inside `configure_logging()` **before the listening socket binds**. The engine core comes up and idles while the port never listens and `/health_generate` is unreachable, with no actionable error. This is easy to hit when a caller forwards a user-supplied level into `ServerArgs` without lowercasing it (this is exactly how I hit it, from a training harness that passed `--sglang-log-level WARN`), and it also happens on direct construction (`Engine(log_level="WARN")` / `ServerArgs(log_level="WARN")`), which bypasses argparse entirely.

It is internally inconsistent too: SGLang's own stdlib logger accepts `WARN` via `getattr(logging, level.upper())` ([server_args.py L7044](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/server_args.py#L7044)), while the HTTP path rejects the same value. This PR normalizes and validates the level in `ServerArgs` so `WARN` (and other casings/aliases) work consistently, turning a silent hang into either a working level or a clear error. Fixes https://github.com/sgl-project/sglang/issues/30353.

## Modifications

`python/sglang/srt/server_args.py`: add a normalizer and call it once at the top of `ServerArgs.__post_init__`, before any consumer reads the level. It lowercases, maps the common stdlib aliases (`warn`→`warning`, `fatal`→`critical`), then validates against the levels accepted by **all** consumers (the stdlib logger, uvicorn, and granian) — their intersection, which deliberately excludes uvicorn-only `trace`:

```python
_VALID_LOG_LEVELS = ("critical", "error", "warning", "info", "debug")
_LOG_LEVEL_ALIASES = {"warn": "warning", "fatal": "critical"}

@classmethod
def _normalize_log_level(cls, level: Optional[str]) -> Optional[str]:
    if level is None:
        return None
    normalized = cls._LOG_LEVEL_ALIASES.get(level.lower(), level.lower())
    if normalized not in cls._VALID_LOG_LEVELS:
        raise ValueError(
            f"Unsupported log level {level!r}. "
            f"Valid levels are {', '.join(cls._VALID_LOG_LEVELS)}."
        )
    return normalized

def _handle_log_level_normalization(self):
    self.log_level = self._normalize_log_level(self.log_level)
    self.log_level_http = self._normalize_log_level(self.log_level_http)
```

Because normalization lands on the `ServerArgs` fields themselves, no call sites change — and every uvicorn/granian site already reads `server_args.log_level_http or server_args.log_level`, so all of them (both `uvicorn.run` sites, the `uvicorn.Config` SSL path, and both granian paths) pick up the normalized value automatically. `log_level_http=None` (meaning "reuse `--log-level`") is preserved as `None`.

**On excluding `trace`:** the accepted set is the intersection of what every consumer accepts, so `trace` is excluded — and this is not a regression. SGLang configures its own stdlib logger with `logging.basicConfig(level=getattr(logging, log_level.upper()))` ([server_args.py L7155](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/server_args.py#L7155)), and stdlib `logging` has no `TRACE` level (`getattr(logging, "TRACE")` raises `AttributeError`); SGLang does not register one via `addLevelName` either (the `trace`/`otlp` args are opentelemetry tracing, unrelated to log levels). So `--log-level trace` already fails today in SGLang's own logging setup — the validation simply turns that latent break into an immediate, clear error rather than blessing a value only uvicorn happens to accept.

Also adds unit tests in `test/registered/unit/server_args/test_server_args.py` (`TestLogLevelNormalization`): casing, `warn`/`fatal` aliases, `log_level_http` including `None` passthrough, unknown-level rejection, and `trace` rejection.

Alternatives considered:
- **argparse `choices=`**: rejected — covers only the CLI (not `Engine(...)`/`ServerArgs(...)` direct construction), would *reject* `WARN` rather than accept it (inconsistent with SGLang's own logger), and needs wiring `choices` into the dataclass-driven arg generation.
- **Fix at the uvicorn/granian call sites**: rejected — 6 call sites; duplicative and easy to miss when a new one is added. Fixing the value once at the source is more robust.
- **Normalize inside uvicorn**: out of scope — SGLang cannot rely on the installed uvicorn version, and it is not SGLang's dependency to patch.

## Accuracy Tests

Not applicable — this changes only server-argument handling (log-level string), not any kernel or model-forward code, so model outputs are unaffected. The behavioral change is verified by unit tests and by a live check across all levels: `WARN`/`warn`→`warning`, `FATAL`/`fatal`→`critical`, `INFO`/`Debug`/`WARNING`/`CRITICAL` lowercased, valid lowercase unchanged, `log_level_http=None` preserved, and `trace`/`verbose`/`notset`/`bogus` raising `ValueError` instead of silently hanging. Before the fix, `uvicorn.Config(log_level="WARN").configure_logging()` raises `KeyError('warn')`; after, the normalized value loads.

## Speed Tests and Profiling

Not applicable — the change runs once at `ServerArgs` construction (two string operations) and touches no inference hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`pre-commit run` on the changed files passes all hooks — isort, ruff, black, codespell.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A — no user-facing docs describe the accepted `--log-level` values; behavior only becomes more lenient/clear.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A — no model-output or speed impact; see the Accuracy Tests / Speed Tests sections above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (ruff/black/isort clean.)

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28847502020](https://github.com/sgl-project/sglang/actions/runs/28847502020)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28847501927](https://github.com/sgl-project/sglang/actions/runs/28847501927)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->