### PR TITLE
[fla] Stop specializing l2norm_fwd_kernel on token count (endless varlen recompiles)

### DIFF
--- a/python/sglang/srt/layers/attention/fla/l2norm.py
+++ b/python/sglang/srt/layers/attention/fla/l2norm.py
@@ -51,13 +51,14 @@ def l2norm_fwd_kernel1(
 #     ],
 #     key=["D", "NB"],
 # )
-@triton.jit
+# T must stay a runtime arg: as constexpr every distinct token count
+# re-specializes the kernel, so varlen batches recompile indefinitely.
+@triton.jit(do_not_specialize=["T"])
 def l2norm_fwd_kernel(
     x,
     y,
     eps,
-    NB: tl.constexpr,
-    T: tl.constexpr,
+    T,
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
@@ -91,7 +92,6 @@ def l2norm_fwd(
         raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
 
     if D <= 512:
-        NB = triton.cdiv(T, 2048)
 
         def grid(meta):
             return (triton.cdiv(T, meta["BT"]),)
@@ -100,7 +100,6 @@ def l2norm_fwd(
             x,
             y,
             eps,
-            NB=NB,
             T=T,
             D=D,
             BD=BD,


### PR DESCRIPTION
## Motivation

`l2norm_fwd_kernel` (the `D <= 512` path in `srt/layers/attention/fla/l2norm.py`) declares the row count `T` as `tl.constexpr`. Every distinct token count therefore produces a new specialization, so under varlen prefill (chunked extend batches with arbitrary token totals) Triton recompiles this kernel essentially forever, on the launch critical path. py-spy on a steady-state serving run of a hybrid linear-attention model showed ~11% of scheduler CPU inside `triton _do_compile` long after warmup, nearly all attributable to this kernel via `chunk` q/k l2norm. It also makes benchmark numbers noisy since compile storms depend on which batch sizes a run happens to hit.

`NB` is in the specialization key too but is never read in the kernel body.

## Modifications

- Make `T` a runtime argument (`do_not_specialize=["T"]`); it is only used as a `make_block_ptr` shape bound, which accepts runtime values.
- Drop the dead `NB` argument.

One compile per `(D, BD, BT)` now. Verified on H200: output matches the previous kernel / a torch reference (bf16, deterministic across calls), and 32 calls with fresh distinct `T` values complete in <0.1 ms each (previously each new `T` paid a full recompile). End-to-end on a hybrid linear-attention model this recovered ~7% serving throughput at concurrency 16 and collapsed run-to-run variance (±15 → ±0.5 tok/s), with GSM8K score/stop-rate unchanged.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-writing-documentation).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #28934374869](https://github.com/sgl-project/sglang/actions/runs/28934374869)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29097403742](https://github.com/sgl-project/sglang/actions/runs/29097403742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->