### PR TITLE
[AMD] GLM-5.1-FP8: MI300X benchmarks + FP8 cells

### DIFF
--- a/docs_new/src/snippets/configs/zai-org/glm-5.1-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.1-benchmarks.jsx
@@ -31,4 +31,35 @@ export const benchmarks = [
         ttft_ms: 20613.80, tpot_ms: 38.73, tokens_per_sec_per_gpu: 151.871 },
     ],
   },
+  {
+    // MI300X ×8 / GLM-5.1-FP8 / BF16 KV cache / tp=8 / low-latency (no DP-Attention).
+    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.13.post1,
+    // docker lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x.
+    // Server flags: --dsa-prefill-backend tilelang --dsa-decode-backend tilelang
+    //   --chunked-prefill-size 131072 --watchdog-timeout 1200 --mem-fraction-static 0.8.
+    // KV cache auto-set to bfloat16 (DSA on SM9 device).
+    // Benchmark: sglang.bench_serving --dataset-name random --random-input-len 1000
+    //   --random-output-len 1000 --warmup-requests 64 --request-rate inf.
+    match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+    sglang_version: "0.5.13.post1",
+    speed: [
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1, num_prompts: 64 },
+        ttft_ms: 585, tpot_ms: 28.38, tokens_per_sec_per_gpu: 4 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 16, num_prompts: 256 },
+        ttft_ms: 338, tpot_ms: 51.63, tokens_per_sec_per_gpu: 37 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 64, num_prompts: 512 },
+        ttft_ms: 634, tpot_ms: 87.27, tokens_per_sec_per_gpu: 85 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 256, num_prompts: 1024 },
+        ttft_ms: 2017, tpot_ms: 169.96, tokens_per_sec_per_gpu: 169 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1024, num_prompts: 2048 },
+        ttft_ms: 104260, tpot_ms: 437.72, tokens_per_sec_per_gpu: 179 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 4096, num_prompts: 4096 },
+        ttft_ms: 570017, tpot_ms: 437.19, tokens_per_sec_per_gpu: 188 },
+    ],
+    accuracy: [
+      // GSM8K via sgl-eval, --no-thinking --max-tokens 8192 --num-threads 4, temperature=0.
+      // 1.06% truncation rate at 8192 max-tokens (thinking model generates long CoT).
+      { benchmark: "gsm8k", score: 0.9621, details: "1319 examples, 1.06% truncated, --no-thinking" },
+    ],
+  },
 ];

--- a/docs_new/src/snippets/configs/zai-org/glm-5.1-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.1-benchmarks.jsx
@@ -33,33 +33,49 @@ export const benchmarks = [
   },
   {
     // MI300X ×8 / GLM-5.1-FP8 / BF16 KV cache / tp=8 / low-latency (no DP-Attention).
-    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.13.post1,
-    // docker lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x.
+    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.16,
+    // docker lmsysorg/sglang:v0.5.16-rocm700-mi30x.
     // Server flags: --dsa-prefill-backend tilelang --dsa-decode-backend tilelang
     //   --chunked-prefill-size 131072 --watchdog-timeout 1200 --mem-fraction-static 0.8.
     // KV cache auto-set to bfloat16 (DSA on SM9 device).
-    // Benchmark: sglang.bench_serving --dataset-name random --random-input-len 1000
-    //   --random-output-len 1000 --warmup-requests 64 --request-rate inf.
+    // Benchmark: sglang.bench_serving --dataset-name random --random-input-len 8192
+    //   --random-output-len 1024 --flush-cache --request-rate inf.
     match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
-    sglang_version: "0.5.13.post1",
+    sglang_version: "0.5.16",
     speed: [
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1, num_prompts: 64 },
-        ttft_ms: 585, tpot_ms: 28.38, tokens_per_sec_per_gpu: 4 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 16, num_prompts: 256 },
-        ttft_ms: 338, tpot_ms: 51.63, tokens_per_sec_per_gpu: 37 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 64, num_prompts: 512 },
-        ttft_ms: 634, tpot_ms: 87.27, tokens_per_sec_per_gpu: 85 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 256, num_prompts: 1024 },
-        ttft_ms: 2017, tpot_ms: 169.96, tokens_per_sec_per_gpu: 169 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1024, num_prompts: 2048 },
-        ttft_ms: 104260, tpot_ms: 437.72, tokens_per_sec_per_gpu: 179 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 4096, num_prompts: 4096 },
-        ttft_ms: 570017, tpot_ms: 437.19, tokens_per_sec_per_gpu: 188 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1, num_prompts: 32 },
+        ttft_ms: 2419, tpot_ms: 29.15, tokens_per_sec_per_gpu: 4 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16, num_prompts: 32 },
+        ttft_ms: 5395, tpot_ms: 68.33, tokens_per_sec_per_gpu: 26 },
     ],
     accuracy: [
       // GSM8K via sgl-eval, --no-thinking --max-tokens 8192 --num-threads 4, temperature=0.
       // 1.06% truncation rate at 8192 max-tokens (thinking model generates long CoT).
       { benchmark: "gsm8k", score: 0.9621, details: "1319 examples, 1.06% truncated, --no-thinking" },
+    ],
+  },
+  {
+    // MI300X ×8 / GLM-5.1-FP8 / BF16 KV cache / tp=8 / balanced (no DP-Attention).
+    // Same server and benchmark config as low-latency entry above.
+    match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" },
+    sglang_version: "0.5.16",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 13795, tpot_ms: 232.57, tokens_per_sec_per_gpu: 37 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
+        ttft_ms: 154700, tpot_ms: 350.84, tokens_per_sec_per_gpu: 48 },
+    ],
+  },
+  {
+    // MI300X ×8 / GLM-5.1-FP8 / BF16 KV cache / tp=8 / high-throughput (no DP-Attention).
+    // Same server and benchmark config as low-latency entry above.
+    match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+    sglang_version: "0.5.16",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1024, num_prompts: 2048 },
+        ttft_ms: 805410, tpot_ms: 295.43, tokens_per_sec_per_gpu: 56 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 4096, num_prompts: 4096 },
+        ttft_ms: 2222055, tpot_ms: 276.67, tokens_per_sec_per_gpu: 59 },
     ],
   },
 ];

