### PR TITLE
Flush request-metrics exporters on shutdown

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -911,11 +911,18 @@ class Engine(EngineScoreMixin, EngineBase):
         """Shutdown the engine; block until the scheduler subprocess releases
         its GPU context so the caller can immediately reallocate on the same
         device."""
-        if (
-            self.tokenizer_manager is not None
-            and self.tokenizer_manager._subprocess_watchdog is not None
-        ):
-            self.tokenizer_manager._subprocess_watchdog.stop()
+        if self.tokenizer_manager is not None:
+            # Flush buffered per-request metrics exporters before teardown so a
+            # short-lived engine does not lose its final records. Guarded with
+            # getattr: not every tokenizer-manager variant builds one (e.g.
+            # MultiTokenizerRouter, which is not a TokenizerManager subclass).
+            exporter_manager = getattr(
+                self.tokenizer_manager, "request_metrics_exporter_manager", None
+            )
+            if exporter_manager is not None:
+                exporter_manager.close()
+            if self.tokenizer_manager._subprocess_watchdog is not None:
+                self.tokenizer_manager._subprocess_watchdog.stop()
 
         send_to_rpc = getattr(self, "send_to_rpc", None)
         if send_to_rpc is not None:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2679,6 +2679,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Stop the watchdog: child exits are expected during shutdown, not crashes.
         if self._subprocess_watchdog is not None:
             self._subprocess_watchdog.stop()
+        # Flush buffered per-request metrics exporters now that all requests have
+        # drained, so their final records are not lost on exit.
+        exporter_manager = getattr(self, "request_metrics_exporter_manager", None)
+        if exporter_manager is not None:
+            exporter_manager.close()
         # Ask schedulers to release resources in userspace and exit (see
         # ShutdownReq), then wait for them before hard-killing the rest.
         self._dispatch_to_scheduler(ShutdownReq())

--- a/python/sglang/srt/observability/request_metrics_exporter.py
+++ b/python/sglang/srt/observability/request_metrics_exporter.py
@@ -68,6 +68,14 @@ class RequestMetricsExporter(ABC):
         """Write a data record corresponding to a single request, containing performance metric data."""
         pass
 
+    def close(self) -> None:
+        """Release resources held by the exporter (flush buffered records, close
+        connections, stop background threads). Called once during shutdown.
+
+        The default is a no-op; exporters with buffered or asynchronous delivery
+        should override this to flush pending records before the process exits."""
+        pass
+
 
 class FileRequestMetricsExporter(RequestMetricsExporter):
     """Lightweight `RequestMetricsExporter` implementation that writes records to files on disk.
@@ -202,6 +210,22 @@ class RequestMetricsExporterManager:
         """Write a record using all configured exporters."""
         for exporter in self._exporters:
             await exporter.write_record(obj, out_dict)
+
+    def close(self) -> None:
+        """Close all configured exporters (best-effort).
+
+        Invoked on server/engine shutdown so exporters with buffered or
+        asynchronous delivery can flush their final records. One exporter
+        failing to close must not prevent the others from closing."""
+        for exporter in self._exporters:
+            try:
+                exporter.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close request metrics exporter %r",
+                    exporter,
+                    exc_info=True,
+                )
 
 
 def create_request_metrics_exporters(

--- a/test/registered/unit/observability/test_request_metrics_exporter.py
+++ b/test/registered/unit/observability/test_request_metrics_exporter.py
@@ -340,6 +340,33 @@ class TestRequestMetricsExporterManager(unittest.TestCase):
         files = os.listdir(self.tmp_dir)
         self.assertEqual(len(files), 1)
 
+    def test_close_delegates_to_all_exporters(self):
+        server_args = _make_server_args(self.tmp_dir, enabled=False)
+        manager = RequestMetricsExporterManager(server_args)
+        e1, e2 = MagicMock(), MagicMock()
+        manager._exporters = [e1, e2]
+
+        manager.close()
+
+        e1.close.assert_called_once_with()
+        e2.close.assert_called_once_with()
+
+    def test_close_is_best_effort_when_one_exporter_raises(self):
+        server_args = _make_server_args(self.tmp_dir, enabled=False)
+        manager = RequestMetricsExporterManager(server_args)
+        bad, good = MagicMock(), MagicMock()
+        bad.close.side_effect = RuntimeError("boom")
+        manager._exporters = [bad, good]
+
+        manager.close()  # must not raise; the good exporter still closes
+
+        good.close.assert_called_once_with()
+
+    def test_close_with_no_exporters_is_noop(self):
+        server_args = _make_server_args(self.tmp_dir, enabled=False)
+        manager = RequestMetricsExporterManager(server_args)
+        manager.close()  # must not raise
+
 
 class TestCreateExporters(unittest.TestCase):
     def setUp(self):
@@ -358,6 +385,17 @@ class TestCreateExporters(unittest.TestCase):
         exporters = create_request_metrics_exporters(server_args)
         self.assertEqual(len(exporters), 1)
         self.assertIsInstance(exporters[0], FileRequestMetricsExporter)
+
+
+class TestRequestMetricsExporterBaseClose(unittest.TestCase):
+    def test_base_close_is_noop(self):
+        # The abstract base provides a no-op close() so exporters without
+        # buffered/async delivery need not override it.
+        server_args = _make_server_args("/tmp/unused")
+        exporter = _ConcreteExporter(
+            server_args, obj_skip_names=None, out_skip_names=None
+        )
+        exporter.close()  # inherits base no-op; must not raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`RequestMetricsExporter` subclasses may buffer records for asynchronous
delivery (e.g. batching on a background thread and POSTing them out-of-band),
but nothing ever closed the exporters on shutdown. As a result a short-lived
`Engine` (offline `generate` then process exit) or a server exiting on SIGTERM
could drop its final buffered records. `FileRequestMetricsExporter` already
defined a `close()`, but it was never invoked anywhere.

## Modifications

- `RequestMetricsExporter.close()`: a no-op by default; exporters with buffered
  or asynchronous delivery override it to flush pending records before the
  process exits.
- `RequestMetricsExporterManager.close()`: closes every configured exporter,
  best-effort — one exporter failing to close does not prevent the others.
- Call it on the two shutdown paths:
  - `Engine.shutdown()` (offline / embedded engine), and
  - `TokenizerManager.sigterm_watchdog()` after in-flight requests drain
    (server SIGTERM path).
  Both call sites are guarded with `getattr(..., None)` since not every
  tokenizer-manager variant builds an exporter manager (e.g.
  `MultiTokenizerRouter`, which is not a `TokenizerManager` subclass).
- Unit tests for the base no-op, manager delegation, and best-effort behavior.

## Accuracy Tests

N/A — this only affects the shutdown path; it does not change model outputs.

## Speed Tests and Profiling

N/A — no changes to the request-serving hot path; `close()` runs only during
shutdown.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results (N/A — shutdown-only change).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28907532160](https://github.com/sgl-project/sglang/actions/runs/28907532160)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28907531970](https://github.com/sgl-project/sglang/actions/runs/28907531970)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->