### PR TITLE
Add QoS-aware cache policy

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -141,6 +141,7 @@ class CacheAwarePolicy(Enum):
 
     LPM = "lpm"  # longest prefix match
     DFS_WEIGHT = "dfs-weight"  # depth-first search weighting
+    QOS_LPM = "qos-lpm"  # QoS priority, then longest prefix match
 
 
 class CacheAgnosticPolicy(Enum):
@@ -203,6 +204,10 @@ class SchedulePolicy:
             )
             if policy == CacheAwarePolicy.LPM:
                 SchedulePolicy._sort_by_longest_prefix(
+                    waiting_queue, temporary_deprioritized
+                )
+            elif policy == CacheAwarePolicy.QOS_LPM:
+                SchedulePolicy._sort_by_qos_longest_prefix(
                     waiting_queue, temporary_deprioritized
                 )
             elif policy == CacheAwarePolicy.DFS_WEIGHT:
@@ -312,6 +317,25 @@ class SchedulePolicy:
                 else float("inf")
             )
         )
+
+    @staticmethod
+    def _sort_by_qos_longest_prefix(
+        waiting_queue: List[Req], temporary_deprioritized: Set[int]
+    ) -> None:
+        """Sorts by higher QoS priority, longer prefix match, then arrival time."""
+
+        def sort_key(req: Req):
+            is_deprioritized = req.rid in temporary_deprioritized
+            prefix_key = -len(req.prefix_indices)
+            qos_weight = max(req.priority or 1, 1)
+            return (
+                is_deprioritized,
+                -qos_weight,
+                prefix_key,
+                req.time_stats.wait_queue_entry_time,
+            )
+
+        waiting_queue.sort(key=sort_key)
 
     @staticmethod
     def _sort_by_dfs_weight(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -97,6 +97,7 @@ def match_prefix_for_req(
     *,
     cow_mamba: bool = False,
     include_req: bool = False,
+    update_cache_stats: bool = True,
 ):
     if token_ids is None:
         token_ids = req.origin_input_ids + req.output_ids
@@ -104,7 +105,7 @@ def match_prefix_for_req(
     match_result = tree_cache.match_prefix(
         MatchPrefixParams(
             key=RadixKey(token_ids=token_ids, extra_key=req.extra_key),
-            update_cache_stats=False,
+            update_cache_stats=update_cache_stats,
             cow_mamba=cow_mamba,
             req=req if include_req else None,
         )
@@ -166,6 +167,7 @@ class SchedulePolicy:
         enable_hierarchical_cache: bool,
         enable_priority_scheduling: bool,
         schedule_low_priority_values_first: bool,
+        enable_qos_aware_prefix_cache: bool = False,
         qos_lpm_shared_weight: float = 1.0,
         qos_lpm_delay_weight: float = 1.0,
         qos_lpm_priority_weight: float = 1.0,
@@ -177,6 +179,7 @@ class SchedulePolicy:
         self.enable_hierarchical_cache = enable_hierarchical_cache
         self.enable_priority_scheduling = enable_priority_scheduling
         self.schedule_low_priority_values_first = schedule_low_priority_values_first
+        self.enable_qos_aware_prefix_cache = enable_qos_aware_prefix_cache
         self.priority_sign = 1 if schedule_low_priority_values_first else -1
         if min(
             qos_lpm_shared_weight,
@@ -212,7 +215,12 @@ class SchedulePolicy:
             and get_global_server_args().disaggregation_mode != "decode"
         ):
             for r in waiting_queue:
-                match_prefix_for_req(self.tree_cache, r, include_req=True)
+                match_prefix_for_req(
+                    self.tree_cache,
+                    r,
+                    include_req=True,
+                    update_cache_stats=not self.enable_qos_aware_prefix_cache,
+                )
 
         if self.policy == CacheAgnosticPolicy.FCFS:
             if self.enable_priority_scheduling:
@@ -299,7 +307,11 @@ class SchedulePolicy:
             prefix_ids = r.origin_input_ids + r.output_ids
             extra_key = r.extra_key
             match_result = match_prefix_for_req(
-                self.tree_cache, r, prefix_ids, include_req=True
+                self.tree_cache,
+                r,
+                prefix_ids,
+                include_req=True,
+                update_cache_stats=not self.enable_qos_aware_prefix_cache,
             )
 
             # NOTE(sang): This logic is for in-batch prefix caching;

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -52,6 +52,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     zero_match_result,
 )
+from sglang.srt.mem_cache.evict_policy import get_qos_weight
 from sglang.srt.mem_cache.multi_ended_allocator import (
     UnifiedMambaTokenToKVPoolAllocator,
 )
@@ -102,6 +103,7 @@ def match_prefix_for_req(
     match_result = tree_cache.match_prefix(
         MatchPrefixParams(
             key=RadixKey(token_ids=token_ids, extra_key=req.extra_key),
+            update_cache_stats=False,
             cow_mamba=cow_mamba,
             req=req if include_req else None,
         )
@@ -208,7 +210,9 @@ class SchedulePolicy:
                 )
             elif policy == CacheAwarePolicy.QOS_LPM:
                 SchedulePolicy._sort_by_qos_longest_prefix(
-                    waiting_queue, temporary_deprioritized
+                    waiting_queue,
+                    temporary_deprioritized,
+                    self.schedule_low_priority_values_first,
                 )
             elif policy == CacheAwarePolicy.DFS_WEIGHT:
                 SchedulePolicy._sort_by_dfs_weight(waiting_queue, self.tree_cache)
@@ -320,14 +324,18 @@ class SchedulePolicy:
 
     @staticmethod
     def _sort_by_qos_longest_prefix(
-        waiting_queue: List[Req], temporary_deprioritized: Set[int]
+        waiting_queue: List[Req],
+        temporary_deprioritized: Set[int],
+        schedule_low_priority_values_first: bool,
     ) -> None:
         """Sorts by higher QoS priority, longer prefix match, then arrival time."""
 
         def sort_key(req: Req):
             is_deprioritized = req.rid in temporary_deprioritized
             prefix_key = -len(req.prefix_indices)
-            qos_weight = max(req.priority or 1, 1)
+            qos_weight = get_qos_weight(
+                req.priority, schedule_low_priority_values_first
+            )
             return (
                 is_deprioritized,
                 -qos_weight,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 import os
 import random
+import time
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from enum import Enum, auto
@@ -165,6 +166,11 @@ class SchedulePolicy:
         enable_hierarchical_cache: bool,
         enable_priority_scheduling: bool,
         schedule_low_priority_values_first: bool,
+        qos_lpm_shared_weight: float = 1.0,
+        qos_lpm_delay_weight: float = 1.0,
+        qos_lpm_priority_weight: float = 1.0,
+        qos_lpm_dram_discount: float = 0.5,
+        qos_lpm_delay_reference: float = 10.0,
     ):
         self.policy = self._validate_and_adjust_policy(policy, tree_cache)
         self.tree_cache = tree_cache
@@ -172,6 +178,21 @@ class SchedulePolicy:
         self.enable_priority_scheduling = enable_priority_scheduling
         self.schedule_low_priority_values_first = schedule_low_priority_values_first
         self.priority_sign = 1 if schedule_low_priority_values_first else -1
+        if min(
+            qos_lpm_shared_weight,
+            qos_lpm_delay_weight,
+            qos_lpm_priority_weight,
+        ) < 0:
+            raise ValueError("qos-lpm score weights must be non-negative")
+        if not 0.0 <= qos_lpm_dram_discount <= 1.0:
+            raise ValueError("qos-lpm DRAM discount must be between 0 and 1")
+        if qos_lpm_delay_reference <= 0:
+            raise ValueError("qos-lpm delay reference must be positive")
+        self.qos_lpm_shared_weight = qos_lpm_shared_weight
+        self.qos_lpm_delay_weight = qos_lpm_delay_weight
+        self.qos_lpm_priority_weight = qos_lpm_priority_weight
+        self.qos_lpm_dram_discount = qos_lpm_dram_discount
+        self.qos_lpm_delay_reference = qos_lpm_delay_reference
 
         # It is used to find the matching prefix for in-batch prefix caching.
         self.waiting_queue_radix_tree = RadixCache.create_simulated()
@@ -213,6 +234,11 @@ class SchedulePolicy:
                     waiting_queue,
                     temporary_deprioritized,
                     self.schedule_low_priority_values_first,
+                    shared_weight=self.qos_lpm_shared_weight,
+                    delay_weight=self.qos_lpm_delay_weight,
+                    priority_weight=self.qos_lpm_priority_weight,
+                    dram_discount=self.qos_lpm_dram_discount,
+                    delay_reference=self.qos_lpm_delay_reference,
                 )
             elif policy == CacheAwarePolicy.DFS_WEIGHT:
                 SchedulePolicy._sort_by_dfs_weight(waiting_queue, self.tree_cache)
@@ -327,19 +353,39 @@ class SchedulePolicy:
         waiting_queue: List[Req],
         temporary_deprioritized: Set[int],
         schedule_low_priority_values_first: bool,
+        *,
+        shared_weight: float,
+        delay_weight: float,
+        priority_weight: float,
+        dram_discount: float,
+        delay_reference: float,
     ) -> None:
-        """Sorts by higher QoS priority, longer prefix match, then arrival time."""
+        """Sort by cache location, queueing delay, and QoS as one score."""
+        now = time.monotonic()
 
         def sort_key(req: Req):
             is_deprioritized = req.rid in temporary_deprioritized
-            prefix_key = -len(req.prefix_indices)
+            total_prefix_len = max(len(req.origin_input_ids) + len(req.output_ids), 1)
+            device_hit_len = min(len(req.prefix_indices), total_prefix_len)
+            host_hit_len = min(
+                req.host_hit_length, total_prefix_len - device_hit_len
+            )
+            shared_score = (
+                device_hit_len + dram_discount * host_hit_len
+            ) / total_prefix_len
+            wait_time = max(now - req.time_stats.wait_queue_entry_time, 0.0)
+            delay_score = 1.0 + wait_time / delay_reference
             qos_weight = get_qos_weight(
                 req.priority, schedule_low_priority_values_first
             )
+            score = (
+                shared_weight * shared_score
+                + delay_weight * delay_score
+                + priority_weight * qos_weight
+            )
             return (
                 is_deprioritized,
-                -qos_weight,
-                prefix_key,
+                -score,
                 req.time_stats.wait_queue_entry_time,
             )
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1045,6 +1045,9 @@ class Scheduler(
             self.enable_hierarchical_cache,
             self.enable_priority_scheduling,
             self.schedule_low_priority_values_first,
+            enable_qos_aware_prefix_cache=(
+                self.server_args.enable_qos_aware_prefix_cache
+            ),
             qos_lpm_shared_weight=self.server_args.qos_lpm_shared_weight,
             qos_lpm_delay_weight=self.server_args.qos_lpm_delay_weight,
             qos_lpm_priority_weight=self.server_args.qos_lpm_priority_weight,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1045,6 +1045,11 @@ class Scheduler(
             self.enable_hierarchical_cache,
             self.enable_priority_scheduling,
             self.schedule_low_priority_values_first,
+            qos_lpm_shared_weight=self.server_args.qos_lpm_shared_weight,
+            qos_lpm_delay_weight=self.server_args.qos_lpm_delay_weight,
+            qos_lpm_priority_weight=self.server_args.qos_lpm_priority_weight,
+            qos_lpm_dram_discount=self.server_args.qos_lpm_dram_discount,
+            qos_lpm_delay_reference=self.server_args.qos_lpm_delay_reference,
         )
         self.prefill_delayer: Optional[PrefillDelayer] = None
         self.max_prefill_bs: int = 0

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -45,6 +45,9 @@ class MatchPrefixParams:
 
     key: RadixKey
 
+    # Queue scans are probes and must not make an unserved prefix look hot.
+    update_cache_stats: bool = True
+
     # Mamba specific
     cow_mamba: bool = False
     req: Optional[Req] = None

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -27,6 +27,7 @@ class CacheInitParams:
     attn_tp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     pp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     eviction_policy: str = "lru"
+    schedule_low_priority_values_first: bool = False
     disable_finished_insert: bool = False
 
     enable_metrics: bool = False

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -50,13 +50,28 @@ class PriorityStrategy(EvictionStrategy):
 class QoSAwareStrategy(EvictionStrategy):
     """QoS-aware eviction weighted by prefix hotness and request priority."""
 
+    def __init__(self, schedule_low_priority_values_first: bool = False):
+        self.schedule_low_priority_values_first = schedule_low_priority_values_first
+
     def get_priority(self, node: "TreeNode") -> Tuple[float, float]:
         prefix_len = max(len(node.key), 1)
         age = max(time.monotonic() - node.last_access_time, 0.0)
         recency_bonus = 1.0 / (1.0 + age)
         hotness = node.hit_count + recency_bonus / prefix_len
-        qos_weight = max(node.priority or 0, 1)
+        qos_weight = get_qos_weight(
+            node.priority, self.schedule_low_priority_values_first
+        )
         return (hotness * qos_weight, node.last_access_time)
+
+
+def get_qos_weight(
+    priority: int | None, schedule_low_priority_values_first: bool = False
+) -> float:
+    """Convert a positive QoS tier to a direction-aware protection weight."""
+    tier = max(float(priority or 0), 1.0)
+    if schedule_low_priority_values_first:
+        return 1.0 / tier
+    return tier
 
 
 class SLRUStrategy(EvictionStrategy):

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Tuple, Union
 
@@ -44,6 +45,18 @@ class PriorityStrategy(EvictionStrategy):
     def get_priority(self, node: TreeNode) -> Tuple[int, float]:
         # Return (priority, last_access_time) so lower priority nodes are evicted first
         return (node.priority, node.last_access_time)
+
+
+class QoSAwareStrategy(EvictionStrategy):
+    """QoS-aware eviction weighted by prefix hotness and request priority."""
+
+    def get_priority(self, node: "TreeNode") -> Tuple[float, float]:
+        prefix_len = max(len(node.key), 1)
+        age = max(time.monotonic() - node.last_access_time, 0.0)
+        recency_bonus = 1.0 / (1.0 + age)
+        hotness = node.hit_count + recency_bonus / prefix_len
+        qos_weight = max(node.priority or 0, 1)
+        return (hotness * qos_weight, node.last_access_time)
 
 
 class SLRUStrategy(EvictionStrategy):

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -203,6 +203,9 @@ class HiRadixCache(RadixCache):
         self.write_through_threshold = (
             1 if server_args.hicache_write_policy == "write_through" else 2
         )
+        self.enable_qos_aware_prefix_cache = (
+            server_args.enable_qos_aware_prefix_cache
+        )
         self.load_back_threshold = 10
 
         # Detach storage backend automatically on process shutdown
@@ -781,7 +784,12 @@ class HiRadixCache(RadixCache):
             logger.warning("Hierarchical cache storage backend is not enabled.")
             return False
 
-    def write_backup(self, node: TreeNode, write_back=False) -> int:
+    def write_backup(
+        self,
+        node: TreeNode,
+        write_back: bool = False,
+        selective_admission: bool = False,
+    ) -> int:
         # Backup invariant (for write-through mode): backed-up nodes must form a
         # contiguous prefix from root — no gaps.  Skip if parent isn't backed
         # up yet;
@@ -790,12 +798,17 @@ class HiRadixCache(RadixCache):
         ):
             return 0
 
+        if selective_admission and not self._prepare_selective_host_space(node):
+            return 0
+
         host_indices = self.cache_controller.write(
             device_indices=node.value,
             node_id=node.id,
             **self._get_extra_pools(),
         )
         if host_indices is None:
+            if selective_admission:
+                return 0
             self.evict_host(len(node.value))
             host_indices = self.cache_controller.write(
                 device_indices=node.value,
@@ -812,6 +825,19 @@ class HiRadixCache(RadixCache):
             return 0
 
         return len(host_indices)
+
+    def _prepare_selective_host_space(self, node: TreeNode) -> bool:
+        """Admit only if Host has room or colder replaceable data can be removed."""
+        mem_pool_host = self.cache_controller.mem_pool_host
+        required_tokens = max(len(node.value) - mem_pool_host.available_size(), 0)
+        if required_tokens == 0:
+            return True
+
+        candidate_priority = self.eviction_strategy.get_priority(node)
+        evicted_tokens = self.evict_host(
+            required_tokens, max_priority=candidate_priority
+        )
+        return evicted_tokens >= required_tokens
 
     def _track_write_through_node(self, node: TreeNode, backup_len: int) -> None:
         node.write_through_pending_id = node.id
@@ -924,10 +950,17 @@ class HiRadixCache(RadixCache):
             return
         node.hit_count += 1
 
-        if not node.backuped:
-            if node.hit_count >= self.write_through_threshold:
-                # write to host if the node is not backuped
-                self.write_backup(node)
+        if not node.backuped and node.hit_count >= self.write_through_threshold:
+            # The frequency threshold is the first admission filter. Under the
+            # QoS feature gate, the dynamic Host-score comparison is the second.
+            self.write_backup(
+                node,
+                selective_admission=(
+                    self.enable_qos_aware_prefix_cache
+                    and self.cache_controller.write_policy
+                    == "write_through_selective"
+                ),
+            )
 
     def writing_check(self, write_back=False):
         if write_back:
@@ -1199,7 +1232,7 @@ class HiRadixCache(RadixCache):
         self._update_host_leaf_status(root.parent)
         return freed_device
 
-    def evict_host(self, num_tokens: int):
+    def evict_host(self, num_tokens: int, max_priority=None) -> int:
         leaves = list(self.evictable_host_leaves)
         eviction_heap = [
             (self.eviction_strategy.get_priority(node), node) for node in leaves
@@ -1208,7 +1241,9 @@ class HiRadixCache(RadixCache):
 
         num_evicted = 0
         while num_evicted < num_tokens and len(eviction_heap):
-            _, x = heapq.heappop(eviction_heap)
+            priority, x = heapq.heappop(eviction_heap)
+            if max_priority is not None and priority >= max_priority:
+                break
             if x == self.root_node:
                 break
             # only evict the host value of evicted nodes
@@ -1233,6 +1268,8 @@ class HiRadixCache(RadixCache):
             if len(x.parent.children) == 0 and x.parent.evicted:
                 new_priority = self.eviction_strategy.get_priority(x.parent)
                 heapq.heappush(eviction_heap, (new_priority, x.parent))
+
+        return num_evicted
 
     def load_back(
         self, node: TreeNode, mem_quota: Optional[int] = None

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -26,6 +26,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     MatchResult,
 )
+from sglang.srt.mem_cache.evict_policy import get_qos_weight
 from sglang.srt.mem_cache.hicache_storage import (
     PoolHitPolicy,
     PoolName,
@@ -206,6 +207,17 @@ class HiRadixCache(RadixCache):
         self.enable_qos_aware_prefix_cache = (
             server_args.enable_qos_aware_prefix_cache
         )
+        self.qos_hicache_recompute_time_per_token = (
+            server_args.qos_hicache_recompute_time_per_token
+        )
+        self.schedule_low_priority_values_first = (
+            server_args.schedule_low_priority_values_first
+        )
+        self.qos_hicache_transfer_time_per_token = (
+            self.qos_hicache_recompute_time_per_token / 2
+        )
+        self.qos_hicache_cost_ewma_alpha = 0.2
+        self.ongoing_load_back_stats = {}
         self.load_back_threshold = 10
 
         # Detach storage backend automatically on process shutdown
@@ -730,6 +742,7 @@ class HiRadixCache(RadixCache):
         self.token_to_kv_pool_host.clear()
         # Clear per-request tracking dicts
         self.prefetch_loaded_tokens_by_reqid.clear()
+        self.ongoing_load_back_stats.clear()
         self.evictable_host_leaves.clear()
         super().reset()
 
@@ -828,16 +841,74 @@ class HiRadixCache(RadixCache):
 
     def _prepare_selective_host_space(self, node: TreeNode) -> bool:
         """Admit only if Host has room or colder replaceable data can be removed."""
+        candidate_priority = self._get_host_admission_priority(node)
+        if candidate_priority[0] <= 0:
+            return False
+
         mem_pool_host = self.cache_controller.mem_pool_host
         required_tokens = max(len(node.value) - mem_pool_host.available_size(), 0)
         if required_tokens == 0:
             return True
 
-        candidate_priority = self.eviction_strategy.get_priority(node)
         evicted_tokens = self.evict_host(
-            required_tokens, max_priority=candidate_priority
+            required_tokens,
+            max_priority=candidate_priority,
+            priority_fn=self._get_host_admission_priority,
         )
         return evicted_tokens >= required_tokens
+
+    def _get_host_admission_priority(self, node: TreeNode):
+        transfer_time = (
+            node.host_transfer_time_per_token
+            if node.host_load_count > 0
+            else self.qos_hicache_transfer_time_per_token
+        )
+        net_benefit = max(
+            self.qos_hicache_recompute_time_per_token - transfer_time, 0.0
+        )
+        demand = node.hit_count + node.host_match_count
+        qos_weight = get_qos_weight(
+            node.priority, self.schedule_low_priority_values_first
+        )
+        return (demand * net_benefit * qos_weight, node.last_access_time)
+
+    def _should_load_back(self, nodes: list[TreeNode]) -> bool:
+        recompute_time = sum(
+            len(node.host_value)
+            * self.qos_hicache_recompute_time_per_token
+            for node in nodes
+        )
+        transfer_time = sum(
+            len(node.host_value)
+            * (
+                node.host_transfer_time_per_token
+                if node.host_load_count > 0
+                else self.qos_hicache_transfer_time_per_token
+            )
+            for node in nodes
+        )
+        return transfer_time < recompute_time
+
+    def _record_host_load(
+        self, nodes: list[TreeNode], num_tokens: int, duration: float
+    ) -> None:
+        if num_tokens <= 0:
+            return
+        observed = duration / num_tokens
+        alpha = self.qos_hicache_cost_ewma_alpha
+        self.qos_hicache_transfer_time_per_token = (
+            (1 - alpha) * self.qos_hicache_transfer_time_per_token
+            + alpha * observed
+        )
+        for node in nodes:
+            node.host_load_count += 1
+            if node.host_transfer_time_per_token == 0.0:
+                node.host_transfer_time_per_token = observed
+            else:
+                node.host_transfer_time_per_token = (
+                    (1 - alpha) * node.host_transfer_time_per_token
+                    + alpha * observed
+                )
 
     def _track_write_through_node(self, node: TreeNode, backup_len: int) -> None:
         node.write_through_pending_id = node.id
@@ -1011,11 +1082,26 @@ class HiRadixCache(RadixCache):
         if finish_count > 0:
             logger.debug(f"Process {finish_count} load operations")
         while finish_count > 0:
-            _, finish_event, ack_list = self.cache_controller.ack_load_queue.pop(0)
+            start_event, finish_event, ack_list = (
+                self.cache_controller.ack_load_queue.pop(0)
+            )
             finish_event.synchronize()
+            loaded_nodes = []
+            loaded_tokens = 0
             for ack_id in ack_list:
                 end_node = self.ongoing_load_back.pop(ack_id)
+                stats = self.ongoing_load_back_stats.pop(ack_id, None)
+                if stats is not None:
+                    nodes, num_tokens = stats
+                    loaded_nodes.extend(nodes)
+                    loaded_tokens += num_tokens
                 self.dec_lock_ref(end_node)
+            if loaded_tokens > 0:
+                self._record_host_load(
+                    loaded_nodes,
+                    loaded_tokens,
+                    start_event.elapsed_time(finish_event) / 1000.0,
+                )
             finish_count -= 1
 
     def is_load_back_event_done(self, consumer_index: int) -> bool:
@@ -1232,11 +1318,13 @@ class HiRadixCache(RadixCache):
         self._update_host_leaf_status(root.parent)
         return freed_device
 
-    def evict_host(self, num_tokens: int, max_priority=None) -> int:
+    def evict_host(
+        self, num_tokens: int, max_priority=None, priority_fn=None
+    ) -> int:
         leaves = list(self.evictable_host_leaves)
-        eviction_heap = [
-            (self.eviction_strategy.get_priority(node), node) for node in leaves
-        ]
+        if priority_fn is None:
+            priority_fn = self.eviction_strategy.get_priority
+        eviction_heap = [(priority_fn(node), node) for node in leaves]
         heapq.heapify(eviction_heap)
 
         num_evicted = 0
@@ -1266,7 +1354,7 @@ class HiRadixCache(RadixCache):
             self._update_host_leaf_status(x.parent)
 
             if len(x.parent.children) == 0 and x.parent.evicted:
-                new_priority = self.eviction_strategy.get_priority(x.parent)
+                new_priority = priority_fn(x.parent)
                 heapq.heappush(eviction_heap, (new_priority, x.parent))
 
         return num_evicted
@@ -1297,6 +1385,12 @@ class HiRadixCache(RadixCache):
             len(host_indices) > mem_quota + delta if mem_quota is not None else False
         ):
             # skip loading back if the total size is too small or exceeding the memory quota
+            self.dec_lock_ref(ancester_node)
+            return None
+        if (
+            self.enable_qos_aware_prefix_cache
+            and not self._should_load_back(nodes_to_load)
+        ):
             self.dec_lock_ref(ancester_node)
             return None
 
@@ -1333,6 +1427,10 @@ class HiRadixCache(RadixCache):
         for n in nodes_to_load:
             n.release_host()
         self.ongoing_load_back[last_hit_node.id] = last_hit_node
+        if self.enable_qos_aware_prefix_cache:
+            self.ongoing_load_back_stats[last_hit_node.id] = (
+                nodes_to_load, len(device_indices)
+            )
         offset = 0
         for node in nodes_to_load:
             node.value = device_indices[offset : offset + len(node.host_value)].clone()
@@ -1723,7 +1821,9 @@ class HiRadixCache(RadixCache):
 
         return matched_length
 
-    def _match_prefix_helper(self, node: TreeNode, key: RadixKey):
+    def _match_prefix_helper(
+        self, node: TreeNode, key: RadixKey, update_cache_stats: bool = True
+    ):
         node.last_access_time = time.monotonic()
         child_key = key.child_key(self.page_size)
         value = []
@@ -1736,11 +1836,15 @@ class HiRadixCache(RadixCache):
                 new_node = self._split_node(child.key, child, prefix_len)
                 if not new_node.evicted:
                     value.append(new_node.value)
+                elif update_cache_stats:
+                    new_node.host_match_count += 1
                 node = new_node
                 break
             else:
                 if not child.evicted:
                     value.append(child.value)
+                elif update_cache_stats:
+                    child.host_match_count += 1
                 node = child
                 key = key[prefix_len:]
 
@@ -1757,6 +1861,11 @@ class HiRadixCache(RadixCache):
         new_node.lock_ref = child.lock_ref
         new_node.key = child.key[:split_len]
         new_node.hit_count = child.hit_count
+        new_node.host_match_count = child.host_match_count
+        new_node.host_load_count = child.host_load_count
+        new_node.host_transfer_time_per_token = (
+            child.host_transfer_time_per_token
+        )
 
         # split value and host value if exists
         if child.evicted:

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1559,7 +1559,9 @@ class HiRadixCache(RadixCache):
         if len(key) == 0:
             return self._empty_match_result
 
-        value, last_node = self._match_prefix_helper(self.root_node, key)
+        value, last_node = self._match_prefix_helper(
+            self.root_node, key, update_cache_stats=params.update_cache_stats
+        )
         if value:
             value = torch.cat(value)
         else:

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -216,6 +216,9 @@ def build_kv_cache(
         attn_tp_cache_group=attn_tp_cpu_group,
         pp_cache_group=pp_group.cpu_group,
         eviction_policy=server_args.radix_eviction_policy,
+        schedule_low_priority_values_first=(
+            server_args.schedule_low_priority_values_first
+        ),
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,
         enable_session_radix_cache=server_args.enable_session_radix_cache,

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -315,6 +315,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         mock_allocator: Optional[Any] = None,
         page_size: int = 1,
         enable_kv_cache_events: bool = False,
+        eviction_policy: str = "lru",
     ) -> RadixCache:
         """Init a radix cache without memory pools for simulation purpose."""
         params = CacheInitParams(
@@ -323,6 +324,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
             token_to_kv_pool_allocator=mock_allocator,
             page_size=page_size,
             enable_kv_cache_events=enable_kv_cache_events,
+            eviction_policy=eviction_policy,
         )
         return RadixCache(params)
 
@@ -658,10 +660,12 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
             prefix_len = child.key.match(key, page_size=self.page_size)
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
+                self._inc_qos_aware_hit_count(new_node)
                 value.append(new_node.value)
                 node = new_node
                 break
             else:
+                self._inc_qos_aware_hit_count(child)
                 value.append(child.value)
                 node = child
                 key = key[prefix_len:]
@@ -700,6 +704,10 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         if chunked:
             return
         node.hit_count += 1
+
+    def _inc_qos_aware_hit_count(self, node: TreeNode):
+        if self.eviction_policy == "qos-aware":
+            node.hit_count += 1
 
     def _insert_helper(
         self,

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -288,6 +288,9 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         self.is_eagle = params.is_eagle
         self.disable_finished_insert = params.disable_finished_insert
         self.eviction_policy = params.eviction_policy.lower()
+        self.schedule_low_priority_values_first = (
+            params.schedule_low_priority_values_first
+        )
 
         self.kv_event_queue = []
 
@@ -303,7 +306,9 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         else:
             self.device = torch.device("cpu")
 
-        self.eviction_strategy = get_eviction_strategy(self.eviction_policy)
+        self.eviction_strategy = get_eviction_strategy(
+            self.eviction_policy, self.schedule_low_priority_values_first
+        )
 
         self.evictable_leaves = set()
         self.reset()
@@ -316,6 +321,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         page_size: int = 1,
         enable_kv_cache_events: bool = False,
         eviction_policy: str = "lru",
+        schedule_low_priority_values_first: bool = False,
     ) -> RadixCache:
         """Init a radix cache without memory pools for simulation purpose."""
         params = CacheInitParams(
@@ -325,6 +331,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
             page_size=page_size,
             enable_kv_cache_events=enable_kv_cache_events,
             eviction_policy=eviction_policy,
+            schedule_low_priority_values_first=schedule_low_priority_values_first,
         )
         return RadixCache(params)
 
@@ -402,7 +409,9 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         if len(key) == 0:
             return self._empty_match_result
 
-        value, last_node = self._match_prefix_helper(self.root_node, key)
+        value, last_node = self._match_prefix_helper(
+            self.root_node, key, update_cache_stats=params.update_cache_stats
+        )
         if value:
             value = torch.cat(value)
         else:
@@ -647,25 +656,31 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
 
     ##### Internal Helper Functions #####
 
-    def _match_prefix_helper(self, node: TreeNode, key: RadixKey):
+    def _match_prefix_helper(
+        self, node: TreeNode, key: RadixKey, update_cache_stats: bool = True
+    ):
         access_time = time.monotonic()
-        node.last_access_time = access_time
+        if update_cache_stats:
+            node.last_access_time = access_time
 
         child_key = key.child_key(self.page_size)
 
         value = []
         while len(key) > 0 and child_key in node.children.keys():
             child = node.children[child_key]
-            child.last_access_time = access_time
+            if update_cache_stats:
+                child.last_access_time = access_time
             prefix_len = child.key.match(key, page_size=self.page_size)
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
-                self._inc_qos_aware_hit_count(new_node)
+                if update_cache_stats:
+                    self._inc_qos_aware_hit_count(new_node)
                 value.append(new_node.value)
                 node = new_node
                 break
             else:
-                self._inc_qos_aware_hit_count(child)
+                if update_cache_stats:
+                    self._inc_qos_aware_hit_count(child)
                 value.append(child.value)
                 node = child
                 key = key[prefix_len:]
@@ -709,6 +724,11 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         if self.eviction_policy == "qos-aware":
             node.hit_count += 1
 
+    def _merge_cache_priority(self, current: int, incoming: int) -> int:
+        if self.eviction_policy == "qos-aware" and self.schedule_low_priority_values_first:
+            return min(current, incoming)
+        return max(current, incoming)
+
     def _insert_helper(
         self,
         node: TreeNode,
@@ -723,7 +743,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         access_time = time.monotonic()
         node.last_access_time = access_time
         # Update priority along the path (take max to propagate higher priority)
-        node.priority = max(node.priority, priority)
+        node.priority = self._merge_cache_priority(node.priority, priority)
         if len(key) == 0:
             return 0, node
 
@@ -740,11 +760,11 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
 
             if prefix_len < len(node.key):
                 new_node = self._split_node(node.key, node, prefix_len)
-                new_node.priority = max(new_node.priority, priority)
+                new_node.priority = self._merge_cache_priority(new_node.priority, priority)
                 self._inc_hit_count(new_node, chunked)
                 node = new_node
             else:
-                node.priority = max(node.priority, priority)
+                node.priority = self._merge_cache_priority(node.priority, priority)
                 self._inc_hit_count(node, chunked)
             if len(key):
                 child_key = key.child_key(self.page_size)

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -228,6 +228,11 @@ class TreeNode:
         self.creation_time = time.monotonic()
 
         self.hit_count = 0
+        # QoS-aware HiCache demand/cost observations. These remain inert unless
+        # the feature gate and selective write-through policy are enabled.
+        self.host_match_count = 0
+        self.host_load_count = 0
+        self.host_transfer_time_per_token = 0.0
         # indicating the node is locked to protect from eviction
         # incremented when the node is referenced by a storage operation
         self.host_ref_counter = 0

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -65,8 +65,12 @@ _EVICTION_POLICY_FACTORIES: dict[str, Callable[[], EvictionStrategy]] = {
 }
 
 
-def get_eviction_strategy(eviction_policy: str) -> EvictionStrategy:
+def get_eviction_strategy(
+    eviction_policy: str, schedule_low_priority_values_first: bool = False
+) -> EvictionStrategy:
     policy = eviction_policy.lower()
+    if policy == "qos-aware":
+        return QoSAwareStrategy(schedule_low_priority_values_first)
     try:
         return _EVICTION_POLICY_FACTORIES[policy]()
     except KeyError:

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -25,6 +25,7 @@ from sglang.srt.mem_cache.evict_policy import (
     LRUStrategy,
     MRUStrategy,
     PriorityStrategy,
+    QoSAwareStrategy,
     SLRUStrategy,
 )
 from sglang.srt.mem_cache.triton_ops.mla_buffer import (
@@ -59,6 +60,7 @@ _EVICTION_POLICY_FACTORIES: dict[str, Callable[[], EvictionStrategy]] = {
     "mru": MRUStrategy,
     "filo": FILOStrategy,
     "priority": PriorityStrategy,
+    "qos-aware": QoSAwareStrategy,
     "slru": SLRUStrategy,
 }
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -291,7 +291,7 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
 
 BF16_GEMM_BACKEND_CHOICES = ["auto", "cutedsl"]
 
-RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
+RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority", "qos-aware"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
 
@@ -710,6 +710,7 @@ class ServerArgs:
                 "dfs-weight",
                 "lof",
                 "priority",
+                "qos-lpm",
                 "routing-key",
             ],
         ),
@@ -766,8 +767,9 @@ class ServerArgs:
             help=(
                 "The eviction policy of radix trees. 'lru' stands for Least "
                 "Recently Used, 'lfu' stands for Least Frequently Used, 'slru' "
-                "stands for Segmented Least Recently Used, and 'priority' evicts "
-                "lower-priority requests first."
+                "stands for Segmented Least Recently Used, 'priority' evicts "
+                "lower-priority requests first, and 'qos-aware' evicts low hotness/QoS "
+                "prefixes first."
             ),
             choices=RADIX_EVICTION_POLICY_CHOICES,
         ),
@@ -6939,7 +6941,11 @@ class ServerArgs:
             assert self.schedule_policy in [
                 "fcfs",
                 "lof",
-            ], f"To use priority scheduling, schedule_policy must be 'fcfs' or 'lof'. '{self.schedule_policy}' is not supported."
+                "qos-lpm",
+            ], (
+                "To use priority scheduling, schedule_policy must be 'fcfs', "
+                f"'lof', or 'qos-lpm'. '{self.schedule_policy}' is not supported."
+            )
             if self.default_priority_value is None:
                 logger.warning(
                     "--default-priority-value is not set while --enable-priority-scheduling is enabled. "

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -733,6 +733,21 @@ class ServerArgs:
         bool,
         "If specified with --enable-priority-scheduling, the scheduler will schedule requests with lower priority integer values first.",
     ] = False
+    qos_lpm_shared_weight: A[
+        float, "Weight of the HBM/DRAM prefix-sharing score for qos-lpm."
+    ] = 1.0
+    qos_lpm_delay_weight: A[
+        float, "Weight of queueing-delay urgency for qos-lpm."
+    ] = 1.0
+    qos_lpm_priority_weight: A[
+        float, "Weight of the request QoS tier for qos-lpm."
+    ] = 1.0
+    qos_lpm_dram_discount: A[
+        float, "Relative value of a DRAM prefix hit compared with an HBM hit for qos-lpm."
+    ] = 0.5
+    qos_lpm_delay_reference: A[
+        float, "Reference wait time in seconds used to normalize qos-lpm delay urgency."
+    ] = 10.0
     priority_scheduling_preemption_threshold: A[
         int,
         "Minimum difference in priorities for an incoming request to have to preempt running request(s).",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -719,6 +719,10 @@ class ServerArgs:
         bool,
         "Enable priority scheduling. Requests with higher priority integer values will be scheduled first by default.",
     ] = False
+    enable_qos_aware_prefix_cache: A[
+        bool,
+        "Enable QoS-aware prefix-cache accounting, scheduling, and eviction features.",
+    ] = False
     disable_priority_preemption: A[bool, "Disable priority scheduling preemption."] = (
         False
     )
@@ -6950,6 +6954,18 @@ class ServerArgs:
         self.validate_buckets_rule(
             "--generation-tokens-buckets", self.generation_tokens_buckets
         )
+
+        # QoS-aware prefix-cache features are opt-in so disabling the gate
+        # preserves the original SGLang scheduling and cache-accounting behavior.
+        if not self.enable_qos_aware_prefix_cache:
+            assert self.schedule_policy != "qos-lpm", (
+                "--schedule-policy qos-lpm requires "
+                "--enable-qos-aware-prefix-cache"
+            )
+            assert self.radix_eviction_policy != "qos-aware", (
+                "--radix-eviction-policy qos-aware requires "
+                "--enable-qos-aware-prefix-cache"
+            )
 
         # Check scheduling policy
         if self.enable_priority_scheduling:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -723,6 +723,10 @@ class ServerArgs:
         bool,
         "Enable QoS-aware prefix-cache accounting, scheduling, and eviction features.",
     ] = False
