### PR TITLE
[Bugfix] Prevent HiCache KV publication beyond sidecar coverage

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -6,7 +6,7 @@ import threading
 import time
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, List, Optional, Set
 
@@ -122,6 +122,7 @@ class PoolTransferResult:
 
     kv_hit_pages: int
     extra_pool_hit_pages: dict[str, int]
+    extra_pool_leading_hit_pages: dict[str, int] = field(default_factory=dict)
 
     @classmethod
     def empty(cls) -> PoolTransferResult:
@@ -136,6 +137,31 @@ class PoolTransferResult:
         self.extra_pool_hit_pages.update(
             {name: sum(rs) for name, rs in results.items()}
         )
+        self.extra_pool_leading_hit_pages.update(
+            {
+                name: next((i for i, hit in enumerate(rs) if not hit), len(rs))
+                for name, rs in results.items()
+            }
+        )
+
+    def clamp_to_all_pages_coverage(
+        self,
+        completed_tokens: int,
+        page_size: int,
+        pool_transfers: Optional[List[PoolTransfer]],
+    ) -> int:
+        required_pools = [
+            transfer.name
+            for transfer in pool_transfers or []
+            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES
+        ]
+        if not required_pools:
+            return completed_tokens
+
+        covered_pages = min(
+            self.extra_pool_leading_hit_pages.get(name, 0) for name in required_pools
+        )
+        return min(completed_tokens, covered_pages * page_size)
 
 
 class HiCacheStorage(ABC):

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1495,6 +1495,9 @@ class HiRadixCache(RadixCache):
         completed_tokens, hash_value = self.cache_controller.terminate_prefetch(
             operation
         )
+        completed_tokens = operation.pool_storage_result.clamp_to_all_pages_coverage(
+            completed_tokens, self.page_size, operation.pool_transfers
+        )
         logger.debug(f"Prefetch {req_id} completed with {completed_tokens} tokens")
 
         min_completed_tokens = completed_tokens

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1495,12 +1495,16 @@ class HiRadixCache(RadixCache):
         completed_tokens, hash_value = self.cache_controller.terminate_prefetch(
             operation
         )
