### PR TITLE
fix(metrics): label PD tokenizer metrics with real engine_type instead of "unified" (#30406)

### DIFF
--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -600,9 +600,7 @@ class TokenizerWorker(TokenizerManager):
         # correct role ("prefill" / "decode").
         if self.enable_metrics:
             self.metrics_collector.labels["engine_type"] = (
-                DisaggregationMode.to_engine_type(
-                    self.server_args.disaggregation_mode
-                )
+                DisaggregationMode.to_engine_type(self.server_args.disaggregation_mode)
             )
 
         # Register this worker with the router for pause/continue broadcasting

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -592,6 +592,19 @@ class TokenizerWorker(TokenizerManager):
             self.server_args.disaggregation_transfer_backend
         )
 
+        # The base __init__ built the tokenizer metric labels while
+        # disaggregation_mode was temporarily forced to "null" (to avoid
+        # re-starting the bootstrap server above), so engine_type was
+        # mislabeled as "unified". Now that the real mode is restored,
+        # re-derive engine_type so PD tokenizer metrics are labeled with the
+        # correct role ("prefill" / "decode").
+        if self.enable_metrics:
+            self.metrics_collector.labels["engine_type"] = (
+                DisaggregationMode.to_engine_type(
+                    self.server_args.disaggregation_mode
+                )
+            )
+
         # Register this worker with the router for pause/continue broadcasting
         reg = TokenizerWorkerRegistration(worker_ipc_name=self.tokenizer_ipc_name)
         self.send_to_scheduler.send_pyobj(reg)


### PR DESCRIPTION
## Motivation

Fixes #30406.

In multi-tokenizer PD mode (`--tokenizer-worker-num > 1` with `--disaggregation-mode prefill|decode`), tokenizer-side token metrics are mislabeled with `engine_type="unified"` on both prefill and decode pods, instead of the actual role:

```text
sglang:prompt_tokens_total{engine_type="unified",...}
sglang:generation_tokens_total{engine_type="unified",...}
```

## Root cause

`TokenizerWorker.__init__` (in `multi_tokenizer_mixin.py`) temporarily forces `server_args.disaggregation_mode = "null"` before calling `super().__init__()`, to avoid re-starting the bootstrap server (that is owned by `MultiTokenizerRouter`):

```python
disaggregation_mode = server_args.disaggregation_mode
server_args.disaggregation_mode = "null"
super().__init__(server_args, port_args)   # builds tokenizer metric labels here
...
self.server_args.disaggregation_mode = disaggregation_mode  # restored afterwards
```

The problem is that `TokenizerManager.init_metric_collector_watchdog()` runs *inside* that `super().__init__()`, and derives the `engine_type` label via `DisaggregationMode.to_engine_type(self.server_args.disaggregation_mode)`. Since the mode is temporarily `"null"`, `to_engine_type` returns `"unified"`, and that stale value is baked into the tokenizer metrics collector's label dict. The real mode is restored right *after* `super().__init__()`, but the metric labels are never refreshed.

(Scheduler metrics are unaffected because schedulers see the real `disaggregation_mode` — consistent with the issue report.)

## Fix

Re-derive the `engine_type` label right after the real `disaggregation_mode` is restored in `TokenizerWorker.__init__`. Metric label *values* are read from `self.metrics_collector.labels` at emit time, and `engine_type` is already one of the label *keys*, so updating the value in place is sufficient and does not change label cardinality:

```python
if self.enable_metrics:
    self.metrics_collector.labels["engine_type"] = (
        DisaggregationMode.to_engine_type(
            self.server_args.disaggregation_mode
        )
    )
```

After this change, prefill pods emit `engine_type="prefill"` and decode pods emit `engine_type="decode"` for `sglang:prompt_tokens_total` / `sglang:generation_tokens_total`, matching the scheduler metrics and the expected behavior in the issue.

## Test Plan

- Launch with `--enable-metrics --tokenizer-worker-num 8 --disaggregation-mode decode` and scrape `/metrics`; `sglang:prompt_tokens_total` / `sglang:generation_tokens_total` now report `engine_type="decode"` (and `="prefill"` on prefill pods) instead of `"unified"`.
- Non-disaggregated (`--disaggregation-mode null`) runs are unchanged: `to_engine_type("null")` still yields `"unified"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28902642340](https://github.com/sgl-project/sglang/actions/runs/28902642340)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28902642109](https://github.com/sgl-project/sglang/actions/runs/28902642109)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->