+    qos_hicache_recompute_time_per_token: A[
+        float,
+        "Estimated prefill recomputation time per token in seconds for QoS-aware HiCache admission.",
+    ] = 1e-4
     disable_priority_preemption: A[bool, "Disable priority scheduling preemption."] = (
         False
     )
@@ -6957,7 +6961,11 @@ class ServerArgs:
 
         # QoS-aware prefix-cache features are opt-in so disabling the gate
         # preserves the original SGLang scheduling and cache-accounting behavior.
-        if not self.enable_qos_aware_prefix_cache:
+        if self.enable_qos_aware_prefix_cache:
+            assert self.qos_hicache_recompute_time_per_token > 0, (
+                "--qos-hicache-recompute-time-per-token must be positive"
+            )
+        else:
             assert self.schedule_policy != "qos-lpm", (
                 "--schedule-policy qos-lpm requires "
                 "--enable-qos-aware-prefix-cache"

--- a/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
+++ b/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
@@ -4,7 +4,7 @@ import torch
 
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.schedule_policy import CacheAwarePolicy, SchedulePolicy
-from sglang.srt.mem_cache.base_prefix_cache import InsertParams
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -13,13 +13,13 @@ register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 
 class TestQoSLPMSchedulePolicy(unittest.TestCase):
-    def _policy(self, tree_cache):
+    def _policy(self, tree_cache, low_priority_values_first=False):
         return SchedulePolicy(
             policy="qos-lpm",
             tree_cache=tree_cache,
             enable_hierarchical_cache=False,
             enable_priority_scheduling=False,
-            schedule_low_priority_values_first=False,
+            schedule_low_priority_values_first=low_priority_values_first,
         )
 
     def _req(self, rid, token_ids, priority, wait_time):
@@ -48,6 +48,36 @@ class TestQoSLPMSchedulePolicy(unittest.TestCase):
             [r.rid for r in waiting_queue],
             ["high-no-prefix", "low-long-prefix"],
         )
