### PR TITLE
[PD] Add decode-side bootstrap timeout cleanup for Mooncake

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -257,6 +257,8 @@ class DecodeRequest:
     waiting_for_input: bool = False
     metadata_buffer_index: int = -1
     is_rebootstrap: bool = False
+    bootstrap_start_time: float = 0.0
+    decode_bootstrap_timeout_recorded: bool = False
 
     # HiCache Status
     prefix_match: Optional[DecodePrefixMatch] = None
@@ -335,6 +337,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         # support aborting them we would need an additional fix in the
         # scheduler. In practice this shouldn't arise in the RL scenario.
         self.held_rebootstrap_reqs: List[Req] = []
+        self.decode_bootstrap_timeout: Optional[int] = (
+            envs.SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT.get()
+            if self.transfer_backend == TransferBackend.MOONCAKE
+            else None
+        )
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         if self.enable_staging and self.is_mla_backend:
             raise RuntimeError(
@@ -576,7 +583,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         )
 
         decode_req = DecodeRequest(
-            req=req, kv_receiver=kv_receiver, is_rebootstrap=is_rebootstrap
+            req=req,
+            kv_receiver=kv_receiver,
+            is_rebootstrap=is_rebootstrap,
+            bootstrap_start_time=time.time(),
         )
         self.queue.append(decode_req)
         return decode_req
@@ -717,6 +727,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         if not self.queue:
             return
 
