### PR TITLE
fix(hunyuan_v3): remap shared_experts.* to shared_mlp.* so shared-expert weights load

### DIFF
--- a/python/sglang/srt/models/hunyuan_v3.py
+++ b/python/sglang/srt/models/hunyuan_v3.py
@@ -544,6 +544,17 @@ class HYV3ForCausalLM(nn.Module):
                 if len(parts) >= 3 and int(parts[2]) >= self.config.num_hidden_layers:
                     continue
 
+            # HunyuanV3 checkpoints name the shared expert
+            # `...mlp.shared_experts.{gate,up,down}_proj.*`, but this model
+            # registers the module as `...mlp.shared_mlp.*`. Without this remap
+            # every shared-expert weight fails the `name not in params_dict`
+            # check below and is silently skipped, leaving `shared_mlp` at its
+            # uninitialized values and producing NaN on the first forward. The
+            # remap must run before stacked_params_mapping so gate/up_proj fuse
+            # into `gate_up_proj`.
+            if "mlp.shared_experts." in name:
+                name = name.replace("mlp.shared_experts.", "mlp.shared_mlp.")
+
             is_found = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:


### PR DESCRIPTION
### Problem

HunyuanV3 (`hy_v3` / `HYV3ForCausalLM`) checkpoints name the shared expert
`model.layers.N.mlp.shared_experts.{gate,up,down}_proj.*`, but the model module is
registered as **`shared_mlp`** (`HYV3MoEFused.__init__`, gated by `num_shared_experts > 0`).

`HYV3ForCausalLM.load_weights` remaps the router (`router.gate` → `gate`) but has **no
remap for the shared expert**. So every `...mlp.shared_experts.*` tensor falls through to:

```python
if name not in params_dict:
    continue
```

and is **silently skipped** — no warning, no error. `shared_mlp` stays uninitialized, the
shared-expert branch emits NaN on the first forward, and it propagates into the residual
stream. The routed experts (`mlp.experts.N.*`) still match, so the model *loads* fine and
the failure only shows up as NaN at inference. Reported in #30816.

This is the same silent-name-drop class as PR #30331 (sibling fix in `hunyuan_v3_nextn.py`).

### Fix

Add a `mlp.shared_experts.` → `mlp.shared_mlp.` remap, mirroring the existing `router.gate`
remap. It is placed **before** `stacked_params_mapping` so the shared expert's
`gate_proj`/`up_proj` fuse into `gate_up_proj` (a `MergedColumnParallelLinear`) just like
the other stacked projections, while `down_proj` loads directly.

- Distinct from routed experts: `mlp.shared_experts.` never matches `mlp.experts.` (the
  routed-expert prefix), so routed weights are untouched.
- No-op when a checkpoint has no shared experts (the substring never appears).

Only `python/sglang/srt/models/hunyuan_v3.py` is changed.

Fixes #30816

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29127139488](https://github.com/sgl-project/sglang/actions/runs/29127139488)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29127139203](https://github.com/sgl-project/sglang/actions/runs/29127139203)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->