### PR TITLE
[lora] Support GDN in_proj_ba adapters for Qwen3.5

### DIFF
--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -208,6 +208,8 @@ class LoRAAdapter(nn.Module):
             self._normalize_in_proj(layer.weights)
             # Stack in_proj_q + in_proj_k + in_proj_v + in_proj_z → in_proj_qkvz for GDN layers
             self._normalize_in_proj_qkvz(layer.weights)
+            # Stack in_proj_b + in_proj_a → in_proj_ba for GDN layers
+            self._normalize_in_proj_ba(layer.weights)
             weight_names = list(layer.weights.keys())
             self.normalize_gate_up_proj(weight_names, layer.weights)
             weight_names = list(layer.weights.keys())
@@ -347,6 +349,25 @@ class LoRAAdapter(nn.Module):
                 weights.pop(k_name)
                 weights.pop(v_name)
                 weights.pop(z_name)
+            elif "in_proj_qkv." in weight_name:
+                # 2-way split (Megatron-Bridge adapter export): in_proj_qkv
+                # covers the q|k|v rows and in_proj_z the z rows, with one
+                # shared lora_A. The stacked buffer expects one A block per
+                # slice, so repeat the qkv A block 3x (q, k, v) before
+                # appending the z block; B rows concatenate directly.
+                z_name = weight_name.replace("in_proj_qkv.", "in_proj_z.")
+                if z_name not in weights:
+                    continue
+                qkvz_name = weight_name.replace("in_proj_qkv.", "in_proj_qkvz.")
+                cat_dim = weights[weight_name].dim() - 2
+                qkv_w = weights[weight_name]
+                if "lora_A" in weight_name:
+                    repeat_dims = [1] * qkv_w.dim()
+                    repeat_dims[cat_dim] = 3
+                    qkv_w = qkv_w.repeat(*repeat_dims)
+                weights[qkvz_name] = torch.cat((qkv_w, weights[z_name]), cat_dim)
+                weights.pop(weight_name)
+                weights.pop(z_name)
             elif "in_proj_qkvz" in weight_name and "lora_A" in weight_name:
                 # Already-merged adapter: replicate the shared A across the 4
                 # stacked slots the buffer expects (q, k, v, z).
@@ -355,6 +376,45 @@ class LoRAAdapter(nn.Module):
                 repeat_dims[ndim - 2] = 4
                 weights[weight_name] = weights[weight_name].repeat(*repeat_dims)
             # else (in_proj_qkvz lora_B, or unrelated): no-op.
