### PR TITLE
feat(moriep): add fp4 combine dtype (SGLANG_MORI_COMBINE_DTYPE=fp4)

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -110,7 +110,7 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
-ARG MORI_COMMIT="e31d426a13e96e1cbff96a1c904d291aefe8c46a"
+ARG MORI_COMMIT="6f072775a73518440b29be60e85dda70db63ca43"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -156,6 +156,7 @@ class CombineDtype(Enum):
     bf16 = "bfloat16"
     fp8 = "float8_blockwise"
     fp8_direct_cast = "float8_direct_cast"
+    fp4 = "fp4_blockwise"  # packed E2M1, blockwise-scaled; ~half the combine transport of fp8
 
 
 @dataclass(frozen=True)
@@ -297,6 +298,8 @@ def init_mori_op(
         combine_quant_type = "fp8_blockwise"
     elif combine_dtype == CombineDtype.fp8_direct_cast:
         combine_quant_type = "fp8_direct_cast"
+    elif combine_dtype == CombineDtype.fp4:
+        combine_quant_type = "fp4_blockwise"
 
     logger.info(
         f"[MORI init] {world_size=} {rank=} {hidden_size=} {params_dtype=} "
@@ -471,12 +474,14 @@ class _MoriEPDispatcherImplBase:
                     self.combine_dtype = CombineDtype.bf16
                 elif combine_dtype == "fp8_direct_cast":
                     self.combine_dtype = CombineDtype.fp8_direct_cast
+                elif combine_dtype == "fp4":
+                    self.combine_dtype = CombineDtype.fp4
         elif "SGLANG_MORI_FP8_COMB" in os.environ:
             # Deprecated: will be removed in a future release
             logger.warning_once(
                 "SGLANG_MORI_FP8_COMB is deprecated "
                 "and will be removed in a future release. "
-                "Use SGLANG_MORI_COMBINE_DTYPE=auto|bf16|fp8|fp8_direct_cast instead."
+                "Use SGLANG_MORI_COMBINE_DTYPE=auto|bf16|fp8|fp4|fp8_direct_cast instead."
             )
             if get_bool_env_var("SGLANG_MORI_FP8_COMB", "False"):
                 self.combine_dtype = CombineDtype.fp8

--- a/test/manual/ep/test_moriep_combine_dtype.py
+++ b/test/manual/ep/test_moriep_combine_dtype.py
@@ -1,0 +1,28 @@
+"""Lightweight (no-GPU) wiring guards for the MoRI blockwise-FP4 combine dtype.
+
+Protects the sglang-side plumbing that exposes ``SGLANG_MORI_COMBINE_DTYPE=fp4`` and maps it to
+MoRI's ``fp4_blockwise`` combine. The end-to-end kernel behaviour is covered by the GPU/eval tests.
+"""
+
+import unittest
+
+from sglang.srt.layers.moe.token_dispatcher.moriep import CombineDtype
+
+
+class TestMoriCombineDtypeFp4(unittest.TestCase):
+    def test_fp4_enum_member_exists(self):
+        self.assertTrue(hasattr(CombineDtype, "fp4"))
+        self.assertEqual(CombineDtype.fp4.value, "fp4_blockwise")
+
+    def test_fp4_value_roundtrip(self):
+        self.assertIs(CombineDtype("fp4_blockwise"), CombineDtype.fp4)
+
+    def test_existing_combine_dtypes_unchanged(self):
+        # Guard against accidentally breaking the existing dtypes when adding fp4.
+        self.assertEqual(CombineDtype.bf16.value, "bfloat16")
+        self.assertEqual(CombineDtype.fp8.value, "float8_blockwise")
+        self.assertEqual(CombineDtype.fp8_direct_cast.value, "float8_direct_cast")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Exposes MoRI's **blockwise-FP4 (E2M1) combine** via `SGLANG_MORI_COMBINE_DTYPE=fp4`. This maps to
MoRI's `fp4_blockwise` combine quant type, which transports each combine element as packed FP4
(2 values/byte) instead of FP8 (1 byte/elem) — **~half the combine payload**. Combine is a
transport-bound step in MoE decode, so this improves decode throughput/latency with no accuracy loss.

Requires the companion MoRI change (`fp4_blockwise` combine kernels). Falls back cleanly: any other
`SGLANG_MORI_COMBINE_DTYPE` value keeps the existing behavior.

## What changed

- `moriep.py`: add `CombineDtype.fp4` (`"fp4_blockwise"`), parse `SGLANG_MORI_COMBINE_DTYPE=fp4`,
  and map it to MoRI's `fp4_blockwise` combine quant type. Existing dtypes
  (`bf16` / `fp8` / `fp8_direct_cast`) are unchanged.
- `test/manual/ep/test_moriep_combine_dtype.py`: no-GPU unit test guarding the `CombineDtype.fp4`
  enum wiring and the existing dtypes.

## Validation (MI355x / gfx950, DeepSeek-R1, TP8 EP8 DP-attention, MoRI-EP)

**Accuracy — gsm8k, 2000 questions, `--parallel 1200`, `SGLANG_MORI_COMBINE_DTYPE=fp4` ×3**

| Run | Accuracy |
|-----|----------|
| 1   | 0.948    |
| 2   | 0.950    |
| 3   | 0.948    |
| **Mean** | **0.949** |


**Profile - With FP4**
<img width="682" height="240" alt="image" src="https://github.com/user-attachments/assets/efbae903-a682-4e13-bffb-5974b186ad01" />


Command Used for Performance -

export SGLANG_USE_AITER=1 SGLANG_AITER_MOE=1 SGLANG_USE_ROCM700A=1
export SGLANG_ROCM_FUSED_DECODE_MLA=1 SGLANG_AITER_MLA_PERSIST=1
export SGLANG_DSR_OPROJ_MXFP4_ASM=1 TORCH_BLAS_PREFER_HIPBLASLT=1
export SGLANG_AITER_AR=1 ROCM_QUICK_REDUCE_QUANTIZATION=INT4 ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB=512
export TRITON_ENABLE_PRELOAD_KERNELS=0 TORCH_NCCL_BLOCKING_WAIT=1
export PYTORCH_ALLOC_CONF=expandable_segments:True
export SGLANG_AITER_FUSED_MLA_CONCAT_CACHE=1 SGLANG_AITER_FUSED_KVB_SPLIT_CAT=1

--- MoRI-EP ---
export MORI_SHMEM_MODE=ISOLATION MORI_SHMEM_HEAP_SIZE=16G SGLANG_MORI_LEC_IN_GRAPH=0
export SGLANG_MORI_DISPATCH_DTYPE=auto
export SGLANG_MORI_COMBINE_DTYPE=fp4 # or fp8 for the baseline
export SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK=4096 SGLANG_MORI_NO_PAD_MASK=1

python -m sglang.launch_server
--model-path /scratch/Deepseek-R1-MXFP4
--tp-size 8 --ep-size 8 --dp-size 8 --enable-dp-attention --enable-dp-lm-head
--moe-a2a-backend mori --deepep-mode normal --moe-dense-tp-size 1
--enforce-shared-experts-fusion
--trust-remote-code --kv-cache-dtype fp8_e4m3
--disable-radix-cache --mem-fraction-static 0.90
--cuda-graph-max-bs 512 --max-running-requests 2048
--host 0.0.0.0 --port 30000`

python /sgl-workspace/sglang/python/sglang/bench_serving.py
--backend sglang --host 127.0.0.1 --port 30000
--dataset-name random
--random-input-len 1024 --random-output-len 2048 --random-range-ratio 1.0
--num-prompts 1536 --max-concurrency 512

**Performance — fp8 vs fp4 combine** (decode-heavy: random, input 1024 / output 2048, 1536 prompts,
max-concurrency 512, identical server config)

| Metric | FP8 combine | FP4 combine | Δ |
|--------|-------------|-------------|---|
| Output token throughput | 12,640.8 tok/s | 13,103.1 tok/s | **+3.7 %** |
| Total token throughput   | 18,961.2 tok/s | 19,654.7 tok/s | **+3.7 %** |
| Request throughput       | 6.17 req/s     | 6.40 req/s     | **+3.7 %** |
| Mean TPOT                | 38.70 ms       | 37.40 ms       | **−3.4 %** |
| Median TPOT              | 38.58 ms       | 36.82 ms       | **−4.6 %** |
| Mean TTFT                | 3,405 ms       | 3,262 ms       | −4.2 %     |
| Mean E2E latency         | 82.6 s         | 79.8 s         | −3.4 %     |

## Test plan

- [x] `test/manual/ep/test_moriep_combine_dtype.py` — passes.
- [x] End-to-end accuracy + perf validated on DeepSeek-R1 with `SGLANG_MORI_COMBINE_DTYPE=fp4`
      (see above).
- [x] `black` / `ruff` / `isort` clean.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29387324713](https://github.com/sgl-project/sglang/actions/runs/29387324713)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29387324571](https://github.com/sgl-project/sglang/actions/runs/29387324571)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

Mori PR reference - https://github.com/ROCm/mori/pull/461