### PR TITLE
[DONT REVIEW][WIP][AMD] Enable MLA DCP for aiter backend

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -37,7 +37,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
+ENV AITER_COMMIT_DEFAULT="d30c77337aff1dbfa5b5c7d0458cf8bfec56b79a"
 
 # ===============================
 # Base image 942 with rocm720 and args
@@ -47,7 +47,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
+ENV AITER_COMMIT_DEFAULT="d30c77337aff1dbfa5b5c7d0458cf8bfec56b79a"
 
 # ===============================
 # Base image 950 and args
@@ -57,7 +57,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
+ENV AITER_COMMIT_DEFAULT="d30c77337aff1dbfa5b5c7d0458cf8bfec56b79a"
 
 # ===============================
 # Base image 950 with rocm720 and args
@@ -67,7 +67,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
+ENV AITER_COMMIT_DEFAULT="d30c77337aff1dbfa5b5c7d0458cf8bfec56b79a"
 
 # ===============================
 # Chosen arch and args
@@ -88,7 +88,7 @@ ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
 ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
 
-ARG AITER_REPO="https://github.com/billishyahao/aiter-kimi.git"
+ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG AITER_COMMIT=""
 ENV AITER_COMMIT="${AITER_COMMIT:-${AITER_COMMIT_DEFAULT}}"
 
@@ -225,7 +225,7 @@ RUN pip uninstall -y aiter
 # block switching to commits that predate that rule (e.g. the current default
 # AITER_COMMIT_DEFAULT). The working tree was just produced by a fresh
 # `git clone` above, so there are no real user changes to preserve.
-RUN git clone ${AITER_REPO} aiter \
+RUN git clone ${AITER_REPO} \
  && cd aiter \
  && git checkout -f ${AITER_COMMIT} \
  && git submodule update --init --recursive \

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -37,7 +37,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="9127c94a18e4398e1eba91f6639e910f0994ad02"
+ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
 
 # ===============================
 # Base image 942 with rocm720 and args
@@ -47,7 +47,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="9127c94a18e4398e1eba91f6639e910f0994ad02"
+ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
 
 # ===============================
 # Base image 950 and args
@@ -57,7 +57,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="9127c94a18e4398e1eba91f6639e910f0994ad02"
+ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
 
 # ===============================
 # Base image 950 with rocm720 and args
@@ -67,7 +67,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="9127c94a18e4398e1eba91f6639e910f0994ad02"
+ENV AITER_COMMIT_DEFAULT="28d08e58899e3aa6490197b5ebb92703c8468009"
 
 # ===============================
 # Chosen arch and args
@@ -88,7 +88,7 @@ ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
 ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
 
-ARG AITER_REPO="https://github.com/ROCm/aiter.git"
+ARG AITER_REPO="https://github.com/billishyahao/aiter-kimi.git"
 ARG AITER_COMMIT=""
 ENV AITER_COMMIT="${AITER_COMMIT:-${AITER_COMMIT_DEFAULT}}"
 
@@ -225,7 +225,7 @@ RUN pip uninstall -y aiter
 # block switching to commits that predate that rule (e.g. the current default
 # AITER_COMMIT_DEFAULT). The working tree was just produced by a fresh
 # `git clone` above, so there are no real user changes to preserve.
-RUN git clone ${AITER_REPO} \
+RUN git clone ${AITER_REPO} aiter \
  && cd aiter \
  && git checkout -f ${AITER_COMMIT} \
  && git submodule update --init --recursive \

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -25,6 +25,13 @@ from sglang.kernels.ops.kvcache.aiter_unified_attention import (
     scatter_req_to_token_to_page_table_kernel,
 )
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.dcp import (
+    dcp_enabled,
+    get_attention_dcp_rank,
+    get_attention_dcp_world_size,
+    update_local_kv_lens_for_dcp,
+)
+from sglang.srt.layers.dcp.planner import plan_dcp_decode_metadata
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
@@ -121,6 +128,11 @@ class ForwardMetadata:
     swa_page_table: Optional[torch.Tensor] = None
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: Optional[torch.Tensor] = None
+    # dcp_g_kv_indptr keeps the GLOBAL per-request kv_indptr so that it can
+    # mask on global positions g(j)=j*W+r. See mla_decode_fwd(cp_world_size,...).
+    dcp_g_kv_indptr: Optional[torch.Tensor] = None
+    dcp_cp_world_size: int = 1
+    dcp_cp_rank: int = 0
 
 
 _AITER_PARTITION_SIZE_ROCM = 256
@@ -298,17 +310,27 @@ class AiterAttnBackend(AttentionBackend):
             self.num_head_padded = 16 if self.num_head < 16 else self.num_head
             self.head_repeat_factor = 16 // self.num_head if self.num_head < 16 else 1
 
+            # when DCP is on, it all-gathers Q across the dcp group, so the
+            # compute op as well as its persist metadata operates on the gathered
+            # head count num_head * dcp_world_size, not the local num_head.
+            # No op for non-dcp case
+            self.dcp_world_size = get_attention_dcp_world_size()
+            _gathered_num_head = self.num_head * self.dcp_world_size
+            self.mla_kernel_num_head_padded = (
+                16 if _gathered_num_head < 16 else _gathered_num_head
+            )
+
             self.enable_dp_attention = is_dp_attention_enabled()
             self.qo_indptr_ = torch.zeros(
                 (max_bs + 1,), dtype=torch.int32, device=model_runner.device
             )
             global _use_mla_ps_kernel, fast_mode, intra_batch_mode
 
-            # current mla_decode_fwd only support fake-nps in self.num_head == 16
+            # current mla_decode_fwd only support fake-nps in num_head == 16
             # so all num_head size does not use qh16 kernel to simulate
             # it should not use fake-nps (fast_mode = False, intra_batch_mode = True)
-            # it will cause gpu-fault or accuracy issue
-            if self.num_head in (32, 64, 128):
+            # it will cause gpu-fault or accuracy issue.
+            if self.mla_kernel_num_head_padded in (32, 64, 128):
                 fast_mode = True
                 intra_batch_mode = False
 
