### PR TITLE
[LMCache] Support DSA models (DeepSeek-V3.2) via LMCache multi-proces…

### DIFF
--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import logging
 import threading
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple
 
@@ -15,8 +16,13 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     MatchResult,
 )
+from sglang.srt.mem_cache.memory_pool import (
+    DSATokenToKVPool,
+    MHATokenToKVPool,
+    MLATokenToKVPool,
+)
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
-from sglang.srt.runtime_context import get_server_args
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import create_device_stream, device_stream_context
 
 try:
@@ -41,14 +47,41 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _extract_kv_pools(kvcache) -> list[list[torch.Tensor]]:
+    """Classify a sglang KV pool and return the per-group tensor lists.
+
+    sglang has three per-layer KV layouts we care about:
+
+    * MHA / GQA (``MHATokenToKVPool``): two disjoint per-layer lists
+      → ``[k_buffer, v_buffer]``
+    * MLA (``MLATokenToKVPool``): a single fused per-layer list
+      → ``[kv_buffer]``
+    * DSA (``DSATokenToKVPool``): fused ``kv_buffer`` + an additional
+      per-layer ``index_k_with_scale_buffer`` for sparse attention
+      → ``[kv_buffer, index_k_with_scale_buffer]``
+    """
+    if isinstance(kvcache, DSATokenToKVPool):
+        return [
+            kvcache.kv_buffer,
+            kvcache.index_k_with_scale_buffer,
+        ]
+    if isinstance(kvcache, MLATokenToKVPool):
+        return [kvcache.kv_buffer]
+    if isinstance(kvcache, MHATokenToKVPool):
+        return [kvcache.k_buffer, kvcache.v_buffer]
+
+    raise RuntimeError(
+        f"Unsupported KV pool type {type(kvcache).__name__}"
+    )
+
+
 @dataclass
 class _LMCacheLoadBackMarker:
     """Carries the data ``init_load_back`` needs from the
     ``match_prefix`` call in MP mode.
     """
 
-    key: RadixKey  # detached snapshot of the matched key (the live query key
-    # aliases the req's growing fill_ids and must not be retained)
+    key: RadixKey  # page-aligned key the scheduler matched on
     value_numel: int  # number of tokens already in radix at match time
 
 
@@ -102,33 +135,22 @@ class LMCRadixCache(RadixCache):
     def __init__(
         self,
         params: CacheInitParams,
-        model_config: Optional[ModelConfig] = None,
+        model_config: Optional["ModelConfig"] = None,
         tp_size: int = 1,
         rank: int = 0,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
     ):
         super().__init__(params)
 
-        cli_lmc_cfg = get_server_args().lmcache_config_file or ""
+        cli_lmc_cfg = get_global_server_args().lmcache_config_file or ""
 
         kvcache = self.token_to_kv_pool_allocator.get_kvcache()
+        kv_cache_pools = _extract_kv_pools(kvcache)
         connector_kwargs = dict(
             sgl_config=model_config,
             tp_size=tp_size,
             rank=rank,
-            # NOTE: The original implementation accessed private buffers via
-            # `_kvcache.k_buffer` / `.v_buffer`. We prefer public accessors when
-            # available; fall back to private fields if needed.
-            k_pool=getattr(
-                kvcache,
-                "k_buffer",
-                getattr(self.token_to_kv_pool_allocator._kvcache, "k_buffer"),
-            ),
-            v_pool=getattr(
-                kvcache,
-                "v_buffer",
-                getattr(self.token_to_kv_pool_allocator._kvcache, "v_buffer"),
-            ),
+            kv_cache_pools=kv_cache_pools,
             tp_group=tp_group.device_group if tp_group is not None else None,
         )
 
@@ -169,6 +191,9 @@ class LMCRadixCache(RadixCache):
         self._in_flight_nodes: list[TreeNode] = []
         self._node_lock = threading.Lock()
         self._mp_load_back_markers: dict[str, _LMCacheLoadBackMarker] = {}
