### PR TITLE
[CI Hot fix] Fix retired dp_attention CP accessors breaking every scheduler start

### DIFF
--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -66,17 +66,14 @@ def get_glm_dsa_cp_layer_shard_info(
 
     ``(None, 1)`` disables sharding (feature off or only one CP rank).
     """
-    from sglang.srt.layers.dp_attention import (
-        get_attention_cp_rank,
-        get_attention_cp_size,
-    )
+    from sglang.srt.runtime_context import get_parallel
 
     if not is_glm_dsa_cache_layer_split_enabled(model_runner):
         return None, 1
-    shard_size = get_attention_cp_size()
+    shard_size = get_parallel().attn_cp_size
     if shard_size <= 1:
         return None, 1
-    return get_attention_cp_rank(), shard_size
+    return get_parallel().attn_cp_rank, shard_size
 
 
 def get_glm_dsa_layer_split_effective_num_layers(
@@ -88,11 +85,11 @@ def get_glm_dsa_layer_split_effective_num_layers(
     layers, plus one extra layer for the remote scratch buffer used when reading
     a layer owned by another CP rank.
     """
-    from sglang.srt.layers.dp_attention import get_attention_cp_size
+    from sglang.srt.runtime_context import get_parallel
 
     if not is_glm_dsa_cache_layer_split_enabled(model_runner):
         return num_layers
-    shard_size = get_attention_cp_size()
+    shard_size = get_parallel().attn_cp_size
     if shard_size <= 1:
         return num_layers
     owned_layers_upper_bound = (num_layers + shard_size - 1) // shard_size

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -37,7 +37,6 @@ import torch
 
 from sglang.srt.layers.attention.dsa import index_buf_accessor
 from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
-from sglang.srt.layers.dp_attention import get_attention_cp_group
 from sglang.srt.mem_cache.memory_pool import (
     GPU_MEMORY_TYPE_KV_CACHE,
     DSATokenToKVPool,
@@ -46,6 +45,7 @@ from sglang.srt.mem_cache.memory_pool import (
     maybe_detect_oob,
     unwrap_write_loc,
 )
+from sglang.srt.runtime_context import get_parallel
 
 if TYPE_CHECKING:
     from sglang.srt.managers.cache_controller import LayerDoneCounter
@@ -113,7 +113,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
     # ---- broadcast plumbing -----------------------------------------------
 
     def _init_layer_broadcast_comm(self) -> None:
-        cp_group = get_attention_cp_group()
+        cp_group = get_parallel().attn_cp_group
         if cp_group.world_size <= 1 or cp_group.pynccl_comm is None:
             return
 
@@ -143,7 +143,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             if tensor.data_ptr() != src_tensor.data_ptr():
                 tensor.copy_(src_tensor)
 
-        cp_group = get_attention_cp_group()
+        cp_group = get_parallel().attn_cp_group
         comm = (
             self.layer_broadcast_comm
             if use_layer_broadcast_comm and self.layer_broadcast_comm is not None

--- a/test/registered/unit/mem_cache/test_dsa_layer_split_broadcast.py
+++ b/test/registered/unit/mem_cache/test_dsa_layer_split_broadcast.py
@@ -45,10 +45,7 @@ def _run(rank: int, world: int, port: int):
         init_distributed_environment,
         initialize_model_parallel,
     )
-    from sglang.srt.layers.dp_attention import (
-        get_attention_cp_rank,
-        get_attention_cp_size,
-    )
+    from sglang.srt.runtime_context import get_parallel
 
     init_distributed_environment(
         world_size=world,
@@ -66,8 +63,8 @@ def _run(rank: int, world: int, port: int):
         LayerSplitDSATokenToKVPool,
     )
 
-    cp_rank = get_attention_cp_rank()
-    cp_size = get_attention_cp_size()
+    cp_rank = get_parallel().attn_cp_rank
+    cp_size = get_parallel().attn_cp_size
     assert cp_size == world
 
     pool = LayerSplitDSATokenToKVPool(


### PR DESCRIPTION
## Motivation

Main is currently broken: every scheduler start crashes with

```
ImportError: cannot import name 'get_attention_cp_size' from 'sglang.srt.layers.dp_attention'
```

`DefaultPoolConfigurator._compute_cell_size` unconditionally calls `get_glm_dsa_layer_split_effective_num_layers` (added in #29421), which imports `get_attention_cp_size` from `sglang.srt.layers.dp_attention`. #29421 was written against a base where those accessors existed, but the `get_parallel()` refactor (#30492 / #30493) retired them before #29421 merged — a semantic conflict, so the names no longer exist anywhere in the tree. This currently fails `test/registered/unit/model_executor/test_pool_configurator.py` and any CI job that launches a server (see the red scheduled full runs on main).

## Modifications

Switch the three files that still reference the retired accessors to the `get_parallel()` API:

- `sglang/srt/layers/cp/utils.py`: `get_attention_cp_size()` / `get_attention_cp_rank()` → `get_parallel().attn_cp_size` / `.attn_cp_rank`
- `sglang/srt/mem_cache/dsa_cache_layer_split.py`: `get_attention_cp_group()` → `get_parallel().attn_cp_group`
- `test/registered/unit/mem_cache/test_dsa_layer_split_broadcast.py`: same rename in the spawned-rank helper

No behavior change: the `get_parallel()` properties resolve to the same `parallel_state` getters the old wrappers delegated to.

cc @merrymercy @Fridge003

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29020960665](https://github.com/sgl-project/sglang/actions/runs/29020960665)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29020960404](https://github.com/sgl-project/sglang/actions/runs/29020960404)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->