### PR TITLE
[AMD] Fix Quark MXFP4 MTP load when nextn layer is bf16 (GLM-5.2): de…

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -110,6 +110,7 @@ def is_deepseek_dsa(config) -> bool:
             "MistralLarge3ForCausalLM",
             "PixtralForConditionalGeneration",
             "GlmMoeDsaForCausalLM",
+            "GlmMoeDsaForCausalLMNextN",
             "LongcatFlashForCausalLM",
             "LongcatFlashForCausalLMNextN",
         )
@@ -536,9 +537,11 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] in [
             "DeepseekV3ForCausalLM",
             "DeepseekV32ForCausalLM",
-            "GlmMoeDsaForCausalLM",
         ]:
             self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"
+
+        if is_draft_model and self.hf_config.architectures[0] == "GlmMoeDsaForCausalLM":
+            self.hf_config.architectures[0] = "GlmMoeDsaForCausalLMNextN"
 
         if (
             is_draft_model
@@ -741,6 +744,7 @@ class ModelConfig:
             or "Glm4MoeLiteForCausalLM" in self.hf_config.architectures
             or "Glm4MoeLiteForCausalLMNextN" in self.hf_config.architectures
             or "GlmMoeDsaForCausalLM" in self.hf_config.architectures
+            or "GlmMoeDsaForCausalLMNextN" in self.hf_config.architectures
             or "LongcatFlashForCausalLM" in self.hf_config.architectures
             or "LongcatFlashForCausalLMNextN" in self.hf_config.architectures
             or "DotsVLMForCausalLM" in self.hf_config.architectures

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -287,6 +287,25 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         },
     )
 
+    def _resolve_nextn_quant_config(self, config, quant_config):
+        """Resolve the quant config used to build the nextn (MTP) model.
+
+        For quark, if the whole MTP/nextn layer is kept unquantized (bf16) and
+        listed in the checkpoint `exclude` set, drop quant for the nextn model.
+        Subclasses (e.g. GLM) override this to do finer, prefix-aware exclude
+        remapping so that mixed-precision MTP layers are handled correctly.
+        """
+        if quant_config is None or quant_config.get_name() != "quark":
+            return quant_config
+
+        from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
+
+        ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
+        mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
+        if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
+            return None
+        return quant_config
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -310,17 +329,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             self.cp_rank = None
             self.cp_size = None
 