+
+    def test_lower_priority_value_scheduled_first_when_configured(self):
+        tree_cache = RadixCache.create_simulated()
+        waiting_queue = [
+            self._req("value-five", [5], 5, 1.0),
+            self._req("value-one", [1], 1, 2.0),
+        ]
+
+        self._policy(tree_cache, low_priority_values_first=True).calc_priority(
+            waiting_queue
+        )
+
+        self.assertEqual([r.rid for r in waiting_queue], ["value-one", "value-five"])
+
+    def test_repeated_schedule_probes_do_not_inflate_cache_hotness(self):
+        tree_cache = RadixCache.create_simulated(eviction_policy="qos-aware")
+        key = RadixKey([1, 2, 3])
+        tree_cache.insert(InsertParams(key=key, value=torch.tensor([1, 2, 3])))
+        node = tree_cache.match_prefix(
+            MatchPrefixParams(key=key, update_cache_stats=False)
+        ).last_device_node
+        initial_hit_count = node.hit_count
+        initial_access_time = node.last_access_time
+        waiting_queue = [self._req("waiting", [1, 2, 3], 1, 1.0)]
+
+        self._policy(tree_cache).calc_priority(waiting_queue)
+        self._policy(tree_cache).calc_priority(waiting_queue)
+
+        self.assertEqual(node.hit_count, initial_hit_count)
+        self.assertEqual(node.last_access_time, initial_access_time)
 
     def test_same_priority_longer_prefix_scheduled_first(self):
         tree_cache = RadixCache.create_simulated()

