### PR TITLE
[Perf] Do not specialize l2norm_fwd_kernel on the token count

### DIFF
--- a/python/sglang/srt/layers/attention/fla/l2norm.py
+++ b/python/sglang/srt/layers/attention/fla/l2norm.py
@@ -56,8 +56,11 @@ def l2norm_fwd_kernel(
     x,
     y,
     eps,
-    NB: tl.constexpr,
-    T: tl.constexpr,
+    # T is the number of tokens in the batch: it changes almost every forward
+    # pass, so it must stay a runtime argument. Marking it tl.constexpr made
+    # Triton specialize (fully recompile, tens of ms on the forward path) for
+    # every new token count.
+    T,
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
@@ -91,7 +94,6 @@ def l2norm_fwd(
         raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
 
     if D <= 512:
-        NB = triton.cdiv(T, 2048)
 
         def grid(meta):
             return (triton.cdiv(T, meta["BT"]),)
@@ -100,7 +102,6 @@ def l2norm_fwd(
             x,
             y,
             eps,
-            NB=NB,
             T=T,
             D=D,
             BD=BD,


### PR DESCRIPTION
## Motivation

`l2norm_fwd_kernel` (used by the GDN / linear-attention path, e.g. Qwen3-Next) declares `T` — the total number of tokens in the batch — as `tl.constexpr`:

```python
def l2norm_fwd_kernel(
    x, y, eps,
    NB: tl.constexpr,
    T: tl.constexpr,   # <- number of tokens
    ...
```

Under chunked prefill / mixed batches, `T` changes almost every forward pass (it is `num_prefill_tokens + num_decode_tokens` of the step). Every new value of `T` makes Triton specialize and **fully recompile** the kernel, which:

- burns scheduler-process CPU continuously: while profiling a Qwen3.5-MoE-style GDN model under a steady mixed prefill+decode load, py-spy showed **~4.4% of wall time inside Triton compilation** (48 compile bursts scattered across a 30s steady-state window, the longest ~110 ms), and the Triton cache kept growing with new `l2norm_fwd_kernel` entries (69 of the latest 70 cache dirs) long after warmup;
- injects tens-of-ms latency spikes directly on the forward path (the compile happens inline on the first step that sees a new `T`), i.e. p99/max ITL spikes that are otherwise hard to attribute;
- only hits the non-CUDA-graph path (prefill / mixed steps), since graph replay freezes `T` — which is exactly where latency is most fragile.

`NB = cdiv(T, 2048)` is also passed as `tl.constexpr` but is **never used in the kernel body**, so it only multiplies the number of specializations.

## Modifications

- Make `T` a runtime argument. It is only used as a `tl.make_block_ptr` shape bound, which does not need to be compile-time constant.
- Drop the dead `NB` argument.

The specialization key now only contains `D` / `BT` / `BD` (fixed per model), so the kernel compiles O(1) times per process instead of once per distinct token count.

## Verification

Script: sweep `T` over all values in `[1000, 1200)` plus equivalence checks (`torch.equal`) against the previous kernel for `T ∈ {1, 15, 16, 17, 63, 255, 1024, 4111, 8192} × D ∈ {64, 128, 512} × {fp32, bf16}` and a 3D-shaped input.

| | before | after |
|---|---|---|
| Triton cache entries after 200 distinct `T` values (fresh `TRITON_CACHE_DIR`) | **202** | **4** |
| Output vs previous kernel | — | bit-exact (`torch.equal`) in all combos |
| GPU kernel time (T=4096, D=128, bf16, torch.profiler, 300 calls) | 1.77 us/call | 1.78 us/call (unchanged, as expected: `T` is only a `boundary_check` bound, which is evaluated per block at runtime anyway) |
| CPU dispatch cost per call (launch-bound loop, no sync) | 26.0 us/call | 24.8 us/call (one less Python `cdiv` + two fewer constexpr args in the specialization key) |

## Checklist

- [x] Format your code with pre-commit
- [x] Provide accuracy results (bit-exact vs current kernel)
- [x] Provide benchmark results







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28873674243](https://github.com/sgl-project/sglang/actions/runs/28873674243)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28873673854](https://github.com/sgl-project/sglang/actions/runs/28873673854)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->