### PR TITLE
[Spec] Reject DSpark speculators-convention checkpoints instead of silently degrading accept length

### DIFF
--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -368,23 +368,14 @@ class DSparkDraftMixin:
                 "DSpark draft requires markov_rank > 0, "
                 f"got markov_rank={dspark_config.markov_rank}."
             )
-        if dspark_config.speculators_convention:
-            raise ValueError(
-                "This checkpoint was trained with the speculators "
-                "(github.com/vllm-project/speculators) DSpark convention "
-                '(speculators_model_type="dspark" in its config), which '
-                "block-drafting in this file does not yet support: DeepSpec "
-                "trains block slot k to predict anchor+k+1 with every slot "
-                "trained, while speculators trains slot j to predict "
-                "anchor+j with slot 0 loss-masked, so every "
-                "run_markov_block slot is read one position early here, "
-                "degrading accept length to ~1 regardless of the "
-                "underlying model's real speculative quality. Loading this "
-                "checkpoint would silently produce near-zero speedup "
-                "rather than an error, so it is refused here instead. See "
-                "sgl-project/sglang#30261 (comment by jessiewei7, "
-                "2026-07-09) for the confirmed diagnosis and reproduction."
-            )
+        # speculators-trained checkpoints (dspark_config.speculators_convention)
+        # use a `gamma + 1`-wide draft block with the anchor as a separate
+        # bonus token, rather than DeepSpec's `gamma`-wide anchor-first block.
+        # That width difference is handled downstream in dspark_draft.py's
+        # DraftBlockProposer/DsparkDraftSampler (see `bonus_anchor` there),
+        # not in this model class -- run_markov_block itself is unaffected
+        # either way, since the caller always hands it exactly `gamma` real
+        # draft-hidden slots regardless of which convention produced them.
         self.gamma = int(dspark_config.resolve_gamma(default=self.block_size))
         self.markov_head = build_markov_head(config)
         self.confidence_head = build_confidence_head(config)

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -368,6 +368,23 @@ class DSparkDraftMixin:
                 "DSpark draft requires markov_rank > 0, "
                 f"got markov_rank={dspark_config.markov_rank}."
             )
+        if dspark_config.speculators_convention:
+            raise ValueError(
+                "This checkpoint was trained with the speculators "
+                "(github.com/vllm-project/speculators) DSpark convention "
+                '(speculators_model_type="dspark" in its config), which '
+                "block-drafting in this file does not yet support: DeepSpec "
+                "trains block slot k to predict anchor+k+1 with every slot "
+                "trained, while speculators trains slot j to predict "
+                "anchor+j with slot 0 loss-masked, so every "
+                "run_markov_block slot is read one position early here, "
+                "degrading accept length to ~1 regardless of the "
+                "underlying model's real speculative quality. Loading this "
+                "checkpoint would silently produce near-zero speedup "
+                "rather than an error, so it is refused here instead. See "
+                "sgl-project/sglang#30261 (comment by jessiewei7, "
+                "2026-07-09) for the confirmed diagnosis and reproduction."
+            )
         self.gamma = int(dspark_config.resolve_gamma(default=self.block_size))
         self.markov_head = build_markov_head(config)
         self.confidence_head = build_confidence_head(config)

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -57,6 +57,7 @@ class DSparkDraftConfig(msgspec.Struct, frozen=True):
     mask_token_id: Optional[int]
     markov_rank: int
     markov_head_type: Optional[str]
+    speculators_convention: bool
 
     def resolve_gamma(self, *, default: Optional[int] = None) -> Optional[int]:
         return self.gamma if self.gamma is not None else default
@@ -268,6 +269,21 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
     else:
         target_layer_ids = base.target_layer_ids
 