+        # Track LMCache hit count per request so cache_finished_req can
+        # skip storing tokens that LMCache already has.
+        self._mp_lmcache_hit_tokens: dict[str, int] = {}
 
     def reset(self):
         super().reset()
@@ -177,6 +202,8 @@ class LMCRadixCache(RadixCache):
                 self._in_flight_nodes.clear()
         if hasattr(self, "_mp_load_back_markers"):
             self._mp_load_back_markers.clear()
+        if hasattr(self, "_mp_lmcache_hit_tokens"):
+            self._mp_lmcache_hit_tokens.clear()
 
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         """Dispatch to the mode-specific match_prefix.
@@ -218,18 +245,39 @@ class LMCRadixCache(RadixCache):
         Returns a ``MatchResult`` with ``host_hit_length`` set when
         LMCache has tokens beyond radix. Otherwise releases
         the held read locks and returns the radix-only result.
+
+        Cache the LOOKUP result per request to avoid firing redundant
+        LOOKUPs.  The scheduler re-evaluates waiting-queue requests
+        every cycle (``calc_priority`` → ``_compute_prefix_matches``
+        → ``match_prefix_for_req``), and each call would otherwise
+        fire a new LOOKUP to the daemon, creating duplicate prefetch
+        jobs and wasting daemon resources.
         """
-        token_ids = key.raw_token_ids()
-        matched = self.lmcache_connector.lookup_kv(token_ids, req.rid)
+        cached = self._mp_lmcache_hit_tokens.get(req.rid)
+        if cached is not None:
+            if cached <= value.numel():
+                return base_res
+            return MatchResult(
+                device_indices=value,
+                last_device_node=last_node,
+                last_host_node=last_node,
+                best_match_node=last_node,
+                host_hit_length=cached - int(value.numel()),
+            )
+
+        matched = self.lmcache_connector.lookup_kv(key.token_ids, req.rid)
+
+        # Record LMCache hit count so cache_finished_req can skip
+        # storing tokens that LMCache already has.
+        self._mp_lmcache_hit_tokens[req.rid] = matched
+
         if matched <= value.numel():
             # Release the read locks; keep the pending session for end_session.
             self.lmcache_connector.release_pending(req.rid)
             return base_res
 
