### PR TITLE
[diffusion] Support Ideogram TurboTime LoRA inference

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/ideogram.py
+++ b/python/sglang/multimodal_gen/configs/sample/ideogram.py
@@ -26,6 +26,33 @@ IDEOGRAM4_PRESETS: dict[str, dict[str, object]] = {
         "mu": 0.5,
         "std": 1.75,
     },
+    "V4_TURBOTIME_LORA_2": {
+        "num_steps": 2,
+        "guidance_schedule": (1.0,) * 2,
+        "mu": 0.5,
+        "std": 1.75,
+        "skip_unconditional": True,
+        "lora_scale": 1.0,
+        "requires_lora": True,
+    },
+    "V4_TURBOTIME_LORA_4": {
+        "num_steps": 4,
+        "guidance_schedule": (1.0,) * 4,
+        "mu": 0.5,
+        "std": 1.75,
+        "skip_unconditional": True,
+        "lora_scale": 1.0,
+        "requires_lora": True,
+    },
+    "V4_TURBOTIME_LORA_8": {
+        "num_steps": 8,
+        "guidance_schedule": (1.0,) * 8,
+        "mu": 0.5,
+        "std": 1.75,
+        "skip_unconditional": True,
+        "lora_scale": 1.0,
+        "requires_lora": True,
+    },
 }
 
 

--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -616,19 +616,23 @@ def refresh_context_on_transformer(
     num_inference_steps: int,
     scm_preset: str | None = None,
     verbose: bool = False,
+    steps_computation_mask: Optional[List[int]] = None,
+    steps_computation_policy: str | None = None,
 ) -> None:
     """Refresh cache-dit context for transformer."""
-    steps_computation_mask = None
-    if scm_preset is not None:
+    if steps_computation_mask is None and scm_preset is not None:
         steps_computation_mask = cache_dit.steps_mask(
             mask_policy=scm_preset, total_steps=num_inference_steps
         )
+    policy = (
+        steps_computation_policy if steps_computation_policy is not None else scm_preset
+    )
     cache_dit.refresh_context(
         transformer,
         cache_config=DBCacheConfig().reset(
             num_inference_steps=num_inference_steps,
             steps_computation_mask=steps_computation_mask,
-            steps_computation_policy=scm_preset,
+            steps_computation_policy=policy,
         ),
         verbose=verbose,
     )

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -22,14 +22,19 @@ from sglang.multimodal_gen.runtime.distributed import (
 )
 from sglang.multimodal_gen.runtime.layers.linear import (
     ColumnParallelLinear,
-    LinearBase,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
+from sglang.multimodal_gen.runtime.layers.quantization.weight_only_fp8 import (
+    WeightOnlyFP8Linear,
+)
 from sglang.multimodal_gen.runtime.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
+)
+from sglang.multimodal_gen.runtime.managers.forward_context import (
+    get_forward_context,
 )
 from sglang.multimodal_gen.utils import get_mixed_precision_state
 
@@ -82,6 +87,26 @@ class BaseLayerWithLoRA(nn.Module):
     def bias(self):
         return getattr(self.base_layer, "bias", None)
 
