### PR TITLE
[Feature] Add --gc-freeze-on-idle: move the long-lived heap out of GC scan scope

### DIFF
--- a/python/sglang/srt/managers/idle_gc.py
+++ b/python/sglang/srt/managers/idle_gc.py
@@ -1,0 +1,53 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Only freeze after the process has been continuously idle this long,
+# so sub-second gaps in a live request stream never trigger it.
+MIN_IDLE_DURATION_S = 5.0
+# Do not freeze more often than this. gc.freeze() itself costs
+# milliseconds; the interval only bounds how much recently-created
+# state an ill-timed freeze can pin.
+MIN_FREEZE_INTERVAL_S = 60.0
+
+
+class IdleGCFreezeGate:
+    """Decide when to broadcast gc.freeze() across the server processes.
+
+    The long-lived heap is live by design (import-graph objects), so
+    freezing at sustained-idle moments — not collecting — is what keeps
+    full collections from re-scanning it during serving. Pure decision
+    logic: the owner observes busy/idle, calls note(), and performs the
+    freeze broadcast when it returns True.
+    """
+
+    def __init__(
+        self,
+        min_idle_duration_s: float = MIN_IDLE_DURATION_S,
+        min_freeze_interval_s: float = MIN_FREEZE_INTERVAL_S,
+    ):
+        self.min_idle_duration_s = min_idle_duration_s
+        self.min_freeze_interval_s = min_freeze_interval_s
+        self.idle_since = None
+        self.seen_work = False
+        self.last_freeze_time = -float("inf")
+
+    def note(self, busy: bool, now: float) -> bool:
+        """Record the current busy/idle state; True means freeze now."""
+        if busy:
+            self.idle_since = None
+            self.seen_work = True
+            return False
+        if self.idle_since is None:
+            self.idle_since = now
+        if not self.seen_work:
+            return False
+        if now - self.idle_since < self.min_idle_duration_s:
+            return False
+        if now - self.last_freeze_time < self.min_freeze_interval_s:
+            return False
+        return True
+
+    def mark_frozen(self, now: float) -> None:
+        self.last_freeze_time = now
+        self.seen_work = False

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -53,6 +53,7 @@ from sglang.srt.lora.lora_registry import LoRARef, LoRARegistry
 from sglang.srt.managers.async_dynamic_batch_tokenizer import AsyncDynamicbatchTokenizer
 from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.idle_gc import IdleGCFreezeGate
 from sglang.srt.managers.io_struct import (
     AbortReq,
     ActiveRanksOutput,
@@ -322,6 +323,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Init metric collector and watchdog
         self.init_metric_collector_watchdog()
+        self.maybe_init_idle_gc()
 
         # Init request dispatcher
         self.init_request_dispatcher()
@@ -555,6 +557,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 hf_config=self.model_config.hf_config,
                 encode_urls=self.encoder_urls,
             )
+
+    def maybe_init_idle_gc(self) -> None:
+        if self.server_args.gc_freeze_on_idle:
+            self.idle_gc_gate = IdleGCFreezeGate()
+        else:
+            self.idle_gc_gate = None
 
     def init_metric_collector_watchdog(self):
         # Metrics
@@ -1842,6 +1850,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         freeze_gc("Tokenizer Manager")
         return None
 
+    async def idle_gc_freeze_watcher(self):
+        """Broadcast gc.freeze() after sustained idle (see IdleGCFreezeGate)."""
+        while True:
+            await asyncio.sleep(2.0)
+            now = time.monotonic()
+            if self.idle_gc_gate.note(busy=bool(self.rid_to_state), now=now):
+                await self.freeze_gc()
+                self.idle_gc_gate.mark_frozen(now)
+
     def create_abort_task(self, obj: GenerateReqInput):
         # Abort the request if the client is disconnected.
         async def abort_request():
@@ -1880,6 +1897,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.asyncio_tasks.add(
             loop.create_task(print_exception_wrapper(self.sigterm_watchdog))
         )
+
+        if self.idle_gc_gate is not None:
+            self.asyncio_tasks.add(
+                loop.create_task(print_exception_wrapper(self.idle_gc_freeze_watcher))
+            )
 
     async def handle_loop(self):
         """The event loop that handles requests"""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1047,6 +1047,10 @@ class ServerArgs:
         Optional[List[int]],
         "Set the garbage collection thresholds (the collection frequency). Accepts 1 to 3 integers.",
     ] = None
