### PR TITLE
Fix VLM runtime stability

### DIFF
--- a/python/sglang/srt/compilation/compile.py
+++ b/python/sglang/srt/compilation/compile.py
@@ -96,7 +96,12 @@ def _infer_dynamic_arg_dims_from_annotations(forward_fn):
             ann is torch.Tensor
             or getattr(getattr(ann, "__args__", [None])[0], "__name__", "") == "Tensor"
         ):
-            dyn[name] = 0
+            # Token positions are normally [T], but mRoPE models pass them
+            # as [rope_axis, T]. The token dimension is consequently the
+            # last dimension in both cases. Marking dim 0 (the old default)
+            # leaves T static for Qwen-VL and makes Dynamo recompile on every
+            # unseen prefill length.
+            dyn[name] = -1 if name in ("positions", "position_ids") else 0
         elif getattr(ann, "__name__", "") in ("IntermediateTensors",) or any(
             getattr(a, "__name__", "") == "IntermediateTensors"
             for a in getattr(ann, "__args__", [])
@@ -104,10 +109,31 @@ def _infer_dynamic_arg_dims_from_annotations(forward_fn):
             dyn[name] = 0
         elif ann == "torch.Tensor" or ann == "Optional[torch.Tensor]":
             # For future import annotations (e.g. from __future__ import annotations), the annotation is a string
-            dyn[name] = 0
+            dyn[name] = -1 if name in ("positions", "position_ids") else 0
     if not dyn:
         raise ValueError("No dynamic dims inferred; pass dynamic_arg_dims explicitly.")
     return dyn
+
+
+def _mark_dynamic_forward_batch(forward_batch) -> None:
+    """Mark runtime-sized ForwardBatch tensors before the first PCG trace.
+
+    ``ForwardBatch`` is deliberately not annotated as a Tensor, so the
+    annotation-based argument inference above cannot see its tensor fields.
+    PCG nevertheless reads sequence- and token-sized metadata from it in
+    attention layers. Leaving those dimensions static gives Dynamo a guard on
+    the dummy capture shape and silently creates a new backend for a real VLM
+    request. All direct tensor fields are batch-major except mRoPE positions,
+    whose token axis is the final dimension.
+    """
+    if forward_batch is None:
+        return
+
+    for name, value in vars(forward_batch).items():
+        if not isinstance(value, torch.Tensor) or value.ndim == 0:
+            continue
+        dims = -1 if name in ("positions", "mrope_positions") else 0
+        _mark_dynamic_on_value(value, dims)
 
 
 def install_torch_compiled(
@@ -129,9 +155,8 @@ def install_torch_compiled(
     if backend_factory is None:
         from sglang.srt.compilation.backend import SGLangBackend
 
-        backend_factory = lambda gm, ex: SGLangBackend(compile_config, graph_pool)(
-            gm, ex
-        )
+        def backend_factory(gm, ex):
+            return SGLangBackend(compile_config, graph_pool)(gm, ex)
 
     compiled_codes: list[type(original_code)] = []
     state = {"compiled": False, "compiled_callable": None}
@@ -172,13 +197,21 @@ def install_torch_compiled(
                 val = ba.arguments[name]
                 if val is not None:
                     _mark_dynamic_on_value(val, dims)
+        _mark_dynamic_forward_batch(ba.arguments.get("forward_batch"))
 
         # Avoid cross-instance cache reuse
         torch._dynamo.eval_frame.remove_from_cache(unbound_fwd.__code__)
 
         bound = types.MethodType(unbound_fwd, self)
         compiled_callable = torch.compile(
-            bound, fullgraph=fullgraph, backend=backend_factory
+            # A multimodal-only argument may first appear after the text
+            # dummy trace (e.g. Qwen3-VL deepstack embeds). Keep that
+            # replacement trace shape-polymorphic instead of baking its first
+            # image length into every subsequent VLM prefill request.
+            bound,
+            fullgraph=fullgraph,
+            backend=backend_factory,
+            dynamic=True,
         )
 
         # Trigger Dynamo so bytecode hook can capture

--- a/python/sglang/srt/compilation/cuda_piecewise_backend.py
+++ b/python/sglang/srt/compilation/cuda_piecewise_backend.py
@@ -18,11 +18,9 @@ from sglang.srt.compilation.compile_phase import (
     is_in_torch_compile_warmup,
 )
 from sglang.srt.compilation.weak_ref_tensor import weak_ref_tensors
-from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import print_warning_once
 
 logger = logging.getLogger(__name__)
-_is_hip = is_hip()
 
 
 @dataclasses.dataclass
@@ -43,7 +41,6 @@ class ConcreteSizeEntry:
 
 
 class CUDAPiecewiseBackend:
-
     def __init__(
         self,
         graph: fx.GraphModule,
@@ -155,15 +152,18 @@ class CUDAPiecewiseBackend:
 
             # During normal capture (PiecewiseCudaGraphRunner.capture()),
             # set_pcg_capture_stream() guarantees a valid stream. However,
-            # Dynamo may silently recompile on HIP/MLA serving batches whose
-            # token count exceeds the captured range. The replacement backend
-            # has no capture stream; fall back there instead of crashing while
-            # preserving the original assertion on other platforms.
+            # Dynamo may silently recompile serving batches when a dynamic
+            # multimodal input introduces a previously unseen guard. The
+            # replacement backend has no capture stream, so it cannot safely
+            # create a CUDA graph. Execute that subgraph normally instead of
+            # crashing the scheduler; subsequent matching shapes still use
+            # their captured graphs.
             stream = get_pcg_capture_stream()
-            if _is_hip and stream is None:
+            if stream is None:
                 print_warning_once(
-                    "PCG capture stream is not set; likely a Dynamo runtime "
-                    "recompilation. Falling back to eager execution for this "
+                    "PCG capture stream is not set. This can be a Dynamo runtime "
+                    "recompilation or an optional VLM branch pre-warmed outside "
+                    "CUDA graph capture; falling back to eager execution for this "
                     "subgraph."
                 )
                 return entry.runnable(*args)

--- a/python/sglang/srt/compilation/xpu_piecewise_backend.py
+++ b/python/sglang/srt/compilation/xpu_piecewise_backend.py
@@ -65,7 +65,7 @@ class XPUPiecewiseBackend(CUDAPiecewiseBackend):
             # at 8192 tokens when the capture grid tops out at 512). The
             # recompiled backend instance has no capture stream; fall back to
             # eager for that sub-graph instead of crashing the scheduler.
-            # Mirrors the HIP fallback in CUDAPiecewiseBackend.__call__.
+            # Mirrors the CUDA fallback in CUDAPiecewiseBackend.__call__.
             stream = get_pcg_capture_stream()
             if stream is None:
                 print_warning_once(

--- a/python/sglang/srt/distributed/device_communicators/cuda_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/cuda_wrapper.py
@@ -9,6 +9,7 @@ convenient for use when we just need to call a few functions.
 
 import ctypes
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -47,24 +48,28 @@ def find_loaded_library(lib_name) -> Optional[str]:
     shared libraries loaded by the process. We can use this file to find the path of the
     a loaded library.
     """  # noqa
-    found = False
+    candidates = []
     with open("/proc/self/maps") as f:
         for line in f:
-            if lib_name in line:
-                found = True
-                break
-    if not found:
+            if lib_name not in line or "/" not in line:
+                continue
+            path = line[line.index("/") :].strip()
+            filename = os.path.basename(path)
+            if filename.rpartition(".so")[0].startswith(lib_name):
+                candidates.append(path)
+
+    if not candidates:
         # the library is not loaded in the current process
         return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = line.index("/")
-    path = line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(
-        lib_name
-    ), f"Unexpected filename: {filename} for library {lib_name}"
-    return path
+
+    # TileLang ships a ``libcudart_stub.so`` that is only sufficient for its
+    # JIT loader.  It can precede the actual CUDA runtime in /proc/self/maps;
+    # choosing it makes CUDA IPC and FlashInfer all-reduce fail when resolving
+    # symbols such as cudaDeviceReset.
+    for path in candidates:
+        if "stub" not in os.path.basename(path):
+            return path
+    return candidates[0]
 
 
 class CudaRTLibrary:

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -77,6 +77,7 @@ from sglang.srt.layers.linear import (
 )
 from sglang.srt.layers.quantization import QuantizationConfig
 from sglang.srt.layers.rotary_embedding import apply_rotary_pos_emb
+from sglang.srt.layers.rotary_embedding.utils import apply_rotary_pos_emb_native_eager
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.utils import add_prefix, get_bool_env_var
 
@@ -456,10 +457,13 @@ class VisionFlash3Attention(nn.Module):
                 fa_kwargs["sinks"] = s_aux
             output = flash_attn_varlen_func(q, k, v, **fa_kwargs)
         else:
+            seqlens_source = cu_seqlens
             cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
             cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
-            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-            max_seqlen = seq_lens.max().item()
+            # The same sequence metadata is shared by every ViT block. Cache
+            # this scalar on its carrier so FA3 does not synchronize once per
+            # layer merely to rediscover an unchanged max sequence length.
+            max_seqlen = resolve_max_seqlen(seqlens_source, cu_seqlens)
 
             fa_kwargs = dict(
                 cu_seqlens_q=cu_seqlens,
@@ -700,7 +704,6 @@ class VisionAiterAttention(nn.Module):
 
 
 class VisionAscendAttention(nn.Module):
-
     def __init__(
         self,
         **kwargs,
@@ -1253,7 +1256,18 @@ class VisionAttention(nn.Module):
                 cos = torch.cat([cos, cos], dim=-1)
                 sin = torch.cat([sin, sin], dim=-1)
 
-            q, k = apply_rotary_pos_emb(q, k, cos, sin)
+            # `apply_rotary_pos_emb` is torch.compile-decorated. Its first
+            # specialization may otherwise be compiled while a ViT CUDA graph
+            # is being captured, which makes Inductor attempt an illegal
+            # CPU-to-CUDA copy. The eager version is captured as part of the
+            # graph, so its pointwise work is still replayed without launch
+            # overhead.
+            rotary_fn = (
+                apply_rotary_pos_emb_native_eager
+                if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get()
+                else apply_rotary_pos_emb
+            )
+            q, k = rotary_fn(q, k, cos, sin)
             q = q.view(original_q_shape)
             k = k.view(original_k_shape)
 
@@ -1275,7 +1289,6 @@ class VisionAttention(nn.Module):
         if self.qk_normalization and not self.qk_normalization_by_head_size:
             # jit kernel
             if can_use_jit_qk_norm(self.head_size, q.dtype):
-
                 # q: [tokens, head, head_size]  ->  [tokens, embed_dim]
                 head_dim_for_norm = head * self.head_size
 

--- a/python/sglang/srt/layers/deepseek_v4_rope.py
+++ b/python/sglang/srt/layers/deepseek_v4_rope.py
@@ -9,28 +9,6 @@ import triton.language as tl
 
 logger = logging.getLogger(__name__)
 
-# tilelang isn't shipped on every platform (e.g. Ascend NPU images) and the
-# only tilelang artifacts in this file are pass_configs that downstream
-# tilelang.jit decorators would consume — the kernels actually defined here
-# are Triton. Keep the import optional so this module loads on NPU.
-try:
-    import tilelang
-
-    tilelang.set_log_level("WARNING")
-
-    pass_configs = {
-        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
-    }
-except ImportError:
-    logger.info(
-        "tilelang not installed; deepseek_v4_rope pass_configs unset. "
-        "Triton kernels in this module still run; only downstream tilelang.jit "
-        "consumers of pass_configs will need to handle the None."
-    )
-    tilelang = None
-    pass_configs = None
-
 FP8 = "float8_e4m3"
 BF16 = "bfloat16"
 FP32 = "float32"
@@ -53,7 +31,6 @@ def precompute_freqs_cis(
     beta_fast,
     beta_slow,
 ) -> torch.Tensor:
-
     def find_correction_dim(num_rotations, dim, base, max_seq_len):
         return (
             dim
@@ -290,7 +267,6 @@ def apply_rotary_emb_triton(
     positions: Optional[torch.Tensor] = None,
     inverse: bool = False,
 ) -> torch.Tensor:
-
     if _USE_BATCHED_ROPE:
         is_3d = x.ndim == 3
         if is_3d:

--- a/python/sglang/srt/layers/rotary_embedding/utils.py
+++ b/python/sglang/srt/layers/rotary_embedding/utils.py
@@ -70,8 +70,7 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
-def apply_rotary_pos_emb_native(
+def apply_rotary_pos_emb_native_eager(
     q: torch.Tensor,
     k: torch.Tensor,
     cos: torch.Tensor,
@@ -92,6 +91,17 @@ def apply_rotary_pos_emb_native(
     k_embed = k_embed.to(orig_k_dtype)
 
     return q_embed, k_embed
+
+
+@torch.compile(dynamic=True, backend=get_compiler_backend())
+def apply_rotary_pos_emb_native(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim=1,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return apply_rotary_pos_emb_native_eager(q, k, cos, sin, unsqueeze_dim)
 
 
 def apply_rotary_pos_emb_npu(

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -120,7 +120,6 @@ class TransportProxyTensor(torch.Tensor):
         *args,
         **kwargs,
     ):
-
         if not isinstance(data, torch.Tensor):
             raise TypeError(
                 f"Input 'data' must be a torch.Tensor, but got {type(data)}"
@@ -1074,32 +1073,36 @@ def general_mm_embed_routine(
                 if forward_batch.mm_inputs[i] is not None
             ]
             server_args = get_server_args()
-            if server_args and server_args.enable_adaptive_dispatch_to_encoder:
-                # Split by precomputed vs non-precomputed so get_embedding_and_mask only sees uniform batches
-                input_embeds, other_info = _embed_mm_inputs_with_split(
-                    mm_inputs_list=mm_inputs_list,
-                    extend_prefix_lens=extend_prefix_lens,
-                    extend_seq_lens=extend_seq_lens,
-                    input_ids=input_ids,
-                    forward_batch=forward_batch,
-                    input_embedding=embed_tokens,
-                    multimodal_model=multimodal_model,
-                    data_embedding_func_mapping=data_embedding_funcs,
-                    placeholder_tokens=placeholder_tokens,
-                    use_deepstack=use_deepstack,
-                )
-            else:
-                input_embeds, other_info = embed_mm_inputs(
-                    mm_inputs_list=mm_inputs_list,
-                    extend_prefix_lens=extend_prefix_lens,
-                    extend_seq_lens=extend_seq_lens,
-                    input_ids=input_ids,
-                    input_embedding=embed_tokens,
-                    multimodal_model=multimodal_model,
-                    data_embedding_func_mapping=data_embedding_funcs,
-                    placeholder_tokens=placeholder_tokens,
-                    use_deepstack=use_deepstack,
-                )
+            # Makes VLM profiles directly attributable: this range includes
+            # encoder/ViT execution and multimodal feature placement, while
+            # the language model range below excludes both.
+            with torch.profiler.record_function("sglang.vlm.mm_embedding"):
+                if server_args and server_args.enable_adaptive_dispatch_to_encoder:
+                    # Split by precomputed vs non-precomputed so get_embedding_and_mask only sees uniform batches
+                    input_embeds, other_info = _embed_mm_inputs_with_split(
+                        mm_inputs_list=mm_inputs_list,
+                        extend_prefix_lens=extend_prefix_lens,
+                        extend_seq_lens=extend_seq_lens,
+                        input_ids=input_ids,
+                        forward_batch=forward_batch,
+                        input_embedding=embed_tokens,
+                        multimodal_model=multimodal_model,
+                        data_embedding_func_mapping=data_embedding_funcs,
+                        placeholder_tokens=placeholder_tokens,
+                        use_deepstack=use_deepstack,
+                    )
+                else:
+                    input_embeds, other_info = embed_mm_inputs(
+                        mm_inputs_list=mm_inputs_list,
+                        extend_prefix_lens=extend_prefix_lens,
+                        extend_seq_lens=extend_seq_lens,
+                        input_ids=input_ids,
+                        input_embedding=embed_tokens,
+                        multimodal_model=multimodal_model,
+                        data_embedding_func_mapping=data_embedding_funcs,
+                        placeholder_tokens=placeholder_tokens,
+                        use_deepstack=use_deepstack,
+                    )
 
             # add for qwen3_vl deepstack
             if use_deepstack:
@@ -1143,12 +1146,13 @@ def general_mm_embed_routine(
     else:
         input_embeds = None
 
-    hidden_states = language_model(
-        input_ids=None,
-        forward_batch=forward_batch,
-        input_embeds=input_embeds,
-        **kwargs,
-    )
+    with torch.profiler.record_function("sglang.vlm.language_model_prefill"):
+        hidden_states = language_model(
+            input_ids=None,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+            **kwargs,
+        )
     return hidden_states
 
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2696,8 +2696,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.prefill_cuda_graph_runner = self.eager_runner
             return
 
-        # Disable prefill CUDA graph for non-language models
-        if not hasattr(self.model, "model"):
+        # Disable prefill CUDA graph for non-language models.  Some VLM
+        # wrappers (for example Kimi-VL) expose the decoder as
+        # ``language_model`` rather than ``model``; resolve_language_model()
+        # supports both forms below, so they are both graph-capturable.
+        if not (hasattr(self.model, "model") or hasattr(self.model, "language_model")):
             logger.warning(
                 "Disable prefill CUDA graph because the model is not a language model"
             )
@@ -2710,9 +2713,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             return
 
-        # Collect attention layers and moe layers from the model
-        self.model.model = resolve_language_model(self.model)
-        language_model = getattr(self.model, "language_model", self.model)
+        # Collect attention layers and moe layers from the model. Keep a VLM
+        # wrapper that exposes ``language_model`` unchanged: assigning it to
+        # ``model`` would register a duplicate module alias and duplicate the
+        # model's state-dict namespace.
+        language_model = resolve_language_model(self.model)
+        if hasattr(self.model, "model"):
+            self.model.model = language_model
 
         # Find the module that owns the decoder `layers`. Models wrap it at
         # varying depths: a direct text model exposes `.layers`, a CausalLM

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -497,6 +497,71 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         attn_backend.init_forward_metadata(fb)
         self._run_forward(fb, num_tokens)
 
+    def run_dummy_multimodal_deepstack_forward(
+        self, language_model: torch.nn.Module, num_tokens: int
+    ) -> bool:
+        """Warm the tensor-valued deepstack branch before serving requests.
+
+        The regular PCG dummy is text-only. Qwen3-VL only provides
+        ``input_deepstack_embeds`` after visual encoding, so leaving this
+        branch cold makes the first image request synchronously recompile the
+        language model. The model/signature checks keep this a no-op for
+        non-deepstack architectures.
+        """
+        if (
+            "input_deepstack_embeds"
+            not in inspect.signature(language_model.forward).parameters
+        ):
+            return False
+
+        num_deepstack = getattr(self.model_runner.model, "num_deepstack_embeddings", 0)
+        if num_deepstack <= 0:
+            return False
+
+        hidden_size = (
+            getattr(getattr(language_model, "config", None), "hidden_size", None)
+            or self.model_runner.model_config.hidden_size
+        )
+        fb, attn_backend = self.capture_prepare(num_tokens)
+        attn_backend.init_forward_metadata(fb)
+        deepstack_embeds = torch.zeros(
+            (num_tokens, hidden_size * num_deepstack),
+            dtype=self.model_runner.dtype,
+            device=self.device,
+        )
+        torch._dynamo.maybe_mark_dynamic(deepstack_embeds, 0)
+
+        fb.dp_local_start_pos = fb.dp_local_num_tokens = None
+        set_dp_buffer_len(
+            fb.global_dp_buffer_len,
+            num_tokens,
+            fb.dp_padding_mode.is_max_len(),
+            fb.global_num_tokens_cpu,
+        )
+        set_is_extend_in_batch(False)
+
+        with (
+            forward_context(
+                ForwardContext(attn_backend=self.model_runner.attn_backend)
+            ),
+            set_tc_piecewise_forward_context(
+                fb,
+                self.attention_layers,
+                self.quant_config,
+                self.moe_layers,
+                self.moe_fusions,
+                dsa_indexers=self.dsa_indexers,
+            ),
+        ):
+            language_model.forward(
+                fb.input_ids,
+                self._get_layer_model_positions(fb),
+                fb,
+                input_embeds=fb.input_embeds,
+                input_deepstack_embeds=deepstack_embeds,
+            )
+        return True
+
     def _has_inactive_dp_rank(self, forward_batch: ForwardBatch) -> bool:
         # DSV4 DP attention / DeepEP collectives need every DP rank to enter
         # the same replay path. Sparse-DP batches (one or more ranks with
@@ -631,7 +696,6 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         Returns ``(forward_batch, attn_backend)`` to mirror decode's
         capture_prepare signature.
         """
-        buffers = self.buffers
         bs = self._capture_req_slots
         # Slot 0 carries num_tokens; slots 1..bs-1 are zero-length sentinels.
         lens_cpu = [num_tokens] + [0] * (bs - 1)
@@ -831,7 +895,6 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         """Pad, populate static buffers, and build the static_forward_batch
         the model code reads during replay.
         """
-        buffers = self.buffers
         num_tokens = len(forward_batch.input_ids)
         static_num_tokens = self._pad_to_bucket(num_tokens, self.capture_num_tokens)
         self.raw_num_tokens = num_tokens

--- a/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py
@@ -200,6 +200,14 @@ class TcPiecewiseCudaGraphBackend(BaseCudaGraphBackend):
                                     f"Compiling num tokens ({num_tokens=})"
                                 )
                             cuda_graph_runner._run_dummy_forward(num_tokens=num_tokens)
+
+                # Qwen3-VL deepstack embeddings are produced only after
+                # visual encoding. First trace the tensor branch above, then
+                # execute it once outside the compile-warmup marker so its
+                # regular kernel/JIT warmup also happens during startup.
+                cuda_graph_runner.run_dummy_multimodal_deepstack_forward(
+                    inner_model, cuda_graph_runner.capture_num_tokens[-1]
+                )
             finally:
                 _toggle_multi_platform_ops(inner_model, reverse=True, num_tokens=16)
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import functools
 import logging
 import time
 from contextlib import nullcontext
@@ -129,12 +130,6 @@ if not _is_hip:
         prepare_context_parallel_metadata,
     )
 
-if _is_xpu:
-    from sgl_kernel import hc_split_sinkhorn
-else:
-    from sglang.srt.layers.mhc import hc_split_sinkhorn, mhc_fused_post_pre, npu_hc_pre
-
-from sglang.srt.runtime_context import get_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
@@ -151,6 +146,28 @@ from sglang.srt.utils.hf_transformers_utils import get_rope_config
 # torch_npu.npu_rms_norm directly (imports elsewhere aren't visible in this module).
 if _is_npu:
     import torch_npu
+
+
+@functools.cache
+def _get_mhc_ops():
+    """Load MHC kernels only when a DeepSeek-V4 layer needs them.
+
+    Model modules are imported eagerly by the registry.  Importing
+    ``sglang.srt.layers.mhc`` at module load imports TileLang, whose runtime
+    loads its private CUDA stub library.  That global side effect breaks
+    FlashInfer TRT-LLM all-reduce workspace initialization for unrelated
+    Hopper models (for example Qwen3-VL).  DeepSeek-V4 is the sole consumer
+    here, so defer the import until its forward path executes.
+    """
+    if _is_xpu:
+        from sgl_kernel import hc_split_sinkhorn
+
+        return hc_split_sinkhorn, None, None
+
+    from sglang.srt.layers.mhc import hc_split_sinkhorn, mhc_fused_post_pre, npu_hc_pre
+
+    return hc_split_sinkhorn, mhc_fused_post_pre, npu_hc_pre
+
 
 logger = logging.getLogger(__name__)
 
@@ -335,7 +352,6 @@ bcg_deepseek_v4_attention_with_output = eager_on_graph(True)(
 
 
 class MqaAttentionBase(nn.Module):
-
     def __init__(
         self,
         config: DeepSeekV4Config,
@@ -1346,7 +1362,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         shape, dtype = x.size(), x.dtype
 
         if _is_npu:
-            return npu_hc_pre(
+            return _get_mhc_ops()[2](
                 x,
                 hc_fn,
                 hc_scale,
@@ -1423,7 +1439,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         else:
             x_flat, mixes = hc_pre_torch_impl(x, hc_fn)
 
-        pre, post, comb = hc_split_sinkhorn(
+        pre, post, comb = _get_mhc_ops()[0](
             mixes,
             hc_scale,
             hc_base,
@@ -1441,7 +1457,6 @@ class DeepseekV4DecoderLayer(nn.Module):
         post: torch.Tensor,
         comb: torch.Tensor,
     ):
-
         if x.shape[0] == 0:
             return torch.empty(
                 (0, self.hc_mult, x.shape[-1]), dtype=x.dtype, device=x.device
@@ -1494,7 +1509,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         use_fused = self.use_fused_mhc_post_pre
 
         if prev_residual is not None and use_fused:
-            residual, post, comb, hidden_states = mhc_fused_post_pre(
+            residual, post, comb, hidden_states = _get_mhc_ops()[1](
                 hidden_states,
                 prev_residual,
                 prev_post,
@@ -1564,7 +1579,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             if fused_mhc is not None:
                 residual, hidden_states, post, comb, norm_fused = fused_mhc
             else:
-                residual, post, comb, hidden_states = mhc_fused_post_pre(
+                residual, post, comb, hidden_states = _get_mhc_ops()[1](
                     hidden_states,
                     residual,
                     post.unsqueeze(-1) if post.ndim == 2 else post,

--- a/python/sglang/srt/models/kimi_vl.py
+++ b/python/sglang/srt/models/kimi_vl.py
@@ -43,6 +43,7 @@
 
 import copy
 import logging
+import math
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Tuple
 
@@ -50,7 +51,6 @@ import torch
 from torch import nn
 from transformers.activations import GELUActivation
 
-from sglang.srt.configs import KimiVLConfig
 from sglang.srt.configs.deepseekvl2 import DeepseekV2Config
 from sglang.srt.configs.kimi_vl import KimiVLConfig
 from sglang.srt.configs.kimi_vl_moonvit import MoonViTConfig
@@ -73,6 +73,8 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
 from sglang.srt.models.kimi_vl_moonvit import MoonVitPretrainedModel
+from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
+from sglang.srt.runtime_context import get_server_args
 from sglang.srt.utils import add_prefix
 
 logger = logging.getLogger(__name__)
@@ -86,7 +88,6 @@ class MaxImageTokenMeta:
 
 
 class KimiVLMultiModalProjector(nn.Module):
-
     def __init__(self, config: KimiVLConfig):
         super().__init__()
 
@@ -124,7 +125,13 @@ class KimiVLForConditionalGeneration(nn.Module):
         self.config = config
         assert isinstance(config.vision_config, MoonViTConfig)
 
-        self.vision_tower = MoonVitPretrainedModel(config.vision_config)
+        self.use_data_parallel = get_server_args().mm_enable_dp_encoder
+        self.vision_tower = MoonVitPretrainedModel(
+            config.vision_config,
+            prefix=add_prefix("vision_tower", prefix),
+            use_data_parallel=self.use_data_parallel,
+            use_tensor_parallel=not self.use_data_parallel,
+        )
 
         self.multi_modal_projector = KimiVLMultiModalProjector(config=config)
         self.quant_config = quant_config
@@ -152,13 +159,26 @@ class KimiVLForConditionalGeneration(nn.Module):
         ):
             return pixel_values
 
-        image_grid_hws = torch.cat([item.image_grid_hws for item in items], dim=0).to(
-            self.vision_tower.device
-        )
-        image_features = self.vision_tower(pixel_values, image_grid_hws)
-        assert isinstance(image_features, list)
-        # lengths = [x.shape[0] for x in image_features]
-        res = self.multi_modal_projector(torch.cat(image_features))  # .split(lengths)
+        image_grid_hws = torch.cat([item.image_grid_hws for item in items], dim=0)
+        image_grid_hws_list = image_grid_hws.tolist()
+        if self.use_data_parallel:
+            image_features = run_dp_sharded_mrope_vision_model(
+                self.vision_tower,
+                pixel_values,
+                image_grid_hws_list,
+                rope_type="rope_2d",
+            )
+        else:
+            image_grid_hws = image_grid_hws.to(self.vision_tower.device)
+            image_features = self.vision_tower(
+                pixel_values,
+                image_grid_hws,
+                max_seqlen=max(math.prod(grid) for grid in image_grid_hws_list),
+            )
+            assert isinstance(image_features, list)
+            image_features = torch.cat(image_features)
+
+        res = self.multi_modal_projector(image_features)
         return res
 
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
@@ -242,8 +262,6 @@ class KimiVLForConditionalGeneration(nn.Module):
             use_default_weight_loading = False
             if "vision" in name:
                 if self.vision_tower is not None:
-                    # We only do sharding for language model and
-                    # not vision model for now.
                     use_default_weight_loading = True
             else:
                 for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/kimi_vl_moonvit.py
+++ b/python/sglang/srt/models/kimi_vl_moonvit.py
@@ -61,9 +61,15 @@ except ImportError:
 
 from sglang.srt.configs import MoonViTConfig
 from sglang.srt.layers.conv import Conv2dLayer
-from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
 from sglang.srt.layers.quantization import QuantizationConfig
 from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix, get_device
 
 
@@ -74,6 +80,7 @@ def multihead_attention(
     v: torch.Tensor,
     q_cu_seqlens: Optional[torch.Tensor] = None,
     k_cu_seqlens: Optional[torch.Tensor] = None,
+    max_seqlen: Optional[int] = None,
 ):
     """Multi-head attention using flash attention 2.
     This function is used to handle the case where the query, key, and value are packed.
@@ -94,25 +101,28 @@ def multihead_attention(
         )
     # Unified format legal check
     assert q.dim() == k.dim() == v.dim() == 3, "q, k, v must have 3 dims"
-    assert q_cu_seqlens[-1] == q.shape[0], "q_cu_seqlens must sum to q.shape[0]"
-    assert (
-        k_cu_seqlens[-1] == k.shape[0] == v.shape[0]
-    ), "k_cu_seqlens must sum to k.shape[0]"
+    # Keep validation on CPU for debugging, but avoid synchronizing the GPU
+    # once per MoonViT layer in the normal packed CUDA path.
+    if not q_cu_seqlens.is_cuda:
+        assert q_cu_seqlens[-1] == q.shape[0], "q_cu_seqlens must sum to q.shape[0]"
+        assert (
+            k_cu_seqlens[-1] == k.shape[0] == v.shape[0]
+        ), "k_cu_seqlens must sum to k.shape[0]"
     assert q.dtype in [
         torch.bfloat16,
         torch.float16,
     ], f"unsupported dtype {q.dtype} for multihead attn"
 
-    max_seqlen_q = (q_cu_seqlens[1:] - q_cu_seqlens[:-1]).max().item()
-    max_seqlen_k = (k_cu_seqlens[1:] - k_cu_seqlens[:-1]).max().item()
+    if max_seqlen is None:
+        max_seqlen = (q_cu_seqlens[1:] - q_cu_seqlens[:-1]).max().item()
     attn_out = flash_attn_varlen_func(
         q,
         k,
         v,
         q_cu_seqlens,
         k_cu_seqlens,
-        max_seqlen_q,
-        max_seqlen_k,
+        max_seqlen,
+        max_seqlen,
         causal=False,
     )
     attn_out = attn_out.flatten(start_dim=-2)
@@ -126,6 +136,7 @@ def sdpa_attention(
     v: torch.Tensor,
     q_cu_seqlens: Optional[torch.Tensor] = None,
     k_cu_seqlens: Optional[torch.Tensor] = None,
+    max_seqlen: Optional[int] = None,
 ) -> torch.Tensor:
     """Multi-head attention using torch scaled dot product attention.
     This function is used to handle the case where the query, key, and value are packed.
@@ -199,7 +210,6 @@ def apply_rope(
 
 
 class Learnable2DInterpPosEmb(nn.Module):
-
     def __init__(
         self, height: int, width: int, dim: int, interpolation_mode: str = "bicubic"
     ) -> None:
@@ -208,6 +218,13 @@ class Learnable2DInterpPosEmb(nn.Module):
         self.width = width
         self.interpolation_mode = interpolation_mode
         self.weight = nn.Parameter(torch.empty(height, width, dim))
+        # In serving, MoonViT weights are immutable and image grids commonly
+        # repeat. Avoid launching bicubic interpolation for every request.
+        # Keep this as a plain cache (rather than a buffer) so it is neither
+        # serialized nor used during training.
+        self._interpolated_pos_emb_cache: dict[
+            tuple[tuple[int, int], torch.dtype, torch.device], torch.Tensor
+        ] = {}
         self.reset_parameters()
 
     def reset_parameters(self):
@@ -216,25 +233,31 @@ class Learnable2DInterpPosEmb(nn.Module):
     def forward(self, x: torch.Tensor, grid_hws: torch.Tensor) -> torch.Tensor:
         pos_embs = []
         for shape in grid_hws.tolist():
+            shape = tuple(shape)
             if shape == self.weight.shape[:-1]:
                 pos_embs.append(self.weight.flatten(end_dim=1))
             else:
-                pos_embs.append(
-                    F.interpolate(
-                        self.weight.permute((2, 0, 1)).unsqueeze(0),
-                        size=shape,
-                        mode=self.interpolation_mode,
+                cache_key = (shape, self.weight.dtype, self.weight.device)
+                pos_emb = self._interpolated_pos_emb_cache.get(cache_key)
+                if pos_emb is None:
+                    pos_emb = (
+                        F.interpolate(
+                            self.weight.permute((2, 0, 1)).unsqueeze(0),
+                            size=shape,
+                            mode=self.interpolation_mode,
+                        )
+                        .squeeze(0)
+                        .permute((1, 2, 0))
+                        .flatten(end_dim=1)
                     )
-                    .squeeze(0)
-                    .permute((1, 2, 0))
-                    .flatten(end_dim=1)
-                )
+                    if not self.training:
+                        self._interpolated_pos_emb_cache[cache_key] = pos_emb
+                pos_embs.append(pos_emb)
         out = x + torch.cat(pos_embs)
         return out
 
 
 class MoonVisionPatchEmbed(nn.Module):
-
     def __init__(
         self,
         out_dim: int,
@@ -408,11 +431,16 @@ class MLP2(nn.Module):
         bias: bool = True,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        use_data_parallel: bool = False,
+        use_tensor_parallel: bool = False,
     ):
         super().__init__()
         assert len(dims) == 3
 
         self.quant_config = quant_config
+        use_tensor_parallel = use_tensor_parallel and not use_data_parallel
+        tp_size = get_parallel().attn_tp_size if use_tensor_parallel else 1
+        tp_rank = get_parallel().attn_tp_rank if use_tensor_parallel else 0
         if isinstance(self.quant_config, ModelSlimConfig):
             self.fc0 = ReplicatedLinear(
                 dims[0],
@@ -428,18 +456,41 @@ class MLP2(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("fc1", prefix),
             )
+        elif use_tensor_parallel:
+            self.fc0 = ColumnParallelLinear(
+                dims[0],
+                dims[1],
+                bias=bias,
+                prefix=add_prefix("fc0", prefix),
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
+            self.fc1 = RowParallelLinear(
+                dims[1],
+                dims[2],
+                bias=bias,
+                prefix=add_prefix("fc1", prefix),
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
         else:
             self.fc0 = nn.Linear(dims[0], dims[1], bias=bias)
             self.fc1 = nn.Linear(dims[1], dims[2], bias=bias)
-            for m in [self.fc0, self.fc1]:
-                nn.init.trunc_normal_(m.weight, std=math.sqrt(2 / m.in_features))
-                if m.bias is not None:
-                    nn.init.zeros_(m.bias)
+            for module in (self.fc0, self.fc1):
+                nn.init.trunc_normal_(
+                    module.weight, std=math.sqrt(2 / module.in_features)
+                )
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
         self.activation = activation
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if isinstance(self.quant_config, ModelSlimConfig):
             x = x.flatten(0, 1)
+            x, _ = self.fc0(x)
+            x = self.activation(x)
+            x, _ = self.fc1(x)
+        elif isinstance(self.fc0, ColumnParallelLinear):
             x, _ = self.fc0(x)
             x = self.activation(x)
             x, _ = self.fc1(x)
@@ -451,7 +502,6 @@ class MLP2(nn.Module):
 
 
 class MoonVitEncoderLayer(nn.Module):
-
     def __init__(
         self,
         num_heads: int,
@@ -461,6 +511,9 @@ class MoonVitEncoderLayer(nn.Module):
         attn_implementation: str = "flash_attention_2",  # use fa2 in sglang by default
         activation=F.gelu,
         attn_bias: bool = False,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+        use_tensor_parallel: bool = False,
     ):
         super().__init__()
         self.num_heads = num_heads
@@ -468,28 +521,63 @@ class MoonVitEncoderLayer(nn.Module):
         self.hidden_size_per_attention_head = self.hidden_dim // self.num_heads
         self.attn_implementation = attn_implementation
 
+        self.use_tensor_parallel = use_tensor_parallel and not use_data_parallel
+        tp_size = get_parallel().attn_tp_size if self.use_tensor_parallel else 1
+        tp_rank = get_parallel().attn_tp_rank if self.use_tensor_parallel else 0
+        self.num_attention_heads_per_partition = self.num_heads // tp_size
+
         self.norm0 = nn.LayerNorm(hidden_dim)
         self.norm1 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP2([hidden_dim, mlp_dim, hidden_dim], activation)
-        self.wqkv = nn.Linear(hidden_dim, hidden_dim * 3, bias=attn_bias)
-        self.wo = nn.Linear(hidden_dim, hidden_dim, bias=attn_bias)
+        self.mlp = MLP2(
+            [hidden_dim, mlp_dim, hidden_dim],
+            activation,
+            prefix=add_prefix("mlp", prefix),
+            use_data_parallel=use_data_parallel,
+            use_tensor_parallel=self.use_tensor_parallel,
+        )
+        if self.use_tensor_parallel:
+            self.wqkv = QKVParallelLinear(
+                hidden_size=hidden_dim,
+                head_size=self.hidden_size_per_attention_head,
+                total_num_heads=num_heads,
+                total_num_kv_heads=num_heads,
+                bias=attn_bias,
+                prefix=add_prefix("wqkv", prefix),
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
+            self.wo = RowParallelLinear(
+                hidden_dim,
+                hidden_dim,
+                bias=attn_bias,
+                prefix=add_prefix("wo", prefix),
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+            )
+        else:
+            self.wqkv = nn.Linear(hidden_dim, hidden_dim * 3, bias=attn_bias)
+            self.wo = nn.Linear(hidden_dim, hidden_dim, bias=attn_bias)
 
     def attention_qkvpacked(
         self,
         x: torch.Tensor,
         cu_seqlens: torch.Tensor,
         rope_freqs_cis: Optional[torch.Tensor] = None,
+        max_seqlen: Optional[int] = None,
     ):
         """
         Args:
             x (torch.Tensor): (batch_size, seqlen, hidden_dim)
             cu_seqlens (torch.Tensor):
         """
-        xqkv = self.wqkv(x)
+        if self.use_tensor_parallel:
+            xqkv, _ = self.wqkv(x)
+        else:
+            xqkv = self.wqkv(x)
 
         qkv_shape = xqkv.size()[:-1] + (
             3,
-            self.num_heads,
+            self.num_attention_heads_per_partition,
             self.hidden_size_per_attention_head,
         )
         # xqkv: (batch_size, seqlen, 3, nheads, headdim)
@@ -500,10 +588,18 @@ class MoonVitEncoderLayer(nn.Module):
 
         attn_func = VL_VISION_ATTENTION_FUNCTIONS[self.attn_implementation]
         attn_out = attn_func(
-            xq, xk, xv, q_cu_seqlens=cu_seqlens, k_cu_seqlens=cu_seqlens
+            xq,
+            xk,
+            xv,
+            q_cu_seqlens=cu_seqlens,
+            k_cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
         )
 
-        attn_out = self.wo(attn_out)
+        if self.use_tensor_parallel:
+            attn_out, _ = self.wo(attn_out)
+        else:
+            attn_out = self.wo(attn_out)
         return attn_out
 
     def forward(
@@ -511,6 +607,7 @@ class MoonVitEncoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         cu_seqlens: torch.Tensor,
         rope_freqs_cis: Union[torch.Tensor, None] = None,
+        max_seqlen: Optional[int] = None,
     ) -> torch.Tensor:
         """
         Args:
@@ -522,7 +619,10 @@ class MoonVitEncoderLayer(nn.Module):
         residual = hidden_states
         hidden_states = self.norm0(hidden_states)
         attn_out = self.attention_qkvpacked(
-            hidden_states, cu_seqlens, rope_freqs_cis=rope_freqs_cis
+            hidden_states,
+            cu_seqlens,
+            rope_freqs_cis=rope_freqs_cis,
+            max_seqlen=max_seqlen,
         )
         hidden_states = residual + attn_out
 
@@ -533,12 +633,14 @@ class MoonVitEncoderLayer(nn.Module):
 
 
 class MoonVitEncoder(nn.Module):
-
     def __init__(
         self,
         hidden_dim: int,
         num_layers: int,
         block_cfg: dict,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+        use_tensor_parallel: bool = False,
     ) -> None:
         super().__init__()
 
@@ -546,12 +648,23 @@ class MoonVitEncoder(nn.Module):
             block_cfg["hidden_dim"] // block_cfg["num_heads"], 512, 512
         )
         self.blocks = nn.ModuleList(
-            [MoonVitEncoderLayer(**block_cfg) for _ in range(num_layers)]
+            [
+                MoonVitEncoderLayer(
+                    prefix=add_prefix(f"blocks.{layer_idx}", prefix),
+                    use_data_parallel=use_data_parallel,
+                    use_tensor_parallel=use_tensor_parallel,
+                    **block_cfg,
+                )
+                for layer_idx in range(num_layers)
+            ]
         )
         self.final_layernorm = nn.LayerNorm(hidden_dim)
 
     def forward(
-        self, hidden_states: torch.Tensor, grid_hw: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
+        grid_hw: torch.Tensor,
+        max_seqlen: Optional[int] = None,
     ) -> torch.Tensor:
         rope_freqs_cis = self.rope_2d.get_freqs_cis_by_seqlens(grid_hws=grid_hw)
 
@@ -562,10 +675,15 @@ class MoonVitEncoder(nn.Module):
             )
         )
         cu_seqlens = lengths.cumsum(dim=0, dtype=torch.int32)
+        if max_seqlen is None:
+            max_seqlen = (grid_hw[:, 0] * grid_hw[:, 1]).max().item()
 
         for _, block in enumerate(self.blocks):
             hidden_states = block(
-                hidden_states, cu_seqlens, rope_freqs_cis=rope_freqs_cis
+                hidden_states,
+                cu_seqlens,
+                rope_freqs_cis=rope_freqs_cis,
+                max_seqlen=max_seqlen,
             )
 
         hidden_states = self.final_layernorm(hidden_states)
@@ -603,7 +721,6 @@ def patch_merger(
 
 
 class MoonVitVLProjector(nn.Module):
-
     def __init__(
         self,
         in_channels: int,
@@ -635,7 +752,15 @@ class MoonVitPretrainedModel(PreTrainedModel):
     _supports_flash_attn_2 = True
     _supports_sdpa = True
 
-    def __init__(self, config: MoonViTConfig, *inputs, **kwargs):
+    def __init__(
+        self,
+        config: MoonViTConfig,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+        use_tensor_parallel: bool = False,
+        *inputs,
+        **kwargs,
+    ):
         from transformers.activations import GELUTanh
 
         super().__init__(config, *inputs, **kwargs)
@@ -660,10 +785,16 @@ class MoonVitPretrainedModel(PreTrainedModel):
                 "attn_bias": True,
                 "attn_implementation": config._attn_implementation,
             },
+            prefix=add_prefix("encoder", prefix),
+            use_data_parallel=use_data_parallel,
+            use_tensor_parallel=use_tensor_parallel,
         )
 
     def forward(
-        self, pixel_values: torch.Tensor, grid_hw: torch.Tensor
+        self,
+        pixel_values: torch.Tensor,
+        grid_hw: torch.Tensor,
+        max_seqlen: Optional[int] = None,
     ) -> torch.Tensor:
         """
         Args:
@@ -674,7 +805,7 @@ class MoonVitPretrainedModel(PreTrainedModel):
             torch.Tensor: The output tokens.
         """
         hidden_states = self.patch_embed(pixel_values, grid_hw)
-        hidden_states = self.encoder(hidden_states, grid_hw)
+        hidden_states = self.encoder(hidden_states, grid_hw, max_seqlen=max_seqlen)
         hidden_states = patch_merger(
             hidden_states, grid_hw, merge_kernel_size=self.merge_kernel_size
         )

--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -77,8 +77,9 @@ def select_best_resolution(original_size, possible_resolutions):
     for width, height in possible_resolutions:
         # Calculate the downscaled size to keep the aspect ratio
         scale = min(width / original_width, height / original_height)
-        downscaled_width, downscaled_height = int(original_width * scale), int(
-            original_height * scale
+        downscaled_width, downscaled_height = (
+            int(original_width * scale),
+            int(original_height * scale),
         )
 
         # Calculate effective and wasted resolutions
@@ -503,7 +504,26 @@ def run_dp_sharded_mrope_vision_model(
     """
     tp_size = get_parallel().attn_tp_size
     if tp_size == 1:
-        return vision_model(pixel_values, grid_thw=torch.tensor(grid_thw_list))
+        grid_thw = torch.tensor(
+            grid_thw_list,
+            # MoonViT's 2D RoPE implementation combines the grid metadata
+            # with CUDA activations. Keep the metadata colocated in that
+            # path; other encoders retain their existing CPU contract.
+            device=pixel_values.device if rope_type == "rope_2d" else None,
+        )
+        if rope_type == "rope_2d":
+            image_embeds = vision_model(
+                pixel_values,
+                grid_hw=grid_thw,
+                max_seqlen=max(math.prod(grid) for grid in grid_thw_list),
+            )
+            # MoonViT returns one tensor per image. The multi-GPU path below
+            # already concatenates these tensors before returning, so keep the
+            # TP=1 DP-encoder path on the same projector-facing contract.
+            if isinstance(image_embeds, list):
+                return torch.cat(image_embeds, dim=0)
+            return image_embeds
+        return vision_model(pixel_values, grid_thw=grid_thw)
 
     # GPU_0 tp_rank_local = 0
     # GPU_1 tp_rank_local = 1
@@ -567,8 +587,13 @@ def run_dp_sharded_mrope_vision_model(
     # Run the vision model on the local pixel_values_local
     if rope_type == "rope_2d":
         if pixel_values_local.shape[0] > 0:
+            local_grid_thw = torch.tensor(
+                local_grid_thw_list, device=pixel_values_local.device
+            )
             image_embeds_local = vision_model(
-                pixel_values_local, torch.tensor(local_grid_thw_list)
+                pixel_values_local,
+                grid_hw=local_grid_thw,
+                max_seqlen=max(math.prod(grid) for grid in local_grid_thw_list),
             )
             if isinstance(image_embeds_local, list):
                 image_embeds_local = torch.cat(image_embeds_local, dim=0)

--- a/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
+++ b/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
@@ -116,6 +116,18 @@ class ViTCudaGraphRunner:
         # x_3d: [S, B, H], B=1, S as graph_key
         return x_3d.shape[0]
 
+    def _capture_context(self):
+        # A DP-sharded encoder intentionally lets each rank capture only the
+        # images it owns (and some ranks can own none). Entering the TP
+        # communication capture in that case requires every TP peer to enter
+        # the same collective capture sequence, which deadlocks on an uneven
+        # image assignment. The encoder's output all-gather is outside this
+        # graph, and all layers are local in DP mode, so capture locally.
+        if getattr(self.vit, "use_data_parallel", False):
+            return nullcontext()
+        ca_comm = get_tp_group().ca_comm
+        return ca_comm.capture() if ca_comm is not None else nullcontext()
+
     def _create_graph(
         self,
         graph_key: int,
@@ -125,7 +137,6 @@ class ViTCudaGraphRunner:
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
     ):
-
         graph = torch.cuda.CUDAGraph()
         vit = self.vit
 
@@ -141,11 +152,7 @@ class ViTCudaGraphRunner:
 
         override_backend = get_server_args().mm_attention_backend
 
-        tp_group = get_tp_group()
-        ca_comm = tp_group.ca_comm
-        capture_ctx = ca_comm.capture() if ca_comm is not None else nullcontext()
-
-        with capture_ctx, torch.cuda.graph(graph):
+        with self._capture_context(), torch.cuda.graph(graph):
             y = None
             deepstack_outs: List[torch.Tensor] = []
             deepstack_capture_idx = 0
@@ -322,7 +329,6 @@ class ViTCudaGraphRunner:
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
         output_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-
         if position_embeddings is not None:
             # update rotary workspace content
             head_dim = position_embeddings[0].shape[1]

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -248,8 +248,10 @@ def _patch_image_processor_kwargs():
     (e.g. KimiVL) that defines ``preprocess()`` without ``**kwargs`` will
     crash with ``TypeError``.
 
-    Fix: wrap ``__call__`` to catch ``TypeError`` and retry with only the
-    kwargs that ``preprocess()`` actually accepts.
+    Fix: wrap ``__call__`` and filter unsupported kwargs before invoking
+    ``preprocess()``.  The accepted-kwargs set is cached per processor class:
+    apart from avoiding the exception/logging slow path, this matters for VLM
+    requests that preprocess many images on the request critical path.
 
     TODO(upstream): KimiVL image_processing_kimi_vl.py needs ``**kwargs``.
     """
@@ -257,30 +259,40 @@ def _patch_image_processor_kwargs():
         from transformers.image_processing_utils import BaseImageProcessor
 
         original = BaseImageProcessor.__call__
+        accepted_kwargs_cache = {}
+        warned_unsupported_kwargs = set()
 
         def safe_call(self, images, *args, **kwargs):
-            try:
-                return original(self, images, *args, **kwargs)
-            except TypeError as e:
-                if "unexpected keyword argument" not in str(e):
-                    raise
+            processor_type = type(self)
+            accepted_kwargs = accepted_kwargs_cache.get(processor_type)
+            if accepted_kwargs is None and processor_type not in accepted_kwargs_cache:
                 sig = inspect.signature(self.preprocess)
                 params = sig.parameters
                 if any(
                     p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
                 ):
-                    raise
-                dropped = {k for k in kwargs if k not in params}
-                if dropped:
+                    accepted_kwargs = None
+                else:
+                    accepted_kwargs = frozenset(params)
+                accepted_kwargs_cache[processor_type] = accepted_kwargs
+
+            if accepted_kwargs is None:
+                return original(self, images, *args, **kwargs)
+
+            dropped = frozenset(kwargs) - accepted_kwargs
+            if dropped:
+                warning_key = (processor_type, dropped)
+                if warning_key not in warned_unsupported_kwargs:
                     logger.warning(
                         "Image processor %s.preprocess() does not accept %s; "
-                        "retrying without them. Update the model's image processor "
-                        "to accept **kwargs.",
-                        type(self).__name__,
-                        dropped,
+                        "filtering them before preprocessing. Update the model's image "
+                        "processor to accept **kwargs.",
+                        processor_type.__name__,
+                        sorted(dropped),
                     )
-                valid = {k: v for k, v in kwargs.items() if k in params}
-                return original(self, images, *args, **valid)
+                    warned_unsupported_kwargs.add(warning_key)
+                kwargs = {k: v for k, v in kwargs.items() if k in accepted_kwargs}
+            return original(self, images, *args, **kwargs)
 
         BaseImageProcessor.__call__ = safe_call
     except ImportError:

--- a/test/registered/cpu/test_rope.py
+++ b/test/registered/cpu/test_rope.py
@@ -11,6 +11,7 @@ from sglang.srt.layers.rotary_embedding.rope_variant import (
     DeepseekScalingRotaryEmbedding,
     apply_rotary_pos_emb_native,
 )
+from sglang.srt.layers.rotary_embedding.utils import apply_rotary_pos_emb_native_eager
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -275,9 +276,14 @@ class TestROPE(CustomTestCase):
             cos = torch.rand(num_tokens, head_size).to(sincos_dtype)
             sin = torch.rand(num_tokens, head_size).to(sincos_dtype)
             q_out_ref, k_out_ref = apply_rotary_pos_emb_native(query, key, cos, sin)
+            q_out_eager, k_out_eager = apply_rotary_pos_emb_native_eager(
+                query, key, cos, sin
+            )
             q_out_sgl, k_out_sgl = torch.ops.sgl_kernel.apply_rotary_pos_emb_cpu(
                 query, key, cos, sin
             )
+            torch.testing.assert_close(q_out_ref, q_out_eager)
+            torch.testing.assert_close(k_out_ref, k_out_eager)
             torch.testing.assert_close(q_out_ref, q_out_sgl, atol=1e-2, rtol=1e-2)
             torch.testing.assert_close(k_out_ref, k_out_sgl, atol=1e-2, rtol=1e-2)
 

--- a/test/registered/cuda_graph/test_cuda_piecewise_backend.py
+++ b/test/registered/cuda_graph/test_cuda_piecewise_backend.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA piecewise backend requires CUDA", allow_module_level=True)
+
+import sglang.srt.compilation.cuda_piecewise_backend as cuda_backend
+from sglang.srt.compilation.cuda_piecewise_backend import (
+    ConcreteSizeEntry,
+    CUDAPiecewiseBackend,
+)
+
+
+def test_runtime_recompile_without_capture_stream_falls_back(monkeypatch):
+    """A Dynamo replacement backend cannot capture outside a PCG session."""
+    compile_config = MagicMock()
+    compile_config.get_capture_sizes.return_value = []
+    backend = CUDAPiecewiseBackend(
+        graph=MagicMock(),
+        compile_config=compile_config,
+        inductor_config={},
+        graph_pool=None,
+        piecewise_compile_index=0,
+        total_piecewise_compiles=1,
+        sym_shape_indices=[0],
+        compiled_graph_for_general_shape=MagicMock(),
+        sglang_backend=MagicMock(),
+    )
+    backend.first_run_finished = True
+    fallback = MagicMock(return_value="fallback-result")
+    backend.concrete_size_entries = {
+        4: ConcreteSizeEntry(
+            runtime_shape=4,
+            need_to_compile=False,
+            use_cudagraph=True,
+            runnable=fallback,
+            num_finished_warmup=1,
+        )
+    }
+
+    monkeypatch.setattr(cuda_backend, "get_pcg_capture_stream", lambda: None)
+    monkeypatch.setattr(cuda_backend, "is_in_torch_compile_warmup", lambda: False)
+    monkeypatch.setattr(cuda_backend, "print_warning_once", lambda _message: None)
+
+    assert backend(4) == "fallback-result"
+    fallback.assert_called_once_with(4)

--- a/test/registered/unit/compilation/test_torch_compile_decoration.py
+++ b/test/registered/unit/compilation/test_torch_compile_decoration.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+from sglang.srt.compilation.compile import (
+    _infer_dynamic_arg_dims_from_annotations,
+    _mark_dynamic_forward_batch,
+)
+
+
+class _MropeModel:
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch,
+    ):
+        return input_ids, positions, forward_batch
+
+
+class _StringAnnotatedMropeModel:
+    def forward(
+        self,
+        input_ids: "torch.Tensor",
+        positions: "torch.Tensor",
+        forward_batch,
+    ):
+        return input_ids, positions, forward_batch
+
+
+def test_positions_marks_the_token_axis_dynamic_for_mrope_and_1d_rope():
+    dynamic_dims = _infer_dynamic_arg_dims_from_annotations(_MropeModel.forward)
+    string_dynamic_dims = _infer_dynamic_arg_dims_from_annotations(
+        _StringAnnotatedMropeModel.forward
+    )
+
+    assert dynamic_dims["input_ids"] == 0
+    assert dynamic_dims["positions"] == -1
+    assert string_dynamic_dims["positions"] == -1
+
+
+def test_forward_batch_marks_token_and_batch_metadata_dynamic():
+    batch = SimpleNamespace(
+        input_embeds=torch.empty(8, 16),
+        seq_lens=torch.empty(2, dtype=torch.int64),
+        mrope_positions=torch.empty(3, 8, dtype=torch.int64),
+        scalar=torch.tensor(1),
+    )
+    marked = []
+
+    def record_mark_dynamic(value, dims):
+        marked.append((id(value), tuple(dims)))
+
+    with patch("torch._dynamo.maybe_mark_dynamic", side_effect=record_mark_dynamic):
+        _mark_dynamic_forward_batch(batch)
+
+    assert (id(batch.input_embeds), (0,)) in marked
+    assert (id(batch.seq_lens), (0,)) in marked
+    assert (id(batch.mrope_positions), (1,)) in marked
+    assert all(value_id != id(batch.scalar) for value_id, _ in marked)

--- a/test/registered/unit/distributed/test_cuda_wrapper.py
+++ b/test/registered/unit/distributed/test_cuda_wrapper.py
@@ -1,0 +1,20 @@
+import io
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+
+from sglang.srt.distributed.device_communicators import cuda_wrapper
+
+
+def test_find_loaded_library_prefers_real_cudart_over_tilelang_stub(monkeypatch):
+    maps = """\
+7f000000-7f010000 r-xp 00000000 00:00 0 /site-packages/tilelang/lib/libcudart_stub.so
+7f020000-7f030000 r-xp 00000000 00:00 0 /cuda/lib64/libcudart.so.13
+"""
+
+    monkeypatch.setattr("builtins.open", lambda *args, **kwargs: io.StringIO(maps))
+
+    assert (
+        cuda_wrapper.find_loaded_library("libcudart") == "/cuda/lib64/libcudart.so.13"
+    )

--- a/test/registered/unit/models/test_kimi_vl.py
+++ b/test/registered/unit/models/test_kimi_vl.py
@@ -1,0 +1,212 @@
+"""CPU-only coverage for Kimi-VL encoder parallelism wiring."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.models.kimi_vl import KimiVLForConditionalGeneration
+from sglang.srt.models.kimi_vl_moonvit import (
+    MoonVitEncoderLayer,
+    multihead_attention,
+)
+from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _VisionTower:
+    dtype = torch.float32
+    device = torch.device("cpu")
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(
+        self, pixel_values, image_grid_hws=None, max_seqlen=None, grid_hw=None
+    ):
+        image_grid_hws = grid_hw if image_grid_hws is None else image_grid_hws
+        self.calls.append((pixel_values, image_grid_hws))
+        # One merged token per image. The real MoonViT returns a list here.
+        return [
+            torch.full((1, 4, 2), index + 1.0)
+            for index in range(image_grid_hws.shape[0])
+        ]
+
+
+class _Projector:
+    def __init__(self):
+        self.input = None
+
+    def __call__(self, image_features):
+        self.input = image_features
+        return image_features
+
+
+class _GridRecordingVisionTower:
+    def __init__(self):
+        self.grid_thw = None
+
+    def __call__(self, pixel_values, grid_hw, max_seqlen=None):
+        self.grid_thw = grid_hw
+        self.max_seqlen = max_seqlen
+        return pixel_values
+
+
+def _bare_model(*, use_data_parallel: bool):
+    """Build just enough of Kimi-VL to exercise ``get_image_feature``."""
+    model = KimiVLForConditionalGeneration.__new__(KimiVLForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(text_config=SimpleNamespace(hidden_size=16))
+    model.use_data_parallel = use_data_parallel
+    model.vision_tower = _VisionTower()
+    model.multi_modal_projector = _Projector()
+    return model
+
+
+def _image_item(feature, grid_hws):
+    return MultimodalDataItem(
+        modality=Modality.IMAGE,
+        offsets=[(0, 1)],
+        feature=feature,
+        model_specific_data={"image_grid_hws": torch.tensor(grid_hws)},
+    )
+
+
+class TestKimiVLEncoderParallelism(CustomTestCase):
+    def test_moonvit_uses_tensor_parallel_layers(self):
+        # At TP=1, sharded layers retain the checkpoint's original tensor
+        # shapes while still exercising the same code path used by multi-GPU.
+        with get_parallel().override(
+            tp_size=1,
+            tp_rank=0,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+        ):
+            layer = MoonVitEncoderLayer(
+                num_heads=2,
+                hidden_dim=8,
+                mlp_dim=16,
+                prefix="vision_tower.encoder.blocks.0",
+                use_tensor_parallel=True,
+            )
+
+        self.assertIsInstance(layer.wqkv, QKVParallelLinear)
+        self.assertIsInstance(layer.wo, RowParallelLinear)
+        self.assertIsInstance(layer.mlp.fc0, ColumnParallelLinear)
+        self.assertIsInstance(layer.mlp.fc1, RowParallelLinear)
+        self.assertEqual(layer.wqkv.weight.shape, (24, 8))
+        self.assertEqual(layer.wo.weight.shape, (8, 8))
+        self.assertEqual(layer.mlp.fc0.weight.shape, (16, 8))
+        self.assertEqual(layer.mlp.fc1.weight.shape, (8, 16))
+
+    def test_encoder_dp_uses_existing_mrope_sharding_helper(self):
+        model = _bare_model(use_data_parallel=True)
+        items = [
+            _image_item(torch.randn(4, 2), [[2, 2]]),
+            _image_item(torch.randn(8, 2), [[4, 2]]),
+        ]
+        sharded_features = torch.randn(3, 4, 2)
+
+        with patch(
+            "sglang.srt.models.kimi_vl.run_dp_sharded_mrope_vision_model",
+            return_value=sharded_features,
+        ) as run_dp:
+            output = model.get_image_feature(items)
+
+        run_dp.assert_called_once()
+        vision_tower, pixel_values, grid_hws = run_dp.call_args.args
+        self.assertIs(vision_tower, model.vision_tower)
+        self.assertEqual(pixel_values.shape, (12, 2))
+        self.assertEqual(grid_hws, [[2, 2], [4, 2]])
+        self.assertEqual(run_dp.call_args.kwargs, {"rope_type": "rope_2d"})
+        self.assertIs(model.multi_modal_projector.input, sharded_features)
+        self.assertIs(output, sharded_features)
+        self.assertEqual(model.vision_tower.calls, [])
+
+    def test_default_path_preserves_existing_feature_wiring(self):
+        model = _bare_model(use_data_parallel=False)
+        items = [
+            _image_item(torch.randn(4, 2), [[2, 2]]),
+            _image_item(torch.randn(8, 2), [[4, 2]]),
+        ]
+
+        output = model.get_image_feature(items)
+
+        self.assertEqual(len(model.vision_tower.calls), 1)
+        pixel_values, image_grid_hws = model.vision_tower.calls[0]
+        self.assertEqual(pixel_values.shape, (12, 2))
+        self.assertEqual(image_grid_hws.tolist(), [[2, 2], [4, 2]])
+        self.assertEqual(model.multi_modal_projector.input.shape, (2, 4, 2))
+        self.assertIs(output, model.multi_modal_projector.input)
+
+    def test_encoder_dp_keeps_moonvit_grid_metadata_on_vision_device(self):
+        vision_tower = _GridRecordingVisionTower()
+        pixel_values = torch.randn(4, 2)
+
+        with get_parallel().override(
+            tp_size=1,
+            tp_rank=0,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+        ):
+            output = run_dp_sharded_mrope_vision_model(
+                vision_tower,
+                pixel_values,
+                [[2, 2]],
+                rope_type="rope_2d",
+            )
+
+        self.assertIs(output, pixel_values)
+        self.assertEqual(vision_tower.grid_thw.device, pixel_values.device)
+        self.assertEqual(vision_tower.grid_thw.tolist(), [[2, 2]])
+        self.assertEqual(vision_tower.max_seqlen, 4)
+
+    def test_encoder_dp_tp1_concatenates_moonvit_image_outputs(self):
+        vision_tower = _VisionTower()
+        pixel_values = torch.randn(4, 2)
+
+        with get_parallel().override(
+            tp_size=1,
+            tp_rank=0,
+            attn_tp_size=1,
+            attn_tp_rank=0,
+        ):
+            output = run_dp_sharded_mrope_vision_model(
+                vision_tower,
+                pixel_values,
+                [[2, 2]],
+                rope_type="rope_2d",
+            )
+
+        self.assertIsInstance(output, torch.Tensor)
+        self.assertEqual(output.shape, (1, 4, 2))
+
+    def test_moonvit_attention_accepts_precomputed_max_seqlen(self):
+        q = torch.randn(4, 2, 4, dtype=torch.bfloat16)
+        cu_seqlens = torch.tensor([0, 4], dtype=torch.int32)
+        fake_output = torch.randn_like(q)
+
+        with patch(
+            "sglang.srt.models.kimi_vl_moonvit.flash_attn_varlen_func",
+            return_value=fake_output,
+        ) as flash_attn:
+            output = multihead_attention(q, q, q, cu_seqlens, cu_seqlens, max_seqlen=4)
+
+        self.assertTrue(torch.equal(output, fake_output.flatten(start_dim=-2)))
+        self.assertEqual(flash_attn.call_args.args[5:7], (4, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_kimi_vl_moonvit.py
+++ b/test/registered/unit/models/test_kimi_vl_moonvit.py
@@ -1,0 +1,50 @@
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+from sglang.srt.models.kimi_vl_moonvit import Learnable2DInterpPosEmb
+
+
+def test_learnable_2d_pos_emb_caches_inference_interpolation(monkeypatch):
+    module = Learnable2DInterpPosEmb(height=2, width=2, dim=4).eval()
+    inputs = torch.zeros(6, 4)
+    grid_hw = torch.tensor([[2, 3]])
+
+    calls = 0
+    original_interpolate = torch.nn.functional.interpolate
+
+    def counting_interpolate(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_interpolate(*args, **kwargs)
+
+    monkeypatch.setattr(torch.nn.functional, "interpolate", counting_interpolate)
+
+    first = module(inputs, grid_hw)
+    second = module(inputs, grid_hw)
+
+    torch.testing.assert_close(first, second)
+    assert calls == 1
+
+
+def test_learnable_2d_pos_emb_does_not_cache_training_interpolation(monkeypatch):
+    module = Learnable2DInterpPosEmb(height=2, width=2, dim=4).train()
+    inputs = torch.zeros(6, 4)
+    grid_hw = torch.tensor([[2, 3]])
+
+    calls = 0
+    original_interpolate = torch.nn.functional.interpolate
+
+    def counting_interpolate(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_interpolate(*args, **kwargs)
+
+    monkeypatch.setattr(torch.nn.functional, "interpolate", counting_interpolate)
+
+    module(inputs, grid_hw)
+    module(inputs, grid_hw)
+
+    assert calls == 2

--- a/test/registered/unit/multimodal/test_vit_cuda_graph_runner.py
+++ b/test/registered/unit/multimodal/test_vit_cuda_graph_runner.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+from sglang.srt.multimodal.vit_cuda_graph_runner import ViTCudaGraphRunner
+
+
+class _Block:
+    def forward(self, x):
+        return x
+
+
+def _runner(*, use_data_parallel: bool) -> ViTCudaGraphRunner:
+    vit = SimpleNamespace(
+        blocks=[_Block()],
+        deepstack_visual_indexes=[],
+        deepstack_merger_list=None,
+        use_data_parallel=use_data_parallel,
+    )
+    return ViTCudaGraphRunner(vit)
+
+
+def test_dp_vit_graph_capture_does_not_enter_tp_communication_capture():
+    runner = _runner(use_data_parallel=True)
+    with patch(
+        "sglang.srt.multimodal.vit_cuda_graph_runner.get_tp_group",
+        side_effect=AssertionError("DP capture must be rank-local"),
+    ):
+        with runner._capture_context():
+            pass
+
+
+def test_non_dp_vit_graph_capture_uses_tp_communication_capture():
+    entered = []
+
+    class Capture:
+        def __enter__(self):
+            entered.append(True)
+
+        def __exit__(self, *args):
+            return False
+
+    group = SimpleNamespace(ca_comm=SimpleNamespace(capture=lambda: Capture()))
+    runner = _runner(use_data_parallel=False)
+    with patch(
+        "sglang.srt.multimodal.vit_cuda_graph_runner.get_tp_group", return_value=group
+    ):
+        with runner._capture_context():
+            pass
+    assert entered == [True]

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -4,12 +4,16 @@ Tests cover the pure utility functions (compat patches, config helpers,
 context length, GGUF detection, etc.) that don't require actual model files.
 """
 
+import inspect
 import tempfile
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from transformers import PretrainedConfig
+from transformers.image_processing_utils import BaseImageProcessor
 
+from sglang.srt.utils import hf_transformers_patches
 from sglang.srt.utils.hf_transformers.common import (
     _is_deepseek_ocr2_model,
     _is_deepseek_ocr_model,
@@ -25,6 +29,33 @@ from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_comp
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+# ---------------------------------------------------------------------------
+# _patch_image_processor_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestImageProcessorKwargsPatch(unittest.TestCase):
+    def test_filters_unsupported_kwargs_and_caches_signature(self):
+        class StrictImageProcessor(BaseImageProcessor):
+            model_input_names = ["pixel_values"]
+
+            def preprocess(self, images, accepted=None):
+                return {"images": images, "accepted": accepted}
+
+        processor = StrictImageProcessor()
+        with patch.object(
+            hf_transformers_patches.inspect,
+            "signature",
+            wraps=inspect.signature,
+        ) as signature:
+            first = processor("first", accepted=True, device="cuda")
+            second = processor("second", accepted=False, device="cuda")
+
+        self.assertEqual(first, {"images": "first", "accepted": True})
+        self.assertEqual(second, {"images": "second", "accepted": False})
+        self.assertEqual(signature.call_count, 1)
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -13,6 +13,7 @@ register_amd_ci(est_time=500, suite="nightly-amd-4-gpu", nightly=True)
 MODELS = [
     SimpleNamespace(model="Qwen/Qwen2.5-VL-72B-Instruct", mmmu_accuracy=0.55),
     SimpleNamespace(model="Qwen/Qwen3-VL-32B-Instruct", mmmu_accuracy=0.55),
+    SimpleNamespace(model="moonshotai/Kimi-VL-A3B-Instruct", mmmu_accuracy=0.30),
     SimpleNamespace(model="OpenGVLab/InternVL2_5-8B", mmmu_accuracy=0.52),
     SimpleNamespace(model="zai-org/GLM-4.1V-9B-Thinking", mmmu_accuracy=0.68),
 ]


### PR DESCRIPTION
## Summary

- make mRoPE and forward-batch metadata dynamic for piecewise CUDA graphs
- avoid capture-stream misuse during runtime recompilation and preserve Kimi deepstack warmup inputs
- fix Kimi MoonViT DP encoder behavior for TP=1 and avoid DP/TP CUDA-graph capture interference
- remove TileLang import side effects from the Qwen/DeepSeek-V4 runtime path

## Root cause

VLM-specific metadata and optional deepstack inputs were specialized by CUDA-graph warmup. Kimi's TP=1 DP vision path also returned a list of image tensors where the projector requires a tensor.

## Validation

- H100 CUDA: Kimi encoder tests (6 passed)
- H100 CUDA: broader VLM/MoE regression set (67 passed)
- `ruff format --check`, `ruff check` (with repository legacy import-style exclusions), `git diff --check`, and project pre-commit hooks

## Impact

Eliminates runtime PCG recompiles for tested 128/256/512 token VLM shapes and restores Kimi-VL TP=1 serving.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->