### PR TITLE
[SUPA][1/N] Add device detection and check_env support

### DIFF
--- a/python/sglang/check_env.py
+++ b/python/sglang/check_env.py
@@ -10,7 +10,7 @@ from collections import OrderedDict, defaultdict
 
 import torch
 
-from sglang.srt.utils import is_hip, is_mps, is_musa, is_npu
+from sglang.srt.utils import is_hip, is_mps, is_musa, is_npu, is_supa
 
 
 def is_cuda_v2():
@@ -505,6 +505,88 @@ class MUSAEnv(BaseEnv):
             return {}
 
 
+class SUPAEnv(BaseEnv):
+    """Environment checker for Biren SUPA GPU"""
+
+    def get_info(self):
+        supa_info = {"SUPA available": torch.supa.is_available()}
+
+        if supa_info["SUPA available"]:
+            supa_info.update(self.get_device_info())
+            supa_info.update(self._get_supa_version_info())
+
+        return supa_info
+
+    def get_device_info(self):
+        devices = defaultdict(list)
+        for k in range(torch.supa.device_count()):
+            devices[torch.supa.get_device_name(k)].append(str(k))
+
+        gpu_info = {}
+        for name, device_ids in devices.items():
+            gpu_info[f"GPU {','.join(device_ids)}"] = name
+
+        return gpu_info
+
+    def _get_supa_version_info(self):
+        from torch_supa.utils.cpp_extension import FULLSTACK_HOME
+
+        supa_info = {"FULLSTACK_HOME": FULLSTACK_HOME}
+
+        if FULLSTACK_HOME and os.path.isdir(FULLSTACK_HOME):
+            supa_info.update(self._get_brcc_info())
+            supa_info.update(self._get_supa_driver_version())
+
+        return supa_info
+
+    def _get_brcc_info(self):
+        from torch_supa.utils.cpp_extension import FULLSTACK_HOME
+
+        try:
+            brcc = os.path.join(FULLSTACK_HOME, "bin/brcc")
+            brcc_output = (
+                subprocess.check_output(f'"{brcc}" --version', shell=True)
+                .decode("utf-8")
+                .strip()
+            )
+            first_line = brcc_output.splitlines()[0]
+            version_str = first_line.split("(")[0].strip()
+            return {"BRCC": version_str}
+        except subprocess.SubprocessError:
+            return {"BRCC": "Not Available"}
+
+    def _get_supa_driver_version(self):
+        try:
+            output = subprocess.check_output(
+                ["brsmi", "-q"],
+                text=True,
+            )
+            for line in output.splitlines():
+                if "Driver Version" in line:
+                    return {"SUPA Driver Version": line.split(":", 1)[1].strip()}
+
+            return {"SUPA Driver Version": "Not Available"}
+        except subprocess.SubprocessError:
+            return {"SUPA Driver Version": "Not Available"}
+
+    def get_topology(self):
+        try:
+            result = subprocess.run(
+                ["brsmi", "topo", "-m"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            return {
+                "SUPA Topology": (
+                    "\n" + result.stdout if result.returncode == 0 else None
+                )
+            }
+        except subprocess.SubprocessError:
+            return {}
+
+
 class MPSEnv(BaseEnv):
     """Environment checker for Apple Silicon MPS"""
 
@@ -590,6 +672,8 @@ if __name__ == "__main__":
         env = NPUEnv()
     elif is_musa():
         env = MUSAEnv()
+    elif is_supa():
+        env = SUPAEnv()
     elif is_mps():
         env = MPSEnv()
     env.check_env()

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -219,6 +219,11 @@ def is_musa() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_supa() -> bool:
+    return hasattr(torch, "supa") and torch.supa.is_available()
+
+
+@lru_cache(maxsize=1)
 def is_mps() -> bool:
     return torch.backends.mps.is_available()
 
@@ -888,6 +893,11 @@ def get_device(device_id: Optional[int] = None) -> str:
             return "musa"
         return "musa:{}".format(device_id)
 
+    if is_supa():
+        if device_id is None:
+            return "supa"
+        return "supa:{}".format(device_id)
+
     if is_mps():
         if device_id is None:
             return "mps"
@@ -897,13 +907,13 @@ def get_device(device_id: Optional[int] = None) -> str:
         return current_platform.get_device(device_id)
     except Exception:
         raise RuntimeError(
-            "No accelerator (CUDA, XPU, HPU, NPU, MUSA, MPS) or platform plugin is available."
+            "No accelerator (CUDA, XPU, HPU, NPU, MUSA, SUPA, MPS) or platform plugin is available."
         )
 
 
 @lru_cache(maxsize=1)
 def get_device_count() -> int:
-    if (hasattr(torch, "cuda") and torch.cuda.is_available()) or is_musa():
+    if (hasattr(torch, "cuda") and torch.cuda.is_available()) or is_musa() or is_supa():
         try:
             return torch.cuda.device_count()
         except RuntimeError:
@@ -928,7 +938,7 @@ def get_device_count() -> int:
 
 
 def get_device_core_count(device_id: int = 0) -> int:
-    if (hasattr(torch, "cuda") and torch.cuda.is_available()) or is_musa():
+    if (hasattr(torch, "cuda") and torch.cuda.is_available()) or is_musa() or is_supa():
         return torch.cuda.get_device_properties(device_id).multi_processor_count
     elif hasattr(torch, "xpu") and torch.xpu.is_available():
         return torch.xpu.get_device_properties(device_id).gpu_eu_count
@@ -938,7 +948,7 @@ def get_device_core_count(device_id: int = 0) -> int:
 
 def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
     major, minor = None, None
-    if (hasattr(torch, "cuda") and torch.cuda.is_available()) or is_musa():
+    if (hasattr(torch, "cuda") and torch.cuda.is_available()) or is_musa() or is_supa():
         major, minor = torch.cuda.get_device_capability(device_id)
 
     if hasattr(torch, "xpu") and torch.xpu.is_available():


### PR DESCRIPTION
## Motivation

Add Biren SUPA GPU backend support to SGLang. SUPA is the software stack for Biren GPUs (BR200 series). This is the first PR (1/N) in a series to enable SGLang inference on SUPA devices, starting with basic device detection and environment checking.

## Modifications

### `python/sglang/srt/utils/common.py`
- Add `is_supa()` detection function (cached) that checks `torch.supa.is_available()`
- Add SUPA branch in `get_device()` to return `"supa"` or `"supa:<id>"`
- Add SUPA to `get_device_count()`, `get_device_core_count()`, and `get_device_capability()` by extending existing CUDA/MUSA paths (SUPA uses PrivateUse1 mapped to `torch.cuda` APIs)
- Update error message to include SUPA in the list of supported accelerators

### `python/sglang/check_env.py`
- Import `is_supa` from `sglang.srt.utils`
- Add `SUPAEnv` class (extends `BaseEnv`) with:
  - `get_info()`: reports SUPA availability and device info
  - `get_device_info()`: enumerates SUPA devices by name and ID
  - `_get_supa_version_info()`: reports `FULLSTACK_HOME` path
  - `_get_brcc_info()`: reports Biren compiler (`brcc`) version
  - `_get_supa_driver_version()`: reports driver version via `brsmi -q`
  - `get_topology()`: reports GPU interconnect topology via `brsmi topo -m`
- Register `SUPAEnv` in the `__main__` dispatch (after MUSA, before MPS)

## Accuracy Tests

N/A — This PR only adds device detection and environment reporting utilities. No model computation or kernel logic is modified.

## Speed Tests and Profiling

N/A — No inference path changes. Only device detection functions are added, which are cached with `@lru_cache`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28998106785](https://github.com/sgl-project/sglang/actions/runs/28998106785)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28998106626](https://github.com/sgl-project/sglang/actions/runs/28998106626)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->