### PR TITLE
[LFM2] Wire Lfm2MoeForCausalLM into the LFM2 serving override tables

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -774,7 +774,7 @@ def _granite_moe_hybrid_overrides(server_args: Any, hf_config: Any) -> dict:
     return {}
 
 
-@_register_for("Lfm2ForCausalLM")
+@_register_for("Lfm2ForCausalLM", "Lfm2MoeForCausalLM")
 def _lfm2_overrides(server_args: Any, hf_config: Any) -> dict:
     if is_sm100_supported() and server_args.attention_backend is None:
         return {"attention_backend": "flashinfer"}
@@ -1123,6 +1123,7 @@ _MAMBA_RADIX_CACHE_ARCHS = frozenset(
         "JetNemotronForCausalLM",
         "JetVLMForConditionalGeneration",
         "Lfm2ForCausalLM",
+        "Lfm2MoeForCausalLM",
         "ZayaForCausalLM",
     }
 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5395,7 +5395,7 @@ class ServerArgs:
             # _glm4_moe_overrides).
             pass
 
-        elif model_arch in ["Lfm2ForCausalLM"]:
+        elif model_arch in ["Lfm2ForCausalLM", "Lfm2MoeForCausalLM"]:
             # Attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _lfm2_overrides).
             assert resolved_view(self).attention_backend != "triton", (


### PR DESCRIPTION
### What

`Lfm2MoeForCausalLM` (LFM2-MoE, e.g. LFM2-8B-A1B) is a registered model, but it was missing from the serving override tables that the dense `Lfm2ForCausalLM` already uses. This adds it alongside the dense arch in three places:

- `_lfm2_overrides` registry (`arg_groups/overrides.py`) - flashinfer attention-backend default on SM100
- `_MAMBA_RADIX_CACHE_ARCHS` (`arg_groups/overrides.py`) - mamba radix cache eligibility
- the LFM2 branch in `server_args.py` - triton-backend guard

Both archs are the same LFM2 hybrid (ShortConv + attention) family, so MoE should get the same backend/cache defaults as dense.

### Testing

Base (non-spec) LFM2-8B-A1B serving on 1xH100: server starts, selects the backend through the registry, initializes `MambaRadixCache`, and generates. 3 lines, no behavior change for any other arch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30457880680](https://github.com/sgl-project/sglang/actions/runs/30457880680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30457880433](https://github.com/sgl-project/sglang/actions/runs/30457880433)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->