### PR TITLE
[security] Sanitize profiler output_dir to prevent path traversal

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -123,7 +123,17 @@ class SchedulerProfilerManager:
         if activities is None:
             activities = ["CPU", "GPU"]
 
-        self.torch_profiler_output_dir = Path(output_dir).expanduser()
+        # Security: sanitize output_dir to prevent path traversal. The
+        # output_dir comes from the /start_profile API request body and could
+        # contain ../ sequences to write trace files to arbitrary locations.
+        resolved = Path(output_dir).expanduser().resolve()
+        # Only allow absolute paths under a known-safe root (default /tmp).
+        safe_root = Path(os.getenv("SGLANG_TORCH_PROFILER_DIR", "/tmp")).resolve()
+        if not str(resolved).startswith(str(safe_root)):
+            raise ValueError(
+                f"output_dir must be under {safe_root}, got: {output_dir}"
+            )
+        self.torch_profiler_output_dir = resolved
         self.torch_profiler_with_stack = with_stack
         self.torch_profiler_record_shapes = record_shapes
         self.profiler_activities = activities

--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -130,9 +130,7 @@ class SchedulerProfilerManager:
         # Only allow absolute paths under a known-safe root (default /tmp).
         safe_root = Path(os.getenv("SGLANG_TORCH_PROFILER_DIR", "/tmp")).resolve()
         if not str(resolved).startswith(str(safe_root)):
-            raise ValueError(
-                f"output_dir must be under {safe_root}, got: {output_dir}"
-            )
+            raise ValueError(f"output_dir must be under {safe_root}, got: {output_dir}")
         self.torch_profiler_output_dir = resolved
         self.torch_profiler_with_stack = with_stack
         self.torch_profiler_record_shapes = record_shapes


### PR DESCRIPTION
## Summary

The `/start_profile` endpoint accepts `output_dir` from the request body (`ProfileReq`). This value goes to `Path(output_dir).expanduser()` (line 126) with **no sanitization**, then `mkdir(parents=True, exist_ok=True)` (line 298) creates the directory, and `os.path.join(self.torch_profiler_output_dir, filename)` (line 329) writes trace files there.

**Severity:** HIGH
**Class:** Path traversal via profiler output_dir

## Root cause

`profiler_manager.py:126`:
```python
self.torch_profiler_output_dir = Path(output_dir).expanduser()
```

`output_dir` comes from the HTTP request body. `expanduser()` expands `~` but does not prevent `../` traversal. `mkdir(parents=True)` creates arbitrary directory structures.

## Impact

- When no `api_key` is configured (default for many deployments), `/start_profile` is open (`ADMIN_OPTIONAL` auth)
- An attacker can write profiler trace files to arbitrary paths
- `mkdir(parents=True)` allows creating directory structures anywhere on disk
- Combined with `num_steps`, this enables disk exhaustion at arbitrary locations

## Fix

`resolve()` the path and check containment against a safe root (default `/tmp` or `SGLANG_TORCH_PROFILER_DIR`):

```python
resolved = Path(output_dir).expanduser().resolve()
safe_root = Path(os.getenv("SGLANG_TORCH_PROFILER_DIR", "/tmp")).resolve()
if not str(resolved).startswith(str(safe_root)):
    raise ValueError(f"output_dir must be under {safe_root}")
```

## Verification

- ruff: clean
- PoC: confirmed no sanitization before fix; fix adds resolve() + containment check
- Single-file change

## Dedup

Searched issues for "path traversal", "output_dir", "profiler security". Zero matches. Novel.

---

_Generated by redthread. Single-purpose security fix._















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29289825151](https://github.com/sgl-project/sglang/actions/runs/29289825151)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29289824947](https://github.com/sgl-project/sglang/actions/runs/29289824947)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->