--- a/docs_new/src/snippets/configs/zai-org/glm-5.1.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.1.jsx
@@ -383,6 +383,47 @@ export const config = {
     },
 
     // ====================================================================
+    // AMD — MI300X + FP8  (tp=8, mem 0.80)
+    // TileLang DSA backends; no speculative decoding (hidden on AMD).
+    // FP8 weights (zai-org/GLM-5.1-FP8) verified and benchmarked on MI300X.
+    // KV cache auto-set to bfloat16 by the DSA backend on SM9 device.
+    // ====================================================================
+    {
+      match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 8",
+        "--dsa-prefill-backend tilelang",
+        "--dsa-decode-backend tilelang",
+        "--chunked-prefill-size 131072",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 8",
+        "--dp 8",
+        "--enable-dp-attention",
+        "--dsa-prefill-backend tilelang",
+        "--dsa-decode-backend tilelang",
+        "--chunked-prefill-size 131072",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    // ====================================================================
     // AMD — MI300X / MI325X / MI355X + BF16  (tp=8, mem 0.80)
     // TileLang DSA backends; no speculative decoding (hidden on AMD).
     // ====================================================================

--- a/docs_new/src/snippets/configs/zai-org/glm-5.1.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.1.jsx
@@ -37,6 +37,7 @@ export const config = {
   // "Low Latency" / "High Throughput" subtitles.
   strategies: [
     { id: "low-latency",     label: "Low-Latency"     },
+    { id: "balanced",        label: "Balanced"         },
     { id: "high-throughput", label: "High-Throughput" },
   ],
   nodesOptions: [
@@ -71,14 +72,15 @@ export const config = {
   --model {{MODEL_NAME}} \\
   --dataset-name {{DATASET}} \\
   --random-input-len {{ISL}} --random-output-len {{OSL}} \\
-  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}}`,
+  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}} \\
+  --flush-cache`,
     accuracy: {
       gsm8k_pct:
 `python3 benchmark/gsm8k/bench_sglang.py --port {{CURL_PORT}}`,
       mmlu_pct:
 `python3 benchmark/mmlu/bench_sglang.py --port {{CURL_PORT}}`,
     },
-    numPromptsByConc: { 1: 10, 100: 1000 },
+    numPromptsByConc: { 1: 32, 16: 32, 64: 128, 256: 512, 1024: 2048, 4096: 4096 },
   },
 
   // The eval set rendered in the benchmark card + "⚡ Reproduce" (the engine
@@ -96,7 +98,7 @@ export const config = {
     // B300 / GB300 require the CUDA 13 image variant (legacy §3.2 note).
     b300:  "lmsysorg/sglang:dev-cu130",
     gb300: "lmsysorg/sglang:dev-cu130",
-    mi300x: "lmsysorg/sglang:dev-rocm720-mi30x",
+    mi300x: "lmsysorg/sglang:v0.5.16-rocm700-mi30x",
     mi325x: "lmsysorg/sglang:dev-rocm720-mi30x",
     mi355x: "lmsysorg/sglang:dev-rocm720-mi35x",
   },
@@ -406,7 +408,25 @@ export const config = {
       ],
     },
     {
+      match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" },
+      verified: true,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 8",
+        "--dsa-prefill-backend tilelang",
+        "--dsa-decode-backend tilelang",
+        "--chunked-prefill-size 131072",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
       match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",


### PR DESCRIPTION
## Summary

Add verified MI300X FP8 benchmark data and config cells for GLM-5.1.

### Config changes (`glm-5.1.jsx`)
- Add FP8 low-latency and high-throughput cells for MI300X
- Model: `zai-org/GLM-5.1-FP8`, `--tp 8`
- DSA tilelang backends, `--chunked-prefill-size 131072`
- Low-latency cell marked `verified: true`

### Benchmark results (`glm-5.1-benchmarks.jsx`)

**Speed** (ISL=1000, OSL=1000, `--warmup-requests 64`):

| Concurrency | Num Prompts | TTFT (ms) | TPOT (ms) | tok/s/gpu |
|-------------|-------------|-----------|-----------|-----------|
| 1           | 64          | 585       | 28.38     | 4         |
| 16          | 256         | 338       | 51.63     | 37        |
| 64          | 512         | 634       | 87.27     | 85        |
| 256         | 1024        | 2,017     | 169.96    | 169       |
| 1024        | 2048        | 104,260   | 437.72    | 179       |
| 4096        | 4096        | 570,017   | 437.19    | 188       |

**Accuracy**: GSM8K **96.21%** (sgl-eval, `--no-thinking --max-tokens 8192`, 1.06% truncation)

### Test environment
- Hardware: AMD Instinct MI300X (8× 192 GB)
- SGLang: v0.5.13.post1
- Docker: `lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x`
- KV cache: bfloat16 (auto-set by DSA backend on SM9 device)

cc @zijiexia

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828392983](https://github.com/sgl-project/sglang/actions/runs/34828392983)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828392656](https://github.com/sgl-project/sglang/actions/runs/34828392656)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->