### PR TITLE
Make the mxfp8 MoE runner backend list extensible

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1928,13 +1928,10 @@ def _moe_runner_backend_quant_constraints(view: Any) -> dict:
                 "flashinfer_trtllm_routed."
             )
     if view.quantization == "mxfp8":
+        from sglang.srt.server_args import MXFP8_MOE_RUNNER_BACKEND_CHOICES
+
         is_gfx95_mxfp8 = is_hip() and is_gfx95_supported()
-        allowed = [
-            "cutlass",
-            "deep_gemm",
-            "flashinfer_trtllm",
-            "flashinfer_trtllm_routed",
-        ]
+        allowed = list(MXFP8_MOE_RUNNER_BACKEND_CHOICES)
         if is_gfx95_mxfp8:
             allowed.append("triton")
         mxfp8_default = "triton" if is_gfx95_mxfp8 else "flashinfer_trtllm"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -268,6 +268,13 @@ MOE_A2A_BACKEND_CHOICES = [
     "megamoe",
 ]
 
+MXFP8_MOE_RUNNER_BACKEND_CHOICES = [
+    "cutlass",
+    "deep_gemm",
+    "flashinfer_trtllm",
+    "flashinfer_trtllm_routed",
+]
+
 FP8_GEMM_RUNNER_BACKEND_CHOICES = [
     "auto",
     "deep_gemm",
@@ -365,6 +372,10 @@ def add_grammar_backend_choices(choices):
 
 def add_moe_runner_backend_choices(choices):
     MOE_RUNNER_BACKEND_CHOICES.extend(choices)
+
+
+def add_mxfp8_moe_runner_backend_choices(choices):
+    MXFP8_MOE_RUNNER_BACKEND_CHOICES.extend(choices)
 
 
 def add_fp8_gemm_runner_backend_choices(choices):


### PR DESCRIPTION
## Motivation

The mxfp8 quantization → MoE runner-backend allowlist is hardcoded inline in `_moe_runner_backend_quant_constraints` (`arg_groups/overrides.py`). Downstream forks that add their own mxfp8-compatible MoE runner backend currently have to patch that constraint logic to avoid the "Overriding ..." warning + fallback.

This mirrors the existing extension hooks (`add_moe_runner_backend_choices`, `add_linear_attn_kernel_backend_choices`, etc.): extract the list into a module-level global and add a registration helper, so external code can extend it without touching OSS constraint logic.

## Changes

- `server_args.py`: add `MXFP8_MOE_RUNNER_BACKEND_CHOICES` (`cutlass`, `flashinfer_trtllm`, `flashinfer_trtllm_routed`) and `add_mxfp8_moe_runner_backend_choices()`.
- `arg_groups/overrides.py`: the mxfp8 branch checks membership against the global and derives its warning message from it (so the message can't drift). Uses the same lazy `from sglang.srt.server_args import ...` pattern already used there for `DETERMINISTIC_ATTENTION_BACKEND_CHOICES`.

No behavior change for the built-in backends.

## Test

`python -m py_compile` on both files; existing arg-resolution tests cover the mxfp8 constraint path. No numerics touched.

## Original commits

- `eec153054`















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29185047580](https://github.com/sgl-project/sglang/actions/runs/29185047580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29185047507](https://github.com/sgl-project/sglang/actions/runs/29185047507)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->