-        nextn_quant_config = quant_config
-        # For quark, if the MTP layer is listed in exclude_layers, set quant_config to None.
-        if nextn_quant_config is not None and nextn_quant_config.get_name() == "quark":
-            from sglang.srt.layers.quantization.quark.utils import (
-                should_ignore_layer,
-            )
-
-            ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
-            mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
-            if should_ignore_layer(mapped_prefix, nextn_quant_config.exclude_layers):
-                nextn_quant_config = None
+        nextn_quant_config = self._resolve_nextn_quant_config(config, quant_config)
 
         self.model = DeepseekModelNextN(
             config, nextn_quant_config, prefix=add_prefix("model", prefix)

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -14,6 +14,7 @@
 
 """Inference-only GLM-4.5, GLM-4.6 and GLM-4.7 model compatible with HuggingFace weights"""
 
+import copy
 import logging
 import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
@@ -80,8 +81,9 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.deepseek_nextn import DeepseekV3ForCausalLMNextN
 from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
-from sglang.srt.models.utils import apply_qk_norm
+from sglang.srt.models.utils import WeightsMapper, apply_qk_norm
 from sglang.srt.runtime_context import get_parallel, get_server_args, get_stream
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
@@ -1484,4 +1486,82 @@ class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
         super().determine_num_fused_shared_experts("GlmMoeDsaForCausalLM")
 
 
-EntryClass = [Glm4MoeForCausalLM, GlmMoeDsaForCausalLM]
+class GlmMoeDsaForCausalLMNextN(DeepseekV3ForCausalLMNextN):
+    # GLM-5.2's MTP layer index differs from DeepSeek's (61), so the inherited
+    # substr mapping would wrongly rewrite GLM's real layer-61 weights. The
+    # exclude_layers remapping for the MTP layer is handled explicitly in
+    # _resolve_nextn_quant_config below instead.
+    hf_to_sglang_mapper = WeightsMapper()
+
+    _NEXTN_SPEC_WEIGHT_NAMES = ("shared_head.norm", "eh_proj", "enorm", "hnorm")
+
+    @classmethod
+    def _map_mtp_ckpt_name(cls, name: str, layer_prefix: str) -> str:
+        # Keep this mapping in sync with DeepseekV2WeightLoaderMixin's NextN
+        # rule: MTP-specific weights live under model.*, while the decoder block
+        # weights live under model.decoder.*.
+        if any(part in name for part in cls._NEXTN_SPEC_WEIGHT_NAMES):
+            return name.replace(layer_prefix, "model", 1)
+        return name.replace(layer_prefix, "model.decoder", 1)
+
+    def _resolve_nextn_quant_config(self, config, quant_config):
+        if quant_config is None or quant_config.get_name() != "quark":
+            return quant_config
+
+        layer_prefix = f"model.layers.{config.num_hidden_layers}"
+
+        # Quark's per-module scheme selection (e.g. MTP self_attn in PTPC-FP8
+        # while MTP MoE is MXFP4) is keyed by "layer_quant_config" patterns
+        # using the checkpoint "model.layers.<N>.*" naming. SGLang queries
+        # schemes by the runtime "model.*"/"model.decoder.*" prefix, so those
+        # keys need the same remap as exclude_layers below, or they silently
+        # fall back to the wrong (layer-type/global) scheme.
+        layer_quant_config = quant_config.quant_config.get("layer_quant_config")
+        needs_layer_quant_remap = bool(layer_quant_config) and any(
+            pattern.startswith(layer_prefix + ".") for pattern in layer_quant_config
+        )
+
+        mtp_excluded = [
+            name
+            for name in quant_config.exclude_layers
+            if name.startswith(layer_prefix + ".")
+        ]
+
+        if not needs_layer_quant_remap and not mtp_excluded:
+            return quant_config
+
+        # Copy before mutating so a shared/cached quant_config instance is never
+        # modified in place. copy.copy() is a shallow copy, so also copy the
+        # nested quant_config dict that we rewrite below.
+        quant_config = copy.copy(quant_config)
+        quant_config.quant_config = dict(quant_config.quant_config)
+
+        if needs_layer_quant_remap:
+            quant_config.quant_config["layer_quant_config"] = {
+                (
+                    self._map_mtp_ckpt_name(pattern, layer_prefix)
+                    if pattern.startswith(layer_prefix + ".")
+                    else pattern
+                ): pattern_config
+                for pattern, pattern_config in layer_quant_config.items()
+            }
+
+        if mtp_excluded:
+            names = set(quant_config.exclude_layers)
+            for name in mtp_excluded:
+                names.add(self._map_mtp_ckpt_name(name, layer_prefix))
+
+            # Fused routed experts are queried by the coarse module prefix
+            # "model.decoder.mlp.experts". Expanded per-expert leaf excludes do
+            # not match that prefix, so add the coarse prefix when any routed
+            # expert in the MTP layer is excluded. This keeps only that fused
+            # MoE module bf16 while the rest of the draft modules use their
+            # quant config.
+            if any(".mlp.experts." in name for name in mtp_excluded):
+                names.add("model.decoder.mlp.experts")
+            quant_config.exclude_layers = list(names)
+
+        return quant_config
+
+
+EntryClass = [Glm4MoeForCausalLM, GlmMoeDsaForCausalLM, GlmMoeDsaForCausalLMNextN]

--- a/test/registered/unit/models/test_nextn_quark_exclude.py
+++ b/test/registered/unit/models/test_nextn_quark_exclude.py
@@ -1,0 +1,122 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.models.deepseek_nextn import DeepseekV3ForCausalLMNextN
+from sglang.srt.models.glm4_moe import GlmMoeDsaForCausalLMNextN
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class _FakeQuarkConfig:
+    """Minimal stand-in for QuarkConfig: only the bits the nextn quant
+    resolution reads (get_name / exclude_layers / quant_config)."""
+
+    def __init__(self, name, exclude_layers, quant_config=None):
+        self._name = name
+        self.exclude_layers = list(exclude_layers)
+        self.quant_config = dict(quant_config or {})
+
+    def get_name(self):
+        return self._name
+
+
+class TestBaseNextNQuarkResolution(unittest.TestCase):
+    """Base DeepseekV3ForCausalLMNextN: non-quark / None configs pass through
+    unchanged, quark configs are resolved against the mapped MTP prefix."""
+
+    def _resolve(self, num_hidden_layers, quant_config):
+        fake_self = SimpleNamespace(
+            hf_to_sglang_mapper=DeepseekV3ForCausalLMNextN.hf_to_sglang_mapper
+        )
+        config = SimpleNamespace(num_hidden_layers=num_hidden_layers)
+        return DeepseekV3ForCausalLMNextN._resolve_nextn_quant_config(
+            fake_self, config, quant_config
+        )
+
+    def test_non_quark_config_unchanged(self):
+        quant_config = _FakeQuarkConfig("fp8", ["model.layers.61.eh_proj"])
+        self.assertIs(self._resolve(61, quant_config), quant_config)
+
+    def test_none_config_unchanged(self):
+        self.assertIsNone(self._resolve(61, None))
+
+
+class TestGlmNextNQuarkResolution(unittest.TestCase):
+    """GLM-5.2 MTP: exclude_layers / layer_quant_config keys recorded under the
+    checkpoint prefix "model.layers.<N>.*" must be remapped to the runtime
+    "model.*"/"model.decoder.*" names SGLang actually queries, without mutating
+    the (possibly shared) input quant_config."""
+
+    _LAYER = 78
+
+    def _resolve(self, quant_config):
+        fake_self = SimpleNamespace(
+            _map_mtp_ckpt_name=GlmMoeDsaForCausalLMNextN._map_mtp_ckpt_name,
+        )
+        config = SimpleNamespace(num_hidden_layers=self._LAYER)
+        return GlmMoeDsaForCausalLMNextN._resolve_nextn_quant_config(
+            fake_self, config, quant_config
+        )
+
+    def test_exclude_names_remapped_to_runtime_prefixes(self):
+        original_excludes = [
+            "model.layers.78.eh_proj",
+            "model.layers.78.self_attn.q_proj",
+            "model.layers.78.mlp.experts.0.gate_proj",
+            "lm_head",
+        ]
+        quant_config = _FakeQuarkConfig("quark", original_excludes)
+
+        resolved = self._resolve(quant_config)
+
+        # A copy is returned; the input is never mutated in place.
+        self.assertIsNot(resolved, quant_config)
+        self.assertEqual(quant_config.exclude_layers, original_excludes)
+
+        names = set(resolved.exclude_layers)
+        # MTP-specific weight -> model.*
+        self.assertIn("model.eh_proj", names)
+        # decoder block weight -> model.decoder.*
+        self.assertIn("model.decoder.self_attn.q_proj", names)
+        # fused routed experts also queried by the coarse module prefix
+        self.assertIn("model.decoder.mlp.experts", names)
+        # original leaf names are preserved too
+        self.assertIn("lm_head", names)
+
+    def test_layer_quant_config_keys_remapped_without_mutation(self):
+        original_lqc = {
+            "model.layers.78.self_attn": "ptpc_fp8",
+            "model.layers.5.self_attn": "keep",
+        }
+        quant_config = _FakeQuarkConfig(
+            "quark", [], quant_config={"layer_quant_config": original_lqc}
+        )
+
+        resolved = self._resolve(quant_config)
+
+        # Input dict is untouched (guards the shallow-copy side-effect bug).
+        self.assertEqual(
+            quant_config.quant_config["layer_quant_config"],
+            {
+                "model.layers.78.self_attn": "ptpc_fp8",
+                "model.layers.5.self_attn": "keep",
+            },
+        )
+        remapped = resolved.quant_config["layer_quant_config"]
+        self.assertIn("model.decoder.self_attn", remapped)
+        self.assertNotIn("model.layers.78.self_attn", remapped)
+        # non-MTP keys are left as-is
+        self.assertIn("model.layers.5.self_attn", remapped)
+
+    def test_no_mtp_excludes_returns_same_config(self):
+        quant_config = _FakeQuarkConfig("quark", ["model.layers.5.self_attn.q_proj"])
+        self.assertIs(self._resolve(quant_config), quant_config)
+
+    def test_non_quark_config_unchanged(self):
+        quant_config = _FakeQuarkConfig("fp8", ["model.layers.78.eh_proj"])
+        self.assertIs(self._resolve(quant_config), quant_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Serving GLM-5.2-MXFP4 (AMD Quark) with MTP/EAGLE enabled crashes at model load.
Quark records the MTP/nextn layer's excluded (bf16) weights and per-module
quant schemes under the **checkpoint** prefix `model.layers.<N>.*` (e.g.
`model.layers.78.eh_proj`). But SGLang builds the draft/MTP runtime modules
under different names — MTP-specific weights under `model.*`, the decoder block
under `model.decoder.*`, and the fused routed experts are queried by the coarse
module prefix `model.decoder.mlp.experts`.
Because of this prefix/granularity mismatch:
- `exclude_layers` lookups miss, so bf16 MTP weights get built as MXFP4 →
  shape/dtype mismatch at load (e.g. `eh_proj` `[6144, 6144] uint8` vs
  `[6144, 12288] bf16`; draft-worker fused-MoE `tensor a (3072) must match
  tensor b (6144)`).
- `layer_quant_config` scheme lookups also miss and silently fall back to the
  wrong scheme.
The existing DeepSeek NextN mapper only handles the 61-layer case
(`model.layers.61 -> model.decoder`), which does not apply to GLM-5.2 (78
layers).

## Modifications

- Add `GlmMoeDsaForCausalLMNextN` (in `glm4_moe.py`) and route GLM DSA draft
  models to it instead of reusing `DeepseekV3ForCausalLMNextN`.
- Extract `_resolve_nextn_quant_config()` in the base NextN class so GLM can
  override the quant-config resolution cleanly (base behavior unchanged).
- In the GLM override, remap MTP `exclude_layers` and `layer_quant_config`
  keys from checkpoint names to the runtime names SGLang queries:
  - `model.layers.<N>.{eh_proj,enorm,hnorm,shared_head.norm}` → `model.*`
  - other decoder-block weights → `model.decoder.*`
  - when any routed expert of the MTP layer is excluded, also add the coarse
    fused-MoE prefix `model.decoder.mlp.experts`
  This keeps **mixed precision**: excluded MTP modules stay bf16 while the rest
  of the draft modules use their Quark quant config.
- Copy the `quant_config` (including the nested `quant_config` dict) before the
  remap so a shared/cached instance is never mutated in place.
- Add a GPU-free unit test (`test_nextn_quark_exclude.py`) covering the remap,
  the fused-MoE coarse prefix, and the no-mutation guarantee.

## Accuracy Tests


bf16 is the faithful representation of the excluded GLM-5.2 nextn weights, so
MTP accept rate and main-path accuracy are unaffected.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28922188565](https://github.com/sgl-project/sglang/actions/runs/28922188565)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #28922188379](https://github.com/sgl-project/sglang/actions/runs/28922188379)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->