@@ -318,10 +340,17 @@ class AiterAttnBackend(AttentionBackend):
             # for non-fp8 kv_cache on tp8, use non-persist kernel to avoid performance degradation
             # head_num=16 (tp8 perf issue), head_num=128 (unsupported, like tp1 or --enable-dp-attention with tp8-dp8)
             if (
-                self.num_head_padded == 16 or self.num_head_padded == 128
-            ) and self.kv_cache_dtype is not fp8_dtype:
+                self.mla_kernel_num_head_padded in (16, 128)
+                and self.kv_cache_dtype is not fp8_dtype
+            ):
                 _use_mla_ps_kernel = False
                 fast_mode = False
+                intra_batch_mode = False
+
+            # aiter currently only support persist cprr kernel
+            if self.dcp_world_size > 1:
+                _use_mla_ps_kernel = True
+                fast_mode = True
                 intra_batch_mode = False
 
             self.max_split_per_batch = 32 if _use_mla_ps_kernel else None
@@ -347,7 +376,9 @@ class AiterAttnBackend(AttentionBackend):
         return "fp8_e4m3"
 
     def make_mla_decode_meta_data_buffer(self, max_seqlen_qo, batch_size):
-        nhead = self.num_head_padded
+        # Under DCP this is the gathered head count (num_head * dcp_world_size);
+        # equals num_head_padded when DCP is off.
+        nhead = self.mla_kernel_num_head_padded
         dtype = self.kv_cache_dtype
 
         if self.enable_dp_attention:
@@ -430,11 +461,12 @@ class AiterAttnBackend(AttentionBackend):
         page_size = self.page_size
         dtype = self.kv_cache_dtype
 
+        # For dcp, kv_indptr here is already localized to this rank's shard
         meta = get_mla_metadata_v1(
             qo_indptr,
             kv_indptr,
             kv_last_page_len,
-            self.num_head_padded // nhead_kv,
+            self.mla_kernel_num_head_padded // nhead_kv,
             nhead_kv,
             False,
             work_metadata,
@@ -451,6 +483,7 @@ class AiterAttnBackend(AttentionBackend):
             intra_batch_mode=intra_batch_mode,
             dtype_q=dtype,
             dtype_kv=dtype,
+            is_cp_round_robin=dcp_enabled(),
         )
 
     def make_mla_prefill_ps_meta_data_buffer(
@@ -747,6 +780,7 @@ class AiterAttnBackend(AttentionBackend):
         q: torch.Tensor,
         k_buffer_flat: torch.Tensor,
         layer,
+        return_lse: bool = False,
         **kwargs,
     ):
         """Wrap mla_decode_fwd with head-dimension padding for num_head < 16.
@@ -755,21 +789,40 @@ class AiterAttnBackend(AttentionBackend):
         repeat-interleaved to reach num_head_padded (16) before the kernel
         call, and the corresponding output columns are sliced back afterward.
         q / o must already be shaped (..., num_head, head_dim).
+
+        When ``return_lse`` is set (DCP case), also returns the
+        per-(token, head) log-sum-exp so the caller can merge partial outputs
+        across dcp ranks.
         """
-        if self.head_repeat_factor > 1:
-            q_in = q.repeat_interleave(self.head_repeat_factor, dim=1)
+        # Head padding is driven by this call's ACTUAL query-head count
+        # (layer.tp_q_head_num), not the backend's static self.num_head: under DCP
+        # the dcp-group-gathered layer has num_local_heads * dcp_world_size heads,
+        # which is usually already >= 16 (no padding) even when num_local_heads < 16.
+        n_heads = layer.tp_q_head_num
+        repeat_factor = (16 // n_heads) if n_heads < 16 else 1
+        if repeat_factor > 1:
+            q_in = q.repeat_interleave(repeat_factor, dim=1)
             o = q.new_empty(
-                (q.shape[0], self.num_head_padded, layer.v_head_dim),
+                (q.shape[0], n_heads * repeat_factor, layer.v_head_dim),
                 dtype=self.input_dtype,
             )
-            mla_decode_fwd(q_in, k_buffer_flat, o, **kwargs)
-            return o[:, :: self.head_repeat_factor, :]
+            _, lse = mla_decode_fwd(
+                q_in, k_buffer_flat, o, return_lse=return_lse, **kwargs
+            )
+            o = o[:, ::repeat_factor, :]
+            if return_lse:
+                return o, lse[:, ::repeat_factor]
+            return o
         else:
             o = q.new_empty(
-                (q.shape[0], layer.tp_q_head_num, layer.v_head_dim),
+                (q.shape[0], n_heads, layer.v_head_dim),
                 dtype=self.input_dtype,
             )
-            mla_decode_fwd(q, k_buffer_flat, o, **kwargs)
+            _, lse = mla_decode_fwd(
+                q, k_buffer_flat, o, return_lse=return_lse, **kwargs
+            )
+            if return_lse:
+                return o, lse
             return o
 
     def mla_fp8_prefill_attn(
@@ -909,6 +962,10 @@ class AiterAttnBackend(AttentionBackend):
             )
         max_kv_len = forward_batch.seq_lens_cpu.max().item()
 
+        # dcp metadata
+        dcp_g_kv_indptr = None
+        dcp_cp_world_size = 1
+        dcp_cp_rank = 0
         if forward_batch.forward_mode.is_decode_or_idle():
             if spec_info is None or forward_batch.forward_mode.is_idle():
                 kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
@@ -927,6 +984,23 @@ class AiterAttnBackend(AttentionBackend):
                         kv_indices,
                         self.req_to_token.stride(0),
                     )
