### PR TITLE
ci: prune uv cache in job teardown to bound its growth

### DIFF
--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -11,12 +11,21 @@ set +e
 set -u
 
 # Bound the persistent uv cache (~/.cache/uv, bind-mounted and shared across all
-# runner containers). Nothing else evicts it, so it grows unbounded — on the
-# 5090 hosts it reached ~500 GB and filled the disk, failing jobs with ENOSPC at
-# dependency install. `--ci` drops rebuildable built wheels while keeping
-# downloaded ones. Runs regardless of venv mode; best effort, never fails the job.
+# runner containers). Nothing else evicts it, so it grows unbounded — on the 5090
+# hosts it reached ~500 GB and filled the disk, failing jobs with ENOSPC at
+# dependency install. Prune only under real disk pressure so healthy jobs pay
+# nothing (just a df check) and no rebuildable wheel is dropped until it matters:
+# `uv cache prune --ci` keeps downloaded wheels + sdist archives (no re-download)
+# but drops built wheels, so a later install may recompile source-built packages.
+# Best effort; runs regardless of venv mode; never fails the job.
 if command -v uv >/dev/null 2>&1; then
-    uv cache prune --ci >/dev/null 2>&1 || true
+    cache_dir="$(uv cache dir 2>/dev/null || echo "${HOME:-/root}/.cache/uv")"
+    [ -d "$cache_dir" ] || cache_dir=/
+    used="$(df --output=pcent "$cache_dir" 2>/dev/null | tr -dc '0-9')"
+    if [ "${used:-0}" -ge 85 ]; then
+        echo "uv cache filesystem at ${used}% — pruning"
+        uv cache prune --ci >/dev/null 2>&1 || true
+    fi
 fi
 
 # Skip entirely when venv mode is disabled — no /tmp/sglang-ci-* dir exists

--- a/scripts/ci/cuda/ci_cleanup_venv.sh
+++ b/scripts/ci/cuda/ci_cleanup_venv.sh
@@ -10,6 +10,15 @@
 set +e
 set -u
 
+# Bound the persistent uv cache (~/.cache/uv, bind-mounted and shared across all
+# runner containers). Nothing else evicts it, so it grows unbounded — on the
+# 5090 hosts it reached ~500 GB and filled the disk, failing jobs with ENOSPC at
+# dependency install. `--ci` drops rebuildable built wheels while keeping
+# downloaded ones. Runs regardless of venv mode; best effort, never fails the job.
+if command -v uv >/dev/null 2>&1; then
+    uv cache prune --ci >/dev/null 2>&1 || true
+fi
+
 # Skip entirely when venv mode is disabled — no /tmp/sglang-ci-* dir exists
 # and there's nothing to sweep. Matches the USE_VENV parsing in
 # ci_install_dependency.sh (accepts 1/true/yes, case-insensitive).


### PR DESCRIPTION
The persistent uv cache (`~/.cache/uv`, bind-mounted and shared across all runner containers) has no eviction, so it grows unbounded. On the 5090 hosts it reached ~500 GB and filled the root disk, failing jobs with ENOSPC at dependency install (`failed to write to file ... os error 28`).

Add a best-effort prune to the `always()` teardown, **gated on disk usage (>=85%)** so it's a pressure valve, not a routine tax:
- Healthy jobs pay only a `df` check — the cache is left intact, so nothing is re-downloaded or recompiled on the next install.
- Under pressure, `uv cache prune --ci` reclaims space; it keeps downloaded wheels + sdist archives (no re-download) and drops built wheels (a later install may recompile source-built packages, which is acceptable only when the disk is actually filling).

Runs in teardown (off the install critical path), regardless of venv mode; never fails the job.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29124935407](https://github.com/sgl-project/sglang/actions/runs/29124935407)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29125166967](https://github.com/sgl-project/sglang/actions/runs/29125166967)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->