### PR TITLE
Fix duplicate tool_index in PoolsideV1Detector non-streaming path

### DIFF
--- a/python/sglang/srt/function_call/poolside_v1_detector.py
+++ b/python/sglang/srt/function_call/poolside_v1_detector.py
@@ -244,7 +244,7 @@ class PoolsideV1Detector(BaseFormatDetector):
 
             calls.append(
                 ToolCallItem(
-                    tool_index=tool_indices[name],
+                    tool_index=len(calls),
                     name=name,
                     parameters=json.dumps(args, ensure_ascii=False),
                 )

--- a/test/registered/unit/function_call/test_poolside_v1_detector.py
+++ b/test/registered/unit/function_call/test_poolside_v1_detector.py
@@ -106,6 +106,24 @@ class TestPoolsideV1Detector(CustomTestCase):
         self.assertEqual(result.calls[1].name, "search")
         self.assertEqual(json.loads(result.calls[1].parameters), {"query": "pizza"})
 
+    def test_same_function_called_twice_gets_sequential_indices(self):
+        """Regression (#25073): non-streaming must assign a per-response
+        sequential `tool_index`, not the function's slot in the tools list.
+        Calling the SAME function twice used to give both calls the same
+        index, so OpenAI-compatible clients merged their argument deltas into
+        one broken call. Mirror the streaming path's `current_tool_id`."""
+        text = (
+            "<tool_call>get_weather\n<arg_key>location</arg_key>\n"
+            "<arg_value>NYC</arg_value>\n</tool_call>\n"
+            "<tool_call>get_weather\n<arg_key>location</arg_key>\n"
+            "<arg_value>SF</arg_value>\n</tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "get_weather")
+        self.assertEqual([c.tool_index for c in result.calls], [0, 1])
+
     def test_leading_text_extracted_as_normal(self):
         text = (
             "Sure, checking now. "


### PR DESCRIPTION
## What

In `PoolsideV1Detector.detect_and_parse`, the non-streaming path set `tool_index=tool_indices[name]` — the function's position in the tools list. When a model calls the same function twice, both `ToolCallItem`s get the same index, so OpenAI-compatible clients group chunks by `index` and merge the two calls' argument deltas into one broken call.

## Why

The general fix in #25796 only touches `base_format_detector.py::parse_base_json`, which Poolside overrides and does not use, so Poolside was left uncovered. This aligns with the accepted per-detector pattern used elsewhere (e.g. hunyuan #28924, gemma4 #25075): emit a per-response sequential index via `tool_index=len(calls)`. Since `calls.append(...)` immediately follows, this yields 0, 1, 2… per emitted call — matching the streaming path's `self.current_tool_id`.

## Test

Adds `test_same_function_called_twice_gets_sequential_indices` to `test/registered/unit/function_call/test_poolside_v1_detector.py`, asserting `[c.tool_index for c in result.calls] == [0, 1]` for two calls to the same function (previously `[0, 0]`).

Related to #25073, which reported the same bug class for the Gemma4 parser and has since been fixed there. The Poolside detector was never covered by that fix and still carries the bug on current `main`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34786001354](https://github.com/sgl-project/sglang/actions/runs/34786001354)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34786001055](https://github.com/sgl-project/sglang/actions/runs/34786001055)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34786001220](https://github.com/sgl-project/sglang/actions/runs/34786001220)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
