### PR TITLE
[BugFix] Reject return_logprob on the MLX backend instead of crashing the scheduler

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -133,6 +133,7 @@ from sglang.srt.utils.hf_transformers_utils import (
 )
 from sglang.srt.utils.network import get_zmq_socket
 from sglang.srt.utils.request_logger import RequestLogger
+from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.srt.utils.watchdog import Watchdog
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
@@ -1026,6 +1027,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 raise ValueError(
                     "The server is not configured to enable custom logit processor. "
                     "Please set `--enable-custom-logit-processor` to enable this feature."
+                )
+
+            # The MLX backend does not compute logprobs; the runner returns a
+            # LogitsProcessorOutput with no logprob tensors, so the shared result
+            # processor would dereference None and crash the scheduler process.
+            # Reject the request cleanly instead of taking down the server.
+            if obj.return_logprob and use_mlx():
+                raise ValueError(
+                    "return_logprob (including OpenAI `logprobs` / `top_logprobs`) "
+                    "is not supported on the MLX backend. Retry without logprobs, "
+                    "or run the server without SGLANG_USE_MLX=1."
                 )
 
     def _validate_mm_limits(

--- a/test/registered/unit/managers/test_mlx_logprob_guard.py
+++ b/test/registered/unit/managers/test_mlx_logprob_guard.py
@@ -17,6 +17,7 @@ from unittest import mock
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -47,7 +48,7 @@ def _patch_use_mlx(value):
     )
 
 
-class TestMlxLogprobGuard(unittest.TestCase):
+class TestMlxLogprobGuard(CustomTestCase):
     def test_return_logprob_rejected_under_mlx(self):
         """THE REGRESSION: logprobs + MLX -> clean ValueError, not a crash."""
         tm, obj = _make_tm(), _make_req(return_logprob=True)

--- a/test/registered/unit/managers/test_mlx_logprob_guard.py
+++ b/test/registered/unit/managers/test_mlx_logprob_guard.py
@@ -1,0 +1,73 @@
+"""Regression: a return_logprob request on the MLX backend must be rejected
+with a clean per-request error, not crash the scheduler.
+
+The MLX runner returns a LogitsProcessorOutput with no logprob tensors, so the
+shared result processor dereferences None
+(`logits_output.next_token_logprobs.tolist()`) and takes down the whole
+scheduler process. `TokenizerManager._validate_one_request` now fails fast when
+`use_mlx()` and the request asks for logprobs.
+
+`use_mlx` is patched, so this is a pure-CPU test and runs on any platform.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_tm():
+    """A TokenizerManager stub carrying only what _validate_one_request reads."""
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.context_len = 100_000
+    tm.num_reserved_tokens = 0
+    tm.validate_total_tokens = False
+    tm.server_args = SimpleNamespace(
+        allow_auto_truncate=False,
+        enable_return_hidden_states=False,
+        enable_custom_logit_processor=False,
+    )
+    return tm
+
+
+def _make_req(return_logprob):
+    obj = GenerateReqInput(text="hi", return_logprob=return_logprob)
+    obj.sampling_params = {}  # normalized shape _validate_one_request expects
+    return obj
+
+
+def _patch_use_mlx(value):
+    return mock.patch(
+        "sglang.srt.managers.tokenizer_manager.use_mlx", return_value=value
+    )
+
+
+class TestMlxLogprobGuard(unittest.TestCase):
+    def test_return_logprob_rejected_under_mlx(self):
+        """THE REGRESSION: logprobs + MLX -> clean ValueError, not a crash."""
+        tm, obj = _make_tm(), _make_req(return_logprob=True)
+        with _patch_use_mlx(True):
+            with self.assertRaises(ValueError) as ctx:
+                tm._validate_one_request(obj, [1, 2, 3])
+        self.assertIn("MLX", str(ctx.exception))
+
+    def test_return_logprob_allowed_when_not_mlx(self):
+        """Non-MLX backends still accept logprobs (guard must not over-reject)."""
+        tm, obj = _make_tm(), _make_req(return_logprob=True)
+        with _patch_use_mlx(False):
+            tm._validate_one_request(obj, [1, 2, 3])  # must not raise
+
+    def test_no_logprob_allowed_under_mlx(self):
+        """A normal (no-logprob) request on MLX is unaffected."""
+        tm, obj = _make_tm(), _make_req(return_logprob=False)
+        with _patch_use_mlx(True):
+            tm._validate_one_request(obj, [1, 2, 3])  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On an `SGLANG_USE_MLX=1` server, any request with `return_logprob` — native, or an OpenAI request with `logprobs` / `top_logprobs` — **crashes the entire scheduler process**, not just the offending request.

The MLX runner returns a `LogitsProcessorOutput` with no logprob tensors (`next_token_logprobs` defaults to `None`), and the shared result processor dereferences it. Reproduced live on an MLX server (`mlx-community/Qwen2.5-0.5B-Instruct-4bit`) with `return_logprob=True`:

```
Scheduler hit an exception: Traceback (most recent call last):
  ...
  File ".../scheduler_components/batch_result_processor.py", line 649, in process_batch_result_decode
    next_token_ids, next_token_logprobs = self._normalize_decode_outputs(
  File ".../scheduler_components/batch_result_processor.py", line 756, in _normalize_decode_outputs
    next_token_logprobs = logits_output.next_token_logprobs.tolist()
AttributeError: 'NoneType' object has no attribute 'tolist'
```

Because it fires inside the scheduler loop, it takes the whole server down.

## Modifications

The MLX backend does not compute logprobs yet, so **fail fast**: `TokenizerManager._validate_one_request` now raises a clear `ValueError` when `use_mlx()` and the request sets `return_logprob`. This turns a fatal server crash into a clean per-request error, and it covers both the native and OpenAI paths (they share this validation).

Actually computing logprobs in the MLX runner (`mx.log_softmax` on the last-position logits, next to the existing `mx.argmax`, plumbed into `LogitsProcessorOutput`) is a larger feature and is left as a follow-up — this PR is scoped to stopping the crash.

## Accuracy Tests

Validated end-to-end on a live MLX server — the logprob request is now rejected cleanly and the server survives to serve the next request:

```
LOGPROB_REQUEST_REJECTED: ValueError :: return_logprob ... is not supported on the MLX backend...
NORMAL_REQUEST_OK: ' Paris. It is the'
```

Added `test/registered/unit/managers/test_mlx_logprob_guard.py`. It patches `use_mlx`, so it is pure-CPU and runs on any CI lane:

- `return_logprob` + MLX → rejected with a clear error
- `return_logprob` on a non-MLX backend → allowed (guard does not over-reject)
- no-logprob request on MLX → allowed

Verified the rejection test fails when the guard is removed while the two "allowed" tests still pass.

## Speed Tests and Profiling

No performance impact: a single cached (`@lru_cache`) `use_mlx()` check in request validation, off the generation hot path.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation — N/A.
- [x] Behavior validated (live MLX repro before/after + regression tests). GSM8K / speed benchmarks are not applicable to a request-validation guard.
- [x] Follow the SGLang code style guidance.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29152708177](https://github.com/sgl-project/sglang/actions/runs/29152708177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29152708130](https://github.com/sgl-project/sglang/actions/runs/29152708130)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->