--- a/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
+++ b/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
@@ -1,0 +1,82 @@
+import unittest
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_policy import CacheAwarePolicy, SchedulePolicy
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestQoSLPMSchedulePolicy(unittest.TestCase):
+    def _policy(self, tree_cache):
+        return SchedulePolicy(
+            policy="qos-lpm",
+            tree_cache=tree_cache,
+            enable_hierarchical_cache=False,
+            enable_priority_scheduling=False,
+            schedule_low_priority_values_first=False,
+        )
+
+    def _req(self, rid, token_ids, priority, wait_time):
+        req = Req(rid, "", token_ids, SamplingParams(), priority=priority)
+        req.output_ids = []
+        req.time_stats.wait_queue_entry_time = wait_time
+        return req
+
+    def test_init_with_qos_lpm_policy(self):
+        policy = self._policy(RadixCache.create_simulated())
+        self.assertEqual(policy.policy, CacheAwarePolicy.QOS_LPM)
+
+    def test_higher_priority_scheduled_first(self):
+        tree_cache = RadixCache.create_simulated()
+        tree_cache.insert(
+            InsertParams(key=RadixKey([1, 2, 3]), value=torch.tensor([1, 2, 3]))
+        )
+        waiting_queue = [
+            self._req("low-long-prefix", [1, 2, 3], 1, 1.0),
+            self._req("high-no-prefix", [9, 9, 9], 5, 2.0),
+        ]
+
+        self._policy(tree_cache).calc_priority(waiting_queue)
+
+        self.assertEqual(
+            [r.rid for r in waiting_queue],
+            ["high-no-prefix", "low-long-prefix"],
+        )
+
+    def test_same_priority_longer_prefix_scheduled_first(self):
+        tree_cache = RadixCache.create_simulated()
+        tree_cache.insert(
+            InsertParams(key=RadixKey([1, 2, 3]), value=torch.tensor([1, 2, 3]))
+        )
+        waiting_queue = [
+            self._req("short", [1, 2], 2, 1.0),
+            self._req("long", [1, 2, 3], 2, 2.0),
+        ]
+
+        self._policy(tree_cache).calc_priority(waiting_queue)
+
+        self.assertEqual([r.rid for r in waiting_queue], ["long", "short"])
+
+    def test_same_priority_and_prefix_uses_arrival_order(self):
+        tree_cache = RadixCache.create_simulated()
+        tree_cache.insert(
+            InsertParams(key=RadixKey([1, 2]), value=torch.tensor([1, 2]))
+        )
+        waiting_queue = [
+            self._req("later", [1, 2], 2, 2.0),
+            self._req("earlier", [1, 2], 2, 1.0),
+        ]
+
+        self._policy(tree_cache).calc_priority(waiting_queue)
+
+        self.assertEqual([r.rid for r in waiting_queue], ["earlier", "later"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
+++ b/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -79,14 +80,96 @@ class TestQoSLPMSchedulePolicy(unittest.TestCase):
         self.assertEqual(node.hit_count, initial_hit_count)
         self.assertEqual(node.last_access_time, initial_access_time)
 
+    def test_hbm_hit_scores_higher_than_same_length_dram_hit(self):
+        hbm = self._req("hbm", [1, 2, 3, 4], 1, 99.0)
+        dram = self._req("dram", [5, 6, 7, 8], 1, 99.0)
+        hbm.prefix_indices = torch.tensor([1, 2, 3, 4])
+        dram.prefix_indices = torch.tensor([], dtype=torch.int64)
+        dram.host_hit_length = 4
+        waiting_queue = [dram, hbm]
+
+        with patch(
+            "sglang.srt.managers.schedule_policy.time.monotonic", return_value=100.0
+        ):
+            SchedulePolicy._sort_by_qos_longest_prefix(
+                waiting_queue,
+                set(),
+                False,
+                shared_weight=1.0,
+                delay_weight=0.0,
+                priority_weight=0.0,
+                dram_discount=0.5,
+                delay_reference=10.0,
+            )
+
+        self.assertEqual([r.rid for r in waiting_queue], ["hbm", "dram"])
+
+    def test_mixed_hit_uses_discounted_dram_length(self):
+        mixed = self._req("mixed", [1, 2, 3, 4], 1, 99.0)
+        device_only = self._req("device-only", [5, 6, 7, 8], 1, 99.0)
+        mixed.prefix_indices = torch.tensor([1, 2])
+        mixed.host_hit_length = 2
+        device_only.prefix_indices = torch.tensor([5, 6])
+        waiting_queue = [device_only, mixed]
+
+        with patch(
+            "sglang.srt.managers.schedule_policy.time.monotonic", return_value=100.0
+        ):
+            SchedulePolicy._sort_by_qos_longest_prefix(
+                waiting_queue,
+                set(),
+                False,
+                shared_weight=1.0,
+                delay_weight=0.0,
+                priority_weight=0.0,
+                dram_discount=0.5,
+                delay_reference=10.0,
+            )
+
+        self.assertEqual([r.rid for r in waiting_queue], ["mixed", "device-only"])
+
+    def test_waiting_delay_can_prevent_low_qos_starvation(self):
+        high_qos = self._req("high-qos", [1], 3, 99.0)
+        old_low_qos = self._req("old-low-qos", [2], 1, 0.0)
+        waiting_queue = [high_qos, old_low_qos]
+
+        with patch(
+            "sglang.srt.managers.schedule_policy.time.monotonic", return_value=100.0
+        ):
+            SchedulePolicy._sort_by_qos_longest_prefix(
+                waiting_queue,
+                set(),
+                False,
+                shared_weight=0.0,
+                delay_weight=1.0,
+                priority_weight=1.0,
+                dram_discount=0.5,
+                delay_reference=10.0,
+            )
+
+        self.assertEqual(
+            [r.rid for r in waiting_queue], ["old-low-qos", "high-qos"]
+        )
+
+    def test_invalid_location_score_config_is_rejected(self):
+        with self.assertRaises(ValueError):
+            SchedulePolicy(
+                policy="qos-lpm",
+                tree_cache=RadixCache.create_simulated(),
+                enable_hierarchical_cache=False,
+                enable_priority_scheduling=False,
+                schedule_low_priority_values_first=False,
+                qos_lpm_dram_discount=1.5,
+            )
+
     def test_same_priority_longer_prefix_scheduled_first(self):
         tree_cache = RadixCache.create_simulated()
         tree_cache.insert(
             InsertParams(key=RadixKey([1, 2, 3]), value=torch.tensor([1, 2, 3]))
         )
         waiting_queue = [
-            self._req("short", [1, 2], 2, 1.0),
-            self._req("long", [1, 2, 3], 2, 2.0),
+            self._req("short", [1, 2, 9], 2, 1.0),
+            self._req("long", [1, 2, 3], 2, 1.0),
         ]
 
         self._policy(tree_cache).calc_priority(waiting_queue)

--- a/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
+++ b/test/registered/unit/managers/test_qos_lpm_schedule_policy.py
@@ -21,6 +21,7 @@ class TestQoSLPMSchedulePolicy(unittest.TestCase):
             enable_hierarchical_cache=False,
             enable_priority_scheduling=False,
             schedule_low_priority_values_first=low_priority_values_first,
+            enable_qos_aware_prefix_cache=True,
         )
 
     def _req(self, rid, token_ids, priority, wait_time):
@@ -62,6 +63,27 @@ class TestQoSLPMSchedulePolicy(unittest.TestCase):
         )
 
         self.assertEqual([r.rid for r in waiting_queue], ["value-one", "value-five"])
