### PR TITLE
[Diffusion] Support SM12.x GPUs (RTX PRO 6000 Blackwell / RTX 50xx / DGX Spark GB10)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -37,7 +37,13 @@ _use_rocm_flydsl = get_bool_env_var("SGLANG_USE_ROCM_FLYDSL")
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_cuda or _is_xpu:
-    from sgl_kernel import fused_add_rmsnorm, rmsnorm
+    try:
+        from sgl_kernel import fused_add_rmsnorm, rmsnorm
+    except ImportError:
+        # sgl_kernel wheels may be unavailable or ABI-incompatible on new
+        # architectures (e.g. SM12.x: RTX PRO 6000 Blackwell, RTX 50xx,
+        # DGX Spark GB10). RMSNorm falls back to the Triton path below.
+        fused_add_rmsnorm = rmsnorm = None
 
 if _is_npu:
     import torch_npu
@@ -83,6 +89,10 @@ class RMSNorm(CustomOp):
             self._forward_method = self.forward_native
         elif _use_aiter:
             self._forward_method = self.forward_aiter
+        elif (_is_cuda or _is_xpu) and rmsnorm is None:
+            # sgl_kernel rmsnorm kernels unavailable (e.g. SM12.x): use the
+            # JIT Triton implementation, which handles residual fusion too.
+            self._forward_method = self.forward_triton
 
     def forward_triton(self, x: torch.Tensor, residual: Optional[torch.Tensor] = None):
         return rms_norm_fn(

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -343,9 +343,13 @@ class CudaPlatformBase(Platform):
         if cls.is_sm120():
             # SM12.x (RTX PRO 6000 Blackwell / RTX 50xx / DGX Spark GB10):
             # FlashInfer's trtllm fp4 GEMM raises BackendSupportedError with
-            # capability 120; cudnn and cutlass both work (within noise of
-            # each other on Cosmos3-Nano GEMM shapes, 2.5-3.3x over BF16),
-            # while "auto" mis-tunes some shapes. Prefer cudnn.
+            # capability 120; cudnn and cutlass both work. cudnn is the
+            # strongest overall (within noise of cutlass on sm_120, ~2x faster
+            # on GB10/sm_121 qkv/gate_up shapes; 2.0-3.3x over BF16 on
+            # Cosmos3-Nano GEMM shapes across both), while "auto" mis-tunes
+            # some shapes. Note: on sm_121 the cudnn heuristic needs a
+            # FlashInfer autotune(True) warmup for the qkv shape
+            # (0.9x untuned -> 2.6x tuned). Prefer cudnn.
             default_backend = "cudnn"
         else:
             default_backend = "trtllm"

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -340,7 +340,15 @@ class CudaPlatformBase(Platform):
     @lru_cache(maxsize=1)
     def get_modelopt_flashinfer_fp4_backend(cls) -> str:
         backend = envs.SGLANG_DIFFUSION_FLASHINFER_FP4_GEMM_BACKEND
-        default_backend = "trtllm"
+        if cls.is_sm120():
+            # SM12.x (RTX PRO 6000 Blackwell / RTX 50xx / DGX Spark GB10):
+            # FlashInfer's trtllm fp4 GEMM raises BackendSupportedError with
+            # capability 120; cudnn and cutlass both work (within noise of
+            # each other on Cosmos3-Nano GEMM shapes, 2.5-3.3x over BF16),
+            # while "auto" mis-tunes some shapes. Prefer cudnn.
+            default_backend = "cudnn"
+        else:
+            default_backend = "trtllm"
         if backend is None:
             return default_backend
 
@@ -361,6 +369,13 @@ class CudaPlatformBase(Platform):
                 default_backend,
             )
             return default_backend
+        if backend == "trtllm" and cls.is_sm120():
+            logger.warning(
+                "FlashInfer fp4 GEMM backend 'trtllm' does not support SM12.x "
+                "(BackendSupportedError with capability 120). Falling back to "
+                "'cudnn'."
+            )
+            return "cudnn"
         return backend
 
     @classmethod

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -27,7 +27,12 @@ __all__ = ["CompressedTensorsW8A8Int8", "NPUCompressedTensorsW8A8Int8"]
 
 _is_cuda = is_cuda()
 if _is_cuda:
