### PR TITLE
[Fix] Preserve missing Mooncake decode prefix metadata

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1920,7 +1920,11 @@ class MooncakeKVReceiver(CommonKVReceiver):
                             else b""
                         ),
                         str(self.required_dst_info_num).encode("ascii"),
-                        str(decode_prefix_len or 0).encode("ascii"),
+                        (
+                            str(decode_prefix_len).encode("ascii")
+                            if not is_dummy and decode_prefix_len is not None
+                            else b""
+                        ),
                     ]
                 )
         self.init_time = time.time()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Mooncake disaggregation currently serializes the optional `decode_prefix_len` metadata with `decode_prefix_len or 0`.

This loses the distinction between two different states:

- `decode_prefix_len = 0`: an explicit zero prefix, which is valid.
- `decode_prefix_len = None`: missing prefix metadata.

In multi-rank bootstrap paths, especially when dummy ranks are involved, a dummy rank may not have real KV transfer metadata. With the old serialization, that missing value is sent as `0`. On the prefill side, `decode_prefix_len` is selected from the received metadata entries by looking for the first non-`None` value. If the dummy metadata arrives first, the request can incorrectly use `0` as the decode prefix length instead of the real prefix length from the non-dummy rank.

This can make Mooncake transfer treat a prefix-cache hit as a zero-prefix transfer, causing unnecessary KV transfer for already cached prefix tokens.


## Modifications

Preserve missing `decode_prefix_len` metadata during Mooncake metadata serialization.

Before this change, the sender always serialized missing values as `0`:

```python
str(decode_prefix_len or 0).encode("ascii")
```

After this change:
- explicit decode_prefix_len = 0 is still serialized as b"0";
- non-zero prefix lengths are serialized normally;
- missing metadata (None) and dummy-rank metadata are serialized as an empty field.

This lets the receiver keep the existing distinction:
- b"0" means an explicit zero prefix;
- b"" means no prefix metadata was provided.

The change is limited to python/sglang/srt/disaggregation/mooncake/conn.py.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29003733088](https://github.com/sgl-project/sglang/actions/runs/29003733088)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29003732996](https://github.com/sgl-project/sglang/actions/runs/29003732996)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->