### PR TITLE
[AMD] Register 2 CPU-bound 1-GPU tests (phase_checker, scripted_runtime_core) for AMD PR CI

### DIFF
--- a/test/registered/model_loading/test_utils_update_weights.py
+++ b/test/registered/model_loading/test_utils_update_weights.py
@@ -9,11 +9,10 @@ from transformers import AutoModelForCausalLM
 
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.weight_sync.utils import update_weights
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 register_cuda_ci(est_time=32, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=32, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 class AsyncEngine(Engine):

--- a/test/registered/model_loading/test_utils_update_weights.py
+++ b/test/registered/model_loading/test_utils_update_weights.py
@@ -9,10 +9,11 @@ from transformers import AutoModelForCausalLM
 
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.weight_sync.utils import update_weights
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 register_cuda_ci(est_time=32, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=32, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 class AsyncEngine(Engine):

--- a/test/registered/scripted_runtime/test_scripted_runtime_core.py
+++ b/test/registered/scripted_runtime/test_scripted_runtime_core.py
@@ -1,7 +1,7 @@
 import unittest
 
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.scripted_runtime.context import ScriptedContext
 from sglang.test.scripted_runtime.http_server import ScriptedHttpServer
 from sglang.test.scripted_runtime.req_handle import ScriptedReqHandle
@@ -17,6 +17,7 @@ from sglang.test.scripted_runtime_chunked_helpers import (
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=460, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=460, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 _CHUNK_SIZE = 64

--- a/test/registered/utils/test_phase_checker.py
+++ b/test/registered/utils/test_phase_checker.py
@@ -11,10 +11,11 @@ from enum import IntEnum
 import torch
 
 from sglang.srt.utils.phase_checker import SimplePhaseChecker
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=120, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class _Phase(IntEnum):


### PR DESCRIPTION
## What
Register 2 CPU-bound NVIDIA-only per-commit tests for AMD 1-GPU PR CI. Both already run on NVIDIA per-commit and use generic torch/device ops or CPU-only logic, so adding `register_amd_ci(...)` next to `register_cuda_ci(...)` is sufficient.

| File | AMD suite | est_time | Why safe on AMD |
|------|-----------|---------:|-----------------|
| `utils/test_phase_checker.py` | `stage-b-test-1-gpu-small-amd` | 120 | `SimplePhaseChecker` device-tensor + subprocess tests; plain `torch.device` ops, no CUDA-only deps |
| `scripted_runtime/test_scripted_runtime_core.py` | `stage-b-test-1-gpu-small-amd` | 460 | Scripted-runtime core logic; no CUDA-only imports / `.cuda()`-only paths |

Standard 2-line edit per file: add `register_amd_ci(...)` alongside `register_cuda_ci(...)` (cuda-style `stage=`/`runner_config=` shape with `-amd` appended).

## Validation (dispatched on upstream — both AMD lanes green)
- ROCm 7.0.0 (mi3xx) `stage-b-test-1-gpu-small-amd`: ✅ https://github.com/sgl-project/sglang/actions/runs/28907747528
- ROCm 7.2.0 `stage-b-test-1-gpu-small-amd-rocm720`: ✅ (all 14 partitions) https://github.com/sgl-project/sglang/actions/runs/28918550073

### Dropped (real ROCm gap)
`model_loading/test_utils_update_weights.py` was initially included but **dropped** — its engine fixture imports `torch_memory_saver`, which isn't available on ROCm (`ModuleNotFoundError` at setup, [failed run](https://github.com/sgl-project/sglang/actions/runs/28907748539)). Left CUDA-only rather than register-and-skip.

## Test plan
- [x] AMD `stage-b-test-1-gpu-small-amd` green (mi3xx)
- [x] rocm720 lane green
- [ ] NVIDIA CI unchanged