### PR TITLE
Default Hunyuan V3 to bfloat16 when the checkpoint has no dtype

### DIFF
--- a/docs_new/cookbook/autoregressive/Tencent/Hunyuan3-Preview.mdx
+++ b/docs_new/cookbook/autoregressive/Tencent/Hunyuan3-Preview.mdx
@@ -155,6 +155,7 @@ import { Hunyuan3PreviewDeployment } from '/src/snippets/autoregressive/hunyuan3
 ```bash Command
 sglang serve \
   --model-path tencent/Hy3-preview \
+  --dtype bfloat16 \
   --tp 8 \
   --speculative-algorithm EAGLE \
   --speculative-num-steps 3 \
@@ -183,6 +184,7 @@ For basic API usage and request examples, please refer to:
 ```bash Command
 sglang serve \
   --model-path tencent/Hy3-preview \
+  --dtype bfloat16 \
   --tp 8 \
   --reasoning-parser hunyuan \
   --tool-call-parser hunyuan \
@@ -252,6 +254,7 @@ Enable the reasoning parser during deployment so that the thinking section (`<th
 ```bash Command
 sglang serve \
   --model-path tencent/Hy3-preview \
+  --dtype bfloat16 \
   --tp 8 \
   --reasoning-parser hunyuan \
   --trust-remote-code \
@@ -339,6 +342,7 @@ Hy3-preview supports streaming OpenAI-compatible tool calls. Enable both parsers
 ```bash Command
 sglang serve \
   --model-path tencent/Hy3-preview \
+  --dtype bfloat16 \
   --tp 8 \
   --reasoning-parser hunyuan \
   --tool-call-parser hunyuan \

--- a/docs_new/cookbook/autoregressive/Tencent/Hy3.mdx
+++ b/docs_new/cookbook/autoregressive/Tencent/Hy3.mdx
@@ -205,6 +205,7 @@ Enable the reasoning parser during deployment so the thinking section is separat
 ```bash Command
 sglang serve \
   --model-path tencent/Hy3 \
+  --dtype bfloat16 \
   --tp 8 \
   --reasoning-parser auto \
   --tool-call-parser auto
@@ -277,6 +278,7 @@ Hy3 supports streaming OpenAI-compatible tool calls. Enable both parsers togethe
 ```bash Command
 sglang serve \
   --model-path tencent/Hy3 \
+  --dtype bfloat16 \
   --tp 8 \
   --reasoning-parser auto \
   --tool-call-parser auto

--- a/docs_new/src/snippets/configs/tencent/hy3.jsx
+++ b/docs_new/src/snippets/configs/tencent/hy3.jsx
@@ -246,6 +246,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 8",
@@ -263,6 +264,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 8",
@@ -279,6 +281,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -295,6 +298,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -311,6 +315,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -327,6 +332,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -343,6 +349,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -359,6 +366,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -375,6 +383,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -391,6 +400,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -407,6 +417,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -423,6 +434,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -435,6 +447,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -451,6 +464,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 4",
@@ -463,6 +477,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 2",
@@ -479,6 +494,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 2",
@@ -491,6 +507,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 2",
@@ -507,6 +524,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 2",
@@ -519,6 +537,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 2",
@@ -535,6 +554,7 @@ sgl-eval run aime26 \\
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--dtype bfloat16",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
         "--tp 2",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1577,6 +1577,17 @@ def _get_and_verify_dtype(
                         "want to use float16."
                     )
                     torch_dtype = torch.bfloat16
+                elif model_type == "hy_v3":
+                    # Hunyuan V3 checkpoints (tencent/Hy3, Hy3-FP8, Hy3-preview)
+                    # ship without a dtype in config.json but are bf16 models.
+                    # Defaulting to float16 breaks bf16-only kernels and
+                    # changes numerics, so downcast to bfloat16 instead.
+                    logger.info(
+                        "For Hunyuan V3, we downcast float32 to bfloat16 instead "
+                        "of float16 by default. Please specify `dtype` if you "
+                        "want to use float16."
+                    )
+                    torch_dtype = torch.bfloat16
                 else:
                     # Following the common practice, we use float16 for float32
                     # models.

--- a/test/registered/unit/configs/test_model_config_dtype.py
+++ b/test/registered/unit/configs/test_model_config_dtype.py
@@ -1,0 +1,43 @@
+"""Tests for _get_and_verify_dtype auto-resolution.
+
+Hunyuan V3 checkpoints (tencent/Hy3, Hy3-FP8, Hy3-preview) ship without a
+dtype in config.json, which the generic rule treats as a float32 checkpoint
+and downcasts to float16. They are bf16 models, so `hy_v3` must resolve to
+bfloat16 (like the existing gemma special case).
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.configs.model_config import _get_and_verify_dtype
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestAutoDtypeResolution(CustomTestCase):
+    def test_hy_v3_without_config_dtype_resolves_to_bf16(self):
+        config = {"model_type": "hy_v3"}
+        self.assertEqual(_get_and_verify_dtype(config, "auto"), torch.bfloat16)
+
+    def test_hy_v3_explicit_dtype_is_honored(self):
+        config = {"model_type": "hy_v3"}
+        self.assertEqual(_get_and_verify_dtype(config, "float16"), torch.float16)
+
+    def test_generic_model_without_config_dtype_resolves_to_fp16(self):
+        config = {"model_type": "llama"}
+        self.assertEqual(_get_and_verify_dtype(config, "auto"), torch.float16)
+
+    def test_config_dtype_takes_precedence_over_special_case(self):
+        config = {"model_type": "hy_v3", "torch_dtype": "bfloat16"}
+        self.assertEqual(_get_and_verify_dtype(config, "auto"), torch.bfloat16)
+
+    def test_gemma_without_config_dtype_resolves_to_bf16(self):
+        config = {"model_type": "gemma2"}
+        self.assertEqual(_get_and_verify_dtype(config, "auto"), torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

All three Hunyuan V3 checkpoints (`tencent/Hy3`, `tencent/Hy3-FP8`, `tencent/Hy3-preview`) ship a `config.json` **without `torch_dtype`**. `_get_and_verify_dtype` treats a missing dtype as a float32 checkpoint, and `--dtype auto` (the default) downcasts float32 to **float16**:

```
tencent/Hy3-FP8, --dtype auto  ->  resolved dtype: torch.float16
```

Hunyuan V3 is a bf16 model, so this is wrong on two levels:

1. **Crash**: fp16 activations hit bf16-only kernel paths. On current main + recent flashinfer, the server dies during decode CUDA-graph capture in the CuTe `fused_add_rmsnorm` dtype check (`ValueError: Mismatched Tensor ... expected dtype=bfloat16`) — with an error message that gives no hint the root cause is dtype resolution.
2. **Silent numerics change**: on stacks where nothing crashes, the model silently runs in fp16 instead of the bf16 it was trained/released with.

None of the Hy3 cookbook commands specify `--dtype`, so they are affected out of the box.

The crash (H200 TP4, `sglang serve --model-path tencent/Hy3-FP8 --tp 4 --trust-remote-code`, abridged traceback — all 4 TP ranks die during decode CUDA-graph capture):

```
[TP2] Scheduler hit an exception: Traceback (most recent call last):
  ...
  File ".../sglang/srt/model_executor/runner/decode_cuda_graph_runner.py", line 363, in __init__
    self.capture()
  ...
  File ".../sglang/srt/models/hunyuan_v3.py", line 403, in forward
    hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
  File ".../sglang/srt/layers/layernorm.py", line 327, in forward_cuda
    fused_add_rmsnorm(x, residual, self.weight.data, self.variance_epsilon)
  File "/usr/local/lib/python3.12/dist-packages/sgl_kernel/elementwise.py", line 160, in fused_add_rmsnorm
    _flashinfer_norm.fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
  File "/usr/local/lib/python3.12/dist-packages/flashinfer/norm/__init__.py", line 274, in fused_add_rmsnorm
    fused_add_rmsnorm_cute(
  File "/usr/local/lib/python3.12/dist-packages/flashinfer/norm/kernels/fused_add_rmsnorm.py", line 1038, in fused_add_rmsnorm_cute
    kernel(input, residual, weight, M, eps)
  File ".../cutlass/cutlass_dsl/tvm_ffi_provider.py", line 593, in __call__
    return tvm_ffi.Function.__call__(self, *args)
  File "python/tvm_ffi/cython/function.pxi", line 968, in tvm_ffi.core.Function.__call__
ValueError: Mismatched Tensor on argument #1 when calling: `__call__(mX: Tensor([n0, 4096], bfloat16),
mR: Tensor([n0, 4096], bfloat16), mW: Tensor([4096], bfloat16), M: int32, eps: float32)`, expected dtype=bfloat16

[...] Received sigquit from a child process. It usually means the child failed.
```

## Modifications

- `_get_and_verify_dtype`: resolve `auto` to **bfloat16** for `model_type == "hy_v3"` when the checkpoint carries no dtype — the same shape as the existing gemma special case. An explicit `--dtype float16` is still honored, and a future `torch_dtype` in the checkpoint config takes precedence.
- Cookbook: add `--dtype bfloat16` to all Hy3 command-generator combos (`hy3.jsx`, 20 entries) and the static example commands in `Hy3.mdx` / `Hunyuan3-Preview.mdx`. This is belt-and-suspenders for users on already-released images that don't contain this fix; it is a no-op once the fix is in.
- New CPU unit test `test/registered/unit/configs/test_model_config_dtype.py` covering: hy_v3 auto → bf16, explicit fp16 honored, generic model auto → fp16 unchanged, config dtype precedence, gemma case unchanged.

## Test

- Unit test: `5 passed` (CPU).
- Resolution check on H200 container: `tencent/Hy3-FP8` + `--dtype auto` now resolves to `torch.bfloat16` (with and without `--trust-remote-code`).
- e2e on H200 TP4: `sglang serve --model-path tencent/Hy3-FP8 --tp 4 --trust-remote-code` (no `--dtype`, i.e. the day-0 cookbook shape) previously crashed at CUDA-graph capture; with this fix the server starts, captures prefill+decode graphs, and greedy generation is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28992851210](https://github.com/sgl-project/sglang/actions/runs/28992851210)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #28993148507](https://github.com/sgl-project/sglang/actions/runs/28993148507)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->