+    gc_freeze_on_idle: A[
+        bool,
+        "Broadcast gc.freeze() to the tokenizer manager, scheduler, and detokenizer after sustained idle periods. Serving accumulates millions of live long-lived objects in GC generation 2 in each process; full collections over them cost hundreds of milliseconds each and can fire during serving. Freezing at idle moments moves that population out of GC scan scope.",
+    ] = False
 
     # -------------------------------------------------------------------------
     # HTTP server

--- a/test/registered/unit/managers/test_idle_gc.py
+++ b/test/registered/unit/managers/test_idle_gc.py
@@ -1,0 +1,57 @@
+"""Unit tests for the idle GC freeze gate."""
+
+import unittest
+
+from sglang.srt.managers.idle_gc import IdleGCFreezeGate
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestIdleGCFreezeGate(CustomTestCase):
+    def test_freezes_after_sustained_idle_following_work(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=5.0, min_freeze_interval_s=60.0)
+        self.assertFalse(gate.note(busy=True, now=100.0))
+        self.assertFalse(gate.note(busy=False, now=101.0))  # idle 0s
+        self.assertFalse(gate.note(busy=False, now=104.0))  # idle 3s
+        self.assertTrue(gate.note(busy=False, now=107.0))  # idle 6s
+        gate.mark_frozen(107.0)
+
+    def test_never_freezes_without_prior_work(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=5.0, min_freeze_interval_s=0.0)
+        self.assertFalse(gate.note(busy=False, now=0.0))
+        self.assertFalse(gate.note(busy=False, now=100.0))
+
+    def test_short_idle_gaps_in_live_traffic_never_freeze(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=5.0, min_freeze_interval_s=0.0)
+        now = 0.0
+        for _ in range(50):
+            self.assertFalse(gate.note(busy=True, now=now))
+            now += 0.5
+            self.assertFalse(gate.note(busy=False, now=now))  # sub-second gap
+            now += 0.5
+
+    def test_min_interval_between_freezes(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=1.0, min_freeze_interval_s=60.0)
+        gate.note(busy=True, now=0.0)
+        gate.note(busy=False, now=1.0)  # idle observed from t=1
+        self.assertTrue(gate.note(busy=False, now=2.5))
+        gate.mark_frozen(2.5)
+        gate.note(busy=True, now=3.0)  # new work
+        gate.note(busy=False, now=4.0)
+        self.assertFalse(gate.note(busy=False, now=10.0))  # interval not passed
+        self.assertTrue(gate.note(busy=False, now=70.0))
+
+    def test_no_refreeze_without_new_work(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=1.0, min_freeze_interval_s=0.0)
+        gate.note(busy=True, now=0.0)
+        gate.note(busy=False, now=1.0)
+        self.assertTrue(gate.note(busy=False, now=2.5))
+        gate.mark_frozen(2.5)
+        self.assertFalse(gate.note(busy=False, now=100.0))
+        self.assertFalse(gate.note(busy=False, now=200.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Serving accumulates millions of live long-lived objects in GC generation 2 in the tokenizer manager, scheduler, and detokenizer (~1.1M in the scheduler alone; a per-type census shows the population is dominated by static import-graph objects, so it is a steady-state property of serving, not accumulated request state). Full collections over that population cost **~400-430 ms each** (`SGLANG_LOG_GC` data; gen0/gen1 are 0.07/0.46 ms), and after an overload episode they can fire in ~2 s bursts during subsequent serving — measured as a sustained **33-41% saturation-throughput loss** on the CPU-bound embedding path, on both v0.5.13.post1 and current latest. Full investigation: #30596.

The key fact driving the design: the population is live, not garbage. An instrumented `gc.collect()` over the scheduler's ~1.08M gen2 objects found ~44k unreachable on the first pass and 0 afterwards — there is nothing to reclaim, so collect-based approaches only add 400 ms stalls (a collect-on-idle variant was implemented and validated first; it made everything worse). The only effective lever, as manual `POST /freeze_gc` recovery already demonstrates, is moving the live population out of scan scope.

This PR automates that: broadcast `gc.freeze()` across the server processes after sustained idle (>= 5 s continuously idle, at most once per 60 s). Since the objects stay resident either way, freezing costs no additional memory.

## Modifications

- `managers/idle_gc.py`: `IdleGCFreezeGate` — pure decision logic: freeze only after >= 5 s of continuous observed idle following work, at most once per 60 s. Sub-second gaps in a live request stream (e.g. Poisson arrivals) never trigger it.
- `TokenizerManager`: `maybe_init_idle_gc()` init helper + an `idle_gc_freeze_watcher` asyncio task (registered in `auto_create_handle_loop`, 2 s poll of `rid_to_state`) that calls the existing `freeze_gc()` broadcast (tokenizer manager -> scheduler -> detokenizer) when the gate fires.
- `server_args.py`: opt-in `--gc-freeze-on-idle` flag (placed next to the existing `gc_threshold`).

Design notes:

- Opt-in, zero default behavior change; reuses the existing `/freeze_gc` broadcast path rather than adding new IPC.
- All three processes must be covered: a scheduler-only variant was validated first — its freezes worked (scheduler gen2 pauses dropped 400 ms -> ~10 ms) yet throughput still degraded, because the tokenizer manager and detokenizer (836k / 758k gen2 objects) kept paying full scans on the request send/receive path.
- Freeze (not collect) because the population is live: collect reclaims nothing and costs ~400 ms per call (validated empirically). Frozen objects were going to stay resident either way.

## Accuracy Tests

No model-output path is touched; the flag is opt-in and default-off. Unit tests (CPU, `test/registered/unit/managers/test_idle_gc.py`, registered in `base-a-test-cpu`) — **5 passed**: freezes after sustained idle, never fires on sub-second idle gaps under live traffic, honors the minimum interval, no re-freeze without new work.

## Speed Tests and Profiling

A6000, Qwen3-Embedding-0.6B, latest image + this patch, `--gc-freeze-on-idle`, overload protocol from #30596, 3 lifetimes:

```text
lifetime   baseline      after 2x overload
r1         738.7 req/s   739.4 req/s
r2         774.9 req/s   811.7 req/s
r3         733.3 req/s   731.0 req/s
(reference without the flag: 33-41% sustained loss in ~60% of
overload episodes on this protocol)
```

Mechanism-level confirmation from the same lifetimes:

```text
first idle freeze broadcast clears all three processes:
  Tokenizer Manager gen2: 836,181 -> 0
  Scheduler         gen2: 1,080,697 -> 0
  Detokenizer       gen2: 756,932 -> 0
subsequent per-minute freezes capture only ~40k new scheduler objects
gen2 collection pauses across the whole lifetime: 132 events,
  max 23.7 ms (vs ~400-430 ms unfrozen)
```

**Generation-path check** (same overload protocol, Qwen3-0.6B generate, 128-in/128-out, c=64, 3 lifetimes per arm, flag off vs on):

```text
arm      baseline thr (req/s)   post-overload thr    itl p99 (ms, base->post)
stock    50.3 / 52.0 / 50.9     47.8 / 49.4 / 51.5   15.2->16.1, 15.6->15.2, 18.0->15.3
freeze   51.9 / 50.8 / 47.7     48.6 / 51.6 / 52.9   16.4->19.4, 18.5->17.4, 16.1->14.5
```

- No arm-level difference: throughput and ITL p99 are statistically indistinguishable (both arms move within the same ±6% noise band). The flag adds no overhead to the generation path.
- Zero gen2 full collections fired in any of the six ~9-minute lifetimes at ~50 req/s — gen2 pressure scales with Python-side request rate, and the embedding path at ~1000 req/s hits 24-27 full collections in an equivalent window. Generation-scale impact at production uptime/concurrency is documented in #9241 (100-300 ms stalls every ~1.5 s), which is what motivated the manual `/freeze_gc` endpoint this PR automates.
- The mechanism behaves identically on generation: the idle watcher fired on schedule, and the first broadcast froze gen2 populations of 833,842 (tokenizer manager) / 1,077,055 (scheduler) / 757,065 (detokenizer) — near-identical to the embedding server's populations, direct evidence the long-lived heap is workload-independent import-graph state.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29797456986](https://github.com/sgl-project/sglang/actions/runs/29797456986)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29797456874](https://github.com/sgl-project/sglang/actions/runs/29797456874)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->