### PR TITLE
[DO NOT MERGE][AMD][DI][CI] Kimi-K2.6 disagg diagnostic recipes for non-MTP GSM8K drop

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -120,6 +120,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Clean up prior Slurm jobs from this runner
         continue-on-error: true

--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -118,6 +118,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Clean up prior Slurm jobs from this runner
         continue-on-error: true

--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -219,6 +219,16 @@ jobs:
             scancel $ACTIVE_JOBS
           fi
 
+      - name: Clean up MI355X scratch
+        if: always()
+        continue-on-error: true
+        run: |
+          LOG_DIR="$HOME/.mi355x_ci/${MATRIX_CONFIG_NAME}"
+          if [ -d "$LOG_DIR" ]; then
+            echo "Removing MI355X scratch directory: $LOG_DIR"
+            rm -rf "$LOG_DIR"
+          fi
+
   collect-results:
     needs: nightly-mi355x-benchmark
     if: github.repository == 'sgl-project/sglang' && always()

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -63,6 +63,13 @@ _MLA_DECODE_MIN_BLOCK_KV = 32
 def _mla_decode_kv_splits_cap(
     base_max_kv_splits: int, sm_count: int, max_context_len: int
 ) -> int:
+    # Diagnostic override: skip the MLA split floor so
+    # --triton-attention-num-kv-splits can force nsplit as low as 1. Tests
+    # whether the decode split-KV online-softmax reduction over a long
+    # MORI-transferred prefix is the source of the non-MTP disagg accuracy drop
+    # (extend/verify use no split-KV and stay correct at ~0.95).
+    if get_bool_env_var("SGLANG_DEBUG_MLA_DECODE_NO_SPLIT_CAP", "false"):
+        return base_max_kv_splits
     if sm_count <= 0:
         return base_max_kv_splits
     sm_cap = next_power_of_2(sm_count)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3011,58 +3011,96 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         self.forward_pass_id += 1
 
-        # --- DIAGNOSTIC (env-gated, one-shot): dump disagg-decode KV metadata +
-        # content for the first few decode batches. Localizes the Kimi-K2.6
-        # non-MTP disagg GSM8K drop: is the decode-side seq_len / req_to_token
-        # mapping wrong, or is the MORI-transferred KV missing/zero at some slots
-        # (e.g. the prefix boundary token)? No-op unless the env is set.
+        # --- DIAGNOSTIC (env-gated): localize the Kimi-K2.6 non-MTP disagg GSM8K
+        # drop. The warmup-probe pass showed the MORI-transferred prefix KV reads
+        # as exactly 0 in the decode KV pool. Here we skip the short warmup probe
+        # (seq_len < 64), inspect a real (long, GSM8K) prefix across several
+        # layers, and page-bucket the zero rows to test whether the gaps are
+        # page-aligned (page_size=256) or a boundary. No-op unless the env is set.
         if (
             os.environ.get("SGLANG_DEBUG_DISAGG_DECODE_DUMP", "0") == "1"
             and forward_batch.forward_mode.is_decode()
-            and getattr(self, "_disagg_decode_dump_count", 0) < 5
         ):
