### PR TITLE
[Cherry pick to release/v0.5.15] Fix NVFP4 online quantization

### DIFF
--- a/python/sglang/srt/layers/quantization/nvfp4_online.py
+++ b/python/sglang/srt/layers/quantization/nvfp4_online.py
@@ -85,6 +85,7 @@ class NvFp4OnlineConfig(ModelOptQuantConfig):
         self.use_per_token_activation = True
         self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
         self.is_fp4_experts = False
+        self.dequant_fp4_to_fp8 = False
         self.activation_scheme = activation_scheme
         self.weight_block_size = weight_block_size
         self.use_mxfp8 = use_mxfp8


### PR DESCRIPTION
`test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py`
`AttributeError: 'NvFp4OnlineConfig' object has no attribute 'dequant_fp4_to_fp8'`

It's broken by https://github.com/sgl-project/sglang/pull/27867















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28869009529](https://github.com/sgl-project/sglang/actions/runs/28869009529)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28869008915](https://github.com/sgl-project/sglang/actions/runs/28869008915)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->