### PR TITLE
Make qwen3_asr config registration idempotent (transformers 5.13 compat)

### DIFF
--- a/python/sglang/srt/configs/qwen3_asr.py
+++ b/python/sglang/srt/configs/qwen3_asr.py
@@ -164,5 +164,18 @@ class Qwen3ASRConfig(PretrainedConfig):
         return self.thinker_config.text_config
 
 
-AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
-AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig)
+# transformers >= 5.13 ships native Qwen3-ASR support and registers these
+# model types itself at import time. AutoConfig.register() refuses duplicates, so
+# calling it again would raise "already used" and crash config import for EVERY
+# model. Make registration best-effort: register when the name is free (older
+# transformers), and defer to the native config when it's already taken.
+for _name, _cls in (
+    ("qwen3_asr", Qwen3ASRConfig),
+    ("qwen3_asr_thinker", Qwen3ASRThinkerConfig),
+):
+    try:
+        AutoConfig.register(_name, _cls)
+    except ValueError as e:
+        err = str(e).lower()
+        if "already registered" not in err and "already used" not in err:
+            logger.warning("Failed to register config %s: %s", _name, e)

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -46,7 +46,11 @@ from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 from sglang.srt.layers.quantization.mxfp4 import Mxfp4Config
 from sglang.srt.layers.quantization.petit import PetitNvFp4Config
 from sglang.srt.layers.quantization.qoq import QoQConfig
-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
+
+try:
+    from sglang.srt.layers.quantization.quark.quark import QuarkConfig
+except Exception:
+    QuarkConfig = None
 from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
 from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
 from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -7,11 +7,12 @@ import torch
 
 from sglang.srt.layers.parameter import GroupQuantScaleParameter, PackedvLLMParameter
 from sglang.srt.layers.quantization.quark.schemes import QuarkLinearScheme
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import get_bool_env_var, is_hip
 from sglang.srt.utils.common import direct_register_custom_op, mxfp_supported
 
 _is_hip = is_hip()
-if _is_hip:
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+if _use_aiter:
     from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
         fused_gemm_afp4wfp4_split_cat as _fused_gemm_afp4wfp4_split_cat_orig,
     )

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -18,15 +18,16 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
-from sglang.srt.utils import BAR_FORMAT, is_hip, set_weight_attrs
+from sglang.srt.utils import BAR_FORMAT, get_bool_env_var, is_hip, set_weight_attrs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import DispatchOutput
 
 _is_hip = is_hip()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
-if _is_hip:
+if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
 
     ON_GFX950 = "gfx950" in torch.cuda.get_device_properties("cuda").gcnArchName

--- a/sgl-kernel/csrc/elementwise/deepseek_v4_topk.cu
+++ b/sgl-kernel/csrc/elementwise/deepseek_v4_topk.cu
@@ -33,9 +33,28 @@ constexpr uint32_t kBlockSize = 512;
 #ifdef SGL_TOPK_DYNAMIC_SMEM_BYTES
 constexpr size_t kSMEM = static_cast<size_t>(SGL_TOPK_DYNAMIC_SMEM_BYTES);
 #else
-constexpr size_t kSMEM = 48 * 1024;  // bytes
+constexpr size_t kSMEM = 48 * 1024;  // bytes (conservative default for multi-arch)
 #endif
 static_assert(kSMEM % (2 * sizeof(int32_t)) == 0, "kSMEM must be a multiple of 8 bytes.");
+
+#ifdef USE_ROCM
+// Runtime GPU architecture detection for ROCm multi-arch shared memory support
+inline static bool is_gfx950_gpu() {
+  static int cached_result = -1;  // -1 = not detected, 0 = no, 1 = yes
+  if (cached_result == -1) {
+    hipDeviceProp_t prop;
+    hipGetDeviceProperties(&prop, 0);
+    // gfx950 supports 64KB LDS, older archs (gfx942, etc.) support 48KB
+    cached_result = (strncmp(prop.gcnArchName, "gfx950", 6) == 0) ? 1 : 0;
+  }
+  return cached_result == 1;
+}
+
+inline static size_t get_ksmem_size() {
+  static const size_t smem_size = is_gfx950_gpu() ? (64 * 1024) : (48 * 1024);
+  return smem_size;
+}
+#endif
 
 struct TopKParams {
   const float* __restrict__ scores;
@@ -90,11 +109,12 @@ __device__ void naive_paged_transform(
   }
 }
 
+template <size_t SMEM_SIZE>
 __device__ void
-radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, uint32_t length, uint32_t topk) {
+radix_topk_impl(const float* __restrict__ input, int32_t* __restrict__ output, uint32_t length, uint32_t topk) {
   constexpr uint32_t RADIX = 256;
   constexpr uint32_t BLOCK_SIZE = kBlockSize;
-  constexpr uint32_t SMEM_INPUT_SIZE = kSMEM / (2 * sizeof(int32_t));
+  constexpr uint32_t SMEM_INPUT_SIZE = SMEM_SIZE / (2 * sizeof(int32_t));
 
   alignas(128) __shared__ uint32_t _s_histogram_buf[2][RADIX + 32];
   alignas(128) __shared__ uint32_t s_counter;
@@ -102,7 +122,8 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, uint32
   alignas(128) __shared__ uint32_t s_num_input[2];
   alignas(128) __shared__ int32_t s_last_remain;
 
-  extern __shared__ uint32_t s_input_idx[][SMEM_INPUT_SIZE];
+  extern __shared__ uint32_t s_input_idx_1d[];
+  uint32_t (*s_input_idx)[SMEM_INPUT_SIZE] = (uint32_t (*)[SMEM_INPUT_SIZE])s_input_idx_1d;
 
   const uint32_t tx = threadIdx.x;
   uint32_t remain_topk = topk;
@@ -242,6 +263,7 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, uint32
   }
 }
 