-        completed_tokens = operation.pool_storage_result.clamp_to_all_pages_coverage(
-            completed_tokens, self.page_size, operation.pool_transfers
+        min_completed_tokens = (
+            operation.pool_storage_result.clamp_to_all_pages_coverage(
+                completed_tokens, self.page_size, operation.pool_transfers
+            )
         )
-        logger.debug(f"Prefetch {req_id} completed with {completed_tokens} tokens")
+        logger.debug(
+            f"Prefetch {req_id} completed with {completed_tokens} tokens, "
+            f"publishing {min_completed_tokens} tokens"
+        )
 
-        min_completed_tokens = completed_tokens
         # Synchronize workers before mutating host cache tree state.
         completed_tokens_tensor = torch.tensor(min_completed_tokens, dtype=torch.int)
         self._all_reduce_attn_groups(

--- a/test/registered/unit/mem_cache/test_hicache_sidecar_coverage.py
+++ b/test/registered/unit/mem_cache/test_hicache_sidecar_coverage.py
@@ -1,0 +1,81 @@
+import unittest
+
+from sglang.srt.mem_cache.hicache_storage import (
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+    PoolTransferResult,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHiCacheSidecarCoverage(unittest.TestCase):
+    def test_full_sidecar_coverage_keeps_completed_tokens(self):
+        result = PoolTransferResult.empty()
+        result.update_extra_pool_hit_pages({PoolName.INDEXER: [True, True, True]})
+
+        completed_tokens = result.clamp_to_all_pages_coverage(
+            completed_tokens=12,
+            page_size=4,
+            pool_transfers=[PoolTransfer(name=PoolName.INDEXER)],
+        )
+
+        self.assertEqual(completed_tokens, 12)
+
+    def test_short_sidecar_result_clamps_completed_tokens(self):
+        result = PoolTransferResult.empty()
+        result.update_extra_pool_hit_pages({PoolName.INDEXER: [True, False, False]})
+
+        completed_tokens = result.clamp_to_all_pages_coverage(
+            completed_tokens=12,
+            page_size=4,
+            pool_transfers=[PoolTransfer(name=PoolName.INDEXER)],
+        )
+
+        self.assertEqual(completed_tokens, 4)
+
+    def test_sidecar_hole_clamps_at_leading_prefix(self):
+        result = PoolTransferResult.empty()
+        result.update_extra_pool_hit_pages({PoolName.INDEXER: [True, False, True]})
+
+        completed_tokens = result.clamp_to_all_pages_coverage(
+            completed_tokens=12,
+            page_size=4,
+            pool_transfers=[PoolTransfer(name=PoolName.INDEXER)],
+        )
+
+        self.assertEqual(result.extra_pool_hit_pages[PoolName.INDEXER], 2)
+        self.assertEqual(completed_tokens, 4)
+
+    def test_missing_required_sidecar_result_clamps_to_zero(self):
+        result = PoolTransferResult.empty()
+
+        completed_tokens = result.clamp_to_all_pages_coverage(
+            completed_tokens=12,
+            page_size=4,
+            pool_transfers=[PoolTransfer(name=PoolName.INDEXER)],
+        )
+
+        self.assertEqual(completed_tokens, 0)
+
+    def test_no_all_pages_sidecars_keeps_completed_tokens(self):
+        result = PoolTransferResult.empty()
+
+        completed_tokens = result.clamp_to_all_pages_coverage(
+            completed_tokens=12,
+            page_size=4,
+            pool_transfers=[
+                PoolTransfer(
+                    name=PoolName.MAMBA,
+                    hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                )
+            ],
+        )
+
+        self.assertEqual(completed_tokens, 12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hiradix_prefetch_sidecar_release.py
+++ b/test/registered/unit/mem_cache/test_hiradix_prefetch_sidecar_release.py
@@ -1,0 +1,66 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.mem_cache.hicache_storage import (
+    PoolName,
+    PoolTransfer,
+    PoolTransferResult,
+)
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHiRadixPrefetchSidecarRelease(unittest.TestCase):
+    def test_releases_kv_tail_beyond_sidecar_coverage(self):
+        page_size = 4
+        host_indices = torch.arange(12)
+        pool_storage_result = PoolTransferResult.empty()
+        pool_storage_result.update_extra_pool_hit_pages(
+            {PoolName.INDEXER: [True, False, True]}
+        )
+        operation = SimpleNamespace(
+            host_indices=host_indices,
+            pool_storage_result=pool_storage_result,
+            pool_transfers=[PoolTransfer(name=PoolName.INDEXER)],
+        )
+        last_host_node = SimpleNamespace(release_host=mock.Mock())
+        controller = SimpleNamespace(
+            terminate_prefetch=mock.Mock(
+                return_value=(12, ["page-0", "page-1", "page-2"])
+            ),
+            mem_pool_host=SimpleNamespace(free=mock.Mock()),
+            append_host_mem_release=mock.Mock(),
+            prefetch_tokens_occupied=12,
+        )
+        cache = object.__new__(HiRadixCache)
+        cache.page_size = page_size
+        cache.cache_controller = controller
+        cache.ongoing_prefetch = {
+            "request": (
+                last_host_node,
+                list(range(12)),
+                host_indices,
+                operation,
+            )
+        }
+        cache.can_terminate_prefetch = mock.Mock(return_value=True)
+        cache._all_reduce_attn_groups = mock.Mock()
+        cache._insert_helper_host = mock.Mock(return_value=0)
+        cache.prefetch_loaded_tokens_by_reqid = {}
+        cache.enable_storage_metrics = False
+
+        self.assertTrue(cache.check_prefetch_progress("request"))
+
+        inserted_indices = cache._insert_helper_host.call_args.args[2]
+        released_indices = controller.append_host_mem_release.call_args.args[0]
+        self.assertTrue(torch.equal(inserted_indices, host_indices[:page_size]))
+        self.assertTrue(torch.equal(released_indices, host_indices[page_size:]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

HiCache can publish KV pages into the host radix tree when a required
`ALL_PAGES` sidecar, such as the DSA indexer, loads only a shorter prefix from
storage. This can bind fresh KV pages to stale sidecar data and corrupt model
output.

The existing aggregate sidecar hit count is not a safe coverage bound because
storage GET results can contain an interior hole. Partial KV prefetches also
skip sidecar IO, leaving no valid sidecar coverage for the loaded KV prefix.

## Modifications

- Track each sidecar's leading contiguous hit count while preserving the
  existing aggregate count used by metrics.
- Clamp KV publication to the minimum leading coverage of required
  `ALL_PAGES` sidecars.
- Preserve the raw KV completion count so loaded pages beyond sidecar coverage
  are released instead of leaked.
- Add CPU unit coverage for full, short, missing, and non-contiguous sidecar
  results, plus host-memory release of the unpublished KV tail.

## Accuracy Tests

```text
PYTHONPATH=python python -m pytest \
  test/registered/unit/mem_cache/test_hicache_sidecar_coverage.py -q

5 passed
```

The additional `check_prefetch_progress` regression is registered in the CPU
CI suite at
`test/registered/unit/mem_cache/test_hiradix_prefetch_sidecar_release.py`.

## Speed Tests and Profiling

Not run. The change performs one linear scan over each sidecar's existing
storage result list and does not add storage IO.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Follow SGLang code style guidance.
- [ ] Run the registered CPU CI suite.
- [ ] Run model-level accuracy and performance validation.

Related issue: https://github.com/sgl-project/sglang/issues/29512







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29067979692](https://github.com/sgl-project/sglang/actions/runs/29067979692)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29067979621](https://github.com/sgl-project/sglang/actions/runs/29067979621)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->