### PR TITLE
[misc] Add init-static value extraction to the general code style rule

### DIFF
--- a/.claude/rules/general-code-style.md
+++ b/.claude/rules/general-code-style.md
@@ -9,6 +9,7 @@ Default conventions for new and modified Python code. Prefer these unless there 
 
 - **Prefer stateless.** Favor pure functions over methods that mutate instance state; pass inputs in, return outputs out.
 - **Prefer immutable.** Default to immutable data (frozen structs, tuples, read-only values); mutate only when there is a clear need.
+- **Extract init-static values at construction.** When a derived value's inputs are frozen for the object's lifetime (typically configuration: constructor args, env vars, server args), compute it once in `__init__` and store it as a well-named attribute (`self.mtp_enabled`, `self.needs_cpu_seq_lens`); later code reads the attribute instead of re-deriving it. Input immutability is the hard precondition — if inputs can change, recompute in place or funnel mutation through a single override point (the frozen `ServerArgs.override()` pattern). If you can't give the value a meaningful name, the boundary is wrong — don't cache unnameable subexpressions.
 - **Functions stay small.** Keep each function under ~100 LOC; split larger ones into named helpers.
 - **Files stay small.** Keep each file under ~2k LOC; split larger modules along cohesive boundaries.
 - **Core functions read like pseudocode.** The main / orchestration function of a unit should be short and read like algorithm pseudocode — push detail into well-named helpers so the top-level flow is obvious.


### PR DESCRIPTION
Add a bullet to .claude/rules/general-code-style.md: values whose inputs are frozen for the object's lifetime are computed once in __init__ and stored as well-named attributes, with input immutability as the hard precondition (shipped examples: needs_cpu_seq_lens in the attention backends).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29054492291](https://github.com/sgl-project/sglang/actions/runs/29054492291)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29054492124](https://github.com/sgl-project/sglang/actions/runs/29054492124)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->