### PR TITLE
Fix DFlash mamba verify init ordering

### DIFF
--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -118,12 +118,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.nccl_port = nccl_port
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
-        self._need_mamba_verify_commit = (
-            self.model_runner.mambaish_config is not None
-            and hasattr(
-                self.model_runner.attn_backend, "update_mamba_state_after_mtp_verify"
-            )
-        )
+        self._need_mamba_verify_commit = False
         self.page_size = server_args.page_size
         # Normalized in arg_groups.speculative_hook.handle_speculative_decoding.
         self.draft_window_size: Optional[int] = (
@@ -286,6 +281,13 @@ class DFlashWorkerV2(BaseSpecWorker):
 
     def init_attention_backends(self):
         self._draft_worker.init_attention_backends()
+        self._need_mamba_verify_commit = (
+            self.model_runner.mambaish_config is not None
+            and hasattr(
+                self.model_runner.attn_backend,
+                "update_mamba_state_after_mtp_verify",
+            )
+        )
 
     def init_cuda_graphs(self):
         capture_decode_cuda_graph = (


### PR DESCRIPTION
## Summary

Fixes a DFlash startup crash introduced in #29218. The new code checked the target `ModelRunner.attn_backend` inside `DFlashWorkerV2.__init__`, but the backend is not ready yet at that point. Before this, the server could fail during scheduler startup with:

```text
AttributeError: 'ModelRunner' object has no attribute 'attn_backend'
```

After moving the mamba verify-commit check until after attention backend init, the DFlash worker no longer reads the target backend too early.

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29057403869](https://github.com/sgl-project/sglang/actions/runs/29057403869)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29057403746](https://github.com/sgl-project/sglang/actions/runs/29057403746)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->