### PR TITLE
Fall back to two-shot all-reduce in TorchSymmMemCommunicator when multicast is unavailable

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/torch_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/torch_symm_mem.py
@@ -61,6 +61,7 @@ class TorchSymmMemCommunicator:
         self.disabled = True
         self.buffer = None
         self.max_size = 0
+        self.use_multimem = False
 
         if not torch_symm_mem_available:
             return
@@ -99,14 +100,26 @@ class TorchSymmMemCommunicator:
             dtype=self.dtype,
         )
         handle = torch_symm_mem.rendezvous(self.buffer, self.group.group_name)
-        if handle.multicast_ptr == 0:
+        # Multicast (NVLS) is only required by the multimem kernel. The
+        # two-shot kernel only needs P2P peer mappings, which are available
+        # on systems without multicast support — e.g. NVIDIA Confidential
+        # Computing / TEE deployments (where the driver disables NVLS) or
+        # topologies without NVLink SHARP. Fall back instead of disabling.
+        self.use_multimem = self.world_size in self._WORLD_SIZES_MULTIMEM.get(
+            self.device_capability, ()
+        )
+        if self.use_multimem and handle.multicast_ptr == 0:
             logger.warning(
                 "TorchSymmMemCommunicator: torch symmetric memory "
-                "multicast operations are not supported."
+                "multicast operations are not supported; falling back to "
+                "the two-shot all-reduce kernel."
             )
-            self.buffer = None
-            self.disabled = True
-            return
+            self.use_multimem = False
+        logger.info(
+            "TorchSymmMemCommunicator: enabled (kernel=%s, max_size=%d)",
+            "multimem" if self.use_multimem else "two_shot",
+            self.max_size,
+        )
         self.disabled = False
 
     def should_torch_symm_mem_allreduce(self, inp: torch.Tensor):
@@ -157,9 +170,7 @@ class TorchSymmMemCommunicator:
         if out is None:
             out = torch.empty_like(inp)
         self.buffer[: inp.numel()].copy_(inp.view(-1))
-        if self.world_size in self._WORLD_SIZES_MULTIMEM.get(
-            self.device_capability, ()
-        ):
+        if self.use_multimem:
             torch.ops.symm_mem.multimem_all_reduce_(
                 self.buffer[: inp.numel()], "sum", self.group.group_name
             )


### PR DESCRIPTION
## Motivation

`TorchSymmMemCommunicator` (enabled via `--enable-torch-symm-mem`) currently **hard-disables itself whenever symmetric-memory multicast is unavailable** (`handle.multicast_ptr == 0`), even though multicast (NVLS) is only required by the `multimem_all_reduce_` kernel. The `two_shot_all_reduce_` kernel — which the communicator already selects for every `(cc_major, world_size)` combination outside `_WORLD_SIZES_MULTIMEM` — only needs P2P peer mappings.

Environments where multicast is unavailable but P2P works fine include:

- **NVIDIA Confidential Computing / TEE deployments** (e.g. Hopper Protected-PCIe mode inside Intel TDX CVMs): the driver hard-disables the whole `cuMulticast*` family under CC modes (`CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED = 0`), while CUDA P2P over NVLink works. This affects every confidential-inference deployment on H100/H200.
- Topologies without NVLink SHARP support.

In these environments, `--enable-torch-symm-mem` today silently degrades to NCCL — e.g. TP2 on Hopper (`world_size=2` is not in `_WORLD_SIZES_MULTIMEM[9]`) would never have used multimem in the first place, yet still gets disabled by the multicast check.

## Modifications

- Only require `multicast_ptr != 0` when the multimem kernel is actually selected; otherwise fall back to `two_shot_all_reduce_` with a warning instead of disabling the communicator.
- Cache the kernel choice in `self.use_multimem` (set in `__init__`, used in `all_reduce`) instead of recomputing membership per call.
- Log the selected kernel and max size at init so deployments can confirm engagement.

No behavior change on NVLS-capable systems: multimem is still preferred whenever `(cc_major, world_size)` is in `_WORLD_SIZES_MULTIMEM` and multicast is available.

## Accuracy Tests

Validated on 8× H200 SXM (HGX, 4 NVSwitches) passed through into an Intel TDX CVM running NVIDIA Protected-PCIe CC mode, driver 570.172.08 — a real `multicast_ptr == 0` environment (`cuMulticastGetGranularity` → `CUDA_ERROR_NOT_SUPPORTED`):

- Op-level: `two_shot_all_reduce_` and `one_shot_all_reduce` produce correct sums on `world_size=2` and `world_size=4` (bf16, 4096 elements), including inside CUDA graph capture/replay.
- End-to-end: DeepSeek-V4-Flash TP2 served with `--enable-torch-symm-mem` + this patch; init logs `TorchSymmMemCommunicator: enabled (kernel=two_shot, max_size=67108864)`; chat outputs correct (spot-checked reasoning/math prompts); long-form generation stable.
- Eligibility guards (dtype, alignment, max-size) unchanged and verified to still decline ineligible tensors.

## Speed Tests and Profiling

8 KB (hidden 4096 × bf16, the per-layer TP all-reduce size) on H200 NVLink, measured inside CUDA graph replay (what a captured decode step actually pays):

| op | ws=2 | ws=4 |
|---|---|---|
| NCCL all-reduce | 25.1 µs | 23.3–27.3 µs |
| symm-mem `two_shot_all_reduce_` | 6.3 µs | 7.8–14.6 µs |

(Eager-mode NCCL reference: 112–118 µs — the gap is launch-path overhead, amplified under TDX.) End-to-end decode TPOT impact on our TP2 workload was within noise because all-reduce is only ~12% of the decode step there; the fix's primary value is that `--enable-torch-symm-mem` engages at all in non-NVLS environments instead of silently falling back to NCCL.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) (all hooks pass).
- [ ] Add unit tests — not included: exercising the fallback requires hardware where `multicast_ptr == 0` (CC-mode or non-SHARP systems), which CI cannot force; happy to add a mocked-handle unit test if maintainers want one.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Note: vLLM's `SymmMemCommunicator` (which this file was adapted from) has the same hard-disable pattern; I can submit the equivalent fix there as a follow-up.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28851267795](https://github.com/sgl-project/sglang/actions/runs/28851267795)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28851267667](https://github.com/sgl-project/sglang/actions/runs/28851267667)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->