### PR TITLE
Allocate single-node DP-attention ports from a free block to avoid collisions

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -534,10 +534,8 @@ class DataParallelController:
                     rank_port_args = PortArgs.init_new(
                         server_args, dp_rank, worker_ports
                     )
-                    # Data parallelism reuses the tensor parallelism group,
-                    # so all dp ranks should use the same nccl port.
-                    rank_port_args.nccl_port = port_args.nccl_port
-                    rank_port_args.instance_id = port_args.instance_id
+                    # Inherit the engine's shared control-plane ports for this rank.
+                    rank_port_args.inherit_dp_shared_ports(port_args)
 
                 reader, writer = mp.Pipe(duplex=False)
                 gpu_id = (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -90,7 +90,12 @@ from sglang.srt.utils.common import (
     torch_release,
 )
 from sglang.srt.utils.hf_transformers_utils import check_gguf_file
-from sglang.srt.utils.network import NetworkAddress, get_free_port, wait_port_available
+from sglang.srt.utils.network import (
+    NetworkAddress,
+    get_free_port,
+    get_free_port_block,
+    wait_port_available,
+)
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.utils import is_in_ci
@@ -7611,24 +7616,23 @@ class PortArgs:
             )
         else:
             # DP attention. Use TCP + port to handle both single-node and multi-node.
+            # dist_init_port + NUM_DERIVED_PORTS derived ports up to load_collector.
+            NUM_DERIVED_PORTS = 6
             if server_args.nnodes == 1 and server_args.dist_init_addr is None:
-                derived_port = server_args.port + ZMQ_TCP_PORT_DELTA
-                if derived_port > 65535:
-                    derived_port = server_args.port - ZMQ_TCP_PORT_DELTA
-                na = NetworkAddress("127.0.0.1", derived_port)
+                # Single node: OS-assigned free block, not the deterministic port.
+                na = NetworkAddress(
+                    "127.0.0.1", get_free_port_block(NUM_DERIVED_PORTS + 1)
+                )
             else:
                 na = NetworkAddress.parse(server_args.dist_init_addr)
 
             dist_init_host = na.host
             dist_init_port = na.port
 
-            # We need 5 consecutive ports from port_base for:
-            # port_base, detokenizer, rpc, metrics, scheduler.
             # In multi-node, all nodes derive ports independently from
             # dist_init_port, so the derivation must be deterministic
             # (no availability-based search). If incrementing would
             # overflow the valid TCP range, decrement instead.
-            NUM_DERIVED_PORTS = 5
             if dist_init_port + NUM_DERIVED_PORTS > 65535:
                 port_base = dist_init_port - NUM_DERIVED_PORTS - 1
             else:
@@ -7683,3 +7687,13 @@ class PortArgs:
                 ).to_tcp(),
                 instance_id=instance_id,
             )
+
+    def inherit_dp_shared_ports(self, engine_port_args: "PortArgs") -> None:
+        """Adopt the engine's shared control-plane ports for a DP-attention rank."""
+        self.nccl_port = engine_port_args.nccl_port
+        self.instance_id = engine_port_args.instance_id
+        self.tokenizer_ipc_name = engine_port_args.tokenizer_ipc_name
+        self.detokenizer_ipc_name = engine_port_args.detokenizer_ipc_name
+        self.rpc_ipc_name = engine_port_args.rpc_ipc_name
+        self.metrics_ipc_name = engine_port_args.metrics_ipc_name
+        self.load_collector_ipc_name = engine_port_args.load_collector_ipc_name

--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -185,6 +185,27 @@ def get_free_port():
     return port
 
 
