### PR TITLE
refactor(attn): decouple TRTLLM MHA backends from FlashInfer

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import torch
-
 from sglang.kernels.ops.kvcache.trtllm_fp8_kv_kernel import (
     fused_fp8_set_kv_buffer,
 )
@@ -23,10 +22,7 @@ from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.flashinfer_backend import (
-    FlashInferAttnBackend,
-    FlashInferMultiStepDraftBackend,
-)
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import canonicalize_stride
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
@@ -71,7 +67,7 @@ class TRTLLMMHAMetadata:
     swa_out_cache_loc: torch.Tensor = None
 
 
-class TRTLLMHAAttnBackend(FlashInferAttnBackend):
+class TRTLLMHAAttnBackend(AttentionBackend):
     """TRTLLM MHA attention kernel from flashinfer."""
 
     # Build the page table on-device from seq_lens (incl. the SWA-translated table
@@ -83,21 +79,15 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self,
         model_runner: ModelRunner,
         skip_prefill: bool = False,
-        kv_indptr_buf: Optional[torch.Tensor] = None,
-        kv_last_page_len_buf: Optional[torch.Tensor] = None,
         speculative_step_id: int = 0,
     ):
-        # Capture workspace size before super().__init__() to preserve user's
-        # SGLANG_FLASHINFER_WORKSPACE_SIZE setting (may be overridden by parent)
+        super().__init__()
+
         env_var = envs.SGLANG_FLASHINFER_WORKSPACE_SIZE
         workspace_size_bytes = (
             env_var.get()
             if env_var.is_set()
             else DEFAULT_WORKSPACE_SIZE_MB * 1024 * 1024
-        )
-
-        super().__init__(
-            model_runner, skip_prefill, kv_indptr_buf, kv_last_page_len_buf
         )
 
         config = model_runner.model_config
@@ -107,11 +97,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.hidden_size = config.hidden_size
 
         # Runtime parameters
+        self.req_to_token_pool = model_runner.req_to_token_pool
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.data_type = model_runner.kv_cache_dtype
         self.q_data_type = model_runner.dtype
         self.page_size = model_runner.page_size
-        self.req_to_token = model_runner.req_to_token_pool.req_to_token
+        self.req_to_token = self.req_to_token_pool.req_to_token
         self.device = model_runner.device
+        self.skip_prefill = skip_prefill
 
         # Workspace allocation
         self.workspace_size = workspace_size_bytes
@@ -141,6 +134,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # SWA hybrid models split the KV cache into full and SWA pools with
         # separate index spaces; SWA layers need a translated page_table.
         self._swa_kv_pool: Optional[SWAKVPool] = self._resolve_swa_kv_pool(model_runner)
+        self.use_sliding_window_kv_pool = self._swa_kv_pool is not None
         # Raw full->swa index mapping tensor for the fused cuda-graph
         # metadata kernel (gather + // page_size happen on device).
         if self._swa_kv_pool is not None:
@@ -949,7 +943,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
 
-class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
+class TRTLLMHAAttnMultiStepDraftBackend:
     """Multi-step TRTLLM MHA attention kernel used by EAGLE."""
 
     # Per-step backends build the page table on-device (sync-free); mirror that so
@@ -959,23 +953,27 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int
     ):
