### PR TITLE
Fix unfinished SWA boundary in legacy radix cache

### DIFF
--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -534,6 +534,7 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                 key=radix_key,
                 value=values,
                 prev_prefix_len=old_prefix_len,
+                swa_evicted_seqlen=req.swa_evicted_seqlen,
             )
         )
         new_prefix_len = result.prefix_len

--- a/test/registered/unit/mem_cache/test_swa_unfinished_insert.py
+++ b/test/registered/unit/mem_cache/test_swa_unfinished_insert.py
@@ -1,0 +1,58 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import InsertResult
+from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSWAUnfinishedInsert(unittest.TestCase):
+    def test_forwards_evicted_boundary_to_insert(self):
+        cache = object.__new__(SWARadixCache)
+        cache.disable = False
+        cache.page_size = 1
+        cache.is_eagle = False
+        cache.req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.arange(4, dtype=torch.int64).reshape(1, 4),
+            write=Mock(),
+        )
+        cache.insert = Mock(return_value=InsertResult(prefix_len=4))
+        last_node = object()
+        cache.match_prefix = Mock(
+            return_value=SimpleNamespace(
+                device_indices=torch.arange(4, dtype=torch.int64),
+                last_device_node=last_node,
+            )
+        )
+        cache.dec_lock_ref = Mock()
+        cache.inc_lock_ref = Mock(
+            return_value=SimpleNamespace(swa_uuid_for_lock="new-lock")
+        )
+
+        req = SimpleNamespace(
+            req_pool_idx=0,
+            extra_key=None,
+            cache_protected_len=0,
+            swa_evicted_seqlen=2,
+            last_node=object(),
+            swa_uuid_for_lock=None,
+            swa_prefix_lock_released=False,
+            prefix_indices=torch.empty(0, dtype=torch.int64),
+        )
+        req.get_fill_ids = lambda: [10, 11, 12, 13]
+
+        cache.cache_unfinished_req(req, chunked=True)
+
+        insert_params = cache.insert.call_args.args[0]
+        self.assertEqual(insert_params.swa_evicted_seqlen, 2)
+        self.assertIs(req.last_node, last_node)
+        self.assertEqual(req.swa_uuid_for_lock, "new-lock")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

During chunked prefill, SWA eviction can release KV pages before an unfinished
request is inserted into the radix tree. The eviction boundary is tracked by
`req.swa_evicted_seqlen`, and `SWARadixCache.insert()` uses it to distinguish
released SWA KV from live reusable KV.

`cache_finished_req()` already forwards this boundary, but the legacy
`SWARadixCache.cache_unfinished_req()` path leaves it at the default value of
zero. Released SWA pages can therefore be represented as reusable cached KV
instead of tombstones.

#29350 fixed the corresponding bookkeeping path for `UnifiedRadixCache`. This
PR applies the same correctness fix to `SWARadixCache`, which remains the
default while `SGLANG_ENABLE_UNIFIED_RADIX_TREE` is disabled.

## Modifications

- Forward `req.swa_evicted_seqlen` through `InsertParams` when caching an
  unfinished request.
- Add a CPU regression test covering boundary propagation and cache lock state.
- Register the regression test in the CPU CI suite.

#30013 also touches this call site as part of a broader SWA-island optimization.
This PR is limited to the unconditional correctness fix and does not introduce
its allocation or decode behavior.

## Accuracy Tests

This change fixes cache bookkeeping and does not modify model forward code or
kernels.

The regression test fails on the unpatched `main` branch:

- `AssertionError: 0 != 2`
- `Ran 1 test in 0.002s`
- `FAILED (failures=1)`

With this fix:

- `Ran 1 test in 0.001s`
- `OK`

## Speed Tests and Profiling

No performance impact is expected. The change only forwards metadata already
maintained by the request and adds no model work, allocation, or KV copy.

## Checklist

- [x] Code formatting and applicable pre-commit checks pass.
- [x] Added a CPU unit test for the regression.
- [x] Documentation is not required because there is no user-facing API or
      configuration change.
- [x] Accuracy implications and performance impact are documented above.
- [x] The change follows the existing SGLang code style.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29143867438](https://github.com/sgl-project/sglang/actions/runs/29143867438)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29143867336](https://github.com/sgl-project/sglang/actions/runs/29143867336)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->