### PR TITLE
Add ZYHowell to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -377,6 +377,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
+    "ZYHowell": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "ZailiWang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Add `ZYHowell` to `.github/CI_PERMISSIONS.json`, inserted in sorted order.

Permissions granted:
- `can_tag_run_ci_label`
- `can_rerun_failed_ci`
- `can_rerun_stage`
- `cooldown_interval_minutes`: 0
- `reason`: custom override











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29123487557](https://github.com/sgl-project/sglang/actions/runs/29123487557)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29123487297](https://github.com/sgl-project/sglang/actions/runs/29123487297)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->