### PR TITLE
[WIP][DSV4] Breakable CUDA graph for mixed-chunk prefill

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -846,6 +846,7 @@ class Envs:
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)
     SGLANG_OPT_FLASHMLA_SPARSE_PREFILL = EnvBool(True)
     SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN = EnvBool(True)
+    SGLANG_EXPERIMENTAL_FORCE_BCG = EnvBool(False)
 
     # SWA radix cache
     # TODO(DSV4): @ispobock this has bug on main branch when retract

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -845,6 +845,7 @@ class Envs:
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)
     SGLANG_OPT_FLASHMLA_SPARSE_PREFILL = EnvBool(True)
+    SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN = EnvBool(True)
 
     # SWA radix cache
     # TODO(DSV4): @ispobock this has bug on main branch when retract

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -42,6 +42,10 @@ class AttentionBackend(ABC):
     prefill_attention_backend_str: Optional[str] = None
     decode_attention_backend_str: Optional[str] = None
 
+    # All scheduler-shared reads of the current BCG replay were enqueued at
+    # the pre-replay snapshot, so the WAR read-done event may publish early.
+    war_reads_done_at_snapshot: bool = False
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Eager entry point. Default = ``_out_graph(fb) + _in_graph(fb)``.
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -62,6 +62,9 @@ if TYPE_CHECKING:
 _is_sm120 = is_sm120_supported()
 _is_xpu = is_xpu()
 
+if not _is_sm120 and not _is_xpu:
+    from sgl_kernel.flash_mla import flash_mla_with_kvcache
+
 logger = logging.getLogger(__name__)
 
 SWA_WINDOW = 128
@@ -368,6 +371,9 @@ class DSV4Metadata:
     # reused across every layer in the chunk. Reset to ``None`` when graph
     # metadata is refreshed so replay rebuilds it from the live batch.
     sparse_prefill_cache: Optional[SparsePrefillChunkCache] = None
+    # Set by init_forward_metadata for mixed batches when the split path is
+    # enabled; None otherwise.
+    mixed_decode_tail_len: Optional[int] = None
 
     @property
     def core_metadata(self) -> DSV4AttnMetadata:
@@ -381,6 +387,7 @@ class DSV4Metadata:
             self.c128_compress_metadata, src=other.c128_compress_metadata
         )
         self.sparse_prefill_cache = None
+        self.mixed_decode_tail_len = None
 
     def refresh_for_breakable_cuda_graph_replay_(self, static_metadata: DSV4Metadata):
         self.core_attn_metadata.refresh_for_breakable_cuda_graph_replay_(
@@ -400,6 +407,7 @@ class DSV4Metadata:
                 src=static_metadata.c128_compress_metadata,
             )
         self.sparse_prefill_cache = None
+        self.mixed_decode_tail_len = None
 
 
 @dataclass
