### PR TITLE
[benchmark] Fix bench_multiturn hanging on failed/truncated/hung requests

### DIFF
--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -445,20 +445,25 @@ class WorkloadGenerator:
                 self.client_records[client_id]["round"] += 1
 
                 if not response.success:
-                    self.failures.append({
-                        "client_id": client_id,
-                        "round": current_round,
-                        "error": response.error or "(no error message)",
-                        "prompt_len": response.prompt_len,
-                        "timestamp": datetime.now().isoformat(),
-                    })
+                    self.failures.append(
+                        {
+                            "client_id": client_id,
+                            "round": current_round,
+                            "error": response.error or "(no error message)",
+                            "prompt_len": response.prompt_len,
+                            "timestamp": datetime.now().isoformat(),
+                        }
+                    )
                     self.completed_requests += 1
                 else:
                     # Extend history with response
                     if self.api_format == "openai":
                         if response.generated_text:
                             self.client_records[client_id]["history"].append(
-                                {"role": "assistant", "content": response.generated_text}
+                                {
+                                    "role": "assistant",
+                                    "content": response.generated_text,
+                                }
                             )
                     else:
                         self.client_records[client_id]["history"].extend(
@@ -468,12 +473,16 @@ class WorkloadGenerator:
                     self.performance_metrics["itl"].extend(response.itl)
                     self.performance_metrics["latency"].append(response.latency)
                     self.performance_metrics["prompt_len"].append(response.prompt_len)
-                    self.performance_metrics["cached_tokens"].append(response.cached_tokens)
-                    self.performance_metrics["generated_len"].append(response.generated_len)
+                    self.performance_metrics["cached_tokens"].append(
+                        response.cached_tokens
+                    )
+                    self.performance_metrics["generated_len"].append(
+                        response.generated_len
+                    )
                     if self.enable_round_barrier:
-                        self.performance_metrics[f"round_{current_round}"]["ttft"].append(
-                            response.ttft
-                        )
+                        self.performance_metrics[f"round_{current_round}"][
+                            "ttft"
+                        ].append(response.ttft)
                         self.performance_metrics[f"round_{current_round}"][
                             "latency"
                         ].append(response.latency)

--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -360,6 +360,7 @@ class WorkloadGenerator:
 
         self.response_queue = queue.Queue()
         self.pbar = tqdm(total=self.total_requests)
+        self.failures = []
         self.performance_metrics = {
             "ttft": [],
             "itl": [],
@@ -389,11 +390,10 @@ class WorkloadGenerator:
         client_id, payload = item
         try:
             response = await self.request_func(payload, self.url, self.pbar)
-            if self.pbar.n == self.pbar.total:
+            if self.completed_requests + 1 >= self.total_requests:
                 self.finished_time = time.perf_counter()
             self.response_queue.put((client_id, response))
         except Exception as e:
-            print(f"Request failed for client {client_id}: {e}")
             failed_response = RequestFuncOutput()
             failed_response.success = False
             failed_response.error = str(e)
@@ -402,6 +402,9 @@ class WorkloadGenerator:
     def request_sender(self):
         async def request_loop():
             while True:
+                if self.completed_requests >= self.total_requests:
+                    break
+
                 if self.sent_requests - self.completed_requests < self.max_parallel:
                     new_request = self.ready_queue.pop()
                     if new_request:
@@ -410,9 +413,6 @@ class WorkloadGenerator:
                 else:
                     await asyncio.sleep(0.05)
                     continue
-
-                if self.pbar.n == self.pbar.total:
-                    break
 
                 # Calculate Poisson-distributed wait time
                 if self.distribution == "poisson":
@@ -441,45 +441,52 @@ class WorkloadGenerator:
                 client_id, response = self.response_queue.get(
                     timeout=10
                 )  # Block until response is available
-                if not response.success:
-                    print(f"Request failed for client {client_id}: {response.error}")
-                    self.completed_requests += 1
-                    continue
-                # Extend history with response
-                if self.api_format == "openai":
-                    if response.generated_text:
-                        self.client_records[client_id]["history"].append(
-                            {"role": "assistant", "content": response.generated_text}
-                        )
-                else:
-                    self.client_records[client_id]["history"].extend(
-                        response.output_ids
-                    )
                 current_round = self.client_records[client_id]["round"]
                 self.client_records[client_id]["round"] += 1
-                self.performance_metrics["ttft"].append(response.ttft)
-                self.performance_metrics["itl"].extend(response.itl)
-                self.performance_metrics["latency"].append(response.latency)
-                self.performance_metrics["prompt_len"].append(response.prompt_len)
-                self.performance_metrics["cached_tokens"].append(response.cached_tokens)
-                self.performance_metrics["generated_len"].append(response.generated_len)
-                if self.enable_round_barrier:
-                    self.performance_metrics[f"round_{current_round}"]["ttft"].append(
-                        response.ttft
-                    )
-                    self.performance_metrics[f"round_{current_round}"][
-                        "latency"
-                    ].append(response.latency)
-                    self.performance_metrics[f"round_{current_round}"][
-                        "prompt_len"
-                    ].append(response.prompt_len)
-                    self.performance_metrics[f"round_{current_round}"][
-                        "cached_tokens"
-                    ].append(response.cached_tokens)
-                    self.performance_metrics[f"round_{current_round}"][
-                        "generated_len"
-                    ].append(response.generated_len)
-                self.completed_requests += 1
+
+                if not response.success:
+                    self.failures.append({
+                        "client_id": client_id,
+                        "round": current_round,
+                        "error": response.error or "(no error message)",
+                        "prompt_len": response.prompt_len,
+                        "timestamp": datetime.now().isoformat(),
+                    })
+                    self.completed_requests += 1
+                else:
+                    # Extend history with response
+                    if self.api_format == "openai":
+                        if response.generated_text:
+                            self.client_records[client_id]["history"].append(
+                                {"role": "assistant", "content": response.generated_text}
+                            )
+                    else:
+                        self.client_records[client_id]["history"].extend(
+                            response.output_ids
+                        )
+                    self.performance_metrics["ttft"].append(response.ttft)
+                    self.performance_metrics["itl"].extend(response.itl)
+                    self.performance_metrics["latency"].append(response.latency)
+                    self.performance_metrics["prompt_len"].append(response.prompt_len)
+                    self.performance_metrics["cached_tokens"].append(response.cached_tokens)
+                    self.performance_metrics["generated_len"].append(response.generated_len)
+                    if self.enable_round_barrier:
+                        self.performance_metrics[f"round_{current_round}"]["ttft"].append(
+                            response.ttft
+                        )
+                        self.performance_metrics[f"round_{current_round}"][
+                            "latency"
+                        ].append(response.latency)
+                        self.performance_metrics[f"round_{current_round}"][
+                            "prompt_len"
+                        ].append(response.prompt_len)
+                        self.performance_metrics[f"round_{current_round}"][
+                            "cached_tokens"
+                        ].append(response.cached_tokens)
+                        self.performance_metrics[f"round_{current_round}"][
+                            "generated_len"
+                        ].append(response.generated_len)
+                    self.completed_requests += 1
 
                 client_total = self.client_records[client_id]["total_rounds"]
                 if self.client_records[client_id]["round"] < client_total:
@@ -537,7 +544,7 @@ class WorkloadGenerator:
                         current_barrier_round += 1
                         barrier_round_completed = 0
             except queue.Empty:
-                if self.pbar.n == self.pbar.total:
+                if self.completed_requests >= self.total_requests:
                     break
             except ValueError as e:
                 print(f"Error processing response for client {client_id}: {e}")
@@ -564,6 +571,17 @@ class WorkloadGenerator:
         response_thread.join()
         self.pbar.close()
 
+        if self.failures:
+            failures_file = "failures.jsonl"
+            try:
+                with open(failures_file, "a") as f:
+                    for fail in self.failures:
+                        f.write(json.dumps(fail) + "\n")
+            except IOError as e:
+                print(f"Error writing failures file: {e}")
+
+        if self.finished_time is None:
+            self.finished_time = time.perf_counter()
         duration = self.finished_time - self.start_time
         sorted_ttft = sorted(self.performance_metrics["ttft"])
         sorted_latency = sorted(self.performance_metrics["latency"])
@@ -708,6 +726,29 @@ class WorkloadGenerator:
             f"  Request Throughput: {performance_data['summary']['throughput']:.2f} requests per second"
         )
         print(f"  Cache Hit Rate: {performance_data['summary']['cache_hit_rate']:.6f}")
+
+        successful = len(self.performance_metrics["ttft"])
+        print(
+            f"  Failed requests: {len(self.failures)}/{self.total_requests} "
+            f"(successful: {successful})"
+        )
+        if self.failures:
+            print("  Failure details (first 20):")
+            for fail in self.failures[:20]:
+                error_preview = fail["error"][:200]
+                print(
+                    f"    client {fail['client_id']} round {fail['round']}: "
+                    f"{error_preview}"
+                )
+            if len(self.failures) > 20:
+                print(
+                    f"    ... and {len(self.failures) - 20} more "
+                    f"(see failures.jsonl)"
+                )
+
+        performance_data["failures"] = self.failures
+        performance_data["summary"]["failed_requests"] = len(self.failures)
+        performance_data["summary"]["successful_requests"] = successful
 
         if self.enable_round_barrier:
             # Print round-basedsummary

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -10,6 +10,7 @@ from sglang.benchmark.serving import RequestFuncOutput
 from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=20 * 60 * 60)