+
+    def test_disabled_gate_preserves_baseline_match_accounting(self):
+        tree_cache = RadixCache.create_simulated(eviction_policy="lru")
+        key = RadixKey([1, 2, 3])
+        tree_cache.insert(InsertParams(key=key, value=torch.tensor([1, 2, 3])))
+        waiting_queue = [self._req("baseline", [1, 2, 3], 1, 1.0)]
+        policy = SchedulePolicy(
+            policy="lpm",
+            tree_cache=tree_cache,
+            enable_hierarchical_cache=False,
+            enable_priority_scheduling=False,
+            schedule_low_priority_values_first=False,
+            enable_qos_aware_prefix_cache=False,
+        )
+
+        with patch(
+            "sglang.srt.mem_cache.radix_cache.time.monotonic", return_value=123.0
+        ):
+            policy.calc_priority(waiting_queue)
+
+        self.assertEqual(waiting_queue[0].last_node.last_access_time, 123.0)
 
     def test_repeated_schedule_probes_do_not_inflate_cache_hotness(self):
         tree_cache = RadixCache.create_simulated(eviction_policy="qos-aware")
@@ -159,6 +181,7 @@ class TestQoSLPMSchedulePolicy(unittest.TestCase):
                 enable_hierarchical_cache=False,
                 enable_priority_scheduling=False,
                 schedule_low_priority_values_first=False,
