### PR TITLE
[router] Return 504 Gateway Timeout, not 502, on upstream request timeout

### DIFF
--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -119,7 +119,7 @@ impl ApiError {
                 (StatusCode::BAD_GATEWAY, "upstream_unreachable")
             }
             ApiError::UpstreamStatus { .. } => (StatusCode::BAD_GATEWAY, "upstream_status"),
-            ApiError::UpstreamTimeout { .. } => (StatusCode::BAD_GATEWAY, "upstream_timeout"),
+            ApiError::UpstreamTimeout { .. } => (StatusCode::GATEWAY_TIMEOUT, "upstream_timeout"),
             ApiError::NoHealthyWorkers { .. } => {
                 (StatusCode::SERVICE_UNAVAILABLE, "no_healthy_workers")
             }
@@ -355,7 +355,7 @@ mod tests {
             worker: worker.clone(),
         };
         let resp = err.into_response();
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
         assert_eq!(
             resp.headers()
                 .get("x-router-error-code")

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -7,7 +7,7 @@
 //! Without a configured `.timeout(...)` on the reqwest client, a stalled
 //! backend hangs the axum handler future forever and the test harness
 //! would just timeout. We assert here that the router returns a fast,
-//! clean 502 (`upstream_timeout`) instead.
+//! clean 504 (`upstream_timeout`) instead.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -95,7 +95,7 @@ async fn non_streaming_request_times_out_when_worker_hangs() {
         elapsed < Duration::from_secs(1),
         "router must short-circuit on upstream timeout; elapsed {elapsed:?}"
     );
-    assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
+    assert_eq!(res.status(), StatusCode::GATEWAY_TIMEOUT);
     assert_eq!(
         res.headers().get("x-router-error-code").unwrap(),
         "upstream_timeout"


### PR DESCRIPTION
## What

`UpstreamTimeout` (the per-request `--request-timeout-secs` budget elapsing on a non-streaming forward) currently returns **502 Bad Gateway**. This changes it to **504 Gateway Timeout**.

## Why

When the budget elapses the worker is healthy and still generating; it has not returned an invalid response. Per RFC 9110:

- **502 Bad Gateway** means the proxy received an invalid response from the upstream.
- **504 Gateway Timeout** means the upstream did not respond in time.

504 is the correct status for a slow-but-alive upstream. It also brings `UpstreamTimeout` in line with the sibling `StaleRequestExpired` arm, which already maps to 504. `UpstreamUnreachable` and `UpstreamStatus` correctly remain 502.

Practical effect: OpenAI-compatible SDKs and fronting proxies (for example LiteLLM fallbacks) classify 504 as a retriable/slow-upstream condition rather than treating the router as a dead backend.

## Changes

- `server/error.rs`: `UpstreamTimeout` now maps to `StatusCode::GATEWAY_TIMEOUT`.
- Updated the `upstream_timeout_envelope_has_code_and_no_leak` unit test.
- Updated the `non_streaming_request_times_out_when_worker_hangs` integration test and its doc comment.

## Testing

The two updated tests assert the new 504 status. The equivalent change passes `cargo test --release` in our build (router unit tests plus `tests/proxy/timeout.rs`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29837296789](https://github.com/sgl-project/sglang/actions/runs/29837296789)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29837296189](https://github.com/sgl-project/sglang/actions/runs/29837296189)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->