+
+                    if (
+                        self.use_mla
+                        and dcp_enabled()
+                        and not forward_batch.forward_mode.is_idle()
+                    ):
+                        dcp_g_kv_indptr = kv_indptr.clone()
+                        dcp_cp_world_size = get_attention_dcp_world_size()
+                        dcp_cp_rank = get_attention_dcp_rank()
+                        kv_lens = forward_batch.seq_lens[:bs].to(torch.int32).clone()
+                        self._plan_dcp_decode_metadata(
+                            kv_indptr,
+                            kv_indices,
+                            kv_lens,
+                            forward_batch.seq_lens_cpu,
+                            bs,
+                        )
                 else:
                     max_q_len = 1
                     page_size = self.page_size
@@ -976,6 +1050,25 @@ class AiterAttnBackend(AttentionBackend):
                 else:
                     kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
                     bs = kv_indptr.shape[0] - 1
+
+                    if self.use_mla and dcp_enabled():
+                        kv_indptr = kv_indptr.clone()
+                        kv_indices = kv_indices.clone()
+                        dcp_g_kv_indptr = kv_indptr.clone()
+                        dcp_cp_world_size = get_attention_dcp_world_size()
+                        dcp_cp_rank = get_attention_dcp_rank()
+                        kv_lens = (
+                            (kv_indptr[1 : bs + 1] - kv_indptr[:bs])
+                            .to(torch.int32)
+                            .clone()
+                        )
+                        self._plan_dcp_decode_metadata(
+                            kv_indptr,
+                            kv_indices,
+                            kv_lens,
+                            None,
+                            bs,
+                        )
 
             if self.use_mla:
                 qo_indptr = self.qo_indptr_[: bs + 1]
@@ -1028,6 +1121,9 @@ class AiterAttnBackend(AttentionBackend):
                 run_graph=False,
                 swa_page_table=swa_page_table,
                 swa_out_cache_loc=swa_out_cache_loc,
+                dcp_g_kv_indptr=dcp_g_kv_indptr,
+                dcp_cp_world_size=dcp_cp_world_size,
+                dcp_cp_rank=dcp_cp_rank,
             )
 
         elif forward_batch.forward_mode.is_draft_extend_v2():
@@ -1054,6 +1150,24 @@ class AiterAttnBackend(AttentionBackend):
                     kv_indices,
                     self.req_to_token.stride(0),
                 )
+
+                if self.use_mla and dcp_enabled():
+                    dcp_g_kv_indptr = kv_indptr.clone()
+                    dcp_cp_world_size = get_attention_dcp_world_size()
+                    dcp_cp_rank = get_attention_dcp_rank()
+                    kv_lens_dcp = forward_batch.seq_lens[:bs].to(torch.int32).clone()
+                    seq_lens_cpu_dcp = (
+                        forward_batch.seq_lens_cpu[:bs]
+                        if forward_batch.seq_lens_cpu is not None
+                        else None
+                    )
+                    self._plan_dcp_decode_metadata(
+                        kv_indptr,
+                        kv_indices,
+                        kv_lens_dcp,
+                        seq_lens_cpu_dcp,
+                        bs,
+                    )
 
                 if _use_mla_ps_kernel:
                     max_seqlen_qo = num_draft_tokens
@@ -1099,6 +1213,9 @@ class AiterAttnBackend(AttentionBackend):
                     reduce_partial_map=reduce_partial_map,
                     num_kv_splits=num_kv_splits,
                     run_graph=False,
+                    dcp_g_kv_indptr=dcp_g_kv_indptr,
+                    dcp_cp_world_size=dcp_cp_world_size,
+                    dcp_cp_rank=dcp_cp_rank,
                 )
             else:
                 self.indices_updater_prefill.update(
@@ -1148,6 +1265,24 @@ class AiterAttnBackend(AttentionBackend):
                     self.req_to_token.stride(0),
                 )
 
+                if self.use_mla and dcp_enabled():
+                    dcp_g_kv_indptr = kv_indptr.clone()
+                    dcp_cp_world_size = get_attention_dcp_world_size()
+                    dcp_cp_rank = get_attention_dcp_rank()
+                    kv_lens_dcp = kv_lens[:bs].to(torch.int32).clone()
+                    seq_lens_cpu_dcp = (
+                        (forward_batch.seq_lens_cpu[:bs] + draft_num)
+                        if forward_batch.seq_lens_cpu is not None
+                        else None
+                    )
+                    self._plan_dcp_decode_metadata(
+                        kv_indptr,
+                        kv_indices,
+                        kv_lens_dcp,
+                        seq_lens_cpu_dcp,
+                        bs,
+                    )
+
                 # if self.kv_cache_dtype == fp8_dtype:
                 if _use_mla_ps_kernel:
                     max_seqlen_qo = draft_num
@@ -1194,6 +1329,9 @@ class AiterAttnBackend(AttentionBackend):
                     reduce_partial_map=reduce_partial_map,
                     num_kv_splits=num_kv_splits,
                     run_graph=False,
+                    dcp_g_kv_indptr=dcp_g_kv_indptr,
+                    dcp_cp_world_size=dcp_cp_world_size,
+                    dcp_cp_rank=dcp_cp_rank,
                 )
             else:
                 bs = len(forward_batch.req_pool_indices)
@@ -1370,6 +1508,40 @@ class AiterAttnBackend(AttentionBackend):
                     swa_out_cache_loc=swa_out_cache_loc,
                 )
 
