### PR TITLE
[Perf][CP]: optimize glm5.2 prefill performance using comm-comp overlap triton kernels

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/__init__.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from sglang.srt.distributed.device_communicators.symm_mem_kernels.allgather_gemm_symm_mem import (
+    AllGatherGemmContextSymmMem,
+    allgather_bf16_gemm_op_symm_mem,
+    allgather_gemm_op_symm_mem,
+    create_allgather_gemm_context_symm_mem,
+    maybe_fused_ag_gate_mm,
+    maybe_fused_ag_shared_experts,
+)
+from sglang.srt.distributed.device_communicators.symm_mem_kernels.moe_reduce_rs_symm_mem import (
+    MoEReduceRSSymmMemContext,
+    create_moe_rs_symm_mem_context,
+    maybe_fused_shared_add_rs,
+    moe_reduce_rs_symm_mem,
+)
+
+__all__ = [
+    "AllGatherGemmContextSymmMem",
+    "MoEReduceRSSymmMemContext",
+    "allgather_bf16_gemm_op_symm_mem",
+    "allgather_gemm_op_symm_mem",
+    "create_allgather_gemm_context_symm_mem",
+    "create_moe_rs_symm_mem_context",
+    "maybe_fused_ag_gate_mm",
+    "maybe_fused_ag_shared_experts",
+    "maybe_fused_shared_add_rs",
+    "moe_reduce_rs_symm_mem",
+]

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/__init__.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/__init__.py
@@ -4,6 +4,7 @@ from sglang.srt.distributed.device_communicators.symm_mem_kernels.allgather_gemm
     AllGatherGemmContextSymmMem,
     allgather_bf16_gemm_op_symm_mem,
     allgather_gemm_op_symm_mem,
+    allgather_humming_fp8_gemm_op_symm_mem,
     create_allgather_gemm_context_symm_mem,
     maybe_fused_ag_gate_mm,
     maybe_fused_ag_shared_experts,
@@ -12,6 +13,7 @@ from sglang.srt.distributed.device_communicators.symm_mem_kernels.moe_reduce_rs_
     MoEReduceRSSymmMemContext,
     create_moe_rs_symm_mem_context,
     maybe_fused_shared_add_rs,
+    moe_mul_sum_add_rs_overlap,
     moe_reduce_rs_symm_mem,
 )
 
@@ -20,10 +22,12 @@ __all__ = [
     "MoEReduceRSSymmMemContext",
     "allgather_bf16_gemm_op_symm_mem",
     "allgather_gemm_op_symm_mem",
+    "allgather_humming_fp8_gemm_op_symm_mem",
     "create_allgather_gemm_context_symm_mem",
     "create_moe_rs_symm_mem_context",
     "maybe_fused_ag_gate_mm",
     "maybe_fused_ag_shared_experts",
     "maybe_fused_shared_add_rs",
+    "moe_mul_sum_add_rs_overlap",
     "moe_reduce_rs_symm_mem",
 ]

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/allgather_gemm_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/allgather_gemm_symm_mem.py
@@ -9,21 +9,14 @@ import dataclasses
 from typing import List, Optional, Tuple
 import triton
 import triton.language as tl
+from triton.language import core
 
 logger = logging.getLogger(__name__)
 
 