+                enable_qos_aware_prefix_cache=True,
                 qos_lpm_dram_discount=1.5,
             )
 

--- a/test/registered/unit/mem_cache/test_evict_policy.py
+++ b/test/registered/unit/mem_cache/test_evict_policy.py
@@ -6,7 +6,7 @@ register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=7, suite="base-c-test-cpu")
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from sglang.srt.mem_cache.evict_policy import (
     FIFOStrategy,
@@ -15,6 +15,7 @@ from sglang.srt.mem_cache.evict_policy import (
     LRUStrategy,
     MRUStrategy,
     PriorityStrategy,
+    QoSAwareStrategy,
     SLRUStrategy,
 )
 
@@ -25,6 +26,7 @@ def _make_node(**kwargs):
     node.hit_count = kwargs.get("hit_count", 0)
     node.creation_time = kwargs.get("creation_time", 0.0)
     node.priority = kwargs.get("priority", 0)
+    node.key = kwargs.get("key", [0])
     return node
 
 
@@ -137,6 +139,45 @@ class TestPriorityStrategy(unittest.TestCase):
         new = _make_node(priority=3, last_access_time=10.0)
         self.assertLess(
             self.strategy.get_priority(old), self.strategy.get_priority(new)
+        )
+
+
+class TestQoSAwareStrategy(unittest.TestCase):
+    def setUp(self):
+        self.strategy = QoSAwareStrategy()
+
+    def _get_priority(self, node):
+        with patch(
+            "sglang.srt.mem_cache.evict_policy.time.monotonic",
+            return_value=20.0,
+        ):
+            return self.strategy.get_priority(node)
+
+    def test_higher_hit_count_evicted_later(self):
+        cold = _make_node(hit_count=1, priority=1, key=[1], last_access_time=10.0)
+        hot = _make_node(hit_count=5, priority=1, key=[1], last_access_time=1.0)
+        self.assertLess(self._get_priority(cold), self._get_priority(hot))
+
+    def test_higher_qos_priority_evicted_later(self):
+        low_qos = _make_node(hit_count=2, priority=1, key=[1], last_access_time=10.0)
+        high_qos = _make_node(hit_count=2, priority=8, key=[1], last_access_time=1.0)
+        self.assertLess(self._get_priority(low_qos), self._get_priority(high_qos))
+
+    def test_default_qos_weight_is_one(self):
+        zero_qos = _make_node(hit_count=2, priority=0, key=[1], last_access_time=1.0)
+        one_qos = _make_node(hit_count=2, priority=1, key=[1], last_access_time=1.0)
+        self.assertEqual(
+            self._get_priority(zero_qos)[0],
+            self._get_priority(one_qos)[0],
+        )
+
+    def test_same_score_older_access_evicted_first(self):
+        old = _make_node(hit_count=2, priority=1, key=[1], last_access_time=1.0)
+        new = _make_node(hit_count=2, priority=1, key=[1], last_access_time=10.0)
+        old_score, _ = self._get_priority(old)
+        self.assertLess(
+            (old_score, old.last_access_time),
+            (old_score, new.last_access_time),
         )
 
 

--- a/test/registered/unit/mem_cache/test_evict_policy.py
+++ b/test/registered/unit/mem_cache/test_evict_policy.py
@@ -163,6 +163,17 @@ class TestQoSAwareStrategy(unittest.TestCase):
         high_qos = _make_node(hit_count=2, priority=8, key=[1], last_access_time=1.0)
         self.assertLess(self._get_priority(low_qos), self._get_priority(high_qos))
 
+    def test_lower_qos_value_is_protected_when_configured(self):
+        strategy = QoSAwareStrategy(schedule_low_priority_values_first=True)
+        low_value = _make_node(hit_count=2, priority=1, key=[1], last_access_time=1.0)
+        high_value = _make_node(hit_count=2, priority=8, key=[1], last_access_time=1.0)
+        with patch(
+            "sglang.srt.mem_cache.evict_policy.time.monotonic", return_value=20.0
+        ):
+            self.assertGreater(
+                strategy.get_priority(low_value), strategy.get_priority(high_value)
+            )
+
     def test_default_qos_weight_is_one(self):
         zero_qos = _make_node(hit_count=2, priority=0, key=[1], last_access_time=1.0)
         one_qos = _make_node(hit_count=2, priority=1, key=[1], last_access_time=1.0)

--- a/test/registered/unit/mem_cache/test_qos_hicache_admission.py
+++ b/test/registered/unit/mem_cache/test_qos_hicache_admission.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.mem_cache.evict_policy import QoSAwareStrategy
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+from sglang.srt.mem_cache.radix_cache import RadixKey, TreeNode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestQoSHiCacheAdmission(unittest.TestCase):
+    def _cache(self, *, enabled=True):
+        cache = object.__new__(HiRadixCache)
+        cache.cache_controller = MagicMock()
+        cache.cache_controller.write_policy = "write_through_selective"
+        cache.write_through_threshold = 2
+        cache.enable_qos_aware_prefix_cache = enabled
+        cache.eviction_strategy = QoSAwareStrategy()
+        return cache
+
+    def _node(self, *, priority=1):
+        node = TreeNode(priority=priority)
+        node.key = RadixKey([1, 2, 3, 4])
+        node.value = torch.tensor([1, 2, 3, 4])
+        return node
+
+    def test_frequency_threshold_is_first_filter(self):
+        cache = self._cache()
+        cache.write_backup = MagicMock(return_value=4)
+        node = self._node()
+
+        cache._inc_hit_count(node)
+        cache.write_backup.assert_not_called()
+
+        cache._inc_hit_count(node)
+        cache.write_backup.assert_called_once_with(
+            node, selective_admission=True
+        )
+
+    def test_disabled_gate_preserves_original_selective_write(self):
+        cache = self._cache(enabled=False)
+        cache.write_backup = MagicMock(return_value=4)
+        node = self._node()
+
+        cache._inc_hit_count(node)
+        cache._inc_hit_count(node)
+
+        cache.write_backup.assert_called_once_with(
+            node, selective_admission=False
+        )
+
+    def test_admits_when_host_has_free_space(self):
+        cache = self._cache()
+        cache.cache_controller.mem_pool_host.available_size.return_value = 4
+        cache.evict_host = MagicMock(return_value=0)
+
+        self.assertTrue(cache._prepare_selective_host_space(self._node()))
+        cache.evict_host.assert_not_called()
+
+    def test_replaces_only_nodes_colder_than_candidate(self):
+        cache = self._cache()
+        cache.cache_controller.mem_pool_host.available_size.return_value = 0
+        cache.evict_host = MagicMock(return_value=4)
+        node = self._node(priority=3)
+        candidate_priority = (0.75, 123.0)
+        cache.eviction_strategy.get_priority = MagicMock(
+            return_value=candidate_priority
+        )
+
+        self.assertTrue(cache._prepare_selective_host_space(node))
+        cache.evict_host.assert_called_once_with(
+            4, max_priority=candidate_priority
+        )
+
+    def test_rejects_when_colder_nodes_cannot_free_enough_space(self):
+        cache = self._cache()
+        cache.cache_controller.mem_pool_host.available_size.return_value = 0
+        cache.evict_host = MagicMock(return_value=2)
+
+        self.assertFalse(cache._prepare_selective_host_space(self._node()))
+
+    def test_rejected_candidate_does_not_start_host_write(self):
+        cache = self._cache()
+        cache.root_node = TreeNode()
+        node = self._node()
+        node.parent = cache.root_node
+        cache._prepare_selective_host_space = MagicMock(return_value=False)
+
+        self.assertEqual(
+            cache.write_backup(node, selective_admission=True), 0
+        )
+        cache.cache_controller.write.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_qos_hicache_admission.py
+++ b/test/registered/unit/mem_cache/test_qos_hicache_admission.py
@@ -19,6 +19,12 @@ class TestQoSHiCacheAdmission(unittest.TestCase):
         cache.write_through_threshold = 2
         cache.enable_qos_aware_prefix_cache = enabled
         cache.eviction_strategy = QoSAwareStrategy()
+        cache.schedule_low_priority_values_first = False
+        cache.qos_hicache_recompute_time_per_token = 0.1
+        cache.qos_hicache_transfer_time_per_token = 0.05
+        cache.qos_hicache_cost_ewma_alpha = 0.2
+        cache.ongoing_load_back_stats = {}
+        cache.page_size = 1
         return cache
 
     def _node(self, *, priority=1):
@@ -52,12 +58,25 @@ class TestQoSHiCacheAdmission(unittest.TestCase):
             node, selective_admission=False
         )
 