+def get_free_port_block(num_ports: int, max_attempts: int = 20) -> int:
+    """Return a base port P such that ports P..P+num_ports-1 are all free.
+
+    The base is seeded from an OS-assigned ephemeral port so concurrent
+    callers (e.g. sibling launch_server.py processes sharing a launch
+    cmdline) get distinct blocks instead of colliding on a deterministically
+    derived port.
+    """
+    if num_ports < 1:
+        raise ValueError(f"num_ports must be >= 1, got {num_ports}")
+    for _ in range(max_attempts):
+        base = get_free_port()
+        if base + num_ports - 1 > MAX_VALID_PORT:
+            continue
+        if all(is_port_available(base + offset) for offset in range(1, num_ports)):
+            return base
+    raise OSError(
+        f"Could not find {num_ports} consecutive free ports in {max_attempts} attempts"
+    )
+
+
 def bind_port(port):
     """Bind to a specific port, assuming it's available."""
     return try_bind_socket(port=port, listen=True)

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1438,5 +1438,44 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestSingleNodeDpAttentionPorts(CustomTestCase):
+    def test_ranks_inherit_engine_shared_ports(self):
+        # Single-node DP attention allocates ports from an OS-assigned free block,
+        # so PortArgs.init_new lands on a different block each call: once in the
+        # engine (dp_rank=None, the binders) and once per rank in
+        # DataParallelController (the connectors). Ranks must inherit the engine's
+        # shared control-plane ports, or they connect to ports the engine never
+        # bound and the server hangs.
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_dp_attention=True,
+            dp_size=2,
+            tp_size=2,
+        )
+        engine = PortArgs.init_new(server_args)
+        rank0 = PortArgs.init_new(server_args, 0, [40001, 40002])
+
+        shared = (
+            "nccl_port",
+            "instance_id",
+            "tokenizer_ipc_name",
+            "detokenizer_ipc_name",
+            "rpc_ipc_name",
+            "metrics_ipc_name",
+            "load_collector_ipc_name",
+        )
+        # The rank inherits the engine's shared ports (what DataParallelController
+        # does); afterwards every shared endpoint matches the engine.
+        rank0.inherit_dp_shared_ports(engine)
+        for attr in shared:
+            self.assertEqual(
+                getattr(engine, attr),
+                getattr(rank0, attr),
+                f"{attr} not inherited from the engine PortArgs",
+            )
+        # scheduler_input stays per-rank (from worker_ports), not overwritten.
+        self.assertIn("40001", rank0.scheduler_input_ipc_name)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/utils/test_socket_utils.py
+++ b/test/registered/utils/test_socket_utils.py
@@ -7,6 +7,7 @@ from sglang.srt.utils.network import (
     _get_addrinfos_for_bind,
     bind_port,
     get_free_port,
+    get_free_port_block,
     get_open_port,
     is_port_available,
     try_bind_socket,
@@ -152,6 +153,49 @@ class TestSocketUtilities(CustomTestCase):
                 self.assertGreater(port, occupied_port)
         finally:
             sock.close()
+
+
+class TestGetFreePortBlock(CustomTestCase):
+    def test_returns_consecutive_free_block(self):
+        """get_free_port_block should return a base whose whole span is free."""
+        num_ports = 7
+        base = get_free_port_block(num_ports)
+        self.assertGreater(base, 0)
+        self.assertLessEqual(base + num_ports - 1, 65535)
+        for offset in range(num_ports):
+            self.assertTrue(is_port_available(base + offset))
+
+    def test_block_avoids_held_ports(self):
+        """A held block is skipped, so concurrent callers get distinct blocks."""
+        base1 = get_free_port_block(7)
+        held = [bind_port(base1 + offset) for offset in range(7)]
+        try:
+            base2 = get_free_port_block(7)
+            block1 = set(range(base1, base1 + 7))
+            block2 = set(range(base2, base2 + 7))
+            self.assertEqual(block1 & block2, set())
+        finally:
+            for sock in held:
+                sock.close()
+
+    def test_block_of_one(self):
+        """A block of size 1 should behave like get_free_port."""
+        base = get_free_port_block(1)
+        self.assertTrue(is_port_available(base))
+
+    def test_invalid_count_raises(self):
+        """get_free_port_block should reject counts below 1."""
+        with self.assertRaises(ValueError):
+            get_free_port_block(0)
+
+    def test_exhausted_attempts_raise(self):
+        """get_free_port_block should raise if no block is ever free."""
+        with patch(
+            "sglang.srt.utils.network.is_port_available",
+            return_value=False,
+        ):
+            with self.assertRaises(OSError):
+                get_free_port_block(2, max_attempts=3)
 
 
 class TestReservePort(CustomTestCase):


### PR DESCRIPTION
## Motivation

The DP-attention path in `PortArgs.init_new` derives `dist_init_port` deterministically as `server_args.port + ZMQ_TCP_PORT_DELTA` (233). When two `launch_server.py` processes on the same host share an identical launch cmdline (same `--port`), they derive the **same** `dist_init_port` and the same block of consecutive ports; the second bring-up then fails with `dist_init_port ... is not available in 30 seconds` and exits.

Single node needs no cross-node agreement, so it can use an OS-assigned free block. The multi-node / explicit `--dist-init-addr` path must stay deterministic (every node independently derives the same ports).

## Modifications

- Add `get_free_port_block(num_ports)` to `srt/utils/network.py`: seeds a base from the existing `get_free_port()` and verifies the consecutive tail via `is_port_available()`, so concurrent callers get distinct blocks. Raises on invalid counts / exhaustion.
- `PortArgs.init_new` single-node DP path now reserves a free block instead of the deterministic `+ZMQ_TCP_PORT_DELTA` derivation. `NUM_DERIVED_PORTS` (6) accounts for `load_collector` so the block size and the multi-node overflow guard cover all 7 ports.
- `PortArgs.init_new` also runs once per rank in `DataParallelController`, so a per-call free block would desync the shared control-plane ports between the engine's binders and the per-rank connectors (silent hang). Add `PortArgs.inherit_dp_shared_ports()` so each rank adopts the engine's shared ports (tokenizer/detokenizer/rpc/metrics/load-collector, `nccl_port`, `instance_id`); only `scheduler_input` stays per-rank.

## Test plan

- `test/registered/utils/test_socket_utils.py` (CPU CI) — `get_free_port_block`: consecutive span, block-of-1, invalid-count, exhaustion, and a held-block collision-avoidance test.
- `test/registered/unit/server_args/test_server_args.py` (CPU CI) — a DP-attention rank inherits the engine's shared control-plane ports (`inherit_dp_shared_ports`); `scheduler_input` stays per-rank. Fails on the pre-fix code (engine vs per-rank ports desync) and passes with the fix.
- Drove `PortArgs.init_new` directly: the engine (`dp_rank=None`) and a per-rank call land on different free blocks; `inherit_dp_shared_ports` makes the per-rank shared ports match the engine's.
- **End-to-end:** launched a single-node DP-attention server (`--enable-dp-attention --dp-size 2 --tp-size 2`) on a small MoE (DeepSeek-V2-Lite) and served real requests — both DP ranks (`dp_rank` 0 and 1) returned correct completions, exercising the full tokenizer→scheduler→detokenizer control plane over the inherited ports (eager mode).

## Original commits

- `c0c579658`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29202367507](https://github.com/sgl-project/sglang/actions/runs/29202367507)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29202367434](https://github.com/sgl-project/sglang/actions/runs/29202367434)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->