### PR TITLE
[AMD][Not-Merge] ci: self-heal driver-level VRAM leaks + graceful GPU cleanup on shutdown

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -277,6 +277,10 @@ jobs:
           run_pytest docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_torch_defaults_reset.py
           exit $failures
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   sgl-kernel-unit-test-2-gpu-amd:
     name: ${{ format('sgl-kernel-unit-test-2-gpu-amd (linux-{0}-2gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, call-gate]
@@ -315,6 +319,10 @@ jobs:
           CONTINUE_ON_ERROR: ${{ needs.check-changes.outputs.continue_on_error }}
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite sgl-kernel-unit-test-2-gpu-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   # =============================================== primary ====================================================
 
@@ -355,6 +363,10 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-gpu-small-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   jit-kernel-unit-test-amd:
     name: ${{ format('jit-kernel-unit-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, call-gate]
@@ -392,6 +404,10 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   jit-kernel-benchmark-test-amd:
     name: ${{ format('jit-kernel-benchmark-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, call-gate]
@@ -428,6 +444,10 @@ jobs:
         timeout-minutes: 30
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-benchmark-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   # =============================================== Wait Jobs for Sequential PR Execution ====================================================
   # These jobs poll GitHub API to wait for previous stages to complete.
@@ -495,6 +515,10 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   stage-b-test-1-gpu-small-amd-nondeterministic:
     name: ${{ format('stage-b-test-1-gpu-small-amd-nondeterministic (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, wait-for-stage-a-amd]
@@ -530,6 +554,10 @@ jobs:
         timeout-minutes: 75
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   stage-b-test-1-gpu-small-amd-mi35x:
     needs: [check-changes, wait-for-stage-a-amd]
@@ -569,6 +597,10 @@ jobs:
         timeout-minutes: 30
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-mi35x ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   stage-b-test-1-gpu-large-amd:
     name: ${{ format('stage-b-test-1-gpu-large-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
@@ -610,6 +642,10 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   stage-b-test-2-gpu-large-amd:
     name: ${{ format('stage-b-test-2-gpu-large-amd (linux-{0}-2gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, wait-for-stage-a-amd]
@@ -649,6 +685,10 @@ jobs:
         timeout-minutes: 45
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   multimodal-gen-test-1-gpu-amd:
     name: ${{ format('multimodal-gen-test-1-gpu-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
@@ -790,6 +830,10 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   multimodal-gen-test-2-gpu-amd:
     name: ${{ format('multimodal-gen-test-2-gpu-amd (linux-{0}-2gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, call-gate]
@@ -928,6 +972,10 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   # AMD counterpart of the CUDA `multimodal-gen-unit-test` job
   # (pr-test-multimodal-gen.yml): the mm_gen `unit` suite is portable,
   # CPU-style unit tests (config / sampling params / storage / loaders / etc.)
@@ -987,6 +1035,10 @@ jobs:
               --suite unit \
               -k "not ltx2_vae_channels_last" \
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   wait-for-stage-b-amd:
     needs: [check-changes, call-gate, wait-for-stage-a-amd]
@@ -1071,6 +1123,10 @@ jobs:
               --retry-timeout-increase 0 \
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   stage-c-test-large-8-gpu-amd:
     name: ${{ format('stage-c-test-large-8-gpu-amd (linux-{0}-8gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
@@ -1119,6 +1175,10 @@ jobs:
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 5400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
+
   stage-c-test-large-8-gpu-amd-mi35x:
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
     if: |
@@ -1158,6 +1218,10 @@ jobs:
         timeout-minutes: 60
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd-mi35x --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   # =============================================== Disaggregation ====================================================
   stage-b-test-large-8-gpu-mi35x-disaggregation-amd:
@@ -1292,6 +1356,10 @@ jobs:
             -e MC_LOG_LEVEL=TRACE \
             -e GLOG_logtostderr=1 \
             -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-large-8-gpu-mi35x-disaggregation-amd --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+
+      - name: Stop CI container
+        if: always()
+        run: bash scripts/ci/amd/amd_ci_stop_container.sh
 
   pr-test-amd-finish:
     needs:

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -310,7 +310,14 @@ case "${ENABLE_CACHE_HOST,,}" in
 esac
 
 echo "Launching container: ci_sglang"
-docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
+# --init runs a minimal init (tini) as PID 1 so that:
+#   * SIGTERM from `docker stop` is forwarded to the sglang process group
+#     instead of being swallowed by a non-forwarding shell PID 1, and
+#   * exited sglang worker children (scheduler / TP / detokenizer procs) are
+#     reaped instead of lingering as zombies that keep KFD contexts (and thus
+#     VRAM) alive. This is central to freeing GPU memory cleanly on shutdown.
+docker run -dt --init --user root --device=/dev/kfd ${DEVICE_FLAG} \
+  --label sglang-ci=1 \
   --ulimit nofile=65536:65536 \
   -v "${GITHUB_WORKSPACE:-$PWD}:/sglang-checkout" \
   $CACHE_VOLUME \

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -293,7 +293,11 @@ add_mount_if_exists "libmnl" "libmnl.so*"
 echo "Mount args: $MOUNT_ARGS"
 
 echo "Launching container: ci_sglang"
-docker run -dt --user root \
+# --init runs tini as PID 1 so SIGTERM from `docker stop` reaches the sglang
+# process group and exited worker children are reaped, instead of leaving
+# zombie KFD contexts that leak VRAM on shutdown.
+docker run -dt --init --user root \
+  --label sglang-ci=1 \
   --device=/dev/kfd \
   --device=/dev/dri \
   ${DEVICE_FLAG} \

--- a/scripts/ci/amd/amd_ci_stop_container.sh
+++ b/scripts/ci/amd/amd_ci_stop_container.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Gracefully tear down the ci_sglang container at the end of a job.
+#
+# Why this exists: the AMD CI jobs launch `ci_sglang` but historically never
+# stopped it -- cleanup was left entirely to the *next* job's
+# "Ensure VRAM is clear" step. When the ephemeral runner pod is recycled (or
+# force-deleted) between jobs, the still-running sglang server is SIGKILLed
+# mid-HIP-operation, which leaves an unreclaimable KFD context and leaks VRAM
+# with no owning process (ROCm/aiter#2061). Running this as an `if: always()`
+# teardown step lets sglang free its GPU memory *before* the pod terminates.
+#
+# This script is intentionally best-effort and never fails the job: a teardown
+# problem must not turn a green test run red. Set -e is deliberately NOT used.
+
+set -uo pipefail
+
+CONTAINER="${1:-ci_sglang}"
+STOP_TIMEOUT="${DOCKER_STOP_TIMEOUT:-60}"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker not available; nothing to tear down."
+    exit 0
+fi
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    echo "Container '$CONTAINER' not found; nothing to tear down."
+    exit 0
+fi
+
+echo "=== Gracefully stopping container '$CONTAINER' ==="
+
+# Step 1: ask the sglang processes inside the container to shut down cleanly.
+# SIGINT lets sglang run its normal teardown (kill_process_tree + torch
+# CUDA/HIP context teardown) so VRAM is released. pkill is best-effort; the
+# container may already be idle.
+echo "Signalling sglang processes inside the container (SIGINT)..."
+docker exec "$CONTAINER" bash -c '
+    pkill -INT -f "sglang::|sglang\.launch_server|sglang\.bench|sglang\.data_parallel|sglang\.srt|sglang serve" 2>/dev/null || true
+' 2>/dev/null || true
+
+# Give sglang a few seconds to unwind before the harder stop.
+sleep 5
+
+# Step 2: `docker stop` with a generous grace period. --init (see
+# amd_ci_start_container.sh) forwards this SIGTERM to the process group and
+# reaps children, so remaining GPU contexts are torn down cleanly instead of
+# being SIGKILLed.
+echo "docker stop --time ${STOP_TIMEOUT} ${CONTAINER}..."
+docker stop --time "$STOP_TIMEOUT" "$CONTAINER" 2>/dev/null || true
+
+# Step 3: remove the container so the name is free for the next job.
+docker rm -f "$CONTAINER" 2>/dev/null || true
+
+# Step 4: best-effort visibility into whether VRAM actually came back.
+if command -v rocm-smi >/dev/null 2>&1; then
+    echo "=== Post-teardown VRAM status ==="
+    timeout 30 rocm-smi --showmemuse 2>&1 || echo "rocm-smi --showmemuse timed out"
+fi
+
+echo "=== Teardown of '$CONTAINER' complete ==="
+exit 0

--- a/scripts/ci/amd/check_vram_clear.sh
+++ b/scripts/ci/amd/check_vram_clear.sh
@@ -20,6 +20,25 @@ check_vram_clear() {
    fi
 }
 
+# Print the indices of GPUs whose VRAM usage is above threshold, one per line.
+# Used by ensure_vram_clear.sh to scope a last-resort `rocm-smi --gpureset` to
+# only the leaked GPUs, so we never touch a device another job is still using.
+#
+# rocm-smi --showmemuse emits one line per card, e.g.:
+#   GPU[0]          : GPU Memory Allocated (VRAM%): 95
+# We extract the card index whenever that percentage is >= 6.
+get_dirty_gpu_indices() {
+    command -v rocm-smi >/dev/null 2>&1 || return 0
+    # Keep only the per-card lines whose VRAM% is >= 6 (same regex as the
+    # check above), then pull the card index out of the "GPU[N]" prefix.
+    # Uses only grep/sort so it works with mawk-only runners too.
+    rocm-smi --showmemuse 2>/dev/null \
+        | grep -E "GPU Memory Allocated \(VRAM%\): ([6-9]|[1-9][0-9]|100)" \
+        | grep -oE 'GPU\[[0-9]+\]' \
+        | grep -oE '[0-9]+' \
+        | sort -un
+}
+
 # If this script is run directly (not sourced), run the check
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     set -e

--- a/scripts/ci/amd/ensure_vram_clear.sh
+++ b/scripts/ci/amd/ensure_vram_clear.sh
@@ -42,7 +42,12 @@ stop_all_gpu_containers() {
     for cid in $gpu_ids; do
         docker ps -a --filter "id=$cid" --format '  {{.ID}} {{.Image}} {{.Status}} {{.Names}}' 2>/dev/null || true
     done
-    echo "$gpu_ids" | xargs -r docker stop --time 5 2>/dev/null || true
+    # Give containers a real chance to tear down gracefully so the sglang
+    # server can free VRAM before we pull the plug. A 5s window used to
+    # SIGKILL an 8-GPU TP server mid-HIP-op, which is exactly what leaves an
+    # unreclaimable KFD context behind. Configurable via DOCKER_STOP_TIMEOUT.
+    local stop_timeout="${DOCKER_STOP_TIMEOUT:-60}"
+    echo "$gpu_ids" | xargs -r docker stop --time "$stop_timeout" 2>/dev/null || true
     echo "$gpu_ids" | xargs -r docker rm -f 2>/dev/null || true
 }
 
@@ -156,6 +161,89 @@ dump_gpu_diagnostics() {
     timeout 30 rocm-smi --showmemuse 2>&1 || echo "rocm-smi --showmemuse timed out"
 }
 
+# List PIDs (host, container, or zombie) that still hold a GPU device file.
+# Empty output means the only thing keeping VRAM allocated is a driver/KFD
+# context with no owning process -- the ROCm/aiter#2061 signature.
+list_gpu_device_holders() {
+    local pids=""
+    if command -v fuser >/dev/null 2>&1; then
+        pids+=" $(fuser /dev/kfd 2>/dev/null || true)"
+        for dev in /dev/dri/renderD*; do
+            [ -e "$dev" ] || continue
+            pids+=" $(fuser "$dev" 2>/dev/null || true)"
+        done
+    elif command -v lsof >/dev/null 2>&1; then
+        pids+=" $(lsof -t /dev/kfd 2>/dev/null || true)"
+        for dev in /dev/dri/renderD*; do
+            [ -e "$dev" ] || continue
+            pids+=" $(lsof -t "$dev" 2>/dev/null || true)"
+        done
+    fi
+    echo "$pids" | tr ' ' '\n' | grep -E '^[0-9]+$' | sort -u || true
+}
+
+# Last-resort recovery for a driver/KFD-level VRAM leak: VRAM is still
+# allocated but NO process (host, container, or zombie) owns it. A per-device
+# `rocm-smi --gpureset` clears the orphaned KFD context without a full node
+# reboot, letting CI self-heal on an otherwise-blocked node.
+#
+# SAFETY: we only reset GPUs that are (a) still dirty AND (b) have no process
+# holding any GPU device file. A GPU actively running another tenant's job
+# always has a device-file holder, so it is never eligible -- this cannot
+# disturb a co-scheduled job on the same node (e.g. GPUs 4-7 busy while 0-3
+# leaked). Gated by AMD_CI_GPU_RESET (default: auto); set to 0 to disable.
+attempt_gpu_reset() {
+    local mode="${AMD_CI_GPU_RESET:-auto}"
+    case "${mode,,}" in
+        0|false|off|no|disable|disabled)
+            echo "GPU reset disabled (AMD_CI_GPU_RESET=${mode}); skipping self-heal."
+            return 1
+            ;;
+    esac
+
+    if ! command -v rocm-smi >/dev/null 2>&1; then
+        echo "rocm-smi not available; cannot attempt GPU reset."
+        return 1
+    fi
+
+    # A reset while any process is still attached can wedge the driver, so
+    # bail out if any GPU device file still has a holder.
+    local holders
+    holders=$(list_gpu_device_holders)
+    if [ -n "$holders" ]; then
+        echo "Skipping GPU reset: processes still hold GPU device files (PIDs below)."
+        echo "$holders"
+        return 1
+    fi
+
+    local dirty_gpus
+    dirty_gpus=$(get_dirty_gpu_indices)
+    if [ -z "$dirty_gpus" ]; then
+        echo "No dirty GPUs detected; nothing to reset."
+        return 1
+    fi
+
+    echo "=== Driver-level leak detected: attempting scoped GPU reset ==="
+    echo "Leaked GPUs with no owning process: $(echo "$dirty_gpus" | tr '\n' ' ')"
+
+    local idx
+    for idx in $dirty_gpus; do
+        echo "Resetting GPU ${idx} (rocm-smi --gpureset -d ${idx})..."
+        timeout 60 rocm-smi --gpureset -d "$idx" 2>&1 \
+            || echo "  GPU ${idx}: reset returned non-zero (unsupported, busy, or needs reboot)."
+    done
+
+    echo "Waiting 15s for GPUs to settle after reset..."
+    sleep 15
+
+    if check_vram_clear; then
+        echo "✓ Scoped GPU reset recovered the leaked VRAM."
+        return 0
+    fi
+    echo "✗ GPU reset did not clear VRAM; a node reboot is still required."
+    return 1
+}
+
 ensure_vram_clear() {
     local max_retries=3
     local retry_count=0
@@ -169,9 +257,11 @@ ensure_vram_clear() {
     echo "========================"
     echo "Running in ROCm mode"
 
-    # Always stop the well-known CI container first (best-effort).
+    # Always stop the well-known CI container first (best-effort). Use a
+    # generous grace period so a leftover sglang server frees VRAM instead of
+    # being SIGKILLed mid-HIP-op (the root cause of the driver-level leak).
     echo "Stopping any existing ci_sglang container..."
-    docker stop ci_sglang 2>/dev/null || true
+    docker stop --time "${DOCKER_STOP_TIMEOUT:-60}" ci_sglang 2>/dev/null || true
     docker rm -f ci_sglang 2>/dev/null || true
 
     # Show initial GPU status
@@ -249,6 +339,15 @@ ensure_vram_clear() {
         fi
     done
 
+    # Process/container-based cleanup exhausted. If the leak is purely
+    # driver-level (VRAM allocated, no owning process — the ROCm/aiter#2061
+    # signature), try a scoped, guarded GPU reset before giving up and
+    # forcing a manual node reboot.
+    if attempt_gpu_reset; then
+        echo "=== RECOVERED: VRAM cleared via scoped GPU reset ==="
+        return 0
+    fi
+
     # Failed after all retries — diagnostics for the last cleanup attempt
     # were already dumped above; just print the actionable hint.
     echo "=== FAILED: VRAM cleanup unsuccessful after $max_retries attempts ==="
@@ -256,7 +355,9 @@ ensure_vram_clear() {
     echo "=================================================================="
     echo "Hint: if no host process / container holds the GPU but VRAM is"
     echo "still allocated, this is almost certainly a zombie KFD context"
-    echo "(see ROCm/aiter#2061). The node will need to be rebooted before"
+    echo "(see ROCm/aiter#2061). A scoped 'rocm-smi --gpureset' was already"
+    echo "attempted automatically (unless AMD_CI_GPU_RESET=0); if it did not"
+    echo "recover the GPUs, the node must be rebooted (or drained) before"
     echo "subsequent jobs can succeed."
     echo "=================================================================="
     return 1


### PR DESCRIPTION
## Summary

Fixes AMD CI jobs getting blocked by an unreclaimable **driver/KFD-level VRAM leak** — VRAM allocated on GPUs with *no owning process* (the [ROCm/aiter#2061](https://github.com/ROCm/aiter/issues/2061) signature). `scripts/ci/amd/ensure_vram_clear.sh` correctly *detected* this but could only fail, so every job landing on the affected node aborted at the pre-flight `Ensure VRAM is clear` step until a manual node reboot.

**Active incident this resolves:** a fleet-wide zombie-KFD outage on the MI35x runners (7+ consecutive days, ~37 jobs across all four AMD workflows). Signature: GPUs 0–3 stuck at ~13–16% VRAM with no owning KFD PID → `ensure_vram_clear.sh` aborts after 3 attempts → test never runs.

Root cause on the runner side:
- the `ci_sglang` container was **never gracefully stopped** — cleanup was deferred entirely to the *next* job;
- it ran **without `--init`**, so `docker stop`'s SIGTERM never reached the sglang process group;
- cleanup used only a **5s** stop grace window, so an 8-GPU TP server was SIGKILLed mid-HIP-op, leaving a zombie KFD context that leaks VRAM.

## Changes
- **`ensure_vram_clear.sh`**: last-resort, scoped, guarded `rocm-smi --gpureset` self-heal. Resets **only** GPUs that are dirty **and** have no process holding any GPU device file, so a co-scheduled job on the same node (e.g. GPUs 4–7 busy while 0–3 leaked) is never disturbed. Gated by `AMD_CI_GPU_RESET` (default on; set `0` to disable).
- **`check_vram_clear.sh`**: `get_dirty_gpu_indices()` (portable grep/sort, mawk-safe) to scope the reset to leaked GPUs (≥6% VRAM → flagged, so the 13–16% incident case is covered).
- Raise cleanup `docker stop` grace window **5s → 60s** (`DOCKER_STOP_TIMEOUT`).
- **`amd_ci_start_container.sh` / `amd_ci_start_container_disagg.sh`**: run with `--init` so SIGTERM reaches sglang and exited workers are reaped.
- New **`amd_ci_stop_container.sh`** + a `Stop CI container` teardown step (`if: always()`) on every GPU job in `pr-test-amd.yml` — frees VRAM at job end and on cancellation.

## Fleet coverage
The recovery (self-heal) and the core prevention (`--init`, 60s stop) live in the **shared scripts**, so they reach every AMD workflow that calls them — not just `pr-test-amd`:

| Workflow | `ensure_vram_clear.sh` (self-heal) | `amd_ci_start_container.sh` (`--init`) |
|---|:--:|:--:|
| `nightly-test-amd` | ✅ | ✅ |
| `nightly-test-amd-rocm720` | ✅ | ✅ |
| `nightly-test-amd-miles-rocm720` | ✅ | ✅ |
| `pr-test-amd-rocm720` | ✅ | ✅ (+ disagg) |
| `pr-test-amd` | ✅ | ✅ (+ per-job teardown step) |

Follow-up (not in this PR): add the workflow-level `Stop CI container` teardown step to the nightly / rocm720 workflows too, for symmetric job-end cleanup.

## Validation

**Before → after** — same pre-flight `Ensure VRAM is clear` step, on MI35x/MI325 hardware:

| | Run | Result |
|---|---|---|
| **Before** (leak, no fix) | [Release Branch Cut → `nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp`](https://github.com/sgl-project/sglang/actions/runs/28848316166/job/85557386910) | ❌ `Ensure VRAM is clear` → **exit 1** (GPUs 0–3 leaked, no owning KFD PID); test never runs |
| **After** (this branch) | [`stage-a-test-1-gpu-small-amd` — Run #28903224071](https://github.com/sgl-project/sglang/actions/runs/28903224071) | ✅ VRAM-clear passes, container starts with `--init`, `Stop CI container` frees VRAM back to **0%** at job end |

- `bash -n` on all scripts + YAML validation of the workflow; the scoped-reset parser was unit-checked against the exact incident signature (GPUs 0–3 dirty, 4–7 clean).

## Test plan
- [x] AMD stage runs green on real hardware — targeted dispatch [`stage-a-test-1-gpu-small-amd` — Run #28903224071](https://github.com/sgl-project/sglang/actions/runs/28903224071) passed on MI325 (this branch's full workflow, incl. the new teardown step).
- [x] `--init` container start + `Stop CI container` teardown verified in that run's logs (VRAM returns to 0% at job end).
- [x] `Ensure VRAM is clear` stays correct on a clean node (scoped-reset path stays dormant when there is no leak); `get_dirty_gpu_indices` unit-checked against the incident signature (GPUs 0–3 dirty, 4–7 clean).
- [ ] Observe the scoped `rocm-smi --gpureset` path actually *engage and recover* on a real leaked node (no device-file holder) — pending a run that lands on a currently-stuck node, or a manual repro.
- [ ] Confirm the AMD runner pods actually have `rocm-smi --gpureset` privileges (needs GPU idle + sufficient caps); if not permitted, the self-heal logs a clean failure and falls back to the reboot path (no regression).
- [ ] Full `pr-test-amd` suite green on the runner pool (blocked earlier only by the missing `run-ci` gate label, not the code).

> Note: the `FailedKillPod` / PreStopHook timeouts also warrant a runner-pod-spec change (a `preStop` hook running `amd_ci_stop_container.sh` + `terminationGracePeriodSeconds: 90`); that lives in the runner scale-set infra repo, outside this tree.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29058385096](https://github.com/sgl-project/sglang/actions/runs/29058385096)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29058385001](https://github.com/sgl-project/sglang/actions/runs/29058385001)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