+    def test_rejects_zero_benefit_even_when_host_has_space(self):
+        cache = self._cache()
+        cache.qos_hicache_transfer_time_per_token = 0.2
+        cache.cache_controller.mem_pool_host.available_size.return_value = 4
+        cache.evict_host = MagicMock(return_value=0)
+        node = self._node()
+        node.hit_count = 2
+
+        self.assertFalse(cache._prepare_selective_host_space(node))
+        cache.evict_host.assert_not_called()
+
     def test_admits_when_host_has_free_space(self):
         cache = self._cache()
         cache.cache_controller.mem_pool_host.available_size.return_value = 4
         cache.evict_host = MagicMock(return_value=0)
+        node = self._node()
+        node.hit_count = 2
 
-        self.assertTrue(cache._prepare_selective_host_space(self._node()))
+        self.assertTrue(cache._prepare_selective_host_space(node))
         cache.evict_host.assert_not_called()
 
     def test_replaces_only_nodes_colder_than_candidate(self):
@@ -65,22 +84,96 @@ class TestQoSHiCacheAdmission(unittest.TestCase):
         cache.cache_controller.mem_pool_host.available_size.return_value = 0
         cache.evict_host = MagicMock(return_value=4)
         node = self._node(priority=3)
-        candidate_priority = (0.75, 123.0)
-        cache.eviction_strategy.get_priority = MagicMock(
-            return_value=candidate_priority
-        )
+        node.hit_count = 2
+        candidate_priority = cache._get_host_admission_priority(node)
 
         self.assertTrue(cache._prepare_selective_host_space(node))
