### PR TITLE
fix deepseekv4-pd-hisparse memory pool bug

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -60,6 +60,7 @@ from sglang.srt.disaggregation.utils import (
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
@@ -84,7 +85,6 @@ from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
 )
-from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import get_num_new_pages
 from sglang.srt.utils.network import NetworkAddress
 from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
@@ -255,7 +255,6 @@ class DecodeRequest:
     kv_receiver: CommonKVReceiver
     waiting_for_input: bool = False
     metadata_buffer_index: int = -1
-    is_rebootstrap: bool = False
 
     # HiCache Status
     prefix_match: Optional[DecodePrefixMatch] = None
@@ -327,13 +326,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self._max_ensure_retries: int = 15  # scheduling cycles
         self._ensure_last_attempt_time: Dict[str, float] = {}
         self._ensure_retry_interval: float = 1.0  # seconds
-        # Retracted requests staged for rebootstrap while generation is paused.
-        # Enqueued into ``self.queue`` only on ``continue_generation`` so the
-        # prefix KV is recomputed under the post-retract (updated) weights.
-        # NOTE: requests held here are not reachable by ``/abort_request``; to
-        # support aborting them we would need an additional fix in the
-        # scheduler. In practice this shouldn't arise in the RL scenario.
-        self.held_rebootstrap_reqs: List[Req] = []
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         if self.enable_staging and self.is_mla_backend:
             raise RuntimeError(
@@ -381,7 +373,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         return self._swa_tail_len(len(req.origin_input_ids)) + len(req.output_ids)
 
     def _prealloc_kv_lens(self, req: Req) -> Tuple[int, int]:
-        allocated_kv_len = self._pre_alloc_fill_len(req)
+        allocated_kv_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
         if self._uses_swa_tail_prealloc():
             return allocated_kv_len, self._swa_tail_len(allocated_kv_len)
         return allocated_kv_len, allocated_kv_len
@@ -400,7 +392,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
         kv_args = kv_args_class()
 
-        attn_tp_size = get_parallel().attn_tp_size
+        attn_tp_size = get_attention_tp_size()
         kv_args.engine_rank = self.tp_rank % (attn_tp_size)
 
         kv_args.pp_rank = self.pp_rank
@@ -485,18 +477,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     )
         return kv_manager
 
-    def add(
-        self, req: Req, is_retracted: bool = False, is_rebootstrap: bool = False
-    ) -> None:
-        """Add a request to the pending queue.
-
-        ``is_rebootstrap`` marks a PD true-retraction request whose prefix KV
-        must be recomputed by the original prefill worker under the current
-        weights (rather than resumed from stale CPU KV). It otherwise follows the
-        same bootstrap-handshake path as a fresh request; the ``/generate``
-        dispatch happens later, after preallocation and ``send_metadata`` (see
-        ``pop_preallocated``).
-        """
+    def add(self, req: Req, is_retracted: bool = False) -> None:
+        """Add a request to the pending queue."""
         if self._check_if_req_exceed_kv_capacity(req):
             return
 
@@ -504,9 +486,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             req.retraction_mb_id = None
             self.retracted_queue.append(req)
         else:
-            decode_req = self._create_receiver_and_enqueue(
-                req, is_rebootstrap=is_rebootstrap
-            )
+            decode_req = self._create_receiver_and_enqueue(req)
 
             # NOTE: fake transfer does not need to resolve prefill dp rank in the pending queue
             if _is_fake_transfer(req, self.scheduler.server_args):
@@ -558,9 +538,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         return None
 
-    def _create_receiver_and_enqueue(
-        self, req: Req, is_rebootstrap: bool = False
-    ) -> DecodeRequest:
+    def _create_receiver_and_enqueue(self, req: Req) -> DecodeRequest:
         backend = (
             TransferBackend.FAKE
             if _is_fake_transfer(req, self.scheduler.server_args)
@@ -574,59 +552,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             bootstrap_room=req.bootstrap_room,
         )
 
-        decode_req = DecodeRequest(
-            req=req, kv_receiver=kv_receiver, is_rebootstrap=is_rebootstrap
-        )
+        decode_req = DecodeRequest(req=req, kv_receiver=kv_receiver)
         self.queue.append(decode_req)
         return decode_req
 
-    def hold_rebootstrap(self, req: Req) -> None:
-        """Stage a retracted request for rebootstrap without enqueuing it yet.
-
-        Retraction is always paired with a weight update
-        (``pause_generation(mode="retract")`` -> ``update_weights`` ->
-        ``continue_generation``). Enqueuing the rebootstrap into ``self.queue``
-        here would leave the preallocation queue non-empty, which makes the
-        scheduler non-idle so ``update_weights``' post-update cache flush
-        asserts and crashes the decode worker. Instead we hold the request and
-        enqueue it from ``enqueue_held_rebootstrap`` on resume, so its prefix KV
-        is recomputed by the prefill worker under the updated weights.
-        """
-        self.held_rebootstrap_reqs.append(req)
-
-    def enqueue_held_rebootstrap(self) -> None:
-        """Enqueue all staged rebootstrap requests when generation resumes."""
-        held = self.held_rebootstrap_reqs
-        self.held_rebootstrap_reqs = []
-        for req in held:
-            self.add(req, is_rebootstrap=True)
-
-    @staticmethod
-    def _rebootstrap_prefill_len(req: Req) -> int:
-        if getattr(req, "pd_rebootstrap_in_progress", False):
-            return len(req.origin_input_ids) + len(req.output_ids)
-        return len(req.origin_input_ids)
-
-    @staticmethod
-    def _pre_alloc_fill_len(req: Req) -> int:
-        if getattr(req, "pd_rebootstrap_in_progress", False):
-            # pause_generation(retract) already popped the boundary token out of
-            # output_ids (it is replayed via the decode-side override at commit
-            # time), so output_ids here is prompt + emitted-tokens-minus-boundary,
-            # i.e. the original seqlen - 1. The prefill recomputes KV for *all* of
-            # these tokens, leaving no just-sampled "pending" token in the list, so
-            # we allocate exactly len(origin)+len(output_ids) with no -1 (unlike
-            # normal decode, where the last token's KV has not been written yet).
-            # This is the same token count as offloading-based retraction, where
-            # offload_kv_cache saves seqlen-1 tokens; the boundary token's KV is
-            # (re)computed on the decode side once generation resumes.
-            return len(req.origin_input_ids) + len(req.output_ids)
-        return len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
-
     def _check_if_req_exceed_kv_capacity(self, req: Req) -> bool:
