### PR TITLE
Fix CuTe DSL DSA paged MQA export

### DIFF
--- a/python/sglang/jit_kernel/dsa/__init__.py
+++ b/python/sglang/jit_kernel/dsa/__init__.py
@@ -1,4 +1,12 @@
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import is_cuda
+
+_is_cuda = is_cuda()
+
+if _is_cuda:
+    from .cutedsl_paged_mqa_logits import CuteDSLPagedMQALogitsRunner, pick_dsl_expand
+else:
+    CuteDSLPagedMQALogitsRunner = None
+    pick_dsl_expand = None
 
 from .paged_mqa_logits import (
     aiter_paged_mqa_logits,
@@ -6,10 +14,6 @@ from .paged_mqa_logits import (
     deepgemm_paged_mqa_logits_native,
     deepgemm_paged_mqa_logits_split,
 )
-
-if not is_hip():
-    # Preserve the original eager import behavior on non-ROCm platforms.
-    from .cutedsl_paged_mqa_logits import CuteDSLPagedMQALogitsRunner, pick_dsl_expand
 
 __all__ = [
     "CuteDSLPagedMQALogitsRunner",

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -58,6 +58,7 @@ global _use_multi_stream
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
+
 if not _is_npu:
     from sglang.jit_kernel.dsa import (
         aiter_paged_mqa_logits,
@@ -71,11 +72,11 @@ else:
     deepgemm_paged_mqa_logits_native = None
     deepgemm_paged_mqa_logits_split = None
 
-if not _is_hip and not _is_npu:
-    # Preserve the original eager import behavior on non-ROCm platforms.
+if _is_cuda:
     from sglang.jit_kernel.dsa import pick_dsl_expand
 else:
     pick_dsl_expand = None
+
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
@@ -928,7 +929,7 @@ class Indexer(MultiPlatformOp):
             and forward_batch.forward_mode.is_target_verify()
             and next_n >= 2
         ):
-            assert pick_dsl_expand is not None, "Not supported on AMD/ROCm. "
+            assert pick_dsl_expand is not None, "CuTe DSL paged MQA is CUDA-only."
             dsl_expand_factor, dsl_atom = pick_dsl_expand(
                 next_n,
                 batch_size=B,


### PR DESCRIPTION
## Summary

Fix the CuTe DSL paged MQA export that got broken by the import reordering in #30374. Before this change, the export pointed at the module instead of the function. This puts the order back so callers get the function again.

I also made the CuTe DSL helper import CUDA-only. For NPU, ROCm, and other backends, we leave a `None` placeholder instead of trying to load CUDA-only code.

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29079820810](https://github.com/sgl-project/sglang/actions/runs/29079820810)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29147456875](https://github.com/sgl-project/sglang/actions/runs/29147456875)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->