### PR TITLE
[Fix] Serialize FanOutCommunicator queueing calls with a FIFO-fair asyncio.Lock

### DIFF
--- a/python/sglang/srt/managers/communicator.py
+++ b/python/sglang/srt/managers/communicator.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from collections import deque
-from typing import Callable, Deque, Generic, List, Optional, TypeVar
+from typing import Callable, Generic, List, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -31,31 +30,26 @@ class FanOutCommunicator(Generic[T]):
         self._mode = mode
         self._result_event: Optional[asyncio.Event] = None
         self._result_values: Optional[List[T]] = None
-        self._ready_queue: Deque[asyncio.Event] = deque()
+        self._queueing_lock = asyncio.Lock()
 
         assert mode in ["queueing", "watching"]
 
     async def queueing_call(self, obj: T):
-        ready_event = asyncio.Event()
-        if self._result_event is not None or len(self._ready_queue) > 0:
-            self._ready_queue.append(ready_event)
-            await ready_event.wait()
-            assert self._result_event is None
-            assert self._result_values is None
+        # asyncio.Lock is FIFO-fair: a new caller cannot acquire while earlier
+        # callers are still waiting, so requests are strictly serialized in
+        # arrival order. It also releases on exception/cancellation, so a
+        # failed caller never blocks the callers queued behind it.
+        async with self._queueing_lock:
+            if obj is not None:
+                self._send(obj)
 
-        if obj is not None:
-            self._send(obj)
+            self._result_event = asyncio.Event()
+            self._result_values = []
+            await self._result_event.wait()
+            result_values = self._result_values
+            self._result_event = self._result_values = None
 
-        self._result_event = asyncio.Event()
-        self._result_values = []
-        await self._result_event.wait()
-        result_values = self._result_values
-        self._result_event = self._result_values = None
-
-        if len(self._ready_queue) > 0:
-            self._ready_queue.popleft().set()
-
-        return result_values
+            return result_values
 
     async def watching_call(self, obj):
         if self._result_event is None:

--- a/test/registered/unit/managers/test_fanout_communicator.py
+++ b/test/registered/unit/managers/test_fanout_communicator.py
@@ -1,0 +1,111 @@
+"""Unit tests for FanOutCommunicator -- no server, no model loading."""
+
+import asyncio
+import unittest
+
+from sglang.srt.managers.communicator import FanOutCommunicator
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestQueueingCall(CustomTestCase):
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_serial_calls(self):
+        async def scenario():
+            sent = []
+            comm = FanOutCommunicator(send=sent.append, fan_out=2, mode="queueing")
+
+            async def respond():
+                comm.handle_recv("r1")
+                comm.handle_recv("r2")
+
+            task = asyncio.create_task(comm("req"))
+            await asyncio.sleep(0)
+            await respond()
+            result = await task
+            self.assertEqual(sent, ["req"])
+            self.assertEqual(result, ["r1", "r2"])
+
+        self._run(scenario())
+
+    def test_concurrent_caller_cannot_bypass_queue(self):
+        """A new caller arriving in the wakeup window must not overtake a
+        queued caller (this interleaving used to raise AssertionError and
+        return 500 on concurrent /server_info requests)."""
+
+        async def scenario():
+            sent = []
+            comm = FanOutCommunicator(send=sent.append, fan_out=1, mode="queueing")
+
+            async def call(name):
+                return await comm(name)
+
+            # A in-flight, B queued behind it.
+            task_a = asyncio.create_task(call("A"))
+            await asyncio.sleep(0)
+            task_b = asyncio.create_task(call("B"))
+            await asyncio.sleep(0)
+
+            # Complete A, then create C before A's wakeup runs, so C's first
+            # step lands between A's cleanup and B's wakeup.
+            comm.handle_recv("resp-A")
+            task_c = asyncio.create_task(call("C"))
+
+            # Drive to completion: feed a response whenever one is in flight.
+            tasks = [task_a, task_b, task_c]
+            for _ in range(100):
+                if all(t.done() for t in tasks):
+                    break
+                if comm._result_event is not None and not comm._result_event.is_set():
+                    comm.handle_recv(f"resp-{len(sent)}")
+                await asyncio.sleep(0)
+
+            results = await asyncio.gather(*tasks)
+            # All callers complete without error, in strict FIFO order.
+            self.assertEqual(sent, ["A", "B", "C"])
+            self.assertEqual(len(results), 3)
+
+        self._run(scenario())
+
+    def test_stress_concurrent_callers(self):
+        """Mirrors test_get_server_info_concurrent without a server: many
+        concurrent callers with jittered responses must all complete."""
+
+        async def scenario():
+            import random
+
+            n_callers = 30
+            sent = []
+            comm = FanOutCommunicator(send=sent.append, fan_out=1, mode="queueing")
+            done = 0
+
+            async def responder():
+                while done < n_callers:
+                    event = comm._result_event
+                    if event is not None and not event.is_set():
+                        comm.handle_recv("resp")
+                    await asyncio.sleep(random.random() * 1e-4)
+
+            async def one_call(i):
+                nonlocal done
+                await asyncio.sleep(random.random() * 1e-4)
+                await comm(f"req-{i}")
+                done += 1
+
+            responder_task = asyncio.create_task(responder())
+            await asyncio.wait_for(
+                asyncio.gather(*[one_call(i) for i in range(n_callers)]),
+                timeout=30,
+            )
+            await responder_task
+            self.assertEqual(len(sent), n_callers)
+
+        self._run(scenario())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_fanout_communicator.py
+++ b/test/registered/unit/managers/test_fanout_communicator.py
@@ -11,27 +11,6 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestQueueingCall(CustomTestCase):
-    def _run(self, coro):
-        return asyncio.run(coro)
-
-    def test_serial_calls(self):
-        async def scenario():
-            sent = []
-            comm = FanOutCommunicator(send=sent.append, fan_out=2, mode="queueing")
-
-            async def respond():
-                comm.handle_recv("r1")
-                comm.handle_recv("r2")
-
-            task = asyncio.create_task(comm("req"))
-            await asyncio.sleep(0)
-            await respond()
-            result = await task
-            self.assertEqual(sent, ["req"])
-            self.assertEqual(result, ["r1", "r2"])
-
-        self._run(scenario())
-
     def test_concurrent_caller_cannot_bypass_queue(self):
         """A new caller arriving in the wakeup window must not overtake a
         queued caller (this interleaving used to raise AssertionError and
@@ -41,19 +20,16 @@ class TestQueueingCall(CustomTestCase):
             sent = []
             comm = FanOutCommunicator(send=sent.append, fan_out=1, mode="queueing")
 
-            async def call(name):
-                return await comm(name)
-
             # A in-flight, B queued behind it.
-            task_a = asyncio.create_task(call("A"))
+            task_a = asyncio.create_task(comm("A"))
             await asyncio.sleep(0)
-            task_b = asyncio.create_task(call("B"))
+            task_b = asyncio.create_task(comm("B"))
             await asyncio.sleep(0)
 
             # Complete A, then create C before A's wakeup runs, so C's first
             # step lands between A's cleanup and B's wakeup.
             comm.handle_recv("resp-A")
-            task_c = asyncio.create_task(call("C"))
+            task_c = asyncio.create_task(comm("C"))
 
             # Drive to completion: feed a response whenever one is in flight.
             tasks = [task_a, task_b, task_c]
@@ -64,47 +40,11 @@ class TestQueueingCall(CustomTestCase):
                     comm.handle_recv(f"resp-{len(sent)}")
                 await asyncio.sleep(0)
 
-            results = await asyncio.gather(*tasks)
             # All callers complete without error, in strict FIFO order.
+            await asyncio.gather(*tasks)
             self.assertEqual(sent, ["A", "B", "C"])
-            self.assertEqual(len(results), 3)
 
-        self._run(scenario())
-
-    def test_stress_concurrent_callers(self):
-        """Mirrors test_get_server_info_concurrent without a server: many
-        concurrent callers with jittered responses must all complete."""
-
-        async def scenario():
-            import random
-
-            n_callers = 30
-            sent = []
-            comm = FanOutCommunicator(send=sent.append, fan_out=1, mode="queueing")
-            done = 0
-
-            async def responder():
-                while done < n_callers:
-                    event = comm._result_event
-                    if event is not None and not event.is_set():
-                        comm.handle_recv("resp")
-                    await asyncio.sleep(random.random() * 1e-4)
-
-            async def one_call(i):
-                nonlocal done
-                await asyncio.sleep(random.random() * 1e-4)
-                await comm(f"req-{i}")
-                done += 1
-
-            responder_task = asyncio.create_task(responder())
-            await asyncio.wait_for(
-                asyncio.gather(*[one_call(i) for i in range(n_callers)]),
-                timeout=30,
-            )
-            await responder_task
-            self.assertEqual(len(sent), n_callers)
-
-        self._run(scenario())
+        asyncio.run(scenario())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Concurrent `/server_info` requests can intermittently return 500: `FanOutCommunicator.queueing_call` has a wakeup-window race where a caller arriving between the previous caller's cleanup and the queued waiter's wakeup bypasses the ready queue and trips `assert self._result_event is None` (seen in scheduled CI on `test_get_server_info_concurrent`). A caller that hits the assert also never hands off to the waiters queued behind it, leaving them hung. Replace the hand-rolled ready queue with a FIFO-fair `asyncio.Lock` and add a unit test that deterministically reproduces the interleaving (fails on main, passes with this fix).



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28998767556](https://github.com/sgl-project/sglang/actions/runs/28998767556)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28998767437](https://github.com/sgl-project/sglang/actions/runs/28998767437)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->