### PR TITLE
[NVIDIA] Extend modelopt_fp4-only MoE heuristics to NVFP4-expert modelopt_mixed

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -867,7 +867,14 @@ def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
             overrides["quantization"] = quant_method
             quantization = quant_method
         if (
-            (quantization in ("fp8", "modelopt_fp4") or quantization is None)
+            (
+                quantization in ("fp8", "modelopt_fp4")
+                or quantization is None
+                or (
+                    quantization == "modelopt_mixed"
+                    and server_args.get_model_config().mixed_nvfp4_moe
+                )
+            )
             and server_args.moe_a2a_backend == "none"
             and server_args.moe_runner_backend == "auto"
         ):

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -376,6 +376,18 @@ class ModelConfig:
                 len(self.nvfp4_moe_meta["exclude_modules"]),
             )
 
+        # True iff a MIXED_PRECISION checkpoint's expert layers are all plain
+        # NVFP4 (w4a4); also set in _parse_modelopt_quant_config.
+        self.mixed_nvfp4_moe: bool = False
+        if (
+            hybrid_quant_cfg is not None
+            and str(hybrid_quant_cfg.get("quant_algo", "")).upper()
+            == "MIXED_PRECISION"
+        ):
+            self.mixed_nvfp4_moe = self._mixed_precision_experts_all_nvfp4(
+                hybrid_quant_cfg.get("quantized_layers")
+            )
+
         # Check model type
         self.attention_chunk_size = getattr(
             self.hf_text_config, "attention_chunk_size", None
@@ -1147,6 +1159,16 @@ class ModelConfig:
 
         return quant_cfg
 
+    @staticmethod
+    def _mixed_precision_experts_all_nvfp4(quantized_layers) -> bool:
+        # Match "experts" as a path segment, not "...shared_expert.up_proj".
+        expert_algos = {
+            str(layer_info.get("quant_algo", "")).upper()
+            for name, layer_info in (quantized_layers or {}).items()
+            if isinstance(layer_info, dict) and "experts" in name.split(".")
+        }
+        return expert_algos == {"NVFP4"}
+
     def _parse_modelopt_quant_config(self, quant_config_dict: dict) -> Optional[dict]:
         """Parse ModelOpt quantization config and return the appropriate quant_method."""
         json_quant_configs = quant_config_dict["quantization"]
@@ -1159,6 +1181,9 @@ class ModelConfig:
                 in ("NVFP4", "W4A16_NVFP4")
                 for layer_info in quantized_layers.values()
                 if isinstance(layer_info, dict)
+            )
+            self.mixed_nvfp4_moe = self._mixed_precision_experts_all_nvfp4(
+                quantized_layers
             )
             if has_modelopt_nvfp4_layers:
                 return {"quant_method": "modelopt_mixed", "quant_algo": quant_algo}

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -271,6 +271,7 @@ def initialize_moe_config(server_args: ServerArgs):
     moe.tbo_token_distribution_threshold = server_args.tbo_token_distribution_threshold
     moe.disable_fp4_allgather = server_args.disable_flashinfer_cutlass_moe_fp4_allgather
     moe.quantization = server_args.quantization
+    moe.mixed_nvfp4_moe = server_args.get_model_config().mixed_nvfp4_moe
 
 
 def get_moe_a2a_backend() -> MoeA2ABackend:
@@ -391,7 +392,10 @@ def should_use_flashinfer_cutlass_moe_fp4_allgather():
         and get_moe_a2a_backend().is_none()
         and get_moe_runner_backend().is_flashinfer_cutlass()
         and is_dp_attention_enabled()
-        and get_flags().moe.quantization == "modelopt_fp4"
+        and (
+            get_flags().moe.quantization == "modelopt_fp4"
+            or bool(get_flags().moe.mixed_nvfp4_moe)
+        )
         and get_parallel().moe_ep_size == get_parallel().attn_dp_size
     )
 

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -291,6 +291,7 @@ class MoeFlags(_FlagGroupBase):
     tbo_token_distribution_threshold: float | None = None
     disable_fp4_allgather: bool | None = None
     quantization: str | None = None
