### PR TITLE
[Spec] Add LFM2 / LFM2-MoE DSpark draft-model support

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1005,6 +1005,8 @@ _MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
         "GraniteMoeHybridForCausalLM",
         "NemotronHForCausalLM",
         "NemotronHPuzzleForCausalLM",
+        "Lfm2ForCausalLM",
+        "Lfm2MoeForCausalLM",
     }
 )
 

--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -12,7 +12,7 @@ Uses optimized causal_conv1d kernels from the mamba package for fast inference.
 """
 
 import logging
-from typing import Iterable, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -23,6 +23,9 @@ from sglang.srt.distributed import get_pp_group
 from sglang.srt.layers.attention.mamba.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
+)
+from sglang.srt.layers.attention.mamba.causal_conv1d_triton import (
+    causal_conv1d_update as causal_conv1d_update_triton,
 )
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
@@ -45,8 +48,14 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
 )
+from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix, make_layers, set_weight_attrs
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.attention.linear.short_conv_backend import (
+        ShortConvMetadata,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +209,55 @@ class Lfm2Attention(nn.Module):
         return out
 
 
+def register_shortconv_verify_buffers(conv: nn.Module) -> None:
+    """Pre-size the per-module tape slot-index buffer used by TARGET_VERIFY.
+
+    Shared by Lfm2ShortConv and Lfm2MoeShortConv (lfm2_moe.py imports it).
+    """
+    conv.register_buffer(
+        "_intermediate_state_indices",
+        torch.arange(256, dtype=torch.int32),
+        persistent=False,
+    )
+
+
+def shortconv_target_verify(
+    conv: nn.Module,
+    Bx: torch.Tensor,
+    meta: "ShortConvMetadata",
+    draft_token_num: int,
+    arch: str,
+) -> torch.Tensor:
+    """Depthwise short conv over a DFlash TARGET_VERIFY block.
+
+    Shared by Lfm2ShortConv and Lfm2MoeShortConv (lfm2_moe.py imports it).
+    Runs the triton update kernel over the [bs, block] layout, recording the
+    per-step conv windows into the speculative tape
+    (``MambaPool.SpeculativeState.intermediate_conv_window``) so the conv
+    state can roll back to the accept boundary after verification.
+    """
+    assert isinstance(meta.layer_cache, MambaPool.SpeculativeState), (
+        f"{arch} TARGET_VERIFY requires --mamba-radix-cache-strategy extra_buffer."
+    )
+    bs = meta.cache_indices.shape[0]
+    Bx_reshaped = Bx.view(bs, draft_token_num, -1).transpose(1, 2)
+    if conv._intermediate_state_indices.shape[0] < bs:
+        conv._intermediate_state_indices = torch.arange(
+            bs, dtype=torch.int32, device=Bx.device
+        )
+    conv_out = causal_conv1d_update_triton(
+        Bx_reshaped,
+        meta.layer_cache.conv[0],
+        conv.conv_weight,
+        conv.conv_bias,
+        activation=None,
+        conv_state_indices=meta.cache_indices,
+        intermediate_conv_window=meta.layer_cache.intermediate_conv_window[0],
+        intermediate_state_indices=conv._intermediate_state_indices[:bs],
+    )
+    return conv_out.transpose(1, 2).reshape(bs * draft_token_num, -1)
+
+
 class Lfm2ShortConv(nn.Module):
     """
     Gated short convolution layer using optimized causal_conv1d kernels.
@@ -257,6 +315,8 @@ class Lfm2ShortConv(nn.Module):
         else:
             self.register_parameter("conv_bias", None)
 
+        register_shortconv_verify_buffers(self)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -285,6 +345,10 @@ class Lfm2ShortConv(nn.Module):
                 self.conv_bias,
                 activation=None,
                 conv_state_indices=meta.cache_indices,
+            )
+        elif forward_batch.forward_mode.is_target_verify():
+            conv_out = shortconv_target_verify(
+                self, Bx, meta, forward_batch.spec_info.draft_token_num, "LFM2"
             )
         else:
             # Prefill: multiple tokens, use varlen kernel
