### PR TITLE
[Fix] Make RowParallelLinear k-size tuple-aware for FP8

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1571,7 +1571,12 @@ class RowParallelLinear(LinearBase):
                 get_tp_group(), disabled=not is_allocation_symmetric()
             )
         with symm_ctx:
-            if should_use_tp_invariant_row_linear(input_parallel.shape[-1]):
+            from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+
+            is_fp8 = isinstance(self.quant_method, Fp8LinearMethod)
+            if not is_fp8 and should_use_tp_invariant_row_linear(
+                input_parallel.shape[-1]
+            ):
                 output_parallel = torch.ops.tp_inv_ops.matmul_tp_inv(
                     input_parallel, self.weight.t(), bias_
                 )

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1571,12 +1571,15 @@ class RowParallelLinear(LinearBase):
                 get_tp_group(), disabled=not is_allocation_symmetric()
             )
         with symm_ctx:
-            from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
-
-            is_fp8 = isinstance(self.quant_method, Fp8LinearMethod)
-            if not is_fp8 and should_use_tp_invariant_row_linear(
-                input_parallel.shape[-1]
-            ):
+            is_tuple = isinstance(input_parallel, tuple)
+            k_size = (
+                input_parallel[0].shape[-1] if is_tuple else input_parallel.shape[-1]
+            )
+            if should_use_tp_invariant_row_linear(k_size):
+                if is_tuple:
+                    raise NotImplementedError(
+                        "FP8 tp-invariant row-linear not yet supported"
+                    )
                 output_parallel = torch.ops.tp_inv_ops.matmul_tp_inv(
                     input_parallel, self.weight.t(), bias_
                 )

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1571,12 +1571,15 @@ class RowParallelLinear(LinearBase):
                 get_tp_group(), disabled=not is_allocation_symmetric()
             )
         with symm_ctx:
+            from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+
             is_tuple = isinstance(input_parallel, tuple)
+            is_fp8 = isinstance(self.quant_method, Fp8LinearMethod)
             k_size = (
                 input_parallel[0].shape[-1] if is_tuple else input_parallel.shape[-1]
             )
             if should_use_tp_invariant_row_linear(k_size):
-                if is_tuple:
+                if is_fp8:
                     raise NotImplementedError(
                         "FP8 tp-invariant row-linear not yet supported"
                     )


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123 

## Problem

This PR fixes an fp8 `RowParallelLinear.forward` crash in the shared-expert `down_proj`.

The crash happens because the true-on-policy tp-invariant matmul path assumes `input_parallel` is a dense tensor, but the fp8 ROCm path can pass a pre-quantized `(x_fp8, x_scale)` tuple instead.

```text
AttributeError: 'tuple' object has no attribute 'shape'
```

fp8 row-linear should not enter the tp-invariant matmul path.

## Root Cause

`RowParallelLinear.forward` chooses between two matmul paths:

```python
with symm_ctx:
    if should_use_tp_invariant_row_linear(input_parallel.shape[-1]):
        output_parallel = torch.ops.tp_inv_ops.matmul_tp_inv(
            input_parallel, self.weight.t(), bias_
        )
    else:
        output_parallel = self.quant_method.apply(
            self, input_parallel, bias=bias_
        )
```

This is unsafe for fp8 layers for two reasons.

1. `matmul_tp_inv` does not support fp8.

   `should_use_tp_invariant_row_linear`, `matmul_tp_inv`, and the `true_on_policy` module are RL bit-invariance additions. They make tensor-parallel row-linear numerically identical across different TP shardings.

   However, `matmul_tp_inv` only accepts dense bf16 / fp16 / fp32 tensors. It has no fp8 path. So an fp8 row-linear layer should not take this branch on any platform (ROCM/CUDA).

2. On ROCm, the fp8 input may be a tuple, not a tensor.

   In DeepSeek V2 / V4 style MLPs, the gate/up projection can use the ROCm `fused_clamp_act_mul` fast path. This path is enabled by `SGLANG_OPT_USE_FUSED_CLAMP_ACT_MUL`.

   For fp8 block quantization, that fast path can return the activation already quantized as:

   ```python
   (x_fp8, x_scale)
   ```

   Then the shared-expert `down_proj` is called with:

   ```python
   input_parallel = (x_fp8, x_scale)
   ```

   But before Python can call `should_use_tp_invariant_row_linear`, it first evaluates the argument:

   ```python
   input_parallel.shape[-1]
   ```

   Since `input_parallel` is a tuple, it has no `.shape`, so the code raises the `AttributeError` above, before either branch is selected.

## Change

Skip the tp-invariant path when the layer uses `Fp8LinearMethod`.

```python
from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod

is_fp8 = isinstance(self.quant_method, Fp8LinearMethod)

if not is_fp8 and should_use_tp_invariant_row_linear(
    input_parallel.shape[-1]
):
    output_parallel = torch.ops.tp_inv_ops.matmul_tp_inv(
        input_parallel, self.weight.t(), bias_
    )
else:
    output_parallel = self.quant_method.apply(
        self, input_parallel, bias=bias_
    )
```

With this gate, fp8 row-linear layers always use `quant_method.apply`.

That is the correct path because `Fp8LinearMethod` already handles both:

- fp8 weights
- pre-quantized tuple inputs like `(x_fp8, x_scale)`

It also avoids the ROCm tuple crash: because `not is_fp8` short-circuits, the `input_parallel.shape[-1]` access on the tuple never happens for fp8 layers.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29632709193](https://github.com/sgl-project/sglang/actions/runs/29632709193)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29632709085](https://github.com/sgl-project/sglang/actions/runs/29632709085)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->