+    mixed_nvfp4_moe: bool | None = None
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5380,6 +5380,7 @@ class ServerArgs:
             if not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set() and (
                 resolved_view(self).quantization == "modelopt_fp4"
                 or self.get_model_config().nvfp4_moe_meta is not None
+                or self.get_model_config().mixed_nvfp4_moe
             ):
                 envs.SGLANG_MOE_NVFP4_DISPATCH.set(True)
                 logger.warning(

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -684,6 +684,59 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
 
         self.assertEqual(result["quant_method"], "modelopt_mixed")
 
+    def test_mixed_precision_nvfp4_experts_sets_mixed_nvfp4_moe(self):
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = MagicMock()
+        model_config.hf_config.model_type = "qwen3_5_moe"
+        model_config.hf_config.architectures = ["Qwen3_5MoeForConditionalGeneration"]
+
+        result = model_config._parse_modelopt_quant_config(
+            {
+                "quantization": {
+                    "quant_algo": "MIXED_PRECISION",
+                    "quantized_layers": {
+                        "model.language_model.layers.0.mlp.experts": {
+                            "quant_algo": "NVFP4",
+                            "group_size": 16,
+                        },
+                        # contains "expert" but is not a routed-experts entry
+                        "model.language_model.layers.0.mlp.shared_expert.up_proj": {
+                            "quant_algo": "FP8"
+                        },
+                        "model.language_model.layers.0.linear_attn.in_proj_qkv": {
+                            "quant_algo": "FP8"
+                        },
+                    },
+                }
+            }
+        )
+
+        self.assertEqual(result["quant_method"], "modelopt_mixed")
+        self.assertTrue(model_config.mixed_nvfp4_moe)
+
+    def test_mixed_precision_w4a16_experts_not_marked_nvfp4_moe(self):
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.hf_config = MagicMock()
+        model_config.hf_config.model_type = "qwen3_5_moe"
+        model_config.hf_config.architectures = ["Qwen3_5MoeForConditionalGeneration"]
+
+        result = model_config._parse_modelopt_quant_config(
+            {
+                "quantization": {
+                    "quant_algo": "MIXED_PRECISION",
+                    "quantized_layers": {
+                        "model.layers.0.mlp.experts": {
+                            "quant_algo": "W4A16_NVFP4",
+                            "group_size": 16,
+                        },
+                    },
+                }
+            }
+        )
+
+        self.assertEqual(result["quant_method"], "modelopt_mixed")
+        self.assertFalse(model_config.mixed_nvfp4_moe)
+
     def test_mixed_precision_override_does_not_hijack_w4afp8(self):
         self.assertIsNone(
             ModelOptMixedPrecisionConfig.override_quantization_method(


### PR DESCRIPTION
## Motivation

Follow-up to #30443. For MIXED_PRECISION checkpoints whose routed experts are plain NVFP4 (e.g. [nvidia/Qwen3.5-397B-A17B-NVFP4-V2](https://huggingface.co/nvidia/Qwen3.5-397B-A17B-NVFP4-V2)), MoE activation handling is identical to `modelopt_fp4` — the experts resolve to the same `ModelOptNvFp4FusedMoEMethod`. But three heuristics still key on the quantization string alone, so such checkpoints silently miss them:

- `SGLANG_MOE_NVFP4_DISPATCH` auto-enable for `--moe-a2a-backend flashinfer`: falls back to bf16 dispatch (~4× a2a bytes);
- FP4-quantize-before-allgather for `flashinfer_cutlass` with DP attention;
- Qwen3-MoE-family default MoE runner on sm100: stays `auto` instead of `flashinfer_trtllm`, which also skips runner-keyed side effects applied downstream.

## Modifications

- `ModelConfig` records `mixed_nvfp4_moe` while parsing MIXED_PRECISION `quantized_layers`: True iff the checkpoint has expert entries and every entry with `experts` as a path segment is plain `NVFP4`. The segment match covers `...mlp.experts` and `...experts.0.up_proj` but not `...mlp.shared_expert.up_proj`. `W4A16_NVFP4` experts keep bf16 activations and are deliberately excluded.
- The three heuristics accept `mixed_nvfp4_moe` in addition to `quantization == "modelopt_fp4"` (plumbed through `MoeFlags` for the allgather check, which runs in the scheduler).
- Unit tests for the new flag in `test_modelopt_loader.py`.

Behavior is unchanged for `modelopt_fp4`, `fp8`, and mixed checkpoints whose experts are not plain NVFP4.

## Verification

- [x] Unit tests: `TestModelOptMixedPrecisionConfig` — 11 passed, including the two new cases
- [x] Arg-resolution A/B on GB200 with the real Qwen3.5-397B-A17B-NVFP4-V2 config (baseline = current main): with this PR, `mixed_nvfp4_moe=True`, the default MoE runner resolves to `flashinfer_trtllm`, and `SGLANG_MOE_NVFP4_DISPATCH` is auto-set for `--moe-a2a-backend flashinfer`; on main, none of the three fire
- [x] Full-weight A/B on 4×GB200, DEP4 (`--tp-size 4 --dp-size 4 --enable-dp-attention`), `flashinfer_cutlass` + `--moe-a2a-backend flashinfer`, `bench_serving` random 1k-in/1k-out + GSM8K (200 examples):

| code | dispatch | tok/s @c32 | tok/s @c128 | GSM8K |
|---|---|---|---|---|
| main | bf16 | 1932 | 6441 | 0.990 |
| this PR | NVFP4 (auto-enabled, log-verified) | 1954 | 6484 | 0.985 |

Accuracy parity within noise. Single-node throughput +0.7–1.1% — the a2a payload shrinks ~4× but stays within NVLink; a larger effect is expected on multi-node EP where the alltoall crosses the network. `flashinfer_cutedsl` + `--moe-a2a-backend flashinfer` with the auto-enabled dispatch also verified end-to-end (2385 tok/s @c32, GSM8K 0.980).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28974152183](https://github.com/sgl-project/sglang/actions/runs/28974152183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28974152104](https://github.com/sgl-project/sglang/actions/runs/28974152104)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

