### PR TITLE
[Bugfix] Fix CUDA graph lookup when padding is disabled

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -416,15 +416,15 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         else:
             cuda_graph_bs = forward_batch.batch_size
 
-        graph_key = cuda_graph_bs
-        if self.enable_pdmux:
-            graph_key = f"{get_current_stream_idx()}_{cuda_graph_bs}"
-
-        is_bs_supported = (
-            self.backend.can_run(forward_batch, graph_key)
-            if self.disable_padding
-            else cuda_graph_bs <= self.max_bs
-        )
+        if self.disable_padding:
+            graph_key = self._make_graph_key(
+                cuda_graph_bs,
+                get_current_stream_idx() if self.enable_pdmux else None,
+                self._resolve_lora_variant(forward_batch),
+            )
+            is_bs_supported = self.backend.can_run(forward_batch, graph_key)
+        else:
+            is_bs_supported = cuda_graph_bs <= self.max_bs
 
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -299,7 +299,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             cuda_graph_bs = forward_batch.batch_size
 
         is_bs_supported = (
-            self.backend.can_run(forward_batch, cuda_graph_bs)
+            self.backend.can_run(forward_batch, self._make_graph_key(cuda_graph_bs))
             if self.disable_padding
             else cuda_graph_bs <= self.max_bs
         )

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -296,7 +296,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             cuda_graph_bs = forward_batch.seq_lens.numel()
 
         is_bs_supported = (
-            self.backend.can_run(forward_batch, cuda_graph_bs)
+            self.backend.can_run(forward_batch, self._make_graph_key(cuda_graph_bs))
             if self.disable_padding
             else cuda_graph_bs <= self.max_bs
         )

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -206,7 +206,7 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             cuda_graph_bs = forward_batch.seq_lens.numel()
 
         is_bs_supported = (
-            self.backend.can_run(forward_batch, cuda_graph_bs)
+            self.backend.can_run(forward_batch, self._make_graph_key(cuda_graph_bs))
             if self.disable_padding
             else cuda_graph_bs <= self.max_bs
         )

