### PR TITLE
Fix GLM-5.2 (GlmMoeDsa) qk_rope_head_dim clobbered by attribute_map

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -758,6 +758,13 @@ class ModelConfig:
             self.kv_lora_rank = self.hf_text_config.kv_lora_rank
             self.qk_nope_head_dim = self.hf_text_config.qk_nope_head_dim
             self.qk_rope_head_dim = self.hf_text_config.qk_rope_head_dim
+            qk_head_dim = getattr(self.hf_text_config, "qk_head_dim", None)
+            if (
+                qk_head_dim is not None
+                and self.qk_nope_head_dim + self.qk_rope_head_dim != qk_head_dim
+            ):
+                self.qk_rope_head_dim = qk_head_dim - self.qk_nope_head_dim
+                self.hf_text_config.qk_rope_head_dim = self.qk_rope_head_dim
             self.v_head_dim = self.hf_text_config.v_head_dim
             self.index_head_dim = (
                 get_dsa_index_head_dim(self.hf_text_config)


### PR DESCRIPTION
## Motivation

`test/registered/8-gpu-models/test_glm52_fp8.py` fails: `GLM-5.2-FP8`
(`GlmMoeDsaForCausalLM`) crashes during weight loading with

```
AssertionError: param.shape=torch.Size([22, 48]) loaded_weight.shape=torch.Size([21, 48])
```

### Root cause

`transformers`' `GlmMoeDsaConfig` declares `attribute_map = {"head_dim": "qk_rope_head_dim"}`.
GLM-5.2-FP8's `config.json` carries **both** `head_dim: 192` and `qk_rope_head_dim: 64`,
so loading the config overwrites `qk_rope_head_dim` with `head_dim` (192), leaving it
inconsistent with the non-aliased `qk_head_dim` (256).

SGLang reads that clobbered value and builds the fused `fused_qkv_a_proj_with_mqa`
projection with `q_lora_rank + kv_lora_rank + qk_rope_head_dim = 2048 + 512 + 192 = 2752`
rows (fp8 block scale → 22 rows), while the checkpoint weights are `2048 + 512 + 64 = 2624`
rows (scale → 21 rows) → shape mismatch. It would also have corrupted attention
(internal `qk_head_dim` becomes `192 + 192 = 384`).

## Modification

In the MLA branch of `ModelConfig._derive_model_shapes`, recover the intended
`qk_rope_head_dim` from `qk_head_dim - qk_nope_head_dim` and write it back to
`hf_text_config`. Guarded by a consistency check, so it is a **no-op** for configs
whose dims are already consistent (e.g. DeepSeek).

## Test

Reproduced and verified on 8×H200 (`tp=8`) with the exact test args:

- **Before:** crash at weight load.
- **After:** server starts (`fired up and ready to roll`), `17 × 24` → `408`, and
  **gsm8k = 0.975** (test baseline `0.92`).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28923303574](https://github.com/sgl-project/sglang/actions/runs/28923303574)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28923303416](https://github.com/sgl-project/sglang/actions/runs/28923303416)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->