### PR TITLE
Add Mooncake Store file-level weight connector for SGLang

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -247,6 +247,7 @@ class ModelConfig:
         language_only: bool = False,
         disable_hybrid_swa_memory: bool = False,
         model_config_parser: str = "auto",
+        model_loader_extra_config: Optional[dict] = None,
     ) -> None:
         # Parse args
         self.model_path = model_path
@@ -259,6 +260,20 @@ class ModelConfig:
         self.is_multi_layer_eagle = is_multi_layer_eagle
         self.disable_hybrid_swa_memory = disable_hybrid_swa_memory
         self.model_config_parser = model_config_parser
+        if isinstance(model_loader_extra_config, str):
+            self.model_loader_extra_config = json.loads(
+                model_loader_extra_config or "{}"
+            )
+        else:
+            self.model_loader_extra_config = model_loader_extra_config or {}
+        if self.model_loader_extra_config.get("mooncake_weight_store_config"):
+            os.environ["MOONCAKE_WEIGHT_STORE_CONFIG"] = self.model_loader_extra_config[
+                "mooncake_weight_store_config"
+            ]
+        if self.model_loader_extra_config.get("materialize_dir"):
+            os.environ["MOONCAKE_MODEL_MATERIALIZE_DIR"] = (
+                self.model_loader_extra_config["materialize_dir"]
+            )
 
         # Validate quantize_and_serve configuration
         self._validate_quantize_and_serve_config()
@@ -528,6 +543,7 @@ class ModelConfig:
             is_draft_model=is_draft_model,
             disable_hybrid_swa_memory=server_args.disable_hybrid_swa_memory,
             model_config_parser=server_args.model_config_parser,
+            model_loader_extra_config=server_args.model_loader_extra_config,
             **kwargs,
         )
 
@@ -1527,11 +1543,23 @@ class ModelConfig:
             # BaseConnector implements __del__() to clean up the local dir.
             # Since config files need to exist all the time, so we DO NOT use
             # with statement to avoid closing the client.
-            client = create_remote_connector(self.model_path)
+            client = create_remote_connector(
+                self.model_path, **self.model_loader_extra_config
+            )
             if is_remote_url(self.model_path):
-                client.pull_files(allow_pattern=["*config.json"])
+                client.pull_files(ignore_pattern=["*.pt", "*.safetensors", "*.bin"])
                 self.model_weights = self.model_path
                 self.model_path = client.get_local_dir()
+
+
+def resolve_remote_tokenizer_path(server_args, model_config: ModelConfig) -> None:
+    from sglang.srt.utils import is_remote_url
+
+    if (
+        is_remote_url(server_args.model_path)
+        and server_args.tokenizer_path == server_args.model_path
+    ):
+        server_args.tokenizer_path = model_config.model_path
 
 
 # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py

--- a/python/sglang/srt/connector/__init__.py
+++ b/python/sglang/srt/connector/__init__.py
@@ -39,6 +39,12 @@ def create_remote_connector(url, device=None, **kwargs) -> BaseConnector:
         return RedisConnector(url)
     elif connector_type == "s3":
         return S3Connector(url)
+    elif connector_type == "mooncake":
+        from sglang.srt.connector.mooncake_store_file import (
+            MooncakeStoreFileConnector,
+        )
+
+        return MooncakeStoreFileConnector(url, device=device, **kwargs)
     elif connector_type == "instance":
         return RemoteInstanceConnector(url, device)
     elif _is_azure_blob_url(url, connector_type):

