### PR TITLE
[RL] update_weights_from_disk: load quantized checkpoints like initial loading

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -165,8 +165,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             weight = layer.weight
 
             if is_fp8_fnuz() or _use_aiter:
-                # ROCm paths transform the weight destructively (dtype
-                # normalize / aiter shuffle); not reload-safe.
+                # ROCm transforms replace the checkpoint-layout parameters.
                 if is_fp8_fnuz():
                     input_scale = getattr(layer, "input_scale", None)
 
@@ -181,21 +180,17 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                     weight_scale = layer.weight_scale.data
 
                 if _use_aiter:
-                    # keep the weight as (N, K)
+                    # Keep the weight as (N, K).
                     layer.weight = Parameter(
                         shuffle_weight(weight, (16, 16)), requires_grad=False
                     )
                 else:
                     layer.weight = Parameter(weight.t(), requires_grad=False)
 
-                # required by torch.compile to be torch.nn.Parameter
+                # Required by torch.compile.
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
             else:
-                # Keep the checkpoint-layout params (and their weight_loader)
-                # so update_weights_from_disk can refill them; the kernel takes
-                # a transposed VIEW of the same storage, so in-place refills
-                # are visible without re-deriving and pointers stay stable for
-                # CUDA graphs.
+                # Keep loader metadata and storage stable across reloads.
                 layer.weight.requires_grad_(False)
                 layer.weight_scale.requires_grad_(False)
                 layer.weight_t = layer.weight.data.t()
@@ -266,8 +261,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         else:
             return apply_fp8_linear(
                 input=x,
-                # CHANNEL keeps the checkpoint-layout weight and derives the
-                # transposed view; TENSOR still stores the transpose in-place.
                 weight=getattr(layer, "weight_t", layer.weight),
                 weight_scale=layer.weight_scale,
                 input_scale=layer.input_scale,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -164,29 +164,41 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         elif self.strategy == QuantizationStrategy.CHANNEL:
             weight = layer.weight
 
-            if is_fp8_fnuz():
-                input_scale = getattr(layer, "input_scale", None)
+            if is_fp8_fnuz() or _use_aiter:
+                # ROCm paths transform the weight destructively (dtype
+                # normalize / aiter shuffle); not reload-safe.
+                if is_fp8_fnuz():
+                    input_scale = getattr(layer, "input_scale", None)
 
-                weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
-                    weight=weight,
-                    weight_scale=layer.weight_scale,
-                    input_scale=input_scale,
-                )
-                if input_scale is not None:
-                    layer.input_scale = Parameter(input_scale, requires_grad=False)
+                    weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
+                        weight=weight,
+                        weight_scale=layer.weight_scale,
+                        input_scale=input_scale,
+                    )
+                    if input_scale is not None:
+                        layer.input_scale = Parameter(input_scale, requires_grad=False)
+                else:
+                    weight_scale = layer.weight_scale.data
+
+                if _use_aiter:
+                    # keep the weight as (N, K)
+                    layer.weight = Parameter(
+                        shuffle_weight(weight, (16, 16)), requires_grad=False
+                    )
+                else:
+                    layer.weight = Parameter(weight.t(), requires_grad=False)
+
+                # required by torch.compile to be torch.nn.Parameter
+                layer.weight_scale = Parameter(weight_scale, requires_grad=False)
             else:
-                weight_scale = layer.weight_scale.data
-
-            if _use_aiter:
-                # keep the weight as (N, K)
-                layer.weight = Parameter(
-                    shuffle_weight(weight, (16, 16)), requires_grad=False
-                )
-            else:
-                layer.weight = Parameter(weight.t(), requires_grad=False)
-
-            # required by torch.compile to be torch.nn.Parameter
-            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+                # Keep the checkpoint-layout params (and their weight_loader)
+                # so update_weights_from_disk can refill them; the kernel takes
+                # a transposed VIEW of the same storage, so in-place refills
+                # are visible without re-deriving and pointers stay stable for
+                # CUDA graphs.
+                layer.weight.requires_grad_(False)
+                layer.weight_scale.requires_grad_(False)
+                layer.weight_t = layer.weight.data.t()
 
         elif self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
