### PR TITLE
[Fix] Exclude GDN in_proj_ba (a/b gate) from on-the-fly FP8 quantization

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -217,7 +217,12 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         self.in_proj_ba = self.create_ba_proj(
             hidden_size=self.hidden_size,
             num_v_heads=self.num_v_heads,
-            quant_config=quant_config,
+            # GDN a/b gate: drives recurrent-state decay, numerically
+            # sensitive. Official static-FP8 checkpoints (quantization_config
+            # ignore list) always exclude in_proj_a/in_proj_b/in_proj_ba from
+            # quantization; mirror that for on-the-fly quant too (conv1d
+            # above already gets the same treatment).
+            quant_config=None,
             prefix=add_prefix("in_proj_ba", prefix),
             tp_rank=self.attn_tp_rank,
             tp_size=self.attn_tp_size,


### PR DESCRIPTION
### Motivation

Fixes #30598.

On-the-fly (`--quantization fp8`) quantization on a bf16 Qwen3.5/Qwen3.6 checkpoint FP8-quantizes
the GatedDeltaNet `in_proj_ba` projection (the fused `a`/`b` gate that drives the recurrent
state-decay), even though the model's own officially-released static-FP8 checkpoints explicitly
**exclude** `conv1d`/`in_proj_a`/`in_proj_b`/`in_proj_ba` from quantization via their
`quantization_config.ignore` list (see #30598 for the full evidence chain, including a runtime
repro showing `Fp8Config(is_checkpoint_fp8_serialized=False).ignored_layers == []` and
`is_layer_skipped(...in_proj_ba...) == False` for the on-the-fly path).

`conv1d` already gets a hardcoded `quant_config=None` in `Qwen3_5GatedDeltaNet.__init__` — this PR
gives `in_proj_ba` the same treatment, so the on-the-fly quantization path stays consistent with
the officially-blessed static-quant recipe regardless of whether the checkpoint carries an
explicit `ignore` list.

### Modifications

- `python/sglang/srt/models/qwen3_5.py`: `in_proj_ba` construction now passes `quant_config=None`
  instead of forwarding the model's `quant_config`, mirroring the existing `conv1d` exclusion.

`in_proj_qkvz` (q/k/v/z) and `out_proj` are left untouched — those are *not* in the official
ignore list and are expected to be quantized.

### Checklist

- [x] Format your code according to the [Code Formatting Guide](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-and-formatting).
- [x] Add unit tests as outlined in the [Running Unit Tests Guide](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci) — n/a, single-line config change verified by manual repro (see below); happy to add a regression test if maintainers point me at the right harness/CI fixture for this model.
- [x] Update documentation as needed, including docstrings or example tutorials.

### Verification

Live-tested on an H200: bf16 checkpoint served two ways —

1. **Baseline (unpatched)**: `Fp8Config(is_checkpoint_fp8_serialized=False)` → `ignored_layers=[]`
   → `is_layer_skipped("...in_proj_ba", ...) == False` → `in_proj_ba` gets FP8-quantized.
2. **Patched**: server loads and serves correctly (`--quantization fp8` + this patch), sample
   generation unaffected (e.g. `17*23=391` greedy-decoded correctly), confirming the change is a
   safe no-op change for correctness/stability — `in_proj_ba` now takes the `UnquantizedLinearMethod`
   path (per `linear.py`'s `if quant_config is None: ...` short-circuit) exactly like `conv1d`.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29038679922](https://github.com/sgl-project/sglang/actions/runs/29038679922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29038679883](https://github.com/sgl-project/sglang/actions/runs/29038679883)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->