### PR TITLE
[AMD] Support DeepSeek V4 DSpark on AMD platform

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -458,6 +458,12 @@ class DeepseekV4HipRadixBackend(
         self.speculative_num_draft_tokens: int = (
             model_runner.server_args.speculative_num_draft_tokens
         )
+        if (
+            self.speculative_num_draft_tokens is not None
+            and getattr(model_runner, "is_draft_worker", False)
+            and model_runner.spec_algorithm.is_dspark()
+        ):
+            self.speculative_num_draft_tokens -= 1
         self.speculative_step_id = speculative_step_id
         self.forward_metadata: Union[
             DSV4Metadata,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -540,14 +540,37 @@ class DeepseekV4HipRadixBackend(
         extend_seq_lens_cpu: List[int],
         need_compress: bool = True,
         use_prefill_cuda_graph: bool = False,
+        compress_gpu_plan: bool = False,
+        extend_start_loc: Optional[torch.Tensor] = None,
     ) -> DSV4Metadata:
-        seq_lens_casual, req_pool_indices_repeated = self.expand_prefill_casually(
-            num_tokens=num_tokens,
-            seq_lens=seq_lens_cpu,
-            extend_seq_lens=extend_seq_lens_cpu,
-            req_pool_indices=req_pool_indices,
-            padded_num_tokens=out_cache_loc.shape[0],
-        )
+        if extend_start_loc is not None:
+            # Ragged/compact verify: vectorized device-side expansion (mirror CUDA
+            # deepseek_v4_backend._expand_prefill_casually_vectorized). Avoids the
+            # per-request python loop in expand_prefill_casually on the decode path.
+            from sglang.srt.speculative.dspark_components.kernels.expand_prefill_casually import (
+                ExpandPrefillCasually,
+            )
+
+            _expanded = ExpandPrefillCasually.execute(
+                req_pool_indices=req_pool_indices,
+                seq_lens=seq_lens,
+                extend_seq_lens=extend_seq_lens,
+                extend_start_loc=extend_start_loc,
+                seq_lens_cpu=None,
+                extend_seq_lens_cpu=None,
+                num_tokens=num_tokens,
+                padded_num_tokens=out_cache_loc.shape[0],
+            )
+            seq_lens_casual = _expanded.seq_lens_casual
+            req_pool_indices_repeated = _expanded.req_pool_indices_repeated
+        else:
+            seq_lens_casual, req_pool_indices_repeated = self.expand_prefill_casually(
+                num_tokens=num_tokens,
+                seq_lens=seq_lens_cpu,
+                extend_seq_lens=extend_seq_lens_cpu,
+                req_pool_indices=req_pool_indices,
+                padded_num_tokens=out_cache_loc.shape[0],
+            )
         core_attn_metadata = self.make_core_attn_metadata(
             req_to_token=self.req_to_token,
             req_pool_indices_repeated=req_pool_indices_repeated,
@@ -567,6 +590,26 @@ class DeepseekV4HipRadixBackend(
         )
         if not need_compress:
             create = _create_dummy_paged_compress_data
+        elif compress_gpu_plan:
+            # DSpark ragged/compact verify: route the compress planner through the
+            # device (GPU-input) path by passing GPU tensors (seq_lens_cpu=None).
+            # The host CPU-plan path asserts 0 < extend_len per request, but ragged
+            # padding slots can legitimately have extend_len == 0 (padded_to_bucket
+            # distributes the leftover tokens). The GPU kernel pads to num_q_tokens
+            # and tolerates empty rows, matching how CUDA defers compress into graph.
+            create = functools.partial(
+                create_paged_compressor_data,
+                is_prefill=True,
+                token_to_kv_pool=self.token_to_kv_pool,
+                req_to_token=self.req_to_token,
+                req_pool_indices=req_pool_indices,
+                seq_lens=seq_lens,
+                seq_lens_cpu=None,
+                extend_lens=extend_seq_lens,
+                extend_lens_cpu=None,
+                num_q_tokens=num_tokens,
+                use_prefill_cuda_graph=use_prefill_cuda_graph,
+            )
         else:
             create = functools.partial(
                 create_paged_compressor_data,
@@ -596,6 +639,7 @@ class DeepseekV4HipRadixBackend(
         extend_seq_lens: Optional[torch.Tensor] = None,
         use_prefill_cuda_graph: bool = False,
         seq_lens_cpu: Optional[List[int]] = None,
+        ragged_layout=None,
     ) -> Union[DSV4Metadata, DSV4RawVerifyMetadata]:
         # HIP path: build target-verify metadata eagerly even when
         # SGLANG_PREP_IN_CUDA_GRAPH is enabled. The raw/lazy-upgrade route can
@@ -609,6 +653,7 @@ class DeepseekV4HipRadixBackend(
             seq_lens_cpu=seq_lens_cpu,
             out_cache_loc=out_cache_loc,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
+            ragged_layout=ragged_layout,
         )
 
     def init_forward_metadata_target_verify_old(
@@ -619,13 +664,33 @@ class DeepseekV4HipRadixBackend(
         seq_lens_cpu: Optional[List[int]] = None,
         out_cache_loc: Optional[torch.Tensor] = None,
         use_prefill_cuda_graph: bool = False,
+        ragged_layout=None,
     ) -> DSV4Metadata:
         batch_size = len(seq_lens)
-        seq_lens = seq_lens + self.speculative_num_draft_tokens
-        seq_lens_cpu = [x + self.speculative_num_draft_tokens for x in seq_lens_cpu]
-        extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
-        extend_seq_lens = self._move_to_device(extend_seq_lens_cpu)
-        num_tokens = self.speculative_num_draft_tokens * batch_size
+        extend_start_loc = None
+        if ragged_layout is not None:
+            # DSpark ragged/compact verify: per-request variable verify length,
+            # fully vectorized on device (verify_lens + extend_start_loc), mirroring
+            # CUDA deepseek_v4_backend._expand_prefill_casually_vectorized -- no
+            # python per-request loop / D2H on the decode critical path.
+            verify_lens_dev = ragged_layout.verify_lens.to(
+                device=seq_lens.device, dtype=torch.int32
+            )
+            extend_start_loc = ragged_layout.extend_start_loc.to(
+                device=seq_lens.device, dtype=torch.int32
+            )
+            extend_seq_lens = verify_lens_dev
+            seq_lens = seq_lens + verify_lens_dev.to(seq_lens.dtype)
+            # padded_to_bucket sets total_verify_tokens == graph_num_tokens (tier).
+            num_tokens = int(ragged_layout.total_verify_tokens)
+            extend_seq_lens_cpu = None
+            seq_lens_cpu = None
+        else:
+            seq_lens = seq_lens + self.speculative_num_draft_tokens
+            seq_lens_cpu = [x + self.speculative_num_draft_tokens for x in seq_lens_cpu]
+            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
+            num_tokens = self.speculative_num_draft_tokens * batch_size
+            extend_seq_lens = self._move_to_device(extend_seq_lens_cpu)
         if out_cache_loc is None:
             out_cache_loc = seq_lens.new_zeros(num_tokens)
         return self.init_forward_metadata_prefill(
@@ -639,6 +704,8 @@ class DeepseekV4HipRadixBackend(
             extend_seq_lens_cpu=extend_seq_lens_cpu,
             need_compress=True,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
+            compress_gpu_plan=ragged_layout is not None,
+            extend_start_loc=extend_start_loc,
         )
 
     def make_forward_metadata_from_raw_verify(
@@ -857,6 +924,13 @@ class DeepseekV4HipRadixBackend(
         chosen_max_seq_len = self.MAX_SEQ_LEN_FOR_CAPTURE
         assert actual_max_seq_len <= chosen_max_seq_len
 
+        # Backend metadata cache key. Ragged/compact target-verify graphs are
+        # keyed by the token tier (graph_num_tokens) to match the cuda-graph
+        # runner (_capture_graph_size returns num_tokens in ragged mode). A fixed
+        # bs key would collide because _ragged_capture_slots caps bs at max_bs, so
+        # several token tiers (e.g. 66,72,...,384) map to the same bs=64.
+        graph_key = bs
+
         if bucket == _GraphBucket.DECODE_OR_IDLE:
             assert out_cache_loc is not None
             assert len(out_cache_loc.shape) == 1, f"{out_cache_loc.shape=}"
@@ -873,21 +947,26 @@ class DeepseekV4HipRadixBackend(
                 out_cache_loc=out_cache_loc_padded,
             )
         elif bucket == _GraphBucket.TARGET_VERIFY:
-            if (
-                getattr(
-                    getattr(forward_batch, "spec_info", None),
-                    "ragged_verify_layout",
-                    None,
-                )
-                is not None
-            ):
-                raise NotImplementedError(
-                    "DSV4 ragged verify is not supported on the HIP backend "
-                    "(DeepseekV4HipRadixBackend) cuda-graph path; disable "
-                    "SGLANG_RAGGED_VERIFY_MODE or use a CUDA device."
-                )
             assert out_cache_loc is not None
-            num_tokens_v = self.speculative_num_draft_tokens * bs
+            ragged_layout = getattr(
+                getattr(forward_batch, "spec_info", None),
+                "ragged_verify_layout",
+                None,
+            )
+            if ragged_layout is not None:
+                # DSpark compact ragged verify. The cuda-graph runner captures at
+                # padded "slots" (bs), so pad the per-request verify layout to the
+                # captured bs to match the graph buffer shapes (mirrors the CUDA
+                # deepseek_v4_backend._resolve_verify_layout path). After padding,
+                # sum(verify_lens) == graph_num_tokens (the token tier).
+                ragged_layout = ragged_layout.padded_to_bucket(padded_bs=bs)
+                # Pad the (compact) out_cache_loc to the captured token tier so the
+                # graph buffer shape stays fixed across replays.
+                num_tokens_v = ragged_layout.graph_num_tokens
+                # Key the cached graph metadata by token tier (see graph_key note).
+                graph_key = num_tokens_v
+            else:
+                num_tokens_v = self.speculative_num_draft_tokens * bs
             out_cache_loc_padded = torch.nn.functional.pad(
                 out_cache_loc,
                 pad=(0, num_tokens_v - len(out_cache_loc)),
@@ -903,6 +982,7 @@ class DeepseekV4HipRadixBackend(
                 # CPU mirror already available here (== seq_lens, no D2H);
                 # pass it so target_verify skips the per-iter seq_lens.tolist() sync.
                 seq_lens_cpu=seq_lens_cpu.tolist(),
+                ragged_layout=ragged_layout,
             )
         elif bucket == _GraphBucket.DRAFT_EXTEND:
             num_tokens_per_bs = self.draft_extend_num_tokens_per_bs
@@ -928,7 +1008,7 @@ class DeepseekV4HipRadixBackend(
             raise NotImplementedError
 
         self.replay_cuda_graph_metadata_from(
-            bs=bs, temp_metadata=temp_metadata, bucket=bucket
+            bs=graph_key, temp_metadata=temp_metadata, bucket=bucket
         )
 
         if in_capture:
@@ -973,19 +1053,11 @@ class DeepseekV4HipRadixBackend(
                 out_cache_loc=out_cache_loc,
             )
         elif forward_batch.forward_mode.is_target_verify():
-            if (
-                getattr(
-                    getattr(forward_batch, "spec_info", None),
-                    "ragged_verify_layout",
-                    None,
-                )
-                is not None
-            ):
-                raise NotImplementedError(
-                    "DSV4 ragged verify is not supported on the HIP backend "
-                    "(DeepseekV4HipRadixBackend); disable SGLANG_RAGGED_VERIFY_MODE "
-                    "or use a CUDA device."
-                )
+            ragged_layout = getattr(
+                getattr(forward_batch, "spec_info", None),
+                "ragged_verify_layout",
+                None,
+            )
             metadata = self.init_forward_metadata_target_verify(
                 max_seq_len=max_seq_len,
                 req_pool_indices=req_pool_indices,
@@ -995,6 +1067,7 @@ class DeepseekV4HipRadixBackend(
                 seq_lens_cpu=(
                     seq_lens_cpu.tolist() if seq_lens_cpu is not None else None
                 ),
+                ragged_layout=ragged_layout,
             )
         elif forward_batch.forward_mode.is_prefill(include_draft_extend_v2=True):
             extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.sampler import apply_custom_logit_processor
 from sglang.srt.managers.schedule_batch import Req
-from sglang.srt.utils import is_cuda, is_musa
+from sglang.srt.utils import is_cuda, is_hip, is_musa
 
 DEFAULT_DFLASH_MASK_TOKEN = "<|MASK|>"
 
@@ -45,6 +45,33 @@ if is_cuda() or is_musa():
         top_k_renorm_prob = None
         top_p_renorm_prob = None
         tree_speculative_sampling_target_only = None
+elif is_hip():
+
+    def _dspark_top_k_renorm_prob_torch(probs, top_ks):
+        top_ks = top_ks.to(device=probs.device)
+        sorted_probs, sorted_indices = torch.sort(probs, dim=-1, descending=True)
+        rank = torch.arange(probs.shape[-1], device=probs.device).view(1, -1)
+        sorted_probs = torch.where(
+            rank < top_ks.view(-1, 1), sorted_probs, torch.zeros_like(sorted_probs)
+        )
+        renorm = torch.zeros_like(probs).scatter_(-1, sorted_indices, sorted_probs)
+        return renorm / renorm.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    def _dspark_top_p_renorm_prob_torch(probs, top_ps):
+        top_ps = top_ps.to(device=probs.device)
+        sorted_probs, sorted_indices = torch.sort(probs, dim=-1, descending=True)
+        cumsum_excl = torch.cumsum(sorted_probs, dim=-1) - sorted_probs
+        sorted_probs = torch.where(
+            cumsum_excl <= top_ps.view(-1, 1),
+            sorted_probs,
+            torch.zeros_like(sorted_probs),
+        )
+        renorm = torch.zeros_like(probs).scatter_(-1, sorted_indices, sorted_probs)
+        return renorm / renorm.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    top_k_renorm_prob = _dspark_top_k_renorm_prob_torch
+    top_p_renorm_prob = _dspark_top_p_renorm_prob_torch
+    tree_speculative_sampling_target_only = None
 else:
     top_k_renorm_prob = None
     top_p_renorm_prob = None

--- a/python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py
+++ b/python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py
@@ -19,9 +19,10 @@ class SoftmaxTemp:
     def execute(cls, *args, **kwargs) -> torch.Tensor:
         if _KERNEL_IMPL == "torch":
             return cls.torch(*args, **kwargs)
+        if _KERNEL_IMPL == "amd_hip":
+            ## Placeholder for amd aiter kernel
+            return cls.triton(*args, **kwargs)
         if _KERNEL_IMPL == "flashinfer":
-            if _flashinfer_softmax is None:
-                return cls.triton(*args, **kwargs)
             return cls.flashinfer(*args, **kwargs)
         return cls.triton(*args, **kwargs)
 

--- a/python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py
+++ b/python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py
@@ -19,7 +19,7 @@ class SoftmaxTemp:
     def execute(cls, *args, **kwargs) -> torch.Tensor:
         if _KERNEL_IMPL == "torch":
             return cls.torch(*args, **kwargs)
-        if _KERNEL_IMPL == "amd_hip":
+        if _KERNEL_IMPL == "aiter":
             ## Placeholder for amd aiter kernel
             return cls.triton(*args, **kwargs)
         if _KERNEL_IMPL == "flashinfer":

--- a/python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py
+++ b/python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py
@@ -20,6 +20,8 @@ class SoftmaxTemp:
         if _KERNEL_IMPL == "torch":
             return cls.torch(*args, **kwargs)
         if _KERNEL_IMPL == "flashinfer":
+            if _flashinfer_softmax is None:
+                return cls.triton(*args, **kwargs)
             return cls.flashinfer(*args, **kwargs)
         return cls.triton(*args, **kwargs)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Support DSpark for GFX950 based on https://github.com/sgl-project/sglang/pull/30261
 
## Modifications

- `python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py`: align with NV path, update `self.speculative_num_draft_tokens` 

- `python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py`: Add hip path and its `top_k_renorm_prob` / `top_p_renorm_prob` function

- `python/sglang/srt/speculative/dspark_components/kernels/softmax_temp.py`: Add aiter kernel placeholder for AMD platform, use triton backend instead now. 

## Server cmd
```
export SGLANG_DEFAULT_THINKING=1
export SGLANG_DSV4_REASONING_EFFORT=max
export SGLANG_OPT_DEEPGEMM_HC_PRENORM=false
export SGLANG_USE_AITER=1
export SGLANG_USE_ROCM700A=${SGLANG_USE_ROCM700A:-0}
export SGLANG_OPT_USE_FUSED_COMPRESS=true
export SGLANG_OPT_FP8_WO_A_GEMM=false
export SGLANG_OPT_USE_JIT_INDEXER_METADATA=false
export SGLANG_OPT_USE_TOPK_V2=false
export SGLANG_OPT_USE_AITER_INDEXER=true
export SGLANG_OPT_USE_TILELANG_INDEXER=false
export SGLANG_OPT_USE_TILELANG_MHC_PRE=false
export SGLANG_OPT_USE_TILELANG_MHC_POST=false
export SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1
export SGLANG_OPT_USE_FUSED_COMPRESS_TRITON=true
export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false
export SGLANG_ROCM_USE_MULTI_STREAM=false
export AITER_BF16_FP8_MOE_BOUND=0
export SGLANG_EAGER_INPUT_NO_COPY=true
export SGLANG_SHARED_EXPERT_TP1=1
export SGLANG_DP_SHARED_EXPERT_LOCAL=1
export SGLANG_DP_USE_GATHERV=1
export SGLANG_DP_USE_REDUCE_SCATTER=1
export GPU_MAX_HW_QUEUES=5

DSPARK=${DSPARK:-1}
if [ "${DSPARK}" = "1" ]; then
    echo "DSpark is enabled"
    export SGLANG_DSPARK_KERNEL_SOFTMAX_TEMP=aiter
    export SGLANG_HACK_FLASHMLA_BACKEND=triton
    export SGLANG_RAGGED_VERIFY_MODE=static
    DSPARK_ARGS="--speculative-algorithm DSPARK --speculative-dspark-block-size 5"
else
    echo "DSpark is disabled"
    export SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton
    DSPARK_ARGS=""
fi

MODEL=/mnt/raid0/pretrained_model/deepseek-ai/DeepSeek-V4-Pro-DSpark

sglang serve \
    --model-path ${MODEL} \
    --trust-remote-code \
    --tp 8 \
    --disable-radix-cache \
    --attention-backend dsv4 \
    --page-size 256 \
    --mem-fraction-static 0.9 \
    --swa-full-tokens-ratio 0.15 \
    --disable-shared-experts-fusion \
    --tool-call-parser deepseekv4 \
    --reasoning-parser deepseek-v4 \
    --kv-cache-dtype fp8_e4m3 \
    --chunked-prefill-size 8192 \
    --cuda-graph-max-bs 64 \
    --max-running-requests 64 \
    ${DSPARK_ARGS}

```
## Accuracy Tests

### GSM8K on DSpark
root@smci355-ccs-aus-n12-13:/mnt/raid0/fangyuan/deepseekv4/dspark# bash client.sh
INPUT_LEN=8192
OUTPUT_LEN=1024
PROFILE=0
TIMESTAMP=20260710_054733
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:29<00:00,  8.83it/s]
Accuracy: 0.925                                                                                                                                                                                                                         Invalid: 0.000                                                                                                                                                                                                                          Latency: 149.338 s                                                                                                                                                                                                                      Output throughput: 776.608 token/s

### GSM8K on Baseline
root@smci355-ccs-aus-n12-13:/mnt/raid0/fangyuan/deepseekv4/dspark# bash client.sh
INPUT_LEN=8192
OUTPUT_LEN=1024
PROFILE=0
TIMESTAMP=20260710_061922
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [03:47<00:00,  5.79it/s]
Accuracy: 0.929
Invalid: 0.000
Latency: 227.995 s
Output throughput: 511.529 token/s


## Speed Tests and Profiling

DSpark | conc | np=4xconc | Total token throughput (tok/s) | Δ | Mean TTFT (ms) | Δ | Mean TPOT (ms) |  Δ
-- | -- | -- | -- | -- | -- | -- | -- | --
  | 2 | 8 | 2552.63 | 221.12% | 1183.95 | 55.19% | 5.43 | 275.51%
  | 4 | 16 | 3833.8 | 178.33% | 1403.64 | 69.88% | 7.39 | 213.80%
  | 8 | 32 | 5079.36 | 133.64% | 2019.84 | 81.73% | 11.45 | 151.44%
  | 16 | 64 | 6302.61 | 102.36% | 3101.25 | 97.28% | 18.75 | 109.07%
  | 32 | 128 | 7469.15 | 91.63% | 5089.2 | 110.92% | 32.84 | 78.87%
  | 64 | 256 | 8061.44 | 65.92% | 11060.75 | 99.10% | 59.25 | 61.45%
baseline | 2 | 8 | 1154.4 |   | 653.44 |   | 14.96 |  
  | 4 | 16 | 2149.85 |   | 980.84 |   | 15.8 |  
  | 8 | 32 | 3800.71 |   | 1650.9 |   | 17.34 |  
  | 16 | 64 | 6157.03 |   | 3016.87 |   | 20.45 |  
  | 32 | 128 | 8151.04 |   | 5644.76 |   | 25.9 |  
  | 64 | 256 | 12228.92 |   | 10961.07 |   | 36.41 |  

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->