### PR TITLE
Fix rel_diff being nan for bitwise-identical tensors

### DIFF
--- a/python/sglang/srt/debug_utils/comparator/tensor_comparator/comparator.py
+++ b/python/sglang/srt/debug_utils/comparator/tensor_comparator/comparator.py
@@ -165,8 +165,10 @@ def compute_diff(
     raw_abs_diff = (x_target - x_baseline).abs()
     max_diff_coord = argmax_coord(raw_abs_diff)
 
-    rel_diff = calc_rel_diff(x_target, x_baseline).item()
     max_abs_diff = raw_abs_diff.max().item()
+    rel_diff = (
+        0.0 if max_abs_diff == 0.0 else calc_rel_diff(x_target, x_baseline).item()
+    )
     mean_abs_diff = raw_abs_diff.mean().item()
 
     include_quantiles: bool = raw_abs_diff.numel() < QUANTILE_NUMEL_THRESHOLD

--- a/test/registered/debug_utils/comparator/tensor_comparator/test_comparator.py
+++ b/test/registered/debug_utils/comparator/tensor_comparator/test_comparator.py
@@ -458,6 +458,20 @@ class TestComputeDiffPredicate:
             is False
         )
 
+    def test_bitwise_predicate(self) -> None:
+        """'rel <= 0' passes only for bitwise-identical tensors."""
+        ident = torch.randn(5, 5)
+        assert (
+            compute_diff(
+                x_baseline=ident, x_target=ident.clone(), predicate="rel <= 0"
+            ).passed
+            is True
+        )
+        x, y = self._near_zero_pair()
+        assert (
+            compute_diff(x_baseline=x, x_target=y, predicate="rel <= 0").passed is False
+        )
+
     def test_predicate_recorded_for_empty_tensor(self) -> None:
         """Empty tensors short-circuit to passed=True and still record the predicate."""
         empty = torch.empty(0)


### PR DESCRIPTION
calc_rel_diff on two bitwise-identical tensors evaluates 0/0 and returns NaN.
Any comparison against NaN is False, so under the predicate DSL a strict
'rel <= 0' criterion (exact-match checking, e.g. deterministic-mode dumps)
spuriously fails precisely on the tensors that match perfectly - including
legitimate all-zero tensors such as grads of starved MoE experts.

A zero max_abs_diff means the tensors are identical, so define their relative
diff as 0.0 instead of computing the 0/0 ratio. Reported rel_diff for identical
tensors changes from NaN to 0.0 accordingly.

Add a regression test: 'rel <= 0' passes for a tensor compared against its
clone and still fails for a sign-flipped near-zero pair.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29017579580](https://github.com/sgl-project/sglang/actions/runs/29017579580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29017579511](https://github.com/sgl-project/sglang/actions/runs/29017579511)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->