### PR TITLE
[Feat]: Add V32_nope sparse decoding support in FlashMLA

### DIFF
--- a/sgl-kernel/cmake/flashmla.cmake
+++ b/sgl-kernel/cmake/flashmla.cmake
@@ -115,6 +115,8 @@ set(FlashMLA_SOURCES
     ${repo-flashmla_SOURCE_DIR}/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h128.cu
     ${repo-flashmla_SOURCE_DIR}/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h64.cu
     ${repo-flashmla_SOURCE_DIR}/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h128.cu
+    ${repo-flashmla_SOURCE_DIR}/csrc/sm90/decode/sparse_fp8/instantiations/v32_no_rope_persistent_h64.cu
+    ${repo-flashmla_SOURCE_DIR}/csrc/sm90/decode/sparse_fp8/instantiations/v32_no_rope_persistent_h128.cu
 
     # sm90 sparse prefill.
     ${repo-flashmla_SOURCE_DIR}/csrc/sm90/prefill/sparse/fwd.cu
@@ -143,6 +145,7 @@ if(FLASHMLA_ENABLE_SM100)
 
         # sm100 sparse decode.
         ${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/instantiations/v32.cu
+        ${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/instantiations/v32_no_rope.cu
         ${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/instantiations/model1.cu
         ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/sparse/fwd_for_small_topk/head128/instantiations/phase1_decode_k512.cu
     )

--- a/sgl-kernel/cmake/flashmla.cmake
+++ b/sgl-kernel/cmake/flashmla.cmake
@@ -1,9 +1,8 @@
 # flash_mla
-# sm90 dense decode HEAD_DIM_K=512 support (sgl-project/FlashMLA#9, merged).
 FetchContent_Declare(
     repo-flashmla
-    URL      https://${GITHUB_ARTIFACTORY}/sgl-project/FlashMLA/archive/05e26647fe840b8baedae486c2d86d5ce4efeb7c.tar.gz
-    URL_HASH SHA256=ce369489bbfc42cdfbba9aa949de0270e64469d530748dea9f4f60b3c69dea9b
+    URL      https://${GITHUB_ARTIFACTORY}/sgl-project/FlashMLA/archive/b6d6325733add3681dd19431093a867790f00a15.tar.gz
+    URL_HASH SHA256=bcec05dbcbc626235307042c486b8ce2652d0d8706427ed04843eab160e70bfa
 )
 FetchContent_Populate(repo-flashmla)
 


### PR DESCRIPTION
## Summary
This PR merely adds some additional new files to the CMake file of flashmla. For detailed information, please refer to https://github.com/sgl-project/FlashMLA/pull/10 

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30420601610](https://github.com/sgl-project/sglang/actions/runs/30420601610)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30420601508](https://github.com/sgl-project/sglang/actions/runs/30420601508)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->