-        input_len = self._rebootstrap_prefill_len(req)
-        if input_len > self.max_total_num_tokens:
-            message = f"Request {req.rid} exceeds the maximum number of tokens: {input_len} > {self.max_total_num_tokens}"
+        if len(req.origin_input_ids) > self.max_total_num_tokens:
+            message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} > {self.max_total_num_tokens}"
             logger.error(message)
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
             self.scheduler.output_streamer.stream_output([req], req.return_logprob)
@@ -690,6 +622,14 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 break
             if uses_swa_tail_prealloc and swa_required > swa_allocatable_tokens:
                 break
+            if (
+                self.scheduler.enable_hisparse
+                and req.kv_cache_cpu.get("_hisparse_retract_state") is not None
+                and not self.scheduler.hisparse_coordinator.can_allocate_device_buffer(
+                    req
+                )
+            ):
+                break
 
             resumed_reqs.append(req)
             indices_to_remove.add(i)
@@ -700,7 +640,15 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 swa_allocatable_tokens -= swa_required
 
             # load from cpu, release the cpu copy
+            hisparse_retract_state = None
+            if self.scheduler.enable_hisparse:
+                hisparse_retract_state = req.kv_cache_cpu.get("_hisparse_retract_state")
             req.load_kv_cache(self.req_to_token_pool, self.token_to_kv_pool_allocator)
+            if hisparse_retract_state is not None:
+                self.scheduler.hisparse_coordinator.restore_retracted_req(
+                    req, hisparse_retract_state
+                )
+                self.scheduler.hisparse_coordinator.admit_request_direct(req)
 
         self.retracted_queue = [
             entry
@@ -793,9 +741,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 error_msg = f"Could not fetch prefill parallel info from {bootstrap_addr} after {count} attempts"
                 logger.error(error_msg)
                 for decode_req in reqs:
-                    # kv_receiver may be None from a prior self.queue cleanup
-                    if decode_req.kv_receiver is not None:
-                        decode_req.kv_receiver.abort()
+                    decode_req.kv_receiver.abort()
                 del self._ensure_retry_count[bootstrap_addr]
                 del self._ensure_last_attempt_time[bootstrap_addr]
             else:
@@ -898,23 +844,14 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
             if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
-                if not getattr(decode_req.req, "finished_output", False):
-                    self.scheduler.output_streamer.stream_output(
-                        [decode_req.req],
-                        decode_req.req.return_logprob,
-                    )
+                self.scheduler.output_streamer.stream_output(
+                    [decode_req.req],
+                    decode_req.req.return_logprob,
+                )
                 decode_req.kv_receiver.clear()
                 decode_req.kv_receiver = None
                 failed_reqs.append(decode_req)
                 indices_to_remove.add(i)
-
-        # DecodeRequest is shared between self.queue and self.pending_reqs;
-        # drop failed reqs from both
-        if failed_reqs:
-            failed_ids = {id(r) for r in failed_reqs}
-            self.pending_reqs = [
-                r for r in self.pending_reqs if id(r) not in failed_ids
-            ]
 
         # HiSparse physical constraint: max requests by device buffer capacity.
         # Each admitted req needs padded_buffer_size from hisparse device pool.
@@ -953,13 +890,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
             # Memory estimation: don't add if the projected memory cannot be met
             # TODO: add new_token ratio
-            origin_input_len = self._rebootstrap_prefill_len(decode_req.req)
+            origin_input_len = len(decode_req.req.origin_input_ids)
             prefix_match: Optional[DecodePrefixMatch] = None
-            use_decode_radix_cache = (
-                self.scheduler.server_args.disaggregation_decode_enable_radix_cache
-                and not decode_req.is_rebootstrap
-            )
-            if use_decode_radix_cache:
+            if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
                 # Match prefix against decode's radix cache.
                 prefix_match = self._match_prefix_and_lock(decode_req.req)
                 prefix_indices = prefix_match.prefix_indices
@@ -971,7 +904,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 prefix_len = prefix_match.l1_prefix_len
                 total_prefix_len = prefix_match.decode_prefix_len
 
-                fill_len = self._pre_alloc_fill_len(decode_req.req)
+                fill_len = origin_input_len + max(len(decode_req.req.output_ids) - 1, 0)
                 required_alloc_tokens = self._required_alloc_tokens(
                     fill_len=fill_len, prefix_len=prefix_len
                 )
@@ -988,7 +921,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 prefix_indices = None
                 prefix_len = 0
                 total_prefix_len = 0
-                required_alloc_tokens = self._pre_alloc_fill_len(decode_req.req)
+                required_alloc_tokens = origin_input_len
 
             required_tokens_for_request = (
                 required_alloc_tokens + self.num_reserved_decode_tokens
@@ -1086,7 +1019,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     .numpy()
                 )
 
-            seq_len = origin_input_len
+            seq_len = len(decode_req.req.origin_input_ids)
 
             def _mamba_payload():
                 return [
@@ -1181,11 +1114,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 state_indices,
                 decode_prefix_len=total_prefix_len,
             )
-            if decode_req.is_rebootstrap:
-                self.kv_manager.submit_prefill_recompute(
-                    decode_req.kv_receiver,
-                    decode_req.req.build_rebootstrap_payload(),
-                )
             if (
                 self.transfer_queue.enable_staging
                 and hasattr(decode_req.kv_receiver, "require_staging")
@@ -1281,11 +1209,17 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             )
 
         if self.scheduler.enable_hisparse:
-            # HiSparse pre-alloc only allocates logical indices (alloc_logical_only),
-            # so the logical pool is the binding constraint for admission control.
-            available_size = (
-                self.token_to_kv_pool_allocator.logical_attn_allocator.available_size()
-            )
+            # HiSparse pre-alloc only allocates logical indices here; device C4
+            # buffers are budgeted separately by hisparse_req_budget. For hybrid
+            # SWA, SWA tail capacity is checked by _swa_tail_allocatable_token_budget,
+            # so the full budget should not be clamped by SWA availability.
+            logical_allocator = self.token_to_kv_pool_allocator.logical_attn_allocator
+            if self._uses_swa_tail_prealloc() and hasattr(
+                logical_allocator, "full_available_size"
+            ):
+                available_size = logical_allocator.full_available_size()
+            else:
+                available_size = logical_allocator.available_size()
         elif self._uses_swa_tail_prealloc():
             available_size = self.token_to_kv_pool_allocator.full_available_size()
             if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
@@ -1419,7 +1353,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             req_pool_indices is not None
         ), "req_pool_indices is full! There is a bug in memory estimation."
 
