### PR TITLE
fix: allocate dspark target-verify buffers eagerly to avoid inference-tensor conflict

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -654,14 +654,22 @@ class DeepseekV4AttnBackend(
 
         # Allocated in __init__ (outside inference_mode) deliberately: lazy
         # allocation inside FlashInfer autotune's inference_mode tags them as
-        # inference tensors, which cannot be inplace-updated during CUDA-graph capture.
-        num_reqs = self.req_to_token.shape[0]
-        self.extend_seq_lens_buffer = torch.full(
-            (num_reqs,),
-            self.speculative_num_draft_tokens,
-            **self.cuda_int32_kwargs,
-        )
-        self.extend_start_loc_buffer = torch.zeros(num_reqs, **self.cuda_int32_kwargs)
+        # inference tensors, which cannot be inplace-updated during CUDA-graph
+        # capture.
+        #
+        # Guarded under speculative_num_draft_tokens to avoid allocating
+        # when the backend is used without speculative decoding (the buffers
+        # are only consumed by the target-verify path).
+        if self.speculative_num_draft_tokens is not None:
+            num_reqs = self.req_to_token.shape[0]
+            self.extend_seq_lens_buffer = torch.full(
+                (num_reqs,),
+                self.speculative_num_draft_tokens,
+                **self.cuda_int32_kwargs,
+            )
+            self.extend_start_loc_buffer = torch.zeros(
+                num_reqs, **self.cuda_int32_kwargs
+            )
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -652,6 +652,19 @@ class DeepseekV4AttnBackend(
             and model_runner.spec_algorithm.is_dspark()
         )
 
+        # Allocated in __init__ (outside inference_mode) deliberately: lazy
+        # allocation inside FlashInfer autotune's inference_mode tags them as
+        # inference tensors, which cannot be inplace-updated during CUDA-graph capture.
+        num_reqs = self.req_to_token.shape[0]
+        self.extend_seq_lens_buffer = torch.full(
+            (num_reqs,),
+            self.speculative_num_draft_tokens,
+            **self.cuda_int32_kwargs,
+        )
+        self.extend_start_loc_buffer = torch.zeros(
+            num_reqs, **self.cuda_int32_kwargs
+        )
+
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
         return pin_tensor.to(self.device, non_blocking=True)
@@ -873,17 +886,6 @@ class DeepseekV4AttnBackend(
             c128_compress_metadata=c128_compress_metadata,
         )
 
-    def _ensure_verify_bs_buffers(self) -> None:
-        if hasattr(self, "extend_seq_lens_buffer"):
-            return
-        num_reqs = self.req_to_token.shape[0]
-        self.extend_seq_lens_buffer = torch.full(
-            (num_reqs,),
-            self.speculative_num_draft_tokens,
-            **self.cuda_int32_kwargs,
-        )
-        self.extend_start_loc_buffer = torch.zeros(num_reqs, **self.cuda_int32_kwargs)
-
     def init_forward_metadata_target_verify(
         self,
         max_seq_len: int,
@@ -901,7 +903,6 @@ class DeepseekV4AttnBackend(
             seq_lens_cpu_list = (
                 seq_lens_cpu.tolist() if seq_lens_cpu is not None else None
             )
-            self._ensure_verify_bs_buffers()
             if ragged_layout is None:
                 self.extend_seq_lens_buffer[:bs].fill_(
                     self.speculative_num_draft_tokens

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -661,9 +661,7 @@ class DeepseekV4AttnBackend(
             self.speculative_num_draft_tokens,
             **self.cuda_int32_kwargs,
         )
-        self.extend_start_loc_buffer = torch.zeros(
-            num_reqs, **self.cuda_int32_kwargs
-        )
+        self.extend_start_loc_buffer = torch.zeros(num_reqs, **self.cuda_int32_kwargs)
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)


### PR DESCRIPTION
## Motivation

DSPARK target-verify buffers (`extend_seq_lens_buffer`, `extend_start_loc_buffer`)
were lazy-allocated by `_ensure_verify_bs_buffers()` on first use. The first use
is the FlashInfer autotune `_dummy_run`, which wraps the forward inside
`torch.inference_mode()`. Tensors allocated there are tagged as inference
tensors, and subsequent CUDA-graph capture (outside inference_mode) fails with:

> Inplace update to inference tensor outside InferenceMode is not allowed.

## Modifications

- Allocate both buffers eagerly in `DeepseekV4AttnBackend.__init__` (runs
  outside inference_mode).
- Remove the now-unnecessary `_ensure_verify_bs_buffers` lazy-init method.

## Checklist

- [x] `pre-commit run --all-files`
- [x] Unit tests — N/A (pure bugfix, no behavioral change)
- [x] Documentation — N/A
- [x] Accuracy / Speed — N/A (no model output or performance impact)



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29077340808](https://github.com/sgl-project/sglang/actions/runs/29077340808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29077340909](https://github.com/sgl-project/sglang/actions/runs/29077340909)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->