### PR TITLE
[Spec] Enable draft extend cuda graph for DeepSeek-V4 attention backend

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -471,6 +471,11 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             )
 
             graph_supported_backend_types.append(DeepseekSparseAttnBackend)
+            from sglang.srt.layers.attention.deepseek_v4_backend import (
+                DeepseekV4AttnBackend,
+            )
+
+            graph_supported_backend_types.append(DeepseekV4AttnBackend)
 
         graph_supported_backend = isinstance(
             self.draft_extend_attn_backend,


### PR DESCRIPTION
DeepseekV4AttnBackend already implements the DRAFT_EXTEND graph bucket (capture + replay); register it in the EAGLE draft worker's supported list so draft extend runs under cuda graph instead of eager.

Verification: test_deepseek_v4_flash_fp8_h200.py (TP=4 + EAGLE) exercises this path -- graph capture happens at server startup, so the test passing covers capture and replay.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29147214733](https://github.com/sgl-project/sglang/actions/runs/29147214733)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29147214595](https://github.com/sgl-project/sglang/actions/runs/29147214595)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->