### PR TITLE
Fix multi-output image generation requests

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -22,6 +22,7 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
     SetLoraReq,
     ShutdownReq,
     UnmergeLoraWeightsReq,
+    expand_request_outputs,
     format_lora_message,
     save_outputs,
 )
@@ -343,8 +344,13 @@ async def process_generation_batch(
     batch,
 ) -> tuple[list[str], OutputBatch]:
     total_start_time = time.perf_counter()
+    expanded_batch = expand_request_outputs(batch)
+    scheduler_payload = (
+        [expanded_batch] if len(expanded_batch) > 1 else [expanded_batch[0]]
+    )
+
     with trace_req(batch.trace_ctx), log_generation_timer(logger, batch.prompt):
-        result = await scheduler_client.forward([batch])
+        result = await scheduler_client.forward(scheduler_payload)
 
         if (
             result.output is None

--- a/python/sglang/multimodal_gen/test/unit/test_openai_utils.py
+++ b/python/sglang/multimodal_gen/test/unit/test_openai_utils.py
@@ -5,11 +5,27 @@ import io
 
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
+from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
 from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
     _parse_size_or_raise,
     _save_upload_to_path,
     _validate_positive_int,
+    process_generation_batch,
 )
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+    OutputBatch,
+    Req,
+)
+
+
+class _FakeSchedulerClient:
+    def __init__(self, result):
+        self.result = result
+        self.forward_arg = None
+
+    async def forward(self, arg):
+        self.forward_arg = arg
+        return self.result
 
 
 def test_save_upload_to_path_accepts_starlette_upload_file(tmp_path):
@@ -57,3 +73,38 @@ def test_validate_positive_int_rejects_non_positive_sampling_fields():
         assert "num_frames must be positive" in exc.detail
     else:
         raise AssertionError("expected bad request")
+
+
+def test_process_generation_batch_expands_multi_output_request(tmp_path):
+    num_outputs = 2
+    req = Req(
+        sampling_params=SamplingParams(
+            request_id="rid",
+            prompt="draw a cube",
+            output_path=str(tmp_path),
+            output_file_name="image.png",
+            num_outputs_per_prompt=num_outputs,
+            seed=42,
+        )
+    )
+    result = OutputBatch(
+        output_file_paths=[
+            str(tmp_path / f"image_{idx}.png") for idx in range(num_outputs)
+        ]
+    )
+    scheduler_client = _FakeSchedulerClient(result)
+
+    paths, returned_result = asyncio.run(
+        process_generation_batch(scheduler_client, req)
+    )
+
+    assert returned_result is result
+    assert paths == result.output_file_paths
+    assert len(scheduler_client.forward_arg) == 1
+    expanded_group = scheduler_client.forward_arg[0]
+    assert len(expanded_group) == num_outputs
+    assert [item.seed for item in expanded_group] == [42, 43]
+    assert [item.num_outputs_per_prompt for item in expanded_group] == [1, 1]
+    assert [item.output_file_name for item in expanded_group] == [
+        f"image_{idx}.png" for idx in range(num_outputs)
+    ]


### PR DESCRIPTION
## Summary



This PR expands OpenAI image generation requests with `num_outputs_per_prompt > 1` before dispatching to the diffusion scheduler. This lets GLM-image handle requests such as `n: 2` by running independent per-output requests, avoiding the GLM-image pipeline's current single-sample assumptions.

## Changes

- Use `expand_request_outputs` in `process_generation_batch`.
- Dispatch expanded multi-output requests as a grouped scheduler payload.
- Add a unit test covering expansion of `num_outputs_per_prompt=2`, including seed and output filename splitting.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28988301447](https://github.com/sgl-project/sglang/actions/runs/28988301447)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28988301297](https://github.com/sgl-project/sglang/actions/runs/28988301297)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->