### PR TITLE
fix(server_args): normalize log level so uvicorn accepts it

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2724,6 +2724,10 @@ class ServerArgs:
         # _handle_model_specific_adjustments never runs.
         self._resolved_overrides = []
 
+        # Model-independent bootstrap: normalize log levels before the
+        # dummy-model short-circuit so the HTTP server gets a valid value.
+        self._handle_log_level()
+
         if self.model_path.lower() in ["none", "dummy"]:
             return
 
@@ -3164,6 +3168,24 @@ class ServerArgs:
                     "--grpc-port is incompatible with --api-key/--admin-api-key: "
                     "the native gRPC listener bypasses HTTP auth middleware."
                 )
+
+    def _handle_log_level(self):
+        # SGLang's own logger accepts aliased levels via getattr(logging,
+        # level.upper()) (e.g. WARN, FATAL), but the same value is forwarded
+        # verbatim to uvicorn, whose LOG_LEVELS map is keyed by lowercase names
+        # with no `warn`/`fatal` aliases -- so `--log-level WARN` raises a
+        # KeyError before the socket binds and the server hangs (issue #30353).
+        # Normalize to a value both consumers accept.
+        aliases = {"warn": "warning", "fatal": "critical"}
+
+        def normalize(level):
+            if level is None:
+                return None
+            level = level.lower()
+            return aliases.get(level, level)
+
+        self.log_level = normalize(self.log_level)
+        self.log_level_http = normalize(self.log_level_http)
 
     def _handle_prefill_delayer_env_compat(self):
         if envs.SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE.get():

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -108,6 +108,40 @@ class TestMambaCacheStochasticRounding(unittest.TestCase):
             server_args._handle_mamba_backend()
 
 
+class TestLogLevelNormalization(unittest.TestCase):
+    """#30353: log levels must be normalized to a value uvicorn also accepts."""
+
+    def test_warn_alias_maps_to_warning(self):
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="WARN").log_level, "warning"
+        )
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="warn").log_level, "warning"
+        )
+
+    def test_fatal_alias_maps_to_critical(self):
+        self.assertEqual(
+            ServerArgs(model_path="dummy", log_level="FATAL").log_level, "critical"
+        )
+
+    def test_uppercase_is_lowercased(self):
+        for raw, expected in [("INFO", "info"), ("Debug", "debug"), ("ERROR", "error")]:
+            self.assertEqual(
+                ServerArgs(model_path="dummy", log_level=raw).log_level, expected
+            )
+
+    def test_log_level_http_normalized_independently(self):
+        args = ServerArgs(model_path="dummy", log_level="info", log_level_http="WARN")
+        self.assertEqual(args.log_level, "info")
+        self.assertEqual(args.log_level_http, "warning")
+
+    def test_log_level_http_none_preserved(self):
+        args = ServerArgs(model_path="dummy", log_level="WARN", log_level_http=None)
+        self.assertIsNone(args.log_level_http)
+        # This is exactly what http_server.py forwards to uvicorn.
+        self.assertEqual(args.log_level_http or args.log_level, "warning")
+
+
 class TestLoadBalanceMethod(unittest.TestCase):
     def _load_balance_args(self, **kwargs):
         server_args = ServerArgs(model_path="dummy", **kwargs)


### PR DESCRIPTION
## Motivation

`--log-level WARN` (or any uppercase / aliased value) silently hangs the HTTP server (issue #30353). SGLang's own stdlib logger accepts it via `getattr(logging, level.upper())`, but the same value is forwarded verbatim to uvicorn, whose `LOG_LEVELS` map is keyed by lowercase names with no `warn`/`fatal` aliases. `uvicorn.Config.configure_logging()` then raises `KeyError('warn')` **before the listening socket binds** — so the port never comes up, `/health_generate` is unreachable, and no clear error surfaces.

Reproduction (no model load needed):

```python
from sglang.srt.server_args import ServerArgs
import uvicorn

sa = ServerArgs(model_path="dummy", log_level="WARN")
resolved = sa.log_level_http or sa.log_level   # exactly what http_server.py forwards
uvicorn.Config(app="x:y", log_level=resolved).configure_logging()
# before this PR: resolved == 'WARN' -> KeyError('warn')
# after this PR:  resolved == 'warning' -> OK
```

## Modifications

`python/sglang/srt/server_args.py`:
- New `_handle_log_level()` that normalizes `log_level` and `log_level_http` — lowercases and maps the two stdlib-logging aliases uvicorn doesn't share (`warn` → `warning`, `fatal` → `critical`). A value SGLang's own logger treats as valid is now also valid for uvicorn.
- Called at the top of `__post_init__`, before the dummy-model short-circuit, since it's model-independent bootstrap (matches the dispatcher's stated ordering principle). This also means the fix applies to the `model_path="dummy"` repro path.

The forwarding sites in `http_server.py` need no change — they read the now-normalized value.

## Tests

`test/registered/unit/server_args/test_server_args.py::TestLogLevelNormalization`:
- `warn`/`WARN` → `warning`, `FATAL` → `critical`
- uppercase lowercased (`INFO`/`Debug`/`ERROR`)
- `log_level_http` normalized independently of `log_level`
- `log_level_http=None` preserved, and the `log_level_http or log_level` expression http_server.py forwards resolves to a uvicorn-valid value

## Accuracy / Speed

Not applicable — argument normalization at startup, no model-output or runtime-path change.

## Checklist

- [x] Format your code according to pre-commit.
- [x] Add unit tests.
- [ ] Update documentation — N/A.
- [x] Provide accuracy and speed benchmark results — N/A.

Closes #30353.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28974254349](https://github.com/sgl-project/sglang/actions/runs/28974254349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28974254180](https://github.com/sgl-project/sglang/actions/runs/28974254180)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->