-        fill_len = self._pre_alloc_fill_len(req)
+        fill_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
         req.kv_allocated_len = fill_len
         req.kv_committed_len = fill_len
 
@@ -1459,22 +1393,44 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 )
 
         if self.scheduler.enable_hisparse:
-            # HiSparse is incompatible with decode-side L1 radix cache. Keep
-            # this path on the upstream full-allocation semantics.
+            # HiSparse direct-to-host is incompatible with decode-side L1 radix
+            # cache, so it allocates from position 0. For hybrid SWA models, keep
+            # the no-HiSparse decode behavior: allocate full logical KV for full
+            # attention layers and only the sliding-window tail for SWA layers.
             assert prefix_len == 0
 
             # Direct-to-host path: only allocate logical indices (no hisparse
             # device indices) and allocate host indices for RDMA destination.
             coordinator = self.scheduler.hisparse_coordinator
             device = self.token_to_kv_pool_allocator.device
-            kv_loc = self.token_to_kv_pool_allocator.alloc_logical_only(
-                prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
-                prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
-                seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
-                seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
-                last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
-                extend_num_tokens=fill_len,
+            prefix_lens_tensor = torch.tensor([0], dtype=torch.int64, device=device)
+            prefix_lens_cpu = torch.tensor([0], dtype=torch.int64)
+            seq_lens_tensor = torch.tensor([fill_len], dtype=torch.int64, device=device)
+            seq_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+            last_loc = torch.tensor([-1], dtype=torch.int64, device=device)
+            swa_tail_len = (
+                self._swa_tail_len(fill_len) if self._uses_swa_tail_prealloc() else None
             )
+            if swa_tail_len is not None:
+                kv_loc = self.token_to_kv_pool_allocator.alloc_extend_swa_tail(
+                    prefix_lens=prefix_lens_tensor,
+                    prefix_lens_cpu=prefix_lens_cpu,
+                    seq_lens=seq_lens_tensor,
+                    seq_lens_cpu=seq_lens_cpu,
+                    last_loc=last_loc,
+                    extend_num_tokens=fill_len,
+                    swa_tail_len=swa_tail_len,
+                )
+                req.swa_evicted_seqlen = fill_len - swa_tail_len
+            else:
+                kv_loc = self.token_to_kv_pool_allocator.alloc_logical_only(
+                    prefix_lens=prefix_lens_tensor,
+                    prefix_lens_cpu=prefix_lens_cpu,
+                    seq_lens=seq_lens_tensor,
+                    seq_lens_cpu=seq_lens_cpu,
+                    last_loc=last_loc,
+                    extend_num_tokens=fill_len,
+                )
 
             # Allocate host indices for the RDMA transfer target.
             host_indices = coordinator.mem_pool_host.alloc_paged_token_slots(
@@ -1662,25 +1618,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self._commit_hicache_local_restore_to_req(decode_req)
 
         # Case 3: Success - commit the transfer
-        # PD true-retraction rebootstrap: the prefill recomputed the prefix KV
-        # under the current weights and sampled a fresh handoff token, but when
-        # there is a remembered boundary token we are *replaying* an
-        # already-emitted token. Override the handoff with it, and skip
-        # re-committing a logprob for it -- it keeps its original behavior
-        # logprob from before the retract (we never re-score generated tokens
-        # under the new policy). A rebootstrap with no boundary token (retracted
-        # before emitting any output) falls through to the normal path so its
-        # first token and logprob are committed as usual.
-        replayed_boundary = (
-            decode_req.is_rebootstrap
-            and decode_req.req.pd_rebootstrap_forced_output_id is not None
-        )
-        if replayed_boundary:
-            committed_output_id = decode_req.req.pd_rebootstrap_forced_output_id
-            decode_req.req.pd_rebootstrap_forced_output_id = None
-        else:
-            committed_output_id = output_id[0].item()
-        decode_req.req.output_ids.append(committed_output_id)
+        decode_req.req.output_ids.append(output_id[0].item())
         decode_req.req.cached_tokens = cached_tokens[0].item()
         # The prefill node already reported its prefix-cache hit in
         # cached_tokens[0]. Seed already_computed with it so that
@@ -1702,7 +1640,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             decode_req.req.output_topk_index = output_topk_index
             decode_req.req.hidden_states_tensor = output_hidden_states
 
-        if decode_req.req.return_logprob and not replayed_boundary:
+        if decode_req.req.return_logprob:
             decode_req.req.logprob.output_token_logprobs_val.append(
                 output_token_logprobs_val[0].item()
             )
@@ -1895,9 +1833,9 @@ class SchedulerDisaggregationDecodeMixin:
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
+            self.process_decode_queue()
             if self._engine_paused:
                 continue
-            self.process_decode_queue()
 
             # Get the next batch to run
             batch = self.get_next_disagg_decode_batch_to_run()
@@ -1927,9 +1865,9 @@ class SchedulerDisaggregationDecodeMixin:
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
             self.process_input_requests(recv_reqs)
+            self.process_decode_queue()
             if self._engine_paused:
                 continue
-            self.process_decode_queue()
 
             self._apply_war_barrier()
 
@@ -2105,7 +2043,26 @@ class SchedulerDisaggregationDecodeMixin:
                 self.disagg_decode_transfer_queue.pop_transferred()
             )  # the requests which kv has arrived
             if self.enable_hisparse:
-                for req in transferred_reqs:
-                    # Direct-to-host: KV data already in host pool, skip staging
-                    self.hisparse_coordinator.admit_request_direct(req)
+                pending_reqs = getattr(self, "_hisparse_pending_admit_reqs", [])
+                admit_candidates = pending_reqs + transferred_reqs
+                admitted_reqs = []
+                deferred_reqs = []
+                for req in admit_candidates:
+                    if not self.hisparse_coordinator.can_allocate_device_buffer(req):
+                        deferred_reqs.append(req)
+                        continue
+                    try:
+                        # Direct-to-host: KV data already in host pool, skip staging.
+                        self.hisparse_coordinator.admit_request_direct(req)
+                    except RuntimeError as e:
+                        logger.warning(
+                            "HiSparse device buffer admission deferred for request %s: %s",
+                            req.rid,
+                            e,
+                        )
+                        deferred_reqs.append(req)
+                        continue
+                    admitted_reqs.append(req)
+                self._hisparse_pending_admit_reqs = deferred_reqs
+                transferred_reqs = admitted_reqs
             self.waiting_queue.extend(transferred_reqs)

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -308,21 +308,34 @@ class HiSparseCoordinator:
                 io_backend="kernel",
             )
 