+    # speculators (github.com/vllm-project/speculators)-trained DSpark
+    # checkpoints use a different block-slot convention than the
+    # DeepSpec-trained ones this file was written against: DeepSpec trains
+    # block slot k to predict anchor+k+1 (every slot trained), while
+    # speculators trains slot j to predict anchor+j with slot 0 loss-masked
+    # (its first slot is never trained to predict anything useful). Every
+    # `run_markov_block` slot is therefore read one position early for a
+    # speculators checkpoint, degrading accept length to ~1 regardless of
+    # the underlying model's real speculative quality. Detected here, not
+    # silently corrected, until the shift is implemented and validated
+    # end-to-end (it isn't yet) -- see sgl-project/sglang#30261 (comment by
+    # jessiewei7, 2026-07-09) for the confirmed diagnosis and reproduction.
+    speculators_model_type = _cfg_get(draft_hf_config, "speculators_model_type", None)
+    speculators_convention = speculators_model_type == "dspark"
+
     return DSparkDraftConfig(
         num_hidden_layers=base.num_hidden_layers,
         num_target_layers=base.num_target_layers,
@@ -277,4 +293,5 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         mask_token_id=mask_token_id,
         markov_rank=markov_rank,
         markov_head_type=markov_head_type,
+        speculators_convention=speculators_convention,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -70,6 +70,7 @@ class DSparkRuntimeConfig(msgspec.Struct, frozen=True):
     gamma: int
     verify_num_draft_tokens: int
     mask_token_id: int
+    speculators_convention: bool
 
 
 def resolve_runtime_config(
@@ -122,6 +123,7 @@ def resolve_runtime_config(
         gamma=gamma,
         verify_num_draft_tokens=gamma + 1,
         mask_token_id=mask_token_id,
+        speculators_convention=draft_config.speculators_convention,
     )
 
 
@@ -168,6 +170,51 @@ def _get_dspark_config(config: Any) -> dict:
         return dict(cfg)
     except Exception:
         return {}
+
+
+def _get_speculators_config(config: Any) -> dict:
+    cfg = _cfg_get(config, "speculators_config", None)
+    if cfg is None:
+        return {}
+    if isinstance(cfg, dict):
+        return cfg
+    try:
+        return dict(cfg)
+    except Exception:
+        return {}
+
+
+def _resolve_speculators_proposal_gamma(config: Any) -> Optional[int]:
+    """speculators checkpoints carry their real draft length in
+    speculators_config.proposal_methods[i].speculative_tokens -- prefer this
+    over block_size (which counts the anchor+gamma block width, off by one
+    from gamma for speculators-trained checkpoints; see the comment on
+    speculators_convention below)."""
+    cfg = _get_speculators_config(config)
+    proposal_methods = cfg.get("proposal_methods") or []
+    if not isinstance(proposal_methods, (list, tuple)) or not proposal_methods:
+        return None
+
+    default_method = cfg.get("default_proposal_method")
+    selected = None
+    if default_method is not None:
+        for method in proposal_methods:
+            if _cfg_get(method, "proposal_type", None) == default_method:
+                selected = method
+                break
+    if selected is None:
+        selected = proposal_methods[0]
+
+    speculative_tokens = _cfg_get(selected, "speculative_tokens", None)
+    if speculative_tokens is None:
+        return None
+    gamma = int(speculative_tokens)
+    if gamma < 1:
+        raise ValueError(
+            "DSpark speculators_config speculative_tokens must be positive, "
+            f"got {gamma}."
+        )
+    return gamma
 
 
 def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
@@ -251,8 +298,49 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
             f"DSpark mask_token_id must be non-negative, got {mask_token_id}."
         )
 
+    # speculators (github.com/vllm-project/speculators)-trained DSpark
+    # checkpoints use a different block-slot convention than the
+    # DeepSpec-trained ones this file was originally written against:
+    # DeepSpec trains block slot k to predict anchor+k+1, with the anchor
+    # itself (slot 0) also a real, trained prediction -- the draft block is
+    # exactly `gamma` slots wide, anchor-first. speculators instead trains
+    # the anchor as a separate, untrained conditioning token and slot j
+    # (j=1..gamma) to predict anchor+j -- the draft block is `gamma + 1`
+    # slots wide, with slot 0 (the anchor) excluded from both the sampled
+    # draft tokens and block-accept verification. Feeding a speculators
+    # checkpoint through the DeepSpec-width path reads every real slot one
+    # position early, degrading accept length to ~1 regardless of the
+    # underlying model's real speculative quality.
+    #
+    # This mirrors vLLM's validated `dspark_bonus_anchor` fix
+    # (vllm-project/vllm#47093 -- vllm/transformers_utils/configs/
+    # speculators/algos.py + vllm/v1/worker/gpu/spec_decode/dspark/
+    # speculator.py's `sample_from_anchor` flag) rather than unconditionally
+    # widening every DSpark block: DeepSpec-trained checkpoints
+    # (speculators_convention=False) keep exactly the behavior they had
+    # before this field existed. Diagnosed by jessiewei7 on
+    # sgl-project/sglang#30261 (2026-07-09); the width fix itself lives in
+    # dspark_draft.py's DraftBlockProposer and DsparkDraftSampler (see
+    # `bonus_anchor` there) -- this function only resolves the config-level
+    # facts (the flag, and the correct gamma to use for such checkpoints).
+    speculators_model_type = _cfg_get(draft_hf_config, "speculators_model_type", None)
+    speculators_convention = (
+        isinstance(speculators_model_type, str)
+        and speculators_model_type.lower() == "dspark"
+    )
+
+    # speculators checkpoints ship their authoritative draft length as
+    # speculators_config.proposal_methods[i].speculative_tokens, not as
+    # block_size (which means the full anchor+gamma block width there, off
+    # by one from gamma for exactly the reason above). Prefer this over
+    # base.block_size when present -- it's the checkpoint's own stated
+    # value for "how many real draft tokens", not something inferred by
+    # subtracting one from block_size and hoping the convention holds.
+    speculators_gamma = _resolve_speculators_proposal_gamma(draft_hf_config)
     gamma = (
-        int(prefixed_block_size) if prefixed_block_size is not None else base.block_size
+        int(prefixed_block_size)
+        if prefixed_block_size is not None
+        else speculators_gamma if speculators_gamma is not None else base.block_size
     )
 
     if prefixed_target_layer_ids is not None:
@@ -268,24 +356,6 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         ]
     else:
         target_layer_ids = base.target_layer_ids
