### PR TITLE
[refactor] hoist force_nonempty_content into BaseReasoningFormatDetector

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -380,7 +380,12 @@ class OpenAIServingChat(OpenAIServingBase):
         # Handle reasoning content
         if self.reasoning_parser and request.separate_reasoning:
             reasoning_text, delta = self._process_reasoning_stream(
-                index, delta, reasoning_parser_dict, content, request
+                index,
+                delta,
+                reasoning_parser_dict,
+                content,
+                request,
+                finish_reason_type,
             )
             if reasoning_text:
                 usage = None
@@ -1620,6 +1625,7 @@ class OpenAIServingChat(OpenAIServingBase):
         reasoning_parser_dict: Dict[int, ReasoningParser],
         content: Dict[str, Any],
         request: ChatCompletionRequest,
+        finish_reason_type: Optional[str] = None,
     ) -> tuple[Optional[str], str]:
         """Process reasoning content in streaming response"""
         if index not in reasoning_parser_dict:
@@ -1635,7 +1641,14 @@ class OpenAIServingChat(OpenAIServingBase):
                 tokenizer=self.tokenizer_manager.tokenizer,
             )
         reasoning_parser = reasoning_parser_dict[index]
-        return reasoning_parser.parse_stream_chunk(delta)
+        reasoning_text, normal_text = reasoning_parser.parse_stream_chunk(delta)
+        if finish_reason_type is not None and finish_reason_type != "abort":
+            end_reasoning_text, end_normal_text = reasoning_parser.parse_stream_end()
+            if end_reasoning_text:
+                reasoning_text = (reasoning_text or "") + end_reasoning_text
+            if end_normal_text:
+                normal_text = (normal_text or "") + end_normal_text
+        return reasoning_text, normal_text
 
     def _get_history_tool_calls_cnt(self, request: ChatCompletionRequest) -> int:
         """Counts the number of tool calls in the request's message history.

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -33,6 +33,7 @@ class BaseReasoningFormatDetector:
         previous_content: str = "",
         thinks_internally: bool = False,
         reasoning_default: str = "always",
+        force_nonempty_content: bool = False,
     ):
         self.think_start_token = think_start_token
         self.think_end_token = think_end_token
@@ -48,6 +49,9 @@ class BaseReasoningFormatDetector:
         self.stripped_think_start = False
         self.think_start_self_label = ""
 
+        self._force_nonempty_content = force_nonempty_content
+        self._accumulated_reasoning = ""
+
         self.continue_final_message = continue_final_message
         if self.continue_final_message:
             self.previous_content = previous_content
@@ -61,6 +65,13 @@ class BaseReasoningFormatDetector:
         if self.think_end_token in self.previous_content:
             self._in_reasoning = False
 
+    def _maybe_apply_force_nonempty(
+        self, ret: StreamingParseResult
+    ) -> StreamingParseResult:
+        if self._force_nonempty_content and not ret.normal_text:
+            ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
+        return ret
+
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         """
         One-time parsing: Detects and parses reasoning sections in the provided text.
@@ -69,7 +80,9 @@ class BaseReasoningFormatDetector:
         in_reasoning = self._in_reasoning or self.think_start_token in text
 
         if not in_reasoning:
-            return StreamingParseResult(normal_text=text)
+            return self._maybe_apply_force_nonempty(
+                StreamingParseResult(normal_text=text)
+            )
 
         # The text is considered to be in a reasoning block.
         think_start_text = self.think_start_token + self.think_start_self_label
@@ -92,11 +105,15 @@ class BaseReasoningFormatDetector:
                 reasoning_text = processed_text[:tool_idx]
                 # Preserve tool_start_token in normal text
                 normal_text = processed_text[tool_idx:]
