### PR TITLE
Support priority request header override

### DIFF
--- a/python/sglang/srt/entrypoints/request_headers.py
+++ b/python/sglang/srt/entrypoints/request_headers.py
@@ -15,6 +15,7 @@ _HEADER_OVERRIDES = {
     "x-override-conversation-id": ("conversation_id", str),
     "x-override-routed-dp-rank": ("routed_dp_rank", int),
     "x-override-disagg-prefill-dp-rank": ("disagg_prefill_dp_rank", int),
+    "x-override-priority": ("priority", int),
 }
 
 

--- a/test/registered/cpu/test_request_headers.py
+++ b/test/registered/cpu/test_request_headers.py
@@ -19,6 +19,7 @@ def _obj():
         conversation_id=None,
         routed_dp_rank=None,
         disagg_prefill_dp_rank=None,
+        priority=None,
     )
 
 
@@ -36,6 +37,7 @@ class TestApplyRoutingHeaders(unittest.TestCase):
                     "x-override-conversation-id": "c1",
                     "x-override-routed-dp-rank": "3",
                     "x-override-disagg-prefill-dp-rank": "5",
+                    "x-override-priority": "7",
                 }
             ),
         )
@@ -46,6 +48,7 @@ class TestApplyRoutingHeaders(unittest.TestCase):
         self.assertEqual(obj.conversation_id, "c1")
         self.assertEqual(obj.routed_dp_rank, 3)
         self.assertEqual(obj.disagg_prefill_dp_rank, 5)
+        self.assertEqual(obj.priority, 7)
 
     def test_absent_headers_leave_obj_unchanged(self):
         obj = _obj()
@@ -75,6 +78,31 @@ class TestApplyRoutingHeaders(unittest.TestCase):
             apply_header_overrides(
                 obj, Headers({"x-override-bootstrap-port": "not-an-int"})
             )
+
+    def test_priority_header_overrides_body_value(self):
+        # The scheduler reads obj.priority, so the header value must be the one
+        # that ends up on the object even when the body already set a priority.
+        obj = _obj()
+        obj.priority = 1
+        apply_header_overrides(obj, Headers({"x-override-priority": "5"}))
+        self.assertEqual(obj.priority, 5)
+
+    def test_negative_priority_header_is_applied(self):
+        obj = _obj()
+        obj.priority = 1
+        apply_header_overrides(obj, Headers({"x-override-priority": "-3"}))
+        self.assertEqual(obj.priority, -3)
+
+    def test_priority_body_value_preserved_when_header_absent(self):
+        obj = _obj()
+        obj.priority = 2
+        apply_header_overrides(obj, Headers({}))
+        self.assertEqual(obj.priority, 2)
+
+    def test_invalid_priority_fails_loud(self):
+        obj = _obj()
+        with self.assertRaises(HTTPException):
+            apply_header_overrides(obj, Headers({"x-override-priority": "high"}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Allow `x-override-priority` to set the request priority field through header overrides.
- Add CPU coverage for priority parsing, override behavior, absent headers, negative values, and invalid values.

## Testing

- `python3 -m py_compile python/sglang/srt/entrypoints/request_headers.py test/registered/cpu/test_request_headers.py`
- `with-proxy uv run pytest -q test/registered/cpu/test_request_headers.py`
- `with-proxy uv run pre-commit run --files python/sglang/srt/entrypoints/request_headers.py test/registered/cpu/test_request_headers.py`

## Original commits

- `e2585a79eb`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29123882166](https://github.com/sgl-project/sglang/actions/runs/29123882166)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29123881992](https://github.com/sgl-project/sglang/actions/runs/29123881992)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->