### PR TITLE
Fix zero expert routed ids for MoE backends

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -1307,7 +1307,9 @@ def zero_experts_compute_triton(
         zero_expert_scales[zero_expert_mask] = 0.0
 
     normal_expert_mask = expert_indices >= num_experts
-    expert_indices[normal_expert_mask] = -1
+    # Keep a valid routed-expert id for MoE kernels that do not accept negative
+    # ids. The zero scale below still removes the routed-expert contribution.
+    expert_indices[normal_expert_mask] = 0
     expert_scales[normal_expert_mask] = 0.0
 
     output = torch.zeros_like(hidden_states).to(hidden_states.device)

--- a/test/registered/moe/test_zero_experts.py
+++ b/test/registered/moe/test_zero_experts.py
@@ -1,0 +1,66 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.moe.ep_moe.kernels import zero_experts_compute_triton
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestZeroExpertsComputeTriton(CustomTestCase):
+    def test_zero_expert_routes_keep_valid_ids(self):
+        num_experts = 4
+        hidden_states = torch.arange(
+            2 * 512, dtype=torch.float32, device="cuda"
+        ).reshape(2, 512)
+        expert_indices = torch.tensor(
+            [[0, 4, 1], [5, 2, 6]], dtype=torch.int64, device="cuda"
+        )
+        expert_scales = torch.tensor(
+            [[0.1, 0.3, 0.2], [0.4, 0.5, 0.6]],
+            dtype=torch.float32,
+            device="cuda",
+        )
+        original_indices = expert_indices.clone()
+        original_scales = expert_scales.clone()
+
+        output = zero_experts_compute_triton(
+            expert_indices=expert_indices,
+            expert_scales=expert_scales,
+            num_experts=num_experts,
+            zero_expert_type="identity",
+            hidden_states=hidden_states,
+        )
+        torch.cuda.synchronize()
+
+        zero_expert_mask = original_indices >= num_experts
+        normal_expert_mask = ~zero_expert_mask
+        self.assertTrue(torch.all(expert_indices >= 0).item())
+        torch.testing.assert_close(
+            expert_indices[normal_expert_mask],
+            original_indices[normal_expert_mask],
+        )
+        torch.testing.assert_close(
+            expert_indices[zero_expert_mask],
+            torch.zeros_like(expert_indices[zero_expert_mask]),
+        )
+        torch.testing.assert_close(
+            expert_scales[normal_expert_mask],
+            original_scales[normal_expert_mask],
+        )
+        torch.testing.assert_close(
+            expert_scales[zero_expert_mask],
+            torch.zeros_like(expert_scales[zero_expert_mask]),
+        )
+
+        expected_scale = (
+            original_scales * zero_expert_mask.to(original_scales.dtype)
+        ).sum(dim=-1, keepdim=True)
+        torch.testing.assert_close(output, hidden_states * expected_scale)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Keep zero-expert routed ids valid before entering the routed MoE backend.
- Use expert id `0` with zero scale instead of `-1` for zero-expert selections.
- Add a CUDA unit test for the zero-expert preprocessing mutation and identity output.

## Why

LongCat-Flash zero experts are represented as top-k ids `>= num_experts`. The previous preprocessing converted those ids to `-1` and zeroed their scales before calling the routed MoE backend. Some MoE kernels still treat the ids as gather/sort inputs and do not handle negative ids reliably, which can surface as CUDA illegal memory access under concurrent serving.

Using a valid expert id with zero scale is mathematically equivalent for the routed-expert contribution and avoids passing negative ids to those kernels.

## Validation

- H200: `python3 -m black --check python/sglang/srt/layers/moe/ep_moe/kernels.py test/registered/moe/test_zero_experts.py`
- H200: `PYTHONPATH=/data/repos/sglang-zero-expert-fix/python pytest -q test/registered/moe/test_zero_experts.py`: `1 passed`
- H200 CI-style entry: `PYTHONPATH=/data/repos/sglang-zero-expert-fix/python python3 test/registered/moe/test_zero_experts.py`: `OK`
- Investigation note: disabling CUDA graph did not avoid the LongCat-Flash-Lite FP8 serving crash; after this id remap, TP8 serving with CUDA graph enabled completed GSM8K without CUDA illegal memory access.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28860955308](https://github.com/sgl-project/sglang/actions/runs/28860955308)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28862814898](https://github.com/sgl-project/sglang/actions/runs/28862814898)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->