### PR TITLE
[PP] Fix proxy tensor buffer sizing and refresh for speculative verify

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -742,7 +742,10 @@ def build_decode_registry(
             def _pp_source(key):
                 def _fn(_fb, ctx):
                     ppx = ctx.pp_proxy_tensors
-                    return None if ppx is None else ppx.tensors[key]
+                    # .get(): a proxy entry can be absent (e.g. topk_indices
+                    # when a DSA model runs a dense attention backend);
+                    # returning None skips the copy for that slot.
+                    return None if ppx is None else ppx.tensors.get(key)
 
                 return _fn
 

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -110,12 +110,17 @@ def _allocate_decode_buffers(
             # mHC (e.g. DSV4) flattens residual into hidden_states (size = hc_hidden_size).
             is_mhc = hc_hidden_size is not None
             hs = hc_hidden_size if is_mhc else hidden_size
+            # Sized in tokens, not requests: under speculative decoding the
+            # verify forward carries num_tokens_per_bs tokens per request and
+            # _dummy_run slices these buffers to num_tokens (same as
+            # topk_indices below). Identical for plain decode where
+            # num_tokens_per_bs == 1.
             pp_proxy_tensors = {
-                "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
             }
             if not is_mhc:
                 pp_proxy_tensors["residual"] = torch.zeros(
-                    (max_bs, hidden_size), dtype=dtype
+                    (max_num_token, hidden_size), dtype=dtype
                 )
             if pp_proxy_topk_size is not None:
                 pp_proxy_tensors["topk_indices"] = torch.zeros(

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -913,6 +913,19 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.buffers.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
             self.buffers.positions[: self.raw_num_token].copy_(forward_batch.positions)
             if (
+                pp_proxy_tensors is not None
+                and self.buffers.pp_proxy_tensors is not None
+            ):
+                # PP + spec verify: the pre-planned load ran without the proxy
+                # (eagle_prepare_for_verify has no access to it), so the
+                # graph's proxy input buffers must be refreshed here -- the
+                # captured graph reads these rows (mirrors fill_from's
+                # side-slot copy).
+                for k, v in pp_proxy_tensors.tensors.items():
+                    buf = self.buffers.pp_proxy_tensors.get(k)
+                    if buf is not None:  # skip markers like __msg_type__
+                        buf[: v.shape[0]].copy_(v)
+            if (
                 self.model_runner.spec_algorithm.is_dflash()
                 and self.model_runner.is_draft_worker
                 and forward_batch.input_embeds is not None
@@ -1056,7 +1069,15 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
         else:
             assert isinstance(output, PPProxyTensors)
-            return PPProxyTensors({k: v[: self.bs] for k, v in output.tensors.items()})
+            # Slice in token rows, not request rows: under speculative verify
+            # each request carries num_tokens_per_bs tokens (identical for
+            # plain decode, where num_tokens_per_bs == 1).
+            return PPProxyTensors(
+                {
+                    k: v[: self.bs * self.num_tokens_per_bs]
+                    for k, v in output.tensors.items()
+                }
+            )
 
     def get_spec_info(self, num_tokens: int):
         spec_info = None

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -132,12 +132,15 @@ class DecodeInputBuffers(ForwardInputBuffers):
             if pp_size > 1:
                 is_mhc = hc_hidden_size is not None
                 hs = hc_hidden_size if is_mhc else hidden_size
+                # Sized in tokens, not requests: under speculative decoding
+                # the verify forward carries num_tokens_per_bs tokens per
+                # request (same as topk_indices below).
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                    "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
                 }
                 if not is_mhc:
                     pp_proxy_tensors["residual"] = torch.zeros(
-                        (max_bs, hidden_size), dtype=dtype
+                        (max_num_token, hidden_size), dtype=dtype
                     )
                 if pp_proxy_topk_size is not None:
                     pp_proxy_tensors["topk_indices"] = torch.zeros(


### PR DESCRIPTION
## Motivation

While enabling pipeline parallelism together with speculative decoding (EAGLE/MTP) on GLM-5.2 (see companion RFC PR), we found four latent bugs in the PP proxy-tensor plumbing. They only manifest when a PP model runs multi-token forwards through the decode CUDA-graph path (`TARGET_VERIFY`, num_tokens_per_bs > 1); plain PP decode is bit-identical before/after this change, because there num_tokens_per_bs == 1 and every fix degenerates to the current behavior.

Although upstream currently rejects PP+spec at argument-parsing time, these are correctness bugs in shared infrastructure and make the invariants consistent (the same dict already sizes `topk_indices` by tokens).

## Modifications

1. **`_allocate_decode_buffers` / `DecodeInputBuffers.create`** — `hidden_states` / `residual` proxy buffers were sized `(max_bs, hidden)` while every other token-axis buffer (`input_ids`, `positions`, and `topk_indices` in the same dict) uses `max_num_token = max_bs * num_tokens_per_bs`. Under verify the `[:num_tokens]` slice silently returns fewer rows; warmup crashes in rotary with `shape '[384, -1, 64]' is invalid for input of size 131072` (bs=128 x 3 draft tokens vs 128 rows).

2. **`DecodeCudaGraphRunner.load_batch`** — the pre-planned early-return path (metadata already initialized by `eagle_prepare_for_verify`) copies `input_ids`/`positions` but never refreshes the `pp_proxy_tensors` input buffers, so the last PP stage replays verify graphs against **stale hidden states** from the previous round.

3. **`DecodeCudaGraphRunner.execute`** — the `PPProxyTensors` output was sliced `[:self.bs]` (request rows) instead of `[:self.bs * self.num_tokens_per_bs]` (token rows). With 3 verify tokens per request only the first `bs` rows reach the next stage: request 0's rows happen to be fresh, every later request in the microbatch reads stale hidden states. Single-request runs look healthy, which makes this one particularly deceptive.

4. **`cuda_graph_buffer_registry`** — the pp-proxy slot source indexed `ppx.tensors[key]` unconditionally; an entry can legitimately be absent (e.g. `topk_indices` when a DSA-family model runs a dense attention backend). Use `.get()` so the documented "source_fn returns None → skip copy" contract applies.

## Validation

Validated on 8x RTX PRO 6000 (SM120), GLM-5.2-NVFP4, TP4xPP2 + EAGLE(2 steps / topk 1 / 3 draft tokens) behind an env-flag build:
- greedy decode identical to non-spec output; GSM8K 20q accuracy 0.900 (matches TP8 baseline)
- concurrent (4-16 requests, staggered arrivals) outputs correct — previously half of each microbatch degenerated to repeated tokens (fix 3)
- without fix 2, single-stream verify output was corrupted after the first token

Happy to split this into separate PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29088148860](https://github.com/sgl-project/sglang/actions/runs/29088148860)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29088148583](https://github.com/sgl-project/sglang/actions/runs/29088148583)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->