### PR TITLE
Seed sgl-kernel topk sigmoid tests on all backends

### DIFF
--- a/sgl-kernel/tests/test_moe_topk_sigmoid.py
+++ b/sgl-kernel/tests/test_moe_topk_sigmoid.py
@@ -5,18 +5,14 @@ import pytest
 import torch
 from sgl_kernel import topk_sigmoid
 
-_IS_HIP = torch.version.hip is not None
-
 
 @pytest.fixture(autouse=True)
 def _deterministic_seed():
-    # AMD/ROCm only: pin RNG so torch.randn produces identical gating scores
-    # across runs. atol=0 indices comparison is otherwise tripped by near-tied
-    # sigmoid scores where hipCUB's tie-break inside torch.topk disagrees with
-    # sgl_kernel.topk_sigmoid. Not observed on CUDA, so leave CUDA behavior
-    # unchanged.
-    if _IS_HIP:
-        torch.manual_seed(0)
+    # Pin RNG on every backend so torch.randn produces identical gating scores
+    # across runs. The exact index comparison can otherwise be tripped by
+    # near-tied sigmoid scores whose rounded values have different top-k
+    # tie-break ordering between torch.topk and sgl_kernel.topk_sigmoid.
+    torch.manual_seed(0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

#25356 seeded these tests on AMD after tie-break flakes showed up. This extends the same fix to every backend now that the same flake has shown up on CUDA too.

https://github.com/sgl-project/sglang/actions/runs/28957635401/job/85934654890



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29076001910](https://github.com/sgl-project/sglang/actions/runs/29076001910)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29076001748](https://github.com/sgl-project/sglang/actions/runs/29076001748)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->