+    def _plan_dcp_decode_metadata(
+        self,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_lens_gpu: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+        bs: int,
+    ):
+        """Localize kv_indptr / kv_indices to this rank's DCP round-robin shard
+        (in place). When ``seq_lens_cpu`` is available, size the plan from a CPU
+        local-length array (``init_metadata_replay=True``) so no per-step GPU->CPU
+        sync is needed.
+        """
+        if seq_lens_cpu is not None:
+            kv_len_arr_cpu = seq_lens_cpu[:bs].to(torch.int32).clone()
+            update_local_kv_lens_for_dcp(kv_len_arr_cpu)
+            plan_dcp_decode_metadata(
+                kv_lens_gpu,
+                kv_indptr,
+                kv_indices,
+                init_metadata_replay=True,
+                fast_decode_kwargs={"kv_len_arr_cpu": kv_len_arr_cpu},
+                bs=bs,
+            )
+        else:
+            plan_dcp_decode_metadata(
+                kv_lens_gpu,
+                kv_indptr,
+                kv_indices,
+                init_metadata_replay=False,
+                fast_decode_kwargs={},
+                bs=bs,
+            )
+
     def init_cuda_graph_state(
         self,
         max_bs: int,
@@ -1397,6 +1569,10 @@ class AiterAttnBackend(AttentionBackend):
         self.cuda_graph_kv_last_page_len = torch.ones(
             max_bs, dtype=torch.int32, device=self.device
         )
+        if self.use_mla and dcp_enabled():
+            self.cuda_graph_dcp_g_kv_indptr = torch.zeros(
+                (max_bs + 1,), dtype=torch.int32, device=self.device
+            )
         if kv_indices_buf is None:
             max_num_blocks_per_seq = (
                 self.max_context_len + self.page_size - 1
@@ -1513,6 +1689,11 @@ class AiterAttnBackend(AttentionBackend):
         reduce_final_map = None
         reduce_partial_map = None
 
+        # DCP metadata which will be populated for MLA decode when dcp enabled
+        dcp_g_kv_indptr = None
+        dcp_cp_world_size = 1
+        dcp_cp_rank = 0
+
         swa_page_table = None
         max_kv_len = (
             seq_lens_cpu.max().item()
@@ -1546,6 +1727,20 @@ class AiterAttnBackend(AttentionBackend):
                         kv_indices,
                         self.req_to_token.stride(0),
                     )
+
+                    if self.use_mla and dcp_enabled() and not forward_mode.is_idle():
+                        self.cuda_graph_dcp_g_kv_indptr[: bs + 1] = kv_indptr
+                        dcp_g_kv_indptr = self.cuda_graph_dcp_g_kv_indptr[: bs + 1]
+                        dcp_cp_world_size = get_attention_dcp_world_size()
+                        dcp_cp_rank = get_attention_dcp_rank()
+                        kv_lens = seq_lens[:bs].to(torch.int32).clone()
+                        self._plan_dcp_decode_metadata(
+                            kv_indptr,
+                            kv_indices,
+                            kv_lens,
+                            seq_lens_cpu,
+                            bs,
+                        )
                 else:
                     max_q_len = 1
                     kv_indices = self.cuda_graph_page_table
@@ -1597,6 +1792,29 @@ class AiterAttnBackend(AttentionBackend):
             else:
                 kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
 
+                if self.use_mla and dcp_enabled() and not forward_mode.is_idle():
+                    assert kv_indptr.shape[0] - 1 == bs, (
+                        "DCP draft-decode cuda-graph expects topk==1 "
+                        f"(bs={bs}, spec kv_indptr rows={kv_indptr.shape[0] - 1})"
+                    )
+                    self.cuda_graph_dcp_g_kv_indptr[: bs + 1] = kv_indptr
+                    dcp_g_kv_indptr = self.cuda_graph_dcp_g_kv_indptr[: bs + 1]
+                    dcp_cp_world_size = get_attention_dcp_world_size()
+                    dcp_cp_rank = get_attention_dcp_rank()
+                    kv_lens = (
+                        (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32).clone()
+                    )
+                    # seq_lens_cpu=None -> GPU-derived lengths (init_metadata_replay
+                    # =False). Built out-of-graph before replay, so the sync is ok.
+                    # TODO(billishyahao): Ideally needs a fast CPU-length path
+                    self._plan_dcp_decode_metadata(
+                        kv_indptr,
+                        kv_indices,
+                        kv_lens,
+                        None,
+                        bs,
+                    )
+
             if self.use_mla:
                 qo_indptr = self.qo_indptr_[: bs + 1]
                 qo_indptr[1 : bs + 1] = torch.cumsum(
@@ -1647,6 +1865,9 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map=reduce_partial_map,
                 num_kv_splits=num_kv_splits,
                 swa_page_table=swa_page_table,
+                dcp_g_kv_indptr=dcp_g_kv_indptr,
+                dcp_cp_world_size=dcp_cp_world_size,
+                dcp_cp_rank=dcp_cp_rank,
                 # num_kv_splits_indptr=num_kv_splits_indptr,
             )
 
@@ -1692,6 +1913,25 @@ class AiterAttnBackend(AttentionBackend):
             max_q_len = self.num_draft_tokens
 
             if self.use_mla:
+                if dcp_enabled():
+                    self.cuda_graph_dcp_g_kv_indptr[: bs + 1] = kv_indptr
+                    dcp_g_kv_indptr = self.cuda_graph_dcp_g_kv_indptr[: bs + 1]
+                    dcp_cp_world_size = get_attention_dcp_world_size()
+                    dcp_cp_rank = get_attention_dcp_rank()
+                    kv_lens_dcp = kv_lens[:bs].to(torch.int32).clone()
+                    seq_lens_cpu_dcp = (
+                        (seq_lens_cpu[:bs] + self.num_draft_tokens)
+                        if seq_lens_cpu is not None
+                        else None
+                    )
+                    self._plan_dcp_decode_metadata(
+                        kv_indptr,
+                        kv_indices,
+                        kv_lens_dcp,
+                        seq_lens_cpu_dcp,
+                        bs,
+                    )
+
                 if _use_mla_ps_kernel:
                     num_kv_splits = self.max_split_per_batch
 
@@ -1733,6 +1973,9 @@ class AiterAttnBackend(AttentionBackend):
                     reduce_final_map=reduce_final_map,
                     reduce_partial_map=reduce_partial_map,
                     num_kv_splits=num_kv_splits,
+                    dcp_g_kv_indptr=dcp_g_kv_indptr,
+                    dcp_cp_world_size=dcp_cp_world_size,
+                    dcp_cp_rank=dcp_cp_rank,
                 )
             else:
                 if self._use_unified_verify:
@@ -1817,6 +2060,23 @@ class AiterAttnBackend(AttentionBackend):
             kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
             max_q_len = num_tokens_per_req
 
+            if self.use_mla and dcp_enabled():
+                self.cuda_graph_dcp_g_kv_indptr[: bs + 1] = kv_indptr
+                dcp_g_kv_indptr = self.cuda_graph_dcp_g_kv_indptr[: bs + 1]
+                dcp_cp_world_size = get_attention_dcp_world_size()
+                dcp_cp_rank = get_attention_dcp_rank()
+                kv_lens_dcp = seq_lens[:bs].to(torch.int32).clone()
+                seq_lens_cpu_dcp = (
+                    seq_lens_cpu[:bs] if seq_lens_cpu is not None else None
+                )
+                self._plan_dcp_decode_metadata(
+                    kv_indptr,
+                    kv_indices,
+                    kv_lens_dcp,
+                    seq_lens_cpu_dcp,
+                    bs,
+                )
+
             if self.use_mla and _use_mla_ps_kernel:
                 num_kv_splits = self.max_split_per_batch
 
@@ -1858,6 +2118,9 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_final_map=reduce_final_map,
                 reduce_partial_map=reduce_partial_map,
                 num_kv_splits=num_kv_splits,
+                dcp_g_kv_indptr=dcp_g_kv_indptr,
+                dcp_cp_world_size=dcp_cp_world_size,
+                dcp_cp_rank=dcp_cp_rank,
             )
         else:
             raise ValueError("Invalid forward mode")
