### PR TITLE
[RL] update_weights_from_disk: load quantized checkpoints like initial loading

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -964,6 +964,10 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
         self.quantization_config = quantization_config
         self.quant_config = quantization_config
 
+    def restore_weights_before_loading(self, layer: torch.nn.Module) -> None:
+        if hasattr(layer.scheme, "restore_weights_before_loading"):
+            layer.scheme.restore_weights_before_loading(layer)
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.scheme.process_weights_after_loading(layer)
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -25,6 +25,8 @@ from sglang.srt.layers.quantization.fp8_utils import (
     dispatch_w8a8_block_fp8_linear,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_block_scale_ue8m0_for_deepgemm,
+    restore_scale_checkpoint_state,
+    snapshot_scale_checkpoint_state,
     validate_fp8_block_shape,
 )
 from sglang.srt.layers.quantization.utils import requantize_with_max_scale
@@ -142,7 +144,13 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             input_scale[:] = torch.finfo(torch.float32).min
             layer.register_parameter("input_scale", input_scale)
 
+    def restore_weights_before_loading(self, layer) -> None:
+        if self.strategy == QuantizationStrategy.BLOCK:
+            restore_scale_checkpoint_state(getattr(layer, "weight_scale", None))
+
     def process_weights_after_loading(self, layer) -> None:
+        if self.strategy == QuantizationStrategy.BLOCK:
+            snapshot_scale_checkpoint_state(getattr(layer, "weight_scale", None))
         if self.strategy == QuantizationStrategy.TENSOR:
             max_w_scale, weight = requantize_with_max_scale(
                 weight=layer.weight,
@@ -165,8 +173,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
             weight = layer.weight
 
             if is_fp8_fnuz() or _use_aiter:
-                # ROCm paths transform the weight destructively (dtype
-                # normalize / aiter shuffle); not reload-safe.
+                # ROCm transforms replace the checkpoint-layout parameters.
                 if is_fp8_fnuz():
                     input_scale = getattr(layer, "input_scale", None)
 
@@ -181,21 +188,17 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
                     weight_scale = layer.weight_scale.data
 
                 if _use_aiter:
-                    # keep the weight as (N, K)
+                    # Keep the weight as (N, K).
                     layer.weight = Parameter(
                         shuffle_weight(weight, (16, 16)), requires_grad=False
                     )
                 else:
                     layer.weight = Parameter(weight.t(), requires_grad=False)
 
-                # required by torch.compile to be torch.nn.Parameter
+                # Required by torch.compile.
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
             else:
-                # Keep the checkpoint-layout params (and their weight_loader)
-                # so update_weights_from_disk can refill them; the kernel takes
-                # a transposed VIEW of the same storage, so in-place refills
-                # are visible without re-deriving and pointers stay stable for
-                # CUDA graphs.
+                # Keep loader metadata and storage stable across reloads.
                 layer.weight.requires_grad_(False)
                 layer.weight_scale.requires_grad_(False)
                 layer.weight_t = layer.weight.data.t()
@@ -266,8 +269,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         else:
             return apply_fp8_linear(
                 input=x,
-                # CHANNEL keeps the checkpoint-layout weight and derives the
-                # transposed view; TENSOR still stores the transpose in-place.
                 weight=getattr(layer, "weight_t", layer.weight),
                 weight_scale=layer.weight_scale,
                 input_scale=layer.input_scale,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -164,29 +164,41 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         elif self.strategy == QuantizationStrategy.CHANNEL:
             weight = layer.weight
 
-            if is_fp8_fnuz():
-                input_scale = getattr(layer, "input_scale", None)
+            if is_fp8_fnuz() or _use_aiter:
+                # ROCm paths transform the weight destructively (dtype
+                # normalize / aiter shuffle); not reload-safe.
+                if is_fp8_fnuz():
+                    input_scale = getattr(layer, "input_scale", None)
 
-                weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
-                    weight=weight,
-                    weight_scale=layer.weight_scale,
-                    input_scale=input_scale,
-                )
-                if input_scale is not None:
-                    layer.input_scale = Parameter(input_scale, requires_grad=False)
+                    weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
+                        weight=weight,
+                        weight_scale=layer.weight_scale,
+                        input_scale=input_scale,
+                    )
+                    if input_scale is not None:
+                        layer.input_scale = Parameter(input_scale, requires_grad=False)
+                else:
+                    weight_scale = layer.weight_scale.data
+
+                if _use_aiter:
+                    # keep the weight as (N, K)
+                    layer.weight = Parameter(
+                        shuffle_weight(weight, (16, 16)), requires_grad=False
+                    )
+                else:
+                    layer.weight = Parameter(weight.t(), requires_grad=False)
+
+                # required by torch.compile to be torch.nn.Parameter
+                layer.weight_scale = Parameter(weight_scale, requires_grad=False)
             else:
