### PR TITLE
fix(tool_call): recover complete DSv32 tool calls dropped on max_tokens truncation

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -199,22 +199,32 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         calls = []
         try:
-            # Extract content between function_calls tags
+            # Extract content between function_calls tags. When the output is
+            # truncated (e.g. by max_tokens) the closing tag never arrives;
+            # fall back to everything after the opener so complete invoke
+            # blocks are still recovered instead of being silently dropped.
             function_calls_match = re.search(
                 self.function_calls_regex,
                 text,
                 re.DOTALL,
             )
-            if not function_calls_match:
-                return StreamingParseResult(normal_text=normal_text, calls=[])
-
-            function_calls_content = function_calls_match.group(1)
+            if function_calls_match:
+                function_calls_content = function_calls_match.group(1)
+            else:
+                function_calls_content = text[idx + len(self.bot_token) :]
 
             # Find all invoke blocks
             for invoke_match in re.finditer(
                 self.invoke_regex, function_calls_content, re.DOTALL
             ):
-                func_name, invoke_content, _ = self._unpack_invoke_match(invoke_match)
+                func_name, invoke_content, is_complete = self._unpack_invoke_match(
+                    invoke_match
+                )
+                if not is_complete:
+                    # Unterminated invoke block (truncated output): drop it
+                    # rather than emitting a call with partial arguments,
+                    # matching the streaming path's behavior.
+                    continue
                 func_args = self._parse_parameters_from_xml(invoke_content)
                 # construct match_result for parse_base_json
                 match_result = {"name": func_name, "parameters": json.loads(func_args)}

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1488,6 +1488,78 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         params = json.loads(params_str)
         self.assertEqual(params["city"], "San Francisco")
 
+    def test_detect_and_parse_truncated_preserves_complete_calls(self):
+        """A complete invoke followed by a max_tokens-truncated one must not
+        be dropped: the closing function_calls tag never arrives, but every
+        complete invoke block should still be returned."""
+        text = (
+            "Check both.<｜DSML｜function_calls>"
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">'
+            '<｜DSML｜parameter name="city" string="true">Paris</｜DSML｜parameter>'
+            "</｜DSML｜invoke>"
+            '<｜DSML｜invoke name="search">'
+            '<｜DSML｜parameter name="query" string="true">WebNav ben'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(result.normal_text, "Check both.")
+        self.assertEqual(len(result.calls), 1)
+        call = result.calls[0]
+        self.assertEqual(call.name, "get_favorite_tourist_spot")
+        self.assertEqual(json.loads(call.parameters), {"city": "Paris"})
+
+    def test_detect_and_parse_truncated_single_call_dropped(self):
+        """A single invoke truncated mid-arguments is dropped instead of
+        being emitted with partial arguments or leaked into content."""
+        text = (
+            "I will check.<｜DSML｜function_calls>"
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">'
+            '<｜DSML｜parameter name="city" string="true">San Fr'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(result.normal_text, "I will check.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_detect_and_parse_truncated_at_opener(self):
+        """Output cut right after the opener yields clean content and no calls."""
+        text = "I will check.<｜DSML｜function_calls>"
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(result.normal_text, "I will check.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_detect_and_parse_truncated_json_format_dropped(self):
+        """Direct-JSON invoke truncated mid-arguments is dropped."""
+        text = (
+            "Check.<｜DSML｜function_calls>"
+            '<｜DSML｜invoke name="get_favorite_tourist_spot">{"city": "San Fr'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(result.normal_text, "Check.")
+        self.assertEqual(len(result.calls), 0)
+
+    def test_detect_and_parse_missing_eot_self_closing_invoke(self):
+        """A complete self-closing invoke survives a missing closing
+        function_calls tag."""
+        tools_with_no_param = self.tools + [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_date",
+                    description="Get the current date.",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+        ]
+        text = 'Go.<｜DSML｜function_calls><｜DSML｜invoke name="get_date"/>'
+        result = self.detector.detect_and_parse(text, tools_with_no_param)
+
+        self.assertEqual(result.normal_text, "Go.")
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_date")
+
     def test_detect_and_parse_no_parameters(self):
         """Test parsing function calls with no parameters (non-streaming)"""
         # Add a no-parameter tool


### PR DESCRIPTION
# Motivation

While running DeepSeek-V3.2 agent loops with tight `max_tokens` budgets, non-streaming responses intermittently came back with **empty `tool_calls`** even though the model had clearly emitted complete tool calls before hitting the token limit. The same requests with `stream=true` returned the calls normally.

Root cause (reproduced at detector level, CPU-only, current main): when the output is truncated by `max_tokens`, the closing `</｜DSML｜function_calls>` tag never arrives, so `detect_and_parse`'s `function_calls_regex` fails to match and **every** invoke block in the response is silently discarded — including calls that completed before the cutoff:

```python
D = "｜DSML｜"
# one COMPLETE call + one truncated by max_tokens
text = (f"Check both.<{D}function_calls>"
  f'<{D}invoke name="get_weather"><{D}parameter name="city" string="true">Paris</{D}parameter></{D}invoke>'
  f'<{D}invoke name="get_weather"><{D}parameter name="city" string="true">San Fr')
DeepSeekV32Detector().detect_and_parse(text, tools)
# before: calls=[]                      <- complete Paris call silently lost
# after:  calls=[get_weather(city=Paris)]
```

This is the DSv32 variant of the failure class just reported in #30480 (hermes/qwen25): non-streaming behavior diverges from streaming when a tool call is cut off by `max_tokens`. For DSv32 it is arguably worse — instead of leaking markup into `content`, it **drops valid completed calls**, so agent clients (LangChain / AI SDK / Continue, etc.) see an assistant turn with no tool calls and no explanation.

# Modifications

`python/sglang/srt/function_call/deepseekv32_detector.py` (`detect_and_parse` only; streaming path already handles this correctly):

1. When the closing `function_calls` tag is missing (truncated output), fall back to parsing the content after the opener instead of returning early, so complete invoke blocks are still recovered.
2. Use the existing `is_complete` flag from `_unpack_invoke_match` (previously ignored via `_`) to drop the trailing unterminated invoke rather than emitting a call with partial arguments — matching the streaming path's behavior. Complete-but-malformed blocks keep the current documented fallback (existing tests unchanged).

`test/registered/unit/function_call/test_function_call_parser.py`: 5 new unit tests in `TestDeepSeekV32Detector` covering: complete call surviving a truncated neighbor, single truncated call dropped cleanly, truncation right at the opener, truncated direct-JSON format, and a self-closing invoke with missing closing wrapper tag.

# Accuracy Tests

Detector-level unit tests (CPU-only):

```
pytest test/registered/unit/function_call/test_function_call_parser.py -k "DeepSeekV32"
# 13 passed (8 existing + 5 new); test_get_model_structural_tag requires xgrammar, unrelated
```

Full `test_function_call_parser.py` run has no new failures vs. clean main (verified via `git stash` A/B).

# Speed Tests and Profiling

N/A — no hot-path change; one extra branch in the non-streaming final parse.

# Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

Related: #30480 (same failure class in hermes/qwen25; that fix is scoped to those detectors, this PR covers the DSv32 side).

cc @CatherineSue @JustinTong0323







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28941268692](https://github.com/sgl-project/sglang/actions/runs/28941268692)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28941268586](https://github.com/sgl-project/sglang/actions/runs/28941268586)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->