### PR TITLE
[DSA] Opt-in MXFP4 index-K cache for GLM-5.x / DeepSeek-V3.2 (port of #26209), with fused-kernel MXFP4 mode

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v32/indexer_k.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v32/indexer_k.cuh
@@ -26,7 +26,10 @@
 
 namespace {
 
+using deepseek_v4::fp8::cast_to_ue8m0;
+using deepseek_v4::fp8::inv_scale_ue8m0;
 using deepseek_v4::fp8::pack_fp8;
+using deepseek_v4::fp8::quant_fp4_e2m1;
 
 constexpr uint32_t kFusedKIndexerBlockSize = 128;
 constexpr uint32_t kFusedKIndexerNumWarps = kFusedKIndexerBlockSize / device::kWarpThreads;
@@ -220,9 +223,13 @@ struct FusedKIndexerNormRopeKernel {
   }
 };
 
-// Indexer K + fused store: LayerNorm + RoPE + fp8 quant + paged store in one
-// launch. Page layout matches fused_store_index_cache.cuh: each page is
+// Indexer K + fused store: LayerNorm + RoPE + quant + paged store in one
+// launch. FP8 page layout matches fused_store_index_cache.cuh: each page is
 // 132*page_size bytes (128*page_size fp8 keys, then 4*page_size fp32 scales).
+// MXFP4 (kIsFp4) pages are 68*page_size bytes (64*page_size packed E2M1
+// pairs, then 4*page_size UE8M0 group exponents -- 4 x 32-elem groups per
+// token), matching store_fp4_index_k_cache in
+// srt/layers/attention/dsv4/fp4_indexer.py bit-for-bit.
 struct FusedKIndexerNormRopeStoreParams {
   const void* __restrict__ k_input;         // (B, 128) DType
   void* __restrict__ cache;                 // (num_pages, 132*page_size) uint8
@@ -237,7 +244,7 @@ struct FusedKIndexerNormRopeStoreParams {
   float eps;
 };
 
-template <typename DType, typename PosT, bool kUsePDL, int32_t kPageBits>
+template <typename DType, typename PosT, bool kUsePDL, int32_t kPageBits, bool kIsFp4>
 K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ FusedKIndexerNormRopeStoreParams params) {
   using namespace device;
 
@@ -245,7 +252,7 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
   constexpr int64_t kRopeDim = 64;
   constexpr int64_t kVecSize = 4;
   constexpr uint32_t kRopeSize = kRopeDim / kVecSize;  // = 16
-  constexpr int64_t kPageBytes = 132ll << kPageBits;
+  constexpr int64_t kPageBytes = (kIsFp4 ? 68ll : 132ll) << kPageBits;
   static_assert(kHeadDim == kWarpThreads * kVecSize);
   static_assert(kRopeDim == kWarpThreads * 2);
   static_assert(kRopeSize <= kWarpThreads);
@@ -316,42 +323,60 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
 
   PDLTriggerSecondary<kUsePDL>();
 
-  // part 3: fp8 act-quant + paged store. Round through bf16 first so the fp8
+  // part 3: act-quant + paged store. Round through bf16 first so the quant
   // scale matches the un-fused path.
 #pragma unroll
   for (int i = 0; i < kVecSize; ++i)
     data[i] = cast<float>(cast<DType>(data[i]));
 
-  float local_max = math::abs(data[0]);
-#pragma unroll
-  for (int i = 1; i < kVecSize; ++i)
-    local_max = math::max(local_max, math::abs(data[i]));
-  const auto abs_max = warp::reduce_max(local_max);
-  const auto scale = fmaxf(1e-4f, abs_max) / math::FP8_E4M3_MAX;
-  const auto inv_scale = 1.0f / scale;
-
   const auto index = static_cast<const int64_t*>(params.indices)[work_id];
   const int32_t page = static_cast<int32_t>(index >> kPageBits);
   const int32_t offset = static_cast<int32_t>(index & ((1 << kPageBits) - 1));
   const auto page_ptr = static_cast<uint8_t*>(params.cache) + page * kPageBytes;
-  const auto value_ptr = page_ptr + offset * kHeadDim;
-  const auto scale_ptr = page_ptr + (kHeadDim << kPageBits) + offset * 4;
 
-  OutStorage result;
-  result[0] = pack_fp8(data[0] * inv_scale, data[1] * inv_scale);
-  result[1] = pack_fp8(data[2] * inv_scale, data[3] * inv_scale);
-  reinterpret_cast<OutStorage*>(value_ptr)[lane_id] = result;
-  if (lane_id == 0) *reinterpret_cast<float*>(scale_ptr) = scale;
+  float local_max = math::abs(data[0]);
+#pragma unroll
+  for (int i = 1; i < kVecSize; ++i)
+    local_max = math::max(local_max, math::abs(data[i]));
+
+  if constexpr (kIsFp4) {
+    // MXFP4: per-32-elem-group (8 lanes) amax -> ceil UE8M0 scale -> packed
+    // E2M1 pairs. `group_max / 6.0f` then the 1e-4 floor matches the Triton
+    // quantizer's operation order (bit parity with the un-fused store).
+    const float group_max = warp::reduce_max<8>(local_max);
+    const float scale_raw = fmaxf(group_max / 6.0f, 1e-4f);
+    const auto scale_exp = static_cast<uint8_t>(cast_to_ue8m0(scale_raw));
+    const float inv_scale = inv_scale_ue8m0(scale_exp);
+    const uint8_t packed0 = quant_fp4_e2m1(data[0] * inv_scale) | (quant_fp4_e2m1(data[1] * inv_scale) << 4);
+    const uint8_t packed1 = quant_fp4_e2m1(data[2] * inv_scale) | (quant_fp4_e2m1(data[3] * inv_scale) << 4);
+    const uint16_t packed = static_cast<uint16_t>(packed0) | (static_cast<uint16_t>(packed1) << 8);
+    const auto value_ptr = page_ptr + offset * (kHeadDim / 2);
+    const auto scale_ptr = page_ptr + ((kHeadDim / 2) << kPageBits) + offset * 4;
+    reinterpret_cast<uint16_t*>(value_ptr)[lane_id] = packed;
+    if ((lane_id & 7) == 0) scale_ptr[lane_id >> 3] = scale_exp;
+  } else {
+    const auto abs_max = warp::reduce_max(local_max);
+    const auto scale = fmaxf(1e-4f, abs_max) / math::FP8_E4M3_MAX;
+    const auto inv_scale = 1.0f / scale;
+    const auto value_ptr = page_ptr + offset * kHeadDim;
+    const auto scale_ptr = page_ptr + (kHeadDim << kPageBits) + offset * 4;
+
+    OutStorage result;
+    result[0] = pack_fp8(data[0] * inv_scale, data[1] * inv_scale);
+    result[1] = pack_fp8(data[2] * inv_scale, data[3] * inv_scale);
+    reinterpret_cast<OutStorage*>(value_ptr)[lane_id] = result;
+    if (lane_id == 0) *reinterpret_cast<float*>(scale_ptr) = scale;
+  }
 }
 
-template <typename DType, bool kUsePDL, uint32_t kPageSize>
+template <typename DType, bool kUsePDL, uint32_t kPageSize, bool kIsFp4 = false>
 struct FusedKIndexerNormRopeStoreKernel {
   static constexpr int32_t kPageBits = std::countr_zero(kPageSize);
-  static constexpr int64_t kPageBytes = 132ll * kPageSize;
+  static constexpr int64_t kPageBytes = (kIsFp4 ? 68ll : 132ll) * kPageSize;
   static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
 
   template <typename PosT>
-  static constexpr auto kernel = fused_k_indexer_norm_rope_store<DType, PosT, kUsePDL, kPageBits>;
+  static constexpr auto kernel = fused_k_indexer_norm_rope_store<DType, PosT, kUsePDL, kPageBits, kIsFp4>;
 
   static void forward(
       const tvm::ffi::TensorView k_input,

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/main_norm_rope.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/main_norm_rope.cuh
@@ -20,20 +20,7 @@ namespace {
 using deepseek_v4::fp8::cast_to_ue8m0;
 using deepseek_v4::fp8::inv_scale_ue8m0;
 using deepseek_v4::fp8::pack_fp8;
-
-SGL_DEVICE uint8_t quant_fp4_e2m1(float x) {
-  const float ax = fminf(fabsf(x), 6.0f);
-  uint8_t idx = 0;
-  idx += ax > 0.25f;
-  idx += ax > 0.75f;
-  idx += ax > 1.25f;
-  idx += ax > 1.75f;
-  idx += ax > 2.5f;
-  idx += ax > 3.5f;
-  idx += ax > 5.0f;
-  if (x < 0.0f && idx != 0) idx |= 0x8;
-  return idx;
-}
+using deepseek_v4::fp8::quant_fp4_e2m1;
 
 // 4 warps per block: warp-per-(token, head) work-item dispatch (Q kernel).
 constexpr uint32_t kFusedQBlockSize = 128;
@@ -680,11 +667,13 @@ struct FusedQIndexerRopeHadamardFp4QuantParams {
   float weight_scale;
   const float* __restrict__ freqs_cis;
   const void* __restrict__ positions;
+  // Row stride for `weight` (V3.2/GLM pass the non-contiguous wk slice directly).
+  int64_t weight_stride_batch;
   uint32_t batch_size;
   uint32_t num_heads;
 };
 
-template <typename DType, typename PosT, bool kUsePDL>
+template <typename DType, typename PosT, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true>
 Q_KERNEL void
 fused_q_indexer_rope_hadamard_fp4_quant(const __grid_constant__ FusedQIndexerRopeHadamardFp4QuantParams params) {
   using namespace device;
@@ -703,7 +692,9 @@ fused_q_indexer_rope_hadamard_fp4_quant(const __grid_constant__ FusedQIndexerRop
   const auto warp_id = threadIdx.x / kWarpThreads;
   const auto lane_id = threadIdx.x % kWarpThreads;
   const auto work_id = blockIdx.x * kFusedQNumWarps + warp_id;
-  const bool is_rope_lane = lane_id >= kWarpThreads - kRopeSize;
+  // V4 ropes the trailing kRopeDim dims (kRopeFirst=false); V3.2/GLM rope the
+  // leading kRopeDim dims (kRopeFirst=true). Select the owning lanes per layout.
+  const bool is_rope_lane = kRopeFirst ? (lane_id < kRopeSize) : (lane_id >= kWarpThreads - kRopeSize);
 
   const uint32_t total_works = params.batch_size * params.num_heads;
   if (work_id >= total_works) return;
@@ -715,12 +706,20 @@ fused_q_indexer_rope_hadamard_fp4_quant(const __grid_constant__ FusedQIndexerRop
 
   PDLWaitPrimary<kUsePDL>();
   Float4 data, freq;
-  const auto weight_val = cast<float>(static_cast<const DType*>(params.weight)[work_id]);
+  const uint32_t head_id = work_id - batch_id * params.num_heads;
+  const auto weight_val =
+      cast<float>(static_cast<const DType*>(params.weight)[batch_id * params.weight_stride_batch + head_id]);
 
   {
     Storage input_vec;
     input_vec.load(input_ptr, lane_id);
-    if (is_rope_lane) freq.load(freqs_cis, lane_id - (kWarpThreads - kRopeSize));
+    if (is_rope_lane) {
+      if constexpr (kRopeFirst) {
+        freq = load_rope_first_cos_sin<kRopeDim>(freqs_cis, lane_id);
+      } else {
+        freq.load(freqs_cis, lane_id - (kWarpThreads - kRopeSize));
+      }
+    }
 #pragma unroll
     for (int i = 0; i < kVecSize; ++i) {
       data[i] = cast<float>(input_vec[i]);
@@ -740,6 +739,8 @@ fused_q_indexer_rope_hadamard_fp4_quant(const __grid_constant__ FusedQIndexerRop
     data[1] = x_real * fxi + x_imag * fxr;
     data[2] = y_real * fyr - y_imag * fyi;
     data[3] = y_real * fyi + y_imag * fyr;
+    // Round through DType so the FP4 codes match the eager reference, which
+    // quantizes the bf16 rope output.
 #pragma unroll
     for (int i = 0; i < kVecSize; ++i)
       data[i] = cast<float>(cast<DType>(data[i]));
@@ -747,7 +748,7 @@ fused_q_indexer_rope_hadamard_fp4_quant(const __grid_constant__ FusedQIndexerRop
 
   PDLTriggerSecondary<kUsePDL>();
 
-  {
+  if constexpr (kHadamard) {
     {
       const float a0 = data[0], a1 = data[1], a2 = data[2], a3 = data[3];
       data[0] = a0 + a1;
@@ -801,10 +802,10 @@ fused_q_indexer_rope_hadamard_fp4_quant(const __grid_constant__ FusedQIndexerRop
   }
 }
 
-template <typename DType, bool kUsePDL>
+template <typename DType, bool kUsePDL, bool kRopeFirst = false, bool kHadamard = true>
 struct FusedQIndexerRopeHadamardFp4QuantKernel {
   template <typename PosT>
-  static constexpr auto kernel = fused_q_indexer_rope_hadamard_fp4_quant<DType, PosT, kUsePDL>;
+  static constexpr auto kernel = fused_q_indexer_rope_hadamard_fp4_quant<DType, PosT, kUsePDL, kRopeFirst, kHadamard>;
 
   static void forward(
       const tvm::ffi::TensorView q_input,
@@ -836,7 +837,7 @@ struct FusedQIndexerRopeHadamardFp4QuantKernel {
         .with_device(device_)
         .verify(q_fp4);
     TensorMatcher({B, H}).with_dtype<int32_t>().with_device(device_).verify(q_sf);
-    TensorMatcher({B, H}).with_dtype<DType>().with_device(device_).verify(weight);
+    TensorMatcher({B, H}).with_strides({-1, 1}).with_dtype<DType>().with_device(device_).verify(weight);
     TensorMatcher({B, H, 1}).with_dtype<float>().with_device(device_).verify(weights_out);
     TensorMatcher({-1, kRopeDim}).with_dtype<float>().with_device(device_).verify(freqs_cis);
     auto pos_dtype = SymbolicDType{};
@@ -861,6 +862,7 @@ struct FusedQIndexerRopeHadamardFp4QuantKernel {
         .weight_scale = static_cast<float>(weight_scale),
         .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
         .positions = positions.data_ptr(),
+        .weight_stride_batch = weight.stride(0),
         .batch_size = batch_size,
         .num_heads = num_heads,
     };

--- a/python/sglang/jit_kernel/dsv32/elementwise.py
+++ b/python/sglang/jit_kernel/dsv32/elementwise.py
@@ -26,10 +26,12 @@ def _jit_k_indexer_norm_rope_module(dtype: torch.dtype):
 
 
 @cache_once
-def _jit_k_indexer_norm_rope_store_module(dtype: torch.dtype, page_size: int):
-    args = make_cpp_args(dtype, is_arch_support_pdl(), page_size)
+def _jit_k_indexer_norm_rope_store_module(
+    dtype: torch.dtype, page_size: int, is_fp4: bool
+):
+    args = make_cpp_args(dtype, is_arch_support_pdl(), page_size, is_fp4)
     return load_jit(
-        f"dpsk_v32_k_indexer_norm_rope_store_p{page_size}",
+        f"dpsk_v32_k_indexer_norm_rope_store_p{page_size}{'_fp4' if is_fp4 else ''}",
         *args,
         cuda_files=[_CUDA_FILE],
         cuda_wrappers=[
@@ -72,12 +74,19 @@ def fused_k_indexer_norm_rope_store(
     cos_sin_cache: torch.Tensor,
     positions: torch.Tensor,
     page_size: int,
+    *,
+    is_fp4: bool = False,
 ) -> None:
-    """V3.2 indexer K + fused store: LayerNorm + RoPE on leading dims + fp8
-    act-quant + paged index-k cache write, in one launch. CUDA only."""
+    """V3.2 indexer K + fused store: LayerNorm + RoPE on leading dims +
+    act-quant + paged index-k cache write, in one launch. CUDA only.
+
+    is_fp4 selects the quant/store format: False writes the FP8 132 B/token
+    layout (128 B fp8 key + 4 B fp32 scale); True writes the MXFP4 68 B/token
+    layout (64 B packed E2M1 pairs + 4 UE8M0 group exponents), bit-identical
+    to store_fp4_index_k_cache on the bf16-rounded key."""
     if not out_cache_loc.is_contiguous():
         out_cache_loc = out_cache_loc.contiguous()
-    module = _jit_k_indexer_norm_rope_store_module(k_input.dtype, page_size)
+    module = _jit_k_indexer_norm_rope_store_module(k_input.dtype, page_size, is_fp4)
     module.forward(
         k_input,
         cache,

--- a/python/sglang/jit_kernel/dsv4/__init__.py
+++ b/python/sglang/jit_kernel/dsv4/__init__.py
@@ -13,6 +13,7 @@ from .compress import (
 from .compress_old import fused_norm_rope_inplace
 from .elementwise import (
     fused_k_norm_rope_flashmla,
+    fused_q_indexer_rope_first_fp4_quant,
     fused_q_indexer_rope_first_quant,
     fused_q_indexer_rope_hadamard_fp4_quant,
     fused_q_indexer_rope_hadamard_quant,
@@ -42,6 +43,7 @@ __all__ = [
     "fused_store_cache",
     "fused_rope_inplace",
     "fused_q_norm_rope",
+    "fused_q_indexer_rope_first_fp4_quant",
     "fused_q_indexer_rope_first_quant",
     "fused_q_indexer_rope_hadamard_fp4_quant",
     "fused_q_indexer_rope_hadamard_quant",

--- a/python/sglang/jit_kernel/dsv4/elementwise.py
+++ b/python/sglang/jit_kernel/dsv4/elementwise.py
@@ -106,6 +106,21 @@ def _jit_main_q_indexer_rope_hadamard_fp4_quant_module(dtype: torch.dtype):
     )
 
 
+# DSA (V3.2 / GLM-5.x) FP4 variant of the indexer Q kernel: rope-first layout
+# (kRopeFirst=true), no Hadamard (kHadamard=false), MXFP4 output.
+@cache_once
+def _jit_main_q_indexer_rope_first_fp4_quant_module(dtype: torch.dtype):
+    args = make_cpp_args(dtype, is_arch_support_pdl(), True, False)
+    return load_jit(
+        make_name("main_q_indexer_rope_first_fp4_quant"),
+        *args,
+        cuda_files=["deepseek_v4/main_norm_rope.cuh"],
+        cuda_wrappers=[
+            ("forward", f"FusedQIndexerRopeHadamardFp4QuantKernel<{args}>::forward"),
+        ],
+    )
+
+
 def fused_rope_inplace(
     q: torch.Tensor,
     k: Optional[torch.Tensor],
@@ -208,6 +223,45 @@ def fused_q_indexer_rope_first_quant(
         positions,
     )
     return q_fp8, weights_out
+
+
+def fused_q_indexer_rope_first_fp4_quant(
+    q_input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: float,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> Tuple[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    """DSA indexer Q: RoPE on the leading dims + MXFP4 act-quant. CUDA only.
+
+    Returns ((q_fp4, q_sf), weights_out): packed E2M1 pairs (B, H, 64) int8,
+    packed UE8M0 group scales (B, H) int32, and the head-gate weights
+    weight * weight_scale (no per-token q_scale -- the FP4 MQA-logits kernels
+    dequantize q via q_sf themselves).
+    """
+    if _is_hip:
+        raise RuntimeError("DSA FP4 indexer requires the CUDA fused Q path.")
+    q_fp4 = torch.empty(
+        (*q_input.shape[:-1], q_input.shape[-1] // 2),
+        dtype=torch.int8,
+        device=q_input.device,
+    )
+    q_sf = torch.empty(q_input.shape[:-1], dtype=torch.int32, device=q_input.device)
+    weights_out = torch.empty(
+        (*q_input.shape[:-1], 1), dtype=torch.float32, device=q_input.device
+    )
+    module = _jit_main_q_indexer_rope_first_fp4_quant_module(q_input.dtype)
+    module.forward(
+        q_input,
+        q_fp4,
+        q_sf,
+        weight,
+        weights_out,
+        float(weight_scale),
+        cos_sin_cache,
+        positions,
+    )
+    return (q_fp4, q_sf), weights_out
 
 
 def fused_q_indexer_rope_hadamard_fp4_quant(

--- a/python/sglang/jit_kernel/include/sgl_kernel/deepseek_v4/fp8_utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/deepseek_v4/fp8_utils.cuh
@@ -31,6 +31,24 @@ SGL_DEVICE float inv_scale_ue8m0(int32_t exp) {
   return __uint_as_float((127 + 127 - exp) << 23);
 }
 
+// Encode one already-scaled value as an FP4 E2M1 code (round-to-nearest via
+// the midpoint thresholds; ties round toward zero, negative zero encodes as
+// +0). Matches the Triton `_fp4_e2m1_code` reference in
+// srt/layers/attention/dsv4/fp4_indexer.py bit-for-bit.
+SGL_DEVICE uint8_t quant_fp4_e2m1(float x) {
+  const float ax = fminf(fabsf(x), 6.0f);
+  uint8_t idx = 0;
+  idx += ax > 0.25f;
+  idx += ax > 0.75f;
+  idx += ax > 1.25f;
+  idx += ax > 1.75f;
+  idx += ax > 2.5f;
+  idx += ax > 3.5f;
+  idx += ax > 5.0f;
+  if (x < 0.0f && idx != 0) idx |= 0x8;
+  return idx;
+}
+
 // Clamp to [-FP8_E4M3_MAX, FP8_E4M3_MAX].
 // Uses platform-specific max from type.cuh (448 for E4M3FN, 224 for E4M3FNUZ).
 SGL_DEVICE float fp8_e4m3_clip(float val) {

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -165,7 +165,10 @@ def _uses_dsa_attention_backend(forward_batch: ForwardBatch) -> bool:
 
 
 if _is_cuda:
-    from sglang.jit_kernel.dsv4 import fused_q_indexer_rope_first_quant
+    from sglang.jit_kernel.dsv4 import (
+        fused_q_indexer_rope_first_fp4_quant,
+        fused_q_indexer_rope_first_quant,
+    )
     from sglang.jit_kernel.dsv32 import (
         fused_k_indexer_norm_rope,
         fused_k_indexer_norm_rope_store,
@@ -385,13 +388,13 @@ class Indexer(MultiPlatformOp):
         self.use_fp4_index_cache = (
             _is_cuda and get_global_server_args().enable_dsa_fp4_indexer
         )
-        # The fused indexer kernels quantize/store the FP8 132 B index-K layout;
-        # the opt-in MXFP4 cache routes Q/K prep through the split path instead.
+        # The fused indexer kernels have both FP8 (132 B) and MXFP4 (68 B)
+        # quant/store modes, so the FP4 index cache keeps fusion enabled
+        # (still interleave-only; NeoX models take the split path).
         self.use_dsa_indexer_fusion = (
             _is_cuda
             and not envs.SGLANG_DISABLE_DSA_INDEXER_FUSION.get()
             and not is_neox_style
-            and not self.use_fp4_index_cache
         )
         self.alt_stream = alt_stream
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
@@ -768,6 +771,7 @@ class Indexer(MultiPlatformOp):
                 self._indexer_cos_sin_cache,
                 positions,
                 page_size,
+                is_fp4=self.use_fp4_index_cache,
             )
             return
 
@@ -803,6 +807,13 @@ class Indexer(MultiPlatformOp):
         # num_tokens (graph split-op contract) slices q/k/positions/out_cache_loc
         # to the unpadded count; the returned q_fp8/weights are sliced to match.
         q_scale_gate = self.softmax_scale * self.n_heads**-0.5
+        # FP4 returns ((q_fp4, q_sf), weights); downstream top-k paths take the
+        # q representation opaquely.
+        fused_q_fn = (
+            fused_q_indexer_rope_first_fp4_quant
+            if self.use_fp4_index_cache
+            else fused_q_indexer_rope_first_quant
+        )
         out_cache_loc = forward_batch.out_cache_loc
         if num_tokens is not None:
             positions = positions[:num_tokens]
@@ -825,7 +836,7 @@ class Indexer(MultiPlatformOp):
             q = self.wq_b(q_lora)[0].view(-1, self.n_heads, self.head_dim)
             if num_tokens is not None:
                 q = q[:num_tokens]
-            return fused_q_indexer_rope_first_quant(
+            return fused_q_fn(
                 q.contiguous(),
                 weights_raw,
                 q_scale_gate,
@@ -852,7 +863,7 @@ class Indexer(MultiPlatformOp):
 
         current_stream.wait_stream(self.alt_stream)
         self.alt_stream.wait_stream(current_stream)
-        q_fp8, weights = fused_q_indexer_rope_first_quant(
+        q_fp8, weights = fused_q_fn(
             q.contiguous(),
             weights_raw,
             q_scale_gate,

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -29,6 +29,10 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_prefill_cp_in_seq_split,
     is_graph_dsa_split_op_surface,
 )
+from sglang.srt.layers.attention.dsv4.fp4_indexer import (
+    quantize_fp4_indexer_tensor,
+    store_fp4_index_k_cache,
+)
 from sglang.srt.layers.dp_attention import attn_tp_all_gather_into_tensor
 from sglang.srt.layers.layernorm import LayerNorm, RMSNorm
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
@@ -378,10 +382,16 @@ class Indexer(MultiPlatformOp):
         self.index_topk = index_topk
         self.q_lora_rank = q_lora_rank
         self.layer_id = layer_id
+        self.use_fp4_index_cache = (
+            _is_cuda and get_global_server_args().enable_dsa_fp4_indexer
+        )
+        # The fused indexer kernels quantize/store the FP8 132 B index-K layout;
+        # the opt-in MXFP4 cache routes Q/K prep through the split path instead.
         self.use_dsa_indexer_fusion = (
             _is_cuda
             and not envs.SGLANG_DISABLE_DSA_INDEXER_FUSION.get()
             and not is_neox_style
+            and not self.use_fp4_index_cache
         )
         self.alt_stream = alt_stream
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
@@ -460,6 +470,39 @@ class Indexer(MultiPlatformOp):
             get_server_args().dsa_paged_mqa_logits_backend
         )
 
+        if self.use_fp4_index_cache:
+            # FP4 index has no non-DeepGEMM fallback: fail loudly rather than
+            # silently degrading to a different cache format.
+            if isinstance(deep_gemm, ImportError):
+                raise RuntimeError(
+                    "--enable-dsa-fp4-indexer requires DeepGEMM, which failed "
+                    f"to import: {deep_gemm}"
+                )
+            if (
+                getattr(deep_gemm, "fp8_fp4_paged_mqa_logits", None) is None
+                or getattr(deep_gemm, "fp8_fp4_mqa_logits", None) is None
+            ):
+                raise RuntimeError(
+                    "--enable-dsa-fp4-indexer requires a DeepGEMM build with the "
+                    "FP4 MQA-logits kernels (fp8_fp4_paged_mqa_logits / "
+                    "fp8_fp4_mqa_logits); the installed deep_gemm lacks them."
+                )
+            if not self.paged_mqa_logits_backend.is_deepgemm():
+                raise ValueError(
+                    "--enable-dsa-fp4-indexer only supports the DeepGEMM paged "
+                    "MQA-logits backend."
+                )
+            if self.dsa_enable_prefill_cp:
+                raise ValueError(
+                    "--enable-dsa-fp4-indexer is not supported with DSA prefill "
+                    "context parallelism."
+                )
+            if self.n_heads < 32:
+                raise ValueError(
+                    "--enable-dsa-fp4-indexer requires index_n_heads >= 32 "
+                    f"(got {self.n_heads})."
+                )
+
     @contextlib.contextmanager
     def _with_real_sm_count(self):
         # When pipeline parallelism is enabled, each PP rank initiates a recv operation after the _pp_launch_batch
@@ -518,6 +561,43 @@ class Indexer(MultiPlatformOp):
         self, weights: torch.Tensor, q_scale: torch.Tensor
     ):
         return weights.unsqueeze(-1) * q_scale * self.softmax_scale
+
+    @torch.compile(dynamic=True)
+    def _get_logits_head_gate_fp4(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ):
+        # FP4 index path: the FP4 MQA-logits kernel dequantizes Q via the packed
+        # per-group scales (q_sf), so the head gate folds in only the softmax
+        # scale, never a per-token q_scale.
+        weights = self._weights_proj_bf16_in_fp32_out(x)
+        weights = weights * (self.n_heads**-0.5 * self.softmax_scale)
+        return weights.unsqueeze(-1)
+
+    @torch.compile(dynamic=True)
+    def _apply_softmax_scale_only(self, weights: torch.Tensor):
+        return (weights * self.softmax_scale).unsqueeze(-1)
+
+    def _fp4_quantize_q(self, query: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        # [num_tokens, n_heads, head_dim] bf16 -> packed E2M1 data
+        # [num_tokens, n_heads, head_dim // 2] int8 + packed UE8M0 group scales
+        # [num_tokens, n_heads] int32 (4 x 32-elem groups per 128-dim head).
+        num_tokens = query.shape[0]
+        q_fp4, q_sf = quantize_fp4_indexer_tensor(
+            query.contiguous().view(-1, self.head_dim)
+        )
+        return (
+            q_fp4.view(num_tokens, self.n_heads, self.head_dim // 2),
+            q_sf.view(num_tokens, self.n_heads),
+        )
+
+    def _quantize_q_for_logits(self, query: torch.Tensor, act_quant):
+        # Returns (q_repr, q_scale). FP8: q_repr is an fp8 tensor and q_scale the
+        # per-token quant scale (folded into the head-gate weights). FP4: q_repr
+        # is the (q_fp4, q_sf) tuple the FP4 MQA-logits kernels consume and
+        # q_scale is None (the kernel applies q_sf itself).
+        if self.use_fp4_index_cache:
+            return self._fp4_quantize_q(query), None
+        return act_quant(query, self.block_size, self.scale_fmt)
 
     @torch.compile(dynamic=True)
     def _scale_head_gates(self, weights_raw: torch.Tensor, q_scale: torch.Tensor):
@@ -893,7 +973,14 @@ class Indexer(MultiPlatformOp):
         # Reuse pre-computed schedule metadata if available (from init_forward_metadata),
         # otherwise fall back to computing it here.
         schedule_metadata = getattr(metadata, "paged_mqa_schedule_metadata", None)
-        assert len(q_fp8.shape) == 3
+        if self.use_fp4_index_cache:
+            # q_fp8 carries the (q_fp4, q_sf) tuple on the FP4 index path.
+            q_fp4, q_sf = q_fp8
+            assert len(q_fp4.shape) == 3 and len(q_sf.shape) == 2
+            q_rows = q_fp4.shape[0]
+        else:
+            assert len(q_fp8.shape) == 3
+            q_rows = q_fp8.shape[0]
         # attn_tp_size > 1 or MAX_LEN padding mode can leave padding in the
         # hidden states; q_offset is the real (unpadded) q length.
         q_offset = sum(metadata.get_dsa_extend_len_cpu())
@@ -944,14 +1031,44 @@ class Indexer(MultiPlatformOp):
         assert len(kv_cache_fp8.shape) == 2
         block_kv = page_size
         num_heads_kv = 1
-        head_dim_with_sf = 132
+        # 68 = 64 B packed E2M1 + 4 B packed UE8M0 scales; 132 = 128 B fp8 +
+        # 4 B fp32 scale (per token, block layout within each page).
+        head_dim_with_sf = 68 if self.use_fp4_index_cache else 132
         kv_cache_fp8 = kv_cache_fp8.view(
             kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
         )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
 
-        if self.paged_mqa_logits_backend.is_aiter():
+        if self.use_fp4_index_cache:
+            if use_dg_native:
+                logits = deep_gemm.fp8_fp4_paged_mqa_logits(
+                    (
+                        q_fp4[:q_offset].view(
+                            B, next_n, q_fp4.shape[1], q_fp4.shape[2]
+                        ),
+                        q_sf[:q_offset].view(B, next_n, q_sf.shape[1]),
+                    ),
+                    kv_cache_fp8,
+                    weights[:q_offset],
+                    seqlens_32_2d,
+                    block_tables[::next_n],
+                    schedule_metadata,
+                    max_seq_len,
+                    clean_logits=False,
+                )
+            else:
+                logits = deep_gemm.fp8_fp4_paged_mqa_logits(
+                    (q_fp4.unsqueeze(1)[:q_offset], q_sf.unsqueeze(1)[:q_offset]),
+                    kv_cache_fp8,
+                    weights[:q_offset],
+                    seqlens_32_2d,
+                    block_tables,
+                    schedule_metadata,
+                    max_seq_len,
+                    clean_logits=False,
+                )
+        elif self.paged_mqa_logits_backend.is_aiter():
             logits = aiter_paged_mqa_logits(
                 q_fp8,
                 kv_cache_fp8,
@@ -1012,8 +1129,8 @@ class Indexer(MultiPlatformOp):
         self._mask_init_and_local_tokens(logits, seqlens_32)
         topk_result = metadata.topk_transform(logits, self.index_topk)
         # Restore possible padding exist in the hidden states.
-        if not _is_hip and q_offset < q_fp8.shape[0]:
-            pad_len = q_fp8.shape[0] - q_offset
+        if not _is_hip and q_offset < q_rows:
+            pad_len = q_rows - q_offset
             padding = torch.full(
                 (pad_len, topk_result.shape[1]),
                 -1,
@@ -1122,8 +1239,14 @@ class Indexer(MultiPlatformOp):
         )
 
         batch_size = len(block_tables)
-        token_nums, _, _ = q_fp8.shape
-        device = q_fp8.device
+        if self.use_fp4_index_cache:
+            # q_fp8 carries the (q_fp4, q_sf) tuple on the FP4 index path.
+            q_fp4, q_sf = q_fp8
+            token_nums = q_fp4.shape[0]
+            device = q_fp4.device
+        else:
+            token_nums, _, _ = q_fp8.shape
+            device = q_fp8.device
         device_index = device.index
         assert device_index is not None, "q_fp8 must be on an indexed CUDA device"
 
@@ -1146,12 +1269,17 @@ class Indexer(MultiPlatformOp):
             seq_len_sum,
             max_seq_len,
         )
-        if _is_fp8_fnuz:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+        if self.use_fp4_index_cache:
+            # (seq, 64) packed E2M1 bytes + (seq, 4) packed UE8M0 scale bytes,
+            # viewed as the int8/int32 pair fp8_fp4_mqa_logits consumes.
+            k_fp8 = k_fp8.view(torch.int8)
+            k_scale = k_scale.view(torch.int32).squeeze(-1)
         else:
-            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
-
-        k_scale = k_scale.view(torch.float32).squeeze(-1)
+            if _is_fp8_fnuz:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fnuz)
+            else:
+                k_fp8 = k_fp8.view(torch.float8_e4m3fn)
+            k_scale = k_scale.view(torch.float32).squeeze(-1)
         kv_fp8 = (k_fp8, k_scale)
 
         # Check if we need to chunk to avoid OOM
@@ -1164,9 +1292,23 @@ class Indexer(MultiPlatformOp):
         )
 
         if not need_chunk:
-            assert q_fp8[:q_offset].shape[0] != 0
+            if self.use_fp4_index_cache:
+                assert q_fp4[:q_offset].shape[0] != 0
+            else:
+                assert q_fp8[:q_offset].shape[0] != 0
             with self._with_real_sm_count():
-                if _is_hip:
+                if self.use_fp4_index_cache:
+                    # n_heads >= 32 is enforced at construction, so no
+                    # _pad_heads_for_deep_gemm equivalent is needed here.
+                    logits = deep_gemm.fp8_fp4_mqa_logits(
+                        (q_fp4[:q_offset], q_sf[:q_offset]),
+                        kv_fp8,
+                        weights[:q_offset],
+                        ks,
+                        ke,
+                        clean_logits=False,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1225,7 +1367,16 @@ class Indexer(MultiPlatformOp):
             end = min(start + max_rows, q_offset)
 
             with self._with_real_sm_count():
-                if _is_hip:
+                if self.use_fp4_index_cache:
+                    logits_chunk = deep_gemm.fp8_fp4_mqa_logits(
+                        (q_fp4[start:end], q_sf[start:end]),
+                        kv_fp8,
+                        weights[start:end],
+                        ks[start:end],
+                        ke[start:end],
+                        clean_logits=False,
+                    )
+                elif _is_hip:
                     from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
 
                     kv, scale = kv_fp8
@@ -1627,6 +1778,19 @@ class Indexer(MultiPlatformOp):
         if out_cache_loc is None:
             out_cache_loc = forward_batch.out_cache_loc
 
+        if self.use_fp4_index_cache:
+            # MXFP4 index cache: quantize the (norm+rope+Hadamard) bf16 key to
+            # E2M1 + packed UE8M0 group scales and store the 68 B/token layout.
+            if not out_cache_loc.is_contiguous():
+                out_cache_loc = out_cache_loc.contiguous()
+            store_fp4_index_k_cache(
+                key,
+                get_token_to_kv_pool().get_index_k_with_scale_buffer(layer_id=layer_id),
+                out_cache_loc,
+                page_size=get_token_to_kv_pool().page_size,
+            )
+            return
+
         if (
             _is_cuda
             and (not _is_fp8_fnuz)
@@ -1723,6 +1887,12 @@ class Indexer(MultiPlatformOp):
         in_piecewise_or_breakable_cuda_graph = (
             _is_in_piecewise_or_breakable_cuda_graph()
         )
+
+        if self.use_fp4_index_cache and in_piecewise_or_breakable_cuda_graph:
+            raise RuntimeError(
+                "--enable-dsa-fp4-indexer is not supported under piecewise/"
+                "breakable CUDA graph; use the default full CUDA graph backend."
+            )
 
         # In piecewise/breakable CUDA graph mode, metadata is fetched inside
         # custom ops via get_tc_piecewise_forward_context() to prevent Dynamo
@@ -1830,7 +2000,7 @@ class Indexer(MultiPlatformOp):
             query, key, weights_raw = self._get_q_k_bf16(
                 q_lora, x, positions, enable_dual_stream, forward_batch=forward_batch
             )
-            q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+            q_fp8, q_scale = self._quantize_q_for_logits(query, act_quant)
             with torch.cuda.stream(self.alt_stream):
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
@@ -1841,6 +2011,8 @@ class Indexer(MultiPlatformOp):
             current_stream.wait_stream(self.alt_stream)
             if self.use_dsa_indexer_fusion:
                 weights = self._scale_head_gates(weights_raw, q_scale)
+            elif self.use_fp4_index_cache:
+                weights = self._apply_softmax_scale_only(weights)
             else:
                 weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
         else:
@@ -1852,7 +2024,7 @@ class Indexer(MultiPlatformOp):
                 current_stream = torch.cuda.current_stream()
                 self.alt_stream.wait_stream(current_stream)
 
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quantize_q_for_logits(query, act_quant)
                 with torch.cuda.stream(self.alt_stream):
                     self._store_index_k_cache(
                         forward_batch=forward_batch,
@@ -1862,7 +2034,7 @@ class Indexer(MultiPlatformOp):
                     )
                 current_stream.wait_stream(self.alt_stream)
             elif not in_piecewise_or_breakable_cuda_graph:
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
+                q_fp8, q_scale = self._quantize_q_for_logits(query, act_quant)
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
                     layer_id=layer_id,
@@ -1939,7 +2111,12 @@ class Indexer(MultiPlatformOp):
                 weights = self._scale_head_gates(weights_raw, q_scale)
             elif weights_proj_lora:
                 weights = self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
-                weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
+                if self.use_fp4_index_cache:
+                    weights = self._apply_softmax_scale_only(weights)
+                else:
+                    weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
+            elif self.use_fp4_index_cache:
+                weights = self._get_logits_head_gate_fp4(x_for_gate)
             else:
                 weights = self._get_logits_head_gate(x_for_gate, q_scale)
 

--- a/python/sglang/srt/layers/attention/dsa/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/dsa/index_buf_accessor.py
@@ -96,7 +96,9 @@ class GetK:
             page_indices=page_indices,
             seq_len=seq_len,
             page_size=pool.page_size,
-            index_head_dim=pool.index_head_dim,
+            # Byte width of the stored key data per token (128 for FP8, 64 for
+            # the packed MXFP4 index cache).
+            index_head_dim=pool.index_k_bytes_per_token,
         )
 
 
@@ -165,7 +167,7 @@ class GetS:
             page_indices=page_indices,
             seq_len=seq_len,
             page_size=pool.page_size,
-            index_head_dim=pool.index_head_dim,
+            index_head_dim=pool.index_k_bytes_per_token,
         )
 
 
@@ -249,7 +251,7 @@ class GetKAndS:
             seq_len_sum=seq_len_sum,
             max_seq_len=max_seq_len,
             page_size=pool.page_size,
-            index_head_dim=pool.index_head_dim,
+            index_head_dim=pool.index_k_bytes_per_token,
         )
 
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -73,6 +73,7 @@ from sglang.srt.mem_cache.utils import (
     set_mla_kv_scale_buffer_triton,
 )
 from sglang.srt.platforms import current_platform
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
@@ -3163,6 +3164,13 @@ class DSATokenToKVPool(MLATokenToKVPool):
             index_buf_size = size
         # num head == 1 and head dim == 128 for index_k in DSA
         assert index_head_dim == 128
+        # Bytes of quantized key data stored per token. FP8 stores one byte per
+        # element (128 B) + 4 B fp32 scale; the opt-in MXFP4 index cache packs two
+        # E2M1 elements per byte (64 B) + 4 packed UE8M0 group scales (4 B).
+        self.use_fp4_index_k = get_global_server_args().enable_dsa_fp4_indexer
+        self.index_k_bytes_per_token = (
+            index_head_dim // 2 if self.use_fp4_index_k else index_head_dim
+        )
 
         if _is_hip:
             if aiter_can_use_preshuffle_paged_mqa():
@@ -3184,16 +3192,16 @@ class DSATokenToKVPool(MLATokenToKVPool):
                 torch.zeros(
                     # Layout:
                     #     ref: test_attention.py :: kv_cache_cast_to_fp8
-                    #     shape: (num_pages, page_size 64 * head_dim 128 + page_size 64 * fp32_nbytes 4)
+                    #     shape: (num_pages, page_size 64 * k_bytes + page_size 64 * 4)
+                    #       where k_bytes = 128 (FP8, one byte/elem) or 64 (MXFP4,
+                    #       two E2M1 elems/byte)
                     #     data: for page i,
-                    #         * buf[i, :page_size * head_dim] for fp8 data
-                    #         * buf[i, page_size * head_dim:].view(float32) for scale
+                    #         * buf[i, :page_size * k_bytes] for quantized key data
+                    #         * buf[i, page_size * k_bytes:] for the per-token 4 B
+                    #           scale (fp32 for FP8; 4 packed UE8M0 exps for MXFP4)
                     (
                         (index_buf_size + page_size + 1) // self.page_size,
-                        self.page_size
-                        * (
-                            index_head_dim + index_head_dim // self.quant_block_size * 4
-                        ),
+                        self.page_size * (self.index_k_bytes_per_token + 4),
                     ),
                     dtype=self.index_k_with_scale_buffer_dtype,
                     device=device,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -202,10 +202,15 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             # Add indexer KV cache overhead for DSA models (DeepSeek V3.2)
             if is_deepseek_dsa(model_config.hf_config):
                 index_head_dim = get_dsa_index_head_dim(model_config.hf_config)
-                indexer_size_per_token = (
-                    index_head_dim
-                    + index_head_dim // DSATokenToKVPool.quant_block_size * 4
-                )
+                if mr.server_args.enable_dsa_fp4_indexer:
+                    # MXFP4 index cache: 2 E2M1 elems/byte + 4 packed UE8M0
+                    # group scales per token.
+                    indexer_size_per_token = index_head_dim // 2 + 4
+                else:
+                    indexer_size_per_token = (
+                        index_head_dim
+                        + index_head_dim // DSATokenToKVPool.quant_block_size * 4
+                    )
                 element_size = torch._utils._element_size(
                     DSATokenToKVPool.index_k_with_scale_buffer_dtype
                 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1557,6 +1557,13 @@ class ServerArgs:
         bool,
         "Enable the experimental FP4 C4 indexer path for DeepSeek V4. Default keeps the existing indexer implementation.",
     ] = False
+    enable_dsa_fp4_indexer: A[
+        bool,
+        "Enable the experimental MXFP4 index-K cache for DSA models (DeepSeek-V3.2 / "
+        "GLM-5.x): stores the indexer K cache as E2M1 + UE8M0 (68 B/token/layer vs "
+        "132 B for FP8) and routes indexer logits through DeepGEMM's FP8/FP4 MQA "
+        "kernels. Opt-in; requires SM100+ and the DeepGEMM FP4 MQA-logits kernels.",
+    ] = False
     disable_custom_all_reduce: A[
         bool,
         "Disable the custom all-reduce kernel and fall back to NCCL.",
@@ -5984,6 +5991,24 @@ class ServerArgs:
                 "--enable-deepseek-v4-fp4-indexer requires SM100 GPUs with "
                 "DeepGEMM FP4 indexer support."
             )
+        if self.enable_dsa_fp4_indexer:
+            if not is_sm100_supported():
+                raise ValueError(
+                    "--enable-dsa-fp4-indexer requires SM100 GPUs with "
+                    "DeepGEMM FP4 MQA-logits support."
+                )
+            if self.enable_hisparse:
+                raise ValueError(
+                    "--enable-dsa-fp4-indexer is not supported together with "
+                    "--enable-hisparse (the HiSparse host mirror assumes the "
+                    "FP8 index-K layout)."
+                )
+            if self.dsa_paged_mqa_logits_backend not in ("auto", "deepgemm"):
+                raise ValueError(
+                    "--enable-dsa-fp4-indexer only supports "
+                    "--dsa-paged-mqa-logits-backend auto/deepgemm; got "
+                    f"{self.dsa_paged_mqa_logits_backend!r}."
+                )
         # FP8 W_o GEMM requires Blackwell (sm100+). Auto-disable on Hopper.
         if is_cuda() and envs.SGLANG_OPT_FP8_WO_A_GEMM.get() and get_device_sm() < 100:
             if envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set():

--- a/test/registered/jit/test_dsa_fp4_index_cache.py
+++ b/test/registered/jit/test_dsa_fp4_index_cache.py
@@ -149,7 +149,7 @@ def test_ragged_logits_fp4_tracks_fp8() -> None:
     finite = torch.isfinite(lf8) & torch.isfinite(lf4)
     corr = torch.corrcoef(torch.stack([lf8[finite], lf4[finite]]))[0, 1].item()
     overlap = _topk_overlap(lf8, lf4, INDEX_TOPK)
-    assert corr > 0.98, f"FP4 ragged logits do not track FP8 (corr={corr:.4f})"
+    assert corr > 0.97, f"FP4 ragged logits do not track FP8 (corr={corr:.4f})"
     assert overlap > 0.80, f"FP4 ragged top-k overlap too low ({overlap:.4f})"
 
 
@@ -216,7 +216,7 @@ def test_paged_logits_fp4_tracks_fp8_and_matches_ragged() -> None:
     finite = torch.isfinite(lp8) & torch.isfinite(lp4)
     corr = torch.corrcoef(torch.stack([lp8[finite], lp4[finite]]))[0, 1].item()
     overlap = _topk_overlap(lp8, lp4, INDEX_TOPK)
-    assert corr > 0.98, f"FP4 paged logits do not track FP8 (corr={corr:.4f})"
+    assert corr > 0.97, f"FP4 paged logits do not track FP8 (corr={corr:.4f})"
     assert overlap > 0.80, f"FP4 paged top-k overlap too low ({overlap:.4f})"
 
     # Ragged and paged FP4 kernels must agree on identical inputs: the prefill

--- a/test/registered/jit/test_dsa_fp4_index_cache.py
+++ b/test/registered/jit/test_dsa_fp4_index_cache.py
@@ -245,3 +245,118 @@ def test_paged_logits_fp4_tracks_fp8_and_matches_ragged() -> None:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ----------------------------------------------------------------------------
+# Fused-kernel MXFP4 mode (is_fp4=True store kernel, rope-first FP4 Q kernel;
+# interleave RoPE — GLM-5.x). The fused K store shares its norm+rope path with
+# fused_k_indexer_norm_rope and rounds through bf16 before quant, so it must
+# match the un-fused bf16-kernel + store_fp4_index_k_cache path bit-for-bit.
+# The Q kernel ropes in fp32 (fma scheduling may differ from the torch
+# reference), so it is held to a high byte-match rate plus exact head-gate
+# weights instead.
+# ----------------------------------------------------------------------------
+
+MAX_POS = 8192
+ROPE_DIM = 64
+HALF = ROPE_DIM // 2
+EPS = 1e-6
+
+
+def _make_rope_inputs(B, seed=0):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    cos = torch.randn(MAX_POS, HALF, device="cuda", generator=g)
+    sin = torch.randn(MAX_POS, HALF, device="cuda", generator=g)
+    cos_sin_cache = torch.cat((cos, sin), dim=-1)
+    positions = torch.randint(
+        0, 4096, (B,), device="cuda", dtype=torch.int32, generator=g
+    )
+    return cos, sin, cos_sin_cache, positions
+
+
+def _rope_first_interleave_ref(x, cos_p, sin_p):
+    x = x.clone()
+    xr = x[..., 0:ROPE_DIM:2].clone()
+    xi = x[..., 1:ROPE_DIM:2].clone()
+    x[..., 0:ROPE_DIM:2] = xr * cos_p - xi * sin_p
+    x[..., 1:ROPE_DIM:2] = xr * sin_p + xi * cos_p
+    return x
+
+
+def test_fused_k_fp4_store_matches_unfused_path() -> None:
+    from sglang.jit_kernel.dsv32 import (
+        fused_k_indexer_norm_rope,
+        fused_k_indexer_norm_rope_store,
+    )
+
+    torch.manual_seed(10)
+    B = 1024
+    total_pages = 32
+    assert B <= total_pages * PAGE_SIZE
+    _, _, cos_sin_cache, positions = _make_rope_inputs(B, seed=10)
+    # Strided input: the non-contiguous wk_weights_proj slice path.
+    kw = torch.randn(B, HEAD_DIM + 64, dtype=torch.bfloat16, device="cuda")
+    key = kw[:, :HEAD_DIM]
+    weight = torch.randn(HEAD_DIM, dtype=torch.float32, device="cuda")
+    bias = torch.randn(HEAD_DIM, dtype=torch.float32, device="cuda")
+    loc = torch.randperm(total_pages * PAGE_SIZE, device="cuda")[:B]
+
+    cache_fused = torch.zeros(
+        total_pages, PAGE_SIZE * (FP4_BYTES + 4), dtype=torch.uint8, device="cuda"
+    )
+    fused_k_indexer_norm_rope_store(
+        key,
+        cache_fused,
+        loc,
+        weight,
+        bias,
+        EPS,
+        cos_sin_cache,
+        positions,
+        PAGE_SIZE,
+        is_fp4=True,
+    )
+
+    # Un-fused reference: the bf16 K kernel (same norm+rope path) + the
+    # standalone Triton FP4 store.
+    k_bf16 = fused_k_indexer_norm_rope(key, weight, bias, EPS, cos_sin_cache, positions)
+    cache_ref = torch.zeros_like(cache_fused)
+    store_fp4_index_k_cache(k_bf16, cache_ref, loc, page_size=PAGE_SIZE)
+
+    assert torch.equal(cache_fused, cache_ref), "fused FP4 K store != un-fused path"
+
+
+def test_fused_q_fp4_matches_eager_reference() -> None:
+    from sglang.jit_kernel.dsv4 import fused_q_indexer_rope_first_fp4_quant
+
+    torch.manual_seed(11)
+    B, H = 256, 32
+    cos, sin, cos_sin_cache, positions = _make_rope_inputs(B, seed=11)
+    q = torch.randn(B, H, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    # Strided head-gate weights: the non-contiguous wk_weights_proj slice path.
+    kw = torch.randn(B, HEAD_DIM + H, dtype=torch.bfloat16, device="cuda")
+    weights_raw = kw[:, HEAD_DIM:]
+    weight_scale = 0.0625
+
+    (q_fp4, q_sf), w_out = fused_q_indexer_rope_first_fp4_quant(
+        q, weights_raw, weight_scale, cos_sin_cache, positions
+    )
+    assert q_fp4.shape == (B, H, FP4_BYTES) and q_fp4.dtype == torch.int8
+    assert q_sf.shape == (B, H) and q_sf.dtype == torch.int32
+
+    # Head-gate weights carry no per-token q_scale on the FP4 path.
+    torch.testing.assert_close(
+        w_out.squeeze(-1), weights_raw.float() * weight_scale, atol=1e-6, rtol=0.0
+    )
+
+    # Eager reference: fp32 rope -> bf16 round -> Triton MXFP4 quant. The
+    # kernel's fp32 fma scheduling may differ by 1 ulp at E2M1 code
+    # boundaries, so demand a very high (not perfect) byte-match rate.
+    cp = cos[positions.long()].unsqueeze(1)
+    sp = sin[positions.long()].unsqueeze(1)
+    ref = _rope_first_interleave_ref(q.float(), cp, sp).to(torch.bfloat16)
+    ref_fp4, ref_sf = quantize_fp4_indexer_tensor(ref.view(-1, HEAD_DIM))
+    byte_match = (q_fp4.view(-1, FP4_BYTES) == ref_fp4).float().mean().item()
+    sf_match = (q_sf.view(-1) == ref_sf).float().mean().item()
+    assert byte_match > 0.999, f"FP4 Q byte match too low: {byte_match:.5f}"
+    assert sf_match > 0.999, f"FP4 Q sf match too low: {sf_match:.5f}"

--- a/test/registered/jit/test_dsa_fp4_index_cache.py
+++ b/test/registered/jit/test_dsa_fp4_index_cache.py
@@ -1,0 +1,247 @@
+"""Correctness tests for the opt-in DSA MXFP4 index-K cache (--enable-dsa-fp4-indexer).
+
+Covers the three contracts the DSA FP4 index path relies on:
+  1. The Triton FP4 quantizer emits exactly DeepGEMM's packed MXFP4 format
+     (E2M1 pairs + packed UE8M0/32 scales).
+  2. store_fp4_index_k_cache and the index_buf_accessor gather agree bit-exactly
+     on the 68 B/token paged layout (write path == ragged read path).
+  3. The DeepGEMM FP4 MQA-logits kernels (ragged + paged) track the FP8 baseline
+     within quantization noise, measured as top-k index-set overlap — the metric
+     that decides indexer selection quality (SM100+ only).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.dsa.index_buf_accessor import (
+    _get_k_and_s_triton,
+    _set_k_and_s_triton,
+)
+from sglang.srt.layers.attention.dsa.triton_kernel import act_quant
+from sglang.srt.layers.attention.dsv4.fp4_indexer import (
+    quantize_fp4_indexer_tensor,
+    store_fp4_index_k_cache,
+)
+from sglang.srt.utils import is_sm100_supported
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
+
+HEAD_DIM = 128
+PAGE_SIZE = 64
+FP4_BYTES = HEAD_DIM // 2
+INDEX_TOPK = 2048
+
+requires_sm100 = pytest.mark.skipif(
+    not is_sm100_supported(),
+    reason="DeepGEMM FP4 MQA-logits kernels require SM100+",
+)
+
+
+def _topk_overlap(a: torch.Tensor, b: torch.Tensor, k: int) -> float:
+    ia = a.topk(k, dim=-1).indices
+    ib = b.topk(k, dim=-1).indices
+    overlaps = []
+    for i in range(a.shape[0]):
+        sa = set(ia[i].tolist())
+        sb = set(ib[i].tolist())
+        overlaps.append(len(sa & sb) / k)
+    return sum(overlaps) / len(overlaps)
+
+
+def test_quantizer_matches_deepgemm_reference() -> None:
+    from deep_gemm.utils.math import per_token_cast_to_fp4
+
+    torch.manual_seed(0)
+    n = 4096
+    x = torch.randn(n, HEAD_DIM, device="cuda", dtype=torch.bfloat16) * 2.0
+
+    k_fp4, k_sf = quantize_fp4_indexer_tensor(x)
+    assert k_fp4.shape == (n, FP4_BYTES) and k_fp4.dtype == torch.int8
+    assert k_sf.shape == (n,) and k_sf.dtype == torch.int32
+
+    ref_fp4, ref_sf = per_token_cast_to_fp4(
+        x.float(), use_ue8m0=True, gran_k=32, use_packed_ue8m0=True
+    )
+    assert torch.equal(k_fp4, ref_fp4)
+    assert torch.equal(k_sf, ref_sf.view(-1))
+
+
+def test_store_and_gather_round_trip() -> None:
+    torch.manual_seed(1)
+    num_tokens = 8 * 1024
+    total_pages = num_tokens // PAGE_SIZE
+    k = torch.randn(num_tokens, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+
+    cache = torch.zeros(
+        total_pages, PAGE_SIZE * (FP4_BYTES + 4), dtype=torch.uint8, device="cuda"
+    )
+    # Scatter through a permutation to exercise non-linear cache locations.
+    loc = torch.randperm(num_tokens, device="cuda")
+    store_fp4_index_k_cache(k, cache, loc, page_size=PAGE_SIZE)
+
+    # Gather everything back in loc order via the accessor kernel at the FP4
+    # byte width (the same call _get_topk_ragged makes through GetKAndS).
+    inv = torch.empty_like(loc)
+    inv[loc] = torch.arange(num_tokens, device="cuda")
+    seq_lens = torch.tensor([num_tokens], dtype=torch.int64, device="cuda")
+    block_tables = torch.arange(total_pages, dtype=torch.int32, device="cuda").view(
+        1, -1
+    )
+    k_out, s_out = _get_k_and_s_triton(
+        buf=cache,
+        page_indices=block_tables,
+        seq_lens=seq_lens,
+        seq_len_sum=num_tokens,
+        max_seq_len=num_tokens,
+        page_size=PAGE_SIZE,
+        index_head_dim=FP4_BYTES,
+    )
+
+    k_ref, sf_ref = quantize_fp4_indexer_tensor(k)
+    assert torch.equal(k_out.view(torch.int8)[loc], k_ref)
+    assert torch.equal(s_out.view(torch.int32).squeeze(-1)[loc], sf_ref)
+
+
+@requires_sm100
+def test_ragged_logits_fp4_tracks_fp8() -> None:
+    import deep_gemm
+
+    torch.manual_seed(2)
+    m, h, n_kv = 128, 64, 8192
+    q = torch.randn(m, h, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(n_kv, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    w = torch.rand(m, h, device="cuda", dtype=torch.float32)
+    ks = torch.zeros(m, dtype=torch.int32, device="cuda")
+    ke = torch.full((m,), n_kv, dtype=torch.int32, device="cuda")
+
+    # FP8 baseline arm: per-token q_scale folded into the head-gate weights,
+    # exactly like the production FP8 path.
+    q_fp8, q_scale = act_quant(q, 128, None)
+    k_fp8, k_scale = act_quant(kv, 128, None)
+    logits_fp8 = deep_gemm.fp8_mqa_logits(
+        q_fp8,
+        (k_fp8, k_scale.squeeze(-1)),
+        (w.unsqueeze(-1) * q_scale).squeeze(-1),
+        ks,
+        ke,
+        clean_logits=False,
+    )
+
+    # FP4 arm: kernel consumes q_sf / k_sf directly, weights carry no q_scale.
+    q4, qsf = quantize_fp4_indexer_tensor(q.view(-1, HEAD_DIM))
+    k4, ksf = quantize_fp4_indexer_tensor(kv)
+    logits_fp4 = deep_gemm.fp8_fp4_mqa_logits(
+        (q4.view(m, h, FP4_BYTES), qsf.view(m, h)),
+        (k4, ksf),
+        w,
+        ks,
+        ke,
+        clean_logits=False,
+        max_seqlen_k=n_kv,
+    )
+
+    lf8, lf4 = logits_fp8.float(), logits_fp4.float()
+    finite = torch.isfinite(lf8) & torch.isfinite(lf4)
+    corr = torch.corrcoef(torch.stack([lf8[finite], lf4[finite]]))[0, 1].item()
+    overlap = _topk_overlap(lf8, lf4, INDEX_TOPK)
+    assert corr > 0.98, f"FP4 ragged logits do not track FP8 (corr={corr:.4f})"
+    assert overlap > 0.80, f"FP4 ragged top-k overlap too low ({overlap:.4f})"
+
+
+@requires_sm100
+def test_paged_logits_fp4_tracks_fp8_and_matches_ragged() -> None:
+    import deep_gemm
+
+    torch.manual_seed(3)
+    B, h, ctx = 4, 64, 4096
+    total_pages = B * ctx // PAGE_SIZE
+    kv_all = torch.randn(B * ctx, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    loc = torch.arange(B * ctx, dtype=torch.int64, device="cuda")
+    block_tables = torch.arange(total_pages, dtype=torch.int32, device="cuda").view(
+        B, -1
+    )
+
+    cache_fp4 = torch.zeros(
+        total_pages, PAGE_SIZE * (FP4_BYTES + 4), dtype=torch.uint8, device="cuda"
+    )
+    store_fp4_index_k_cache(kv_all, cache_fp4, loc, page_size=PAGE_SIZE)
+
+    cache_fp8 = torch.zeros(
+        total_pages, PAGE_SIZE * (HEAD_DIM + 4), dtype=torch.uint8, device="cuda"
+    )
+    k8, k8s = act_quant(kv_all, 128, None)
+    _set_k_and_s_triton(
+        buf=cache_fp8, loc=loc, index_k=k8, index_k_scale=k8s, page_size=PAGE_SIZE
+    )
+
+    qd = torch.randn(B, h, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    wd = torch.rand(B, h, device="cuda", dtype=torch.float32)
+    ctx_lens = torch.full((B, 1), ctx, dtype=torch.int32, device="cuda")
+    sched = deep_gemm.get_paged_mqa_logits_metadata(
+        ctx_lens, PAGE_SIZE, deep_gemm.get_num_sms()
+    )
+
+    qd8, qd8s = act_quant(qd, 128, None)
+    logits_p8 = deep_gemm.fp8_paged_mqa_logits(
+        qd8.unsqueeze(1),
+        cache_fp8.view(total_pages, PAGE_SIZE, 1, HEAD_DIM + 4),
+        (wd.unsqueeze(-1) * qd8s).squeeze(-1),
+        ctx_lens,
+        block_tables,
+        sched,
+        ctx,
+        clean_logits=False,
+    )
+
+    qd4, qd4sf = quantize_fp4_indexer_tensor(qd.view(-1, HEAD_DIM))
+    qd4 = qd4.view(B, h, FP4_BYTES)
+    qd4sf = qd4sf.view(B, h)
+    logits_p4 = deep_gemm.fp8_fp4_paged_mqa_logits(
+        (qd4.unsqueeze(1), qd4sf.unsqueeze(1)),
+        cache_fp4.view(total_pages, PAGE_SIZE, 1, FP4_BYTES + 4),
+        wd,
+        ctx_lens,
+        block_tables,
+        sched,
+        ctx,
+        clean_logits=False,
+    )
+
+    lp8, lp4 = logits_p8.float(), logits_p4.float()
+    finite = torch.isfinite(lp8) & torch.isfinite(lp4)
+    corr = torch.corrcoef(torch.stack([lp8[finite], lp4[finite]]))[0, 1].item()
+    overlap = _topk_overlap(lp8, lp4, INDEX_TOPK)
+    assert corr > 0.98, f"FP4 paged logits do not track FP8 (corr={corr:.4f})"
+    assert overlap > 0.80, f"FP4 paged top-k overlap too low ({overlap:.4f})"
+
+    # Ragged and paged FP4 kernels must agree on identical inputs: the prefill
+    # (ragged) and decode (paged) paths read the same cache and must select the
+    # same tokens.
+    k4_all, ksf_all = quantize_fp4_indexer_tensor(kv_all)
+    ks1 = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ke1 = torch.full((1,), ctx, dtype=torch.int32, device="cuda")
+    for i in range(B):
+        li = deep_gemm.fp8_fp4_mqa_logits(
+            (qd4[i : i + 1], qd4sf[i : i + 1]),
+            (
+                k4_all[i * ctx : (i + 1) * ctx],
+                ksf_all[i * ctx : (i + 1) * ctx],
+            ),
+            wd[i : i + 1],
+            ks1,
+            ke1,
+            clean_logits=False,
+            max_seqlen_k=ctx,
+        )
+        diff = (li[0, :ctx] - lp4[i, :ctx]).abs()
+        fin = torch.isfinite(li[0, :ctx]) & torch.isfinite(lp4[i, :ctx])
+        assert diff[fin].max().item() < 1e-3, "ragged/paged FP4 logits diverge"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Motivation

- The DSA (GLM-5.x / DeepSeek-V3.2) lightning-indexer K cache is stored as FP8: 128 B key + 4 B fp32 scale = **132 B/token/layer**.
- DeepSeek-V4 ships an opt-in MXFP4 indexer (#26209): E2M1 elements + packed UE8M0 group-32 scales = **68 B/token/layer**, with DeepGEMM FP4 MQA-logits kernels that measured 1.49–1.53× over FP8.
- This PR ports that to the shared DSA path behind `--enable-dsa-fp4-indexer` (default **off**): a ~48% cut of the indexer KV footprint, returned to the main KV pool as ~**+9.9% `max_total_num_tokens`**, plus the FP4 logits-kernel speedup.
- The fused indexer kernels (#27705, ~+10% single-stream) get a native **MXFP4 quant/store mode**, so on GLM-5.x (interleave) the flag keeps the fused path — FP4 is perf-neutral on top of fusion, instead of paying the ~8.5% split-path cost.
- Primary target/validation model: **nvidia/GLM-5.2-NVFP4**. DeepSeek-V3.2 (NeoX) is also supported: it takes the split indexer path under the flag (same as its FP8 default today); once the NeoX fusion fix (#30342) lands, the fused MXFP4 mode extends to it with a template knob.

## Modifications

1. **Server arg** `--enable-dsa-fp4-indexer` (default off) + fail-loud guards at `Indexer` construction: SM100+ only; DeepGEMM build must expose `fp8_fp4_paged_mqa_logits` / `fp8_fp4_mqa_logits` (there is no non-DeepGEMM FP4 fallback); DeepGEMM paged-MQA backend only; incompatible with `--enable-hisparse`, DSA prefill-CP, piecewise/breakable CUDA graph; `index_n_heads >= 32`.
2. **Pool** (`memory_pool.py`): `DSATokenToKVPool.index_k_bytes_per_token` = 128 (FP8) / 64 (MXFP4); rows sized `page_size * (index_k_bytes_per_token + 4)` (same block layout: K block, then per-token 4 B scales — fp32 for FP8, 4 packed UE8M0 exponents for FP4). `index_buf_accessor` gathers parametrized on the byte width; `pool_configurator` capacity estimate updated (that is what raises `max_total_num_tokens`).
3. **Routing** (`dsa_indexer.py`): under the flag, K stores go through the MXFP4 store (fused on interleave, split on NeoX), decode/verify top-k through `deep_gemm.fp8_fp4_paged_mqa_logits` over the 68 B paged view, prefill top-k through `deep_gemm.fp8_fp4_mqa_logits` over the gathered `(k_fp4, k_sf)` pair. Q is carried as the `(q_fp4, q_sf)` tuple the FP4 kernels consume; the per-token `q_scale` fold into the head-gate weights is dropped (the kernel applies `q_sf` itself).
4. **Fused kernels** (interleave path):
   - `csrc/deepseek_v32/indexer_k.cuh`: `kIsFp4` template mode on `fused_k_indexer_norm_rope_store` — LayerNorm + RoPE + per-32-elem-group amax (`warp::reduce_max<8>`) → UE8M0 ceil scale → packed E2M1 pairs into the 68 B page layout. Rounds through bf16 before quant and uses the Triton quantizer's scale order (`max(amax/6, 1e-4)`), so the output is **bit-identical** to the un-fused bf16-K-kernel + `store_fp4_index_k_cache` path.
   - `csrc/deepseek_v4/main_norm_rope.cuh`: `FusedQIndexerRopeHadamardFp4QuantKernel` generalized with the same `kRopeFirst/kHadamard` knobs as the FP8 Q kernel (defaults keep the V4 instantiation byte-compatible) plus a weight row stride for the non-contiguous `wk_weights_proj` slice; new rope-first (no-Hadamard) instantiation for DSA. `quant_fp4_e2m1` moves to the shared `sgl_kernel/deepseek_v4/fp8_utils.cuh`.
   - New JIT wrappers with distinct module cache keys: `fused_q_indexer_rope_first_fp4_quant`, `fused_k_indexer_norm_rope_store(..., is_fp4=)`.
5. **Tests** — `test/registered/jit/test_dsa_fp4_index_cache.py` (6 tests): quantizer format contract vs DeepGEMM's `per_token_cast_to_fp4(use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)` (bit-equal); store→gather round-trip on the 68 B layout (bit-exact, scattered locs); FP4-vs-FP8 logits top-2048 index-set overlap (ragged + paged + ragged↔paged consistency, SM100-gated); fused K FP4 store byte-exact vs un-fused (strided inputs); fused Q FP4 vs eager reference (>99.9% byte match, exact head-gate weights).

Not changed:

- Flag off: the FP8 path is byte-identical (132 B sizing and kernel dispatch untouched).
- The fusion gate (`is_neox_style` clause) and the split path.
- The DeepSeek-V4 native indexer (shared kernels extended with defaulted template args; `test/registered/jit/deepseek_v4/test_fp4_indexer.py` 12/12).
- No NVFP4/E4M3 mode — the DeepGEMM sm100 MQA-logits kernel hardcodes E2M1 + UE8M0; this is MXFP4 only.
- Index-share / `skip_topk` logic; spec decode is wired through the same FP4 paged call (next_n≥2 shapes) but not yet validated E2E.

Cache reduction at fixed `--mem-fraction-static 0.85` (startup `max_total_num_tokens`, B300 ×4, tp4 ep4):

| model | FP8 index | MXFP4 index | delta |
|---|---|---|---|
| nvidia/GLM-5.2-NVFP4 | 2,292,288 | 2,519,680 | **+9.92%** |
| deepseek-ai/DeepSeek-V3.2 | 1,651,392 | 1,815,488 | **+9.94%** |

Exactly the layout prediction `(576+132)/(576+68) = 1.0994`.

## Accuracy Tests

GSM8K full set, `python3 -m sglang.test.few_shot_gsm8k --num-questions 1319 --num-shots 20`, `/flush_cache` between runs, B300 ×4, `--tp 4 --ep 4 --disable-radix-cache`, fused indexer path in both arms:

```
nvidia/GLM-5.2-NVFP4, fused FP8 index (baseline):
Accuracy: 0.945   Accuracy: 0.942   Accuracy: 0.945   Accuracy: 0.937   Accuracy: 0.944   mean 0.943

nvidia/GLM-5.2-NVFP4, fused MXFP4 index (this PR, flag on):
Accuracy: 0.936   Accuracy: 0.939   Accuracy: 0.947   Accuracy: 0.948   Accuracy: 0.939   mean 0.942
```

- Flat (−0.08 pt, distributions fully overlapping) — better than the ~1.5 pt envelope #26209 measured on V4-Flash.
- The fused FP4 path drops the Hadamard rotation exactly like fused FP8 does; the flat result shows that costs nothing measurable.

AIME25 (harder signal) — `sgl-eval run aime25 --n-repeats 8 --max-tokens 65536 --temperature 1.0 --top-p 0.95 --num-threads 128`, same launch, sequential arms:

nvidia/GLM-5.2-NVFP4 (fused path both arms):

```
FP8 index   : pass@1[avg-of-8] = 92.08% +/- 3.05% (SEM 1.08%)   pass@8 100.00%   majority@8 95.00%   no_answer 1.25%
MXFP4 index : pass@1[avg-of-8] = 91.25% +/- 3.96% (SEM 1.40%)   pass@8 100.00%   majority@8 96.67%   no_answer 1.25%
```

deepseek-ai/DeepSeek-V3.2 (split path under the flag):

```
FP8 index   : pass@1[avg-of-8] = 88.75% +/- 1.73% (SEM 0.61%)   pass@8 93.33%   majority@8 90.00%
MXFP4 index : pass@1[avg-of-8] = 91.25% +/- 2.48% (SEM 0.88%)   pass@8 93.33%   majority@8 93.33%
```

- Parity within noise on both models (GLM -0.83 pt, V3.2 nominally +2.5 pt; SEM ~1 pt); wall-clock equal across arms.

DeepSeek-V3.2 (NeoX → split path under the flag), GSM8K ×5, radix on:

```
FP8 index : Accuracy: 0.955   Accuracy: 0.958   Accuracy: 0.957   Accuracy: 0.955   Accuracy: 0.959   mean 0.957
MXFP4 index: Accuracy: 0.956   Accuracy: 0.957   Accuracy: 0.958   Accuracy: 0.960   Accuracy: 0.957   mean 0.958
```

Unit tests:

```
python3 -m pytest test/registered/jit/test_dsa_fp4_index_cache.py -q
6 passed, 21 warnings in 10.58s

python3 -m pytest test/registered/jit/test_dsv32_indexer_fusion.py -q
7 passed, 21 warnings in 7.13s

python3 -m pytest test/registered/jit/deepseek_v4/test_fp4_indexer.py -q   # shared main_norm_rope.cuh, V4 path
12 passed, 7 warnings in 6.67s
```

## Speed Tests and Profiling

Kernel-level, DeepGEMM paged MQA-logits FP8 vs FP4 (B300, B=256, H=64, D=128, NextN=1, block_kv=64; 50 iters, CUDA-event timed):

| case | FP8 µs | FP4 µs | FP4 speedup |
|---|---|---|---|
| B=256, L=8192 | 49.01 | 29.99 | **1.63×** |
| B=256, L=32768 | 170.54 | 97.13 | **1.76×** |

(#26209 measured 1.49× / 1.53× for the same cases on B200.)

GLM-5.2-NVFP4 GSM8K wall-clock, same servers as the accuracy runs (5 runs/arm, fused path both arms): FP8 **186.9 s / 759 tok/s** vs MXFP4 **187.0 s / 758 tok/s** — **neutral on top of fusion**. (An earlier revision that forced the split path under the flag cost ~8.5% here; the fused MXFP4 kernels recover all of it.)

AIME25 wall-clock was equal across arms on both models.

> During validation we briefly hit a long-decode instability; it turned out to be the fused top-k v2 tie-overflow already fixed upstream by #30512, and all numbers in this PR were measured with that fix included.

Refs: #26209 #27705 #30111 #30342 #30378







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28958182240](https://github.com/sgl-project/sglang/actions/runs/28958182240)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28958182103](https://github.com/sgl-project/sglang/actions/runs/28958182103)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->