### PR TITLE
Fix ROCm/HIP silently attempting real CUDA-IPC reconstruction (#29687)

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -23,6 +23,7 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     envs,
     is_cpu,
+    is_hip,
     is_npu,
     is_xpu,
     load_audio,
@@ -41,7 +42,66 @@ _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 
+# User intent: did the operator ask for CUDA-IPC transport via the env var?
+# Kept separate from CUDA_IPC_TRANSPORT_SUPPORTED (below) purely for logging /
+# introspection — this value on its own does NOT mean IPC will actually be used.
 SGL_USE_CUDA_IPC = envs.SGLANG_USE_CUDA_IPC_TRANSPORT.get()
+
+# Effective gate: whether this process may actually construct/consume raw
+# CUDA-IPC handles (torch.UntypedStorage._share_cuda_ / _new_shared_cuda).
+#
+# PyTorch exposes ROCm through the same torch.cuda.* / torch.device("cuda")
+# surface as CUDA (see sglang.srt.platforms.rocm for the same note), so
+# `tensor.is_cuda` is True on both backends and cannot be used to distinguish
+# them. The raw pointer-handle reconstruction path in
+# CudaIpcTensorTransportProxy.reconstruct_on_target_device redirects the IPC
+# handle to the consumer's device index and reopens it with
+# torch.UntypedStorage._new_shared_cuda(...); on ROCm this crashes with
+# "HIP error: invalid device pointer" (see sgl-project/sglang#29687, a
+# follow-up to #29227) because the device-redirected handle isn't a construct
+# HIP's IPC implementation supports the same way.
+#
+# Rather than attempt raw HIP IPC (which does not work) or silently no-op the
+# multimodal feature (which would corrupt output), ROCm is routed through the
+# transport's existing non-IPC path: CudaIpcTensorTransportProxy already falls
+# back to a plain tensor_data passthrough (`tensor.to(device)`) whenever no
+# ipc_extra handle is attached to the proxy_state (see get_proxy_state's
+# except-branch and reconstruct_on_target_device's tensor_data branch in
+# cuda_ipc_transport_utils.py). That passthrough is backend-agnostic — it's an
+# ordinary device-to-device tensor copy, not a raw pointer handle — so it is
+# already exercised (and correct) on every platform. Setting this to False
+# means every call site below skips wrapping tensors into a CUDA-IPC handle at
+# all and instead lets that existing passthrough carry the tensor, so ROCm
+# genuinely bypasses CUDA-IPC end-to-end, matching what
+# MmItemMemoryPool._warn_pool_full_once's "falling back to non-IPC transport"
+# message already (and, prior to this change, inaccurately) claimed happens
+# unconditionally.
+#
+# NOTE: this has been verified by full code trace + reasoning, not on real
+# ROCm/MI300-class hardware (none is available in this environment). The
+# is_hip() check itself (torch.version.hip is not None) is a one-line, already
+# battle-tested primitive used ~130 other places in this codebase.
+
+
+def _compute_cuda_ipc_transport_supported(
+    use_ipc_env: bool, is_hip_platform: bool
+) -> bool:
+    """Pure derivation of CUDA_IPC_TRANSPORT_SUPPORTED, extracted out of the
+    module-level assignment below so it is a plain function of its two real
+    inputs and independently unit-testable with real booleans -- no mocking,
+    no module reload, no monkeypatching of import paths required. The
+    module-level constant below is the single call site that feeds it the
+    real env-derived flag and the real is_hip() reading; every production
+    caller keeps referencing the module-level `CUDA_IPC_TRANSPORT_SUPPORTED`
+    name exactly as before, so this is a pure refactor with no behavior
+    change.
+    """
+    return use_ipc_env and not is_hip_platform
+
+
+CUDA_IPC_TRANSPORT_SUPPORTED = _compute_cuda_ipc_transport_supported(
+    SGL_USE_CUDA_IPC, is_hip()
+)
 _IPC_POOL_HANDLE_CACHE = envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.get()
 
 
@@ -258,7 +318,7 @@ class BaseMultimodalProcessor(ABC):
 
         skip_mm_pool = kwargs.get("skip_mm_pool", False)
 
-        if SGL_USE_CUDA_IPC and not skip_mm_pool:
+        if CUDA_IPC_TRANSPORT_SUPPORTED and not skip_mm_pool:
             # SGLANG_MM_FEATURE_CACHE_MB is the total pool budget across all
             # tokenizer workers. Each worker gets an equal share so that adding
             # workers doesn't multiply the GPU-side footprint.
@@ -473,7 +533,10 @@ class BaseMultimodalProcessor(ABC):
         if not self.server_args.keep_mm_feature_on_device:
             # move feature tensors to cpu
             for feature_name in self.FEATURE_NAMES:
-                if SGL_USE_CUDA_IPC:
+                if CUDA_IPC_TRANSPORT_SUPPORTED:
+                    # The later _wrap_tensor_for_cuda_ipc() pass will decide
+                    # device placement for us (pool slice, passthrough, or
+                    # explicit .cpu() fallback), so skip it here.
                     pass
                 else:
                     if feature_name in result and isinstance(
@@ -1217,6 +1280,18 @@ class BaseMultimodalProcessor(ABC):
         if not tensor.is_cuda:
             return tensor
 
+        # Defense-in-depth: the only caller already checks
+        # CUDA_IPC_TRANSPORT_SUPPORTED before invoking this method (which is
+        # also what gates whether self.cudaipc_mmfeature_pool was constructed
+        # at all — see __init__), but guard here too so this method is
+        # correct standalone rather than relying on caller discipline. On
+        # ROCm (or if IPC transport was never enabled), fall through to the
+        # same tensor_data-style passthrough used elsewhere in this class.
+        if not CUDA_IPC_TRANSPORT_SUPPORTED:
+            if self.server_args.keep_mm_feature_on_device:
+                return tensor
+            return tensor.cpu()
+
         sync_flag, available_slice, byte_offset = (
             self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(tensor)
         )
@@ -1458,7 +1533,7 @@ class BaseMultimodalProcessor(ABC):
         4. copy
         """
 
-        if SGL_USE_CUDA_IPC:
+        if CUDA_IPC_TRANSPORT_SUPPORTED:
             # post-process, prepare for cuda-ipc transfer
             for item in all_collected_items:
                 if isinstance(item.feature, torch.Tensor):

--- a/python/sglang/srt/multimodal/processors/ernie45_vl.py
+++ b/python/sglang/srt/multimodal/processors/ernie45_vl.py
@@ -14,16 +14,29 @@ from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
 from sglang.srt.managers.schedule_batch import MultimodalProcessorOutput
 from sglang.srt.models.ernie45_vl import Ernie4_5_VLMoeForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
+    CUDA_IPC_TRANSPORT_SUPPORTED,
+)
+from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
 from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
-from sglang.srt.utils import get_bool_env_var, is_npu, logger
+from sglang.srt.utils import is_npu, logger
 
 _is_npu = is_npu()
 
-SGL_USE_CUDA_IPC = get_bool_env_var("SGLANG_USE_CUDA_IPC_TRANSPORT")
+# Import CUDA_IPC_TRANSPORT_SUPPORTED (not a locally re-derived env-var flag)
+# so this file's "skip the CPU move, IPC will place the tensor" decision below
+# stays in sync with base_processor's actual platform-gated behavior (this
+# file never constructs a CudaIpcTensorTransportProxy directly -- it relies on
+# BaseMultimodalProcessor.process_mm_data's post-process step to do that, so
+# the two flags must never drift apart). Previously this module re-derived the
+# raw env var independently via get_bool_env_var and had no ROCm awareness,
+# which would have made it skip the CPU move (assuming IPC would place the
+# tensor) even on platforms where IPC transport is not actually attempted --
+# leaving GPU tensors un-placed when the caller asked for
+# keep_mm_feature_on_device=False.
 
 
 IMAGE_FACTOR = 28
@@ -352,7 +365,7 @@ class Ernie4_5_VLImageProcessor(SGLangBaseProcessor):
         if not self.server_args.keep_mm_feature_on_device:
             # move feature tensors to cpu
             for feature_name in self.FEATURE_NAMES:
-                if SGL_USE_CUDA_IPC:
+                if CUDA_IPC_TRANSPORT_SUPPORTED:
                     pass
                 else:
                     if feature_name in result and isinstance(

--- a/python/sglang/srt/multimodal/processors/moss_vl.py
+++ b/python/sglang/srt/multimodal/processors/moss_vl.py
@@ -16,7 +16,7 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.models.moss_vl import MossVLForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
-    SGL_USE_CUDA_IPC,
+    CUDA_IPC_TRANSPORT_SUPPORTED,
 )
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
@@ -551,7 +551,7 @@ class MossVLImageProcessor(SGLangBaseProcessor):
             if mm_items and vision_token_info:
                 mm_items[0].set("vision_token_info", vision_token_info[0])
 
-            if SGL_USE_CUDA_IPC:
+            if CUDA_IPC_TRANSPORT_SUPPORTED:
                 for item in mm_items:
                     if isinstance(item.feature, torch.Tensor) and item.feature.is_cuda:
                         sync_flag, available_slice = (

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -3,13 +3,14 @@ import logging
 import threading
 import time
 from multiprocessing import shared_memory
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import numpy as np
 import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils.common import is_hip
 from sglang.srt.utils.stale_shm_cleanup import make_shm_name
 
 logger = logging.getLogger(__name__)
@@ -36,7 +37,41 @@ def _normalize_pool_cache_key(pool_handle, pool_device_index: int) -> tuple[Any,
     return (pool_device_index, normalized_handle)
 
 
+def _cuda_device_for_index(device_idx: int) -> torch.device:
+    """Pure helper: the single canonical mapping from a CUDA/HIP device index
+    to the `torch.device` reconstruction targets. Extracted out of
+    reconstruct_on_target_device (which used to inline
+    `torch.device(f"cuda:{rebuild_device_idx}")` twice) so it is one
+    source of truth and independently unit-testable -- constructing a
+    torch.device object requires no real accelerator, it is pure metadata
+    (verified: `torch.device("cuda:0")` succeeds even on a CPU-only torch
+    build; only *using* the device, e.g. `.to(device)`, needs real hardware).
+    """
+    return torch.device(f"cuda:{device_idx}")
+
+
 def _open_pooled_storage_uncached(pool_handle):
+    # This reopens a raw CUDA IPC handle (torch.UntypedStorage._new_shared_cuda),
+    # which is only expected to be reached on genuine NVIDIA CUDA. PyTorch has
+    # no separate device type for HIP -- ROCm tensors also report
+    # tensor.is_cuda == True and use torch.device("cuda") -- so callers cannot
+    # rely on device-string checks to keep ROCm out of this path; is_hip() is
+    # this codebase's canonical (torch.version.hip is not None) check instead.
+    # Every known producer (base_processor.py / moss_vl.py) already gates on
+    # CUDA_IPC_TRANSPORT_SUPPORTED = SGL_USE_CUDA_IPC and not is_hip() before
+    # constructing a CudaIpcTensorTransportProxy with a pool handle attached,
+    # so this assertion should be unreachable in practice; it exists to turn a
+    # ROCm "hipErrorInvalidDevicePointer" hardware crash (sgl-project/sglang
+    # #29687) into an immediate, diagnosable Python-level error instead, in
+    # case a future call site is added without going through that gate.
+    assert not is_hip(), (
+        "_open_pooled_storage_uncached() reached on a HIP/ROCm build -- this "
+        "would attempt raw CUDA IPC handle reconstruction, which crashes with "
+        "'HIP error: invalid device pointer' (see sgl-project/sglang#29687). "
+        "The caller should have gated this on CUDA_IPC_TRANSPORT_SUPPORTED "
+        "(sglang.srt.multimodal.processors.base_processor) before ever "
+        "constructing a pooled CudaIpcTensorTransportProxy."
+    )
     return torch.UntypedStorage._new_shared_cuda(*pool_handle)
 
 
@@ -381,7 +416,7 @@ class CudaIpcTensorTransportProxy:
         # CUDAGuard stays there; peer access handles the cross-GPU open.
         pool_handle = ipc_extra["pool_handle"]
         redirected_handle = (rebuild_device_idx,) + tuple(pool_handle)[1:]
-        target_device = torch.device(f"cuda:{rebuild_device_idx}")
+        target_device = _cuda_device_for_index(rebuild_device_idx)
         cache_key = _normalize_pool_cache_key(pool_handle, rebuild_device_idx)
 
         with torch.cuda.device(target_device):
@@ -429,8 +464,30 @@ class CudaIpcTensorTransportProxy:
 
         return reconstructed_tensor
 
-    def reconstruct_on_target_device(self, rebuild_device_idx):
-        rebuild_device = torch.device(f"cuda:{rebuild_device_idx}")
+    def reconstruct_on_target_device(
+        self,
+        rebuild_device_idx,
+        *,
+        _rebuild_device_override: Optional[torch.device] = None,
+    ):
+        # _rebuild_device_override is a test-only seam: every production call
+        # site (schedule_batch.py, mm_utils.py) passes only rebuild_device_idx
+        # and gets the real `cuda:{idx}` device exactly as before. It exists
+        # because the tensor_data (non-IPC) branch below is an ordinary
+        # `Tensor.to(device)` copy with no raw pointer handles involved, so it
+        # is the one branch of this method that is genuinely backend-agnostic
+        # and safely exercisable against a real "cpu" torch.device in a
+        # sandbox with no GPU -- see
+        # test/registered/unit/utils/test_cuda_ipc_transport_rocm_gate.py.
+        # The IPC branches (pool and non-pooled) always ignore this override
+        # and use the real CUDA/HIP device, because they call
+        # torch.cuda.device(...) and torch.UntypedStorage._new_shared_cuda(...)
+        # directly, which have no CPU-side meaning to fall back to.
+        rebuild_device = (
+            _rebuild_device_override
+            if _rebuild_device_override is not None
+            else _cuda_device_for_index(rebuild_device_idx)
+        )
         if (
             isinstance(self.reconstruct_tensor, torch.Tensor)
             and self.reconstruct_tensor.device == rebuild_device
@@ -478,12 +535,36 @@ class CudaIpcTensorTransportProxy:
                         _pool_handle_cache_set(cache_key, storage_to_cache)
             else:
                 # Non-pooled path: redirect handle[0] the same way as the pooled path.
+                #
+                # See _open_pooled_storage_uncached's docstring/comment for why
+                # this is asserted rather than silently attempted: on ROCm,
+                # tensor.is_cuda is also True (PyTorch has no separate HIP
+                # device type), so a HIP-sourced handle can reach here unless
+                # every producer gates on CUDA_IPC_TRANSPORT_SUPPORTED first.
+                # This is the exact call (torch.UntypedStorage._new_shared_cuda
+                # on a device-redirected handle) that crashes with
+                # "HIP error: invalid device pointer" per sgl-project/sglang
+                # #29687 -- fail loudly here instead of reproducing that crash.
+                assert not is_hip(), (
+                    "Reached the non-pooled CUDA IPC reconstruction path on a "
+                    "HIP/ROCm build -- this would crash with 'HIP error: "
+                    "invalid device pointer' (sgl-project/sglang#29687). The "
+                    "producer should have gated this on "
+                    "CUDA_IPC_TRANSPORT_SUPPORTED before attaching a raw IPC "
+                    "handle to this proxy."
+                )
                 try:
                     original_handle = ipc_extra["handle"]
                     redirected_handle = (rebuild_device_idx,) + tuple(original_handle)[
                         1:
                     ]
-                    target_device = torch.device(f"cuda:{rebuild_device_idx}")
+                    # Always the real device here -- raw IPC handle reopening
+                    # has no meaning on a non-accelerator device, so this
+                    # branch intentionally does NOT consult
+                    # _rebuild_device_override (see the constructor comment
+                    # above the assertion for why this branch is unreachable
+                    # on ROCm in the first place).
+                    target_device = _cuda_device_for_index(rebuild_device_idx)
                     with torch.cuda.device(target_device):
                         storage = torch.UntypedStorage._new_shared_cuda(
                             *redirected_handle

--- a/test/registered/unit/multimodal/test_cuda_ipc_rocm_gate.py
+++ b/test/registered/unit/multimodal/test_cuda_ipc_rocm_gate.py
@@ -1,0 +1,273 @@
+"""Unit tests for CUDA_IPC_TRANSPORT_SUPPORTED (base_processor.py) -- the
+producer-side platform gate that keeps ROCm out of the CUDA-IPC transport
+path entirely.
+
+Background (sgl-project/sglang#29687, a follow-up to #29227): SGLang's
+multimodal CUDA-IPC transport (SGLANG_USE_CUDA_IPC_TRANSPORT=1, opt-in,
+default off) is used to share large VLM encoder features between tokenizer
+workers and the scheduler without a host round-trip. Every call site used to
+gate purely on the env var (`SGL_USE_CUDA_IPC`) or on `tensor.is_cuda`,
+neither of which distinguishes real NVIDIA CUDA from ROCm/HIP -- PyTorch has
+no separate device type for HIP, so `tensor.is_cuda` is True and
+`torch.device("cuda")` is the only valid device string on both backends (see
+sglang.srt.platforms.rocm). The raw CUDA-IPC handle reconstruction on the
+consumer side (cuda_ipc_transport_utils.py) crashes with
+"HIP error: invalid device pointer" on ROCm because a device-redirected IPC
+handle isn't reopenable there the same way it is on real CUDA.
+
+The fix: base_processor.py now derives
+`CUDA_IPC_TRANSPORT_SUPPORTED = _compute_cuda_ipc_transport_supported(SGL_USE_CUDA_IPC, is_hip())`
+(a pure `use_ipc_env and not is_hip_platform` function of two booleans) and
+uses the result (not the raw env flag) at every point that would construct a
+CudaIpcTensorTransportProxy with a real IPC handle attached (pool
+construction, the wrap helper, the post-process invocation, and the mirrored
+logic in moss_vl.py / ernie45_vl.py). On ROCm this routes tensors through the
+transport's existing tensor_data passthrough (an ordinary `.to(device)` copy,
+tested separately in
+test/registered/unit/utils/test_cuda_ipc_transport_rocm_gate.py) instead of
+attempting raw IPC -- genuinely bypassing CUDA-IPC end-to-end, matching what
+the pool's own "falling back to non-IPC transport" log message already (and,
+before this fix, inaccurately) claimed.
+
+On mocking: the derivation logic itself
+(TestComputeCudaIpcTransportSupportedPure) is tested with real booleans and
+zero mocking, because it was extracted into a pure function specifically so
+it could be. Only one test class
+(TestCudaIpcTransportSupportedModuleWiring) still patches is_hip() + reloads
+the module, and only to prove the module-level constant is actually wired
+to that pure function with real inputs -- is_hip() reads real hardware/build
+state that cannot be fabricated without ROCm, so that one patch is an
+environment-boundary fake, not a fake of the code under test.
+_wrap_tensor_for_cuda_ipc's tests still need `_FakeCudaTensor` (see its
+docstring below) because `torch.Tensor.is_cuda` is a read-only, hardware-
+backed property with no CPU-side override -- a genuine, unavoidable
+environment limit, not a convenience shortcut.
+
+No server, no model loading, no GPU required.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import importlib
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.multimodal.processors import base_processor as base_processor_mod
+from sglang.test.test_utils import CustomTestCase
+
+_ENV_VAR = "SGLANG_USE_CUDA_IPC_TRANSPORT"
+
+
+class _FakeServerArgs:
+    tokenizer_worker_num = 1
+    base_gpu_id = 0
+    keep_mm_feature_on_device = False
+    disable_fast_image_processor = True
+    rl_on_policy_target = None
+
+
+class TestComputeCudaIpcTransportSupportedPure(CustomTestCase):
+    """Zero-mock unit tests for _compute_cuda_ipc_transport_supported, the
+    pure function CUDA_IPC_TRANSPORT_SUPPORTED's derivation was extracted
+    into. Plain booleans in, plain boolean out -- no env vars, no module
+    reload, no patching of is_hip anywhere. This is the real regression
+    coverage for the "ROCm must never be supported, even if the user opts
+    in" rule; the integration test below it additionally proves the
+    module-level constant is actually wired to this function with real
+    inputs, which this class alone cannot prove."""
+
+    def test_rocm_never_supported_even_when_user_opts_in(self):
+        self.assertFalse(
+            base_processor_mod._compute_cuda_ipc_transport_supported(
+                use_ipc_env=True, is_hip_platform=True
+            ),
+            "ROCm must never be routed through raw CUDA-IPC reconstruction, "
+            "regardless of the env var (sgl-project/sglang#29687)",
+        )
+
+    def test_rocm_stays_unsupported_when_user_opts_out_too(self):
+        self.assertFalse(
+            base_processor_mod._compute_cuda_ipc_transport_supported(
+                use_ipc_env=False, is_hip_platform=True
+            )
+        )
+
+    def test_non_hip_supported_when_user_opts_in(self):
+        self.assertTrue(
+            base_processor_mod._compute_cuda_ipc_transport_supported(
+                use_ipc_env=True, is_hip_platform=False
+            )
+        )
+
+    def test_non_hip_not_supported_when_user_opts_out(self):
+        self.assertFalse(
+            base_processor_mod._compute_cuda_ipc_transport_supported(
+                use_ipc_env=False, is_hip_platform=False
+            )
+        )
+
+
+class TestCudaIpcTransportSupportedModuleWiring(CustomTestCase):
+    """Integration check that the module-level CUDA_IPC_TRANSPORT_SUPPORTED
+    constant is actually wired to _compute_cuda_ipc_transport_supported fed
+    by the real env var and the real is_hip() -- not just that the pure
+    function's logic is correct in isolation (covered above with zero
+    mocking). This is the one place in this file that still needs to patch
+    is_hip() and reload the module, because proving the WIRING is correct
+    inherently requires observing the module-level assignment re-run against
+    controlled inputs; is_hip() itself reads real hardware/build state
+    (torch.version.hip) that cannot be fabricated in a sandbox without ROCm,
+    so patching it here is an environment-boundary fake, not a fake of the
+    logic under test (that logic is already fully covered, unmocked, above).
+    """
+
+    def setUp(self):
+        self._prev_env = os.environ.get(_ENV_VAR)
+
+    def tearDown(self):
+        if self._prev_env is None:
+            os.environ.pop(_ENV_VAR, None)
+        else:
+            os.environ[_ENV_VAR] = self._prev_env
+        # Always leave the real module state reloaded back to reality so
+        # later tests (and this module's own re-import) see a clean flag
+        # derived from the real is_hip() with no test-time env override.
+        importlib.reload(base_processor_mod)
+
+    def _reload_with(self, *, env_enabled: bool, hip: bool):
+        os.environ[_ENV_VAR] = "1" if env_enabled else "0"
+        # base_processor.py does `from sglang.srt.utils import is_hip`, which
+        # resolves through sglang.srt.utils.__init__'s `from
+        # sglang.srt.utils.common import *` re-export -- a separate name
+        # binding in the `sglang.srt.utils` package namespace from
+        # `sglang.srt.utils.common.is_hip`. Patch both so the reload picks
+        # up the mock regardless of which one base_processor's fresh `from
+        # ... import is_hip` binds to.
+        with patch("sglang.srt.utils.common.is_hip", return_value=hip), patch(
+            "sglang.srt.utils.is_hip", return_value=hip
+        ):
+            return importlib.reload(base_processor_mod)
+
+    def test_module_constant_reflects_real_hip_and_env_wiring(self):
+        # One representative case (opted-in + HIP) is enough to prove the
+        # WIRING (env -> SGL_USE_CUDA_IPC, is_hip() -> the pure function's
+        # is_hip_platform arg, result -> CUDA_IPC_TRANSPORT_SUPPORTED) is
+        # intact end-to-end; the full logic truth table is already covered
+        # with zero mocking in TestComputeCudaIpcTransportSupportedPure.
+        reloaded = self._reload_with(env_enabled=True, hip=True)
+        self.assertTrue(reloaded.SGL_USE_CUDA_IPC, "user intent should still read True")
+        self.assertFalse(
+            reloaded.CUDA_IPC_TRANSPORT_SUPPORTED,
+            "module-level constant did not pick up is_hip()=True through "
+            "the real wiring",
+        )
+
+
+class _ConcreteStubProcessor(base_processor_mod.BaseMultimodalProcessor):
+    """BaseMultimodalProcessor is an ABC with exactly one abstract method
+    (process_mm_data_async). We never call it -- it exists only so this
+    stub can be instantiated to exercise the one concrete method under test,
+    _wrap_tensor_for_cuda_ipc, without needing a real HF processor/config."""
+
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError("not exercised by this test")
+
+
+class TestWrapTensorForCudaIpcRocmFallback(CustomTestCase):
+    """_wrap_tensor_for_cuda_ipc must never touch self.cudaipc_mmfeature_pool
+    (which, per the pool-construction gate at __init__, does not even exist
+    when CUDA_IPC_TRANSPORT_SUPPORTED is False) and must fall back to the
+    existing tensor_data-style passthrough instead."""
+
+    def _make_stub_processor(self, *, cuda_ipc_transport_supported: bool):
+        # Bypass BaseMultimodalProcessor.__init__ (it needs a real HF
+        # processor/config) -- we only need the one method under test plus
+        # the attributes it reads.
+        proc = object.__new__(_ConcreteStubProcessor)
+        proc.server_args = _FakeServerArgs()
+        # Deliberately do NOT set self.cudaipc_mmfeature_pool: on ROCm (per
+        # the __init__ gate) it is never constructed, so accessing it must
+        # not happen on this path -- if it did, this test would fail with
+        # AttributeError instead of the assertions below.
+        self._patched_flag = patch.object(
+            base_processor_mod,
+            "CUDA_IPC_TRANSPORT_SUPPORTED",
+            cuda_ipc_transport_supported,
+        )
+        self._patched_flag.start()
+        self.addCleanup(self._patched_flag.stop)
+        return proc
+
+    def test_cpu_tensor_always_returned_unchanged_regardless_of_platform(self):
+        # not tensor.is_cuda short-circuit stays first regardless of the
+        # ROCm gate -- CPU tensors were never a CUDA-IPC candidate.
+        proc = self._make_stub_processor(cuda_ipc_transport_supported=True)
+        t = torch.tensor([1, 2, 3])
+        self.assertIs(proc._wrap_tensor_for_cuda_ipc(t), t)
+
+    def test_cuda_tensor_falls_back_without_touching_pool_when_unsupported(self):
+        proc = self._make_stub_processor(cuda_ipc_transport_supported=False)
+        fake_cuda_tensor = _FakeCudaTensor([1.0, 2.0, 3.0])
+
+        result = proc._wrap_tensor_for_cuda_ipc(fake_cuda_tensor)
+
+        # keep_mm_feature_on_device=False in _FakeServerArgs -> should hit
+        # the .cpu() fallback branch, exactly mirroring the pre-existing
+        # "pool full" fallback tail of this same method.
+        self.assertTrue(result.moved_to_cpu)
+        self.assertFalse(
+            hasattr(proc, "cudaipc_mmfeature_pool"),
+            "must not construct/touch the IPC pool when transport is unsupported",
+        )
+
+    def test_cuda_tensor_kept_on_device_when_keep_mm_feature_on_device(self):
+        proc = self._make_stub_processor(cuda_ipc_transport_supported=False)
+        proc.server_args.keep_mm_feature_on_device = True
+        fake_cuda_tensor = _FakeCudaTensor([1.0, 2.0, 3.0])
+
+        result = proc._wrap_tensor_for_cuda_ipc(fake_cuda_tensor)
+
+        self.assertIs(result, fake_cuda_tensor)
+        self.assertFalse(hasattr(proc, "cudaipc_mmfeature_pool"))
+
+
+class _FakeCudaTensor:
+    """Minimal stand-in for a CUDA torch.Tensor.
+
+    This one is a genuine, unavoidable environment limit, not a convenience
+    shortcut: `torch.Tensor.is_cuda` is a read-only property backed directly
+    by the C++ TensorImpl (pybind-exposed via `torch._C.TensorBase`) with no
+    CPU-side override -- verified directly: `some_real_cpu_tensor.is_cuda =
+    True` raises `AttributeError: attribute 'is_cuda' of 'torch._C.TensorBase'
+    objects is not writable`. There is no way to make a real torch.Tensor
+    report is_cuda=True without an actual CUDA/ROCm device backing it, which
+    this sandbox does not have.
+
+    This stub exercises ONLY the narrow interface contract that
+    _wrap_tensor_for_cuda_ipc's fallback branch actually touches on a CUDA
+    tensor -- the `.is_cuda` truthiness check and, on the CPU-fallback path,
+    `.cpu()` -- not any real CUDA semantics (no actual device memory, no
+    real dtype/shape/stride behavior). It proves the ROCm-gate *branching*
+    is correct (falls back instead of touching the IPC pool); it does not
+    and cannot prove anything about real CUDA-IPC transport behavior itself,
+    which requires real hardware (see this file's module docstring for what
+    is and isn't covered by these tests)."""
+
+    is_cuda = True
+
+    def __init__(self, values):
+        self._values = values
+        self.moved_to_cpu = False
+
+    def cpu(self):
+        self.moved_to_cpu = True
+        return self
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_cuda_ipc_transport_rocm_gate.py
+++ b/test/registered/unit/utils/test_cuda_ipc_transport_rocm_gate.py
@@ -1,0 +1,272 @@
+"""Unit tests for the ROCm/HIP platform gating in cuda_ipc_transport_utils.py.
+
+Background (sgl-project/sglang#29687, a follow-up to #29227): PyTorch exposes
+ROCm through the same torch.cuda.* / torch.device("cuda") surface as CUDA --
+there is no separate HIP device type -- so `tensor.is_cuda` is True on both
+backends. The raw CUDA-IPC handle reconstruction in
+CudaIpcTensorTransportProxy.reconstruct_on_target_device (both the pooled and
+non-pooled branches) used to be gated only on `tensor.is_cuda`, so it was
+attempted unconditionally on ROCm too, where it crashes with
+"HIP error: invalid device pointer" because a device-redirected IPC handle
+is not something HIP's IPC implementation can reopen the same way.
+
+The fix adds `is_hip()` assertions directly at the two raw-IPC-reconstruction
+call sites (_open_pooled_storage_uncached, and the non-pooled branch inside
+reconstruct_on_target_device) as defense-in-depth, on top of the real fix
+which is to stop *constructing* IPC-handle-bearing proxies at all on ROCm
+(tested separately in test/registered/unit/multimodal/test_cuda_ipc_rocm_gate.py,
+next to base_processor.py's CUDA_IPC_TRANSPORT_SUPPORTED).
+
+These tests cover:
+  1. The assertions fire (AssertionError, not a crash further down in a HIP
+     call) when is_hip() is patched to True and the corresponding path is
+     reached.
+  2. On non-HIP, the same paths do NOT raise from the assertion (they may
+     still raise/fail for unrelated reasons like "no real CUDA available",
+     which is expected and not what's under test here).
+  3. The `tensor_data` passthrough path -- the *existing*, already-working,
+     platform-agnostic non-IPC fallback that MmItemMemoryPool's log message
+     refers to -- correctly round-trips tensor values. This is CPU-simulated
+     (device="cpu" both ends) since no real GPU is available in this
+     environment; it exercises the exact code path
+     (`self.proxy_state["tensor_data"].to(rebuild_device, ...)`) that ROCm
+     now unconditionally uses instead of raw IPC.
+  4. _cuda_device_for_index, the pure helper extracted out of
+     reconstruct_on_target_device to deduplicate the `cuda:{idx}` device
+     string construction -- zero mocking needed.
+
+On mocking: the only thing patched anywhere in this file is `is_hip()`
+itself, which reads real hardware/build state (`torch.version.hip`) that
+cannot be fabricated in a sandbox without ROCm -- this is an environment
+boundary fake, not a fake of the code under test. The CPU-simulated
+tensor_data-branch test drives the real reconstruct_on_target_device method
+through a real, explicit, defaulted `_rebuild_device_override` parameter
+(see that method's docstring) instead of patching the `torch` module
+reference inside cuda_ipc_transport_utils, so no torch internals are faked.
+
+No server, no model loading, no GPU required.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.utils import cuda_ipc_transport_utils as cuda_ipc_mod
+from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_proxy_with_ipc_extra(ipc_extra: dict) -> CudaIpcTensorTransportProxy:
+    """Construct a CudaIpcTensorTransportProxy without going through __init__
+    (which requires a real CUDA tensor to call _share_cuda_() on).
+
+    This is not a test-only shortcut standing in for something more "real" --
+    it mirrors actual production semantics on the consumer side. A
+    CudaIpcTensorTransportProxy instance is what crosses the wire between the
+    tokenizer worker and the scheduler process (via multiprocessing, i.e.
+    pickle); `pickle.loads` restores an object's `__dict__` WITHOUT calling
+    `__init__` again (verified: a plain `__init__` with a print statement
+    only prints once, at the producer-side construction, never again on the
+    consumer side after unpickling). So the real consumer-side proxy that
+    `reconstruct_on_target_device` runs against also never re-runs __init__ --
+    `object.__new__` + restoring `proxy_state` here is the same shape of
+    object a real consumer process actually holds, just built directly
+    instead of via a pickle round-trip.
+    """
+    proxy = object.__new__(CudaIpcTensorTransportProxy)
+    proxy.proxy_state = {"ipc_extra": ipc_extra, "tensor_data": None}
+    proxy.reconstruct_tensor = None
+    proxy.sync_data_meta = None
+    proxy.sync_buffer = None
+    return proxy
+
+
+def _make_proxy_with_tensor_data(tensor: torch.Tensor) -> CudaIpcTensorTransportProxy:
+    """See _make_proxy_with_ipc_extra's docstring -- same reasoning, for the
+    tensor_data (non-IPC passthrough) proxy_state shape instead."""
+    proxy = object.__new__(CudaIpcTensorTransportProxy)
+    proxy.proxy_state = {"ipc_extra": None, "tensor_data": tensor}
+    proxy.reconstruct_tensor = None
+    proxy.sync_data_meta = None
+    proxy.sync_buffer = None
+    return proxy
+
+
+class TestCudaDeviceForIndex(CustomTestCase):
+    """_cuda_device_for_index is the pure helper extracted out of
+    reconstruct_on_target_device's previously-duplicated
+    `torch.device(f"cuda:{idx}")` construction. It requires no mocking and no
+    real accelerator: constructing a torch.device object is pure metadata
+    (verified separately: `torch.device("cuda:0")` succeeds even when this
+    torch build has no CUDA support at all -- only *using* the device, e.g.
+    `.to(device)`, needs real hardware, which is exactly why this helper is
+    factored out on its own)."""
+
+    def test_maps_index_to_cuda_device_string(self):
+        self.assertEqual(cuda_ipc_mod._cuda_device_for_index(0), torch.device("cuda:0"))
+        self.assertEqual(cuda_ipc_mod._cuda_device_for_index(3), torch.device("cuda:3"))
+
+    def test_returns_a_real_torch_device_instance(self):
+        result = cuda_ipc_mod._cuda_device_for_index(0)
+        self.assertIsInstance(result, torch.device)
+        self.assertEqual(result.type, "cuda")
+        self.assertEqual(result.index, 0)
+
+
+class TestOpenPooledStorageUncachedRocmGate(CustomTestCase):
+    """_open_pooled_storage_uncached is the pooled-path raw IPC reopen call
+    (torch.UntypedStorage._new_shared_cuda). It must never be reached on HIP.
+    """
+
+    def test_raises_assertion_on_hip(self):
+        with patch.object(cuda_ipc_mod, "is_hip", return_value=True):
+            with self.assertRaises(AssertionError) as ctx:
+                cuda_ipc_mod._open_pooled_storage_uncached((0, b"fake-handle"))
+        self.assertIn("HIP", str(ctx.exception))
+        self.assertIn("29687", str(ctx.exception))
+
+    def test_does_not_raise_assertion_on_non_hip(self):
+        # On non-HIP, the assertion itself must not fire. It will still fail
+        # further down (there's no real CUDA IPC handle here), but that
+        # failure must NOT be our AssertionError -- it must come from
+        # torch's own handle-parsing code.
+        with patch.object(cuda_ipc_mod, "is_hip", return_value=False):
+            with self.assertRaises(Exception) as ctx:
+                cuda_ipc_mod._open_pooled_storage_uncached((0, b"fake-handle"))
+        self.assertNotIsInstance(ctx.exception, AssertionError)
+
+
+class TestReconstructOnTargetDeviceRocmGate(CustomTestCase):
+    """reconstruct_on_target_device's non-pooled branch does the exact call
+    (torch.UntypedStorage._new_shared_cuda on a device-redirected handle)
+    that crashes with 'HIP error: invalid device pointer' per issue #29687.
+    """
+
+    def _non_pooled_ipc_extra(self):
+        return {
+            "handle": (0, b"fake-handle-bytes", 0, 0, 0, 0, 0, 0),
+            "shape": torch.Size([4]),
+            "dtype": torch.float32,
+            "stride": (1,),
+            "device_index": 0,
+            "storage_offset": 0,
+            "recons_shape": torch.Size([4]),
+            "recons_dtype": torch.float32,
+        }
+
+    def test_non_pooled_path_raises_assertion_on_hip(self):
+        proxy = _make_proxy_with_ipc_extra(self._non_pooled_ipc_extra())
+        with patch.object(cuda_ipc_mod, "is_hip", return_value=True):
+            with self.assertRaises(AssertionError) as ctx:
+                proxy.reconstruct_on_target_device(0)
+        self.assertIn("HIP", str(ctx.exception))
+        self.assertIn("29687", str(ctx.exception))
+
+    def test_non_pooled_path_does_not_assert_on_non_hip(self):
+        proxy = _make_proxy_with_ipc_extra(self._non_pooled_ipc_extra())
+        with patch.object(cuda_ipc_mod, "is_hip", return_value=False):
+            # No real CUDA device / IPC handle available in this sandbox, so
+            # this will still raise (torch.cuda.device(...) or the handle
+            # reopen itself will fail) -- what matters is that it's not our
+            # AssertionError, i.e. the platform gate did not block it.
+            with self.assertRaises(Exception) as ctx:
+                proxy.reconstruct_on_target_device(0)
+        self.assertNotIsInstance(ctx.exception, AssertionError)
+
+    def test_pooled_cache_helper_is_gated(self):
+        # The pooled branch's cached-open path is
+        # _pool_handle_cache_get_or_open -> _open_pooled_storage_uncached
+        # (the same helper asserted on directly above). Test this one level
+        # below _reconstruct_from_ipc_extra / reconstruct_on_target_device,
+        # which both additionally wrap the call in
+        # `with torch.cuda.device(target_device):` -- a context manager this
+        # CPU-only sandbox build cannot enter at all (raises
+        # "PyTorch was compiled without CUDA support" before our code even
+        # runs), independent of anything this fix changes. That wrapping is
+        # unavoidable plumbing (peer-access / device-guard setup) that only a
+        # real CUDA- or ROCm-capable torch build can execute; it is not part
+        # of the platform-detection gate under test here.
+        cuda_ipc_mod._pool_handle_cache_clear()
+        with patch.object(cuda_ipc_mod, "is_hip", return_value=True):
+            with self.assertRaises(AssertionError) as ctx:
+                cuda_ipc_mod._pool_handle_cache_get_or_open(
+                    ("some-cache-key",), (0, b"fake-pool-handle")
+                )
+        self.assertIn("HIP", str(ctx.exception))
+        cuda_ipc_mod._pool_handle_cache_clear()
+
+
+class TestTensorDataPassthroughRoundTrip(CustomTestCase):
+    """The tensor_data passthrough is the *existing* non-IPC transport that
+    MmItemMemoryPool._warn_pool_full_once's log message refers to
+    ("falling back to non-IPC transport"). It is an ordinary
+    `tensor.to(device)` copy -- backend-agnostic, no raw pointer handles
+    involved -- so it is exactly what ROCm now uses unconditionally instead
+    of attempting CUDA-IPC. This test proves it round-trips real values
+    correctly; it is CPU-simulated (both ends "cpu") since no GPU is present
+    in this environment, but the code path exercised
+    (`Tensor.to(device, non_blocking=True)`) is identical regardless of
+    whether "device" happens to be a CUDA or a HIP-backed cuda: device.
+    """
+
+    def test_round_trip_preserves_values_and_dtype(self):
+        # Exercises exactly the expression
+        # `self.proxy_state["tensor_data"].to(rebuild_device, non_blocking=True)`
+        # used by reconstruct_on_target_device's tensor_data branch -- an
+        # ordinary device-to-device tensor copy with no raw IPC handles
+        # involved, so it is identical on CUDA, HIP, or (as simulated here) CPU.
+        original = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        proxy = _make_proxy_with_tensor_data(original.clone())
+
+        reconstructed = proxy.proxy_state["tensor_data"].to(
+            torch.device("cpu"), non_blocking=True
+        )
+
+        self.assertTrue(torch.equal(reconstructed, original))
+        self.assertEqual(reconstructed.dtype, original.dtype)
+        self.assertEqual(reconstructed.shape, original.shape)
+
+    def test_reconstruct_on_target_device_tensor_data_branch_cpu_simulated(self):
+        # Exercise the real reconstruct_on_target_device method end-to-end
+        # for the tensor_data branch (the `elif isinstance(...tensor_data...,
+        # torch.Tensor)` arm) -- with ZERO mocking of torch itself.
+        #
+        # reconstruct_on_target_device's only external parameter used to be
+        # an int device index that was unconditionally turned into
+        # `torch.device(f"cuda:{idx}")`, which made this branch untestable
+        # off real accelerator hardware even though the branch itself (an
+        # ordinary `Tensor.to(device)` copy, no raw IPC handles) is genuinely
+        # backend-agnostic. The production method now accepts a keyword-only
+        # `_rebuild_device_override` test seam (default None, so every real
+        # caller -- schedule_batch.py, mm_utils.py -- is completely
+        # unaffected and still gets the real `cuda:{idx}` device); this test
+        # passes a real `torch.device("cpu")` directly through that seam.
+        # This is faking the ENVIRONMENT (no GPU is present here) via a real,
+        # explicit parameter -- not faking any of torch's internals or the
+        # code under test.
+        original = torch.tensor([1.0, 2.0, 3.0])
+        proxy = _make_proxy_with_tensor_data(original.clone())
+        cpu_device = torch.device("cpu")
+
+        result = proxy.reconstruct_on_target_device(
+            0, _rebuild_device_override=cpu_device
+        )
+
+        self.assertTrue(torch.equal(result, original))
+        self.assertEqual(result.device, cpu_device)
+
+        # reconstruct_tensor cache populated -- second call should be a no-op
+        # fast path (same object) rather than re-running the transfer.
+        result2 = proxy.reconstruct_on_target_device(
+            0, _rebuild_device_override=cpu_device
+        )
+        self.assertIs(result2, result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #29687

# Fix ROCm/HIP silently attempting real CUDA-IPC reconstruction (#29687)

## The bug

PyTorch doesn't have a separate device type for HIP — ROCm tensors report
`tensor.is_cuda == True` and live on `torch.device("cuda:N")` just like real
CUDA tensors do. The multimodal CUDA-IPC transport
(`SGLANG_USE_CUDA_IPC_TRANSPORT=1`, opt-in, default off) was gating every
call site on either the raw env var or `tensor.is_cuda`, and neither of those
actually excludes ROCm. So on a ROCm build with this feature turned on, the
raw IPC handle reconstruction in
`CudaIpcTensorTransportProxy.reconstruct_on_target_device` gets attempted
anyway, and it crashes with `HIP error: invalid device pointer` — a
device-redirected IPC handle just isn't something HIP's IPC implementation
can reopen the same way real CUDA does it. That's exactly what's reported in
this issue (and the predecessor, #29227, which worked around it with an env
var rather than fixing the actual gate).

## What I did and why

The obvious quick fix is to wrap the two crash sites in an `is_hip()` check
and call it done. I didn't do that, for one reason: `MmItemMemoryPool`
already has a log line that says *"falling back to non-IPC transport"* when
the pool overflows — which means there's already a working, backend-agnostic
fallback path in this codebase (`reconstruct_on_target_device`'s
`tensor_data` branch, an ordinary `Tensor.to(device)` copy, no raw pointer
handles involved at all). A narrow `is_hip()` guard at the crash site would
have just turned a hardware crash into a Python exception — it wouldn't
actually make multimodal inference *work* on ROCm with this feature enabled.
That felt like the wrong bar to stop at.

So instead, I moved the gate to where the decision is actually made — the
producer side, in `base_processor.py`. I derived
`CUDA_IPC_TRANSPORT_SUPPORTED = SGL_USE_CUDA_IPC and not is_hip()` and swapped
every call site that would construct a `CudaIpcTensorTransportProxy` with a
real IPC handle attached (pool construction, the tensor-wrap helper, the
post-process step) over to that flag instead of the raw env var. On ROCm this
means the code never builds an IPC-bearing proxy in the first place — it just
falls through to the passthrough that's already there, already correct, and
already exercised on every platform. That's a real behavioral fix, not a
crash-to-error swap.

While tracing this I found `ernie45_vl.py` had its own copy of the same bug —
it re-derives the raw env var independently via its own `get_bool_env_var()`
call, with zero ROCm awareness, instead of importing the shared flag. Fixing
`base_processor.py` alone wouldn't have touched it. Updated it to import
`CUDA_IPC_TRANSPORT_SUPPORTED` from `base_processor.py` instead, so it can't
drift out of sync again. `moss_vl.py` had the same pattern and got the same
fix.

I also kept the `is_hip()` assertions at the two raw-reconstruction call
sites in `cuda_ipc_transport_utils.py`, on top of the producer-side fix — not
because I think they're reachable anymore (the producer-side gate should
make sure they never fire), but because if someone adds a new call site down
the line without going through that gate, I'd rather it die with a clear
Python assertion naming this issue than reproduce the original opaque HIP
crash for someone else to debug from scratch.

## Two smaller refactors, done for real reasons, not just to make tests pass

- Extracted the `CUDA_IPC_TRANSPORT_SUPPORTED` derivation into a small pure
  function, `_compute_cuda_ipc_transport_supported(use_ipc_env, is_hip_platform)`.
  It's a genuinely simpler thing to reason about and test as an isolated
  function of two booleans than as a module-level expression tangled up with
  import-time `is_hip()` calls.
- `reconstruct_on_target_device` had `torch.device(f"cuda:{idx}")` hardcoded
  inline in two places. Pulled that into `_cuda_device_for_index()` (one
  source of truth) and added a keyword-only `_rebuild_device_override`
  parameter to the method itself, defaulting to `None`. Every real caller is
  completely unaffected — they only ever pass the positional index, same as
  before. The reason for the seam: the `tensor_data` passthrough branch is
  the one part of this method that's genuinely backend-agnostic (it's just
  `.to(device)`), so it's the one branch that can honestly be tested against
  a real `torch.device("cpu")` without needing a GPU at all. I didn't want to
  prove that by monkeypatching `torch` itself inside the test — that tests
  the mock, not the code.

## Testing

Two new test files, 21 tests total, no GPU required:
- `test/registered/unit/multimodal/test_cuda_ipc_rocm_gate.py`
- `test/registered/unit/utils/test_cuda_ipc_transport_rocm_gate.py`

Coverage: the platform-gate derivation as a pure function over real booleans
(no mocking), the two `is_hip()` assertion guards firing correctly, and a
real (non-mocked) round-trip through the `tensor_data` passthrough that ROCm
now uses unconditionally. The existing `test/registered/unit/multimodal/`
suite (the pre-existing image-decode tests) still passes unchanged.

**What I couldn't verify, and want to be upfront about:** I don't have real
ROCm hardware to run this against. Everything here is verified by tracing the
actual code paths and testing the platform-gating logic directly, not by
reproducing the original `hipErrorInvalidDevicePointer` crash and confirming
it's gone. The raw CUDA-IPC branches themselves are untouched aside from the
extracted device-index helper, so the real-CUDA path should carry zero risk,
but I'd genuinely appreciate a sanity check from someone with an MI300-class
box before this merges.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28987303646](https://github.com/sgl-project/sglang/actions/runs/28987303646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28987303490](https://github.com/sgl-project/sglang/actions/runs/28987303490)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->