@@ -317,6 +381,8 @@ class Lfm2DecoderLayer(nn.Module):
         super().__init__()
         self.layer_type = config.layer_types[layer_id]
         self.is_attention_layer = self.layer_type == "full_attention"
+        # Set by Lfm2Model.set_dflash_layers_to_capture for DFlash aux capture.
+        self._is_layer_to_capture = False
 
         self.operator_norm = RMSNorm(config.hidden_size, eps=config.norm_eps)
         self.ffn_norm = RMSNorm(config.hidden_size, eps=config.norm_eps)
@@ -349,9 +415,13 @@ class Lfm2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: Optional[torch.Tensor],
         forward_batch: ForwardBatch,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not forward_batch.forward_mode.is_idle():
+            if captured_last_layer_outputs is not None:
+                captured_last_layer_outputs.append(hidden_states)
+
             residual = hidden_states
             normed = self.operator_norm(hidden_states)
 
@@ -402,6 +472,15 @@ class Lfm2Model(nn.Module):
             config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
         )
         self.embedding_norm = RMSNorm(config.hidden_size, eps=config.norm_eps)
+        self.layers_to_capture: List[int] = []
+
+    def set_dflash_layers_to_capture(self, layers_to_capture: List[int]):
+        self.layers_to_capture = list(layers_to_capture)
+        for layer_id in self.layers_to_capture:
+            # A tap on the final layer (layer_id == len(self.layers)) is
+            # captured after the loop in forward(); only mark real layers.
+            if layer_id < len(self.layers):
+                self.layers[layer_id]._is_layer_to_capture = True
 
     def forward(
         self,
@@ -415,16 +494,30 @@ class Lfm2Model(nn.Module):
         )
 
         residual = None
+        aux_hidden_states: List[torch.Tensor] = []
         for i in range(len(self.layers)):
