### PR TITLE
Reserve SMs for DeepGEMM MegaMoE

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -876,6 +876,11 @@ class Envs:
     # DeepGemm Mega MoE
     SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE = EnvBool(False)
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK = EnvInt(1024)
+    # 0 means derive from DeepGEMM's current device SM count.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS = EnvInt(0)
+    # DeepGEMM MegaMoE uses a whole-grid software barrier; keep a small even
+    # safety margin so every launched CTA can be resident on Blackwell.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS = EnvInt(2)
 
     # When set, the mega-MoE x slot is packed E2M1 (FP4) instead of FP8 E4M3.
     # Halves symm-buffer footprint and unlocks the MXF4 mainloop downstream.

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import os
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -58,6 +58,36 @@ def _apply_mega_moe_dg_env() -> None:
     _MEGA_MOE_DG_ENV_APPLIED = True
 
 
+def _resolve_mega_moe_deep_gemm_num_sms(current_num_sms: int) -> int:
+    explicit_num_sms = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.get()
+    if explicit_num_sms > 0:
+        target_num_sms = min(explicit_num_sms, current_num_sms)
+    else:
+        reserved_num_sms = max(envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.get(), 0)
+        target_num_sms = current_num_sms - reserved_num_sms
+
+    target_num_sms = max(1, min(target_num_sms, current_num_sms))
+    if current_num_sms >= 2:
+        target_num_sms = max(2, target_num_sms)
+        target_num_sms -= target_num_sms % 2
+    return target_num_sms
+
+
+@contextmanager
+def _configure_mega_moe_deep_gemm_num_sms(deep_gemm):
+    current_num_sms = deep_gemm.get_num_sms()
+    target_num_sms = _resolve_mega_moe_deep_gemm_num_sms(current_num_sms)
+    if target_num_sms == current_num_sms:
+        yield current_num_sms
+        return
+
+    deep_gemm.set_num_sms(target_num_sms)
+    try:
+        yield target_num_sms
+    finally:
+        deep_gemm.set_num_sms(current_num_sms)
+
+
 def _get_mega_moe_symm_buffer(
     group,
     num_experts: int,
@@ -65,6 +95,7 @@ def _get_mega_moe_symm_buffer(
     num_topk: int,
     hidden: int,
     intermediate_hidden: int,
+    num_sms: int,
 ) -> SymmBuffer:
     import deep_gemm
 
@@ -77,6 +108,7 @@ def _get_mega_moe_symm_buffer(
         num_topk,
         hidden,
         intermediate_hidden,
+        num_sms,
     )
     buf = _MEGA_MOE_SYMM_BUFFER.get(key)
     if buf is None:
@@ -197,69 +229,71 @@ def _run_mega_routed(
         f"cuda_graph_max_bs / chunked_prefill_size accordingly"
     )
 
-    buf = _get_mega_moe_symm_buffer(
-        ep_group,
-        num_experts=num_experts,
-        num_max_tokens_per_rank=num_max_tokens_per_rank,
-        num_topk=top_k,
-        hidden=hidden_size,
-        intermediate_hidden=intermediate_size,
-    )
-
-    if num_tokens > 0:
-        topk_ids_in = topk_ids.to(torch.int32)
-        topk_weights_in = topk_weights.to(torch.float32)
-    else:
-        topk_ids_in = hidden_states.new_empty((0, top_k), dtype=torch.int32)
-        topk_weights_in = hidden_states.new_empty((0, top_k), dtype=torch.float32)
-
-    use_fp4_acts = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS.get()
-    if use_fp4_acts:
-        # FP4 path goes through DeepGEMM's mega_moe_pre_dispatch which
-        # handles the E2M1 packing variant. The jit implementation
-        # only emits FP8.
-        deep_gemm.mega_moe_pre_dispatch(
-            hidden_states,
-            topk_ids_in,
-            topk_weights_in,
-            buf.x,
-            buf.x_sf,
-            buf.topk_idx,
-            buf.topk_weights,
-            num_tokens=num_tokens,
-            group_size=32,
-            use_fp4_acts=True,
-        )
-    else:
-        mega_moe_pre_dispatch(
-            hidden_states,
-            topk_ids_in,
-            topk_weights_in,
-            buf.x,
-            buf.x_sf,
-            buf.topk_idx,
-            buf.topk_weights,
-            quant_group_size=32,
+    with _configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+        buf = _get_mega_moe_symm_buffer(
+            ep_group,
+            num_experts=num_experts,
+            num_max_tokens_per_rank=num_max_tokens_per_rank,
+            num_topk=top_k,
+            hidden=hidden_size,
+            intermediate_hidden=intermediate_size,
+            num_sms=num_sms,
         )
 
-    # Allocate at least one row so y has a non-null CUDA data_ptr;
-    # the DeepGEMM tvm-ffi binding rejects nullptr in convert_to_torch_tensor().
-    y = torch.empty(
-        (max(num_tokens, 1), hidden_size),
-        dtype=torch.bfloat16,
-        device=hidden_states.device,
-    )
-    swiglu_limit = getattr(moe.config, "swiglu_limit", None)
-    deep_gemm.fp8_fp4_mega_moe(
-        y,
-        moe.experts.mega_l1_weights,
-        moe.experts.mega_l2_weights,
-        buf,
-        recipe=(1, 1, 32),
-        activation="swiglu",
-        activation_clamp=swiglu_limit,
-        fast_math=True,
-    )
+        if num_tokens > 0:
+            topk_ids_in = topk_ids.to(torch.int32)
+            topk_weights_in = topk_weights.to(torch.float32)
+        else:
+            topk_ids_in = hidden_states.new_empty((0, top_k), dtype=torch.int32)
+            topk_weights_in = hidden_states.new_empty((0, top_k), dtype=torch.float32)
+
+        use_fp4_acts = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS.get()
+        if use_fp4_acts:
+            # FP4 path goes through DeepGEMM's mega_moe_pre_dispatch which
+            # handles the E2M1 packing variant. The jit implementation
+            # only emits FP8.
+            deep_gemm.mega_moe_pre_dispatch(
+                hidden_states,
+                topk_ids_in,
+                topk_weights_in,
+                buf.x,
+                buf.x_sf,
+                buf.topk_idx,
+                buf.topk_weights,
+                num_tokens=num_tokens,
+                group_size=32,
+                use_fp4_acts=True,
+            )
+        else:
+            mega_moe_pre_dispatch(
+                hidden_states,
+                topk_ids_in,
+                topk_weights_in,
+                buf.x,
+                buf.x_sf,
+                buf.topk_idx,
+                buf.topk_weights,
+                quant_group_size=32,
+            )
+
+        # Allocate at least one row so y has a non-null CUDA data_ptr;
+        # the DeepGEMM tvm-ffi binding rejects nullptr in convert_to_torch_tensor().
+        y = torch.empty(
+            (max(num_tokens, 1), hidden_size),
+            dtype=torch.bfloat16,
+            device=hidden_states.device,
+        )
+        swiglu_limit = getattr(moe.config, "swiglu_limit", None)
+        deep_gemm.fp8_fp4_mega_moe(
+            y,
+            moe.experts.mega_l1_weights,
+            moe.experts.mega_l2_weights,
+            buf,
+            recipe=(1, 1, 32),
+            activation="swiglu",
+            activation_clamp=swiglu_limit,
+            fast_math=True,
+        )
     y = y[:num_tokens]
 
     if not moe.experts.should_fuse_routed_scaling_factor_in_topk:

--- a/test/registered/unit/layers/moe/test_mega_moe_deepgemm_num_sms.py
+++ b/test/registered/unit/layers/moe/test_mega_moe_deepgemm_num_sms.py
@@ -1,0 +1,104 @@
+"""Unit tests for DeepGEMM MegaMoE SM-count selection."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.moe import mega_moe
+from sglang.test.test_utils import CustomTestCase
+
+
+class FakeDeepGemm:
+    def __init__(self, num_sms: int):
+        self._num_sms = num_sms
+        self.set_num_sms_calls = []
+
+    def get_num_sms(self) -> int:
+        return self._num_sms
+
+    def set_num_sms(self, num_sms: int) -> None:
+        self.set_num_sms_calls.append(num_sms)
+        self._num_sms = num_sms
+
+
+class TestMegaMoEDeepGemmNumSms(CustomTestCase):
+    def test_reserves_even_sms_and_restores_original(self):
+        deep_gemm = FakeDeepGemm(num_sms=152)
+
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(0),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(2),
+        ):
+            with mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+                self.assertEqual(num_sms, 150)
+                self.assertEqual(deep_gemm.get_num_sms(), 150)
+
+        self.assertEqual(deep_gemm.get_num_sms(), 152)
+        self.assertEqual(deep_gemm.set_num_sms_calls, [150, 152])
+
+    def test_rounds_reserved_sms_down_to_even_count(self):
+        deep_gemm = FakeDeepGemm(num_sms=148)
+
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(0),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(1),
+        ):
+            with mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+                self.assertEqual(num_sms, 146)
+
+        self.assertEqual(deep_gemm.set_num_sms_calls, [146, 148])
+
+    def test_explicit_num_sms_wins_over_reserved_sms(self):
+        deep_gemm = FakeDeepGemm(num_sms=152)
+
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(144),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(2),
+        ):
+            with mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+                self.assertEqual(num_sms, 144)
+
+        self.assertEqual(deep_gemm.set_num_sms_calls, [144, 152])
+
+    def test_explicit_num_sms_is_rounded_down_to_even_count(self):
+        deep_gemm = FakeDeepGemm(num_sms=152)
+
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(147),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(0),
+        ):
+            with mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+                self.assertEqual(num_sms, 146)
+
+        self.assertEqual(deep_gemm.set_num_sms_calls, [146, 152])
+
+    def test_does_not_choose_one_sm_for_clustered_kernel(self):
+        deep_gemm = FakeDeepGemm(num_sms=148)
+
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(0),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(200),
+        ):
+            with mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+                self.assertEqual(num_sms, 2)
+
+        self.assertEqual(deep_gemm.set_num_sms_calls, [2, 148])
+
+    def test_zero_reserve_leaves_deepgemm_unchanged(self):
+        deep_gemm = FakeDeepGemm(num_sms=148)
+
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(0),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(0),
+        ):
+            with mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+                self.assertEqual(num_sms, 148)
+
+        self.assertEqual(deep_gemm.set_num_sms_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reserve a small even number of SMs before calling DeepGEMM MegaMoE on Blackwell
- add override envs for MegaMoE DeepGEMM SM selection
- add unit coverage for default reserve, explicit override, even rounding, and restoration

## Root Cause
DeepGEMM MegaMoE launches one CTA per active SM with cluster size 2 and uses a whole-grid software barrier. With `sgl-deep-gemm==0.1.4`, the Blackwell path now reports this failure as `DeepGEMM grid sync timeout` instead of silently hanging. If any other GPU work keeps one physical SM from admitting the MegaMoE CTA, the barrier never observes all CTAs.

SGLang can avoid triggering this by launching MegaMoE with a small SM reserve. The default reserve is 2 SMs, with `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS` and `SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS` available for explicit tuning.

## Validation
- `python3 -m pytest -q test/registered/unit/layers/moe/test_mega_moe_deepgemm_num_sms.py` on B300: `6 passed`
- targeted B300 repro with full 148 SMs plus a side-stream `_sleep` kernel reproduced `DeepGEMM grid sync timeout` and `barrier.cuh:45`
- same targeted repro with active SMs reduced to 146 completed without timeout
- pre-commit hooks from `git commit` passed, including ruff and black-jupyter

Fixes #30399







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28991940443](https://github.com/sgl-project/sglang/actions/runs/28991940443)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28991940355](https://github.com/sgl-project/sglang/actions/runs/28991940355)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->