-                return StreamingParseResult(
-                    normal_text=normal_text, reasoning_text=reasoning_text
+                return self._maybe_apply_force_nonempty(
+                    StreamingParseResult(
+                        normal_text=normal_text, reasoning_text=reasoning_text
+                    )
                 )
             # Assume reasoning was truncated before end token
-            return StreamingParseResult(reasoning_text=processed_text)
+            return self._maybe_apply_force_nonempty(
+                StreamingParseResult(reasoning_text=processed_text)
+            )
 
         # Extract reasoning content
         if self.think_end_token in processed_text:
@@ -104,12 +121,16 @@ class BaseReasoningFormatDetector:
             reasoning_text = splits[0]
             normal_text = splits[1]
 
-            return StreamingParseResult(
-                normal_text=normal_text, reasoning_text=reasoning_text
+            return self._maybe_apply_force_nonempty(
+                StreamingParseResult(
+                    normal_text=normal_text, reasoning_text=reasoning_text
+                )
             )
         else:
             # think_end_token is in self.previous_content for continue_final_message=True case
-            return StreamingParseResult(normal_text=processed_text)
+            return self._maybe_apply_force_nonempty(
+                StreamingParseResult(normal_text=processed_text)
+            )
 
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
         """
@@ -121,6 +142,15 @@ class BaseReasoningFormatDetector:
         If stream_reasoning is True:
             Streams reasoning content as it arrives
         """
+        ret = self._parse_streaming_increment_impl(new_text)
+        if self._force_nonempty_content:
+            if self._in_reasoning:
+                self._accumulated_reasoning += ret.reasoning_text
+            else:
+                self._accumulated_reasoning = ""
+        return ret
+
+    def _parse_streaming_increment_impl(self, new_text: str) -> StreamingParseResult:
         self._buffer += new_text
         current_text = self._buffer
 
@@ -183,6 +213,28 @@ class BaseReasoningFormatDetector:
 
         return StreamingParseResult()
 
+    def finish(self) -> StreamingParseResult:
+        """
+        Called once when the stream ends. When force_nonempty_content is set
+        and the stream was truncated mid-reasoning (no closing think token),
+        reclassify the accumulated reasoning (plus any partial token still
+        buffered) as content so the response is not empty.
+        """
+        if not (self._force_nonempty_content and self._in_reasoning):
+            return StreamingParseResult()
+        # stream_reasoning=False never clears _buffer, so the opening think
+        # token (stripped only from the base class's local view) survives here.
+        buffer = self._buffer
+        think_start_text = self.think_start_token + self.think_start_self_label
+        if buffer.startswith(think_start_text):
+            buffer = buffer[len(think_start_text) :]
+        normal_text = self._accumulated_reasoning + buffer
+        self._accumulated_reasoning = ""
+        self._buffer = ""
+        if normal_text:
+            return StreamingParseResult(normal_text=normal_text)
+        return StreamingParseResult()
+
 
 class DeepSeekR1Detector(BaseReasoningFormatDetector):
     """
@@ -211,6 +263,7 @@ class DeepSeekR1Detector(BaseReasoningFormatDetector):
         force_reasoning: bool = True,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         # DeepSeek-R1 is assumed to be reasoning until `</think>` token
         super().__init__(
@@ -220,6 +273,7 @@ class DeepSeekR1Detector(BaseReasoningFormatDetector):
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
         )
         # https://github.com/sgl-project/sglang/pull/3202#discussion_r1950153599
 
@@ -246,6 +300,7 @@ class Qwen3Detector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         think_excluded_tokens = [
             "<tool_call>",
@@ -266,6 +321,7 @@ class Qwen3Detector(BaseReasoningFormatDetector):
             previous_content=previous_content,
             thinks_internally=True,
             reasoning_default="enable_thinking",
+            force_nonempty_content=force_nonempty_content,
         )
 
 
@@ -284,6 +340,7 @@ class KimiDetector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         super().__init__(
             "◁think▷",
@@ -292,6 +349,7 @@ class KimiDetector(BaseReasoningFormatDetector):
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
         )
 
 
@@ -311,6 +369,7 @@ class KimiK2Detector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         think_excluded_tokens = [
             "<think>",
@@ -334,6 +393,7 @@ class KimiK2Detector(BaseReasoningFormatDetector):
             continue_final_message=continue_final_message,
             previous_content=previous_content,
             reasoning_default="thinking",
+            force_nonempty_content=force_nonempty_content,
         )
 
 
@@ -350,7 +410,12 @@ class Glm45Detector(BaseReasoningFormatDetector):
             If True, streams reasoning content as it arrives.
     """
 
-    def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = False):
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = False,
+        force_nonempty_content: bool = False,
+    ):
         think_excluded_tokens = [
             "<tool_call>",
             "</tool_call>",
@@ -367,6 +432,7 @@ class Glm45Detector(BaseReasoningFormatDetector):
             tool_start_token="<tool_call>",
             thinks_internally=True,
             reasoning_default="enable_thinking",
+            force_nonempty_content=force_nonempty_content,
         )
 
 
