### PR TITLE
[scheduler] Park chunked prefill on token-budget exhaustion instead of overcommitting (server-killing OOM)

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -813,12 +813,18 @@ class PrefillAdder:
                 _rem_tokens = min(
                     _rem_tokens, int(self.rem_swa_tokens) - self.page_size
                 )
-            # The chunked_req must be added to the list; otherwise, it will cause a memory leak.
-            # Therefore, in certain cases where _rem_tokens <= 0, it should be replaced with rem_chunk_tokens.
+            # Token budget exhausted (pool full and nothing evictable — running
+            # requests hold the tree locked): park this chunk for the tick
+            # instead of overcommitting. The scheduler keeps self.chunked_req
+            # and calls add_chunked_req again next tick once decode frees
+            # tokens, so there is no leak — this is the same early-return the
+            # hybrid-SWA path uses, and update_running_batch already treats a
+            # parked chunk (fill_len == len(prefix_indices)) as a no-op stash.
+            # Overcommitting past the budget made
+            # alloc_paged_token_slots_extend raise ("Prefill out of memory",
+            # available < chunk) and killed the whole TP group at once.
             if _rem_tokens <= 0:
-                if self.is_hybrid_swa:
-                    return req
-                _rem_tokens = self.rem_chunk_tokens
+                return req
 
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices


### PR DESCRIPTION
## Motivation

When the prefill token budget is exhausted — `rem_total_tokens <= 0` because the KV pool is full and nothing is evictable (running requests hold the radix tree lock-referenced) — `PrefillAdder.add_chunked_req` on the non-hybrid-SWA path **discards the budget and admits the chunk anyway** (`_rem_tokens = self.rem_chunk_tokens`). The allocation then fails downstream:

```
RuntimeError: Prefill out of memory. Try to lower your batch size.
Try to allocate 2048 tokens.
Available full tokens: 704 (full_available_size=704 + full_evictable_size_=0)
```

raised from `alloc_paged_token_slots_extend` (`mem_cache/common.py`), which kills every scheduler rank in the same tick — the whole TP group exits and the server goes down. Observed in production (GLM-5.2 / `GlmMoeDsaForCausalLM`, 8×H100, fp8 KV, chunked prefill + priority scheduling): **5 full-server crashes in 9 hours** under concurrent long-context load, each with the exact signature above and the tree fully lock-referenced (`full_lock=1` on every node in the pretty-print dump). This is the crash-instead-of-degrade failure mode also mentioned in #30505 ("a retracted/requeued request would be far preferable").

## Modifications

Park the chunk for the tick instead of overcommitting — the same early-return the hybrid-SWA branch directly above already uses:

- The scheduler keeps `self.chunked_req` and calls `add_chunked_req` again next tick, so the chunk resumes as soon as decode frees tokens. No leak: the old comment's concern ("must be added to the list; otherwise, it will cause a memory leak") predates parked-chunk support — `update_running_batch` explicitly treats a parked chunk (`fill_len == len(prefix_indices)`) as a no-op stash, which is how hybrid-SWA models already run this path in production.
- No deadlock: the park condition only holds while running requests keep the pool locked; when decode completes, tokens are freed and the chunk proceeds. If `rem_total_tokens > 0`, `evict_from_tree_cache` reclaims evictable tokens before allocation as before.

## Verification

- Before: 5/5 reproductions crash the server (production traces above).
- After (same checkpoint/config, saturation workload — 14 concurrent ~40k-token unique-prefix prompts with long decode holding the pool locked): `token_usage` peaks at **1.00**, zero "Prefill out of memory" logs, zero restarts, all 14 requests complete (the last ones simply finish later as their chunks resume tick by tick).

## Checklist

- [x] Format your code: `pre-commit run --all-files`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29071402219](https://github.com/sgl-project/sglang/actions/runs/29071402219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29071402147](https://github.com/sgl-project/sglang/actions/runs/29071402147)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->