### PR TITLE
kda: track mamba states for the radix cache

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1098,9 +1098,10 @@ _MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
 
 def supports_mamba_cache_extra_buffer(view: Any, model_arch: str) -> bool:
     """Whether ``model_arch`` supports the extra_buffer strategy on the
-    configured linear-attention backend (pure read)."""
+    configured linear-attention backends (pure read)."""
     if model_arch in _MAMBA_EXTRA_BUFFER_ARCHS:
-        return view.linear_attn_backend == "triton"
+        prefill_backend = view.linear_attn_prefill_backend or view.linear_attn_backend
+        return view.linear_attn_backend == "triton" and prefill_backend == "triton"
     return False
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1089,6 +1089,7 @@ _MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
         "BailingMoeV2_5ForCausalLM",
         "FalconH1ForCausalLM",
         "GraniteMoeHybridForCausalLM",
+        "KimiLinearForCausalLM",
         "NemotronHForCausalLM",
         "NemotronHPuzzleForCausalLM",
     }

--- a/python/sglang/srt/layers/attention/fla/kda.py
+++ b/python/sglang/srt/layers/attention/fla/kda.py
@@ -1128,9 +1128,9 @@ def chunk_kda_fwd(
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
     )
-    del Aqk, v_new, h
+    del Aqk, v_new
 
-    return o
+    return o, h
 
 
 def chunk_kda(
@@ -1147,6 +1147,7 @@ def chunk_kda(
     A_log: Optional[torch.Tensor] = None,
     dt_bias: Optional[torch.Tensor] = None,
     lower_bound: Optional[float] = None,
+    output_intermediate_states: bool = False,
     **kwargs,
 ):
     if scale is None:
@@ -1156,7 +1157,7 @@ def chunk_kda(
         q = l2norm_fwd(q.contiguous())
         k = l2norm_fwd(k.contiguous())
 
-    o = chunk_kda_fwd(
+    o, h = chunk_kda_fwd(
         q=q,
         k=k,
         v=v.contiguous(),
@@ -1170,4 +1171,6 @@ def chunk_kda(
         dt_bias=dt_bias,
         lower_bound=lower_bound,
     )
+    if output_intermediate_states:
+        return o, h
     return o

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -175,8 +175,8 @@ class KDAKernelDispatcher:
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
         **kwargs,
-    ) -> torch.Tensor:
-        return self.extend_kernel.extend(
+    ) -> tuple:
+        out = self.extend_kernel.extend(
             q,
             k,
             v,
@@ -187,6 +187,11 @@ class KDAKernelDispatcher:
             query_start_loc=query_start_loc,
             **kwargs,
         )
+        # The triton kernel also returns per-chunk states for radix tracking;
+        # the fused backends don't materialize them.
+        if isinstance(out, tuple):
+            return out
+        return out, None
 
 
 class KDAAttnBackend(MambaAttnBackendBase):
@@ -194,13 +199,31 @@ class KDAAttnBackend(MambaAttnBackendBase):
 
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
+        conv_shape = model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape
+        # KDA stores conv state as [.., kernel-1, packed QKV dim]; keep the base
+        # (.., dim, window) convention so _init_track_conv_indices reads the
+        # window length from [-1].
+        self.conv_states_shape = (*conv_shape[:-2], conv_shape[-1], conv_shape[-2])
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()
         self.kernel_dispatcher = KDAKernelDispatcher(decode_backend, prefill_backend)
 
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        super().init_forward_metadata(forward_batch)
+        if self.forward_metadata.has_mamba_track_mask:
+            self.forward_metadata.mamba_track_mask_indices = (
+                forward_batch.mamba_track_mask.nonzero(as_tuple=True)[0]
+            )
+            self.forward_metadata.conv_states_mask_indices = (
+                forward_batch.mamba_track_indices[
+                    self.forward_metadata.mamba_track_mask_indices
+                ]
+            )
+
     def forward_decode(
         self,
         layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
         mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
         a: torch.Tensor,
         b: torch.Tensor,
@@ -258,7 +281,7 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 "KDA packed decode requires one token per sequence (T=1): "
                 f"got {qkv.shape[0]} tokens for {cache_indices.shape[0]} requests."
             )
-            return self.kernel_dispatcher.packed_decode(
+            core_attn_out = self.kernel_dispatcher.packed_decode(
                 mixed_qkv=qkv,
                 a=a,
                 b=b,
@@ -275,13 +298,17 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 replayssm_write_pos=replayssm_write_pos,
                 replayssm_force_flush=replayssm_force_flush,
             )
+            self._track_mamba_state_decode(
+                forward_batch, conv_states, ssm_states, cache_indices
+            )
+            return core_attn_out
 
         q, k, v = qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
         k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
         v = v.unflatten(-1, (-1, layer.head_v_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
 
-        return self.kernel_dispatcher.decode(
+        core_attn_out = self.kernel_dispatcher.decode(
             q=q,
             k=k,
             v=v,
@@ -293,6 +320,10 @@ class KDAAttnBackend(MambaAttnBackendBase):
             cache_indices=cache_indices,
             query_start_loc=query_start_loc,
         )
+        self._track_mamba_state_decode(
+            forward_batch, conv_states, ssm_states, cache_indices
+        )
+        return core_attn_out
 
     def forward_extend(
         self,
@@ -312,6 +343,14 @@ class KDAAttnBackend(MambaAttnBackendBase):
         ssm_states = mamba_cache_params.temporal
 
         has_initial_state = forward_batch.extend_prefix_lens > 0
+
+        if self.forward_metadata.has_mamba_track_mask:
+            # Boundary conv state = the raw pre-conv inputs at the tracked chunk
+            # boundary. KDA's conv layout is [.., window, packed dim], so the
+            # [rows, window, dim] gather from mixed_qkv assigns directly.
+            mamba_cache_params.conv[0][
+                self.forward_metadata.conv_states_mask_indices
+            ] = mixed_qkv[self.forward_metadata.track_conv_indices]
 
         splits = [layer.q_dim, layer.k_dim, layer.v_dim]
         q, k, v = mixed_qkv.transpose(0, 1).split(splits, dim=0)
@@ -362,7 +401,7 @@ class KDAAttnBackend(MambaAttnBackendBase):
         k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
         v = v.unflatten(-1, (-1, layer.head_v_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
 
-        core_attn_out = self.kernel_dispatcher.extend(
+        core_attn_out, intermediate_states = self.kernel_dispatcher.extend(
             q=q,
             k=k,
             v=v,
@@ -383,5 +422,10 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 or forward_batch.forward_mode.is_draft_extend_v2()
             ),
         )
+
+        if intermediate_states is not None:
+            self._track_mamba_state_extend(
+                forward_batch, intermediate_states, ssm_states, self.forward_metadata
+            )
 
         return core_attn_out

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -156,7 +156,7 @@ class TritonKDAKernel(LinearAttnKernelBase):
         dt_bias: Optional[torch.Tensor] = None,
         lower_bound: Optional[float] = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> tuple:
         return chunk_kda(
             q=q,
             k=k,
@@ -170,4 +170,5 @@ class TritonKDAKernel(LinearAttnKernelBase):
             A_log=A_log,
             dt_bias=dt_bias,
             lower_bound=lower_bound,
+            output_intermediate_states=True,
         )

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1345,6 +1345,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 disable_overlap_schedule=False,
                 page_size=None,
                 linear_attn_backend="triton",
+                linear_attn_prefill_backend=None,
             )
             defaults.update(kw)
             return ResolvedView(
@@ -1426,11 +1427,76 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             )["mamba_radix_cache_strategy"],
             "extra_buffer",
         )
-        # extra-buffer support requires the triton linear-attn backend
-        self.assertFalse(
-            supports_mamba_cache_extra_buffer(
-                SimpleNamespace(linear_attn_backend="fla"), "Qwen3NextForCausalLM"
-            )
+        for arch in ("Qwen3NextForCausalLM", "KimiLinearForCausalLM"):
+            for base_backend, prefill_backend, expected in (
+                ("triton", None, True),
+                ("triton", "triton", True),
+                ("triton", "flashinfer", False),
+                ("triton", "flashkda", False),
+                ("triton", "cutedsl", False),
+                ("cutedsl", "triton", False),
+            ):
+                with self.subTest(
+                    arch=arch,
+                    base_backend=base_backend,
+                    prefill_backend=prefill_backend,
+                ):
+                    self.assertEqual(
+                        supports_mamba_cache_extra_buffer(
+                            SimpleNamespace(
+                                linear_attn_backend=base_backend,
+                                linear_attn_prefill_backend=prefill_backend,
+                            ),
+                            arch,
+                        ),
+                        expected,
+                    )
+
+        self.assertEqual(
+            _mamba_radix_cache_resolution(
+                _view(
+                    "KimiLinearForCausalLM",
+                    linear_attn_prefill_backend="flashkda",
+                )
+            ),
+            {
+                "uses_mamba_radix_cache": True,
+                "mamba_radix_cache_strategy": "no_buffer",
+                "disable_overlap_schedule": True,
+            },
+        )
+
+    def test_mamba_radix_cache_prefill_backend_validation(self):
+        from sglang.srt.server_args import ServerArgs
+
+        for arch, prefill_backend in (
+            ("KimiLinearForCausalLM", "flashkda"),
+            ("KimiLinearForCausalLM", "cutedsl"),
+            ("Qwen3NextForCausalLM", "flashinfer"),
+            ("Qwen3NextForCausalLM", "cutedsl"),
+        ):
+            with self.subTest(arch=arch, prefill_backend=prefill_backend):
+                extra_buffer_view = SimpleNamespace(
+                    linear_attn_backend="triton",
+                    linear_attn_prefill_backend=prefill_backend,
+                )
+                with self.assertRaisesRegex(
+                    AssertionError,
+                    f"extra_buffer is not supported for {arch}",
+                ):
+                    ServerArgs._validate_mamba_extra_buffer(
+                        None, extra_buffer_view, arch
+                    )
+
+        no_buffer_view = SimpleNamespace(
+            page_size=1,
+            disable_overlap_schedule=True,
+            attention_backend="triton",
+            linear_attn_backend="triton",
+            linear_attn_prefill_backend="flashkda",
+        )
+        ServerArgs._validate_mamba_no_buffer(
+            None, no_buffer_view, "KimiLinearForCausalLM"
         )
 
     def test_qwen3_5_hybrid_coupled_declaration(self):


### PR DESCRIPTION
## What
Wire mamba radix-cache state tracking into the KDA backend (mirroring what GDN already has), and enable the `extra_buffer` strategy for `KimiLinearForCausalLM`.

## Why
The `extra_buffer` radix cache commits ping-pong track slots that the KDA backend never wrote — a prefix hit restores a never-written state and silently corrupts output (warm-rerun collapse). GDN/Mamba2 already call `_track_mamba_state_extend/_decode`; KDA called neither.

## Changes
- `fla/kda.py`: `chunk_kda_fwd` returns `(o, h)` instead of dropping `h`; `chunk_kda(output_intermediate_states=True)` forwards it. Fused backends return `None` and stay untracked.
- `kda_backend.py`: `KDAKernelDispatcher.extend` returns `(out, h | None)`; `KDAAttnBackend.__init__` stores `conv_states_shape` in the base `(dim, window)` convention; new `init_forward_metadata` sets the track mask indices; `forward_extend` writes the boundary conv window and tracks SSM `h` after extend; both packed and split `forward_decode` paths call `_track_mamba_state_decode`.
- `kda_triton.py`: pass `output_intermediate_states=True`.
- `overrides.py`: add `KimiLinearForCausalLM` to `_MAMBA_EXTRA_BUFFER_ARCHS`.

`KimiLinearForCausalLM` is a KDA-backed hybrid already in `_MAMBA_RADIX_CACHE_ARCHS` but missing from `_MAMBA_EXTRA_BUFFER_ARCHS`; the track wiring makes the extra_buffer strategy safe for it.

## Verification
- `py_compile` + `pre-commit` pass.
- KDA track mirrors upstream GDN's existing track wiring (`gdn_backend.py`), which runs in production for `Qwen3Next`/`Qwen3_5`.
- e2e (`moonshotai/Kimi-Linear-48B-A3B-Instruct`, TP2, `--mamba-radix-cache-strategy extra_buffer`): GSM8K 200q warm1=94.50%/stop96.50%, warm2=94.50%/stop99.50%/error0 (warm-rerun score does not collapse — the track-correct smoke test). Radix hits are real: warm2 throughput 1487 tok/s vs warm1 670 tok/s.





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29248362688](https://github.com/sgl-project/sglang/actions/runs/29248362688)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29248362330](https://github.com/sgl-project/sglang/actions/runs/29248362330)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->