### PR TITLE
fix: add WebSocket auth check to prevent API key bypass (CVE-2026-????)

### DIFF
--- a/python/sglang/srt/utils/auth.py
+++ b/python/sglang/srt/utils/auth.py
@@ -168,6 +168,23 @@ def add_api_key_middleware(
 
         async def __call__(self, scope, receive, send):
             if scope["type"] != "http":
+                if scope["type"] == "websocket":
+                    headers = dict(scope.get("headers", []))
+                    authz = headers.get(b"authorization", b"").decode()
+                    level = _get_auth_level_from_app_and_scope(
+                        self.fastapi_app, scope
+                    )
+                    decision = decide_request_auth(
+                        method="GET",
+                        path=scope.get("path", ""),
+                        authorization_header=authz or None,
+                        api_key=self.api_key,
+                        admin_api_key=self.admin_api_key,
+                        auth_level=level,
+                    )
+                    if not decision.allowed:
+                        await send({"type": "websocket.close", "code": 4001})
+                        return
                 await self.app(scope, receive, send)
                 return
 


### PR DESCRIPTION
The ASGI auth middleware (auth.py:170) explicitly skipped all non-HTTP connections, leaving WebSocket endpoints like /v1/realtime completely unauthenticated even when --api-key is configured. Any WebSocket client can connect to the realtime transcription endpoint without authentication.

This fix extracts the Authorization header from the WebSocket handshake request and applies the same auth decision as HTTP requests. Unauthorized connections are rejected with WebSocket close code 4001.

Fixed: python/sglang/srt/utils/auth.py

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29111648672](https://github.com/sgl-project/sglang/actions/runs/29111648672)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29111648304](https://github.com/sgl-project/sglang/actions/runs/29111648304)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->