### PR TITLE
[2/6][kimi-deterministic] Disable dsv3_fused_a_gemm for qkv_a_proj under deterministic inference

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_attention.py
+++ b/python/sglang/kernels/ops/attention/flash_attention.py
@@ -297,6 +297,7 @@ def flash_attn_varlen_func(
             cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
+            qv=qv,
             seqused_q=seqused_q,
             seqused_k=seqused_k,
             page_table=page_table,

--- a/python/sglang/kernels/ops/attention/flash_attention_v4.py
+++ b/python/sglang/kernels/ops/attention/flash_attention_v4.py
@@ -34,6 +34,7 @@ def flash_attn_varlen_func(
     v: torch.Tensor,
     cu_seqlens_q: Optional[torch.Tensor] = None,
     cu_seqlens_k: Optional[torch.Tensor] = None,
+    qv: Optional[torch.Tensor] = None,
     seqused_q: Optional[torch.Tensor] = None,
     seqused_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
@@ -75,7 +76,7 @@ def flash_attn_varlen_func(
             "vendored FA4 package is importable."
         ) from _flash_attn_import_error
 
-    q, k, v = [_maybe_contiguous(t) for t in (q, k, v)]
+    q, k, v, qv = [_maybe_contiguous(t) for t in (q, k, v, qv)]
     cu_seqlens_q, cu_seqlens_k = [
         _maybe_contiguous(t) for t in (cu_seqlens_q, cu_seqlens_k)
     ]
@@ -118,6 +119,7 @@ def flash_attn_varlen_func(
         q=q,
         k=k,
         v=v,
+        qv=qv,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
         seqused_q=seqused_q,
@@ -189,7 +191,7 @@ def flash_attn_with_kvcache(
     return_softmax_lse: bool = False,
     **_: object,
 ):
-    if k is not None or v is not None or qv is not None:
+    if k is not None or v is not None:
         raise NotImplementedError("FA4 does not support updating KV cache in-place.")
     if rotary_cos is not None or rotary_sin is not None or rotary_seqlens is not None:
         raise NotImplementedError("FA4 path does not support rotary embedding.")
@@ -206,6 +208,7 @@ def flash_attn_with_kvcache(
         q=q,
         k=k_cache,
         v=v_cache,
+        qv=qv,
         cu_seqlens_q=cu_seqlens_q,
         seqused_k=cache_seqlens,
         max_seqlen_q=max_seqlen_q,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1537,6 +1537,9 @@ class FlashAttentionBackend(AttentionBackend):
                     return output, lse
                 return output
             else:
+                # FA4 absorbed MLA is shared by extend and decode: once qv is
+                # threaded through the wrappers, decode's flash_attn_with_kvcache
+                # call takes the same qv/ver arguments as this extend path.
                 assert self.fa_impl_ver in (3, 4), "Only FA3/FA4 support here"
                 # Do absorbed multi-latent attention
                 kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id).to(

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1537,7 +1537,7 @@ class FlashAttentionBackend(AttentionBackend):
                     return output, lse
                 return output
             else:
-                assert self.fa_impl_ver == 3, "Only FA3 support here"
+                assert self.fa_impl_ver in (3, 4), "Only FA3/FA4 support here"
                 # Do absorbed multi-latent attention
                 kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id).to(
                     q.dtype

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -133,8 +133,9 @@ def handle_attention_cutlass_mla(attn, forward_batch):
 
 
 def handle_attention_fa4(attn, forward_batch):
-    # TODO(cicirori): use FA4 MHA for DeepSeekV3 for now
-    return AttnForwardMethod.MHA_CHUNKED_KV
+    if get_server_args().enable_deterministic_inference:
+        return _dispatch_mla_subtype(attn, forward_batch)
+    return _handle_attention_backend(attn, forward_batch, "fa4")
 
 
 def handle_attention_trtllm_mla(attn, forward_batch):

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -12,7 +12,7 @@ from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods
 )
 from sglang.srt.models.deepseek_common.utils import _is_hip
 from sglang.srt.runtime_context import get_server_args
-from sglang.srt.utils import use_intel_amx_backend
+from sglang.srt.utils import is_sm100_supported, use_intel_amx_backend
 
 MHA_ONE_SHOT_SUPPORTED_BACKENDS = ["fa3", "flashinfer", "flashmla"]
 
@@ -133,6 +133,12 @@ def handle_attention_cutlass_mla(attn, forward_batch):
 
 
 def handle_attention_fa4(attn, forward_batch):
+    # FA4 absorbed MLA feeds q_nope through the qv argument, which
+    # flash_attn.cute only implements on Blackwell (SM100); keep the
+    # pre-existing MHA chunked-KV path elsewhere. Deterministic inference
+    # requires MLA and rejects fa4 on non-SM100 at startup (server_args).
+    if not is_sm100_supported():
+        return AttnForwardMethod.MHA_CHUNKED_KV
     if get_server_args().enable_deterministic_inference:
         return _dispatch_mla_subtype(attn, forward_batch)
     return _handle_attention_backend(attn, forward_batch, "fa4")

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -11,8 +11,8 @@ from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods
     AttnForwardMethod,
 )
 from sglang.srt.models.deepseek_common.utils import _is_hip
-from sglang.srt.runtime_context import get_server_args
-from sglang.srt.utils import is_sm100_supported, use_intel_amx_backend
+from sglang.srt.runtime_context import get_exec, get_server_args
+from sglang.srt.utils import is_sm100_or_sm110_supported, use_intel_amx_backend
 
 MHA_ONE_SHOT_SUPPORTED_BACKENDS = ["fa3", "flashinfer", "flashmla"]
 
@@ -134,12 +134,12 @@ def handle_attention_cutlass_mla(attn, forward_batch):
 
 def handle_attention_fa4(attn, forward_batch):
     # FA4 absorbed MLA feeds q_nope through the qv argument, which
-    # flash_attn.cute only implements on Blackwell (SM100); keep the
+    # flash_attn.cute only implements on SM100/SM110 (not SM120); keep the
     # pre-existing MHA chunked-KV path elsewhere. Deterministic inference
-    # requires MLA and rejects fa4 on non-SM100 at startup (server_args).
-    if not is_sm100_supported():
+    # requires MLA and rejects fa4 on other archs at startup (server_args).
+    if not is_sm100_or_sm110_supported():
         return AttnForwardMethod.MHA_CHUNKED_KV
-    if get_server_args().enable_deterministic_inference:
+    if get_exec().deterministic.enable_deterministic_inference:
         return _dispatch_mla_subtype(attn, forward_batch)
     return _handle_attention_backend(attn, forward_batch, "fa4")
 

--- a/python/sglang/srt/models/deepseek_common/utils.py
+++ b/python/sglang/srt/models/deepseek_common/utils.py
@@ -59,6 +59,7 @@ NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]
 
 FORWARD_ABSORB_CORE_ATTENTION_BACKENDS = [
     "fa3",
+    "fa4",
     "dsa",
     "nsa",  # Deprecated alias for "dsa"
     "flashinfer",

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -183,6 +183,7 @@ from sglang.srt.models.deepseek_common.utils import (
     is_wint4afp8_or_wint4a16_config,
 )
 from sglang.srt.runtime_context import (
+    get_exec,
     get_flags,
     get_forward,
     get_model,
@@ -1777,6 +1778,7 @@ class DeepseekV2AttentionMLA(
         )
         self.use_min_latency_fused_a_gemm = (
             self.has_fused_proj
+            and not get_exec().deterministic.enable_deterministic_inference
             and not self.is_packed_weight
             and fused_a_gemm_weight_eligible(self.fused_qkv_a_proj_with_mqa)
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7263,10 +7263,12 @@ class ServerArgs:
 
             attention_backend = resolved_view(self).attention_backend
             if is_deepseek_model:
-                deepseek_deterministic_attention_backends = ["fa3", "triton"]
-                if attention_backend not in deepseek_deterministic_attention_backends:
+                if (
+                    attention_backend
+                    not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND
+                ):
                     raise ValueError(
-                        f"Currently only {deepseek_deterministic_attention_backends} attention backends are supported for deterministic inference with DeepSeek models. But you're using {attention_backend}."
+                        f"Currently only {RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND} attention backends are supported for deterministic inference with DeepSeek models. But you're using {attention_backend}."
                     )
 
             if attention_backend not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7270,6 +7270,13 @@ class ServerArgs:
                     raise ValueError(
                         f"Currently only {RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND} attention backends are supported for deterministic inference with DeepSeek models. But you're using {attention_backend}."
                     )
+                if attention_backend == "fa4" and not is_sm100_supported():
+                    raise ValueError(
+                        "Deterministic inference with DeepSeek models on the fa4 "
+                        "attention backend requires Blackwell (SM100): it runs "
+                        "absorbed MLA, whose qv argument flash_attn.cute only "
+                        "implements on Blackwell."
+                    )
 
             if attention_backend not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND:
                 # Currently, only certain backends support radix cache. Support for other backends is in progress

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -82,6 +82,7 @@ from sglang.srt.utils.common import (
     is_npu,
     is_remote_url,
     is_sm90_supported,
+    is_sm100_or_sm110_supported,
     is_sm100_supported,
     is_sm120_supported,
     is_xpu,
@@ -7270,12 +7271,12 @@ class ServerArgs:
                     raise ValueError(
                         f"Currently only {RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND} attention backends are supported for deterministic inference with DeepSeek models. But you're using {attention_backend}."
                     )
-                if attention_backend == "fa4" and not is_sm100_supported():
+                if attention_backend == "fa4" and not is_sm100_or_sm110_supported():
                     raise ValueError(
                         "Deterministic inference with DeepSeek models on the fa4 "
-                        "attention backend requires Blackwell (SM100): it runs "
+                        "attention backend requires SM100/SM110: it runs "
                         "absorbed MLA, whose qv argument flash_attn.cute only "
-                        "implements on Blackwell."
+                        "implements on those archs."
                     )
 
             if attention_backend not in RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -288,6 +288,15 @@ is_sm100_supported = lru_cache(maxsize=1)(
         _check_cuda_device_version, device_capability_majors=[10], cuda_version=(12, 8)
     )
 )
+# Datacenter Blackwell (SM100) plus SM110; excludes consumer Blackwell (SM120).
+# This is the arch set flash_attn.cute accepts for the absorbed-MLA qv argument.
+is_sm100_or_sm110_supported = lru_cache(maxsize=1)(
+    partial(
+        _check_cuda_device_version,
+        device_capability_majors=[10, 11],
+        cuda_version=(12, 8),
+    )
+)
 is_sm80_supported = lru_cache(maxsize=1)(
     partial(
         _check_cuda_device_version, device_capability_majors=[8], cuda_version=(11, 0)

--- a/test/registered/kernels/ops/attention/test_flash_attention_4.py
+++ b/test/registered/kernels/ops/attention/test_flash_attention_4.py
@@ -11,7 +11,11 @@ import torch
 import torch.nn.functional as F
 from einops import rearrange, repeat
 
-from sglang.kernels.ops.attention.flash_attention import flash_attn_varlen_func
+from sglang.kernels.ops.attention.flash_attention import (
+    flash_attn_varlen_func,
+    flash_attn_with_kvcache,
+)
+from sglang.srt.utils import is_sm100_or_sm110_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -1508,7 +1512,8 @@ def _generate_block_kvcache(
 
 
 @pytest.mark.skipif(
-    skip_condition, reason="FA4 Requires compute capability of 10 or above."
+    not is_sm100_or_sm110_supported(),
+    reason="flash_attn.cute implements qv on SM100/SM110 only (not SM120).",
 )
 @pytest.mark.parametrize("mha_type", ["mqa", "gqa"])
 @pytest.mark.parametrize(
@@ -1565,6 +1570,23 @@ def test_flash_attn_varlen_qv_deepseek_absorbed(seqlen_q, seqlen_k, mha_type):
         ver=4,
     )
     out = rearrange(out_unpad, "(b s) h d -> b s h d", b=batch_size)
+
+    # Decode enters through the flash_attn_with_kvcache wrapper; it must
+    # thread qv/num_splits down to the same varlen kernel call bit-for-bit.
+    out_kvcache = flash_attn_with_kvcache(
+        q=rearrange(q, "b s h d -> (b s) h d"),
+        k_cache=k_cache_paged,
+        v_cache=v_cache_paged,
+        qv=rearrange(qv, "b s h d -> (b s) h d"),
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        max_seqlen_q=seqlen_q,
+        causal=True,
+        num_splits=1,
+        ver=4,
+    )
+    assert torch.equal(out_kvcache, out_unpad)
 
     key_padding_mask = rearrange(
         torch.arange(seqlen_k, device=device), "s -> 1 s"

--- a/test/registered/kernels/ops/attention/test_flash_attention_4.py
+++ b/test/registered/kernels/ops/attention/test_flash_attention_4.py
@@ -1507,5 +1507,94 @@ def _generate_block_kvcache(
     return k_cache, v_cache, page_table, k_cache_paged, v_cache_paged, num_blocks
 
 
+@pytest.mark.skipif(
+    skip_condition, reason="FA4 Requires compute capability of 10 or above."
+)
+@pytest.mark.parametrize("mha_type", ["mqa", "gqa"])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (1, 128),  # plain decode
+        (4, 1024),  # speculative decode (multiple q rows per request)
+        (64, 800),  # chunked extend
+        (16, 20000),  # long context
+    ],
+)
+def test_flash_attn_varlen_qv_deepseek_absorbed(seqlen_q, seqlen_k, mha_type):
+    """DeepSeek absorbed-MLA FA4 shape: rope q/k head_dim 64, latent v/qv
+    head_dim 512, varlen q over a paged KV cache, num_splits=1. Mirrors the
+    production calls in flashattention_backend.py, where extend
+    (flash_attn_varlen_func) and decode (flash_attn_with_kvcache) share this
+    qv-threaded path.
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.random.manual_seed(seqlen_q + seqlen_k)
+    batch_size = 5
+    nheads = 8
+    nheads_k = 1 if mha_type == "mqa" else 4
+    d, dv = 64, 512
+    page_size = 128
+
+    q = torch.randn(batch_size, seqlen_q, nheads, d, device=device, dtype=dtype)
+    qv = torch.randn(batch_size, seqlen_q, nheads, dv, device=device, dtype=dtype)
+    k_cache, v_cache, page_table, k_cache_paged, v_cache_paged, _ = (
+        _generate_block_kvcache(
+            seqlen_k, page_size, batch_size, nheads_k, d, dv, device, dtype, dtype
+        )
+    )
+    cache_seqlens = torch.randint(
+        seqlen_q, seqlen_k + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    cache_seqlens[0] = seqlen_k
+    cu_seqlens_q = (
+        torch.arange(batch_size + 1, dtype=torch.int32, device=device) * seqlen_q
+    )
+
+    out_unpad = flash_attn_varlen_func(
+        rearrange(q, "b s h d -> (b s) h d"),
+        k_cache_paged,
+        v_cache_paged,
+        qv=rearrange(qv, "b s h d -> (b s) h d"),
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=None,  # KV comes from the paged cache via seqused_k
+        seqused_k=cache_seqlens,
+        page_table=page_table,
+        causal=True,
+        num_splits=1,
+        ver=4,
+    )
+    out = rearrange(out_unpad, "(b s) h d -> b s h d", b=batch_size)
+
+    key_padding_mask = rearrange(
+        torch.arange(seqlen_k, device=device), "s -> 1 s"
+    ) < rearrange(cache_seqlens, "b -> b 1")
+    k_rep = repeat(k_cache, "b s h d -> b s (h g) d", g=nheads // nheads_k)
+    v_rep = repeat(v_cache, "b s h d -> b s (h g) d", g=nheads // nheads_k)
+    out_ref, _ = attention_ref(
+        q, k_rep, v_rep, None, key_padding_mask, causal=True, qv=qv
+    )
+    out_pt, _ = attention_ref(
+        q,
+        k_rep,
+        v_rep,
+        None,
+        key_padding_mask,
+        causal=True,
+        qv=qv,
+        upcast=False,
+        reorder_ops=True,
+    )
+
+    print(f"Output max diff: {(out - out_ref).abs().max().item()}")
+    print(f"Pytorch max diff: {(out_pt - out_ref).abs().max().item()}")
+    assert (out - out_ref).abs().max().item() <= 2 * (
+        out_pt - out_ref
+    ).abs().max().item() + 1e-5
+    assert (out - out_ref).abs().mean().item() <= 1.5 * (
+        out_pt - out_ref
+    ).abs().mean().item()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
> **Stacked series (2/6)**: stacked on `kimi-deterministic/1-fa4-mla-backend` (#30817), so the diff below includes 1/6. This PR's own change is the last commit (576e5bb0a). Combined CI: #30822.

## Motivation

`fused_qkv_a_proj_with_mqa` picks kernels by batch size (`dsv3_fused_a_gemm` for 1-16 rows, cuBLAS otherwise); `dsv3_fused_a_gemm` is outside the deterministic aten overrides, so qkv_a projection bits change with decode batch size. (Attention-side min-latency GEMM; unrelated to DeepEP low_latency.)

## Modifications

One condition in the `use_min_latency_fused_a_gemm` init: disabled under deterministic inference, so the projection always runs through the batch-invariant `aten.mm` override. An explicit `matmul_persistent` branch was ablated bitwise-identical and dropped.

## Accuracy Tests

Kimi-K2-Instruct-BF16, 16 GPUs (TP16 / DP8-attention / EP16, fa4 + deep_gemm + deepep normal, radix on), 128 prompts (1k-16k) x 512 tokens, abs tol 0.0: replay, shuffled concurrency-32, bs1 vs bs128, cached-prefix extend vs cold prefill, decode logprobs vs prefill rescoring (65,536 tokens) — all bitwise identical.

## Speed Tests and Profiling

Microbenchmark on GB300 at the qkv_a shapes (`x[M,7168] @ W[7168,2112]`, bf16, 200-iter mean):

| M | cuBLAS `torch.mm` | `matmul_persistent` (deterministic `aten.mm` override) | `dsv3_fused_a_gemm` |
|---|---|---|---|
| 1-16 | ~20 us | ~30 us | ~24 us |
| 32-1024 | 16-20 us | ~30 us | n/a |
| 4096 / 8192 | 71 / 157 us | 74 / 164 us (<5%) | n/a |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29979965453](https://github.com/sgl-project/sglang/actions/runs/29979965453)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29979965539](https://github.com/sgl-project/sglang/actions/runs/29979965539)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->