-
-    # speculators (github.com/vllm-project/speculators)-trained DSpark
-    # checkpoints use a different block-slot convention than the
-    # DeepSpec-trained ones this file was written against: DeepSpec trains
-    # block slot k to predict anchor+k+1 (every slot trained), while
-    # speculators trains slot j to predict anchor+j with slot 0 loss-masked
-    # (its first slot is never trained to predict anything useful). Every
-    # `run_markov_block` slot is therefore read one position early for a
-    # speculators checkpoint, degrading accept length to ~1 regardless of
-    # the underlying model's real speculative quality. Detected here, not
-    # silently corrected, until the shift is implemented and validated
-    # end-to-end (it isn't yet) -- see sgl-project/sglang#30261 (comment by
-    # jessiewei7, 2026-07-09) for the confirmed diagnosis and reproduction.
-    speculators_model_type = _cfg_get(draft_hf_config, "speculators_model_type", None)
-    speculators_convention = (
-        isinstance(speculators_model_type, str)
-        and speculators_model_type.lower() == "dspark"
-    )
 
     return DSparkDraftConfig(
         num_hidden_layers=base.num_hidden_layers,

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -282,7 +282,10 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
     # end-to-end (it isn't yet) -- see sgl-project/sglang#30261 (comment by
     # jessiewei7, 2026-07-09) for the confirmed diagnosis and reproduction.
     speculators_model_type = _cfg_get(draft_hf_config, "speculators_model_type", None)
-    speculators_convention = speculators_model_type == "dspark"
+    speculators_convention = (
+        isinstance(speculators_model_type, str)
+        and speculators_model_type.lower() == "dspark"
+    )
 
     return DSparkDraftConfig(
         num_hidden_layers=base.num_hidden_layers,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -56,11 +56,33 @@ def greedy_step_sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tenso
 
 
 class DsparkDraftSampler:
+    """CUDA-graph-folded fast path for the all-greedy case.
 
-    def __init__(self, *, model, gamma, max_bs, device, confidence_fn=None, out=None):
+    ``bonus_anchor`` mirrors DraftBlockProposer's flag (see its docstring):
+    when set, the draft forward pass this sampler consumes was run over
+    ``gamma + 1`` query positions (anchor + gamma real draft slots, the
+    speculators convention) rather than ``gamma`` (DeepSpec's anchor-first
+    convention), and slot 0's hidden state/logits must be excluded from the
+    sampled draft tokens the same way DraftBlockProposer.propose excludes it
+    on the non-graph path.
+    """
+
+    def __init__(
+        self,
+        *,
+        model,
+        gamma,
+        max_bs,
+        device,
+        confidence_fn=None,
+        out=None,
+        bonus_anchor: bool = False,
+    ):
         self.model = model
         self.markov_head = model.markov_head
         self.gamma = int(gamma)
+        self.bonus_anchor = bool(bonus_anchor)
+        self.draft_width = self.gamma + 1 if self.bonus_anchor else self.gamma
         if out is not None:
             assert out.shape == (int(max_bs) * self.gamma,) and out.dtype == torch.int64
             self.out = out
@@ -76,20 +98,37 @@ class DsparkDraftSampler:
         )
 
     def __call__(self, hidden_states, input_ids):
-        bs = hidden_states.shape[0] // self.gamma
-        base_logits, confidence_tap = self.model.compute_base_logits(hidden_states)
+        bs = hidden_states.shape[0] // self.draft_width
+        hidden_3d = hidden_states.view(bs, self.draft_width, -1)
+        ids_2d = input_ids.view(bs, self.draft_width)
+        anchor = ids_2d[:, 0]
+        # Slot 0 is the anchor. Under bonus_anchor it's a conditioning-only
+        # token (untrained as a draft prediction); slots 1..gamma are the
+        # real draft positions. Under DeepSpec's anchor-first convention,
+        # slot 0 IS itself a trained draft prediction, so draft_width ==
+        # gamma and no slicing is needed -- the branch below is a no-op then.
+        # .contiguous(): the [:, 1:, :] slice breaks the (bs*draft_width, H)
+        # contiguous layout .view() below needs -- reshape() would silently
+        # copy anyway in that case, but .view() is used deliberately
+        # elsewhere in this class to catch accidental copies; stay consistent.
+        draft_hidden = (
+            hidden_3d[:, 1:, :].contiguous() if self.bonus_anchor else hidden_3d
+        )
+
+        base_logits, confidence_tap = self.model.compute_base_logits(
+            draft_hidden.reshape(bs * self.gamma, -1)
+        )
         base_logits = base_logits.view(bs, self.gamma, -1)
-        anchor = input_ids.view(bs, self.gamma)[:, 0]
         draft_tokens, _ = self.markov_head.sample_block(
             base_logits,
             first_prev_tokens=anchor,
-            hidden_states=hidden_states.view(bs, self.gamma, -1),
+            hidden_states=draft_hidden,
             sampler=greedy_step_sampler,
         )
         self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
         if self.confidence_out is not None:
             confidence = self.confidence_fn(
-                draft_hidden=hidden_states.view(bs, self.gamma, -1),
+                draft_hidden=draft_hidden,
                 anchor_tokens=anchor,
                 draft_tokens=draft_tokens,
                 confidence_tap=confidence_tap,
@@ -215,6 +254,31 @@ def sample_draft_block(
 
 
 class DraftBlockProposer:
+    """Runs the DSpark draft model's forward pass and samples its block.
+
+    ``bonus_anchor`` (from DSparkDraftConfig.speculators_convention, threaded
+    in by dspark_worker_v2.py) selects between two block layouts:
+
+    - False (DeepSpec, the original convention this class was written for):
+      the draft block is exactly ``gamma`` slots wide, anchor-first -- slot 0
+      IS the anchor token and is itself a real, trained draft prediction.
+      ``self.gamma`` (the real draft-token count used everywhere else in the
+      codebase -- verify window sizing, KV commit, accept-length accounting)
+      already equals the forward-pass width; no adjustment needed.
+    - True (speculators): the draft block is ``gamma + 1`` slots wide --
+      slot 0 is still the anchor token (the draft transformer must see it to
+      attend to), but it's an untrained conditioning token, not a draft
+      prediction, so its hidden state/logits are excluded before sampling.
+      Only this class's own internal forward-pass sizing changes
+      (``draft_width``); ``self.gamma`` itself, and everything downstream
+      that reads it, is unaffected.
+
+    Mirrors vLLM's validated `dspark_bonus_anchor`/`sample_from_anchor` fix
+    (vllm-project/vllm#47093) rather than unconditionally widening every
+    DSpark block the way an earlier draft of this fix did -- see the
+    docstring on ``speculators_convention`` in dspark_config.py.
+    """
+
     def __init__(
         self,
         *,
@@ -224,6 +288,7 @@ class DraftBlockProposer:
         mask_token_id: int,
         draft_block_spec_info,
         dp_moe_sync: bool = False,
+        bonus_anchor: bool = False,
     ) -> None:
         self.draft_model = draft_model
         self.draft_model_runner = draft_model_runner
@@ -232,6 +297,8 @@ class DraftBlockProposer:
         self._draft_block_spec_info = draft_block_spec_info
         self._draft_sampler = None
         self._dp_moe_sync = dp_moe_sync
+        self.bonus_anchor = bool(bonus_anchor)
+        self.draft_width = self.gamma + 1 if self.bonus_anchor else self.gamma
 
     def attach_draft_sampler(self, draft_sampler) -> None:
         self._draft_sampler = draft_sampler
@@ -290,8 +357,14 @@ class DraftBlockProposer:
                 folded_confidence = draft_sampler.confidence_out[:bs]
         else:
             with self._base_logits_context():
+                # fwd.draft_hidden_3d is always exactly gamma slots wide
+                # (DraftBlockProposer._run_forward already excludes the
+                # anchor's own hidden state when bonus_anchor is set) --
+                # base_logits must come from the same gamma real draft
+                # slots, never from the wider raw_hidden that includes the
+                # anchor under bonus_anchor.
                 base_logits, confidence_tap = self.draft_model.compute_base_logits(
-                    fwd.raw_hidden
+                    fwd.draft_hidden_3d.reshape(bs * self.gamma, -1)
                 )
                 base_logits = base_logits.view(bs, self.gamma, -1)
             draft_block = sample_draft_block(
@@ -344,17 +417,22 @@ class DraftBlockProposer:
         device: str,
         embed_module,
     ) -> DraftForwardResult:
-        gamma = self.gamma
+        draft_width = self.draft_width
         prefix_lens = batch.seq_lens
         positions_2d = verify_window.positions_2d
         verify_cache_loc_2d = verify_window.verify_cache_loc_2d
 
+        # draft_width == gamma (DeepSpec, anchor-first) or gamma + 1
+        # (speculators, anchor is a separate bonus/conditioning token) -- see
+        # this class's docstring. positions_2d/verify_cache_loc_2d are always
+        # allocated verify_num_draft_tokens (= gamma + 1) wide, so slicing to
+        # draft_width is in-bounds either way.
         draft_block_ids = torch.full(
-            (bs, gamma), int(self._mask_token_id), dtype=torch.long, device=device
+            (bs, draft_width), int(self._mask_token_id), dtype=torch.long, device=device
         )
         draft_block_ids[:, 0].copy_(draft_input.bonus_tokens.view(-1))
-        draft_positions = positions_2d[:, :gamma].reshape(-1)
-        draft_cache_loc = verify_cache_loc_2d[:, :gamma].reshape(-1)
+        draft_positions = positions_2d[:, :draft_width].reshape(-1)
+        draft_cache_loc = verify_cache_loc_2d[:, :draft_width].reshape(-1)
 
         draft_owns_embed = hasattr(self.draft_model, "forward_embed")
         draft_input_embeds: Optional[torch.Tensor] = None
@@ -363,9 +441,15 @@ class DraftBlockProposer:
             draft_input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
 
         if batch.seq_lens_cpu is not None:
-            draft_seq_lens_cpu = batch.seq_lens_cpu + gamma
+            draft_seq_lens_cpu = batch.seq_lens_cpu + draft_width
             draft_seq_lens_sum = int(draft_seq_lens_cpu.sum())
         elif draft_input.reserved_seq_lens_cpu is not None:
+            # TODO(bonus_anchor): reserved_seq_lens_cpu/reserved_seq_lens_sum
+            # come pre-computed from elsewhere (CUDA-graph-padded reservation
+            # sizing) and are used as-is here, unlike the branch above. Not
+            # verified against bonus_anchor=True -- if this path is ever hit
+            # for a speculators checkpoint, confirm the reservation already
+            # accounts for draft_width (gamma + 1), not just gamma.
             draft_seq_lens_cpu = draft_input.reserved_seq_lens_cpu
             draft_seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
         else:
@@ -393,7 +477,20 @@ class DraftBlockProposer:
         raw_hidden = logits_output.hidden_states
         if raw_hidden is None:
             raise RuntimeError("DSpark draft model returned no hidden states.")
-        draft_hidden_3d = raw_hidden.view(bs, gamma, -1)
+        # draft_hidden_3d is always exactly gamma slots wide -- the real
+        # draft-hidden states callers (propose(), base_logits computation)
+        # consume, regardless of which convention produced them. Under
+        # bonus_anchor, slot 0 of the draft_width-wide forward output is the
+        # anchor's own hidden state and is excluded here, not downstream.
+        raw_hidden_3d = raw_hidden.view(bs, draft_width, -1)
+        # .contiguous(): downstream consumers of DraftForwardResult.draft_hidden_3d
+        # (propose()'s base_logits reshape, DraftProposal.draft_hidden feeding
+        # confidence/KV-inject code) are not all guaranteed to use .reshape()
+        # over .view() -- keep this slice's output actually contiguous rather
+        # than relying on every consumer tolerating a non-contiguous view.
+        draft_hidden_3d = (
+            raw_hidden_3d[:, 1:, :].contiguous() if self.bonus_anchor else raw_hidden_3d
+        )
         return DraftForwardResult(
             draft_block_ids=draft_block_ids,
             raw_hidden=raw_hidden,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -128,6 +128,20 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.verify_num_draft_tokens = runtime_config.verify_num_draft_tokens
         self.speculative_num_draft_tokens = self.verify_num_draft_tokens
         self._mask_token_id = runtime_config.mask_token_id
+        # speculators-trained checkpoints use a gamma+1-wide draft block
+        # (anchor is a separate bonus/conditioning token) instead of
+        # DeepSpec's gamma-wide anchor-first block -- see the docstring on
+        # DSparkDraftConfig.speculators_convention (dspark_config.py) and on
+        # DraftBlockProposer (dspark_draft.py). Threaded through to both the
+        # eager (DraftBlockProposer) and CUDA-graph-folded (DsparkDraftSampler)
+        # draft-sampling paths below.
+        self._bonus_anchor = runtime_config.speculators_convention
+        if self.tp_rank == 0 and self._bonus_anchor:
+            logger.info(
+                "DSpark draft checkpoint uses the speculators bonus-anchor "
+                "convention (gamma+1-wide draft block, anchor excluded from "
+                "sampling)."
+            )
 
         if self.tp_rank == 0:
             logger.info(
@@ -197,6 +211,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             mask_token_id=self._mask_token_id,
             draft_block_spec_info=self._draft_block_spec_info,
             dp_moe_sync=self._draft_is_moe and server_args.enable_dp_attention,
+            bonus_anchor=self._bonus_anchor,
         )
         self._verify_epilogue = None
         if (
@@ -351,6 +366,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                 if self._verify_epilogue is not None
                 else None
             ),
+            bonus_anchor=self._bonus_anchor,
         )
 
     def clear_cache_pool(self):

--- a/test/registered/spec/dspark/test_dspark_speculators_convention.py
+++ b/test/registered/spec/dspark/test_dspark_speculators_convention.py
@@ -1,0 +1,48 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.speculative.dspark_components.dspark_config import (
+    parse_dspark_draft_config,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _base_dspark_hf_config(**overrides) -> SimpleNamespace:
+    fields = dict(
+        architectures=["DeepseekV4ForCausalLM"],
+        dspark_block_size=5,
+        dspark_markov_rank=256,
+        dspark_markov_head_type="vanilla",
+        dspark_target_layer_ids=[40, 41, 42],
+        dspark_noise_token_id=128799,
+    )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
+    def test_deepspec_checkpoint_not_flagged(self):
+        # No speculators_model_type field at all -- the normal DeepSpec case.
+        config = parse_dspark_draft_config(draft_hf_config=_base_dspark_hf_config())
+        self.assertFalse(config.speculators_convention)
+
+    def test_other_speculators_model_type_not_flagged(self):
+        # speculators_model_type present but not "dspark" -- a different
+        # speculators-trained architecture, not the DSpark slot-shift case.
+        config = parse_dspark_draft_config(
+            draft_hf_config=_base_dspark_hf_config(speculators_model_type="eagle3")
+        )
+        self.assertFalse(config.speculators_convention)
+
+    def test_speculators_dspark_checkpoint_flagged(self):
+        config = parse_dspark_draft_config(
+            draft_hf_config=_base_dspark_hf_config(speculators_model_type="dspark")
+        )
+        self.assertTrue(config.speculators_convention)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/dspark/test_dspark_speculators_convention.py
+++ b/test/registered/spec/dspark/test_dspark_speculators_convention.py
@@ -4,6 +4,10 @@ from types import SimpleNamespace
 from sglang.srt.speculative.dspark_components.dspark_config import (
     parse_dspark_draft_config,
 )
+from sglang.srt.speculative.dspark_components.dspark_draft import (
+    DraftBlockProposer,
+    DsparkDraftSampler,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -65,6 +69,119 @@ class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
             draft_hf_config=_base_dspark_hf_config(speculators_model_type=123)
         )
         self.assertFalse(config.speculators_convention)
+
+
+def _speculators_hf_config(
+    *, block_size: int, speculative_tokens: int, default_method: str = "greedy"
+) -> SimpleNamespace:
+    # Matches the real structure of RedHatAI/GLM-5.2-speculator.dspark's
+    # config.json (verified directly against the checkpoint on the Hub):
+    # block_size is the full anchor+gamma block width, while
+    # speculators_config.proposal_methods[i].speculative_tokens is the
+    # authoritative gamma (real draft token count).
+    return SimpleNamespace(
+        architectures=["Qwen3DSparkModel"],
+        block_size=block_size,
+        markov_rank=256,
+        markov_head_type="vanilla",
+        mask_token_id=128799,
+        speculators_model_type="dspark",
+        speculators_config={
+            "algorithm": "dspark",
+            "default_proposal_method": default_method,
+            "proposal_methods": [
+                {
+                    "proposal_type": default_method,
+                    "speculative_tokens": speculative_tokens,
+                    "verifier_accept_k": 1,
+                }
+            ],
+        },
+    )
+
+
+class TestSpeculatorsProposalGamma(CustomTestCase):
+    def test_gamma_from_speculators_config_not_block_size(self):
+        # Ground truth: RedHatAI/GLM-5.2-speculator.dspark has block_size=8
+        # but speculative_tokens=7 -- gamma must be 7, not 8. Using
+        # block_size directly here is exactly the bug this whole fix exists
+        # to prevent (one draft slot too many, anchor read as a draft slot).
+        config = parse_dspark_draft_config(
+            draft_hf_config=_speculators_hf_config(block_size=8, speculative_tokens=7)
+        )
+        self.assertEqual(config.gamma, 7)
+        self.assertTrue(config.speculators_convention)
+
+    def test_gamma_falls_back_to_block_size_without_speculators_config(self):
+        # DeepSpec-native checkpoints have no speculators_config at all --
+        # gamma must still resolve from block_size as before.
+        config = parse_dspark_draft_config(draft_hf_config=_base_dspark_hf_config())
+        self.assertEqual(config.gamma, 5)  # dspark_block_size=5 in the fixture
+        self.assertFalse(config.speculators_convention)
+
+    def test_gamma_respects_default_proposal_method_selection(self):
+        # Multiple proposal methods present; must pick the one named by
+        # default_proposal_method, not just proposal_methods[0].
+        cfg = _speculators_hf_config(
+            block_size=17, speculative_tokens=16, default_method="probabilistic"
+        )
+        cfg.speculators_config["proposal_methods"] = [
+            {"proposal_type": "greedy", "speculative_tokens": 99},
+            {"proposal_type": "probabilistic", "speculative_tokens": 16},
+        ]
+        config = parse_dspark_draft_config(draft_hf_config=cfg)
+        self.assertEqual(config.gamma, 16)
+
+
+def _dummy_draft_model():
+    return SimpleNamespace(markov_head=SimpleNamespace())
+
+
+class TestDraftBlockWidth(CustomTestCase):
+    """draft_width is the one piece of state that must flip between gamma
+    (DeepSpec, anchor is itself a trained draft slot) and gamma + 1
+    (speculators, anchor is a separate untrained conditioning token) -- see
+    DraftBlockProposer's docstring. Every other consumer (verify window
+    sizing, KV commit, accept-length accounting) keeps reading plain gamma
+    unchanged; only the draft-forward-pass's own block construction differs.
+    """
+
+    def test_deepspec_convention_draft_width_equals_gamma(self):
+        proposer = DraftBlockProposer(
+            draft_model=None,
+            draft_model_runner=None,
+            gamma=7,
+            mask_token_id=0,
+            draft_block_spec_info=None,
+            bonus_anchor=False,
+        )
+        self.assertEqual(proposer.draft_width, 7)
+
+    def test_speculators_convention_draft_width_is_gamma_plus_one(self):
+        proposer = DraftBlockProposer(
+            draft_model=None,
+            draft_model_runner=None,
+            gamma=7,
+            mask_token_id=0,
+            draft_block_spec_info=None,
+            bonus_anchor=True,
+        )
+        self.assertEqual(proposer.draft_width, 8)
+
+    def test_draft_sampler_draft_width_matches_proposer(self):
+        for bonus_anchor, expected_width in ((False, 7), (True, 8)):
+            with self.subTest(bonus_anchor=bonus_anchor):
+                sampler = DsparkDraftSampler(
+                    model=_dummy_draft_model(),
+                    gamma=7,
+                    max_bs=4,
+                    device="cpu",
+                    bonus_anchor=bonus_anchor,
+                )
+                self.assertEqual(sampler.draft_width, expected_width)
+                # The sampled-token output buffer stays gamma-wide regardless
+                # -- only the input hidden_states/input_ids width changes.
+                self.assertEqual(sampler.out.shape, (4 * 7,))
 
 
 if __name__ == "__main__":

--- a/test/registered/spec/dspark/test_dspark_speculators_convention.py
+++ b/test/registered/spec/dspark/test_dspark_speculators_convention.py
@@ -43,6 +43,29 @@ class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
         )
         self.assertTrue(config.speculators_convention)
 
+    def test_speculators_dspark_checkpoint_flagged_case_insensitive(self):
+        # Checkpoint config values are author-controlled strings, not a
+        # validated enum -- a future speculators release or a different
+        # checkpoint author could write "DSpark"/"Dspark" instead of the
+        # lowercase "dspark" seen in every checkpoint verified so far.
+        for variant in ("DSpark", "DSPARK", "Dspark"):
+            with self.subTest(variant=variant):
+                config = parse_dspark_draft_config(
+                    draft_hf_config=_base_dspark_hf_config(
+                        speculators_model_type=variant
+                    )
+                )
+                self.assertTrue(config.speculators_convention)
+
+    def test_non_string_speculators_model_type_not_flagged(self):
+        # Malformed config where the field is present but not a string (e.g.
+        # accidentally set to a number or a dict) -- must not crash on
+        # .lower() and must not be treated as a match.
+        config = parse_dspark_draft_config(
+            draft_hf_config=_base_dspark_hf_config(speculators_model_type=123)
+        )
+        self.assertFalse(config.speculators_convention)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Superseded by #30982

This PR was automatically closed when its base branch (`sglang-dspark`) merged into `main`
The identical fix, rebased onto current `main`, is open at **#30982**