+template <size_t SMEM_SIZE>
 __global__ __launch_bounds__(kBlockSize) void deepseek_v4_topk_transform_kernel(const TopKParams params) {
   const auto bid = blockIdx.x;
   const auto seq_len = params.seq_lens[bid];
@@ -258,7 +280,7 @@ __global__ __launch_bounds__(kBlockSize) void deepseek_v4_topk_transform_kernel(
   }
 
   __shared__ int32_t s_topk_indices[kMaxTopK];
-  radix_topk(score_ptr, s_topk_indices, static_cast<uint32_t>(seq_len), topk);
+  radix_topk_impl<SMEM_SIZE>(score_ptr, s_topk_indices, static_cast<uint32_t>(seq_len), topk);
 
   __syncthreads();
   for (uint32_t i = threadIdx.x; i < topk; i += kBlockSize) {
@@ -270,15 +292,15 @@ __global__ __launch_bounds__(kBlockSize) void deepseek_v4_topk_transform_kernel(
   }
 }
 
-template <auto* f, size_t kMaxDynamicSMEM>
-void setup_kernel_smem_once() {
+template <auto* f>
+void setup_kernel_smem_runtime(size_t max_dynamic_smem) {
   [[maybe_unused]]
-  static const auto result = [] {
+  static const auto result = [max_dynamic_smem] {
 #ifdef USE_ROCM
     return ::cudaFuncSetAttribute(
-        reinterpret_cast<const void*>(f), ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+        reinterpret_cast<const void*>(f), ::cudaFuncAttributeMaxDynamicSharedMemorySize, max_dynamic_smem);
 #else
-    return ::cudaFuncSetAttribute(f, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+    return ::cudaFuncSetAttribute(f, ::cudaFuncAttributeMaxDynamicSharedMemorySize, max_dynamic_smem);
 #endif
   }();
   TORCH_CHECK(
@@ -364,8 +386,19 @@ void deepseek_v4_topk_transform_512(
   const dim3 grid(static_cast<uint32_t>(B));
   const dim3 block(kBlockSize);
 
-  setup_kernel_smem_once<deepseek_v4_topk_transform_kernel, kSMEM>();
-  deepseek_v4_topk_transform_kernel<<<grid, block, kSMEM, stream>>>(params);
+#ifdef USE_ROCM
+  const size_t kSmem_runtime = get_ksmem_size();
+  if (kSmem_runtime == 64 * 1024) {
+    setup_kernel_smem_runtime<deepseek_v4_topk_transform_kernel<64 * 1024>>(kSmem_runtime);
+    deepseek_v4_topk_transform_kernel<64 * 1024><<<grid, block, kSmem_runtime, stream>>>(params);
+  } else {
+    setup_kernel_smem_runtime<deepseek_v4_topk_transform_kernel<48 * 1024>>(kSmem_runtime);
+    deepseek_v4_topk_transform_kernel<48 * 1024><<<grid, block, kSmem_runtime, stream>>>(params);
+  }
+#else
+  setup_kernel_smem_runtime<deepseek_v4_topk_transform_kernel<kSMEM>>(kSMEM);
+  deepseek_v4_topk_transform_kernel<kSMEM><<<grid, block, kSMEM, stream>>>(params);
+#endif
 
   const auto err = cudaGetLastError();
   TORCH_CHECK(err == cudaSuccess, "deepseek_v4_topk_transform kernel launch failed: ", ::cudaGetErrorString(err));

--- a/sgl-kernel/csrc/elementwise/dsv4_norm_rope.cu
+++ b/sgl-kernel/csrc/elementwise/dsv4_norm_rope.cu
@@ -120,18 +120,40 @@ __device__ __forceinline__ float inv_scale_ue8m0(int32_t exp) {
   return __uint_as_float(static_cast<uint32_t>((127 + 127 - exp) << 23));
 }
 
-static constexpr float kFP8Max = 448.0f;
+#ifdef USE_ROCM
+// Runtime GPU architecture detection for ROCm multi-arch FP8 support
+inline static bool is_gfx950_gpu() {
+  static int cached_result = -1;  // -1 = not detected, 0 = no, 1 = yes
+  if (cached_result == -1) {
+    hipDeviceProp_t prop;
+    hipGetDeviceProperties(&prop, 0);
+    // gfx950 uses E4M3FN (max=448), older archs (gfx942, etc.) use E4M3FNUZ (max=224)
+    cached_result = (strncmp(prop.gcnArchName, "gfx950", 6) == 0) ? 1 : 0;
+  }
+  return cached_result == 1;
+}
+
+inline static float get_fp8_max() {
+  static const float fp8_max = is_gfx950_gpu() ? 448.0f : 224.0f;
+  return fp8_max;
+}
+#endif
+
+static constexpr float kFP8Max = 448.0f;  // CUDA default, overridden at runtime for ROCm
 
 #ifndef USE_ROCM
+template <int FP8_MAX = 448>
 __device__ __forceinline__ fp8x2_e4m3_t pack_fp8(float x, float y) {
-  x = fmaxf(fminf(x, kFP8Max), -kFP8Max);
-  y = fmaxf(fminf(y, kFP8Max), -kFP8Max);
+  constexpr float kMax = static_cast<float>(FP8_MAX);
+  x = fmaxf(fminf(x, kMax), -kMax);
+  y = fmaxf(fminf(y, kMax), -kMax);
   return __nv_fp8x2_e4m3(float2{x, y});
 }
 #else
 // Software float -> FP8 E4M3 conversion for ROCm
+template <int FP8_MAX = 448>
 __device__ __forceinline__ uint8_t cvt_float_to_fp8_e4m3(float val) {
-  constexpr float kMax = kFP8Max;
+  constexpr float kMax = static_cast<float>(FP8_MAX);
   val = fmaxf(fminf(val, kMax), -kMax);
   if (val == 0.0f) return 0;
 
@@ -169,9 +191,10 @@ __device__ __forceinline__ uint8_t cvt_float_to_fp8_e4m3(float val) {
   return sign | (static_cast<uint8_t>(exp8) << 3) | static_cast<uint8_t>(mant3);
 }
 
+template <int FP8_MAX = 448>
 __device__ __forceinline__ fp8x2_e4m3_t pack_fp8(float x, float y) {
-  uint8_t x8 = cvt_float_to_fp8_e4m3(x);
-  uint8_t y8 = cvt_float_to_fp8_e4m3(y);
+  uint8_t x8 = cvt_float_to_fp8_e4m3<FP8_MAX>(x);
+  uint8_t y8 = cvt_float_to_fp8_e4m3<FP8_MAX>(y);
   return static_cast<uint16_t>(x8) | (static_cast<uint16_t>(y8) << 8);
 }
 #endif
@@ -324,7 +347,7 @@ struct FusedKNormRopeFlashMLAParams {
   float eps;
 };
 
-template <int64_t kHeadDim, int64_t kRopeDim, int32_t kPageBits>
+template <int64_t kHeadDim, int64_t kRopeDim, int32_t kPageBits, int FP8_MAX = 448>
 __global__ __launch_bounds__(kFusedKBlockSize, 8) void fused_k_norm_rope_flashmla_kernel(
     const __grid_constant__ FusedKNormRopeFlashMLAParams params) {
   constexpr int64_t kVecSize = 2;
@@ -394,10 +417,11 @@ __global__ __launch_bounds__(kFusedKBlockSize, 8) void fused_k_norm_rope_flashml
   } else {
     float x = data[0], y = data[1];
     float abs_max = warp_reduce_max(fmaxf(fabsf(x), fabsf(y)));
-    float scale_raw = fmaxf(1e-4f, abs_max) / kFP8Max;
+    constexpr float fp8_max = static_cast<float>(FP8_MAX);
+    float scale_raw = fmaxf(1e-4f, abs_max) / fp8_max;
     int32_t scale_ue8m0 = cast_to_ue8m0(scale_raw);
     float inv_scale = inv_scale_ue8m0(scale_ue8m0);
-    fp8x2_e4m3_t result = pack_fp8(x * inv_scale, y * inv_scale);
+    fp8x2_e4m3_t result = pack_fp8<FP8_MAX>(x * inv_scale, y * inv_scale);
     auto scale_ptr = page_ptr + (576ll << kPageBits) + offset * 8;
     reinterpret_cast<fp8x2_e4m3_t*>(value_ptr)[tx] = result;
     if (lane_id == 0) static_cast<uint8_t*>(scale_ptr)[warp_id] = static_cast<uint8_t>(scale_ue8m0);
@@ -421,6 +445,7 @@ struct FusedQIndexerRopeHadamardQuantParams {
   uint32_t num_heads;
 };
 
+template <int FP8_MAX = 448>
 __global__ __launch_bounds__(kFusedQBlockSize, 16) void fused_q_indexer_rope_hadamard_quant_kernel(
     const __grid_constant__ FusedQIndexerRopeHadamardQuantParams params) {
   constexpr int64_t kHeadDim = 128;
@@ -506,12 +531,13 @@ __global__ __launch_bounds__(kFusedQBlockSize, 16) void fused_q_indexer_rope_had
     for (int i = 1; i < kVecSize; ++i)
       local_max = fmaxf(local_max, fabsf(data[i]));
     float abs_max = warp_reduce_max(local_max);
-    float scale = fmaxf(1e-4f, abs_max) / kFP8Max;
+    constexpr float fp8_max = static_cast<float>(FP8_MAX);
+    float scale = fmaxf(1e-4f, abs_max) / fp8_max;
     float inv_scale = 1.0f / scale;
 
     OutStorage result;
-    result[0] = pack_fp8(data[0] * inv_scale, data[1] * inv_scale);
-    result[1] = pack_fp8(data[2] * inv_scale, data[3] * inv_scale);
+    result[0] = pack_fp8<FP8_MAX>(data[0] * inv_scale, data[1] * inv_scale);
+    result[1] = pack_fp8<FP8_MAX>(data[2] * inv_scale, data[3] * inv_scale);
 
     auto out_row = static_cast<uint8_t*>(params.q_fp8) + work_id * kHeadDim;
     result.store(out_row, lane_id);
@@ -619,9 +645,21 @@ void dsv4_fused_k_norm_rope_flashmla(
   // Dispatch on page_size (must be power of 2).
   TORCH_CHECK(page_size > 0 && (page_size & (page_size - 1)) == 0, "page_size must be a power of 2");
 
-#define LAUNCH_K_KERNEL(PAGE_BITS)                                 \
-  fused_k_norm_rope_flashmla_kernel<kHeadDim, kRopeDim, PAGE_BITS> \
+#ifdef USE_ROCM
+  const bool use_gfx950_fp8 = is_gfx950_gpu();
+#define LAUNCH_K_KERNEL(PAGE_BITS)                                           \
+  if (use_gfx950_fp8) {                                                      \
+    fused_k_norm_rope_flashmla_kernel<kHeadDim, kRopeDim, PAGE_BITS, 448>    \
+        <<<static_cast<uint32_t>(B), kFusedKBlockSize, 0, stream>>>(params); \
+  } else {                                                                   \
+    fused_k_norm_rope_flashmla_kernel<kHeadDim, kRopeDim, PAGE_BITS, 224>    \
+        <<<static_cast<uint32_t>(B), kFusedKBlockSize, 0, stream>>>(params); \
+  }
+#else
+#define LAUNCH_K_KERNEL(PAGE_BITS)                                      \
+  fused_k_norm_rope_flashmla_kernel<kHeadDim, kRopeDim, PAGE_BITS, 448> \
       <<<static_cast<uint32_t>(B), kFusedKBlockSize, 0, stream>>>(params)
+#endif
 
   switch (page_size) {
     case 1:
@@ -696,5 +734,13 @@ void dsv4_fused_q_indexer_rope_hadamard_quant(
   const uint32_t total_works = static_cast<uint32_t>(B * H);
   const uint32_t num_blocks = CEILDIV(total_works, kFusedQNumWarps);
 
-  fused_q_indexer_rope_hadamard_quant_kernel<<<num_blocks, kFusedQBlockSize, 0, stream>>>(params);
+#ifdef USE_ROCM
+  if (is_gfx950_gpu()) {
+    fused_q_indexer_rope_hadamard_quant_kernel<448><<<num_blocks, kFusedQBlockSize, 0, stream>>>(params);
+  } else {
+    fused_q_indexer_rope_hadamard_quant_kernel<224><<<num_blocks, kFusedQBlockSize, 0, stream>>>(params);
+  }
+#else
+  fused_q_indexer_rope_hadamard_quant_kernel<448><<<num_blocks, kFusedQBlockSize, 0, stream>>>(params);
+#endif
 }

--- a/sgl-kernel/csrc/elementwise/topk.cu
+++ b/sgl-kernel/csrc/elementwise/topk.cu
@@ -18,24 +18,45 @@
 #include <cstdint>
 #include <optional>
 
+#include "utils.h"
+
 namespace {
 
 constexpr int TopK = 2048;
 constexpr int kThreadsPerBlock = 1024;
 
 #ifdef USE_ROCM
-// On ROCm, the per-workgroup LDS budget depends on the target arch, so we inject a
-// per-arch value from `setup_rocm.py` via `-DSGL_TOPK_DYNAMIC_SMEM_BYTES=...`.
-#ifdef SGL_TOPK_DYNAMIC_SMEM_BYTES
-constexpr size_t kSmem = static_cast<size_t>(SGL_TOPK_DYNAMIC_SMEM_BYTES);
+// For multi-arch ROCm builds, use conservative compile-time value for device arrays.
+// Runtime dispatch will select optimal size based on GPU architecture.
+// - gfx942 (MI300): hardware limit ~64KB total LDS, use 48KB for dynamic smem
+// - gfx950 (MI350): can handle 128KB, use 64KB for better performance
+// Compile-time value must be the MINIMUM to work on all archs.
+constexpr size_t kSmem = 48 * 1024;  // Conservative value for compile-time device arrays
+
+// Runtime GPU architecture detection (same as FP8 code)
+inline static bool is_gfx950_gpu() {
+  static int cached_result = -1;
+  if (cached_result == -1) {
+    hipDeviceProp_t prop;
+    hipGetDeviceProperties(&prop, 0);
+    cached_result = (strncmp(prop.gcnArchName, "gfx950", 6) == 0) ? 1 : 0;
+  }
+  return cached_result == 1;
+}
+
+// Cached shared memory size - initialized once, used for all subsequent calls
+inline static size_t get_ksmem_size() {
+  static const size_t smem_size = is_gfx950_gpu() ? (64 * 1024) : (48 * 1024);
+  return smem_size;
+}
 #else
-constexpr size_t kSmem = 48 * 1024;  // bytes
-#endif
-#else
-// Reduced from 128KB to 32KB to improve occupancy.
+// CUDA: Reduced from 128KB to 32KB to improve occupancy.
 // Each radix pass needs at most ~TopK candidates in the threshold bin,
 // so 4K entries per round (2 rounds = 8K entries = 32KB) is sufficient.
 constexpr size_t kSmem = 8 * 1024 * sizeof(uint32_t);  // 32KB (bytes)
+inline size_t get_ksmem_size() {
+  return kSmem;
+}
 #endif
 
 struct FastTopKParams {
@@ -87,13 +108,14 @@ __device__ __forceinline__ auto convert_to_uint32(float x) -> uint32_t {
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
+template <size_t SMEM_SIZE>
 __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restrict__ index, int row_start, int length) {
   // An optimized topk kernel copied from tilelang kernel
   // We assume length > TopK here, or it will crash
   int topk = TopK;
   constexpr auto BLOCK_SIZE = 1024;
   constexpr auto RADIX = 256;
-  constexpr auto SMEM_INPUT_SIZE = kSmem / (2 * sizeof(int));
+  constexpr auto SMEM_INPUT_SIZE = SMEM_SIZE / (2 * sizeof(int));
 
   alignas(128) __shared__ int s_histogram_buf[2][RADIX + 128];
   alignas(128) __shared__ int s_counter;
@@ -102,7 +124,10 @@ __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restri
 
   auto& s_histogram = s_histogram_buf[0];
   // allocate for two rounds
-  extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
+  // Use 1D extern declaration to avoid type conflicts between template instantiations,
+  // then cast to 2D pointer for convenient indexing
+  extern __shared__ int s_input_idx_1d[];
+  int (*s_input_idx)[SMEM_INPUT_SIZE] = (int (*)[SMEM_INPUT_SIZE])s_input_idx_1d;
 
   const int tx = threadIdx.x;
 
@@ -251,6 +276,7 @@ __device__ void fast_topk_cuda_tl(const float* __restrict__ input, int* __restri
   }
 }
 
+template <size_t SMEM_SIZE>
 __global__ __launch_bounds__(kThreadsPerBlock)  // topk
     void topk_kernel(const FastTopKParams params) {
   const auto& [input, row_starts, indices, lengths, input_stride] = params;
@@ -262,10 +288,11 @@ __global__ __launch_bounds__(kThreadsPerBlock)  // topk
   if (length <= TopK) {
     return naive_topk_cuda(score, indice, length);
   } else {
-    return fast_topk_cuda_tl(score, indice, row_start, length);
+    return fast_topk_cuda_tl<SMEM_SIZE>(score, indice, row_start, length);
   }
 }
 
+template <size_t SMEM_SIZE>
 __global__ __launch_bounds__(kThreadsPerBlock)  // decode
     void topk_transform_decode_kernel(
         const FastTopKParams params,
@@ -284,7 +311,7 @@ __global__ __launch_bounds__(kThreadsPerBlock)  // decode
     return naive_topk_transform(score, length, dst_page_entry, src_page_entry);
   } else {
     __shared__ int s_indices[TopK];
-    fast_topk_cuda_tl(score, s_indices, row_start, length);
+    fast_topk_cuda_tl<SMEM_SIZE>(score, s_indices, row_start, length);
     // copy src[s_indices] to dst, we manually unroll here
     static_assert(TopK % kThreadsPerBlock == 0);
     static_assert(TopK / kThreadsPerBlock == 2);
@@ -297,6 +324,7 @@ __global__ __launch_bounds__(kThreadsPerBlock)  // decode
   }
 }
 
+template <size_t SMEM_SIZE>
 __global__ __launch_bounds__(kThreadsPerBlock)  // prefill
     void topk_transform_prefill_kernel(
         const FastTopKParams params,
@@ -336,7 +364,7 @@ __global__ __launch_bounds__(kThreadsPerBlock)  // prefill
     return naive_topk_transform(score, length, dst_page_entry, src_page_entry);
   } else {
     __shared__ int s_indices[TopK];
-    fast_topk_cuda_tl(score, s_indices, row_start, length);
+    fast_topk_cuda_tl<SMEM_SIZE>(score, s_indices, row_start, length);
     // copy src[s_indices] to dst, we manually unroll here
     static_assert(TopK % kThreadsPerBlock == 0);
     static_assert(TopK / kThreadsPerBlock == 2);
@@ -349,6 +377,7 @@ __global__ __launch_bounds__(kThreadsPerBlock)  // prefill
   }
 }
 
+template <size_t SMEM_SIZE>
 __global__ __launch_bounds__(kThreadsPerBlock)  // prefill, ragged kv
     void topk_transform_prefill_ragged_kernel(
         const FastTopKParams params,
@@ -367,7 +396,7 @@ __global__ __launch_bounds__(kThreadsPerBlock)  // prefill, ragged kv
     return naive_topk_transform_ragged(score, length, dst_indices_entry, offset);
   } else {
     __shared__ int s_indices[TopK];
-    fast_topk_cuda_tl(score, s_indices, row_start, length);
+    fast_topk_cuda_tl<SMEM_SIZE>(score, s_indices, row_start, length);
     // copy src[s_indices] to dst, we manually unroll here
     static_assert(TopK % kThreadsPerBlock == 0);
     static_assert(TopK / kThreadsPerBlock == 2);
@@ -430,6 +459,19 @@ void setup_kernel_smem_once() {
   TORCH_CHECK(result == cudaSuccess, "set_up_kernel_once failed:", ::cudaGetErrorString(result));
 }
 
+// Runtime version for dynamic smem size
+template <auto* f>
+void setup_kernel_smem_runtime(size_t max_dynamic_smem) {
+  cudaError_t result;
+#ifdef USE_ROCM
+  result = ::cudaFuncSetAttribute(
+      reinterpret_cast<const void*>(f), ::cudaFuncAttributeMaxDynamicSharedMemorySize, max_dynamic_smem);
+#else
+  result = ::cudaFuncSetAttribute(f, ::cudaFuncAttributeMaxDynamicSharedMemorySize, max_dynamic_smem);
+#endif
+  TORCH_CHECK(result == cudaSuccess, "setup_kernel_smem_runtime failed:", ::cudaGetErrorString(result));
+}
+
 }  // namespace
 
 #define CHECK_CUDA(x) TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
@@ -447,8 +489,23 @@ void fast_topk_interface(
   const auto stream = at::cuda::getCurrentCUDAStream().stream();
   const auto grid = dim3{static_cast<uint32_t>(B)};
   const auto block = dim3{kThreadsPerBlock};
-  setup_kernel_smem_once<topk_kernel, kSmem>();
-  topk_kernel<<<grid, block, kSmem, stream>>>(params);
+  const auto kSmem_runtime = get_ksmem_size();
+
+#ifdef USE_ROCM
+  // Runtime dispatch based on GPU architecture and cached shared memory size
+  if (kSmem_runtime == 64 * 1024) {
+    setup_kernel_smem_runtime<topk_kernel<64 * 1024>>(kSmem_runtime);
+    topk_kernel<64 * 1024><<<grid, block, kSmem_runtime, stream>>>(params);
+  } else {
+    setup_kernel_smem_runtime<topk_kernel<48 * 1024>>(kSmem_runtime);
+    topk_kernel<48 * 1024><<<grid, block, kSmem_runtime, stream>>>(params);
+  }
+#else
+  // CUDA: use compile-time constant for both template and runtime allocation
+  setup_kernel_smem_runtime<topk_kernel<kSmem>>(kSmem_runtime);
+  topk_kernel<kSmem><<<grid, block, kSmem_runtime, stream>>>(params);
+#endif
+
   const auto result = cudaGetLastError();
   TORCH_CHECK(result == cudaSuccess, "topk kernel failed:", ::cudaGetErrorString(result));
 }
@@ -489,14 +546,49 @@ void fast_topk_transform_interface(
   // extend and draft extend: row_starts_opt is not null, invokes the prefill kernel
   // decode: row_starts_opt is null, invokes the decode kernel
   // target verify: row_starts_opt is null, invokes the prefill kernel
+  const auto kSmem_runtime = get_ksmem_size();
   const auto is_decode = !row_starts_opt.has_value() && prefill_bs == B;
+
+#ifdef USE_ROCM
+  if (kSmem_runtime == 64 * 1024) {
+    if (is_decode) {
+      setup_kernel_smem_runtime<topk_transform_decode_kernel<64 * 1024>>(kSmem_runtime);
+      topk_transform_decode_kernel<64 * 1024><<<grid, block, kSmem_runtime, stream>>>(
+          params, dst_page_table.data_ptr<int32_t>(), src_page_table.data_ptr<int32_t>(), src_stride);
+    } else {
+      setup_kernel_smem_runtime<topk_transform_prefill_kernel<64 * 1024>>(kSmem_runtime);
+      topk_transform_prefill_kernel<64 * 1024><<<grid, block, kSmem_runtime, stream>>>(
+          params,
+          dst_page_table.data_ptr<int32_t>(),
+          src_page_table.data_ptr<int32_t>(),
+          src_stride,
+          cu_seqlens_q.data_ptr<int32_t>(),
+          prefill_bs);
+    }
+  } else {
+    if (is_decode) {
+      setup_kernel_smem_runtime<topk_transform_decode_kernel<48 * 1024>>(kSmem_runtime);
+      topk_transform_decode_kernel<48 * 1024><<<grid, block, kSmem_runtime, stream>>>(
+          params, dst_page_table.data_ptr<int32_t>(), src_page_table.data_ptr<int32_t>(), src_stride);
+    } else {
+      setup_kernel_smem_runtime<topk_transform_prefill_kernel<48 * 1024>>(kSmem_runtime);
+      topk_transform_prefill_kernel<48 * 1024><<<grid, block, kSmem_runtime, stream>>>(
+          params,
+          dst_page_table.data_ptr<int32_t>(),
+          src_page_table.data_ptr<int32_t>(),
+          src_stride,
+          cu_seqlens_q.data_ptr<int32_t>(),
+          prefill_bs);
+    }
+  }
+#else
   if (is_decode) {
-    setup_kernel_smem_once<topk_transform_decode_kernel, kSmem>();
-    topk_transform_decode_kernel<<<grid, block, kSmem, stream>>>(
+    setup_kernel_smem_runtime<topk_transform_decode_kernel<kSmem>>(kSmem_runtime);
+    topk_transform_decode_kernel<kSmem><<<grid, block, kSmem_runtime, stream>>>(
         params, dst_page_table.data_ptr<int32_t>(), src_page_table.data_ptr<int32_t>(), src_stride);
   } else {
-    setup_kernel_smem_once<topk_transform_prefill_kernel, kSmem>();
-    topk_transform_prefill_kernel<<<grid, block, kSmem, stream>>>(
+    setup_kernel_smem_runtime<topk_transform_prefill_kernel<kSmem>>(kSmem_runtime);
+    topk_transform_prefill_kernel<kSmem><<<grid, block, kSmem_runtime, stream>>>(
         params,
         dst_page_table.data_ptr<int32_t>(),
         src_page_table.data_ptr<int32_t>(),
@@ -504,6 +596,7 @@ void fast_topk_transform_interface(
         cu_seqlens_q.data_ptr<int32_t>(),
         prefill_bs);
   }
+#endif
 
   const auto result = cudaGetLastError();
   TORCH_CHECK(result == cudaSuccess, "topk kernel failed:", ::cudaGetErrorString(result));
@@ -536,10 +629,23 @@ void fast_topk_transform_ragged_interface(
   const auto stream = at::cuda::getCurrentCUDAStream().stream();
   const auto grid = dim3{static_cast<uint32_t>(B)};
   const auto block = dim3{kThreadsPerBlock};
+  const auto kSmem_runtime = get_ksmem_size();
 
-  setup_kernel_smem_once<topk_transform_prefill_ragged_kernel, kSmem>();
-  topk_transform_prefill_ragged_kernel<<<grid, block, kSmem, stream>>>(
+#ifdef USE_ROCM
+  if (kSmem_runtime == 64 * 1024) {
+    setup_kernel_smem_runtime<topk_transform_prefill_ragged_kernel<64 * 1024>>(kSmem_runtime);
+    topk_transform_prefill_ragged_kernel<64 * 1024><<<grid, block, kSmem_runtime, stream>>>(
+        params, topk_indices_ragged.data_ptr<int32_t>(), topk_indices_offset.data_ptr<int32_t>());
+  } else {
+    setup_kernel_smem_runtime<topk_transform_prefill_ragged_kernel<48 * 1024>>(kSmem_runtime);
+    topk_transform_prefill_ragged_kernel<48 * 1024><<<grid, block, kSmem_runtime, stream>>>(
+        params, topk_indices_ragged.data_ptr<int32_t>(), topk_indices_offset.data_ptr<int32_t>());
+  }
+#else
+  setup_kernel_smem_runtime<topk_transform_prefill_ragged_kernel<kSmem>>(kSmem_runtime);
+  topk_transform_prefill_ragged_kernel<kSmem><<<grid, block, kSmem_runtime, stream>>>(
       params, topk_indices_ragged.data_ptr<int32_t>(), topk_indices_offset.data_ptr<int32_t>());
+#endif
 
   const auto result = cudaGetLastError();
   TORCH_CHECK(result == cudaSuccess, "topk kernel failed:", ::cudaGetErrorString(result));

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -374,19 +374,34 @@ __device__ __forceinline__ dstDtype castFromFloat(float val) {
 using FP8_TYPE = c10::Float8_e4m3fn;
 C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
 #else  // USE_ROCM
-#if HIP_FP8_TYPE_FNUZ
+// Include both FP8 types for multi-arch support
+#include <c10/util/Float8_e4m3fn.h>
 #include <c10/util/Float8_e4m3fnuz.h>
+
+// Note: Runtime GPU architecture detection functions removed.
+// For multi-arch ROCm builds, use compile-time constants instead of runtime detection.
+#ifdef USE_ROCM
+#include <hip/hip_runtime.h>
+#endif  // USE_ROCM
+
+// FP8_TYPE definition for backward compatibility
+// NOTE: FP8_E4M3_MAX is deprecated for kernels with multi-arch support.
+// Kernels should use template parameters and runtime dispatch instead.
+// gfx942: E4M3FNUZ with max=224.0f, gfx950: E4M3FN with max=448.0f
+#if HIP_FP8_TYPE_FNUZ && HIP_FP8_TYPE_E4M3
+// Multi-arch build: Use gfx942 (E4M3FNUZ) type for legacy code paths.
+// Modern kernels (e.g., per_token_quant_fp8) use runtime dispatch to select the correct max.
 using FP8_TYPE = c10::Float8_e4m3fnuz;
 constexpr auto FP8_E4M3_MAX = 224.0f;
-#else
-#if HIP_FP8_TYPE_E4M3
-#include <c10/util/Float8_e4m3fn.h>
+#elif HIP_FP8_TYPE_FNUZ
+using FP8_TYPE = c10::Float8_e4m3fnuz;
+constexpr auto FP8_E4M3_MAX = 224.0f;
+#elif HIP_FP8_TYPE_E4M3
 using FP8_TYPE = c10::Float8_e4m3fn;
 C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
 #else
 #error "fp8 is not supported in this processor (arch < gfx942)."
-#endif  // HIP_FP8_TYPE_E4M3
-#endif  // HIP_FP8_TYPE_FNUZ
+#endif  // FP8 type selection
 #endif  // USE_ROCM
 
 #define FULL_MASK 0xffffffff

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -81,7 +81,7 @@ if amdgpu_target_env == default_target and torch.cuda.is_available():
         print(f"Using default target: {default_target}")
 
 # Validate all target architectures
-supported_archs = ["gfx942", "gfx950"]
+supported_archs = ["gfx942", "gfx950", "gfx1100", "gfx1201"]
 for arch in amdgpu_targets:
     if arch not in supported_archs:
         print(

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -64,31 +64,42 @@ libraries = ["hiprtc", "amdhip64", "c10", "torch", "torch_python"]
 extra_link_args = ["-Wl,-rpath,$ORIGIN/../../torch/lib", f"-L/usr/lib/{arch}-linux-gnu"]
 
 default_target = "gfx942"
-amdgpu_target = os.environ.get("AMDGPU_TARGET", default_target)
+amdgpu_target_env = os.environ.get("AMDGPU_TARGET", default_target)
 
-if torch.cuda.is_available():
+# Support multi-arch: Parse semicolon-separated architectures
+# Examples: "gfx942" or "gfx942;gfx950"
+amdgpu_targets = amdgpu_target_env.split(";")
+
+# Auto-detect current GPU if not explicitly set and single-arch mode
+if amdgpu_target_env == default_target and torch.cuda.is_available():
     try:
-        amdgpu_target = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+        detected_arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+        print(f"Auto-detected GPU architecture: {detected_arch}")
+        amdgpu_targets = [detected_arch]
     except Exception as e:
         print(f"Warning: Failed to detect GPU properties: {e}")
-else:
-    print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
+        print(f"Using default target: {default_target}")
 
-if amdgpu_target not in ["gfx942", "gfx950"]:
-    print(
-        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
-    )
-    sys.exit(1)
+# Validate all target architectures
+supported_archs = ["gfx942", "gfx950"]
+for arch in amdgpu_targets:
+    if arch not in supported_archs:
+        print(
+            f"Error: Unsupported GPU architecture '{arch}'. Expected one of: {supported_archs}"
+        )
+        sys.exit(1)
 
-fp8_macro = (
-    "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"
-)
+print(f"Building for architectures: {', '.join(amdgpu_targets)}")
 
-# Dynamic shared-memory budget for the TopK kernels.
-# - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
-#   (leaves room for static shared allocations in the kernel).
-# - gfx95x (MI350): LDS is larger (e.g. 160KB per CU) -> allow the original 128KB dynamic smem.
-topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
+# Multi-arch build: Define both FP8 types so compile-time selection can work
+# For single-arch builds, we still define both to keep code consistent
+fp8_macros = [
+    "-DHIP_FP8_TYPE_FNUZ=1",  # For gfx942
+    "-DHIP_FP8_TYPE_E4M3=1",  # For gfx950
+]
+
+# Note: SMEM sizing for topk kernel uses compile-time constant (48KB) that works on all archs.
+# Multi-arch builds must use the minimum value that is safe on all target architectures.
 
 hipcc_flags = [
     "-DNDEBUG",
@@ -97,12 +108,16 @@ hipcc_flags = [
     "-Xcompiler",
     "-fPIC",
     "-std=c++17",
-    f"--amdgpu-target={amdgpu_target}",
     "-DENABLE_BF16",
     "-DENABLE_FP8",
-    fp8_macro,
-    f"-DSGL_TOPK_DYNAMIC_SMEM_BYTES={topk_dynamic_smem_bytes}",
 ]
+
+# Add architecture targets (multi-arch support)
+for arch in amdgpu_targets:
+    hipcc_flags.append(f"--offload-arch={arch}")
+
+# Add FP8 macros
+hipcc_flags.extend(fp8_macros)
 
 ext_modules = [
     CUDAExtension(


### PR DESCRIPTION
transformers 5.13 ships native Qwen3-ASR and registers `qwen3_asr` / 
    `qwen3_asr_thinker` at import time. SGLang unconditional `AutoConfig.register()` then raises 
    "already used", which crashes config import for **every** model (registration happens at 
    import in `configs/__init__.py`).

    **Fix:** wrap registration in try/except so it registers when the name is free (older 
    transformers) and defers to the native config when already taken. The `except` narrowly
    matches the "already registered/used" message and re-raises anything else.


    No RDNA/MXFP4 dependency — this is a general transformers-compat fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29095109386](https://github.com/sgl-project/sglang/actions/runs/29095109386)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29095109139](https://github.com/sgl-project/sglang/actions/runs/29095109139)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->