-@triton.jit
-def __syncthreads():
-    """PTX bar.sync (block-level __syncthreads)."""
-    tl.inline_asm_elementwise(
-        asm="bar.sync 0;",
-        constraints=("=r"),
-        args=[],
-        dtype=tl.int32,
-        is_pure=False,
-        pack=1
-    )
+@core.extern
+def __syncthreads(_semantic=None):
+    return tl.tensor(_semantic.builder.create_barrier(), tl.void)
 
 
 @triton.jit

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/allgather_gemm_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/allgather_gemm_symm_mem.py
@@ -1,0 +1,718 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+import dataclasses
+from typing import List, Optional, Tuple
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def __syncthreads():
+    """PTX bar.sync (block-level __syncthreads)."""
+    tl.inline_asm_elementwise(
+        asm="bar.sync 0;",
+        constraints=("=r"),
+        args=[],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1
+    )
+
+
+@triton.jit
+def tid(axis: tl.constexpr = 0):
+    """PTX threadIdx.x/y/z."""
+    if axis == 0:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.x;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1
+        )
+    elif axis == 1:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.y;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1
+        )
+    else:
+        return tl.inline_asm_elementwise(
+            asm="mov.u32 $0, %tid.z;",
+            constraints=("=r"),
+            args=[],
+            dtype=tl.int32,
+            is_pure=True,
+            pack=1
+        )
+
+
+@triton.jit
+def ld_sys(ptr):
+    """ld.global.acquire.sys.b32 — system-scope acquire load."""
+    return tl.inline_asm_elementwise(
+        asm="ld.global.acquire.sys.b32 $0, [$1];",
+        constraints=("=r,l"),
+        args=[ptr],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1
+    )
+
+
+@triton.jit
+def st_sys(ptr, val):
+    """st.global.release.sys.b32 — system-scope release store."""
+    tl.inline_asm_elementwise(
+        asm="""
+        st.global.release.sys.b32 [$1], $2;
+        mov.u32 $0, 0;
+        """,
+        constraints=("=r,l,r"),
+        args=[ptr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1
+    )
+
+
+@dataclasses.dataclass
+class AllGatherGemmContextSymmMem:
+    """Context for AG->GEMM overlap. Holds symm_mem buffers and handles."""
+
+    rank: int
+    num_ranks: int
+    NUM_COMM_SMS: int
+    NUM_GEMM_SMS: int
+    ag_stream: torch.cuda.Stream
+
+    symm_input_buf: torch.Tensor           # [world_size, M, K]
+    symm_ag_a_buf: torch.Tensor            # [M * world_size, K]
+    ag_signal_buf: torch.Tensor            # [world_size] uint32
+
+    # symm_mem rendezvous handles
+    input_hdl: object = None
+    ag_hdl: object = None
+    signal_hdl: object = None
+
+    mc_ag_a_buf: Optional[torch.Tensor] = None  # deprecated (NVLS)
+    peer_signal_ptrs: Optional[torch.Tensor] = None
+    peer_symm_input_bufs: Optional[List[torch.Tensor]] = None
+    group: Optional[object] = None
+
+    def finalize(self):
+        """Release symm_mem resources with a barrier for lock-step teardown."""
+        self.symm_input_buf = None
+        self.symm_ag_a_buf = None
+        self.ag_signal_buf = None
+        self.input_hdl = None
+        self.ag_hdl = None
+        self.signal_hdl = None
+        self.mc_ag_a_buf = None
+        self.peer_signal_ptrs = None
+        self.peer_symm_input_bufs = None
+        if dist.is_initialized():
+            dist.barrier(group=self.group)
+
+    def get_input_buf(self, M, K):
+        """Return this rank's [M, K] shard view in symm_input_buf."""
+        return self.symm_input_buf[self.rank, :M, :]
+
+
+def create_allgather_gemm_context_symm_mem(
+    ag_stream: torch.cuda.Stream,
+    rank: int,
+    world_size: int,
+    max_M: int,
+    K: int,
+    NUM_COMM_SMS: int = 0,
+    enable_multicast: bool = False,
+    group: Optional[object] = None,
+):
+    """Create AG->GEMM context with symm_mem buffers.
+
+    group: process group for symm_mem rendezvous (defaults to WORLD;
+        set to TP group when pipeline parallelism is used).
+    """
+    if not dist.is_initialized():
+        raise RuntimeError("torch.distributed must be initialized before creating the context.")
+
+    device = torch.cuda.current_device()
+    rendezvous_group = group if group is not None else dist.group.WORLD
+
+    symm_input_buf = symm_mem.empty(
+        (world_size, max_M, K), dtype=torch.bfloat16, device=device,
+    )
+    symm_ag_a_buf = symm_mem.empty(
+        (max_M * world_size, K), dtype=torch.bfloat16, device=device,
+    )
+    ag_signal_buf = symm_mem.empty(
+        (world_size,), dtype=torch.uint32, device=device,
+    )
+
+    symm_input_buf.zero_()
+    symm_ag_a_buf.zero_()
+    ag_signal_buf.zero_()
+
+    input_hdl = symm_mem.rendezvous(symm_input_buf, group=rendezvous_group)
+    ag_hdl = symm_mem.rendezvous(symm_ag_a_buf, group=rendezvous_group)
+    signal_hdl = symm_mem.rendezvous(ag_signal_buf, group=rendezvous_group)
+
+    input_hdl.barrier()
+
+    mc_ag_a_buf = None
+    if enable_multicast:
+        logger.warning(
+            "enable_multicast is deprecated in the symm_mem migration; "
+            "mc_ag_a_buf will be None. Reactivate via ag_hdl.multicast_ptr if needed."
+        )
+
+    peer_signal_ptrs = torch.tensor(
+        [signal_hdl.get_buffer(r, (world_size,), torch.uint32).data_ptr()
+         for r in range(world_size)],
+        dtype=torch.int64,
+        device=device,
+    )
+
+    peer_symm_input_bufs = [
+        input_hdl.get_buffer(r, (world_size, max_M, K), torch.bfloat16)
+        for r in range(world_size)
+    ]
+
+    num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+    num_gemm_sms = num_sms - NUM_COMM_SMS
+
+    ctx = AllGatherGemmContextSymmMem(
+        rank=rank,
+        num_ranks=world_size,
+        NUM_COMM_SMS=NUM_COMM_SMS,
+        NUM_GEMM_SMS=num_gemm_sms,
+        ag_stream=ag_stream,
+        symm_input_buf=symm_input_buf,
+        symm_ag_a_buf=symm_ag_a_buf,
+        ag_signal_buf=ag_signal_buf,
+        input_hdl=input_hdl,
+        ag_hdl=ag_hdl,
+        signal_hdl=signal_hdl,
+        mc_ag_a_buf=mc_ag_a_buf,
+        peer_signal_ptrs=peer_signal_ptrs,
+        peer_symm_input_bufs=peer_symm_input_bufs,
+        group=group,
+    )
+
+    return ctx
+
+
+def cp_engine_full_mesh_pull_ag(
+    rank: int,
+    world_size: int,
+    M_local: int,
+    K: int,
+    symm_input: torch.Tensor,
+    symm_ag_a: torch.Tensor,
+    peer_symm_input_bufs: List[torch.Tensor],
+    ag_signal: torch.Tensor,
+):
+    """AllGather via Copy Engine full-mesh pull (PtoP data + PtoP signal).
+
+    Signal writes via cuStreamWriteValue32.
+    Caller must wrap in `with torch.cuda.stream(ag_stream):`.
+    """
+    # Self-shard: local copy + PtoP signal via cuStreamWriteValue32
+    local_dst = symm_ag_a[rank * M_local : (rank + 1) * M_local, :]
+    local_dst.copy_(symm_input)
+    _SymmetricMemory.stream_write_value32(ag_signal, rank, 1)
+
+    # Remote shards in rotated order
+    for offset in range(1, world_size):
+        src_rank = (rank + offset) % world_size
+        remote_src = peer_symm_input_bufs[src_rank][src_rank, :M_local, :]
+        local_dst = symm_ag_a[src_rank * M_local : (src_rank + 1) * M_local, :]
+        local_dst.copy_(remote_src)
+        # cuStreamWriteValue32 issues a system level fence before the write
+        _SymmetricMemory.stream_write_value32(ag_signal, src_rank, 1)
+
+
+@triton.jit
+def consumer_bf16_a_block_fp8_matmul(
+    # Pointers
+    A_ptr,           # bf16 [M, K] gathered A (symm_mem)
+    B_ptr,           # fp8 [N, K] weight (col-major)
+    C_ptr,           # output [M, N]
+    Bs_ptr,          # B scale [N//group_n, K//group_k]
+    ag_signal_ptr,   # [world_size] uint32
+    # Dimensions
+    M, N, K,
+    M_local,
+    M_local_tiles,
+    # Block quantization
+    group_n, group_k,
+    # Strides
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    stride_Bs_k, stride_Bs_n,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    needs_masking: tl.constexpr,
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    """Non-persistent consumer GEMM: polls AG signal per rank-shard, then
+    computes bf16-A on-the-fly-quantized block-FP8 matmul.
+
+    Rank-aware tile rotation aligns CTA scheduling with AG signal arrival
+    order (self-shard first, then peers in rotated order).
+    """
+    fp8_max = 448.0
+    pid = tl.program_id(axis=0)
+
+    num_pid_m = M_local_tiles * world_size
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # Rank-aware tile rotation
+    logical_src_rank = min(pid_m // M_local_tiles, world_size - 1)
+    tile_in_rank = pid_m - logical_src_rank * M_local_tiles
+    src_rank = (rank + logical_src_rank) % world_size
+    pid_m = src_rank * M_local_tiles + tile_in_rank
+
+    tile_row_start = src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
+
+    # Poll AG signal for src_rank's shard
+    if tid(0) == 0:
+        while ld_sys(ag_signal_ptr + src_rank) != 1:
+            pass
+    __syncthreads()
+
+    offs_am = (tile_row_start + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    a_ptrs = A_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = B_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    offs_bsn = offs_bn // group_n
+    Bs_ptrs = Bs_ptr + offs_bsn * stride_Bs_n
+    n_tiles_k_per_group_k = group_k // BLOCK_SIZE_K
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        if needs_masking:
+            a_bf16 = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        else:
+            a_bf16 = tl.load(a_ptrs)
+            b = tl.load(b_ptrs)
+
+        # On-the-fly A quantization: per-row absmax
+        a_absmax = tl.max(tl.abs(a_bf16), axis=1)
+        a_s = tl.maximum(a_absmax, 1e-12) / fp8_max
+        a_fp8 = tl.clamp(a_bf16 / a_s[:, None], -fp8_max, fp8_max)
+        a_fp8 = a_fp8.to(B_ptr.dtype.element_ty)
+
+        b_s = tl.load(Bs_ptrs)
+
+        scale_step_k = tl.where((k + 1) % n_tiles_k_per_group_k == 0, 1, 0)
+        accumulator += tl.dot(a_fp8, b) * a_s[:, None] * b_s[None, :]
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+        Bs_ptrs += scale_step_k * stride_Bs_k
+
+    c = accumulator.to(tl.bfloat16)
+
+    offs_cm = tile_row_start + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    rank_row_end = (src_rank + 1) * M_local
+    c_mask = (offs_cm[:, None] < rank_row_end) & (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def allgather_gemm_op_symm_mem(
+    ctx: AllGatherGemmContextSymmMem,
+    a_bf16: torch.Tensor,
+    b_fp8: torch.Tensor,
+    b_scale: torch.Tensor,
+    block_size: list,
+    output_dtype: torch.dtype = torch.bfloat16,
+    GROUP_SIZE_M: int = 32,
+):
+    """AG->GEMM overlap: CE-driven AllGather on ag_stream + consumer GEMM on
+    current_stream with per-rank-shard signal polling for compute-comm overlap.
+
+    Returns (gathered_A [M*world_size, K], C [M*world_size, N]).
+    """
+    assert len(block_size) == 3
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = block_size
+
+    M_local, K = a_bf16.shape
+    N = b_fp8.shape[0]
+    M = M_local * ctx.num_ranks
+
+    assert a_bf16.dtype == torch.bfloat16, f"Expected bf16 A, got {a_bf16.dtype}"
+    assert a_bf16.shape[1] == b_fp8.shape[1], "K dimension mismatch"
+    assert a_bf16.is_contiguous()
+
+    num_pid_n = triton.cdiv(N, BLOCK_SIZE_N)
+
+    # Copy A shard to symmetric memory
+    symm_input = ctx.get_input_buf(M_local, K)
+    symm_input.copy_(a_bf16)
+
+    symm_ag_a = ctx.symm_ag_a_buf
+    ag_signal = ctx.ag_signal_buf
+
+    assert ag_signal.numel() >= ctx.num_ranks
+
+    c = torch.empty((M, N), dtype=output_dtype, device=a_bf16.device)
+
+    current_stream = torch.cuda.current_stream()
+    ag_stream = ctx.ag_stream
+
+    ctx.input_hdl.barrier()
+    ag_signal.fill_(0)
+    ctx.input_hdl.barrier()
+
+    ag_stream.wait_stream(current_stream)
+
+    # Step 1: AG on ag_stream (CE, no SM consumption)
+    with torch.cuda.stream(ag_stream):
+        cp_engine_full_mesh_pull_ag(
+            rank=ctx.rank,
+            world_size=ctx.num_ranks,
+            M_local=M_local,
+            K=K,
+            symm_input=symm_input,
+            symm_ag_a=symm_ag_a,
+            peer_symm_input_bufs=ctx.peer_symm_input_bufs,
+            ag_signal=ag_signal,
+        )
+
+    # Step 2: consumer GEMM on current_stream
+    needs_masking = bool(K % BLOCK_SIZE_K != 0)
+    M_local_tiles = triton.cdiv(M_local, BLOCK_SIZE_M)
+    num_pid_m_grid = M_local_tiles * ctx.num_ranks
+    num_tiles = num_pid_m_grid * num_pid_n
+
+    consumer_bf16_a_block_fp8_matmul[(num_tiles,)](
+        symm_ag_a,
+        b_fp8,
+        c,
+        b_scale,
+        ag_signal,
+        M, N, K,
+        M_local,
+        M_local_tiles,
+        BLOCK_SIZE_N,  # group_n
+        BLOCK_SIZE_K,  # group_k
+        symm_ag_a.stride(0),
+        symm_ag_a.stride(1),
+        b_fp8.stride(1),
+        b_fp8.stride(0),
+        c.stride(0),
+        c.stride(1),
+        b_scale.stride(1),
+        b_scale.stride(0),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        needs_masking=needs_masking,
+        rank=ctx.rank,
+        world_size=ctx.num_ranks,
+        num_warps=4,
+        num_stages=3,
+    )
+
+    current_stream.wait_stream(ag_stream)
+
+    return symm_ag_a[:M_local*ctx.num_ranks,:], c
+
+
+def maybe_fused_ag_shared_experts(
+    hidden_states: torch.Tensor,
+    shared_experts_is_fp8: bool,
+    w_fp8: Optional[torch.Tensor],
+    w_scale: Optional[torch.Tensor],
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """Fused AG + fp8-quant + gate_up gemm. Returns (None, None) to fall back.
+
+    Standalone wrapper around allgather_gemm_op_symm_mem that handles
+    communicator lookup, context creation, and output allocation.
+    """
+    from sglang.srt.distributed.device_communicators.torch_symm_mem import (
+        TorchSymmMemCommunicator,
+    )
+
+    comm = TorchSymmMemCommunicator.get_active_comm()
+    if comm is None:
+        return None, None
+    if not shared_experts_is_fp8:
+        return None, None
+    if w_fp8 is None or w_scale is None:
+        return None, None
+    _, K = hidden_states.shape
+
+    ctx = comm.get_or_create_ag_gemm_ctx(K=K)
+    if ctx is None:
+        return None, None
+
+    try:
+        block_size = [64, 128, 128]
+        allgather_output, gate_up_full = allgather_gemm_op_symm_mem(
+            ctx=ctx,
+            a_bf16=hidden_states,
+            b_fp8=w_fp8.contiguous(),
+            b_scale=w_scale,
+            block_size=block_size,
+        )
+    except Exception:
+        return None, None
+
+    return allgather_output, gate_up_full
+
+
+
+# ============================================================================
+# Consumer BF16 Matmul Kernel (non-persistent, polls AG signal, then computes
+# bf16 matmul C = A @ W^T where W is [N, K] row-major / F.linear format)
+# ============================================================================
+@triton.jit
+def consumer_bf16_matmul(
+    # Pointers
+    A_ptr,           # bf16 [M, K] gathered A (symm_mem)
+    B_ptr,           # bf16 [N, K] weight (row-major, F.linear format)
+    C_ptr,           # output [M, N]
+    ag_signal_ptr,   # [world_size] uint32
+    # Dimensions
+    M, N, K,
+    M_local,
+    M_local_tiles,
+    # Strides
+    stride_am, stride_ak,
+    stride_bk, stride_bn,
+    stride_cm, stride_cn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    needs_masking: tl.constexpr,
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    """Non-persistent consumer BF16 GEMM: polls AG signal per rank-shard, then
+    computes bf16 matmul C = A @ W^T where W is [N, K] row-major.
+    Rank-aware tile rotation aligns CTA scheduling with AG signal arrival
+    order (self-shard first, then peers in rotated order).
+    """
+    pid = tl.program_id(axis=0)
+    num_pid_m = M_local_tiles * world_size
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+    # Rank-aware tile rotation
+    logical_src_rank = min(pid_m // M_local_tiles, world_size - 1)
+    tile_in_rank = pid_m - logical_src_rank * M_local_tiles
+    src_rank = (rank + logical_src_rank) % world_size
+    pid_m = src_rank * M_local_tiles + tile_in_rank
+    tile_row_start = src_rank * M_local + tile_in_rank * BLOCK_SIZE_M
+    # Poll AG signal for src_rank's shard
+    if tid(0) == 0:
+        while ld_sys(ag_signal_ptr + src_rank) != 1:
+            pass
+    __syncthreads()
+    offs_am = (tile_row_start + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = B_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        if needs_masking:
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        else:
+            a = tl.load(a_ptrs)
+            b = tl.load(b_ptrs)
+        accumulator += tl.dot(a, b)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+    c = accumulator.to(tl.bfloat16)
+    offs_cm = tile_row_start + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    rank_row_end = (src_rank + 1) * M_local
+    c_mask = (offs_cm[:, None] < rank_row_end) & (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+# ============================================================================
+# AllGather -> BF16 GEMM Operation (AG first, BF16 GEMM follows with tile-level signaling)
+# ============================================================================
+def allgather_bf16_gemm_op_symm_mem(
+    ctx: AllGatherGemmContextSymmMem,
+    a_bf16: torch.Tensor,
+    w_bf16: torch.Tensor,
+    block_size: list,
+    output_dtype: torch.dtype = torch.bfloat16,
+    GROUP_SIZE_M: int = 32,
+):
+    """AG->BF16 Matmul overlap: CE-driven AllGather on ag_stream + consumer BF16
+    GEMM on current_stream with per-rank-shard signal polling.
+    Unlike allgather_gemm_op_symm_mem which uses FP8 block-wise matmul, this
+    performs a pure BF16 matmul (C = A @ W^T) without quantization.
+    Args:
+        ctx: AllGatherGemmContextSymmMem context
+        a_bf16: bf16 activation tensor [M, K] (local shard for this rank)
+        w_bf16: bf16 weight tensor [N, K] (row-major, F.linear format)
+        block_size: [BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K]
+        output_dtype: output dtype
+        GROUP_SIZE_M: swizzle group size for GEMM
+    Returns:
+        (gathered_A, C) where gathered_A is [M * world_size, K] and
+        C is [M * world_size, N] with C = gathered_A @ W^T.
+    """
+    assert len(block_size) == 3
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = block_size
+    M_local, K = a_bf16.shape
+    N = w_bf16.shape[0]
+    M = M_local * ctx.num_ranks
+    assert a_bf16.dtype == torch.bfloat16, f"Expected bf16 A, got {a_bf16.dtype}"
+    assert w_bf16.dtype == torch.bfloat16, f"Expected bf16 W, got {w_bf16.dtype}"
+    assert a_bf16.shape[1] == w_bf16.shape[1], "K dimension mismatch between A and W"
+    assert a_bf16.is_contiguous()
+    num_pid_n = triton.cdiv(N, BLOCK_SIZE_N)
+    # Copy A shard to symmetric memory
+    symm_input = ctx.get_input_buf(M_local, K)
+    symm_input.copy_(a_bf16)
+    symm_ag_a = ctx.symm_ag_a_buf
+    ag_signal = ctx.ag_signal_buf
+    assert ag_signal.numel() >= ctx.num_ranks
+    c = torch.empty((M, N), dtype=output_dtype, device=a_bf16.device)
+    current_stream = torch.cuda.current_stream()
+    ag_stream = ctx.ag_stream
+    ctx.input_hdl.barrier()
+    ag_signal.fill_(0)
+    ctx.input_hdl.barrier()
+    ag_stream.wait_stream(current_stream)
+    # Step 1: AG on ag_stream (CE, no SM consumption)
+    with torch.cuda.stream(ag_stream):
+        cp_engine_full_mesh_pull_ag(
+            rank=ctx.rank,
+            world_size=ctx.num_ranks,
+            M_local=M_local,
+            K=K,
+            symm_input=symm_input,
+            symm_ag_a=symm_ag_a,
+            peer_symm_input_bufs=ctx.peer_symm_input_bufs,
+            ag_signal=ag_signal,
+        )
+    # Step 2: consumer BF16 GEMM on current_stream
+    needs_masking = bool(K % BLOCK_SIZE_K != 0)
+    M_local_tiles = triton.cdiv(M_local, BLOCK_SIZE_M)
+    num_pid_m_grid = M_local_tiles * ctx.num_ranks
+    num_tiles = num_pid_m_grid * num_pid_n
+    consumer_bf16_matmul[(num_tiles,)](
+        symm_ag_a,
+        w_bf16,
+        c,
+        ag_signal,
+        M, N, K,
+        M_local,
+        M_local_tiles,
+        symm_ag_a.stride(0),
+        symm_ag_a.stride(1),
+        w_bf16.stride(1),  # stride_bk (K is dim 1 in [N, K] row-major)
+        w_bf16.stride(0),  # stride_bn (N is dim 0 in [N, K] row-major)
+        c.stride(0),
+        c.stride(1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        needs_masking=needs_masking,
+        rank=ctx.rank,
+        world_size=ctx.num_ranks,
+        num_warps=4,
+        num_stages=3,
+    )
+    current_stream.wait_stream(ag_stream)
+    return symm_ag_a[:M, :], c
+
+
+def maybe_fused_ag_gate_mm(
+    hidden_states: torch.Tensor,
+    gate_weight: torch.Tensor,
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """Fused AllGather + gate matmul.  Returns ``(ag_out, router_logits)``
+    or ``(None, None)`` on fallback.
+
+    This is a convenience wrapper that:
+      1. Retrieves the active ``TorchSymmMemCommunicator``
+      2. Gets/creates the AG+GEMM context (cached per K, shared with
+         shared-experts path via ``get_or_create_ag_gemm_ctx``)
+      3. Calls :func:`allgather_bf16_gemm_op_symm_mem`
+      4. Falls back to ``(None, None)`` on any error
+
+    Args:
+        hidden_states: Local shard [M_local, K] in bf16.
+        gate_weight: Gate projection weight [N, K] in bf16.
+
+    Returns:
+        ``(ag_out, router_logits)`` on success, ``(None, None)`` on failure.
+    """
+    from sglang.srt.distributed.device_communicators.torch_symm_mem import (
+        TorchSymmMemCommunicator,
+    )
+
+    comm = TorchSymmMemCommunicator.get_active_comm()
+    if comm is None:
+        return None, None
+    if gate_weight.dtype != torch.bfloat16:
+        return None, None
+
+    _, K = hidden_states.shape
+
+    ctx = comm.get_or_create_ag_gemm_ctx(K=K)
+    if ctx is None:
+        return None, None
+
+    try:
+        block_size = [64, 128, 128]
+        allgather_output, router_logits = allgather_bf16_gemm_op_symm_mem(
+            ctx=ctx,
+            a_bf16=hidden_states,
+            w_bf16=gate_weight,
+            block_size=block_size,
+        )
+    except Exception:
+        logger.warning(
+            "maybe_fused_ag_gate_mm failed, falling back to separate AG + matmul",
+            exc_info=True,
+        )
+        return None, None
+
+    return allgather_output, router_logits

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/allgather_gemm_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/allgather_gemm_symm_mem.py
@@ -447,11 +447,20 @@ def maybe_fused_ag_shared_experts(
     shared_experts_is_fp8: bool,
     w_fp8: Optional[torch.Tensor],
     w_scale: Optional[torch.Tensor],
+    is_humming: bool = True,
+    humming_weight: Optional[torch.Tensor] = None,
+    humming_scale: Optional[torch.Tensor] = None,
+    humming_group_size: int = 128,
 ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
-    """Fused AG + fp8-quant + gate_up gemm. Returns (None, None) to fall back.
+    """Fused AG + GEMM for shared experts. Returns (None, None) to fall back.
 
-    Standalone wrapper around allgather_gemm_op_symm_mem that handles
-    communicator lookup, context creation, and output allocation.
+    Supports two quantization paths:
+    - fp8 block-wise (W8A8): uses allgather_gemm_op_symm_mem (existing)
+    - humming fp8 (W8A8): uses allgather_humming_fp8_gemm_op_symm_mem
+
+    The path is selected at the Python level (not via kernel constexpr)
+    because the two weight formats have different dtype, shape, and dequant
+    logic — a single kernel with constexpr branches would waste registers.
     """
     from sglang.srt.distributed.device_communicators.torch_symm_mem import (
         TorchSymmMemCommunicator,
@@ -460,6 +469,41 @@ def maybe_fused_ag_shared_experts(
     comm = TorchSymmMemCommunicator.get_active_comm()
     if comm is None:
         return None, None
+    
+
+    _, K = hidden_states.shape
+    if is_humming:
+        if humming_weight is None or humming_scale is None:
+            return None, None
+        ctx = comm.get_or_create_ag_gemm_ctx(K=K)
+        if ctx is None:
+            return None, None
+        try:
+            # BLOCK_SIZE_K must divide group_size (128); 128 keeps one scale
+            # per K-tile for the W8A8 block-fp8 consumer kernel.
+            block_size = [64, 128, 128]
+            allgather_output, gate_up_full = allgather_humming_fp8_gemm_op_symm_mem(
+                ctx=ctx,
+                a_bf16=hidden_states,
+                w_humming=humming_weight,
+                w_scale=humming_scale,
+                group_size=humming_group_size,
+                block_size=block_size,
+            )
+        except Exception:
+            # Layout/comm failure: fall back to the non-fused path, but log so
+            # a regression in the fused kernel is visible instead of silent.
+            logger.exception(
+                "humming fused AG+GEMM failed (K=%d, w=%s %s, scale=%s %s, "
+                "group=%d); falling back to non-fused shared experts",
+                K,
+                tuple(humming_weight.shape), humming_weight.dtype,
+                tuple(humming_scale.shape), humming_scale.dtype,
+                humming_group_size,
+            )
+            return None, None
+        return allgather_output, gate_up_full
+
     if not shared_experts_is_fp8:
         return None, None
     if w_fp8 is None or w_scale is None:
@@ -563,7 +607,7 @@ def consumer_bf16_matmul(
     c_mask = (offs_cm[:, None] < rank_row_end) & (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
     tl.store(c_ptrs, c, mask=c_mask)
 # ============================================================================
-# AllGather -> BF16 GEMM Operation (AG first, BF16 GEMM follows with tile-level signaling)
+# AllGather -> Humming 4-bit GEMM Operation
 # ============================================================================
 def allgather_bf16_gemm_op_symm_mem(
     ctx: AllGatherGemmContextSymmMem,
@@ -655,6 +699,123 @@ def allgather_bf16_gemm_op_symm_mem(
     current_stream.wait_stream(ag_stream)
     return symm_ag_a[:M, :], c
 
+# ============================================================================
+# AllGather -> Humming FP8 (W8A8) GEMM Operation
+# Reuses consumer_bf16_a_block_fp8_matmul (on-the-fly A→fp8 quant + fp8 GEMM)
+# with group_n=1 for humming's per-channel-N / group-K weight scale.
+# ============================================================================
+def allgather_humming_fp8_gemm_op_symm_mem(
+    ctx: AllGatherGemmContextSymmMem,
+    a_bf16: torch.Tensor,
+    w_humming: torch.Tensor,
+    w_scale: torch.Tensor,
+    group_size: int,
+    block_size: list,
+    output_dtype: torch.dtype = torch.bfloat16,
+    GROUP_SIZE_M: int = 32,
+):
+    """AG → humming FP8 (W8A8) GEMM overlap for shared experts.
+
+    Humming FP8 is W8A8: the activation is dynamically quantized to fp8 e4m3
+    (per-row absmax) inside the consumer kernel, then an fp8 GEMM is run against
+    the fp8 weight; the result is scaled by the per-row A scale and the
+    weight's per-channel-N / group-K scale.
+
+    Weight is humming's int32 [N, K//4] packed fp8 e4m3 (4 bytes per int32,
+    pre-interleave layout) → view as fp8 [N, K]. Scale is bf16 [N, K//group_size]
+    (per-channel N, group in K → group_n=1, group_k=group_size). Reuses the
+    proven W8A8 block-fp8 consumer kernel with on-the-fly A quantization.
+
+    Returns (gathered_A [M*world_size, K], C [M*world_size, N]).
+    """
+    assert len(block_size) == 3
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = block_size
+    M_local, K = a_bf16.shape
+    N = w_humming.shape[0]
+    M = M_local * ctx.num_ranks
+
+    assert a_bf16.dtype == torch.bfloat16, f"Expected bf16 A, got {a_bf16.dtype}"
+    # Weight is int32 [N, K//4] (4 fp8 e4m3 bytes per int32) -> view as fp8 [N, K].
+    assert w_humming.dtype == torch.int32, (
+        f"Expected int32 packed fp8 weight, got {w_humming.dtype}")
+    assert w_humming.is_contiguous(), "humming weight must be contiguous for fp8 view"
+    w_fp8 = w_humming.view(torch.float8_e4m3fn)
+    assert w_fp8.shape == (N, K), (
+        f"fp8 view {tuple(w_fp8.shape)} != ({N}, {K}); "
+        f"weight {tuple(w_humming.shape)} (expected int32 [N, K//4])")
+    assert w_scale.dtype == torch.bfloat16, f"Expected bf16 scale, got {w_scale.dtype}"
+    assert w_scale.shape == (N, K // group_size), (
+        f"scale {tuple(w_scale.shape)} != ({N}, {K // group_size})")
+    # The block kernel holds one weight scale per K-tile, so BLOCK_SIZE_K must
+    # divide the K group size (use block_size = [64, 128, 128]).
+    assert group_size % BLOCK_SIZE_K == 0, (
+        f"group_size {group_size} must be divisible by BLOCK_SIZE_K {BLOCK_SIZE_K}")
+    assert a_bf16.is_contiguous()
+
+    symm_input = ctx.get_input_buf(M_local, K)
+    symm_input.copy_(a_bf16)
+    symm_ag_a = ctx.symm_ag_a_buf
+    ag_signal = ctx.ag_signal_buf
+    assert ag_signal.numel() >= ctx.num_ranks
+
+    c = torch.empty((M, N), dtype=output_dtype, device=a_bf16.device)
+    current_stream = torch.cuda.current_stream()
+    ag_stream = ctx.ag_stream
+
+    ctx.input_hdl.barrier()
+    ag_signal.fill_(0)
+    ctx.input_hdl.barrier()
+    ag_stream.wait_stream(current_stream)
+
+    with torch.cuda.stream(ag_stream):
+        cp_engine_full_mesh_pull_ag(
+            rank=ctx.rank,
+            world_size=ctx.num_ranks,
+            M_local=M_local,
+            K=K,
+            symm_input=symm_input,
+            symm_ag_a=symm_ag_a,
+            peer_symm_input_bufs=ctx.peer_symm_input_bufs,
+            ag_signal=ag_signal,
+        )
+
+    needs_masking = bool(K % BLOCK_SIZE_K != 0)
+    M_local_tiles = triton.cdiv(M_local, BLOCK_SIZE_M)
+    num_pid_n = triton.cdiv(N, BLOCK_SIZE_N)
+    num_tiles = M_local_tiles * ctx.num_ranks * num_pid_n
+
+    consumer_bf16_a_block_fp8_matmul[(num_tiles,)](
+        symm_ag_a,
+        w_fp8,
+        c,
+        w_scale,
+        ag_signal,
+        M, N, K,
+        M_local,
+        M_local_tiles,
+        1,              # group_n: per-channel-N scale [N, K//group_size]
+        group_size,     # group_k
+        symm_ag_a.stride(0),
+        symm_ag_a.stride(1),
+        w_fp8.stride(1),   # stride_bk (K is dim 1 in [N, K] row-major)
+        w_fp8.stride(0),   # stride_bn (N is dim 0 in [N, K] row-major)
+        c.stride(0),
+        c.stride(1),
+        w_scale.stride(1), # stride_Bs_k
+        w_scale.stride(0), # stride_Bs_n
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        needs_masking=needs_masking,
+        rank=ctx.rank,
+        world_size=ctx.num_ranks,
+        num_warps=4,
+        num_stages=3,
+    )
+
+    current_stream.wait_stream(ag_stream)
+    return symm_ag_a[: M_local * ctx.num_ranks, :], c
 
 def maybe_fused_ag_gate_mm(
     hidden_states: torch.Tensor,

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/moe_reduce_rs_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/moe_reduce_rs_symm_mem.py
@@ -9,6 +9,12 @@ import torch.distributed._symmetric_memory as symm_mem
 
 import triton
 import triton.language as tl
+from triton.language import core
+
+
+@core.extern
+def __syncthreads(_semantic=None):
+    return tl.tensor(_semantic.builder.create_barrier(), tl.void)
 
 
 @triton.jit
@@ -123,6 +129,7 @@ def barrier_on_this_grid(barrier_ptr):
     All CTAs atomically increment, CTA-0 spins until count == expected
     then sets high-bit to release everyone.
     """
+    __syncthreads()
     pid_size_x = tl.num_programs(axis=0)
     pid_size_y = tl.num_programs(axis=1)
     pid_size_z = tl.num_programs(axis=2)
@@ -138,7 +145,7 @@ def barrier_on_this_grid(barrier_ptr):
             while (_load_acquire(barrier_ptr) & 0x80000000) == 0:
                 pass
 
-    tl.debug_barrier()
+    __syncthreads()
 
 
 @triton.jit
@@ -199,6 +206,7 @@ def barrier_all_intra_node_atomic_cas_block(
     Phase 1: CAS remote peer's flag[local_rank] 0->1 (notify peer).
     Phase 2: CAS local flag[thread_idx] 1->0 (wait for peer, reset).
     """
+    __syncthreads()
     flat_tid = _get_flat_tid()
     local_rank_offset = rank - local_rank
 
@@ -215,7 +223,7 @@ def barrier_all_intra_node_atomic_cas_block(
         local_addr = local_base + flat_tid
         _cas_sys_acquire(local_addr, 1, 0)
 
-    tl.debug_barrier()
+    __syncthreads()
 
 
 @dataclass
@@ -674,8 +682,6 @@ def maybe_fused_shared_add_rs(
     if comm is None:
         return None
 
-    '''if shared_output is None:
-        return None'''
     M, _, N = final_hidden_states.shape
     if M == 0 or (M % tp_size) != 0:
         return None

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/moe_reduce_rs_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/moe_reduce_rs_symm_mem.py
@@ -1,0 +1,709 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _get_tid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %tid.x;
+        mov.u32 $1, %tid.y;
+        mov.u32 $2, %tid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _get_ntid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %ntid.x;
+        mov.u32 $1, %ntid.y;
+        mov.u32 $2, %ntid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _get_flat_tid():
+    tid_x, tid_y, tid_z = _get_tid()
+    ntid_x, ntid_y, _ = _get_ntid()
+    return tid_z * ntid_y * ntid_x + tid_y * ntid_x + tid_x
+
+
+@triton.jit
+def _get_flat_bid():
+    return (
+        tl.program_id(2) * tl.num_programs(1) * tl.num_programs(0)
+        + tl.program_id(1) * tl.num_programs(0)
+        + tl.program_id(0)
+    )
+
+
+@triton.jit
+def _atomic_add_release(ptr, val):
+    """atom.global.release.gpu.add.u32"""
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32   %inc;
+            atom.global.release.gpu.add.u32 %inc, [$1], $2;
+        }
+        """,
+        "=r, l, r",
+        [ptr, tl.cast(val, tl.uint32)],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _load_acquire(ptr):
+    """ld.global.acquire.gpu.u32"""
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32   %val;
+            ld.global.acquire.gpu.u32 %val, [$1];
+            mov.u32 $0, %val;
+        }
+        """,
+        "=r, l",
+        [ptr],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _store_release_with_highbit(ptr, expected):
+    """st.release.gpu with high-bit set (expected | 0x80000000)."""
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32   %mask, %val;
+            mov.u32  %mask, 0x80000000;
+            or.b32   %val, %mask, $2;
+            st.global.release.gpu.u32   [$1], %val;
+        }
+        """,
+        "=r, l, r",
+        [ptr, tl.cast(expected, tl.uint32)],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def barrier_on_this_grid(barrier_ptr):
+    """Synchronize all CTAs in this kernel launch (split-counter pattern).
+
+    All CTAs atomically increment, CTA-0 spins until count == expected
+    then sets high-bit to release everyone.
+    """
+    pid_size_x = tl.num_programs(axis=0)
+    pid_size_y = tl.num_programs(axis=1)
+    pid_size_z = tl.num_programs(axis=2)
+    expected = pid_size_x * pid_size_y * pid_size_z
+
+    if _get_flat_tid() == 0:
+        _atomic_add_release(barrier_ptr, 1)
+        if _get_flat_bid() == 0:
+            while _load_acquire(barrier_ptr) != expected:
+                pass
+            _store_release_with_highbit(barrier_ptr, expected)
+        else:
+            while (_load_acquire(barrier_ptr) & 0x80000000) == 0:
+                pass
+
+    tl.debug_barrier()
+
+
+@triton.jit
+def _cas_sys_release(addrs, expected, desired):
+    """atom.global.release.sys.cas.b32 — spins until CAS succeeds."""
+    return tl.inline_asm_elementwise(
+        f"""
+        {{
+            .reg .u32   %tmp32_<1>;
+            .reg .pred  %p<1>;
+            cas_loop:
+                atom.global.release.sys.cas.b32 %tmp32_0, [$1], {expected}, {desired};
+                setp.eq.u32 %p0, %tmp32_0, {expected};
+                @!%p0 bra cas_loop;
+            mov.u32 $0, %tmp32_0;
+        }}
+        """,
+        "=r, l",
+        [addrs],
+        dtype=addrs.dtype,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _cas_sys_acquire(addrs, expected, desired):
+    """atom.global.acquire.sys.cas.b32 — spins until CAS succeeds."""
+    return tl.inline_asm_elementwise(
+        f"""
+        {{
+            .reg .u32   %tmp32_<1>;
+            .reg .pred  %p<1>;
+            cas_loop:
+                atom.global.acquire.sys.cas.b32 %tmp32_0, [$1], {expected}, {desired};
+                setp.eq.u32 %p0, %tmp32_0, {expected};
+                @!%p0 bra cas_loop;
+            mov.u32 $0, %tmp32_0;
+        }}
+        """,
+        "=r, l",
+        [addrs],
+        dtype=addrs.dtype,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def barrier_all_intra_node_atomic_cas_block(
+    local_rank: tl.constexpr,
+    rank: tl.constexpr,
+    local_world_size: tl.constexpr,
+    symm_flag_ptr,
+):
+    """Cross-rank intra-node barrier via CAS on symmetric memory flags.
+
+    Phase 1: CAS remote peer's flag[local_rank] 0->1 (notify peer).
+    Phase 2: CAS local flag[thread_idx] 1->0 (wait for peer, reset).
+    """
+    flat_tid = _get_flat_tid()
+    local_rank_offset = rank - local_rank
+
+    ptrs = symm_flag_ptr.to(tl.pointer_type(tl.uint64))
+
+    if flat_tid < local_world_size:
+        peer = flat_tid + local_rank_offset
+        remote_base = tl.load(ptrs + peer).to(tl.pointer_type(tl.uint32))
+        remote_addr = remote_base + local_rank
+        _cas_sys_release(remote_addr, 0, 1)
+
+    if flat_tid < local_world_size:
+        local_base = tl.load(ptrs + rank).to(tl.pointer_type(tl.uint32))
+        local_addr = local_base + flat_tid
+        _cas_sys_acquire(local_addr, 1, 0)
+
+    tl.debug_barrier()
+
+
+@dataclass
+class MoEReduceRSSymmMemContext:
+    """Context for symm_mem-based MoE reduce-scatter. Holds pre-allocated
+    symmetric buffers and synchronization resources."""
+
+    max_M: int   # max tokens (NOT ntokens * topk)
+    N: int
+    num_experts: int
+    topk: int
+    dtype: torch.dtype
+    # distributed
+    rank: int
+    num_ranks: int
+    num_local_ranks: int
+    n_chunks_max: int
+    # local sync primitives
+    grid_barrier: torch.Tensor   # [1] int32
+    gemm_counter: torch.Tensor   # [n_chunks_max] int32
+    gemm_done_flag: torch.Tensor # [n_chunks_max] int32
+    rs_counter: torch.Tensor     # [n_chunks_max * num_ranks] int32
+    group: Optional[object] = None
+
+    # Computed in __post_init__
+    local_rank: int = field(init=False)
+    nnodes: int = field(init=False)
+    num_sms: int = field(init=False)  # GPU SM count, queried once at init
+
+    # symm_mem handle and buffers
+    symm_mem_hdl: Optional[object] = field(default=None, init=False)
+    symm_reduce_scatter_buffer: Optional[torch.Tensor] = field(default=None, init=False)
+
+    buf_tuple: Optional[Tuple[torch.Tensor, ...]] = field(default=None, init=False)
+    signal_pad_tuple: Optional[Tuple[torch.Tensor, ...]] = field(default=None, init=False)
+
+    # GPU-side pointer arrays for Triton kernel (int64)
+    buf_ptrs: Optional[torch.Tensor] = field(default=None, init=False)
+    signal_pad_ptrs: Optional[torch.Tensor] = field(default=None, init=False)
+
+    def __post_init__(self):
+        assert self.dtype in [torch.bfloat16, torch.float16], \
+            "Only float16 / bfloat16 are supported"
+
+        self.local_rank = self.rank % self.num_local_ranks
+        self.nnodes = self.num_ranks // self.num_local_ranks
+        self.num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+        ntokens = self.max_M
+
+        self.symm_reduce_scatter_buffer = symm_mem.empty(
+            (ntokens, self.N),
+            dtype=self.dtype,
+            device=torch.cuda.current_device(),
+        )
+        rendezvous_group = self.group if self.group is not None else dist.group.WORLD
+        self.symm_mem_hdl = symm_mem.rendezvous(
+            self.symm_reduce_scatter_buffer,
+            group=rendezvous_group,
+        )
+
+        self.buf_tuple = tuple(
+            self.symm_mem_hdl.get_buffer(i, (ntokens, self.N), self.dtype)
+            for i in range(self.num_ranks)
+        )
+
+        self.signal_pad_tuple = tuple(
+            self.symm_mem_hdl.get_signal_pad(i, (self.num_ranks,), torch.int32)
+            for i in range(self.num_ranks)
+        )
+
+        self.buf_ptrs = torch.tensor(
+            [buf.data_ptr() for buf in self.buf_tuple],
+            dtype=torch.int64,
+            device=torch.cuda.current_device(),
+        )
+        self.signal_pad_ptrs = torch.tensor(
+            [pad.data_ptr() for pad in self.signal_pad_tuple],
+            dtype=torch.int64,
+            device=torch.cuda.current_device(),
+        )
+
+        barrier_group = self.group if self.group is not None else None
+        dist.barrier(group=barrier_group)
+
+    def finalize(self):
+        """Release resources. symm_mem tensors freed by Python GC."""
+        barrier_group = self.group if self.group is not None else None
+        dist.barrier(group=barrier_group)
+        self.symm_reduce_scatter_buffer = None
+        self.symm_mem_hdl = None
+        self.buf_tuple = None
+        self.signal_pad_tuple = None
+        self.buf_ptrs = None
+        self.signal_pad_ptrs = None
+
+
+def create_moe_rs_symm_mem_context(
+    rank: int,
+    world_size: int,
+    local_world_size: int,
+    max_token_num: int,
+    hidden_dim: int,
+    num_experts: int,
+    topk: int,
+    input_dtype: torch.dtype,
+    n_chunks_max: int = 8,
+    group: Optional[object] = None,
+) -> MoEReduceRSSymmMemContext:
+    """Create MoEReduceRSSymmMemContext (symm_mem replacement for NVSHMEM version).
+
+    group: process group for symm_mem rendezvous (defaults to WORLD;
+        set to TP group when pipeline parallelism is used).
+    """
+    device = torch.cuda.current_device()
+    grid_barrier = torch.zeros((1,), dtype=torch.int32, device=device)
+    gemm_counter = torch.zeros((n_chunks_max,), dtype=torch.int32, device=device)
+    gemm_done_flag = torch.zeros((n_chunks_max,), dtype=torch.int32, device=device)
+    rs_counter = torch.zeros(
+        (n_chunks_max * world_size,), dtype=torch.int32, device=device)
+
+    return MoEReduceRSSymmMemContext(
+        max_M=max_token_num,
+        N=hidden_dim,
+        num_experts=num_experts,
+        topk=topk,
+        dtype=input_dtype,
+        rank=rank,
+        num_ranks=world_size,
+        num_local_ranks=local_world_size,
+        n_chunks_max=n_chunks_max,
+        grid_barrier=grid_barrier,
+        gemm_counter=gemm_counter,
+        gemm_done_flag=gemm_done_flag,
+        rs_counter=rs_counter,
+        group=group,
+    )
+
+
+@triton.jit
+def moe_reduce_rs_symm_mem_kernel(
+    # input
+    x_ptr,                          # [M * topk, N]
+    shared_expert_out_ptr,          # [M, N]
+    routed_scaling_factor,          # scalar float
+    # symmetric buffer pointer array
+    buf_ptrs,                       # int64[world_size]
+    # sync
+    signal_pad_ptrs,                # int64[world_size]
+    grid_barrier_ptr,               # int32[1]
+    # problem sizes
+    M, N, topk,
+    N_CHUNKS: tl.constexpr,
+    # strides
+    stride_xm: tl.constexpr,
+    stride_xn: tl.constexpr,
+    stride_bm: tl.constexpr,
+    stride_bn: tl.constexpr,
+    stride_se_m: tl.constexpr,
+    stride_se_n: tl.constexpr,
+    # distributed
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+    # tile sizes
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    TOPK: tl.constexpr,
+    DTYPE: tl.constexpr,
+):
+    """Fused topk-reduce + add shared_expert_out + A2A push into symm buffers.
+
+    Equivalent to: reduce_scatter(routed_scaling_factor * sum_topk(x) + shared_expert_out)
+    Phase 1 pushes reduced tiles into peer symm buffers; after grid+cross-rank
+    barriers, the host sums contributions for the final reduce-scatter output.
+    """
+    pid = tl.program_id(axis=0)
+    npid = tl.num_programs(axis=0)
+
+    M_per_rank = M // world_size
+    N_per_chunk = N // N_CHUNKS
+    N_per_chunk = tl.multiple_of(N_per_chunk, 16)
+
+    n_blocks_m = tl.cdiv(M_per_rank, BLOCK_SIZE_M)
+    n_blocks_n = tl.cdiv(N_per_chunk, BLOCK_SIZE_N)
+    blocks_per_rank = n_blocks_m * n_blocks_n
+
+    dst_segment_offset = M_per_rank.to(tl.int64) * stride_bm * rank
+
+    # Phase 1: topk-reduce + add shared_expert + A2A push
+    for n_chunk in tl.range(0, N_CHUNKS, step=1, loop_unroll_factor=1):
+        offs_n_chunk = n_chunk * N_per_chunk * stride_xn
+
+        total_tiles = world_size * blocks_per_rank
+
+        for tile_id in range(pid, total_tiles, npid):
+            peer = tile_id // blocks_per_rank
+            bid = tile_id % blocks_per_rank
+
+            bid_m = bid // n_blocks_n
+            bid_n = bid % n_blocks_n
+
+            offs_m = bid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            offs_n = bid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            mask_m = offs_m < M_per_rank
+            mask_n = offs_n < N_per_chunk
+            mask = mask_m[:, None] & mask_n[None, :]
+
+            # topk reduce (fp32 accumulator for precision)
+            offs_in = offs_m[:, None].to(tl.int64) * stride_xm * TOPK + offs_n[None, :].to(tl.int64) * stride_xn
+            src_segment_offset = peer.to(tl.int64) * M_per_rank * TOPK * stride_xm
+            input_ptrs = x_ptr + offs_n_chunk + src_segment_offset + offs_in
+
+            reduced = tl.load(input_ptrs, mask=mask, other=0.0).to(tl.float32)
+            for j in tl.static_range(1, TOPK):
+                reduced += tl.load(input_ptrs + j * stride_xm, mask=mask, other=0.0).to(tl.float32)
+            reduced = reduced * routed_scaling_factor
+
+            # add shared expert output
+            se_segment_offset = peer.to(tl.int64) * M_per_rank * stride_se_m
+            se_ptrs = (shared_expert_out_ptr
+                       + offs_n_chunk
+                       + se_segment_offset
+                       + offs_m[:, None].to(tl.int64) * stride_se_m
+                       + offs_n[None, :].to(tl.int64) * stride_se_n)
+            shared_expert_val = tl.load(se_ptrs, mask=mask, other=0.0).to(tl.float32)
+            reduced = reduced + shared_expert_val
+
+            # A2A push into peer's symm buffer
+            peer_buf_ptr = tl.load(buf_ptrs + peer).to(tl.pointer_type(DTYPE))
+            peer_buf_ptr = tl.multiple_of(peer_buf_ptr, 16)
+            dst_ptrs = (peer_buf_ptr
+                        + offs_n_chunk
+                        + dst_segment_offset
+                        + offs_m[:, None].to(tl.int64) * stride_bm
+                        + offs_n[None, :].to(tl.int64) * stride_bn)
+            tl.store(dst_ptrs, reduced, mask=mask)
+
+    # Grid barrier (all local CTAs done writing)
+    barrier_on_this_grid(grid_barrier_ptr)
+
+    # Cross-rank barrier (CAS-based intra-node sync)
+    if pid == 0:
+        barrier_all_intra_node_atomic_cas_block(
+            rank,
+            rank,
+            world_size,
+            signal_pad_ptrs,
+        )
+
+
+@triton.jit
+def moe_reduce_rs_without_se_symm_mem_kernel(
+    # input
+    x_ptr,                          # [M * topk, N]
+    routed_scaling_factor,          # scalar float
+    # symmetric buffer pointer array
+    buf_ptrs,                       # int64[world_size]
+    # sync
+    signal_pad_ptrs,                # int64[world_size]
+    grid_barrier_ptr,               # int32[1]
+    # problem sizes
+    M, N, topk,
+    N_CHUNKS: tl.constexpr,
+    # strides
+    stride_xm: tl.constexpr,
+    stride_xn: tl.constexpr,
+    stride_bm: tl.constexpr,
+    stride_bn: tl.constexpr,
+    # distributed
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+    # tile sizes
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    TOPK: tl.constexpr,
+    DTYPE: tl.constexpr,
+):
+    """Fused topk-reduce + add shared_expert_out + A2A push into symm buffers.
+
+    Equivalent to: reduce_scatter(routed_scaling_factor * sum_topk(x) + shared_expert_out)
+    Phase 1 pushes reduced tiles into peer symm buffers; after grid+cross-rank
+    barriers, the host sums contributions for the final reduce-scatter output.
+    """
+    pid = tl.program_id(axis=0)
+    npid = tl.num_programs(axis=0)
+
+    M_per_rank = M // world_size
+    N_per_chunk = N // N_CHUNKS
+    N_per_chunk = tl.multiple_of(N_per_chunk, 16)
+
+    n_blocks_m = tl.cdiv(M_per_rank, BLOCK_SIZE_M)
+    n_blocks_n = tl.cdiv(N_per_chunk, BLOCK_SIZE_N)
+    blocks_per_rank = n_blocks_m * n_blocks_n
+
+    dst_segment_offset = M_per_rank.to(tl.int64) * stride_bm * rank
+
+    # Phase 1: topk-reduce + add shared_expert + A2A push
+    for n_chunk in tl.range(0, N_CHUNKS, step=1, loop_unroll_factor=1):
+        offs_n_chunk = n_chunk * N_per_chunk * stride_xn
+
+        total_tiles = world_size * blocks_per_rank
+
+        for tile_id in range(pid, total_tiles, npid):
+            peer = tile_id // blocks_per_rank
+            bid = tile_id % blocks_per_rank
+
+            bid_m = bid // n_blocks_n
+            bid_n = bid % n_blocks_n
+
+            offs_m = bid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            offs_n = bid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            mask_m = offs_m < M_per_rank
+            mask_n = offs_n < N_per_chunk
+            mask = mask_m[:, None] & mask_n[None, :]
+
+            # topk reduce (fp32 accumulator for precision)
+            offs_in = offs_m[:, None].to(tl.int64) * stride_xm * TOPK + offs_n[None, :].to(tl.int64) * stride_xn
+            src_segment_offset = peer.to(tl.int64) * M_per_rank * TOPK * stride_xm
+            input_ptrs = x_ptr + offs_n_chunk + src_segment_offset + offs_in
+
+            reduced = tl.load(input_ptrs, mask=mask, other=0.0).to(tl.float32)
+            for j in tl.static_range(1, TOPK):
+                reduced += tl.load(input_ptrs + j * stride_xm, mask=mask, other=0.0).to(tl.float32)
+            reduced = reduced * routed_scaling_factor
+
+            # A2A push into peer's symm buffer
+            peer_buf_ptr = tl.load(buf_ptrs + peer).to(tl.pointer_type(DTYPE))
+            peer_buf_ptr = tl.multiple_of(peer_buf_ptr, 16)
+            dst_ptrs = (peer_buf_ptr
+                        + offs_n_chunk
+                        + dst_segment_offset
+                        + offs_m[:, None].to(tl.int64) * stride_bm
+                        + offs_n[None, :].to(tl.int64) * stride_bn)
+            tl.store(dst_ptrs, reduced, mask=mask)
+
+    # Grid barrier (all local CTAs done writing)
+    barrier_on_this_grid(grid_barrier_ptr)
+
+    # Cross-rank barrier (CAS-based intra-node sync)
+    if pid == 0:
+        barrier_all_intra_node_atomic_cas_block(
+            rank,
+            rank,
+            world_size,
+            signal_pad_ptrs,
+        )
+
+
+def moe_reduce_rs_symm_mem(
+    grouped_gemm_out: torch.Tensor,
+    shared_expert_out: torch.Tensor,
+    ctx: MoEReduceRSSymmMemContext,
+    ntokens: int,
+    n_chunks: int,
+    out: torch.Tensor,
+    routed_scaling_factor: float,
+    BLOCK_SIZE_M: int = 64,
+    BLOCK_SIZE_N: int = 128,
+) -> torch.Tensor:
+    """Fused reduce-topk + add shared expert + reduce-scatter via symm_mem.
+
+    output = reduce_scatter(routed_scaling_factor * sum_topk(grouped_gemm_out)
+                            + shared_expert_out)
+    """
+
+    N = ctx.N
+    topk = ctx.topk
+    world_size = ctx.num_ranks
+    rank = ctx.rank
+
+    my_buf = ctx.buf_tuple[rank]
+    buf_ptrs = ctx.buf_ptrs
+
+    ctx.grid_barrier.zero_()
+
+    if shared_expert_out is not None:
+        moe_reduce_rs_symm_mem_kernel[(ctx.num_sms,)](
+            grouped_gemm_out,
+            shared_expert_out,
+            routed_scaling_factor,
+            buf_ptrs,
+            ctx.signal_pad_ptrs,
+            ctx.grid_barrier,
+            M=ntokens,
+            N=N,
+            topk=topk,
+            N_CHUNKS=n_chunks,
+            stride_xm=N,
+            stride_xn=1,
+            stride_bm=my_buf.stride(0),
+            stride_bn=my_buf.stride(1),
+            stride_se_m=shared_expert_out.stride(0),
+            stride_se_n=shared_expert_out.stride(1),
+            rank=rank,
+            world_size=world_size,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            TOPK=topk,
+            DTYPE=tl.bfloat16 if grouped_gemm_out.dtype == torch.bfloat16 else tl.float16,
+            num_warps=32,
+            num_stages=1,
+        )
+    else:
+        moe_reduce_rs_without_se_symm_mem_kernel[(ctx.num_sms,)](
+            grouped_gemm_out,
+            routed_scaling_factor,
+            buf_ptrs,
+            ctx.signal_pad_ptrs,
+            ctx.grid_barrier,
+            M=ntokens,
+            N=N,
+            topk=topk,
+            N_CHUNKS=n_chunks,
+            stride_xm=N,
+            stride_xn=1,
+            stride_bm=my_buf.stride(0),
+            stride_bn=my_buf.stride(1),
+            rank=rank,
+            world_size=world_size,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            TOPK=topk,
+            DTYPE=tl.bfloat16 if grouped_gemm_out.dtype == torch.bfloat16 else tl.float16,
+            num_warps=32,
+            num_stages=1,
+        )
+
+    # Phase 2: local reduce — sum world_size contributions
+    ntokens_per_rank = ntokens // world_size
+    torch.sum(
+        ctx.symm_reduce_scatter_buffer[:ntokens].view(world_size, ntokens_per_rank, N),
+        dim=0,
+        out=out,
+    )
+    return out
+
+
+def maybe_fused_shared_add_rs(
+    final_hidden_states: torch.Tensor,
+    shared_output: Optional[torch.Tensor],
+    tp_size: int,
+    n_shared_experts: int,
+    top_k: int,
+    routed_scaling_factor: float,
+) -> Optional[torch.Tensor]:
+    """Fused add-shared + reduce-scatter. Returns None to fall back.
+
+    Standalone wrapper around moe_reduce_rs_symm_mem that handles
+    communicator lookup, context creation, and output allocation.
+    """
+    from sglang.srt.distributed.device_communicators.torch_symm_mem import (
+        TorchSymmMemCommunicator,
+    )
+
+    comm = TorchSymmMemCommunicator.get_active_comm()
+    if comm is None:
+        return None
+
+    '''if shared_output is None:
+        return None'''
+    M, _, N = final_hidden_states.shape
+    if M == 0 or (M % tp_size) != 0:
+        return None
+
+    ctx = comm.get_or_create_moe_rs_ctx(
+        N=N,
+        num_experts=n_shared_experts,
+        topk=top_k,
+        dtype=final_hidden_states.dtype,
+    )
+    if ctx is None:
+        return None
+
+    out = torch.empty(
+        (M // tp_size, N),
+        dtype=final_hidden_states.dtype,
+        device=final_hidden_states.device,
+    )
+    try:
+        moe_reduce_rs_symm_mem(
+            grouped_gemm_out=final_hidden_states.view(M * top_k, N),
+            shared_expert_out=shared_output,
+            ctx=ctx,
+            ntokens=M,
+            n_chunks=N // 512,
+            out=out,
+            routed_scaling_factor=routed_scaling_factor,
+        )
+    except Exception:
+        return None
+    return out

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/moe_reduce_rs_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_kernels/moe_reduce_rs_symm_mem.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
@@ -10,6 +11,8 @@ import torch.distributed._symmetric_memory as symm_mem
 import triton
 import triton.language as tl
 from triton.language import core
+
+logger = logging.getLogger(__name__)
 
 
 @core.extern
@@ -243,9 +246,6 @@ class MoEReduceRSSymmMemContext:
     n_chunks_max: int
     # local sync primitives
     grid_barrier: torch.Tensor   # [1] int32
-    gemm_counter: torch.Tensor   # [n_chunks_max] int32
-    gemm_done_flag: torch.Tensor # [n_chunks_max] int32
-    rs_counter: torch.Tensor     # [n_chunks_max * num_ranks] int32
     group: Optional[object] = None
 
     # Computed in __post_init__
@@ -340,10 +340,6 @@ def create_moe_rs_symm_mem_context(
     """
     device = torch.cuda.current_device()
     grid_barrier = torch.zeros((1,), dtype=torch.int32, device=device)
-    gemm_counter = torch.zeros((n_chunks_max,), dtype=torch.int32, device=device)
-    gemm_done_flag = torch.zeros((n_chunks_max,), dtype=torch.int32, device=device)
-    rs_counter = torch.zeros(
-        (n_chunks_max * world_size,), dtype=torch.int32, device=device)
 
     return MoEReduceRSSymmMemContext(
         max_M=max_token_num,
@@ -356,9 +352,6 @@ def create_moe_rs_symm_mem_context(
         num_local_ranks=local_world_size,
         n_chunks_max=n_chunks_max,
         grid_barrier=grid_barrier,
-        gemm_counter=gemm_counter,
-        gemm_done_flag=gemm_done_flag,
-        rs_counter=rs_counter,
         group=group,
     )
 
@@ -661,6 +654,308 @@ def moe_reduce_rs_symm_mem(
     return out
 
 
+# ---------------------------------------------------------------------------
+# MoE mul-sum + add shared output + reduce-scatter overlap kernel (for humming)
+# ---------------------------------------------------------------------------
+
+@triton.jit
+def moe_mul_sum_add_rs_overlap_kernel(
+    # ---- input/output pointers ----
+    inputs_ptr,                         # [M * topk, N] flattened grouped_gemm_out
+    topk_weights_ptr,                   # [M, topk]
+    topk_ids_ptr,                       # [M, topk]
+    expert_map_ptr,                     # [num_experts] or None
+    shared_expert_out_ptr,              # [M, N] or None
+    routed_scaling_factor,              # scalar float
+    # ---- symmetric buffer pointer arrays ----
+    buf_ptrs,                           # int64[world_size]
+    # ---- sync ----
+    signal_pad_ptrs,                    # int64[world_size]
+    grid_barrier_ptr,                   # int32[1]
+    # ---- problem sizes (runtime) ----
+    M,                                  # ntokens (logical)
+    N,                                  # hidden dimension
+    topk,
+    N_CHUNKS: tl.constexpr,
+    # ---- strides (constexpr) ----
+    stride_xm: tl.constexpr,           # stride for flattened [M*topk, N] input (row stride = N)
+    stride_xn: tl.constexpr,           # column stride for input (1)
+    stride_bm: tl.constexpr,           # symm buffer row stride
+    stride_bn: tl.constexpr,           # symm buffer column stride
+    stride_se_m: tl.constexpr,         # shared_expert_out row stride
+    stride_se_n: tl.constexpr,         # shared_expert_out column stride
+    # ---- distributed (constexpr) ----
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+    # ---- tile sizes (constexpr) ----
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    TOPK: tl.constexpr,
+    DTYPE: tl.constexpr,
+    # ---- gating flags ----
+    HAS_EXPERT_MAP: tl.constexpr,
+    IS_EP: tl.constexpr,
+    HAS_SHARED_EXPERT: tl.constexpr,
+):
+    """Fused moe_fused_mul_sum + add_shared_output + A2A push for reduce-scatter.
+
+    Equivalent to:
+        output = reduce_scatter(
+            routed_scaling_factor * sum_topk(inputs, topk_weights, topk_ids)
+            + shared_expert_out
+        )
+
+    Phase 1: Each CTA computes a tile — topk weighted sum (with expert_map/is_ep
+             gating) + optional shared expert add — then pushes the result into
+             the appropriate peer's symmetric memory buffer.
+    Phase 2: Grid barrier + cross-rank barrier.
+    (Host performs the final local reduction via torch.sum.)
+    """
+    pid = tl.program_id(axis=0)
+    npid = tl.num_programs(axis=0)
+
+    M_per_rank = M // world_size
+    N_per_chunk = N // N_CHUNKS
+    N_per_chunk = tl.multiple_of(N_per_chunk, 16)
+
+    n_blocks_m = tl.cdiv(M_per_rank, BLOCK_SIZE_M)
+    n_blocks_n = tl.cdiv(N_per_chunk, BLOCK_SIZE_N)
+    blocks_per_rank = n_blocks_m * n_blocks_n
+
+    # Pre-compute destination segment offset for A2A push
+    dst_segment_offset = M_per_rank.to(tl.int64) * stride_bm * rank
+
+    # === Phase 1: topk weighted sum + optional shared expert add + A2A push ===
+    for n_chunk in tl.range(0, N_CHUNKS, step=1, loop_unroll_factor=1):
+        offs_n_chunk = n_chunk * N_per_chunk * stride_xn
+
+        total_tiles = world_size * blocks_per_rank
+
+        for tile_id in range(pid, total_tiles, npid):
+            peer = tile_id // blocks_per_rank
+            bid = tile_id % blocks_per_rank
+
+            bid_m = bid // n_blocks_n
+            bid_n = bid % n_blocks_n
+
+            offs_m = bid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            offs_n = bid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+            mask_m = offs_m < M_per_rank
+            mask_n = offs_n < N_per_chunk
+            mask = mask_m[:, None] & mask_n[None, :]
+
+            # --- topk weighted sum (adapted from moe_fused_mul_sum_kernel) ---
+            # Input layout: [M * topk, N] where stride_xm = N (row-major)
+            # For token `offs_m` and topk index `n`:
+            #   row offset in flattened input = offs_m * TOPK * stride_xm + n * stride_xm
+            # Source segment for peer `p` starts at: p * M_per_rank * TOPK * stride_xm
+            src_segment_offset = peer.to(tl.int64) * M_per_rank * TOPK * stride_xm
+            base_input_offset = (offs_m[:, None].to(tl.int64) * TOPK * stride_xm
+                                 + offs_n[None, :].to(tl.int64) * stride_xn)
+            input_ptrs = inputs_ptr + offs_n_chunk + src_segment_offset + base_input_offset
+
+            # topk_ids / topk_weights: [M, topk], row-major
+            # Token index within peer's segment: peer * M_per_rank + offs_m
+            # For token t, topk slot n: index = t * TOPK + n
+            token_offset_in_peer = peer.to(tl.int64) * M_per_rank + offs_m.to(tl.int64)
+
+            # Accumulate topk weighted sum in fp32
+            acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+            for n in tl.static_range(TOPK):
+                # Load weight for this topk slot
+                w_val = tl.load(
+                    topk_weights_ptr + token_offset_in_peer * TOPK + n,
+                    mask=mask_m,
+                    other=0.0,
+                ).to(tl.float32)
+                if routed_scaling_factor != 1.0:
+                    w_val = w_val * routed_scaling_factor
+
+                # Load expert output with optional gating mask
+                if HAS_EXPERT_MAP:
+                    id_val = tl.load(
+                        topk_ids_ptr + token_offset_in_peer * TOPK + n,
+                        mask=mask_m,
+                        other=0,
+                    )
+                    expert_mask = tl.load(expert_map_ptr + id_val) >= 0
+                    a_vec = tl.load(
+                        input_ptrs + n * stride_xm,
+                        mask=mask & expert_mask[:, None],
+                        other=0.0,
+                    ).to(tl.float32)
+                elif IS_EP:
+                    id_val = tl.load(
+                        topk_ids_ptr + token_offset_in_peer * TOPK + n,
+                        mask=mask_m,
+                        other=0,
+                    )
+                    expert_mask = id_val >= 0
+                    a_vec = tl.load(
+                        input_ptrs + n * stride_xm,
+                        mask=mask & expert_mask[:, None],
+                        other=0.0,
+                    ).to(tl.float32)
+                else:
+                    a_vec = tl.load(
+                        input_ptrs + n * stride_xm,
+                        mask=mask,
+                        other=0.0,
+                    ).to(tl.float32)
+                acc += a_vec * w_val[:, None]
+
+            # --- add shared expert output (optional) ---
+            if HAS_SHARED_EXPERT:
+                se_segment_offset = peer.to(tl.int64) * M_per_rank * stride_se_m
+                se_ptrs = (shared_expert_out_ptr
+                           + offs_n_chunk
+                           + se_segment_offset
+                           + offs_m[:, None].to(tl.int64) * stride_se_m
+                           + offs_n[None, :].to(tl.int64) * stride_se_n)
+                shared_expert_val = tl.load(se_ptrs, mask=mask, other=0.0).to(tl.float32)
+                acc = acc + shared_expert_val
+
+            # --- A2A push into peer's symmetric memory buffer ---
+            peer_buf_ptr = tl.load(buf_ptrs + peer).to(tl.pointer_type(DTYPE))
+            peer_buf_ptr = tl.multiple_of(peer_buf_ptr, 16)
+            dst_ptrs = (peer_buf_ptr
+                        + offs_n_chunk
+                        + dst_segment_offset
+                        + offs_m[:, None].to(tl.int64) * stride_bm
+                        + offs_n[None, :].to(tl.int64) * stride_bn)
+            tl.store(dst_ptrs, acc.to(DTYPE), mask=mask)
+
+    # === Phase 2: Synchronize ===
+    # Grid barrier: all CTAs on this device must finish pushing
+    barrier_on_this_grid(grid_barrier_ptr)
+
+    # Cross-rank barrier: only CTA 0 participates
+    if pid == 0:
+        barrier_all_intra_node_atomic_cas_block(
+            rank,
+            rank,
+            world_size,
+            signal_pad_ptrs,
+        )
+
+
+def moe_mul_sum_add_rs_overlap(
+    grouped_gemm_out: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    shared_expert_out: Optional[torch.Tensor],
+    ctx: MoEReduceRSSymmMemContext,
+    ntokens: int,
+    n_chunks: int,
+    out: torch.Tensor,
+    routed_scaling_factor: float,
+    expert_map: Optional[torch.Tensor] = None,
+    is_ep: bool = False,
+    BLOCK_SIZE_M: int = 64,
+    BLOCK_SIZE_N: int = 128,
+) -> torch.Tensor:
+    """Fused moe_fused_mul_sum + add_shared_output + reduce-scatter via symm_mem.
+
+    output = reduce_scatter(
+        routed_scaling_factor * sum_topk(grouped_gemm_out, topk_weights, topk_ids)
+        + shared_expert_out
+    )
+
+    This kernel reuses MoEReduceRSSymmMemContext, so it shares the same
+    symmetric memory buffers and synchronization resources with the
+    non-humming reduce-scatter path.
+
+    Args:
+        grouped_gemm_out: [M, topk, N] or [M*topk, N] expert outputs.
+        topk_weights: [M, topk] gating weights.
+        topk_ids: [M, topk] expert indices.
+        shared_expert_out: [M, N] shared expert output, or None.
+        ctx: MoEReduceRSSymmMemContext with pre-allocated symmetric buffers.
+        ntokens: M (number of tokens).
+        n_chunks: number of chunks along N dimension.
+        out: pre-allocated output tensor [M // world_size, N].
+        routed_scaling_factor: scaling factor for routed experts.
+        expert_map: optional expert mapping (values < 0 mean invalid).
+        is_ep: whether expert parallelism is used.
+        BLOCK_SIZE_M: tile size in M dimension (auto if None).
+        BLOCK_SIZE_N: tile size in N dimension (auto if None).
+
+    Returns:
+        out: [M // world_size, N] reduce-scatter output.
+    """
+    N = ctx.N
+    topk = ctx.topk
+    world_size = ctx.num_ranks
+    rank = ctx.rank
+    has_expert_map = expert_map is not None
+    has_shared_expert = shared_expert_out is not None
+
+    assert ntokens % world_size == 0, \
+        f"ntokens ({ntokens}) must be divisible by world_size ({world_size})"
+    assert N % n_chunks == 0, \
+        f"N ({N}) must be divisible by n_chunks ({n_chunks})"
+    assert ntokens <= ctx.max_M, \
+        f"ntokens ({ntokens}) exceeds max_M ({ctx.max_M})"
+
+    # Flatten grouped_gemm_out to [M * topk, N] if needed
+    if grouped_gemm_out.ndim == 3:
+        M_in, topk_in, N_in = grouped_gemm_out.shape
+        assert topk_in == topk, f"topk mismatch: got {topk_in}, expected {topk}"
+        x_flat = grouped_gemm_out.reshape(M_in * topk_in, N_in)
+    else:
+        x_flat = grouped_gemm_out
+
+    my_buf = ctx.buf_tuple[rank]
+    buf_ptrs = ctx.buf_ptrs
+
+    # Reset grid barrier before launch
+    ctx.grid_barrier.zero_()
+
+    # Launch single persistent kernel (intra-SM: all SMs)
+    moe_mul_sum_add_rs_overlap_kernel[(ctx.num_sms,)](
+        x_flat,
+        topk_weights,
+        topk_ids,
+        expert_map,
+        shared_expert_out,
+        routed_scaling_factor,
+        buf_ptrs,
+        ctx.signal_pad_ptrs,
+        ctx.grid_barrier,
+        M=ntokens,
+        N=N,
+        topk=topk,
+        N_CHUNKS=n_chunks,
+        stride_xm=N,
+        stride_xn=1,
+        stride_bm=my_buf.stride(0),
+        stride_bn=my_buf.stride(1),
+        stride_se_m=shared_expert_out.stride(0) if has_shared_expert else 1,
+        stride_se_n=shared_expert_out.stride(1) if has_shared_expert else 1,
+        rank=rank,
+        world_size=world_size,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        TOPK=topk,
+        DTYPE=tl.bfloat16 if x_flat.dtype == torch.bfloat16 else tl.float16,
+        HAS_EXPERT_MAP=has_expert_map,
+        IS_EP=is_ep,
+        HAS_SHARED_EXPERT=has_shared_expert,
+        num_warps=32,
+        num_stages=1,
+    )
+
+    # Phase 2: local reduce — sum world_size contributions for reduce-scatter
+    ntokens_per_rank = ntokens // world_size
+    torch.sum(
+        ctx.symm_reduce_scatter_buffer[:ntokens].view(world_size, ntokens_per_rank, N),
+        dim=0,
+        out=out,
+    )
+    return out
+
+
 def maybe_fused_shared_add_rs(
     final_hidden_states: torch.Tensor,
     shared_output: Optional[torch.Tensor],
@@ -668,11 +963,18 @@ def maybe_fused_shared_add_rs(
     n_shared_experts: int,
     top_k: int,
     routed_scaling_factor: float,
+    is_humming: bool = False,
+    topk_weights: Optional[torch.Tensor] = None,
+    topk_ids: Optional[torch.Tensor] = None,
+    expert_map: Optional[torch.Tensor] = None,
+    is_ep: bool = False,
 ) -> Optional[torch.Tensor]:
     """Fused add-shared + reduce-scatter. Returns None to fall back.
 
-    Standalone wrapper around moe_reduce_rs_symm_mem that handles
-    communicator lookup, context creation, and output allocation.
+    Standalone wrapper that handles communicator lookup, context creation,
+    and output allocation. When is_humming=True, uses the mul-sum overlap
+    kernel that performs per-token topk weighted sum with topk_weights/topk_ids.
+    Otherwise, uses the simple reduce-topk kernel.
     """
     from sglang.srt.distributed.device_communicators.torch_symm_mem import (
         TorchSymmMemCommunicator,
@@ -701,15 +1003,40 @@ def maybe_fused_shared_add_rs(
         device=final_hidden_states.device,
     )
     try:
-        moe_reduce_rs_symm_mem(
-            grouped_gemm_out=final_hidden_states.view(M * top_k, N),
-            shared_expert_out=shared_output,
-            ctx=ctx,
-            ntokens=M,
-            n_chunks=N // 512,
-            out=out,
-            routed_scaling_factor=routed_scaling_factor,
+        if is_humming:
+            # humming path: per-token topk weighted sum
+            assert topk_weights is not None, \
+                "topk_weights is required when is_humming=True"
+            assert topk_ids is not None, \
+                "topk_ids is required when is_humming=True"
+            moe_mul_sum_add_rs_overlap(
+                grouped_gemm_out=final_hidden_states.view(M * top_k, N)
+                    if final_hidden_states.ndim == 2
+                    else final_hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                shared_expert_out=shared_output,
+                ctx=ctx,
+                ntokens=M,
+                n_chunks=N // 512,
+                out=out,
+                routed_scaling_factor=routed_scaling_factor,
+                expert_map=expert_map,
+                is_ep=is_ep,
+            )
+        else:
+            moe_reduce_rs_symm_mem(
+                grouped_gemm_out=final_hidden_states.view(M * top_k, N),
+                shared_expert_out=shared_output,
+                ctx=ctx,
+                ntokens=M,
+                n_chunks=N // 512,
+                out=out,
+                routed_scaling_factor=routed_scaling_factor,
+            )
+    except Exception as e:
+        logger.warning(
+            "maybe_fused_shared_add_rs failed, falling back to default path: %s", e
         )
-    except Exception:
         return None
     return out

--- a/python/sglang/srt/distributed/device_communicators/torch_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/torch_symm_mem.py
@@ -11,6 +11,7 @@ from torch.distributed import ProcessGroup
 from sglang.srt.distributed.device_communicators.all_reduce_utils import (
     TORCH_SYMM_MEM_ALL_REDUCE_MAX_SIZES,
 )
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_cuda, is_hip
 
 try:
@@ -58,9 +59,20 @@ class TorchSymmMemCommunicator:
             device: Target CUDA device (index, 'cuda:X', or torch.device).
         """
 
+        # disabled: entire communicator unusable.
+        # allreduce_disabled: only the allreduce fast path is off; buffers
+        # may still serve fused-kernel contexts (RS/AG).
         self.disabled = True
         self.buffer = None
         self.max_size = 0
+        self.allreduce_disabled = True
+        self.use_cp = False  # set True during CP-mode forward
+        # Lazy fused-kernel contexts (cached on first use).
+        self._moe_rs_ctx = None
+        self._moe_rs_key = None
+        self._ag_gemm_ctx = None
+        self._ag_gemm_key = None
+        self._ag_gemm_stream: Optional[torch.cuda.Stream] = None
 
         if not torch_symm_mem_available:
             return
@@ -99,15 +111,32 @@ class TorchSymmMemCommunicator:
             dtype=self.dtype,
         )
         handle = torch_symm_mem.rendezvous(self.buffer, self.group.group_name)
+        # Enable communicator; allreduce gated separately by multicast.
+        self.disabled = False
         if handle.multicast_ptr == 0:
             logger.warning(
                 "TorchSymmMemCommunicator: torch symmetric memory "
-                "multicast operations are not supported."
+                "multicast operations are not supported; symm-mem all-reduce "
+                "fast path disabled (fused-kernel contexts may still work)."
             )
-            self.buffer = None
-            self.disabled = True
+            self.allreduce_disabled = True
             return
-        self.disabled = False
+        self.allreduce_disabled = False
+
+    def set_use_cp(self, value: bool) -> None:
+        """Set the CP mode flag for fused kernels."""
+        self.use_cp = value
+
+    @staticmethod
+    def get_active_comm() -> "Optional[TorchSymmMemCommunicator]":
+        """Return the TP group's communicator if enabled and use_cp is active, else None."""
+        from sglang.srt.distributed import get_tp_group
+
+        # TODO(zxdu): maybe use cp group here?
+        comm = get_tp_group().torch_symm_mem_comm
+        if comm is None or comm.disabled or not comm.use_cp:
+            return None
+        return comm
 
     def should_torch_symm_mem_allreduce(self, inp: torch.Tensor):
         """
@@ -122,7 +151,7 @@ class TorchSymmMemCommunicator:
         Returns:
             True if the symmetric-memory path can handle this tensor.
         """
-        if self.disabled:
+        if self.disabled or self.allreduce_disabled:
             return False
         if inp.device != self.device:
             return False
@@ -169,3 +198,108 @@ class TorchSymmMemCommunicator:
             )
         out.copy_(self.buffer[: inp.numel()].view(out.shape))
         return out
+
+    def _get_max_forward_tokens(self) -> int:
+        """Return max tokens per forward (chunked_prefill_size or max_prefill_tokens)."""
+        server_args = get_global_server_args()
+        cps = server_args.chunked_prefill_size
+        if cps is not None and cps > 0:
+            return cps
+        return server_args.max_prefill_tokens
+
+    def get_or_create_moe_rs_ctx(
+        self,
+        N: int,
+        num_experts: int,
+        topk: int,
+        dtype: torch.dtype,
+        n_chunks_max: int = 8,
+    ):
+        """Lazy-init / cache the MoE reduce-scatter symm-mem context."""
+        if self.disabled:
+            return None
+        key = (N, num_experts, topk, dtype, n_chunks_max, self.world_size)
+        if self._moe_rs_key == key and self._moe_rs_ctx is not None:
+            return self._moe_rs_ctx
+        if self._moe_rs_ctx is not None:
+            try:
+                self._moe_rs_ctx.finalize()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "TorchSymmMemCommunicator: failed to finalize stale MoE RS "
+                    "context: %s",
+                    e,
+                )
+            self._moe_rs_ctx = None
+            self._moe_rs_key = None
+
+        from sglang.srt.distributed.device_communicators.symm_mem_kernels import (
+            create_moe_rs_symm_mem_context,
+        )
+
+        max_M = self._get_max_forward_tokens()
+
+        self._moe_rs_ctx = create_moe_rs_symm_mem_context(
+            # TODO(zxdu): check whether we should use cp group here or not?
+            rank=dist.get_rank(self.group),
+            world_size=self.world_size,
+            local_world_size=self.world_size,
+            max_token_num=max_M,
+            hidden_dim=N,
+            num_experts=num_experts,
+            topk=topk,
+            input_dtype=dtype,
+            n_chunks_max=n_chunks_max,
+            group=self.group,
+        )
+        self._moe_rs_key = key
+        return self._moe_rs_ctx
+
+    def get_or_create_ag_gemm_ctx(
+        self,
+        K: int,
+        NUM_COMM_SMS: int = 0,
+    ):
+        """Lazy-init / cache the all-gather + GEMM symm-mem context."""
+        if self.disabled:
+            return None
+        key = (K, NUM_COMM_SMS, self.world_size)
+        if self._ag_gemm_key == key and self._ag_gemm_ctx is not None:
+            return self._ag_gemm_ctx
+        if self._ag_gemm_ctx is not None:
+            try:
+                self._ag_gemm_ctx.finalize()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "TorchSymmMemCommunicator: failed to finalize stale AG+GEMM "
+                    "context: %s",
+                    e,
+                )
+            self._ag_gemm_ctx = None
+            self._ag_gemm_key = None
+
+        from sglang.srt.distributed.device_communicators.symm_mem_kernels import (
+            create_allgather_gemm_context_symm_mem,
+        )
+
+        if self._ag_gemm_stream is None:
+            self._ag_gemm_stream = torch.cuda.Stream(
+                device=self.device, priority=-1
+            )
+
+        max_M = self._get_max_forward_tokens()
+
+        self._ag_gemm_ctx = create_allgather_gemm_context_symm_mem(
+            ag_stream=self._ag_gemm_stream,
+            rank=dist.get_rank(self.group),
+            world_size=self.world_size,
+            max_M=max_M // self.world_size,
+            K=K,
+            NUM_COMM_SMS=NUM_COMM_SMS,
+            enable_multicast=False,
+            group=self.group,
+        )
+        self._ag_gemm_key = key
+        return self._ag_gemm_ctx
+
+

--- a/python/sglang/srt/distributed/device_communicators/torch_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/torch_symm_mem.py
@@ -13,6 +13,7 @@ from sglang.srt.distributed.device_communicators.all_reduce_utils import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_exec
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_cuda, is_hip
 
 try:
@@ -60,9 +61,20 @@ class TorchSymmMemCommunicator:
             device: Target CUDA device (index, 'cuda:X', or torch.device).
         """
 
+        # disabled: entire communicator unusable.
+        # allreduce_disabled: only the allreduce fast path is off; buffers
+        # may still serve fused-kernel contexts (RS/AG).
         self.disabled = True
         self.buffer = None
         self.max_size = 0
+        self.allreduce_disabled = True
+        self.use_cp = False  # set True during CP-mode forward
+        # Lazy fused-kernel contexts (cached on first use).
+        self._moe_rs_ctx = None
+        self._moe_rs_key = None
+        self._ag_gemm_ctx = None
+        self._ag_gemm_key = None
+        self._ag_gemm_stream: Optional[torch.cuda.Stream] = None
 
         if not torch_symm_mem_available:
             return
@@ -113,15 +125,32 @@ class TorchSymmMemCommunicator:
             dtype=self.dtype,
         )
         handle = torch_symm_mem.rendezvous(self.buffer, self.group.group_name)
+        # Enable communicator; allreduce gated separately by multicast.
+        self.disabled = False
         if handle.multicast_ptr == 0:
             logger.warning(
                 "TorchSymmMemCommunicator: torch symmetric memory "
-                "multicast operations are not supported."
+                "multicast operations are not supported; symm-mem all-reduce "
+                "fast path disabled (fused-kernel contexts may still work)."
             )
-            self.buffer = None
-            self.disabled = True
+            self.allreduce_disabled = True
             return
-        self.disabled = False
+        self.allreduce_disabled = False
+
+    def set_use_cp(self, value: bool) -> None:
+        """Set the CP mode flag for fused kernels."""
+        self.use_cp = value
+
+    @staticmethod
+    def get_active_comm() -> "Optional[TorchSymmMemCommunicator]":
+        """Return the TP group's communicator if enabled and use_cp is active, else None."""
+        from sglang.srt.distributed import get_tp_group
+
+        # TODO(zxdu): maybe use cp group here?
+        comm = get_tp_group().torch_symm_mem_comm
+        if comm is None or comm.disabled or not comm.use_cp:
+            return None
+        return comm
 
     def should_torch_symm_mem_allreduce(self, inp: torch.Tensor):
         """
@@ -136,7 +165,7 @@ class TorchSymmMemCommunicator:
         Returns:
             True if the symmetric-memory path can handle this tensor.
         """
-        if self.disabled:
+        if self.disabled or self.allreduce_disabled:
             return False
         if inp.device != self.device:
             return False
@@ -183,3 +212,108 @@ class TorchSymmMemCommunicator:
             )
         out.copy_(self.buffer[: inp.numel()].view(out.shape))
         return out
+
+    def _get_max_forward_tokens(self) -> int:
+        """Return max tokens per forward (chunked_prefill_size or max_prefill_tokens)."""
+        server_args = get_global_server_args()
+        cps = server_args.chunked_prefill_size
+        if cps is not None and cps > 0:
+            return cps
+        return server_args.max_prefill_tokens
+
+    def get_or_create_moe_rs_ctx(
+        self,
+        N: int,
+        num_experts: int,
+        topk: int,
+        dtype: torch.dtype,
+        n_chunks_max: int = 8,
+    ):
+        """Lazy-init / cache the MoE reduce-scatter symm-mem context."""
+        if self.disabled:
+            return None
+        key = (N, num_experts, topk, dtype, n_chunks_max, self.world_size)
+        if self._moe_rs_key == key and self._moe_rs_ctx is not None:
+            return self._moe_rs_ctx
+        if self._moe_rs_ctx is not None:
+            try:
+                self._moe_rs_ctx.finalize()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "TorchSymmMemCommunicator: failed to finalize stale MoE RS "
+                    "context: %s",
+                    e,
+                )
+            self._moe_rs_ctx = None
+            self._moe_rs_key = None
+
+        from sglang.srt.distributed.device_communicators.symm_mem_kernels import (
+            create_moe_rs_symm_mem_context,
+        )
+
+        max_M = self._get_max_forward_tokens()
+
+        self._moe_rs_ctx = create_moe_rs_symm_mem_context(
+            # TODO(zxdu): check whether we should use cp group here or not?
+            rank=dist.get_rank(self.group),
+            world_size=self.world_size,
+            local_world_size=self.world_size,
+            max_token_num=max_M,
+            hidden_dim=N,
+            num_experts=num_experts,
+            topk=topk,
+            input_dtype=dtype,
+            n_chunks_max=n_chunks_max,
+            group=self.group,
+        )
+        self._moe_rs_key = key
+        return self._moe_rs_ctx
+
+    def get_or_create_ag_gemm_ctx(
+        self,
+        K: int,
+        NUM_COMM_SMS: int = 0,
+    ):
+        """Lazy-init / cache the all-gather + GEMM symm-mem context."""
+        if self.disabled:
+            return None
+        key = (K, NUM_COMM_SMS, self.world_size)
+        if self._ag_gemm_key == key and self._ag_gemm_ctx is not None:
+            return self._ag_gemm_ctx
+        if self._ag_gemm_ctx is not None:
+            try:
+                self._ag_gemm_ctx.finalize()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "TorchSymmMemCommunicator: failed to finalize stale AG+GEMM "
+                    "context: %s",
+                    e,
+                )
+            self._ag_gemm_ctx = None
+            self._ag_gemm_key = None
+
+        from sglang.srt.distributed.device_communicators.symm_mem_kernels import (
+            create_allgather_gemm_context_symm_mem,
+        )
+
+        if self._ag_gemm_stream is None:
+            self._ag_gemm_stream = torch.cuda.Stream(
+                device=self.device, priority=-1
+            )
+
+        max_M = self._get_max_forward_tokens()
+
+        self._ag_gemm_ctx = create_allgather_gemm_context_symm_mem(
+            ag_stream=self._ag_gemm_stream,
+            rank=dist.get_rank(self.group),
+            world_size=self.world_size,
+            max_M=max_M // self.world_size,
+            K=K,
+            NUM_COMM_SMS=NUM_COMM_SMS,
+            enable_multicast=False,
+            group=self.group,
+        )
+        self._ag_gemm_key = key
+        return self._ag_gemm_ctx
+
+

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -263,6 +263,7 @@ class GroupCoordinator:
         use_pymscclpp: bool,
         use_custom_allreduce: bool,
         use_torch_symm_mem_all_reduce: bool,
+        use_torch_symm_mem_comm: bool,
         use_hpu_communicator: bool,
         use_xpu_communicator: bool,
         use_npu_communicator: bool,
@@ -347,6 +348,7 @@ class GroupCoordinator:
         self.use_pymscclpp = use_pymscclpp
         self.use_custom_allreduce = use_custom_allreduce
         self.use_torch_symm_mem_all_reduce = use_torch_symm_mem_all_reduce
+        self.use_torch_symm_mem_comm = use_torch_symm_mem_comm
         self.use_hpu_communicator = use_hpu_communicator
         self.use_xpu_communicator = use_xpu_communicator
         self.use_npu_communicator = use_npu_communicator
@@ -431,7 +433,10 @@ class GroupCoordinator:
             logger.info("[AR] All-reduce call path: NCCL (custom AR disabled)")
 
         self.torch_symm_mem_comm: Optional[TorchSymmMemCommunicator] = None
-        if self.use_torch_symm_mem_all_reduce and self.world_size > 1:
+        if (
+            self.use_torch_symm_mem_all_reduce
+            or (envs.SGLANG_OPT_USE_TORCH_SYMM_MEM_FUSED_KERNEL.get() and self.use_torch_symm_mem_comm)
+        ) and self.world_size > 1:
             self.torch_symm_mem_comm = TorchSymmMemCommunicator(
                 group=self.cpu_group,
                 device=self.device,
@@ -651,7 +656,7 @@ class GroupCoordinator:
             outplace_all_reduce_method = "pymscclpp"
         elif (
             self.torch_symm_mem_comm is not None
-            and not self.torch_symm_mem_comm.disabled
+            and not self.torch_symm_mem_comm.allreduce_disabled
             and self.torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
         ):
             outplace_all_reduce_method = "torch_symm_mem"
@@ -759,7 +764,7 @@ class GroupCoordinator:
             assert not qr_comm.disabled
             out = qr_comm.quick_all_reduce(input_)
         elif outplace_all_reduce_method == "torch_symm_mem":
-            assert not torch_symm_mem_comm.disabled
+            assert not torch_symm_mem_comm.allreduce_disabled
             out = torch_symm_mem_comm.all_reduce(input_)
         elif outplace_all_reduce_method == "pymscclpp":
             assert not pymscclpp_comm.disabled
@@ -776,8 +781,8 @@ class GroupCoordinator:
         if pynccl_comm is not None and not pynccl_comm.disabled:
             pynccl_comm.all_reduce(input_)
         elif (
-            torch_symm_mem_comm is not None
-            and not torch_symm_mem_comm.disabled
+            torch_symm_mem_comm is not None 
+            and not torch_symm_mem_comm.allreduce_disabled
             and torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
         ):
             torch_symm_mem_comm.all_reduce(input_, out=input_)
@@ -1630,6 +1635,7 @@ def init_world_group(
         use_pymscclpp=False,
         use_custom_allreduce=False,
         use_torch_symm_mem_all_reduce=False,
+        use_torch_symm_mem_comm=False,
         use_hpu_communicator=False,
         use_xpu_communicator=False,
         use_npu_communicator=False,
@@ -1648,6 +1654,7 @@ def init_model_parallel_group(
     group_name: Optional[str] = None,
     use_mscclpp_allreduce: Optional[bool] = None,
     use_torch_symm_mem_allreduce: Optional[bool] = None,
+    use_torch_symm_mem_comm: Optional[bool] = None,
     recovered_rank: bool = False,
 ) -> GroupCoordinator:
     if use_custom_allreduce is None:
@@ -1656,6 +1663,8 @@ def init_model_parallel_group(
         use_mscclpp_allreduce = _ENABLE_MSCCLPP_ALL_REDUCE
     if use_torch_symm_mem_allreduce is None:
         use_torch_symm_mem_allreduce = _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE
+    if use_torch_symm_mem_comm is None:
+        use_torch_symm_mem_comm = _ENABLE_TORCH_SYMM_MEM_COMM
     return GroupCoordinator(
         group_ranks=group_ranks,
         local_rank=local_rank,
@@ -1668,6 +1677,7 @@ def init_model_parallel_group(
         use_pymscclpp=use_mscclpp_allreduce,
         use_custom_allreduce=use_custom_allreduce,
         use_torch_symm_mem_all_reduce=use_torch_symm_mem_allreduce,
+        use_torch_symm_mem_comm=use_torch_symm_mem_comm,
         use_hpu_communicator=True,
         use_xpu_communicator=True,
         use_npu_communicator=True,
@@ -1806,6 +1816,7 @@ logger = logging.getLogger(__name__)
 _ENABLE_CUSTOM_ALL_REDUCE = True
 _ENABLE_MSCCLPP_ALL_REDUCE = False
 _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = False
+_ENABLE_TORCH_SYMM_MEM_COMM = False
 
 
 def set_custom_all_reduce(enable: bool):
@@ -2088,6 +2099,7 @@ def initialize_model_parallel(
         use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
         group_name="tp",
         recovered_rank=recovered_rank,
+        use_torch_symm_mem_comm=True,
     )
 
     if duplicate_tp_group:
@@ -2164,6 +2176,7 @@ def initialize_model_parallel(
             use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
             group_name="attn_cp",
             recovered_rank=recovered_rank,
+            use_torch_symm_mem_comm=True,
         )
 
     from sglang.srt.layers.sampler import SYNC_TOKEN_IDS_ACROSS_TP

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -284,6 +284,7 @@ class GroupCoordinator:
         use_pymscclpp: bool,
         use_custom_allreduce: bool,
         use_torch_symm_mem_all_reduce: bool,
+        use_torch_symm_mem_comm: bool,
         use_hpu_communicator: bool,
         use_xpu_communicator: bool,
         use_npu_communicator: bool,
@@ -415,6 +416,7 @@ class GroupCoordinator:
         self.use_pymscclpp = use_pymscclpp
         self.use_custom_allreduce = use_custom_allreduce
         self.use_torch_symm_mem_all_reduce = use_torch_symm_mem_all_reduce
+        self.use_torch_symm_mem_comm = use_torch_symm_mem_comm
         self.use_hpu_communicator = use_hpu_communicator
         self.use_xpu_communicator = use_xpu_communicator
         self.use_npu_communicator = use_npu_communicator
@@ -500,7 +502,10 @@ class GroupCoordinator:
             logger.info("[AR] All-reduce call path: NCCL (custom AR disabled)")
 
         self.torch_symm_mem_comm: Optional[TorchSymmMemCommunicator] = None
-        if self.use_torch_symm_mem_all_reduce and self.world_size > 1:
+        if (
+            self.use_torch_symm_mem_all_reduce
+            or (envs.SGLANG_OPT_USE_TORCH_SYMM_MEM_FUSED_KERNEL.get() and self.use_torch_symm_mem_comm)
+        ) and self.world_size > 1:
             self.torch_symm_mem_comm = TorchSymmMemCommunicator(
                 group=self.cpu_group,
                 device=self.device,
@@ -930,7 +935,7 @@ class GroupCoordinator:
             return "pymscclpp"
         if (
             self.torch_symm_mem_comm is not None
-            and not self.torch_symm_mem_comm.disabled
+            and not self.torch_symm_mem_comm.allreduce_disabled
             and self.torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
         ):
             return "torch_symm_mem"
@@ -996,7 +1001,7 @@ class GroupCoordinator:
             assert not qr_comm.disabled
             out = qr_comm.quick_all_reduce(input_)
         elif outplace_all_reduce_method == "torch_symm_mem":
-            assert not torch_symm_mem_comm.disabled
+            assert not torch_symm_mem_comm.allreduce_disabled
             out = torch_symm_mem_comm.all_reduce(input_)
         elif outplace_all_reduce_method == "pymscclpp":
             assert not pymscclpp_comm.disabled
@@ -1013,8 +1018,8 @@ class GroupCoordinator:
         if pynccl_comm is not None and not pynccl_comm.disabled:
             pynccl_comm.all_reduce(input_)
         elif (
-            torch_symm_mem_comm is not None
-            and not torch_symm_mem_comm.disabled
+            torch_symm_mem_comm is not None 
+            and not torch_symm_mem_comm.allreduce_disabled
             and torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
         ):
             torch_symm_mem_comm.all_reduce(input_, out=input_)
@@ -1870,6 +1875,7 @@ def init_world_group(
         use_pymscclpp=False,
         use_custom_allreduce=False,
         use_torch_symm_mem_all_reduce=False,
+        use_torch_symm_mem_comm=False,
         use_hpu_communicator=False,
         use_xpu_communicator=False,
         use_npu_communicator=False,
@@ -1888,6 +1894,7 @@ def init_model_parallel_group(
     group_name: Optional[str] = None,
     use_mscclpp_allreduce: Optional[bool] = None,
     use_torch_symm_mem_allreduce: Optional[bool] = None,
+    use_torch_symm_mem_comm: Optional[bool] = None,
     recovered_rank: bool = False,
     rank_offset: int = 0,
     max_world_size: Optional[int] = None,
@@ -1898,6 +1905,8 @@ def init_model_parallel_group(
         use_mscclpp_allreduce = _ENABLE_MSCCLPP_ALL_REDUCE
     if use_torch_symm_mem_allreduce is None:
         use_torch_symm_mem_allreduce = _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE
+    if use_torch_symm_mem_comm is None:
+        use_torch_symm_mem_comm = _ENABLE_TORCH_SYMM_MEM_COMM
     return GroupCoordinator(
         group_ranks=group_ranks,
         local_rank=local_rank,
@@ -1910,6 +1919,7 @@ def init_model_parallel_group(
         use_pymscclpp=use_mscclpp_allreduce,
         use_custom_allreduce=use_custom_allreduce,
         use_torch_symm_mem_all_reduce=use_torch_symm_mem_allreduce,
+        use_torch_symm_mem_comm=use_torch_symm_mem_comm,
         use_hpu_communicator=True,
         use_xpu_communicator=True,
         use_npu_communicator=True,
@@ -2101,6 +2111,7 @@ _ENABLE_CUSTOM_ALL_REDUCE = True
 _ENABLE_MSCCLPP_ALL_REDUCE = False
 _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = False
 _ENABLE_FLASHINFER_ALLREDUCE_ONLY = False
+_ENABLE_TORCH_SYMM_MEM_COMM = False
 
 
 def set_custom_all_reduce(enable: bool):
@@ -2452,6 +2463,7 @@ def initialize_model_parallel(
         recovered_rank=recovered_rank,
         rank_offset=rank_offset,
         max_world_size=max_world_size,
+        use_torch_symm_mem_comm=True,
     )
 
     if duplicate_tp_group:
@@ -2532,6 +2544,7 @@ def initialize_model_parallel(
             recovered_rank=recovered_rank,
             rank_offset=rank_offset,
             max_world_size=max_world_size,
+            use_torch_symm_mem_comm=True,
         )
 
     if duplicate_attn_cp_group and is_hip():

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -899,6 +899,8 @@ class Envs:
     SGLANG_OPT_USE_JIT_EP_ACTIVATION = EnvBool(True)
     SGLANG_OPT_FUSE_WQA_WKV = EnvBool(True)
     SGLANG_OPT_SWIGLU_CLAMP_FUSION = EnvBool(True)
+    # Fused AG-GEMM and MoE reduce-scatter via torch symmetric memory.
+    SGLANG_OPT_USE_TORCH_SYMM_MEM_FUSED_KERNEL = EnvBool(False)
 
     # Cache / overlap
     SGLANG_OPT_USE_FUSED_STORE_CACHE = EnvBool(True)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1204,6 +1204,8 @@ class Envs:
     SGLANG_MEMORY_SAVER_CUDA_GRAPH = EnvBool(False)
     # Reuse wholly-free graph-pool segments for step-local eager allocations.
     SGLANG_ENABLE_GRAPH_POOL_BORROW = EnvBool(False)
+    
+    SGLANG_OPT_USE_TORCH_SYMM_MEM_FUSED_KERNEL = EnvBool(False)
     # Eager forward wraps the ForwardBatch's own tensors instead of copying them
     # into the CUDA graph buffer registry (no per-iter device-to-device copy).
     SGLANG_EAGER_INPUT_NO_COPY = EnvBool(False)

--- a/python/sglang/srt/layers/communicator_dsa_cp.py
+++ b/python/sglang/srt/layers/communicator_dsa_cp.py
@@ -22,6 +22,8 @@ from sglang.srt.layers.attention.dsa.utils import (
     dsa_use_prefill_cp,
     is_dsa_enable_prefill_cp,
 )
+from sglang.srt.distributed import get_tp_group
+
 from sglang.srt.layers.communicator import (
     CommunicateContext,
     CommunicateSimpleFn,
@@ -197,7 +199,9 @@ class DSACPCommunicateWithAllReduceAndLayerNormFn(
             hidden_states, residual = layernorm(hidden_states, residual)
         # for prefill: attn tp scattered -> full
         # for decode: attn tp full -> full
-        if dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch):
+        _comm = get_tp_group().torch_symm_mem_comm
+
+        if (dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch)) and (_comm is None or not _comm.use_cp):
             hidden_states = dsa_cp_gather_hidden_states(hidden_states)
         return hidden_states, residual
 
@@ -242,6 +246,7 @@ class DSACPCommunicateSummableTensorPairFn(CommunicateSummableTensorPairFn):
     ):
         # for prefill: full -> attn tp scattered
         # for decode: full -> attn tp full
-        if dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch):
+        _comm = get_tp_group().torch_symm_mem_comm
+        if (dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch)) and (_comm is None or not _comm.use_cp):
             hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
         return hidden_states, residual

--- a/python/sglang/srt/layers/communicator_dsa_cp.py
+++ b/python/sglang/srt/layers/communicator_dsa_cp.py
@@ -22,6 +22,8 @@ from sglang.srt.layers.attention.dsa.utils import (
     dsa_use_prefill_cp,
     is_dsa_enable_prefill_cp,
 )
+from sglang.srt.distributed import get_tp_group
+
 from sglang.srt.layers.communicator import (
     CommunicateContext,
     CommunicateSimpleFn,
@@ -178,7 +180,9 @@ class DSACPCommunicateWithAllReduceAndLayerNormFn(
             hidden_states, residual = layernorm(hidden_states, residual)
         # for prefill: attn tp scattered -> full
         # for decode: attn tp full -> full
-        if dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch):
+        _comm = get_tp_group().torch_symm_mem_comm
+
+        if (dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch)) and (_comm is None or not _comm.use_cp):
             hidden_states = dsa_cp_gather_hidden_states(hidden_states)
         return hidden_states, residual
 
@@ -223,6 +227,7 @@ class DSACPCommunicateSummableTensorPairFn(CommunicateSummableTensorPairFn):
     ):
         # for prefill: full -> attn tp scattered
         # for decode: full -> attn tp full
-        if dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch):
+        _comm = get_tp_group().torch_symm_mem_comm
+        if (dsa_use_prefill_cp(forward_batch) or mla_use_prefill_cp(forward_batch)) and (_comm is None or not _comm.use_cp):
             hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
         return hidden_states, residual

--- a/python/sglang/srt/layers/moe/moe_runner/humming.py
+++ b/python/sglang/srt/layers/moe/moe_runner/humming.py
@@ -522,6 +522,13 @@ class HummingRunnerCore(MoeRunnerCore):
         routed_scaling_factor = (
             self.config.routed_scaling_factor if apply_routed_scaling_factor else None
         )
+        # if enable fused topk reduce rs, skip moe_fused_mul_sum
+        from sglang.srt.distributed import get_tp_group
+        comm = get_tp_group().torch_symm_mem_comm
+        fused_topk_reduce_rs = comm is not None and comm.use_cp
+        if fused_topk_reduce_rs:
+            return buffers["down_output"].view(*topk_ids.shape, -1)
+        
         moe_fused_mul_sum(
             inputs=buffers["down_output"].view(*topk_ids.shape, -1),
             topk_weights=topk_weights,

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -149,6 +149,7 @@ def inplace_fused_experts(
         a2_scale,
         block_shape,
         False,
+        False,
         routed_scaling_factor,
         gemm1_alpha,
         gemm1_limit,
@@ -183,6 +184,7 @@ def outplace_fused_experts(
     a2_scale: Optional[torch.Tensor] = None,
     block_shape: Optional[List[int]] = None,
     no_combine: bool = False,
+    no_topk_reduce: bool = False,
     routed_scaling_factor: Optional[float] = None,
     gemm1_alpha: Optional[float] = None,
     gemm1_limit: Optional[float] = None,
@@ -215,6 +217,7 @@ def outplace_fused_experts(
         a2_scale,
         block_shape,
         no_combine=no_combine,
+        no_topk_reduce=no_topk_reduce,
         routed_scaling_factor=routed_scaling_factor,
         gemm1_alpha=gemm1_alpha,
         gemm1_limit=gemm1_limit,
@@ -250,6 +253,40 @@ def fused_experts(
         moe_runner_config.num_experts is None
         or moe_runner_config.num_experts != moe_runner_config.num_local_experts
     )
+    from sglang.srt.distributed import get_tp_group
+    comm = get_tp_group().torch_symm_mem_comm
+    fused_topk_reduce_rs = comm is not None and comm.use_cp
+    if fused_topk_reduce_rs:
+        return outplace_fused_experts(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            b1,
+            b2,
+            moe_runner_config.activation,
+            moe_runner_config.is_gated,
+            moe_runner_config.apply_router_weight_on_input,
+            use_fp8_w8a8,
+            use_int8_w8a8,
+            use_int8_w8a16,
+            use_int4_w4a16,
+            per_channel_quant,
+            w1_scale,
+            w2_scale,
+            w1_zp,
+            w2_zp,
+            a1_scale,
+            a2_scale,
+            block_shape,
+            no_topk_reduce=True,
+            routed_scaling_factor=moe_runner_config.routed_scaling_factor,
+            gemm1_alpha=moe_runner_config.gemm1_alpha,
+            gemm1_limit=moe_runner_config.gemm1_clamp_limit,
+            filter_expert=filter_expert,
+            swiglu_limit=moe_runner_config.swiglu_limit,
+        )
     if moe_runner_config.inplace:
         assert not moe_runner_config.no_combine, "no combine + inplace makes no sense"
         inplace_fused_experts(
@@ -447,6 +484,7 @@ def _fused_moe_kernel_sequence(
     activation: str,
     is_gated: bool,
     no_combine: bool,
+    no_topk_reduce: bool,
     inplace: bool,
     apply_router_weight_on_input: bool,
     routed_scaling_factor: Optional[float],
@@ -475,7 +513,7 @@ def _fused_moe_kernel_sequence(
     )
     total_tokens = num_tokens * topk + padded_tokens
 
-    if no_combine:
+    if no_combine or no_topk_reduce:
         assert not inplace
         out_hidden_states = torch.empty(
             (num_tokens, topk, w2.shape[1]),
@@ -683,9 +721,10 @@ def _fused_moe_kernel_sequence(
         dtype=hidden_states.dtype,
     )
 
-    # LoRA hooks force the second kernel to write to intermediate_cache3 so
-    # hooks.after_down can inspect/modify it before reduction.
-    _use_intermediate = not no_combine and (topk != 1 or hooks)
+    # LoRA hooks and no_topk_reduce both need intermediate_cache3.
+    _use_intermediate = not no_combine and not no_topk_reduce and (
+        topk != 1 or hooks 
+    )
 
     out_slice = None
     if use_fused_moe_sum_all_reduce:
@@ -740,7 +779,7 @@ def _fused_moe_kernel_sequence(
     if routed_scaling_factor is None:
         routed_scaling_factor = 1.0
 
-    if no_combine:
+    if no_combine or no_topk_reduce:
         pass
     elif _is_cuda or _is_musa:
         if use_fused_moe_sum_all_reduce:
@@ -842,6 +881,7 @@ def fused_experts_impl(
     a2_scale: Optional[torch.Tensor] = None,
     block_shape: Optional[List[int]] = None,
     no_combine: bool = False,
+    no_topk_reduce: bool = False,
     routed_scaling_factor: Optional[float] = None,
     gemm1_alpha: Optional[float] = None,
     gemm1_limit: Optional[float] = None,
@@ -915,6 +955,7 @@ def fused_experts_impl(
         activation=activation,
         is_gated=is_gated,
         no_combine=no_combine,
+        no_topk_reduce=no_topk_reduce,
         inplace=inplace,
         apply_router_weight_on_input=apply_router_weight_on_input,
         routed_scaling_factor=routed_scaling_factor,

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -158,6 +158,7 @@ def inplace_fused_experts(
         a2_scale,
         block_shape,
         False,
+        False,
         routed_scaling_factor,
         gemm1_alpha,
         gemm1_limit,
@@ -194,6 +195,7 @@ def outplace_fused_experts(
     a2_scale: Optional[torch.Tensor] = None,
     block_shape: Optional[List[int]] = None,
     no_combine: bool = False,
+    no_topk_reduce: bool = False,
     routed_scaling_factor: Optional[float] = None,
     gemm1_alpha: Optional[float] = None,
     gemm1_limit: Optional[float] = None,
@@ -228,6 +230,7 @@ def outplace_fused_experts(
         a2_scale,
         block_shape,
         no_combine=no_combine,
+        no_topk_reduce=no_topk_reduce,
         routed_scaling_factor=routed_scaling_factor,
         gemm1_alpha=gemm1_alpha,
         gemm1_limit=gemm1_limit,
@@ -267,6 +270,40 @@ def fused_experts(
         moe_runner_config.num_experts is None
         or moe_runner_config.num_experts != moe_runner_config.num_local_experts
     )
+    from sglang.srt.distributed import get_tp_group
+    comm = get_tp_group().torch_symm_mem_comm
+    fused_topk_reduce_rs = comm is not None and comm.use_cp
+    if fused_topk_reduce_rs:
+        return outplace_fused_experts(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            b1,
+            b2,
+            moe_runner_config.activation,
+            moe_runner_config.is_gated,
+            moe_runner_config.apply_router_weight_on_input,
+            use_fp8_w8a8,
+            use_int8_w8a8,
+            use_int8_w8a16,
+            use_int4_w4a16,
+            per_channel_quant,
+            w1_scale,
+            w2_scale,
+            w1_zp,
+            w2_zp,
+            a1_scale,
+            a2_scale,
+            block_shape,
+            no_topk_reduce=True,
+            routed_scaling_factor=moe_runner_config.routed_scaling_factor,
+            gemm1_alpha=moe_runner_config.gemm1_alpha,
+            gemm1_limit=moe_runner_config.gemm1_clamp_limit,
+            filter_expert=filter_expert,
+            swiglu_limit=moe_runner_config.swiglu_limit,
+        )
     if moe_runner_config.inplace:
         assert not moe_runner_config.no_combine, "no combine + inplace makes no sense"
         inplace_fused_experts(
@@ -485,6 +522,7 @@ def _fused_moe_kernel_sequence(
     activation: str,
     is_gated: bool,
     no_combine: bool,
+    no_topk_reduce: bool,
     inplace: bool,
     apply_router_weight_on_input: bool,
     routed_scaling_factor: Optional[float],
@@ -538,7 +576,7 @@ def _fused_moe_kernel_sequence(
     )
     total_tokens = num_tokens * topk + padded_tokens
 
-    if no_combine:
+    if no_combine or no_topk_reduce:
         assert not inplace
         out_hidden_states = torch.empty(
             (num_tokens, topk, w2.shape[1]),
@@ -794,9 +832,10 @@ def _fused_moe_kernel_sequence(
         dtype=hidden_states.dtype,
     )
 
-    # LoRA hooks force the second kernel to write to intermediate_cache3 so
-    # hooks.after_down can inspect/modify it before reduction.
-    _use_intermediate = not no_combine and (topk != 1 or hooks)
+    # LoRA hooks and no_topk_reduce both need intermediate_cache3.
+    _use_intermediate = not no_combine and not no_topk_reduce and (
+        topk != 1 or hooks 
+    )
 
     out_slice = None
     if use_fused_moe_sum_all_reduce:
@@ -851,7 +890,7 @@ def _fused_moe_kernel_sequence(
     if routed_scaling_factor is None:
         routed_scaling_factor = 1.0
 
-    if no_combine:
+    if no_combine or no_topk_reduce:
         pass
     elif _is_cuda or _is_musa:
         if use_fused_moe_sum_all_reduce:
@@ -953,6 +992,7 @@ def fused_experts_impl(
     a2_scale: Optional[torch.Tensor] = None,
     block_shape: Optional[List[int]] = None,
     no_combine: bool = False,
+    no_topk_reduce: bool = False,
     routed_scaling_factor: Optional[float] = None,
     gemm1_alpha: Optional[float] = None,
     gemm1_limit: Optional[float] = None,
@@ -1030,6 +1070,7 @@ def fused_experts_impl(
         activation=activation,
         is_gated=is_gated,
         no_combine=no_combine,
+        no_topk_reduce=no_topk_reduce,
         inplace=inplace,
         apply_router_weight_on_input=apply_router_weight_on_input,
         routed_scaling_factor=routed_scaling_factor,

--- a/python/sglang/srt/layers/quantization/humming.py
+++ b/python/sglang/srt/layers/quantization/humming.py
@@ -628,6 +628,19 @@ class HummingLinearMethod(LinearMethodBase):
             torch_dtype=layer.param_dtype,
         )
 
+        # The fused AG+GEMM triton kernel needs the plain packed layout, i.e.
+        # the tensors as they are before Humming's C++-specific interleaved
+        # repack. Only the shared-experts gate_up projection feeds that kernel;
+        # keeping the pre-repack pair on every Humming linear pins a second
+        # weight copy per layer (measured +13.6 GB/GPU on GLM-5.2 TP8).
+        prefix = getattr(layer, "prefix", "")
+        keep_pre_repacked = (
+            envs.SGLANG_OPT_USE_TORCH_SYMM_MEM_FUSED_KERNEL.get()
+            and "shared_experts" in prefix
+            and prefix.endswith("gate_up_proj")
+        )
+        layer.pre_repacked_weight = layer.weight if keep_pre_repacked else None
+        layer.pre_repacked_scale = layer.weight_scale if keep_pre_repacked else None
         # preprocess weight for inference
         HummingMethod.transform_humming_layer(layer)
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -49,7 +49,13 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.distributed import (
     divide,
     get_pp_group,
+    get_tp_group,
     tensor_model_parallel_all_reduce,
+)
+from sglang.srt.distributed.device_communicators.symm_mem_kernels import (
+    maybe_fused_ag_shared_experts,
+    maybe_fused_shared_add_rs,
+    maybe_fused_ag_gate_mm,
 )
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
@@ -290,6 +296,7 @@ class DeepseekV2MLP(nn.Module):
         should_allreduce_fusion: bool = False,
         use_reduce_scatter: bool = False,
         gemm_output_zero_allocator: BumpAllocator = None,
+        precomputed_gate_up: Optional[torch.Tensor] = None,
     ):
         if (self.tp_size == 1) and x.shape[0] == 0:
             return x
@@ -322,17 +329,20 @@ class DeepseekV2MLP(nn.Module):
             )
             return out
 
-        if (
-            gemm_output_zero_allocator is not None
-            and x.shape[0] <= 256
-            and self.gate_up_proj.weight.dtype == torch.uint8
-        ):
-            y = gemm_output_zero_allocator.allocate(
-                x.shape[0] * self.gate_up_proj.output_size_per_partition
-            ).view(x.shape[0], self.gate_up_proj.output_size_per_partition)
-            x = (x, None, y)
+        if precomputed_gate_up is not None:
+            gate_up = precomputed_gate_up
+        else:
+            if (
+                gemm_output_zero_allocator is not None
+                and x.shape[0] <= 256
+                and self.gate_up_proj.weight.dtype == torch.uint8
+            ):
+                y = gemm_output_zero_allocator.allocate(
+                    x.shape[0] * self.gate_up_proj.output_size_per_partition
+                ).view(x.shape[0], self.gate_up_proj.output_size_per_partition)
+                x = (x, None, y)
 
-        gate_up, _ = self.gate_up_proj(x)
+            gate_up, _ = self.gate_up_proj(x)
         # Fast path: fused silu+clamp+fp8_quant+deepgemm when conditions met.
         # Only valid when down_proj does NOT need an all-reduce and its weights
         # are fp8 (uint8 storage with weight_scale_inv).
@@ -933,7 +943,7 @@ class DeepseekV2MoE(nn.Module):
             else None
         )
         with torch.cuda.stream(self.alt_stream):
-            shared_output = self._forward_shared_experts(
+            _, shared_output = self._forward_shared_experts(
                 hidden_states, gemm_output_zero_allocator
             )
         # router_logits: (num_tokens, n_experts)
@@ -1040,11 +1050,29 @@ class DeepseekV2MoE(nn.Module):
                 and not self._fuse_shared_experts_inside_sbo
                 and not skip_shared_experts
             ):
-                shared_output = self._forward_shared_experts(
+                ag_out, shared_output = self._forward_shared_experts(
                     hidden_states, gemm_output_zero_allocator
                 )
-            # router_logits: (num_tokens, n_experts)
-            router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+                if ag_out is not None:
+                    # calculate allgather in the overlap kernel
+                    hidden_states = ag_out
+            else:
+                shared_output = None
+            
+            if shared_output is None:
+                # fuse allgather with gate matmul
+                ag_out, router_logits = maybe_fused_ag_gate_mm(
+                    hidden_states,
+                    self.gate.weight
+                )
+                if ag_out is not None:
+                    hidden_states = ag_out
+                else:
+                    # fallback: separate allgather + gate matmul
+                    router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+            else:
+                router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+
             topk_kwargs = (
                 {"input_ids": input_ids_global}
                 if getattr(self, "is_hash", False)
@@ -1072,7 +1100,7 @@ class DeepseekV2MoE(nn.Module):
                 nonlocal shared_output
                 self.alt_stream.wait_stream(torch.cuda.current_stream())
                 with torch.cuda.stream(self.alt_stream):
-                    shared_output = self._forward_shared_experts(
+                    _, shared_output = self._forward_shared_experts(
                         hidden_states, gemm_output_zero_allocator
                     )
 
@@ -1112,9 +1140,21 @@ class DeepseekV2MoE(nn.Module):
             and not self._fuse_shared_experts_inside_sbo
             and not skip_shared_experts
         ):
-            shared_output = self._forward_shared_experts(
+            _, shared_output = self._forward_shared_experts(
                 hidden_states, gemm_output_zero_allocator
             )
+        # Fused shared-add + reduce-scatter path (falls through if not applicable).
+        fused_out = maybe_fused_shared_add_rs(
+            final_hidden_states,
+            shared_output,
+            self.tp_size,
+            self.n_shared_experts,
+            # if fuse shared experts, topk for moe equals to num_experts_per_tok + num_fused_shared_experts
+            self.top_k + self.num_fused_shared_experts,
+            self.routed_scaling_factor,
+        )
+        if fused_out is not None:
+            return fused_out
 
         final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
             self.experts,
@@ -1213,11 +1253,11 @@ class DeepseekV2MoE(nn.Module):
                 if self.alt_stream is not None:
                     self.alt_stream.wait_stream(torch.cuda.current_stream())
                     with torch.cuda.stream(self.alt_stream):
-                        shared_output = self._forward_shared_experts(hidden_states)
+                        _, shared_output = self._forward_shared_experts(hidden_states)
                         shared_output.record_stream(self.alt_stream)
                         shared_event = self.alt_stream.record_event()
                 else:
-                    shared_output = self._forward_shared_experts(hidden_states)
+                    _, shared_output = self._forward_shared_experts(hidden_states)
             topk_kwargs = (
                 {"input_ids": input_ids_global}
                 if getattr(self, "is_hash", False)
@@ -1242,7 +1282,7 @@ class DeepseekV2MoE(nn.Module):
 
             def _deepep_dispatch_hook(dispatcher: BaseDispatcher):
                 nonlocal shared_output
-                shared_output = self._forward_shared_experts(hidden_states)
+                _, shared_output = self._forward_shared_experts(hidden_states)
                 for handle in deepep_dispatch_hook_handle:
                     handle.remove()
 
@@ -1318,7 +1358,7 @@ class DeepseekV2MoE(nn.Module):
                 with deep_gemm_wrapper.configure_deep_gemm_num_sms(
                     dispatcher.meta_overlap_args["compute_num_sms"]
                 ):
-                    shared_output = self._forward_shared_experts(hidden_states)
+                    _, shared_output = self._forward_shared_experts(hidden_states)
 
                 pre_combine_hook_handle.remove()
 
@@ -1416,14 +1456,27 @@ class DeepseekV2MoE(nn.Module):
         return final_hidden_states
 
     def _forward_shared_experts(
-        self, hidden_states, gemm_output_zero_allocator: BumpAllocator = None
+        self, hidden_states, gemm_output_zero_allocator: BumpAllocator = None,
     ):
         if (hidden_states.shape[0] > 0) and (self.num_fused_shared_experts == 0):
-            return self.shared_experts(
+            shared = getattr(self, "shared_experts", None)
+            ag_out, gate_up_local = maybe_fused_ag_shared_experts(
+                hidden_states,
+                getattr(self, "shared_experts_is_fp8", False),
+                shared.gate_up_proj.weight if shared is not None else None,
+                shared.gate_up_proj.weight_scale_inv if shared is not None else None,
+            )
+            if gate_up_local is not None and ag_out is not None:
+                return ag_out, self.shared_experts(
+                    hidden_states, gemm_output_zero_allocator=gemm_output_zero_allocator,
+                    precomputed_gate_up=gate_up_local,
+                )
+
+            return None, self.shared_experts(
                 hidden_states, gemm_output_zero_allocator=gemm_output_zero_allocator
             )
         else:
-            return None
+            return None, None
 
     def op_gate(self, state):
         if state.hidden_states_mlp_input.shape[0] > 0:
@@ -2534,6 +2587,9 @@ class DeepseekV2Model(nn.Module):
         if dsa_use_prefill_cp(
             forward_batch, self.dsa_enable_prefill_cp
         ) or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp):
+            _comm = get_tp_group().torch_symm_mem_comm
+            if _comm is not None:
+                _comm.set_use_cp(True)
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
@@ -2599,6 +2655,10 @@ class DeepseekV2Model(nn.Module):
                 ].layer_scatter_modes.layer_output_mode,
                 zero_allocator=zero_allocator,
             )
+
+        _comm = get_tp_group().torch_symm_mem_comm
+        if _comm is not None:
+            _comm.set_use_cp(False)
 
         if not self.pp_group.is_last_rank:
             proxy_tensors = {

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1018,7 +1018,7 @@ class DeepseekV2MoE(nn.Module):
 
         # Shared expert on alt stream, issued AFTER the main (routed) branch. See note above.
         with torch.cuda.stream(self.alt_stream):
-            shared_output = self._forward_shared_experts(
+            _, shared_output = self._forward_shared_experts(
                 hidden_states,
                 gemm_output_zero_allocator,
                 pre_quant_input=pre_quant_input,
@@ -1194,6 +1194,9 @@ class DeepseekV2MoE(nn.Module):
                 pre_quant_input=pre_quant_input,
             )
         # Fused shared-add + reduce-scatter path (falls through if not applicable).
+        # When humming runner is active, pass topk info for the mul-sum overlap
+        # kernel which fuses topk weighted sum + add shared + RS in one kernel.
+        is_humming = get_moe_runner_backend().is_humming()
         fused_out = maybe_fused_shared_add_rs(
             final_hidden_states,
             shared_output,
@@ -1202,6 +1205,9 @@ class DeepseekV2MoE(nn.Module):
             # if fuse shared experts, topk for moe equals to num_experts_per_tok + num_fused_shared_experts
             self.top_k + self.num_fused_shared_experts,
             self.routed_scaling_factor,
+            is_humming=is_humming,
+            topk_weights=topk_output.topk_weights if is_humming else None,
+            topk_ids=topk_output.topk_ids if is_humming else None,
         )
         if fused_out is not None:
             return fused_out
@@ -1524,13 +1530,35 @@ class DeepseekV2MoE(nn.Module):
     ):
         if (hidden_states.shape[0] > 0) and (self.num_fused_shared_experts == 0):
 
-            shared = getattr(self, "shared_experts", None)
-            ag_out, gate_up_local = maybe_fused_ag_shared_experts(
-                hidden_states,
-                getattr(self, "shared_experts_is_fp8", False),
-                shared.gate_up_proj.weight if shared is not None else None,
-                shared.gate_up_proj.weight_scale_inv if shared is not None else None,
-            )
+            if shared is None:
+                return None, None
+
+            shared_experts_is_fp8 = self.shared_experts_is_fp8
+            gate_up = shared.gate_up_proj
+
+            from sglang.srt.layers.quantization.humming import HummingLinearMethod
+            is_humming = isinstance(gate_up.quant_method, HummingLinearMethod)
+
+            if is_humming:
+                ag_out, gate_up_local = maybe_fused_ag_shared_experts(
+                    hidden_states,
+                    shared_experts_is_fp8=False,
+                    w_fp8=None,
+                    w_scale=None,
+                    is_humming=True,
+                    humming_weight=gate_up.pre_repacked_weight,
+                    humming_scale=gate_up.pre_repacked_scale,
+                    humming_group_size=(
+                        gate_up.quant_method.weight_schema.weight_scale_group_size
+                    ),
+                )
+            else:
+                ag_out, gate_up_local = maybe_fused_ag_shared_experts(
+                    hidden_states,
+                    shared_experts_is_fp8,
+                    gate_up.weight if not shared_experts_is_fp8 else None,
+                    gate_up.weight_scale_inv if shared_experts_is_fp8 else None,
+                )
             if gate_up_local is not None and ag_out is not None:
                 return ag_out, self.shared_experts(
                     hidden_states, gemm_output_zero_allocator=gemm_output_zero_allocator,
@@ -2859,15 +2887,15 @@ class DeepseekV2Model(nn.Module):
         )
 
         # CP-v2 shards/gathers at the eager-runner boundary instead.
+        use_prefill_cp = dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
         use_cp_v1 = (
-            dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
-            or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+            use_prefill_cp or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
         ) and not is_cp_v2_active(forward_batch)
-
-        if use_cp_v1:
+        if use_prefill_cp:
             _comm = get_tp_group().torch_symm_mem_comm
             if _comm is not None:
                 _comm.set_use_cp(True)
+        if use_cp_v1:
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -52,7 +52,13 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.distributed import (
     divide,
     get_pp_group,
+    get_tp_group,
     tensor_model_parallel_all_reduce,
+)
+from sglang.srt.distributed.device_communicators.symm_mem_kernels import (
+    maybe_fused_ag_shared_experts,
+    maybe_fused_shared_add_rs,
+    maybe_fused_ag_gate_mm,
 )
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
@@ -318,6 +324,7 @@ class DeepseekV2MLP(nn.Module):
         forward_batch=None,
         gemm_output_zero_allocator: BumpAllocator = None,
         gateup_pre_quant: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        precomputed_gate_up: Optional[torch.Tensor] = None,
     ):
         if (self.tp_size == 1) and x.shape[0] == 0:
             return x
@@ -347,7 +354,9 @@ class DeepseekV2MLP(nn.Module):
             out, _ = self.down_proj((out_fp4, out_scale))
             return out
 
-        if gateup_pre_quant is not None:
+        if precomputed_gate_up is not None:
+            gate_up = precomputed_gate_up
+        elif gateup_pre_quant is not None:
             # SGLANG_OPT_MOE_QUANT_ONCE: reuse the caller's per-token-group-128
             # fp8 (q, scale) of x for the gate_up GEMM instead of re-quantizing
             # inside the fp8 linear method. q rows may be padded to a multiple
@@ -1079,13 +1088,31 @@ class DeepseekV2MoE(nn.Module):
                 and not self._fuse_shared_experts_inside_sbo
                 and not skip_shared_experts
             ):
-                shared_output = self._forward_shared_experts(
+                ag_out, shared_output = self._forward_shared_experts(
                     hidden_states,
                     gemm_output_zero_allocator,
                     pre_quant_input=pre_quant_input,
                 )
-            # router_logits: (num_tokens, n_experts)
-            router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+                if ag_out is not None:
+                    # calculate allgather in the overlap kernel
+                    hidden_states = ag_out
+            else:
+                shared_output = None
+            
+            if shared_output is None:
+                # fuse allgather with gate matmul
+                ag_out, router_logits = maybe_fused_ag_gate_mm(
+                    hidden_states,
+                    self.gate.weight
+                )
+                if ag_out is not None:
+                    hidden_states = ag_out
+                else:
+                    # fallback: separate allgather + gate matmul
+                    router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+            else:
+                router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
+
             topk_kwargs = (
                 {"input_ids": input_ids_global}
                 if getattr(self, "is_hash", False)
@@ -1114,7 +1141,7 @@ class DeepseekV2MoE(nn.Module):
                 nonlocal shared_output
                 self.alt_stream.wait_stream(torch.cuda.current_stream())
                 with torch.cuda.stream(self.alt_stream):
-                    shared_output = self._forward_shared_experts(
+                    _, shared_output = self._forward_shared_experts(
                         hidden_states, gemm_output_zero_allocator
                     )
 
@@ -1161,11 +1188,23 @@ class DeepseekV2MoE(nn.Module):
             and not self._fuse_shared_experts_inside_sbo
             and not skip_shared_experts
         ):
-            shared_output = self._forward_shared_experts(
+            _, shared_output = self._forward_shared_experts(
                 hidden_states,
                 gemm_output_zero_allocator,
                 pre_quant_input=pre_quant_input,
             )
+        # Fused shared-add + reduce-scatter path (falls through if not applicable).
+        fused_out = maybe_fused_shared_add_rs(
+            final_hidden_states,
+            shared_output,
+            self.tp_size,
+            self.n_shared_experts,
+            # if fuse shared experts, topk for moe equals to num_experts_per_tok + num_fused_shared_experts
+            self.top_k + self.num_fused_shared_experts,
+            self.routed_scaling_factor,
+        )
+        if fused_out is not None:
+            return fused_out
 
         final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
             self.experts,
@@ -1263,7 +1302,7 @@ class DeepseekV2MoE(nn.Module):
                 if self.alt_stream is not None:
                     self.alt_stream.wait_stream(torch.cuda.current_stream())
                     with torch.cuda.stream(self.alt_stream):
-                        shared_output = self._forward_shared_experts(hidden_states)
+                        _, shared_output = self._forward_shared_experts(hidden_states)
                         shared_output.record_stream(self.alt_stream)
                         shared_event = self.alt_stream.record_event()
                     if is_in_breakable_cuda_graph():
@@ -1274,7 +1313,7 @@ class DeepseekV2MoE(nn.Module):
                         # allocator recycles shared_output across the break.
                         torch.cuda.current_stream().wait_event(shared_event)
                 else:
-                    shared_output = self._forward_shared_experts(hidden_states)
+                    _, shared_output = self._forward_shared_experts(hidden_states)
             topk_kwargs = (
                 {"input_ids": input_ids_global}
                 if getattr(self, "is_hash", False)
@@ -1303,7 +1342,7 @@ class DeepseekV2MoE(nn.Module):
 
             def _deepep_dispatch_hook(dispatcher: BaseDispatcher):
                 nonlocal shared_output
-                shared_output = self._forward_shared_experts(hidden_states)
+                _, shared_output = self._forward_shared_experts(hidden_states)
                 for handle in deepep_dispatch_hook_handle:
                     handle.remove()
 
@@ -1379,7 +1418,7 @@ class DeepseekV2MoE(nn.Module):
                 with deep_gemm_wrapper.configure_deep_gemm_num_sms(
                     dispatcher.meta_overlap_args["compute_num_sms"]
                 ):
-                    shared_output = self._forward_shared_experts(hidden_states)
+                    _, shared_output = self._forward_shared_experts(hidden_states)
 
                 pre_combine_hook_handle.remove()
 
@@ -1484,6 +1523,19 @@ class DeepseekV2MoE(nn.Module):
         pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ):
         if (hidden_states.shape[0] > 0) and (self.num_fused_shared_experts == 0):
+
+            shared = getattr(self, "shared_experts", None)
+            ag_out, gate_up_local = maybe_fused_ag_shared_experts(
+                hidden_states,
+                getattr(self, "shared_experts_is_fp8", False),
+                shared.gate_up_proj.weight if shared is not None else None,
+                shared.gate_up_proj.weight_scale_inv if shared is not None else None,
+            )
+            if gate_up_local is not None and ag_out is not None:
+                return ag_out, self.shared_experts(
+                    hidden_states, gemm_output_zero_allocator=gemm_output_zero_allocator,
+                    precomputed_gate_up=gate_up_local,
+                )
             if pre_quant_input is not None:
                 # SGLANG_OPT_MOE_QUANT_ONCE: (q, s) rows may be padded to a
                 # multiple of 4; the padded rows flow through the MLP (all ops
@@ -1491,12 +1543,12 @@ class DeepseekV2MoE(nn.Module):
                 out = self.shared_experts(
                     hidden_states, gateup_pre_quant=pre_quant_input
                 )
-                return out[: hidden_states.shape[0]]
-            return self.shared_experts(
+                return None, out[: hidden_states.shape[0]]
+            return None, self.shared_experts(
                 hidden_states, gemm_output_zero_allocator=gemm_output_zero_allocator
             )
         else:
-            return None
+            return None, None
 
     def _moe_quant_once_enabled(self) -> bool:
         """SGLANG_OPT_MOE_QUANT_ONCE: quantize the (dp-gathered) MoE input to
@@ -2813,6 +2865,9 @@ class DeepseekV2Model(nn.Module):
         ) and not is_cp_v2_active(forward_batch)
 
         if use_cp_v1:
+            _comm = get_tp_group().torch_symm_mem_comm
+            if _comm is not None:
+                _comm.set_use_cp(True)
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
@@ -2881,6 +2936,10 @@ class DeepseekV2Model(nn.Module):
                 ].layer_scatter_modes.layer_output_mode,
                 zero_allocator=zero_allocator,
             )
+
+        _comm = get_tp_group().torch_symm_mem_comm
+        if _comm is not None:
+            _comm.set_use_cp(False)
 
         if not self.pp_group.is_last_rank:
             proxy_tensors = {

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -222,6 +222,9 @@ def _freqs_cis_to_cos_sin(
     _FREQS_CIS_TO_COS_SIN[key] = (cos, sin)
     return cos, sin
 
+def _cp_fused_symm_mem_enabled() -> bool:
+    """True when CP AG/RS should be handled by torch_symm_mem fused kernels."""
+    return envs.SGLANG_OPT_USE_TORCH_SYMM_MEM_FUSED_KERNEL.get() and not get_is_capture_mode()
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.deepseek_v4_backend import (
@@ -1539,7 +1542,8 @@ class DeepseekV4DecoderLayer(nn.Module):
         )
         if _use_cp:
             if get_moe_a2a_backend().is_none():
-                hidden_states = dsa_cp_gather_hidden_states(hidden_states)
+                if not _cp_fused_symm_mem_enabled() or not self.mlp.experts.moe_runner_config.inplace:
+                    hidden_states = dsa_cp_gather_hidden_states(hidden_states)
             else:
                 assert get_moe_a2a_backend().is_deepep(), (
                     "CP requires DeepEP (moe_a2a_backend == deepep). "
@@ -1572,7 +1576,8 @@ class DeepseekV4DecoderLayer(nn.Module):
             skip_shared_experts=_do_shared_local,
         )
         if _use_cp and get_moe_a2a_backend().is_none():
-            hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
+            if not _cp_fused_symm_mem_enabled():
+                hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
         elif _use_tp_moe_gather:
             hidden_states, global_hidden_states = (
                 get_local_dp_buffer(get_tp_group()),
@@ -2071,6 +2076,9 @@ class DeepseekV4Model(nn.Module):
             input_ids_global = input_ids
 
         if dsa_use_prefill_cp(forward_batch):
+            _comm = get_tp_group().torch_symm_mem_comm
+            if _comm is not None and _cp_fused_symm_mem_enabled():
+                _comm.set_use_cp(True)
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
@@ -2118,6 +2126,9 @@ class DeepseekV4Model(nn.Module):
                     hidden_states, prev_residual, prev_post, prev_comb
                 )
 
+        _comm = get_tp_group().torch_symm_mem_comm
+        if _comm is not None:
+            _comm.set_use_cp(False)
         # CP all-gather only on the last PP rank; PP IPC carries CP-split tensors.
         if self.pp_group.is_last_rank and dsa_use_prefill_cp(forward_batch):
             hidden_states = cp_all_gather_rerange_output(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3048,12 +3048,12 @@ class DeepseekV4Model(nn.Module):
         # TBO when capturing -- a perf-only downgrade, not a correctness one.
         run_tbo = self._can_run_tbo(forward_batch) and not capture_dspark
         if use_prefill_cp and not run_tbo:
+            _comm = get_tp_group().torch_symm_mem_comm
+            if _comm is not None and _cp_fused_symm_mem_enabled():
+                _comm.set_use_cp(True)
             if cp_v2_active:
                 input_ids = cp_round_robin_input_ids_v2(input_ids, forward_batch)
             else:
-                _comm = get_tp_group().torch_symm_mem_comm
-                if _comm is not None and _cp_fused_symm_mem_enabled():
-                    _comm.set_use_cp(True)
                 if self.pp_group.is_first_rank:
                     hidden_states = cp_split_and_rebuild_data(
                         forward_batch, hidden_states

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -472,6 +472,9 @@ def _freqs_cis_to_cos_sin(
     _FREQS_CIS_TO_COS_SIN[key] = (cos, sin)
     return cos, sin
 
+def _cp_fused_symm_mem_enabled() -> bool:
+    """True when CP AG/RS should be handled by torch_symm_mem fused kernels."""
+    return envs.SGLANG_OPT_USE_TORCH_SYMM_MEM_FUSED_KERNEL.get() and not get_is_capture_mode()
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.deepseek_v4_backend import (
@@ -2251,7 +2254,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         )
         if _use_cp:
             moe_a2a_backend = get_moe_a2a_backend()
-            if moe_a2a_backend.is_none():
+            if moe_a2a_backend.is_none() and not _cp_fused_symm_mem_enabled():
                 hidden_states = dsa_cp_gather_hidden_states(hidden_states)
             else:
                 assert moe_a2a_backend.is_deepep() or moe_a2a_backend.is_megamoe(), (
@@ -2288,7 +2291,8 @@ class DeepseekV4DecoderLayer(nn.Module):
                 skip_shared_experts=_do_shared_local,
             )
         if _use_cp and get_moe_a2a_backend().is_none():
-            hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
+            if not _cp_fused_symm_mem_enabled():
+                hidden_states = dsa_cp_reduce_scatter_hidden_states(hidden_states)
         elif _use_tp_moe_gather:
             hidden_states, global_hidden_states = (
                 get_local_dp_buffer(get_tp_group()),
@@ -3047,6 +3051,9 @@ class DeepseekV4Model(nn.Module):
             if cp_v2_active:
                 input_ids = cp_round_robin_input_ids_v2(input_ids, forward_batch)
             else:
+                _comm = get_tp_group().torch_symm_mem_comm
+                if _comm is not None and _cp_fused_symm_mem_enabled():
+                    _comm.set_use_cp(True)
                 if self.pp_group.is_first_rank:
                     hidden_states = cp_split_and_rebuild_data(
                         forward_batch, hidden_states
@@ -3103,6 +3110,9 @@ class DeepseekV4Model(nn.Module):
                     hidden_states, prev_residual, prev_post, prev_comb
                 )
 
+        _comm = get_tp_group().torch_symm_mem_comm
+        if _comm is not None:
+            _comm.set_use_cp(False)
         # CP all-gather only on the last PP rank; PP IPC carries CP-split tensors.
         if (
             self.pp_group.is_last_rank


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Recently, we develop communication-computation overlap kernels to optimize prefill performance for DeepSeek-V4 Flash/Pro models~(PR #28639  ) using our agent skills~(PR #29047 ). In this PR, we extend it to GLM models including GLM5.1 and newly released GLM5.2. 

Specifically, we fuse the collective communications with  adjacent computation kernels in CP mode: 

1.  `dsa_cp_gather_hidden_states` with `MoE gate matmul`

2.  `moe_sum_reduce` with `dsa_cp_reduce_scatter_hidden_states`

- Coauthor: @Zqy11 



## Modifications

<!-- Detail the changes made in this pull request. -->

Most of the detailed modifications can be found in PR #28639 . Here we specify only new modifications in this PR.

- New Triton Kernels` (symm_mem_kernels/)`:  Compared with the fused kernel applied to DSV4, we add  `allgather_bf16_gemm_op_symm_mem` to fuse cp allgather with moe gate matmul using copy engine and two cuda streams. 
- Model & Layer` (deepseek_v2.py) `: We integrate `maybe_fused_ag_gate_mm`  into the MoE forward path to replace origin comm+comp with our fused kernel.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

We use `python -m benchmark.gsm8k.bench_sglang --port <port> --num-questions 1000` to test the accuracy for 3 times.

| index | baseline  | overlap kernel |
| ------------- | ------------- | ------------- |
| 1  | 0.947| 0.947 |
| 2 | 0.946| 0.945  |
| 3 | 0.951 | 0.948 |


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->


### Experiment Setup
2 nodes, each with 8 × H20 GPUs and 4 dual-port 200Gbps NICs per node. GLM5.2 model with CP8-TP8-PP2 for prefill. 
Benchmark settings : Input length 16k/32k/64k/128k, output length 1.

`python -m sglang.bench_serving \
  --backend sglang --host localhost --port <port> \
  --dataset-name random \
  --dataset-path <dataset> \
  --num-prompts 300 --max-concurrency 1 \
  --random-input-len 16384 --random-range-ratio 0.0  --random-output-len 1 \
  --random-range-ratio 1.0 --request-rate inf`

### Performance

We evaluate the mean TTFT performance of GLM5.2 :

|  input length| baseline  | overlap kernel |improvements|
| ------------- | ------------- | ------------- |------------- |
| 16k  | 1196.06| 1160.89 | +3.0%| 
| 32k | 2005.82| 1943.88| +3.0%| 
| 64k | 3731.18 | 3591.45| + 3.7% | 
| 128k | 7485.09 | 7250.04 | +3.1% | 


Some experimental results for GLM 5.1:
|  input length| baseline  | overlap kernel |improvements|
| ------------- | ------------- | ------------- |------------- |
| 16k  | 1266.15| 1233.75 | +2.6%| 
| 32k | 2179.66| 2121.62| +2.6%| 
| 64k | 4209.18 | 4065.00| + 3.4% | 
| 128k | 8889.67 | 8647.89 | +2.7% | 



### Profiling:

GLM5.2:

|  kernel| baseline  | overlap kernel |
| ------------- | ------------- | ------------- |
| allgather + matmul  | 541.8us <img width="1860" height="1006" alt="image" src="https://github.com/user-attachments/assets/ba337f88-a2dd-4d2a-8747-6ad2ddd8f468" />| 420.9us <img width="2250" height="1190" alt="image" src="https://github.com/user-attachments/assets/6f1c2a70-880a-4c35-b25e-69e491d7227a" />| 
| topk_sum_reduce + reduce scatter | 588.7us<img width="1976" height="1048" alt="image" src="https://github.com/user-attachments/assets/399d968d-82a5-460d-81e8-e99ada9e1b12" />| 431.5us <img width="1196" height="626" alt="image" src="https://github.com/user-attachments/assets/298897c7-80da-4b53-bb0b-825d1ec5917a" />| 


According to the profilings, our overlap kernels can achieve `((541.8-420.9) + (588.7-431.5))/9300 = 3.0%` performance improvements for GLM 5.2 , which the layer execution time is roughly 9.3ms in our profilings.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32845947816](https://github.com/sgl-project/sglang/actions/runs/32845947816)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32845947675](https://github.com/sgl-project/sglang/actions/runs/32845947675)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32845947795](https://github.com/sgl-project/sglang/actions/runs/32845947795)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->