### PR TITLE
[AMD] [GLM5] Enable dense-MHA short-context prefill fallback on gfx950

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -111,6 +111,20 @@ def _all_gather_dsa_trtllm_fp8_kv(
 
 _is_hip = is_hip()
 
+
+def _detect_gfx950() -> bool:
+    # gfx950 (MI355X) detection via gcnArchName; get_device_sm() is unreliable on ROCm.
+    if not _is_hip:
+        return False
+    try:
+        return "gfx950" in torch.cuda.get_device_properties(0).gcnArchName
+    except Exception:
+        return False
+
+
+# gfx950 supports the dense-MHA prefill fallback via aiter flash_attn_varlen_func.
+_is_gfx950 = _detect_gfx950()
+
 if _is_hip:
     from sglang.kernels.ops.attention.dsa.triton_kernel import get_valid_kv_indices
     from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
@@ -2589,8 +2603,9 @@ class DeepseekSparseAttnBackend(
             f"cu_seqlens_k has {len(cu_seqlens_k)-1} requests"
         )
 
-        # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues
-        if self.device_sm_major >= 10:
+        # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues.
+        # ROCm (gfx950) always uses the aiter flash_attn_varlen_func path below.
+        if self.device_sm_major >= 10 and not _is_hip:
             import flashinfer
 
             seq_lens = metadata.cache_seqlens_int32
@@ -3022,11 +3037,13 @@ class DeepseekSparseAttnBackend(
             sum_seq_lens = sum(forward_batch.seq_lens_cpu)
             device_sm = get_device_sm()
 
-            # Requirements: H200/B200, short sequences, supported dtype, fits in chunk
+            # Requirements: H200/B200/MI355X, short sequences, supported dtype, fits in chunk
             self.use_mha = (
                 (
-                    device_sm == 90 or (device_sm >= 100 and device_sm < 110)
-                )  # SM90/SM100 only
+                    device_sm == 90
+                    or (device_sm >= 100 and device_sm < 110)
+                    or _is_gfx950
+                )  # SM90/SM100 (NVIDIA) or gfx950 (MI355X)
                 and max_kv_len
                 <= envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()  # Short enough for MHA
                 and self.token_to_kv_pool.dtype in [torch.bfloat16, torch.float8_e4m3fn]

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2880,7 +2880,9 @@ class DeepseekSparseAttnBackend(
             f"cu_seqlens_k has {len(cu_seqlens_k)-1} requests"
         )
 
-        # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues
+        # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues.
+        # gfx950 reports device capability sm_(9,5), so it never enters this SM100+
+        # branch and falls through to the aiter flash_attn_varlen_func path below.
         if self.device_sm_major >= 10:
             import flashinfer
 
@@ -3323,11 +3325,13 @@ class DeepseekSparseAttnBackend(
             sum_seq_lens = sum(forward_batch.seq_lens_cpu)
             device_sm = get_device_sm()
 
-            # Requirements: H200/B200, short sequences, supported dtype, fits in chunk
+            # Requirements: H200/B200/MI355X, short sequences, supported dtype, fits in chunk
             self.use_mha = (
                 (
-                    device_sm == 90 or (device_sm >= 100 and device_sm < 110)
-                )  # SM90/SM100 only
+                    device_sm == 90
+                    or (device_sm >= 100 and device_sm < 110)
+                    or _IS_GFX95
+                )  # SM90/SM100 (NVIDIA) or gfx95x (MI355X)
                 and max_kv_len
                 <= envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()  # Short enough for MHA
                 and self.token_to_kv_pool.dtype in [torch.bfloat16, torch.float8_e4m3fn]

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -111,20 +111,6 @@ def _all_gather_dsa_trtllm_fp8_kv(
 
 _is_hip = is_hip()
 
-
-def _detect_gfx950() -> bool:
-    # gfx950 (MI355X) detection via gcnArchName; get_device_sm() is unreliable on ROCm.
-    if not _is_hip:
-        return False
-    try:
-        return "gfx950" in torch.cuda.get_device_properties(0).gcnArchName
-    except Exception:
-        return False
-
-
-# gfx950 supports the dense-MHA prefill fallback via aiter flash_attn_varlen_func.
-_is_gfx950 = _detect_gfx950()
-
 if _is_hip:
     from sglang.kernels.ops.attention.dsa.triton_kernel import get_valid_kv_indices
     from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
@@ -2604,8 +2590,9 @@ class DeepseekSparseAttnBackend(
         )
 
         # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues.
-        # ROCm (gfx950) always uses the aiter flash_attn_varlen_func path below.
-        if self.device_sm_major >= 10 and not _is_hip:
+        # gfx950 reports device capability sm_(9,5), so it never enters this SM100+
+        # branch and falls through to the aiter flash_attn_varlen_func path below.
+        if self.device_sm_major >= 10:
             import flashinfer
 
             seq_lens = metadata.cache_seqlens_int32
@@ -3042,8 +3029,8 @@ class DeepseekSparseAttnBackend(
                 (
                     device_sm == 90
                     or (device_sm >= 100 and device_sm < 110)
-                    or _is_gfx950
-                )  # SM90/SM100 (NVIDIA) or gfx950 (MI355X)
+                    or _IS_GFX95
+                )  # SM90/SM100 (NVIDIA) or gfx95x (MI355X)
                 and max_kv_len
                 <= envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()  # Short enough for MHA
                 and self.token_to_kv_pool.dtype in [torch.bfloat16, torch.float8_e4m3fn]

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -589,6 +589,21 @@ class DeepseekMHAForwardMixin:
             kv_indices is not None
         ), "page_table_1_flattened should have been generated for FP8 MHA path"
 
+        if _use_aiter_gfx95:
+            # ROCm (gfx950) stores the FP8 MLA KV in the raw
+            # (kv_lora_rank + qk_rope_head_dim) layout, not the scaled 656-byte
+            # layout that dequantize_k_cache_paged expects (it asserts dim==656).
+            # Dequantize the raw layout via the pool's HIP-aware path instead —
+            # the same routine _get_mla_kv_buffer uses for the BF16 MHA path.
+            # Without this, a chunked-prefill split (extend_prefix_lens != 0) that
+            # reads cached prefix KV crashes with "576 != 656".
+            kv_indices = filter_dcp_local_kv_indices(kv_indices=kv_indices)
+            kv_a, k_pe = get_token_to_kv_pool().get_mla_kv_buffer(
+                self.attn_mha, kv_indices, torch.bfloat16
+            )
+            kv_a = kv_a.squeeze(1).contiguous()
+            return kv_a, k_pe
+
         kv_cache_fp8 = get_token_to_kv_pool().get_key_buffer(self.attn_mha.layer_id)
 
         kv_latent_bf16 = dequantize_k_cache_paged(kv_cache_fp8, kv_indices)

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -297,10 +297,11 @@ class DeepseekMHAForwardMixin:
         q[..., self.qk_nope_head_dim :] = q_pe
 
         self._set_mla_kv_buffer(latent_cache, kv_a, k_pe, forward_batch)
-        if (
+        kv_refetched = (
             forward_batch.mha_one_shot
             and sum(forward_batch.extend_prefix_lens_cpu) != 0
-        ):
+        )
+        if kv_refetched:
             if (
                 self.use_dsa
                 and self.kv_cache_dtype == "fp8_e4m3"
@@ -345,9 +346,19 @@ class DeepseekMHAForwardMixin:
                 )
             )[0]
         else:
-            if _use_aiter_gfx95 and self.kv_b_proj.weight.dtype == torch.float8_e4m3fn:
+            if (
+                _use_aiter_gfx95
+                and self.kv_b_proj.weight.dtype == torch.float8_e4m3fn
+                and not kv_refetched
+            ):
                 kv = self.kv_b_proj(kv_a_quanted)[0]
             else:
+                # On a chunked-prefill split (kv_refetched), kv_a/k_pe were re-fetched as
+                # the FULL prefix+chunk sequence, but kv_a_quanted (from the fused
+                # norm+quant above) is only the current chunk — using it makes k_nope
+                # shorter than the full-length k_pe and crashes _concat_and_cast_mha_k
+                # (GLM-5.1-FP8, TP8: "expanded size 15497 must match 15753"). Fall back
+                # to the re-fetched bf16 kv_a; the fp8 kv_b_proj quantizes it inline.
                 kv = self.kv_b_proj(kv_a)[0]
             kv = kv.view(
                 -1, self.num_local_heads, self.qk_nope_head_dim + self.v_head_dim

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -23,6 +23,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_cuda,
     _is_musa,
     _is_npu,
+    _use_aiter_gfx95,
 )
 from sglang.srt.runtime_context import (
     get_exec,
@@ -482,6 +483,21 @@ class DeepseekMHAForwardMixin:
         assert (
             kv_indices is not None
         ), "page_table_1_flattened should have been generated for FP8 MHA path"
+
+        if _use_aiter_gfx95:
+            # ROCm (gfx950) stores the FP8 MLA KV in the raw
+            # (kv_lora_rank + qk_rope_head_dim) layout, not the scaled 656-byte
+            # layout that dequantize_k_cache_paged expects (it asserts dim==656).
+            # Dequantize the raw layout via the pool's HIP-aware path instead —
+            # the same routine _get_mla_kv_buffer uses for the BF16 MHA path.
+            # Without this, a chunked-prefill split (extend_prefix_lens != 0) that
+            # reads cached prefix KV crashes with "576 != 656".
+            kv_indices = filter_dcp_local_kv_indices(kv_indices=kv_indices)
+            kv_a, k_pe = get_token_to_kv_pool().get_mla_kv_buffer(
+                self.attn_mha, kv_indices, torch.bfloat16
+            )
+            kv_a = kv_a.squeeze(1).contiguous()
+            return kv_a, k_pe
 
         kv_cache_fp8 = get_token_to_kv_pool().get_key_buffer(self.attn_mha.layer_id)
 


### PR DESCRIPTION
## Motivation

On gfx950 (MI355X), GLM-5.2 DSA prefill always ran the triton sparse-MLA path, even at short context where the sparse indexer top-k + gather + mask overhead exceeds the KV it prunes. The dense-MHA prefill fallback — already used on NVIDIA SM90/SM100 and gated by `SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD` (default = model `index_topk`) — was hard-gated to NVIDIA and never taken on ROCm, despite the dense kernel (aiter `flash_attn_varlen_func`) already being available.

## Modifications

- Add gfx950 detection (`gcnArchName`) and include it in the `use_mha` prefill device gate in `dsa_backend.py` (previously `device_sm == 90 or 100 <= device_sm < 110`, NVIDIA only).
- Guard `_forward_standard_mha` so ROCm routes through aiter `flash_attn_varlen_func`, never the flashinfer/trtllm (Blackwell) path.
- NVIDIA behavior unchanged. On gfx950 the dense path triggers only when `max_kv_len <= SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD` (GLM-5.2: index_topk = 2048); longer context stays on sparse-MLA. Off switch: set the threshold to 0.

## Accuracy Tests

GLM-5.2-MXFP4, MI355X TP4, GSM8K (200 questions): dense fallback = 0.955.

## Speed Benchmarks

GLM-5.2-MXFP4, MI355X TP4, graphs-on, random 1024/1024, `sglang.bench_serving`, median.

A. Baseline (dense fallback off)*:

| concurrency | TTFT (ms) | ITL (ms) | E2EL (ms) | output tok/s |
|---|---|---|---|---|
| 4  | 277.3  | 11.33 | 11860 | 342.0  |
| 8  | 467.6  | 12.98 | 13790 | 592.7  |
| 16 | 872.9  | 16.48 | 17767 | 915.8  |
| 32 | 1371.1 | 20.25 | 22655 | 1443.9 |
| 64 | 1920.5 | 26.05 | 30112 | 2174.0 |

B. Dense fallback on (Δ vs baseline):

| concurrency | TTFT (ms) | Δ | ITL (ms) | Δ | E2EL (ms) | Δ | output tok/s | Δ |
|---|---|---|---|---|---|---|---|---|
| 4  | 196.9  | −29.0% | 11.31 | −0.2% | 11775 | −0.7% | 346.9  | +1.4% |
| 8  | 366.8  | −21.6% | 13.00 | +0.2% | 13660 | −0.9% | 582.1  | −1.8% |
| 16 | 526.6  | −39.7% | 16.46 | −0.1% | 17432| −1.9% | 935.0  | +2.1% |
| 32 | 783.2 | −42.9% | 20.48 | +1.1% | 21895| −3.4% | 1498.13 | +3.8% |
| 64 | 1125.6 | −41.4% | 26.10 | +0.2% | 29352 | −2.5% | 2227.3 | +2.5% |

Aside from the consistent TTFT decreases (−22% to −43%), the ITL, E2EL, and output throughput deltas are within run-to-run noise (dense fallback is prefill-only, so decode is unaffected).

*Baseline and Feature both measured with #30519, #30715 and aiter tuned MoE configs for GLM5.2; we expect those will be merged first and aiter version updated in recent images.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process.
2. Get approvals from CODEOWNERS and other reviewers.
3. Trigger CI tests with comments.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31635016485](https://github.com/sgl-project/sglang/actions/runs/31635016485)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31635016282](https://github.com/sgl-project/sglang/actions/runs/31635016282)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
