### PR TITLE
feat(hicache): expose host cache capacity

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -599,8 +599,9 @@ class DataParallelController:
         for i in range(len(scheduler_pipe_readers)):
             scheduler_info.append(scheduler_pipe_readers[i].recv())
 
-        self.max_total_num_tokens = scheduler_info[0]["max_total_num_tokens"]
-        self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
+        self.scheduler_info = scheduler_info[0]
+        self.max_total_num_tokens = self.scheduler_info["max_total_num_tokens"]
+        self.max_req_input_len = self.scheduler_info["max_req_input_len"]
 
     def maybe_external_dp_rank_routing(self, req: Req):
         if req.routed_dp_rank is not None:
@@ -695,12 +696,7 @@ def run_data_parallel_controller_process(
             proc.pid for proc in controller.scheduler_procs if proc is not None
         ]
         pipe_writer.send(
-            {
-                "status": "ready",
-                "max_total_num_tokens": controller.max_total_num_tokens,
-                "max_req_input_len": controller.max_req_input_len,
-                SCHEDULER_PIDS_ARG: scheduler_pids,
-            }
+            {**controller.scheduler_info, SCHEDULER_PIDS_ARG: scheduler_pids}
         )
         if server_args.node_rank == 0:
             controller.event_loop()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1483,6 +1483,12 @@ class Scheduler(
             "max_total_num_tokens": self.max_total_num_tokens,
             "max_req_input_len": self.max_req_input_len,
         }
+        if self.enable_hierarchical_cache:
+            host_pool = getattr(
+                self.tree_cache, "token_to_kv_pool_host", None
+            ) or getattr(self.tree_cache, "full_kv_pool_host", None)
+            if host_pool is not None:
+                result_dict["hicache_host_total_tokens"] = host_pool.size
 
         return result_dict
 

--- a/python/sglang/srt/ray/data_parallel_controller.py
+++ b/python/sglang/srt/ray/data_parallel_controller.py
@@ -268,8 +268,9 @@ class RayDataParallelController(DataParallelController):
 
         # Store init info from the first actor (same across all actors)
         if scheduler_infos:
-            self.max_total_num_tokens = scheduler_infos[0]["max_total_num_tokens"]
-            self.max_req_input_len = scheduler_infos[0]["max_req_input_len"]
+            self.scheduler_info = scheduler_infos[0]
+            self.max_total_num_tokens = self.scheduler_info["max_total_num_tokens"]
+            self.max_req_input_len = self.scheduler_info["max_req_input_len"]
 
         # Start event loops (non-blocking — runs until actor is killed)
         self.event_loop_refs.extend(

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -478,12 +478,7 @@ class RayEngine(Engine):
         )
         dp_thread.start()
 
-        scheduler_infos = [
-            {
-                "max_total_num_tokens": controller.max_total_num_tokens,
-                "max_req_input_len": controller.max_req_input_len,
-            }
-        ]
+        scheduler_infos = [controller.scheduler_info]
 
         event_loop_refs = controller.event_loop_refs
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
SGLang now includes the realized HiCache host token capacity in scheduler initialization metadata when hierarchical caching is enabled. The complete scheduler payload is preserved through standard and Ray data-parallel controllers, so integrations receive the field in every launch topology.

### How This Was Implemented
- Reads the initialized host pool from the scheduler and publishes its page-aligned token capacity as `hicache_host_total_tokens`.
- Supports standard, unified, and hybrid cache layouts through their existing host-pool attributes.
- Forwards the first scheduler's full initialization payload through standard DP and Ray DP instead of rebuilding a two-field subset.
- Leaves the field absent when HiCache or a host pool is unavailable.

<details>
<summary>Walkthrough</summary>

#### Mental model

The scheduler owns the authoritative allocated host pool. Its initialization handshake now carries that raw pool capacity through every engine/controller path without interpreting cache policy.

```mermaid
flowchart LR
    H["Allocated HiCache host pool"] --> S["Scheduler.get_init_info"]
    S --> D["Direct engine"]
    S --> P["Standard or Ray DP controller"]
    P --> E["Engine scheduler_infos"]
    D --> E
    E --> I["In-process integrations"]
```

#### Boundaries and limitations

`hicache_host_total_tokens` is raw physical host-pool capacity. It does not combine device and host tiers, interpret write-back/write-through overlap, include L3 storage, or track runtime policy changes; consumers apply their own semantics.

</details>

### Validation
- `pre-commit run --files python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/data_parallel_controller.py python/sglang/srt/ray/data_parallel_controller.py python/sglang/srt/ray/engine.py` — passed.
- `python -m py_compile` on the four changed Python modules — passed.
<!-- codex-pr-description:end -->











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28864471424](https://github.com/sgl-project/sglang/actions/runs/28864471424)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28864471183](https://github.com/sgl-project/sglang/actions/runs/28864471183)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
