### PR TITLE
[CI] Fix model inventory for nested test model tables

### DIFF
--- a/scripts/ci/list_stage_models.py
+++ b/scripts/ci/list_stage_models.py
@@ -134,16 +134,30 @@ def looks_like_model_id(value: str, deny: Optional[Set[str]] = None) -> bool:
 
 
 def _string_values(node: ast.AST) -> List[str]:
-    """String constants directly held by ``node`` (a Constant, Tuple, or List)."""
-    if isinstance(node, ast.Constant):
-        return [node.value] if isinstance(node.value, str) else []
-    if isinstance(node, (ast.Tuple, ast.List)):
-        out: List[str] = []
-        for elt in node.elts:
-            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-                out.append(elt.value)
-        return out
-    return []
+    """Static string constants reachable from an assignment RHS.
+
+    Shared test helpers often define model tables as lists of dataclass
+    constructors or dicts, e.g. ``[ModelCase(base="org/model")]``. Walk the
+    RHS recursively so name references to those tables can still populate the
+    inventory. String fragments inside f-strings are skipped because they are
+    partial/dynamic and can look like truncated model ids.
+    """
+    fstring_fragments = {
+        id(part)
+        for joined in ast.walk(node)
+        if isinstance(joined, ast.JoinedStr)
+        for part in joined.values
+        if isinstance(part, ast.Constant)
+    }
+    out: List[str] = []
+    for child in ast.walk(node):
+        if (
+            isinstance(child, ast.Constant)
+            and isinstance(child.value, str)
+            and id(child) not in fstring_fragments
+        ):
+            out.append(child.value)
+    return out
 
 
 def extract_constants_from_source(

--- a/scripts/ci/test_list_stage_models.py
+++ b/scripts/ci/test_list_stage_models.py
@@ -115,6 +115,41 @@ class ConstantTable(unittest.TestCase):
         table = lsm.extract_constants_from_source(source)
         self.assertEqual(table["M"], {"meta-llama/Llama-3.1-8B-Instruct"})
 
+    def test_nested_static_model_tables(self):
+        source = (
+            "CASES = [\n"
+            "    ModelCase(\n"
+            '        base="meta-llama/Llama-2-7b-hf",\n'
+            "        adaptors=[\n"
+            '            LoRAAdaptor(name="winddude/wizardLM-LlaMA-LoRA-7B"),\n'
+            "        ],\n"
+            "    ),\n"
+            "    {\n"
+            '        "model_path": "Qwen/Qwen3-8B",\n'
+            '        "mime": "text/plain",\n'
+            "    },\n"
+            "]\n"
+        )
+        table = lsm.extract_constants_from_source(source)
+        self.assertEqual(
+            table["CASES"],
+            {
+                "Qwen/Qwen3-8B",
+                "meta-llama/Llama-2-7b-hf",
+                "winddude/wizardLM-LlaMA-LoRA-7B",
+            },
+        )
+
+    def test_nested_fstring_fragments_are_skipped(self):
+        source = (
+            "CASES = [\n"
+            '    f"meta-llama/Llama-3.1-8B-Instruct-{suffix}",\n'
+            '    {"model_path": "Qwen/Qwen3-8B"},\n'
+            "]\n"
+        )
+        table = lsm.extract_constants_from_source(source)
+        self.assertEqual(table["CASES"], {"Qwen/Qwen3-8B"})
+
     def test_deny_excludes_from_constant_table(self):
         source = 'BAD = "weird/thing"\nGOOD = "meta-llama/Llama-3.1-8B-Instruct"\n'
         table = lsm.extract_constants_from_source(source, deny={"weird/thing"})


### PR DESCRIPTION
## Motivation

The CI model inventory extractor currently misses model ids stored in nested static helper tables. One concrete case is `python/sglang/test/lora_utils.py`, where LoRA test cases are defined as `LoRAModelCase(base=..., adaptors=[...])` entries and registered tests reference the table by name. Because the constant table only handled direct string/list/tuple values, some LoRA base/adaptor model ids were omitted from the prewarm inventory.

## Modifications

- Recursively collect static string constants from assignment RHS nodes when building the model constant table.
- Keep f-string literal fragments excluded so dynamic/partial model ids are not accidentally captured.
- Add regression coverage for nested dataclass/dict-style model tables and nested f-string fragments.

## Accuracy Tests

Not applicable. This only changes CI static analysis for model inventory generation and does not affect runtime model outputs.

## Speed Tests and Profiling

Not applicable. This does not affect inference runtime.

## Tests

- `python3 -m unittest discover -s scripts/ci -p 'test_list_stage_models.py'`
- `python3 -m compileall -q scripts/ci/list_stage_models.py scripts/ci/test_list_stage_models.py`
- `/tmp/sglang-check-tools/bin/ruff check scripts/ci/list_stage_models.py scripts/ci/test_list_stage_models.py`
- `PYTHONPATH=/tmp/sglang-check-tools /tmp/sglang-check-tools/bin/codespell --config .codespellrc scripts/ci/list_stage_models.py scripts/ci/test_list_stage_models.py`
- `python3 scripts/ci/check_registered_tests.py`
- `python3 scripts/ci/check_workflow_job_names.py`
- `git diff --check`

Inventory sanity checks:

- CUDA inventory: distinct models `207 -> 209`, unresolved files `417 -> 412`, parse failures `0`
- AMD inventory: distinct models `148 -> 150`, unresolved files `169 -> 165`, parse failures `0`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28930440306](https://github.com/sgl-project/sglang/actions/runs/28930440306)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28930440125](https://github.com/sgl-project/sglang/actions/runs/28930440125)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->