### PR TITLE
Fix decode receiver cleanup bookkeeping

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -580,6 +580,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self.queue.append(decode_req)
         return decode_req
 
+    def _release_kv_receiver(self, decode_req: DecodeRequest) -> None:
+        """Release a request's KV receiver and keep pending bookkeeping in sync."""
+        if decode_req.kv_receiver is not None:
+            decode_req.kv_receiver.clear()
+            decode_req.kv_receiver = None
+        if self.pending_reqs:
+            self.pending_reqs = [
+                pending for pending in self.pending_reqs if pending is not decode_req
+            ]
+
     def hold_rebootstrap(self, req: Req) -> None:
         """Stage a retracted request for rebootstrap without enqueuing it yet.
 
@@ -793,9 +803,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 error_msg = f"Could not fetch prefill parallel info from {bootstrap_addr} after {count} attempts"
                 logger.error(error_msg)
                 for decode_req in reqs:
-                    # kv_receiver may be None from a prior self.queue cleanup
-                    if decode_req.kv_receiver is not None:
-                        decode_req.kv_receiver.abort()
+                    decode_req.kv_receiver.abort()
                 del self._ensure_retry_count[bootstrap_addr]
                 del self._ensure_last_attempt_time[bootstrap_addr]
             else:
@@ -903,18 +911,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         [decode_req.req],
                         decode_req.req.return_logprob,
                     )
-                decode_req.kv_receiver.clear()
-                decode_req.kv_receiver = None
+                self._release_kv_receiver(decode_req)
                 failed_reqs.append(decode_req)
                 indices_to_remove.add(i)
-
-        # DecodeRequest is shared between self.queue and self.pending_reqs;
-        # drop failed reqs from both
-        if failed_reqs:
-            failed_ids = {id(r) for r in failed_reqs}
-            self.pending_reqs = [
-                r for r in self.pending_reqs if id(r) not in failed_ids
-            ]
 
         # HiSparse physical constraint: max requests by device buffer capacity.
         # Each admitted req needs padded_buffer_size from hisparse device pool.
@@ -1596,6 +1595,11 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 ):
                     self.staging_handler.register_decode_req(dr.req.bootstrap_room, dr)
 
+    def _release_kv_receiver(self, decode_req: DecodeRequest) -> None:
+        if decode_req.kv_receiver is not None:
+            decode_req.kv_receiver.clear()
+            decode_req.kv_receiver = None
+
     def _commit_transfer_to_req(self, decode_req: DecodeRequest):
         idx = decode_req.metadata_buffer_index
         (
@@ -1636,8 +1640,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 "(bootstrap_room=0)",
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
-            decode_req.kv_receiver.clear()
-            decode_req.kv_receiver = None
+            self._release_kv_receiver(decode_req)
             return
         elif actual_room != expected_room:
             # Real corruption detected (mismatch)
@@ -1655,8 +1658,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 "Metadata corruption detected - bootstrap_room mismatch",
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
-            decode_req.kv_receiver.clear()
-            decode_req.kv_receiver = None
+            self._release_kv_receiver(decode_req)
             return
 
         self._commit_hicache_local_restore_to_req(decode_req)
@@ -1720,8 +1722,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 ].tolist()
             )
 
-        decode_req.kv_receiver.clear()
-        decode_req.kv_receiver = None
+        self._release_kv_receiver(decode_req)
         decode_req.req.time_stats.set_wait_queue_entry_time()
         return
 
@@ -1818,8 +1819,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     self.scheduler.hisparse_coordinator.request_finished(decode_req.req)
                 # release pre-allocated kv cache, but don't insert into the tree since it's failed
                 release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
-                decode_req.kv_receiver.clear()
-                decode_req.kv_receiver = None
+                self._release_kv_receiver(decode_req)
                 indices_to_remove.add(i)
                 if self.scheduler.metrics_reporter.enable_metrics:
                     self.scheduler.metrics_collector.increment_transfer_failed_reqs()

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.decode import (
+    DecodeRequest,
     DecodePreallocQueue,
     DecodeTransferQueue,
     HiCacheRestoreResult,
@@ -29,7 +30,9 @@ class FakeReceiver:
 
 
 class TestDecodeQueueCleanup(CustomTestCase):
-    def test_prealloc_abort_clears_receiver_before_removing_request(self):
+    def test_given_pending_prealloc_abort_when_popping_then_receiver_is_released_and_pending_request_is_removed(
+        self,
+    ):
         receiver = FakeReceiver()
         req = SimpleNamespace(
             rid="abort-prealloc",
@@ -40,7 +43,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
 
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
         queue.queue = [decode_req]
-        queue.pending_reqs = []
+        queue.pending_reqs = [decode_req]
         queue.retracted_queue = []
         queue._resolve_pending_reqs = MagicMock()
         queue._update_handshake_waiters = MagicMock()
@@ -60,75 +63,32 @@ class TestDecodeQueueCleanup(CustomTestCase):
         self.assertEqual(preallocated, [])
         self.assertEqual(failed, [decode_req])
         self.assertEqual(queue.queue, [])
+        self.assertEqual(queue.pending_reqs, [])
         self.assertTrue(receiver.clear_called)
         self.assertIsNone(decode_req.kv_receiver)
         scheduler.output_streamer.stream_output.assert_called_once_with(
             [req], req.return_logprob
         )
 
-    def test_prealloc_abort_also_drops_from_pending_reqs(self):
-        # Same DecodeRequest lives in both queue and pending_reqs (add() slow
-        # path). Aborting must drop it from both, and compare by identity since
-        # DecodeRequest's dataclass __eq__ would compare the tensor receiver.
-        class BadEqReceiver(FakeReceiver):
-            def __eq__(self, other):
-                raise TypeError("use identity comparison, not value equality")
-
-            __hash__ = object.__hash__
-
-        receiver = BadEqReceiver()
-        req = SimpleNamespace(
-            rid="abort-shared",
-            finished_reason=FINISH_ABORT("aborted"),
-            return_logprob=False,
-        )
-        decode_req = SimpleNamespace(req=req, kv_receiver=receiver)
+    def test_given_equal_pending_requests_when_releasing_receiver_then_only_same_object_is_removed(
+        self,
+    ):
+        receiver = FakeReceiver()
+        req = SimpleNamespace(rid="release-by-identity")
+        decode_req = DecodeRequest(req=req, kv_receiver=receiver)
+        equal_decode_req = DecodeRequest(req=req, kv_receiver=receiver)
 
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
-        queue.queue = [decode_req]
-        queue.pending_reqs = [decode_req]  # same object, dual ownership
-        queue.retracted_queue = []
-        queue._resolve_pending_reqs = MagicMock()
-        queue._update_handshake_waiters = MagicMock()
-        queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
-        queue._allocatable_token_budgets = MagicMock(return_value=0)
-        queue._hicache_pending_restore_tokens = MagicMock(return_value=0)
+        queue.pending_reqs = [equal_decode_req, decode_req]
 
-        scheduler = MagicMock()
-        scheduler.running_batch.reqs = []
-        scheduler.enable_priority_scheduling = False
-        scheduler.enable_hisparse = False
-        scheduler.output_streamer = MagicMock()
-        queue.scheduler = scheduler
+        self.assertEqual(equal_decode_req, decode_req)
 
-        # Must not raise on the receiver __eq__ above.
-        preallocated, failed = queue.pop_preallocated()
+        queue._release_kv_receiver(decode_req)
 
-        self.assertEqual(preallocated, [])
-        self.assertEqual(failed, [decode_req])
-        self.assertEqual(queue.queue, [])
-        self.assertTrue(all(r is not decode_req for r in queue.pending_reqs))
+        self.assertEqual(queue.pending_reqs, [equal_decode_req])
+        self.assertIs(queue.pending_reqs[0], equal_decode_req)
+        self.assertTrue(receiver.clear_called)
         self.assertIsNone(decode_req.kv_receiver)
-
-    def test_ensure_prefill_info_tolerates_cleared_receiver(self):
-        # A req whose kv_receiver was already cleared must not crash on .abort().
-        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
-        queue._max_ensure_retries = 1
-        queue._ensure_retry_interval = 0
-        queue._ensure_retry_count = {"127.0.0.1:11500": 0}
-        queue._ensure_last_attempt_time = {}
-        queue.kv_manager = MagicMock()
-        queue.kv_manager.try_ensure_parallel_info.return_value = False
-
-        cleared_req = SimpleNamespace(
-            req=SimpleNamespace(rid="cleared"), kv_receiver=None
-        )
-        addr_to_reqs = {"127.0.0.1:11500": [cleared_req]}
-
-        ready, remaining = queue._ensure_prefill_info(addr_to_reqs)
-
-        self.assertEqual(ready, {})
-        self.assertEqual(remaining, [])
 
     @patch("sglang.srt.disaggregation.decode.release_kv_cache")
     @patch("sglang.srt.disaggregation.decode.prepare_abort")


### PR DESCRIPTION
## Motivation

A decode request can be present in both `DecodePreallocQueue.queue` and `DecodePreallocQueue.pending_reqs` while the decode worker waits for prefill parallel info. If the prealloc abort path releases that request's KV receiver from `queue` but leaves the same request object in `pending_reqs`, a later pending-resolution cycle can revisit a released request and fail when it tries to use the cleared receiver.

At a high level, the failure path is:

`pop_preallocated()` abort cleanup clears `decode_req.kv_receiver` -> the same `DecodeRequest` remains in `pending_reqs` -> `_resolve_pending_reqs()` / `_ensure_prefill_info()` later processes the stale request -> receiver access sees `None`.

## Modifications

This PR keeps decode receiver ownership bookkeeping consistent at the release site:

- Adds `DecodePreallocQueue._release_kv_receiver()` to clear a request's receiver and remove that exact `DecodeRequest` object from `pending_reqs` using identity comparison.
- Routes the prealloc abort cleanup path through that helper.
- Removes the downstream defensive `None` tolerance so `pending_reqs` continues to mean requests waiting on prefill info with a live receiver.
- Adds a small `DecodeTransferQueue._release_kv_receiver()` helper and routes existing transfer cleanup paths through it to avoid repeating `clear(); kv_receiver = None` pairs.
- Updates unit coverage for the pending prealloc-abort case and for identity-based removal from `pending_reqs`.

## Accuracy Tests

Not applicable; this is decode queue cleanup bookkeeping and does not affect model outputs.

## Speed Tests and Profiling

Not applicable; this change is not on the model forward path and should not affect inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Validation:

- `python3 -m py_compile python/sglang/srt/disaggregation/decode.py test/registered/unit/disaggregation/test_decode_queue_cleanup.py`
- `git diff --check`

I could not run the focused pytest target in this local shell because `/usr/bin/python3` does not have `pytest` or `torch` installed.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29048221618](https://github.com/sgl-project/sglang/actions/runs/29048221618)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29048221480](https://github.com/sgl-project/sglang/actions/runs/29048221480)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->