@@ -254,7 +266,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         else:
             return apply_fp8_linear(
                 input=x,
-                weight=layer.weight,
+                # CHANNEL keeps the checkpoint-layout weight and derives the
+                # transposed view; TENSOR still stores the transpose in-place.
+                weight=getattr(layer, "weight_t", layer.weight),
                 weight_scale=layer.weight_scale,
                 input_scale=layer.input_scale,
                 bias=bias,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -393,6 +393,36 @@ class Fp8Config(QuantizationConfig):
             )
 
 
+def _snapshot_scale_checkpoint_state(scale) -> None:
+    """Record the scale state the first process pass starts from.
+
+    Captured at the first process_weights_after_loading call, i.e. after
+    create_weights and any model-__init__ override, but before the first
+    transform latches the format flag or repacks the layout.
+    restore_weights_before_loading returns to this state so a reloaded
+    checkpoint is loaded and processed exactly like initial loading.
+    """
+    if scale is not None and not hasattr(scale, "_ckpt_format_ue8m0"):
+        scale._ckpt_format_ue8m0 = scale.format_ue8m0
+        scale._ckpt_shape = tuple(scale.data.shape)
+        scale._ckpt_dtype = scale.data.dtype
+
+
+def _restore_scale_checkpoint_state(scale) -> None:
+    if scale is None or not hasattr(scale, "_ckpt_format_ue8m0"):
+        return
+    scale.format_ue8m0 = scale._ckpt_format_ue8m0
+    if tuple(scale.data.shape) != scale._ckpt_shape:
+        # The UE8M0 requant repacked the scale layout. Hand the loader a
+        # checkpoint-shaped buffer to refill, and keep the kernel-layout
+        # buffer so the requant re-fills the SAME storage afterwards (CUDA
+        # graphs hold its pointer).
+        scale._kernel_buffer = scale.data
+        scale.data = torch.empty(
+            scale._ckpt_shape, dtype=scale._ckpt_dtype, device=scale.data.device
+        )
+
+
 class Fp8LinearMethod(LinearMethodBase):
     """Linear method for FP8.
 
@@ -588,7 +618,22 @@ class Fp8LinearMethod(LinearMethodBase):
             else:
                 layer.register_parameter("input_scale", None)
 
+    def restore_weights_before_loading(self, layer: Module) -> None:
+        """Prepare the layer for a fresh checkpoint-layout load.
+
+        format_ue8m0 describes the scale VALUES (set once the first
+        process_weights_after_loading requants them), but a reload overwrites
+        those values with raw checkpoint scales, so the latched flag must be
+        returned to its pre-processing state or the re-run skips the requant
+        and serves raw scales as UE8M0. Restore rather than hard-reset:
+        construction-time opt-outs (e.g. deepseek_v4 wo_a) legitimately
+        start True and must stay True.
+        """
+        if self.block_quant:
+            _restore_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
+
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
+        _snapshot_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
         # If ROCm, normalize the weights and scales to e4m3fnuz
         if _is_fp8_fnuz:
             # activation_scheme: dynamic
@@ -1238,7 +1283,22 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_input_scale = None
             layer.w2_input_scale = None
 
+    def restore_weights_before_loading(self, layer: Module) -> None:
+        """Prepare expert weights for a fresh checkpoint-layout load.
+
+        Same contract as Fp8LinearMethod.restore_weights_before_loading: the
+        UE8M0 flags describe the scale values, so they must return to their
+        pre-processing state before a reload refills the scales.
+        """
+        if self.block_quant:
+            _restore_scale_checkpoint_state(
+                getattr(layer, "w13_weight_scale_inv", None)
+            )
+            _restore_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
+
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
+        _snapshot_scale_checkpoint_state(getattr(layer, "w13_weight_scale_inv", None))
+        _snapshot_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
         if _use_aiter and self.is_fp4_expert:
             gu_intv = envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -394,32 +394,24 @@ class Fp8Config(QuantizationConfig):
 
 
 def _snapshot_scale_checkpoint_state(scale) -> None:
-    """Record the scale state the first process pass starts from.
-
-    Captured at the first process_weights_after_loading call, i.e. after
-    create_weights and any model-__init__ override, but before the first
-    transform latches the format flag or repacks the layout.
-    restore_weights_before_loading returns to this state so a reloaded
-    checkpoint is loaded and processed exactly like initial loading.
-    """
-    if scale is not None and not hasattr(scale, "_ckpt_format_ue8m0"):
-        scale._ckpt_format_ue8m0 = scale.format_ue8m0
-        scale._ckpt_shape = tuple(scale.data.shape)
-        scale._ckpt_dtype = scale.data.dtype
+    """Capture the scale layout expected by the checkpoint loader."""
+    if scale is not None and not hasattr(scale, "_checkpoint_format_ue8m0"):
+        scale._checkpoint_format_ue8m0 = scale.format_ue8m0
+        scale._checkpoint_shape = tuple(scale.data.shape)
+        scale._checkpoint_dtype = scale.data.dtype
 
 
 def _restore_scale_checkpoint_state(scale) -> None:
-    if scale is None or not hasattr(scale, "_ckpt_format_ue8m0"):
+    """Restore a scale parameter to its checkpoint-loading layout."""
+    if scale is None or not hasattr(scale, "_checkpoint_format_ue8m0"):
         return
-    scale.format_ue8m0 = scale._ckpt_format_ue8m0
-    if tuple(scale.data.shape) != scale._ckpt_shape:
-        # The UE8M0 requant repacked the scale layout. Hand the loader a
-        # checkpoint-shaped buffer to refill, and keep the kernel-layout
-        # buffer so the requant re-fills the SAME storage afterwards (CUDA
-        # graphs hold its pointer).
-        scale._kernel_buffer = scale.data
+    scale.format_ue8m0 = scale._checkpoint_format_ue8m0
+    if tuple(scale.data.shape) != scale._checkpoint_shape:
+        scale._reload_kernel_buffer = scale.data
         scale.data = torch.empty(
-            scale._ckpt_shape, dtype=scale._ckpt_dtype, device=scale.data.device
+            scale._checkpoint_shape,
+            dtype=scale._checkpoint_dtype,
+            device=scale.data.device,
         )
 
 
@@ -619,16 +611,6 @@ class Fp8LinearMethod(LinearMethodBase):
                 layer.register_parameter("input_scale", None)
 
     def restore_weights_before_loading(self, layer: Module) -> None:
-        """Prepare the layer for a fresh checkpoint-layout load.
-
-        format_ue8m0 describes the scale VALUES (set once the first
-        process_weights_after_loading requants them), but a reload overwrites
-        those values with raw checkpoint scales, so the latched flag must be
-        returned to its pre-processing state or the re-run skips the requant
-        and serves raw scales as UE8M0. Restore rather than hard-reset:
-        construction-time opt-outs (e.g. deepseek_v4 wo_a) legitimately
-        start True and must stay True.
-        """
         if self.block_quant:
             _restore_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
 
@@ -1284,12 +1266,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w2_input_scale = None
 
     def restore_weights_before_loading(self, layer: Module) -> None:
-        """Prepare expert weights for a fresh checkpoint-layout load.
-
-        Same contract as Fp8LinearMethod.restore_weights_before_loading: the
-        UE8M0 flags describe the scale values, so they must return to their
-        pre-processing state before a reload refills the scales.
-        """
         if self.block_quant:
             _restore_scale_checkpoint_state(
                 getattr(layer, "w13_weight_scale_inv", None)

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1348,8 +1348,32 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
         weight.to(weight_scale_inv.device), weight_scale_inv, weight_block_size
     )
 
-    offloader.update_param(weight, new_weight)
-    weight_scale_inv.data = new_weight_scale_inv
+    # Reuse existing storage where possible: on weight reloads this re-runs
+    # after the loader refilled raw checkpoint values, and captured CUDA
+    # graphs hold pointers to the buffers of the first pass.
+    if (
+        weight.data.shape == new_weight.shape
+        and weight.data.dtype == new_weight.dtype
+        and weight.device == new_weight.device
+    ):
+        weight.data.copy_(new_weight)
+    else:
+        offloader.update_param(weight, new_weight)
+
+    kernel_buffer = getattr(weight_scale_inv, "_kernel_buffer", None)
+    if (
+        kernel_buffer is not None
+        and kernel_buffer.shape == new_weight_scale_inv.shape
+        and kernel_buffer.dtype == new_weight_scale_inv.dtype
+    ):
+        # restore_weights_before_loading swapped in a checkpoint-shaped buffer
+        # for the refill; put the repacked scales back into the original
+        # kernel-layout storage.
+        kernel_buffer.copy_(new_weight_scale_inv)
+        weight_scale_inv.data = kernel_buffer
+        del weight_scale_inv._kernel_buffer
+    else:
+        weight_scale_inv.data = new_weight_scale_inv
 
 
 def requant_block_scale_ue8m0_for_deepgemm(

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1348,9 +1348,7 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
         weight.to(weight_scale_inv.device), weight_scale_inv, weight_block_size
     )
 
-    # Reuse existing storage where possible: on weight reloads this re-runs
-    # after the loader refilled raw checkpoint values, and captured CUDA
-    # graphs hold pointers to the buffers of the first pass.
+    # Preserve buffers referenced by captured CUDA graphs.
     if (
         weight.data.shape == new_weight.shape
         and weight.data.dtype == new_weight.dtype
@@ -1360,18 +1358,15 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
     else:
         offloader.update_param(weight, new_weight)
 
-    kernel_buffer = getattr(weight_scale_inv, "_kernel_buffer", None)
+    kernel_buffer = getattr(weight_scale_inv, "_reload_kernel_buffer", None)
     if (
         kernel_buffer is not None
         and kernel_buffer.shape == new_weight_scale_inv.shape
         and kernel_buffer.dtype == new_weight_scale_inv.dtype
     ):
-        # restore_weights_before_loading swapped in a checkpoint-shaped buffer
-        # for the refill; put the repacked scales back into the original
-        # kernel-layout storage.
         kernel_buffer.copy_(new_weight_scale_inv)
         weight_scale_inv.data = kernel_buffer
-        del weight_scale_inv._kernel_buffer
+        del weight_scale_inv._reload_kernel_buffer
     else:
         weight_scale_inv.data = new_weight_scale_inv
 
@@ -1540,11 +1535,7 @@ def inverse_transform_scale_ue8m0(sf_packed, mn):
 
 # Inverse impl can refer to DeepGEMM's torch impl in get_mn_major_tma_aligned_packed_ue8m0_tensor_torch_impl
 def _inverse_transform_scale_ue8m0_impl(sf_packed):
-    """
-    NOTE: We assume k is aligned
-    :param sf_packed: (scale_mn, scale_k/4) int32
-    :return: (scale_mn, scale_k), float32
-    """
+    """Unpack row-repeated UE8M0 scales into their block grid."""
     if len(sf_packed.shape) == 3:
         return torch.stack(
             [_inverse_transform_scale_ue8m0_impl(x) for x in sf_packed], dim=0
@@ -1554,26 +1545,27 @@ def _inverse_transform_scale_ue8m0_impl(sf_packed):
     assert len(sf_packed.shape) == 2, f"{sf_packed.shape=}"
     assert sf_packed.dtype == torch.int32
 
-    mn_repeat_128, k_div_4 = sf_packed.shape
-    mn = mn_repeat_128 // block_size
+    weight_mn, k_div_4 = sf_packed.shape
+    num_blocks = ceil_div(weight_mn, block_size)
     k = k_div_4 * 4
 
     # packed u8 -> fp32
-    sf_u8 = sf_packed.contiguous().flatten().view(torch.uint8).view(mn_repeat_128, k)
+    sf_u8 = sf_packed.contiguous().flatten().view(torch.uint8).view(weight_mn, k)
     sf_fp32 = (sf_u8.to(torch.int32) << 23).view(torch.float32)
 
-    # remove repeat
-    sf_reshaped = sf_fp32.view(mn, block_size, k)
-    sf_unrepeated = sf_reshaped[:, 0:1, :]
-    if not torch.all(sf_unrepeated == sf_reshaped):
+    # Take one scale row per block and verify the repeated rows.
+    block_first_rows = torch.arange(num_blocks, device=sf_fp32.device) * block_size
+    sf_unrepeated = sf_fp32.index_select(0, block_first_rows)
+    block_ids = torch.arange(weight_mn, device=sf_fp32.device) // block_size
+    if not torch.all(sf_fp32 == sf_unrepeated.index_select(0, block_ids)):
         from sglang.srt.debug_utils.dumper import get_tensor_info
 
         raise AssertionError(
-            f"sf_unrepeated != sf_reshaped ({get_tensor_info(sf_unrepeated)=} {get_tensor_info(sf_reshaped)=})"
+            f"scale rows differ within a block ({get_tensor_info(sf_fp32)=} {get_tensor_info(sf_unrepeated)=})"
         )
-    sf_unrepeated = sf_unrepeated.squeeze(1).contiguous()
+    sf_unrepeated = sf_unrepeated.contiguous()
 
-    assert sf_unrepeated.shape == (mn, k)
+    assert sf_unrepeated.shape == (num_blocks, k)
     return sf_unrepeated
 
 

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -421,7 +421,10 @@ class SchedulerWeightUpdaterManager:
                         skip_tensor_list=recv_req.skip_tensor_list,
                     )
                 except Exception as e:
-                    raise RuntimeError(f"[{role or 'target'}] {e}") from e
+                    # Exception notes identify the failing tensor.
+                    notes = "; ".join(getattr(e, "__notes__", []))
+                    detail = f"{e}" + (f" ({notes})" if notes else "")
+                    raise RuntimeError(f"[{role or 'target'}] {detail}") from e
 
             if recv_req.action == "checksum":
                 payload = _merge_checksum_payloads(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1918,6 +1918,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
 
         target_device = torch.device(self.device)
+
+        if weight_name_filter is None:
+            # Return latched quant state (e.g. fp8 UE8M0 format flags) to its
+            # pre-processing value so load + process re-derive the kernel layout
+            # from the fresh checkpoint bytes, exactly like initial loading.
+            restore_weight(self.model, target_device)
+        elif self.model_config.quantization is not None:
+            return False, (
+                "weight_name_filter is not supported for quantized models: "
+                "process_weights_after_loading re-derives kernel state for every "
+                "layer, which is only correct when all source weights were refilled."
+            )
+
+        original_model_path = self.model_config.model_path
         self.model_config.model_path = model_path
         load_config = LoadConfig(load_format=load_format)
 
@@ -1956,6 +1970,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
                 del iter
                 gc.collect()
+                # Roll back from the ORIGINAL checkpoint (model_path already
+                # points at the new one), and restore latched quant state
+                # again: the failed attempt may have processed some layers.
+                self.model_config.model_path = original_model_path
+                restore_weight(self.model, target_device)
                 iter = get_weight_iter(self.model_config)
                 self.model = model_load_weights(self.model, iter)
                 return False, message

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1919,16 +1919,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         target_device = torch.device(self.device)
 
-        if weight_name_filter is None:
-            # Return latched quant state (e.g. fp8 UE8M0 format flags) to its
-            # pre-processing value so load + process re-derive the kernel layout
-            # from the fresh checkpoint bytes, exactly like initial loading.
-            restore_weight(self.model, target_device)
-        elif self.model_config.quantization is not None:
+        if (
+            weight_name_filter is not None
+            and self.model_config.quantization is not None
+        ):
             return False, (
                 "weight_name_filter is not supported for quantized models: "
-                "process_weights_after_loading re-derives kernel state for every "
-                "layer, which is only correct when all source weights were refilled."
+                "all weights must be reloaded before post-processing."
             )
 
         original_model_path = self.model_config.model_path
@@ -1938,6 +1935,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Only support DefaultModelLoader for now
         loader = get_model_loader(load_config, self.model_config)
         if not isinstance(loader, DefaultModelLoader):
+            self.model_config.model_path = original_model_path
             message = f"Failed to get model loader: {loader}."
             return False, message
 
@@ -1960,9 +1958,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             try:
                 iter = get_weight_iter(self.model_config)
             except Exception as e:
+                self.model_config.model_path = original_model_path
                 message = f"Failed to get weights iterator: {e}."
                 return False, message
             try:
+                if weight_name_filter is None:
+                    restore_weight(self.model, target_device)
                 model = model_load_weights(self.model, iter)
             except Exception as e:
                 message = (
@@ -1970,9 +1971,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
                 del iter
                 gc.collect()
-                # Roll back from the ORIGINAL checkpoint (model_path already
-                # points at the new one), and restore latched quant state
-                # again: the failed attempt may have processed some layers.
                 self.model_config.model_path = original_model_path
                 restore_weight(self.model, target_device)
                 iter = get_weight_iter(self.model_config)

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -7,10 +7,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
     block_quant_dequant,
     inverse_transform_scale_ue8m0,
 )
-from sglang.srt.layers.quantization.modelopt_quant import (
-    ModelOptFp4LinearMethod,
-    ModelOptNvFp4FusedMoEMethod,
-)
 
 # chunk to avoid too high GPU memory peak
 CHUNK_NUMEL = 64 * 1024 * 1024
@@ -154,15 +150,11 @@ def compare_weights(
 
 
 def select_comparable_weight(quant_method) -> Optional[type]:
-    """Map a module's quant_method to its ComparableWeight. None means raw (bitwise equal) compare."""
+    """Return a quantized comparator, or None for bitwise comparison."""
     if (
         isinstance(quant_method, (Fp8LinearMethod, Fp8MoEMethod))
         and quant_method.block_quant
         and not quant_method.use_mxfp8
     ):
         return Fp8BlockComparable
