### PR TITLE
[CI] Move piecewise CUDA graph (pcg) tests to nightly

### DIFF
--- a/test/registered/cuda_graph/piecewise/test_pcg_glm52_fp4.py
+++ b/test/registered/cuda_graph/piecewise/test_pcg_glm52_fp4.py
@@ -11,7 +11,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=900, stage="base-c", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=900, suite="nightly-4-gpu-b200", nightly=True)
 
 GLM52_FP4_MODEL = "nvidia/GLM-5.2-NVFP4"
 

--- a/test/registered/cuda_graph/piecewise/test_pcg_glm52_fp8_tp8.py
+++ b/test/registered/cuda_graph/piecewise/test_pcg_glm52_fp8_tp8.py
@@ -11,7 +11,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=900, stage="base-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=900, suite="nightly-8-gpu-h200", nightly=True)
 
 GLM52_FP8_MODEL = "zai-org/GLM-5.2-FP8"
 

--- a/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding.py
+++ b/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding.py
@@ -11,7 +11,7 @@ import unittest
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.server_fixtures.pcg_spec_fixture import PCGSpecBase
 
-register_cuda_ci(est_time=531, stage="base-b", runner_config="2-gpu-large")
+register_cuda_ci(est_time=531, suite="nightly-4-gpu", nightly=True)
 
 
 class TestPCGWithEAGLE3(PCGSpecBase, unittest.TestCase):

--- a/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding_dflash.py
+++ b/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding_dflash.py
@@ -15,7 +15,7 @@ from sglang.test.test_utils import (
     CustomTestCase,
 )
 
-register_cuda_ci(est_time=531, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=531, suite="nightly-1-gpu", nightly=True)
 
 
 class TestPCGWithDFlash(PCGSpecBase, CustomTestCase):

--- a/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding_extra.py
+++ b/test/registered/cuda_graph/piecewise/test_pcg_with_speculative_decoding_extra.py
@@ -1,7 +1,6 @@
 """Extra: PCG coexistence with non-EAGLE3 speculative decoding variants.
 
-EAGLE3 stays per-commit in the sibling file
-test_pcg_with_speculative_decoding.py.
+EAGLE3 lives in the sibling file test_pcg_with_speculative_decoding.py.
 """
 
 import unittest
@@ -9,7 +8,7 @@ import unittest
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.server_fixtures.pcg_spec_fixture import PCGSpecBase
 
-register_cuda_ci(est_time=531, stage="extra-a", runner_config="2-gpu-large")
+register_cuda_ci(est_time=531, suite="nightly-4-gpu", nightly=True)
 
 
 class TestPCGWithMTP(PCGSpecBase, unittest.TestCase):

--- a/test/registered/cuda_graph/piecewise/test_piecewise_cuda_graph_support_1_gpu.py
+++ b/test/registered/cuda_graph/piecewise/test_piecewise_cuda_graph_support_1_gpu.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
 )
 
 # CI Registration
-register_cuda_ci(est_time=180, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=180, suite="nightly-1-gpu", nightly=True)
 register_amd_ci(est_time=180, suite="stage-b-test-1-gpu-large-amd")
 
 

--- a/test/registered/prefill_only/test_fa_skip_kv_cache_piecewise_nan.py
+++ b/test/registered/prefill_only/test_fa_skip_kv_cache_piecewise_nan.py
@@ -38,11 +38,11 @@ from sglang.srt.utils import get_device_sm
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-# Route to the H100 runner (1-gpu-large, SM90) -- NOT 1-gpu-small, which is an
-# RTX 5090 (SM120/Blackwell) where FA3 does not exist. FA3 + the piecewise embedding
-# path this regression covers only runs on Ampere/Ada/Hopper (SM 80-90), so the test
-# must land on the H100 pool to actually execute (on 1-gpu-small it would skip 100%).
-register_cuda_ci(est_time=600, stage="base-b", runner_config="1-gpu-large")
+# Route to the nightly 1-GPU suite, which runs on the H100 pool (1-gpu-h100, SM90).
+# FA3 + the piecewise embedding path this regression covers only runs on
+# Ampere/Ada/Hopper (SM 80-90), so the test must land on the H100 pool to actually
+# execute (on the RTX 5090 SM120/Blackwell 1-gpu-small runner it would skip 100%).
+register_cuda_ci(est_time=600, suite="nightly-1-gpu", nightly=True)
 
 # Lowest/highest CUDA SM that supports the FA3 + piecewise embedding path. FA3 is
 # unavailable on Blackwell (sm100 B200 / sm120 consumer e.g. RTX 5090); the gate is


### PR DESCRIPTION
## Motivation

Move all piecewise CUDA graph (pcg) tests out of the NVIDIA per-commit **base/extra** CI stages and into **nightly** suites. These tests are relatively heavy (spec-decoding coexistence, GLM-5.2 FP4/FP8, multi-GPU) and are better suited to nightly cadence than per-commit.

## Changes

Each `register_cuda_ci(...)` is converted from the new-style `stage`/`runner_config` pair to the legacy `suite="nightly-…", nightly=True` form (what `run_suite.py`'s selector matches for nightly runs), routed to the closest matching GPU hardware:

| Test | Was (per-commit) | Now (nightly) |
|---|---|---|
| `test_pcg_glm52_fp4` | base-c / 4-gpu-b200 | `nightly-4-gpu-b200` |
| `test_pcg_glm52_fp8_tp8` | base-c / 8-gpu-h200 | `nightly-8-gpu-h200` |
| `test_pcg_with_speculative_decoding` (EAGLE3) | base-b / 2-gpu-large | `nightly-4-gpu` |
| `test_pcg_with_speculative_decoding_extra` (MTP/…) | extra-a / 2-gpu-large | `nightly-4-gpu` |
| `test_pcg_with_speculative_decoding_dflash` | base-b / 1-gpu-small | `nightly-1-gpu` |
| `test_piecewise_cuda_graph_support_1_gpu` | base-b / 1-gpu-large | `nightly-1-gpu` |
| `test_fa_skip_kv_cache_piecewise_nan` | base-b / 1-gpu-large | `nightly-1-gpu` |

## Notes

- **2-GPU tests** fold into `nightly-4-gpu` — NVIDIA has no general 2-GPU nightly job, and `nightly-4-gpu` runs on the 4-gpu-h100 pool.
- **1-GPU tests** move to the `nightly-1-gpu` H100 pool. This is required for `test_fa_skip_kv_cache_piecewise_nan`, whose FA3 path needs SM90 (absent on the old 1-gpu-small RTX 5090 runner); comments updated accordingly.
- The **AMD** registration on `test_piecewise_cuda_graph_support_1_gpu` is left unchanged (still per-commit AMD) — this change is scoped to NVIDIA CI.
- All four target suites (`nightly-1-gpu`, `nightly-4-gpu`, `nightly-4-gpu-b200`, `nightly-8-gpu-h200`) are already dispatched by `nightly-test-nvidia.yml`.

## Verification

- Pre-commit `validate registered test CI registries` passes.
- `validate_all_suites` passes registry-wide; `filter_tests` confirms all pcg tests now resolve into their nightly suites and **zero remain in any per-commit CUDA suite**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28980744323](https://github.com/sgl-project/sglang/actions/runs/28980744323)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28980744148](https://github.com/sgl-project/sglang/actions/runs/28980744148)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->