### PR TITLE
refactor _biased_grouped_topk_postprocess to _postprocess_topk_ids_cuda

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1373,7 +1373,7 @@ def _zero_topk_weights_padded_region(
 
 
 @torch.compile(dynamic=True, backend=get_compiler_backend())
-def _biased_grouped_topk_postprocess(
+def _postprocess_topk_ids_cuda(
     topk_ids, expert_location_dispatch_info, num_token_non_padded
 ):
     topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
@@ -1826,7 +1826,7 @@ def _post_process_topk_ids(
             # so split, dispatch the routed cols, recombine.
             shared_cols = topk_ids[:, -num_fused_shared_experts:]
             routed_cols = topk_ids[:, :-num_fused_shared_experts]
-            routed_cols = _biased_grouped_topk_postprocess(
+            routed_cols = _postprocess_topk_ids_cuda(
                 routed_cols, expert_location_dispatch_info, num_token_non_padded
             )
             topk_ids = torch.cat([routed_cols, shared_cols], dim=-1)
@@ -1835,7 +1835,7 @@ def _post_process_topk_ids(
             # space, so keep the routed physical ids separately for statistics.
             recorder_topk_ids = routed_cols
         else:
-            topk_ids = _biased_grouped_topk_postprocess(
+            topk_ids = _postprocess_topk_ids_cuda(
                 topk_ids, expert_location_dispatch_info, num_token_non_padded
             )
     elif _is_hip:

--- a/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
+++ b/test/registered/unit/eplb/test_deepep_waterfill_eplb.py
@@ -80,7 +80,7 @@ class TestDeepEPWaterfillEPLB(CustomTestCase):
             get_parallel().override(moe_ep_size=8, moe_ep_rank=7),
             patch.object(
                 topk_module,
-                "_biased_grouped_topk_postprocess",
+                "_postprocess_topk_ids_cuda",
                 side_effect=fake_eplb_postprocess,
             ),
         ):
@@ -119,7 +119,7 @@ class TestDeepEPWaterfillEPLB(CustomTestCase):
             ),
             patch.object(
                 topk_module,
-                "_biased_grouped_topk_postprocess",
+                "_postprocess_topk_ids_cuda",
                 side_effect=fake_eplb_postprocess,
             ),
         ):


### PR DESCRIPTION

Fixes #30442 

## Motivation

As suggested by @merrymercy, this PR renames the generic CUDA top-k postprocessing helper from `_biased_grouped_topk_postprocess` to `_postprocess_topk_ids_cuda` to better reflect its actual functionality.

## Modifications

* Renamed function definition in `python/sglang/srt/layers/moe/topk.py`.
* Updated the corresponding mock string references in `test/registered/unit/eplb/test_deepep_waterfill_eplb.py`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28994459377](https://github.com/sgl-project/sglang/actions/runs/28994459377)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28994459274](https://github.com/sgl-project/sglang/actions/runs/28994459274)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->