### PR TITLE
Fix hybrid attention graph hook test fixture

### DIFF
--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -142,6 +142,7 @@ def test_hybrid_wrappers_forward_in_graph_hook():
             kv_cache_dtype=torch.bfloat16,
             token_to_kv_pool=None,
             req_to_token_pool=None,
+            server_args=SimpleNamespace(speculative_attention_mode="decode"),
         ),
         prefill_backend=make_fake("prefill", calls),
         decode_backend=make_fake("decode", calls),


### PR DESCRIPTION
## Summary

Fixes the hybrid attention graph hook test from #29843 by adding the fake model runner field that became required after #30708

cc @hnyls2002 

## Failure

```text
FAILED registered/attention/test_trtllm_mha_graph_metadata.py::test_hybrid_wrappers_forward_in_graph_hook - AttributeError: 'types.SimpleNamespace' object has no attribute 'server_args'
```











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29100926571](https://github.com/sgl-project/sglang/actions/runs/29100926571)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29100926319](https://github.com/sgl-project/sglang/actions/runs/29100926319)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->