### PR TITLE
Fix CUDA graph lookup when padding is disabled

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -416,9 +416,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         else:
             cuda_graph_bs = forward_batch.batch_size
 
-        graph_key = cuda_graph_bs
-        if self.enable_pdmux:
-            graph_key = f"{get_current_stream_idx()}_{cuda_graph_bs}"
+        graph_key = self._make_graph_key(
+            cuda_graph_bs,
+            get_current_stream_idx() if self.enable_pdmux else None,
+            self._resolve_lora_variant(forward_batch),
+        )
 
         is_bs_supported = (
             self.backend.can_run(forward_batch, graph_key)


### PR DESCRIPTION
With `--disable-cuda-graph-padding`, even exact captured batch sizes currently fall back to eager mode.

This happens because `can_run_graph()` looks up the graph using a raw batch size, while the backend stores captured graphs using `ShapeKey`, so the keys never match.

This change uses `_make_graph_key()` for the lookup. After the fix, exact captured batch sizes use CUDA graph, while non-exact sizes correctly fall back to eager mode without padding.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29075368371](https://github.com/sgl-project/sglang/actions/runs/29075368371)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29075368278](https://github.com/sgl-project/sglang/actions/runs/29075368278)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->