### PR TITLE
[BUG] Fix HiSparse preallocation for hybrid SWA decode

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1193,11 +1193,17 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             )
 
         if self.scheduler.enable_hisparse:
-            # HiSparse pre-alloc only allocates logical indices (alloc_logical_only),
-            # so the logical pool is the binding constraint for admission control.
-            available_size = (
-                self.token_to_kv_pool_allocator.logical_attn_allocator.available_size()
-            )
+            # HiSparse pre-alloc only allocates logical indices here; device C4
+            # buffers are budgeted separately by hisparse_req_budget. For hybrid
+            # SWA, SWA tail capacity is checked by _swa_tail_allocatable_token_budget,
+            # so the full budget should not be clamped by SWA availability.
+            logical_allocator = self.token_to_kv_pool_allocator.logical_attn_allocator
+            if self._uses_swa_tail_prealloc() and hasattr(
+                logical_allocator, "full_available_size"
+            ):
+                available_size = logical_allocator.full_available_size()
+            else:
+                available_size = logical_allocator.available_size()
         elif self._uses_swa_tail_prealloc():
             available_size = self.token_to_kv_pool_allocator.full_available_size()
             if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
@@ -1371,22 +1377,44 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 )
 
         if self.scheduler.enable_hisparse:
-            # HiSparse is incompatible with decode-side L1 radix cache. Keep
-            # this path on the upstream full-allocation semantics.
+            # HiSparse direct-to-host is incompatible with decode-side L1 radix
+            # cache, so it allocates from position 0. For hybrid SWA models, keep
+            # the no-HiSparse decode behavior: allocate full logical KV for full
+            # attention layers and only the sliding-window tail for SWA layers.
             assert prefix_len == 0
 
             # Direct-to-host path: only allocate logical indices (no hisparse
             # device indices) and allocate host indices for RDMA destination.
             coordinator = self.scheduler.hisparse_coordinator
             device = self.token_to_kv_pool_allocator.device
-            kv_loc = self.token_to_kv_pool_allocator.alloc_logical_only(
-                prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
-                prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
-                seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
-                seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
-                last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
-                extend_num_tokens=fill_len,
+            prefix_lens_tensor = torch.tensor([0], dtype=torch.int64, device=device)
+            prefix_lens_cpu = torch.tensor([0], dtype=torch.int64)
+            seq_lens_tensor = torch.tensor([fill_len], dtype=torch.int64, device=device)
+            seq_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+            last_loc = torch.tensor([-1], dtype=torch.int64, device=device)
+            swa_tail_len = (
+                self._swa_tail_len(fill_len) if self._uses_swa_tail_prealloc() else None
             )
+            if swa_tail_len is not None:
+                kv_loc = self.token_to_kv_pool_allocator.alloc_extend_swa_tail(
+                    prefix_lens=prefix_lens_tensor,
+                    prefix_lens_cpu=prefix_lens_cpu,
+                    seq_lens=seq_lens_tensor,
+                    seq_lens_cpu=seq_lens_cpu,
+                    last_loc=last_loc,
+                    extend_num_tokens=fill_len,
+                    swa_tail_len=swa_tail_len,
+                )
+                req.swa_evicted_seqlen = fill_len - swa_tail_len
+            else:
+                kv_loc = self.token_to_kv_pool_allocator.alloc_logical_only(
+                    prefix_lens=prefix_lens_tensor,
+                    prefix_lens_cpu=prefix_lens_cpu,
+                    seq_lens=seq_lens_tensor,
+                    seq_lens_cpu=seq_lens_cpu,
+                    last_loc=last_loc,
+                    extend_num_tokens=fill_len,
+                )
 
             # Allocate host indices for the RDMA transfer target.
             host_indices = coordinator.mem_pool_host.alloc_paged_token_slots(

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -402,6 +402,27 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             extend_num_tokens,
         )
 
+    def alloc_extend_swa_tail(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        swa_tail_len: int,
+    ):
+        """Allocate logical full/SWA-tail indices without C4 device pages."""
+        return self.logical_attn_allocator.alloc_extend_swa_tail(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+            swa_tail_len=swa_tail_len,
+        )
+
     def alloc_device_buffer(self, allocated_indices, need_size: int):
         assert need_size % self.hisparse_page_size == 0
         hisparse_indices = self.full_to_hisparse_device_index_mapping[allocated_indices]


### PR DESCRIPTION
## Motivation

HiSparse decode preallocation did not correctly handle hybrid SWA models. The existing path allocated logical indices with the generic HiSparse logic, which could incorrectly clamp admission control by SWA availability and allocate full logical KV for SWA layers instead of only the sliding-window tail.


## Changes

- Use full logical allocator availability for HiSparse admission control when SWA tail preallocation is enabled.
- Add `alloc_extend_swa_tail` support to the HiSparse KV pool allocator.
- Update the HiSparse direct-to-host decode path to preserve the normal hybrid SWA allocation behavior:
  - allocate full logical KV for full-attention layers
  - allocate only the SWA tail for sliding-window layers
  - track `swa_evicted_seqlen` accordingly
 
## test res
befor-deepseekv4-hisparse：
<img width="2780" height="122" alt="image" src="https://github.com/user-attachments/assets/0bc90060-5db6-4303-abe0-39123338cb56" />


after-deepseekv4-fix_bug-hisparse：
<img width="3240" height="104" alt="image" src="https://github.com/user-attachments/assets/9bb2f4f0-8fd6-4094-90e9-dea8d0706c30" />

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28995858064](https://github.com/sgl-project/sglang/actions/runs/28995858064)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28995857971](https://github.com/sgl-project/sglang/actions/runs/28995857971)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->