### PR TITLE
[NPU][bugfix] Fix NPU KernelLaunch Failure in rotate_input_ids_triton with Empty Batch

### DIFF
--- a/python/sglang/kernels/ops/speculative/multi_layer_eagle.py
+++ b/python/sglang/kernels/ops/speculative/multi_layer_eagle.py
@@ -78,6 +78,7 @@ def rotate_input_ids(
 
     # rotate_input_ids_triton skipped: batch_size=0 (empty extend_seq_lens).
     # This is expected when a DP rank has no requests.
+    # TODO: @iforgetmyname Remove NPU-specific guard after triton-ascend fixes zero-sized grid kernel launch abort
     if batch_size == 0 and _is_npu:
         return input_ids
 

--- a/python/sglang/kernels/ops/speculative/multi_layer_eagle.py
+++ b/python/sglang/kernels/ops/speculative/multi_layer_eagle.py
@@ -15,9 +15,10 @@
 import triton
 import triton.language as tl
 
-from sglang.srt.utils import is_cpu
+from sglang.srt.utils import is_cpu, is_npu
 
 _is_cpu = is_cpu()
+_is_npu = is_npu()
 
 if _is_cpu:
     from sgl_kernel import rotate_input_ids_cpu
@@ -77,7 +78,7 @@ def rotate_input_ids(
 
     # rotate_input_ids_triton skipped: batch_size=0 (empty extend_seq_lens).
     # This is expected when a DP rank has no requests.
-    if batch_size == 0:
+    if batch_size == 0 and _is_npu:
         return input_ids
 
     BLOCK_SIZE = 4096 if select_index is not None else 8

--- a/python/sglang/kernels/ops/speculative/multi_layer_eagle.py
+++ b/python/sglang/kernels/ops/speculative/multi_layer_eagle.py
@@ -74,6 +74,12 @@ def rotate_input_ids(
         return input_ids
 
     batch_size = extend_seq_lens.shape[0]
+
+    # rotate_input_ids_triton skipped: batch_size=0 (empty extend_seq_lens).
+    # This is expected when a DP rank has no requests.
+    if batch_size == 0:
+        return input_ids
+
     BLOCK_SIZE = 4096 if select_index is not None else 8
     grid = (batch_size,)
 

--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -63,6 +63,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
         end_layer: Optional[int] = None,
         enable_alt_stream: bool = True,
         enable_kv_cache_copy: bool = False,
+        **kwargs,
     ):
         self.use_fia = get_bool_env_var("ASCEND_USE_FIA", "False")
         super().__init__(
@@ -82,6 +83,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
             end_layer=end_layer,
             enable_alt_stream=enable_alt_stream,
             enable_kv_cache_copy=enable_kv_cache_copy,
+            **kwargs,
         )
 
     def _create_buffers(self):


### PR DESCRIPTION
## Motivation

This PR fixes an NPU runtime crash introduced by PR #28492 (Refactor / simplify MultiLayerEagleDraftExtendCudaGraphRunner to use rotation).
When extend_seq_lens has a batch size of 0 (e.g., a DP rank with no active requests), rotate_input_ids_triton launches a triton kernel with an empty grid. This violates NPU parameter verification rules and triggers the error:

> KernelLaunch failed because value 0 for parameter coreDim is invalid. Expected value: not equal to 0.

Root cause is confirmed via commit comparison: the issue does not exist on pre-PR commit bf231f01, and stably reproduces on merged commit 24bf8d91.

## Modifications

- Add an early return guard in rotate_input_ids_triton: when batch_size == 0, return input_ids directly without launching the kernel.
- This handles the empty batch edge case for DP ranks with no requests, and avoids invalid kernel launches on NPU platforms.

## Accuracy Tests

No accuracy impact. The fix only skips kernel execution for empty batches and does not alter behavior for valid inputs.

## Speed Tests and Profiling

No performance impact. The added boundary check has negligible overhead and only takes effect on empty batch scenarios.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29146698673](https://github.com/sgl-project/sglang/actions/runs/29146698673)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29146698670](https://github.com/sgl-project/sglang/actions/runs/29146698670)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->