### PR TITLE
Turn off  topk v2 for DSA models by default to avoid seldom IMA issues

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4098,6 +4098,10 @@ class ServerArgs:
         ]:
             # Set attention backend for DeepSeek
             if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
+                # Keep DSA on the legacy top-k path by default until top-k v2
+                # supports all DSA decode shapes safely.
+                envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+
                 if envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.is_set():
                     logger.warning(
                         f"Dense attention kv len threshold is manually set to {envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()} for DSA. Caution: This may cause performance regression if the threshold is larger than the index topk of model."

--- a/test/registered/8-gpu-models/test_glm52_fp8.py
+++ b/test/registered/8-gpu-models/test_glm52_fp8.py
@@ -15,7 +15,8 @@ COMMON_ARGS = [
     "--trust-remote-code",
     "--reasoning-parser=glm45",
     "--tool-call-parser=glm47",
-    "--mem-fraction-static=0.8",
+    "--mem-fraction-static=0.85",
+    "--max-running-requests=256",
     "--enable-metrics",
 ]
 

--- a/test/registered/8-gpu-models/test_glm52_fp8.py
+++ b/test/registered/8-gpu-models/test_glm52_fp8.py
@@ -15,7 +15,7 @@ COMMON_ARGS = [
     "--trust-remote-code",
     "--reasoning-parser=glm45",
     "--tool-call-parser=glm47",
-    "--mem-fraction-static=0.85",
+    "--mem-fraction-static=0.8",
     "--enable-metrics",
 ]
 


### PR DESCRIPTION
## Summary
- Disable SGLANG_OPT_USE_TOPK_V2 for DSA models during model-specific server-args handling.
- Add server-args unit coverage for the DSA model env override.

## Tests
- pre-commit hooks from git commit: isort, ruff, black-jupyter, codespell, registered test registry checks, etc.
- /Users/baizhou.zhang/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile python/sglang/srt/server_args.py test/registered/unit/server_args/test_server_args.py
- git diff --check

Note: targeted pytest/unittest could not run in this local environment because pytest and runtime deps such as orjson are not installed.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29011107637](https://github.com/sgl-project/sglang/actions/runs/29011107637)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29011107482](https://github.com/sgl-project/sglang/actions/runs/29011107482)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->