### PR TITLE
mhc: portable Triton hc_split_sinkhorn  fallback for non-TileLang bac…

### DIFF
--- a/benchmark/kernels/bench_hc_split_sinkhorn.py
+++ b/benchmark/kernels/bench_hc_split_sinkhorn.py
@@ -1,0 +1,95 @@
+"""Before/after benchmark for the DeepSeek-V4 mHC `hc_split_sinkhorn` fallback.
+
+On backends without TileLang (e.g. ROCm/AMD), `hc_split_sinkhorn` has no tuned
+CUDA path, so the alternative is a vectorized-torch implementation. This script
+compares that torch baseline (BEFORE) against the fused Triton fallback (AFTER)
+that ships in sglang.srt.layers.mhc.
+
+Run:
+    python3 benchmark/kernels/bench_hc_split_sinkhorn.py
+"""
+
+import argparse
+import statistics
+
+import torch
+
+from sglang.srt.layers.mhc import _hc_split_sinkhorn_triton  # AFTER (fused Triton)
+
+HC, ITERS, EPS = 4, 20, 1e-6  # DeepSeek-V4: hc_mult=4, 20 Sinkhorn iterations
+
+
+def sinkhorn_torch_baseline(mixes, hc_scale, hc_base, hc, iters, eps):
+    """BEFORE: vectorized-torch fallback (the alternative when TileLang is absent).
+
+    mixes: [b, s, (2 + hc) * hc]  ->  pre/post: [b, s, hc], comb: [b, s, hc, hc]
+    """
+    b, s, _ = mixes.shape
+    m = mixes.reshape(b * s, -1)
+    pre = torch.sigmoid(m[:, :hc] * hc_scale[0] + hc_base[:hc]) + eps
+    post = 2.0 * torch.sigmoid(m[:, hc : 2 * hc] * hc_scale[1] + hc_base[hc : 2 * hc])
+    comb = (m[:, 2 * hc :] * hc_scale[2] + hc_base[2 * hc :]).view(-1, hc, hc)
+
+    row_max = comb.max(dim=2, keepdim=True).values
+    comb = torch.exp(comb - row_max)
+    comb = comb / comb.sum(dim=2, keepdim=True) + eps
+    comb = comb / (comb.sum(dim=1, keepdim=True) + eps)
+    for _ in range(iters - 1):
+        comb = comb / (comb.sum(dim=2, keepdim=True) + eps)
+        comb = comb / (comb.sum(dim=1, keepdim=True) + eps)
+    return (
+        pre.view(b, s, hc),
+        post.view(b, s, hc),
+        comb.view(b, s, hc, hc),
+    )
+
+
+def time_ms(fn, trials=30, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    out = []
+    for _ in range(trials):
+        st = torch.cuda.Event(enable_timing=True)
+        en = torch.cuda.Event(enable_timing=True)
+        st.record()
+        fn()
+        en.record()
+        torch.cuda.synchronize()
+        out.append(st.elapsed_time(en))
+    return statistics.median(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true", help="verify before==after first")
+    args = ap.parse_args()
+
+    dev = "cuda"
+    mix_hc = (2 + HC) * HC
+    print(f"device: {torch.cuda.get_device_name(0)}")
+
+    if args.check:
+        torch.manual_seed(0)
+        mix = torch.randn(1, 4096, mix_hc, device=dev)
+        sc = torch.rand(3, device=dev) + 0.5
+        ba = torch.randn(mix_hc, device=dev)
+        a = sinkhorn_torch_baseline(mix, sc, ba, HC, ITERS, EPS)
+        b = _hc_split_sinkhorn_triton(mix, sc, ba, HC, ITERS, EPS)
+        md = max((a[i] - b[i]).abs().max().item() for i in range(3))
+        print(f"max|before-after| = {md:.2e}  ({'OK' if md < 1e-4 else 'MISMATCH'})\n")
+
+    print(f"{'tokens':>8} | {'BEFORE torch (ms)':>18} | {'AFTER triton (ms)':>18} | {'speedup':>8}")
+    print("-" * 62)
+    for n in [1, 8, 32, 128, 512, 2048, 8192, 32768]:
+        torch.manual_seed(0)
+        mix = torch.randn(1, n, mix_hc, device=dev)
+        sc = torch.rand(3, device=dev) + 0.5
+        ba = torch.randn(mix_hc, device=dev)
+        t_before = time_ms(lambda: sinkhorn_torch_baseline(mix, sc, ba, HC, ITERS, EPS))
+        t_after = time_ms(lambda: _hc_split_sinkhorn_triton(mix, sc, ba, HC, ITERS, EPS))
+        print(f"{n:>8} | {t_before:>18.4f} | {t_after:>18.4f} | {t_before / t_after:>7.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/layers/mhc.py
+++ b/python/sglang/srt/layers/mhc.py
@@ -4,11 +4,72 @@ import math
 from typing import Tuple
 
 import torch
+import triton
+import triton.language as tl
 
-from sglang.jit_kernel.utils import is_arch_support_pdl
 from sglang.srt.environ import envs
+<<<<<<< ours
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
+=======
+>>>>>>> theirs
 from sglang.srt.layers.utils.common import strict_contiguous
+from sglang.srt.utils import is_cuda
+
+# TileLang is CUDA-only. On non-CUDA backends (e.g. ROCm/AMD) it is unavailable,
+# so import it optionally and fall back to a portable Triton implementation for
+# the kernels that provide one (currently hc_split_sinkhorn). This keeps mhc.py
+# importable -- and the DeepSeek-V4 mHC path runnable -- on backends without
+# TileLang.
+try:
+    import tilelang
+    import tilelang.language as T
+
+    from sglang.jit_kernel.utils import is_arch_support_pdl
+    from sglang.srt.layers.attention.nsa.utils import (
+        is_nsa_prefill_cp_round_robin_split,
+    )
+
+    _HAS_TILELANG = True
+except Exception:
+    T = None
+    _HAS_TILELANG = False
+
+    def is_arch_support_pdl() -> bool:
+        return False
+
+    def is_nsa_prefill_cp_round_robin_split(*args, **kwargs) -> bool:
+        return False
+
+    class _TileLangStub:
+        """Minimal stand-in so module-level decorators/annotations resolve when
+        TileLang is absent. The decorated TileLang kernels are never executed on
+        the non-TileLang path -- dispatch routes to the Triton fallback."""
+
+        JITKernel = object
+
+        class PassConfigKey:
+            TL_DISABLE_WARP_SPECIALIZED = "TL_DISABLE_WARP_SPECIALIZED"
+            TL_DISABLE_TMA_LOWER = "TL_DISABLE_TMA_LOWER"
+            TL_PTXAS_REGISTER_USAGE_LEVEL = "TL_PTXAS_REGISTER_USAGE_LEVEL"
+
+        @staticmethod
+        def set_log_level(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def jit(*dargs, **dkwargs):
+            # Supports both @tilelang.jit and @tilelang.jit(...).
+            if len(dargs) == 1 and callable(dargs[0]) and not dkwargs:
+                return dargs[0]
+
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    tilelang = _TileLangStub()
+
+_IS_CUDA = is_cuda()
 
 logger = logging.getLogger(__name__)
 
@@ -132,13 +193,13 @@ def hc_split_sinkhorn_kernel(hc: int, sinkhorn_iters: int, eps: float):
     return hc_split_sinkhorn_kernel_
 
 
-def hc_split_sinkhorn(
+def _hc_split_sinkhorn_tilelang(
     mixes: torch.Tensor,
     hc_scale: torch.Tensor,
     hc_base: torch.Tensor,
-    hc_mult: int = 4,
-    sinkhorn_iters: int = 20,
-    eps: float = 1e-6,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    eps: float,
 ):
     b, s, _ = mixes.size()
     pre = mixes.new_empty(b, s, hc_mult)
@@ -154,6 +215,136 @@ def hc_split_sinkhorn(
         comb.view(-1, hc_mult, hc_mult),
     )
     return pre, post, comb
+
+
+@triton.jit
+def _hc_split_sinkhorn_triton_kernel(
+    mixes_ptr,
+    scale_ptr,
+    base_ptr,
+    pre_ptr,
+    post_ptr,
+    comb_ptr,
+    n,
+    eps,
+    HC: tl.constexpr,
+    ITERS: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    """Portable fallback mirroring hc_split_sinkhorn_kernel_ (the TileLang path).
+
+    One program handles BLOCK_T tokens, each with an (HC, HC) combination tile.
+    Faithfully reproduces the truncated ``ITERS``-iteration Sinkhorn -- the
+    iteration count is part of the trained model definition, so this matches the
+    TileLang result rather than iterating to convergence.
+    """
+    pid = tl.program_id(0)
+    t = pid * BLOCK_T + tl.arange(0, BLOCK_T)
+    tmask = t < n
+    mix_hc = (2 + HC) * HC
+
+    j = tl.arange(0, HC)
+    k = tl.arange(0, HC)
+
+    s0 = tl.load(scale_ptr + 0)
+    s1 = tl.load(scale_ptr + 1)
+    s2 = tl.load(scale_ptr + 2)
+
+    row = t[:, None] * mix_hc
+
+    # pre = sigmoid(mixes[:HC] * scale0 + base[:HC]) + eps
+    b_pre = tl.load(base_ptr + j)[None, :]
+    m_pre = tl.load(mixes_ptr + row + j[None, :], mask=tmask[:, None], other=0.0)
+    pre = tl.sigmoid(m_pre * s0 + b_pre) + eps
+    tl.store(pre_ptr + t[:, None] * HC + j[None, :], pre, mask=tmask[:, None])
+
+    # post = 2 * sigmoid(mixes[HC:2HC] * scale1 + base[HC:2HC])
+    b_post = tl.load(base_ptr + (j + HC))[None, :]
+    m_post = tl.load(
+        mixes_ptr + row + (j + HC)[None, :], mask=tmask[:, None], other=0.0
+    )
+    post = 2.0 * tl.sigmoid(m_post * s1 + b_post)
+    tl.store(post_ptr + t[:, None] * HC + j[None, :], post, mask=tmask[:, None])
+
+    # comb[j, k] = mixes[2HC + j*HC + k] * scale2 + base[2HC + j*HC + k]
+    off = 2 * HC + j[None, :, None] * HC + k[None, None, :]
+    b_comb = tl.load(base_ptr + (2 * HC + j[:, None] * HC + k[None, :]))[None, :, :]
+    m_comb = tl.load(
+        mixes_ptr + row[:, :, None] + off, mask=tmask[:, None, None], other=0.0
+    )
+    comb = m_comb * s2 + b_comb
+
+    # row softmax, then alternating row/col normalization (Sinkhorn).
+    row_max = tl.max(comb, axis=2)[:, :, None]
+    comb = tl.exp(comb - row_max)
+    row_sum = tl.sum(comb, axis=2)[:, :, None]
+    comb = comb / row_sum + eps
+    col_sum = tl.sum(comb, axis=1)[:, None, :]
+    comb = comb / (col_sum + eps)
+
+    for _ in range(ITERS - 1):
+        row_sum = tl.sum(comb, axis=2)[:, :, None]
+        comb = comb / (row_sum + eps)
+        col_sum = tl.sum(comb, axis=1)[:, None, :]
+        comb = comb / (col_sum + eps)
+
+    cbase = t[:, None, None] * (HC * HC) + j[None, :, None] * HC + k[None, None, :]
+    tl.store(comb_ptr + cbase, comb, mask=tmask[:, None, None])
+
+
+def _hc_split_sinkhorn_triton(
+    mixes: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    eps: float,
+    block_t: int = 64,
+):
+    b, s, _ = mixes.size()
+    n = b * s
+    mixes_flat = mixes.reshape(n, (2 + hc_mult) * hc_mult).contiguous()
+    pre = mixes.new_empty(n, hc_mult, dtype=torch.float32)
+    post = mixes.new_empty(n, hc_mult, dtype=torch.float32)
+    comb = mixes.new_empty(n, hc_mult, hc_mult, dtype=torch.float32)
+    grid = (triton.cdiv(n, block_t),)
+    _hc_split_sinkhorn_triton_kernel[grid](
+        mixes_flat,
+        hc_scale.contiguous(),
+        hc_base.contiguous(),
+        pre,
+        post,
+        comb,
+        n,
+        eps,
+        HC=hc_mult,
+        ITERS=sinkhorn_iters,
+        BLOCK_T=block_t,
+    )
+    return (
+        pre.view(b, s, hc_mult),
+        post.view(b, s, hc_mult),
+        comb.view(b, s, hc_mult, hc_mult),
+    )
+
+
+def hc_split_sinkhorn(
+    mixes: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int = 4,
+    sinkhorn_iters: int = 20,
+    eps: float = 1e-6,
+):
+    # Prefer the tuned TileLang kernel on CUDA; use the portable Triton fallback
+    # on backends where TileLang is unavailable (e.g. ROCm/AMD).
+    if _HAS_TILELANG and _IS_CUDA:
+        return _hc_split_sinkhorn_tilelang(
+            mixes, hc_scale, hc_base, hc_mult, sinkhorn_iters, eps
+        )
+    return _hc_split_sinkhorn_triton(
+        mixes, hc_scale, hc_base, hc_mult, sinkhorn_iters, eps
+    )
 
 
 @tilelang.jit(

--- a/test/registered/unit/layers/test_mhc_sinkhorn_triton.py
+++ b/test/registered/unit/layers/test_mhc_sinkhorn_triton.py
@@ -1,0 +1,113 @@
+"""Unit test for the portable Triton hc_split_sinkhorn fallback (mHC / DeepSeek-V4).
+
+Validates the vendor-neutral Triton kernel against a pure-torch reference of the
+TileLang kernel math. This is the fallback used on backends without TileLang
+(e.g. ROCm/AMD). No server, no model loading.
+"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small")
+
+import unittest
+
+import torch
+
+from sglang.srt.layers import mhc
+from sglang.test.test_utils import CustomTestCase
+
+
+def _sinkhorn_ref(mixes, hc_scale, hc_base, hc, iters, eps):
+    """Pure-torch reference mirroring hc_split_sinkhorn_kernel_ in mhc.py.
+
+    mixes: [n, (2 + hc) * hc]  ->  pre/post: [n, hc], comb: [n, hc, hc]
+    """
+    n = mixes.shape[0]
+    pre = torch.sigmoid(mixes[:, :hc] * hc_scale[0] + hc_base[:hc]) + eps
+    post = 2.0 * torch.sigmoid(
+        mixes[:, hc : 2 * hc] * hc_scale[1] + hc_base[hc : 2 * hc]
+    )
+    comb = (mixes[:, 2 * hc :] * hc_scale[2] + hc_base[2 * hc :]).view(n, hc, hc)
+
+    row_max = comb.max(dim=2, keepdim=True).values
+    comb = torch.exp(comb - row_max)
+    row_sum = comb.sum(dim=2, keepdim=True)
+    comb = comb / row_sum + eps
+    col_sum = comb.sum(dim=1, keepdim=True)
+    comb = comb / (col_sum + eps)
+    for _ in range(iters - 1):
+        row_sum = comb.sum(dim=2, keepdim=True)
+        comb = comb / (row_sum + eps)
+        col_sum = comb.sum(dim=1, keepdim=True)
+        comb = comb / (col_sum + eps)
+    return pre, post, comb
+
+
+class TestMhcSinkhornTriton(CustomTestCase):
+    EPS = 1e-6
+
+    def _check(self, n, hc, iters, seed=0):
+        torch.manual_seed(seed)
+        dev = "cuda"
+        mix_hc = (2 + hc) * hc
+        mixes = torch.randn(n, mix_hc, device=dev, dtype=torch.float32)
+        scale = torch.rand(3, device=dev, dtype=torch.float32) + 0.5
+        base = torch.randn(mix_hc, device=dev, dtype=torch.float32)
+
+        ref_pre, ref_post, ref_comb = _sinkhorn_ref(
+            mixes, scale, base, hc, iters, self.EPS
+        )
+
+        # Exercise the fallback via the 3D public API shape [b, s, mix_hc].
+        pre, post, comb = mhc._hc_split_sinkhorn_triton(
+            mixes.view(1, n, mix_hc), scale, base, hc, iters, self.EPS
+        )
+        pre = pre.reshape(n, hc)
+        post = post.reshape(n, hc)
+        comb = comb.reshape(n, hc, hc)
+
+        torch.testing.assert_close(pre, ref_pre, atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(post, ref_post, atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(comb, ref_comb, atol=1e-5, rtol=1e-4)
+
+    def test_default_dsv4_shape(self):
+        # DeepSeek-V4: hc_mult=4, 20 Sinkhorn iterations.
+        for n in (1, 7, 128, 4096):
+            with self.subTest(n=n):
+                self._check(n=n, hc=4, iters=20)
+
+    def test_varied_iters(self):
+        for iters in (1, 2, 5, 10):
+            with self.subTest(iters=iters):
+                self._check(n=512, hc=4, iters=iters)
+
+    def test_varied_hc(self):
+        for hc in (2, 4, 8):
+            with self.subTest(hc=hc):
+                self._check(n=256, hc=hc, iters=20)
+
+    def test_dispatch_selects_triton_without_tilelang(self):
+        # When TileLang is unavailable (or non-CUDA), the public dispatcher must
+        # route to the Triton fallback and stay numerically correct.
+        if mhc._HAS_TILELANG and mhc._IS_CUDA:
+            self.skipTest("TileLang path active; fallback dispatch not exercised here")
+        n, hc, iters = 1024, 4, 20
+        mix_hc = (2 + hc) * hc
+        torch.manual_seed(1)
+        mixes = torch.randn(1, n, mix_hc, device="cuda", dtype=torch.float32)
+        scale = torch.rand(3, device="cuda", dtype=torch.float32) + 0.5
+        base = torch.randn(mix_hc, device="cuda", dtype=torch.float32)
+
+        pre, post, comb = mhc.hc_split_sinkhorn(mixes, scale, base, hc, iters, self.EPS)
+        r_pre, r_post, r_comb = _sinkhorn_ref(
+            mixes.view(n, mix_hc), scale, base, hc, iters, self.EPS
+        )
+        torch.testing.assert_close(pre.reshape(n, hc), r_pre, atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(post.reshape(n, hc), r_post, atol=1e-5, rtol=1e-4)
+        torch.testing.assert_close(
+            comb.reshape(n, hc, hc), r_comb, atol=1e-5, rtol=1e-4
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`hc_split_sinkhorn` (DeepSeek-V4 mHC) is implemented only in TileLang, which is
CUDA-only. On backends without TileLang (e.g. ROCm/AMD) the module fails to
import, and even the existing torch pre-norm branch
(`SGLANG_OPT_USE_TILELANG_MHC_PRE=false`) still calls the TileLang Sinkhorn
kernel unconditionally — so there is **no portable path** for this op.

This mirrors the situation the Intel XPU work hit in #27783 ("performance kernel
will be provided later"), and it blocks the DeepSeek-V4 mHC path on AMD. This PR
provides that portable kernel and aligns with the AMD roadmap item (#23494) of
rewriting TileLang kernels in Triton for NSA/DSA models.

## Changes

- **`python/sglang/srt/layers/mhc.py`**
  - Make the `import tilelang` optional (a small stub keeps module-level
    decorators/annotations resolvable when TileLang is absent). The module now
    imports on non-CUDA backends.
  - Add a fused Triton `hc_split_sinkhorn` implementation.
  - `hc_split_sinkhorn(...)` now dispatches: tuned TileLang kernel on CUDA when
    available, portable Triton fallback otherwise. **The CUDA path is unchanged**
    (the original kernel is preserved, only renamed to the internal helper).
- **`test/registered/unit/layers/test_mhc_sinkhorn_triton.py`** — registered unit
  test verifying Triton vs a torch reference across token counts, iteration
  counts, and `hc_mult` values, plus the dispatch path.
- **`benchmark/kernels/bench_hc_split_sinkhorn.py`** — before/after microbench.

## Design note (iteration count)

The Sinkhorn loop uses a fixed iteration count (20 for DeepSeek-V4). Validation
against real DeepSeek-V4-Flash weights shows the matrix is **not** doubly-
stochastic at 20 iters (row-sum error ~3–8%) — i.e. the truncated result *is*
the trained target. The fallback therefore reproduces the exact N-iteration
result rather than iterating to convergence, matching the TileLang kernel.

## Correctness

- Matches a pure-torch reference of the TileLang math to ~1e-7 on synthetic
  inputs and on real DeepSeek-V4-Flash `hc_attn`/`hc_ffn` weights.
- `python3 -m pytest -q test/registered/unit/layers/test_mhc_sinkhorn_triton.py`
  → all pass.

## Benchmark (AMD Instinct MI250X; before = vectorized torch, after = Triton)

| tokens | BEFORE torch (ms) | AFTER triton (ms) | speedup |
|-------:|------------------:|------------------:|--------:|
| 1      | 0.973 | 0.089 | 10.9x |
| 128    | 1.000 | 0.090 | 11.1x |
| 2048   | 1.008 | 0.085 | 11.9x |
| 8192   | 1.006 | 0.095 | 10.6x |
| 32768  | 1.130 | 0.142 | 8.0x  |

Reproduce: `python3 benchmark/kernels/bench_hc_split_sinkhorn.py --check`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29066470541](https://github.com/sgl-project/sglang/actions/runs/29066470541)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29066470365](https://github.com/sgl-project/sglang/actions/runs/29066470365)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->