### PR TITLE
[CI] Fix DSA top-k v2 test metadata

### DIFF
--- a/test/registered/kernels/test_dsa_indexer.py
+++ b/test/registered/kernels/test_dsa_indexer.py
@@ -640,6 +640,17 @@ class TestDSAIndexer(CustomTestCase):
             )
         ).contiguous()
 
+        topk_v2_plan = None
+        if (
+            topk_transform_method == TopkTransformMethod.PAGED
+            and row_starts is None
+            and batch_idx_list is None
+            and envs.SGLANG_OPT_USE_TOPK_V2.get()
+        ):
+            from sglang.jit_kernel.dsv4.topk import plan_topk_v2
+
+            topk_v2_plan = plan_topk_v2(seq_lens_expanded)
+
         attn_metadata = DSAMetadata(
             page_size=1,
             cache_seqlens_int32=seq_lens_expanded.clone(),
@@ -659,6 +670,7 @@ class TestDSAIndexer(CustomTestCase):
                 if topk_transform_method == TopkTransformMethod.RAGGED
                 else None
             ),
+            topk_v2_plan=topk_v2_plan,
         )
 
         metadata_sgl = DSAIndexerMetadata(


### PR DESCRIPTION
## Summary

Fix `test_dsa_indexer.py` by populating `DSAMetadata.topk_v2_plan` for the top-k v2 path broken by #30274

### Before

```bash
python test/registered/kernels/test_dsa_indexer.py

.........FFF.
======================================================================
FAIL: test_topk_fused_backends_equivalence (__main__.TestDSAIndexer.test_topk_fused_backends_equivalence) (tie_break=None, topk_transform_method='PAGED', with_row_starts=False)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/sgl-workspace/test/registered/kernels/test_dsa_indexer.py", line 968, in test_topk_fused_backends_equivalence
    self._run_fused_topk_backend_equivalence_test(
  File "/sgl-workspace/test/registered/kernels/test_dsa_indexer.py", line 676, in _run_fused_topk_backend_equivalence_test
    out_sgl = metadata_sgl.topk_transform(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa_backend.py", line 318, in topk_transform
    return self.topk_backend.topk_transform(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py", line 111, in topk_transform
    return _topk_transform_v2_paged(logits, lengths, topk, attn_metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py", line 291, in _topk_transform_v2_paged
    plan is not None and plan.shape[0] == num_rows + 1
AssertionError: topk_v2_plan must be preprocessed per forward (see DSAMetadata.topk_v2_plan)

======================================================================
FAIL: test_topk_fused_backends_equivalence (__main__.TestDSAIndexer.test_topk_fused_backends_equivalence) (tie_break='small', topk_transform_method='PAGED', with_row_starts=False)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/sgl-workspace/test/registered/kernels/test_dsa_indexer.py", line 968, in test_topk_fused_backends_equivalence
    self._run_fused_topk_backend_equivalence_test(
  File "/sgl-workspace/test/registered/kernels/test_dsa_indexer.py", line 676, in _run_fused_topk_backend_equivalence_test
    out_sgl = metadata_sgl.topk_transform(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa_backend.py", line 318, in topk_transform
    return self.topk_backend.topk_transform(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py", line 111, in topk_transform
    return _topk_transform_v2_paged(logits, lengths, topk, attn_metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py", line 291, in _topk_transform_v2_paged
    plan is not None and plan.shape[0] == num_rows + 1
AssertionError: topk_v2_plan must be preprocessed per forward (see DSAMetadata.topk_v2_plan)

======================================================================
FAIL: test_topk_fused_backends_equivalence (__main__.TestDSAIndexer.test_topk_fused_backends_equivalence) (tie_break='large', topk_transform_method='PAGED', with_row_starts=False)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/sgl-workspace/test/registered/kernels/test_dsa_indexer.py", line 968, in test_topk_fused_backends_equivalence
    self._run_fused_topk_backend_equivalence_test(
  File "/sgl-workspace/test/registered/kernels/test_dsa_indexer.py", line 676, in _run_fused_topk_backend_equivalence_test
    out_sgl = metadata_sgl.topk_transform(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa_backend.py", line 318, in topk_transform
    return self.topk_backend.topk_transform(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py", line 111, in topk_transform
    return _topk_transform_v2_paged(logits, lengths, topk, attn_metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py", line 291, in _topk_transform_v2_paged
    plan is not None and plan.shape[0] == num_rows + 1
AssertionError: topk_v2_plan must be preprocessed per forward (see DSAMetadata.topk_v2_plan)

----------------------------------------------------------------------
Ran 11 tests in 9.341s

FAILED (failures=3)
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

### After

```bash
python test/registered/kernels/test_dsa_indexer.py

...........
----------------------------------------------------------------------
Ran 11 tests in 9.310s

OK
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28860200606](https://github.com/sgl-project/sglang/actions/runs/28860200606)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28860200460](https://github.com/sgl-project/sglang/actions/runs/28860200460)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->