-                weight_scale = layer.weight_scale.data
-
-            if _use_aiter:
-                # keep the weight as (N, K)
-                layer.weight = Parameter(
-                    shuffle_weight(weight, (16, 16)), requires_grad=False
-                )
-            else:
-                layer.weight = Parameter(weight.t(), requires_grad=False)
-
-            # required by torch.compile to be torch.nn.Parameter
-            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+                # Keep the checkpoint-layout params (and their weight_loader)
+                # so update_weights_from_disk can refill them; the kernel takes
+                # a transposed VIEW of the same storage, so in-place refills
+                # are visible without re-deriving and pointers stay stable for
+                # CUDA graphs.
+                layer.weight.requires_grad_(False)
+                layer.weight_scale.requires_grad_(False)
+                layer.weight_t = layer.weight.data.t()
 
         elif self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
@@ -254,7 +266,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
         else:
             return apply_fp8_linear(
                 input=x,
-                weight=layer.weight,
+                # CHANNEL keeps the checkpoint-layout weight and derives the
+                # transposed view; TENSOR still stores the transpose in-place.
+                weight=getattr(layer, "weight_t", layer.weight),
                 weight_scale=layer.weight_scale,
                 input_scale=layer.input_scale,
                 bias=bias,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -65,6 +65,8 @@ from sglang.srt.layers.quantization.fp8_utils import (
     mxfp8_group_quantize,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_block_scale_ue8m0_for_deepgemm,
+    restore_scale_checkpoint_state,
+    snapshot_scale_checkpoint_state,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
@@ -411,36 +413,6 @@ class Fp8Config(QuantizationConfig):
             )
 
 
-def _snapshot_scale_checkpoint_state(scale) -> None:
-    """Record the scale state the first process pass starts from.
-
-    Captured at the first process_weights_after_loading call, i.e. after
-    create_weights and any model-__init__ override, but before the first
-    transform latches the format flag or repacks the layout.
-    restore_weights_before_loading returns to this state so a reloaded
-    checkpoint is loaded and processed exactly like initial loading.
-    """
-    if scale is not None and not hasattr(scale, "_ckpt_format_ue8m0"):
-        scale._ckpt_format_ue8m0 = scale.format_ue8m0
-        scale._ckpt_shape = tuple(scale.data.shape)
-        scale._ckpt_dtype = scale.data.dtype
-
-
-def _restore_scale_checkpoint_state(scale) -> None:
-    if scale is None or not hasattr(scale, "_ckpt_format_ue8m0"):
-        return
-    scale.format_ue8m0 = scale._ckpt_format_ue8m0
-    if tuple(scale.data.shape) != scale._ckpt_shape:
-        # The UE8M0 requant repacked the scale layout. Hand the loader a
-        # checkpoint-shaped buffer to refill, and keep the kernel-layout
-        # buffer so the requant re-fills the SAME storage afterwards (CUDA
-        # graphs hold its pointer).
-        scale._kernel_buffer = scale.data
-        scale.data = torch.empty(
-            scale._ckpt_shape, dtype=scale._ckpt_dtype, device=scale.data.device
-        )
-
-
 class Fp8LinearMethod(LinearMethodBase):
     """Linear method for FP8.
 
@@ -631,18 +603,8 @@ class Fp8LinearMethod(LinearMethodBase):
                 layer.register_parameter("input_scale", None)
 
     def restore_weights_before_loading(self, layer: Module) -> None:
-        """Prepare the layer for a fresh checkpoint-layout load.
-
-        format_ue8m0 describes the scale VALUES (set once the first
-        process_weights_after_loading requants them), but a reload overwrites
-        those values with raw checkpoint scales, so the latched flag must be
-        returned to its pre-processing state or the re-run skips the requant
-        and serves raw scales as UE8M0. Restore rather than hard-reset:
-        construction-time opt-outs (e.g. deepseek_v4 wo_a) legitimately
-        start True and must stay True.
-        """
         if self.block_quant:
-            _restore_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
+            restore_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
 
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
         if self.convert_mxfp8_to_block:
@@ -671,10 +633,8 @@ class Fp8LinearMethod(LinearMethodBase):
             self._process_mxfp8_linear_weight_scale(layer)
             return
 
-        # The newer MXFP8 branches above own their scale layout and return before
-        # DeepGEMM's block-FP8 requantization. Snapshot only the checkpoint-layout
-        # block-FP8 scale that the reload restore protocol is responsible for.
-        _snapshot_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
+        # MXFP8 paths manage their own scale layouts above.
+        snapshot_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
         # If ROCm, normalize the weights and scales to e4m3fnuz
         if _is_fp8_fnuz:
             # activation_scheme: dynamic
@@ -1364,21 +1324,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w2_input_scale = None
 
     def restore_weights_before_loading(self, layer: Module) -> None:
-        """Prepare expert weights for a fresh checkpoint-layout load.
-
-        Same contract as Fp8LinearMethod.restore_weights_before_loading: the
-        UE8M0 flags describe the scale values, so they must return to their
-        pre-processing state before a reload refills the scales.
-        """
         if self.block_quant:
-            _restore_scale_checkpoint_state(
-                getattr(layer, "w13_weight_scale_inv", None)
-            )
-            _restore_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
+            restore_scale_checkpoint_state(getattr(layer, "w13_weight_scale_inv", None))
+            restore_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
 
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
-        _snapshot_scale_checkpoint_state(getattr(layer, "w13_weight_scale_inv", None))
-        _snapshot_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
+        snapshot_scale_checkpoint_state(getattr(layer, "w13_weight_scale_inv", None))
+        snapshot_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
         if _use_aiter and self.is_fp4_expert:
             gu_intv = envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -411,6 +411,36 @@ class Fp8Config(QuantizationConfig):
             )
 
 
+def _snapshot_scale_checkpoint_state(scale) -> None:
+    """Record the scale state the first process pass starts from.
+
+    Captured at the first process_weights_after_loading call, i.e. after
+    create_weights and any model-__init__ override, but before the first
+    transform latches the format flag or repacks the layout.
+    restore_weights_before_loading returns to this state so a reloaded
+    checkpoint is loaded and processed exactly like initial loading.
+    """
+    if scale is not None and not hasattr(scale, "_ckpt_format_ue8m0"):
+        scale._ckpt_format_ue8m0 = scale.format_ue8m0
+        scale._ckpt_shape = tuple(scale.data.shape)
+        scale._ckpt_dtype = scale.data.dtype
+
+
+def _restore_scale_checkpoint_state(scale) -> None:
+    if scale is None or not hasattr(scale, "_ckpt_format_ue8m0"):
+        return
+    scale.format_ue8m0 = scale._ckpt_format_ue8m0
+    if tuple(scale.data.shape) != scale._ckpt_shape:
+        # The UE8M0 requant repacked the scale layout. Hand the loader a
+        # checkpoint-shaped buffer to refill, and keep the kernel-layout
+        # buffer so the requant re-fills the SAME storage afterwards (CUDA
+        # graphs hold its pointer).
+        scale._kernel_buffer = scale.data
+        scale.data = torch.empty(
+            scale._ckpt_shape, dtype=scale._ckpt_dtype, device=scale.data.device
+        )
+
+
 class Fp8LinearMethod(LinearMethodBase):
     """Linear method for FP8.
 
@@ -600,6 +630,20 @@ class Fp8LinearMethod(LinearMethodBase):
             else:
                 layer.register_parameter("input_scale", None)
 
+    def restore_weights_before_loading(self, layer: Module) -> None:
+        """Prepare the layer for a fresh checkpoint-layout load.
+
+        format_ue8m0 describes the scale VALUES (set once the first
+        process_weights_after_loading requants them), but a reload overwrites
+        those values with raw checkpoint scales, so the latched flag must be
+        returned to its pre-processing state or the re-run skips the requant
+        and serves raw scales as UE8M0. Restore rather than hard-reset:
+        construction-time opt-outs (e.g. deepseek_v4 wo_a) legitimately
+        start True and must stay True.
+        """
+        if self.block_quant:
+            _restore_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
+
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
         if self.convert_mxfp8_to_block:
             from sglang.srt.layers.quantization.mxfp8_block_convert import (
@@ -626,6 +670,11 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.weight_scale_inv.format_ue8m0 = True
             self._process_mxfp8_linear_weight_scale(layer)
             return
+
+        # The newer MXFP8 branches above own their scale layout and return before
+        # DeepGEMM's block-FP8 requantization. Snapshot only the checkpoint-layout
+        # block-FP8 scale that the reload restore protocol is responsible for.
+        _snapshot_scale_checkpoint_state(getattr(layer, "weight_scale_inv", None))
         # If ROCm, normalize the weights and scales to e4m3fnuz
         if _is_fp8_fnuz:
             # activation_scheme: dynamic
@@ -1314,7 +1363,22 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_input_scale = None
             layer.w2_input_scale = None
 
+    def restore_weights_before_loading(self, layer: Module) -> None:
+        """Prepare expert weights for a fresh checkpoint-layout load.
+
+        Same contract as Fp8LinearMethod.restore_weights_before_loading: the
+        UE8M0 flags describe the scale values, so they must return to their
+        pre-processing state before a reload refills the scales.
+        """
+        if self.block_quant:
+            _restore_scale_checkpoint_state(
+                getattr(layer, "w13_weight_scale_inv", None)
+            )
+            _restore_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
+
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
+        _snapshot_scale_checkpoint_state(getattr(layer, "w13_weight_scale_inv", None))
+        _snapshot_scale_checkpoint_state(getattr(layer, "w2_weight_scale_inv", None))
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
         if _use_aiter and self.is_fp4_expert:
             gu_intv = envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1419,9 +1419,7 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
         weight.to(weight_scale_inv.device), weight_scale_inv, weight_block_size
     )
 
-    # Reuse existing storage where possible: on weight reloads this re-runs
-    # after the loader refilled raw checkpoint values, and captured CUDA
-    # graphs hold pointers to the buffers of the first pass.
+    # Preserve buffers referenced by captured CUDA graphs.
     if (
         weight.data.shape == new_weight.shape
         and weight.data.dtype == new_weight.dtype
@@ -1431,20 +1429,39 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
     else:
         offloader.update_param(weight, new_weight)
 
-    kernel_buffer = getattr(weight_scale_inv, "_kernel_buffer", None)
+    kernel_buffer = getattr(weight_scale_inv, "_reload_kernel_buffer", None)
     if (
         kernel_buffer is not None
         and kernel_buffer.shape == new_weight_scale_inv.shape
         and kernel_buffer.dtype == new_weight_scale_inv.dtype
     ):
-        # restore_weights_before_loading swapped in a checkpoint-shaped buffer
-        # for the refill; put the repacked scales back into the original
-        # kernel-layout storage.
         kernel_buffer.copy_(new_weight_scale_inv)
         weight_scale_inv.data = kernel_buffer
-        del weight_scale_inv._kernel_buffer
+        del weight_scale_inv._reload_kernel_buffer
     else:
         weight_scale_inv.data = new_weight_scale_inv
+
+
+def snapshot_scale_checkpoint_state(scale) -> None:
+    """Capture the scale layout expected by the checkpoint loader."""
+    if scale is not None and not hasattr(scale, "_checkpoint_format_ue8m0"):
+        scale._checkpoint_format_ue8m0 = scale.format_ue8m0
+        scale._checkpoint_shape = tuple(scale.data.shape)
+        scale._checkpoint_dtype = scale.data.dtype
+
+
+def restore_scale_checkpoint_state(scale) -> None:
+    """Restore a scale parameter to its checkpoint-loading layout."""
+    if scale is None or not hasattr(scale, "_checkpoint_format_ue8m0"):
+        return
+    scale.format_ue8m0 = scale._checkpoint_format_ue8m0
+    if tuple(scale.data.shape) != scale._checkpoint_shape:
+        scale._reload_kernel_buffer = scale.data
+        scale.data = torch.empty(
+            scale._checkpoint_shape,
+            dtype=scale._checkpoint_dtype,
+            device=scale.data.device,
+        )
 
 
 def requant_block_scale_ue8m0_for_deepgemm(
@@ -1611,13 +1628,7 @@ def inverse_transform_scale_ue8m0(sf_packed, mn):
 
 # Inverse impl can refer to DeepGEMM's torch impl in get_mn_major_tma_aligned_packed_ue8m0_tensor_torch_impl
 def _inverse_transform_scale_ue8m0_impl(sf_packed):
-    """
-    NOTE: We assume k is aligned
-    :param sf_packed: (weight_mn, scale_k/4) int32 — transform_scale_ue8m0
-        broadcasts each 128-block's scale to one packed row per WEIGHT row, so
-        weight_mn need not be a multiple of 128 (the last block may be partial)
-    :return: (ceil(weight_mn/128), scale_k), float32
-    """
+    """Unpack row-repeated UE8M0 scales into their block grid."""
     if len(sf_packed.shape) == 3:
         return torch.stack(
             [_inverse_transform_scale_ue8m0_impl(x) for x in sf_packed], dim=0
@@ -1635,7 +1646,7 @@ def _inverse_transform_scale_ue8m0_impl(sf_packed):
     sf_u8 = sf_packed.contiguous().flatten().view(torch.uint8).view(weight_mn, k)
     sf_fp32 = (sf_u8.to(torch.int32) << 23).view(torch.float32)
 
-    # remove repeat: take the first row of each block, verify the rest match
+    # Take one scale row per block and verify the repeated rows.
     block_first_rows = torch.arange(num_blocks, device=sf_fp32.device) * block_size
     sf_unrepeated = sf_fp32.index_select(0, block_first_rows)
     block_ids = torch.arange(weight_mn, device=sf_fp32.device) // block_size

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1419,8 +1419,32 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
         weight.to(weight_scale_inv.device), weight_scale_inv, weight_block_size
     )
 
-    offloader.update_param(weight, new_weight)
-    weight_scale_inv.data = new_weight_scale_inv
+    # Reuse existing storage where possible: on weight reloads this re-runs
+    # after the loader refilled raw checkpoint values, and captured CUDA
+    # graphs hold pointers to the buffers of the first pass.
+    if (
+        weight.data.shape == new_weight.shape
+        and weight.data.dtype == new_weight.dtype
+        and weight.device == new_weight.device
+    ):
+        weight.data.copy_(new_weight)
+    else:
+        offloader.update_param(weight, new_weight)
+
+    kernel_buffer = getattr(weight_scale_inv, "_kernel_buffer", None)
+    if (
+        kernel_buffer is not None
+        and kernel_buffer.shape == new_weight_scale_inv.shape
+        and kernel_buffer.dtype == new_weight_scale_inv.dtype
+    ):
+        # restore_weights_before_loading swapped in a checkpoint-shaped buffer
+        # for the refill; put the repacked scales back into the original
+        # kernel-layout storage.
+        kernel_buffer.copy_(new_weight_scale_inv)
+        weight_scale_inv.data = kernel_buffer
+        del weight_scale_inv._kernel_buffer
+    else:
+        weight_scale_inv.data = new_weight_scale_inv
 
 
 def requant_block_scale_ue8m0_for_deepgemm(

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1613,8 +1613,10 @@ def inverse_transform_scale_ue8m0(sf_packed, mn):
 def _inverse_transform_scale_ue8m0_impl(sf_packed):
     """
     NOTE: We assume k is aligned
-    :param sf_packed: (scale_mn, scale_k/4) int32
-    :return: (scale_mn, scale_k), float32
+    :param sf_packed: (weight_mn, scale_k/4) int32 — transform_scale_ue8m0
+        broadcasts each 128-block's scale to one packed row per WEIGHT row, so
+        weight_mn need not be a multiple of 128 (the last block may be partial)
+    :return: (ceil(weight_mn/128), scale_k), float32
     """
     if len(sf_packed.shape) == 3:
         return torch.stack(
@@ -1625,26 +1627,27 @@ def _inverse_transform_scale_ue8m0_impl(sf_packed):
     assert len(sf_packed.shape) == 2, f"{sf_packed.shape=}"
     assert sf_packed.dtype == torch.int32
 
-    mn_repeat_128, k_div_4 = sf_packed.shape
-    mn = mn_repeat_128 // block_size
+    weight_mn, k_div_4 = sf_packed.shape
+    num_blocks = ceil_div(weight_mn, block_size)
     k = k_div_4 * 4
 
     # packed u8 -> fp32
-    sf_u8 = sf_packed.contiguous().flatten().view(torch.uint8).view(mn_repeat_128, k)
+    sf_u8 = sf_packed.contiguous().flatten().view(torch.uint8).view(weight_mn, k)
     sf_fp32 = (sf_u8.to(torch.int32) << 23).view(torch.float32)
 
-    # remove repeat
-    sf_reshaped = sf_fp32.view(mn, block_size, k)
-    sf_unrepeated = sf_reshaped[:, 0:1, :]
-    if not torch.all(sf_unrepeated == sf_reshaped):
+    # remove repeat: take the first row of each block, verify the rest match
+    block_first_rows = torch.arange(num_blocks, device=sf_fp32.device) * block_size
+    sf_unrepeated = sf_fp32.index_select(0, block_first_rows)
+    block_ids = torch.arange(weight_mn, device=sf_fp32.device) // block_size
+    if not torch.all(sf_fp32 == sf_unrepeated.index_select(0, block_ids)):
         from sglang.srt.debug_utils.dumper import get_tensor_info
 
         raise AssertionError(
-            f"sf_unrepeated != sf_reshaped ({get_tensor_info(sf_unrepeated)=} {get_tensor_info(sf_reshaped)=})"
+            f"scale rows differ within a block ({get_tensor_info(sf_fp32)=} {get_tensor_info(sf_unrepeated)=})"
         )
-    sf_unrepeated = sf_unrepeated.squeeze(1).contiguous()
+    sf_unrepeated = sf_unrepeated.contiguous()
 
-    assert sf_unrepeated.shape == (mn, k)
+    assert sf_unrepeated.shape == (num_blocks, k)
     return sf_unrepeated
 
 

--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
 import torch
 
 from sglang.srt.configs.load_config import LoadConfig
-from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
+from sglang.srt.model_loader.loader import (
+    DefaultModelLoader,
+    get_model_loader,
+    restore_weights_before_loading,
+)
 from sglang.srt.model_loader.utils import set_default_torch_dtype
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.platforms import current_platform
@@ -118,6 +122,21 @@ class WeightUpdater:
         )
 
         target_device = torch.device(self.device)
+
+        if weight_name_filter is None:
+            # Return latched quant state (for example FP8 UE8M0 flags and
+            # repacked scale layouts) to its checkpoint representation before
+            # refilling it. The subsequent load + postprocess then follows the
+            # same state transition as the initial model load.
+            restore_weights_before_loading(self.get_model(), target_device)
+        elif self.model_config.quantization is not None:
+            return False, (
+                "weight_name_filter is not supported for quantized models: "
+                "post-loading processing is model-wide and is only correct "
+                "when every source weight has been refilled."
+            )
+
+        original_model_path = self.model_config.model_path
         self.model_config.model_path = model_path
         load_config = LoadConfig(load_format=load_format)
 
@@ -146,6 +165,7 @@ class WeightUpdater:
             try:
                 iter = get_weight_iter(self.model_config)
             except Exception as e:
+                self.model_config.model_path = original_model_path
                 message = f"Failed to get weights iterator: {e}."
                 return False, message
             try:
@@ -156,6 +176,12 @@ class WeightUpdater:
                 )
                 del iter
                 gc.collect()
+                # The failed pass may already have processed some layers.
+                # Restore their checkpoint-facing state before reloading the
+                # pristine boot checkpoint, and ensure the iterator resolves
+                # that original path rather than the failed update path.
+                self.model_config.model_path = original_model_path
+                restore_weights_before_loading(self.get_model(), target_device)
                 iter = get_weight_iter(self.model_config)
                 model_load_weights(self.get_model(), iter)
                 return False, message

--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -123,17 +123,13 @@ class WeightUpdater:
 
         target_device = torch.device(self.device)
 
-        if weight_name_filter is None:
-            # Return latched quant state (for example FP8 UE8M0 flags and
-            # repacked scale layouts) to its checkpoint representation before
-            # refilling it. The subsequent load + postprocess then follows the
-            # same state transition as the initial model load.
-            restore_weights_before_loading(self.get_model(), target_device)
-        elif self.model_config.quantization is not None:
+        if (
+            weight_name_filter is not None
+            and self.model_config.quantization is not None
+        ):
             return False, (
                 "weight_name_filter is not supported for quantized models: "
-                "post-loading processing is model-wide and is only correct "
-                "when every source weight has been refilled."
+                "all weights must be reloaded before post-processing."
             )
 
         original_model_path = self.model_config.model_path
@@ -143,6 +139,7 @@ class WeightUpdater:
         # Only support DefaultModelLoader for now
         loader = get_model_loader(load_config, self.model_config)
         if not isinstance(loader, DefaultModelLoader):
+            self.model_config.model_path = original_model_path
             message = f"Failed to get model loader: {loader}."
             return False, message
 
@@ -169,6 +166,8 @@ class WeightUpdater:
                 message = f"Failed to get weights iterator: {e}."
                 return False, message
             try:
+                if weight_name_filter is None:
+                    restore_weights_before_loading(self.get_model(), target_device)
                 model = model_load_weights(self.get_model(), iter)
             except Exception as e:
                 message = (
@@ -176,10 +175,6 @@ class WeightUpdater:
                 )
                 del iter
                 gc.collect()
-                # The failed pass may already have processed some layers.
-                # Restore their checkpoint-facing state before reloading the
-                # pristine boot checkpoint, and ensure the iterator resolves
-                # that original path rather than the failed update path.
                 self.model_config.model_path = original_model_path
                 restore_weights_before_loading(self.get_model(), target_device)
                 iter = get_weight_iter(self.model_config)

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -849,6 +849,25 @@ class DefaultModelLoader(BaseModelLoader):
                     quant_method.process_weights_after_loading(module)
 
 
+def restore_weights_before_loading(model, target_device):
+    """Return quant state to its checkpoint layout before a weight reload.
+
+    The inverse counterpart of the process_weights_after_loading loop above:
+    quant methods that latch flags or repack parameters during processing opt
+    in via a restore_weights_before_loading hook, so a subsequent
+    load + process pass consumes the refilled checkpoint bytes exactly like
+    initial loading. A no-op for methods without the hook (and therefore at
+    initial load, where nothing has been processed yet).
+    """
+    for _, module in model.named_modules():
+        quant_method = getattr(module, "quant_method", None)
+        if quant_method is not None and hasattr(
+            quant_method, "restore_weights_before_loading"
+        ):
+            with device_loading_context(module, target_device):
+                quant_method.restore_weights_before_loading(module)
+
+
 class LayeredModelLoader(DefaultModelLoader):
     """Model loader that loads weights layer by layer so that one can quantize a
     layer before loading another to make the peak memory envelope smaller."""

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -849,16 +849,10 @@ class DefaultModelLoader(BaseModelLoader):
                     quant_method.process_weights_after_loading(module)
 
 
-def restore_weights_before_loading(model, target_device):
-    """Return quant state to its checkpoint layout before a weight reload.
-
-    The inverse counterpart of the process_weights_after_loading loop above:
-    quant methods that latch flags or repack parameters during processing opt
-    in via a restore_weights_before_loading hook, so a subsequent
-    load + process pass consumes the refilled checkpoint bytes exactly like
-    initial loading. A no-op for methods without the hook (and therefore at
-    initial load, where nothing has been processed yet).
-    """
+def restore_weights_before_loading(
+    model: nn.Module, target_device: torch.device
+) -> None:
+    """Restore quantized modules to their checkpoint-loading state."""
     for _, module in model.named_modules():
         quant_method = getattr(module, "quant_method", None)
         if quant_method is not None and hasattr(


### PR DESCRIPTION
## Problem

`update_weights_from_disk` re-runs `load_weights` + `process_weights_after_loading` on the live model, but the fp8 process passes assume checkpoint-layout inputs and a first run. Reloading a plain HF fp8 checkpoint — the disaggregated RL flow, where the trainer publishes HF checkpoints, existing engines reload them, and freshly spun-up engines init-load the same files — breaks three ways:

1. **compressed-tensors CHANNEL fp8** (e.g. GLM-4.5-Air-FP8): `process_weights_after_loading` rebinds `layer.weight = Parameter(weight.t())`, dropping `weight_loader`. The reload crashes (fused params hit `AttributeError`; plain linears hit `default_weight_loader`'s shape assert), and the rollback re-crashes the same way.
2. **blockwise fp8 + DeepGEMM UE8M0**: the requant is latched by `format_ue8m0` and repacks `weight_scale_inv` into the DeepGEMM layout (shape changes). On reload, fused-scale refills crash (`split_with_sizes expects split_sizes to sum exactly to 64, got [2048, 2048, 4096]`); shape-surviving layers silently serve raw scales as UE8M0. `DeepseekV2WeightLoaderMixin.post_load_weights` reads the same stale flag and inverse-transforms the fresh raw scales, corrupting `w_kc`/`w_vc` independently.
3. **rollback bug** (all formats): `model_config.model_path` is switched before loading, so a failed update "rolls back" from the NEW path.

The invariant this PR enforces: **`update_weights_from_disk(ckpt)` ≡ `init(ckpt)`**, with no CUDA graph recapture.

## Fix (one commit per file group)

- **`loader.py` + `model_runner.py`**: introduce `restore_weights_before_loading` — the inverse counterpart of the `process_weights_after_loading` loop. Quant methods opt in to return latched state to its checkpoint layout, and `update_weights_from_disk` runs it before loading, so load + process re-derive kernel state from the refilled bytes exactly like initial loading (no-op for methods without the hook, and therefore at initial load). Rollback re-reads the ORIGINAL path and restores again first. `weight_name_filter` is rejected for quantized models (re-deriving every layer is only correct under full refills).
- **`fp8.py` + `fp8_utils.py`**: `Fp8LinearMethod`/`Fp8MoEMethod` snapshot the scale state at the first process pass (`format_ue8m0` value plus checkpoint shape/dtype — captured after `create_weights` and any model-`__init__` override, which can legitimately start True) and implement the restore hook: restore the flag, and when the layout was repacked, hand the loader a checkpoint-shaped buffer while stashing the kernel-layout buffer. `requant_weight_ue8m0_inplace` copies the repacked scales back into that SAME storage (and the weight in place) so captured CUDA graphs keep valid pointers.
- **`compressed_tensors_w8a8_fp8.py`** (CHANNEL, CUDA): keep the checkpoint-layout `weight`/`weight_scale` Parameters (loader intact) and hand the kernel a derived transposed VIEW (`layer.weight_t`) of the same storage — in-place refills are visible without re-deriving, pointers stay stable, and the process pass is idempotent by construction. ROCm branches unchanged.
- **`fp8_utils.py` (weights-checker support)**: the packed-UE8M0 inverse now handles weights whose row count is not a multiple of 128 (partial last block), so `/weights_checker` can verify requanted layers instead of crashing.

## Validation

This is the `main` twin of sgl-project/sglang#30749 (same fixes on the `sglang-miles` branch), validated there with a same-base reload oracle — `init(ckpt)` → `/weights_checker snapshot` → `reset_tensors` (poisons every param so a no-op reload cannot pass) → `/update_weights_from_disk(ckpt)` → per-tensor `compare` vs the post-init snapshot → greedy-generation signature unchanged — across Qwen3.6-35B-A3B-FP8 (H200 + B200 tp1), GLM-4.5-Air-FP8 (H200 tp2), GLM-5.1-FP8 (756GB, H200 + B200 tp8, production serving config), Kimi-K2.6-NVFP4 (B200 tp8), Kimi-K2.5 int4 (H200 tp8), and MXFP8 (B200 tp1). Unpatched controls fail with exactly the crash signatures quoted above; patched runs are tensor-bit-equal to init with identical generations.

## Compatibility

- Initial loading: byte-identical (the snapshot is a no-op observation; restore never runs at init).
- `update_weights_from_tensor` / `update_weights_from_distributed`: unaffected (no restore hooks run on those paths). Trainers that push kernel-format tensors keep working.
- Related: #27685 discusses generalizing post-load processing for RL weight updates; the restore hook introduced here is the load-side counterpart and composes with that direction.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29771560191](https://github.com/sgl-project/sglang/actions/runs/29771560191)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29771559762](https://github.com/sgl-project/sglang/actions/runs/29771559762)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->