### PR TITLE
Fix Mistral Large 3 EAGLE DSA detection

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -108,7 +108,6 @@ def is_deepseek_dsa(config) -> bool:
             "DeepseekV32ForCausalLM",
             "DeepseekV3ForCausalLMNextN",
             "MistralLarge3ForCausalLM",
-            "MistralLarge3ForCausalLMEagle",
             "PixtralForConditionalGeneration",
             "GlmMoeDsaForCausalLM",
             "GlmMoeDsaForCausalLMNextN",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -108,6 +108,7 @@ def is_deepseek_dsa(config) -> bool:
             "DeepseekV32ForCausalLM",
             "DeepseekV3ForCausalLMNextN",
             "MistralLarge3ForCausalLM",
+            "MistralLarge3ForCausalLMEagle",
             "PixtralForConditionalGeneration",
             "GlmMoeDsaForCausalLM",
             "GlmMoeDsaForCausalLMNextN",

--- a/python/sglang/srt/models/mistral_large_3_eagle.py
+++ b/python/sglang/srt/models/mistral_large_3_eagle.py
@@ -64,6 +64,10 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         )
         self.start_layer = 0
         self.end_layer = self.config.num_hidden_layers
+        local_layer_ids = list(range(self.start_layer, self.end_layer))
+        self.next_full_attention_layer_id = dict(
+            zip(local_layer_ids, local_layer_ids[1:])
+        )
 
         self.fc = RowParallelLinear(
             self.config.hidden_size * 2,

--- a/python/sglang/srt/models/mistral_large_3_eagle.py
+++ b/python/sglang/srt/models/mistral_large_3_eagle.py
@@ -34,12 +34,13 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         nn.Module.__init__(self)
 
         self.config = config
+        self.use_dsa = is_deepseek_dsa(config)
         self.vocab_size = config.vocab_size
         assert get_pp_group().world_size == 1
         self.pp_group = get_pp_group()
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.mla_enable_prefill_cp = (
-            is_prefill_context_parallel_enabled() and not is_deepseek_dsa(config)
+            is_prefill_context_parallel_enabled() and not self.use_dsa
         )
 
         self.embed_tokens = VocabParallelEmbedding(

--- a/test/registered/unit/models/test_mistral_large_3_eagle.py
+++ b/test/registered/unit/models/test_mistral_large_3_eagle.py
@@ -1,0 +1,73 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from torch import nn
+
+from sglang.srt.models.mistral_large_3_eagle import MistralLarge3EagleModel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _DummyModule(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+
+class _FakePPGroup:
+    world_size = 1
+    is_first_rank = True
+    is_last_rank = True
+
+
+def _make_dsa_eagle_config():
+    return SimpleNamespace(
+        architectures=["MistralLarge3ForCausalLMEagle"],
+        index_topk=1,
+        vocab_size=32000,
+        hidden_size=16,
+        num_hidden_layers=0,
+        rms_norm_eps=1e-6,
+    )
+
+
+class TestMistralLarge3EagleModel(CustomTestCase):
+    def test_initializes_dsa_state_for_inherited_forward_path(self):
+        with (
+            patch(
+                "sglang.srt.models.mistral_large_3_eagle.get_pp_group",
+                return_value=_FakePPGroup(),
+            ),
+            patch(
+                "sglang.srt.models.mistral_large_3_eagle.is_dsa_enable_prefill_cp",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.models.mistral_large_3_eagle."
+                "is_prefill_context_parallel_enabled",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.models.mistral_large_3_eagle.VocabParallelEmbedding",
+                _DummyModule,
+            ),
+            patch(
+                "sglang.srt.models.mistral_large_3_eagle.RowParallelLinear",
+                _DummyModule,
+            ),
+            patch("sglang.srt.models.mistral_large_3_eagle.RMSNorm", _DummyModule),
+            patch(
+                "sglang.srt.models.deepseek_v2.get_attn_backend",
+                return_value=SimpleNamespace(use_mha=False),
+            ),
+        ):
+            model = MistralLarge3EagleModel(_make_dsa_eagle_config())
+
+            self.assertTrue(model.use_dsa)
+            self.assertTrue(model._dsa_forward_uses_topk())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_mistral_large_3_eagle.py
+++ b/test/registered/unit/models/test_mistral_large_3_eagle.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from torch import nn
 
+from sglang.srt.configs.model_config import is_deepseek_dsa
 from sglang.srt.models.mistral_large_3_eagle import MistralLarge3EagleModel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -22,19 +23,19 @@ class _FakePPGroup:
     is_last_rank = True
 
 
-def _make_dsa_eagle_config():
+def _make_eagle_config_with_index_topk():
     return SimpleNamespace(
         architectures=["MistralLarge3ForCausalLMEagle"],
         index_topk=1,
         vocab_size=32000,
         hidden_size=16,
-        num_hidden_layers=0,
+        num_hidden_layers=3,
         rms_norm_eps=1e-6,
     )
 
 
 class TestMistralLarge3EagleModel(CustomTestCase):
-    def test_initializes_dsa_state_for_inherited_forward_path(self):
+    def test_initializes_non_dsa_state_for_inherited_forward_path(self):
         with (
             patch(
                 "sglang.srt.models.mistral_large_3_eagle.get_pp_group",
@@ -57,16 +58,23 @@ class TestMistralLarge3EagleModel(CustomTestCase):
                 "sglang.srt.models.mistral_large_3_eagle.RowParallelLinear",
                 _DummyModule,
             ),
+            patch(
+                "sglang.srt.models.mistral_large_3_eagle.DeepseekV2DecoderLayer",
+                _DummyModule,
+            ),
             patch("sglang.srt.models.mistral_large_3_eagle.RMSNorm", _DummyModule),
             patch(
                 "sglang.srt.models.deepseek_v2.get_attn_backend",
                 return_value=SimpleNamespace(use_mha=False),
             ),
         ):
-            model = MistralLarge3EagleModel(_make_dsa_eagle_config())
+            config = _make_eagle_config_with_index_topk()
+            model = MistralLarge3EagleModel(config)
 
-            self.assertTrue(model.use_dsa)
-            self.assertTrue(model._dsa_forward_uses_topk())
+            self.assertFalse(is_deepseek_dsa(config))
+            self.assertFalse(model.use_dsa)
+            self.assertFalse(model._dsa_forward_uses_topk())
+            self.assertEqual(model.next_full_attention_layer_id, {0: 1, 1: 2})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `MistralLarge3ForCausalLMEagle` to `is_deepseek_dsa` so the Mistral Large 3 EAGLE/MTP draft path keeps DSA enabled when `index_topk` is present.

## Context
The linked nightly job failed on the Mistral Large 3 `TP8+MTP` variant: https://github.com/sgl-project/sglang/actions/runs/28848316166/job/85985158242

`mistral_utils.py` maps the EAGLE draft config to `MistralLarge3ForCausalLMEagle`, but the DSA classifier only allowed `MistralLarge3ForCausalLM`. That made the draft config miss the DSA path even though it carries `index_topk`.

## Test Plan
- `python3 -m py_compile python/sglang/srt/configs/model_config.py`
- `git diff --check`
- Local source-level check for `is_deepseek_dsa` on Mistral Large 3 EAGLE with `index_topk`















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29060630543](https://github.com/sgl-project/sglang/actions/runs/29060630543)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29060630420](https://github.com/sgl-project/sglang/actions/runs/29060630420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->