### PR TITLE
Add tanujtiwari1998 to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1238,6 +1238,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
+    "tanujtiwari1998": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "thecodingwizard": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Add `tanujtiwari1998` to `.github/CI_PERMISSIONS.json` with a 60-minute cooldown interval, inserted in sorted order.

Permissions granted:
- `can_tag_run_ci_label`
- `can_rerun_failed_ci`
- `can_rerun_stage`
- `cooldown_interval_minutes`: 60
- `reason`: custom override











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29014719679](https://github.com/sgl-project/sglang/actions/runs/29014719679)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29014719615](https://github.com/sgl-project/sglang/actions/runs/29014719615)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->