+    @staticmethod
+    def _add_lora_delta(
+        base_output: torch.Tensor | tuple[torch.Tensor, torch.Tensor | None],
+        delta: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:
+        if isinstance(base_output, tuple):
+            out, output_bias = base_output
+            return out + delta.to(dtype=out.dtype), output_bias
+        return base_output + delta.to(dtype=base_output.dtype)
+
+    @staticmethod
+    def _runtime_lora_scale() -> float:
+        try:
+            forward_batch = get_forward_context().forward_batch
+        except AssertionError:
+            return 1.0
+        if forward_batch is None:
+            return 1.0
+        return float(getattr(forward_batch, "runtime_lora_scale", 1.0))
+
     @torch.compile()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         lora_A = self.lora_A
@@ -91,6 +116,10 @@ class BaseLayerWithLoRA(nn.Module):
             lora_A = self.lora_A.to_local()
 
         # TODO: Support multiple LoRA adapters when use not merged mode
+        runtime_lora_scale = self._runtime_lora_scale()
+        if runtime_lora_scale == 0.0:
+            return self.base_layer(x)
+
         if not self.merged and not self.disable_lora:
             lora_dtype = lora_A.dtype
             x_lora = x.to(dtype=lora_dtype)
@@ -105,12 +134,10 @@ class BaseLayerWithLoRA(nn.Module):
                 delta = delta * (
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
-            delta = delta * self.strength
-            out, output_bias = self.base_layer(x)
-            return out + delta.to(dtype=out.dtype), output_bias
+            delta = delta * self.strength * runtime_lora_scale
+            return self._add_lora_delta(self.base_layer(x), delta)
         else:
-            out, output_bias = self.base_layer(x)
-            return out, output_bias
+            return self.base_layer(x)
 
     def slice_lora_a_weights(self, A: torch.Tensor) -> torch.Tensor:
         return A
@@ -462,6 +489,10 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         if self.merged or self.disable_lora:
             return self.base_layer(input_)
 
+        runtime_lora_scale = self._runtime_lora_scale()
+        if runtime_lora_scale == 0.0:
+            return self.base_layer(input_)
+
         lora_A = self.lora_A
         lora_B = self.lora_B
         if isinstance(self.lora_B, DTensor):
@@ -486,7 +517,7 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
                 delta_parallel = delta_parallel * (
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
-            delta_parallel = delta_parallel * self.strength
+            delta_parallel = delta_parallel * self.strength * runtime_lora_scale
             output_parallel = output_parallel + delta_parallel.to(
                 dtype=output_parallel.dtype
             )
@@ -575,6 +606,10 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
         if self.merged or self.disable_lora:
             return self.base_layer(input_)
 
+        runtime_lora_scale = self._runtime_lora_scale()
+        if runtime_lora_scale == 0.0:
+            return self.base_layer(input_)
+
         lora_A = self.lora_A
         lora_B = self.lora_B
         if isinstance(self.lora_B, DTensor):
@@ -606,7 +641,7 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
                 delta_parallel = delta_parallel * (
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
-            delta_parallel = delta_parallel * self.strength
+            delta_parallel = delta_parallel * self.strength * runtime_lora_scale
             output_parallel = output_parallel + delta_parallel.to(
                 dtype=output_parallel.dtype
             )
@@ -664,6 +699,11 @@ class LinearWithLoRA(BaseLayerWithLoRA):
             lora_A = self.lora_A.to_local()
 
         # TODO: Support multiple LoRA adapters when use not merged mode
+        runtime_lora_scale = self._runtime_lora_scale()
+        if runtime_lora_scale == 0.0:
+            # nn.Linear.forward() returns a single tensor
+            return self.base_layer(x)
+
         if not self.merged and not self.disable_lora:
             lora_dtype = lora_A.dtype
             x_lora = x.to(dtype=lora_dtype)
@@ -678,7 +718,7 @@ class LinearWithLoRA(BaseLayerWithLoRA):
                 delta = delta * (
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
-            delta = delta * self.strength
+            delta = delta * self.strength * runtime_lora_scale
             # nn.Linear.forward() returns a single tensor, not a tuple
             out = self.base_layer(x)
             return out + delta.to(dtype=out.dtype)
@@ -686,6 +726,32 @@ class LinearWithLoRA(BaseLayerWithLoRA):
             # nn.Linear.forward() returns a single tensor
             out = self.base_layer(x)
             return out
+
+
+class WeightOnlyFP8LinearWithLoRA(LinearWithLoRA):
+    """
+    Dynamic-only LoRA wrapper for storage-only FP8 linear layers.
+
+    Merging LoRA into FP8 storage weights requires dequantizing, applying the
+    delta, and requantizing weight_scale consistently. Keep the first FP8 path
+    explicit and only support dynamic LoRA.
+    """
+
+    def set_lora_weights(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        lora_path: str | None = None,
+        strength: float = 1.0,
+        clear_existing: bool = False,
+        merge_weights: bool = True,
+    ) -> None:
+        if merge_weights:
+            raise ValueError(
+                "Weight-only FP8 LoRA only supports dynamic mode; "
+                "please use --lora-merge-mode dynamic."
+            )
+        super().set_lora_weights(A, B, lora_path, strength, clear_existing, False)
 
 
 def wrap_with_lora_layer(
@@ -696,11 +762,12 @@ def wrap_with_lora_layer(
     """
     transform the given layer to its corresponding LoRA layer
     """
-    supported_layer_types: dict[
-        type[LinearBase] | type[nn.Linear], type[BaseLayerWithLoRA]
-    ] = {
+    supported_layer_types: dict[type[nn.Module], type[BaseLayerWithLoRA]] = {
         # the order matters
         # VocabParallelEmbedding: VocabParallelEmbeddingWithLoRA,
+        # Weight-only FP8 LoRA is currently dynamic-only and intended for
+        # single-GPU deployments.
+        WeightOnlyFP8Linear: WeightOnlyFP8LinearWithLoRA,
         QKVParallelLinear: QKVParallelLinearWithLoRA,
         MergedColumnParallelLinear: MergedColumnParallelLinearWithLoRA,
         ColumnParallelLinear: ColumnParallelLinearWithLoRA,

--- a/python/sglang/multimodal_gen/runtime/models/dits/base.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/base.py
@@ -23,6 +23,7 @@ class BaseDiT(nn.Module, ABC):
     _compile_conditions: list = []
     param_names_mapping: dict
     reverse_param_names_mapping: dict
+    lora_param_names_mapping: dict = {}
     hidden_size: int
     num_attention_heads: int
     num_channels_latents: int

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ideogram.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ideogram.py
@@ -347,6 +347,37 @@ class Ideogram4DenoisingStage(DenoisingStage):
         preset_cfg = IDEOGRAM4_PRESETS[preset]
         num_steps = int(preset_cfg["num_steps"])
         device = get_local_torch_device()
+
+        skip_unconditional = bool(preset_cfg.get("skip_unconditional", False))
+        lora_scale = float(preset_cfg.get("lora_scale", 0.0))
+        requires_lora = bool(preset_cfg.get("requires_lora", False))
+
+        if skip_unconditional and any(
+            float(guidance) != 1.0 for guidance in preset_cfg["guidance_schedule"]
+        ):
+            raise ValueError("skip_unconditional requires guidance_schedule to be 1.0")
+
+        if (
+            lora_scale == 0.0
+            and getattr(server_args, "lora_path", None) is not None
+            and getattr(server_args, "lora_merge_mode", "auto") != "dynamic"
+        ):
+            raise ValueError(
+                f"Ideogram 4 preset {preset} disables LoRA, but request-local LoRA "
+                "switching requires --lora-merge-mode dynamic when --lora-path is set."
+            )
+
+        pipeline = self.pipeline() if self.pipeline else None
+        if requires_lora and (
+            pipeline is None or not pipeline.is_lora_effective("transformer")
+        ):
+            raise ValueError(
+                f"Ideogram 4 preset {preset} requires an active LoRA on transformer. "
+                "Please start the server with --lora-path and --lora-merge-mode dynamic."
+            )
+
+        batch.runtime_lora_scale = lora_scale
+
         schedule = get_schedule_for_resolution(
             (batch.height, batch.width),
             known_mean=float(preset_cfg["mu"]),
@@ -402,6 +433,7 @@ class Ideogram4DenoisingStage(DenoisingStage):
                 "ideogram4_schedule_deltas": schedule_deltas,
                 "ideogram4_guidance_schedule": guidance_schedule,
                 "ideogram4_text_z_padding": text_z_padding,
+                "ideogram4_skip_unconditional": skip_unconditional,
                 "ideogram4_attn_mask": attn_mask,
                 "ideogram4_attn_mask_meta": build_varlen_mask_meta(attn_mask),
                 "ideogram4_neg_position_ids": neg_position_ids,
@@ -429,6 +461,7 @@ class Ideogram4DenoisingStage(DenoisingStage):
         schedule_values = ctx.extra["ideogram4_schedule_values"]
         schedule_deltas = ctx.extra["ideogram4_schedule_deltas"]
         guidance_schedule = ctx.extra["ideogram4_guidance_schedule"]
+        skip_unconditional = ctx.extra["ideogram4_skip_unconditional"]
         i = step.t_int
 
         t_val = schedule_values[i + 1]
@@ -457,30 +490,35 @@ class Ideogram4DenoisingStage(DenoisingStage):
                 )
                 pos_v = pos_out[:, max_text_tokens : max_text_tokens + num_image_tokens]
 
-            self._manage_unconditional_transformer_use_site(batch)
-            with set_forward_context(
-                current_timestep=i,
-                attn_metadata=step.attn_metadata,
-                forward_batch=batch,
-            ):
-                neg_v = self._run_ideogram_transformer(
-                    self.unconditional_transformer,
-                    dict(
-                        llm_features=ctx.extra["ideogram4_neg_llm_features"],
-                        x=z,
-                        t=t,
-                        position_ids=ctx.extra["ideogram4_neg_position_ids"],
-                        segment_ids=ctx.extra["ideogram4_neg_segment_ids"],
-                        indicator=ctx.extra["ideogram4_neg_indicator"],
-                        attn_mask=ctx.extra["ideogram4_neg_attn_mask"],
-                        attn_mask_meta=ctx.extra["ideogram4_neg_attn_mask_meta"],
-                    ),
-                )
+            if not skip_unconditional:
+                self._manage_unconditional_transformer_use_site(batch)
+                with set_forward_context(
+                    current_timestep=i,
+                    attn_metadata=step.attn_metadata,
+                    forward_batch=batch,
+                ):
+                    neg_v = self._run_ideogram_transformer(
+                        self.unconditional_transformer,
+                        dict(
+                            llm_features=ctx.extra["ideogram4_neg_llm_features"],
+                            x=z,
+                            t=t,
+                            position_ids=ctx.extra["ideogram4_neg_position_ids"],
+                            segment_ids=ctx.extra["ideogram4_neg_segment_ids"],
+                            indicator=ctx.extra["ideogram4_neg_indicator"],
+                            attn_mask=ctx.extra["ideogram4_neg_attn_mask"],
+                            attn_mask_meta=ctx.extra["ideogram4_neg_attn_mask_meta"],
+                        ),
+                    )
 
         with maybe_nvtx_range("scheduler_step", use_nvtx):
-            velocity = (
-                guidance_schedule[i] * pos_v + (1.0 - guidance_schedule[i]) * neg_v
-            )
+            if skip_unconditional:
+                velocity = pos_v
+            else:
+                velocity = (
+                    guidance_schedule[i] * pos_v + (1.0 - guidance_schedule[i]) * neg_v
+                )
+
             ctx.latents = z + velocity * schedule_deltas[i]
 
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/denoising.py
@@ -299,7 +299,10 @@ class ProgressiveDenoisingStage(DenoisingStage):
         pass
 
     def _refresh_cache_dit_context(
-        self, n_remaining: int, scm_preset: str | None
+        self,
+        n_remaining: int,
+        scm_preset: str | None,
+        ctx: DenoisingContext | None = None,
     ) -> None:
         """Refresh cache-dit activations and step counter at a stage transition.
 
@@ -610,7 +613,7 @@ class ProgressiveDenoisingStage(DenoisingStage):
                 # residual-diff decision for the first full-res steps.
                 if self._cache_dit_enabled:
                     n_remaining = n_steps - stage_end
-                    self._refresh_cache_dit_context(n_remaining, _get_scm_preset())
+                    self._refresh_cache_dit_context(n_remaining, _get_scm_preset(), ctx)
                     logger.info(
                         "cache-dit context refreshed at stage transition "
                         "(step %d, %d steps remaining)",

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/ideogram.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/ideogram.py
@@ -22,6 +22,7 @@ from diffusers.utils.torch_utils import randn_tensor
 from sglang.multimodal_gen.configs.sample.ideogram import IDEOGRAM4_PRESETS
 from sglang.multimodal_gen.runtime.cache.cache_dit_integration import (
     refresh_context_on_dual_transformer,
+    refresh_context_on_transformer,
 )
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.layers.attention import build_varlen_mask_meta
@@ -451,14 +452,32 @@ class Ideogram4ProgressiveDenoisingStage(
     # ------------------------------------------------------------------
 
     def _refresh_cache_dit_context(
-        self, n_remaining: int, scm_preset: str | None
+        self,
+        n_remaining: int,
+        scm_preset: str | None,
+        ctx: DenoisingContext | None = None,
     ) -> None:
-        """Refresh both conditional and unconditional transformers."""
+        """Refresh active Cache-DiT transformer contexts after a stage transition."""
         # Recompute the full SCM config here so custom compute/cache bins stay
         # active after a progressive-resolution stage transition.
-        _, scm_policy, steps_computation_mask, steps_computation_mask_2 = (
-            self._cache_dit_scm_masks(n_remaining, n_remaining)
+        skip_unconditional = bool(
+            ctx is not None and ctx.extra.get("ideogram4_skip_unconditional", False)
         )
+
+        _, scm_policy, steps_computation_mask, steps_computation_mask_2 = (
+            self._cache_dit_scm_masks(
+                n_remaining, None if skip_unconditional else n_remaining
+            )
+        )
+        if skip_unconditional:
+            refresh_context_on_transformer(
+                self.transformer,
+                n_remaining,
+                steps_computation_mask=steps_computation_mask,
+                steps_computation_policy=scm_policy,
+            )
+            return
+
         refresh_context_on_dual_transformer(
             self.transformer,
             self.unconditional_transformer,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR adds support for Ideogram 4 TurboTime-style distilled LoRA inference, targeting the public [ostris/ideogram_4_turbotime_lora](https://huggingface.co/ostris/ideogram_4_turbotime_lora) adapter. This LoRA is designed for few-step generation with no CFG and no unconditional transformer branch.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Add Ideogram 4 TurboTime LoRA presets:
  - `V4_TURBOTIME_LORA_2`
  - `V4_TURBOTIME_LORA_4`
  - `V4_TURBOTIME_LORA_8`

- Add request-local LoRA scaling for diffusion LoRA layers.
  - Base Ideogram presets such as `V4_DEFAULT_20`, `V4_QUALITY_48`, and `V4_TURBO_12` use `runtime_lora_scale=0.0`, so they can still run the base model even when the server is started with `--lora-path`.
  - TurboTime LoRA presets use `runtime_lora_scale=1.0` and require an active LoRA on the main transformer.

- Support request-local dynamic LoRA for Ideogram 4 quantized checkpoints.
  - NF4 uses the existing dynamic LoRA path.
  - FP8 is enabled by adding dynamic LoRA support for weight-only FP8 linear layers.

- Update the Ideogram 4 denoising path to skip the unconditional transformer when the selected preset declares `skip_unconditional=True`.

- Update progressive-resolution Cache-DiT refresh logic so that, when the unconditional branch is skipped, only the active transformer context is refreshed.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
## Accuracy Tests

Manual smoke tests were run with Ideogram 4 FP8 and the public TurboTime LoRA adapter.

Server command:

```bash
sglang serve \
  --model-path ideogram-ai/ideogram-4-fp8 \
  --model-type diffusion \
  --num-gpus 1 \
  --performance-mode speed \
  --host 0.0.0.0 \
  --port 30010 \
  --lora-path ostris/ideogram_4_turbotime_lora \
  --lora-merge-mode dynamic \
  --lora-scale 1.0 \
  --enable-torch-compile
```

Tested presets:
- Base: `V4_DEFAULT_20`, `V4_QUALITY_48`, `V4_TURBO_12`
- LoRA: `V4_TURBOTIME_LORA_2`, `V4_TURBOTIME_LORA_4`, `V4_TURBOTIME_LORA_8`

Example request:

```python
import json
import time
from openai import OpenAI

client = OpenAI(api_key="EMPTY", base_url="http://localhost:30010/v1")

caption = {
    "high_level_description": "A golden retriever riding a skateboard down a sunny sidewalk.",
    "style_description": {
        "aesthetics": "warm, playful, vibrant",
        "lighting": "bright afternoon sunlight, long soft shadows",
        "photo": "shallow depth of field, eye-level, 85mm lens",
        "medium": "photograph",
        "color_palette": ["#F5C542", "#87CEEB", "#4A4A4A", "#FFFFFF", "#2E8B57"],
    },
    "compositional_deconstruction": {
        "background": "A sun-drenched suburban sidewalk lined with green hedges and a white picket fence. Dappled light filters through overhead trees.",
        "elements": [
            {
                "type": "obj",
                "bbox": [200, 300, 800, 900],
                "desc": "A golden retriever with a fluffy coat, standing on a red skateboard with all four paws. Its tongue is out and ears are flapping in the wind.",
            },
            {
                "type": "obj",
                "bbox": [250, 750, 750, 950],
                "desc": "A worn red skateboard with black wheels rolling along the concrete sidewalk.",
            },
        ],
    },
}

t0 = time.perf_counter()
response = client.images.generate(
    model="ideogram-ai/ideogram-4-fp8",
    prompt=json.dumps(caption, separators=(",", ":"), ensure_ascii=False),
    size="1024x1024",
    n=1,
    response_format="b64_json",
    extra_body={
        "preset": "V4_TURBOTIME_LORA_8",
        "seed": 42,
    },
)
print("cost time:", round(time.perf_counter() - t0, 2), "s")
print("num images returned:", len(response.data))
assert len(response.data) == 1
assert response.data[0].b64_json is not None
```

Also verified request-local behavior with the same prompt and seed sequence:

1. `V4_DEFAULT_20`
2. `V4_TURBOTIME_LORA_8`
3. `V4_DEFAULT_20`

The two `V4_DEFAULT_20` requests used the base-model path, while `V4_TURBOTIME_LORA_8` used the LoRA path and skipped the unconditional transformer branch.

## Speed Tests and Profiling

- GPU: NVIDIA B200
- The following table compares the base Ideogram 4 preset with the TurboTime LoRA presets using the same prompt and seed.

<table>
  <tr>
    <th>Preset</th>
    <th align="center">V4_DEFAULT_20</th>
    <th align="center">V4_TURBOTIME_<br>LORA_8</th>
    <th align="center">V4_TURBOTIME_<br>LORA_4</th>
    <th align="center">V4_TURBOTIME_<br>LORA_2</th>
  </tr>
  <tr>
    <td>Output</td>
    <td align="center"><img width="190" alt="ideogram4_20steps" src="https://github.com/user-attachments/assets/296fbe7a-6c75-4663-b592-932938dc2e13" /></td>
    <td align="center"><img width="190" alt="LoRA_8steps" src="https://github.com/user-attachments/assets/c4afe5a0-5b79-4e05-836c-17294e341b15" /></td>
    <td align="center"><img width="190" alt="LoRA_4steps" src="https://github.com/user-attachments/assets/b0773676-5a69-4c5c-aeb5-5e0a794cc671" /></td>
    <td align="center"><img width="190" alt="LoRA_2steps" src="https://github.com/user-attachments/assets/f775e030-a8f4-4ffc-a0d5-e4f1bf082761" /></td>
  </tr>
  <tr>
    <td>Denoising steps</td>
    <td align="center">20</td>
    <td align="center">8</td>
    <td align="center">4</td>
    <td align="center">2</td>
  </tr>
  <tr>
    <td>Latency</td>
    <td align="center">3.46s</td>
    <td align="center">0.96s</td>
    <td align="center">0.58s</td>
    <td align="center">0.39s</td>
  </tr>
</table>

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28930430183](https://github.com/sgl-project/sglang/actions/runs/28930430183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28930430162](https://github.com/sgl-project/sglang/actions/runs/28930430162)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->