### PR TITLE
Handle psutil memory probe failures in ZMQ setup

### DIFF
--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -222,13 +222,20 @@ def get_zmq_socket_on_host(
 
 
 def config_socket(socket, socket_type: zmq.SocketType):
-    mem = psutil.virtual_memory()
-    total_mem = mem.total / 1024**3
-    available_mem = mem.available / 1024**3
-    if total_mem > 32 and available_mem > 16:
-        buf_size = int(0.5 * 1024**3)
+    buf_size = -1
+    try:
+        mem = psutil.virtual_memory()
+    except (OSError, ValueError):
+        logger.debug(
+            "Failed to inspect system memory for ZMQ socket buffer sizing; "
+            "using default socket buffers.",
+            exc_info=True,
+        )
     else:
-        buf_size = -1
+        total_mem = mem.total / 1024**3
+        available_mem = mem.available / 1024**3
+        if total_mem > 32 and available_mem > 16:
+            buf_size = int(0.5 * 1024**3)
 
     def set_send_opt():
         socket.setsockopt(zmq.SNDHWM, 0)

--- a/test/registered/unit/utils/test_network.py
+++ b/test/registered/unit/utils/test_network.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+import zmq
+
+from sglang.srt.utils.network import config_socket
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class FakeSocket:
+    def __init__(self):
+        self.options = []
+
+    def setsockopt(self, option, value):
+        self.options.append((option, value))
+
+
+class TestConfigSocket(CustomTestCase):
+    def test_uses_default_buffer_when_memory_probe_fails(self):
+        socket = FakeSocket()
+
+        with patch(
+            "sglang.srt.utils.network.psutil.virtual_memory",
+            side_effect=ValueError("invalid literal for int() with base 10: b'kB'"),
+        ):
+            config_socket(socket, zmq.DEALER)
+
+        self.assertIn((zmq.SNDHWM, 0), socket.options)
+        self.assertIn((zmq.RCVHWM, 0), socket.options)
+        self.assertIn((zmq.SNDBUF, -1), socket.options)
+        self.assertIn((zmq.RCVBUF, -1), socket.options)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes a GB300 CI startup failure where `psutil.virtual_memory()` can raise while parsing `/proc/meminfo`, aborting ZeroMQ socket setup before the server starts.

The ZMQ buffer size decision is only a best-effort memory heuristic, so this falls back to the existing conservative/default buffer behavior (`-1`) when memory probing fails.

## Root Cause

On the failing `base-c-test-4-gpu-gb300` job, `psutil.virtual_memory()` raised `ValueError: invalid literal for int() with base 10: b'kB'` from its Linux meminfo parser. `config_socket()` did not handle that, so tokenizer manager IPC setup crashed before tests ran.

## Validation

- `python -m py_compile python/sglang/srt/utils/network.py test/registered/unit/utils/test_network.py`
- Isolated local repro for `config_socket()` with `psutil.virtual_memory()` mocked to raise the CI `ValueError`
- Commit hooks: Python AST, isort, ruff, CI registry validation, and other pre-commit checks

Full registered test execution needs the normal SGLang CI environment because package-level imports pull the full runtime stack.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28920949419](https://github.com/sgl-project/sglang/actions/runs/28920949419)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28920989308](https://github.com/sgl-project/sglang/actions/runs/28920989308)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->