-    def alloc_device_buffer(self, req: Req) -> None:
+    def device_buffer_alloc_size(self, req: Req) -> int:
         if self.is_dsv4_hisparse:
-            allocated_len = req.extend_range.end
+            return self.padded_buffer_size
+
+        allocated_len = req.kv_allocated_len
+        page_size = self.mem_pool_device.page_size
+        # Allocate only enough for current tokens (page-aligned).
+        # When prefill already fills device_buffer_size, include the reserved page.
+        alloc_size = min(
+            ((allocated_len + page_size - 1) // page_size) * page_size,
+            self.device_buffer_size,
+        )
+        if alloc_size == self.device_buffer_size:
             alloc_size = self.padded_buffer_size
-        else:
-            allocated_len = req.kv_allocated_len
-            page_size = self.mem_pool_device.page_size
-            # Allocate only enough for current tokens (page-aligned).
-            # When prefill already fills device_buffer_size, include the reserved page.
-            alloc_size = min(
-                ((allocated_len + page_size - 1) // page_size) * page_size,
-                self.device_buffer_size,
-            )
-            if alloc_size == self.device_buffer_size:
-                alloc_size = self.padded_buffer_size
+        return alloc_size
+
+    def can_allocate_device_buffer(self, req: Req) -> bool:
+        alloc_size = self.device_buffer_alloc_size(req)
+        return (
+            self.token_to_kv_pool_allocator.hisparse_attn_allocator.available_size()
+            >= alloc_size
+        )
+
+    def alloc_device_buffer(self, req: Req) -> None:
+        allocated_len = (
+            req.extend_range.end if self.is_dsv4_hisparse else req.kv_allocated_len
+        )
+        alloc_size = self.device_buffer_alloc_size(req)
 
         compressed_logical_indices = (
             self.mem_pool_device.translate_loc_from_full_to_compressed(
@@ -750,11 +763,109 @@ class HiSparseCoordinator:
         self._skip_first_backup[req.req_pool_idx] = False
         req.hisparse_staging = False
 
-    def retract_req(self, req: Req) -> None:
+    def _release_req_device_buffer(self, req: Req, allocated_len: int) -> None:
+        req_idx = req.req_pool_idx
+        hisparse_locs = []
+
+        current_cap = int(self.req_device_buffer_size[req_idx])
+        if current_cap > 0:
+            side_buf_hi = self.req_to_device_buffer[req_idx, :current_cap]
+            hisparse_locs.append(side_buf_hi[side_buf_hi > 0])
+
+        if allocated_len > 0:
+            allocated_locs = self.req_to_token_pool.req_to_token[
+                req_idx, :allocated_len
+            ]
+            compressed_locs = (
+                self.mem_pool_device.translate_loc_from_full_to_compressed(
+                    allocated_locs
+                )
+            )
+            mapped_hi = self.mem_pool_device.full_to_hisparse_device_index_mapping[
+                compressed_locs
+            ]
+            hisparse_locs.append(mapped_hi[mapped_hi > 0])
+            self.mem_pool_device.full_to_hisparse_device_index_mapping[
+                compressed_locs
+            ] = 0
+
+        if hisparse_locs:
+            all_hi = torch.unique(torch.cat(hisparse_locs))
+            if all_hi.numel() > 0:
+                self.token_to_kv_pool_allocator.free_hisparse_indices(all_hi)
+
+        self.req_device_buffer_tokens[:, req_idx, :] = -1
+        self.req_device_buffer_token_locs[:, req_idx, :] = -1
+        self.req_to_device_buffer[req_idx, :] = 0
+        self.req_device_buffer_size[req_idx] = 0
+        self.lru_slots[:, req_idx, :].copy_(self._lru_init)
+
+    def offload_retracted_req(self, req: Req):
         if req.hisparse_staging:
             self.abort_staging_request(req)
-        else:
-            self.request_finished(req)
+            return None
+
+        self.wait_for_pending_backup()
+        req_idx = req.req_pool_idx
+        allocated_len = req.kv_allocated_len
+
+        host_len = self.host_token_len(req.seqlen - 1)
+        if host_len > 0:
+            latest_pos = host_len - 1
+            current_cap = int(self.req_device_buffer_size[req_idx])
+            buffer_slot = min(latest_pos, self.device_buffer_size)
+            if (
+                current_cap > buffer_slot
+                and self.req_to_host_pool[req_idx, latest_pos] < 0
+            ):
+                host_locs = self.mem_pool_host.alloc_paged_token_slots(
+                    self.req_to_host_pool,
+                    self.req_to_host_pool_allocated_len,
+                    req_idx,
+                    latest_pos,
+                    1,
+                )
+                device_locs = self.req_to_device_buffer[
+                    req_idx, buffer_slot : buffer_slot + 1
+                ]
+                if torch.all(device_locs > 0):
+                    self.mem_pool_host.backup_from_device_all_layer(
+                        self.mem_pool_device,
+                        host_locs,
+                        device_locs,
+                        io_backend="kernel",
+                    )
+
+        host_allocated_len = int(self.req_to_host_pool_allocated_len[req_idx])
+        host_state = {
+            "host_indices": self.req_to_host_pool[req_idx, :host_allocated_len].clone(),
+            "host_allocated_len": host_allocated_len,
+            "skip_first_backup": self._skip_first_backup[req_idx],
+        }
+
+        self._release_req_device_buffer(req, allocated_len)
+        self.req_to_host_pool[req_idx, :] = -1
+        self.req_to_host_pool_allocated_len[req_idx] = 0
+        self._skip_first_backup[req_idx] = False
+        return host_state
+
+    def restore_retracted_req(self, req: Req, host_state) -> None:
+        if host_state is None:
+            return
+        req_idx = req.req_pool_idx
+        host_allocated_len = int(host_state["host_allocated_len"])
+        self.req_to_host_pool[req_idx, :] = -1
+        if host_allocated_len > 0:
+            self.req_to_host_pool[req_idx, :host_allocated_len] = host_state[
+                "host_indices"
+            ].to(device=self.req_to_host_pool.device)
+        self.req_to_host_pool_allocated_len[req_idx] = host_allocated_len
+        self._skip_first_backup[req_idx] = bool(
+            host_state.get("skip_first_backup", False)
+        )
+
+    def retract_req(self, req: Req) -> None:
+        self.offload_retracted_req(req)
 
     def request_finished(self, req: Req):
         # release resources only after the execution of a potential overlapped batch
@@ -770,21 +881,7 @@ class HiSparseCoordinator:
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv_allocated_len
 
-        # release memory -- only free actually-allocated buffer indices
-        current_cap = int(self.req_device_buffer_size[req.req_pool_idx])
-        if current_cap > 0:
-            side_buf_hi = self.req_to_device_buffer[req.req_pool_idx, :current_cap]
-            all_hi = torch.unique(side_buf_hi[side_buf_hi > 0])
-            if all_hi.numel() > 0:
-                self.token_to_kv_pool_allocator.free_hisparse_indices(all_hi)
-
-        allocated_locs = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :allocated_len
-        ]
-        compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
-            allocated_locs
-        )
-        self.mem_pool_device.full_to_hisparse_device_index_mapping[compressed_locs] = 0
+        self._release_req_device_buffer(req, allocated_len)
 
         host_indices = self.mem_pool_host.allocated_host_indices(
             self.req_to_host_pool,
@@ -795,10 +892,6 @@ class HiSparseCoordinator:
             self.mem_pool_host.free(host_indices)
 
         # clear req info
-        self.req_device_buffer_tokens[:, req.req_pool_idx, :] = -1
-        self.req_device_buffer_token_locs[:, req.req_pool_idx, :] = -1
-        self.req_to_device_buffer[req.req_pool_idx, :] = 0
-        self.req_device_buffer_size[req.req_pool_idx] = 0
         self.req_to_host_pool[req.req_pool_idx, :] = -1
         self.req_to_host_pool_allocated_len[req.req_pool_idx] = 0
         self.lru_slots[:, req.req_pool_idx, :].copy_(self._lru_init)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -66,6 +66,7 @@ from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
     ScheduleBatchDisaggregationDecodeMixin,
 )
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
+from sglang.srt.distributed.parallel_state import get_tensor_model_parallel_rank
 from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
@@ -106,10 +107,9 @@ from sglang.srt.observability.req_time_stats import (
     DPControllerReqTimeStats,
     SchedulerReqTimeStats,
 )
-from sglang.srt.runtime_context import get_parallel, get_server_args
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
-from sglang.srt.server_args import ServerArgs
+from sglang.srt.server_args import ServerArgs, get_global_server_args
 from sglang.srt.utils import flatten_nested_list
 from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
 
@@ -986,10 +986,6 @@ class Req(ReqDllmMixin):
         self.bootstrap_host: str = bootstrap_host
         self.bootstrap_port: Optional[int] = bootstrap_port
         self.bootstrap_room: Optional[int] = bootstrap_room
-        # Decode-local: the already-emitted boundary token to replay when a
-        # retracted request is rebootstrapped. Set in pause_generation(retract)
-        # and consumed in the decode transfer commit; never plumbed to prefill.
-        self.pd_rebootstrap_forced_output_id: Optional[int] = None
         self.skip_radix_cache_insert = bootstrap_host == FAKE_BOOTSTRAP_HOST
         self.disagg_kv_sender: Optional[BaseKVSender] = None
 
@@ -1035,7 +1031,7 @@ class Req(ReqDllmMixin):
         """Check if this request is prefill-only (no token generation needed)."""
         # NOTE: when spec is enabled, prefill_only optimizations are disabled
 
-        spec_alg = get_server_args().speculative_algorithm
+        spec_alg = get_global_server_args().speculative_algorithm
         return self.sampling_params.max_new_tokens == 0 and spec_alg is None
 
     @property
@@ -1056,7 +1052,7 @@ class Req(ReqDllmMixin):
     def _cache_commit_len(self) -> int:
         # Report only the prompt prefix so thinking + answer fall into the
         # overallocated range and are reclaimed by release_kv_cache. #22373.
-        if get_server_args().strip_thinking_cache and self.reasoning_tokens > 0:
+        if get_global_server_args().strip_thinking_cache and self.reasoning_tokens > 0:
             return min(self.kv_committed_len, len(self.origin_input_ids))
         return self.kv_committed_len
 
@@ -1507,54 +1503,6 @@ class Req(ReqDllmMixin):
         )
         del self.kv_cache_cpu
 
-    def build_rebootstrap_payload(self) -> dict:
-        """Build the prefill ``/generate`` payload that asks the original prefill
-        worker to recompute this request's prefix KV under the current weights
-        (PD true-retraction rebootstrap).
-
-        ``input_ids`` are coerced to plain ``int`` so the payload is always
-        JSON-serializable even when ``origin_input_ids``/``output_ids`` hold
-        numpy scalars. The sampling-param allow-list forces ``max_new_tokens=1``
-        and drops stop/grammar/min_new_tokens so the recompute only re-derives
-        the prefix KV and samples a single handoff token. The already-emitted
-        boundary token is replayed on the *decode* side (the transfer commit
-        overrides the sampled handoff with it), so it is intentionally not sent
-        to the prefill here.
-        """
-        # TODO: multi-modal requests are not supported here. The payload only
-        # carries token ``input_ids`` and drops any image/audio/video inputs, so
-        # the rebootstrap recompute would not reproduce the original prefix KV
-        # for multi-modal requests. Add multi-modal support before enabling it.
-        sp = self.sampling_params
-        return {
-            "input_ids": [int(x) for x in self.origin_input_ids]
-            + [int(x) for x in self.output_ids],
-            "sampling_params": {
-                "max_new_tokens": 1,
-                "temperature": sp.temperature,
-                "top_p": sp.top_p,
-                "top_k": sp.top_k,
-                "min_p": sp.min_p,
-                "frequency_penalty": sp.frequency_penalty,
-                "presence_penalty": sp.presence_penalty,
-                "repetition_penalty": sp.repetition_penalty,
-                "ignore_eos": sp.ignore_eos,
-                "skip_special_tokens": sp.skip_special_tokens,
-                "spaces_between_special_tokens": sp.spaces_between_special_tokens,
-                "no_stop_trim": sp.no_stop_trim,
-            },
-            "return_logprob": False,
-            "stream": False,
-            "rid": self.rid,
-            "bootstrap_host": self.bootstrap_host,
-            "bootstrap_port": self.bootstrap_port,
-            "bootstrap_room": self.bootstrap_room,
-            "priority": self.priority,
-            "extra_key": self.extra_key,
-            "routing_key": self.routing_key,
-            "disagg_prefill_dp_rank": self.disagg_prefill_dp_rank,
-        }
-
     def log_time_stats(self):
         # If overlap schedule, we schedule one decode batch ahead so this gets called twice.
         if self.has_log_time_stats:
@@ -1577,7 +1525,7 @@ class Req(ReqDllmMixin):
         self.has_log_time_stats = True
 
     def set_finish_with_abort(self, error_msg: str):
-        if get_parallel().tp_rank == 0:
+        if get_tensor_model_parallel_rank() == 0:
             logger.error(f"{error_msg}, {self.rid=}")
         self.multimodal_inputs = None
         self.grammar = None
@@ -1648,17 +1596,16 @@ def release_req(
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
     tree_cache: BasePrefixCache,
     hisparse_coordinator: Optional[HiSparseCoordinator],
-    offload_kv: bool = True,
 ) -> None:
-    if hisparse_coordinator is not None and not req.finished():
-        hisparse_coordinator.retract_req(req)
-
-    # In decode disaggregation the retracted KV is offloaded to host so it can be
-    # restored later without recompute (see resume_retracted_reqs/load_kv_cache).
-    # Callers that will recompute the KV instead (PD true-retraction rebootstrap)
-    # pass offload_kv=False to skip the wasteful device->host copy.
-    if server_args.disaggregation_mode == "decode" and offload_kv:
+    hisparse_retract_state = None
+    if server_args.disaggregation_mode == "decode":
         req.offload_kv_cache(req_to_token_pool, token_to_kv_pool_allocator)
+        if hisparse_coordinator is not None and not req.finished():
+            hisparse_retract_state = hisparse_coordinator.offload_retracted_req(req)
+            if hisparse_retract_state is not None:
+                req.kv_cache_cpu["_hisparse_retract_state"] = hisparse_retract_state
+    elif hisparse_coordinator is not None and not req.finished():
+        hisparse_coordinator.retract_req(req)
     # TODO (csy): for preempted requests, we may want to insert into the tree
     release_kv_cache(req, tree_cache, is_insert=False)
     # NOTE(lsyin): we should use the newly evictable memory instantly.
@@ -1676,7 +1623,6 @@ def retract_all(
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
     tree_cache: BasePrefixCache,
     hisparse_coordinator: Optional[HiSparseCoordinator],
-    offload_kv: bool = True,
 ) -> List[Req]:
     retracted_reqs = reqs
     for idx in range(len(reqs)):
@@ -1688,7 +1634,6 @@ def retract_all(
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
             tree_cache=tree_cache,
             hisparse_coordinator=hisparse_coordinator,
-            offload_kv=offload_kv,
         )
     return retracted_reqs
 
@@ -1803,9 +1748,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # Read by ForwardBatch ngram embedding init
     ne_token_table: torch.Tensor = None
-    # Mask marking chunked (not-yet-finished) prefill requests whose sampled
-    # pseudo next-token must NOT be written into the ngram token table.
-    ne_skip_token_table_update: torch.Tensor = None
 
     req_pool_indices: torch.Tensor = None  # shape: [b], int64
     seq_lens: torch.Tensor = None  # shape: [b], int64
@@ -2205,7 +2147,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 req.already_computed = seq_len
             req.is_retracted = False
 
-            if get_server_args().enable_mamba_extra_buffer():
+            if get_global_server_args().enable_mamba_extra_buffer():
                 track_entry = self._mamba_radix_cache_v2_req_prepare_for_extend(req)
                 mamba_track_mask_cpu.append(track_entry.track_mask)
                 mamba_track_indices_cpu.append(track_entry.track_index)
@@ -2310,7 +2252,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_logprob_start_lens = extend_logprob_start_lens
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
 
-        if get_server_args().enable_mamba_extra_buffer():
+        if get_global_server_args().enable_mamba_extra_buffer():
             self.mamba_track_indices = torch.tensor(
                 mamba_track_indices_cpu,
                 dtype=torch.int64,
@@ -2344,7 +2286,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self,
         req: Req,
     ) -> _MambaRadixCacheV2TrackEntry:
-        mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
+        mamba_cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
 
         def _force_track_h(i: int) -> int:
             assert i % mamba_cache_chunk_size == 0
@@ -2395,7 +2337,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # In lazy mode, skip the swap — the second ping-pong slot is not
             # allocated yet; it will be allocated on demand at the track boundary
             # in mamba_lazy_prealloc_at_boundary during prepare_for_decode.
-            if not get_server_args().enable_mamba_extra_buffer_lazy():
+            if not get_global_server_args().enable_mamba_extra_buffer_lazy():
                 req.mamba_next_track_idx = (
                     self.req_to_token_pool.get_mamba_ping_pong_other_idx(
                         req.mamba_next_track_idx
@@ -2517,7 +2459,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         evict_from_tree_cache(self.tree_cache, num_tokens)
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens
 
-    def retract_all(self, server_args: ServerArgs, offload_kv: bool = True):
+    def retract_all(self, server_args: ServerArgs):
         retracted_reqs = retract_all(
             reqs=self.reqs,
             server_args=server_args,
@@ -2525,7 +2467,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             tree_cache=self.tree_cache,
             hisparse_coordinator=self.hisparse_coordinator,
-            offload_kv=offload_kv,
         )
         self.reqs = []
         return retracted_reqs
@@ -2736,15 +2677,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 self.req_pool_indices_cpu,
             )
 
-        if get_server_args().enable_mamba_extra_buffer():
-            mamba_track_interval = get_server_args().mamba_track_interval
+        if get_global_server_args().enable_mamba_extra_buffer():
+            mamba_track_interval = get_global_server_args().mamba_track_interval
 
             if len(self.reqs) == 0:
                 self.mamba_track_indices = torch.empty(
                     (0,), dtype=torch.int64, device=self.device
                 )
             else:
-                if get_server_args().enable_mamba_extra_buffer_lazy():
+                if get_global_server_args().enable_mamba_extra_buffer_lazy():
                     self.mamba_lazy_prealloc_at_boundary(mamba_track_interval)
                 set_mamba_track_indices_from_reqs(self)
 
@@ -2932,7 +2873,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def maybe_evict_swa(self):
         if self.tree_cache.supports_swa():
             sliding_window_size = self.tree_cache.sliding_window_size
-            server_args = get_server_args()
+            server_args = get_global_server_args()
 
             release_leaf_lock = (
                 envs.SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW.get()

--- a/python/sglang/srt/managers/scheduler_components/pool_stats_observer.py
+++ b/python/sglang/srt/managers/scheduler_components/pool_stats_observer.py
@@ -283,7 +283,16 @@ class SchedulerPoolStatsObserver:
         )
 
     def _get_swa_token_info(self) -> PoolStats:
-        full_available_size = self.token_to_kv_pool_allocator.full_available_size()
+        if self.enable_hisparse and hasattr(
+            self.token_to_kv_pool_allocator, "logical_attn_allocator"
+        ):
+            logical_allocator = self.token_to_kv_pool_allocator.logical_attn_allocator
+            if hasattr(logical_allocator, "full_available_size"):
+                full_available_size = logical_allocator.full_available_size()
+            else:
+                full_available_size = logical_allocator.available_size()
+        else:
+            full_available_size = self.token_to_kv_pool_allocator.full_available_size()
         full_evictable_size = self.tree_cache.full_evictable_size()
         swa_available_size = self.token_to_kv_pool_allocator.swa_available_size()
         swa_evictable_size = self.tree_cache.swa_evictable_size()

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -85,6 +85,14 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def get_kvcache(self):
         return self._kvcache
 
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        return self.logical_attn_allocator.get_cpu_copy(indices, mamba_indices)
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        return self.logical_attn_allocator.load_cpu_copy(
+            kv_cache_cpu, indices, mamba_indices
+        )
+
     def alloc(self, need_size: int):
         if self.page_size != 1:
             raise NotImplementedError(
@@ -159,9 +167,8 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             extra_indices = self.hisparse_attn_allocator.alloc(
                 need_size - len(hisparse_indices)
             )
-            assert (
-                extra_indices is not None
-            ), "Hisparse allocation failed in alloc_device_buffer"
+            if extra_indices is None:
+                return None
             buffer_indices = torch.cat([hisparse_indices, extra_indices])
         return buffer_indices
 
@@ -356,6 +363,47 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def get_kvcache(self):
         return self._kvcache
 
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        kvcache = self._kvcache
+        c4_indices, _ = kvcache._compressed_indices_from_full(indices, 4)
+        c128_indices, _ = kvcache._compressed_indices_from_full(indices, 128)
+
+        swa_mask = None
+        swa_indices = None
+        full_to_swa_index_mapping = getattr(kvcache, "full_to_swa_index_mapping", None)
+        if full_to_swa_index_mapping is not None:
+            mapped_swa_indices = full_to_swa_index_mapping[indices]
+            swa_mask = mapped_swa_indices > 0
+            if torch.any(swa_mask):
+                swa_indices = mapped_swa_indices[swa_mask]
+                swa_cpu = kvcache.swa_kv_pool.get_cpu_copy(swa_indices)
+                swa_mask = swa_mask.cpu()
+            else:
+                swa_cpu = None
+        else:
+            swa_cpu = None
+
+        return {
+            "swa": swa_cpu,
+            "swa_mask": swa_mask,
+            # HiSparse C4 KV lives in the coordinator-managed host/device pools.
+            # The device pool is only a hot cache and cannot provide a full CPU copy.
+            "c4": None,
+            "c4_indexer": kvcache.c4_indexer_kv_pool.get_cpu_copy(c4_indices),
+            "c128": kvcache.c128_kv_pool.get_cpu_copy(c128_indices),
+            "attention_state": kvcache._get_state_cpu_copy(
+                kvcache.compress_state_pools, swa_indices
+            ),
+            "indexer_state": kvcache._get_state_cpu_copy(
+                kvcache.indexer_compress_state_pools, swa_indices
+            ),
+        }
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        return self.logical_attn_allocator.load_cpu_copy(
+            kv_cache_cpu, indices, mamba_indices
+        )
+
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
         return self.logical_attn_allocator.translate_loc_from_full_to_swa(kv_indices)
 
@@ -400,6 +448,27 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             seq_lens_cpu,
             last_loc,
             extend_num_tokens,
+        )
+
+    def alloc_extend_swa_tail(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        swa_tail_len: int,
+    ):
+        """Allocate logical full/SWA-tail indices without C4 device pages."""
+        return self.logical_attn_allocator.alloc_extend_swa_tail(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+            swa_tail_len=swa_tail_len,
         )
 
     def alloc_device_buffer(self, allocated_indices, need_size: int):
@@ -447,9 +516,8 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             extra_indices = self.hisparse_attn_allocator.alloc(
                 need_size - len(hisparse_indices)
             )
-            assert (
-                extra_indices is not None
-            ), "Hisparse allocation failed in alloc_device_buffer"
+            if extra_indices is None:
+                return None
             buffer_indices = torch.cat([hisparse_indices, extra_indices])
         return buffer_indices
 


### PR DESCRIPTION
We ran the deepseekv4-hisprase on B200 and found numerous bugs, such as abnormal usage of the full token pool, and the lack of preemptive logic in hisparse-c4-pool, among others.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29015684459](https://github.com/sgl-project/sglang/actions/runs/29015684459)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29015684343](https://github.com/sgl-project/sglang/actions/runs/29015684343)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->