### PR TITLE
[bench] Measure embedding transfer latency and response payload size

### DIFF
--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -108,6 +108,7 @@ class RequestFuncOutput:
     start_time: float = 0.0
     cached_tokens: int = 0
     cached_tokens_details: Optional[Dict[str, Any]] = None
+    response_bytes: int = 0
 
     @staticmethod
     def init_new(request_func_input: RequestFuncInput):
@@ -778,8 +779,12 @@ async def async_request_openai_embeddings(
                 url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
-                    await response.json()
+                    body = await response.read()
+                    # Stop the clock at transfer completion; parsing below is
+                    # excluded so encoding_format comparisons stay client-neutral.
                     output.latency = time.perf_counter() - st
+                    json.loads(body)
+                    output.response_bytes = len(body)
                     output.success = True
                     output.output_len = 0
                 else:
@@ -989,6 +994,10 @@ class BenchmarkMetrics:
     max_output_tokens_per_s: float = 0.0
     max_concurrent_requests: int = 0
 
+    # Response payload size in bytes (non-streaming backends, e.g. sglang-embedding)
+    total_response_bytes: int = 0
+    mean_response_bytes: float = 0.0
+
 
 async def get_request(
     input_requests: List[DatasetRow],
@@ -1057,10 +1066,12 @@ def calculate_metrics(
         and backend in ("sglang-oai", "sglang-oai-chat")
     )
 
+    total_response_bytes = 0
     for i in range(len(outputs)):
         if outputs[i].success:
             output_len = outputs[i].output_len
             output_lens.append(output_len)
+            total_response_bytes += outputs[i].response_bytes
             retokenized_output_len = len(
                 tokenizer.encode(outputs[i].generated_text, add_special_tokens=False)
             )
@@ -1206,6 +1217,8 @@ def calculate_metrics(
         concurrency=np.sum(e2e_latencies) / dur_s,
         max_output_tokens_per_s=max_output_tokens_per_s,
         max_concurrent_requests=max_concurrent_requests,
+        total_response_bytes=total_response_bytes,
+        mean_response_bytes=total_response_bytes / completed if completed else 0.0,
     )
 
     return metrics, output_lens
@@ -1586,6 +1599,12 @@ async def benchmark(
             "Input token throughput (tok/s):", metrics.input_throughput
         )
     )
+    if is_embedding:
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Mean response KB per request:", metrics.mean_response_bytes / 1024
+            )
+        )
     if not is_embedding:
         print(
             "{:<40} {:<10.2f}".format(
@@ -1769,6 +1788,8 @@ async def benchmark(
             "accept_length": accept_length,
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
             "max_concurrent_requests": metrics.max_concurrent_requests,
+            "total_response_bytes": metrics.total_response_bytes,
+            "mean_response_bytes": metrics.mean_response_bytes,
         }
 
         if args.cache_report:

--- a/test/registered/unit/bench/test_bench_serving_embedding_payload.py
+++ b/test/registered/unit/bench/test_bench_serving_embedding_payload.py
@@ -1,0 +1,148 @@
+"""Unit tests for the sglang-embedding benchmark request function."""
+
+import argparse
+import asyncio
+import base64
+import json
+import struct
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import sglang.benchmark.serving as bench_serving
+from sglang.benchmark.serving import RequestFuncInput, async_request_openai_embeddings
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# get_request_headers() reads the module-level `args` that the CLI entrypoint
+# sets; provide the same global for direct request-function calls.
+bench_serving.args = argparse.Namespace(header=None)
+
+EMBEDDING_DIM = 8
+FLOAT_EMBEDDING = [0.125 * i for i in range(EMBEDDING_DIM)]
+BASE64_EMBEDDING = base64.b64encode(
+    struct.pack(f"<{EMBEDDING_DIM}f", *FLOAT_EMBEDDING)
+).decode("ascii")
+
+
+def _embedding_response(embedding):
+    return json.dumps(
+        {
+            "object": "list",
+            "data": [{"object": "embedding", "embedding": embedding, "index": 0}],
+            "model": "test-model",
+            "usage": {"prompt_tokens": 3, "total_tokens": 3},
+        }
+    ).encode()
+
+
+class _EmbeddingServer:
+    """Serves canned /v1/embeddings responses and records request payloads."""
+
+    def __init__(self, response_body: bytes, status: int = 200):
+        self.requests = []
+        self.response_body = response_body
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers["Content-Length"])
+                outer.requests.append(json.loads(self.rfile.read(length)))
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(outer.response_body)
+
+            def log_message(self, *args):
+                pass
+
+        self.server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}/v1/embeddings"
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def shutdown(self):
+        self.server.shutdown()
+
+
+def _run_request(api_url: str, extra_request_body=None):
+    request_func_input = RequestFuncInput(
+        prompt="hello world",
+        api_url=api_url,
+        prompt_len=3,
+        output_len=0,
+        model="test-model",
+        lora_name="",
+        image_data=None,
+        extra_request_body=extra_request_body or {},
+    )
+    return asyncio.run(async_request_openai_embeddings(request_func_input))
+
+
+class TestEmbeddingRequestPayload(CustomTestCase):
+    def test_float_response_records_payload_bytes(self):
+        body = _embedding_response(FLOAT_EMBEDDING)
+        server = _EmbeddingServer(body)
+        try:
+            output = _run_request(server.url)
+        finally:
+            server.shutdown()
+
+        self.assertTrue(output.success)
+        self.assertGreater(output.latency, 0)
+        self.assertEqual(output.response_bytes, len(body))
+        self.assertEqual(output.output_len, 0)
+
+    def test_base64_response_records_payload_bytes(self):
+        body = _embedding_response(BASE64_EMBEDDING)
+        server = _EmbeddingServer(body)
+        try:
+            output = _run_request(
+                server.url, extra_request_body={"encoding_format": "base64"}
+            )
+        finally:
+            server.shutdown()
+
+        self.assertTrue(output.success)
+        self.assertEqual(output.response_bytes, len(body))
+        # base64 of an 8-dim fp32 embedding is far smaller than its
+        # JSON float-list form.
+        self.assertLess(len(body), len(_embedding_response(FLOAT_EMBEDDING)))
+
+    def test_extra_request_body_passes_encoding_format(self):
+        server = _EmbeddingServer(_embedding_response(BASE64_EMBEDDING))
+        try:
+            _run_request(server.url, extra_request_body={"encoding_format": "base64"})
+            payload = server.requests[0]
+        finally:
+            server.shutdown()
+
+        self.assertEqual(payload["encoding_format"], "base64")
+        self.assertEqual(payload["model"], "test-model")
+        self.assertEqual(payload["input"], "hello world")
+
+    def test_invalid_json_body_fails_request(self):
+        server = _EmbeddingServer(b"not json")
+        try:
+            output = _run_request(server.url)
+        finally:
+            server.shutdown()
+
+        self.assertFalse(output.success)
+        self.assertIn("JSONDecodeError", output.error)
+
+    def test_non_200_fails_request(self):
+        server = _EmbeddingServer(b'{"error": "boom"}', status=500)
+        try:
+            output = _run_request(server.url)
+        finally:
+            server.shutdown()
+
+        self.assertFalse(output.success)
+        self.assertEqual(output.response_bytes, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The `sglang-embedding` backend of `python -m sglang.benchmark.serving` parses the response JSON (`await response.json()`) before stopping the latency clock, so client-side parse cost is counted inside E2E latency. For embedding responses this is not noise: a 1024-dim float-list body parses an order of magnitude slower than a base64 string, so any comparison across `encoding_format` values (roadmap #15344 encoding-formats item, #30434, #28803) measures the client instead of the server. The benchmark also records nothing about response payload size — the primary quantity that changes across encoding formats.

## Modifications

- `async_request_openai_embeddings`: read the raw body (`await response.read()`), stop the latency clock at transfer completion, then validate the body parses as JSON (failures still mark the request unsuccessful, matching previous behavior) and record `len(body)` as `response_bytes`.
- `RequestFuncOutput.response_bytes`, `BenchmarkMetrics.total_response_bytes` / `mean_response_bytes`, aggregated over successful requests.
- Embedding runs print `Mean response KB per request`; the output-file rows gain the two byte fields.
- No new CLI flag: `encoding_format` already passes through via the existing `--extra-request-body '{"encoding_format": "base64"}'`.

## Accuracy Tests

Not applicable — no change to any model or serving path; this only changes what the benchmark client measures.

Unit tests (CPU, stdlib mock HTTP server, no GPU): `test/registered/unit/bench/test_bench_serving_embedding_payload.py` — 5 passed: payload-bytes recording for float and base64 responses, `encoding_format` passthrough, invalid-JSON body marked unsuccessful, non-200 marked unsuccessful.

## Speed Tests and Profiling

This PR changes measurement semantics, not serving speed. Two validations on RTX A6000 / Qwen3-Embedding-0.6B:

1. Payload metric (50-token inputs, concurrency 64): `float` 16.20 KB/request vs `base64` 5.59 KB/request — matches the 2.9x expected from the wire format.
2. Calibration against the unmodified benchmark on the same fresh server (alternating back-to-back runs): stock 792.9 / 870.0 req/s vs this PR 816.6 / 823.3 req/s — the <5% delta is inside stock's own run-to-run variance, i.e. the timing change does not distort single-embedding-per-request measurements; it matters for the per-format comparison above.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (benchmark-internal change; no user-facing docs affected)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28992706294](https://github.com/sgl-project/sglang/actions/runs/28992706294)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28992706209](https://github.com/sgl-project/sglang/actions/runs/28992706209)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->