### PR TITLE
test: cover PP-local KV buffer shape

### DIFF
--- a/test/registered/unit/mem_cache/test_kv_buffer_shape.py
+++ b/test/registered/unit/mem_cache/test_kv_buffer_shape.py
@@ -1,0 +1,41 @@
+"""Unit tests for KV buffer shape helpers."""
+
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestKVBufferShape(CustomTestCase):
+    def test_get_kv_buffer_shape_uses_local_start_layer(self):
+        pool = MHATokenToKVPool(
+            size=4,
+            page_size=1,
+            dtype=torch.float16,
+            head_num=2,
+            head_dim=4,
+            layer_num=2,
+            device="cpu",
+            enable_memory_saver=False,
+            start_layer=4,
+            end_layer=6,
+            enable_alt_stream=False,
+        )
+
+        with self.assertRaises(IndexError):
+            pool.get_key_buffer(0)
+
+        k_shape, v_shape = pool.get_kv_buffer_shape()
+        self.assertEqual(k_shape, torch.Size((5, 2, 4)))
+        self.assertEqual(v_shape, torch.Size((5, 2, 4)))
+        self.assertEqual(k_shape, pool.get_key_buffer(pool.start_layer).shape)
+        self.assertEqual(v_shape, pool.get_value_buffer(pool.start_layer).shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`get_kv_buffer_shape()` should use the rank-local first layer when a PP stage does not own layer 0. The eager path now depends on that helper for DCP metadata shape lookup, so this adds a small regression test for the helper behavior.

Refs #30464.

## Modifications

- Add a CPU unit test for `MHATokenToKVPool` with `start_layer > 0`.
- Check that direct layer-0 access is invalid while `get_kv_buffer_shape()` returns the local start-layer shapes.

## Accuracy Tests

Not run. This is a unit-test-only change and does not change model output behavior.

## Speed Tests and Profiling

Not run. This is a unit-test-only change.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28919658776](https://github.com/sgl-project/sglang/actions/runs/28919658776)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28919658662](https://github.com/sgl-project/sglang/actions/runs/28919658662)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->