### PR TITLE
Fix MoE functionality on RDNA (gfx1100/gfx1201) via Python-level fallback dispatch

### DIFF
--- a/python/sglang/jit_kernel/csrc/moe/moe_align_kernel.cu
+++ b/python/sglang/jit_kernel/csrc/moe/moe_align_kernel.cu
@@ -43,7 +43,19 @@ inline uint32_t next_pow2(uint32_t x) noexcept {
 
 namespace moe {
 
-__device__ __forceinline__ int warp_exclusive_scan(int v, uint64_t mask = 0xffffffffffffffffull) {
+#ifdef USE_ROCM
+// ROCm's templated __shfl_*_sync builtins require an 8-byte mask
+// (static_assert(sizeof(MaskT) == 8)) because AMD wavefront width varies by
+// arch (32 on RDNA, 64 on CDNA).
+using warp_mask_t = uint64_t;
+#define WARP_FULL_MASK 0xffffffffffffffffull
+#else
+// CUDA: 32-lane warps take a plain 32-bit mask
+using warp_mask_t = unsigned;
+#define WARP_FULL_MASK 0xffffffffu
+#endif
+
+__device__ __forceinline__ int warp_exclusive_scan(int v, warp_mask_t mask = WARP_FULL_MASK) {
   int original = v;
 #pragma unroll
   for (int offset = 1; offset < WARP_SIZE; offset <<= 1) {

--- a/python/sglang/jit_kernel/csrc/moe/moe_align_kernel.cu
+++ b/python/sglang/jit_kernel/csrc/moe/moe_align_kernel.cu
@@ -43,7 +43,7 @@ inline uint32_t next_pow2(uint32_t x) noexcept {
 
 namespace moe {
 
-__device__ __forceinline__ int warp_exclusive_scan(int v, unsigned mask = 0xffffffffu) {
+__device__ __forceinline__ int warp_exclusive_scan(int v, uint64_t mask = 0xffffffffffffffffull) {
   int original = v;
 #pragma unroll
   for (int offset = 1; offset < WARP_SIZE; offset <<= 1) {

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
@@ -82,13 +82,13 @@ def moe_align_block_size(
     # RDNA (gfx11xx/gfx12xx) always uses the JIT kernel: it hardcodes WARP_SIZE=32
     # for both host and device compile passes, avoiding the host/device WARP_SIZE
     # split that the sgl-kernel C++ moe_align_kernel.cu has on RDNA fat builds.
-    use_jit_align = _is_rdna
+    use_jit_align = False
     if _SGLANG_EXPERIMENTAL_LORA_OPTI:
         from sglang.srt.lora.trtllm_lora_temp.environ import lora_envs
 
-        use_jit_align = (
-            use_jit_align or lora_envs.SGLANG_OPT_USE_JIT_KERNEL_MOE_ALIGN.get()
-        )
+        use_jit_align = lora_envs.SGLANG_OPT_USE_JIT_KERNEL_MOE_ALIGN.get()
+    if _is_rdna:
+        use_jit_align = True
     if use_jit_align:
         from sglang.jit_kernel.moe_align import (
             moe_align_block_size as jit_moe_align_block_size,

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
@@ -6,7 +6,7 @@ import torch
 import triton
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import is_cuda, is_hip, is_musa, is_xpu
+from sglang.srt.utils import is_cuda, is_hip, is_musa, is_rdna_supported, is_xpu
 
 _SGLANG_EXPERIMENTAL_LORA_OPTI = envs.SGLANG_EXPERIMENTAL_LORA_OPTI.get()
 
@@ -14,6 +14,7 @@ _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
 _is_musa = is_musa()
+_is_rdna = _is_hip and is_rdna_supported()
 
 if _is_cuda or _is_hip or _is_xpu or _is_musa:
     from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
@@ -78,11 +79,16 @@ def moe_align_block_size(
     )
 
     # ===== TO BE REFACTORED ====
-    use_jit_align = False
+    # RDNA (gfx11xx/gfx12xx) always uses the JIT kernel: it hardcodes WARP_SIZE=32
+    # for both host and device compile passes, avoiding the host/device WARP_SIZE
+    # split that the sgl-kernel C++ moe_align_kernel.cu has on RDNA fat builds.
+    use_jit_align = _is_rdna
     if _SGLANG_EXPERIMENTAL_LORA_OPTI:
         from sglang.srt.lora.trtllm_lora_temp.environ import lora_envs
 
-        use_jit_align = lora_envs.SGLANG_OPT_USE_JIT_KERNEL_MOE_ALIGN.get()
+        use_jit_align = (
+            use_jit_align or lora_envs.SGLANG_OPT_USE_JIT_KERNEL_MOE_ALIGN.get()
+        )
     if use_jit_align:
         from sglang.jit_kernel.moe_align import (
             moe_align_block_size as jit_moe_align_block_size,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -109,6 +109,7 @@ from sglang.srt.utils import (
     is_hip,
     is_musa,
     is_npu,
+    is_rdna_supported,
     is_xpu,
 )
 from sglang.srt.utils.patch_torch import register_fake_if_exists
@@ -129,6 +130,7 @@ _is_npu = is_npu()
 _is_xpu = is_xpu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_musa = is_musa()
+_is_rdna = _is_hip and is_rdna_supported()
 
 if _is_cuda:
     from sgl_kernel import moe_fused_gate
@@ -500,7 +502,10 @@ class TopK(MultiPlatformOp):
                 expert_location_dispatch_info=expert_location_dispatch_info,
             )
         else:
-            self.topk_config.torch_native = False
+            # WARP_SIZE in the sgl-kernel topk_softmax/topk_sigmoid kernels resolves
+            # differently for host vs. device compile passes on RDNA (wave32) fat
+            # builds, so route RDNA through the pure-PyTorch fallback instead.
+            self.topk_config.torch_native = _is_rdna
             with use_symmetric_memory(
                 get_tp_group(), disabled=not is_allocation_symmetric()
             ):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3654,6 +3654,18 @@ def is_gfx942_supported():
         return False
 
 
+@lru_cache(maxsize=1)
+def is_rdna_supported():
+    """
+    Returns whether the current platform is AMD RDNA (gfx11xx / gfx12xx — Radeon consumer/workstation GPUs).
+    """
+    if torch.version.hip:
+        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        return any(gfx in gcn_arch for gfx in ["gfx11", "gfx12"])
+    else:
+        return False
+
+
 def get_hip_version():
     if torch.version.hip:
         return tuple(map(int, torch.version.hip.split("-")[0].split(".")))


### PR DESCRIPTION
## Problem

sgl-kernel's `WARP_SIZE` macro (in `sgl-kernel/include/utils.h`) is defined as:

\`\`\`cpp
#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
  WARP_SIZE = 64
#else
  WARP_SIZE = 32
#endif
\`\`\`

In a fat multi-arch build that targets both CDNA (wave64) and RDNA (wave32),
the host compile pass has `__HIP_DEVICE_COMPILE__` undefined, so `WARP_SIZE`
always resolves to 64 on the host regardless of target arch - while the RDNA
device pass resolves it to 32. This mismatch breaks host-computed
launch-parameters (grid/block sizing) for the MoE gating (`topk_softmax`/
`topk_sigmoid`) and token-alignment (`moe_align_block_size`) C++ kernels when
running on RDNA (gfx1100/gfx1201).

## Fix
Proper fix in sgl-kernel would require bigger refactoring, this does **not** touch the sgl-kernel C++ build or the
`WARP_SIZE` macro (which correctly serves CDNA). Instead, this adds a
Python-level dispatch gate so RDNA routes around the affected C++ kernels
entirely and falls back to other options:

- `is_rdna_supported()` (new, in `common.py`): runtime check for gfx11xx/gfx12xx.
- `topk.py`: on RDNA, force `topk_config.torch_native = True` so
  `select_experts()` uses the pure-PyTorch `fused_topk_native()` path instead
  of the C++ `topk_softmax`/`topk_sigmoid` ops. (Grouped-topk/DeepSeek-style
  gating was already pure PyTorch on HIP and needed no change.)
- `moe_align_block_size.py`: on RDNA, always use the existing JIT-compiled
  fallback kernel instead of the sgl-kernel C++ version. The JIT kernel is
  compiled per-target at runtime (not as part of a fat multi-arch binary) and
  already hardcodes `WARP_SIZE=32` unconditionally, so it has no host/device
  split problem.

## Possible future fix

Forcing RDNA onto the JIT `moe_align_kernel.cu` path exposed a second,
previously-latent bug: `warp_exclusive_scan()` passed a 32-bit `unsigned`
mask to `__shfl_up_sync`. ROCm's templated warp-sync builtins
(`amd_warp_sync_functions.h`) require an 8-byte mask type
(`static_assert(sizeof(MaskT) == 8)`) because AMD wavefront width varies by
architecture (32 on RDNA, 64 on CDNA), unlike CUDA's fixed 32-lane warps
which take a plain 32-bit mask. Fixed by widening the parameter to
`uint64_t`. All call sites use the default argument, so this is a
self-contained, backward-compatible change.

## Scope / safety

- CUDA: `is_rdna_supported()` returns `False` (checks `torch.version.hip`
  first) - no behavior change, existing code paths unaffected.
- RDNA: routes to the already-existing pure-PyTorch / JIT fallback paths.
- The mask-type widening is safe on both CUDA and ROCm - the default value
  is unchanged semantically (all bits set), just represented as 64 bits
  instead of 32.
























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29234821999](https://github.com/sgl-project/sglang/actions/runs/29234821999)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29234821893](https://github.com/sgl-project/sglang/actions/runs/29234821893)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->