-    if isinstance(quant_method, (ModelOptFp4LinearMethod, ModelOptNvFp4FusedMoEMethod)):
-        raise NotImplementedError(
-            f"weight checker has no ComparableWeight for {type(quant_method).__name__}"
-        )
     return None


### PR DESCRIPTION
## Problem

`update_weights_from_disk` re-runs `load_weights` + `process_weights_after_loading` on the live model, but the fp8 process passes assume checkpoint-layout inputs and a first run. Reloading a plain HF fp8 checkpoint — the disaggregated-rollout flow where the trainer publishes checkpoints, existing engines reload them, and freshly spun-up engines init-load the same files — breaks three ways:

1. **compressed-tensors CHANNEL fp8** (GLM-4.5-Air-FP8, GLM-4.7-FP8): `process_weights_after_loading` rebinds `layer.weight = Parameter(weight.t())`, dropping `weight_loader`. The reload crashes (fused params hit `AttributeError`; plain linears hit `default_weight_loader`'s shape assert), and the rollback re-crashes the same way.
2. **blockwise fp8 + DeepGEMM UE8M0** (Blackwell): the requant is latched by `format_ue8m0` and repacks `weight_scale_inv` into the DeepGEMM layout (shape changes). On reload, fused-scale refills crash (`split_with_sizes expects split_sizes to sum exactly to 64, got [2048, 2048, 4096]`); shape-surviving layers silently serve raw scales as UE8M0. `DeepseekV2WeightLoaderMixin.post_load_weights` reads the same stale flag and inverse-transforms the fresh raw scales, corrupting `w_kc`/`w_vc` independently.
3. **rollback bug** (all formats): `model_config.model_path` is switched before loading, so a failed update "rolls back" from the NEW path.

The invariant this PR enforces: **`update_weights_from_disk(ckpt)` ≡ `init(ckpt)`**, with no CUDA graph recapture.

## Fix (one commit per file group)

- **`model_runner.py`**: `update_weights_from_disk` runs `restore_weight()` before loading, so the disk path follows the same restore → load → process session protocol as `begin/end_weight_update`. Rollback re-reads the ORIGINAL path and restores again first. `weight_name_filter` is rejected for quantized models (re-deriving every layer is only correct under full refills).
- **`fp8.py` + `fp8_utils.py`**: `Fp8LinearMethod`/`Fp8MoEMethod` snapshot the scale state at the first process pass (`format_ue8m0` value plus checkpoint shape/dtype — captured after `create_weights` and any model-`__init__` override such as deepseek_v4 `wo_a`, which legitimately starts True) and implement `restore_weights_before_loading`: restore the flag, and when the layout was repacked, hand the loader a checkpoint-shaped buffer while stashing the kernel-layout buffer. `requant_weight_ue8m0_inplace` copies the repacked scales back into that SAME storage (and the weight in place) so captured CUDA graphs keep valid pointers.
- **`compressed_tensors_w8a8_fp8.py`** (CHANNEL, CUDA): keep the checkpoint-layout `weight`/`weight_scale` Parameters (loader intact) and hand the kernel a derived transposed VIEW (`layer.weight_t`) of the same storage — in-place refills are visible without re-deriving, pointers stay stable, and the process pass is idempotent by construction. ROCm branches unchanged.
- **`weight_checker_comparator.py` + `weight_updater.py`**: the packed-UE8M0 inverse now handles weights whose row count is not a multiple of 128 and trims the /4 column padding before block-size inference; nvfp4/int4/mxfp8 map to raw bit-exact compare (same-checkpoint reloads are deterministic-transform-identical); the RPC error carries the failing tensor's name (exception notes were dropped).

## Validation

Same-base reload oracle, standalone server, no trainer: `init(ckpt)` → logprob signature (with measured self-noise tolerance) → `/weights_checker snapshot` → `reset_tensors` (poisons every param so a no-op reload cannot pass) → `/update_weights_from_disk(ckpt)` → `compare` per tensor vs the post-init snapshot → signature unchanged. Official checkpoints only.

| cell | GPU | unpatched | patched |
|---|---|---|---|
| Qwen3.6-35B-A3B-FP8 (blockwise, dense+MoE) | H200 tp1 | — | **PASS** |
| Qwen3.6-35B-A3B-FP8 (+ DeepGEMM UE8M0) | B200 tp1 | **crash** (repacked-scale refill) | **PASS** (tensors bit-equal, generations identical) |
| GLM-4.5-Air-FP8 (CT-CHANNEL, 106B) | H200 tp2 | **crash** (weight_loader lost) | **PASS** |
| GLM-5.1-FP8 (blockwise + DSA/MLA, 756GB, production serving config) | H200 tp8 | — | **PASS** (full tensor compare + identical generations) |
| GLM-5.1-FP8 | B200 tp8 | — | **PASS** (tensor compare through the packed UE8M0 layouts) |
| Kimi-K2.6-NVFP4 (modelopt fp4, 595GB) | B200 tp8 | — | **PASS** (no engine changes needed; checker gained nvfp4 support) |
| Kimi-K2.5 int4 W4A16 (595GB) | H200 tp8 | — | **PASS** (WNA16 restore protocol now fires on the disk path) |
| Qwen3-30B MXFP8 | B200 tp1 | — | **PASS** (out of the box) |

## Compatibility

- Initial loading: byte-identical (the snapshot is a no-op observation; restore never runs at init).
- Bare `update_weights_from_tensor` / `update_weights_from_distributed`: unaffected (no restore hooks run on those paths).
- Trainers using `begin/end_weight_update` sessions with fp8-block models on Blackwell: `begin` now restores checkpoint scale state, so pushes must be plain HF scales and `end` re-derives. Pairs with radixark/miles#1623 — ship the two in the same image.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29771557189](https://github.com/sgl-project/sglang/actions/runs/29771557189)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29771557019](https://github.com/sgl-project/sglang/actions/runs/29771557019)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->