### PR TITLE
[cuda-graph] Size breakable-graph shared buffer from warmup output; slice by produced row count

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -110,10 +110,11 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
         dummies: Optional[Any] = None,
         post_warmup_hook: Optional[Callable[[], None]] = None,
     ) -> None:
+        warmup_out = None
         for _ in range(2):
             self._device_module.synchronize()
             self._tp_group.barrier()
-            forward_fn()
+            warmup_out = forward_fn()
             if post_warmup_hook is not None:
                 post_warmup_hook()
 
@@ -122,23 +123,54 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             eager_on_graph(True)(forward_fn) if self._debug_eager else forward_fn
         )
         size = shape_key.size
+        if self._shared_output_buffer is None:
+            self._shared_output_buffer = self._alloc_full_buffer(warmup_out, size)
         with BreakableCUDAGraphCapture(
             cuda_graph=graph,
             pool=self._pool,
             stream=self._capture_stream,
         ):
             out = captured_fn()
-            if self._shared_output_buffer is not None:
-                self._copy_output_to_buffer(out, self._shared_output_buffer, size)
+            out_rows = self._output_rows(out, size)
+            self._copy_output_to_buffer(out, self._shared_output_buffer, out_rows)
 
-        if self._shared_output_buffer is None:
-            self._shared_output_buffer = out
-            stored = self._slice_output(out, size)
-        else:
-            stored = self._slice_output(self._shared_output_buffer, size)
-
+        stored = self._slice_output(self._shared_output_buffer, out_rows)
         self._graphs[shape_key] = graph
         self._outputs[shape_key] = stored
+
+    def _output_rows(self, output: Any, cap: int) -> int:
+        """Leading-dim row count actually produced by the body, clamped to ``cap``.
+
+        A body that shards or prunes its output along dim 0 returns fewer than
+        ``cap`` rows; everything else returns exactly ``cap``.
+        """
+        if torch.is_tensor(output):
+            return min(cap, output.shape[0])
+        if isinstance(output, PPProxyTensors):
+            rows = [t.shape[0] for t in output.tensors.values()]
+            return min([cap, *rows])
+        if isinstance(output, (list, tuple)) and output:
+            return min(self._output_rows(o, cap) for o in output if o is not None)
+        return cap
+
+    def _alloc_full_buffer(self, output: Any, size: int) -> Any:
+        """A same-structure buffer as ``output`` but with ``size`` leading rows."""
+        if output is None:
+            return None
+        if torch.is_tensor(output):
+            return output.new_empty((size, *output.shape[1:]))
+        if isinstance(output, PPProxyTensors):
+            return PPProxyTensors(
+                {
+                    key: t.new_empty((size, *t.shape[1:]))
+                    for key, t in output.tensors.items()
+                }
+            )
+        if isinstance(output, tuple):
+            return tuple(self._alloc_full_buffer(o, size) for o in output)
+        if isinstance(output, list):
+            return [self._alloc_full_buffer(o, size) for o in output]
+        raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _slice_output(self, output: Any, num_tokens: int) -> Any:
         if output is None:


### PR DESCRIPTION
## Motivation

`BreakableCudaGraphBackend.capture_one` aliases the first capture's output tensor as the shared output buffer and slices every capture's output by the shape-key size. This assumes the graph body always produces exactly `shape_key.size` leading rows. A body that shards or prunes its output along dim 0 (e.g. a model-level sequence-parallel scheme that keeps hidden states sharded through the captured region and gathers them later) produces fewer rows, so:

- the shared buffer, created by aliasing the first capture's (possibly sharded) output, can be too small for later captures, and
- the stored output view is sliced to the wrong row count.

## Modifications

- Allocate the shared output buffer up front from the warmup output, sized to the full shape-key size of the first capture (preserving the existing assumption that the first capture is the largest), instead of aliasing the first capture's output tensor.
- Copy and slice each capture's output by the row count the body actually produced (`_output_rows`, clamped to the shape-key size), so sharded/pruned outputs get correctly sized views and full outputs behave exactly as before.

## Testing

Validated on an internal deployment: CUDA-graph capture/replay with a model-level SP scheme returning sharded outputs from the captured region, plus no-regression runs with standard full-row outputs. In this environment I ran `python3 -m py_compile`, black, and isort on the changed file; CI will exercise the graph backends.

## Original commits

- `3f1d32f1c`

— Claude







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29138701070](https://github.com/sgl-project/sglang/actions/runs/29138701070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29138700966](https://github.com/sgl-project/sglang/actions/runs/29138700966)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->