### PR TITLE
[DSV4] Fix draft SWA transfer for disaggregated MTP

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -668,6 +668,7 @@ def setup_state_kv_args(
     from sglang.srt.disaggregation.base.conn import StateType
     from sglang.srt.hardware_backend.npu.memory_pool_npu import NPUMLATokenToKVPool
     from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
+    from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.mem_cache.memory_pool import (
         DSATokenToKVPool,
         HybridLinearKVPool,
@@ -756,6 +757,82 @@ def setup_state_kv_args(
                 append_state_component(
                     kv_args, StateType.DSA, data_ptrs, data_lens, item_lens
                 )
+
+    # DSV4 NextN shares the target allocator, so target and draft use the same
+    # local SWA indices. Keep draft buffers in a separate positional component
+    # to avoid mixing them into the target's heterogeneous state layout, while
+    # reusing the existing SWA transport dispatch. NPU has a different paged
+    # state layout and is intentionally left unchanged.
+    if (
+        not is_npu()
+        and isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
+        and isinstance(draft_token_to_kv_pool, DeepSeekV4TokenToKVPool)
+    ):
+        if not draft_token_to_kv_pool.compression_ratios or not all(
+            ratio == 0 for ratio in draft_token_to_kv_pool.compression_ratios
+        ):
+            raise RuntimeError(
+                "DSV4 draft state transfer expects SWA-only NextN layers"
+            )
+        if token_to_kv_pool._unified_kv != draft_token_to_kv_pool._unified_kv:
+            raise RuntimeError(
+                "DSV4 target and draft pools must use the same unified-KV mode"
+            )
+
+        if token_to_kv_pool._unified_kv:
+            target_geometry = (
+                token_to_kv_pool.unified_swa_window,
+                token_to_kv_pool.unified_swa_ring_size,
+                token_to_kv_pool.unified_swa_pages,
+            )
+            draft_geometry = (
+                draft_token_to_kv_pool.unified_swa_window,
+                draft_token_to_kv_pool.unified_swa_ring_size,
+                draft_token_to_kv_pool.unified_swa_pages,
+            )
+            if target_geometry != draft_geometry:
+                raise RuntimeError(
+                    "DSV4 target and draft pools must share SWA ring geometry: "
+                    f"target={target_geometry}, draft={draft_geometry}"
+                )
+            draft_ptrs, draft_lens, draft_item_lens = (
+                draft_token_to_kv_pool.get_unified_swa_ring_buf_infos()
+            )
+            draft_state_type = StateType.SWA_RING
+        else:
+            if (
+                token_to_kv_pool.full_to_swa_index_mapping
+                is not draft_token_to_kv_pool.full_to_swa_index_mapping
+            ):
+                raise RuntimeError(
+                    "DSV4 target and draft pools must share the SWA index mapping"
+                )
+            target_geometry = (
+                token_to_kv_pool.page_size,
+                token_to_kv_pool.sliding_window,
+            )
+            draft_geometry = (
+                draft_token_to_kv_pool.page_size,
+                draft_token_to_kv_pool.sliding_window,
+            )
+            if target_geometry != draft_geometry:
+                raise RuntimeError(
+                    "DSV4 target and draft pools must share paged SWA geometry: "
+                    f"target={target_geometry}, draft={draft_geometry}"
+                )
+            draft_ptrs, draft_lens, draft_item_lens = (
+                draft_token_to_kv_pool.get_state_buf_infos()
+            )
+            draft_state_type = StateType.SWA
+
+        if draft_ptrs:
+            append_state_component(
+                kv_args,
+                draft_state_type,
+                draft_ptrs,
+                draft_lens,
+                draft_item_lens,
+            )
 
     if (
         StateType.MAMBA not in kv_args.state_types

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -1,7 +1,10 @@
 import unittest
+from types import SimpleNamespace
 
 import numpy as np
+import torch
 
+from sglang.srt.disaggregation.base.conn import KVArgs, StateType
 from sglang.srt.disaggregation.common.utils import (
     group_concurrent_contiguous,
     pack_int_lists,
@@ -9,7 +12,11 @@ from sglang.srt.disaggregation.common.utils import (
     unpack_int_lists,
     unpack_list_of_buffers,
 )
-from sglang.srt.disaggregation.utils import get_dsv4_c128_state_indices
+from sglang.srt.disaggregation.utils import (
+    get_dsv4_c128_state_indices,
+    setup_state_kv_args,
+)
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
@@ -115,6 +122,88 @@ class TestDSV4C128StateIndices(unittest.TestCase):
             get_dsv4_c128_state_indices(7, 129, online=False, ring_size=256),
             np.array([15], dtype=np.int32),
         )
+
+
+def _buf_infos(*ptrs):
+    return list(ptrs), [ptr + 100 for ptr in ptrs], [ptr + 200 for ptr in ptrs]
+
+
+def _make_dsv4_target(*, unified, mapping=None):
+    pool = object.__new__(DeepSeekV4TokenToKVPool)
+    pool._unified_kv = unified
+    pool.page_size = 256
+    pool.sliding_window = 128
+    pool.full_to_swa_index_mapping = mapping
+    pool.unified_swa_window = 128
+    pool.unified_swa_ring_size = 131
+    pool.unified_swa_pages = 524
+    pool.get_state_buf_infos = lambda: _buf_infos(11)
+    pool.get_unified_swa_ring_buf_infos = lambda: (
+        _buf_infos(12) if unified else ([], [], [])
+    )
+    pool.get_c128_state_buf_infos = lambda: ([], [], [])
+    return pool
+
+
+def _make_dsv4_draft(*, unified, mapping=None):
+    pool = object.__new__(DeepSeekV4TokenToKVPool)
+    pool._unified_kv = unified
+    pool.compression_ratios = [0]
+    pool.page_size = 256
+    pool.sliding_window = 128
+    pool.full_to_swa_index_mapping = mapping
+    pool.unified_swa_window = 128
+    pool.unified_swa_ring_size = 131
+    pool.unified_swa_pages = 524
+    pool.compress_state_pools = [None]
+    pool.indexer_compress_state_pools = [None]
+    if unified:
+        pool.unified_kv_pool = SimpleNamespace(
+            swa_pages=524,
+            kv_buffer=[torch.empty((524, 16), dtype=torch.uint8)],
+        )
+    else:
+        pool.swa_kv_pool = SimpleNamespace(
+            kv_buffer=[torch.empty((2, 16), dtype=torch.uint8)]
+        )
+    return pool
+
+
+class TestDSV4DraftStateRegistration(unittest.TestCase):
+    def test_draft_state_is_a_separate_component(self):
+        mapping = torch.arange(16)
+        cases = [
+            (
+                "paged",
+                _make_dsv4_target(unified=False, mapping=mapping),
+                _make_dsv4_draft(unified=False, mapping=mapping),
+                [StateType.SWA, StateType.SWA],
+                [[11]],
+            ),
+            (
+                "unified",
+                _make_dsv4_target(unified=True),
+                _make_dsv4_draft(unified=True),
+                [StateType.SWA, StateType.SWA_RING, StateType.SWA_RING],
+                [[11], [12]],
+            ),
+        ]
+
+        for name, target, draft, expected_types, target_ptrs in cases:
+            with self.subTest(name=name):
+                if draft._unified_kv:
+                    expected_infos = draft.get_unified_swa_ring_buf_infos()
+                else:
+                    expected_infos = draft.get_state_buf_infos()
+                kv_args = KVArgs()
+
+                setup_state_kv_args(kv_args, target, draft)
+
+                self.assertEqual(kv_args.state_types, expected_types)
+                self.assertEqual(kv_args.state_data_ptrs[:-1], target_ptrs)
+                self.assertEqual(kv_args.state_data_ptrs[-1], expected_infos[0])
+                self.assertEqual(kv_args.state_data_lens[-1], expected_infos[1])
+                self.assertEqual(kv_args.state_item_lens[-1], expected_infos[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

When both prefill and decode enable EAGLE for DeepSeek V4, prefill builds prompt SWA state for the draft NextN layer. Disaggregation already registers the draft pool's contiguous KV buffers, but the DSV4 NextN layer has compression ratio 0 and stores its state in the paged SWA pool, or in the SWA-ring prefix of the unified KV pool. Those buffers were not registered, so decode started with missing or stale draft prompt state until newly generated tokens refilled the sliding window.

This is the DSV4/SWA counterpart of #23539. The draft worker shares the target request pool and SWA allocator mapping; unified mode also uses matching ring geometry. Therefore the draft buffers can reuse the existing SWA transport types. They are registered as a separate positional component so they do not become part of the target model's heterogeneous DSV4 state layout. This change is limited to the non-NPU DSV4 path.

## Modifications

- Register paged draft NextN state as an additional `StateType.SWA` component and unified draft ring buffers as an additional `StateType.SWA_RING` component.
- Validate the existing DSV4 invariants used for shared indexing: SWA-only draft layers, matching pool mode and geometry, and a shared paged SWA mapping.
- Reuse the existing state-component wire format and SWA transfer dispatch; no draft-specific state type or backend changes are added.
- Add focused CPU coverage for paged and unified draft-state registration.

## Accuracy Tests

- A 20-sample GSM8K smoke test on a 1P1D DSV4 deployment with real bilateral EAGLE completed with non-empty responses and no KV registration or transfer failures.
- Patched result: 90% strict match and 95% flexible match. This small smoke test is a functional check, not a statistical accuracy claim.

## Speed Tests and Profiling

With EAGLE top-k 1, 3 speculative steps, and 4 draft tokens:

The strongest improvement appears in the early decode window, before locally generated tokens replace the transferred 128-token draft SWA prompt state. After aligning each DP rank at its first stable decode batch:

| Stable decode window | Main AL | Patched AL | Change |
|---|---:|---:|---:|
| First 8 verify steps | 2.4844 | 2.9219 | +17.61% |
| First 16 verify steps | 2.5625 | 2.9531 | +15.24% |
| First 32 verify steps | 2.6094 | 2.9531 | +13.17% |

This time-segmented result directly matches the failure mode: the missing prompt SWA state hurts draft proposals most at the beginning, and its impact decays as newly generated tokens fill the local SWA window.

Across the full requests, the improvement is diluted by later decode steps after the local SWA window has been refilled:

| Metric | Main | Patched | Change |
|---|---:|---:|---:|
| Request-weighted acceptance length | 2.8054 | 2.9139 | +3.87% |
| Request-weighted acceptance rate | 60.18% | 63.80% | +3.62 pp |

The workload is intentionally small, so these numbers validate the expected direction rather than establish an end-to-end throughput claim.

## Validation

- `python -m pytest -q test/registered/unit/disaggregation/test_disaggregation_wire.py test/registered/unit/disaggregation/test_minimax_sparse_disagg_state_kv_args.py` (18 passed, 2 subtests passed)
- `pre-commit run --all-files --show-diff-on-failure`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required for this internal state-transfer fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28919874867](https://github.com/sgl-project/sglang/actions/runs/28919874867)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28919874782](https://github.com/sgl-project/sglang/actions/runs/28919874782)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