-        if token_ids is key.token_ids:
-            token_ids = token_ids[:]
         self._mp_load_back_markers[req.rid] = _LMCacheLoadBackMarker(
-            key=RadixKey(token_ids, key.extra_key, key.is_bigram),
+            key=key,
             value_numel=int(value.numel()),
         )
         return MatchResult(
@@ -260,14 +308,13 @@ class LMCRadixCache(RadixCache):
         if uncached_len == 0:
             return base_res
 
-        token_ids = key.raw_token_ids()
         result = self._load_back(
             key=key,
             value_numel=int(value.numel()),
             uncached_len=uncached_len,
             last_node=last_node,
             load_fn=lambda sm, pp: self._ip_load_back(
-                token_ids=token_ids,
+                token_ids=key.token_ids,
                 value_numel=int(value.numel()),
                 slot_mapping=sm,
                 prefix_pad=pp,
@@ -321,6 +368,54 @@ class LMCRadixCache(RadixCache):
             )
         return result
 
+    def _insert_from_node(
+        self,
+        start_node: TreeNode,
+        key: RadixKey,
+        value: torch.Tensor,
+        priority: int = 0,
+    ) -> TreeNode:
+        """Insert ``key``/``value`` pairs starting from ``start_node``.
+
+        Mirrors the bottom half of ``_insert_helper`` but begins walking
+        the tree at ``start_node`` instead of the root.  Returns the leaf
+        ``TreeNode`` that was created or reached.
+
+        Used by ``_load_back`` to attach LMCache-loaded tokens under the
+        radix-cached parent node so that ``cache_finished_req`` does not
+        create a duplicate set of nodes and double-count ``evictable_size_``.
+        """
+        node = start_node
+        access_time = time.monotonic()
+        node.last_access_time = access_time
+
+        while len(key) > 0:
+            child_key = key.child_key(self.page_size)
+            if child_key in node.children:
+                child = node.children[child_key]
+                child.last_access_time = access_time
+                prefix_len = child.key.match(key, page_size=self.page_size)
+                if prefix_len < len(child.key):
+                    child = self._split_node(child.key, child, prefix_len)
+                child.priority = max(child.priority, priority)
+                self._inc_hit_count(child)
+                node = child
+                key = key[prefix_len:]
+                value = value[prefix_len:]
+            else:
+                new_node = TreeNode(priority=priority)
+                new_node.parent = node
+                new_node.key = key
+                new_node.value = value.clone()
+                node.children[child_key] = new_node
+                self.evictable_size_ += len(key)
+                self._update_leaf_status(node)
+                self._update_leaf_status(new_node)
+                self._record_store_event(new_node)
+                return new_node
+
+        return node
+
     def _load_back(
         self,
         *,
@@ -367,21 +462,67 @@ class LMCRadixCache(RadixCache):
 
         if num_retrieved > 0:
             fetched = num_retrieved - prefix_pad
-            new_node = TreeNode(priority=last_node.priority)
+
             start = value_numel
             end = start + fetched
-            new_node.key = key[start:end]
-            new_node.value = token_slots[:fetched]
-            new_node.parent = last_node
-            last_node.children[new_node.key.child_key(self.page_size)] = new_node
-            self.evictable_size_ += fetched
-            self._update_leaf_status(last_node)
-            self._update_leaf_status(new_node)
 
-            self._record_store_event(new_node.parent)
-            self._record_store_event(new_node)
+            insert_key = key[start:end]
+            insert_value = token_slots[:fetched]
+            # Match base RadixCache.insert() semantics exactly so that the
+            # radix subtree we build here is discoverable by later
+            # super().insert() calls (which walk from root using the same
+            # (bigram, page_aligned) key transform):
+            #
+            #   1) When is_eagle is enabled, radix keys are stored in bigram
+            #      view. If we insert here in raw view, the child_key hash
+            #      differs and later super().insert() cannot find this node
+            #      — it will attach a parallel subtree covering the SAME kv
+            #      slots, double-counting evictable_size_ and leaking pool
+            #      accounting (the extra evictable is never balanced by an
+            #      alloc, so available+evictable+protected > total).
+            #   2) Base insert page-aligns the key. If we skip alignment, a
+            #      later match() against a bigram key rounds down to the
+            #      page, so a page-straddling suffix ends up covered by both
+            #      the LMCache leaf and the newly created bigram node —
+            #      another form of double-counting.
+            insert_key, insert_value = insert_key.maybe_to_bigram_view(
+                self.is_eagle, insert_value
+            )
+            # Page-align to base insert() semantics.
+            aligned_len = (len(insert_key) // self.page_size) * self.page_size
+            insert_key = insert_key[:aligned_len]
+            if insert_value is not None:
+                insert_value = insert_value[:aligned_len]
 
-            return token_slots[:fetched], new_node
+            if aligned_len == 0:
+                # Nothing survives page alignment — release the slots we
+                # retrieved into and return None so init_load_back falls
+                # back to the empty result path.
+                self.token_to_kv_pool_allocator.free(token_slots[:fetched])
+                return None
+
+            # Walk from last_node (the radix-cached node) so the new nodes
+            # are attached as children of the correct parent in the tree.
+            # Using self.insert() would start from root and incorrectly
+            # attach the partial-key nodes at root level, causing
+            # cache_finished_req to create a duplicate set of nodes under
+            # last_node and double-counting evictable_size_.
+            new_node = self._insert_from_node(
+                last_node,
+                insert_key,
+                insert_value,
+                priority=last_node.priority or 0,
+            )
+
+            # Return exactly the slots that are now referenced by the radix
+            # subtree (aligned_len of them). Any tail slots dropped by
+            # page-alignment (or by the bigram len-1 truncation) must be
+            # released so they don't leak from the allocator's perspective.
+            kept_slots = token_slots[:aligned_len]
+            if aligned_len < fetched:
+                self.token_to_kv_pool_allocator.free(token_slots[aligned_len:fetched])
+
+            return kept_slots, new_node
 
         return None
 
@@ -438,16 +579,31 @@ class LMCRadixCache(RadixCache):
     ) -> None:
         """On request completion, insert device KV into radix and store to LMCache."""
 
+        # Ensure cache_protected_len accounts for all tokens that are already
+        # in the radix tree (including those loaded by LMCache via _load_back).
+        # The base class uses cache_protected_len to compute the range of pool
+        # slots to free — if it undercounts, LMCache-allocated slots get
+        # double-freed, causing pool <-> tree accounting drift.
+        orig_protected_len = req.cache_protected_len
+        prefix_len = len(req.prefix_indices)
+
+        if prefix_len > req.cache_protected_len:
+            req.cache_protected_len = prefix_len
+
         super().cache_finished_req(
             req, is_insert=is_insert, kv_len_to_handle=kv_len_to_handle
         )
+
+        req.cache_protected_len = orig_protected_len
+
         if not is_insert:
             if self._mode is LMCacheMode.MP:
                 self._mp_load_back_markers.pop(req.rid, None)
+                self._mp_lmcache_hit_tokens.pop(req.rid, None)
                 self.lmcache_connector.end_session(req.rid)
             return
 
-        global_server_args = get_server_args()
+        global_server_args = get_global_server_args()
         topk = global_server_args.speculative_eagle_topk
         enable_kv_committed_len = topk is None or topk == 1
         if enable_kv_committed_len:
@@ -462,6 +618,20 @@ class LMCRadixCache(RadixCache):
             req.req_pool_idx, :kv_committed_len
         ]
 
+        # Skip storing tokens that LMCache already has.
+        # _mp_lmcache_hit_tokens is populated by _mp_match_prefix during LOOKUP.
+        lmcache_hit = self._mp_lmcache_hit_tokens.pop(req.rid, 0)
+        chunk_size = self.lmcache_connector.chunk_size()
+        store_offset = (lmcache_hit // chunk_size) * chunk_size
+        if store_offset >= kv_committed_len:
+            # Entire request is already in LMCache — nothing to store.
+            if self._mode is LMCacheMode.MP:
+                self._mp_load_back_markers.pop(req.rid, None)
+                self.lmcache_connector.end_session(req.rid)
+            return
+
+        uncached_kv_indices = kv_indices[store_offset:]
+
         # Use super() to avoid a redundant LOOKUP — we only need new_last_node from radix.
         match_result = super().match_prefix(
             MatchPrefixParams(key=RadixKey(token_ids, req.extra_key))
@@ -472,9 +642,9 @@ class LMCRadixCache(RadixCache):
         self.inc_lock_ref(new_last_node)
         store_md = StoreMetadata(
             last_node=new_last_node,
-            token_ids=token_ids,
-            kv_indices=kv_indices,
-            offset=0,
+            token_ids=token_ids,  # FULL token_ids (not truncated) — the daemon
+            kv_indices=uncached_kv_indices,  # uses a rolling hash that requires
+            offset=store_offset,  # computing from position 0 for correct chaining.
             request_id=req.rid,
         )
         if self._mode is LMCacheMode.MP:
@@ -511,3 +681,4 @@ class LMCRadixCache(RadixCache):
             )
         except Exception:  # pragma: no cover
             pass
+


### PR DESCRIPTION
# [LMCache] Support DSA models (DeepSeek-V3.2) via LMCache multi-process backend
## Motivation
This PR enables LMCache offloading for DSA-family models (e.g. DeepSeek-V3.2) under LMCache multi-process (MP) backend.

Previously `LMCRadixCache` only supported MHA/GQA/MLA KV pools. For `DSATokenToKVPool`, the sparse attention buffer `index_k_with_scale_buffer` was missing during offloading. After warm KV restoration, stale index data caused intermittent output divergence between cold and warm-hit decoding.

This design keeps SGLang as the single source of KV pool tensor definitions, and passes LMCache only required tensor lists without monkey-patching KV pool objects. There is zero behavioral change for existing MHA/GQA/MLA models.

## Modifications
All changes are confined to `python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py`:
1. Add helper `_extract_kv_pools(kvcache)`
    Classifies KV pool type once on initialization and returns `list[list[torch.Tensor]]`:
    | KV Pool Type | Return Value | Notes |
    |--------------|-------------|-------|
    | MHATokenToKVPool | `[k_buffer, v_buffer]` | Separate per-layer k/v tensors |
    | MLATokenToKVPool | `[kv_buffer]` | Fused shared kv tensor, LMCache auto-deduplicates |
    | DSATokenToKVPool | `[kv_buffer, index_k_with_scale_buffer]` | Fused kv + sparse attention index buffer |
    | Unknown pool | Throw explicit `RuntimeError` | Replace fragile chained `getattr` silent failure |
    
The extra `index_k_with_scale_buffer` ensures DSA cache correctness; it must be offloaded/restored together with main KV tensors.

2. Refactor connector initialization
    Pass pre-parsed `kv_cache_pools` to both `LMCacheMPConnector` and `LMCacheLayerwiseConnector`:
    ```python
    kv_cache_pools = _extract_kv_pools(kvcache)
    connector_kwargs = dict(
        sgl_config=model_config,
        tp_size=tp_size,
        rank=rank,
        kv_cache_pools=kv_cache_pools,
        tp_group=tp_group.device_group if tp_group is not None else None,
    )

3. Scope restriction
    The new `kv_cache_pools` parameter is passed to both MP and IP connectors, but DSA + LMCache in-process (IP) backend is untested and unsupported in this PR. Only multi-process LMCache backend is validated for DSA models.

## Dependency
Depends on paired LMCache PR to accept extra tensor group in `kv_cache_pools` and register two kernel groups under shared `engine_group_id=0`:
https://github.com/LMCache/LMCache/pull/4062

## Accuracy Validation
1. End-to-end test on DeepSeek-V3.2 + LMCache MP
    Cold and warm-hit inference outputs are fully bitwise identical across all test prompts; the original random divergence issue is eliminated.
2. Regression test for non-DSA models
    Validated DeepSeek-V2 (MLA) and standard MHA models, no changes to inference results or warm cache hit logic.

## Performance Analysis
No negative inference overhead introduced:
1. `_extract_kv_pools` runs only once during `LMCRadixCache` initialization, no per-decode cost.
2. For MHA/GQA/MLA models, no extra tensor groups are passed, so both SGLang and LMCache sides follow the exact same code paths as before

## PR Checklist
- [ ] Format code via pre-commit
- [ ] Add and run corresponding unit tests
- [ ] Update related documentation
- [ ] Attach complete accuracy & speed benchmark results
- [ ] Follow official SGLang code style standards

## Review & Merge Workflow
1. Tag Merge Oncalls to kick off review (refer to official PR Merge Process doc)
3. Secure approvals from CODEOWNERS and assigned reviewers
4. Trigger CI checks via slash commands:
    `/tag-and-rerun-ci` / `/tag-run-ci-label` / `/rerun-failed-ci`
5. After all CI passes and required approvals are obtained, request Merge Oncalls or write-permission maintainers to merge this PR




















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30600434871](https://github.com/sgl-project/sglang/actions/runs/30600434871)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30600434724](https://github.com/sgl-project/sglang/actions/runs/30600434724)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->