### PR TITLE
[PD] Fix HiSparse + SWA decode hang/rejection for long inputs

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1285,10 +1285,17 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             )
 
         if self.scheduler.enable_hisparse:
-            # HiSparse pre-alloc only allocates logical indices (alloc_logical_only),
-            # so the logical pool is the binding constraint for admission control.
+            # HiSparse pre-alloc allocates full-attention KV for the whole prompt
+            # but only the sliding-window tail for SWA layers (alloc_extend_swa_tail),
+            # so the FULL-attention pool is the binding constraint for the full
+            # request length here. Using logical_attn_allocator.available_size()
+            # (= min(full, swa)) would cap a single request at the SWA pool
+            # (~full/10), making any request with input+output > SWA pool
+            # un-admittable (stuck in PD transfer -> bootstrap timeout / hang).
+            # The SWA (tail) requirement is separately enforced by the swa_tail
+            # gate below.
             available_size = (
-                self.token_to_kv_pool_allocator.logical_attn_allocator.available_size()
+                self.token_to_kv_pool_allocator.logical_attn_allocator.full_available_size()
             )
         elif self._uses_swa_tail_prealloc():
             available_size = self.token_to_kv_pool_allocator.full_available_size()
@@ -1463,22 +1470,39 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 )
 
         if self.scheduler.enable_hisparse:
-            # HiSparse is incompatible with decode-side L1 radix cache. Keep
-            # this path on the upstream full-allocation semantics.
+            # HiSparse is incompatible with decode-side L1 radix cache.
             assert prefix_len == 0
 
             # Direct-to-host path: only allocate logical indices (no hisparse
             # device indices) and allocate host indices for RDMA destination.
             coordinator = self.scheduler.hisparse_coordinator
             device = self.token_to_kv_pool_allocator.device
-            kv_loc = self.token_to_kv_pool_allocator.alloc_logical_only(
-                prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
-                prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
-                seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
-                seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
-                last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
-                extend_num_tokens=fill_len,
-            )
+            if self._uses_swa_tail_prealloc():
+                # Tail-only SWA allocation: full-attention layers get the whole
+                # prompt, SWA layers only get the sliding-window tail. Without
+                # this, alloc_logical_only reserves SWA at full prompt length and
+                # a single long request nearly fills the SWA pool, stalling decode
+                # once the few spare pages run out before eviction catches up.
+                swa_tail = self._swa_tail_len(fill_len)
+                kv_loc = self.token_to_kv_pool_allocator.alloc_extend_swa_tail(
+                    prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
+                    prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
+                    seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
+                    seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
+                    last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
+                    extend_num_tokens=fill_len,
+                    swa_tail_len=swa_tail,
+                )
+                req.swa_evicted_seqlen = fill_len - swa_tail
+            else:
+                kv_loc = self.token_to_kv_pool_allocator.alloc_logical_only(
+                    prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
+                    prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
+                    seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
+                    seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
+                    last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
+                    extend_num_tokens=fill_len,
+                )
 
             # Allocate host indices for the RDMA transfer target.
             host_indices = coordinator.mem_pool_host.alloc_paged_token_slots(

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -402,6 +402,26 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             extend_num_tokens,
         )
 
+    def alloc_extend_swa_tail(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        swa_tail_len: int,
+    ):
+        return self.logical_attn_allocator.alloc_extend_swa_tail(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+            swa_tail_len,
+        )
+
     def alloc_device_buffer(self, allocated_indices, need_size: int):
         assert need_size % self.hisparse_page_size == 0
         hisparse_indices = self.full_to_hisparse_device_index_mapping[allocated_indices]


### PR DESCRIPTION
On a decode node running DeepSeek-V4 (hybrid SWA) with HiSparse under PD disaggregation, long-input requests are wrongly rejected (HTTP 400) or stall in KV transfer until the bootstrap timeout fires. Disabling HiSparse with an otherwise identical config makes the same requests pass.

Root cause: the HiSparse decode pre-alloc path collapses the single-request limit to the SWA pool (~full/10) in two independent places, because the `DeepSeekV4HiSparseTokenToKVPoolAllocator` wrapper does not expose the underlying SWA allocator's tail-window semantics.

  1. Admission control used `logical_attn_allocator.available_size()` (= min(full, swa)), so a request whose input+output exceeds the SWA pool can never be admitted, or an in-flight long request starves the SWA-bounded budget of everything behind it. The full-attention pool is the real binding constraint for the whole request length; SWA is separately gated by the swa_tail check. Use `full_available_size()`.

  2. Pre-alloc used `alloc_logical_only`, which reserves SWA at the full prompt length. A single long request nearly fills the SWA pool, leaving too few spare pages for decode to make progress before eviction catches up. When `_uses_swa_tail_prealloc()` holds, allocate the sliding-window tail only via `alloc_extend_swa_tail` and set `req.swa_evicted_seqlen`, matching the non-HiSparse path.

Also forward `alloc_extend_swa_tail` on the HiSparse allocator so `_uses_swa_tail_prealloc()` resolves to True; the wrapper only changes the c4 (device) pool, not SWA, so delegating to the wrapped SWA allocator is safe.

Fixes #30401

cc @alphabetc1 @yhyang201

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29076368059](https://github.com/sgl-project/sglang/actions/runs/29076368059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29076367839](https://github.com/sgl-project/sglang/actions/runs/29076367839)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->