### PR TITLE
[Feature] Add sjf schedule policy: shortest-job-first with aging for prefill-only

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 import os
 import random
+import time
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from enum import Enum, auto
@@ -144,6 +145,12 @@ def match_prefix_for_req(
     return match_result
 
 
+# Aging rate for the "sjf" policy: tokens of job-length credit granted per
+# second of queue wait. At 1024 tok/s an 8192-token request outranks a fresh
+# 128-token request after ~8 seconds of waiting.
+SJF_AGING_TOKENS_PER_S = 1024.0
+
+
 class CacheAwarePolicy(Enum):
     """Scheduling policies that are aware of the tree cache."""
 
@@ -158,6 +165,7 @@ class CacheAgnosticPolicy(Enum):
     LOF = "lof"  # longest output first
     RANDOM = "random"
     ROUTING_KEY = "routing-key"  # prioritize by routing key frequency in running batch
+    SJF = "sjf"  # shortest job first (uncached input length) with aging
 
 
 class SchedulePolicy:
@@ -231,6 +239,11 @@ class SchedulePolicy:
             elif policy == CacheAgnosticPolicy.ROUTING_KEY:
                 if running_batch is not None:
                     SchedulePolicy._sort_by_routing_key(waiting_queue, running_batch)
+            elif policy == CacheAgnosticPolicy.SJF:
+                SchedulePolicy._sort_by_shortest_job(
+                    waiting_queue,
+                    get_server_args().sjf_aging_tokens_per_s,
+                )
             else:
                 raise ValueError(f"Unknown CacheAgnostic Policy: {policy=}")
 
@@ -359,6 +372,27 @@ class SchedulePolicy:
             )
         else:
             waiting_queue.sort(key=lambda x: -x.sampling_params.max_new_tokens)
+
+    @staticmethod
+    def _sort_by_shortest_job(
+        waiting_queue: List[Req],
+        aging_tokens_per_s: float = SJF_AGING_TOKENS_PER_S,
+    ) -> None:
+        """Shortest-job-first with aging for prefill-only workloads.
+
+        Sorts by uncached input length (the service-time proxy) minus an
+        aging credit per waited second, so sufficiently old long requests
+        overtake fresh short ones instead of starving.
+        """
+        now = time.perf_counter()
+
+        def effective_job_len(req: Req) -> float:
+            uncached = len(req.origin_input_ids) - req.num_matched_prefix_tokens
+            entry = req.time_stats.wait_queue_entry_time
+            waited_s = (now - entry) if entry > 0 else 0.0
+            return uncached - aging_tokens_per_s * waited_s
+
+        waiting_queue.sort(key=effective_job_len)
 
     @staticmethod
     def _sort_randomly(waiting_queue: List[Req]) -> None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -712,9 +712,14 @@ class ServerArgs:
                 "lof",
                 "priority",
                 "routing-key",
+                "sjf",
             ],
         ),
     ] = "fcfs"
