### PR TITLE
test(disagg): set MC_GID_INDEX on RoCE hosts so mooncake KV transfer works

### DIFF
--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -58,9 +58,12 @@ class PDDisaggregationServerBase(CustomTestCase):
         cls._fail_fast_stop = None
 
         # config transfer backend and rdma devices
+        cls._mc_gid_index_set = False
         if is_in_ci():
             cls.transfer_backend = ["--disaggregation-transfer-backend", "mooncake"]
-            cls.rdma_devices = ["--disaggregation-ib-device", get_rdma_devices_args()]
+            ib_devices = get_rdma_devices_args()
+            cls.rdma_devices = ["--disaggregation-ib-device", ib_devices]
+            cls._mc_gid_index_set = _maybe_set_roce_gid_index(ib_devices)
         else:
             cls.transfer_backend = [
                 "--disaggregation-transfer-backend",
@@ -183,6 +186,8 @@ class PDDisaggregationServerBase(CustomTestCase):
         if cls._fail_fast_stop is not None:
             cls._fail_fast_stop.set()
         os.environ.pop("MC_TCP_ENABLE_CONNECTION_POOL")
+        if getattr(cls, "_mc_gid_index_set", False):
+            os.environ.pop("MC_GID_INDEX", None)
         for process in [cls.process_lb, cls.process_decode, cls.process_prefill]:
             if process:
                 try:
@@ -371,3 +376,83 @@ def get_rdma_devices_args():
 
     # Deduplicate while preserving order
     return ",".join(dict.fromkeys(rdma_devices))
+
+
+_IB_SYSFS = "/sys/class/infiniband"
+
+
+def _roce_v2_gid_index(device: str):
+    """Return a RoCEv2 GID index for a device, preferring a global (routable)
+    GID over a link-local (fe80::) one, or None if the device has no RoCEv2 GID.
+    """
+    port = os.path.join(_IB_SYSFS, device, "ports", "1")
+    types_dir = os.path.join(port, "gid_attrs", "types")
+    try:
+        indices = sorted(int(x) for x in os.listdir(types_dir) if x.isdigit())
+    except OSError:
+        return None
+    fallback = None
+    for i in indices:
+        try:
+            with open(os.path.join(types_dir, str(i))) as f:
+                if f.read().strip() != "RoCE v2":
+                    continue
+        except OSError:
+            continue
+        if fallback is None:
+            fallback = i
+        try:
+            with open(os.path.join(port, "gids", str(i))) as f:
+                gid = f.read().strip()
+        except OSError:
+            gid = ""
+        # Prefer a global GID; link-local (fe80::) entries don't route between
+        # NICs on some fabrics.
+        if gid and not gid.lower().startswith("fe80"):
+            return i
+    return fallback
+
+
+def _detect_roce_gid_index(devices):
+    """Return a single RoCEv2 GID index shared by all `devices`, or None.
+
+    None when any device is InfiniBand (mooncake selects the GID automatically
+    there), when a device has no RoCEv2 GID, or when devices disagree on the
+    index — MC_GID_INDEX is a single global value, so a divergent set can't be
+    satisfied and is left to mooncake's own selection.
+    """
+    picked = None
+    for device in [d.strip() for d in devices if d.strip()]:
+        try:
+            with open(os.path.join(_IB_SYSFS, device, "ports", "1", "link_layer")) as f:
+                if f.read().strip() != "Ethernet":
+                    return None
+        except OSError:
+            return None
+        idx = _roce_v2_gid_index(device)
+        if idx is None:
+            return None
+        if picked is None:
+            picked = idx
+        elif picked != idx:
+            return None
+    return picked
+
+
+def _maybe_set_roce_gid_index(ib_devices) -> bool:
+    """Export MC_GID_INDEX for a RoCE fabric; return True if this call set it.
+
+    On RoCE-only hosts mooncake's automatic GID selection can come up empty
+    ("GID is NULL, please check your GID index by specifying MC_GID_INDEX"),
+    leaving the KV-transfer RDMA endpoint with no GID so every prefill->decode
+    transfer fails and PD accuracy collapses to 0. InfiniBand hosts don't need
+    this (auto GID works), and a user-provided MC_GID_INDEX is left untouched.
+    """
+    if not ib_devices or os.environ.get("MC_GID_INDEX"):
+        return False
+    gid_index = _detect_roce_gid_index(ib_devices.split(","))
+    if gid_index is None:
+        return False
+    os.environ["MC_GID_INDEX"] = str(gid_index)
+    logger.warning("RoCE fabric detected; set MC_GID_INDEX=%d for mooncake", gid_index)
+    return True


### PR DESCRIPTION
## Problem

On RoCE-only `8-gpu-h200` runners, the PD disaggregation tests in `test_disaggregation_hybrid_attention.py` (`TestDisaggregationHybridAttention*`) fail with a GSM8K score of **0.0**. Every prefill→decode KV transfer errors out:

```
Decode transfer failed ... KVTransferError: Failed to get kvcache from prefill instance, it might be dead
Prefill transfer failed ... KVTransferError: Decode instance could be dead, remote mooncake session <ip>:<port> is not alive
```

so all `/v1/completions` return 500 and the eval scores 0.0.

## Root cause

Mooncake's automatic RDMA GID selection returns NULL on the host's bonded RoCE NIC and logs:

```
GID is NULL, please check your GID index by specifying MC_GID_INDEX
```

The transfer endpoint then has no GID, so the session never establishes. The `8-gpu-h200` hosts where these tests pass today are native **InfiniBand**, where auto GID selection works — the failure only appeared once a RoCE-only host joined the pool.

## Fix

The PD fixture now auto-detects a RoCE fabric (`link_layer == Ethernet`) for the selected IB devices and exports `MC_GID_INDEX` to a RoCEv2 GID index shared by those devices, preferring a global (routable) GID over a link-local (`fe80::`) one. It is a no-op on InfiniBand, when the selected devices disagree on the index (`MC_GID_INDEX` is a single global value), or when the user has already set `MC_GID_INDEX`. It is cleared in teardown only if this fixture set it.

## Validation

Reproduced and fixed on a RoCE-only H200 host (`Qwen/Qwen3-Next-80B-A3B-Instruct`, prefill tp2 + decode tp2/dp2):

- Before: KV transfer fails on every request, score **0.0**.
- After (fixture auto-sets `MC_GID_INDEX=3`, no manual env): `Ran 1 test ... OK`, score **0.955** (threshold 0.90).

Independent checks on the host: `ib_write_bw` RoCEv2 loopback (same-NIC and cross-NIC) works, and RoCEv2 GID index 3 is present and identical on both selected NICs. The GID auto-detection helper is unit-tested (RoCE → index, InfiniBand → None, divergent devices → None).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29067918358](https://github.com/sgl-project/sglang/actions/runs/29067918358)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29067918313](https://github.com/sgl-project/sglang/actions/runs/29067918313)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->