@@ -1967,10 +2230,11 @@ class AiterAttnBackend(AttentionBackend):
             V_Buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
             kv_lora_rank = V_Buffer.shape[-1]
             qk_rope_head_dim = K_Buffer.shape[-1] - kv_lora_rank
-            qk_nope_head_dim = k.shape[-1] - qk_rope_head_dim
-            assert len(q.shape) == 3
-            assert len(k.shape) == 3
-            assert len(v.shape) == 3
+            if k is not None:
+                qk_nope_head_dim = k.shape[-1] - qk_rope_head_dim
+                assert len(q.shape) == 3
+                assert len(k.shape) == 3
+                assert len(v.shape) == 3
 
             if (
                 forward_batch.forward_mode.is_extend()
@@ -2000,7 +2264,18 @@ class AiterAttnBackend(AttentionBackend):
                         )
                     return output
                 elif layer.qk_head_dim != (kv_lora_rank + qk_rope_head_dim):
-                    K_Buffer = torch.index_select(K_Buffer, 0, kv_indices)
+                    dcp_meta = forward_batch.attn_dcp_metadata
+                    if (
+                        dcp_enabled()
+                        and dcp_meta is not None
+                        and dcp_meta.dcp_kv_buffer is not None
+                        and any(forward_batch.extend_prefix_lens_cpu)
+                    ):
+                        K_Buffer = torch.index_select(
+                            dcp_meta.dcp_kv_buffer, 0, dcp_meta.dcp_kv_indices
+                        )
+                    else:
+                        K_Buffer = torch.index_select(K_Buffer, 0, kv_indices)
                     kvc, k_pe = torch.split(
                         K_Buffer, [kv_lora_rank, qk_rope_head_dim], dim=-1
                     )
@@ -2100,10 +2375,20 @@ class AiterAttnBackend(AttentionBackend):
 
                 num_kv_splits = self.forward_metadata.num_kv_splits
 
+                dcp_cp_world_size = self.forward_metadata.dcp_cp_world_size
+                dcp_verify = dcp_cp_world_size > 1
+                dcp_kwargs = {}
+                if dcp_verify:
+                    dcp_kwargs = dict(
+                        g_kv_indptr=self.forward_metadata.dcp_g_kv_indptr,
+                        cp_world_size=dcp_cp_world_size,
+                        cp_rank=self.forward_metadata.dcp_cp_rank,
+                    )
                 o = self._mla_decode_fwd_with_head_pad(
                     q,
                     K_Buffer.view(-1, 1, 1, layer.qk_head_dim),
                     layer,
+                    return_lse=dcp_verify,
                     qo_indptr=self.forward_metadata.qo_indptr,
                     kv_indptr=self.forward_metadata.kv_indptr,
                     kv_indices=self.forward_metadata.kv_indices,
@@ -2121,7 +2406,9 @@ class AiterAttnBackend(AttentionBackend):
                     kv_scale=k_descale,
                     intra_batch_mode=intra_batch_mode,
                     num_kv_splits=num_kv_splits,
+                    **dcp_kwargs,
                 )
+                # (o, lse) when DCP; the model merges across ranks.
                 return o
             elif forward_batch.forward_mode.is_draft_extend_v2():
                 work_metadata = self.forward_metadata.work_metadata
@@ -2134,6 +2421,17 @@ class AiterAttnBackend(AttentionBackend):
 
                 num_kv_splits = self.forward_metadata.num_kv_splits
 
+                # DCP round-robin CP for draft-extend (qseqlen>1): same as verify.
+                dcp_cp_world_size = self.forward_metadata.dcp_cp_world_size
+                dcp_de = dcp_cp_world_size > 1
+                dcp_kwargs = {}
+                if dcp_de:
+                    dcp_kwargs = dict(
+                        g_kv_indptr=self.forward_metadata.dcp_g_kv_indptr,
+                        cp_world_size=dcp_cp_world_size,
+                        cp_rank=self.forward_metadata.dcp_cp_rank,
+                    )
+
                 if self.forward_metadata.run_graph is not True:
                     bs, q_pad, q_mask = pad_sequence_with_mask(
                         q.view(q.shape[0], -1),
@@ -2145,6 +2443,7 @@ class AiterAttnBackend(AttentionBackend):
                         q_pad.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                         K_Buffer.view(-1, 1, 1, layer.qk_head_dim),
                         layer,
+                        return_lse=dcp_de,
                         qo_indptr=self.forward_metadata.qo_indptr,
                         kv_indptr=self.forward_metadata.kv_indptr,
                         kv_indices=self.forward_metadata.kv_indices,
@@ -2162,15 +2461,20 @@ class AiterAttnBackend(AttentionBackend):
                         kv_scale=k_descale,
                         intra_batch_mode=intra_batch_mode,
                         num_kv_splits=num_kv_splits,
+                        **dcp_kwargs,
                     )
 
                     total_valid_q = int(qo_indptr[-1].item())