-        super().__init__(model_runner, topk, speculative_num_steps)
+        self.topk = topk
+        self.speculative_num_steps = speculative_num_steps
+        self.attn_backends: list[TRTLLMHAAttnBackend] = []
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i] = TRTLLMHAAttnBackend(
-                model_runner,
-                skip_prefill=True,
-                kv_indptr_buf=self.kv_indptr[i],
-                kv_last_page_len_buf=self.kv_last_page_len,
-                speculative_step_id=i,
+            self.attn_backends.append(
+                TRTLLMHAAttnBackend(
+                    model_runner,
+                    skip_prefill=True,
+                    speculative_step_id=i,
+                )
             )
 
+        self.max_context_len = model_runner.model_config.context_len
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+        for attn_backend in self.attn_backends:
+            attn_backend.init_forward_metadata(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
-        for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
+        for attn_backend in self.attn_backends:
+            attn_backend.init_cuda_graph_state(max_bs, max_num_tokens)
 
     def init_forward_metadata_out_graph(
         self,
@@ -995,8 +993,8 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
             forward_mode=ForwardMode.DECODE,
             encoder_lens=forward_batch.encoder_lens,
         )
-        for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata_out_graph(
+        for attn_backend in self.attn_backends:
+            attn_backend.init_forward_metadata_out_graph(
                 inner_fb, in_capture=in_capture
             )
 
@@ -1012,5 +1010,5 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
             forward_mode=ForwardMode.DECODE,
             encoder_lens=forward_batch.encoder_lens,
         )
-        for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata_in_graph(inner_fb)
+        for attn_backend in self.attn_backends:
+            attn_backend.init_forward_metadata_in_graph(inner_fb)

--- a/test/registered/unit/spec/test_resolve_swa_kv_pool.py
+++ b/test/registered/unit/spec/test_resolve_swa_kv_pool.py
@@ -1,10 +1,17 @@
 """Unit tests for attention-backend SWA KV pool resolution."""
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
-from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.flashinfer_backend import (
+    FlashInferAttnBackend,
+    FlashInferMultiStepDraftBackend,
+)
+from sglang.srt.layers.attention.trtllm_mha_backend import (
+    TRTLLMHAAttnBackend,
+    TRTLLMHAAttnMultiStepDraftBackend,
+)
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -36,6 +43,46 @@ def _mock_runner(
 
 
 class TestResolveSwaKvPool(CustomTestCase):
+    def test_trtllm_mha_backends_are_decoupled_from_flashinfer(self):
+        self.assertTrue(issubclass(TRTLLMHAAttnBackend, AttentionBackend))
+        self.assertFalse(issubclass(TRTLLMHAAttnBackend, FlashInferAttnBackend))
+        self.assertFalse(
+            issubclass(
+                TRTLLMHAAttnMultiStepDraftBackend, FlashInferMultiStepDraftBackend
+            )
+        )
+
+    @patch("sglang.srt.layers.attention.trtllm_mha_backend.TRTLLMHAAttnBackend")
+    def test_multistep_backend_initializes_only_trtllm_steps(self, backend_cls):
+        runner = MagicMock()
+        runner.model_config.context_len = 4096
+
+        backend = TRTLLMHAAttnMultiStepDraftBackend(
+            runner, topk=1, speculative_num_steps=3
+        )
+
+        self.assertEqual(len(backend.attn_backends), 2)
+        self.assertEqual(backend.max_context_len, 4096)
+        self.assertFalse(hasattr(backend, "kv_indptr"))
+        self.assertFalse(hasattr(backend, "kv_last_page_len"))
+        self.assertEqual(
+            [call.kwargs["speculative_step_id"] for call in backend_cls.call_args_list],
+            [0, 1],
+        )
+
+    @patch("sglang.srt.layers.attention.trtllm_mha_backend.TRTLLMHAAttnBackend")
+    def test_multistep_backend_handles_no_draft_steps(self, backend_cls):
+        runner = MagicMock()
+        runner.model_config.context_len = 4096
+
+        backend = TRTLLMHAAttnMultiStepDraftBackend(
+            runner, topk=1, speculative_num_steps=1
+        )
+
+        self.assertEqual(backend.attn_backends, [])
+        self.assertEqual(backend.max_context_len, 4096)
+        backend_cls.assert_not_called()
+
     def test_active_pool_is_swa_returns_it(self):
         for name, resolve, pool_type in _RESOLVERS:
             with self.subTest(backend=name):


### PR DESCRIPTION
Closes #28808.

## Motivation

`TRTLLMHAAttnBackend` overrides the FlashInfer attention paths but still inherits `FlashInferAttnBackend`, causing FlashInfer wrappers, index updaters, workspaces, and draft index buffers to be initialized even though the TRTLLM-MHA path does not use them.

## Modifications

- Make `TRTLLMHAAttnBackend` inherit directly from `AttentionBackend` and initialize only the shared pool, context, workspace, and SWA state it consumes.
- Make `TRTLLMHAAttnMultiStepDraftBackend` a standalone wrapper that creates only TRTLLM-MHA per-step backends.
- Remove the unused `kv_indptr` and `kv_last_page_len` constructor plumbing from the TRTLLM-MHA path.
- Add regression tests for the inheritance hierarchy, per-step initialization, absence of FlashInfer draft buffers, and the zero-draft-step edge case.

## Accuracy Tests

N/A. This is an inheritance and initialization refactor; attention kernels and numerical paths are unchanged.

## Speed Tests and Profiling

N/A. The change removes unused initialization allocations; runtime kernel execution is unchanged.

## Validation

- `python -m compileall` on the modified implementation and test files
- `ruff check --select=F401,F821,UP037,I` on the modified files
- `ruff format --check` on the modified files
- `python scripts/ci/check_registered_tests.py`
- `git diff --check`

The targeted pytest module could not be collected in the local Windows environment because SGLang imports Unix/Linux-only runtime dependencies (`resource`); CI should exercise the registered CUDA/AMD unit test.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) (not applicable; no public API or user-facing behavior changed).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) (not applicable; no numerical or kernel changes).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29129366064](https://github.com/sgl-project/sglang/actions/runs/29129366064)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29129365911](https://github.com/sgl-project/sglang/actions/runs/29129365911)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->