+        self._mark_decode_bootstrap_timeouts(rids_to_check)
+
         # Still poll if any receiver was aborted, otherwise it stays stuck.
         if all(decode_req.waiting_for_input for decode_req in self.queue) and not any(
             decode_req.kv_receiver.conclude_state == KVPoll.Failed
@@ -730,6 +742,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
+                continue
+            if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
                 continue
 
             if poll == KVPoll.Bootstrapping:
@@ -759,6 +773,68 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
             else:
                 raise ValueError(f"Unexpected poll case: {poll}")
+
+    def _mark_decode_bootstrap_timeouts(
+        self, rids_to_check: Optional[List[str]] = None
+    ) -> None:
+        decode_bootstrap_timeout = getattr(self, "decode_bootstrap_timeout", None)
+        if decode_bootstrap_timeout is None or decode_bootstrap_timeout <= 0:
+            return
+
+        now = time.time()
+        for decode_req in self.queue:
+            if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
+                continue
+            if _is_fake_transfer(decode_req.req, self.scheduler.server_args):
+                continue
+            if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                continue
+            if decode_req.kv_receiver is None:
+                continue
+            if decode_req.kv_receiver.conclude_state == KVPoll.Failed:
+                continue
+
+            bootstrap_start_time = getattr(decode_req, "bootstrap_start_time", None)
+            if bootstrap_start_time is None:
+                continue
+
+            elapsed = now - bootstrap_start_time
+            if elapsed < decode_bootstrap_timeout:
+                continue
+
+            error_message = (
+                f"Decode bootstrap timed out for request rank={self.tp_rank} "
+                f"{decode_req.req.rid=} {decode_req.req.bootstrap_room=} "
+                f"after {elapsed:.1f}s before decode transfer"
+            )
+            logger.error(error_message)
+            decode_req.kv_receiver.kv_mgr.record_failure(
+                decode_req.req.bootstrap_room,
+                error_message,
+            )
+            decode_req.kv_receiver.kv_mgr.update_status(
+                decode_req.req.bootstrap_room, KVPoll.Failed
+            )
+            if (
+                not getattr(decode_req.kv_receiver, "abort_notified", False)
+                and hasattr(decode_req.kv_receiver, "bootstrap_infos")
+                and decode_req.kv_receiver.bootstrap_infos is not None
+            ):
+                decode_req.kv_receiver._send_abort_notification()
+                decode_req.kv_receiver.abort_notified = True
+            prepare_abort(
+                decode_req.req,
+                error_message,
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
+            if (
+                not getattr(
+                    decode_req, "decode_bootstrap_timeout_recorded", False
+                )
+                and self.scheduler.metrics_reporter.enable_metrics
+            ):
+                self.scheduler.metrics_collector.increment_decode_bootstrap_timeout_reqs()
+                decode_req.decode_bootstrap_timeout_recorded = True
 
     def _ensure_prefill_info(
         self, addr_to_reqs: Dict[str, List[DecodeRequest]]
@@ -808,6 +884,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         """Batch-resolve prefill_dp_ranks for pending requests and initialize receivers."""
         if not self.pending_reqs:
             return
+        self.pending_reqs = [
+            decode_req
+            for decode_req in self.pending_reqs
+            if not isinstance(decode_req.req.finished_reason, FINISH_ABORT)
+        ]
+        if not self.pending_reqs:
+            return
 
         # Group pending requests by bootstrap_addr
         addr_to_reqs: Dict[str, List[DecodeRequest]] = {}
@@ -852,6 +935,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self, rids_to_check: Optional[List[str]] = None
     ) -> Tuple[List[DecodeRequest], List[DecodeRequest]]:
         """Pop the preallocated requests from the pending queue (FIFO)."""
+        self._mark_decode_bootstrap_timeouts(rids_to_check)
         self._resolve_pending_reqs()
         self._update_handshake_waiters(rids_to_check)
 
@@ -1202,6 +1286,18 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self.queue = [
             entry for i, entry in enumerate(self.queue) if i not in indices_to_remove
         ]
+        if failed_reqs and logger.isEnabledFor(logging.INFO):
+            logger.info(
+                "Removed failed decode prealloc requests: %s, remaining_prealloc_queue=%d",
+                [
+                    {
+                        "rid": decode_req.req.rid,
+                        "bootstrap_room": decode_req.req.bootstrap_room,
+                    }
+                    for decode_req in failed_reqs
+                ],
+                len(self.queue),
+            )
 
         return preallocated_reqs, failed_reqs
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -517,6 +517,12 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             documentation="The number of bootstrap failed requests.",
             labelnames=labels.keys(),
         )
+        self.num_decode_bootstrap_timeout_reqs = Counter(
+            name="sglang:num_decode_bootstrap_timeout_reqs_total",
+            documentation="The number of decode-side early bootstrap timeout requests.",
+            labelnames=labels.keys(),
+        )
+        self.num_decode_bootstrap_timeout_reqs.labels(**self.labels).inc(0)
         self.num_transfer_failed_reqs = Counter(
             name="sglang:num_transfer_failed_reqs_total",
             documentation="The number of transfer failed requests.",
@@ -1107,6 +1113,9 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
 
     def increment_bootstrap_failed_reqs(self) -> None:
         self.num_bootstrap_failed_reqs.labels(**self.labels).inc(1)
+
+    def increment_decode_bootstrap_timeout_reqs(self) -> None:
+        self.num_decode_bootstrap_timeout_reqs.labels(**self.labels).inc(1)
 
     def increment_transfer_failed_reqs(self) -> None:
         self.num_transfer_failed_reqs.labels(**self.labels).inc(1)

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -1,9 +1,11 @@
 import unittest
+from http import HTTPStatus
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.decode import (
+    DecodeRequest,
     DecodePreallocQueue,
     DecodeTransferQueue,
     HiCacheRestoreResult,
@@ -28,7 +30,107 @@ class FakeReceiver:
         return None
 
 
+class FakeBootstrapReceiver:
+    def __init__(self):
+        self.conclude_state = KVPoll.Bootstrapping
+        self.kv_mgr = MagicMock()
+        self.abort_notified = False
+        self.bootstrap_infos = object()
+        self._send_abort_notification = MagicMock()
+
+
 class TestDecodeQueueCleanup(CustomTestCase):
+    def test_decode_bootstrap_timeout_marks_request_failed_once(self):
+        receiver = FakeBootstrapReceiver()
+        req = SimpleNamespace(
+            rid="decode-timeout",
+            bootstrap_room=11,
+            bootstrap_host="127.0.0.1",
+            finished_reason=None,
+        )
+        decode_req = DecodeRequest(
+            req=req,
+            kv_receiver=receiver,
+            bootstrap_start_time=100.0,
+        )
+
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.queue = [decode_req]
+        queue.decode_bootstrap_timeout = 10
+        queue.tp_rank = 0
+        queue.scheduler = SimpleNamespace(
+            server_args=SimpleNamespace(disaggregation_transfer_backend="mooncake"),
+            metrics_reporter=SimpleNamespace(enable_metrics=True),
+            metrics_collector=MagicMock(),
+        )
+
+        def mark_aborted(req, *args, **kwargs):
+            req.finished_reason = FINISH_ABORT("timed out")
+
+        with (
+            patch("sglang.srt.disaggregation.decode.time.time", return_value=111.0),
+            patch(
+                "sglang.srt.disaggregation.decode.prepare_abort",
+                side_effect=mark_aborted,
+            ) as mock_prepare_abort,
+        ):
+            queue._mark_decode_bootstrap_timeouts()
+            queue._mark_decode_bootstrap_timeouts()
+
+        receiver.kv_mgr.record_failure.assert_called_once()
+        receiver.kv_mgr.update_status.assert_called_once_with(11, KVPoll.Failed)
+        receiver._send_abort_notification.assert_called_once()
+        self.assertTrue(receiver.abort_notified)
+        mock_prepare_abort.assert_called_once()
+        self.assertEqual(
+            mock_prepare_abort.call_args.kwargs["status_code"],
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+        metrics_collector = queue.scheduler.metrics_collector
+        metrics_collector.increment_decode_bootstrap_timeout_reqs.assert_called_once()
+        self.assertTrue(decode_req.decode_bootstrap_timeout_recorded)
+        self.assertIsInstance(req.finished_reason, FINISH_ABORT)
+
+    def test_decode_bootstrap_timeout_skips_fake_transfer(self):
+        receiver = FakeBootstrapReceiver()
+        req = SimpleNamespace(
+            rid="fake-transfer",
+            bootstrap_room=12,
+            bootstrap_host=None,
+            finished_reason=None,
+        )
+        decode_req = DecodeRequest(
+            req=req,
+            kv_receiver=receiver,
+            bootstrap_start_time=100.0,
+        )
+
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.queue = [decode_req]
+        queue.decode_bootstrap_timeout = 10
+        queue.tp_rank = 0
+        queue.scheduler = SimpleNamespace(
+            server_args=SimpleNamespace(disaggregation_transfer_backend="fake"),
+            metrics_reporter=SimpleNamespace(enable_metrics=True),
+            metrics_collector=MagicMock(),
+        )
+
+        with (
+            patch("sglang.srt.disaggregation.decode.time.time", return_value=111.0),
+            patch(
+                "sglang.srt.disaggregation.decode.prepare_abort"
+            ) as mock_prepare_abort,
+        ):
+            queue._mark_decode_bootstrap_timeouts()
+
+        receiver.kv_mgr.record_failure.assert_not_called()
+        receiver.kv_mgr.update_status.assert_not_called()
+        receiver._send_abort_notification.assert_not_called()
+        mock_prepare_abort.assert_not_called()
+        metrics_collector = queue.scheduler.metrics_collector
+        metrics_collector.increment_decode_bootstrap_timeout_reqs.assert_not_called()
+        self.assertFalse(decode_req.decode_bootstrap_timeout_recorded)
+
     def test_prealloc_abort_clears_receiver_before_removing_request(self):
         receiver = FakeReceiver()
         req = SimpleNamespace(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  In Mooncake PD disaggregation, the prefill side has `SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT`, but the decode side does not proactively clean the corresponding request during the early bootstrap/prealloc stage.

  In production, this caused stale decode-side bootstrap requests to remain alive after the prefill side had already timed out and cleaned up the request. This is especially visible under bursty high concurrency or long-context traffic, where the decode node may temporarily have no KV slots available for new requests and requests wait in the decode prealloc/bootstrap path.

  Production serving has TTFT and error-latency requirements. Once the prefill side has timed out a bootstrap request, the decode side should not keep waiting for a later implicit cleanup path. The stale request should be failed and removed from decode prealloc promptly.

  This PR adds a Mooncake decode-side early bootstrap timeout cleanup path, along with cleanup logging and a metric for observability.

## Modifications

  - Record decode-side bootstrap start time when the decode receiver is created.
  - Add Mooncake-only decode-side early bootstrap timeout handling.
  - Mark timed-out decode requests as failed and abort them with HTTP 500.
  - Clean failed requests from the decode prealloc queue.
  - Best-effort notify prefill when bootstrap info is available.
  - Add metric: `sglang:num_decode_bootstrap_timeout_reqs_total`
  - Add cleanup log for removed failed decode prealloc requests.
 
## Accuracy Tests

  Not applicable. This change does not affect model outputs.

## Speed Tests and Profiling

  Not applicable. The timeout check is lightweight and only scans decode prealloc requests.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes:
  - Documentation is not updated because this is an internal Mooncake PD cleanup path.
  - Accuracy and speed benchmarks are not applicable because this PR does not change model outputs or the forward path.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29087322156](https://github.com/sgl-project/sglang/actions/runs/29087322156)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29087322000](https://github.com/sgl-project/sglang/actions/runs/29087322000)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->