### PR TITLE
[Fix] Support mimo state_capturer routing replay

### DIFF
--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -266,6 +266,7 @@ class MiMoV2MoE(nn.Module):
         self.topk = TopK(
             top_k=config.num_experts_per_tok,
             renormalize=config.norm_topk_prob,
+            layer_id=self.layer_id,
             use_grouped_topk=True,
             num_expert_group=config.n_group,
             topk_group=config.topk_group,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When CUDA graph capture with using routing replay, we got error: 

```
File ".../sglang/srt/state_capturer/base.py", line 41, in capture
    self.buffer[:batch, layer_id, :] = topk_indices
RuntimeError: The expanded size of the tensor (48) must match the existing size (128)
at non-singleton dimension 2. Target sizes: [128, 1, 48, 8]. Tensor sizes: [128, 8]
```

## Modifications

<!-- Detail the changes made in this pull request. -->

layer_id is None because TopK do not pass the parameter, and None will be insert a new axis which will cause shape error.

Update like what `experts_type` do: 

```
self.topk = TopK(
    top_k=config.num_experts_per_tok,
    renormalize=config.norm_topk_prob,
    layer_id=self.layer_id,
    use_grouped_topk=True,
    num_expert_group=config.n_group,
    topk_group=config.topk_group,
    correction_bias=self.gate.e_score_correction_bias,
    scoring_func=config.scoring_func,
    quant_config=quant_config,
    routed_scaling_factor=1.0,
    apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
    # Some Fp4 MoE backends require the output format to be bypassed but the MTP layers are unquantized
    # and requires the output format to be standard. We use quant_config to determine the output format.
    output_format=TopKOutputFormat.STANDARD if quant_config is None else None,
)
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28850176852](https://github.com/sgl-project/sglang/actions/runs/28850176852)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28850176706](https://github.com/sgl-project/sglang/actions/runs/28850176706)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->