+                    if dcp_de:
+                        o_t, lse_t = o
+                        return o_t[:total_valid_q], lse_t[:total_valid_q]
                     return o[:total_valid_q]
                 else:
                     o = self._mla_decode_fwd_with_head_pad(
                         q,
                         K_Buffer.view(-1, 1, 1, layer.qk_head_dim),
                         layer,
+                        return_lse=dcp_de,
                         qo_indptr=self.forward_metadata.qo_indptr,
                         kv_indptr=self.forward_metadata.kv_indptr,
                         kv_indices=self.forward_metadata.kv_indices,
@@ -2188,7 +2492,9 @@ class AiterAttnBackend(AttentionBackend):
                         kv_scale=k_descale,
                         intra_batch_mode=intra_batch_mode,
                         num_kv_splits=num_kv_splits,
+                        **dcp_kwargs,
                     )
+                    # (o, lse) when DCP; the model merges across ranks.
                     return o
             else:
                 raise ValueError(
@@ -2455,10 +2761,21 @@ class AiterAttnBackend(AttentionBackend):
 
             num_kv_splits = self.forward_metadata.num_kv_splits
 
-            o = self._mla_decode_fwd_with_head_pad(
+            dcp_cp_world_size = self.forward_metadata.dcp_cp_world_size
+            dcp_decode = dcp_cp_world_size > 1
+            dcp_kwargs = {}
+            if dcp_decode:
+                dcp_kwargs = dict(
+                    g_kv_indptr=self.forward_metadata.dcp_g_kv_indptr,
+                    cp_world_size=dcp_cp_world_size,
+                    cp_rank=self.forward_metadata.dcp_cp_rank,
+                )
+
+            mla_out = self._mla_decode_fwd_with_head_pad(
                 q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                 k_buffer.view(-1, 1, 1, layer.qk_head_dim),
                 layer,
+                return_lse=dcp_decode,
                 qo_indptr=self.forward_metadata.qo_indptr,
                 kv_indptr=self.forward_metadata.kv_indptr,
                 kv_indices=self.forward_metadata.kv_indices,
@@ -2476,7 +2793,12 @@ class AiterAttnBackend(AttentionBackend):
                 kv_scale=k_descale,
                 intra_batch_mode=intra_batch_mode,
                 num_kv_splits=num_kv_splits,
+                **dcp_kwargs,
             )
+            if dcp_decode:
+                # (o, lse); lse is [tokens, heads] over this rank's KV shard.
+                return mla_out
+            o = mla_out
         else:
             self.logits_soft_cap = layer.logit_cap
 

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -267,8 +267,12 @@ class EagerRunner(BaseRunner):
             forward_batch = self.load_batch(forward_batch, pp_proxy_tensors)
 
         if forward_batch.needs_forward_metadata_init():
-            if hasattr(model_runner.model, "prepare_context_parallel_metadata_for_dcp"):
-                # prepare kv cache buffer for dcp to gather kv cache
+            if (
+                hasattr(model_runner.model, "prepare_context_parallel_metadata_for_dcp")
+                and forward_batch.extend_prefix_lens is not None
+                and not forward_batch.forward_mode.is_target_verify()
+            ):
+                # prepare kv cache buffer for dcp to gather kv cache. Skip for target verify
                 forward_batch.attn_dcp_metadata = (
                     model_runner.model.prepare_context_parallel_metadata_for_dcp(
                         forward_batch.seq_lens,

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -12,6 +12,8 @@ from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.layers.dcp import (
     all_gather_kv_cache_for_mha_chunk_extend,
     all_gather_kv_cache_for_mha_extend,
+    all_gather_kv_cache_for_mla_extend,
+    dcp_enabled,
     filter_dcp_local_kv_indices,
 )
 from sglang.srt.layers.quantization.fp8_utils import (
@@ -300,6 +302,24 @@ class DeepseekMHAForwardMixin:
         q[..., self.qk_nope_head_dim :] = q_pe
 
         self._set_mla_kv_buffer(latent_cache, kv_a, k_pe, forward_batch)
+        if (
+            not forward_batch.mha_one_shot
+            and dcp_enabled()
+            and forward_batch.attn_dcp_metadata is not None
+            and forward_batch.attn_dcp_metadata.dcp_kv_buffer is not None
+            and sum(forward_batch.extend_prefix_lens_cpu) != 0
+        ):
+            all_gather_kv_cache_for_mla_extend(
+                get_token_to_kv_pool(),
+                self.attn_mha,
+                forward_batch.extend_prefix_lens_cpu,
+                forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
+                forward_batch.attn_dcp_metadata.dcp_extend_prefix_lens_sum,
+                forward_batch.attn_dcp_metadata.dcp_kv_buffer,
+                self.kv_lora_rank,
+                kv_a.unsqueeze(1),
+                k_pe,
+            )
         if (
             forward_batch.mha_one_shot
             and sum(forward_batch.extend_prefix_lens_cpu) != 0

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -547,12 +547,26 @@ class DeepseekMLAForwardMixin:
         fuse_rope_for_trtllm_mla = self._fuse_rope_for_trtllm_mla(forward_batch)
         skip_rope_for_dsa_tilelang_fused = self._skip_rope_for_dsa_tilelang_fused()
         skip_rope_for_aiter_fused_mla = self._skip_rope_for_aiter_fused_mla()
-        if (
-            self.rotary_emb is not None
-            and (not fuse_rope_for_trtllm_mla)
-            and (not skip_rope_for_dsa_tilelang_fused)
-            and (not skip_rope_for_aiter_fused_mla)
-            and (not _use_aiter or not _is_gfx95_supported or self.use_dsa)
+
+        force_rope_for_dcp_decode = (
+            get_parallel().dcp_enabled
+            and (
+                forward_batch.forward_mode.is_decode()
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend_v2()
+            )
+            and _use_aiter_gfx95
+            and self.current_attention_backend
+            not in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS
+        )
+        if self.rotary_emb is not None and (
+            force_rope_for_dcp_decode
+            or (
+                (not fuse_rope_for_trtllm_mla)
+                and (not skip_rope_for_dsa_tilelang_fused)
+                and (not skip_rope_for_aiter_fused_mla)
+                and (not _use_aiter or not _is_gfx95_supported or self.use_dsa)
+            )
         ):
             q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
 
@@ -570,8 +584,20 @@ class DeepseekMLAForwardMixin:
 
         # all_gather q_pe, q_nope_out,take tp8 as an example， q_pe [B, H, ROPE_DIM], q_nope_out [B, H, NOPE_DIM] gathered to [B, H * dcp_world_size, ROPE_DIM] [B, H * dcp_world_size, NOPE_DIM] for decode batch, and all gather k_pe, k_nope for extend batch.
         if get_parallel().dcp_enabled:
-            if forward_batch.forward_mode.is_decode():
-                # if forward_batch.forward_mode is decode, gather q
+            # aiter spec verify (TARGET_VERIFY, qseqlen>1) uses the same round-robin
+            # CP decode path as plain decode: gather Q across dcp ranks and merge the
+            # per-rank partials via lse (forward_absorb_core), NOT the is_extend()
+            # prefix-KV-gather below. TARGET_VERIFY.is_extend() is True, so it must be
+            # handled before the is_extend() branch.
+            if forward_batch.forward_mode.is_decode() or (
+                _use_aiter
+                and (
+                    forward_batch.forward_mode.is_target_verify()
+                    or forward_batch.forward_mode.is_draft_extend_v2()
+                )
+            ):
+                # gather q (heads dim); token dim is bs (decode) or bs*qlen (verify/
+                # draft-extend)
                 q_nope_out, q_pe = all_gather_q_for_mla_decode(
                     q_nope_out=q_nope_out,
                     q_pe=q_pe,
@@ -757,6 +783,32 @@ class DeepseekMLAForwardMixin:
                             else {}
                         ),
                     )
+        elif (
+            _use_aiter
+            and (
+                forward_batch.forward_mode.is_decode()
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend_v2()
+            )
+            and get_parallel().dcp_enabled
+        ):
+            q = torch.cat([q_nope_out, q_pe], dim=-1)
+            if llama_4_scaling is not None:
+                q *= llama_4_scaling
+            get_token_to_kv_pool().set_mla_kv_buffer(
+                self.attn_mqa,
+                forward_batch.out_cache_loc,
+                k_nope,
+                k_pe,
+            )
+            attn_output, lse = self.attn_mqa_for_dcp_decode(
+                q,
+                None,
+                None,
+                forward_batch,
+                save_kv_cache=False,
+                **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
+            )
         else:
             if _use_aiter_gfx95:
                 cos = self.rotary_emb.cos_cache
@@ -799,8 +851,18 @@ class DeepseekMLAForwardMixin:
                 **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
             )
 
-        # correct attn_output with respect to lse from other ranks
-        if forward_batch.forward_mode.is_decode() and get_parallel().dcp_enabled:
+        # correct attn_output with respect to lse from other ranks (decode + aiter
+        # spec verify). The -1 token dim is bs (decode) or bs*draft_num (verify).
+        if (
+            forward_batch.forward_mode.is_decode()
+            or (
+                _use_aiter
+                and (
+                    forward_batch.forward_mode.is_target_verify()
+                    or forward_batch.forward_mode.is_draft_extend_v2()
+                )
+            )
+        ) and get_parallel().dcp_enabled:
             attn_output = attn_output.view(
                 -1,
                 self.num_local_heads * get_parallel().attn_dcp_size,

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -682,6 +682,11 @@ class KimiK25ForConditionalGeneration(nn.Module):
             return
         super().__setattr__(name, value)
 
+    def prepare_context_parallel_metadata_for_dcp(self, *args, **kwargs):
+        return self.language_model.prepare_context_parallel_metadata_for_dcp(
+            *args, **kwargs
+        )
+
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         device = self.vision_tower.device
         target_dtype = self.vision_tower.patch_embed.proj.weight.dtype

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3041,8 +3041,7 @@ class ServerArgs:
         handle_pd_disaggregation(self)
 
     def _handle_dcp_validation(self):
-        # Decode context parallel (DCP) is currently implemented and validated
-        # only on AMD HIP/ROCm. Reject invalid or unverified configurations
+        # Reject invalid or unverified configurations
         # early instead of letting them fail deeper in model initialization.
         if self.dcp_size < 1:
             raise ValueError(
@@ -3053,6 +3052,7 @@ class ServerArgs:
         if not self.dcp_size > 1:
             return
         if is_hip():
+            self._validate_aiter_mla_dcp()
             return
         elif is_cuda():
             if self.speculative_algorithm is not None:
@@ -3069,6 +3069,40 @@ class ServerArgs:
                 "--decode-context-parallel-size > 1) is currently only "
                 f"supported on the AMD HIP platform, but got dcp_size="
                 f"{self.dcp_size} on a non-HIP platform."
+            )
+
+    def _validate_aiter_mla_dcp(self):
+        """Validate aiter MLA decode-context-parallel (DCP) against the set
+        of round-robin CP (cprr) kernels aiter ships on gfx950.
+        """
+        from sglang.srt.configs.model_config import AttentionArch
+
+        model_config = self.get_model_config()
+        if model_config.attention_arch != AttentionArch.MLA:
+            return
+
+        # aiter has not supported fp8 kvcache yet
+        if "fp8" in (self.kv_cache_dtype or ""):
+            raise ValueError(
+                "aiter MLA decode context parallel (--dcp-size > 1) does not "
+                "support fp8 kv-cache: aiter's round-robin CP (cprr) MLA kernel "
+                "has no fp8-kv variant (get_heuristic_kernel_mla fails for "
+                "kv_type:fp8 cprr:1). Use bf16 kv-cache with --dcp-size, or drop "
+                "--dcp-size for fp8 kv-cache."
+            )
+
+        # aiter only supports gathered head count in (16, 32, 64, 128)
+        attn_dp_size = self.dp_size if self.enable_dp_attention else 1
+        attn_tp_size = max(1, self.tp_size // attn_dp_size // self.attn_cp_size)
+        local_heads = max(1, model_config.num_attention_heads // attn_tp_size)
+        gathered_heads = local_heads * self.dcp_size
+        if gathered_heads not in (16, 32, 64, 128):
+            raise ValueError(
+                "aiter MLA decode context parallel has cprr kernels only for a "
+                f"gathered head count in (16, 32, 64, 128); got "
+                f"{gathered_heads} (num_attention_heads="
+                f"{model_config.num_attention_heads} / attn_tp={attn_tp_size} = "
+                f"{local_heads} local heads x dcp_size {self.dcp_size})."
             )
 
     def _handle_load_balance_method(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Enable Decode Context Parallel (DCP) for MLA models on the aiter attention backend (AMD ROCm, gfx950).

DCP shards the KV cache across ranks along the sequence dimension using round-robin (global-position) assignment, so each rank only stores and attends over `1/W` of the context during decode. This cuts decode-time HBM traffic and improves TPOT for long-context workloads, while keeping outputs numerically lossless (each rank returns a partial attention + LSE that are merged across the DCP group). The path also supports speculative decoding — DeepSeek built-in MTP and a separate EAGLE3 draft — for a linear draft chain.

Previously DCP was only available on the CUDA/FA3 path; this PR brings it to the aiter MLA backend on AMD.

## Modifications

<!-- Detail the changes made in this pull request. -->
- **`layers/attention/aiter_backend.py`** — aiter-native round-robin CP (cprr) decode:
  - All-gather Q across the DCP group so the kernel operates on the *gathered* head count (`num_head * dcp_world_size`); per-rank partial attention returns `(out, lse)` and is merged with `cp_lse_ag_out_rs_mla`.
  - Persist cprr kernel selection + DCP-aware metadata (`get_mla_metadata_v1(..., is_cp_round_robin=True)`, global `g_kv_indptr`, `cp_world_size`, `cp_rank`).
  - cuda-graph metadata built for the DCP decode path **and** the multi-step draft-decode / draft-extend branches (built-in MTP).
  - fp8 kv-cache plumbing threaded through the metadata (gated off in validation until aiter ships an fp8 cprr kernel — see limitations).
- **`models/deepseek_common/attention_forward_methods/forward_mla.py`** — force rope in `prepare` for DCP decode / target-verify / draft-extend on non-`FORWARD_ABSORB` backends (the fused rope+cache-write kernel writes at the *virtual* `out_cache_loc`, wrong under the DCP virtual allocator); DCP-aware `set_mla_kv_buffer` write (`loc % W` owner filter + `loc // W` physical map); gather Q for decode/verify, gather prefix-KV for extend; cross-rank LSE merge.
- **`models/deepseek_common/attention_forward_methods/forward_mha.py`** — DCP support wiring for the MHA prefix-KV gather path.
- **`models/kimi_k25.py`** — delegate `prepare_context_parallel_metadata_for_dcp` to `self.language_model`, so the radix-cached prefix KV is gathered under DCP on the `KimiK25ForConditionalGeneration` wrapper (previously silently corrupted on radix-cache hits).
- **`model_executor/runner/eager_runner.py`** — minor DCP wiring for the eager path.
- **`server_args.py`** — `_validate_aiter_mla_dcp`: reject DCP configurations the aiter cprr kernel set can’t serve, with actionable errors (fp8 kv-cache rejected; gathered head count must be in `{16, 32, 64, 128}`).
- **`docker/rocm.Dockerfile`** — bump `AITER_COMMIT_DEFAULT` `9127c94a…` → `28d08e5889…` (build that ships the bf16 cprr MLA kernels: `qh64/qseqlen1` decode and `qh32/qseqlen4` verify).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Model: `DeepSeek-R1-0528-MXFP4` / `Kimi-K2.5-MXFP4`. aiter backend, `--page-size 1`, gsm8k (greedy, 5-shot). Radix cache ON unless noted.

**R1 tp8 dcp4 (gathered heads = 64) + built-in MTP, cuda-graph, 1300q:**

| config | Accuracy | Invalid |
|--------|------:|------:|
| MTP off | 0.945 | 0.000 |
| MTP-1   | 0.940 | 0.000 |
| MTP-2   | 0.943 | 0.000 |
| MTP-3   | 0.934 | 0.000 |


**Kimi-K2.5 tp8 dcp8 (gathered heads = 64) + EAGLE3 draft, 1300q:**

| config | radix ON | radix OFF |
|--------|------:|------:|
| spec off (DCP decode) | 0.928 | — |
| EAGLE3 steps 1–5 | 0.912–0.938 | ~0.925 |
| dcp8 gsm8k | 0.932 | 0.925 |

## Speed Tests and Profiling

**Kimi-K2.5-MXFP4, 64k input / 128 output, dcp8 vs tp8** (aiter, page_size 1, radix ON).
Random unique prompts (no prefix reuse), `--max-concurrency ∈ {1, 2, 4}`, num-prompts = 10×concurrency (4 at conc 1), medians, 1 warmup.

| Concurrency | Config | TTFT (ms) | TPOT (ms) | TPOT speedup (tp8/dcp8) |
|:-:|:--|:-:|:-:|:-:|
| **1** | dcp8 | 1747 | **10.58** | **1.35×** |
|   | tp8  | 1700 | 14.28 |  |
| **2** | dcp8 | 2773 | **10.65** | **1.37×** |
|   | tp8  | 2045 | 14.59 |  |
| **4** | dcp8 | 5391 | **22.37** | **1.17×** |
|   | tp8  | 5235 | 26.12 |  |

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->