### PR TITLE
fix: write_through_selective double-counts hits from same request lif…

### DIFF
--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -67,6 +67,7 @@ class InsertParams:
     # General
     chunked: bool = False
     priority: int = 0
+    is_finished: bool = False
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1632,6 +1632,7 @@ class HiRadixCache(RadixCache):
         value = params.value
         chunked = params.chunked
         priority = params.priority
+        is_finished = params.is_finished
 
         if priority is None:
             priority = 0
@@ -1665,7 +1666,8 @@ class HiRadixCache(RadixCache):
                     # update parent status as a new leaf is added into device
                     self._update_leaf_status(node.parent)
                 else:
-                    self._inc_hit_count(node, chunked)
+                    if not is_finished:
+                        self._inc_hit_count(node, chunked)
                     total_prefix_length += prefix_len
             else:
                 # partial match, split the node
@@ -1680,7 +1682,8 @@ class HiRadixCache(RadixCache):
                     # update parent status as a new leaf is added into device
                     self._update_leaf_status(new_node.parent)
                 else:
-                    self._inc_hit_count(new_node, chunked)
+                    if not is_finished:
+                        self._inc_hit_count(new_node, chunked)
                     total_prefix_length += prefix_len
                 node = new_node
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -464,7 +464,12 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         if is_insert:
             priority = getattr(req, "priority", 0) or 0
             result = self.insert(
-                InsertParams(key=radix_key, value=values, priority=priority)
+                InsertParams(
+                    key=radix_key,
+                    value=values,
+                    priority=priority,
+                    is_finished=True,
+                )
             )
             # Free the duplicates that were already in the tree
             self.token_to_kv_pool_allocator.free(


### PR DESCRIPTION
…ecycle

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
write_through_selective (threshold 2) was intended to only back up prefixes shared across multiple requests. However, a single request's lifecycle produces two hit-count increments on the same prefix node:

1. cache_unfinished_req -> _inc_hit_count (0->1)
2. cache_finished_req -> _inc_hit_count (1->2)

This causes the threshold to be reached within one request, so every prefill prefix gets backed up.
 
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Skip _inc_hit_count when the insert comes from cache_finished_req (i.e., is_finished=True). This ensures hit_count only reflects cross-request sharing, preserving the selective policy's intended behavior.

Changes
- base_prefix_cache.py: Add `is_finished: bool = False` field to `InsertParams`
- radix_cache.py: Pass `is_finished=True` in cache_finished_req insert
- hiradix_cache.py:  Guard the two existing-node `_inc_hit_count` call sites with `if not is_finished`

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29043629384](https://github.com/sgl-project/sglang/actions/runs/29043629384)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29043629212](https://github.com/sgl-project/sglang/actions/runs/29043629212)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->