### PR TITLE
feat(hicache): retain hinted prompt KV in Mooncake L3

### DIFF
--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -1891,6 +1891,7 @@ class MMReceiverBase(ABC):
             ),
             http_worker_ipc=recv_req.http_worker_ipc,
             dllm_config=self.scheduler.dllm_config,
+            kv_hints=recv_req.kv_hints,
         )
         req.tokenizer = self.scheduler.tokenizer
         return req

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -358,6 +358,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_params: Optional[Dict] = None,
         priority: Optional[int] = None,
         session_id: Optional[str] = None,
+        kv_hints: Optional[Dict] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -396,6 +397,7 @@ class Engine(EngineScoreMixin, EngineBase):
             session_id=session_id,
             session_params=session_params,
             priority=priority,
+            kv_hints=kv_hints,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 
@@ -462,6 +464,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_params: Optional[Dict] = None,
         priority: Optional[int] = None,
         session_id: Optional[str] = None,
+        kv_hints: Optional[Dict] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -500,6 +503,7 @@ class Engine(EngineScoreMixin, EngineBase):
             session_id=session_id,
             session_params=session_params,
             priority=priority,
+            kv_hints=kv_hints,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -1188,6 +1188,12 @@ class HiCacheController:
         Manage backup operations from host memory to storage backend.
         """
         while not self.storage_stop_event.is_set():
+            renew = getattr(self.storage_backend, "renew_retained_pages", None)
+            if renew is not None:
+                try:
+                    renew()
+                except Exception:
+                    logger.warning("Storage retention renewal failed", exc_info=True)
             try:
                 operation = self.backup_queue.get(block=True, timeout=1)
                 if operation is None:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -167,6 +167,12 @@ class StorageOperation:
         return self.id < other.id
 
 
+class RetentionOperation:
+    def __init__(self, logical_keys: List[str], ttl_seconds: int):
+        self.logical_keys = logical_keys
+        self.ttl_seconds = ttl_seconds
+
+
 class PrefetchOperation(StorageOperation):
     def __init__(
         self,
@@ -1077,6 +1083,10 @@ class HiCacheController:
         self.backup_queue.put(operation)
         return operation.id
 
+    def retain_storage(self, logical_keys: List[str], ttl_seconds: int) -> None:
+        """Queue a storage retention request without blocking the scheduler."""
+        self.backup_queue.put(RetentionOperation(logical_keys, ttl_seconds))
+
     # todo: deprecate
     def _generic_page_set(self, hash_values, host_indices, extra_info=None) -> bool:
         data = [
@@ -1191,6 +1201,12 @@ class HiCacheController:
             try:
                 operation = self.backup_queue.get(block=True, timeout=1)
                 if operation is None:
+                    continue
+
+                if isinstance(operation, RetentionOperation):
+                    self.storage_backend.retain_pages(
+                        operation.logical_keys, operation.ttl_seconds
+                    )
                     continue
 
                 if not self.backup_skip:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -1188,12 +1188,6 @@ class HiCacheController:
         Manage backup operations from host memory to storage backend.
         """
         while not self.storage_stop_event.is_set():
