### PR TITLE
feat: add opt-in prefill timers and multimodal embedding-cache hit co…

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -791,6 +791,12 @@ class Envs:
     # Metrics
     SGLANG_ENABLE_METRICS_DEVICE_TIMER = EnvBool(False)
     SGLANG_ENABLE_METRICS_DP_ATTENTION = EnvBool(False)
+    # Opt-in prefill diagnostics: log GPU-synced wall time per prefill forward /
+    # per attention-metadata plan. The sync perturbs pipelining; leave off for
+    # headline latency runs. (Unlike SGLANG_ENABLE_METRICS_DEVICE_TIMER, these
+    # cover attention planning and log per event rather than via a reporter.)
+    SGLANG_PREFILL_FORWARD_TIMER = EnvBool(False)
+    SGLANG_ATTN_PLAN_TIMER = EnvBool(False)
 
     # Tokenizer (Kimi tiktoken: cache all_special_tokens / all_special_ids; the ITL can differ by +10x under high batch size).
     SGLANG_PATCH_TOKENIZER = EnvBool(True)

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -7,6 +7,7 @@ import hashlib
 import pickle
 from abc import abstractmethod
 from collections import defaultdict
+from dataclasses import dataclass
 from multiprocessing import shared_memory
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
@@ -358,6 +359,26 @@ class MultiModalityDataPaddingPatternMultimodalTokens(MultiModalityDataPaddingPa
 embedding_cache: Optional[MultiModalStaticCache] = None
 
 
+@dataclass
+class MMEmbeddingCacheStats:
+    """Running hit/miss counters for the multimodal (ViT) embedding cache.
+
+    Incremented on every per-item cache lookup during prefill; a hit means the
+    item's vision-encoder output was reused (ViT encode skipped). Server-level
+    counters (not per-request): read for logging/metrics, reset never.
+    """
+
+    hits: int = 0
+    misses: int = 0
+
+    def record(self, hits: int, misses: int) -> None:
+        self.hits += hits
+        self.misses += misses
+
+
+mm_cache_stats = MMEmbeddingCacheStats()
+
+
 def init_mm_embedding_cache(max_size: int = 0):
     global embedding_cache
     embedding_cache = MultiModalStaticCache(max_size)
@@ -594,6 +615,9 @@ def _get_chunked_embedding_by_item(
             cached_embeddings[idx] = cached.embedding
         else:
             miss_items.append((idx, item, start, end))
+    mm_cache_stats.record(
+        hits=len(overlapping) - len(miss_items), misses=len(miss_items)
+    )
 
     # 3. Batch encode all cache-miss items in one ViT call
     if miss_items:

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -16,6 +16,7 @@ from typing import (
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
+from sglang.srt.managers import mm_utils
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.observability.metrics_collector import (
@@ -548,6 +549,13 @@ class SchedulerMetricsReporter:
             f"#queue-req: {len(self.scheduler.waiting_queue)}, "
             f"#pending-token: {prefill_stats.num_pending_tokens}, "
         )
+
+        # Multimodal (ViT) embedding-cache cumulative hit/miss counters; only
+        # present once a multimodal item has been looked up (text-only workloads
+        # never see this segment).
+        mm_stats = mm_utils.mm_cache_stats
+        if mm_stats.hits or mm_stats.misses:
+            msg += f"mm-cache-hit: {mm_stats.hits}/{mm_stats.hits + mm_stats.misses}, "
 
         if self.scheduler.disaggregation_mode == DisaggregationMode.PREFILL:
             msg += f"#bootstrap-req: {len(self.scheduler.disagg_prefill_bootstrap_queue.queue)}, "

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Tuple, Union
 
@@ -266,6 +267,17 @@ class EagerRunner(BaseRunner):
         if not model_runner.server_args.enable_pdmux:
             forward_batch = self.load_batch(forward_batch, pp_proxy_tensors)
 
+        # SGLANG_PREFILL_FORWARD_TIMER: GPU-synced wall time of one prefill
+        # forward, covering attention-metadata planning + model.forward (for VLMs:
+        # ViT encode + LM prefill). Measures server-side prefill cost only — it
+        # excludes HTTP, base64 decode, and image preprocessing, which happen in
+        # the tokenizer process. Opt-in diagnostic: the sync perturbs pipelining,
+        # so leave off for headline latency runs.
+        prefill_timer_enabled = envs.SGLANG_PREFILL_FORWARD_TIMER.get()
+        if prefill_timer_enabled:
+            torch.cuda.synchronize()
+            prefill_timer_start = time.perf_counter()
+
         if forward_batch.needs_forward_metadata_init():
             if hasattr(model_runner.model, "prepare_context_parallel_metadata_for_dcp"):
                 # prepare kv cache buffer for dcp to gather kv cache
@@ -288,7 +300,21 @@ class EagerRunner(BaseRunner):
                 # Prepare model-specific attention metadata before planning,
                 # e.g. Moss-VL's prefill cross-attention custom mask.
                 model_runner.model.prepare_forward_batch(forward_batch)
+            # SGLANG_ATTN_PLAN_TIMER: GPU-synced wall time of attention-metadata
+            # planning for this prefill (whatever init_forward_metadata does for
+            # the active backend). Opt-in diagnostic.
+            plan_timer_enabled = envs.SGLANG_ATTN_PLAN_TIMER.get()
+            if plan_timer_enabled:
+                torch.cuda.synchronize()
+                plan_timer_start = time.perf_counter()
             model_runner.attn_backend.init_forward_metadata(forward_batch)
+            if plan_timer_enabled:
+                torch.cuda.synchronize()
+                logger.info(
+                    "[ATTN_PLAN] tokens=%d dt=%.1fms",
+                    forward_batch.input_ids.shape[0],
+                    (time.perf_counter() - plan_timer_start) * 1e3,
+                )
 
         cp_v2_active = is_cp_v2_active(forward_batch)
         forward_positions = forward_batch.positions
@@ -382,6 +408,13 @@ class EagerRunner(BaseRunner):
                     forward_batch,
                     **kwargs,
                 )
+        if prefill_timer_enabled:
+            torch.cuda.synchronize()
+            logger.info(
+                "[PREFILL_FORWARD] tokens=%d dt=%.1fms",
+                forward_batch.input_ids.shape[0],
+                (time.perf_counter() - prefill_timer_start) * 1e3,
+            )
         return ret
 
     def _execute_idle(


### PR DESCRIPTION
…unters

Three small serving-observability additions, all backend/model-agnostic:

- SGLANG_PREFILL_FORWARD_TIMER=1: GPU-synced wall time of each prefill forward (attention planning + model.forward; for VLMs this includes the vision encode). Measures the server-side prefill boundary, excluding HTTP/tokenizer-process preprocessing. Off by default; the sync perturbs pipelining, so it is a diagnostic, not an always-on metric.
- SGLANG_ATTN_PLAN_TIMER=1: GPU-synced wall time of attention-metadata planning (init_forward_metadata) per prefill. Off by default.
- mm_cache_stats: always-on hit/miss counters for the multimodal (ViT) embedding cache, incremented per item lookup during prefill; surfaced as 'mm-cache-hit: H/N' on the scheduler's standard prefill log line.

Both timers cost one env read per prefill when disabled.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28884665531](https://github.com/sgl-project/sglang/actions/runs/28884665531)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #28884665251](https://github.com/sgl-project/sglang/actions/runs/28884665251)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->