### PR TITLE
remove draft worker allocate cpu memory when using hisparse

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -857,7 +857,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Init ngram embedding token table
         self.maybe_init_ngram_embedding()
 
-        if self.enable_hisparse:
+        if self.enable_hisparse and not self.is_draft_worker:
             from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -423,7 +423,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.forward_pass_id = 0
         self.init_new_workspace = False
         self.draft_model_idx = draft_model_idx
-        self.enable_hisparse = server_args.enable_hisparse
+        self.enable_hisparse = server_args.enable_hisparse and not is_draft_worker
 
         self.remote_instance_transfer_engine = None
         self.remote_instance_transfer_engine_session_id = ""


### PR DESCRIPTION
## problem
When I used pd to deploy deepseekv4 and enabled hisparse and dp on the decode node, the log showed that 16 times of host memory was requested. Obviously, both the target worker and the draft worker would request the same size of CPU memory space, but the draft worker is neither c4 nor c128, and does not need to apply for the corresponding CPU memory space.
<img width="2024" height="1286" alt="image" src="https://github.com/user-attachments/assets/0293733a-8e87-4e5b-a7be-208a423dee58" />























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28913151760](https://github.com/sgl-project/sglang/actions/runs/28913151760)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28913151605](https://github.com/sgl-project/sglang/actions/runs/28913151605)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->