-            renew = getattr(self.storage_backend, "renew_retained_pages", None)
-            if renew is not None:
-                try:
-                    renew()
-                except Exception:
-                    logger.warning("Storage retention renewal failed", exc_info=True)
             try:
                 operation = self.backup_queue.get(block=True, timeout=1)
                 if operation is None:

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -152,6 +152,17 @@ MultimodalDataInputFormat = Union[
 
 
 @dataclass
+class KvRetentionHint:
+    prefix_tokens: int
+    ttl_seconds: int
+
+
+@dataclass
+class KvHintEnvelope:
+    retention: List[KvRetentionHint] = field(default_factory=list)
+
+
+@dataclass
 class GenerateReqInput:
     # Request ID(s). If omitted, generated during normalization. For batch
     # requests, a string is expanded to per-item IDs using it as a prefix.
@@ -252,6 +263,8 @@ class GenerateReqInput:
     disagg_prefill_dp_rank: Optional[int] = None
     # Routing key for routing-key schedule policy
     routing_key: Optional[str] = None
+    # Provider-neutral KV cache intent supplied by an upstream router.
+    kv_hints: Optional[Union[KvHintEnvelope, List[Optional[KvHintEnvelope]]]] = None
     # Conversation id used for tracking requests
     conversation_id: Optional[str] = None
     # Internal IPC endpoint of the HTTP/tokenizer worker that owns this request.
@@ -347,6 +360,7 @@ class GenerateReqInput:
         if self.session_id is not None and self.session_params is not None:
             raise ValueError("session_id and session_params cannot both be set.")
         self._handle_parallel_sampling()
+        self._coerce_kv_hints()
 
         if self.is_single:
             self._normalize_single_inputs()
@@ -457,6 +471,7 @@ class GenerateReqInput:
         self._normalize_logprob_params(num)
         self._normalize_custom_logit_processor(num)
         self._normalize_extra_key(num)
+        self._normalize_kv_hints()
         self._normalize_bootstrap_params(num)
 
     def _expand_inputs(self, num):
@@ -641,6 +656,28 @@ class GenerateReqInput:
         else:
             raise ValueError("extra_key should be a list or a string.")
 
+    def _normalize_kv_hints(self):
+        if not isinstance(self.kv_hints, list):
+            return
+        if len(self.kv_hints) != self.batch_size:
+            raise ValueError(
+                "The length of kv_hints should be equal to the batch size."
+            )
+        self.kv_hints = self.kv_hints * self.parallel_sample_num
+
+    def _coerce_kv_hints(self):
+        if isinstance(self.kv_hints, dict):
+            self.kv_hints = msgspec.convert(self.kv_hints, type=KvHintEnvelope)
+        elif isinstance(self.kv_hints, list):
+            self.kv_hints = [
+                (
+                    msgspec.convert(hint, type=KvHintEnvelope)
+                    if isinstance(hint, dict)
+                    else hint
+                )
+                for hint in self.kv_hints
+            ]
+
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
         # Normalize bootstrap_host
@@ -757,6 +794,9 @@ class GenerateReqInput:
             routed_dp_rank=self.routed_dp_rank,
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
+            kv_hints=(
+                self.kv_hints[i] if isinstance(self.kv_hints, list) else self.kv_hints
+            ),
             http_worker_ipc=self.http_worker_ipc,
             priority=self.priority,
             extra_key=self.extra_key[i] if self.extra_key is not None else None,
@@ -870,6 +910,9 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     # For observability
     # Pickled Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]]
     time_stats: Optional[PickleWrapper] = None
+    # Provider-neutral KV cache intent. Keep new IPC fields at the end because
+    # BaseReq uses positional array-like encoding.
+    kv_hints: Optional[KvHintEnvelope] = None
 
     def wrap_pickle_fields(self):
         self.mm_inputs = wrap_as_pickle(self.mm_inputs)

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -153,13 +153,12 @@ MultimodalDataInputFormat = Union[
 
 @dataclass
 class KvRetentionHint:
-    prefix_tokens: int
     ttl_seconds: int
 
 
 @dataclass
 class KvHintEnvelope:
-    retention: List[KvRetentionHint] = field(default_factory=list)
+    retain_full_prompt: Optional[KvRetentionHint] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -711,6 +711,7 @@ class Req(ReqDllmMixin):
         return_pooled_hidden_states: bool = False,
         multi_item_delimiter_indices: Optional[List[int]] = None,
         session_id: Optional[str] = None,
+        kv_hints=None,
     ):
         # Input and output info
         self.rid = rid
@@ -734,6 +735,7 @@ class Req(ReqDllmMixin):
 
         self.session = session
         self.session_id = session_id
+        self.kv_hints = kv_hints
         self.input_embeds = input_embeds
         self.positional_embed_overrides = positional_embed_overrides
         self.multi_item_delimiter_indices = multi_item_delimiter_indices

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2107,6 +2107,7 @@ class Scheduler(
                 dllm_config=self.dllm_config,
                 time_stats=recv_req.time_stats,
                 multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
+                kv_hints=recv_req.kv_hints,
             )
             req.tokenizer = self.tokenizer
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1183,6 +1183,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 priority=obj.priority,
                 extra_key=obj.extra_key,
                 routing_key=obj.routing_key,
+                kv_hints=obj.kv_hints,
                 token_type_ids=token_type_ids,
                 need_wait_for_mm_inputs=obj.need_wait_for_mm_inputs,
                 num_items_assigned=obj.num_items_assigned,

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -54,9 +54,9 @@ def maybe_apply_kv_hints(req: Req, tree_cache: BasePrefixCache) -> None:
 
     hints = getattr(req, "kv_hints", None)
     retention = (
-        hints.get("retention", [])
+        hints.get("retain_full_prompt")
         if isinstance(hints, dict)
-        else getattr(hints, "retention", [])
+        else getattr(hints, "retain_full_prompt", None)
     )
     if not retention:
         return

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -117,6 +117,9 @@ def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
         return
 
     tree_cache.cache_unfinished_req(req, **kwargs)
+    apply_kv_hints = getattr(tree_cache, "apply_kv_hints", None)
+    if apply_kv_hints is not None:
+        apply_kv_hints(req)
 
 
 def write_cache_indices(
@@ -644,10 +647,11 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
             req.mamba_pool_idx = None
         return
 
-    tree_cache.cache_finished_req(
-        req,
-        is_insert=is_insert and not getattr(req, "skip_radix_cache_insert", False),
-    )
+    should_insert = is_insert and not getattr(req, "skip_radix_cache_insert", False)
+    tree_cache.cache_finished_req(req, is_insert=should_insert)
+    apply_kv_hints = getattr(tree_cache, "apply_kv_hints", None)
+    if should_insert and apply_kv_hints is not None:
+        apply_kv_hints(req)
 
     # StreamingSession.cache_finished_req handles speculative tail trim
     # and bookkeeping flag sync internally, then sets req_pool_idx = None.

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -46,6 +46,30 @@ MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY = 2
 MAMBA_STATE_PER_REQ_NO_CACHE = 1
 
 logger = logging.getLogger(__name__)
+_unsupported_cache_kv_hints_logged = False
+
+
+def maybe_apply_kv_hints(req: Req, tree_cache: BasePrefixCache) -> None:
+    global _unsupported_cache_kv_hints_logged
+
+    hints = getattr(req, "kv_hints", None)
+    retention = (
+        hints.get("retention", [])
+        if isinstance(hints, dict)
+        else getattr(hints, "retention", [])
+    )
+    if not retention:
+        return
+
+    apply_kv_hints = getattr(tree_cache, "apply_kv_hints", None)
+    if apply_kv_hints is not None:
+        apply_kv_hints(req)
+    elif not _unsupported_cache_kv_hints_logged:
+        logger.warning(
+            "Ignoring KV retention hints: prefix cache %s does not support them",
+            type(tree_cache).__name__,
+        )
+        _unsupported_cache_kv_hints_logged = True
 
 
 def kv_to_page_indices(kv_indices: np.ndarray, page_size: int):
@@ -117,9 +141,7 @@ def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
         return
 
     tree_cache.cache_unfinished_req(req, **kwargs)
-    apply_kv_hints = getattr(tree_cache, "apply_kv_hints", None)
-    if apply_kv_hints is not None:
-        apply_kv_hints(req)
+    maybe_apply_kv_hints(req, tree_cache)
 
 
 def write_cache_indices(
@@ -649,9 +671,8 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
 
     should_insert = is_insert and not getattr(req, "skip_radix_cache_insert", False)
     tree_cache.cache_finished_req(req, is_insert=should_insert)
-    apply_kv_hints = getattr(tree_cache, "apply_kv_hints", None)
-    if should_insert and apply_kv_hints is not None:
-        apply_kv_hints(req)
+    if should_insert:
+        maybe_apply_kv_hints(req, tree_cache)
 
     # StreamingSession.cache_finished_req handles speculative tail trim
     # and bookkeeping flag sync internally, then sets req_pool_idx = None.

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -214,12 +214,12 @@ class HiRadixCache(RadixCache):
         super().__init__(params=params)
 
     def apply_kv_hints(self, req) -> int:
-        """Queue bounded L3 retention intent after its prefix is committed."""
+        """Queue bounded L3 retention after the full prompt is committed."""
         hints = getattr(req, "kv_hints", None)
         retention = (
-            hints.get("retention", [])
+            hints.get("retain_full_prompt")
             if isinstance(hints, dict)
-            else getattr(hints, "retention", [])
+            else getattr(hints, "retain_full_prompt", None)
         )
         backend = getattr(self.cache_controller, "storage_backend", None)
         supported = (
@@ -238,63 +238,51 @@ class HiRadixCache(RadixCache):
                 self._retention_unsupported_logged = True
             return 0
 
-        max_hints = backend.retention_max_hints
         max_pages = backend.retention_max_pages
         max_ttl_seconds = backend.retention_max_ttl_seconds
-        applied_indices = getattr(req, "_kv_retention_applied_indices", set())
+        if getattr(req, "_kv_retention_applied", False):
+            return 0
         page_ttls = getattr(req, "_kv_retention_page_ttls", {})
         desired_page_ttls = {}
-        matched_indices = set()
 
-        for index, hint in enumerate(retention[:max_hints]):
-            if index in applied_indices:
-                continue
-            try:
-                prefix_tokens = (
-                    hint.get("prefix_tokens")
-                    if isinstance(hint, dict)
-                    else hint.prefix_tokens
-                )
-                ttl_seconds = (
-                    hint.get("ttl_seconds")
-                    if isinstance(hint, dict)
-                    else hint.ttl_seconds
-                )
-                prefix_tokens = min(int(prefix_tokens), len(req.origin_input_ids))
-                prefix_tokens -= prefix_tokens % self.page_size
-                ttl_seconds = min(int(ttl_seconds), max_ttl_seconds)
-                if prefix_tokens <= 0 or ttl_seconds <= 0:
-                    continue
+        try:
+            ttl_seconds = (
+                retention.get("ttl_seconds")
+                if isinstance(retention, dict)
+                else retention.ttl_seconds
+            )
+            prefix_tokens = len(req.origin_input_ids)
+            prefix_tokens -= prefix_tokens % self.page_size
+            ttl_seconds = min(int(ttl_seconds), max_ttl_seconds)
+            if prefix_tokens <= 0 or ttl_seconds <= 0:
+                return 0
 
-                key = RadixKey(
-                    req.origin_input_ids[:prefix_tokens],
-                    req.extra_key,
-                    is_bigram=self.is_eagle,
-                ).page_aligned(self.page_size)
-                match = self.match_prefix(MatchPrefixParams(key=key))
-                if len(match.device_indices) != len(key):
-                    logger.info(
-                        "Skipped KV retention hint: matched %d of %d prefix tokens",
-                        len(match.device_indices),
-                        len(key),
-                    )
-                    continue
-                node = match.last_device_node
-                page_hashes = node.get_prefix_hash_values(node)
-                if len(page_hashes) != len(key) // self.page_size:
-                    continue
-                matched_indices.add(index)
-                for page_hash in page_hashes:
-                    desired_page_ttls[page_hash] = max(
-                        ttl_seconds, desired_page_ttls.get(page_hash, 0)
-                    )
-            except Exception:
-                if not self._retention_apply_failed_logged:
-                    logger.warning("Failed to apply KV retention hint", exc_info=True)
-                    self._retention_apply_failed_logged = True
+            key = RadixKey(
+                req.origin_input_ids[:prefix_tokens],
+                req.extra_key,
+                is_bigram=self.is_eagle,
+            ).page_aligned(self.page_size)
+            match = self.match_prefix(MatchPrefixParams(key=key))
+            if len(match.device_indices) != len(key):
+                logger.info(
+                    "Skipped KV retention hint: matched %d of %d prompt tokens",
+                    len(match.device_indices),
+                    len(key),
+                )
+                return 0
+            node = match.last_device_node
+            page_hashes = node.get_prefix_hash_values(node)
+            if len(page_hashes) != len(key) // self.page_size:
+                return 0
+            desired_page_ttls = {page_hash: ttl_seconds for page_hash in page_hashes}
+        except Exception:
+            if not self._retention_apply_failed_logged:
+                logger.warning("Failed to apply KV retention hint", exc_info=True)
+                self._retention_apply_failed_logged = True
+            return 0
 
         updates_by_ttl = {}
-        bounded = len(retention) > max_hints
+        bounded = False
         for page_hash, ttl_seconds in desired_page_ttls.items():
             previous_ttl = page_ttls.get(page_hash, 0)
             if ttl_seconds <= previous_ttl:
@@ -308,8 +296,7 @@ class HiRadixCache(RadixCache):
         for ttl_seconds, page_hashes in updates_by_ttl.items():
             self.cache_controller.retain_storage(page_hashes, ttl_seconds)
 
-        applied_indices.update(matched_indices)
-        req._kv_retention_applied_indices = applied_indices
+        req._kv_retention_applied = True
         req._kv_retention_page_ttls = page_ttls
         queued_pages = sum(len(page_hashes) for page_hashes in updates_by_ttl.values())
         if queued_pages:
@@ -320,8 +307,7 @@ class HiRadixCache(RadixCache):
             )
         if bounded and not self._retention_bounded_logged:
             logger.warning(
-                "Bounded KV retention hints to %d hints and %d unique pages per request",
-                max_hints,
+                "Bounded KV retention to %d unique pages per request",
                 max_pages,
             )
             self._retention_bounded_logged = True

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -204,6 +204,7 @@ class HiRadixCache(RadixCache):
         self.load_back_threshold = 10
         self._retention_unsupported_logged = False
         self._retention_apply_failed_logged = False
+        self._retention_bounded_logged = False
 
         # Detach storage backend automatically on process shutdown
         atexit.register(self.shutdown)
@@ -213,7 +214,7 @@ class HiRadixCache(RadixCache):
         super().__init__(params=params)
 
     def apply_kv_hints(self, req) -> int:
-        """Apply bounded L3 retention intent after its prefix is committed."""
+        """Queue bounded L3 retention intent after its prefix is committed."""
         hints = getattr(req, "kv_hints", None)
         retention = (
             hints.get("retention", [])
@@ -226,19 +227,28 @@ class HiRadixCache(RadixCache):
             and self.enable_storage
             and self.cache_controller.storage_backend_type == "mooncake"
             and self.cache_controller.write_policy == "write_through"
-            and getattr(backend, "_can_use_group_semantics", lambda: False)()
+            and getattr(backend, "_can_retain_groups", lambda: False)()
         )
         if not supported:
             if retention and not self._retention_unsupported_logged:
                 logger.warning(
                     "Ignoring KV retention hints: requires HiCache write_through "
-                    "with Mooncake group semantics"
+                    "with Mooncake retain_groups support"
                 )
                 self._retention_unsupported_logged = True
             return 0
 
-        accepted = 0
-        for hint in retention:
+        max_hints = backend.retention_max_hints
+        max_pages = backend.retention_max_pages
+        max_ttl_seconds = backend.retention_max_ttl_seconds
+        applied_indices = getattr(req, "_kv_retention_applied_indices", set())
+        page_ttls = getattr(req, "_kv_retention_page_ttls", {})
+        desired_page_ttls = {}
+        matched_indices = set()
+
+        for index, hint in enumerate(retention[:max_hints]):
+            if index in applied_indices:
+                continue
             try:
                 prefix_tokens = (
                     hint.get("prefix_tokens")
@@ -252,7 +262,8 @@ class HiRadixCache(RadixCache):
                 )
                 prefix_tokens = min(int(prefix_tokens), len(req.origin_input_ids))
                 prefix_tokens -= prefix_tokens % self.page_size
-                if prefix_tokens <= 0 or int(ttl_seconds) <= 0:
+                ttl_seconds = min(int(ttl_seconds), max_ttl_seconds)
+                if prefix_tokens <= 0 or ttl_seconds <= 0:
                     continue
 
                 key = RadixKey(
@@ -272,21 +283,49 @@ class HiRadixCache(RadixCache):
                 page_hashes = node.get_prefix_hash_values(node)
                 if len(page_hashes) != len(key) // self.page_size:
                     continue
-                retained_pages = backend.retain_pages(
-                    page_hashes, int(ttl_seconds)
-                )
-                accepted += retained_pages
-                logger.info(
-                    "Applied KV retention hint to %d/%d pages for %d seconds",
-                    retained_pages,
-                    len(page_hashes),
-                    int(ttl_seconds),
-                )
+                matched_indices.add(index)
+                for page_hash in page_hashes:
+                    desired_page_ttls[page_hash] = max(
+                        ttl_seconds, desired_page_ttls.get(page_hash, 0)
+                    )
             except Exception:
                 if not self._retention_apply_failed_logged:
                     logger.warning("Failed to apply KV retention hint", exc_info=True)
                     self._retention_apply_failed_logged = True
-        return accepted
+
+        updates_by_ttl = {}
+        bounded = len(retention) > max_hints
+        for page_hash, ttl_seconds in desired_page_ttls.items():
+            previous_ttl = page_ttls.get(page_hash, 0)
+            if ttl_seconds <= previous_ttl:
+                continue
+            if page_hash not in page_ttls and len(page_ttls) >= max_pages:
+                bounded = True
+                continue
+            page_ttls[page_hash] = ttl_seconds
+            updates_by_ttl.setdefault(ttl_seconds, []).append(page_hash)
+
+        for ttl_seconds, page_hashes in updates_by_ttl.items():
+            self.cache_controller.retain_storage(page_hashes, ttl_seconds)
+
+        applied_indices.update(matched_indices)
+        req._kv_retention_applied_indices = applied_indices
+        req._kv_retention_page_ttls = page_ttls
+        queued_pages = sum(len(page_hashes) for page_hashes in updates_by_ttl.values())
+        if queued_pages:
+            logger.info(
+                "Queued KV retention for %d pages across %d TTL groups",
+                queued_pages,
+                len(updates_by_ttl),
+            )
+        if bounded and not self._retention_bounded_logged:
+            logger.warning(
+                "Bounded KV retention hints to %d hints and %d unique pages per request",
+                max_hints,
+                max_pages,
+            )
+            self._retention_bounded_logged = True
+        return queued_pages
 
     def _all_reduce_attn_groups(self, tensor: torch.Tensor, op):
         reduced = False

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -202,6 +202,8 @@ class HiRadixCache(RadixCache):
             1 if server_args.hicache_write_policy == "write_through" else 2
         )
         self.load_back_threshold = 10
+        self._retention_unsupported_logged = False
+        self._retention_apply_failed_logged = False
 
         # Detach storage backend automatically on process shutdown
         atexit.register(self.shutdown)
@@ -209,6 +211,68 @@ class HiRadixCache(RadixCache):
         self.evictable_host_leaves = set()
 
         super().__init__(params=params)
+
+    def apply_kv_hints(self, req) -> int:
+        """Apply bounded L3 retention intent after its prefix is committed."""
+        hints = getattr(req, "kv_hints", None)
+        retention = (
+            hints.get("retention", [])
+            if isinstance(hints, dict)
+            else getattr(hints, "retention", [])
+        )
+        backend = getattr(self.cache_controller, "storage_backend", None)
+        supported = (
+            retention
+            and self.enable_storage
+            and self.cache_controller.storage_backend_type == "mooncake"
+            and self.cache_controller.write_policy == "write_through"
+            and getattr(backend, "_can_use_group_semantics", lambda: False)()
+        )
+        if not supported:
+            if retention and not self._retention_unsupported_logged:
+                logger.warning(
+                    "Ignoring KV retention hints: requires HiCache write_through "
+                    "with Mooncake group semantics"
+                )
+                self._retention_unsupported_logged = True
+            return 0
+
+        accepted = 0
+        for hint in retention:
+            try:
+                prefix_tokens = (
+                    hint.get("prefix_tokens")
+                    if isinstance(hint, dict)
+                    else hint.prefix_tokens
+                )
+                ttl_seconds = (
+                    hint.get("ttl_seconds")
+                    if isinstance(hint, dict)
+                    else hint.ttl_seconds
+                )
+                prefix_tokens = min(int(prefix_tokens), len(req.origin_input_ids))
+                prefix_tokens -= prefix_tokens % self.page_size
+                if prefix_tokens <= 0 or int(ttl_seconds) <= 0:
+                    continue
+
+                key = RadixKey(
+                    req.origin_input_ids[:prefix_tokens],
+                    req.extra_key,
+                    is_bigram=self.is_eagle,
+                ).page_aligned(self.page_size)
+                match = self.match_prefix(MatchPrefixParams(key=key))
+                if len(match.device_indices) != len(key):
+                    continue
+                node = match.last_device_node
+                page_hashes = node.get_prefix_hash_values(node)
+                if len(page_hashes) != len(key) // self.page_size:
+                    continue
+                accepted += backend.retain_pages(page_hashes, int(ttl_seconds))
+            except Exception:
+                if not self._retention_apply_failed_logged:
+                    logger.warning("Failed to apply KV retention hint", exc_info=True)
+                    self._retention_apply_failed_logged = True
+        return accepted
 
     def _all_reduce_attn_groups(self, tensor: torch.Tensor, op):
         reduced = False

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -262,12 +262,26 @@ class HiRadixCache(RadixCache):
                 ).page_aligned(self.page_size)
                 match = self.match_prefix(MatchPrefixParams(key=key))
                 if len(match.device_indices) != len(key):
+                    logger.info(
+                        "Skipped KV retention hint: matched %d of %d prefix tokens",
+                        len(match.device_indices),
+                        len(key),
+                    )
                     continue
                 node = match.last_device_node
                 page_hashes = node.get_prefix_hash_values(node)
                 if len(page_hashes) != len(key) // self.page_size:
                     continue
-                accepted += backend.retain_pages(page_hashes, int(ttl_seconds))
+                retained_pages = backend.retain_pages(
+                    page_hashes, int(ttl_seconds)
+                )
+                accepted += retained_pages
+                logger.info(
+                    "Applied KV retention hint to %d/%d pages for %d seconds",
+                    retained_pages,
+                    len(page_hashes),
+                    int(ttl_seconds),
+                )
             except Exception:
                 if not self._retention_apply_failed_logged:
                     logger.warning("Failed to apply KV retention hint", exc_info=True)

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
@@ -293,7 +293,7 @@ You can enable it in any of the three supported configuration methods:
 
 When `enable_group_semantics` is set to `true`, SGLang passes Mooncake `group_ids` for physical objects derived from the same logical HiCache page. This allows Mooncake to apply group-aware metadata routing, lease refresh, and eviction behavior to related KV objects such as MHA K/V pairs, split-head shards, MLA objects, and supported sidecar objects.
 
-This option is disabled by default. It requires a Mooncake version that exposes `ReplicateConfig.group_ids`. If the installed Mooncake package does not support it, SGLang automatically falls back to the existing write path and prints a warning.
+This option is disabled by default. It requires a Mooncake version that exposes `ReplicateConfig.group_ids`. If the installed Mooncake package does not support it, SGLang automatically falls back to the existing write path and prints a warning. KV retention hints additionally require Mooncake's `retain_groups` API and HiCache's `write_through` policy. SGLang queues retention on the storage worker and bounds each request to four hints, 8,192 unique pages, and a 24-hour TTL by default. The bounds can be changed with `retention_max_hints`, `retention_max_pages`, and `retention_max_ttl_seconds` in `--hicache-storage-backend-extra-config`.
 
 Example:
 

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
@@ -293,7 +293,7 @@ You can enable it in any of the three supported configuration methods:
 
 When `enable_group_semantics` is set to `true`, SGLang passes Mooncake `group_ids` for physical objects derived from the same logical HiCache page. This allows Mooncake to apply group-aware metadata routing, lease refresh, and eviction behavior to related KV objects such as MHA K/V pairs, split-head shards, MLA objects, and supported sidecar objects.
 
-This option is disabled by default. It requires a Mooncake version that exposes `ReplicateConfig.group_ids`. If the installed Mooncake package does not support it, SGLang automatically falls back to the existing write path and prints a warning. KV retention hints additionally require Mooncake's `retain_groups` API and HiCache's `write_through` policy. SGLang queues retention on the storage worker and bounds each request to four hints, 8,192 unique pages, and a 24-hour TTL by default. The bounds can be changed with `retention_max_hints`, `retention_max_pages`, and `retention_max_ttl_seconds` in `--hicache-storage-backend-extra-config`.
+This option is disabled by default. It requires a Mooncake version that exposes `ReplicateConfig.group_ids`. If the installed Mooncake package does not support it, SGLang automatically falls back to the existing write path and prints a warning. KV retention hints additionally require Mooncake's `retain_groups` API and HiCache's `write_through` policy. SGLang queues retention on the storage worker and bounds each request to 8,192 unique pages and a 24-hour TTL by default. The bounds can be changed with `retention_max_pages` and `retention_max_ttl_seconds` in `--hicache-storage-backend-extra-config`.
 
 Example:
 

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -2,7 +2,6 @@ import ctypes
 import json
 import logging
 import os
-import threading
 import time
 import uuid
 from collections.abc import Sequence
@@ -394,14 +393,6 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 if extra_config
                 else 86400
             )
-            self.retention_renew_interval_seconds = float(
-                extra_config.get("retention_renew_interval_seconds", 1.0)
-                if extra_config
-                else 1.0
-            )
-            self._retained_pages: dict[str, float] = {}
-            self._retention_lock = threading.Lock()
-            self._last_retention_renewal = 0.0
             if self.enable_group_semantics and not self._supports_group_ids:
                 logger.warning(
                     "Mooncake group semantics is enabled, but the installed "
@@ -703,79 +694,21 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         return self._use_group_semantics
 
     def retain_pages(self, logical_keys: List[str], ttl_seconds: int) -> int:
-        """Keep existing Mooncake page groups leased until the requested deadline."""
+        """Ask Mooncake to retain existing page groups for the requested TTL."""
         if not self._can_use_group_semantics() or self.mem_pool_host.kv_buffer is None:
             return 0
         ttl_seconds = min(int(ttl_seconds), self.retention_max_ttl_seconds)
         if ttl_seconds <= 0 or self.retention_max_pages <= 0:
             return 0
-
-        deadline = time.monotonic() + ttl_seconds
-        accepted = 0
-        with self._retention_lock:
-            unique_keys = dict.fromkeys(logical_keys)
-            if len(self._retained_pages) >= self.retention_max_pages and any(
-                key not in self._retained_pages for key in unique_keys
-            ):
-                now = time.monotonic()
-                self._retained_pages = {
-                    key: expiry
-                    for key, expiry in self._retained_pages.items()
-                    if expiry > now
-                }
-            for key in unique_keys:
-                if (
-                    key not in self._retained_pages
-                    and len(self._retained_pages) >= self.retention_max_pages
-                ):
-                    continue
-                self._retained_pages[key] = max(
-                    deadline, self._retained_pages.get(key, 0.0)
-                )
-                accepted += 1
-
-        return accepted
-
-    def _retention_anchor_keys(self, logical_keys: List[str]) -> List[str]:
-        tagged = self._tag_keys(logical_keys)
-        if self.is_mla_backend:
-            return [f"{key}_{self.mla_suffix}_k" for key in tagged]
-        suffix = (
-            self.mha_suffix[0] if isinstance(self.mha_suffix, list) else self.mha_suffix
-        )
-        return [f"{key}_{suffix}_k" for key in tagged]
-
-    def renew_retained_pages(self, force: bool = False) -> int:
-        """Refresh Mooncake read leases for active retained page groups."""
-        now = time.monotonic()
-        with self._retention_lock:
-            if (
-                not force
-                and now - self._last_retention_renewal
-                < self.retention_renew_interval_seconds
-            ):
-                return 0
-            self._last_retention_renewal = now
-            self._retained_pages = {
-                key: expiry
-                for key, expiry in self._retained_pages.items()
-                if expiry > now
-            }
-            logical_keys = list(self._retained_pages)
-
-        if not logical_keys:
-            return 0
+        unique_keys = list(dict.fromkeys(logical_keys))[: self.retention_max_pages]
+        group_ids = [self._make_group_id(key) for key in self._tag_keys(unique_keys)]
         try:
             return sum(
                 result == 1
-                for result in self._batch_exist(
-                    self._retention_anchor_keys(logical_keys)
-                )
+                for result in self.store.retain_groups(group_ids, ttl_seconds * 1000)
             )
         except Exception:
-            logger.warning(
-                "Failed to renew Mooncake KV retention leases", exc_info=True
-            )
+            logger.warning("Failed to retain Mooncake KV page groups", exc_info=True)
             return 0
 
     def _make_group_id(self, logical_key: str) -> str:
@@ -1324,12 +1257,9 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
     def close(self):
         # MooncakeDistributedStore will automatically call the destructor, so
         # it is unnecessary to close it manually.
-        with self._retention_lock:
-            self._retained_pages.clear()
+        pass
 
     def clear(self) -> None:
-        with self._retention_lock:
-            self._retained_pages.clear()
         self.store.remove_all()
 
     def _put_batch_zero_copy_impl(

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -2,6 +2,7 @@ import ctypes
 import json
 import logging
 import os
+import threading
 import time
 import uuid
 from collections.abc import Sequence
@@ -385,6 +386,22 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 and self._supports_group_ids
                 and self._replicate_config_cls is not None
             )
+            self.retention_max_pages = int(
+                extra_config.get("retention_max_pages", 8192) if extra_config else 8192
+            )
+            self.retention_max_ttl_seconds = int(
+                extra_config.get("retention_max_ttl_seconds", 86400)
+                if extra_config
+                else 86400
+            )
+            self.retention_renew_interval_seconds = float(
+                extra_config.get("retention_renew_interval_seconds", 1.0)
+                if extra_config
+                else 1.0
+            )
+            self._retained_pages: dict[str, float] = {}
+            self._retention_lock = threading.Lock()
+            self._last_retention_renewal = 0.0
             if self.enable_group_semantics and not self._supports_group_ids:
                 logger.warning(
                     "Mooncake group semantics is enabled, but the installed "
@@ -684,6 +701,82 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
 
     def _can_use_group_semantics(self) -> bool:
         return self._use_group_semantics
+
+    def retain_pages(self, logical_keys: List[str], ttl_seconds: int) -> int:
+        """Keep existing Mooncake page groups leased until the requested deadline."""
+        if not self._can_use_group_semantics() or self.mem_pool_host.kv_buffer is None:
+            return 0
+        ttl_seconds = min(int(ttl_seconds), self.retention_max_ttl_seconds)
+        if ttl_seconds <= 0 or self.retention_max_pages <= 0:
+            return 0
+
+        deadline = time.monotonic() + ttl_seconds
+        accepted = 0
+        with self._retention_lock:
+            unique_keys = dict.fromkeys(logical_keys)
+            if len(self._retained_pages) >= self.retention_max_pages and any(
+                key not in self._retained_pages for key in unique_keys
+            ):
+                now = time.monotonic()
+                self._retained_pages = {
+                    key: expiry
+                    for key, expiry in self._retained_pages.items()
+                    if expiry > now
+                }
+            for key in unique_keys:
+                if (
+                    key not in self._retained_pages
+                    and len(self._retained_pages) >= self.retention_max_pages
+                ):
+                    continue
+                self._retained_pages[key] = max(
+                    deadline, self._retained_pages.get(key, 0.0)
+                )
+                accepted += 1
+
+        return accepted
+
+    def _retention_anchor_keys(self, logical_keys: List[str]) -> List[str]:
+        tagged = self._tag_keys(logical_keys)
+        if self.is_mla_backend:
+            return [f"{key}_{self.mla_suffix}_k" for key in tagged]
+        suffix = (
+            self.mha_suffix[0] if isinstance(self.mha_suffix, list) else self.mha_suffix
+        )
+        return [f"{key}_{suffix}_k" for key in tagged]
+
+    def renew_retained_pages(self, force: bool = False) -> int:
+        """Refresh Mooncake read leases for active retained page groups."""
+        now = time.monotonic()
+        with self._retention_lock:
+            if (
+                not force
+                and now - self._last_retention_renewal
+                < self.retention_renew_interval_seconds
+            ):
+                return 0
+            self._last_retention_renewal = now
+            self._retained_pages = {
+                key: expiry
+                for key, expiry in self._retained_pages.items()
+                if expiry > now
+            }
+            logical_keys = list(self._retained_pages)
+
+        if not logical_keys:
+            return 0
+        try:
+            return sum(
+                result == 1
+                for result in self._batch_exist(
+                    self._retention_anchor_keys(logical_keys)
+                )
+            )
+        except Exception:
+            logger.warning(
+                "Failed to renew Mooncake KV retention leases", exc_info=True
+            )
+            return 0
 
     def _make_group_id(self, logical_key: str) -> str:
         return f"sglang-hicache:{logical_key}"
@@ -1231,9 +1324,12 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
     def close(self):
         # MooncakeDistributedStore will automatically call the destructor, so
         # it is unnecessary to close it manually.
-        pass
+        with self._retention_lock:
+            self._retained_pages.clear()
 
     def clear(self) -> None:
+        with self._retention_lock:
+            self._retained_pages.clear()
         self.store.remove_all()
 
     def _put_batch_zero_copy_impl(

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -385,13 +385,29 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 and self._supports_group_ids
                 and self._replicate_config_cls is not None
             )
-            self.retention_max_pages = int(
-                extra_config.get("retention_max_pages", 8192) if extra_config else 8192
+            self.retention_max_pages = max(
+                0,
+                int(
+                    extra_config.get("retention_max_pages", 8192)
+                    if extra_config
+                    else 8192
+                ),
             )
-            self.retention_max_ttl_seconds = int(
-                extra_config.get("retention_max_ttl_seconds", 86400)
-                if extra_config
-                else 86400
+            self.retention_max_hints = max(
+                0,
+                int(
+                    extra_config.get("retention_max_hints", 4)
+                    if extra_config
+                    else 4
+                ),
+            )
+            self.retention_max_ttl_seconds = max(
+                0,
+                int(
+                    extra_config.get("retention_max_ttl_seconds", 86400)
+                    if extra_config
+                    else 86400
+                ),
             )
             if self.enable_group_semantics and not self._supports_group_ids:
                 logger.warning(
@@ -693,9 +709,12 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
     def _can_use_group_semantics(self) -> bool:
         return self._use_group_semantics
 
+    def _can_retain_groups(self) -> bool:
+        return self._can_use_group_semantics() and hasattr(self.store, "retain_groups")
+
     def retain_pages(self, logical_keys: List[str], ttl_seconds: int) -> int:
         """Ask Mooncake to retain existing page groups for the requested TTL."""
-        if not self._can_use_group_semantics() or self.mem_pool_host.kv_buffer is None:
+        if not self._can_retain_groups() or self.mem_pool_host.kv_buffer is None:
             return 0
         ttl_seconds = min(int(ttl_seconds), self.retention_max_ttl_seconds)
         if ttl_seconds <= 0 or self.retention_max_pages <= 0:

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -703,10 +703,15 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         unique_keys = list(dict.fromkeys(logical_keys))[: self.retention_max_pages]
         group_ids = [self._make_group_id(key) for key in self._tag_keys(unique_keys)]
         try:
-            return sum(
-                result == 1
-                for result in self.store.retain_groups(group_ids, ttl_seconds * 1000)
+            results = self.store.retain_groups(group_ids, ttl_seconds * 1000)
+            accepted = sum(result == 1 for result in results)
+            logger.info(
+                "Mooncake KV retention accepted %d/%d page groups for %d seconds",
+                accepted,
+                len(group_ids),
+                ttl_seconds,
             )
+            return accepted
         except Exception:
             logger.warning("Failed to retain Mooncake KV page groups", exc_info=True)
             return 0

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -393,14 +393,6 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                     else 8192
                 ),
             )
-            self.retention_max_hints = max(
-                0,
-                int(
-                    extra_config.get("retention_max_hints", 4)
-                    if extra_config
-                    else 4
-                ),
-            )
             self.retention_max_ttl_seconds = max(
                 0,
                 int(

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -313,6 +313,7 @@ class Session:
             extra_key=req.extra_key,
             http_worker_ipc=req.http_worker_ipc,
             time_stats=req.time_stats,
+            kv_hints=req.kv_hints,
         )
         if last_req is not None:
             new_req.multimodal_inputs = last_req.multimodal_inputs

--- a/test/registered/unit/managers/data/kv_hint_envelope.json
+++ b/test/registered/unit/managers/data/kv_hint_envelope.json
@@ -1,9 +1,4 @@
 {
   "token_ids": [11, 22, 33, 44],
-  "kv_hints": {
-    "retention": [
-      {"prefix_tokens": 2, "ttl_seconds": 300},
-      {"prefix_tokens": 4, "ttl_seconds": 3600}
-    ]
-  }
+  "kv_hints": {"retain_full_prompt": {"ttl_seconds": 3600}}
 }

--- a/test/registered/unit/managers/data/kv_hint_envelope.json
+++ b/test/registered/unit/managers/data/kv_hint_envelope.json
@@ -1,0 +1,9 @@
+{
+  "token_ids": [11, 22, 33, 44],
+  "kv_hints": {
+    "retention": [
+      {"prefix_tokens": 2, "ttl_seconds": 300},
+      {"prefix_tokens": 4, "ttl_seconds": 3600}
+    ]
+  }
+}

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1,7 +1,21 @@
 import copy
+import json
 import unittest
+from array import array
+from pathlib import Path
 
-from sglang.srt.managers.io_struct import GenerateReqInput
+import msgspec
+from pydantic import TypeAdapter
+
+from sglang.srt.managers.io_struct import (
+    GenerateReqInput,
+    KvHintEnvelope,
+    KvRetentionHint,
+    TokenizedGenerateReqInput,
+    _msgpack_decoder,
+    _msgpack_encoder,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import (
     register_amd_ci,
     register_cpu_ci,
@@ -50,6 +64,73 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
         # Check modalities
         self.assertEqual(req.modalities, ["image", "image"])
+
+    def test_kv_hints_match_cross_language_fixture(self):
+        fixture_path = Path(__file__).with_name("data") / "kv_hint_envelope.json"
+        fixture = json.loads(fixture_path.read_text())
+        hints = msgspec.convert(fixture["kv_hints"], type=KvHintEnvelope)
+
+        self.assertEqual(
+            hints.retention,
+            [
+                KvRetentionHint(prefix_tokens=2, ttl_seconds=300),
+                KvRetentionHint(prefix_tokens=4, ttl_seconds=3600),
+            ],
+        )
+
+        req = GenerateReqInput(
+            input_ids=[fixture["token_ids"], fixture["token_ids"]],
+            sampling_params=[{}, {}],
+            kv_hints=hints,
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req[0].kv_hints, hints)
+        self.assertEqual(req[1].kv_hints, hints)
+
+        parsed = TypeAdapter(GenerateReqInput).validate_python(
+            {"input_ids": fixture["token_ids"], "kv_hints": fixture["kv_hints"]}
+        )
+        self.assertIsInstance(parsed.kv_hints, KvHintEnvelope)
+
+    def test_kv_hints_follow_parallel_sampling_expansion(self):
+        first = KvHintEnvelope(
+            retention=[KvRetentionHint(prefix_tokens=2, ttl_seconds=300)]
+        )
+        second = KvHintEnvelope(
+            retention=[KvRetentionHint(prefix_tokens=4, ttl_seconds=3600)]
+        )
+        req = GenerateReqInput(
+            input_ids=[[1, 2], [3, 4]],
+            sampling_params={"n": 2},
+            kv_hints=[first, second],
+        )
+
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req.kv_hints, [first, second, first, second])
+
+    def test_tokenized_kv_hints_survive_ipc_round_trip(self):
+        hints = KvHintEnvelope(
+            retention=[KvRetentionHint(prefix_tokens=2, ttl_seconds=300)]
+        )
+        req = TokenizedGenerateReqInput(
+            input_text="",
+            input_ids=array("q", [1, 2]),
+            input_embeds=None,
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            return_logprob=False,
+            logprob_start_len=0,
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            stream=False,
+            kv_hints=hints,
+        )
+
+        decoded = _msgpack_decoder.decode(_msgpack_encoder.encode(req))
+
+        self.assertEqual(decoded.kv_hints, hints)
 
     def test_list_of_images_to_list_of_lists(self):
         """Test that a list of images is converted to a list of single-image lists."""

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -71,11 +71,8 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         hints = msgspec.convert(fixture["kv_hints"], type=KvHintEnvelope)
 
         self.assertEqual(
-            hints.retention,
-            [
-                KvRetentionHint(prefix_tokens=2, ttl_seconds=300),
-                KvRetentionHint(prefix_tokens=4, ttl_seconds=3600),
-            ],
+            hints.retain_full_prompt,
+            KvRetentionHint(ttl_seconds=3600),
         )
 
         req = GenerateReqInput(
@@ -93,12 +90,8 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertIsInstance(parsed.kv_hints, KvHintEnvelope)
 
     def test_kv_hints_follow_parallel_sampling_expansion(self):
-        first = KvHintEnvelope(
-            retention=[KvRetentionHint(prefix_tokens=2, ttl_seconds=300)]
-        )
-        second = KvHintEnvelope(
-            retention=[KvRetentionHint(prefix_tokens=4, ttl_seconds=3600)]
-        )
+        first = KvHintEnvelope(retain_full_prompt=KvRetentionHint(ttl_seconds=300))
+        second = KvHintEnvelope(retain_full_prompt=KvRetentionHint(ttl_seconds=3600))
         req = GenerateReqInput(
             input_ids=[[1, 2], [3, 4]],
             sampling_params={"n": 2},
@@ -110,9 +103,7 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(req.kv_hints, [first, second, first, second])
 
     def test_tokenized_kv_hints_survive_ipc_round_trip(self):
-        hints = KvHintEnvelope(
-            retention=[KvRetentionHint(prefix_tokens=2, ttl_seconds=300)]
-        )
+        hints = KvHintEnvelope(retain_full_prompt=KvRetentionHint(ttl_seconds=300))
         req = TokenizedGenerateReqInput(
             input_text="",
             input_ids=array("q", [1, 2]),

--- a/test/registered/unit/mem_cache/test_kv_retention_hints.py
+++ b/test/registered/unit/mem_cache/test_kv_retention_hints.py
@@ -17,7 +17,6 @@ class TestKvRetentionHints(CustomTestCase):
     def test_committed_prefix_is_page_aligned_and_uses_tree_hashes(self):
         backend = SimpleNamespace(
             _can_retain_groups=lambda: True,
-            retention_max_hints=4,
             retention_max_pages=8192,
             retention_max_ttl_seconds=86400,
         )
@@ -44,7 +43,7 @@ class TestKvRetentionHints(CustomTestCase):
             origin_input_ids=array("q", [11, 22, 33, 44, 55]),
             extra_key="tenant",
             kv_hints=KvHintEnvelope(
-                retention=[KvRetentionHint(prefix_tokens=5, ttl_seconds=300)]
+                retain_full_prompt=KvRetentionHint(ttl_seconds=300)
             ),
         )
 
@@ -63,7 +62,6 @@ class TestKvRetentionHints(CustomTestCase):
     def test_retention_is_bounded_across_the_request(self):
         backend = SimpleNamespace(
             _can_retain_groups=lambda: True,
-            retention_max_hints=1,
             retention_max_pages=1,
             retention_max_ttl_seconds=15,
         )
@@ -89,12 +87,7 @@ class TestKvRetentionHints(CustomTestCase):
         req = SimpleNamespace(
             origin_input_ids=array("q", [11, 22, 33, 44]),
             extra_key=None,
-            kv_hints=KvHintEnvelope(
-                retention=[
-                    KvRetentionHint(prefix_tokens=4, ttl_seconds=30),
-                    KvRetentionHint(prefix_tokens=4, ttl_seconds=10),
-                ]
-            ),
+            kv_hints=KvHintEnvelope(retain_full_prompt=KvRetentionHint(ttl_seconds=30)),
         )
 
         self.assertEqual(cache.apply_kv_hints(req), 1)
@@ -117,9 +110,7 @@ class TestKvRetentionHints(CustomTestCase):
 
     def test_unsupported_prefix_cache_warns_once(self):
         req = SimpleNamespace(
-            kv_hints=KvHintEnvelope(
-                retention=[KvRetentionHint(prefix_tokens=2, ttl_seconds=300)]
-            )
+            kv_hints=KvHintEnvelope(retain_full_prompt=KvRetentionHint(ttl_seconds=300))
         )
         common._unsupported_cache_kv_hints_logged = False
 

--- a/test/registered/unit/mem_cache/test_kv_retention_hints.py
+++ b/test/registered/unit/mem_cache/test_kv_retention_hints.py
@@ -1,0 +1,49 @@
+from array import array
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from sglang.srt.managers.io_struct import KvHintEnvelope, KvRetentionHint
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestKvRetentionHints(CustomTestCase):
+    def test_committed_prefix_is_page_aligned_and_uses_tree_hashes(self):
+        backend = SimpleNamespace(
+            _can_use_group_semantics=lambda: True,
+            retain_pages=Mock(return_value=2),
+        )
+        cache = object.__new__(HiRadixCache)
+        cache.page_size = 2
+        cache.is_eagle = False
+        cache.enable_storage = True
+        cache._retention_unsupported_logged = False
+        cache.cache_controller = SimpleNamespace(
+            storage_backend=backend,
+            storage_backend_type="mooncake",
+            write_policy="write_through",
+        )
+        node = SimpleNamespace(get_prefix_hash_values=lambda _: ["page0", "page1"])
+        cache.match_prefix = Mock(
+            return_value=SimpleNamespace(
+                device_indices=[0, 1, 2, 3], last_device_node=node
+            )
+        )
+        req = SimpleNamespace(
+            origin_input_ids=array("q", [11, 22, 33, 44, 55]),
+            extra_key="tenant",
+            kv_hints=KvHintEnvelope(
+                retention=[KvRetentionHint(prefix_tokens=5, ttl_seconds=300)]
+            ),
+        )
+
+        accepted = cache.apply_kv_hints(req)
+
+        self.assertEqual(accepted, 2)
+        backend.retain_pages.assert_called_once_with(["page0", "page1"], 300)
+        matched_key = cache.match_prefix.call_args.args[0].key
+        self.assertEqual(list(matched_key.token_ids), [11, 22, 33, 44])
+        self.assertEqual(matched_key.extra_key, "tenant")

--- a/test/registered/unit/mem_cache/test_kv_retention_hints.py
+++ b/test/registered/unit/mem_cache/test_kv_retention_hints.py
@@ -1,8 +1,11 @@
 from array import array
+from queue import Queue
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+from sglang.srt.managers.cache_controller import HiCacheController, RetentionOperation
 from sglang.srt.managers.io_struct import KvHintEnvelope, KvRetentionHint
+from sglang.srt.mem_cache import common
 from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -13,18 +16,23 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 class TestKvRetentionHints(CustomTestCase):
     def test_committed_prefix_is_page_aligned_and_uses_tree_hashes(self):
         backend = SimpleNamespace(
-            _can_use_group_semantics=lambda: True,
-            retain_pages=Mock(return_value=2),
+            _can_retain_groups=lambda: True,
+            retention_max_hints=4,
+            retention_max_pages=8192,
+            retention_max_ttl_seconds=86400,
         )
         cache = object.__new__(HiRadixCache)
         cache.page_size = 2
         cache.is_eagle = False
         cache.enable_storage = True
         cache._retention_unsupported_logged = False
+        cache._retention_apply_failed_logged = False
+        cache._retention_bounded_logged = False
         cache.cache_controller = SimpleNamespace(
             storage_backend=backend,
             storage_backend_type="mooncake",
             write_policy="write_through",
+            retain_storage=Mock(),
         )
         node = SimpleNamespace(get_prefix_hash_values=lambda _: ["page0", "page1"])
         cache.match_prefix = Mock(
@@ -40,10 +48,83 @@ class TestKvRetentionHints(CustomTestCase):
             ),
         )
 
-        accepted = cache.apply_kv_hints(req)
+        queued = cache.apply_kv_hints(req)
 
-        self.assertEqual(accepted, 2)
-        backend.retain_pages.assert_called_once_with(["page0", "page1"], 300)
+        self.assertEqual(queued, 2)
+        cache.cache_controller.retain_storage.assert_called_once_with(
+            ["page0", "page1"], 300
+        )
+        self.assertEqual(cache.apply_kv_hints(req), 0)
+        cache.cache_controller.retain_storage.assert_called_once()
         matched_key = cache.match_prefix.call_args.args[0].key
         self.assertEqual(list(matched_key.token_ids), [11, 22, 33, 44])
         self.assertEqual(matched_key.extra_key, "tenant")
+
+    def test_retention_is_bounded_across_the_request(self):
+        backend = SimpleNamespace(
+            _can_retain_groups=lambda: True,
+            retention_max_hints=1,
+            retention_max_pages=1,
+            retention_max_ttl_seconds=15,
+        )
+        cache = object.__new__(HiRadixCache)
+        cache.page_size = 2
+        cache.is_eagle = False
+        cache.enable_storage = True
+        cache._retention_unsupported_logged = False
+        cache._retention_apply_failed_logged = False
+        cache._retention_bounded_logged = False
+        cache.cache_controller = SimpleNamespace(
+            storage_backend=backend,
+            storage_backend_type="mooncake",
+            write_policy="write_through",
+            retain_storage=Mock(),
+        )
+        node = SimpleNamespace(get_prefix_hash_values=lambda _: ["page0", "page1"])
+        cache.match_prefix = Mock(
+            return_value=SimpleNamespace(
+                device_indices=[0, 1, 2, 3], last_device_node=node
+            )
+        )
+        req = SimpleNamespace(
+            origin_input_ids=array("q", [11, 22, 33, 44]),
+            extra_key=None,
+            kv_hints=KvHintEnvelope(
+                retention=[
+                    KvRetentionHint(prefix_tokens=4, ttl_seconds=30),
+                    KvRetentionHint(prefix_tokens=4, ttl_seconds=10),
+                ]
+            ),
+        )
+
+        self.assertEqual(cache.apply_kv_hints(req), 1)
+        cache.cache_controller.retain_storage.assert_called_once_with(["page0"], 15)
+
+    def test_controller_dispatches_retention_on_backup_worker(self):
+        controller = object.__new__(HiCacheController)
+        controller.backup_queue = Queue()
+        controller.storage_backend = SimpleNamespace(retain_pages=Mock())
+        controller.storage_stop_event = Mock()
+        controller.storage_stop_event.is_set.side_effect = [False, True]
+
+        controller.retain_storage(["page0"], 300)
+
+        operation = controller.backup_queue.queue[0]
+        self.assertIsInstance(operation, RetentionOperation)
+        controller.storage_backend.retain_pages.assert_not_called()
+        controller.backup_thread_func()
+        controller.storage_backend.retain_pages.assert_called_once_with(["page0"], 300)
+
+    def test_unsupported_prefix_cache_warns_once(self):
+        req = SimpleNamespace(
+            kv_hints=KvHintEnvelope(
+                retention=[KvRetentionHint(prefix_tokens=2, ttl_seconds=300)]
+            )
+        )
+        common._unsupported_cache_kv_hints_logged = False
+
+        with patch.object(common.logger, "warning") as warning:
+            common.maybe_apply_kv_hints(req, object())
+            common.maybe_apply_kv_hints(req, object())
+
+        warning.assert_called_once()

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -80,6 +80,7 @@ def _fake_store_class():
         def __init__(self):
             self.batch_put_calls = []
             self.batch_exist_calls = []
+            self.retain_group_calls = []
             self.existing_keys = set()
             self.objects = {}
             type(self).instances.append(self)
@@ -103,6 +104,10 @@ def _fake_store_class():
         def batch_is_exist(self, keys):
             self.batch_exist_calls.append(list(keys))
             return [1 if key in self.existing_keys else 0 for key in keys]
+
+        def retain_groups(self, group_ids, ttl_ms):
+            self.retain_group_calls.append((list(group_ids), ttl_ms))
+            return [1] * len(group_ids)
 
         def batch_put_from(self, keys, ptrs, sizes, *args):
             self.batch_put_calls.append(
@@ -273,29 +278,29 @@ def _make_store(
 
 
 class TestMooncakeGroupSemantics(CustomTestCase):
-    def test_retention_renews_tagged_group_anchor(self):
+    def test_retention_delegates_tagged_groups_and_ttl_to_mooncake(self):
         store, fake_store = _make_store(extra_backend_tag="tag")
         store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
-        fake_store.existing_keys.add("tag_page0_0_k")
 
         accepted = store.retain_pages(["page0"], ttl_seconds=300)
-        renewed = store.renew_retained_pages(force=True)
 
         self.assertEqual(accepted, 1)
-        self.assertEqual(renewed, 1)
-        self.assertEqual(fake_store.batch_exist_calls[-1], ["tag_page0_0_k"])
-        self.assertIn("page0", store._retained_pages)
+        self.assertEqual(
+            fake_store.retain_group_calls[-1],
+            (["sglang-hicache:tag_page0"], 300_000),
+        )
 
-    def test_retention_is_bounded_and_uses_max_deadline(self):
-        store, _ = _make_store()
+    def test_retention_request_is_bounded_and_ttl_is_capped(self):
+        store, fake_store = _make_store()
         store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
         store.retention_max_pages = 1
+        store.retention_max_ttl_seconds = 15
 
-        self.assertEqual(store.retain_pages(["page0"], ttl_seconds=10), 1)
-        first_deadline = store._retained_pages["page0"]
-        self.assertEqual(store.retain_pages(["page1"], ttl_seconds=10), 0)
-        self.assertEqual(store.retain_pages(["page0"], ttl_seconds=20), 1)
-        self.assertGreater(store._retained_pages["page0"], first_deadline)
+        self.assertEqual(store.retain_pages(["page0", "page1"], ttl_seconds=20), 1)
+        self.assertEqual(
+            fake_store.retain_group_calls[-1],
+            (["sglang-hicache:page0"], 15_000),
+        )
 
     def test_group_id_detection_uses_class_attribute_without_instantiating(self):
         fake_store_cls = _fake_store_class()

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -79,6 +79,7 @@ def _fake_store_class():
 
         def __init__(self):
             self.batch_put_calls = []
+            self.batch_exist_calls = []
             self.existing_keys = set()
             self.objects = {}
             type(self).instances.append(self)
@@ -100,6 +101,7 @@ def _fake_store_class():
             return self.objects.get(key)
 
         def batch_is_exist(self, keys):
+            self.batch_exist_calls.append(list(keys))
             return [1 if key in self.existing_keys else 0 for key in keys]
 
         def batch_put_from(self, keys, ptrs, sizes, *args):
@@ -271,6 +273,30 @@ def _make_store(
 
 
 class TestMooncakeGroupSemantics(CustomTestCase):
+    def test_retention_renews_tagged_group_anchor(self):
+        store, fake_store = _make_store(extra_backend_tag="tag")
+        store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
+        fake_store.existing_keys.add("tag_page0_0_k")
+
+        accepted = store.retain_pages(["page0"], ttl_seconds=300)
+        renewed = store.renew_retained_pages(force=True)
+
+        self.assertEqual(accepted, 1)
+        self.assertEqual(renewed, 1)
+        self.assertEqual(fake_store.batch_exist_calls[-1], ["tag_page0_0_k"])
+        self.assertIn("page0", store._retained_pages)
+
+    def test_retention_is_bounded_and_uses_max_deadline(self):
+        store, _ = _make_store()
+        store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
+        store.retention_max_pages = 1
+
+        self.assertEqual(store.retain_pages(["page0"], ttl_seconds=10), 1)
+        first_deadline = store._retained_pages["page0"]
+        self.assertEqual(store.retain_pages(["page1"], ttl_seconds=10), 0)
+        self.assertEqual(store.retain_pages(["page0"], ttl_seconds=20), 1)
+        self.assertGreater(store._retained_pages["page0"], first_deadline)
+
     def test_group_id_detection_uses_class_attribute_without_instantiating(self):
         fake_store_cls = _fake_store_class()
         with patch.dict(

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -302,6 +302,14 @@ class TestMooncakeGroupSemantics(CustomTestCase):
             (["sglang-hicache:page0"], 15_000),
         )
 
+    def test_retention_requires_retain_groups_capability(self):
+        store, fake_store = _make_store()
+        store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
+        delattr(type(fake_store), "retain_groups")
+
+        self.assertFalse(store._can_retain_groups())
+        self.assertEqual(store.retain_pages(["page0"], ttl_seconds=300), 0)
+
     def test_group_id_detection_uses_class_attribute_without_instantiating(self):
         fake_store_cls = _fake_store_class()
         with patch.dict(


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This draft adds a provider-neutral `kv_hints` request envelope and applies full-prompt retention to committed HiCache pages in Mooncake L3. It lets Dynamo request bounded prompt-KV survival without pinning GPU/host cache or moving routing, scheduling, and eviction policy out of SGLang.

CLOSES: DYN-3309

Companion PRs: [Dynamo #11534](https://github.com/ai-dynamo/dynamo/pull/11534) and [Mooncake #2835](https://github.com/kvcache-ai/Mooncake/pull/2835). The cross-layer design is tracked in [SGLang RFC #27574](https://github.com/sgl-project/sglang/issues/27574).

### How This Was Implemented
- Added `KvHintEnvelope { retain_full_prompt }` to engine, tokenizer-manager, scheduler, session, and disaggregated request plumbing with a cross-language JSON fixture.
- Resolves the page-aligned full prompt against committed HiRadix nodes and uses their exact tagged Mooncake page hashes.
- Reuses HiCache's storage-worker queue so Mooncake metadata I/O never blocks the scheduler thread.
- Requires HiCache `write_through`, Mooncake group semantics, and `retain_groups`; unsupported configurations warn once and inference continues.
- Bounds each request to 8,192 unique pages and a 24-hour TTL by default, with backend-extra-config overrides.

<details>
<summary>Walkthrough</summary>

#### Mental model

The hint expresses retention intent only. SGLang remains responsible for radix insertion and page identity, while Mooncake owns the L3 lease and eviction protection.

```mermaid
flowchart LR
    A["Engine request + KvHintEnvelope"] --> B["Tokenizer manager and scheduler Req"]
    B --> C["Normal HiRadix insertion"]
    C --> D["Resolve committed page hashes"]
    D --> E["Queue RetentionOperation"]
    E --> F["HiCache storage worker"]
    F --> G["Mooncake retain_groups(group_ids, ttl)"]
```

#### State and ordering

Retention is attempted only after ordinary unfinished or finished radix insertion. The full prompt is rounded down to the HiCache page size, matched back to a single committed prefix, and converted to the page hashes already used by Mooncake group publication.

Each request tracks the pages and maximum TTL already applied, so unfinished/final cache events do not repeatedly renew the same lease. Nested/shared pages are deduplicated and a later shorter TTL cannot reduce an earlier request-local TTL.

#### Request lifecycle

1. `GenerateReqInput` validates and normalizes the provider-neutral envelope, including batch and parallel-sampling expansion.
2. The hint survives tokenizer IPC, disaggregated encode/decode plumbing, and session request construction.
3. After radix insertion, `HiRadixCache.apply_kv_hints` verifies that the complete page-aligned prompt is committed.
4. A `RetentionOperation` enters the existing storage backup queue; the storage worker calls Mooncake `retain_groups` asynchronously.
5. Missing capability, partial acceptance, or Mooncake failure affects retention only; generation remains fail-open and logs the outcome.

#### Boundaries and limitations

- This retains L3 objects only. GPU L1 and host L2 remain normally evictable.
- Only classic HiRadix + Mooncake `write_through` is supported; Unified/Hybrid/Mamba caches warn and ignore the hint.
- There is no prefetch, demote, share, release, routing, or scheduler-priority behavior in this PR.
- Bounds are per request, not a global byte-aware or tenant-fair retention budget.
- A Mooncake release containing `retain_groups` is required before this can leave draft.

</details>

### Validation
- `.venv/bin/python -m pytest -q test/registered/unit/managers/test_io_struct.py test/registered/unit/mem_cache/test_kv_retention_hints.py test/registered/unit/mem_cache/test_mooncake_group_semantics.py` — 43 passed.
- `pre-commit run ruff --files <changed Python files>` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Two-worker MiniMax M2.7 TP4 H100 validation through Dynamo, real Codex, real Claude Code, Mooncake, compressed `DYN_REQUEST_TRACE`, and Tachometer — passed functional retention attribution.

### Benchmark Results

The final A/B seeded each client on one worker, drove Mooncake eviction with 70 × 16,384-token pressure requests, flushed both workers' local caches, then resumed each session on the other worker. Every final probe had `router_cached=0`, isolating request-time Mooncake restoration.

| Probe | Control L3 tokens | Retained L3 tokens | Retention TTL | Probe latency delta |
|---|---:|---:|---:|---:|
| Codex | 4,640 shared-prefix tokens | 20,800 tokens | 30 minutes | +23.1% |
| Claude Code | 0 tokens | 13,600 tokens | 1 hour | +34.0% |

| Pressure outcome | Result |
|---|---:|
| Completed pressure requests | 70 |
| Total pressure input | 1,146,881 tokens |
| Mooncake eviction | 144,904 keys / 34.27 GiB |
| Mooncake accepted retained groups | Codex 1,300/1,300; Claude 850/850 |

The mechanism survived eviction, but it is not yet a latency win on this single-node H100 topology: Mooncake materialization was slower than recomputing these prefixes. This PR should remain a draft until the dependency and L3 materialization-cost follow-ups are resolved.
<!-- codex-pr-description:end -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29104181095](https://github.com/sgl-project/sglang/actions/runs/29104181095)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29104180864](https://github.com/sgl-project/sglang/actions/runs/29104180864)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->