### PR TITLE
[Perf] Qwen3-MoE: O(1) expert-weight resolution in load_weights (fixes quadratic RL weight-sync cost)

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -18,6 +18,7 @@
 """Inference-only Qwen3MoE model compatible with HuggingFace weights."""
 
 import logging
+import re
 import math
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar
 
@@ -103,6 +104,9 @@ Qwen3MoeConfig = None
 _is_flashinfer_available = is_flashinfer_available()
 
 logger = logging.getLogger(__name__)
+
+# Checkpoint-name fragment of a routed-expert weight, e.g. "experts.7.gate_proj."
+_EXPERT_WEIGHT_NAME_RE = re.compile(r"experts\.\d+\.\w+\.")
 _is_cuda = is_cuda()
 _is_npu = is_npu()
 
@@ -1112,6 +1116,15 @@ class Qwen3MoeForCausalLM(nn.Module):
             ckpt_up_proj_name="up_proj",
             num_experts=self.config.num_experts,
         )
+        # Index the expert mapping by its checkpoint-name fragment
+        # ("experts.{E}.{proj}.") so each incoming tensor resolves in O(1).
+        # The previous per-tensor linear scan over the num_experts * 3 entries is
+        # quadratic over a checkpoint and dominates update_weights_from_tensor
+        # time for RL weight sync on MoE models (#30848).
+        expert_params_index = {
+            weight_name: (param_name, expert_id, shard_id)
+            for param_name, weight_name, expert_id, shard_id in expert_params_mapping
+        }
 
         # Pre-define `params_dict` to avoid repeated expensive traversal of model parameters.
         params_dict = dict(self.named_parameters())
@@ -1169,20 +1182,17 @@ class Qwen3MoeForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Track if this is an expert weight to enable early skipping
-                is_expert_weight = False
-
-                for mapping in expert_params_mapping:
-                    param_name, weight_name, expert_id, shard_id = mapping
-                    if weight_name not in name:
-                        continue
-
-                    # Mark as expert weight regardless of whether we can process it
-                    is_expert_weight = True
-
-                    name = name.replace(weight_name, param_name)
+                expert_match = _EXPERT_WEIGHT_NAME_RE.search(name)
+                expert_entry = (
+                    expert_params_index.get(expert_match.group(0))
+                    if expert_match is not None
+                    else None
+                )
+                if expert_entry is not None:
+                    param_name, expert_id, shard_id = expert_entry
+                    name = name.replace(expert_match.group(0), param_name)
                     if name not in params_dict:
-                        # Expert weight not on this rank, will be skipped below
+                        # Expert weight not on this rank, skip all remaining processing
                         continue
 
                     param = params_dict[name]
@@ -1194,12 +1204,7 @@ class Qwen3MoeForCausalLM(nn.Module):
                         shard_id=shard_id,
                         expert_id=expert_id,
                     )
-                    break
                 else:
-                    if is_expert_weight:
-                        # This is an expert weight but not mapped to this rank, skip all remaining processing
-                        continue
-
                     # Skip loading extra bias for GPTQ models.
                     if name.endswith(".bias") and name not in params_dict:
                         continue


### PR DESCRIPTION
## Motivation

Fixes #30848.

`Qwen3MoeForCausalLM.load_weights` resolves every incoming tensor by linearly scanning the `num_experts × 3` expert mapping (substring test per entry). Negligible for a one-shot disk load, but `update_weights_from_tensor` flows (RL weight sync) feed the full ~18k expert tensors of a 30B-A3B through it **every training step**, making name resolution quadratic and the dominant sync cost — measured **~60 s per full pass** on H100s (verl + SGLang disaggregated RL), for both sparse-delta and full-broadcast weight sync. Dense models (~340 tensors) apply in <1 s through the same flow.

## Modifications

Build a dict index of the expert mapping once, keyed by the checkpoint-name fragment (`experts.{E}.{proj}.`), and resolve each tensor with one regex match + O(1) lookup instead of the per-tensor scan.

Behavior is unchanged, branch by branch:
- expert weight on this rank → same `weight_loader(param, w, name, shard_id=, expert_id=)` call
- expert weight not on this rank (expert parallelism) → skipped, as before
- regex-matching but unmapped fragments (e.g. out-of-range expert id, non-proj names) → fall to the generic path, exactly like the old `is_expert_weight=False` case
- stacked/mtp/PP-skip handling untouched

Verified branch-level equivalence with a 28-case simulation of old vs new resolution (all expert ids × 3 projections, out-of-range ids, unmapped fragments, non-expert names, EP-absent params) — zero mismatches. The same approach has been running in production on our side (implemented externally in verl's custom weight loader) and removes the bottleneck entirely.

The same pattern exists in other MoE models (qwen2_moe, deepseek variants); happy to follow up there if this shape is acceptable.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests). (equivalence covered by simulation; no behavior change intended)
- [x] Update documentation / docstrings as needed.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29145515865](https://github.com/sgl-project/sglang/actions/runs/29145515865)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29145515836](https://github.com/sgl-project/sglang/actions/runs/29145515836)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->