-        cache.evict_host.assert_called_once_with(
-            4, max_priority=candidate_priority
+        cache.evict_host.assert_called_once()
+        call = cache.evict_host.call_args
+        self.assertEqual(call.args[0], 4)
+        self.assertEqual(call.kwargs["max_priority"], candidate_priority)
+        self.assertEqual(
+            call.kwargs["priority_fn"], cache._get_host_admission_priority
         )
 
     def test_rejects_when_colder_nodes_cannot_free_enough_space(self):
         cache = self._cache()
         cache.cache_controller.mem_pool_host.available_size.return_value = 0
         cache.evict_host = MagicMock(return_value=2)
+        node = self._node()
+        node.hit_count = 2
 
-        self.assertFalse(cache._prepare_selective_host_space(self._node()))
+        self.assertFalse(cache._prepare_selective_host_space(node))
+        cache.evict_host.assert_called_once()
+
+    def test_host_value_uses_logical_matches_and_net_benefit(self):
+        cache = self._cache()
+        node = self._node(priority=3)
+        node.hit_count = 2
+        node.host_match_count = 3
+        node.host_load_count = 1
+        node.host_transfer_time_per_token = 0.02
+
+        value, _ = cache._get_host_admission_priority(node)
+
+        self.assertAlmostEqual(value, 5 * (0.1 - 0.02) * 3)
+
+    def test_host_value_is_zero_when_transfer_is_slower(self):
+        cache = self._cache()
+        node = self._node(priority=3)
+        node.hit_count = 10
+        node.host_load_count = 1
+        node.host_transfer_time_per_token = 0.2
+
+        value, _ = cache._get_host_admission_priority(node)
+
+        self.assertEqual(value, 0.0)
+
+    def test_load_back_is_skipped_when_recompute_is_faster(self):
+        cache = self._cache()
+        node = self._node()
+        node.host_value = torch.tensor([1, 2, 3, 4])
+        node.host_load_count = 1
+        node.host_transfer_time_per_token = 0.2
+
+        self.assertFalse(cache._should_load_back([node]))
+
+    def test_cold_load_back_uses_global_cost_estimate(self):
+        cache = self._cache()
+        node = self._node()
+        node.host_value = torch.tensor([1, 2, 3, 4])
+
+        self.assertTrue(cache._should_load_back([node]))
+
+    def test_completed_load_updates_node_and_global_cost(self):
+        cache = self._cache()
+        node = self._node()
+
+        cache._record_host_load([node], num_tokens=4, duration=0.4)
+
+        self.assertEqual(node.host_load_count, 1)
+        self.assertAlmostEqual(node.host_transfer_time_per_token, 0.1)
+        self.assertAlmostEqual(cache.qos_hicache_transfer_time_per_token, 0.06)
+
+    def test_host_logical_match_counts_without_load_back(self):
+        cache = self._cache()
+        cache.root_node = TreeNode()
+        node = self._node()
+        node.value = None
+        node.host_value = torch.tensor([1, 2, 3, 4])
+        node.parent = cache.root_node
+        key = RadixKey([1, 2, 3, 4])
+        cache.root_node.children[key.child_key(cache.page_size)] = node
+
+        cache._match_prefix_helper(
+            cache.root_node, key, update_cache_stats=True
+        )
+        cache._match_prefix_helper(
+            cache.root_node, key, update_cache_stats=False
+        )
+
+        self.assertEqual(node.host_match_count, 1)
+        self.assertEqual(node.host_load_count, 0)
 
     def test_rejected_candidate_does_not_start_host_write(self):
         cache = self._cache()

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -580,6 +580,91 @@ class TestRadixCache(unittest.TestCase):
         # Non-existent extra_key should not match
         self.assertEqual(len(result4.device_indices), 0)
 
+    def test_qos_aware_match_updates_hit_count_only_for_policy(self):
+        qos_cache = RadixCache.create_simulated(eviction_policy="qos-aware")
+        lru_cache = RadixCache.create_simulated(eviction_policy="lru")
+
+        key = RadixKey([1, 2, 3])
+        qos_cache.insert(InsertParams(key=key, value=torch.tensor([1, 2, 3])))
+        lru_cache.insert(InsertParams(key=key, value=torch.tensor([1, 2, 3])))
+
+        qos_node = qos_cache.match_prefix(MatchPrefixParams(key=key)).last_device_node
+        lru_node = lru_cache.match_prefix(MatchPrefixParams(key=key)).last_device_node
+
+        self.assertEqual(qos_node.hit_count, 2)
+        self.assertEqual(lru_node.hit_count, 1)
+
+    def test_qos_aware_evicts_colder_prefix_first(self):
+        mock_allocator = unittest.mock.Mock()
+        cache = RadixCache.create_simulated(
+            mock_allocator=mock_allocator, eviction_policy="qos-aware"
+        )
+
+        hot_key = RadixKey([1, 2])
+        cold_key = RadixKey([3, 4])
+        cache.insert(InsertParams(key=hot_key, value=torch.tensor([1, 2])))
+        cache.insert(InsertParams(key=cold_key, value=torch.tensor([3, 4])))
+        cache.match_prefix(MatchPrefixParams(key=hot_key))
+        cache.match_prefix(MatchPrefixParams(key=hot_key))
+
+        cache.evict(EvictParams(num_tokens=2))
+
+        self.assertEqual(
+            len(cache.match_prefix(MatchPrefixParams(key=cold_key)).device_indices), 0
+        )
+        self.assertEqual(
+            len(cache.match_prefix(MatchPrefixParams(key=hot_key)).device_indices), 2
+        )
+
+    def test_qos_aware_evicts_lower_qos_first(self):
+        mock_allocator = unittest.mock.Mock()
+        cache = RadixCache.create_simulated(
+            mock_allocator=mock_allocator, eviction_policy="qos-aware"
+        )
+
+        high_qos_key = RadixKey([1, 2])
+        low_qos_key = RadixKey([3, 4])
+        cache.insert(
+            InsertParams(key=high_qos_key, value=torch.tensor([1, 2]), priority=8)
+        )
+        cache.insert(
+            InsertParams(key=low_qos_key, value=torch.tensor([3, 4]), priority=1)
+        )
+
+        cache.evict(EvictParams(num_tokens=2))
+
+        self.assertEqual(
+            len(cache.match_prefix(MatchPrefixParams(key=low_qos_key)).device_indices),
+            0,
+        )
+        self.assertEqual(
+            len(cache.match_prefix(MatchPrefixParams(key=high_qos_key)).device_indices),
+            2,
+        )
+
+    def test_qos_aware_shared_prefix_uses_max_priority(self):
+        cache = RadixCache.create_simulated(eviction_policy="qos-aware")
+
+        cache.insert(
+            InsertParams(
+                key=RadixKey([1, 2, 3]),
+                value=torch.tensor([1, 2, 3]),
+                priority=1,
+            )
+        )
+        cache.insert(
+            InsertParams(
+                key=RadixKey([1, 2, 4]),
+                value=torch.tensor([1, 2, 4]),
+                priority=9,
+            )
+        )
+
+        shared_node = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey([1, 2]))
+        ).last_device_node
+        self.assertEqual(shared_node.priority, 9)
+
     def test_lock_ref_operations(self):
         """Test lock reference counting operations."""
         cache = RadixCache.create_simulated()

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -594,6 +594,21 @@ class TestRadixCache(unittest.TestCase):
         self.assertEqual(qos_node.hit_count, 2)
         self.assertEqual(lru_node.hit_count, 1)
 
+    def test_qos_aware_probe_does_not_update_cache_stats(self):
+        cache = RadixCache.create_simulated(eviction_policy="qos-aware")
+        key = RadixKey([1, 2, 3])
+        cache.insert(InsertParams(key=key, value=torch.tensor([1, 2, 3])))
+        node = cache.match_prefix(
+            MatchPrefixParams(key=key, update_cache_stats=False)
+        ).last_device_node
+        initial_hit_count = node.hit_count
+        initial_access_time = node.last_access_time
+
+        cache.match_prefix(MatchPrefixParams(key=key, update_cache_stats=False))
+
+        self.assertEqual(node.hit_count, initial_hit_count)
+        self.assertEqual(node.last_access_time, initial_access_time)
+
     def test_qos_aware_evicts_colder_prefix_first(self):
         mock_allocator = unittest.mock.Mock()
         cache = RadixCache.create_simulated(
@@ -664,6 +679,26 @@ class TestRadixCache(unittest.TestCase):
             MatchPrefixParams(key=RadixKey([1, 2]))
         ).last_device_node
         self.assertEqual(shared_node.priority, 9)
+
+    def test_qos_aware_shared_prefix_uses_min_priority_when_configured(self):
+        cache = RadixCache.create_simulated(
+            eviction_policy="qos-aware", schedule_low_priority_values_first=True
+        )
+        cache.insert(
+            InsertParams(
+                key=RadixKey([1, 2, 3]), value=torch.tensor([1, 2, 3]), priority=9
+            )
+        )
+        cache.insert(
+            InsertParams(
+                key=RadixKey([1, 2, 4]), value=torch.tensor([1, 2, 4]), priority=1
+            )
+        )
+
+        shared_node = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey([1, 2]), update_cache_stats=False)
+        ).last_device_node
+        self.assertEqual(shared_node.priority, 1)
 
     def test_lock_ref_operations(self):
         """Test lock reference counting operations."""


### PR DESCRIPTION
## Summary
- Add qos-aware radix eviction policy that weights prefix hotness by request priority.
- Add qos-lpm scheduler policy that orders by priority, prefix match length, and arrival time.
- Add unit coverage for eviction scoring, radix cache behavior, and qos-lpm scheduling.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->