+
+    def _normalize_in_proj_ba(self, weights: Dict[str, torch.Tensor]):
+        """Normalize in_proj_ba weights for GDN (GatedDeltaNet) layers like
+        Qwen3.5.
+
+        Two adapter formats are handled:
+
+        1. Split: ``in_proj_b + in_proj_a`` (HF checkpoint naming, also the
+           Megatron-Bridge adapter export) are present as separate weights →
+           concatenate them into ``in_proj_ba`` (B rows b|a; A blocks b, a).
+
+        2. Already-merged: the adapter has a single ``in_proj_ba`` weight
+           (PEFT trained against SGLang's fused Linear). The stacked buffer
+           expects two per-slice ``A`` blocks, so repeat ``lora_A`` 2x along
+           the rank dim. ``lora_B`` is already full-output-dim and matches
+           the buffer directly.
+        """
+        for weight_name in list(weights.keys()):
+            # NB: match with the trailing dot so the merged "in_proj_ba."
+            # names don't take the split branch.
+            if "in_proj_b." in weight_name:
+                a_name = weight_name.replace("in_proj_b.", "in_proj_a.")
+                if a_name not in weights:
+                    continue
+                ba_name = weight_name.replace("in_proj_b.", "in_proj_ba.")
+                cat_dim = weights[weight_name].dim() - 2
+                weights[ba_name] = torch.cat(
+                    (weights[weight_name], weights[a_name]), cat_dim
+                )
+                weights.pop(weight_name)
+                weights.pop(a_name)
+            elif "in_proj_ba" in weight_name and "lora_A" in weight_name:
+                # Already-merged adapter: replicate the shared A across the 2
+                # stacked slots the buffer expects (b, a).
+                ndim = weights[weight_name].dim()
+                repeat_dims = [1] * ndim
+                repeat_dims[ndim - 2] = 2
+                weights[weight_name] = weights[weight_name].repeat(*repeat_dims)
+            # else (in_proj_ba lora_B, or unrelated): no-op.
 
     def normalize_gate_up_proj(
         self, weight_names: List[str], weights: Dict[str, torch.Tensor]

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -253,6 +253,8 @@ def get_normalized_target_modules(
         "v_proj": "qkv_proj",
         "gate_proj": "gate_up_proj",
         "up_proj": "gate_up_proj",
+        "in_proj_b": "in_proj_ba",
+        "in_proj_a": "in_proj_ba",
         "out_proj": "out_proj",
         "embed_tokens": "embed_tokens",
         "vocab_emb": "embed_tokens",
@@ -291,6 +293,7 @@ def get_stacked_multiply(
     stacked_rank = {
         "qkv_proj": 3,
         "in_proj_qkvz": 4,  # GDN packed input projection
+        "in_proj_ba": 2,  # GDN packed b/a input projection
         "gate_up_proj": 2,
         "gate_up_proj_moe": 2,
         "in_proj": 2,
@@ -342,6 +345,7 @@ _KNOWN_LORA_TARGET_MODULES = frozenset(
         "out_proj",
         "in_proj",
         "in_proj_qkvz",
+        "in_proj_ba",
         "up_proj",
         "gate_up_proj",
         "down_proj",

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1071,6 +1071,7 @@ class Qwen3_5ForCausalLM(nn.Module):
         "o_proj",
         "out_proj",
         "in_proj_qkvz",
+        "in_proj_ba",
         "gate_up_proj",
         "down_proj",
         "lm_head",
@@ -1096,6 +1097,9 @@ class Qwen3_5ForCausalLM(nn.Module):
             key_dim = config.linear_key_head_dim * config.linear_num_key_heads
             value_dim = config.linear_value_head_dim * config.linear_num_value_heads
             return config.hidden_size, key_dim * 2 + value_dim * 2
+        elif module_name == "in_proj_ba":
+            # b + a projections: one scalar per linear-attention value head each
+            return config.hidden_size, config.linear_num_value_heads * 2
         elif module_name == "gate_up_proj":
             # MoE: shared expert uses shared_expert_intermediate_size
             # Dense: regular MLP uses intermediate_size


### PR DESCRIPTION
## Motivation

Qwen3.5's GatedDeltaNet (GDN) has two packed input projections: `in_proj_qkvz` (already LoRA-supported) and `in_proj_ba` — the delta-rule β/α gate projections. LoRA adapter weights covering `in_proj_ba` are currently **silently dropped at load time** (not in `_KNOWN_LORA_TARGET_MODULES`, warning only). An adapter trained against the fused megatron-side `in_proj` (Megatron-Bridge exports it split 4-way as `in_proj_qkv/z/b/a`) therefore serves **base weights for the β/α slices** — a quiet train/serve mismatch for RL.

## Modifications

- `models/qwen3_5.py`: add `in_proj_ba` to `supported_lora_modules` + `get_hidden_dim` (`2 * linear_num_value_heads`)
- `lora/utils.py`: register `in_proj_ba` in `_KNOWN_LORA_TARGET_MODULES`, `get_stacked_multiply` (=2), and `in_proj_b`/`in_proj_a` → `in_proj_ba` name normalization
- `lora/lora.py`: new `_normalize_in_proj_ba` (split b+a concat, merged repeat×2); extend `_normalize_in_proj_qkvz` to accept the **2-way `in_proj_qkv` + `in_proj_z` layout** emitted by Megatron-Bridge adapter export (shared `lora_A` repeated ×3 for the q|k|v slices) — previously only the 4-way PEFT layout and pre-merged form were handled

`MergedColumnParallelLinearWithLoRA` wraps the base layer generically (2-equal-slice path, same as gate_up) — no layer/mem-pool/manager changes needed.

## Validation

- Normalization unit checks: MB 2-way qkvz, b+a split, merged ba, and 4-way PEFT regression — all pass
- End-to-end RL (miles) on `Qwen/Qwen3.5-35B-A3B`, 8×H200 TP2/EP8 colocate, LoRA on attention + MoE experts + shared expert + GDN `in_proj`/`out_proj`: rollout-vs-train `logprob_abs_diff = 0.0100`, zero adapter weights skipped













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28927579933](https://github.com/sgl-project/sglang/actions/runs/28927579933)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28978966210](https://github.com/sgl-project/sglang/actions/runs/28978966210)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

## Model coverage

Also covers **Qwen3.6** with no additional changes: Qwen3.6 checkpoints declare the same `Qwen3_5(Moe)ForConditionalGeneration` architectures / `qwen3_5*` model_type, so they dispatch to `qwen3_5.py` and pick up this LoRA support directly. Verified with a 10-step LoRA RL run on `Qwen/Qwen3.6-35B-A3B` (full target set incl. GDN `in_proj_qkvz`/`in_proj_ba`/`out_proj`): rollout↔train `logprob_abs_diff` 0.010 at step 0, KL ≤ 0.004, reward 0.19 → 0.47, zero adapter weights skipped.