+    sjf_aging_tokens_per_s: A[
+        float,
+        "Aging rate for --schedule-policy sjf: tokens of job-length credit granted per second of queue wait. Higher values approach FCFS; lower values approach pure shortest-job-first.",
+    ] = 1024.0
     enable_priority_scheduling: A[
         bool,
         "Enable priority scheduling. Requests with higher priority integer values will be scheduled first by default.",

--- a/test/registered/unit/managers/test_schedule_policy_sjf.py
+++ b/test/registered/unit/managers/test_schedule_policy_sjf.py
@@ -1,0 +1,78 @@
+"""Unit tests for the sjf (shortest-job-first with aging) schedule policy."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers.schedule_policy import SchedulePolicy
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _req(rid, input_len, matched=0, entry_time=0.0):
+    return SimpleNamespace(
+        rid=rid,
+        origin_input_ids=list(range(input_len)),
+        num_matched_prefix_tokens=matched,
+        time_stats=SimpleNamespace(wait_queue_entry_time=entry_time),
+    )
+
+
+NOW = 10_000.0
+PERF_COUNTER = "sglang.srt.managers.schedule_policy.time.perf_counter"
+
+
+class TestSortByShortestJob(CustomTestCase):
+    def test_orders_by_input_length(self):
+        queue = [_req("long", 8192), _req("short", 50), _req("mid", 512)]
+        with patch(PERF_COUNTER, return_value=NOW):
+            SchedulePolicy._sort_by_shortest_job(queue)
+
+        self.assertEqual([r.rid for r in queue], ["short", "mid", "long"])
+
+    def test_uncached_length_is_the_job_size(self):
+        # 8192 input with 8100 cached beats a fully-uncached 512 request
+        queue = [_req("cold-512", 512), _req("warm-8192", 8192, matched=8100)]
+        with patch(PERF_COUNTER, return_value=NOW):
+            SchedulePolicy._sort_by_shortest_job(queue)
+
+        self.assertEqual([r.rid for r in queue], ["warm-8192", "cold-512"])
+
+    def test_aging_prevents_starvation(self):
+        # an 8192-token request that has waited 10s outranks a fresh
+        # 50-token request (8192 - 1024*10 < 50)
+        queue = [
+            _req("fresh-short", 50, entry_time=NOW),
+            _req("old-long", 8192, entry_time=NOW - 10.0),
+        ]
+        with patch(PERF_COUNTER, return_value=NOW):
+            SchedulePolicy._sort_by_shortest_job(queue)
+
+        self.assertEqual([r.rid for r in queue], ["old-long", "fresh-short"])
+
+    def test_aging_rate_parameter_scales_credit(self):
+        # at 8192 tok/s aging, a 1s-old long request already overtakes
+        queue = [
+            _req("fresh-short", 50, entry_time=NOW),
+            _req("old-long", 8192, entry_time=NOW - 1.001),
+        ]
+        with patch(PERF_COUNTER, return_value=NOW):
+            SchedulePolicy._sort_by_shortest_job(queue, aging_tokens_per_s=8192.0)
+
+        self.assertEqual([r.rid for r in queue], ["old-long", "fresh-short"])
+
+    def test_unset_entry_time_gets_no_aging_credit(self):
+        queue = [
+            _req("unset-long", 8192, entry_time=0.0),
+            _req("short", 50, entry_time=NOW),
+        ]
+        with patch(PERF_COUNTER, return_value=NOW):
+            SchedulePolicy._sort_by_shortest_job(queue)
+
+        self.assertEqual([r.rid for r in queue], ["short", "unset-long"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_server_args_cli_metadata.py
+++ b/test/registered/unit/test_server_args_cli_metadata.py
@@ -111,7 +111,16 @@ class TestServerArgsMigratedCliMetadata(CustomTestCase):
         )
         self.assertEqual(
             self.actions_by_option["--schedule-policy"].choices,
-            ["lpm", "random", "fcfs", "dfs-weight", "lof", "priority", "routing-key"],
+            [
+                "lpm",
+                "random",
+                "fcfs",
+                "dfs-weight",
+                "lof",
+                "priority",
+                "routing-key",
+                "sjf",
+            ],
         )
         self.assertEqual(
             self.actions_by_option["--load-balance-method"].choices,


### PR DESCRIPTION
## Motivation

For prefill-only workloads (embeddings, scoring, reranking) a request's service time is a known function of its uncached input length — there is no output-length uncertainty. Under FCFS, mixed-length traffic makes short requests pay a head-of-line penalty behind long prefills; queueing theory predicts the penalty grows with service-time heterogeneity (M/G/1), and length-aware prefill scheduling is an active research direction (LAPS, PrefillOnly's JCT scheduling, Multi-Bin batching).

Measured on Qwen3-Embedding-0.6B (A6000) with a mixed-length workload (equal request counts at 128/512/2048/8192 tokens, Poisson arrivals): at 1x saturation, queueing delay is uniform across length buckets (~385-477 ms) while service time spans 23-194 ms — a 128-token request waits ~17x its own service time (p99 65x).

Related roadmap: #15344 (prefill-only performance / mixed-length behavior).

## Modifications

`--schedule-policy sjf`: sort the waiting queue by

```text
effective_len = (input_len - num_matched_prefix_tokens)
                - sjf_aging_tokens_per_s * time_waited
```

- `schedule_policy.py`: `CacheAgnosticPolicy.SJF` + `_sort_by_shortest_job()` (same shape as the existing cache-agnostic sorters).
- `server_args.py`: `sjf` added to `--schedule-policy` choices; new `--sjf-aging-tokens-per-s` (default 1024 — higher approaches FCFS, lower approaches pure shortest-job-first).

Design notes:

- Uncached length is the job-cost proxy (PrefillOnly reports 0.987 correlation with actual JCT); `num_matched_prefix_tokens` is already populated at schedule time for cache-agnostic policies.
- The aging credit bounds starvation: an 8192-token request outranks a fresh 128-token request after ~8 s of waiting.
- Opt-in; no default behavior change. Not combined with `--enable-priority-scheduling` (which asserts fcfs/lof), same as the other non-fcfs policies.
- Intended for prefill-only serving; for generation workloads output length is unknown, so sjf is not recommended there (noted in the sorter docstring).

## Accuracy Tests

- Output integrity gate: 32 mixed-length prompts served at concurrency 1 through fcfs and sjf servers produce **bitwise-identical embeddings** (min cosine 1.0) — the policy only reorders the waiting queue.
- Unit tests (CPU, `test/registered/unit/managers/test_schedule_policy_sjf.py`, `base-a-test-cpu`) — **5 passed**: length ordering, uncached-length semantics, aging anti-starvation, aging-rate scaling, unset-entry-time handling.

## Speed Tests and Profiling

A6000, Qwen3-Embedding-0.6B, mixed-length workload as above, per-bucket latency in ms.

At 1x saturation (Poisson 18 req/s, 512 requests):

```text
bucket    fcfs mean/p99     sjf mean/p99      p99 change
 128       409 / 1538        166 /  353         -77%
 512       507 / 1687        188 /  391         -77%
2048       505 / 1857        217 /  495         -73%
8192       664 / 1930        745 / 2164         +12%
```

At 1.5x sustained overload (27 req/s):

```text
bucket    fcfs mean/p99     sjf mean/p99
 128      2938 / 6695        233 /  373        mean -92%, p99 -94%
 512      3021 / 6041        239 /  414
2048      3097 / 6597        296 /  462
8192      3151 / 7275       3810 / 7384        mean +21%, p99 +1.5%
```

Full rate sweep — p99 of the shortest (128-token) bucket:

```text
offered rate     0.5x      1x      1.5x      2x
fcfs p99         545     1538     6695    11159   (20x blowup)
sjf  p99         359      353      373      369   (flat)
```

Long-bucket (8192) p99 under sjf is never worse than fcfs by more than ~12%, and at 2x sustained overload it converges to parity (11713 vs 11857) — the aging credit prevents starvation in the worst case. Honesty note: at 2x overload the 2048 bucket starts absorbing pressure under sjf (p99 3060 vs its 1x value 495) — the expected SJF cascade; the policy trades a bounded mid/long premium for keeping the shortest 75% of traffic at near-service latency where FCFS collapses uniformly.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29117681931](https://github.com/sgl-project/sglang/actions/runs/29117681931)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29117681638](https://github.com/sgl-project/sglang/actions/runs/29117681638)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->