### PR TITLE
[Feature] Support encoding_format="base64" in /v1/embeddings

### DIFF
--- a/docs_new/docs/supported-models/embedding_models.mdx
+++ b/docs_new/docs/supported-models/embedding_models.mdx
@@ -37,6 +37,31 @@ response = requests.post(url + "/v1/embeddings", json=payload).json()
 print("Embedding:", response["data"][0]["embedding"])
 ```
 
+### Output Encoding Formats
+
+The OpenAI-compatible embeddings endpoint supports two `encoding_format` values:
+
+- `"float"` (default): returns each embedding as a JSON list of floats.
+- `"base64"`: returns each dense embedding as a base64 string containing little-endian float32 bytes — about 2.9x smaller than the float-list form and decodable with a zero-copy `np.frombuffer`.
+
+```python
+import base64
+import numpy as np
+import requests
+
+payload = {
+    "model": "Qwen/Qwen3-Embedding-4B",
+    "input": "What is the capital of France?",
+    "encoding_format": "base64",
+}
+
+response = requests.post(url + "/v1/embeddings", json=payload).json()
+embedding = np.frombuffer(
+    base64.b64decode(response["data"][0]["embedding"]), dtype="<f4"
+)
+print("Embedding:", embedding)
+```
+
 
 ## Multimodal Embedding Example
 

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1083,7 +1083,7 @@ class EmbeddingRequest(BaseModel):
 
 
 class EmbeddingObject(BaseModel):
-    embedding: List[float]
+    embedding: Union[List[float], str]
     index: int
     object: str = "embedding"
 

--- a/python/sglang/srt/entrypoints/openai/serving_embedding.py
+++ b/python/sglang/srt/entrypoints/openai/serving_embedding.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import base64
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import jinja2
+import numpy as np
 from fastapi import Request
 from fastapi.responses import ORJSONResponse
 
@@ -41,6 +43,13 @@ class OpenAIServingEmbedding(OpenAIServingBase):
 
     def _validate_request(self, request: EmbeddingRequest) -> Optional[str]:
         """Validate that the input is not empty or whitespace only."""
+        if request.encoding_format not in ("float", "base64"):
+            return (
+                "Unsupported encoding_format "
+                f"{request.encoding_format!r}. "
+                "Supported values are 'float' and 'base64'."
+            )
+
         if not (input := request.input):
             return "Input cannot be empty"
 
@@ -254,18 +263,53 @@ class OpenAIServingEmbedding(OpenAIServingBase):
         if not isinstance(ret, list):
             ret = [ret]
 
-        response = self._build_embedding_response(ret)
+        try:
+            response = self._build_embedding_response(ret, request.encoding_format)
+        except ValueError as e:
+            return self.create_error_response(str(e))
         return response
 
-    def _build_embedding_response(self, ret: List[Dict[str, Any]]) -> EmbeddingResponse:
+    @staticmethod
+    def _encode_embedding_base64(embedding: List[float]) -> str:
+        """Encode dense embeddings as little-endian float32 base64.
+
+        Uses one vectorized numpy conversion instead of per-element Python
+        serialization: at embedding response sizes the per-float cost is
+        measurable at high request rates, and little-endian float32 bytes
+        let clients decode with a zero-copy frombuffer.
+        """
+        if not isinstance(embedding, list):
+            raise ValueError(
+                "encoding_format='base64' only supports dense embedding lists"
+            )
+        try:
+            values = np.asarray(embedding, dtype="<f4")
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                "encoding_format='base64' only supports dense float embeddings"
+            ) from e
+        if values.ndim != 1:
+            raise ValueError(
+                "encoding_format='base64' only supports dense float embeddings"
+            )
+        return base64.b64encode(values.tobytes()).decode("ascii")
+
+    def _build_embedding_response(
+        self,
+        ret: List[Dict[str, Any]],
+        encoding_format: str = "float",
+    ) -> EmbeddingResponse:
         """Build the embedding response"""
         embedding_objects = []
         prompt_tokens = 0
 
         for idx, ret_item in enumerate(ret):
+            embedding = ret_item["embedding"]
+            if encoding_format == "base64":
+                embedding = self._encode_embedding_base64(embedding)
             embedding_objects.append(
                 EmbeddingObject(
-                    embedding=ret_item["embedding"],
+                    embedding=embedding,
                     index=idx,
                 )
             )

--- a/test/registered/unit/entrypoints/openai/test_serving_embedding.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_embedding.py
@@ -2,6 +2,8 @@
 Unit tests for the OpenAIServingEmbedding class from serving_embedding.py.
 """
 
+import asyncio
+import base64
 import importlib
 import importlib.abc
 import importlib.machinery
@@ -12,6 +14,7 @@ import uuid
 from unittest.mock import MagicMock, Mock
 
 import jinja2
+import numpy as np
 
 
 # Stub out sgl_kernel (and all submodules) before any sglang import so
@@ -183,6 +186,94 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         self.assertEqual(adapted_request.input_ids, [1, 2, 3, 4, 5])
         # self.assertEqual(adapted_request.rid, "test-id")
         self.assertEqual(processed_request, self.token_ids_req)
+
+    def test_base64_encoding_format_returns_base64_embedding(self):
+        """encoding_format=base64 should encode dense embeddings as float32 bytes."""
+        request = EmbeddingRequest(
+            model="test-model",
+            input="Hello, how are you?",
+            encoding_format="base64",
+        )
+        adapted_request, processed_request = (
+            self.serving_embedding._convert_to_internal_request(request)
+        )
+
+        response = asyncio.run(
+            self.serving_embedding._handle_non_streaming_request(
+                adapted_request,
+                processed_request,
+                self.request,
+            )
+        )
+
+        embedding = response.data[0].embedding
+        self.assertIsInstance(embedding, str)
+        values = np.frombuffer(base64.b64decode(embedding), dtype="<f4")
+        self.assertEqual(values.shape, (100,))
+        np.testing.assert_allclose(values[:2], [0.1, 0.2], rtol=1e-6)
+
+    def test_rejects_unsupported_encoding_format(self):
+        """Unsupported embedding formats should not silently return float lists."""
+        request = EmbeddingRequest(
+            model="test-model",
+            input="Hello, how are you?",
+            encoding_format="bytes",
+        )
+
+        error = self.serving_embedding._validate_request(request)
+
+        self.assertIn("Unsupported encoding_format", error)
+        self.assertIn("float", error)
+        self.assertIn("base64", error)
+
+    def test_base64_rejects_sparse_embedding_outputs(self):
+        """base64 currently only supports dense embedding lists."""
+
+        async def mock_generate_sparse_embedding():
+            yield {
+                "embedding": {"indices": [1], "values": [0.1]},
+                "meta_info": {
+                    "id": f"embd-{uuid.uuid4()}",
+                    "prompt_tokens": 5,
+                },
+            }
+
+        self.tokenizer_manager.generate_request = Mock(
+            return_value=mock_generate_sparse_embedding()
+        )
+        request = EmbeddingRequest(
+            model="test-model",
+            input="Hello, how are you?",
+            encoding_format="base64",
+        )
+        adapted_request, processed_request = (
+            self.serving_embedding._convert_to_internal_request(request)
+        )
+
+        try:
+            response = asyncio.run(
+                self.serving_embedding._handle_non_streaming_request(
+                    adapted_request,
+                    processed_request,
+                    self.request,
+                )
+            )
+        except Exception as exc:
+            self.fail(
+                "sparse embedding base64 requests should return an error response, "
+                f"not raise {type(exc).__name__}: {exc}"
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"base64", response.body)
+        self.assertIn(b"dense", response.body)
+
+    def test_base64_rejects_nested_embedding_lists(self):
+        """Nested lists must error rather than be silently flattened."""
+        with self.assertRaises(ValueError) as ctx:
+            self.serving_embedding._encode_embedding_base64([[0.1, 0.2], [0.3, 0.4]])
+
+        self.assertIn("dense", str(ctx.exception))
 
     def test_convert_multimodal_request(self):
         """Test converting multimodal request to internal format."""


### PR DESCRIPTION
## Motivation

The `/v1/embeddings` endpoint currently ignores `request.encoding_format` and always returns JSON float lists, and unsupported values are silently accepted. Two problems:

1. **OpenAI SDK compatibility**: the official `openai-python` SDK sends `encoding_format="base64"` by default and decodes client-side, so float-only responses break the canonical client.
2. **Response payload pressure**: a 1024-dim fp32 embedding is ~16.2 KB as a JSON float list vs 5.6 KB as base64 (2.9x). Production embedding-serving work (e.g. Snowflake's Arctic embedding inference writeup) identifies per-element float serialization as a first-order bottleneck for this workload class; a single vectorized conversion to little-endian fp32 bytes is cheap and lets clients decode with a zero-copy `np.frombuffer`.

Implements the "Support additional encoding and response formats (e.g., base64, bytes, torch.Tensor) for non-generation models" item from the Prefill-Only roadmap #15344. Related: #28803 proposes the same `encoding_format` semantics from the SDK-compatibility angle — happy to consolidate/co-author whichever direction maintainers prefer; this PR additionally carries docs, sparse/nested-input rejection with clear errors, and benchmark evidence.

## Modifications

- `protocol.py`: `EmbeddingObject.embedding` widened to `Union[List[float], str]`.
- `serving_embedding.py`:
  - `_validate_request` rejects any `encoding_format` other than `"float"`/`"base64"` before the forward pass.
  - `_encode_embedding_base64`: one vectorized `np.asarray(embedding, dtype="<f4").tobytes()` + base64; an `ndim` guard makes nested lists error instead of being silently flattened; sparse (dict) outputs are rejected with a clear message.
- `docs/supported_models/retrieval_ranking/embedding_models.md`: documents both output formats with an example.
- Default behavior is unchanged: `encoding_format` unset or `"float"` returns float lists.

## Accuracy Tests

No change to model forward or pooling. Output integrity checked end-to-end on Qwen/Qwen3-Embedding-0.6B (RTX A6000):

- base64 responses decode to exactly 4096 bytes / 1024 fp32 values and match the float-list output bit-for-bit.
- Unit tests (`test/registered/unit/entrypoints/openai/test_serving_embedding.py`, 16 passed): float default unchanged, base64 round-trip, unsupported-format rejection, sparse-output rejection, nested-list rejection.

## Speed Tests and Profiling

Measured with `python -m sglang.benchmark.serving --backend sglang-embedding` (latency at transfer completion), token-exact 50-token inputs, seed 42, radix cache flushed, fresh server per run, 3 runs per arm, RTX A6000, Qwen/Qwen3-Embedding-0.6B, concurrency 64, `encoding_format` passed via `--extra-request-body`:

```
float:            763.9 +- 33.9 req/s   mean 76.1 ms, p99 101.6 ms
base64:          1022.1 +- 51.5 req/s   mean 57.1 ms, p99  85.8 ms   (1.34x)
```

Distributions are non-overlapping. Payload: 5.60 vs 16.20 KB per request (2.9x smaller), constant across scenarios. At >=512-token inputs throughput is encoding-parity (GPU-bound; 139.5 vs 139.8 req/s) — the throughput win is a short-input/high-request-rate effect, the payload reduction applies everywhere. For context, the same setup measures HuggingFace TEI at 1002.6 req/s on this workload: this change brings SGLang to parity with the embedding-native engine on its strongest scenario.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29040891916](https://github.com/sgl-project/sglang/actions/runs/29040891916)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29040891741](https://github.com/sgl-project/sglang/actions/runs/29040891741)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->