### PR TITLE
[fix] Repoint the prefetch-dispatch test at the loader's current config binding

### DIFF
--- a/test/registered/unit/model_loader/test_prefetch_checkpoints.py
+++ b/test/registered/unit/model_loader/test_prefetch_checkpoints.py
@@ -271,7 +271,7 @@ class TestPrefetchDispatch(CustomTestCase):
                 return_value=("/dummy", ["f.safetensors"], True),
             ),
             patch(
-                "sglang.srt.model_loader.loader.get_global_server_args",
+                "sglang.srt.model_loader.loader.get_server_args",
                 return_value=self._server_args(prefetch, disable_mmap),
             ),
             patch(


### PR DESCRIPTION
## Motivation

#30146 (merged 40 minutes before #30493) added `TestPrefetchDispatch` cases that patch `sglang.srt.model_loader.loader.get_global_server_args`; #30493 flipped that import to `runtime_context.get_server_args`. Both PRs were green individually — the combination leaves six unit tests failing on `main` with `AttributeError: module ... does not have the attribute 'get_global_server_args'`.

## Modifications

One line: the patch target follows the loader's current module-level binding (`loader.get_server_args`), which is what the dispatch code reads — interception is unchanged.

## Verification

`test_prefetch_checkpoints.py` 13/13 pass on main + this fix (was 7/13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29007872709](https://github.com/sgl-project/sglang/actions/runs/29007872709)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29007872568](https://github.com/sgl-project/sglang/actions/runs/29007872568)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->