@@ -381,6 +447,7 @@ class GptOssDetector(BaseReasoningFormatDetector):
         force_reasoning: bool = True,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         super().__init__(
             "<|channel|>analysis<|message|>",
@@ -389,6 +456,7 @@ class GptOssDetector(BaseReasoningFormatDetector):
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
         )
         self.parser = HarmonyParser()
 
@@ -447,6 +515,7 @@ class MiniMaxAppendThinkDetector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         # scheduler.py need `reasoning_parser.detector.think_end_token`
         super().__init__(
@@ -456,6 +525,7 @@ class MiniMaxAppendThinkDetector(BaseReasoningFormatDetector):
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
         )
         self.is_first_chunk = False
 
@@ -489,17 +559,12 @@ class Nemotron3Detector(BaseReasoningFormatDetector):
             "</think>",
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
+            tool_start_token="<tool_call>",
             continue_final_message=continue_final_message,
             previous_content=previous_content,
             reasoning_default="enable_thinking",
+            force_nonempty_content=force_nonempty_content,
         )
-        self._force_nonempty_content = force_nonempty_content
-
-    def detect_and_parse(self, text: str) -> StreamingParseResult:
-        ret = super().detect_and_parse(text)
-        if self._force_nonempty_content and not ret.normal_text:
-            ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
-        return ret
 
 
 class MistralDetector(BaseReasoningFormatDetector):
@@ -518,6 +583,7 @@ class MistralDetector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         super().__init__(
             "[THINK]",
@@ -527,6 +593,7 @@ class MistralDetector(BaseReasoningFormatDetector):
             continue_final_message=continue_final_message,
             previous_content=previous_content,
             reasoning_default="mistral",
+            force_nonempty_content=force_nonempty_content,
         )
 
 
@@ -544,6 +611,7 @@ class HunyuanDetector(BaseReasoningFormatDetector):
         continue_final_message: bool = False,
         previous_content: str = "",
         tokenizer=None,
+        force_nonempty_content: bool = False,
     ):
         t = resolve_hunyuan_tokens(tokenizer)
         think_open = t["think"]
@@ -558,6 +626,7 @@ class HunyuanDetector(BaseReasoningFormatDetector):
             tool_start_token=t["tool_calls"],
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
         )
 
 
@@ -570,6 +639,7 @@ class Gemma4Detector(BaseReasoningFormatDetector):
         force_reasoning: bool = False,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         super().__init__(
             "<|channel>",
@@ -579,6 +649,7 @@ class Gemma4Detector(BaseReasoningFormatDetector):
             continue_final_message=continue_final_message,
             previous_content=previous_content,
             reasoning_default="explicit_enable_thinking",
+            force_nonempty_content=force_nonempty_content,
         )
         self.think_start_self_label = "thought\n"
 
@@ -631,9 +702,9 @@ class Apertus2509Detector(BaseReasoningFormatDetector):
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
         )
         self._force_reasoning = force_reasoning
