### PR TITLE
[fix] base-a-test-cpu breakage from the flexkv connector (#29701)

### DIFF
--- a/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/flexkv/flexkv_radix_cache.py
@@ -388,9 +388,9 @@ class FlexKVRadixCache(RadixCache):
             return
 
         # Compute the committed prefix mirroring LMCRadixCache's logic.
-        from sglang.srt.server_args import get_global_server_args
+        from sglang.srt.runtime_context import get_server_args
 
-        global_server_args = get_global_server_args()
+        global_server_args = get_server_args()
         topk = global_server_args.speculative_eagle_topk
         enable_kv_committed_len = topk is None or topk == 1
         if enable_kv_committed_len:

--- a/test/registered/unit/mem_cache/test_registry.py
+++ b/test/registered/unit/mem_cache/test_registry.py
@@ -35,6 +35,7 @@ def _make_ctx(
     server_args.radix_cache_backend = backend
     server_args.enable_streaming_session = enable_streaming
     server_args.enable_lmcache = enable_lmcache
+    server_args.enable_flexkv = False
     return TreeCacheBuildContext(
         server_args=server_args,
         params=MagicMock(),


### PR DESCRIPTION
## Summary

#29701 broke two `base-a-test-cpu` shards on main (and every PR's merge-ref CI since):

1. **`test_legacy_global_ratchet.py`** — the new `flexkv_radix_cache.py` calls the legacy `get_global_server_args` shim, growing the ratchet count to 281 > baseline 280. Switch to the `runtime_context.get_server_args()` accessor the ratchet asks for.
2. **`test_registry.py::test_fallback_to_radix_cache`** — the new `enable_flexkv` branch in `default_radix_cache_factory` fires on the test's bare `MagicMock` server_args (auto-attr is truthy) and assigns a MagicMock into `os.environ` → `TypeError: str expected`. Pin `enable_flexkv = False` in `_make_ctx` like the other flags.

## Verification

`test_registry.py` + `test_legacy_global_ratchet.py`: 24 passed locally on this branch; both reproduce the CI failures on current main.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28854200472](https://github.com/sgl-project/sglang/actions/runs/28854200472)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28854200312](https://github.com/sgl-project/sglang/actions/runs/28854200312)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->