### PR TITLE
[Spec] Size shared logits buffer for adaptive candidates

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -836,7 +836,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
     def max_decode_logits_rows(self) -> int:
         """Rows the shared logits buffer needs."""
-        num_tokens_per_bs = self.decode_num_tokens_per_bs()
+        num_draft_tokens = getattr(
+            self.server_args, "max_speculative_num_draft_tokens", None
+        )
+        num_tokens_per_bs = self.decode_num_tokens_per_bs(
+            num_draft_tokens=num_draft_tokens
+        )
         capture_bs, _ = get_batch_sizes_to_capture(self, num_tokens_per_bs)
         return max(capture_bs) * num_tokens_per_bs
 

--- a/test/registered/unit/model_executor/test_model_runner_decode_rows.py
+++ b/test/registered/unit/model_executor/test_model_runner_decode_rows.py
@@ -1,0 +1,53 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _FakeSpecAlgorithm:
+    def __init__(self):
+        self.calls = []
+
+    def is_speculative(self):
+        return True
+
+    def get_num_tokens_per_bs_for_target_verify(
+        self, num_draft_tokens, is_draft_worker
+    ):
+        self.calls.append((num_draft_tokens, is_draft_worker))
+        return num_draft_tokens
+
+
+class _FakeModelRunner:
+    decode_num_tokens_per_bs = ModelRunner.decode_num_tokens_per_bs
+    max_decode_logits_rows = ModelRunner.max_decode_logits_rows
+
+    def __init__(self):
+        self.server_args = SimpleNamespace(
+            speculative_num_draft_tokens=4,
+            max_speculative_num_draft_tokens=8,
+        )
+        self.spec_algorithm = _FakeSpecAlgorithm()
+        self.is_draft_worker = False
+
+
+class TestModelRunnerDecodeRows(unittest.TestCase):
+    def test_max_decode_logits_rows_uses_adaptive_max_draft_tokens(self):
+        runner = _FakeModelRunner()
+
+        with patch(
+            "sglang.srt.model_executor.model_runner.get_batch_sizes_to_capture",
+            return_value=([1, 32], []),
+        ) as mock_get_batch_sizes:
+            self.assertEqual(runner.max_decode_logits_rows(), 256)
+
+        self.assertEqual(runner.spec_algorithm.calls, [(8, False)])
+        mock_get_batch_sizes.assert_called_once_with(runner, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #30549

## Motivation

`--speculative-adaptive` can build runtime states for candidate steps larger than the active `speculative_num_draft_tokens`. The shared logits buffer was sized from the active decode geometry only, so a larger adaptive candidate could request more rows during CUDA graph capture and hit:

```text
shared logits buffer holds 128 rows but caller needs 256
```

## Modifications

- Size `ModelRunner.max_decode_logits_rows()` with `ServerArgs.max_speculative_num_draft_tokens`.
- Preserve existing sizing for non-adaptive speculative decoding, because `max_speculative_num_draft_tokens` equals the active draft-token count there.
- Add CPU unit coverage for the regression geometry: active draft tokens `4`, adaptive max draft tokens `8`, and `cuda_graph_max_bs=32` should require `256` shared logits rows.

## Accuracy Tests

- `python3 -m py_compile python/sglang/srt/model_executor/model_runner.py test/registered/unit/model_executor/test_model_runner_decode_rows.py`
- Added `test/registered/unit/model_executor/test_model_runner_decode_rows.py` for the adaptive shared-buffer sizing path.
- Full server reproduction was not run; it requires a CUDA speculative-serving setup like the issue environment.

## Speed Tests and Profiling

Not run. This only increases the shared logits buffer row cap when adaptive speculative candidates can require a larger CUDA graph shape; it does not change logits computation or runtime selection.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28965352815](https://github.com/sgl-project/sglang/actions/runs/28965352815)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28965352031](https://github.com/sgl-project/sglang/actions/runs/28965352031)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->