--- a/python/sglang/srt/connector/mooncake_store_file.py
+++ b/python/sglang/srt/connector/mooncake_store_file.py
@@ -1,0 +1,556 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import fnmatch
+import itertools
+import json
+import logging
+import math
+import os
+import struct
+from typing import Generator, Optional, Tuple
+from urllib.parse import urlparse
+
+import torch
+
+from sglang.srt.connector import BaseFileConnector
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = "~/.config/mooncake/weight_store.json"
+DEFAULT_METADATA_DIR = "/tmp/mooncake-sglang-models"
+WEIGHT_PATTERNS = ["*.safetensors", "*.bin", "*.pt", "*.pth", "*.gguf"]
+_CLIENT_COUNTER = itertools.count(1)
+SAFETENSORS_DTYPES = {
+    "BOOL": (torch.bool, 1),
+    "U8": (torch.uint8, 1),
+    "I8": (torch.int8, 1),
+    "I16": (torch.int16, 2),
+    "I32": (torch.int32, 4),
+    "I64": (torch.int64, 8),
+    "F8_E4M3": (torch.float8_e4m3fn, 1),
+    "F8_E5M2": (torch.float8_e5m2, 1),
+    "F16": (torch.float16, 2),
+    "BF16": (torch.bfloat16, 2),
+    "F32": (torch.float32, 4),
+    "F64": (torch.float64, 8),
+}
+
+
+def _matches(path: str, patterns: Optional[list[str]]) -> bool:
+    return bool(patterns) and any(
+        fnmatch.fnmatch(path, pattern) for pattern in patterns
+    )
+
+
+def _parse_size(value) -> int:
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    if text.isdigit():
+        return int(text)
+    units = {
+        "KB": 1024,
+        "MB": 1024**2,
+        "GB": 1024**3,
+    }
+    upper = text.upper()
+    for suffix, multiplier in units.items():
+        if upper.endswith(suffix):
+            return int(float(upper[: -len(suffix)].strip()) * multiplier)
+    raise ValueError(f"invalid size: {value!r}")
+
+
+def _checkpoint_id_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "mooncake":
+        raise ValueError(f"invalid Mooncake Store model URL: {url!r}")
+    checkpoint_id = parsed.netloc + parsed.path
+    checkpoint_id = checkpoint_id.strip("/")
+    if not checkpoint_id:
+        raise ValueError(f"Mooncake Store model URL has no checkpoint id: {url!r}")
+    return checkpoint_id
+
+
+def _load_store_config(path: Optional[str]) -> dict:
+    config_path = (
+        path or os.environ.get("MOONCAKE_WEIGHT_STORE_CONFIG") or DEFAULT_CONFIG_PATH
+    )
+    with open(os.path.expanduser(config_path), encoding="utf-8") as f:
+        config = json.load(f)
+    config["_config_path"] = config_path
+    return config
+
+
+def _unique_local_hostname(local_hostname: str) -> str:
+    try:
+        name, port_text = local_hostname.rsplit(":", 1)
+        port = int(port_text)
+    except ValueError:
+        name = local_hostname
+        port = 12346
+
+    counter = next(_CLIENT_COUNTER)
+    unique_port = port + counter
+    if unique_port > 65535:
+        unique_port = 10000 + (unique_port % 50000)
+    return f"{name}-{os.getpid()}-{counter}:{unique_port}"
+
+
+def _create_store(config: dict):
+    from mooncake.store import MooncakeDistributedStore
+
+    store = MooncakeDistributedStore()
+    configured_local_hostname = config.get("local_hostname", "sglang-client:12346")
+    local_hostname = _unique_local_hostname(configured_local_hostname)
+    metadata_server = config["metadata_server"]
+    global_segment_size = _parse_size(config.get("global_segment_size", 0))
+    local_buffer_size = _parse_size(config.get("local_buffer_size", "512MB"))
+    protocol = config.get("protocol", "tcp")
+    rdma_devices = config.get("rdma_devices", "")
+    master_server_addr = config.get(
+        "master_server_addr", config.get("master_server_address", "")
+    )
+
+    setup_config = {
+        "local_hostname": local_hostname,
+        "metadata_server": metadata_server,
+        "global_segment_size": global_segment_size,
+        "local_buffer_size": local_buffer_size,
+        "protocol": protocol,
+        "rdma_devices": rdma_devices,
+        "master_server_addr": master_server_addr,
+    }
+
+    try:
+        result = store.setup(
+            local_hostname,
+            metadata_server,
+            global_segment_size,
+            local_buffer_size,
+            protocol,
+            rdma_devices,
+            master_server_addr,
+        )
+    except TypeError:
+        result = store.setup(setup_config)
+
+    if result != 0:
+        raise RuntimeError(f"failed to setup MooncakeDistributedStore: {result}")
+    return store, local_hostname
+
+
+class MooncakeStoreFileConnector(BaseFileConnector):
+    """File-level Mooncake Store connector.
+
+    Metadata files are materialized locally for HuggingFace/SGLang config
+    loading. Weight files are not materialized: each safetensors shard is read
+    one tensor at a time from file-level Mooncake chunks, coalesced into a
+    reused registered buffer, and streamed straight to the target device.
+    """
+
+    def __init__(self, url: str, device=None, **kwargs) -> None:
+        super().__init__(url)
+        self.checkpoint_id = _checkpoint_id_from_url(url)
+        self.device = device
+
+        config = _load_store_config(kwargs.get("mooncake_weight_store_config"))
+        self.store, self.local_hostname = _create_store(config)
+
+        from mooncake.weight_store import READY, ModelFileCacheClient
+
+        self.ready_status = READY
+        self.client = ModelFileCacheClient(
+            self.store,
+            replica_num=int(config.get("replica_num", 1)),
+            file_chunk_size=_parse_size(config.get("file_chunk_size", "64MB")),
+            progress=False,
+        )
+        self.manifest = self.client.inspect_model(self.checkpoint_id)
+        if self.manifest.status != self.ready_status:
+            raise RuntimeError(
+                f"Mooncake checkpoint {self.checkpoint_id!r} is not READY: "
+                f"{self.manifest.status}"
+            )
+
+        root = kwargs.get("metadata_dir") or kwargs.get("materialize_dir")
+        root = root or os.environ.get("MOONCAKE_MODEL_MATERIALIZE_DIR")
+        root = root or DEFAULT_METADATA_DIR
+        self.local_dir = os.path.join(root, self.checkpoint_id)
+        os.makedirs(self.local_dir, exist_ok=True)
+
+        self.file_chunk_size = _parse_size(config.get("file_chunk_size", "64MB"))
+        self.tensor_batch_buffer_size = _parse_size(
+            kwargs.get(
+                "tensor_batch_buffer_size",
+                config.get("tensor_batch_buffer_size", "512MB"),
+            )
+        )
+        if self.tensor_batch_buffer_size <= 0:
+            raise ValueError("tensor_batch_buffer_size must be positive")
+        batch_device = kwargs.get(
+            "tensor_batch_device", config.get("tensor_batch_device", "auto")
+        )
+        tensor_batch_device = (
+            self.device
+            if batch_device == "auto" and self.device is not None
+            else ("cpu" if batch_device == "auto" else batch_device)
+        )
+        try:
+            self.tensor_batch_device = torch.device(tensor_batch_device)
+        except (RuntimeError, TypeError) as error:
+            raise ValueError(
+                f"invalid tensor_batch_device: {tensor_batch_device!r}"
+            ) from error
+        if (
+            self.tensor_batch_device.type == "cuda"
+            and self.tensor_batch_device.index is None
+        ):
+            self.tensor_batch_device = torch.device("cuda", torch.cuda.current_device())
+        self._range_read_disabled = False
+        self._batch_buffer = {"buffer": None, "ptr": None, "size": 0}
+        logger.info(
+            "Initialized MooncakeStoreFileConnector checkpoint=%s local_dir=%s "
+            "local_hostname=%s batch_device=%s batch_size=%d",
+            self.checkpoint_id,
+            self.local_dir,
+            self.local_hostname,
+            self.tensor_batch_device,
+            self.tensor_batch_buffer_size,
+        )
+
+    def glob(self, allow_pattern: Optional[list[str]] = None) -> list[str]:
+        paths = [record.path for record in self.manifest.files]
+        if allow_pattern is not None:
+            paths = [path for path in paths if _matches(path, allow_pattern)]
+        return [f"{self.url.rstrip('/')}/{path}" for path in sorted(paths)]
+
+    def pull_files(
+        self,
+        allow_pattern: Optional[list[str]] = None,
+        ignore_pattern: Optional[list[str]] = None,
+    ) -> None:
+        for record in self.manifest.files:
+            path = record.path
+            if allow_pattern is not None and not _matches(path, allow_pattern):
+                continue
+            if ignore_pattern is not None and _matches(path, ignore_pattern):
+                continue
+            if ignore_pattern is None and _matches(path, WEIGHT_PATTERNS):
+                continue
+
+            output_path = os.path.join(self.local_dir, path)
+            if self._local_file_matches(output_path, record.size):
+                continue
+            logger.info(
+                "Materializing Mooncake metadata file %s to %s",
+                path,
+                output_path,
+            )
+            self.client.materialize_file(self.checkpoint_id, path, output_path)
+
+    def weight_iterator(
+        self, rank: int = 0
+    ) -> Generator[Tuple[str, torch.Tensor], None, None]:
+        del rank
+        for record in self._weight_records():
+            logger.info(
+                "Streaming Mooncake safetensors shard %s (%d bytes) by tensor",
+                record.path,
+                record.size,
+            )
+            reader = _SequentialChunkReader(self.store, record, self.file_chunk_size)
+            header_size = struct.unpack("<Q", reader.read(0, 8))[0]
+            if header_size > record.size - 8:
+                raise RuntimeError(
+                    f"invalid safetensors header size for {record.path}: {header_size}"
+                )
+            header = json.loads(reader.read(8, header_size).decode("utf-8"))
+            data_offset = 8 + header_size
+
+            tensor_infos = self._parse_tensor_infos(header, data_offset, record.size)
+            batches = self._tensor_batches(tensor_infos)
+            for batch in batches:
+                tensors = self._read_tensor_batch(reader, record, batch)
+                for name, tensor in tensors:
+                    yield name, tensor
+
+    def close(self):
+        if self.closed:
+            return
+        self.closed = True
+        slot = getattr(self, "_batch_buffer", None)
+        if slot is not None and slot["ptr"] is not None:
+            result = self.store.unregister_buffer(slot["ptr"])
+            if result != 0:
+                logger.warning(
+                    "Failed to unregister Mooncake tensor batch buffer: %s", result
+                )
+            slot["ptr"] = None
+            slot["buffer"] = None
+            slot["size"] = 0
+        closer = getattr(getattr(self, "store", None), "close", None)
+        if closer is not None:
+            closer()
+        # Do not remove local_dir: metadata files must remain available for the
+        # lifetime of SGLang config/tokenizer users and are useful for debugging.
+
+    def _weight_records(self):
+        records = [
+            record
+            for record in self.manifest.files
+            if record.path.endswith(".safetensors")
+        ]
+        if not records:
+            raise RuntimeError(
+                f"Mooncake checkpoint {self.checkpoint_id!r} has no safetensors files"
+            )
+        return sorted(records, key=lambda record: record.path)
+
+    @staticmethod
+    def _local_file_matches(path: str, size: int) -> bool:
+        try:
+            return os.path.getsize(path) == size
+        except OSError:
+            return False
+
+    def _read_tensor_batch(self, reader, record, batch):
+        batch_size = sum(info["size"] for info in batch)
+        if batch_size == 0:
+            return [
+                (info["name"], torch.empty(info["shape"], dtype=info["dtype"]))
+                for info in batch
+            ]
+
+        if not self._ensure_batch_buffer(batch_size):
+            return [self._read_tensor_fallback(reader, record, info) for info in batch]
+
+        slot = self._batch_buffer
+
+        keys = []
+        dst_offsets = []
+        src_offsets = []
+        sizes = []
+        tensor_offset = 0
+        for info in batch:
+            fragments = self._range_fragments(
+                record,
+                info["offset"],
+                info["size"],
+                destination_offset=tensor_offset,
+            )
+            for key, dst, src, fragment_size in zip(*fragments):
+                if (
+                    keys
+                    and keys[-1] == key
+                    and dst_offsets[-1][0] + sizes[-1][0] == dst[0]
+                    and src_offsets[-1][0] + sizes[-1][0] == src[0]
+                ):
+                    sizes[-1][0] += fragment_size[0]
+                else:
+                    keys.append(key)
+                    dst_offsets.append(dst)
+                    src_offsets.append(src)
+                    sizes.append(fragment_size)
+            info["buffer_offset"] = tensor_offset
+            tensor_offset += info["size"]
+
+        try:
+            results = self.store.get_into_ranges(
+                [slot["ptr"]],
+                [keys],
+                [dst_offsets],
+                [src_offsets],
+                [sizes],
+            )
+            if len(results) != 1 or len(results[0]) != len(keys):
+                raise RuntimeError(
+                    f"get_into_ranges returned an invalid result for {record.path}"
+                )
+            for key, expected_sizes, actual_sizes in zip(keys, sizes, results[0]):
+                if actual_sizes != expected_sizes:
+                    raise RuntimeError(
+                        f"get_into_ranges failed for {key}: "
+                        f"expected {expected_sizes}, got {actual_sizes}"
+                    )
+        except Exception as error:
+            self._range_read_disabled = True
+            logger.warning(
+                "Mooncake batched range read failed for %s; falling back to "
+                "sequential get for this connector: %s",
+                record.path,
+                error,
+            )
+            return [self._read_tensor_fallback(reader, record, info) for info in batch]
+
+        tensors = []
+        for info in batch:
+            start = info["buffer_offset"]
+            raw = slot["buffer"][start : start + info["size"]]
+            tensor = raw.view(info["dtype"]).reshape(info["shape"])
+            tensors.append((info["name"], tensor))
+        return tensors
+
+    def _ensure_batch_buffer(self, required_size: int) -> bool:
+        register_buffer = getattr(self.store, "register_buffer", None)
+        unregister_buffer = getattr(self.store, "unregister_buffer", None)
+        get_into_ranges = getattr(self.store, "get_into_ranges", None)
+        if self._range_read_disabled or not all(
+            callable(method)
+            for method in (register_buffer, unregister_buffer, get_into_ranges)
+        ):
+            return False
+
+        slot = self._batch_buffer
+        if slot["size"] >= required_size:
+            return True
+
+        if slot["ptr"] is not None:
+            result = unregister_buffer(slot["ptr"])
+            if result != 0:
+                raise RuntimeError(
+                    f"failed to resize Mooncake tensor batch buffer: {result}"
+                )
+            slot["buffer"] = None
+            slot["ptr"] = None
+            slot["size"] = 0
+
+        size = max(required_size, self.tensor_batch_buffer_size)
+        buffer = torch.empty(size, dtype=torch.uint8, device=self.tensor_batch_device)
+        buffer_ptr = buffer.data_ptr()
+        result = register_buffer(buffer_ptr, size)
+        if result != 0:
+            logger.warning(
+                "Failed to register tensor buffer for %s, falling back to get: %s",
+                "tensor batch buffer",
+                result,
+            )
+            self._range_read_disabled = True
+            return False
+
+        slot["buffer"] = buffer
+        slot["ptr"] = buffer_ptr
+        slot["size"] = size
+        return True
+
+    @staticmethod
+    def _read_tensor_fallback(reader, record, info):
+        payload = reader.read(info["offset"], info["size"])
+        tensor = torch.frombuffer(payload, dtype=info["dtype"]).reshape(info["shape"])
+        return info["name"], tensor
+
+    def _range_fragments(
+        self, record, offset: int, size: int, destination_offset: int = 0
+    ):
+        keys = []
+        dst_offsets = []
+        src_offsets = []
+        sizes = []
+        copied = 0
+        while copied < size:
+            absolute_offset = offset + copied
+            chunk_index = absolute_offset // self.file_chunk_size
+            source_offset = absolute_offset % self.file_chunk_size
+            fragment_size = min(size - copied, self.file_chunk_size - source_offset)
+            keys.append(record.chunks[chunk_index])
+            dst_offsets.append([destination_offset + copied])
+            src_offsets.append([source_offset])
+            sizes.append([fragment_size])
+            copied += fragment_size
+        return keys, dst_offsets, src_offsets, sizes
+
+    @staticmethod
+    def _tensor_records(header: dict):
+        records = [
+            (name, metadata)
+            for name, metadata in header.items()
+            if name != "__metadata__"
+        ]
+        return sorted(records, key=lambda item: item[1]["data_offsets"][0])
+
+    def _parse_tensor_infos(self, header: dict, data_offset: int, file_size: int):
+        infos = []
+        for name, metadata in self._tensor_records(header):
+            dtype_name = metadata["dtype"]
+            if dtype_name not in SAFETENSORS_DTYPES:
+                raise ValueError(
+                    f"unsupported safetensors dtype {dtype_name!r} for {name}"
+                )
+            dtype, element_size = SAFETENSORS_DTYPES[dtype_name]
+            shape = tuple(metadata["shape"])
+            start, end = metadata["data_offsets"]
+            if start < 0 or end < start or data_offset + end > file_size:
+                raise RuntimeError(
+                    f"invalid safetensors data offsets for {name}: "
+                    f"[{start}, {end}] in a {file_size}-byte file"
+                )
+            tensor_size = end - start
+            expected_size = math.prod(shape) * element_size
+            if tensor_size != expected_size:
+                raise RuntimeError(
+                    f"invalid safetensors tensor size for {name}: "
+                    f"expected {expected_size}, got {tensor_size}"
+                )
+            infos.append(
+                {
+                    "name": name,
+                    "dtype": dtype,
+                    "shape": shape,
+                    "offset": data_offset + start,
+                    "size": tensor_size,
+                }
+            )
+        return infos
+
+    def _tensor_batches(self, infos):
+        batches = []
+        current = []
+        current_size = 0
+        for info in infos:
+            if current and current_size + info["size"] > self.tensor_batch_buffer_size:
+                batches.append(current)
+                current = []
+                current_size = 0
+            current.append(info)
+            current_size += info["size"]
+        if current:
+            batches.append(current)
+        return batches
+
+
+class _SequentialChunkReader:
+    def __init__(self, store, record, chunk_size: int) -> None:
+        self.store = store
+        self.record = record
+        self.chunk_size = chunk_size
+        self.chunk_index = -1
+        self.chunk = b""
+
+    def read(self, offset: int, size: int) -> bytearray:
+        if offset < 0 or size < 0 or offset + size > self.record.size:
+            raise ValueError(
+                f"invalid range for {self.record.path}: offset={offset}, size={size}"
+            )
+        output = bytearray(size)
+        output_offset = 0
+        while output_offset < size:
+            absolute_offset = offset + output_offset
+            chunk_index = absolute_offset // self.chunk_size
+            if chunk_index != self.chunk_index:
+                chunk_key = self.record.chunks[chunk_index]
+                chunk = self.store.get(chunk_key)
+                if chunk is None:
+                    raise KeyError(chunk_key)
+                self.chunk = bytes(chunk)
+                self.chunk_index = chunk_index
+
+            chunk_offset = absolute_offset - chunk_index * self.chunk_size
+            copy_size = min(size - output_offset, len(self.chunk) - chunk_offset)
+            if copy_size <= 0:
+                raise RuntimeError(
+                    f"invalid chunk size for {self.record.path} chunk {chunk_index}"
+                )
+            output[output_offset : output_offset + copy_size] = memoryview(self.chunk)[
+                chunk_offset : chunk_offset + copy_size
+            ]
+            output_offset += copy_size
+        return output

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -568,6 +568,9 @@ class Scheduler(
 
     def init_model_config(self):
         self.model_config = ModelConfig.from_server_args(self.server_args)
+        from sglang.srt.configs.model_config import resolve_remote_tokenizer_path
+
+        resolve_remote_tokenizer_path(self.server_args, self.model_config)
         if _is_npu:
             # make sure the page size is not larger than block_size and chunked_prefill_size on NPU backend
             # the npu backend request the defined page size to be no larger than block_size and chunked_prefill_size
@@ -670,6 +673,8 @@ class Scheduler(
             self.tokenizer = self.processor = None
         else:
             if self.model_config.is_multimodal:
+                from sglang.srt.utils import is_remote_url
+
                 self.processor = get_processor(
                     server_args.tokenizer_path,
                     tokenizer_mode=server_args.tokenizer_mode,
@@ -677,7 +682,11 @@ class Scheduler(
                     revision=server_args.revision,
                     use_fast=not server_args.disable_fast_image_processor,
                     tokenizer_backend=server_args.tokenizer_backend,
-                    model_name=server_args.model_path,
+                    model_name=(
+                        self.model_config.model_path
+                        if is_remote_url(server_args.model_path)
+                        else server_args.model_path
+                    ),
                 )
                 self.tokenizer = get_tokenizer_from_processor(self.processor)
             else:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -304,6 +304,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.model_path = server_args.model_path
         self.served_model_name = server_args.served_model_name
         self.model_config = model_config_class.from_server_args(server_args)
+        if model_config_class is ModelConfig:
+            from sglang.srt.configs.model_config import resolve_remote_tokenizer_path
+
+            resolve_remote_tokenizer_path(server_args, self.model_config)
         self.is_generation = self.model_config.is_generation
         self.context_len = self.model_config.context_len
         self.image_token_id = self.model_config.image_token_id
@@ -3075,6 +3079,13 @@ async def print_exception_wrapper(func):
 
 
 def _get_processor_wrapper(server_args):
+    from sglang.srt.utils import is_remote_url
+
+    processor_model_name = (
+        server_args.tokenizer_path
+        if is_remote_url(server_args.model_path)
+        else server_args.model_path
+    )
     try:
         processor = get_processor(
             server_args.tokenizer_path,
@@ -3083,7 +3094,7 @@ def _get_processor_wrapper(server_args):
             revision=server_args.revision,
             use_fast=not server_args.disable_fast_image_processor,
             tokenizer_backend=server_args.tokenizer_backend,
-            model_name=server_args.model_path,
+            model_name=processor_model_name,
         )
     except ValueError as e:
         error_message = str(e)
@@ -3098,7 +3109,7 @@ def _get_processor_wrapper(server_args):
                 revision=server_args.revision,
                 use_fast=True,
                 tokenizer_backend=server_args.tokenizer_backend,
-                model_name=server_args.model_path,
+                model_name=processor_model_name,
             )
         else:
             raise e

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -283,13 +283,19 @@ class TpModelWorker(BaseTpWorker):
             self.tokenizer = self.processor = None
         else:
             if self.model_config.is_multimodal:
+                from sglang.srt.utils import is_remote_url
+
                 self.processor = get_processor(
                     server_args.tokenizer_path,
                     tokenizer_mode=server_args.tokenizer_mode,
                     trust_remote_code=server_args.trust_remote_code,
                     revision=server_args.revision,
                     tokenizer_backend=server_args.tokenizer_backend,
-                    model_name=server_args.model_path,
+                    model_name=(
+                        self.model_config.model_path
+                        if is_remote_url(server_args.model_path)
+                        else server_args.model_path
+                    ),
                 )
                 self.tokenizer = get_tokenizer_from_processor(self.processor)
             else:
@@ -378,6 +384,10 @@ class TpModelWorker(BaseTpWorker):
             is_draft_model=self.is_draft_worker,
             context_length=self.context_length,
         )
+        if not self.is_draft_worker:
+            from sglang.srt.configs.model_config import resolve_remote_tokenizer_path
+
+            resolve_remote_tokenizer_path(self.server_args, self.model_config)
 
     def _init_model_runner(self):
         from sglang.srt.model_executor.model_runner import ModelRunner

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2563,7 +2563,9 @@ class RemoteModelLoader(BaseModelLoader):
                 model = _initialize_model(model_config, self.load_config, quant_config)
 
             with create_remote_connector(
-                model_weights, device=device_config.device
+                model_weights,
+                device=device_config.device,
+                **(load_config.model_loader_extra_config or {}),
             ) as client:
                 connector_type = get_connector_type(client)
                 if connector_type == ConnectorType.KV:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -29,6 +29,7 @@ import socket
 import tempfile
 import uuid
 from functools import cached_property
+from urllib.parse import urlparse
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from sglang.jit_kernel.kv_canary.consts import RealKvHashMode
@@ -3177,7 +3178,11 @@ class ServerArgs:
         if self.tokenizer_path is None:
             self.tokenizer_path = self.model_path
         if self.served_model_name is None:
-            self.served_model_name = self.model_path
+            self.served_model_name = (
+                self._default_remote_served_model_name(self.model_path)
+                if is_remote_url(self.model_path)
+                else self.model_path
+            )
         if self.device is None:
             self.device = get_device()
         # strip device index from user if any (e.g. "cuda:0" -> "cuda")
@@ -3207,6 +3212,12 @@ class ServerArgs:
             self._quantization_explicitly_unset = False
         if self.speculative_draft_model_quantization == "unquant":
             self.speculative_draft_model_quantization = None
+
+    @staticmethod
+    def _default_remote_served_model_name(model_path: str) -> str:
+        parsed = urlparse(model_path)
+        name = os.path.basename(parsed.path.rstrip("/")) or parsed.netloc
+        return name.replace(":", "_") or model_path.replace(":", "_")
 
     def _handle_modelscope_paths(self):
         """Resolve model / tokenizer / speculative-draft paths from the local

--- a/test/registered/model_loading/test_mooncake_store_file_connector.py
+++ b/test/registered/model_loading/test_mooncake_store_file_connector.py
@@ -1,0 +1,329 @@
+import ctypes
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+try:
+    import torch
+    from safetensors.torch import save
+except ModuleNotFoundError:
+    torch = None
+    save = None
+
+
+class _Record:
+    def __init__(self, path, size, chunks):
+        self.path = path
+        self.size = size
+        self.chunks = chunks
+
+
+class _Manifest:
+    def __init__(self, status, files):
+        self.status = status
+        self.files = files
+
+
+class _FakeStore:
+    manifest = None
+    objects = {}
+    range_calls = 0
+    registered_buffers = []
+    unregistered_buffers = []
+    fail_ranges = False
+    range_key_batches = []
+
+    def setup(self, *args, **kwargs):
+        return 0
+
+    def get(self, key):
+        return self.objects.get(key)
+
+    def register_buffer(self, ptr, size):
+        self.registered_buffers.append((ptr, size))
+        return 0
+
+    def unregister_buffer(self, ptr):
+        self.unregistered_buffers.append(ptr)
+        return 0
+
+    def get_into_ranges(
+        self,
+        buffer_ptrs,
+        all_keys,
+        all_dst_offsets,
+        all_src_offsets,
+        all_sizes,
+    ):
+        type(self).range_calls += 1
+        self.range_key_batches.append([list(keys) for keys in all_keys])
+        if self.fail_ranges:
+            return [
+                [[-1 for _ in key_sizes] for key_sizes in sizes] for sizes in all_sizes
+            ]
+        results = []
+        for base_ptr, keys, dst_offsets, src_offsets, sizes in zip(
+            buffer_ptrs,
+            all_keys,
+            all_dst_offsets,
+            all_src_offsets,
+            all_sizes,
+        ):
+            buffer_results = []
+            for key, key_dst, key_src, key_sizes in zip(
+                keys, dst_offsets, src_offsets, sizes
+            ):
+                data = self.objects[key]
+                for dst, src, size in zip(key_dst, key_src, key_sizes):
+                    ctypes.memmove(base_ptr + dst, data[src : src + size], size)
+                buffer_results.append(list(key_sizes))
+            results.append(buffer_results)
+        return results
+
+
+class _FakeModelFileCacheClient:
+    def __init__(self, store, **kwargs):
+        self.store = store
+
+    def inspect_model(self, checkpoint_id):
+        return self.store.manifest
+
+    def materialize_file(self, checkpoint_id, path, output_path):
+        for record in self.store.manifest.files:
+            if record.path == path:
+                output = Path(output_path)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_bytes(
+                    b"".join(self.store.get(key) for key in record.chunks)
+                )
+                return
+        raise KeyError(path)
+
+
+def _install_fake_mooncake_modules():
+    mooncake_mod = types.ModuleType("mooncake")
+    store_mod = types.ModuleType("mooncake.store")
+    weight_store_mod = types.ModuleType("mooncake.weight_store")
+
+    store_mod.MooncakeDistributedStore = _FakeStore
+    weight_store_mod.READY = "READY"
+    weight_store_mod.ModelFileCacheClient = _FakeModelFileCacheClient
+
+    sys.modules["mooncake"] = mooncake_mod
+    sys.modules["mooncake.store"] = store_mod
+    sys.modules["mooncake.weight_store"] = weight_store_mod
+
+
+class MooncakeStoreFileConnectorTest(unittest.TestCase):
+    def setUp(self):
+        _install_fake_mooncake_modules()
+        _FakeStore.range_calls = 0
+        _FakeStore.registered_buffers = []
+        _FakeStore.unregistered_buffers = []
+        _FakeStore.fail_ranges = False
+        _FakeStore.range_key_batches = []
+        self.tmp = Path(__file__).parent / ".tmp_mooncake_connector_test"
+        if self.tmp.exists():
+            import shutil
+
+            shutil.rmtree(self.tmp)
+        self.tmp.mkdir()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        for name in ("mooncake", "mooncake.store", "mooncake.weight_store"):
+            sys.modules.pop(name, None)
+
+    def test_materializes_metadata_and_streams_weights(self):
+        if torch is None or save is None:
+            self.skipTest("torch and safetensors are required")
+
+        from sglang.srt.connector import create_remote_connector
+
+        config_path = self.tmp / "weight-store.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "local_hostname": "test-client:12346",
+                    "metadata_server": "http://127.0.0.1:8080/metadata",
+                    "global_segment_size": "0",
+                    "local_buffer_size": "64MB",
+                    "protocol": "tcp",
+                    "rdma_devices": "",
+                    "master_server_addr": "127.0.0.1:50051",
+                    "replica_num": 1,
+                    "file_chunk_size": 32,
+                }
+            )
+        )
+
+        tensor = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        safetensors_payload = save({"linear.weight": tensor})
+        chunk_size = 32
+        weight_chunks = [
+            safetensors_payload[offset : offset + chunk_size]
+            for offset in range(0, len(safetensors_payload), chunk_size)
+        ]
+        weight_keys = [f"weight-chunk-{index}" for index in range(len(weight_chunks))]
+        _FakeStore.objects = {
+            "config-chunk": b'{"model_type":"test"}',
+            **dict(zip(weight_keys, weight_chunks)),
+        }
+        _FakeStore.manifest = _Manifest(
+            "READY",
+            [
+                _Record(
+                    "config.json",
+                    len(_FakeStore.objects["config-chunk"]),
+                    ["config-chunk"],
+                ),
+                _Record(
+                    "model-00001-of-00001.safetensors",
+                    len(safetensors_payload),
+                    weight_keys,
+                ),
+            ],
+        )
+
+        connector = create_remote_connector(
+            "mooncake://MiniMax-M2.7",
+            mooncake_weight_store_config=str(config_path),
+            materialize_dir=str(self.tmp / "metadata"),
+        )
+
+        connector.pull_files(ignore_pattern=["*.safetensors", "*.bin", "*.pt"])
+        self.assertTrue(
+            (self.tmp / "metadata" / "MiniMax-M2.7" / "config.json").exists()
+        )
+        self.assertFalse(
+            (
+                self.tmp
+                / "metadata"
+                / "MiniMax-M2.7"
+                / "model-00001-of-00001.safetensors"
+            ).exists()
+        )
+
+        loaded = dict(connector.weight_iterator())
+        self.assertTrue(torch.equal(loaded["linear.weight"], tensor))
+
+    def test_tensor_stream_loads_tensor_across_chunks(self):
+        if torch is None or save is None:
+            self.skipTest("torch and safetensors are required")
+
+        from sglang.srt.connector import create_remote_connector
+        from sglang.srt.connector.mooncake_store_file import (
+            MooncakeStoreFileConnector,
+        )
+
+        config_path = self.tmp / "weight-store.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "local_hostname": "test-client:12346",
+                    "metadata_server": "http://127.0.0.1:8080/metadata",
+                    "global_segment_size": "0",
+                    "local_buffer_size": "64MB",
+                    "protocol": "tcp",
+                    "master_server_addr": "127.0.0.1:50051",
+                    "file_chunk_size": 32,
+                    "tensor_batch_buffer_size": "1KB",
+                }
+            )
+        )
+
+        first_tensor = torch.arange(64, dtype=torch.float32).reshape(8, 8)
+        second_tensor = torch.arange(64, 128, dtype=torch.float32).reshape(8, 8)
+        payload = save(
+            {
+                "first.weight": first_tensor,
+                "second.weight": second_tensor,
+            }
+        )
+        chunk_size = 32
+        chunks = [
+            payload[offset : offset + chunk_size]
+            for offset in range(0, len(payload), chunk_size)
+        ]
+        chunk_keys = [f"weight-chunk-{index}" for index in range(len(chunks))]
+        _FakeStore.objects = dict(zip(chunk_keys, chunks))
+        _FakeStore.manifest = _Manifest(
+            "READY",
+            [_Record("model.safetensors", len(payload), chunk_keys)],
+        )
+
+        connector = create_remote_connector(
+            "mooncake://stream-test",
+            mooncake_weight_store_config=str(config_path),
+            materialize_dir=str(self.tmp / "metadata"),
+        )
+
+        self.assertIsInstance(connector, MooncakeStoreFileConnector)
+        loaded = dict(connector.weight_iterator())
+        self.assertTrue(torch.equal(loaded["first.weight"], first_tensor))
+        self.assertTrue(torch.equal(loaded["second.weight"], second_tensor))
+        self.assertEqual(_FakeStore.range_calls, 1)
+        range_keys = _FakeStore.range_key_batches[0][0]
+        self.assertTrue(
+            all(left != right for left, right in zip(range_keys, range_keys[1:]))
+        )
+        self.assertEqual(len(_FakeStore.registered_buffers), 1)
+        connector.close()
+        self.assertEqual(
+            _FakeStore.unregistered_buffers,
+            [_FakeStore.registered_buffers[0][0]],
+        )
+
+        _FakeStore.fail_ranges = True
+        fallback_connector = create_remote_connector(
+            "mooncake://stream-test",
+            mooncake_weight_store_config=str(config_path),
+            materialize_dir=str(self.tmp / "metadata"),
+        )
+        fallback_loaded = dict(fallback_connector.weight_iterator())
+        self.assertTrue(torch.equal(fallback_loaded["first.weight"], first_tensor))
+        self.assertTrue(torch.equal(fallback_loaded["second.weight"], second_tensor))
+
+    def test_tensor_stream_resolves_cuda_device_for_worker_threads(self):
+        if torch is None or not torch.cuda.is_available():
+            self.skipTest("CUDA is required")
+
+        from sglang.srt.connector import create_remote_connector
+
+        config_path = self.tmp / "weight-store.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "local_hostname": "test-client:12346",
+                    "metadata_server": "http://127.0.0.1:8080/metadata",
+                    "global_segment_size": "0",
+                    "local_buffer_size": "64MB",
+                    "protocol": "rdma",
+                    "master_server_addr": "127.0.0.1:50051",
+                    "file_chunk_size": 32,
+                }
+            )
+        )
+        _FakeStore.objects = {}
+        _FakeStore.manifest = _Manifest("READY", [])
+
+        connector = create_remote_connector(
+            "mooncake://device-test",
+            device="cuda",
+            mooncake_weight_store_config=str(config_path),
+            materialize_dir=str(self.tmp / "metadata"),
+        )
+
+        self.assertEqual(connector.tensor_batch_device.type, "cuda")
+        self.assertEqual(
+            connector.tensor_batch_device.index, torch.cuda.current_device()
+        )
+        connector.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This connector lets SGLang load model weights directly from a remote **MooncakeStore** over RDMA, treating the store as a generic model cache: `--model-path mooncake://<checkpoint> --load-format remote`, without staging weight files to local disk.

The design deliberately keeps storage **decoupled** from the inference engine. Weights are stored as plain files, and the engine loads files exactly as it would from disk — only the source changes (disk → MooncakeStore). This trades some raw load throughput for generality (any file-based loader can adopt it) and operability (import / list / delete are managed independently of the serving process). It is complementary to the tightly-coupled, higher-performance approach in #21661.

Related design discussion / RFC on the Mooncake side: kvcache-ai/Mooncake#2282 (Unified KVCache and Model Weight Management). The Mooncake-side control plane (import / list / inspect / verify / delete) lives in a separate Mooncake PR: kvcache-ai/Mooncake#2829.

## Modifications

<!-- Detail the changes made in this pull request. -->

- `connector/mooncake_store_file.py`: `MooncakeStoreFileConnector`. Reads safetensors headers from Mooncake chunks, identifies tensor boundaries from `data_offsets`, coalesces each tensor batch into a single `get_into_ranges()` against a reused registered buffer on the target CUDA device (GPUDirect RDMA), and yields `(name, tensor)` to `DefaultLoader`. Only metadata/tokenizer/config files are materialized locally.
- `connector/__init__.py`: register the `mooncake://` scheme.
- `model_loader/loader.py`: pass `model_loader_extra_config` through to the remote connector.
- `configs/model_config.py`: resolve remote model config/tokenizer files and propagate the Mooncake store config (also via `MOONCAKE_WEIGHT_STORE_CONFIG` env) to the loader.
- `server_args.py`: derive a filesystem-safe `served_model_name` for remote (`mooncake://`) model paths.
- `managers/{scheduler,tokenizer_manager,tp_worker}.py`: thread remote tokenizer metadata paths through the manager processes.
- `test/registered/model_loading/test_mooncake_store_file_connector.py`: connector unit tests.

## Usage

**1. Import weights into MooncakeStore** (Mooncake side; control plane lives in the separate Mooncake PR kvcache-ai/Mooncake#2829):

    python -m mooncake.weight_store.cli \
        --master-server-addr <master_ip:50051> \
        --metadata-server <metadata_ip:8080> \
        --protocol rdma --rdma-devices <mlx5_x> \
        --local-hostname <host_ip:port> \
        model import \
        --checkpoint-id Qwen3-235B-A22B \
        --model-id Qwen/Qwen3-235B-A22B \
        --revision main \
        --source /path/to/local/weights

    # inspect / list to confirm it landed
    python -m mooncake.weight_store.cli ... model list
    python -m mooncake.weight_store.cli ... model inspect Qwen3-235B-A22B

**2. Launch SGLang loading from the store** (this PR). Point `--model-path` at
the `mooncake://<checkpoint-id>` scheme and use `--load-for

    python -m sglang.launch_server \
        --model-path mooncake://Qwen3-235B-A22B \
        --load-format remote \
        --tp 8

The store connection is read from the Mooncake config file (or the `MOONCAKE_WEIGHT_STORE_CONFIG` env var). No extra `--model-is needed — the connector defaults to the GPUDirect RDMA fast path.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

End-to-end, cross-machine (one storage node + one 8×H20 node): loaded **Qwen3-235B-A22B** from MooncakeStore and verified inference output is correct. The connector only changes the weight source, not compute, so model outputs are
unaffected.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Cross-machine setup (one storage node + one 8×H20 node), weights loaded from MooncakeStore over RDMA. Zero extra config needed — the connector defaults to the GPUDirect RDMA fast path, reading weights straight into device memory.

| Model | Weights (dtype) | TP | Weight Loading Time |
|-------|-----------------|----|--------------------|
| Qwen3-235B-A22B | ~438 GB (BF16) | 8 | ~30s |

Only Qwen3-235B-A22B was measured on our setup; more models to follow.

Known limitation: generic file-level storage makes TP-aware loading harder than a format-coupled approach, so raw load throughput currently trails the tensor-level, format-coupled path in #21661 (which reports 16s for the same model). Closing that gap (e.g. optional TP-aware layout hints on top of the generic file layout) is the main follow-up.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29066099590](https://github.com/sgl-project/sglang/actions/runs/29066099590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29066099499](https://github.com/sgl-project/sglang/actions/runs/29066099499)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