-        self._force_nonempty_content = force_nonempty_content
         self._tool_start_token = "<|tools_prefix|>["
         self._tool_end_token = "<|tools_suffix|>"
         self._reasoning_acc: str = ""
@@ -654,9 +725,7 @@ class Apertus2509Detector(BaseReasoningFormatDetector):
             normal_text="".join(text_parts),
             reasoning_text="".join(reasoning_parts),
         )
-        if self._force_nonempty_content and not ret.normal_text:
-            ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
-        return ret
+        return self._maybe_apply_force_nonempty(ret)
 
     def detect_and_parse_block_sequence(self, text: str) -> list[tuple[str, str]]:
         """Return an ordered sequence of blocks: [("reasoning"|"text", content), ...]"""
@@ -864,6 +933,7 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
         force_reasoning: bool = True,
         continue_final_message: bool = False,
         previous_content: str = "",
+        force_nonempty_content: bool = False,
     ):
         # The chat template puts <|START_THINKING|> in the assistant prefix
         # when reasoning is enabled, so the *generated* text usually starts
@@ -877,6 +947,7 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
             previous_content=previous_content,
+            force_nonempty_content=force_nonempty_content,
         )
         # Streaming state machine. The model emits, in order:
         #   1. reasoning  (between START_THINKING [in prefix] and END_THINKING)
@@ -1169,4 +1240,10 @@ class ReasoningParser:
     ) -> Tuple[Optional[str], Optional[str]]:
         """Streaming call: incremental parsing"""
         ret = self.detector.parse_streaming_increment(chunk_text)
+        return ret.reasoning_text, ret.normal_text
+
+    def parse_stream_end(self) -> Tuple[Optional[str], Optional[str]]:
+        """Streaming call: flush any detector-specific buffered state once
+        the stream ends."""
+        ret = self.detector.finish()
         return ret.reasoning_text, ret.normal_text

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -3,6 +3,7 @@
 import unittest
 
 from sglang.srt.parser.reasoning_parser import (
+    Apertus2509Detector,
     BaseReasoningFormatDetector,
     DeepSeekR1Detector,
     Gemma4Detector,
@@ -679,6 +680,68 @@ class TestNemotron3Detector(CustomTestCase):
         # Normal text already exists, no swap needed
         self.assertEqual(result.normal_text, text)
         self.assertEqual(result.reasoning_text, "")
+
+    def test_streaming_truncated_reasoning_reclassified_on_finish(self):
+        """force_nonempty_content: truncated reasoning (no think_end) is flushed
+        as normal_text when the stream ends so content is non-empty."""
+        detector = Nemotron3Detector(force_nonempty_content=True)
+        detector.parse_streaming_increment(detector.think_start_token)
+        detector.parse_streaming_increment("reasoning part one")
+        detector.parse_streaming_increment(" more reasoning")
+        end = detector.finish()
+        self.assertEqual(end.reasoning_text, "")
+        self.assertEqual(end.normal_text, "reasoning part one more reasoning")
+
+    def test_streaming_tool_start_ends_reasoning_and_noops_finish(self):
+        """tool_start_token interrupts reasoning; finish() then no-ops."""
+        detector = Nemotron3Detector(force_nonempty_content=True)
+        detector.parse_streaming_increment(detector.think_start_token)
+        detector.parse_streaming_increment("reasoning here")
+        result = detector.parse_streaming_increment(
+            detector.tool_start_token + "payload"
+        )
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, detector.tool_start_token + "payload")
+        self.assertFalse(detector._in_reasoning)
+        end = detector.finish()
+        self.assertEqual(end.normal_text, "")
+
+    def test_streaming_truncated_no_stream_reasoning_strips_think_start(self):
+        """force_nonempty_content + stream_reasoning=False: the opening think
+        token must not leak into content when truncation is flushed on finish."""
+        detector = Nemotron3Detector(
+            force_nonempty_content=True, stream_reasoning=False
+        )
+        detector.parse_streaming_increment(detector.think_start_token)
+        detector.parse_streaming_increment("hidden reasoning")
+        end = detector.finish()
+        self.assertEqual(end.reasoning_text, "")
+        self.assertEqual(end.normal_text, "hidden reasoning")
+        self.assertNotIn(detector.think_start_token, end.normal_text)
+
+
+class TestApertus2509DetectorForceNonempty(CustomTestCase):
+    """force_nonempty_content swap on Apertus2509 (non-streaming, via base helper)."""
+
+    def test_swap_when_only_reasoning(self):
+        detector = Apertus2509Detector(force_nonempty_content=True)
+        text = (
+            detector.think_start_token
+            + "apertus reasoning only"
+            + detector.think_end_token
+        )
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.normal_text, "apertus reasoning only")
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_no_swap_when_normal_exists(self):
+        detector = Apertus2509Detector(force_nonempty_content=True)
+        text = (
+            detector.think_start_token + "reason" + detector.think_end_token + "answer"
+        )
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "reason")
+        self.assertEqual(result.normal_text, "answer")
 
 
 class TestGemma4Detector(CustomTestCase):


