### PR TITLE
fix(function_call): stop leaking truncated tool-call markup into non-streaming content

### DIFF
--- a/python/sglang/srt/function_call/hermes_detector.py
+++ b/python/sglang/srt/function_call/hermes_detector.py
@@ -46,14 +46,26 @@ class HermesDetector(BaseFormatDetector):
         calls = []
         try:
             for match in self.tool_call_regex.findall(text):
-                raw = match[0] or match[1]
-                if not raw:
-                    continue
-                parsed = json.loads(raw.strip())
-                if isinstance(parsed, list):
-                    calls.extend(self.parse_base_json(parsed, tools))
+                if match[0]:
+                    parsed = json.loads(match[0].strip())
+                elif match[1]:
+                    # Unterminated <tool_call> block: generation was cut
+                    # off (e.g. by max_tokens) before the closing tag.
+                    # The streaming path drops the markup from content,
+                    # so drop the unparsable block here too instead of
+                    # leaking raw markup into content; finish_reason
+                    # ("length") tells the client the call is incomplete.
+                    try:
+                        parsed = json.loads(match[1].strip())
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Dropping truncated tool call block: %s",
+                            match[1][:80],
+                        )
+                        continue
                 else:
-                    calls.extend(self.parse_base_json(parsed, tools))
+                    continue
+                calls.extend(self.parse_base_json(parsed, tools))
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
             logger.error(f"Error in detect_and_parse: {e}")

--- a/python/sglang/srt/function_call/qwen25_detector.py
+++ b/python/sglang/srt/function_call/qwen25_detector.py
@@ -55,6 +55,13 @@ class Qwen25Detector(BaseFormatDetector):
         idx = text.find(self.bot_token)
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
+            # A bare opener at the end of the output means the tool call
+            # was cut off (e.g. by max_tokens) before the "\n" of the
+            # full bot_token arrived. It is markup, not content — the
+            # streaming path drops it, so drop it here too.
+            opener = self.bot_token.rstrip("\n")
+            if normal_text.endswith(opener):
+                normal_text = normal_text[: -len(opener)].strip()
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
         # Find all <tool_call>\n...\n</tool_call> blocks

--- a/test/registered/unit/function_call/test_hermes_detector.py
+++ b/test/registered/unit/function_call/test_hermes_detector.py
@@ -109,6 +109,40 @@ class TestHermesDetector(CustomTestCase):
         self.assertEqual(len(result.calls), 0)
         self.assertEqual(result.normal_text, text)
 
+    # ==================== truncated tool call Tests ====================
+    # A tool call cut off by max_tokens must not leak raw <tool_call>
+    # markup into content: the streaming path drops the markup, and
+    # finish_reason ("length") already tells the client the call is
+    # incomplete, so non-streaming must drop it too.
+
+    def test_truncated_tool_call_dropped_from_content(self):
+        text = (
+            "I will check.\n<tool_call>\n"
+            '{"name": "get_weather", "arguments": {"city": "San Fr'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, "I will check.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_valid_call_preserved_when_followed_by_truncated_call(self):
+        text = (
+            '<tool_call>{"name": "get_weather", "arguments": {"city": "SF"}}'
+            "</tool_call>\n"
+            '<tool_call>{"name": "search", "arguments": {"query": "wea'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "SF"})
+
+    def test_unterminated_block_with_complete_json_still_parsed(self):
+        text = 'ok.<tool_call>{"name": "get_weather", "arguments": {"city": "SF"}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, "ok.")
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+
     # ==================== structure_info Tests ====================
 
     def test_structure_info(self):

--- a/test/registered/unit/function_call/test_qwen25_detector.py
+++ b/test/registered/unit/function_call/test_qwen25_detector.py
@@ -1,0 +1,79 @@
+"""Unit tests for Qwen25Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestQwen25Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = Qwen25Detector()
+
+    def test_single_tool_call(self):
+        text = (
+            "<tool_call>\n"
+            '{"name": "get_weather", "arguments": {"city": "Beijing"}}'
+            "\n</tool_call>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"city": "Beijing"})
+
+    # ==================== truncated tool call Tests ====================
+    # A tool call cut off by max_tokens must not leak raw <tool_call>
+    # markup into content: the streaming path drops the markup, and
+    # finish_reason ("length") already tells the client the call is
+    # incomplete, so non-streaming must drop it too.
+
+    def test_bare_opener_at_end_dropped_from_content(self):
+        # Cut off right at the opener, before the "\n" of the full
+        # bot_token ("<tool_call>\n") was generated.
+        text = "I will check.\n<tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, "I will check.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_truncated_arguments_dropped_from_content(self):
+        text = (
+            "I will check.\n<tool_call>\n"
+            '{"name": "get_weather", "arguments": {"city": "San Fr'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, "I will check.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_opener_inside_content_not_stripped(self):
+        # A bare opener only counts as truncated markup at the very end
+        # of the output; elsewhere the text is returned unchanged.
+        text = "The literal tag <tool_call> is mentioned here."
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(result.normal_text, text)
+        self.assertEqual(len(result.calls), 0)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #30480.

When a tool call is truncated by `max_tokens`, non-streaming responses leak raw
tool-call markup into `content` while streaming drops it — the same request
diverges based only on `stream`:

- `HermesDetector.detect_and_parse` returns the **entire original text**
  (opener tag + partial JSON) whenever any block fails to parse, and the single
  outer `try` means one truncated call also discards all valid calls before it.
- `Qwen25Detector.detect_and_parse` leaks a bare trailing `<tool_call>` opener
  (output cut before the `\n` of the full bot_token) into content.

Streaming already drops the markup in both detectors, and `finish_reason`
(`"length"`) tells the client the call is incomplete, so non-streaming should
drop it too. Same failure class as vllm-project/vllm#47903.

## Modifications

- `hermes_detector.py`: parse unterminated blocks (the `<tool_call>(.*)` regex
  alternative) under a per-block guard — a truncated block is dropped with a
  warning instead of leaking the whole text, and valid calls parsed from other
  blocks survive. Behavior deliberately preserved: a **complete but malformed**
  block still returns the original text unchanged
  (`test_malformed_json_returns_original_text` untouched), and an unterminated
  block containing complete JSON is still parsed as a call.
- `qwen25_detector.py`: strip a bare trailing opener from `normal_text` when
  the full bot_token never appeared; a literal `<tool_call>` elsewhere in
  content is not touched.
- Unit tests for both (7 new tests): truncation mid-arguments, bare trailing
  opener, valid-call-before-truncated-call survival, unterminated-complete-JSON
  parsing, literal opener mid-content untouched, plus a complete-call control.

Note: this adds `test/registered/unit/function_call/test_qwen25_detector.py`,
which #26386 (open, test-only) also proposes to create — happy to rebase on top
if that lands first.

```
$ PYTHONPATH=python python -m pytest test/registered/unit/function_call/test_hermes_detector.py test/registered/unit/function_call/test_qwen25_detector.py -q
19 passed in 1.98s
```

Full `test/registered/unit/function_call/` suite: 396 passed; the 11 failures
in `test_function_call_parser.py` (structural-tag tests) fail identically on
clean main in my environment and are unrelated.

## Accuracy Tests

N/A — no model forward changes.

## Speed Tests and Profiling

N/A — parsing-only change on the truncation error path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31538019489](https://github.com/sgl-project/sglang/actions/runs/31538019489)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31538019406](https://github.com/sgl-project/sglang/actions/runs/31538019406)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->