### PR TITLE
Kvtc RFC

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -208,6 +208,42 @@ class RotaryEmbedding(MultiPlatformOp):
         cos, sin = cos_sin.chunk(2, dim=-1)
         return cos, sin
 
+    def forward_native_keys_batch(
+        self,
+        positions: torch.Tensor,
+        key: torch.Tensor,
+    ):
+        positions = positions.flatten()
+        cos_sin = self.cos_sin_cache.index_select(0, positions)
+        cos, sin = cos_sin.chunk(2, dim=-1)
+
+        cos = cos[:, None, None, :].to(key.dtype)
+        sin = sin[:, None, None, :].to(key.dtype)
+        x1, x2 = torch.chunk(key, 2, dim=-1)
+
+        o1 = x1 * cos - x2 * sin
+        o2 = x2 * cos + x1 * sin
+
+        return torch.cat((o1, o2), dim=-1)
+
+    def invert_native_keys_batch(
+        self,
+        positions: torch.Tensor,
+        key: torch.Tensor,
+    ):
+        positions = positions.flatten()
+        cos_sin = self.cos_sin_cache.index_select(0, positions)
+        cos, sin = cos_sin.chunk(2, dim=-1)
+
+        cos = cos[:, None, None, :].to(key.dtype)
+        sin = -sin[:, None, None, :].to(key.dtype)
+        x1, x2 = torch.chunk(key, 2, dim=-1)
+
+        o1 = x1 * cos - x2 * sin
+        o2 = x2 * cos + x1 * sin
+
+        return torch.cat((o1, o2), dim=-1)
+
     def forward_native(
         self,
         positions: torch.Tensor,
@@ -233,14 +269,54 @@ class RotaryEmbedding(MultiPlatformOp):
             cos_sin = self.cos_sin_cache.index_select(0, positions)
         cos, sin = cos_sin.chunk(2, dim=-1)
 
-        query_shape = query.shape
-        query = query.view(num_tokens, -1, self.head_size)
-        query_rot = query[..., : self.rotary_dim]
-        query_pass = query[..., self.rotary_dim :]
-        query_rot = self._apply_rotary_emb_wrapped(
-            query_rot, cos, sin, self.is_neox_style
-        )
-        query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+        if query is not None:
+            query_shape = query.shape
+            query = query.view(num_tokens, -1, self.head_size)
+            query_rot = query[..., : self.rotary_dim]
+            query_pass = query[..., self.rotary_dim :]
+            query_rot = self._apply_rotary_emb_wrapped(
+                query_rot, cos, sin, self.is_neox_style
+            )
+            query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+        key_shape = key.shape
+        key = key.view(num_tokens, -1, self.head_size)
+        key_rot = key[..., : self.rotary_dim]
+        key_pass = key[..., self.rotary_dim :]
+        key_rot = self._apply_rotary_emb_wrapped(key_rot, cos, sin, self.is_neox_style)
+        key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+        return query, key
+
+    def invert_native(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        offsets: Optional[torch.Tensor] = None,
+        fused_set_kv_buffer_arg: Optional[FusedSetKVBufferArg] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """A PyTorch-native implementation of forward()."""
+        assert (
+            fused_set_kv_buffer_arg is None
+        ), "fused_set_kv_buffer_arg is not supported for native implementation"
+
+        if offsets is not None:
+            positions = positions + offsets
+        positions = positions.flatten()
+        num_tokens = positions.shape[0]
+        cos_sin = self.cos_sin_cache.index_select(0, positions)
+        cos, sin = cos_sin.chunk(2, dim=-1)
+        sin = -sin
+
+        if query is not None:
+            query_shape = query.shape
+            query = query.view(num_tokens, -1, self.head_size)
+            query_rot = query[..., : self.rotary_dim]
+            query_pass = query[..., self.rotary_dim :]
+            query_rot = self._apply_rotary_emb_wrapped(
+                query_rot, cos, sin, self.is_neox_style
+            )
+            query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
 
         key_shape = key.shape
         key = key.view(num_tokens, -1, self.head_size)

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
     from sglang.srt.mem_cache.memory_pool_host import HostKVCache
 
+from sglang.srt.mem_cache.memory_pool_host import KVTCHostMemoryRequest, NPUMHATokenToKVPoolHybrid
 from sglang.srt.distributed import (
     get_pipeline_model_parallel_rank,
     get_pipeline_model_parallel_world_size,
@@ -1248,3 +1249,390 @@ class HiCacheController:
 
             except Empty:
                 continue
+
+
+class KVTCCacheOperation:
+
+        counter = 0
+
+        def __init__(
+                self,
+                host_indices_compressed: torch.Tensor,
+                device_indices_compressed: torch.Tensor,
+                token_indices_compressed: torch.Tensor,
+                host_indices_sink: torch.Tensor,
+                device_indices_sink: torch.Tensor,
+                node_id: int,
+                priority: Optional[int] = None,
+                ):
+            self.host_indices_compressed = host_indices_compressed
+            self.device_indices_compressed = device_indices_compressed
+            self.token_indices_compressed = token_indices_compressed
+
+            self.host_indices_sink = host_indices_sink
+            self.device_indices_sink = device_indices_sink
+
+            self.node_ids = [node_id]
+            self.data = None
+
+            self.id = KVTCCacheOperation.counter
+            KVTCCacheOperation.counter += 1
+            #default priority is the order of creation
+            self.priority=priority if priority is not None else self.id
+
+        @staticmethod
+        def merge_ops(ops: List[KVTCCacheOperation]) -> KVTCCacheOperation:
+            assert len(ops) > 0
+            if len(ops) == 1:
+                if ops[0].node_ids[0] == -1:
+                    ops[0].node_ids = []
+                return ops[0]
+
+            host_indices_compressed = torch.cat([op.host_indices_compressed for op in ops])
+            device_indices_compressed = torch.cat([op.device_indices_compressed for op in ops])
+            token_indices_compressed = torch.cat([op.token_indices_compressed for op in ops])
+
+            host_indices_sink = torch.cat([op.host_indices_sink for op in ops])
+            device_indices_sink = torch.cat([op.device_indices_sink for op in ops])
+
+            node_ids = []
+            priority = min(op.priority for op in ops)
+            for op in ops:
+                node_ids.extend(op.node_ids)
+
+            merged_op = KVTCCacheOperation(
+                    host_indices_compressed,
+                    device_indices_compressed,
+                    token_indices_compressed,
+                    host_indices_sink,
+                    device_indices_sink,
+                    -1,
+                    priority,
+                    )
+            merged_op.node_ids = node_ids
+            return merged_op
+
+        def __lt__(self, other: KVTCCacheOperation):
+            return self.priority < other.priority
+
+
+class KVTCHiCacheController:
+
+    def __init__(
+        self,
+        token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+        mem_pool_host: NPUMHATokenToKVPoolHybrid,
+        page_size: int,
+        tp_group: torch.distributed.ProcessGroup,
+        load_cache_event: threading.Event,
+        write_policy: str = "write_through_selective",
+        io_backend: str = "",
+        storage_backend: Optional[str] = None,
+        prefetch_threshold: int = 256,
+        model_name: Optional[str] = None,
+        storage_backend_extra_config: Optional[dict] = None,
+        pp_rank: int = 0,
+        pp_size: int = 1,
+        enable_storage_metrics: bool = False,
+    ):
+        if storage_backend is not None:
+            raise ValueError("KVTC doesn't support storage tier")
+
+        self.tp_group = tp_group
+        self.mem_pool_device_allocator = token_to_kv_pool_allocator
+        mem_pool_device = token_to_kv_pool_allocator.get_kvcache()
+        from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+
+        if isinstance(mem_pool_device, HybridLinearKVPool):
+            mem_pool_device = mem_pool_device.full_kv_pool
+        self.mem_pool_device = mem_pool_device
+        assert isinstance(mem_pool_host, NPUMHATokenToKVPoolHybrid)
+        self.mem_pool_host = mem_pool_host
+        self.write_policy = write_policy
+        self.page_size = page_size
+        self.io_backend = io_backend
+        self.pp_rank = pp_rank
+        self.pp_size = pp_size
+
+        self.device = self.mem_pool_device.device
+        self.layer_num = self.mem_pool_device.layer_num
+        self.layer_done_counter = LayerDoneCounter(self.layer_num)
+        self.mem_pool_device.register_layer_transfer_counter(self.layer_done_counter)
+
+        if write_policy not in [
+            "write_through",
+            "write_through_selective",
+            "write_back",
+        ]:
+            raise ValueError(f"Invalid write policy: {write_policy}")
+
+        self.load_queue: List[KVTCCacheOperation] = []
+        self.write_queue: List[KVTCCacheOperation] = []
+        self.ack_load_queue: List[HiCacheAck] = []
+        self.ack_write_queue: List[HiCacheAck] = []
+
+        self.stop_event = threading.Event()
+        self.write_buffer = TransferBuffer(self.stop_event)
+        self.load_buffer = TransferBuffer(
+            self.stop_event, buffer_count=10,
+        )
+
+        self.write_stream = device_module.Stream()
+        self.load_stream = device_module.Stream()
+
+    def reset(self):
+        self.stop_event.set()
+
+        self.load_queue.clear()
+        self.write_queue.clear()
+        self.write_buffer.clear()
+        self.load_buffer.clear()
+        self.ack_write_queue.clear()
+        self.ack_load_queue.clear()
+
+        self.stop_event.clear()
+
+    def _sink_and_compressed_indices(
+            self,
+            memory_indices,
+            token_indices,
+            ):
+        sink_tokens = torch.arange(start=0, end=128, device=self.device)
+        sink_tokens_range = 0
+
+        if torch.all(token_indices[:128] == sink_tokens):
+            sink_tokens_range = 128
+
+        sink_memory_indices = memory_indices[:sink_tokens_range]
+        compressed_memory_indices = memory_indices[sink_tokens_range:]
+
+        sink_token_indices = token_indices[:sink_tokens_range]
+        compressed_token_indices = token_indices[sink_tokens_range:]
+
+        return sink_memory_indices, sink_token_indices, compressed_memory_indices, compressed_token_indices
+
+    def move_indices(self, host_indices: torch.Tensor, device_indices: torch.Tensor):
+        # move indices to GPU if using kernels, to host if using direct indexing
+        if self.io_backend == "kernel":
+            if not host_indices.is_cuda:
+                host_indices = host_indices.to(self.device, non_blocking=True)
+            return host_indices, device_indices
+        elif self.io_backend == "direct":
+            if self.mem_pool_host.layout == "layer_first":
+                device_indices = device_indices.cpu()
+                host_indices, idx = host_indices.sort()
+                return host_indices, device_indices.index_select(0, idx)
+            elif self.mem_pool_host.layout == "page_first_direct":
+                return host_indices, device_indices.cpu()
+            else:
+                raise ValueError(
+                    f"Unsupported layout {self.mem_pool_host.layout!r} for io backend 'direct'"
+                )
+        elif self.io_backend == "kernel_ascend":
+            return host_indices, device_indices.cpu()
+        else:
+            raise ValueError(f"Unsupported io backend")
+
+    def write(
+        self,
+        device_indices: torch.Tensor,
+        token_indices: torch.Tensor,
+        priority: Optional[int] = None,
+        node_id: int = -1,
+    ) -> Optional[torch.Tensor]:
+        """
+        Back up KV caches from device memory to host memory.
+        """
+
+        (
+            sink_device_indices,
+            sink_token_indices,
+            compressed_device_indices,
+            compressed_token_indices
+        ) = self._sink_and_compressed_indices(device_indices, token_indices)
+
+        sink_host_indices, compressed_host_indices = self.mem_pool_host.alloc(
+                sink_token_indices.numel(),
+                compressed_token_indices.numel(),
+        )
+        if sink_host_indices is None or compressed_host_indices is None:
+            # TODO rethink this assert
+            assert sink_host_indices is None and compressed_host_indices is None
+            return None
+
+
+        write_op = KVTCCacheOperation(
+                compressed_host_indices,
+                compressed_device_indices,
+                compressed_token_indices,
+                sink_host_indices,
+                sink_device_indices,
+                node_id,
+                )
+
+        self.write_queue.append(write_op)
+
+        self.start_writing()
+
+        host_indices = torch.cat((sink_host_indices, compressed_host_indices))
+
+        return host_indices
+
+    def start_writing(self) -> None:
+        if len(self.write_queue) == 0:
+            return
+
+        op = KVTCCacheOperation.merge_ops(self.write_queue)
+
+        host_indices_sink, device_indices_sink = self.move_indices(
+                op.host_indices_sink,
+                op.device_indices_sink
+                )
+        host_indices_compressed, device_indices_compressed = self.move_indices(
+                op.host_indices_compressed,
+                op.device_indices_compressed,
+                )
+        self.write_queue.clear()
+
+        start_event = device_module.Event()
+        finish_event = device_module.Event()
+
+        start_event.record()
+        with device_module.stream(self.write_stream):
+            start_event.wait(self.write_stream)
+
+            write_req = KVTCHostMemoryRequest(
+                self.mem_pool_device,
+                host_indices_compressed,
+                device_indices_compressed,
+                op.token_indices_compressed,
+                host_indices_sink,
+                device_indices_sink,
+                self.io_backend,
+                None,
+            )
+
+            self.mem_pool_host.backup_from_device_all_layer(write_req)
+            # TODO I don't think we need to call record_stream. Is there sth ascend specific for streams?
+            finish_event.record()
+            # NOTE: We must save the host indices and device indices here,
+            # this is because we need to guarantee that these tensors are
+            # still alive when the write stream is executing.
+            if host_indices_sink.is_cuda:
+                host_indices_sink.record_stream(self.write_stream)
+            if device_indices_sink.is_cuda:
+                device_indices_sink.record_stream(self.write_stream)
+            if host_indices_compressed.is_cuda:
+                host_indices_compressed.record_stream(self.write_stream)
+            if device_indices_compressed.is_cuda:
+                device_indices_compressed.record_stream(self.write_stream)
+
+        self.ack_write_queue.append(HiCacheAck(start_event, finish_event, op.node_ids))
+
+    def load(
+        self,
+        host_indices: torch.Tensor,
+        token_indices: torch.Tensor,
+        priority: Optional[int] = None,
+        node_id: int = -1,
+    ) -> Optional[torch.Tensor]:
+
+        device_indices = self.mem_pool_device_allocator.alloc(host_indices.numel())
+        if device_indices is None:
+            return None
+
+        (
+            sink_host_indices,
+            sink_token_indices,
+            compressed_host_indices,
+            compressed_token_indices
+        ) = self._sink_and_compressed_indices(host_indices, token_indices)
+
+        sink_device_indices = device_indices[:len(sink_token_indices)]
+        compressed_device_indices = device_indices[len(sink_token_indices):]
+
+        self.load_queue.append(
+            KVTCCacheOperation(
+                compressed_host_indices,
+                compressed_device_indices,
+                compressed_token_indices,
+                sink_host_indices,
+                sink_device_indices,
+                node_id,
+                None,
+            )
+        )
+
+        return device_indices
+
+    def start_loading(self) -> int:
+        if len(self.load_queue) == 0:
+            return -1
+
+        producer_id = self.layer_done_counter.update_producer()
+
+        op = KVTCCacheOperation.merge_ops(self.load_queue)
+
+        sink_host_indices, sink_device_indices = self.move_indices(op.host_indices_sink, op.device_indices_sink)
+        compressed_host_indices, compressed_device_indices = self.move_indices(op.host_indices_compressed, op.device_indices_compressed)
+
+        self.load_queue.clear()
+
+        producer_event = self.layer_done_counter.events[producer_id]
+        producer_event.start_event.record()
+
+        with device_module.stream(self.load_stream):
+            producer_event.start_event.wait(self.load_stream)
+            for i in range(self.layer_num):
+                load_req = KVTCHostMemoryRequest(
+                       self.mem_pool_device,
+                       compressed_host_indices,
+                       compressed_device_indices,
+                       op.token_indices_compressed,
+                       sink_host_indices,
+                       sink_device_indices,
+                       self.io_backend,
+                       i,
+                )
+
+                self.mem_pool_host.load_to_device_per_layer(load_req)
+
+                producer_event.complete(i)
+            # NOTE: We must save the host indices and device indices here,
+            # this is because we need to guarantee that these tensors are
+            # still alive when the load stream is executing.
+            if sink_host_indices.is_cuda:
+                sink_host_indices.record_stream(self.load_stream)
+            if sink_device_indices.is_cuda:
+                sink_device_indices.record_stream(self.load_stream)
+            if compressed_host_indices.is_cuda:
+                compressed_host_indices.record_stream(self.load_stream)
+            if compressed_device_indices.is_cuda:
+                compressed_device_indices.record_stream(self.load_stream)
+
+        self.ack_load_queue.append(
+            HiCacheAck(
+                start_event=producer_event.start_event,
+                finish_event=producer_event.finish_event,
+                node_ids=op.node_ids,
+            )
+        )
+        return producer_id
+
+    def evict_device(self, device_indices: torch.Tensor) -> int:
+        self.mem_pool_device_allocator.free(device_indices)
+        return len(device_indices)
+
+    def evict_host(self, host_indices: torch.Tensor, backup_only: bool = True) -> int:
+        if not backup_only:
+            raise ValueError("Other eviction policies are not supported yet.")
+
+        self.mem_pool_host.free(host_indices)
+        return len(host_indices)
+
+    def append_host_mem_release(self, host_indices: torch.Tensor):
+        if host_indices.numel() == 0:
+            return
+        pages = host_indices.split(self.mem_pool_host.page_size)
+        for page in pages:
+            self.host_mem_release_queue.put(page)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1219,7 +1219,7 @@ class Req(ReqDllmMixin):
 
     def _compute_max_prefix_len(self, input_len: int) -> int:
         # NOTE: the matched length is at most 1 less than the input length to enable logprob computation
-        max_prefix_len = input_len - 1
+        max_prefix_len = input_len - 1 - get_global_server_args().hicache_kvtc_sliding_window
         if self.return_logprob and self.logprob_start_len >= 0:
             max_prefix_len = min(max_prefix_len, self.logprob_start_len)
         return max(max_prefix_len, 0)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -14,6 +15,10 @@ from typing import (
 import torch
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.distributed import (
+    get_tensor_model_parallel_rank,
+    get_pipeline_model_parallel_rank,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.io_struct import AbortReq
@@ -810,6 +815,26 @@ class SchedulerBatchResultProcessor:
                 req.multimodal_inputs.release_features()
             self._maybe_collect_routed_experts(req)
             self._maybe_collect_indexer_topk(req)
+
+            if self.server_args.dump_kv_path:
+                req.offload_kv_cache(
+                    self.req_to_token_pool, self.token_to_kv_pool_allocator
+                )
+
+                pp_rank =  get_pipeline_model_parallel_rank()
+                tp_rank =  get_tensor_model_parallel_rank()
+                req_path = Path(f"{self.server_args.dump_kv_path}/tp_{tp_rank}_pp_{pp_rank}")
+                req_path.mkdir(parents=True, exist_ok=True)
+                for (lid, token_chunk) in enumerate(req.kv_cache_cpu):
+                    for (tid, (k_chunk, v_chunk)) in enumerate(token_chunk):
+                        torch.save(
+                            k_chunk,
+                            req_path / f"{req.rid}-K-chunk_{tid}-layer_{lid}.bin"
+                        )
+                        torch.save(
+                            v_chunk,
+                            req_path / f"{req.rid}-V-chunk_{tid}-layer_{lid}.bin"
+                        )
 
             if self.server_args.disaggregation_decode_enable_offload_kvcache:
                 # Asynchronously offload KV cache; release_kv_cache will be called after Device->Host transfer completes

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.unified_cache_components.tree_component import (
         TreeComponent,
     )
+    from sglang.srt.layers.rotary_embedding.base import RotaryEmbedding
 
 
 @dataclasses.dataclass
@@ -52,3 +53,5 @@ class CacheInitParams:
     component_registry_override: Optional[dict[ComponentType, type[TreeComponent]]] = (
         None
     )
+
+    rotary_embeddings: Optional[RotaryEmbedding] = None

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 import torch
 
 from sglang.srt.disaggregation.kv_events import StorageMedium
-from sglang.srt.managers.cache_controller import HiCacheController, PrefetchOperation
+from sglang.srt.managers.cache_controller import HiCacheController, KVTCHiCacheController, PrefetchOperation
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefParams,
     DecLockRefResult,
@@ -46,6 +46,7 @@ from sglang.srt.mem_cache.memory_pool import (
 from sglang.srt.mem_cache.memory_pool_host import (
     MLATokenToKVPoolHost,
     get_mha_host_pool_cls,
+    NPUMHATokenToKVPoolHybrid,
 )
 from sglang.srt.mem_cache.radix_cache import (
     RadixCache,
@@ -77,7 +78,24 @@ class HiRadixCache(RadixCache):
         self.page_size = params.page_size
         self.kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
 
-        if isinstance(self.kv_cache, MHATokenToKVPool):
+        if server_args.hicache_kvtc_params and isinstance(self.kv_cache, MHATokenToKVPool):
+            self.token_to_kv_pool_host = NPUMHATokenToKVPoolHybrid(
+                self.kv_cache,
+                server_args.hicache_ratio,
+                server_args.hicache_size,
+                self.page_size,
+                server_args.hicache_mem_layout,
+                server_args.hicache_kvtc_params,
+                server_args.hicache_kvtc_k_cr,
+                server_args.hicache_kvtc_v_cr,
+                rotary_emb=params.rotary_embeddings,
+                tp_rank=params.tp_cache_group.rank(),
+                tp_size=params.tp_cache_group.size(),
+                pp_rank=params.pp_rank,
+                pp_size=params.pp_size,
+                allocator_type=server_args.hicache_storage_backend,
+            )
+        elif isinstance(self.kv_cache, MHATokenToKVPool):
             self.token_to_kv_pool_host = get_mha_host_pool_cls(self.kv_cache)(
                 self.kv_cache,
                 server_args.hicache_ratio,
@@ -125,7 +143,24 @@ class HiRadixCache(RadixCache):
         self.prefetch_stop_policy = server_args.hicache_storage_prefetch_policy
 
         self.load_cache_event = threading.Event()
-        if isinstance(self.kv_cache, DSATokenToKVPool):
+        if isinstance(self.token_to_kv_pool_host, NPUMHATokenToKVPoolHybrid):
+            self.cache_controller = KVTCHiCacheController(
+                params.token_to_kv_pool_allocator,
+                self.token_to_kv_pool_host,
+                self.page_size,
+                self.tp_group,
+                load_cache_event=self.load_cache_event,
+                write_policy=server_args.hicache_write_policy,
+                io_backend=server_args.hicache_io_backend,
+                storage_backend=server_args.hicache_storage_backend,
+                prefetch_threshold=prefetch_threshold,
+                model_name=server_args.served_model_name,
+                storage_backend_extra_config=extra_config,
+                pp_rank=self.pp_rank,
+                pp_size=self.pp_size,
+                enable_storage_metrics=self.enable_storage_metrics,
+            )
+        elif isinstance(self.token_to_kv_pool_host, DSATokenToKVPool):
             attach_hybrid_dsa_pool_to_hiradix_cache(
                 self,
                 params,
@@ -765,18 +800,37 @@ class HiRadixCache(RadixCache):
         ):
             return 0
 
-        host_indices = self.cache_controller.write(
-            device_indices=node.value,
-            node_id=node.id,
-            **self._get_extra_pools(),
-        )
-        if host_indices is None:
-            self.evict_host(len(node.value))
+        if isinstance(self.token_to_kv_pool_host, NPUMHATokenToKVPoolHybrid):
+            token_indices_start = node.parent.prefix_len
+            token_indices_end = token_indices_start + len(node.key)
+            token_indices = torch.arange(start=token_indices_start, end=token_indices_end, device=self.device)
+            host_indices = self.cache_controller.write(
+                device_indices=node.value,
+                token_indices=token_indices,
+                node_id=node.id,
+                **self._get_extra_pools(),
+            )
+            if host_indices is None:
+                self.evict_host(len(node.value))
+                host_indices = self.cache_controller.write(
+                    device_indices=node.value,
+                    token_indices=token_indices,
+                    node_id=node.id,
+                    **self._get_extra_pools(),
+                )
+        else:
             host_indices = self.cache_controller.write(
                 device_indices=node.value,
                 node_id=node.id,
                 **self._get_extra_pools(),
             )
+            if host_indices is None:
+                self.evict_host(len(node.value))
+                host_indices = self.cache_controller.write(
+                    device_indices=node.value,
+                    node_id=node.id,
+                    **self._get_extra_pools(),
+                )
         if host_indices is not None:
             node.host_value = host_indices.clone()
             assert len(node.host_value) > 0
@@ -1167,18 +1221,37 @@ class HiRadixCache(RadixCache):
             self.dec_lock_ref(ancester_node)
             return None
 
-        device_indices = self.cache_controller.load(
-            host_indices=host_indices,
-            node_id=last_hit_node.id,
-            **self._get_extra_pools(),
-        )
-        if device_indices is None:
-            self.evict(EvictParams(num_tokens=len(host_indices)))
+        if isinstance(self.token_to_kv_pool_host, NPUMHATokenToKVPoolHybrid):
+            token_indices = torch.arange(start=ancester_node.prefix_len, end=last_hit_node.prefix_len, device=self.device)
+
+            device_indices = self.cache_controller.load(
+                host_indices=host_indices,
+                token_indices=token_indices,
+                node_id=last_hit_node.id,
+                **self._get_extra_pools(),
+            )
+            if device_indices is None:
+                self.evict(EvictParams(num_tokens=len(host_indices)))
+                device_indices = self.cache_controller.load(
+                    host_indices=host_indices,
+                    token_indices=token_indices,
+                    node_id=last_hit_node.id,
+                    **self._get_extra_pools(),
+                )
+        else:
             device_indices = self.cache_controller.load(
                 host_indices=host_indices,
                 node_id=last_hit_node.id,
                 **self._get_extra_pools(),
             )
+            if device_indices is None:
+                self.evict(EvictParams(num_tokens=len(host_indices)))
+                device_indices = self.cache_controller.load(
+                    host_indices=host_indices,
+                    node_id=last_hit_node.id,
+                    **self._get_extra_pools(),
+                )
+
         self.dec_lock_ref(ancester_node)
         if device_indices is None:
             # no sufficient GPU memory to load back KV caches

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -217,6 +217,7 @@ def build_kv_cache(
         pp_size=ps.pp_size,
         chunked_prefill_size=effective_chunked_prefill_size,
         sliding_window_size=sliding_window_size,
+        rotary_embeddings=tp_worker.model_runner.model.model.layers[0].self_attn.rotary_emb
     )
 
     tree_cache = create_tree_cache(

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -242,6 +242,7 @@ class HostKVCache(abc.ABC):
         pin_memory: bool,
         device: str,
         allocator_type: str = "default",
+        skip_size_check=False
     ):
         self.device_pool = device_pool
         self.page_size = page_size
@@ -262,9 +263,10 @@ class HostKVCache(abc.ABC):
         self.start_layer = device_pool.start_layer
         self.end_layer = device_pool.end_layer
 
-        assert (
-            self.size > device_pool.size
-        ), "The host memory should be larger than the device memory with the current protocol"
+        if skip_size_check == False:
+            assert (
+                self.size > device_pool.size
+            ), "The host memory should be larger than the device memory with the current protocol"
 
         # Verify there is enough available host memory.
         host_mem = psutil.virtual_memory()
@@ -392,6 +394,7 @@ class MHATokenToKVPoolHost(HostKVCache):
         pin_memory: bool = True,
         device: str = "cpu",
         allocator_type: str = "default",
+        skip_size_check=False,
     ):
         super().__init__(
             device_pool,
@@ -402,6 +405,7 @@ class MHATokenToKVPoolHost(HostKVCache):
             pin_memory,
             device,
             allocator_type,
+            skip_size_check,
         )
         self.element_dim = self.device_pool.head_num * self.device_pool.head_dim
         self.can_use_jit = _is_cuda and can_use_hicache_jit_kernel(

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -39,7 +39,7 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
 )
 from sglang.srt.mem_cache.mmap_allocator import alloc_mmap
-from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu
+from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu, get_available_gpu_memory
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
@@ -64,6 +64,8 @@ if _is_cuda or _is_hip:
     )
 if _is_npu:
     from sgl_kernel_npu.kvcacheio import TransferDirection, transfer_kv_dim_exchange
+    import torch
+    import torch_npu
 
 logger = logging.getLogger(__name__)
 
@@ -3264,6 +3266,340 @@ class DSAIndexerPoolHost(HostKVCache):
             page_index = int(indices[i]) // self.page_size
             ptr_list.append(base_ptr + page_index * page_stride_bytes)
         return ptr_list, [page_stride_bytes] * len(ptr_list)
+
+class NPUMHATokenToKVPoolCompressed(HostKVCache):
+    def __init__(
+        self,
+        device_pool: MHATokenToKVPool,
+        host_to_device_ratio: float,
+        host_size: int,
+        page_size: int,
+        kvtc_params_path: str = "",
+        kvtc_k_compression_ratio: float = 0,
+        kvtc_v_compression_ratio: float = 0,
+        rotary_emb = None,
+        tp_rank: int = 0,
+        tp_size: int = 1,
+        pp_rank: int = 0,
+        pp_size: int = 1,
+        skip_size_check: bool = False,
+    ):
+        self.device_pool = device_pool
+        self.page_size = page_size
+        self.device = "cpu"
+        self.dtype = device_pool.store_dtype
+        self.compressed_dtype = torch.float32
+        self.rotary_emb = rotary_emb
+        self.tp_rank = tp_rank
+        self.pp_rank = pp_rank
+
+        formatter = logging.Formatter(f"[%(asctime)s TP{tp_rank} PP{pp_rank}] %(message)s")
+        for handler in logger.handlers:
+            handler.setFormatter(formatter)
+
+        self.head_num = self.device_pool.head_num
+        self.head_dim = self.device_pool.head_dim
+        self.layer_num = self.device_pool.layer_num
+        self.token_stride_size = self.head_num * self.head_dim * self.dtype.itemsize
+        self.layout_dim = self.token_stride_size * self.layer_num
+
+        self.device_page_shape = (self.layer_num, page_size, self.head_num, self.head_dim)
+
+        self.k_kvtc = False
+        self.v_kvtc = False
+
+        p = self.layer_num * self.head_num * self.head_dim
+
+        if kvtc_params_path:
+            logger.info("Using KVTC compression")
+
+            logger.info(
+                f"KVTC calibration data loading. avail mem={get_available_gpu_memory('npu', torch.npu.current_device()):.4f} GB"
+            )
+
+            kvtc_params = torch.load(kvtc_params_path, map_location="cpu")
+            self.k_kvtc = "keys" in kvtc_params and kvtc_k_compression_ratio > 0
+            self.v_kvtc = "values" in kvtc_params and kvtc_v_compression_ratio > 0
+
+            worker_key = f"tp_{self.tp_rank}_pp_{self.pp_rank}"
+
+            if self.k_kvtc:
+                logger.info(
+                    f"NPU compressed K basis loading begin. avail mem={get_available_gpu_memory('npu', torch.npu.current_device()):.4f} GB"
+                )
+                keys_params = kvtc_params["keys"].get(worker_key)
+                if keys_params is None:
+                    raise Exception(f"Wrong K KVTC config - missing {worker_key}")
+
+                k_dim_limit = p // int(kvtc_k_compression_ratio)
+
+                self.kvtc_k_mu = self._copy_with_trim(keys_params["mu"])
+
+                if self.kvtc_k_mu.shape[0] != p:
+                    logger.error(f"K mu mismatch {self.kvtc_k_mu.shape} vs {p}")
+
+                self.kvtc_k_V = self._copy_with_trim(keys_params["basis"], (p, k_dim_limit))
+                if self.kvtc_k_V.shape[0] != p:
+                    logger.error(f"K V mismatch {self.kvtc_k_V.shape} vs {p}")
+
+                self.offload_page_shape_k = (self.page_size, self.kvtc_k_V.shape[1])
+
+                logger.info(
+                    f"NPU compressed K basis loading end. avail mem={get_available_gpu_memory('npu', torch.npu.current_device()):.4f} GB"
+                )
+                logger.debug(
+                    f"K basis final shape {self.kvtc_k_V.shape}, offload page shape {self.offload_page_shape_k}"
+                )
+
+            if self.v_kvtc:
+                logger.info(
+                    f"NPU compressed V basis loading begin. avail mem={get_available_gpu_memory('npu', torch.npu.current_device()):.4f} GB"
+                )
+                values_params = kvtc_params["values"].get(worker_key)
+                if values_params is None:
+                    raise Exception(f"Wrong V KVTC config - missing {worker_key}")
+
+                v_dim_limit = p // int(kvtc_v_compression_ratio)
+
+                self.kvtc_v_mu = self._copy_with_trim(values_params["mu"])
+
+                if self.kvtc_v_mu.shape[0] != p:
+                    logger.error(f"V mu mismatch {self.kvtc_v_mu.shape} vs {p}")
+
+                self.kvtc_v_V = self._copy_with_trim(values_params["basis"], (p, v_dim_limit))
+                if self.kvtc_v_V.shape[0] != p:
+                    logger.error(f"V V mismatch {self.kvtc_v_V.shape} vs {p}")
+
+                self.offload_page_shape_v = (self.page_size, self.kvtc_v_V.shape[1])
+
+                logger.info(
+                    f"NPU compressed V basis loading end. avail mem={get_available_gpu_memory('npu', torch.npu.current_device()):.4f} GB"
+                )
+                logger.debug(
+                    f"V basis final shape {self.kvtc_v_V.shape}, offload page shape {self.offload_page_shape_v}"
+                )
+
+            torch_npu.npu.synchronize()
+
+
+        self.size_per_token = self.get_size_per_token()
+        if host_size > 0:
+            self.size = int(host_size * 1e9 // self.size_per_token)
+        else:
+            self.size = int(device_pool.size * host_to_device_ratio)
+
+        # Align up the host memory pool size to the page size
+        self.page_num = self.size // self.page_size + 1
+        self.size = self.page_num * self.page_size
+        if skip_size_check == False:
+            assert (
+                self.size > device_pool.size
+            ), f"The host memory should be larger than the device memory with the current protocol ({self.size} vs {device_pool.size})"
+
+        self.init_kv_buffer()
+
+        # A lock for synchronized operations on memory allocation and state transitions.
+        self.lock = threading.RLock()
+        self.clear()
+
+    def _copy_with_trim(self, in_tensor: torch.Tensor, out_shape=None) -> torch.Tensor:
+        out_shape = out_shape or in_tensor.shape
+        out_slices = tuple(slice(0, x) for x in out_shape)
+
+        return in_tensor[out_slices].to(self.device_pool.device)
+
+    def init_kv_buffer(self):
+        logger.info(f"NPU compressed pool alloc begin. avail mem={get_available_gpu_memory('npu', torch.npu.current_device()):.2f} GB")
+        # [size, head_num, head_dim] for each layer
+        # The padded slot 0 is used for writing dummy outputs from padded tokens.
+        # Continuous memory improves the efficiency of Ascend`s transmission backend,
+        # while other backends remain unchanged.
+        if self.k_kvtc:
+            self.k_buffer = torch.zeros(
+                (
+                    self.page_num,
+                    *self.offload_page_shape_k
+                ),
+                dtype=self.compressed_dtype,
+                device=self.device,
+                pin_memory=True,
+            )
+        else:
+            self.k_buffer = torch.zeros(
+                (
+                    self.layer_num,
+                    self.page_num,
+                    self.page_size,
+                    self.head_num,
+                    self.head_dim,
+                ),
+                dtype=self.dtype,
+                device=self.device,
+                pin_memory=True,
+            )
+
+        if self.v_kvtc:
+            self.v_buffer = torch.zeros(
+                (
+                    self.page_num,
+                    *self.offload_page_shape_v
+                ),
+                dtype=self.compressed_dtype,
+                device=self.device,
+                pin_memory=True,
+            )
+        else:
+            self.v_buffer = torch.zeros(
+                (
+                    self.layer_num,
+                    self.page_num,
+                    self.page_size,
+                    self.head_num,
+                    self.head_dim,
+                ),
+                dtype=self.dtype,
+                device=self.device,
+                pin_memory=True,
+            )
+
+        logger.info(f"NPU compressed pool alloc end(pages={self.page_num}. avail mem={get_available_gpu_memory('npu', torch.npu.current_device()):.2f} GB")
+
+    def get_size_per_token(self):
+        size = 0
+        if self.k_kvtc:
+            size += self.offload_page_shape_k[1] * self.compressed_dtype.itemsize
+        else:
+            size += self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize
+
+        if self.v_kvtc:
+            size += self.offload_page_shape_v[1] * self.compressed_dtype.itemsize
+        else:
+            size += self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize
+
+        return size
+
+    def get_ksize_per_token(self):
+        return self.get_size_per_token() // 2
+
+    def load_to_device_per_layer(
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        layer_id,
+        token_indices,
+        io_backend,
+    ):
+        if layer_id != 0:
+            return
+
+        assert len(token_indices) == host_indices.size(0)
+        assert(device_indices.size(0) % self.page_size == 0)
+        num_pages = device_indices.size(0) // self.page_size
+        token_indices = torch.Tensor(token_indices).to(device_pool.device, dtype=torch.int64)
+
+        for page in range(num_pages):
+            host_page = host_indices[page * self.page_size] // self.page_size
+            device_page = device_indices[page * self.page_size] // self.page_size
+            page_token_indices = token_indices[page * self.page_size : page * self.page_size + self.page_size]
+
+            if self.k_kvtc:
+                X_k = (
+                    torch.matmul(
+                        self.k_buffer[host_page].to(device=self.device_pool.device), self.kvtc_k_V.T
+                    )
+                    + self.kvtc_k_mu
+                )
+                device_pool.k_buffer[:, device_page, ...] = (
+                    self.rotary_emb.forward_native_keys_batch(
+                        page_token_indices,
+                        X_k.reshape(
+                            self.device_page_shape[1],
+                            self.device_page_shape[0],
+                            *self.device_page_shape[2:]
+                        ),
+                    ).transpose(1, 0)
+                )
+            else:
+                device_pool.k_buffer[:, device_page, ...] = self.k_buffer[:, host_page, ...].to(
+                    device=self.device_pool.device
+                )
+
+            if self.v_kvtc:
+                X_v = (
+                    (
+                        torch.matmul(
+                            self.v_buffer[host_page].to(device=self.device_pool.device),
+                            self.kvtc_v_V.T,
+                        )
+                        + self.kvtc_v_mu
+                    )
+                    .reshape(self.page_size, self.layer_num, -1)
+                    .transpose(1, 0)
+                )
+                device_pool.v_buffer[:, device_page, ...] = X_v.reshape(*self.device_page_shape).to(
+                    dtype=self.dtype
+                )
+            else:
+                device_pool.v_buffer[:, device_page, ...] = self.v_buffer[:, host_page, ...].to(
+                    device=self.device_pool.device
+                )
+
+    def backup_from_device_all_layer(
+        self, device_pool, host_indices, device_indices, token_indices, token_io_backend
+    ):
+        assert len(token_indices) == host_indices.size(0), f"{len(token_indices)=} {host_indices.size(0)}"
+        assert (device_indices.size(0) % self.page_size == 0)
+        num_pages = device_indices.size(0) // self.page_size
+        token_indices = torch.Tensor(token_indices).to(device_pool.device, dtype=torch.int64)
+
+        for page in range(num_pages):
+            host_page = host_indices[page * self.page_size] // self.page_size
+            device_page = device_indices[page * self.page_size] // self.page_size
+            page_token_indices = token_indices[page * self.page_size : page * self.page_size + self.page_size]
+
+            if self.k_kvtc:
+                X_k = device_pool.k_buffer[:, device_page, ...].transpose(1, 0)
+                X_k_unrotated = self.rotary_emb.invert_native_keys_batch(page_token_indices, X_k)
+                self.k_buffer[host_page] = torch.matmul(
+                    (X_k_unrotated.reshape(self.page_size, -1) - self.kvtc_k_mu), self.kvtc_k_V
+                ).to(device=self.device)
+            else:
+                self.k_buffer[:, host_page, ...] = device_pool.k_buffer[:, device_page, ...].to(
+                    device=self.device
+                )
+
+            if self.v_kvtc:
+                X_v = (
+                    device_pool.v_buffer[:, device_page, ...]
+                    .transpose(1, 0)
+                    .reshape(self.page_size, -1)
+                )
+                self.v_buffer[host_page] = torch.matmul((X_v - self.kvtc_v_mu), self.kvtc_v_V).to(
+                    device=self.device
+                )
+            else:
+                self.v_buffer[:, host_page, ...] = device_pool.v_buffer[:, device_page, ...].to(
+                    device=self.device
+                )
+
+    def get_data_page(self, index, flat: bool = True) -> torch.Tensor:
+        raise NotImplementedError()
+
+    def get_dummy_flat_data_page(self) -> torch.Tensor:
+        raise NotImplementedError()
+
+    def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:
+        raise NotImplementedError()
+
+    def get_split_heads_page_buffer_meta(
+        self, indices: torch.Tensor, split_factor: int
+    ):
+        raise NotImplementedError()
+
+    def get_page_buffer_meta(self, indices):
+        raise NotImplementedError()
+
 
 class NPUMHATokenToKVPoolHybrid:
     """

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -82,6 +82,18 @@ def synchronized(func):
     return wrapper
 
 
+@dataclass
+class KVTCHostMemoryRequest:
+    device_memory_pool: KVCache
+    host_indices_compressed: torch.Tensor
+    device_indices_compressed: torch.Tensor
+    token_indices_compressed: torch.Tensor
+    host_indices_sink: torch.Tensor
+    device_indices_sink: torch.Tensor
+    io_backend: str
+    layer_id: int | None
+
+
 class HostTensorAllocator:
     def __init__(self):
         """Initialize the HostTensorAllocator."""

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -3264,3 +3264,281 @@ class DSAIndexerPoolHost(HostKVCache):
             page_index = int(indices[i]) // self.page_size
             ptr_list.append(base_ptr + page_index * page_stride_bytes)
         return ptr_list, [page_stride_bytes] * len(ptr_list)
+
+class NPUMHATokenToKVPoolHybrid:
+    """
+    The hybird pool uses two pools internaly:
+    - MHATokenToKVPoolHost for the sink tokens (not compressed)
+    - NPUMLATokenToKVPool for the rest of the tokens (compressed)
+
+    The requests are routed to the pools based on `host_indices` values
+    Host indices from range <0, compressed_pool_size) belong to the compressed pool
+    Host indices from range <compressed_pool_size, MAX) belong to the uncompressed pool
+    Internally, the uncompressed pool uses indices starting at 0, so before routing,
+    the indices must be shifted
+    """
+    def __init__(
+        self,
+        device_pool: MHATokenToKVPool,
+        host_to_device_ratio: float,
+        host_size: int,
+        page_size: int,
+        layout: str,
+        kvtc_params_path: str = "",
+        kvtc_k_compression_ratio: float = 0,
+        kvtc_v_compression_ratio: float = 0,
+        enable_memory_saver: bool = False,
+        rotary_emb = None,
+        tp_rank: int = 0,
+        tp_size: int = 1,
+        pp_rank: int = 0,
+        pp_size: int = 1,
+        allocator_type: str = "default",
+    ):
+
+        self.page_size = page_size
+        self.tp_rank = tp_rank
+
+        if host_size == 0:
+            host_size = int(device_pool.size * host_to_device_ratio)
+
+        compressed_pool_size = int(host_size * 0.90)
+        sink_pool_size = int(host_size * 0.1)
+
+        self.compressed_pool = NPUMHATokenToKVPoolCompressed(
+                device_pool=device_pool,
+                host_size=compressed_pool_size,
+                page_size=page_size,
+                kvtc_params_path=kvtc_params_path,
+                kvtc_k_compression_ratio=kvtc_k_compression_ratio,
+                kvtc_v_compression_ratio=kvtc_v_compression_ratio,
+                rotary_emb=rotary_emb,
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+                pp_rank=pp_rank,
+                pp_size=pp_size,
+                host_to_device_ratio=-1,
+                skip_size_check=False,
+                )
+        self.sink_pool = MHATokenToKVPoolHost(
+                device_pool=device_pool,
+                host_size=sink_pool_size,
+                page_size=page_size,
+                layout=layout,
+                allocator_type=allocator_type,
+                host_to_device_ratio=-1,
+                skip_size_check=True,
+                )
+
+        self.init_kv_buffer()
+
+        self.sink_token_shift = self.compressed_pool.size
+
+        self.lock = threading.RLock()
+        self.clear()
+        self.size = self.compressed_pool.size
+
+    def init_kv_buffer(self):
+        self.compressed_pool.init_kv_buffer()
+        self.sink_pool.init_kv_buffer()
+
+
+    def _load_sink_to_device_per_layer(
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        layer_id,
+        io_backend,
+    ):
+        assert torch.all(host_indices >= self.sink_token_shift), f"{host_indices=}"
+
+        host_indices_shifted = host_indices - self.sink_token_shift
+
+        self.sink_pool.load_to_device_per_layer(
+                device_pool,
+                host_indices_shifted,
+                device_indices,
+                layer_id,
+                io_backend,
+                )
+
+    def _load_compressed_to_device_per_layer(
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        token_indices,
+        layer_id,
+        io_backend,
+    ):
+
+        assert torch.all(host_indices < self.sink_token_shift), f"{host_indices=}"
+
+        self.compressed_pool.load_to_device_per_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                layer_id,
+                token_indices,
+                io_backend,
+                )
+
+    def load_to_device_per_layer(self, req: KVTCHostMemoryRequest):
+        device_pool = req.device_memory_pool
+        host_idx_compressed = req.host_indices_compressed
+        device_idx_compressed = req.device_indices_compressed
+        token_idx_compressed = req.token_indices_compressed
+        host_idx_sink = req.host_indices_sink
+        device_idx_sink = req.device_indices_sink
+        layer_id = req.layer_id
+        io_backend = req.io_backend
+
+        if host_idx_compressed.numel() != 0:
+            self._load_compressed_to_device_per_layer(
+                    device_pool,
+                    host_idx_compressed,
+                    device_idx_compressed,
+                    token_idx_compressed,
+                    layer_id,
+                    io_backend,
+                    )
+
+        if host_idx_sink.numel() != 0:
+            self._load_sink_to_device_per_layer(
+                    device_pool,
+                    host_idx_sink,
+                    device_idx_sink,
+                    layer_id,
+                    io_backend,
+                    )
+
+    def _backup_sink_from_device_all_layer(
+            self,
+            device_pool: KVCache,
+            host_indices: torch.Tensor,
+            device_indices: torch.Tensor,
+            io_backend: str,
+    ):
+        assert torch.all(host_indices >= self.sink_token_shift), f"{host_indices=}"
+
+        host_indices_shifted = host_indices - self.sink_token_shift
+
+        self.sink_pool.backup_from_device_all_layer(
+                device_pool,
+                host_indices_shifted,
+                device_indices,
+                io_backend,
+                )
+
+    def _backup_compressed_from_device_all_layer(
+            self,
+            device_pool: KVCache,
+            host_indices: torch.Tensor,
+            device_indices: torch.Tensor,
+            token_indices: torch.Tensor,
+            io_backend: str,
+    ):
+
+        self.compressed_pool.backup_from_device_all_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                token_indices,
+                io_backend,
+                )
+
+    def backup_from_device_all_layer(self, req: KVTCHostMemoryRequest):
+        device_pool = req.device_memory_pool
+        host_idx_compressed = req.host_indices_compressed
+        device_idx_compressed = req.device_indices_compressed
+        token_idx_compressed = req.token_indices_compressed
+        host_idx_sink = req.host_indices_sink
+        device_idx_sink = req.device_indices_sink
+        io_backend = req.io_backend
+
+        if host_idx_compressed.numel() != 0:
+            self._backup_compressed_from_device_all_layer(
+                    device_pool,
+                    host_idx_compressed,
+                    device_idx_compressed,
+                    token_idx_compressed,
+                    io_backend,
+                    )
+        if host_idx_sink.numel() != 0:
+            self._backup_sink_from_device_all_layer(
+                    device_pool,
+                    host_idx_sink,
+                    device_idx_sink,
+                    io_backend,
+                    )
+
+    @synchronized
+    def clear(self):
+        self.compressed_pool.clear()
+        self.sink_pool.clear()
+
+    def available_size(self):
+        return self.compressed_pool.available_size()
+
+    @synchronized
+    def alloc(
+            self,
+            need_sink: int,
+            need_compressed: int
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+
+        if need_sink != 0:
+            sink_tokens = self.sink_pool.alloc(need_sink)
+            if sink_tokens == None:
+                return None, None
+            sink_tokens += self.sink_token_shift
+        else:
+            sink_tokens = torch.empty(0, dtype=torch.int64)
+
+        if need_compressed != 0:
+            compressed_tokens = self.compressed_pool.alloc(need_compressed)
+            if compressed_tokens == None:
+                if sink_tokens.numel() > 0:
+                    self.free(sink_tokens)
+                return None, None
+        else:
+            compressed_tokens = torch.empty(0, dtype=torch.int64)
+
+        return sink_tokens, compressed_tokens
+
+    @synchronized
+    def free(self, indices: torch.Tensor) -> tuple[int, int]:
+        sink_indices = indices[indices >= self.sink_token_shift]
+        compressed_tokens = indices[indices < self.sink_token_shift]
+        freed_sink = 0
+        freed_compressed = 0
+
+        if sink_indices.numel() > 0:
+            sink_indices -= self.sink_token_shift
+            freed_sink = self.sink_pool.free(sink_indices)
+
+        if compressed_tokens.numel() > 0:
+            freed_compressed = self.compressed_pool.free(compressed_tokens)
+
+        return freed_sink, freed_compressed
+
+    def get_size_per_token(self):
+        raise NotImplementedError()
+
+    def get_data_page(self, index, flat: bool = True) -> torch.Tensor:
+        raise NotImplementedError()
+
+    def get_dummy_flat_data_page(self) -> torch.Tensor:
+        raise NotImplementedError()
+
+    def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:
+        raise NotImplementedError()
+
+    def get_split_heads_page_buffer_meta(
+        self, indices: torch.Tensor, split_factor: int
+    ):
+        raise NotImplementedError()
+
+    def get_page_buffer_meta(self, indices):
+        raise NotImplementedError()

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -248,6 +248,13 @@ class TreeNode:
         TreeNode.counter += 1
 
     @property
+    def prefix_len(self):
+        ret =  self.parent.prefix_len if self.parent else 0
+        ret += len(self.key)
+
+        return ret
+
+    @property
     def evicted(self):
         return self.value is None
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -705,6 +705,11 @@ class ServerArgs:
     hicache_storage_backend: Optional[str] = None
     hicache_storage_prefetch_policy: str = "timeout"
     hicache_storage_backend_extra_config: Optional[str] = None
+    hicache_kvtc_params: str = ""
+    hicache_kvtc_k_cr: float = 0.0
+    hicache_kvtc_v_cr: float = 0.0
+    hicache_kvtc_sliding_window: int = 0
+    dump_kv_path: str = ""
 
     # Hierarchical sparse attention
     enable_hisparse: bool = False
@@ -6589,6 +6594,38 @@ class ServerArgs:
             type=str,
             default=ServerArgs.hicache_storage_backend_extra_config,
             help="A dictionary in JSON string format, or a string starting with a leading '@' and a config file in JSON/YAML/TOML format, containing extra configuration for the storage backend.",
+        )
+
+        # KVTC
+        parser.add_argument(
+            "--hicache-kvtc-params",
+            type=str,
+            default=ServerArgs.hicache_kvtc_params,
+            help="Path to KVTC calibration file",
+        )
+        parser.add_argument(
+            "--hicache-kvtc-k-cr",
+            type=float,
+            default=ServerArgs.hicache_kvtc_k_cr,
+            help="KVTC compression ratio of the K cache",
+        )
+        parser.add_argument(
+            "--hicache-kvtc-v-cr",
+            type=float,
+            default=ServerArgs.hicache_kvtc_v_cr,
+            help="KVTC compression ratio of the V cache",
+        )
+        parser.add_argument(
+            "--hicache-kvtc-sw",
+            type=int,
+            default=ServerArgs.hicache_kvtc_sliding_window,
+            help="KVTC sliding window size",
+        )
+        parser.add_argument(
+            "--dump-kv-path",
+            type=str,
+            default=ServerArgs.dump_kv_path,
+            help="Path for dumping KV-cache contents onto local storage",
         )
 
         # Hierarchical sparse attention


### PR DESCRIPTION
## Motivation

This is an initial implementation of KVTC (https://arxiv.org/pdf/2511.01815). It's still work in progress and we're publishing it as an RFC. 

When it comes to calibration, we decided to implement is as a separate step outside of SGlang runtime. We'll publish the code responsible for the calibration soon. 

More details on our further steps will be available as a separate Github issue. 

## Modifications

We're adding:
- new host memory pool with compression
- new hybrid host memory pool. It comprises of the compressed memory pool and an instance of MHATokenToKVPoolHost. We're using the latter to store uncompressed sink tokens (please refer to the KVTC paper for more details).
- new cache manager 
- an option to dump KV cache to storage. We're using to generate data for calibration. 

## Test setup
We used two Ascend 910B3 cards to run Qwen3-30-A3B with 80G of host memory for L2 cache and two tensor parallelism workers. 

## Accuracy Tests

We tested our solution against ruler, gsm8k and qasper benchmarks with 4096 context length. The results as follows:
<img width="377" height="387" alt="obraz" src="https://github.com/user-attachments/assets/e27d209a-84c6-406c-900d-bc86ac546b7f" />

<img width="1082" height="695" alt="obraz" src="https://github.com/user-attachments/assets/78062b83-9c00-496f-a73e-c93043f16e58" />




## Speed Tests and Profiling
For performance benchmarks we used the sglang's built-in `bench_serving` with ` --max-concurrency 16 --num-prompts 350 --random-input-len 40000 --random-output-len 32 --dataset-name random`. For the baseline and each compression ratio we 
- ran the benchmark to populate L2 cache
- forced data eviction from L1 cache
- run the same benchmark to gather the results. 
<img width="506" height="139" alt="obraz" src="https://github.com/user-attachments/assets/04c5402b-6687-412e-ba28-3bc4a4d1d6d8" />
<img width="540" height="314" alt="obraz" src="https://github.com/user-attachments/assets/dd8f4578-9b72-4875-8d0d-ae47fa658d2b" />
<img width="535" height="322" alt="obraz" src="https://github.com/user-attachments/assets/f1d66ec4-81c6-45ae-8258-b276b4a15fc5" />
<img width="800" height="451" alt="obraz" src="https://github.com/user-attachments/assets/7c765f33-28f4-47fa-bf50-a287ee76d554" />



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->