### PR DESCRIPTION
## Motivation

`force_nonempty_content` (introduced in #20284) is a per-request opt-in flag (`chat_template_kwargs={"force_nonempty_content": True}`) that reclassifies reasoning as content when the model emits no normal text — for code agents that only read the `content` field. Two problems with the current state:

1. The non-streaming swap logic is **copy-pasted** across `Nemotron3Detector` and `Apertus2509Detector`.
2. `ReasoningParser.__init__` passes the kwarg **unconditionally** with no `inspect.signature` guard, so setting it on any model other than Nemotron3/Apertus (`qwen3`, `deepseek`, ...) crashes with `TypeError: __init__() got an unexpected keyword argument 'force_nonempty_content'`.
3. Streaming truncation (model hits `max_tokens` mid-reasoning, no closing think token) was only handled for Nemotron3 via a bespoke override; Apertus had no streaming coverage at all.

## Modifications

- Move `force_nonempty_content` into `BaseReasoningFormatDetector.__init__` and centralize the non-streaming swap in a single `_apply_force_nonempty` helper applied at every `detect_and_parse` return path.
- Generalize the streaming truncation path: base `finish()` now reclassifies accumulated reasoning + buffered residue as content when the stream ends mid-reasoning. Adds `parse_stream_end()` to `ReasoningParser` and wires `finish_reason_type` through `_process_reasoning_stream` so the flush fires on the final chunk (skipping graceful abort).
- Thread `force_nonempty_content` through all detector subclasses so the flag is accepted by every model instead of crashing.

`Nemotron3Detector` drops its `detect_and_parse` / `parse_streaming_increment` / `finish` overrides entirely (now pure inheritance). `Apertus2509Detector` keeps its custom streaming state machine (no `super()` call), so streaming truncation there remains a known gap to be addressed separately.

## Behavior note

Streaming `finish()` re-emits already-streamed reasoning as `content` (so reasoning appears in both `reasoning_content` and `content` when truncated). This matches the original #20284 motive — code agents that only read `content` get a non-empty response. Non-streaming does a clean swap (no duplication). This stream/non-stream divergence is intentional for the truncation case; flagging for reviewer awareness.

## Tests

- Adds base-level + `Apertus2509Detector` non-streaming swap tests (Apertus had zero `force_nonempty_content` coverage before).
- Existing Nemotron3 `force_nonempty_content` tests remain green (base behavior is equivalent).

## Checklist

- [ ] Format code with pre-commit
- [ ] Add / update tests
- [ ] Update docs

Draft — seeking early feedback on the hoist + the streaming `finish()` generalization before finalizing.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28959216089](https://github.com/sgl-project/sglang/actions/runs/28959216089)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28959215998](https://github.com/sgl-project/sglang/actions/runs/28959215998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->