-            hidden_states, residual = self.layers[i](
+            layer = self.layers[i]
+            hidden_states, residual = layer(
                 layer_id=i,
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
                 forward_batch=forward_batch,
+                captured_last_layer_outputs=(
+                    aux_hidden_states if layer._is_layer_to_capture else None
+                ),
             )
 
-        return self.embedding_norm(hidden_states)
+        if (
+            not forward_batch.forward_mode.is_idle()
+            and len(self.layers) in self.layers_to_capture
+        ):
+            aux_hidden_states.append(hidden_states)
+
+        hidden_states = self.embedding_norm(hidden_states)
+        if not aux_hidden_states:
+            return hidden_states
+        return hidden_states, aux_hidden_states
 
 
 class Lfm2ForCausalLM(nn.Module):
@@ -461,6 +554,20 @@ class Lfm2ForCausalLM(nn.Module):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.model.embed_tokens
 
+    @property
+    def capture_aux_hidden_states(self) -> bool:
+        return bool(self.model.layers_to_capture)
+
+    def set_dflash_layers_to_capture(self, layer_ids: List[int]):
+        if not self.pp_group.is_last_rank:
+            return
+
+        if layer_ids is None:
+            raise ValueError("DFLASH requires explicit layer_ids for aux hidden capture.")
+
+        # Mark layer L to capture its input, which is the output of layer L-1.
+        self.model.set_dflash_layers_to_capture([val + 1 for val in layer_ids])
+
     @torch.no_grad()
     def forward(
         self,
@@ -471,8 +578,14 @@ class Lfm2ForCausalLM(nn.Module):
         **kwargs,
     ):
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
+        aux_hidden_states = None
+        # Capture-enabled idle batches return a bare tensor (layers skip the
+        # append on IDLE), so narrow on the actual return shape.
+        if isinstance(hidden_states, tuple):
+            hidden_states, aux_hidden_states = hidden_states
+
         return self.logits_processor(
-            input_ids, hidden_states, self.lm_head, forward_batch
+            input_ids, hidden_states, self.lm_head, forward_batch, aux_hidden_states
         )
 
     def load_weights(

--- a/python/sglang/srt/models/lfm2_dspark.py
+++ b/python/sglang/srt/models/lfm2_dspark.py
@@ -1,0 +1,21 @@
+"""LFM2-family DSpark draft model.
+
+Registered as its own architecture (rather than reusing Qwen3DSparkModel) so the
+LFM2 draft can evolve independently of other DSpark drafts, e.g. adding
+ShortConv / conv1d layers to the drafter, without touching the shared classes.
+
+Today's LFM2 draft checkpoints use an attention-only Qwen3-style GQA backbone
+with interleaved RoPE, so this is a thin subclass of DSparkDraftModel. All the
+family-specific settings come from the checkpoint config (rope_is_neox_style,
+enable_confidence_head) and its canonical weight names, so no adaptation is
+needed here.
+"""
+
+from sglang.srt.models.dspark import DSparkDraftModel
+
+
+class Lfm2DSparkDraftModel(DSparkDraftModel):
+    pass
+
+
+EntryClass = [Lfm2DSparkDraftModel]

--- a/python/sglang/srt/models/lfm2_moe.py
+++ b/python/sglang/srt/models/lfm2_moe.py
@@ -12,7 +12,7 @@ Key MoE characteristics:
 - Post-hoc normalization of top-k weights
 """
 
-from typing import Iterable, Optional, Set, Tuple
+from typing import Iterable, List, Optional, Set, Tuple
 
 import torch
 from torch import nn
@@ -46,6 +46,10 @@ from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
+)
+from sglang.srt.models.lfm2 import (
+    register_shortconv_verify_buffers,
+    shortconv_target_verify,
 )
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix, make_layers, set_weight_attrs
@@ -320,6 +324,8 @@ class Lfm2MoeShortConv(nn.Module):
         else:
             self.register_parameter("conv_bias", None)
 
+        register_shortconv_verify_buffers(self)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -346,6 +352,10 @@ class Lfm2MoeShortConv(nn.Module):
                 self.conv_bias,
                 activation=None,
                 conv_state_indices=meta.cache_indices,
+            )
+        elif forward_batch.forward_mode.is_target_verify():
+            conv_out = shortconv_target_verify(
+                self, Bx, meta, forward_batch.spec_info.draft_token_num, "LFM2-MoE"
             )
         else:
             Bx_t = Bx.transpose(0, 1).contiguous()
@@ -382,6 +392,8 @@ class Lfm2MoeDecoderLayer(nn.Module):
         super().__init__()
         self.layer_type = config.layer_types[layer_id]
         self.is_attention_layer = self.layer_type == "full_attention"
+        # Set by Lfm2MoeModel.set_dflash_layers_to_capture for DFlash aux capture.
+        self._is_layer_to_capture = False
 
         self.operator_norm = RMSNorm(config.hidden_size, eps=config.norm_eps)
         self.ffn_norm = RMSNorm(config.hidden_size, eps=config.norm_eps)
@@ -424,9 +436,13 @@ class Lfm2MoeDecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: Optional[torch.Tensor],
         forward_batch: ForwardBatch,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not forward_batch.forward_mode.is_idle():
+            if captured_last_layer_outputs is not None:
+                captured_last_layer_outputs.append(hidden_states)
+
             residual = hidden_states
             normed = self.operator_norm(hidden_states)
 
@@ -477,6 +493,15 @@ class Lfm2MoeModel(nn.Module):
             config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
         )
         self.embedding_norm = RMSNorm(config.hidden_size, eps=config.norm_eps)
+        self.layers_to_capture: List[int] = []
+
+    def set_dflash_layers_to_capture(self, layers_to_capture: List[int]):
+        self.layers_to_capture = list(layers_to_capture)
+        for layer_id in self.layers_to_capture:
+            # A tap on the final layer (layer_id == len(self.layers)) is
+            # captured after the loop in forward(); only mark real layers.
+            if layer_id < len(self.layers):
+                self.layers[layer_id]._is_layer_to_capture = True
 
     def forward(
         self,
@@ -490,16 +515,30 @@ class Lfm2MoeModel(nn.Module):
         )
 
         residual = None
+        aux_hidden_states: List[torch.Tensor] = []
         for i in range(len(self.layers)):
-            hidden_states, residual = self.layers[i](
+            layer = self.layers[i]
+            hidden_states, residual = layer(
                 layer_id=i,
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
                 forward_batch=forward_batch,
+                captured_last_layer_outputs=(
+                    aux_hidden_states if layer._is_layer_to_capture else None
+                ),
             )
 
-        return self.embedding_norm(hidden_states)
+        if (
+            not forward_batch.forward_mode.is_idle()
+            and len(self.layers) in self.layers_to_capture
+        ):
+            aux_hidden_states.append(hidden_states)
+
+        hidden_states = self.embedding_norm(hidden_states)
+        if not aux_hidden_states:
+            return hidden_states
+        return hidden_states, aux_hidden_states
 
 
 class Lfm2MoeForCausalLM(nn.Module):
@@ -535,6 +574,23 @@ class Lfm2MoeForCausalLM(nn.Module):
     def get_num_kv_cache_layers(self) -> int:
         return self.num_attention_layers
 
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.model.embed_tokens
+
+    @property
+    def capture_aux_hidden_states(self) -> bool:
+        return bool(self.model.layers_to_capture)
+
+    def set_dflash_layers_to_capture(self, layer_ids: List[int]):
+        if not self.pp_group.is_last_rank:
+            return
+
+        if layer_ids is None:
+            raise ValueError("DFLASH requires explicit layer_ids for aux hidden capture.")
+
+        # Mark layer L to capture its input, which is the output of layer L-1.
+        self.model.set_dflash_layers_to_capture([val + 1 for val in layer_ids])
+
     @torch.no_grad()
     def forward(
         self,
@@ -545,8 +601,14 @@ class Lfm2MoeForCausalLM(nn.Module):
         **kwargs,
     ):
         hidden_states = self.model(input_ids, positions, forward_batch, inputs_embeds)
+        aux_hidden_states = None
+        # Capture-enabled idle batches return a bare tensor (layers skip the
+        # append on IDLE), so narrow on the actual return shape.
+        if isinstance(hidden_states, tuple):
+            hidden_states, aux_hidden_states = hidden_states
+
         return self.logits_processor(
-            input_ids, hidden_states, self.lm_head, forward_batch
+            input_ids, hidden_states, self.lm_head, forward_batch, aux_hidden_states
         )
 
     def load_weights(

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -1,13 +1,22 @@
-from typing import Optional
+import logging
+import math
+from typing import Callable, Optional
 
 import torch
 
 from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.speculative.dflash_utils import can_dflash_use_fused_qkv_proj
 from sglang.srt.speculative.dspark_components.kernels.commit_inject_layout import (
     BuildCommitInjectLayout,
 )
 from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 from sglang.srt.speculative.triton_ops.cache_locs import assign_extend_cache_locs_func
+from sglang.srt.speculative.triton_ops.fused_kv_materialize import (
+    FusedKVMaterializeHelper,
+)
+from sglang.srt.utils import is_cuda, is_hip
+
+logger = logging.getLogger(__name__)
 
 
 class TargetHiddenKvInjector:
@@ -27,6 +36,108 @@ class TargetHiddenKvInjector:
         self.device = device
         self.verify_num_draft_tokens = verify_num_draft_tokens
         self._block_pos_offsets = block_pos_offsets
+        # Fused KV materialization (batched GEMM + single Triton norm/rope kernel)
+        # replaces the per-layer eager loop in write_target_hidden_kv. None if the
+        # draft is ineligible or we are off-CUDA; the eager path stays as fallback.
+        self._fused_kv_helper = self._build_fused_kv_helper()
+
+    def _build_fused_kv_helper(self) -> Optional[FusedKVMaterializeHelper]:
+        """Build the fused KV helper, mirroring DFlashWorkerV2._init_fused_kv_helper.
+
+        The Triton kernel handles both neox and interleaved RoPE, so unlike the
+        DFlash worker this does not reject interleaved-rotary drafts. Returns
+        None (eager write_target_hidden_kv fallback) on any failure.
+        """
+        try:
+            if not (is_cuda() or is_hip()):
+                return None
+            layers = self.draft_model.layers
+            if len(layers) == 0 or not self.draft_model.supports_fused_context_kv:
+                return None
+
+            for layer_idx, layer in enumerate(layers):
+                attn = layer.self_attn
+                eligible, reason = can_dflash_use_fused_qkv_proj(attn.qkv_proj)
+                if not eligible:
+                    logger.info(
+                        "DSpark fused KV disabled: %s (layer=%d).", reason, layer_idx
+                    )
+                    return None
+                # The kernel writes V straight through; non-unit scales would need
+                # to be folded in, which the fused path does not do.
+                k_scale = attn.attn.k_scale
+                v_scale = attn.attn.v_scale
+                if k_scale is not None and not math.isclose(float(k_scale), 1.0):
+                    logger.info(
+                        "DSpark fused KV disabled: non-unit k_scale (layer=%d).",
+                        layer_idx,
+                    )
+                    return None
+                if v_scale is not None and not math.isclose(float(v_scale), 1.0):
+                    logger.info(
+                        "DSpark fused KV disabled: non-unit v_scale (layer=%d).",
+                        layer_idx,
+                    )
+                    return None
+
+            first_attn = layers[0].self_attn
+            helper = FusedKVMaterializeHelper(
+                layers=layers,
+                rotary_emb=first_attn.rotary_emb,
+                num_kv_heads=first_attn.num_kv_heads,
+                head_dim=first_attn.head_dim,
+                device=self.device,
+                max_position_hint=self.model_runner.model_config.context_len
+                + int(self.verify_num_draft_tokens),
+            )
+            logger.info(
+                "DSpark fused KV materialization enabled (n_layers=%d, neox=%s).",
+                len(layers),
+                helper.is_neox_style,
+            )
+            return helper
+        except Exception as e:
+            logger.warning(
+                "DSpark fused KV init failed, using eager KV path: %s", e
+            )
+            return None
+
+    def _inject_fused(
+        self,
+        *,
+        target_hidden: torch.Tensor,
+        cache_loc: torch.Tensor,
+        positions: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor],
+        commit_lens: Optional[torch.Tensor],
+    ) -> None:
+        pool = self.draft_model_runner.token_to_kv_pool
+        ctx_hidden = self.draft_model.project_target_hidden(target_hidden)
+
+        def _write_layer_kv(
+            layer_idx: int, cache_k: torch.Tensor, cache_v: torch.Tensor
+        ) -> None:
+            attn = self.draft_model.layers[layer_idx].self_attn.attn
+            if cache_loc_2d is not None and commit_lens is not None:
+                pool.set_kv_buffer_prefix_valid(
+                    attn,
+                    cache_loc_2d,
+                    commit_lens,
+                    cache_k,
+                    cache_v,
+                    attn.k_scale,
+                    attn.v_scale,
+                )
+            else:
+                pool.set_kv_buffer(
+                    attn, cache_loc, cache_k, cache_v, attn.k_scale, attn.v_scale
+                )
+
+        self._fused_kv_helper.materialize(
+            ctx_hidden=ctx_hidden,
+            positions=positions,
+            write_layer_kv=_write_layer_kv,
+        )
 
     def inject_target_hidden(
         self,
@@ -68,6 +179,24 @@ class TargetHiddenKvInjector:
             return
 
         with torch.inference_mode():
+            if self._fused_kv_helper is not None:
+                try:
+                    self._inject_fused(
+                        target_hidden=target_hidden,
+                        cache_loc=cache_loc,
+                        positions=positions,
+                        cache_loc_2d=cache_loc_2d,
+                        commit_lens=commit_lens,
+                    )
+                    return
+                except Exception as e:
+                    logger.warning(
+                        "DSpark fused KV append failed; falling back to the "
+                        "per-layer eager path: %s",
+                        e,
+                    )
+                    self._fused_kv_helper = None
+
             self.draft_model.write_target_hidden_kv(
                 target_hidden=target_hidden,
                 pool=pool,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -680,6 +680,50 @@ class DSparkWorkerV2(BaseSpecWorker):
             new_seq_lens=next_draft_input.new_seq_lens,
         )
 
+    def _commit_mamba_states_after_verify(
+        self,
+        *,
+        batch,
+        seq_lens_pre_verify: torch.Tensor,
+        seq_lens_post_verify: torch.Tensor,
+        commit_lens: torch.Tensor,
+    ) -> None:
+        """Commit hybrid linear-attention (mamba / short-conv) states for the
+        accepted verify steps (see call site). No-op when the target backend
+        has no commit hook (pure-attention targets)."""
+        attn_backend = self.target_worker.model_runner.attn_backend
+        if not hasattr(attn_backend, "update_mamba_state_after_mtp_verify"):
+            return
+
+        last_correct_step_indices = commit_lens.to(torch.int64) - 1
+        mamba_steps_to_track = None
+
+        if batch.mamba_track_indices is not None:
+            mamba_track_interval = self.server_args.mamba_track_interval
+            to_track_mask = (
+                seq_lens_pre_verify // mamba_track_interval
+                != seq_lens_post_verify // mamba_track_interval
+            )
+            tracking_point = (
+                seq_lens_post_verify // mamba_track_interval * mamba_track_interval
+            )
+            to_track_ith = torch.clamp(tracking_point - seq_lens_pre_verify - 1, min=0)
+            can_track_mask = to_track_mask & (
+                to_track_ith < commit_lens.to(to_track_ith.dtype)
+            )
+            mamba_steps_to_track = torch.where(
+                can_track_mask,
+                to_track_ith.to(torch.int64),
+                torch.full_like(to_track_ith, -1, dtype=torch.int64),
+            )
+
+        attn_backend.update_mamba_state_after_mtp_verify(
+            last_correct_step_indices=last_correct_step_indices,
+            mamba_track_indices=batch.mamba_track_indices,
+            mamba_steps_to_track=mamba_steps_to_track,
+            model=self.target_worker.model_runner.model,
+        )
+
     def _forward_decode(
         self, batch: ScheduleBatch, on_publish
     ) -> GenerationBatchResult:
@@ -873,6 +917,19 @@ class DSparkWorkerV2(BaseSpecWorker):
                 )
             else:
                 on_publish(new_seq_lens)
+
+        # Hybrid linear-attention targets (e.g. LFM2 ShortConv): TARGET_VERIFY
+        # ran the conv kernels in tape mode; commit the state of each request's
+        # last committed block step (commit_lens - 1) back to the persistent
+        # caches, else the conv state absorbs rejected drafts and decoding is
+        # not lossless. Mirrors DFlashWorkerV2._commit_mamba_states_after_verify;
+        # no-op for pure-attention targets.
+        self._commit_mamba_states_after_verify(
+            batch=batch,
+            seq_lens_pre_verify=prefix_lens,
+            seq_lens_post_verify=new_seq_lens,
+            commit_lens=commit_lens,
+        )
 
         folded_commit = folded_accept and epilogue.folds_commit
         if not folded_commit:

--- a/python/sglang/srt/speculative/triton_ops/fused_kv_materialize.py
+++ b/python/sglang/srt/speculative/triton_ops/fused_kv_materialize.py
@@ -49,9 +49,15 @@ def _fused_norm_rope_kernel_stacked(
     kv_size: tl.constexpr,
     rotary_dim: tl.constexpr,
     half_rotary_dim: tl.constexpr,
+    IS_NEOX: tl.constexpr,
     BLOCK_HD: tl.constexpr,
 ):
-    """Fused RMSNorm(K) + RoPE(K) materialization. Grid: (total_ctx, num_kv_heads, n_layers)."""
+    """Fused RMSNorm(K) + RoPE(K) materialization. Grid: (total_ctx, num_kv_heads, n_layers).
+
+    IS_NEOX selects the rotation pairing: neox pairs dims (i, i + rotary/2);
+    interleaved (GPT-J style, e.g. liquid_lfm draft exports) pairs (2i, 2i+1).
+    The cos/sin cache layout is identical for both styles.
+    """
     ctx_id = tl.program_id(0)
     head_id = tl.program_id(1)
     layer_id = tl.program_id(2)
@@ -97,15 +103,25 @@ def _fused_norm_rope_kernel_stacked(
         cos_sin_base + half_rotary_dim + offs, mask=mask_half, other=0.0
     ).to(tl.float32)
 
-    k_first = tl.where(mask_half, k_normed, 0.0)
-    k_second_raw = tl.load(
-        k_base + half_rotary_dim + offs, mask=mask_half, other=0.0
+    if IS_NEOX:
+        first_offs = offs
+        second_offs = half_rotary_dim + offs
+    else:
+        first_offs = 2 * offs
+        second_offs = 2 * offs + 1
+
+    k_first_raw = tl.load(k_base + first_offs, mask=mask_half, other=0.0).to(tl.float32)
+    norm_w_first = tl.load(
+        k_norm_weight_ptr + layer_id * k_norm_weight_stride_layer + first_offs,
+        mask=mask_half,
+        other=1.0,
     ).to(tl.float32)
+    k_first = k_first_raw * inv_rms * norm_w_first
+    k_second_raw = tl.load(k_base + second_offs, mask=mask_half, other=0.0).to(
+        tl.float32
+    )
     norm_w_second = tl.load(
-        k_norm_weight_ptr
-        + layer_id * k_norm_weight_stride_layer
-        + half_rotary_dim
-        + offs,
+        k_norm_weight_ptr + layer_id * k_norm_weight_stride_layer + second_offs,
         mask=mask_half,
         other=1.0,
     ).to(tl.float32)
@@ -115,10 +131,8 @@ def _fused_norm_rope_kernel_stacked(
     k_rot_second = k_second * cos_v + k_first * sin_v
 
     tl.store(v_write + offs, v_raw, mask=mask_hd)
-    tl.store(k_write + offs, k_rot_first.to(v_raw.dtype), mask=mask_half)
-    tl.store(
-        k_write + half_rotary_dim + offs, k_rot_second.to(v_raw.dtype), mask=mask_half
-    )
+    tl.store(k_write + first_offs, k_rot_first.to(v_raw.dtype), mask=mask_half)
+    tl.store(k_write + second_offs, k_rot_second.to(v_raw.dtype), mask=mask_half)
     mask_pass = (offs >= rotary_dim) & (offs < head_dim)
     tl.store(k_write + offs, k_normed.to(v_raw.dtype), mask=mask_pass)
 
@@ -134,6 +148,7 @@ def _fused_norm_rope_stacked(
     rotary_dim: int,
     k_out: Optional[torch.Tensor] = None,
     v_out: Optional[torch.Tensor] = None,
+    is_neox_style: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Fused RMSNorm + RoPE materialization for all layers."""
     if kv.ndim != 3:
@@ -234,6 +249,7 @@ def _fused_norm_rope_stacked(
         kv_size,
         rotary_dim,
         half_rotary_dim,
+        is_neox_style,
         BLOCK_HD,
     )
     return k_out, v_out
@@ -266,8 +282,6 @@ class FusedKVMaterializeHelper:
         self.rotary_dim = int(getattr(rotary_emb, "rotary_dim", head_dim))
         self.is_neox_style = bool(getattr(rotary_emb, "is_neox_style", True))
 
-        if not self.is_neox_style:
-            raise NotImplementedError("Only neox-style RoPE is supported.")
         if self.rotary_dim <= 0 or self.rotary_dim > self.head_dim:
             raise ValueError(
                 "Invalid fused KV rotary/head dim pair: "
@@ -452,6 +466,7 @@ class FusedKVMaterializeHelper:
             self.rotary_dim,
             k_out=tmp_k,
             v_out=tmp_v,
+            is_neox_style=self.is_neox_style,
         )
         for layer_idx in range(self.n_layers):
             write_layer_kv(layer_idx, cache_k[layer_idx], cache_v[layer_idx])


### PR DESCRIPTION
### What

Adds DSpark speculative-decoding support for the LFM2 hybrid (ShortConv + attention) family: both the dense **LFM2** and MoE **LFM2-MoE** targets. Stacked on top of this PR (#30261); base is `sglang-dspark`.

Two commits:

1. **Interleaved RoPE in the fused-KV kernel** - the fused RMSNorm+RoPE materialization only handled neox rotation. Adds an `IS_NEOX` constexpr selecting the pairing (neox: `(i, i+rotary/2)`; interleaved/GPT-J: `(2i, 2i+1)`); no change for existing neox drafts. LFM2 draft exports rotate interleaved and need this.
2. **LFM2 / LFM2-MoE target support** - the draft is a DSpark checkpoint (Qwen3-style GQA backbone, markov + confidence heads) exported with interleaved RoPE. It registers as its own `Lfm2DSparkDraftModel` arch (a thin `DSparkDraftModel` subclass, mirroring `Qwen3DSparkModel`) so the LFM2 draft can gain LFM2-specific layers - e.g. ShortConv/conv1d - later without touching the shared classes. Interleaved RoPE and the confidence head come from the checkpoint config; the kernel change handles the rotation. Only the target side needs code beyond that: aux-hidden capture + ShortConv block verify/rollback in `lfm2.py`/`lfm2_moe.py`, hybrid-state commit after verify in the DSpark worker (mirrors the DFlash worker so decoding stays lossless), routing the draft KV injector through the fused-KV path, and marking the LFM2 archs eligible for the `extra_buffer` mamba radix strategy that spec-v2 rollback needs.

Net: 7 files, +422/-23, no changes to existing DSpark behavior.

Base LFM2-MoE serving parity (the attention-backend / radix-cache override tables for `Lfm2MoeForCausalLM`) is independent of DSpark and is split into its own PR: #30780. Pair with it for the 8B target's serving defaults.

### Speedup

1xH100 80GB, bs=1, temperature 0, block size 7, accept length / speedup vs the same server minus spec flags:

| dataset | LFM2.5-1.2B + 5L | LFM2.5-8B-A1B + 3L |
|---|---|---|
| math500 (chat math) | 4.82 / **2.10x** | 5.42 / **2.21x** |
| aime (competition math) | 4.36 / 1.95x | 6.20 / **2.42x** |
| humaneval (code) | 4.41 / 1.93x | - |
| mbpp (code) | 4.45 / 1.95x | 4.80 / 1.96x |
| gsm8k (grade-school math) | 3.73 / 1.49x | 3.51 / 1.24x |
| mtbench (multi-turn chat) | 2.35 / 1.05x | 5.87 / **2.32x** |

Floor is short chat on the small dense target (~1.05x); ceiling is long reasoning on the MoE (2.3-2.4x, accept near the block-7 limit). Accuracy at parity with baseline on every scoreable bench.

Note: interleaved RoPE (commit 1) is not optional for these drafts. Serving them neox collapses accept length to ~1.9 vs ~5.1 interleaved.

### Status / testing

Validated in serving on 1xH100 across the benches above (dense + MoE, draft depths 2L/3L/5L): 1.2B math500 accept 5.09, 8B math500 accept 5.94, unchanged whether the draft registers as `Lfm2DSparkDraftModel` or the generic `Qwen3DSparkModel`. The MoE ShortConv decode uses the same CUDA conv1d_update kernel as dense (an earlier triton swap was removed after confirming it gave identical accept, 5.936 both ways).

Public draft checkpoints for testing:
- dense: https://huggingface.co/tugot17/LFM2.5-1.2B-Instruct-DSpark-5L (target `LiquidAI/LFM2.5-1.2B-Instruct`)
- MoE: https://huggingface.co/tugot17/LFM2.5-8B-A1B-DSpark-3L (target `LiquidAI/LFM2.5-8B-A1B`)

```bash
python -m sglang.launch_server \
  --model-path LiquidAI/LFM2.5-1.2B-Instruct \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path tugot17/LFM2.5-1.2B-Instruct-DSpark-5L \
  --speculative-draft-attention-backend flashinfer
```

Happy to add a CI test against these.

Opening this to gauge whether you'd want LFM2 support folded into #30261 before it merges, or taken as a fast-follow after. Either works for us.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29102692229](https://github.com/sgl-project/sglang/actions/runs/29102692229)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29102692022](https://github.com/sgl-project/sglang/actions/runs/29102692022)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->