--- a/test/registered/unit/model_executor/test_decode_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_decode_cuda_graph_runner.py
@@ -1,0 +1,144 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+from sglang.srt.model_executor.runner.shape_key import ShapeKey
+from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
+    EAGLEDraftCudaGraphRunner,
+)
+from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
+    EAGLEDraftExtendCudaGraphRunner,
+)
+from sglang.srt.speculative.multi_layer_eagle_draft_extend_cuda_graph_runner import (
+    MultiLayerEagleDraftExtendCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _NoSpecAlgorithm:
+    def is_eagle(self):
+        return False
+
+    def is_standalone(self):
+        return False
+
+    def is_dflash(self):
+        return False
+
+    def is_ngram(self):
+        return False
+
+
+class _RecordingBackend:
+    def __init__(self, supported_keys):
+        self.supported_keys = set(supported_keys)
+        self.seen_keys = []
+
+    def can_run(self, forward_batch, shape_key):
+        self.seen_keys.append(shape_key)
+        return shape_key in self.supported_keys
+
+
+class TestDecodeCudaGraphRunner(CustomTestCase):
+    def _build_runner(self, supported_keys, *, enable_pdmux=False):
+        runner = DecodeCudaGraphRunner.__new__(DecodeCudaGraphRunner)
+        runner.backend = _RecordingBackend(supported_keys)
+        runner.capture_hidden_mode = CaptureHiddenMode.NULL
+        runner.disable_padding = True
+        runner.enable_pdmux = enable_pdmux
+        runner.enable_two_batch_overlap = False
+        runner.is_encoder_decoder = False
+        runner.num_tokens_per_bs = 1
+        runner.record_nolora_graph = False
+        runner.require_mlp_sync = False
+        runner.require_mlp_tp_gather = False
+        runner.model_runner = SimpleNamespace(spec_algorithm=_NoSpecAlgorithm())
+        return runner
+
+    def _build_forward_batch(self, batch_size, *, lora_ids=None):
+        return SimpleNamespace(
+            batch_size=batch_size,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+            lora_ids=lora_ids,
+            replace_embeds=None,
+            spec_info=None,
+        )
+
+    def test_disable_padding_uses_exact_shape_key(self):
+        expected_key = ShapeKey(size=16)
+        runner = self._build_runner([expected_key])
+
+        self.assertTrue(runner.can_run_graph(self._build_forward_batch(16)))
+        self.assertFalse(runner.can_run_graph(self._build_forward_batch(15)))
+        self.assertEqual(
+            runner.backend.seen_keys,
+            [expected_key, ShapeKey(size=15)],
+        )
+
+    @patch(
+        "sglang.srt.model_executor.runner.decode_cuda_graph_runner."
+        "get_current_stream_idx",
+        return_value=3,
+    )
+    def test_disable_padding_uses_pdmux_stream_in_shape_key(self, _):
+        expected_key = ShapeKey(size=16, stream_idx=3)
+        runner = self._build_runner([expected_key], enable_pdmux=True)
+
+        self.assertTrue(runner.can_run_graph(self._build_forward_batch(16)))
+        self.assertEqual(runner.backend.seen_keys, [expected_key])
+
+    def test_speculative_runners_use_exact_shape_key(self):
+        runner_classes = (
+            EAGLEDraftCudaGraphRunner,
+            EAGLEDraftExtendCudaGraphRunner,
+            MultiLayerEagleDraftExtendCudaGraphRunner,
+        )
+
+        for runner_class in runner_classes:
+            with self.subTest(runner_class=runner_class.__name__):
+                expected_key = ShapeKey(size=16)
+                runner = runner_class.__new__(runner_class)
+                runner.backend = _RecordingBackend([expected_key])
+                runner.disable_padding = True
+                runner.require_mlp_sync = False
+                runner.require_mlp_tp_gather = False
+                runner.model_runner = SimpleNamespace(spec_algorithm=_NoSpecAlgorithm())
+
+                exact_batch = SimpleNamespace(
+                    batch_size=16,
+                    seq_lens=SimpleNamespace(numel=lambda: 16),
+                )
+                non_exact_batch = SimpleNamespace(
+                    batch_size=15,
+                    seq_lens=SimpleNamespace(numel=lambda: 15),
+                )
+
+                self.assertTrue(runner.can_run_graph(exact_batch))
+                self.assertFalse(runner.can_run_graph(non_exact_batch))
+                self.assertEqual(
+                    runner.backend.seen_keys,
+                    [expected_key, ShapeKey(size=15)],
+                )
+
+    def test_disable_padding_uses_lora_variant_in_shape_key(self):
+        expected_key = ShapeKey(size=16, variant_label="lora")
+        runner = self._build_runner([expected_key])
+        runner.record_nolora_graph = True
+
+        self.assertTrue(
+            runner.can_run_graph(
+                self._build_forward_batch(16, lora_ids=["adapter", None])
+            )
+        )
+        self.assertEqual(runner.backend.seen_keys, [expected_key])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--disable-cuda-graph-padding` should use a captured CUDA graph for an exact capture size and fall back to eager execution for an uncaptured size.

After CUDA graph backends migrated to typed `ShapeKey` keys, the decode runners still queried `backend.can_run()` with a bare integer (or a legacy PDMux string). The lookup therefore missed every captured graph and silently sent exact-size batches to eager execution.

## Modifications

- Build the decode lookup key with the same `_make_graph_key()` path used by capture and replay, including PDMux stream and LoRA variant fields.
- Use typed shape keys in the EAGLE draft, draft-extend, and multi-layer draft-extend runners as well.
- Add CPU regression coverage for:
  - exact captured size accepted and non-exact size rejected
  - PDMux stream keys
  - LoRA variant keys
  - speculative runner lookups

## Accuracy Tests

This changes graph selection only; model math and outputs are unchanged.

A pure-SGLang GB200 runtime check reproduced the bug before the patch: with graph padding disabled, an exact captured batch reported `cuda graph: False`. With the typed-key patch, the exact batch reported `cuda graph: True`, while non-exact batches correctly remained eager. A latest-container validation is in progress and will be added here.

## Speed Tests and Profiling

The fix restores CUDA graph replay for exact captured batches that previously ran eager. No comparative throughput claim is included yet.

## Checklist

- [x] Format checked with Black.
- [x] Ruff checks pass.
- [x] Added CPU unit tests.
- [ ] CI unit tests.
- [ ] Documentation update is not needed; this restores the documented flag behavior.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29073130379](https://github.com/sgl-project/sglang/actions/runs/29073130379)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29073130214](https://github.com/sgl-project/sglang/actions/runs/29073130214)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->