### PR TITLE
No needed

### DIFF
--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -83,9 +83,27 @@ class GeneratedSharedPrefixDataset(BaseDataset):
                 "or set --gsp-group-distribution=zipf"
             )
 
+        prompts_per_group = args.gsp_prompts_per_group
+        warmup_requests = getattr(args, "warmup_requests", 0) or 0
+        num_groups = args.gsp_num_groups
+        if warmup_requests > 0 and num_groups > 0:
+            extra_per_group = warmup_requests // num_groups
+            remainder = warmup_requests % num_groups
+            prompts_per_group += extra_per_group
+            if remainder > 0:
+                prompts_per_group += 1  # one extra in first few groups
+            print(
+                f"[gsp] warmup_requests={warmup_requests}: "
+                f"generating {prompts_per_group} prompts per group "
+                f"(original {args.gsp_prompts_per_group} + {warmup_requests} warmup). "
+                f"First {warmup_requests} prompts will be consumed by warmup, "
+                f"remaining {args.gsp_prompts_per_group * num_groups} for benchmark.",
+                flush=True,
+            )
+
         return cls(
-            num_groups=args.gsp_num_groups,
-            prompts_per_group=args.gsp_prompts_per_group,
+            num_groups=num_groups,
+            prompts_per_group=prompts_per_group,
             system_prompt_len=args.gsp_system_prompt_len,
             question_len=args.gsp_question_len,
             output_len=args.gsp_output_len,

--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -1322,56 +1322,65 @@ async def benchmark(
         async with semaphore:
             return await request_func(request_func_input=request_func_input, pbar=pbar)
 
-    # Warmup
-    print(f"Starting warmup with {warmup_requests} sequences...")
-
-    # Handle the data structure difference for the warmup request
-    if args.dataset_name == "mooncake":
-        # For mooncake, input_requests is a list of dicts.
-        # We need to build a temporary DatasetRow for the warmup phase.
-        warmup_record = input_requests[0]
-
-        # Build prompt from hash_ids, just like in the async generator
-        hash_ids = warmup_record.get("hash_ids", [])
-        prompt_text = ""
-        for hash_id in hash_ids:
-            prompt_text += f"{hash_id}" + " ".join(["hi"] * 512)
-        prompt_text += "Can you tell me a detailed story in 1000 words?"
-
-        output_len = warmup_record.get("output_length", 32)
-        prompt_len = len(tokenizer.encode(prompt_text))
-
-        # Create a temporary DatasetRow object for warmup
-        test_request = DatasetRow(
-            prompt=prompt_text,
-            prompt_len=prompt_len,
-            output_len=output_len,
-            image_data=None,  # Mooncake doesn't have image data
-        )
+    # Warmup: pop dedicated prompts from the front so the test set is
+    # not contaminated by cache-warm entries. If warmup_requests exceeds
+    # the available prompts, repeat from the beginning.
+    if len(input_requests) > warmup_requests >= 0:
+        warmup_inputs = input_requests[:warmup_requests]
+        input_requests = input_requests[warmup_requests:]
     else:
-        # For all other datasets, input_requests is a list of DatasetRow objects
-        test_request = input_requests[0]
+        raise ValueError(
+            f"warmup_requests ({warmup_requests}) must be 0 or "
+            f"less than the total number of input requests ({len(input_requests)})."
+        )
 
     if lora_names is not None and len(lora_names) != 0:
         lora_name = lora_names[0]
     else:
         lora_name = None
 
-    # Create the test input once
-    test_input = RequestFuncInput(
-        model=model_id,
-        prompt=test_request.prompt,
-        api_url=api_url,
-        prompt_len=test_request.prompt_len,
-        output_len=min(test_request.output_len, 32),
-        lora_name=lora_name,
-        image_data=test_request.image_data,
-        extra_request_body=extra_request_body,
-    )
-
-    # Run warmup requests
     warmup_tasks = []
-    for _ in range(warmup_requests):
+    for warmup_input in warmup_inputs:
+        # Handle the data structure difference for the warmup request
+        if args.dataset_name == "mooncake":
+            # For mooncake, input_requests is a list of dicts.
+            # We need to build a temporary DatasetRow for the warmup phase.
+            warmup_record = warmup_input
+
+            # Build prompt from hash_ids, just like in the async generator
+            hash_ids = warmup_record.get("hash_ids", [])
+            prompt_text = ""
+            for hash_id in hash_ids:
+                prompt_text += f"{hash_id}" + " ".join(["hi"] * 512)
+            prompt_text += "Can you tell me a detailed story in 1000 words?"
+
+            output_len = warmup_record.get("output_length", 32)
+            prompt_len = len(tokenizer.encode(prompt_text))
+
+            # Create a temporary DatasetRow object for warmup
+            test_request = DatasetRow(
+                prompt=prompt_text,
+                prompt_len=prompt_len,
+                output_len=output_len,
+                image_data=None,  # Mooncake doesn't have image data
+            )
+        else:
+            # For all other datasets, input_requests is a list of DatasetRow objects
+            test_request = warmup_input
+
+        # Create the test input once
+        test_input = RequestFuncInput(
+            model=model_id,
+            prompt=test_request.prompt,
+            api_url=api_url,
+            prompt_len=test_request.prompt_len,
+            output_len=min(test_request.output_len, 32),
+            lora_name=lora_name,
+            image_data=test_request.image_data,
+            extra_request_body=extra_request_body,
+        )
+
+        # Run warmup requests
         warmup_tasks.append(
             asyncio.create_task(request_func(request_func_input=test_input))
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Currently, in GSP (Generated Shared Prefix) benchmark scenarios, such as the 90% cache scenario, there is an issue where the first prompt from the test set is used for warmup. In a Radix Cache scenario, this causes the first prompt to be 100% cached during actual testing, resulting in anomalous performance metrics.

## Modifications

<!-- Detail the changes made in this pull request. -->

Based on the existing interfaces, two modifications were made:

1. Before generation on the actual test set, the number of warmup prompts was added to the GSP prompts to generate an additional number of test samples equal to the warmup count.
2. During the actual benchmark phase, the test dataset is split into two parts: one dedicated to warmup, and the other for actual evaluation (which corresponds to the original test set).

So, you can keep using it exactly as before. The only change is that GSP now uses unique prompts for warmup, instead of reusing the first test entry.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28988682309](https://github.com/sgl-project/sglang/actions/runs/28988682309)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28988682205](https://github.com/sgl-project/sglang/actions/runs/28988682205)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->