-            self._disagg_decode_dump_count = (
-                getattr(self, "_disagg_decode_dump_count", 0) + 1
+            fb = forward_batch
+            seq_cpu = (
+                fb.seq_lens_cpu
+                if fb.seq_lens_cpu is not None
+                else fb.seq_lens.detach().cpu()
             )
-            try:
-                fb = forward_batch
-                seq_cpu = (
-                    fb.seq_lens_cpu
-                    if fb.seq_lens_cpu is not None
-                    else fb.seq_lens.detach().cpu()
+            s0 = int(seq_cpu[0].item()) if seq_cpu.numel() else 0
+            if s0 >= 64 and getattr(self, "_disagg_decode_dump_count", 0) < 3:
+                self._disagg_decode_dump_count = (
+                    getattr(self, "_disagg_decode_dump_count", 0) + 1
                 )
-                seq = seq_cpu.tolist()
-                r0 = int(fb.req_pool_indices[0].item())
-                s0 = int(seq[0])
-                slots = self.req_to_token_pool.req_to_token[r0, :s0]
-                neg = int((slots < 0).sum().item())
-                translate = getattr(
-                    self.token_to_kv_pool_allocator, "translate_kv_loc", None
-                )
-                phys = translate(slots) if translate is not None else slots
-                kbuf = self.token_to_kv_pool.get_key_buffer(0)
-                rows = kbuf[phys.to(kbuf.device).long()].float()
-                rownorm = rows.reshape(rows.shape[0], -1).norm(dim=-1)
-                logger.warning(
-                    "[DISAGG_DECODE_DUMP #%d rank=%s] mode=%s bs=%d seq_lens[:8]=%s | "
-                    "req0 pool_idx=%d seq_len=%d kv_slots=%d neg_slots=%d | "
-                    "KV L0 absmean=%.4e zero_rows=%d first3_norm=%s last3_norm=%s",
-                    self._disagg_decode_dump_count,
-                    getattr(self, "tp_rank", "?"),
-                    fb.forward_mode,
-                    len(seq),
-                    seq[:8],
-                    r0,
-                    s0,
-                    int(slots.numel()),
-                    neg,
-                    rows.abs().mean().item(),
-                    int((rownorm == 0).sum().item()),
-                    [round(x, 3) for x in rownorm[:3].tolist()],
-                    [round(x, 3) for x in rownorm[-3:].tolist()],
-                )
-            except Exception as e:  # never let the probe break a run
-                logger.warning("[DISAGG_DECODE_DUMP] failed: %r", e)
+                try:
+                    page_size = int(
+                        getattr(
+                            self.token_to_kv_pool,
+                            "page_size",
+                            getattr(self.server_args, "page_size", 1),
+                        )
+                        or 1
+                    )
+                    r0 = int(fb.req_pool_indices[0].item())
+                    slots = self.req_to_token_pool.req_to_token[r0, :s0]
+                    translate = getattr(
+                        self.token_to_kv_pool_allocator, "translate_kv_loc", None
+                    )
+                    phys = (translate(slots) if translate is not None else slots).to(
+                        "cpu"
+                    ).long()
+                    # Exclude the current (last) token: its KV is written later
+                    # this forward, so it is legitimately 0 here.
+                    pref = phys[:-1]
+                    neg = int((pref < 0).sum().item())
+                    nlayers = int(
+                        getattr(
+                            self.token_to_kv_pool,
+                            "layer_num",
+                            getattr(self.model_config, "num_hidden_layers", 1),
+                        )
+                    )
+                    layers = sorted({0, nlayers // 2, max(0, nlayers - 1)})
+                    msgs = []
+                    zero_idx0 = []
+                    for li, lyr in enumerate(layers):
+                        try:
+                            kbuf = self.token_to_kv_pool.get_key_buffer(lyr)
+                            rows = (
+                                kbuf[pref.to(kbuf.device)]
+                                .float()
+                                .reshape(pref.numel(), -1)
+                            )
+                            rn = rows.norm(dim=-1)
+                            zmask = rn == 0
+                            msgs.append(
+                                f"L{lyr}:zero={int(zmask.sum().item())}/{pref.numel()} "
+                                f"mean={rows.abs().mean().item():.3e}"
+                            )
+                            if li == 0:
+                                zero_idx0 = torch.nonzero(zmask).flatten().tolist()
+                        except Exception as e:
+                            msgs.append(f"L{lyr}:ERR {e!r}")
+                    zpages = sorted({i // page_size for i in zero_idx0})
+                    npages = (pref.numel() + page_size - 1) // page_size
+                    logger.warning(
+                        "[DISAGG_DECODE_DUMP #%d rank=%s] seq_len=%d prefix=%d "
+                        "page_size=%d neg_slots=%d | %s | zero_pos_first20=%s | "
+                        "zero_pages=%d/%d %s",
+                        self._disagg_decode_dump_count,
+                        getattr(self, "tp_rank", "?"),
+                        s0,
+                        pref.numel(),
+                        page_size,
+                        neg,
+                        " ".join(msgs),
+                        zero_idx0[:20],
+                        len(zpages),
+                        npages,
+                        zpages[:20],
+                    )
+                except Exception as e:  # never let the probe break a run
+                    logger.warning("[DISAGG_DECODE_DUMP] failed: %r", e)
 
         # Try msprob debugger
         if self.msprobe_debugger is not None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3083,10 +3083,26 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                             msgs.append(f"L{lyr}:ERR {e!r}")
                     zpages = sorted({i // page_size for i in zero_idx0})
                     npages = (pref.numel() + page_size - 1) // page_size
+                    # RoPE/position check: decode's current-token position must be
+                    # seq_len-1 per request; an off-by-one here (vs the absolute
+                    # positions the transferred keys were RoPE'd with at prefill)
+                    # corrupts attention scores while leaving KV norms untouched.
+                    pos = getattr(fb, "positions", None)
+                    pos_cpu = pos.detach().cpu() if pos is not None else None
+                    pos0 = (
+                        int(pos_cpu[0].item())
+                        if pos_cpu is not None and pos_cpu.numel()
+                        else -1
+                    )
+                    pos_mismatch = (
+                        int((pos_cpu != (seq_cpu.to(pos_cpu.dtype) - 1)).sum().item())
+                        if pos_cpu is not None and pos_cpu.numel() == seq_cpu.numel()
+                        else -1
+                    )
                     logger.warning(
                         "[DISAGG_DECODE_DUMP #%d rank=%s] seq_len=%d prefix=%d "
-                        "page_size=%d neg_slots=%d | %s | zero_pos_first20=%s | "
-                        "zero_pages=%d/%d %s",
+                        "page_size=%d neg_slots=%d | %s | zero_pages=%d/%d %s | "
+                        "pos0=%d exp=%d pos_vs_(seq-1)_mismatch=%d",
                         self._disagg_decode_dump_count,
                         getattr(self, "tp_rank", "?"),
                         s0,
@@ -3094,10 +3110,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                         page_size,
                         neg,
                         " ".join(msgs),
-                        zero_idx0[:20],
                         len(zpages),
                         npages,
                         zpages[:20],
+                        pos0,
+                        s0 - 1,
+                        pos_mismatch,
                     )
                 except Exception as e:  # never let the probe break a run
                     logger.warning("[DISAGG_DECODE_DUMP] failed: %r", e)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3011,6 +3011,59 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         self.forward_pass_id += 1
 
+        # --- DIAGNOSTIC (env-gated, one-shot): dump disagg-decode KV metadata +
+        # content for the first few decode batches. Localizes the Kimi-K2.6
+        # non-MTP disagg GSM8K drop: is the decode-side seq_len / req_to_token
+        # mapping wrong, or is the MORI-transferred KV missing/zero at some slots
+        # (e.g. the prefix boundary token)? No-op unless the env is set.
+        if (
+            os.environ.get("SGLANG_DEBUG_DISAGG_DECODE_DUMP", "0") == "1"
+            and forward_batch.forward_mode.is_decode()
+            and getattr(self, "_disagg_decode_dump_count", 0) < 5
+        ):
+            self._disagg_decode_dump_count = (
+                getattr(self, "_disagg_decode_dump_count", 0) + 1
+            )
+            try:
+                fb = forward_batch
+                seq_cpu = (
+                    fb.seq_lens_cpu
+                    if fb.seq_lens_cpu is not None
+                    else fb.seq_lens.detach().cpu()
+                )
+                seq = seq_cpu.tolist()
+                r0 = int(fb.req_pool_indices[0].item())
+                s0 = int(seq[0])
+                slots = self.req_to_token_pool.req_to_token[r0, :s0]
+                neg = int((slots < 0).sum().item())
+                translate = getattr(
+                    self.token_to_kv_pool_allocator, "translate_kv_loc", None
+                )
+                phys = translate(slots) if translate is not None else slots
+                kbuf = self.token_to_kv_pool.get_key_buffer(0)
+                rows = kbuf[phys.to(kbuf.device).long()].float()
+                rownorm = rows.reshape(rows.shape[0], -1).norm(dim=-1)
+                logger.warning(
+                    "[DISAGG_DECODE_DUMP #%d rank=%s] mode=%s bs=%d seq_lens[:8]=%s | "
+                    "req0 pool_idx=%d seq_len=%d kv_slots=%d neg_slots=%d | "
+                    "KV L0 absmean=%.4e zero_rows=%d first3_norm=%s last3_norm=%s",
+                    self._disagg_decode_dump_count,
+                    getattr(self, "tp_rank", "?"),
+                    fb.forward_mode,
+                    len(seq),
+                    seq[:8],
+                    r0,
+                    s0,
+                    int(slots.numel()),
+                    neg,
+                    rows.abs().mean().item(),
+                    int((rownorm == 0).sum().item()),
+                    [round(x, 3) for x in rownorm[:3].tolist()],
+                    [round(x, 3) for x in rownorm[-3:].tolist()],
+                )
+            except Exception as e:  # never let the probe break a run
+                logger.warning("[DISAGG_DECODE_DUMP] failed: %r", e)
+
         # Try msprob debugger
         if self.msprobe_debugger is not None:
             rank_id = (

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -26,9 +26,10 @@
 #                        off (e.g. hosts with a broken RDMA driver)
 #   SGLANG_USE_CHECKOUT_RUNTIME
 #                      - default 1. Reinstall this workflow checkout's Python
-#                        sglang package inside each runtime container before
-#                        launching servers/bench. Set 0 to use the image's
-#                        baked-in sglang package.
+#                        sglang package inside each runtime container, and the
+#                        checkout sglang-router package inside the bench
+#                        container, before launching servers/bench. Set 0 to
+#                        use the image's baked-in packages.
 #   RUNNER_NAME        - GitHub runner name (a built-in default env var)
 #   GITHUB_RUN_ID      - GitHub Actions run id (a built-in default env var)
 #                        The allocation is named
@@ -184,7 +185,7 @@ if [[ "$SGLANG_USE_CHECKOUT_RUNTIME" == "1" ]]; then
     echo "Staging checkout runtime: sha=$CHECKOUT_SHA -> $CHECKOUT_STAGE"
     rm -rf "$CHECKOUT_STAGE"
     mkdir -p "$CHECKOUT_STAGE"
-    tar --exclude='__pycache__' --exclude='*.pyc' \
+    tar --exclude='__pycache__' --exclude='*.pyc' --exclude='.git/config' \
         -C "$GITHUB_WORKSPACE" -cf - . | tar -C "$CHECKOUT_STAGE" -xf -
     CHECKOUT_DOCKER_ARGS="$CHECKOUT_DOCKER_ARGS -e SGLANG_CHECKOUT_SHA=$CHECKOUT_SHA -v $CHECKOUT_STAGE:/sglang-checkout:ro"
 else
@@ -387,6 +388,80 @@ if not actual.startswith(expected):
 PY
 EOF
 
+cat > "$WORKDIR/install_checkout_router.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+case "${SGLANG_USE_CHECKOUT_RUNTIME:-1}" in
+  0|false|False|FALSE|no|No|NO|off|Off|OFF)
+    echo "[checkout-router] disabled; using image-baked sglang-router"
+    python3 - <<'PY' || true
+import importlib.metadata
+import sglang_router
+
+print(f"[checkout-router] sglang_router_file={sglang_router.__file__}")
+print(
+    "[checkout-router] sglang_router_version="
+    f"{importlib.metadata.version('sglang-router')}"
+)
+try:
+    import sglang_router.sglang_router_rs as rs
+
+    print(f"[checkout-router] sglang_router_rs_file={rs.__file__}")
+except Exception as exc:
+    print(f"[checkout-router] sglang_router_rs_import_error={exc}")
+PY
+    exit 0
+    ;;
+esac
+
+RUNTIME_CHECKOUT="${RUNTIME_CHECKOUT:-/tmp/sglang-checkout-runtime}"
+ROUTER_SRC="$RUNTIME_CHECKOUT/sgl-model-gateway/bindings/python"
+WHEEL_DIR="${SGLANG_ROUTER_WHEEL_DIR:-/tmp/sglang-router-wheels}"
+
+if [[ ! -f "$ROUTER_SRC/pyproject.toml" ]]; then
+  echo "[checkout-router] ERROR: invalid router checkout: $ROUTER_SRC" >&2
+  exit 1
+fi
+
+echo "[checkout-router] building sglang-router from $ROUTER_SRC"
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-4}"
+python3 -m maturin --version >/dev/null 2>&1 \
+  || python3 -m pip install --no-cache-dir "maturin<1.14"
+
+# Match the ROCm image build recipe when compiling from the checkout copy.
+if [[ -f "$RUNTIME_CHECKOUT/sgl-model-gateway/Cargo.toml" ]]; then
+  sed -i -E 's|^(smg-[a-zA-Z-]+)\s*=\s*"~1\.0\.0"|\1 = "=1.0.0"|' \
+    "$RUNTIME_CHECKOUT/sgl-model-gateway/Cargo.toml"
+fi
+
+rm -rf "$WHEEL_DIR"
+mkdir -p "$WHEEL_DIR"
+(
+  cd "$ROUTER_SRC"
+  ulimit -n 65536 || true
+  python3 -m maturin build --release --features vendored-openssl --out "$WHEEL_DIR"
+)
+
+python3 -m pip uninstall -y sglang-router || true
+python3 -m pip install --force-reinstall --no-deps "$WHEEL_DIR"/*.whl
+
+python3 - <<'PY'
+import importlib.metadata
+import sglang_router
+import sglang_router.sglang_router_rs as rs
+from sglang_router.sglang_router_rs import Router
+
+print(f"[checkout-router] sglang_router_file={sglang_router.__file__}")
+print(
+    "[checkout-router] sglang_router_version="
+    f"{importlib.metadata.version('sglang-router')}"
+)
+print(f"[checkout-router] sglang_router_rs_file={rs.__file__}")
+print(f"[checkout-router] Router={Router}")
+PY
+EOF
+
 cat > "$WORKDIR/prefill_entry.sh" <<EOF
 #!/bin/bash
 set -euo pipefail
@@ -467,6 +542,7 @@ docker run $DOCKER_COMMON --name mi355x_bench \
     else
       export PYTHONPATH=/sgl-workspace/sglang/python:\${PYTHONPATH:-}
     fi
+    bash \$CIDIR/install_checkout_router.sh
     echo "[wait] prefill"; for i in \$(seq 1 600); do curl -sf http://\$PIP:$PPORT/health >/dev/null && break; sleep 5; done
     echo "[wait] decode";  for i in \$(seq 1 600); do curl -sf http://\$DIP:$DPORT/health >/dev/null && break; sleep 5; done
     python3 -m sglang_router.launch_router \

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -121,6 +121,7 @@ emit("LBPORT", rt["lb_port"])
 emit("MEMFRAC", rt["mem_fraction_static"])
 emit("PAGE", rt["page_size"])
 emit("MAXREQ", rt["max_running_requests"])
+emit("MAXTOK", rt.get("max_total_tokens", ""))
 emit("CHUNK", rt["chunked_prefill_size"])
 # swa is DSV4-specific; emit empty when a model omits it so the flag is dropped.
 emit("SWA", rt.get("swa_full_tokens_ratio", ""))
@@ -266,6 +267,7 @@ PY
 EXTRA_FLAGS=""
 (( PDP > 1 )) && EXTRA_FLAGS="$EXTRA_FLAGS --enable-dp-attention --dp-size $PDP"
 (( PEP > 1 )) && EXTRA_FLAGS="$EXTRA_FLAGS --ep-size $PEP"
+[[ -n "$MAXTOK" ]] && EXTRA_FLAGS="$EXTRA_FLAGS --max-total-tokens $MAXTOK"
 if [[ "$MTP_ENABLED" == "1" ]]; then
     EXTRA_FLAGS="$EXTRA_FLAGS --speculative-algorithm $MTP_ALGO \
 --speculative-num-steps $MTP_STEPS --speculative-eagle-topk $MTP_TOPK \

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -24,6 +24,11 @@
 #   SLURM_NODELIST     - optional explicit node pin (else scheduler chooses)
 #   SLURM_EXCLUDE      - optional comma-separated nodes to keep the scheduler
 #                        off (e.g. hosts with a broken RDMA driver)
+#   SGLANG_USE_CHECKOUT_RUNTIME
+#                      - default 1. Reinstall this workflow checkout's Python
+#                        sglang package inside each runtime container before
+#                        launching servers/bench. Set 0 to use the image's
+#                        baked-in sglang package.
 #   RUNNER_NAME        - GitHub runner name (a built-in default env var)
 #   GITHUB_RUN_ID      - GitHub Actions run id (a built-in default env var)
 #                        The allocation is named
@@ -52,6 +57,11 @@ set -x
 SLURM_PARTITION="${SLURM_PARTITION:-amd-sglang}"
 TIME_LIMIT="${TIME_LIMIT:-02:30:00}"
 MODEL_PATH="${MODEL_PATH:-${MODEL:-}}"
+SGLANG_USE_CHECKOUT_RUNTIME="${SGLANG_USE_CHECKOUT_RUNTIME:-1}"
+case "${SGLANG_USE_CHECKOUT_RUNTIME,,}" in
+    0|false|no|off) SGLANG_USE_CHECKOUT_RUNTIME=0 ;;
+    *) SGLANG_USE_CHECKOUT_RUNTIME=1 ;;
+esac
 
 if [[ -z "$MODEL_PATH" ]]; then
     echo "ERROR: set MODEL_PATH (local snapshot) or MODEL" >&2
@@ -162,6 +172,23 @@ echo "recipe: image=$IMAGE attn=${ATTN:-$PATTN/$DATTN} ib=$IB ptp=$PTP dtp=$DTP 
 WORKDIR="$HOME/.mi355x_ci/${MATRIX_CONFIG_NAME}"
 rm -rf "$WORKDIR"; mkdir -p "$WORKDIR"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Stage the workflow checkout on shared NFS so Slurm compute-node containers can
+# reinstall the same code SHA the workflow checked out. The container gets a
+# read-only mount and copies it to /tmp before mutating pyproject.toml.
+CHECKOUT_DOCKER_ARGS="-e SGLANG_USE_CHECKOUT_RUNTIME=$SGLANG_USE_CHECKOUT_RUNTIME"
+if [[ "$SGLANG_USE_CHECKOUT_RUNTIME" == "1" ]]; then
+    CHECKOUT_STAGE="$WORKDIR/checkout"
+    CHECKOUT_SHA="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+    echo "Staging checkout runtime: sha=$CHECKOUT_SHA -> $CHECKOUT_STAGE"
+    rm -rf "$CHECKOUT_STAGE"
+    mkdir -p "$CHECKOUT_STAGE"
+    tar --exclude='__pycache__' --exclude='*.pyc' \
+        -C "$GITHUB_WORKSPACE" -cf - . | tar -C "$CHECKOUT_STAGE" -xf -
+    CHECKOUT_DOCKER_ARGS="$CHECKOUT_DOCKER_ARGS -e SGLANG_CHECKOUT_SHA=$CHECKOUT_SHA -v $CHECKOUT_STAGE:/sglang-checkout:ro"
+else
+    echo "SGLANG_USE_CHECKOUT_RUNTIME=0; using sglang package baked into image."
+fi
 
 # Accuracy-gate helpers (written when enabled). Pre-stage the GSM8K test set on
 # shared NFS from the login node (which has internet) so the in-container eval
@@ -281,7 +308,7 @@ fi
 DOCKER_COMMON="--rm --network host --ipc host --shm-size 32g --privileged \
 --security-opt seccomp=unconfined \
 --device /dev/kfd --device /dev/dri --device /dev/infiniband \
--v /it-share:/it-share:ro -v $HOME:/host_home"
+-v /it-share:/it-share:ro -v $HOME:/host_home $CHECKOUT_DOCKER_ARGS"
 
 # ---------------------------------------------------------------------------
 # Write per-role scripts that srun dispatches to each compute node.
@@ -292,16 +319,109 @@ DOCKER_COMMON="--rm --network host --ipc host --shm-size 32g --privileged \
 # `${MODEL_SERVER_ARGS[@]}` refs are backslash-escaped to survive into the script
 # and expand after `source`. For DSV4 those arrays are empty and $DSV4_ENV_STR is
 # set, so the resulting docker argv is byte-identical to the pre-Kimi launcher.
+cat > "$WORKDIR/install_checkout_sglang.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+case "${SGLANG_USE_CHECKOUT_RUNTIME:-1}" in
+  0|false|False|FALSE|no|No|NO|off|Off|OFF)
+    echo "[checkout-sglang] disabled; using image-baked sglang"
+    exit 0
+    ;;
+esac
+
+CHECKOUT_SRC="${CHECKOUT_SRC:-/sglang-checkout}"
+RUNTIME_CHECKOUT="${RUNTIME_CHECKOUT:-/tmp/sglang-checkout-runtime}"
+
+if [[ ! -f "$CHECKOUT_SRC/python/sglang/version.py" ]]; then
+  echo "[checkout-sglang] ERROR: invalid checkout mount: $CHECKOUT_SRC" >&2
+  exit 1
+fi
+
+echo "[checkout-sglang] reinstalling sglang from $CHECKOUT_SRC"
+rm -rf "$RUNTIME_CHECKOUT"
+mkdir -p "$RUNTIME_CHECKOUT"
+tar --exclude='__pycache__' --exclude='*.pyc' \
+  -C "$CHECKOUT_SRC" -cf - . | tar -C "$RUNTIME_CHECKOUT" -xf -
+
+git config --global --add safe.directory "$RUNTIME_CHECKOUT" || true
+
+# The ROCm pyproject variant is the one used by AMD CI. Mutate only the private
+# /tmp copy so prefill/decode/bench never race on the read-only checkout mount.
+rm -f "$RUNTIME_CHECKOUT/python/pyproject.toml"
+cp "$RUNTIME_CHECKOUT/python/pyproject_other.toml" "$RUNTIME_CHECKOUT/python/pyproject.toml"
+for f in README.md LICENSE; do
+  if [[ -f "$RUNTIME_CHECKOUT/$f" && ! -e "$RUNTIME_CHECKOUT/python/$f" ]]; then
+    cp "$RUNTIME_CHECKOUT/$f" "$RUNTIME_CHECKOUT/python/$f"
+  fi
+done
+
+python3 -m pip uninstall -y sglang || true
+python3 -m pip install --no-deps --no-build-isolation -e "$RUNTIME_CHECKOUT/python"
+
+export RUNTIME_CHECKOUT
+export PYTHONPATH="$RUNTIME_CHECKOUT/python:${PYTHONPATH:-}"
+python3 - <<'PY'
+import importlib.metadata
+import os
+import subprocess
+import sglang
+
+checkout = os.environ["RUNTIME_CHECKOUT"]
+expected = os.path.realpath(os.path.join(checkout, "python", "sglang")) + os.sep
+actual = os.path.realpath(os.path.dirname(sglang.__file__)) + os.sep
+try:
+    sha = subprocess.check_output(
+        ["git", "-C", checkout, "rev-parse", "HEAD"], text=True
+    ).strip()
+except Exception:
+    sha = os.environ.get("SGLANG_CHECKOUT_SHA", "unknown")
+
+print(f"[checkout-sglang] sha={sha}")
+print(f"[checkout-sglang] sglang_file={sglang.__file__}")
+print(f"[checkout-sglang] sglang_version={importlib.metadata.version('sglang')}")
+if not actual.startswith(expected):
+    raise SystemExit(f"sglang did not import from checkout: {sglang.__file__}")
+PY
+EOF
+
+cat > "$WORKDIR/prefill_entry.sh" <<EOF
+#!/bin/bash
+set -euo pipefail
+CIDIR=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}
+source "\$CIDIR/model_flags.sh"
+bash "\$CIDIR/install_checkout_sglang.sh"
+if [[ "\${SGLANG_USE_CHECKOUT_RUNTIME:-1}" != "0" ]]; then
+  export PYTHONPATH=/tmp/sglang-checkout-runtime/python:\${PYTHONPATH:-}
+fi
+exec python3 -m sglang.launch_server \
+  --model-path $MODEL_PATH --host 0.0.0.0 --port $PPORT \
+  $COMMON_FLAGS "\${MODEL_SERVER_ARGS[@]}" \
+  --disaggregation-mode prefill --disaggregation-bootstrap-port $PBOOT
+EOF
+
+cat > "$WORKDIR/decode_entry.sh" <<EOF
+#!/bin/bash
+set -euo pipefail
+CIDIR=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}
+source "\$CIDIR/model_flags.sh"
+bash "\$CIDIR/install_checkout_sglang.sh"
+if [[ "\${SGLANG_USE_CHECKOUT_RUNTIME:-1}" != "0" ]]; then
+  export PYTHONPATH=/tmp/sglang-checkout-runtime/python:\${PYTHONPATH:-}
+fi
+exec python3 -m sglang.launch_server \
+  --model-path $MODEL_PATH --host 0.0.0.0 --port $DPORT \
+  $COMMON_FLAGS "\${MODEL_SERVER_ARGS[@]}" \
+  --disaggregation-mode decode --disaggregation-bootstrap-port $DBOOT
+EOF
+
 cat > "$WORKDIR/prefill.sh" <<EOF
 #!/bin/bash
 source "$WORKDIR/model_flags.sh"
 docker rm -f mi355x_prefill 2>/dev/null || true
 docker run $DOCKER_COMMON --name mi355x_prefill \
   -e HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 $MORI_ENV $DSV4_ENV_STR "\${MODEL_ENV_ARGS[@]}" \
-  $IMAGE python3 -m sglang.launch_server \
-  --model-path $MODEL_PATH --host 0.0.0.0 --port $PPORT \
-  $COMMON_FLAGS "\${MODEL_SERVER_ARGS[@]}" \
-  --disaggregation-mode prefill --disaggregation-bootstrap-port $PBOOT
+  $IMAGE bash /host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}/prefill_entry.sh
 EOF
 
 cat > "$WORKDIR/decode.sh" <<EOF
@@ -310,10 +430,7 @@ source "$WORKDIR/model_flags.sh"
 docker rm -f mi355x_decode 2>/dev/null || true
 docker run $DOCKER_COMMON --name mi355x_decode \
   -e HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 $MORI_ENV $DSV4_ENV_STR "\${MODEL_ENV_ARGS[@]}" \
-  $IMAGE python3 -m sglang.launch_server \
-  --model-path $MODEL_PATH --host 0.0.0.0 --port $DPORT \
-  $COMMON_FLAGS "\${MODEL_SERVER_ARGS[@]}" \
-  --disaggregation-mode decode --disaggregation-bootstrap-port $DBOOT
+  $IMAGE bash /host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}/decode_entry.sh
 EOF
 
 # Probe payload + validator (separate files to avoid quoting inside the
@@ -341,7 +458,13 @@ docker rm -f mi355x_bench 2>/dev/null || true
 docker run $DOCKER_COMMON --name mi355x_bench \
   -e PIP=\$PIP -e DIP=\$DIP \
   $IMAGE bash -lc '
-    export PYTHONPATH=/sgl-workspace/sglang/python:\$PYTHONPATH
+    CIDIR=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}
+    bash \$CIDIR/install_checkout_sglang.sh
+    if [ "\${SGLANG_USE_CHECKOUT_RUNTIME:-1}" != "0" ]; then
+      export PYTHONPATH=/tmp/sglang-checkout-runtime/python:\${PYTHONPATH:-}
+    else
+      export PYTHONPATH=/sgl-workspace/sglang/python:\${PYTHONPATH:-}
+    fi
     echo "[wait] prefill"; for i in \$(seq 1 600); do curl -sf http://\$PIP:$PPORT/health >/dev/null && break; sleep 5; done
     echo "[wait] decode";  for i in \$(seq 1 600); do curl -sf http://\$DIP:$DPORT/health >/dev/null && break; sleep 5; done
     python3 -m sglang_router.launch_router \
@@ -351,7 +474,6 @@ docker run $DOCKER_COMMON --name mi355x_bench \
       --host 0.0.0.0 --port $LBPORT \
       --disable-circuit-breaker &
     for i in \$(seq 1 30); do curl -sf http://127.0.0.1:$LBPORT/health >/dev/null && break; sleep 2; done
-    CIDIR=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}
     echo "[probe] PD end-to-end check via LB"
     curl -sf -X POST http://127.0.0.1:$LBPORT/generate \
       -H "content-type: application/json" -d @\$CIDIR/probe.json > \$CIDIR/probe_out.json \

--- a/scripts/ci/slurm/nightly-configs.yaml
+++ b/scripts/ci/slurm/nightly-configs.yaml
@@ -356,3 +356,63 @@ kimik26-fp8-mi355x-mtp-sglang:
       search-space:
         - conc-list: [1, 8, 16, 32, 64, 128, 256]
           config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp.yaml
+
+# ---------------------------------------------------------------------------
+# DIAGNOSTIC Kimi-K2.6 variants for the non-MTP disagg GSM8K accuracy drop
+# (~0.88 vs single-node 0.944 while MTP passes ~0.95). Not part of the default
+# nightly signal — trigger explicitly via the workflow_dispatch `configs` input.
+# Each isolates ONE variable vs the base 1p1d.yaml / 1p1d-mtp.yaml recipes and
+# trims the perf sweep to conc=1 (only the accuracy gate matters here):
+#   * -aiterdecode : non-MTP, decode backend triton -> aiter (control: is it
+#                    the backend or the decode forward-mode path?)
+#   * -nocudagraph : non-MTP + --disable-cuda-graph (is it HIP graph
+#                    capture/replay over the transferred prefix?)
+#   * -mtp-specdecode : MTP + --speculative-attention-mode decode (does routing
+#                    verify through the decode-mode path break MTP too?)
+kimik26-fp8-mi355x-aiterdecode-sglang:
+  model: moonshotai/Kimi-K2.6
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--moonshotai--Kimi-K2.6
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-aiterdecode.yaml
+
+kimik26-fp8-mi355x-nocudagraph-sglang:
+  model: moonshotai/Kimi-K2.6
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--moonshotai--Kimi-K2.6
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-nocudagraph.yaml
+
+kimik26-fp8-mi355x-mtp-specdecode-sglang:
+  model: moonshotai/Kimi-K2.6
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--moonshotai--Kimi-K2.6
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp-specdecode.yaml

--- a/scripts/ci/slurm/nightly-configs.yaml
+++ b/scripts/ci/slurm/nightly-configs.yaml
@@ -432,3 +432,19 @@ kimik26-fp8-mi355x-kvdump-sglang:
       search-space:
         - conc-list: [1]
           config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-kvdump.yaml
+
+kimik26-fp8-mi355x-nsplit1-sglang:
+  model: moonshotai/Kimi-K2.6
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--moonshotai--Kimi-K2.6
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-nsplit1.yaml

--- a/scripts/ci/slurm/nightly-configs.yaml
+++ b/scripts/ci/slurm/nightly-configs.yaml
@@ -416,3 +416,19 @@ kimik26-fp8-mi355x-mtp-specdecode-sglang:
       search-space:
         - conc-list: [1]
           config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp-specdecode.yaml
+
+kimik26-fp8-mi355x-kvdump-sglang:
+  model: moonshotai/Kimi-K2.6
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--moonshotai--Kimi-K2.6
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-kvdump.yaml

--- a/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-dp8ep8-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-dp8ep8-mtp.yaml
@@ -33,6 +33,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-dp8ep8.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-dp8ep8.yaml
@@ -33,6 +33,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d-mtp.yaml
@@ -33,6 +33,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/dsv4flash/1k1k/1p1d.yaml
@@ -35,6 +35,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-dp8ep8-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-dp8ep8-mtp.yaml
@@ -33,6 +33,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-dp8ep8.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-dp8ep8.yaml
@@ -33,6 +33,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d-mtp.yaml
@@ -33,6 +33,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsv4flash/1k1k/1p1d.yaml
@@ -33,6 +33,7 @@ runtime:
   mem_fraction_static: 0.90
   page_size: 256
   max_running_requests: 256
+  max_total_tokens: 8551168
   chunked_prefill_size: 8192
   swa_full_tokens_ratio: 0.1
 

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-aiterdecode.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-aiterdecode.yaml
@@ -1,0 +1,79 @@
+# MI355X Kimi-K2.6 (FP8) 2-node 1P1D disaggregation recipe (DIAGNOSTIC:
+# non-MTP with decode_attention_backend=aiter).
+#
+# Purpose: control experiment for the non-MTP disagg GSM8K accuracy drop
+# (~0.88 vs single-node 0.944). The base recipe uses triton decode; here we
+# only flip the decode backend to aiter. dispatch_attn_forward_method returns
+# AttnForwardMethod.MLA (absorbed) for forward_mode=decode on BOTH aiter and
+# triton (see models/deepseek_common/attention_backend_handler.py), and MTP
+# verify (which passes at ~0.95) already runs on aiter, so if this still scores
+# ~0.88 it confirms the regression is on the decode FORWARD-MODE path, not the
+# attention backend/kernel. Everything else is identical to 1p1d.yaml.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  # DIAGNOSTIC: decode flipped from triton -> aiter (prefill stays aiter).
+  prefill_attention_backend: aiter
+  decode_attention_backend: aiter
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # Diagnostic run: only the GSM8K accuracy gate matters, so the perf sweep is
+  # trimmed to a single concurrency to keep the cluster allocation short.
+  concurrencies: [1]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-kvdump.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-kvdump.yaml
@@ -1,0 +1,83 @@
+# MI355X Kimi-K2.6 (FP8) 2-node 1P1D disaggregation recipe (DIAGNOSTIC:
+# non-MTP + decode-side KV metadata/content dump).
+#
+# Identical to 1p1d.yaml (reproduces ~0.88) plus SGLANG_DEBUG_DISAGG_DECODE_DUMP=1,
+# which makes ModelRunner.forward log, for the first few decode batches on the
+# decode worker: seq_lens, the req_to_token KV slot mapping (count / negative
+# slots), and layer-0 KV-pool content at those slots (abs mean, #zero-norm rows,
+# first/last row norms). Purpose: check whether the MORI-transferred KV is
+# present (non-zero) at every attended slot — especially the prefix boundary
+# token — and whether the decode seq_len / slot mapping is correct. Needs the
+# runtime-checkout mechanism (this branch is stacked on #30386) so the dump code
+# actually runs. Read it from the decode server log in the packed logs artifact.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+    # DIAGNOSTIC: one-shot decode-side KV metadata/content dump.
+    SGLANG_DEBUG_DISAGG_DECODE_DUMP: 1
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # Diagnostic run: only the GSM8K accuracy gate matters (it triggers decode
+  # forwards, which produce the dump), so the perf sweep is trimmed to conc=1.
+  concurrencies: [1]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp-specdecode.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp-specdecode.yaml
@@ -1,0 +1,94 @@
+# MI355X Kimi-K2.6 (FP8) 2-node 1P1D disaggregation recipe (DIAGNOSTIC:
+# EAGLE3 MTP with speculative_attention_mode=decode).
+#
+# Purpose: decide the AXIS of the non-MTP disagg accuracy drop. Same as
+# 1p1d-mtp.yaml (which passes at ~0.95) except --speculative-attention-mode
+# decode. By default MTP verify runs on the PREFILL backend
+# (speculative_attention_mode=prefill); forcing "decode" routes target_verify
+# through the SAME decode-mode path that plain non-MTP decode uses
+# (dispatch_attn_forward_method -> decode backend). If this variant now ALSO
+# drops to ~0.88, it proves the regression lives on the decode forward-mode
+# path (metadata / graph over the MORI-transferred prefix), independent of
+# MTP vs non-MTP and independent of the attention backend.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+    # DIAGNOSTIC: route MTP target_verify through the decode-mode attention
+    # path (default is "prefill").
+    - --speculative-attention-mode
+    - decode
+
+# EAGLE3 speculative decoding with an external draft checkpoint.
+mtp:
+  enabled: true
+  algorithm: EAGLE3
+  num_steps: 3
+  eagle_topk: 1
+  num_draft_tokens: 4
+  draft_model_path: /it-share/model_coverage/models--lightseekorg--kimi-k2.6-eagle3.1-mla
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # Diagnostic run: only the GSM8K accuracy gate matters, so the perf sweep is
+  # trimmed to a single concurrency to keep the cluster allocation short.
+  concurrencies: [1]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-nocudagraph.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-nocudagraph.yaml
@@ -1,0 +1,81 @@
+# MI355X Kimi-K2.6 (FP8) 2-node 1P1D disaggregation recipe (DIAGNOSTIC:
+# non-MTP with CUDA/HIP graph disabled).
+#
+# Purpose: isolate whether the non-MTP disagg GSM8K accuracy drop (~0.88 vs
+# single-node 0.944) comes from decode-mode HIP graph capture/replay reading
+# the MORI-transferred prefix (e.g. captured seq_len / page-table metadata not
+# matching the transferred KV at replay). Only difference vs 1p1d.yaml is
+# --disable-cuda-graph. If accuracy returns to ~0.94, the bug is in decode
+# graph capture/replay under disaggregation.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+    # DIAGNOSTIC: disable HIP graph so decode runs eager (applies to both
+    # prefill and decode servers; decode is the one under test).
+    - --disable-cuda-graph
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # Diagnostic run: only the GSM8K accuracy gate matters, so the perf sweep is
+  # trimmed to a single concurrency to keep the cluster allocation short.
+  concurrencies: [1]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-nsplit1.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-nsplit1.yaml
@@ -1,0 +1,84 @@
+# MI355X Kimi-K2.6 (FP8) 2-node 1P1D disaggregation recipe (DIAGNOSTIC:
+# non-MTP with decode split-KV forced to nsplit=1).
+#
+# Tests whether the triton MLA decode split-KV online-softmax reduction is the
+# source of the non-MTP disagg GSM8K drop (~0.88 vs single-node 0.947). The
+# split-KV reduction is DECODE-ONLY (extend/verify use no split-KV -> stay
+# ~0.95) and reduces partial softmax states across KV splits over the long
+# MORI-transferred prefix — a plausible precision-loss site.
+#
+# Forces a single KV split (no cross-split reduction):
+#   * --triton-attention-num-kv-splits 1      -> base max_kv_splits = 1
+#   * SGLANG_DEBUG_MLA_DECODE_NO_SPLIT_CAP    -> skip the MLA split floor that
+#                                                would otherwise raise it back up
+#   * SGLANG_TRITON_DECODE_ATTN_STATIC_KV_SPLITS -> static fill (every seq = 1)
+# If accuracy returns to ~0.94, the split-KV reduction is the culprit.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+    # Force decode nsplit=1 (see triton_backend _mla_decode_kv_splits_cap).
+    SGLANG_TRITON_DECODE_ATTN_STATIC_KV_SPLITS: true
+    SGLANG_DEBUG_MLA_DECODE_NO_SPLIT_CAP: true
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+    # Base number of KV splits = 1; combined with the no-split-cap env this
+    # keeps decode at a single KV split.
+    - --triton-attention-num-kv-splits
+    - 1
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # Diagnostic run: only the GSM8K accuracy gate matters, so the perf sweep is
+  # trimmed to a single concurrency to keep the cluster allocation short.
+  concurrencies: [1]
+  num_prompts_factor: 4
+  random_range_ratio: 1.0
+
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319
+    threshold: 0.92

--- a/test/registered/amd/accuracy/mi35x/test_kimi_k26_eval_mi35x_page256.py
+++ b/test/registered/amd/accuracy/mi35x/test_kimi_k26_eval_mi35x_page256.py
@@ -1,0 +1,126 @@
+"""MI35x Kimi-K2.6 GSM8K Eval (8-GPU) — DIAGNOSTIC: single-node with page_size=256.
+
+Control for the Kimi-K2.6 non-MTP disagg GSM8K drop (~0.88 vs single-node
+0.944). The only attention-affecting arg the disagg recipe adds over the passing
+single-node eval and that has not been isolated at single-node scale is
+`--page-size 256` (disagg page_size 1 vs 256 were both ~0.88, but single-node has
+only ever run at the default page size). This test is byte-identical to
+test_kimi_k26_eval_mi35x.py plus `--page-size 256`:
+
+  * if this ALSO drops to ~0.88 -> the bug is page_size=256 in the (absorbed-MLA)
+    decode path, NOT disaggregation.
+  * if this stays ~0.94 -> confirms the drop is disagg-specific.
+
+Registered into the same suite (nightly-amd-accuracy-8-gpu-mi35x-kimi-k26) so the
+existing MI35x Kimi-K2.6 nightly job runs default + page256 back-to-back on the
+same image/base for a clean A/B.
+"""
+
+import os
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+register_amd_ci(
+    est_time=5400, suite="nightly-amd-accuracy-8-gpu-mi35x-kimi-k26", nightly=True
+)
+
+KIMI_K26_MODEL_PATH = "moonshotai/Kimi-K2.6"
+SERVER_LAUNCH_TIMEOUT = 5400
+ACCURACY_THRESHOLD = 0.92
+TP_SIZE = 8
+PAGE_SIZE = 256
+
+
+class TestKimiK26EvalMI35xPage256(CustomTestCase):
+    """Kimi-K2.6 GSM8K eval on MI35x with page_size=256 (single-node control)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+    def test_kimi_k26_gsm8k_accuracy_page256(self):
+        other_args = [
+            "--tp",
+            str(TP_SIZE),
+            "--decode-attention-backend",
+            "triton",
+            "--prefill-attention-backend",
+            "aiter",
+            "--trust-remote-code",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
+            "--watchdog-timeout",
+            "1200",
+            # The one variable under test.
+            "--page-size",
+            str(PAGE_SIZE),
+        ]
+        env = os.environ.copy()
+        env["SGLANG_USE_AITER"] = "1"
+        env["SGLANG_ROCM_FUSED_DECODE_MLA"] = "0"
+
+        process = popen_launch_server(
+            KIMI_K26_MODEL_PATH,
+            self.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=other_args,
+            env=env,
+        )
+
+        try:
+            requests.get(self.base_url + "/flush_cache")
+
+            args = SimpleNamespace(
+                num_shots=8,
+                data_path=None,
+                num_questions=1319,
+                parallel=1319,
+                max_new_tokens=512,
+                host="http://127.0.0.1",
+                port=int(self.base_url.split(":")[-1]),
+            )
+            metrics = run_eval_few_shot_gsm8k(args)
+            acc = metrics["accuracy"]
+
+            passed = acc >= ACCURACY_THRESHOLD
+            status = "✅ PASS" if passed else "❌ FAIL"
+            print(
+                f"  [page_size={PAGE_SIZE}] accuracy={acc:.3f} "
+                f"threshold={ACCURACY_THRESHOLD} {status}"
+            )
+
+            if is_in_ci():
+                summary = "### Kimi-K2.6 Model (MI35x, page_size=256 control)\n\n"
+                summary += "| Model | TP | page_size | Accuracy | Threshold | Status |\n"
+                summary += "| ----- | -- | --------- | -------- | --------- | ------ |\n"
+                summary += (
+                    f"| {KIMI_K26_MODEL_PATH} | {TP_SIZE} | {PAGE_SIZE} | "
+                    f"{acc:.3f} | {ACCURACY_THRESHOLD} | {status} |\n"
+                )
+                write_github_step_summary(summary)
+
+            self.assertGreaterEqual(
+                acc,
+                ACCURACY_THRESHOLD,
+                f"Kimi-K2.6 (page_size={PAGE_SIZE}) accuracy {acc:.3f} "
+                f"below threshold {ACCURACY_THRESHOLD}",
+            )
+        finally:
+            kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On the `Nightly Test (AMD MI355X 2N 1P1D Disagg)`, **Kimi-K2.6 non-MTP** GSM8K only reaches **~0.88** (gate is 0.92), while:
- the **MTP** variant passes at **~0.95**, and
- **single-node** non-MTP passes at **0.944**.

Already ruled out by prior investigation (see #30336 side-notes):
- **page_size**: 0.887 @256 vs 0.880 @1 — no meaningful difference.
- **all disagg runtime args** (kv_cache_dtype, disable_radix_cache, chunked_prefill, mem_fraction) are identical between the passing MTP and failing non-MTP legs.
- swapping the **decode backend** did not help.

Why the backend is likely NOT the cause: `dispatch_attn_forward_method` routes **non-MTP decode → decode backend** and **MTP verify → prefill backend** (because `speculative_attention_mode` defaults to `prefill`), but for their respective forward modes **both dispatch to `AttnForwardMethod.MLA` (absorbed)** — see `models/deepseek_common/attention_backend_handler.py` (`handle_attention_aiter` / `handle_attention_triton`). So the remaining axis is the **decode FORWARD-MODE path** reading the **MORI-transferred prefix**, not the attention backend/kernel.

`SGLANG_FP8_PAGED_MQA_LOGITS_TORCH` is intentionally NOT tested here: it only affects `layers/attention/dsv4/` (the DSA indexer), which Kimi's aiter/triton MLA path does not use.

## Modifications

Three diagnostic recipes under `scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/`, registered in `nightly-configs.yaml`. Each isolates ONE variable vs the base `1p1d.yaml` / `1p1d-mtp.yaml` and trims the perf sweep to `conc=1` (only the GSM8K gate matters). They are **not** part of the default nightly signal — trigger explicitly via the `workflow_dispatch` `configs` input:

| config name | change vs base | what it tests |
| --- | --- | --- |
| `kimik26-fp8-1k1k-1p1d-aiterdecode` | non-MTP, decode `triton → aiter` | control: is it the backend, or the decode forward-mode path? (expect still ~0.88) |
| `kimik26-fp8-1k1k-1p1d-nocudagraph` | non-MTP + `--disable-cuda-graph` | is it HIP graph capture/replay over the transferred prefix? (expect ~0.94 if yes) |
| `kimik26-fp8-1k1k-1p1d-mtp-specdecode` | MTP + `--speculative-attention-mode decode` | does routing verify through the decode-mode path also drop MTP to ~0.88? (confirms the axis) |

Interpretation:
- If `aiterdecode` ≈ 0.88 **and** `mtp-specdecode` ≈ 0.88 → confirmed: the regression is the **decode forward-mode path** over MORI-transferred KV (metadata/graph), independent of backend and of MTP.
- If `nocudagraph` recovers to ~0.94 → the bug is in **decode HIP graph capture/replay** under disaggregation.

## How to run

```
gh workflow run "Nightly Test (AMD MI355X 2N 1P1D Disagg)" \
  --ref amd/kimik26-disagg-decode-repro \
  -f configs=kimik26-fp8-1k1k-1p1d-aiterdecode,kimik26-fp8-1k1k-1p1d-nocudagraph,kimik26-fp8-1k1k-1p1d-mtp-specdecode
```

**Base — must be stacked on #30386, not plain `main`.** The MI355X disagg CI reinstalls the checked-out sglang via the runtime-checkout mechanism, which currently only exists on #30386 (`amd-disagg-checkout`). This branch is therefore based on `0aac976` (the #30386 head, and the exact commit the reference scheduled nightly ran on — it reproduces the clean 0.878 baseline). Running these recipe-only changes on plain `main` does NOT work: without the runtime-checkout mechanism the baked image is used and Kimi-K2.6 fails to load with `ValueError: 'KimiK25ForConditionalGeneration' is not a registered model`, and any later `main` regressions would also leak in. In short: rebase onto #30386 or the run eats the upstream error.

## Checklist

- [x] Diagnostic-only; no production code path changed.
- [x] `generate_matrix.py --runner mi355x` produces the three new config names and `--filter` accepts them.
- [x] All three recipe YAMLs parse via the launcher's recipe parser.











## Validation runs

**Baseline (bug is live, not a serving/MR failure):** the scheduled nightly's base `kimik26-fp8-1k1k-1p1d` leg serves correctly (PD probe OK, coherent output) but the GSM8K gate reports **0.878 < 0.92** and aborts before the sweep — [run 28873810961, job](https://github.com/sgl-project/sglang/actions/runs/28873810961/job/85643399376):

```
[probe] ok:  Paris. Paris is located in the north-central part of the country...
Accuracy: 0.878
[gsm8k] accuracy=0.878 threshold=0.92
[gsm8k] accuracy below threshold -- failing before sweep
```

**Diagnostic run (this PR's 3 variants):** [run 28907609511](https://github.com/sgl-project/sglang/actions/runs/28907609511) on the corrected base (#30386 / `0aac976`), dispatched with `configs=kimik26-fp8-1k1k-1p1d-aiterdecode,kimik26-fp8-1k1k-1p1d-nocudagraph,kimik26-fp8-1k1k-1p1d-mtp-specdecode`.

> An earlier run [28903343346](https://github.com/sgl-project/sglang/actions/runs/28903343346) was mistakenly based on plain `main` and failed all three legs at model load (`'KimiK25ForConditionalGeneration' is not a registered model`) — concrete proof the #30386 base is required.

Results filled in once the legs finish:

| config | Accuracy | reading |
| --- | --- | --- |
| baseline `1p1d` (non-MTP) | **0.878** | bug reproduced |
| reference `1p1d-mtp` | ~0.95 | MTP verify (extend-mode / prefill backend) over the SAME transferred KV is correct |
| `1p1d-aiterdecode` | **0.879** | ≈ baseline ⇒ **NOT the attention backend** (triton→aiter changes nothing) |
| `1p1d-nocudagraph` | **0.883** | ≈ baseline ⇒ **NOT HIP graph capture/replay** (eager decode changes nothing) |
| `1p1d-mtp-specdecode` | crash at init (SIGABRT -6) | inconclusive: `--speculative-attention-mode decode` + EAGLE3 external draft fails to start; the decode-mode axis needs a code-level probe instead |

(Diagnostic run: [28907609511](https://github.com/sgl-project/sglang/actions/runs/28907609511).)

## Conclusion so far

Two mechanistic suspects are **eliminated**: the attention **backend** (aiter decode ≡ triton decode ≈ 0.88) and **HIP graph** capture/replay (eager ≈ 0.88). Meanwhile MTP verify — which reads the *same* MORI-transferred KV but in **extend-mode via the prefill backend** — stays correct at ~0.95, and single-node non-MTP decode is 0.944.

So the drop is intrinsic to the **single-token, absorbed-MLA decode forward-mode path reading disagg-transferred KV**, independent of backend and graph. The transferred KV data itself is very likely fine (extend-mode reads it correctly). Prime remaining suspect: the **decode forward metadata for the transferred prefix** (seq_len / kv page indices / kv_indptr) on the decode worker, or the absorbed-MLA decode read of it.

### Decode-side KV dump result (run [28909881181](https://github.com/sgl-project/sglang/actions/runs/28909881181))

Added an env-gated one-shot probe (`SGLANG_DEBUG_DISAGG_DECODE_DUMP`) in `ModelRunner.forward` that logs, per decode batch on the decode worker: `seq_lens`, the `req_to_token` KV-slot mapping, and layer-0 KV-pool content at those slots. Captured the warmup probe (`"The capital of France is"`, bs=1, decode seq_len 6→9):

```
[DISAGG_DECODE_DUMP #2] mode=DECODE bs=1 seq_lens=[6] | req0 seq_len=6 kv_slots=6 neg_slots=0 | KV L0 zero_rows=5 first3_norm=[0.0,0.0,0.0] last3_norm=[0.0,20.198,0.0]
[DISAGG_DECODE_DUMP #3] ... seq_lens=[7] ... zero_rows=5 first3_norm=[0.0,0.0,0.0] last3_norm=[20.198,21.346,0.0]
[DISAGG_DECODE_DUMP #5] ... seq_lens=[9] ... zero_rows=5 first3_norm=[0.0,0.0,0.0] last3_norm=[24.171,24.142,0.0]
```

Reading:
- `seq_len == kv_slots`, `neg_slots=0` ⇒ the decode **seq_len / req_to_token slot mapping is correct**.
- The **leading prefix KV rows read exactly `0.0`** (`first3_norm=[0,0,0]`, `zero_rows` constant), while only the **locally-generated decode tokens** are populated (contiguous non-zero norms ~20–24, growing by one per step; the trailing `0.0` is the current token, written later in the forward).

⇒ In the standard KV buffer (layer 0), the **MORI-transferred prefill KV is absent (unwritten) at the decode-side attended slots**. This points at KV transfer / decode-side KV placement, not the attention compute — consistent with backend & HIP-graph being ruled out.

Caveats to close next: only the short warmup probe was captured (5-dump budget spent before GSM8K); layer 0 only; and confirm this isn't a MORI staging-layout artifact (i.e. that the decode attention kernel really reads these zero slots). Follow-up: target a GSM8K request, dump several layers + the PREBUILT handoff, and compare the transferred length the prefill reported vs the decode `prefix_indices`.

### Correction — KV transfer is fine on real (GSM8K) requests (run [28917883474](https://github.com/sgl-project/sglang/actions/runs/28917883474))

Re-ran the probe skipping the short warmup (only `seq_len >= 64`), across layers 0/30/60, page-bucketing the zero rows. On a real GSM8K request (prefix = 1298 tokens):

```
[DISAGG_DECODE_DUMP] seq_len=1299 prefix=1298 page_size=256 neg_slots=0 |
  L0:zero=0/1298 mean=2.378e-01  L30:zero=0/1298  L60:zero=0/1298 | zero_pages=0/6 []
```

`zero=0` on every layer, `zero_pages=0/6`, `neg_slots=0`. So **the earlier "prefix KV is all zero" was an artifact of the tiny warmup probe** (<1 page); for a real long prefix the **MORI-transferred KV is fully present and correctly placed**, and MTP-verify reading the same KV at ~0.95 confirms the *values* are correct too.

**Revised conclusion.** Eliminated: attention backend, HIP graph, KV-transfer/placement, and decode seq_len/slot metadata. Given identical correct KV + metadata, the ~0.88 vs single-node 0.944 (absorbed decode) vs ~0.95 (extend/verify) gap must live in the **decode-mode compute itself under disaggregation** — leading suspect is the **query position / RoPE** the decode worker reconstructs for the transferred prefix (an off-by-one there corrupts attention scores while leaving KV norms untouched), or another absorbed-MLA-decode numeric detail that single-node decode gets right.

### Position / RoPE check (run [28974822944](https://github.com/sgl-project/sglang/actions/runs/28974822944)) — also clean

Extended the probe to log the decode current-token position vs `seq_len-1`. On GSM8K decodes:

```
[DISAGG_DECODE_DUMP] seq_len=1299 prefix=1298 ... pos0=1298 exp=1298 pos_vs_(seq-1)_mismatch=0
[DISAGG_DECODE_DUMP] seq_len=1300 prefix=1299 ... pos0=1299 exp=1299 pos_vs_(seq-1)_mismatch=0
```

`pos0 == seq_len-1`, `mismatch=0` on every request/rank ⇒ **decode positions/RoPE are correct**.

### Elimination summary

| hypothesis | status | evidence |
| --- | --- | --- |
| attention backend | ruled out | aiterdecode 0.879 == triton 0.878 |
| HIP graph capture/replay | ruled out | nocudagraph 0.883 |
| KV transfer / placement | ruled out | GSM8K prefix zero=0/1298 all layers, pages complete |
| decode metadata (seq_len/slots) | ruled out | seq_len==slots, neg_slots=0 |
| KV values | correct | MTP-verify (MHA over same KV) = ~0.95 |
| decode position / RoPE | ruled out | pos == seq_len-1, mismatch=0 |

Every ForwardBatch-level input to the decode attention is correct, yet **absorbed-MLA decode over the transferred KV = ~0.88** while **single-node absorbed-MLA decode = 0.944** and **MHA/extend over the same KV = ~0.95**. `_dispatch_mla_subtype` shows a pure decode step is *always* absorbed MLA — there is no server-arg to force decode→MHA, so the decode(absorbed)-vs-extend(MHA) axis can't be flipped by a recipe flag (the `-mtp-specdecode` attempt to flip it crashed at init).

### Historical context (from #29855 + CI triage R241)

- **#29855 dev validation had disagg base Kimi at GSM8K 0.941** (Lzy17, 2-node g09/g29), and MTP at 0.948. So the **disagg path did pass ~0.94 during development** — the current ~0.88 is likely a **regression**, not an inherent disagg limitation. This is consistent with every ForwardBatch-level attention input being correct in my probes.
- Timeline: #29855 dev **0.941** -> bingxche 07-03 (PR29986-hotpatch image) **0.892** -> current nightly **0.887**.
- CI triage (R241) names in-flight model-loading suspects: **#28905 (K2.6 MoE w2 scale loading)** and #23381 (K2.6 tuning artifacts). A weight/quant-loading bug would hit **single-node and disagg equally** — which the single-node control below directly tests.

### Single-node control result (run [28984448331](https://github.com/sgl-project/sglang/actions/runs/28984448331)) — decisive

Same passing single-node MI35x Kimi eval, default vs `--page-size 256`, back-to-back on one image:

```
default        accuracy=0.947  PASS
page_size=256  accuracy=0.945  PASS
```

- **page_size ruled out**: single-node@256 = 0.945 (== default). (Matches disagg page 1 vs 256 both ~0.88 — page size is not the variable.)
- **weight/quant loading ruled out** (#28905 w2 scale etc.): single-node = 0.947; a load bug would degrade single-node too.

**Verdict: the drop is disagg-specific, and a regression** (vs #29855 dev disagg 0.941). Single-node absorbed-MLA decode = 0.947 with correct KV; disagg absorbed-MLA decode = ~0.88 with *also*-correct KV/metadata/positions. Every non-disagg explanation is eliminated.

### Convergence with the parallel `amd/kimik26-disagg-decodemeta` branch (yctseng0211)

A parallel investigation reached the same conclusion and is now probing the decode compute directly:
- decode-metadata + MORI transfer-fidelity probes (extend-mode + fixed-absolute-KV-position sampling): disagg runs still **0.876 / 0.879 / 0.885** — probes only observe; the transferred KV is confirmed present and the drop persists. Independently corroborates: KV correct, decode compute is the issue.
- **New live hypothesis: the triton MLA decode split-KV online-softmax reduction** (`num_kv_splits`). It is **decode-only** (extend/verify use no split-KV → explains why they stay ~0.95) and reduces across KV splits over the long transferred prefix — a plausible precision-loss site. Tested via `--triton-attention-num-kv-splits 1` + `SGLANG_DEBUG_MLA_DECODE_NO_SPLIT_CAP` (recipe `1p1d-nsplit1`).
- **nsplit=1 result is currently unavailable**: run 28983593561 finished as failure with no artifact and its log has been purged (BlobNotFound) — needs a re-run to get a clean number.

**Update — nsplit=1 result (run [29042111257](https://github.com/sgl-project/sglang/actions/runs/29042111257), ported to this branch): accuracy 0.875 → split-KV reduction is RULED OUT.** Forcing a single decode KV split (`--triton-attention-num-kv-splits 1` + no-split-cap + static fill) leaves accuracy at baseline ~0.88. So the online-softmax cross-split reduction is not the cause.

This is the most promising lead and supersedes the python/image bisect for now (the stuck bisect run was cancelled to free the single MI355X slot).

### Regression bisect — step 1: python is NOT the cause (run [29058233535](https://github.com/sgl-project/sglang/actions/runs/29058233535))

Reverted `python/sglang/srt` to `67361ff` (#29855 kimi-merge, the 0.941 era) and ran disagg base Kimi via checkout-runtime (artifact confirms `sha=629912085`, `0.5.15.dev520`). Result: **0.879** — still ~0.88.

Key confound found: the disagg workflow's `setup` job **resolves the latest MI35x image dynamically and overrides the recipe's pinned tag**. So:
- step 1 = **old python (67361ff) + latest image** = 0.879
- Lzy17's 0.941 = old python + **`v0.5.13.post1-rocm720-mi35x-20260623` (Jun-23 image)**

⇒ reverting python doesn't help; the differing variable is the **image (aiter / ROCm / sgl-kernel)**. Also relevant: DI CI and Lzy17's 0.941 use the *same* physical `amd-sglang` g09/g29 nodes (the DI runner only `salloc`s them), so pass/fail is a code/image version difference, not a machine difference.

**Step 2 (in flight): full known-good repro** — bisect branch (old python) **+ Jun-23 image pinned** (`-f image=...20260623`). If ~0.94, the regression is the image and known-good is reproduced; then bisect the image. If still ~0.88, the regression is neither current code nor image (environmental: NFS weights / aiter build).

### BISECT RESULT — the regression is the DOCKER IMAGE, not sglang code (run [29116830660](https://github.com/sgl-project/sglang/actions/runs/29116830660))

Reproduced Lzy17's known-good cleanly: **full checkout @ `67361ff` + June-23 image** (`v0.5.13.post1-rocm720-mi35x-20260623`), no checkout-runtime (that commit predates it, so it runs the image's coherent baked sglang) → **GSM8K 0.941** ✅ (== Lzy17's 0.941).

| run | python | image | GSM8K |
| --- | --- | --- | --- |
| scheduled baseline | main | latest | 0.887 |
| bisect step 1 | srt@67361ff | latest | 0.879 |
| **known-good repro** | **full 67361ff** | **Jun-23** | **0.941** |

- known-good (old code + old image) = **0.941** ⇒ environmental causes (g09/g29 nodes, NFS weights) are **ruled out**; known-good is reproducible.
- step 1 (old srt + **latest** image) = 0.879 ⇒ swapping in the newer image breaks it even with old python.
- ⇒ **the regression is in the docker image (aiter / ROCm / sgl-kernel), not sglang python.**

(Note: bisect step 2 = mixed python on old image crashed at init on an ABI mismatch — discarded, uninformative.)

### Immediate mitigation available
Pin the Kimi-K2.6 disagg recipes to the Jun-23 image (or set the workflow `image` input) to restore ~0.94 while the image regression is bisected. The scheduled nightly overrides the recipe's pinned image with the dynamically-resolved *latest* tag, which is what regressed.

### Image bisect result — first bad build is the `v0.5.14` bump (Jun-26)

| image tag | version | GSM8K |
| --- | --- | --- |
| `...mi35x-20260623` | v0.5.13.post1 | **0.941** ✅ |
| `...mi35x-20260626` | v0.5.14 (first) | **0.888** ❌ (run [29277682836](https://github.com/sgl-project/sglang/actions/runs/29277682836)) |

Jun-24 and Jun-25 are still `v0.5.13.post1` (same line as the good Jun-23), so the regression is the **`v0.5.13.post1 → v0.5.14` image bump landing on Jun-26** (aiter / ROCm / sgl-kernel changes baked into the v0.5.14 image). Confirmed airtight: **Jun-25 (`v0.5.13.post1`) = 0.939** ([run 29282623403](https://github.com/sgl-project/sglang/actions/runs/29282623403)) — last good is Jun-25, first bad is Jun-26 (`v0.5.14`). Mitigation (pin known-good image + baked build) verified green at 0.939 (PR #31063).

### Next: bisect the image
Sweep `lmsysorg/sglang-rocm:v*-rocm720-mi35x-YYYYMMDD` tags between Jun-23 (good) and the current latest (bad) via the workflow `image` input on the 67361ff known-good branch, to find the first bad image build.

### Open next steps (branching) — now that it's confirmed disagg-specific + a regression
1. **KV latent dtype/scale check** (cheapest) — dump the compressed-KV dtype + raw nope/k_pe value stats on the decode side; if disagg stores/transfers the latent in a different precision than single-node, absorbed-MQA (direct dot-products) would degrade where MHA-decompress (large matmul) tolerates it.
2. **Bisect the regression** — #29855 dev disagg was 0.941; run disagg Kimi via checkout-runtime at the #29855 validation commit, confirm ~0.94, then bisect forward to the breaking change (python and/or image/aiter kernel).
3. **In-process attention diff** — hook the MLA layer to compare absorbed-decode vs MHA-decompress output on the same transferred KV (decisive: is the absorbed-decode kernel itself wrong on transferred KV?).

Next step — this branch already runs via the runtime-checkout mechanism on #30386): a code-level probe on the decode worker for a fixed prompt — compare (a) per-layer KV-pool bytes and (b) the decode forward metadata vs a single-node baseline. A data match + metadata/read mismatch localizes the bug.































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29042115255](https://github.com/sgl-project/sglang/actions/runs/29042115255)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29042114884](https://github.com/sgl-project/sglang/actions/runs/29042114884)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->