@@ -1096,6 +1104,15 @@ class DeepseekV4AttnBackend(
             return
 
         self.forward_metadata = self._build_forward_metadata(forward_batch)
+        if (
+            envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
+            and forward_batch.forward_mode.is_mixed()
+            and not _is_sm120
+            and not _is_xpu
+        ):
+            self.forward_metadata.mixed_decode_tail_len = (
+                forward_batch.num_mixed_decode_tokens
+            )
         self.init_forward_metadata_in_graph(forward_batch)
 
     def _build_forward_metadata(
@@ -1406,6 +1423,31 @@ class DeepseekV4AttnBackend(
                 q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                 or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
             ):
+                if (
+                    envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
+                    and forward_batch.forward_mode.is_mixed()
+                    and not _is_sm120
+                    and not _is_xpu
+                ):
+                    num_tail = metadata.mixed_decode_tail_len
+                    if num_tail is not None and 0 < num_tail < q.shape[0]:
+                        return self._forward_mixed_split(
+                            q=q,
+                            layer_id=layer_id,
+                            compress_ratio=compress_ratio,
+                            forward_batch=forward_batch,
+                            token_to_kv_pool=token_to_kv_pool,
+                            core_attn_metadata=core_attn_metadata,
+                            attn_sink=attn_sink,
+                            num_tail=num_tail,
+                            swa_k_cache=swa_k_cache,
+                            swa_page_indices=swa_page_indices,
+                            swa_topk_lengths=swa_topk_lengths,
+                            extra_k_cache=extra_k_cache,
+                            extra_indices=extra_indices,
+                            extra_topk_lengths=extra_topk_lengths,
+                            flashmla_metadata=flashmla_metadata,
+                        )
                 return self._forward_prefill_sparse(
                     q=q,
                     layer_id=layer_id,
@@ -1460,6 +1502,81 @@ class DeepseekV4AttnBackend(
             return o
 
         raise NotImplementedError("ragged attention")
+
+    def _forward_mixed_split(
+        self,
+        q: torch.Tensor,
+        layer_id: int,
+        compress_ratio: Literal[0, 4, 128],
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: DeepSeekV4TokenToKVPool,
+        core_attn_metadata: DSV4AttnMetadata,
+        attn_sink: torch.Tensor,
+        num_tail: int,
+        swa_k_cache: torch.Tensor,
+        swa_page_indices: torch.Tensor,
+        swa_topk_lengths: torch.Tensor,
+        extra_k_cache: Optional[torch.Tensor],
+        extra_indices: Optional[torch.Tensor],
+        extra_topk_lengths: Optional[torch.Tensor],
+        flashmla_metadata,
+    ) -> torch.Tensor:
+        """Split a mixed-chunk batch at the prefill/decode boundary so the
+        decode tail reads the fp8 KV cache directly instead of paying the
+        per-layer bf16 dequant of the sparse-prefill workspace path."""
+        num_head = q.shape[0] - num_tail
+        metadata = self.forward_metadata
+        if metadata.sparse_prefill_cache is None:
+            seq_lens_cpu = forward_batch.seq_lens_cpu
+            assert seq_lens_cpu is not None
+            num_head_reqs = int(forward_batch.seq_lens.shape[0]) - num_tail
+            metadata.sparse_prefill_cache = SparsePrefillChunkCache.build(
+                seq_lens=forward_batch.seq_lens[:num_head_reqs].to(torch.int32),
+                extend_seq_lens=forward_batch.extend_seq_lens[:num_head_reqs].to(
+                    torch.int32
+                ),
+                req_pool_indices=forward_batch.req_pool_indices[:num_head_reqs].to(
+                    torch.int32
+                ),
+                req_to_token=self.req_to_token,
+                full_to_swa=token_to_kv_pool.full_to_swa_index_mapping,
+                swa_window_size=SWA_WINDOW,
+                swa_page_size=token_to_kv_pool.swa_window_size,
+                num_qo_tokens=num_head,
+                max_seq_len=int(seq_lens_cpu[:num_head_reqs].max().item()),
+            )
+        o_head = self._forward_prefill_sparse(
+            q=q[:num_head],
+            layer_id=layer_id,
+            compress_ratio=compress_ratio,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+            core_attn_metadata=core_attn_metadata,
+            attn_sink=attn_sink,
+        )
+        o_tail = flash_mla_with_kvcache(
+            q=q[num_head:],
+            k_cache=swa_k_cache,
+            head_dim_v=self.head_dim_v,
+            block_table=None,
+            cache_seqlens=None,
+            tile_scheduler_metadata=flashmla_metadata,
+            softmax_scale=self.softmax_scale,
+            is_fp8_kvcache=True,
+            indices=swa_page_indices[num_head:],
+            topk_length=swa_topk_lengths[num_head:],
+            attn_sink=attn_sink,
+            extra_k_cache=extra_k_cache,
+            extra_indices_in_kvcache=(
+                extra_indices[num_head:] if extra_indices is not None else None
+            ),
+            extra_topk_length=(
+                extra_topk_lengths[num_head:]
+                if extra_topk_lengths is not None
+                else None
+            ),
+        )[0].squeeze(1)
+        return torch.cat([o_head, o_tail], dim=0)
 
     def _forward_prefill_sparse(
         self,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1227,6 +1227,66 @@ class DeepseekV4AttnBackend(
         assert isinstance(capture_metadata, DSV4Metadata)
         capture_metadata.refresh_for_breakable_cuda_graph_replay_(static_metadata)
         self.forward_metadata = capture_metadata
+        self._prepare_bcg_prefill_replay(capture_metadata, forward_batch)
+
+    def _prepare_bcg_prefill_replay(
+        self, metadata: DSV4Metadata, forward_batch: ForwardBatch
+    ) -> None:
+        """Pre-build the sparse-prefill cache and split boundary from the
+        live batch so BCG replays read no scheduler-shared state mid-replay,
+        allowing the WAR read-done event to publish at the snapshot."""
+        self.war_reads_done_at_snapshot = False
+        if _is_sm120 or _is_xpu:
+            return
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+        extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
+        if (
+            seq_lens_cpu is None
+            or extend_seq_lens_cpu is None
+            or forward_batch.extend_seq_lens is None
+        ):
+            return
+
+        num_tail = 0
+        if (
+            envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
+            and forward_batch.forward_mode.is_mixed()
+            and forward_batch.num_mixed_decode_tokens is not None
+        ):
+            num_tail = forward_batch.num_mixed_decode_tokens
+
+        num_head_reqs = int(forward_batch.seq_lens.shape[0]) - num_tail
+        num_qo_tokens = int(len(forward_batch.input_ids)) - num_tail
+        if num_head_reqs <= 0 or num_qo_tokens <= 0:
+            return
+
+        head_seq_lens_cpu = seq_lens_cpu[:num_head_reqs]
+        window = SWA_WINDOW - 1
+        total_swa = 0
+        for seq_len, ext_len in zip(
+            head_seq_lens_cpu.tolist(), extend_seq_lens_cpu[:num_head_reqs]
+        ):
+            total_swa += min(int(seq_len), int(ext_len) + window)
+
+        metadata.sparse_prefill_cache = SparsePrefillChunkCache.build(
+            seq_lens=forward_batch.seq_lens[:num_head_reqs].to(torch.int32),
+            extend_seq_lens=forward_batch.extend_seq_lens[:num_head_reqs].to(
+                torch.int32
+            ),
+            req_pool_indices=forward_batch.req_pool_indices[:num_head_reqs].to(
+                torch.int32
+            ),
+            req_to_token=self.req_to_token,
+            full_to_swa=self.token_to_kv_pool.full_to_swa_index_mapping,
+            swa_window_size=SWA_WINDOW,
+            swa_page_size=self.token_to_kv_pool.swa_window_size,
+            num_qo_tokens=num_qo_tokens,
+            max_seq_len=int(head_seq_lens_cpu.max().item()),
+            total_swa=total_swa,
+        )
+        if num_tail > 0:
+            metadata.mixed_decode_tail_len = num_tail
+        self.war_reads_done_at_snapshot = True
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int) -> None:
         self.cuda_graph_metadata_of_bucket_and_bs: Dict[
@@ -1423,31 +1483,25 @@ class DeepseekV4AttnBackend(
                 q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                 or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
             ):
-                if (
-                    envs.SGLANG_OPT_MIXED_SPLIT_DECODE_ATTN.get()
-                    and forward_batch.forward_mode.is_mixed()
-                    and not _is_sm120
-                    and not _is_xpu
-                ):
-                    num_tail = metadata.mixed_decode_tail_len
-                    if num_tail is not None and 0 < num_tail < q.shape[0]:
-                        return self._forward_mixed_split(
-                            q=q,
-                            layer_id=layer_id,
-                            compress_ratio=compress_ratio,
-                            forward_batch=forward_batch,
-                            token_to_kv_pool=token_to_kv_pool,
-                            core_attn_metadata=core_attn_metadata,
-                            attn_sink=attn_sink,
-                            num_tail=num_tail,
-                            swa_k_cache=swa_k_cache,
-                            swa_page_indices=swa_page_indices,
-                            swa_topk_lengths=swa_topk_lengths,
-                            extra_k_cache=extra_k_cache,
-                            extra_indices=extra_indices,
-                            extra_topk_lengths=extra_topk_lengths,
-                            flashmla_metadata=flashmla_metadata,
-                        )
+                num_tail = metadata.mixed_decode_tail_len
+                if num_tail is not None and 0 < num_tail < q.shape[0]:
+                    return self._forward_mixed_split(
+                        q=q,
+                        layer_id=layer_id,
+                        compress_ratio=compress_ratio,
+                        forward_batch=forward_batch,
+                        token_to_kv_pool=token_to_kv_pool,
+                        core_attn_metadata=core_attn_metadata,
+                        attn_sink=attn_sink,
+                        num_tail=num_tail,
+                        swa_k_cache=swa_k_cache,
+                        swa_page_indices=swa_page_indices,
+                        swa_topk_lengths=swa_topk_lengths,
+                        extra_k_cache=extra_k_cache,
+                        extra_indices=extra_indices,
+                        extra_topk_lengths=extra_topk_lengths,
+                        flashmla_metadata=flashmla_metadata,
+                    )
                 return self._forward_prefill_sparse(
                     q=q,
                     layer_id=layer_id,

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -187,6 +187,7 @@ def build_swa_token_ids(
     req_to_token: torch.Tensor,
     full_to_swa: torch.Tensor,
     swa_window: int,
+    total_swa: Optional[int] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Build a flat list of physical SWA-cache token IDs covering each
     request's positional union of every query's SWA window.
@@ -230,7 +231,8 @@ def build_swa_token_ids(
     swa_first_pos = (seq_lens - swa_gather_lens).to(torch.int32)
     swa_offsets = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
     swa_offsets[1:] = torch.cumsum(swa_gather_lens, dim=0).to(torch.int32)
-    total_swa = int(swa_offsets[-1].item())  # one CPU sync per chunk
+    if total_swa is None:
+        total_swa = int(swa_offsets[-1].item())  # one CPU sync per chunk
 
     swa_token_ids = torch.empty(total_swa, dtype=torch.int32, device=device)
     if total_swa == 0:
@@ -417,6 +419,7 @@ class SparsePrefillChunkCache:
         swa_page_size: int,
         num_qo_tokens: int,
         max_seq_len: int,
+        total_swa: Optional[int] = None,
     ) -> "SparsePrefillChunkCache":
         device = seq_lens.device
         num_reqs = seq_lens.shape[0]
@@ -432,6 +435,7 @@ class SparsePrefillChunkCache:
                 req_to_token=req_to_token,
                 full_to_swa=full_to_swa,
                 swa_window=swa_window_size,
+                total_swa=total_swa,
             )
         )
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1736,6 +1736,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # Staging consumed by resolve_forward_inputs (prefill H2D / mixed gather).
     prefill_input_ids_cpu: Optional[torch.Tensor] = None
     mix_running_indices: Optional[torch.Tensor] = None
+    # Set by mix_with_running: number of decode tokens appended after the
+    # prefill tokens (one per running request).
+    num_mixed_decode_tokens: Optional[int] = None
     input_embeds: torch.Tensor = None  # shape: [b, hidden_size], float32
 
     # Token replacement embeddings and absolute positions (optional).
@@ -2402,6 +2405,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # Decode tokens of the running portion live in future_map.output_tokens_buf.
         self.input_ids = None
         self.mix_running_indices = running_batch.req_pool_indices
+        self.num_mixed_decode_tokens = running_bs
         out_cache_loc = torch.cat([self.out_cache_loc, running_batch.out_cache_loc])
 
         self.merge_batch(running_batch)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -447,6 +447,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     extend_seq_lens_cpu: Optional[List[int]] = None
     extend_logprob_start_lens_cpu: Optional[List[int]] = None
     extend_input_logprob_token_ids_gpu: Optional[torch.Tensor] = None
+    # Mixed-chunk: number of decode tokens at the batch tail (from
+    # ScheduleBatch.mix_with_running); None for non-mixed batches.
+    num_mixed_decode_tokens: Optional[int] = None
 
     # For DP attention (MLP sync sizes)
     original_global_num_tokens_cpu: Optional[List[int]] = None
@@ -702,6 +705,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Scalar config / flags
             return_logprob=batch.return_logprob,
             is_extend_in_batch=batch.is_extend_in_batch,
+            num_mixed_decode_tokens=batch.num_mixed_decode_tokens,
             all_extend_in_batch=batch.all_extend_in_batch,
             can_run_dp_cuda_graph=batch.can_run_dp_cuda_graph,
             can_run_dp_breakable_cuda_graph=batch.can_run_dp_breakable_cuda_graph,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -982,6 +982,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             static_num_tokens = len(static_forward_batch.input_ids)
             raw_num_tokens = self.raw_num_tokens
 
+            if self.model_runner.attn_backend.war_reads_done_at_snapshot:
+                read_done = self.device_module.Event()
+                read_done.record()
+                self.model_runner.war_fastpath_read_done_event = read_done
+
             if self.layer_model is not None:
                 # BCG / Full: replay the captured body, run the LM head +
                 # logits_processor eagerly. For Full, slice hidden_states to
@@ -1011,6 +1016,13 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                             ).copy_(ie[:static_n])
                     hs = self.backend.replay(shape_key, static_forward_batch, **kwargs)
                     return hs[:raw_num_tokens] if full_path else hs
+
+                static_forward_batch.global_num_tokens_for_logprob_cpu = (
+                    forward_batch.global_num_tokens_for_logprob_cpu
+                )
+                static_forward_batch.global_num_tokens_for_logprob_gpu = (
+                    forward_batch.global_num_tokens_for_logprob_gpu
+                )
 
                 original_layer_forward = self.layer_model.forward
                 self.layer_model.forward = replay_layer_forward

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3328,6 +3328,13 @@ class ServerArgs:
         """
         from sglang.srt.configs.model_config import is_deepseek_v4
 
+        if envs.SGLANG_EXPERIMENTAL_FORCE_BCG.get():
+            logger.warning(
+                "SGLANG_EXPERIMENTAL_FORCE_BCG=1: skipping breakable-CG "
+                "incompatibility rules"
+            )
+            return
+
         rules = [
             # MLA prefill takes a different attn-forward path under BCG.
             ("MLA attention", lambda: self.use_mla_backend()),


### PR DESCRIPTION
**Status: WIP / experimental draft — not ready to merge.** Opened to share the approach and measurements; see the open-problems list below.

## Motivation

With mixed-chunk enabled, the steady state is 100% mixed steps running fully eager: launching a ~180 ms step costs ~170 ms of Python launch time (measured), so the GPU queue never builds backlog and every scheduler pause surfaces as a GPU bubble (~7 ms/step). BCG cuts launch CPU ~6x (2156 kernel launches -> 62 graph replays + eager attention breaks), but naively enabling it made throughput worse. Three integration issues were found and fixed.

## What this PR does

1. **WAR read-done event for BCG prefill replays** — the fast path (`Scheduler._apply_war_barrier`) was only fed by the decode graph; BCG replays fell back to `wait_stream(forward)`, turning batch-assembly D2H syncs into a ~90 ms/step wall. The DSV4 backend now pre-builds the sparse-prefill chunk cache from the live batch in the replay-prepare hook (sync-free: `total_swa` computed CPU-side), moving all scheduler-shared reads to the snapshot, and the prefill runner publishes the event when the backend opts in (`war_reads_done_at_snapshot`).
2. **Mixed decode/prefill split under replay** — the #30338 split gate relied on `forward_mode.is_mixed()`, which is normalized to EXTEND at replay; the boundary now flows through the refreshed metadata.
3. **Live logprob counts for the eager logits tail** — the static batch carries capture-time bucket-padded `global_num_tokens_for_logprob_*`, making the DP-attention hidden gather + vocab all-gather + reorder copies run over every padded token (e.g. 16384 rows) instead of the sampling positions (~1.8k rows); the runner now passes the live counts.

Enablement is gated behind `SGLANG_EXPERIMENTAL_FORCE_BCG=1`, which bypasses the four breakable-CG incompatibility rules (MLA / DSV4 capture-pool pressure / MoE A2A bucket cap / DP-attention) pending proper graduation.

## Results

8xB300, DeepSeek-V4-Pro FP4, 8k1k, conc 2048 (megamoe + dp-attention + mixed-chunk), radix cache with forced misses, num_prompts = 6x conc, warmup = 2x conc; additionally `--cuda-graph-bs-prefill 512 1024 1536 2048 2560 2816` and `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=2816`:

| | Throughput (tok/s) | Median TPOT | GSM8K (n=200) |
|---|---:|---:|---:|
| eager, no split | 8983 | 196.3 ms | — |
| eager + mixed split (#30338) | 9828 | 177.2 ms | 0.970 |
| BCG, no integration fixes | 8471 | 208.6 ms | 0.975 |
| BCG + WAR event + split-under-replay | 9486 | 183.6 ms | 0.980 |
| **BCG + all fixes (this PR)** | **10076** | **172.5 ms** | **0.985** |
| BCG + all fixes + `--enable-dp-lm-head` | 10105 | 172.0 ms | — |

All runs 12288/12288 successful, zero scheduler exceptions. Steady-state traces confirm: launch CPU 171 -> 29 ms/step, graphs replayed on >66k mixed steps under DP attention.

`--enable-dp-lm-head` is neutral (+0.3%, within run variance) once the logits-gather sizing is fixed — before the fix it would mask the oversized gather entirely (the DP gather path is skipped), at the cost of replicating the LM head (~1.85 GB/GPU). We keep it off by default.

## Why this is a draft — open problems

1. **The four incompatibility rules are bypassed, not graduated.** They need to become conditional: MoE A2A is safe when capture buckets ≤ `NUM_MAX_TOKENS_PER_RANK`; DSV4 capture-pool pressure is bounded by a small bucket list (the old default ran to 16384); the MLA rule should exclude the DSV4 backend (its whole attention is an eager break); DP-attention is validated here for one topology only.
2. **Prefill capture buckets are manual** (`--cuda-graph-bs-prefill`); needs defaults derived from `chunked_prefill_size` + the mixed budget (steady mixed steps land exactly on chunk-size tokens by construction).
3. **The WAR snapshot contract is backend-declared** (`war_reads_done_at_snapshot`); needs review that eviction/allocator interactions cannot invalidate it, plus a debug assertion story.
4. **Residual replay overhead remains** (~4% vs the GPU-bound floor): per-layer attention-break output copies (~30 MB x 61/step) could write directly into the static slots; the multimem all-gather capacity (`recommended_max_tokens(include_prefill=False)`) needs prefill-aware sizing.
5. **Coverage**: validated only on 8xB300 DSV4-Pro at conc 2048; no CI tests for BCG x DSV4 x DP-attention capture/replay or accuracy.

Depends on #30338.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28889917824](https://github.com/sgl-project/sglang/actions/runs/28889917824)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28889917584](https://github.com/sgl-project/sglang/actions/runs/28889917584)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->