### PR TITLE
[trtllm_mla] Fuse cuda-graph metadata rebuild into one triton kernel

### DIFF
--- a/python/sglang/kernels/ops/kvcache/__init__.py
+++ b/python/sglang/kernels/ops/kvcache/__init__.py
@@ -70,6 +70,7 @@ _TRITON_KERNELS = [
     ("trtllm_fp8_kv_kernel", "fused_fp8_set_kv_buffer"),
     ("trtllm_mha_page_table", "build_trtllm_mha_page_table"),
     ("trtllm_mha_graph_metadata", "update_trtllm_mha_graph_metadata"),
+    ("trtllm_mla_graph_metadata", "update_trtllm_mla_graph_metadata"),
     ("aiter_unified_attention", "scatter_ragged_to_page_table_kernel"),
     ("aiter_unified_attention", "scatter_req_to_token_to_page_table_kernel"),
     ("cache_move", "store_cache_4d"),

--- a/python/sglang/kernels/ops/kvcache/trtllm_mla_graph_metadata.py
+++ b/python/sglang/kernels/ops/kvcache/trtllm_mla_graph_metadata.py
@@ -1,23 +1,16 @@
 """Fused CUDA-graph metadata update for the TRTLLM MLA backend.
 
-`TRTLLMMLABackend._apply_cuda_graph_metadata` used to rebuild the replay
-metadata with several small host dispatches per graph replay: a seq_lens
-slice, an allocating `seq_lens + num_draft_tokens` add, a `seq_lens_k.copy_`,
-and the block-KV-indices triton launch. Repeated several times per decode
-step (draft-decode steps + target-verify + draft-extend) on every TP rank,
-the per-rank CPU jitter skews `cudaGraphLaunch` across ranks and is paid as
-spin time inside the first custom all-reduce of every replayed graph.
-
-This kernel performs the whole update in ONE launch (recordable into the
-captured graph, so replay pays zero host dispatches for it):
+One launch, recordable into a captured cuda graph:
   - seq_lens_k[i]          = seq_lens[i] + seqlen_offset   (int32, optional)
   - block_kv_indices[i, p] = req_to_token[req_pool_indices[i],
                                           p * page_size] // page_size
     for p < cdiv(seq_lens[i] + seqlen_offset, page_size)
 
-The block-KV-indices part mirrors ``create_flashmla_kv_indices_triton``
-(same 2D grid: one CTA per (row, page-block)) with the always-None
-``kv_start_idx`` dropped and the seqlen offset folded in.
+Rebuilding this metadata with separate aten ops and kernel launches costs
+per-replay host dispatch on every TP rank, several times per decode step
+(draft-decode steps + target-verify + draft-extend); the per-rank jitter
+skews `cudaGraphLaunch` across ranks and is paid as spin time inside the
+first custom all-reduce of every replayed graph.
 """
 
 from typing import Optional

--- a/python/sglang/kernels/ops/kvcache/trtllm_mla_graph_metadata.py
+++ b/python/sglang/kernels/ops/kvcache/trtllm_mla_graph_metadata.py
@@ -1,0 +1,114 @@
+"""Fused CUDA-graph metadata update for the TRTLLM MLA backend.
+
+`TRTLLMMLABackend._apply_cuda_graph_metadata` used to rebuild the replay
+metadata with several small host dispatches per graph replay: a seq_lens
+slice, an allocating `seq_lens + num_draft_tokens` add, a `seq_lens_k.copy_`,
+and the block-KV-indices triton launch. Repeated several times per decode
+step (draft-decode steps + target-verify + draft-extend) on every TP rank,
+the per-rank CPU jitter skews `cudaGraphLaunch` across ranks and is paid as
+spin time inside the first custom all-reduce of every replayed graph.
+
+This kernel performs the whole update in ONE launch (recordable into the
+captured graph, so replay pays zero host dispatches for it):
+  - seq_lens_k[i]          = seq_lens[i] + seqlen_offset   (int32, optional)
+  - block_kv_indices[i, p] = req_to_token[req_pool_indices[i],
+                                          p * page_size] // page_size
+    for p < cdiv(seq_lens[i] + seqlen_offset, page_size)
+
+The block-KV-indices part mirrors ``create_flashmla_kv_indices_triton``
+(same 2D grid: one CTA per (row, page-block)) with the always-None
+``kv_start_idx`` dropped and the seqlen offset folded in.
+"""
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.ops.kvcache.kv_indices import (
+    get_num_kv_index_blocks_flashmla,
+    get_num_page_per_block_flashmla,
+)
+
+
+@triton.jit
+def update_trtllm_mla_graph_metadata_kernel(
+    # inputs
+    req_pool_indices_ptr,  # [bs] int
+    seq_lens_ptr,  # [bs] int
+    req_to_token_ptr,  # [pool_size, req_to_token_stride] int32
+    # outputs
+    seq_lens_k_ptr,  # [bs] int32, or None
+    block_kv_indices_ptr,  # [bs, block_kv_indices_stride] int32
+    # scalars
+    seqlen_offset,  # added to seq_lens for seq_lens_k / KV coverage
+    req_to_token_stride,
+    block_kv_indices_stride,
+    # constexpr
+    PAGE_SIZE: tl.constexpr,
+    HAS_SEQ_LENS_K: tl.constexpr,
+    NUM_PAGE_PER_BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    blk = tl.program_id(axis=1)
+
+    seqlen = (tl.load(seq_lens_ptr + pid) + seqlen_offset).to(tl.int32)
+    if HAS_SEQ_LENS_K and blk == 0:
+        tl.store(seq_lens_k_ptr + pid, seqlen)
+
+    num_pages = tl.cdiv(seqlen, PAGE_SIZE)
+    # One CTA per page-block (grid axis 1); CTAs beyond this sequence's
+    # block count are guarded out.
+    if blk * NUM_PAGE_PER_BLOCK < num_pages:
+        req_pool_index = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
+        page_idx = blk * NUM_PAGE_PER_BLOCK + tl.arange(0, NUM_PAGE_PER_BLOCK)
+        mask = page_idx < num_pages
+        token = tl.load(
+            req_to_token_ptr
+            + req_pool_index * req_to_token_stride
+            + page_idx.to(tl.int64) * PAGE_SIZE,
+            mask=mask,
+            other=0,
+        )
+        tl.store(
+            block_kv_indices_ptr
+            + pid.to(tl.int64) * block_kv_indices_stride
+            + page_idx,
+            token // PAGE_SIZE,
+            mask=mask,
+        )
+
+
+def update_trtllm_mla_graph_metadata(
+    *,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    req_to_token: torch.Tensor,
+    block_kv_indices: torch.Tensor,
+    bs: int,
+    seqlen_offset: int,
+    page_size: int,
+    seq_lens_k: Optional[torch.Tensor] = None,
+):
+    """Launch the fused metadata update (one kernel for the whole replay init)."""
+    if bs == 0:
+        return
+
+    grid = (
+        bs,
+        get_num_kv_index_blocks_flashmla(block_kv_indices.shape[1], page_size),
+    )
+    update_trtllm_mla_graph_metadata_kernel[grid](
+        req_pool_indices,
+        seq_lens,
+        req_to_token,
+        seq_lens_k,
+        block_kv_indices,
+        seqlen_offset,
+        req_to_token.stride(0),
+        block_kv_indices.stride(0),
+        PAGE_SIZE=page_size,
+        HAS_SEQ_LENS_K=seq_lens_k is not None,
+        NUM_PAGE_PER_BLOCK=get_num_page_per_block_flashmla(page_size),
+    )

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -379,22 +379,17 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
     ):
         """Shared decode / target-verify / draft-extend capture+replay body.
 
-        One fused triton kernel (update_trtllm_mla_graph_metadata) rebuilds
-        seq_lens_k and block_kv_indices. The previous implementation issued
-        several small host dispatches per graph replay (slice, allocating
-        add, copy_, kv-indices launch); the fused launch is recorded into
-        the captured graph, so replay pays no host dispatches for it.
-
-        The draft-extend max_seq_len_q / sum_seq_lens_q refresh is dropped:
-        both are static per captured shape and already set by
-        :py:meth:`_init_cuda_graph_metadata`.
+        One fused triton kernel rebuilds seq_lens_k and block_kv_indices;
+        the launch is recorded into the captured graph, so replay pays no
+        host dispatches for it. The q-side metadata (max_seq_len_q,
+        sum_seq_lens_q, cu_seqlens_q) is static per captured shape and set
+        by :py:meth:`_init_cuda_graph_metadata`.
 
         Public entry: :py:meth:`init_forward_metadata_in_graph` (which routes
         the non-decode-family modes to the FlashInferMLA parent).
         """
         metadata = self.decode_cuda_graph_metadata[bs]
-        # Target-verify scores num_draft_tokens extra KV entries per request;
-        # decode and draft-extend read seq_lens as-is.
+        # Target-verify scores num_draft_tokens extra KV entries per request.
         seqlen_offset = self.num_draft_tokens if forward_mode.is_target_verify() else 0
         update_trtllm_mla_graph_metadata(
             req_pool_indices=req_pool_indices[:bs],
@@ -448,8 +443,8 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 forward_batch.seq_lens.device,
             )
         else:
-            # The metadata rebuild itself is recorded inside the captured
-            # graph (init_forward_metadata_in_graph); replay-prep only points
+            # The rebuild is recorded inside the captured graph
+            # (init_forward_metadata_in_graph); replay-prep only repoints
             # forward_decode_metadata at the captured per-bs buffers.
             self.forward_decode_metadata = self.decode_cuda_graph_metadata[bs]
 

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -24,6 +24,9 @@ from sglang.kernels.ops.kvcache.kv_indices import (
     get_num_kv_index_blocks_flashmla,
     get_num_page_per_block_flashmla,
 )
+from sglang.kernels.ops.kvcache.trtllm_mla_graph_metadata import (
+    update_trtllm_mla_graph_metadata,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.flashinfer_mla_backend import (
     FlashInferMLAAttnBackend,
@@ -376,38 +379,32 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
     ):
         """Shared decode / target-verify / draft-extend capture+replay body.
 
-        Public entry: :py:meth:`init_forward_metadata_out_graph` (which routes
+        One fused triton kernel (update_trtllm_mla_graph_metadata) rebuilds
+        seq_lens_k and block_kv_indices. The previous implementation issued
+        several small host dispatches per graph replay (slice, allocating
+        add, copy_, kv-indices launch); the fused launch is recorded into
+        the captured graph, so replay pays no host dispatches for it.
+
+        The draft-extend max_seq_len_q / sum_seq_lens_q refresh is dropped:
+        both are static per captured shape and already set by
+        :py:meth:`_init_cuda_graph_metadata`.
+
+        Public entry: :py:meth:`init_forward_metadata_in_graph` (which routes
         the non-decode-family modes to the FlashInferMLA parent).
         """
         metadata = self.decode_cuda_graph_metadata[bs]
-
-        if forward_mode.is_target_verify():
-            seq_lens = seq_lens[:bs] + self.num_draft_tokens
-            metadata.seq_lens_k.copy_(seq_lens)
-        elif forward_mode.is_draft_extend_v2():
-            num_tokens_per_bs = self.num_draft_tokens
-            metadata.max_seq_len_q = num_tokens_per_bs
-            metadata.sum_seq_lens_q = num_tokens_per_bs * bs
-            seq_lens = seq_lens[:bs]
-            metadata.seq_lens_k.copy_(seq_lens)
-
-        # Update block indices for new sequences.
-        create_flashmla_kv_indices_triton[
-            (
-                bs,
-                get_num_kv_index_blocks_flashmla(
-                    metadata.block_kv_indices.shape[1], self.page_size
-                ),
-            )
-        ](
-            self.req_to_token,
-            req_pool_indices[:bs],
-            seq_lens,
-            None,
-            metadata.block_kv_indices,
-            self.req_to_token.stride(0),
-            metadata.block_kv_indices.shape[1],
-            PAGED_SIZE=self.page_size,
+        # Target-verify scores num_draft_tokens extra KV entries per request;
+        # decode and draft-extend read seq_lens as-is.
+        seqlen_offset = self.num_draft_tokens if forward_mode.is_target_verify() else 0
+        update_trtllm_mla_graph_metadata(
+            req_pool_indices=req_pool_indices[:bs],
+            seq_lens=seq_lens[:bs],
+            req_to_token=self.req_to_token,
+            block_kv_indices=metadata.block_kv_indices,
+            bs=bs,
+            seqlen_offset=seqlen_offset,
+            page_size=self.page_size,
+            seq_lens_k=metadata.seq_lens_k,
         )
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:
@@ -450,19 +447,28 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 forward_batch.seq_lens,
                 forward_batch.seq_lens.device,
             )
-            self._apply_cuda_graph_metadata(
-                bs=bs,
-                req_pool_indices=forward_batch.req_pool_indices,
-                seq_lens=forward_batch.seq_lens,
-                forward_mode=forward_mode,
-            )
         else:
-            self._apply_cuda_graph_metadata(
-                bs=bs,
-                req_pool_indices=forward_batch.req_pool_indices,
-                seq_lens=forward_batch.seq_lens,
-                forward_mode=forward_mode,
-            )
+            # The metadata rebuild itself is recorded inside the captured
+            # graph (init_forward_metadata_in_graph); replay-prep only points
+            # forward_decode_metadata at the captured per-bs buffers.
+            self.forward_decode_metadata = self.decode_cuda_graph_metadata[bs]
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
+        forward_mode = forward_batch.forward_mode
+
+        if (
+            not forward_mode.is_decode_or_idle()
+            and not forward_mode.is_target_verify()
+            and not forward_mode.is_draft_extend_v2()
+        ):
+            return super().init_forward_metadata_in_graph(forward_batch)
+
+        self._apply_cuda_graph_metadata(
+            bs=forward_batch.batch_size,
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens,
+            forward_mode=forward_mode,
+        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize the metadata for a forward pass."""

--- a/test/registered/attention/test_trtllm_mla_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mla_graph_metadata.py
@@ -1,6 +1,6 @@
 """Correctness tests for the fused TRTLLM-MLA cuda-graph metadata kernel.
 
-Validates the single-launch triton kernel against the pre-fusion reference
+Validates the single-launch triton kernel against an unfused reference
 pipeline (aten ``seq_lens + offset`` -> ``seq_lens_k`` build plus
 ``create_flashmla_kv_indices_triton``), and pins the init-hook contract: the
 metadata rebuild is recorded inside the captured graph
@@ -143,12 +143,20 @@ class TestTRTLLMMLAGraphMetadataHooks(CustomTestCase):
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
 class TestTRTLLMMLAGraphMetadataKernel(CustomTestCase):
-    """Fused kernel must bit-match the pre-fusion reference pipeline."""
+    """Fused kernel must bit-match the unfused reference pipeline."""
 
-    def _run_parity_case(self, bs, page_size, seqlen_offset, with_seq_lens_k, seed):
+    def _run_parity_case(
+        self,
+        bs,
+        page_size,
+        seqlen_offset,
+        with_seq_lens_k,
+        seed,
+        pool_size=8,
+        max_context_len=2048,
+        seq_lens=None,
+    ):
         g = torch.Generator(device="cpu").manual_seed(seed)
-        pool_size = 8
-        max_context_len = 2048
         req_to_token = torch.randint(
             0,
             pool_size * max_context_len,
@@ -159,9 +167,15 @@ class TestTRTLLMMLAGraphMetadataKernel(CustomTestCase):
         req_pool_indices = torch.randperm(pool_size, generator=g)[:bs].to(
             DEVICE, dtype=torch.int64
         )
-        seq_lens = torch.randint(
-            1, max_context_len - seqlen_offset, (bs,), generator=g, dtype=torch.int64
-        ).to(DEVICE)
+        if seq_lens is None:
+            seq_lens = torch.randint(
+                1,
+                max_context_len - seqlen_offset,
+                (bs,),
+                generator=g,
+                dtype=torch.int64,
+            )
+        seq_lens = seq_lens.to(DEVICE)
 
         max_blocks = max_context_len // page_size
         block_kv_indices = torch.full(
@@ -188,8 +202,8 @@ class TestTRTLLMMLAGraphMetadataKernel(CustomTestCase):
             seq_lens_k=seq_lens_k,
         )
 
-        # Pre-fusion reference: aten seq_lens_k build + the original
-        # kv-indices kernel fed with the already-offset lens.
+        # Unfused reference: aten seq_lens_k build + kv-indices kernel fed
+        # with the already-offset lens.
         seq_lens_k_ref = (seq_lens + seqlen_offset).to(torch.int32)
         create_flashmla_kv_indices_triton[
             (bs, get_num_kv_index_blocks_flashmla(max_blocks, page_size))
@@ -233,6 +247,36 @@ class TestTRTLLMMLAGraphMetadataKernel(CustomTestCase):
                                 + seqlen_offset * 7
                                 + int(with_seq_lens_k),
                             )
+
+    def test_large_seqlen_coverage(self):
+        """~1M-token sequences (15k+ pages per row, hundreds of CTAs per row)
+        to catch narrow-int overflow in the page/row index arithmetic."""
+        max_context_len = 1_000_064
+        self._run_parity_case(
+            bs=2,
+            page_size=64,
+            seqlen_offset=4,
+            with_seq_lens_k=True,
+            seed=7,
+            pool_size=2,
+            max_context_len=max_context_len,
+            seq_lens=torch.tensor([1_000_000, 999_983], dtype=torch.int64),
+        )
+
+    def test_large_batch_coverage(self):
+        """16k-request batch to catch grid-axis-0 / row-stride issues."""
+        bs = 16 * 1024
+        seq_lens = torch.arange(bs, dtype=torch.int64) % 257 + 1
+        self._run_parity_case(
+            bs=bs,
+            page_size=32,
+            seqlen_offset=2,
+            with_seq_lens_k=True,
+            seed=8,
+            pool_size=bs,
+            max_context_len=512,
+            seq_lens=seq_lens,
+        )
 
     def test_metadata_update_records_inside_cuda_graph(self):
         """The in-graph hook body must be graph-recordable: replaying the

--- a/test/registered/attention/test_trtllm_mla_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mla_graph_metadata.py
@@ -1,0 +1,280 @@
+"""Correctness tests for the fused TRTLLM-MLA cuda-graph metadata kernel.
+
+Validates the single-launch triton kernel against the pre-fusion reference
+pipeline (aten ``seq_lens + offset`` -> ``seq_lens_k`` build plus
+``create_flashmla_kv_indices_triton``), and pins the init-hook contract: the
+metadata rebuild is recorded inside the captured graph
+(``init_forward_metadata_in_graph``) while replay-prep
+(``init_forward_metadata_out_graph``) only repoints
+``forward_decode_metadata`` — regressing either side silently replays stale
+block KV indices.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.attention.trtllm_mla_backend as trtllm_mla_backend
+from sglang.kernels.ops.kvcache.kv_indices import (
+    create_flashmla_kv_indices_triton,
+    get_num_kv_index_blocks_flashmla,
+)
+from sglang.kernels.ops.kvcache.trtllm_mla_graph_metadata import (
+    update_trtllm_mla_graph_metadata,
+)
+from sglang.srt.layers.attention.trtllm_mla_backend import TRTLLMMLABackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+# The fused metadata kernel is plain Triton (no trtllm-gen dependency), so any
+# CUDA runner covers it.
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+DEVICE = "cuda"
+
+
+def _make_backend_for_hook_test(page_size=64, num_draft_tokens=4, device="cpu"):
+    """Backend with just the state the cuda-graph metadata path touches."""
+    backend = TRTLLMMLABackend.__new__(TRTLLMMLABackend)
+    backend.device = torch.device(device)
+    backend.max_context_len = 256
+    backend.page_size = page_size
+    backend.num_draft_tokens = num_draft_tokens
+    backend.req_to_token = torch.zeros(4, 256, dtype=torch.int32, device=device)
+    backend.decode_cuda_graph_metadata = {}
+    max_blocks = backend._calc_padded_blocks(backend.max_context_len)
+    backend.decode_cuda_graph_kv_indices = torch.full(
+        (4, max_blocks), -1, dtype=torch.int32, device=device
+    )
+    backend.forward_decode_metadata = None
+    return backend
+
+
+def _make_fb(bs, forward_mode, device="cpu"):
+    return SimpleNamespace(
+        batch_size=bs,
+        req_pool_indices=torch.arange(bs, dtype=torch.int64, device=device),
+        seq_lens=torch.ones(bs, dtype=torch.int64, device=device),
+        forward_mode=forward_mode,
+        spec_info=None,
+        positions=torch.arange(bs, dtype=torch.int64, device=device),
+    )
+
+
+class TestTRTLLMMLAGraphMetadataHooks(CustomTestCase):
+    """The rebuild must run in the in-graph hook, and only there."""
+
+    def _patched_calls(self):
+        calls = []
+        patcher = patch.object(
+            trtllm_mla_backend,
+            "update_trtllm_mla_graph_metadata",
+            lambda **kwargs: calls.append(kwargs),
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()
+        return calls
+
+    def test_decode_rebuild_runs_in_graph_hook_only(self):
+        calls = self._patched_calls()
+        backend = _make_backend_for_hook_test()
+        fb = _make_fb(bs=2, forward_mode=ForwardMode.DECODE)
+
+        backend.init_forward_metadata_out_graph(fb, in_capture=True)
+        self.assertEqual(calls, [])
+        self.assertIs(
+            backend.forward_decode_metadata, backend.decode_cuda_graph_metadata[2]
+        )
+
+        backend.init_forward_metadata_in_graph(fb)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["seqlen_offset"], 0)
+        self.assertIsNone(calls[0]["seq_lens_k"])
+
+        # Replay-prep must not launch the rebuild (it is recorded in the
+        # graph) but must repoint forward_decode_metadata.
+        calls.clear()
+        backend.forward_decode_metadata = None
+        backend.init_forward_metadata_out_graph(fb)
+        self.assertEqual(calls, [])
+        self.assertIs(
+            backend.forward_decode_metadata, backend.decode_cuda_graph_metadata[2]
+        )
+
+    def test_target_verify_applies_draft_token_offset(self):
+        calls = self._patched_calls()
+        backend = _make_backend_for_hook_test(num_draft_tokens=4)
+        fb = _make_fb(bs=2, forward_mode=ForwardMode.TARGET_VERIFY)
+
+        backend.init_forward_metadata_out_graph(fb, in_capture=True)
+        backend.init_forward_metadata_in_graph(fb)
+
+        metadata = backend.decode_cuda_graph_metadata[2]
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["seqlen_offset"], 4)
+        self.assertIs(calls[0]["seq_lens_k"], metadata.seq_lens_k)
+
+    def test_draft_extend_v2_uses_static_q_metadata(self):
+        calls = self._patched_calls()
+        backend = _make_backend_for_hook_test(num_draft_tokens=4)
+        fb = _make_fb(bs=2, forward_mode=ForwardMode.DRAFT_EXTEND_V2)
+
+        backend.init_forward_metadata_out_graph(fb, in_capture=True)
+        backend.init_forward_metadata_in_graph(fb)
+
+        metadata = backend.decode_cuda_graph_metadata[2]
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["seqlen_offset"], 0)
+        self.assertIs(calls[0]["seq_lens_k"], metadata.seq_lens_k)
+        # The q-side metadata is static per captured shape; the in-graph hook
+        # must not need to refresh it.
+        self.assertEqual(metadata.max_seq_len_q, 4)
+        self.assertEqual(metadata.sum_seq_lens_q, 8)
+        torch.testing.assert_close(
+            metadata.cu_seqlens_q,
+            torch.tensor([0, 4, 8], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA required")
+class TestTRTLLMMLAGraphMetadataKernel(CustomTestCase):
+    """Fused kernel must bit-match the pre-fusion reference pipeline."""
+
+    def _run_parity_case(self, bs, page_size, seqlen_offset, with_seq_lens_k, seed):
+        g = torch.Generator(device="cpu").manual_seed(seed)
+        pool_size = 8
+        max_context_len = 2048
+        req_to_token = torch.randint(
+            0,
+            pool_size * max_context_len,
+            (pool_size, max_context_len),
+            generator=g,
+            dtype=torch.int32,
+        ).to(DEVICE)
+        req_pool_indices = torch.randperm(pool_size, generator=g)[:bs].to(
+            DEVICE, dtype=torch.int64
+        )
+        seq_lens = torch.randint(
+            1, max_context_len - seqlen_offset, (bs,), generator=g, dtype=torch.int64
+        ).to(DEVICE)
+
+        max_blocks = max_context_len // page_size
+        block_kv_indices = torch.full(
+            (bs, max_blocks), -1, dtype=torch.int32, device=DEVICE
+        )
+        block_kv_indices_ref = torch.full(
+            (bs, max_blocks), -1, dtype=torch.int32, device=DEVICE
+        )
+
+        seq_lens_k = (
+            torch.zeros(bs, dtype=torch.int32, device=DEVICE)
+            if with_seq_lens_k
+            else None
+        )
+
+        update_trtllm_mla_graph_metadata(
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            req_to_token=req_to_token,
+            block_kv_indices=block_kv_indices,
+            bs=bs,
+            seqlen_offset=seqlen_offset,
+            page_size=page_size,
+            seq_lens_k=seq_lens_k,
+        )
+
+        # Pre-fusion reference: aten seq_lens_k build + the original
+        # kv-indices kernel fed with the already-offset lens.
+        seq_lens_k_ref = (seq_lens + seqlen_offset).to(torch.int32)
+        create_flashmla_kv_indices_triton[
+            (bs, get_num_kv_index_blocks_flashmla(max_blocks, page_size))
+        ](
+            req_to_token,
+            req_pool_indices,
+            seq_lens_k_ref,
+            None,
+            block_kv_indices_ref,
+            req_to_token.stride(0),
+            max_blocks,
+            PAGED_SIZE=page_size,
+        )
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(
+            block_kv_indices, block_kv_indices_ref, rtol=0, atol=0
+        )
+        if with_seq_lens_k:
+            torch.testing.assert_close(seq_lens_k, seq_lens_k_ref, rtol=0, atol=0)
+
+    def test_parity_with_reference_pipeline(self):
+        for bs in (1, 3, 8):
+            for page_size in (32, 64):
+                for seqlen_offset in (0, 4):
+                    for with_seq_lens_k in (False, True):
+                        with self.subTest(
+                            bs=bs,
+                            page_size=page_size,
+                            seqlen_offset=seqlen_offset,
+                            with_seq_lens_k=with_seq_lens_k,
+                        ):
+                            self._run_parity_case(
+                                bs=bs,
+                                page_size=page_size,
+                                seqlen_offset=seqlen_offset,
+                                with_seq_lens_k=with_seq_lens_k,
+                                seed=1234
+                                + bs * 31
+                                + page_size
+                                + seqlen_offset * 7
+                                + int(with_seq_lens_k),
+                            )
+
+    def test_metadata_update_records_inside_cuda_graph(self):
+        """The in-graph hook body must be graph-recordable: replaying the
+        captured graph after mutating seq_lens must refresh seq_lens_k and
+        block_kv_indices without any host relaunch."""
+        backend = _make_backend_for_hook_test(
+            page_size=64, num_draft_tokens=2, device=DEVICE
+        )
+        backend.req_to_token = torch.arange(
+            4 * 256, dtype=torch.int32, device=DEVICE
+        ).reshape(4, 256)
+        fb = _make_fb(bs=2, forward_mode=ForwardMode.TARGET_VERIFY, device=DEVICE)
+        fb.seq_lens = torch.tensor([3, 4], dtype=torch.int64, device=DEVICE)
+
+        backend.init_forward_metadata_out_graph(fb, in_capture=True)
+        # Warmup launch (triton JIT) before capture.
+        backend.init_forward_metadata_in_graph(fb)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            backend.init_forward_metadata_in_graph(fb)
+
+        fb.seq_lens.copy_(torch.tensor([65, 130], dtype=torch.int64, device=DEVICE))
+        graph.replay()
+        torch.cuda.synchronize()
+
+        metadata = backend.decode_cuda_graph_metadata[2]
+        torch.testing.assert_close(
+            metadata.seq_lens_k,
+            torch.tensor([67, 132], dtype=torch.int32, device=DEVICE),
+            rtol=0,
+            atol=0,
+        )
+        # Row 1 covers ceil(132 / 64) = 3 pages after the replayed rebuild.
+        torch.testing.assert_close(
+            metadata.block_kv_indices[1, :3],
+            backend.req_to_token[1, ::64][:3] // 64,
+            rtol=0,
+            atol=0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/attention/unittests/mla/test_trtllm_mla.py
+++ b/test/registered/attention/unittests/mla/test_trtllm_mla.py
@@ -13,6 +13,12 @@ from sglang.test.kits.attention_unittest.attention_methods.mla_attention import 
     MLAAttentionCase,
     run_mla_attention_case,
 )
+from sglang.test.kits.attention_unittest.runner_modes.cuda_graph_decode_runner import (
+    run_mla_cuda_graph_decode_case,
+)
+from sglang.test.kits.attention_unittest.runner_modes.speculative_target_verify_runner import (
+    run_mla_eagle_verify_cuda_graph_case,
+)
 
 # trtllm_mla goes through FlashInfer's XQA MLA path. Per PLAN.md and the
 # project's is_sm120_supported helper (device_capability_majors=[12]), the
@@ -156,10 +162,52 @@ class TestTRTLLMMLAAttentionBackendCorrectness(CustomTestCase):
         ),
     )
 
+    # CUDA-graph capture+replay through the runner; exercises the fused
+    # in-graph metadata rebuild (init_forward_metadata_in_graph).
+    CUDA_GRAPH_CASES = (
+        MLAAttentionCase(
+            name="runner_cuda_graph_decode_trtllm_mla_page_boundary",
+            backend="trtllm_mla",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=4,
+            page_size=64,
+            prefix_lens=(61, 62, 63),
+        ),
+    )
+    EAGLE_VERIFY_CUDA_GRAPH_CASES = (
+        (
+            MLAAttentionCase(
+                name="runner_cuda_graph_eagle_verify_trtllm_mla_chain",
+                backend="trtllm_mla",
+                forward_mode=ForwardMode.TARGET_VERIFY,
+                num_heads=4,
+                page_size=64,
+                prefix_lens=(4, 7),
+                extend_lens=(3, 3),
+            ),
+            1,
+        ),
+    )
+
     def test_projected_mla_attention_cases(self):
         for case in self.CASES:
             with self.subTest(case=case.name, backend=case.backend):
                 run_mla_attention_case(self, case, **MLA_SHAPE_KWARGS)
+
+    def test_runner_mode_cuda_graph_decode_cases(self):
+        for case in self.CUDA_GRAPH_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                run_mla_cuda_graph_decode_case(self, case, **MLA_SHAPE_KWARGS)
+
+    def test_runner_mode_eagle_verify_cuda_graph_cases(self):
+        for case, topk in self.EAGLE_VERIFY_CUDA_GRAPH_CASES:
+            with self.subTest(case=case.name, backend=case.backend, topk=topk):
+                run_mla_eagle_verify_cuda_graph_case(
+                    self,
+                    case,
+                    topk=topk,
+                    **MLA_SHAPE_KWARGS,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Follow-up to #29843 (trtllm_mha) and #29499 (dsa) for the TRTLLM MLA backend. `TRTLLMMLABackend._apply_cuda_graph_metadata` rebuilds replay metadata with several host dispatches per graph replay (`seq_lens` slice, `+ num_draft_tokens` add, `seq_lens_k.copy_`, `create_flashmla_kv_indices_triton`), repeated per decode step on every TP rank. The per-rank CPU jitter skews `cudaGraphLaunch` and is paid as spin time in the first custom all-reduce of each replay.

## Modifications

- Add `sglang/kernels/ops/kvcache/trtllm_mla_graph_metadata.py`: one fused triton kernel computing `seq_lens_k = seq_lens + seqlen_offset` and rebuilding `block_kv_indices` in a single launch.
- Record the rebuild inside the captured graph via `init_forward_metadata_in_graph` (runners already call it since #29843); `init_forward_metadata_out_graph` now only repoints `forward_decode_metadata`.
- Drop the replay-time `max_seq_len_q` / `sum_seq_lens_q` refresh (static per captured shape, set in `_init_cuda_graph_metadata`).
- `TokenspeedMLABackend` inherits the fused path unchanged.

## Benchmarks

8×B200, `Kimi-K2.5-NVFP4`, TP8 + `tokenspeed_mla` + EAGLE3 3/1/4; `generated-shared-prefix`, sys 73360 / question 6640 / output 1000, `--max-concurrency 1` (single-batch decode). `sglang:fwd_occupancy` over decode windows (`SGLANG_ENABLE_METRICS_DEVICE_TIMER=1`):

| decode `fwd_occupancy` (median) | before | after |
| --- | --- | --- |
| | 96.59% | **96.98%** (+0.39 pp) |

Per decode step (EAGLE3 iteration ≈ 7.0 ms wall, ~2.55 tokens): GPU forward time **unchanged (~6.8 ms)**, GPU idle / host stall **~241 µs → ~213 µs (−28 µs/step)** — the optimization is host-side only. Accept length (2.55) and TPOT (2.77 → 2.76 ms) unchanged. Gains scale in higher-batch / larger-TP regimes where the per-rank host-dispatch tail is on the collective's critical path.

## Testing

- `test/registered/attention/test_trtllm_mla_graph_metadata.py`: fused-kernel bit-parity vs the unfused reference over bs × page_size {32,64} × offset; heavy shapes (~1M tokens, 16k-req batch); hook-contract + graph-recordability (capture in `CUDAGraph`, mutate `seq_lens`, replay, verify refresh).
- `test/registered/attention/unittests/mla/test_trtllm_mla.py`: trtllm_mla CUDA-graph decode + eagle-verify runner cases.

## Profile
### Eager ops between draft and target
Before
<img width="711" height="496" alt="Screenshot 2026-07-17 at 4 30 17 PM" src="https://github.com/user-attachments/assets/8246b1dc-9c2c-4399-9544-7ec3765484fe" />

After
<img width="843" height="496" alt="Screenshot 2026-07-17 at 4 29 58 PM" src="https://github.com/user-attachments/assets/214015f1-47e2-470a-87dd-b55e50ae0c9e" />


### Eager ops between target and draft extend
Before
<img width="780" height="505" alt="Screenshot 2026-07-17 at 4 32 00 PM" src="https://github.com/user-attachments/assets/b0fd325b-4096-458d-bff2-65b9c24bc29d" />

After
<img width="830" height="515" alt="Screenshot 2026-07-17 at 4 32 28 PM" src="https://github.com/user-attachments/assets/8903bc4b-a6ab-4d16-8890-48bdb79cbbef" />


### Eager ops between iterations (draft extend and draft)
Before 
<img width="702" height="505" alt="Screenshot 2026-07-17 at 4 31 20 PM" src="https://github.com/user-attachments/assets/24ba7b30-1ca6-406a-b59d-131d4a286842" />

After
<img width="693" height="496" alt="Screenshot 2026-07-17 at 4 30 48 PM" src="https://github.com/user-attachments/assets/5d9315d5-42d0-41c1-a5d6-2bdce740b21e" />