+STREAM_REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=600, sock_read=300)
 
 
 async def async_request_sglang_generate(
@@ -31,10 +32,14 @@ async def async_request_sglang_generate(
         output = RequestFuncOutput()
 
         try:
-            async with session.post(url=url, json=payload, headers=headers) as response:
+            async with session.post(
+                url=url, json=payload, headers=headers,
+                timeout=STREAM_REQUEST_TIMEOUT,
+            ) as response:
                 if response.status == 200:
                     prompt_tokens = 0
                     cached_tokens = 0
+                    done_received = False
 
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -45,7 +50,7 @@ async def async_request_sglang_generate(
                         latency = time.perf_counter() - st
 
                         if chunk == "[DONE]":
-                            pass
+                            done_received = True
                         else:
                             data = json.loads(chunk)
 
@@ -69,20 +74,33 @@ async def async_request_sglang_generate(
 
                                 most_recent_timestamp = timestamp
 
-                    output.generated_text = generated_text
-                    output.output_ids = all_output_ids
-                    output.success = True
-                    output.latency = latency
-                    output.prompt_len = prompt_tokens
-                    output.cached_tokens = cached_tokens
-                    output.generated_len = len(output.itl) + 1
+                    if not done_received:
+                        output.success = False
+                        output.error = (
+                            f"Stream truncated: connection closed before [DONE] "
+                            f"(received {len(all_output_ids)} output ids)"
+                        )
+                    else:
+                        output.generated_text = generated_text
+                        output.output_ids = all_output_ids
+                        output.success = True
+                        output.latency = latency
+                        output.prompt_len = prompt_tokens
+                        output.cached_tokens = cached_tokens
+                        output.generated_len = len(output.itl) + 1
                 else:
-                    output.error = response.reason or ""
+                    try:
+                        body = await response.text()
+                    except Exception:
+                        body = ""
+                    output.error = (
+                        f"HTTP {response.status}: "
+                        f"{body or response.reason or '(empty)'}"
+                    )
                     output.success = False
         except Exception as e:
             output.success = False
             output.error = str(e)
-            print(f"Request failed: {e}")
 
     if pbar:
         pbar.update(1)
@@ -108,11 +126,15 @@ async def async_request_openai_chat_completions(
         output = RequestFuncOutput()
 
         try:
-            async with session.post(url=url, json=payload) as response:
+            async with session.post(
+                url=url, json=payload,
+                timeout=STREAM_REQUEST_TIMEOUT,
+            ) as response:
                 if response.status == 200:
                     prompt_tokens = 0
                     cached_tokens = 0
                     completion_tokens = 0
+                    done_received = False
 
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -123,7 +145,7 @@ async def async_request_openai_chat_completions(
                         latency = time.perf_counter() - st
 
                         if chunk == "[DONE]":
-                            pass
+                            done_received = True
                         else:
                             data = json.loads(chunk)
 
@@ -153,22 +175,35 @@ async def async_request_openai_chat_completions(
                                 details = usage.get("prompt_tokens_details", {}) or {}
                                 cached_tokens = details.get("cached_tokens", 0)
 
-                    output.generated_text = generated_text
-                    output.output_ids = []  # Not available from OpenAI endpoint
-                    output.success = True
-                    output.latency = latency
-                    output.prompt_len = prompt_tokens
-                    output.cached_tokens = cached_tokens
-                    output.generated_len = (
-                        completion_tokens if completion_tokens else len(output.itl) + 1
-                    )
+                    if not done_received:
+                        output.success = False
+                        output.error = (
+                            f"Stream truncated: connection closed before [DONE] "
+                            f"(generated {len(output.itl) + 1} tokens)"
+                        )
+                    else:
+                        output.generated_text = generated_text
+                        output.output_ids = []  # Not available from OpenAI endpoint
+                        output.success = True
+                        output.latency = latency
+                        output.prompt_len = prompt_tokens
+                        output.cached_tokens = cached_tokens
+                        output.generated_len = (
+                            completion_tokens if completion_tokens else len(output.itl) + 1
+                        )
                 else:
-                    output.error = response.reason or ""
+                    try:
+                        body = await response.text()
+                    except Exception:
+                        body = ""
+                    output.error = (
+                        f"HTTP {response.status}: "
+                        f"{body or response.reason or '(empty)'}"
+                    )
                     output.success = False
         except Exception as e:
             output.success = False
             output.error = str(e)
-            print(f"Request failed: {e}")
 
     if pbar:
         pbar.update(1)

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -33,7 +33,9 @@ async def async_request_sglang_generate(
 
         try:
             async with session.post(
-                url=url, json=payload, headers=headers,
+                url=url,
+                json=payload,
+                headers=headers,
                 timeout=STREAM_REQUEST_TIMEOUT,
             ) as response:
                 if response.status == 200:
@@ -127,7 +129,8 @@ async def async_request_openai_chat_completions(
 
         try:
             async with session.post(
-                url=url, json=payload,
+                url=url,
+                json=payload,
                 timeout=STREAM_REQUEST_TIMEOUT,
             ) as response:
                 if response.status == 200:
@@ -189,7 +192,9 @@ async def async_request_openai_chat_completions(
                         output.prompt_len = prompt_tokens
                         output.cached_tokens = cached_tokens
                         output.generated_len = (
-                            completion_tokens if completion_tokens else len(output.itl) + 1
+                            completion_tokens
+                            if completion_tokens
+                            else len(output.itl) + 1
                         )
                 else:
                     try:


### PR DESCRIPTION
## Summary

The hicache multi-turn benchmark (`benchmark/hicache/bench_multiturn.py`) hangs indefinitely when a request fails, is truncated, or hangs mid-stream. The exit condition (`pbar.n == pbar.total`) can never be reached because:
- Failed requests skipped follow-up generation (`continue`), so `total_requests` was unreachable.
- Hung streams never returned, blocking a concurrent-request slot forever.

In a 1000-request / 10-round run this manifested as the progress bar stuck at 9963/10000 for hours with no failure output and no final metrics.

### `python/sglang/test/kits/cache_hit_kit.py`
- Add per-request `STREAM_REQUEST_TIMEOUT` (`total=600s`, `sock_read=300s`) so hung streams fail fast instead of blocking for the 20h session default. `sock_read` is sized to tolerate long TTFTs (e.g. 32k prefill under 16-way concurrency).
- Detect stream truncation: if `[DONE]` is never received, mark the request as failed with a descriptive error instead of silently reporting success with empty `output_ids`.
- Read response body on non-200 so the error message contains the server error detail rather than just the HTTP reason phrase.

### `benchmark/hicache/bench_multiturn.py`
- Record failures (`client_id`, `round`, `error`, `timestamp`) to `self.failures` and persist them to `failures.jsonl`; include them in the metrics JSONL.
- On failure, still advance the client's round and generate the follow-up sub-question so `total_requests` stays reachable and the bench can finish.
- Switch exit conditions in `request_sender` and `response_handler` from `pbar.n == pbar.total` to `completed_requests >= total_requests`.
- Print a failure summary at the end of `run()` (count + first 20 details).
- Guard `finished_time` against `None` when all requests fail.

## Test plan

- [x] Syntax check both files (`python -m py_compile`)
- [x] End-to-end smoke test against a mock server covering four cases:
  - normal success → `success=True`
  - HTTP 500 → `success=False`, error contains response body
  - stream truncation (FIN without `[DONE]`) → `success=False`, error says "Stream truncated"
  - hung stream (no data) → `success=False` after `sock_read` fires (~3s in test, 300s in prod)
- [x] Full 1000-request / 10-round run against a live server: `Failed requests: 2/1000 (successful: 998)`, both failures captured as `Timeout on reading data from socket` with client_id/round, pbar reached 1000/1000, metrics summary printed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28942353251](https://github.com/sgl-project/sglang/actions/runs/28942353251)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28942353079](https://github.com/sgl-project/sglang/actions/runs/28942353079)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->