### PR TITLE
[perf] Vectorize text-only extend mrope position computation

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1101,17 +1101,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 )
                 if mm_input is None or rl_on_policy_target is not None:
                     # text only
-                    mrope_positions = torch.tensor(
-                        [
-                            [
-                                pos
-                                for pos in range(
-                                    extend_prefix_len,
-                                    extend_prefix_len + extend_seq_len,
-                                )
-                            ]
-                        ]
-                        * 3
+                    mrope_positions = (
+                        torch.arange(
+                            extend_prefix_len,
+                            extend_prefix_len + extend_seq_len,
+                            dtype=torch.int64,
+                        )
+                        .unsqueeze(0)
+                        .expand(3, -1)
                     )
                 else:
                     mrope_positions = mm_input.mrope_positions[

--- a/test/registered/unit/model_executor/test_mrope_textonly_extend.py
+++ b/test/registered/unit/model_executor/test_mrope_textonly_extend.py
@@ -1,0 +1,111 @@
+"""Unit tests for the vectorized text-only extend branch of
+``ForwardBatch._compute_mrope_positions``.
+
+The text-only extend branch used to build mrope positions with a Python list
+comprehension over every extend token (``torch.tensor([[pos for pos in
+range(...)]] * 3)``), which costs ~1.4 ms per 4k-token chunk on the scheduler
+hot path. It is now a ``torch.arange(...).unsqueeze(0).expand(3, -1)``. These
+tests pin the contract: identical values/shape, int64 dtype, and unchanged
+behavior when text-only and multimodal requests share a batch.
+
+Usage:
+    python -m pytest test/registered/unit/model_executor/test_mrope_textonly_extend.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+
+def _make_mm_input(prompt_len: int) -> SimpleNamespace:
+    """Minimal stand-in for MultimodalInputs as read by mrope computation."""
+    return SimpleNamespace(
+        mrope_positions=torch.arange(prompt_len, dtype=torch.int64)
+        .unsqueeze(0)
+        .repeat(3, 1),
+        mrope_position_delta=torch.tensor([[0]], dtype=torch.int64),
+        mrope_position_delta_repeated_cache=None,
+    )
+
+
+def _fb(forward_mode: ForwardMode, seq_lens_cpu: torch.Tensor) -> ForwardBatch:
+    fb = ForwardBatch.__new__(ForwardBatch)
+    fb.forward_mode = forward_mode
+    fb.seq_lens_cpu = seq_lens_cpu
+    return fb
+
+
+class TestTextOnlyExtendMropePositions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+        cls.model_runner = SimpleNamespace(device="cpu")
+
+    def test_text_only_extend_matches_enumeration(self):
+        """One column per extend token: prefix, prefix+1, ..., on all 3 axes."""
+        extend_len, prefix_len = 4096, 128
+        batch = SimpleNamespace(
+            multimodal_inputs=[None],
+            extend_lens=[extend_len],
+            prefix_lens=[prefix_len],
+        )
+        fb = _fb(ForwardMode.EXTEND, torch.tensor([prefix_len + extend_len]))
+
+        fb._compute_mrope_positions(self.model_runner, batch)
+
+        self.assertEqual(fb.mrope_positions.shape, (3, extend_len))
+        self.assertEqual(fb.mrope_positions.dtype, torch.int64)
+        expected = torch.arange(prefix_len, prefix_len + extend_len)
+        for axis in range(3):
+            self.assertTrue(torch.equal(fb.mrope_positions[axis], expected))
+
+    def test_mixed_text_and_mm_batch_concatenates(self):
+        """Text-only and multimodal requests in one extend batch: widths add up
+        and each request keeps its own positions."""
+        text_extend, mm_prompt = 7, 5
+        batch = SimpleNamespace(
+            multimodal_inputs=[None, _make_mm_input(mm_prompt)],
+            extend_lens=[text_extend, mm_prompt],
+            prefix_lens=[0, 0],
+        )
+        fb = _fb(ForwardMode.EXTEND, torch.tensor([text_extend, mm_prompt]))
+
+        fb._compute_mrope_positions(self.model_runner, batch)
+
+        self.assertEqual(fb.mrope_positions.shape, (3, text_extend + mm_prompt))
+        self.assertTrue(
+            torch.equal(fb.mrope_positions[0, :text_extend], torch.arange(text_extend))
+        )
+        self.assertTrue(
+            torch.equal(
+                fb.mrope_positions[:, text_extend:],
+                _make_mm_input(mm_prompt).mrope_positions,
+            )
+        )
+
+    def test_text_only_decode_single_column(self):
+        """Decode path is untouched: one column with seq_len - 1."""
+        seq_len = 25
+        batch = SimpleNamespace(
+            multimodal_inputs=[None],
+            extend_lens=None,
+            prefix_lens=None,
+        )
+        fb = _fb(ForwardMode.DECODE, torch.tensor([seq_len]))
+
+        fb._compute_mrope_positions(self.model_runner, batch)
+
+        self.assertEqual(fb.mrope_positions.shape, (3, 1))
+        self.assertEqual(fb.mrope_positions[0, 0].item(), seq_len - 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`ForwardBatch._compute_mrope_positions` builds the text-only extend branch with a Python list comprehension over every extend token:

```python
mrope_positions = torch.tensor(
    [[pos for pos in range(extend_prefix_len, extend_prefix_len + extend_seq_len)]] * 3
)
```

This sits on the scheduler hot path for every extend/chunked-prefill step of mrope models (Qwen2/2.5/3-VL, Qwen3.5) and costs ~1.4 ms per 4096-token chunk (~2.9 ms at 8192) of pure Python looping per step. We hit it while profiling mixed-chunk serving of Qwen3.5-397B on 8xH800: py-spy showed `_compute_mrope_positions` at ~1.1% of scheduler wall time under a 4k-chunk + 63-decode mixed load.

## Modifications

Replace the per-token list comprehension with a vectorized equivalent:

```python
mrope_positions = (
    torch.arange(extend_prefix_len, extend_prefix_len + extend_seq_len, dtype=torch.int64)
    .unsqueeze(0)
    .expand(3, -1)
)
```

Values, shape `[3, extend_seq_len]`, and int64 dtype are identical; the downstream `torch.cat(...).to(...)` consumes the expanded view unchanged (`cat` materializes it, so no stride-0 view escapes the function). Added a CPU unit test pinning the contract (text-only extend enumeration, mixed text+mm batch concatenation, decode path untouched).

## Accuracy Tests

**Unit test**: `python -m pytest test/registered/unit/model_executor/test_mrope_textonly_extend.py -v` — 3 passed.

**Differential test against the original implementation**: the old method is extracted verbatim from `origin/main` via AST (not a re-typed copy) and both versions are executed end-to-end through `_compute_mrope_positions` — including the downstream `torch.cat(...).to(...)` — on identical inputs. **All 422 cases are bit-exact** (values, shape, dtype=int64):

- exhaustive small grid: prefix 0–8 × extend-len 1–8 (72 cases)
- random large shapes: prefix up to 200k, extend up to 8192, batch size 1–5 (200 cases)
- mixed text-only + multimodal requests in one extend batch (100 cases)
- decode batches, untouched-path sanity (50 cases)

Reproduction script attached in the PR comment below.

**Edge case `extend_seq_len == 0`** (the only input where the two implementations differ):

- Structurally unreachable: `Req._compute_max_prefix_len` caps prefix matching at `input_len - 1` ("the matched length is at most 1 less than the input length to enable logprob computation"), so every request entering an extend batch carries ≥ 1 token.
- If constructed artificially anyway: a single-request batch yields the identical `(3, 0)` int64 result after the downstream cat+to. In a mixed batch, the **old** code's empty tensor is float32 (dtype inferred from the empty Python list) and silently promotes the whole concatenated batch to float32 before the final `.to(torch.int64)`; values survive today only because positions stay < 2^24. The new code stays int64 throughout and removes that hazard.

## Speed Tests and Profiling

Micro-benchmark (CPU, best of 5 runs x 100 iters/call):

| extend_seq_len | old (us/call) | new (us/call) | speedup |
|---:|---:|---:|---:|
| 1024 | 363 | 6.4 | 57x |
| 4096 | 1429 | 7.5 | 190x |
| 8192 | 2855 | 9.1 | 314x |

For a 4096-token chunked prefill step this removes ~1.4 ms of scheduler CPU per step per text-only request being extended.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29091221340](https://github.com/sgl-project/sglang/actions/runs/29091221340)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29091221121](https://github.com/sgl-project/sglang/actions/runs/29091221121)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->