-    from sgl_kernel import int8_scaled_mm
+    try:
+        from sgl_kernel import int8_scaled_mm
+    except ImportError:
+        # sgl_kernel unavailable/ABI-incompatible (e.g. SM12.x GPUs); the
+        # diffusion runtime does not use these LLM kernels.
+        int8_scaled_mm = None
 
 
 class CompressedTensorsW8A8Int8(CompressedTensorsLinearScheme):

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -55,7 +55,15 @@ _is_sm120_supported = is_sm120_supported()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_cuda or _is_musa:
-    from sgl_kernel import sgl_per_token_quant_fp8
+    try:
+        from sgl_kernel import sgl_per_token_quant_fp8
+    except ImportError:
+        # sgl_kernel wheels may be unavailable or ABI-incompatible on new
+        # architectures (e.g. SM12.x: RTX PRO 6000 Blackwell, RTX 50xx,
+        # DGX Spark GB10). The diffusion runtime (multimodal_gen) does not
+        # need these LLM FP8 kernels; keep the module importable and fail
+        # only if the kernels are actually used.
+        sgl_per_token_quant_fp8 = None
 
     from sglang.jit_kernel.per_tensor_quant_fp8 import (
         per_tensor_quant_fp8 as sgl_per_tensor_quant_fp8,
@@ -67,7 +75,10 @@ if _is_cuda or _is_musa:
 
         enable_sgl_per_token_group_quant_8bit = True
     except ImportError:
-        from sgl_kernel import sgl_per_token_group_quant_fp8
+        try:
+            from sgl_kernel import sgl_per_token_group_quant_fp8
+        except ImportError:
+            sgl_per_token_group_quant_fp8 = None
 
         enable_sgl_per_token_group_quant_8bit = False
 

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -157,7 +157,12 @@ if _use_aiter:
 
 
 if _is_cuda:
-    from sgl_kernel import fp8_blockwise_scaled_mm, fp8_scaled_mm
+    try:
+        from sgl_kernel import fp8_blockwise_scaled_mm, fp8_scaled_mm
+    except ImportError:
+        # sgl_kernel unavailable/ABI-incompatible (e.g. SM12.x GPUs); the
+        # diffusion runtime does not use these LLM kernels.
+        fp8_blockwise_scaled_mm = fp8_scaled_mm = None
 
     from sglang.srt.utils.patch_torch import register_fake_if_exists
 

--- a/python/sglang/srt/layers/quantization/gguf.py
+++ b/python/sglang/srt/layers/quantization/gguf.py
@@ -36,27 +36,45 @@ _is_musa = is_musa()
 _is_npu = is_npu()
 
 if _is_cuda:
-    from sgl_kernel import moe_align_block_size, moe_sum
-    from sgl_kernel.quantization import (
-        ggml_dequantize,
-        ggml_moe_a8,
-        ggml_moe_a8_vec,
-        ggml_moe_get_block_size,
-        ggml_mul_mat_a8,
-        ggml_mul_mat_vec_a8,
-    )
+    try:
+        from sgl_kernel import moe_align_block_size, moe_sum
+    except ImportError:
+        # sgl_kernel unavailable/ABI-incompatible (e.g. SM12.x GPUs); the
+        # diffusion runtime does not use these LLM kernels.
+        moe_align_block_size = moe_sum = None
+    try:
+        from sgl_kernel.quantization import (
+            ggml_dequantize,
+            ggml_moe_a8,
+            ggml_moe_a8_vec,
+            ggml_moe_get_block_size,
+            ggml_mul_mat_a8,
+            ggml_mul_mat_vec_a8,
+        )
+    except ImportError:
+        ggml_dequantize = ggml_moe_a8 = ggml_moe_a8_vec = None
+        ggml_moe_get_block_size = ggml_mul_mat_a8 = ggml_mul_mat_vec_a8 = None
 
     from sglang.jit_kernel.activation import gelu_and_mul, silu_and_mul
 elif _is_musa:
-    from sgl_kernel import gelu_and_mul, moe_align_block_size, moe_sum, silu_and_mul
-    from sgl_kernel.quantization import (
-        ggml_dequantize,
-        ggml_moe_a8,
-        ggml_moe_a8_vec,
-        ggml_moe_get_block_size,
-        ggml_mul_mat_a8,
-        ggml_mul_mat_vec_a8,
-    )
+    try:
+        from sgl_kernel import gelu_and_mul, moe_align_block_size, moe_sum, silu_and_mul
+    except ImportError:
+        # sgl_kernel unavailable/ABI-incompatible (e.g. SM12.x GPUs); the
+        # diffusion runtime does not use these LLM kernels.
+        gelu_and_mul = moe_align_block_size = moe_sum = silu_and_mul = None
+    try:
+        from sgl_kernel.quantization import (
+            ggml_dequantize,
+            ggml_moe_a8,
+            ggml_moe_a8_vec,
+            ggml_moe_get_block_size,
+            ggml_mul_mat_a8,
+            ggml_mul_mat_vec_a8,
+        )
+    except ImportError:
+        ggml_dequantize = ggml_moe_a8 = ggml_moe_a8_vec = None
+        ggml_moe_get_block_size = ggml_mul_mat_a8 = ggml_mul_mat_vec_a8 = None
 elif _is_npu:
     from gguf import dequantize as gguf_dequantize
 else:

--- a/python/sglang/srt/layers/quantization/int8_kernel.py
+++ b/python/sglang/srt/layers/quantization/int8_kernel.py
@@ -20,7 +20,12 @@ if _is_cuda:
 
         enable_sgl_per_token_group_quant_8bit = True
     except ImportError:
-        from sgl_kernel import sgl_per_token_group_quant_int8
+        try:
+            from sgl_kernel import sgl_per_token_group_quant_int8
+        except ImportError:
+            # sgl_kernel unavailable/ABI-incompatible (e.g. SM12.x GPUs); the
+            # diffusion runtime does not use these LLM kernels.
+            sgl_per_token_group_quant_int8 = None
 
         enable_sgl_per_token_group_quant_8bit = False
 

--- a/python/sglang/srt/layers/quantization/qoq.py
+++ b/python/sglang/srt/layers/quantization/qoq.py
@@ -20,7 +20,12 @@ from sglang.srt.utils import is_cuda
 
 _is_cuda = is_cuda()
 if _is_cuda:
-    from sgl_kernel import qserve_w4a8_per_chn_gemm, qserve_w4a8_per_group_gemm
+    try:
+        from sgl_kernel import qserve_w4a8_per_chn_gemm, qserve_w4a8_per_group_gemm
+    except ImportError:
+        # sgl_kernel unavailable/ABI-incompatible (e.g. SM12.x GPUs); the
+        # diffusion runtime does not use these LLM kernels.
+        qserve_w4a8_per_chn_gemm = qserve_w4a8_per_group_gemm = None
 
 
 QoQ_SUPPORTED_WEIGHT_BITS = [4]

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -43,7 +43,12 @@ _is_cpu = is_cpu()
 _is_cpu_arm64 = is_host_cpu_arm64()
 
 if _is_cuda:
-    from sgl_kernel import int8_scaled_mm
+    try:
+        from sgl_kernel import int8_scaled_mm
+    except ImportError:
+        # sgl_kernel unavailable/ABI-incompatible (e.g. SM12.x GPUs); the
+        # diffusion runtime does not use these LLM kernels.
+        int8_scaled_mm = None
 
     @register_fake_if_exists("sgl_kernel::int8_scaled_mm")
     def _int8_scaled_mm_abstract(


### PR DESCRIPTION
# What does this PR do?

Makes the SGLang diffusion runtime (`multimodal_gen`) usable on **SM12.x GPUs** — RTX PRO 6000 Blackwell, RTX 50xx, and DGX Spark (GB10, sm_121). Today the runtime crashes at import time on these GPUs and the FP4 path selects backends that reject capability 120.

## Problems fixed

1. **Import-time crash**: several `sglang.srt` quantization modules (`fp8_kernel`, `fp8_utils`, `int8_kernel`, `qoq`, `gguf`, `w8a8_int8`, `compressed_tensors_w8a8_int8`) and `multimodal_gen`'s `layernorm.py` import `sgl_kernel` at module scope. On SM12.x, sgl_kernel wheels are unavailable or ABI-incompatible (`undefined symbol: _ZN3c104cuda29c10_cuda_check_implementation...` with torch 2.12), so importing the diffusion runtime dies before reaching any diffusion code — even though it never calls those LLM kernels.
2. **FP4 GEMM backend selection**: `get_modelopt_flashinfer_fp4_backend()` defaulted to `auto`/`trtllm`, but FlashInfer's `trtllm` fp4 backend raises `BackendSupportedError ... with capability 120`.
3. **RMSNorm**: `sgl_kernel.rmsnorm` unavailable → needs a working fallback.

## Changes

- **`platforms/cuda.py`**: default FP4 GEMM backend = `cudnn` on SM12.x; explicit `trtllm` requests are re-routed to `cudnn` with a warning; `get_modelopt_fp4_gemm_op()` prefers FlashInfer on SM12.x.
- **`layers/layernorm.py`**: when sgl_kernel rmsnorm kernels are missing, `RMSNorm` selects the existing JIT Triton path (`forward_triton`) at construction time.
- **`srt` quantization modules**: module-scope `sgl_kernel` imports wrapped in `try/except ImportError` with `None` fallbacks — kernels fail only if actually used, imports always succeed.

## Measured (RTX PRO 6000 Blackwell, sm_120, torch 2.12.1+cu132, flashinfer 0.6.14)

**FP4 GEMM via FlashInfer on Cosmos3-Nano GEMM shapes** (M=37440 gen tokens @480p, hidden 4096, FFN 12288, incl. per-forward activation quantize):

| proj | shape (M×K→N) | BF16 | cudnn | cutlass |
|---|---|---|---|---|
| qkv | 37440×4096→12288 | 9.36ms | **3.00ms (3.12×)** | 3.12ms (3.00×) |
| out | 37440×4096→4096 | 3.17ms | 1.25ms (2.53×) | **1.22ms (2.61×)** |
| gate_up | 37440×4096→24576 | 21.59ms | 6.50ms (3.32×) | **6.45ms (3.35×)** |
| down | 37440×12288→4096 | 9.97ms | **3.73ms (2.67×)** | 3.70ms (2.69×) |

rel-err 0.134 (4-bit noise floor). `auto` mis-tunes `down` (4.92ms vs 3.73ms) — hence the explicit `cudnn` default.

**Triton RMSNorm fallback**: rel-err 4e-8 vs `forward_native`, 0.42ms vs 4.12ms ([37440, 4096] bf16, residual-carry exact).

**Platform resolution after patch**: `fp4_gemm_op=flashinfer.mm_fp4 backend=cudnn`, `fp4_quantize_op=flashinfer.fp4_quantize`, attention default → SDPA (the existing SM12.x fallback, now actually reachable).

**Unit tests** (run on the NVlabs/Sana `sol-engine` snapshot of this runtime, same patches): 335 passed / 4 skipped / 3 pre-existing failures (fail identically on the unmodified tree).

## Notes

- The gate uses `is_sm120()` (capability major == 12) so DGX Spark GB10 (sm_121) is covered.
- No behavior change on Hopper/sm_100 Blackwell datacenter parts: `trtllm` default and sgl_kernel fast paths are untouched where the wheels work.
- Same patch submitted to the NVlabs/Sana `sol-engine` snapshot of this runtime: NVlabs/Sana#419.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29058383698](https://github.com/sgl-project/sglang/actions/runs/29058383698)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29058383496](https://github.com/sgl-project/sglang/actions/runs/29058383496)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->