### PR TITLE
[Fix] fused_moe_kernel: OOB write for filtered experts when FUSE_SUM_ALL_REDUCE is enabled (EP)

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
@@ -442,7 +442,11 @@ def fused_moe_kernel(
     off_experts = off_experts_i32.to(tl.int64)
 
     if filter_expert and off_experts == -1:
-        if not FUSE_ADD_TO_OUTPUT and not (FUSE_SUM_ALL_REDUCE and LORA_PRESERVE_BASE):
+        # FUSE_SUM_ALL_REDUCE: C is the combined output (num_tokens rows), while
+        # write_zeros_to_output indexes by offs_token (num_tokens*topk range) --
+        # storing would go out of bounds AND race with other blocks' atomic_add.
+        # The output was zero-initialized on the host, so skipping is correct.
+        if not FUSE_ADD_TO_OUTPUT and not FUSE_SUM_ALL_REDUCE:
             # Write zeros only when this kernel owns the full output; the experimental LoRA
             # add path (LORA_PRESERVE_BASE) keeps the base output from the prior MoE kernel.
             write_zeros_to_output(


### PR DESCRIPTION
## Motivation

`--enable-fused-moe-sum-all-reduce` fuses the topk combine (`moe_sum_reduce`) into the tail of the down-proj `fused_moe_kernel` via `tl.atomic_add`. However, enabling it on an **EP deployment** immediately crashes with `CUDA error: an illegal memory access was encountered`.

Root cause: under `FUSE_SUM_ALL_REDUCE`, `C` points to the **combined** output with `num_tokens` rows, but the filtered-expert branch (`filter_expert=True`, blocks of non-local experts marked `expert_id == -1`) still calls `write_zeros_to_output`, which indexes `C` with `offs_token` spanning the `num_tokens * topk` expanded range:

- out-of-bounds store → illegal memory access;
- even for rows that stay in bounds, the zero-store races with `tl.atomic_add` from other blocks and can wipe already-accumulated partial sums.

This is likely why the flag currently only works on TP-only setups, where `filter_expert=False` and this branch is never taken.

## Modifications

In the filtered-expert early-exit of `fused_moe_kernel`, skip `write_zeros_to_output` when `FUSE_SUM_ALL_REDUCE` is set. The host side already zero-initializes the output buffer before launch on this path (`out_slice.zero_()` in `fused_moe.py`), so skipping the zero-write is sufficient and correct.

One-line condition change:

```python
- if not FUSE_ADD_TO_OUTPUT and not (FUSE_SUM_ALL_REDUCE and LORA_PRESERVE_BASE):
+ if not FUSE_ADD_TO_OUTPUT and not FUSE_SUM_ALL_REDUCE:
```

(The previous condition only skipped for the experimental LoRA `FUSE_SUM_ALL_REDUCE and LORA_PRESERVE_BASE` combination; the plain `FUSE_SUM_ALL_REDUCE` EP case fell through to the OOB write.)

## Accuracy Tests

Shapes from Qwen3.5-397B-A17B-FP8, TP8+EP8 rank0: 64 local experts, topk=10, hidden=4096, moe_intermediate=1024, FP8 block-quant [128,128], 8192 tokens, 12.5% local hit rate (non-local slots = -1).

Against an fp32 dense reference (both paths share the same FP8 quantization noise floor):

| path | max_abs | rel_l2 |
|---|---|---|
| baseline (`moe_sum_reduce`) vs fp32 ref | 1.20e-07 | 4.3911e-02 |
| fused (atomic_add) vs fp32 ref | 1.20e-07 | 4.3921e-02 |
| baseline vs fused | 1.49e-08 | 1.44e-03 |

The baseline-vs-fused delta is bf16 atomic accumulation vs fp32-sum-then-cast rounding, as expected.

End-to-end smoke on Qwen3.5-397B-A17B-FP8 (TP8+EP8, H100x8): greedy (`temperature=0`) chat completion output is **byte-identical** between baseline and `--enable-fused-moe-sum-all-reduce` after this fix.

## Speed Tests and Profiling

Microbench (same 397B EP8 shapes as above, H100, median of 3x `triton.testing.do_bench`, full fused-MoE layer call):

| M (tokens) | baseline (ms) | fused (ms) | gain |
|---|---|---|---|
| 512 | 0.365 | 0.349 | +4.4% |
| 2048 | 0.520 | 0.477 | +8.4% |
| 4096 | 0.803 | 0.715 | +11.0% |
| 8192 | 1.336 | 1.157 | +13.4% |
| 16384 | 2.447 | 2.088 | +14.7% |

Small-M (decode-like, M=16..256) shows no regression (+1% to +5%).

End-to-end prefill throughput (Qwen3.5-397B-A17B-FP8, TP8+EP8, `chunked_prefill_size=8192`, 8k-token prompts, 96 requests, concurrency 32, `bench_serving --dataset-name random-ids`, 2 runs each):

| config | input throughput (tok/s) |
|---|---|
| baseline | 36156 / 36158 |
| `--enable-fused-moe-sum-all-reduce` | 36884 / 36891 |

**+2.0%** end-to-end, highly repeatable.

Note: the fusion helps when EP filtering makes hits sparse (atomic traffic scales with hit rate, while the baseline's `intermediate_cache3` write+read is always full-size). On a TP-only setup (all experts local, 100% hit rate) the same microbench shows the fused path is slower (atomic RMW doubles output traffic), so the flag should stay opt-in — this PR only fixes the EP crash, it does not change any default.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28923023596](https://github.com/sgl-project/sglang/actions/runs/28923023596)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28923023440](https://github.com/sgl-project/sglang/actions/runs/28923023440)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->