### PR TITLE
Enable RDNA3/4 (gfx1100/gfx1201) for ROCm kernels

### DIFF
--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -46,7 +46,11 @@ from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 from sglang.srt.layers.quantization.mxfp4 import Mxfp4Config
 from sglang.srt.layers.quantization.petit import PetitNvFp4Config
 from sglang.srt.layers.quantization.qoq import QoQConfig
-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
+
+try:
+    from sglang.srt.layers.quantization.quark.quark import QuarkConfig
+except Exception:
+    QuarkConfig = None
 from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
 from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
 from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -7,11 +7,12 @@ import torch
 
 from sglang.srt.layers.parameter import GroupQuantScaleParameter, PackedvLLMParameter
 from sglang.srt.layers.quantization.quark.schemes import QuarkLinearScheme
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import get_bool_env_var, is_hip
 from sglang.srt.utils.common import direct_register_custom_op, mxfp_supported
 
 _is_hip = is_hip()
-if _is_hip:
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+if _use_aiter:
     from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
         fused_gemm_afp4wfp4_split_cat as _fused_gemm_afp4wfp4_split_cat_orig,
     )

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -18,15 +18,16 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
-from sglang.srt.utils import BAR_FORMAT, is_hip, set_weight_attrs
+from sglang.srt.utils import BAR_FORMAT, get_bool_env_var, is_hip, set_weight_attrs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import DispatchOutput
 
 _is_hip = is_hip()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
-if _is_hip:
+if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
 
     ON_GFX950 = "gfx950" in torch.cuda.get_device_properties("cuda").gcnArchName

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -81,7 +81,7 @@ if amdgpu_target_env == default_target and torch.cuda.is_available():
         print(f"Using default target: {default_target}")
 
 # Validate all target architectures
-supported_archs = ["gfx942", "gfx950"]
+supported_archs = ["gfx942", "gfx950", "gfx1100", "gfx1201"]
 for arch in amdgpu_targets:
     if arch not in supported_archs:
         print(


### PR DESCRIPTION
Minimal enablement to build/run sgl-kernel and SGLang on RDNA3/4.

  - `sgl-kernel/setup_rocm.py`: add `gfx1100`, `gfx1201` to `supported_archs` (multi-arch 
  `;`-split machinery already present).
  - `quantization/__init__.py`: make `QuarkConfig` import non-fatal.
  - `quark_w4a4_mxfp4.py` / `quark_int4fp8_moe.py`: gate `aiter` imports behind `SGLANG_USE_AITER` 















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28885752021](https://github.com/sgl-project/sglang/actions/runs/28885752021)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28885751800](https://github.com/sgl-project/sglang/actions/runs/28885751800)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->