### PR TITLE
feat(tokenizer): tokenize chat prompts once instead of twice

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -440,6 +440,9 @@ class ModelConfig:
             and is_multimodal_chunked_prefill_supported(self.hf_config.architectures)
         )
         self.is_encoder_decoder = is_encoder_decoder_model(self.hf_config.architectures)
+        self.always_run_mm_processor = always_run_mm_processor(
+            self.hf_config.architectures
+        )
         self.is_local_attention_model = is_local_attention_model(
             self.hf_config.architectures
         )
@@ -1807,6 +1810,15 @@ def is_encoder_decoder_model(model_architectures: List[str]):
         "MllamaForConditionalGeneration",
         "MossVLForConditionalGeneration",
     ]
+    return any(model in model_architectures for model in models)
+
+
+def always_run_mm_processor(model_architectures: List[str]):
+    """Archs whose text-only requests must still run the multimodal processor.
+
+    Such models can't take the text-only input_ids fast path in serving.
+    """
+    models = ["MossVLForConditionalGeneration"]
     return any(model in model_architectures for model in models)
 
 

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -731,7 +731,7 @@ class AnthropicServing:
         try:
             # Convert to internal request
             adapted_request, processed_request = (
-                self.openai_serving_chat._convert_to_internal_request(
+                await self.openai_serving_chat._convert_to_internal_request(
                     chat_request, raw_request
                 )
             )
@@ -781,7 +781,7 @@ class AnthropicServing:
 
         try:
             adapted_request, processed_request = (
-                self.openai_serving_chat._convert_to_internal_request(
+                await self.openai_serving_chat._convert_to_internal_request(
                     chat_request, raw_request
                 )
             )
@@ -1424,7 +1424,7 @@ class AnthropicServing:
             is_multimodal = (
                 self.openai_serving_chat.tokenizer_manager.model_config.is_multimodal
             )
-            processed = self.openai_serving_chat._process_messages(
+            processed = await self.openai_serving_chat._process_messages(
                 chat_request, is_multimodal
             )
 

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -90,8 +90,8 @@ class OpenAIServingBase(ABC):
                 request_logger.log_openai_received_request(request, request=raw_request)
 
             # Convert to internal format
-            adapted_request, processed_request = self._convert_to_internal_request(
-                request, raw_request
+            adapted_request, processed_request = (
+                await self._convert_to_internal_request(request, raw_request)
             )
 
             if isinstance(adapted_request, (GenerateReqInput, EmbeddingReqInput)):
@@ -162,7 +162,7 @@ class OpenAIServingBase(ABC):
         return "".join(parts) if parts else None
 
     @abstractmethod
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: OpenAIServingRequest,
         raw_request: Request = None,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -235,12 +235,6 @@ class OpenAIServingChat(OpenAIServingBase):
         except Exception:
             self._tokenizer_auto_adds_specials = True
 
-        # MossVL always runs the mm processor, so it can't take the text-only
-        # input_ids fast path in _multimodal_prompt_kwargs.
-        self._forces_mm_processor = "MossVLForConditionalGeneration" in (
-            self.tokenizer_manager.model_config.hf_config.architectures or []
-        )
-
     def _handle_last_assistant_message(
         self,
         messages: List[Dict[str, Any]],
@@ -661,7 +655,7 @@ class OpenAIServingChat(OpenAIServingBase):
         prompt_ids = processed_messages.prompt_ids
         can_skip_reencode = (
             not has_mm_data
-            and not self._forces_mm_processor
+            and not self.tokenizer_manager.model_config.always_run_mm_processor
             and isinstance(prompt_ids, list)
             and prompt_ids
         )
@@ -964,7 +958,10 @@ class OpenAIServingChat(OpenAIServingBase):
                 )
 
             if is_multimodal and (
-                image_data or video_data or audio_data or self._forces_mm_processor
+                image_data
+                or video_data
+                or audio_data
+                or self.tokenizer_manager.model_config.always_run_mm_processor
             ):
                 # The mm processor consumes text; text-only requests skip this
                 # and pass prompt_ids straight through (see

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -235,6 +235,12 @@ class OpenAIServingChat(OpenAIServingBase):
         except Exception:
             self._tokenizer_auto_adds_specials = True
 
+        # MossVL always runs the mm processor, so it can't take the text-only
+        # input_ids fast path in _multimodal_prompt_kwargs.
+        self._forces_mm_processor = "MossVLForConditionalGeneration" in (
+            self.tokenizer_manager.model_config.hf_config.architectures or []
+        )
+
     def _handle_last_assistant_message(
         self,
         messages: List[Dict[str, Any]],
@@ -532,7 +538,7 @@ class OpenAIServingChat(OpenAIServingBase):
 
         return None
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: ChatCompletionRequest,
         raw_request: Request = None,
@@ -565,7 +571,8 @@ class OpenAIServingChat(OpenAIServingBase):
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
 
         # Process messages and apply chat template
-        processed_messages = self._process_messages(request, is_multimodal)
+        processed_messages = await self._process_messages(request, is_multimodal)
+
         # Build sampling parameters
         sampling_params = request.to_sampling_params(
             stop=processed_messages.stop,
@@ -573,10 +580,11 @@ class OpenAIServingChat(OpenAIServingBase):
             tool_call_constraint=processed_messages.tool_call_constraint,
         )
 
+        # Handle single vs multiple requests
         if request.input_ids is not None:
             prompt_kwargs = {"input_ids": processed_messages.prompt_ids}
         elif is_multimodal:
-            prompt_kwargs = {"text": processed_messages.prompt}
+            prompt_kwargs = self._multimodal_prompt_kwargs(processed_messages)
         else:
             if isinstance(processed_messages.prompt_ids, str):
                 prompt_kwargs = {"text": processed_messages.prompt_ids}
@@ -637,7 +645,31 @@ class OpenAIServingChat(OpenAIServingBase):
 
         return adapted_request, request
 
-    def _process_messages(
+    def _multimodal_prompt_kwargs(
+        self, processed_messages: MessageProcessingResult
+    ) -> Dict[str, Any]:
+        """Prompt kwargs for a multimodal model.
+
+        With mm data: pass text (the mm processor consumes it). Text-only:
+        pass prompt_ids to skip the re-encode in _tokenize_one_request.
+        """
+        has_mm_data = bool(
+            processed_messages.image_data
+            or processed_messages.video_data
+            or processed_messages.audio_data
+        )
+        prompt_ids = processed_messages.prompt_ids
+        can_skip_reencode = (
+            not has_mm_data
+            and not self._forces_mm_processor
+            and isinstance(prompt_ids, list)
+            and prompt_ids
+        )
+        if can_skip_reencode:
+            return {"input_ids": prompt_ids}
+        return {"text": processed_messages.prompt}
+
+    async def _process_messages(
         self, request: ChatCompletionRequest, is_multimodal: bool
     ) -> MessageProcessingResult:
         """Process chat messages and apply chat template"""
@@ -714,14 +746,21 @@ class OpenAIServingChat(OpenAIServingBase):
                 stop=request.stop or [],
             )
         elif self.template_manager.chat_template_name is None:
-            result = self._apply_jinja_template(request, tools, is_multimodal)
+            result = await self._apply_jinja_template(request, tools, is_multimodal)
         else:
             result = self._apply_conversation_template(request, is_multimodal)
 
         result.tool_call_constraint = tool_call_constraint
         return result
 
-    def _apply_jinja_template(
+    async def _encode_text(self, text: str, encode_kwargs: Dict[str, Any]) -> List[int]:
+        dynamic_batch_tokenizer = self.tokenizer_manager.async_dynamic_batch_tokenizer
+        if dynamic_batch_tokenizer is not None:
+            result = await dynamic_batch_tokenizer.encode(text, **encode_kwargs)
+            return result["input_ids"]
+        return self.tokenizer_manager.tokenizer.encode(text, **encode_kwargs)
+
+    async def _apply_jinja_template(
         self,
         request: ChatCompletionRequest,
         tools: Optional[List[Dict]],
@@ -875,7 +914,8 @@ class OpenAIServingChat(OpenAIServingBase):
             # can skip add_special_tokens=False on tokenizers that don't auto-add
             # specials (Kimi-like, OpenAI-chat analogue of #25265). Chat
             # templates already include role/special tokens, so the encode must
-            # avoid double BOS on tokenizers that would add it.
+            # avoid double BOS on tokenizers that would add it. Encoding via
+            # _encode_text lets it use the dynamic batch tokenizer when enabled.
             encode_kwargs = (
                 {"add_special_tokens": False}
                 if self._tokenizer_auto_adds_specials
@@ -890,9 +930,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     return_dict=False,
                     **extra_template_kwargs,
                 )
-                prompt_ids = self.tokenizer_manager.tokenizer.encode(
-                    rendered_prompt, **encode_kwargs
-                )
+                prompt_ids = await self._encode_text(rendered_prompt, encode_kwargs)
             except Exception:
                 # If the first attempt fails, try with flat function-only format.
                 # Some templates (e.g. Mistral) expect tools without the OpenAI wrapper.
@@ -912,9 +950,7 @@ class OpenAIServingChat(OpenAIServingBase):
                             **extra_template_kwargs,
                         )
                     )
-                    prompt_ids = self.tokenizer_manager.tokenizer.encode(
-                        rendered_prompt, **encode_kwargs
-                    )
+                    prompt_ids = await self._encode_text(rendered_prompt, encode_kwargs)
                 except (jinja2.TemplateError, TypeError) as template_error:
                     # Template errors (e.g., from raise_exception in Jinja templates)
                     # and TypeError (e.g., tojson filter on Jinja2 Undefined variables)
@@ -927,7 +963,12 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_ids, assistant_prefix
                 )
 
-            if is_multimodal:
+            if is_multimodal and (
+                image_data or video_data or audio_data or self._forces_mm_processor
+            ):
+                # The mm processor consumes text; text-only requests skip this
+                # and pass prompt_ids straight through (see
+                # _multimodal_prompt_kwargs).
                 prompt = self.tokenizer_manager.tokenizer.decode(prompt_ids)
 
         stop = request.stop

--- a/python/sglang/srt/entrypoints/openai/serving_classify.py
+++ b/python/sglang/srt/entrypoints/openai/serving_classify.py
@@ -47,7 +47,7 @@ class OpenAIServingClassify(OpenAIServingBase):
     def _request_id_prefix(self) -> str:
         return "classify-"
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: ClassifyRequest,
         raw_request: Request = None,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -62,7 +62,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
 
         return None
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: CompletionRequest,
         raw_request: Request = None,

--- a/python/sglang/srt/entrypoints/openai/serving_embedding.py
+++ b/python/sglang/srt/entrypoints/openai/serving_embedding.py
@@ -74,7 +74,7 @@ class OpenAIServingEmbedding(OpenAIServingBase):
                         return f"Token ID at index {i} must be non-negative"
         return None
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: EmbeddingRequest,
         raw_request: Request = None,

--- a/python/sglang/srt/entrypoints/openai/serving_rerank.py
+++ b/python/sglang/srt/entrypoints/openai/serving_rerank.py
@@ -242,7 +242,7 @@ class OpenAIServingRerank(OpenAIServingBase):
 
         return None
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: V1RerankReqInput,
         raw_request: Request = None,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -481,11 +481,19 @@ class OpenAIServingResponses(OpenAIServingChat):
         )
 
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-        processed_messages = self._process_messages(chat_request, is_multimodal)
+        processed_messages = await self._process_messages(chat_request, is_multimodal)
 
         if is_multimodal:
-            request_prompts = [processed_messages.prompt]
-            engine_prompts = [processed_messages.prompt]
+            # Text-only requests get input_ids to skip a re-encode; see
+            # _multimodal_prompt_kwargs. Downstream: str -> text, list -> ids.
+            prompt_kwargs = self._multimodal_prompt_kwargs(processed_messages)
+            engine_prompt = (
+                prompt_kwargs["input_ids"]
+                if "input_ids" in prompt_kwargs
+                else prompt_kwargs["text"]
+            )
+            request_prompts = [engine_prompt]
+            engine_prompts = [engine_prompt]
         else:
             request_prompts = [processed_messages.prompt_ids]
             engine_prompts = [processed_messages.prompt_ids]

--- a/python/sglang/srt/entrypoints/openai/serving_score.py
+++ b/python/sglang/srt/entrypoints/openai/serving_score.py
@@ -25,7 +25,7 @@ class OpenAIServingScore(OpenAIServingBase):
     def _request_id_prefix(self) -> str:
         return "score-"
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: ScoringRequest,
         raw_request: Request = None,

--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -31,7 +31,7 @@ class OpenAIServingTokenize(OpenAIServingBase):
     def _request_id_prefix(self) -> str:
         return "tok-"
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self, request: TokenizeRequest, raw_request: Request
     ) -> tuple[TokenizeRequest, TokenizeRequest]:
         return request, request
@@ -47,7 +47,7 @@ class OpenAIServingTokenize(OpenAIServingBase):
             max_model_len = getattr(tokenizer, "model_max_length", -1)
 
             if request.messages is not None:
-                token_ids = self._tokenize_chat_request(request)
+                token_ids = await self._tokenize_chat_request(request)
                 tokens = token_ids
                 count = len(token_ids)
             elif isinstance(request.prompt, str):
@@ -84,7 +84,7 @@ class OpenAIServingTokenize(OpenAIServingBase):
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
 
-    def _tokenize_chat_request(self, request: TokenizeRequest) -> List[int]:
+    async def _tokenize_chat_request(self, request: TokenizeRequest) -> List[int]:
         if self.chat_serving is None:
             raise ValueError("Chat template tokenization requires a template manager.")
 
@@ -94,7 +94,7 @@ class OpenAIServingTokenize(OpenAIServingBase):
             raise ValueError(validation_error)
 
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-        processed_messages = self.chat_serving._process_messages(
+        processed_messages = await self.chat_serving._process_messages(
             chat_request, is_multimodal
         )
 
@@ -121,7 +121,7 @@ class OpenAIServingDetokenize(OpenAIServingBase):
     def _request_id_prefix(self) -> str:
         return "detok-"
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self, request: DetokenizeRequest, raw_request: Request
     ) -> tuple[DetokenizeRequest, DetokenizeRequest]:
         return request, request

--- a/python/sglang/srt/entrypoints/openai/serving_transcription.py
+++ b/python/sglang/srt/entrypoints/openai/serving_transcription.py
@@ -84,7 +84,7 @@ class OpenAIServingTranscription(OpenAIServingBase):
         # Validation is done in the route handler for form data
         return None
 
-    def _convert_to_internal_request(
+    async def _convert_to_internal_request(
         self,
         request: TranscriptionRequest,
         raw_request: Request = None,

--- a/test/registered/prefill_only/test_serving_rerank.py
+++ b/test/registered/prefill_only/test_serving_rerank.py
@@ -57,7 +57,7 @@ class TestOpenAIServingRerankUnit(unittest.TestCase):
             instruct="Retrieve semantically similar text.",
         )
 
-        adapted, processed = self.handler._convert_to_internal_request(req)
+        adapted, processed = asyncio.run(self.handler._convert_to_internal_request(req))
 
         # Avoid importing EmbeddingReqInput (requires torch). Use duck-typing checks instead.
         self.assertTrue(hasattr(adapted, "is_cross_encoder_request"))
@@ -72,7 +72,7 @@ class TestOpenAIServingRerankUnit(unittest.TestCase):
         )
         handler = OpenAIServingRerank(tm)
         req = V1RerankReqInput(query="q", documents=["d1"])
-        adapted, processed = handler._convert_to_internal_request(req)
+        adapted, processed = asyncio.run(handler._convert_to_internal_request(req))
         self.assertIs(adapted, req)
         self.assertIs(processed, req)
 
@@ -168,7 +168,7 @@ class TestOpenAIServingRerankUnit(unittest.TestCase):
 
         handler = OpenAIServingRerank(_TM())
         req = V1RerankReqInput(query="q", documents=["d1", "d2"], return_documents=True)
-        adapted, _ = handler._convert_to_internal_request(req)
+        adapted, _ = asyncio.run(handler._convert_to_internal_request(req))
         raw_request = Mock()
 
         res = asyncio.run(

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -39,7 +39,7 @@ class _MockTokenizerManager:
     """Minimal mock that satisfies OpenAIServingChat."""
 
     def __init__(self):
-        self.model_config = Mock(is_multimodal=False)
+        self.model_config = Mock(is_multimodal=False, always_run_mm_processor=False)
         self.server_args = Mock(
             enable_cache_report=False,
             tool_call_parser="hermes",

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -15,7 +15,7 @@ import unittest
 import uuid
 from http import HTTPStatus
 from typing import Optional
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from fastapi import Request
 
@@ -125,7 +125,9 @@ class ServingChatTestCase(unittest.TestCase):
             patch(
                 "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
             ) as conv_mock,
-            patch.object(self.chat, "_process_messages") as proc_mock,
+            patch.object(
+                self.chat, "_process_messages", new_callable=AsyncMock
+            ) as proc_mock,
         ):
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
@@ -144,7 +146,9 @@ class ServingChatTestCase(unittest.TestCase):
                 None,
             )
 
-            adapted, processed = self.chat._convert_to_internal_request(self.basic_req)
+            adapted, processed = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(self.basic_req)
+            )
             self.assertIsInstance(adapted, GenerateReqInput)
             self.assertFalse(adapted.stream)
             self.assertEqual(adapted.session_id, "session-1")
@@ -161,7 +165,9 @@ class ServingChatTestCase(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "return_prompt_token_ids is not supported with streaming"
         ):
-            self.chat._convert_to_internal_request(req, self.fastapi_request)
+            get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req, self.fastapi_request)
+            )
 
     def test_convert_to_internal_request_rejects_stream_return_meta_info(self):
         req = ChatCompletionRequest(
@@ -174,7 +180,9 @@ class ServingChatTestCase(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "return_meta_info is not supported with streaming"
         ):
-            self.chat._convert_to_internal_request(req, self.fastapi_request)
+            get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req, self.fastapi_request)
+            )
 
     def test_convert_to_internal_request_input_ids_bypasses_template(self):
         self.tm.tokenizer = None
@@ -189,8 +197,8 @@ class ServingChatTestCase(unittest.TestCase):
         with patch(
             "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
         ) as conv_mock:
-            adapted, processed = self.chat._convert_to_internal_request(
-                req, self.fastapi_request
+            adapted, processed = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req, self.fastapi_request)
             )
 
         self.assertEqual(processed, req)
@@ -226,7 +234,9 @@ class ServingChatTestCase(unittest.TestCase):
             tool_choice="required",
         )
 
-        with patch.object(self.chat, "_process_messages") as proc_mock:
+        with patch.object(
+            self.chat, "_process_messages", new_callable=AsyncMock
+        ) as proc_mock:
             proc_mock.return_value = MessageProcessingResult(
                 "",
                 [1, 2, 3],
@@ -237,7 +247,9 @@ class ServingChatTestCase(unittest.TestCase):
                 None,
             )
 
-            adapted, _ = self.chat._convert_to_internal_request(req)
+            adapted, _ = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req)
+            )
 
         self.assertTrue(adapted.require_reasoning)
 
@@ -269,7 +281,9 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"thinking": False},
         )
 
-        with patch.object(self.chat, "_process_messages") as proc_mock:
+        with patch.object(
+            self.chat, "_process_messages", new_callable=AsyncMock
+        ) as proc_mock:
             proc_mock.return_value = MessageProcessingResult(
                 "",
                 [1, 2, 3],
@@ -280,7 +294,9 @@ class ServingChatTestCase(unittest.TestCase):
                 None,
             )
 
-            adapted, _ = self.chat._convert_to_internal_request(req)
+            adapted, _ = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req)
+            )
 
         self.assertFalse(adapted.require_reasoning)
 
@@ -362,7 +378,9 @@ class ServingChatTestCase(unittest.TestCase):
             tool_choice="required",
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        get_or_create_event_loop().run_until_complete(
+            self.chat._process_messages(req, is_multimodal=False)
+        )
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertNotIn("thinking", kwargs)
@@ -398,7 +416,9 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"thinking": True},
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        get_or_create_event_loop().run_until_complete(
+            self.chat._process_messages(req, is_multimodal=False)
+        )
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertTrue(kwargs["thinking"])
@@ -434,7 +454,9 @@ class ServingChatTestCase(unittest.TestCase):
             chat_template_kwargs={"thinking": False},
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        get_or_create_event_loop().run_until_complete(
+            self.chat._process_messages(req, is_multimodal=False)
+        )
 
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertFalse(kwargs["thinking"])
@@ -466,7 +488,9 @@ class ServingChatTestCase(unittest.TestCase):
             ],
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        get_or_create_event_loop().run_until_complete(
+            self.chat._process_messages(req, is_multimodal=False)
+        )
 
         expected_tools = [tool.model_dump() for tool in req.tools]
         kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
@@ -504,7 +528,9 @@ class ServingChatTestCase(unittest.TestCase):
             [1, 2, 3],
         ]
 
-        self.chat._process_messages(req, is_multimodal=False)
+        get_or_create_event_loop().run_until_complete(
+            self.chat._process_messages(req, is_multimodal=False)
+        )
 
         first_tools = self.tm.tokenizer.apply_chat_template.call_args_list[0].kwargs[
             "tools"
@@ -559,7 +585,9 @@ class ServingChatTestCase(unittest.TestCase):
             parser = parser_cls.return_value
             parser.get_structure_constraint.return_value = ("structural_tag", "tag")
 
-            self.chat._process_messages(req, is_multimodal=False)
+            get_or_create_event_loop().run_until_complete(
+                self.chat._process_messages(req, is_multimodal=False)
+            )
 
             parser.get_structure_constraint.assert_called_once()
             self.assertFalse(
@@ -601,7 +629,9 @@ class ServingChatTestCase(unittest.TestCase):
                 )
 
                 with self.assertRaisesRegex(ValueError, "must be a JSON object"):
-                    self.chat._process_messages(req, is_multimodal=False)
+                    get_or_create_event_loop().run_until_complete(
+                        self.chat._process_messages(req, is_multimodal=False)
+                    )
 
                 self.tm.tokenizer.apply_chat_template.assert_not_called()
 
@@ -636,7 +666,9 @@ class ServingChatTestCase(unittest.TestCase):
             ],
         )
 
-        self.chat._process_messages(req, is_multimodal=False)
+        get_or_create_event_loop().run_until_complete(
+            self.chat._process_messages(req, is_multimodal=False)
+        )
 
         messages = self.tm.tokenizer.apply_chat_template.call_args.args[0]
         self.assertEqual(
@@ -679,7 +711,9 @@ class ServingChatTestCase(unittest.TestCase):
                 )
 
                 with self.assertRaisesRegex(ValueError, "must be a JSON object"):
-                    self.chat._process_messages(req, is_multimodal=False)
+                    get_or_create_event_loop().run_until_complete(
+                        self.chat._process_messages(req, is_multimodal=False)
+                    )
 
     def test_dsv_encoders_accept_object_tool_call_arguments_string(self):
         """DeepSeek encoders accept object-shaped OpenAI JSON string arguments."""
@@ -715,7 +749,9 @@ class ServingChatTestCase(unittest.TestCase):
                     ],
                 )
 
-                self.chat._process_messages(req, is_multimodal=False)
+                get_or_create_event_loop().run_until_complete(
+                    self.chat._process_messages(req, is_multimodal=False)
+                )
 
     def test_stop_str_isolation_between_requests(self):
         """Test that stop strings from one request don't affect subsequent requests.
@@ -1382,8 +1418,8 @@ class ServingChatTestCase(unittest.TestCase):
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
-                req, self.fastapi_request
+            adapted_request, _ = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req, self.fastapi_request)
             )
 
             async def run_stream():
@@ -1594,8 +1630,8 @@ class ServingChatTestCase(unittest.TestCase):
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
-            adapted_request, _ = self.chat._convert_to_internal_request(
-                req, self.fastapi_request
+            adapted_request, _ = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req, self.fastapi_request)
             )
             chunks = self._run_chat_stream(adapted_request, req)
 
@@ -1732,8 +1768,8 @@ class ServingChatTestCase(unittest.TestCase):
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
-                req, self.fastapi_request
+            adapted_request, _ = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req, self.fastapi_request)
             )
 
             async def run_stream():
@@ -1879,8 +1915,8 @@ class ServingChatTestCase(unittest.TestCase):
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_mock.return_value = conv_ins
 
-            adapted_request, _ = self.chat._convert_to_internal_request(
-                req, self.fastapi_request
+            adapted_request, _ = get_or_create_event_loop().run_until_complete(
+                self.chat._convert_to_internal_request(req, self.fastapi_request)
             )
 
             async def run_stream():
@@ -1990,7 +2026,9 @@ class ServingChatTestCase(unittest.TestCase):
                 return_value=([{"role": "user", "content": "hi"}], None),
             ),
         ):
-            self.chat._process_messages(req, False)
+            get_or_create_event_loop().run_until_complete(
+                self.chat._process_messages(req, False)
+            )
         _, kwargs = self.tm.tokenizer.apply_chat_template.call_args
         return kwargs
 

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -62,7 +62,9 @@ class ServingCompletionTestCase(unittest.TestCase):
     # ---------- prompt-handling ----------
     def test_single_token_ids_prompt(self):
         req = CompletionRequest(model="x", prompt=[1, 2, 3, 4], max_tokens=100)
-        internal, _ = self.sc._convert_to_internal_request(req)
+        internal, _ = get_or_create_event_loop().run_until_complete(
+            self.sc._convert_to_internal_request(req)
+        )
         self.assertEqual(internal.input_ids, [1, 2, 3, 4])
 
     # ---------- echo-handling ----------
@@ -225,7 +227,9 @@ class ServingCompletionTestCase(unittest.TestCase):
             stream=True,
         )
 
-        adapted_request, _ = self.sc._convert_to_internal_request(req)
+        adapted_request, _ = get_or_create_event_loop().run_until_complete(
+            self.sc._convert_to_internal_request(req)
+        )
 
         async def run_stream():
             chunks = []
@@ -336,7 +340,9 @@ class ServingCompletionTestCase(unittest.TestCase):
             return_cached_tokens_details=True,
         )
 
-        adapted_request, _ = self.sc._convert_to_internal_request(req)
+        adapted_request, _ = get_or_create_event_loop().run_until_complete(
+            self.sc._convert_to_internal_request(req)
+        )
 
         async def run_stream():
             chunks = []

--- a/test/registered/unit/entrypoints/openai/test_serving_embedding.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_embedding.py
@@ -250,10 +250,8 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         )
 
         adapted_request, _ = asyncio.run(
-            asyncio.run(
-                self.serving_embedding._convert_to_internal_request(
-                    self.image_only_multimodal_req
-                )
+            self.serving_embedding._convert_to_internal_request(
+                self.image_only_multimodal_req
             )
         )
 
@@ -291,10 +289,8 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         self.tokenizer_manager.tokenizer.chat_template = None
 
         adapted_request, _ = asyncio.run(
-            asyncio.run(
-                self.serving_embedding._convert_to_internal_request(
-                    self.image_only_multimodal_req
-                )
+            self.serving_embedding._convert_to_internal_request(
+                self.image_only_multimodal_req
             )
         )
 

--- a/test/registered/unit/entrypoints/openai/test_serving_embedding.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_embedding.py
@@ -2,6 +2,7 @@
 Unit tests for the OpenAIServingEmbedding class from serving_embedding.py.
 """
 
+import asyncio
 import importlib
 import importlib.abc
 import importlib.machinery
@@ -151,7 +152,7 @@ class ServingEmbeddingTestCase(unittest.TestCase):
 
     def test_convert_single_string_request(self):
         """Test converting single string request to internal format."""
-        adapted_request, processed_request = (
+        adapted_request, processed_request = asyncio.run(
             self.serving_embedding._convert_to_internal_request(self.basic_req)
         )
 
@@ -162,7 +163,7 @@ class ServingEmbeddingTestCase(unittest.TestCase):
 
     def test_convert_list_string_request(self):
         """Test converting list of strings request to internal format."""
-        adapted_request, processed_request = (
+        adapted_request, processed_request = asyncio.run(
             self.serving_embedding._convert_to_internal_request(self.list_req)
         )
 
@@ -175,7 +176,7 @@ class ServingEmbeddingTestCase(unittest.TestCase):
 
     def test_convert_token_ids_request(self):
         """Test converting token IDs request to internal format."""
-        adapted_request, processed_request = (
+        adapted_request, processed_request = asyncio.run(
             self.serving_embedding._convert_to_internal_request(self.token_ids_req)
         )
 
@@ -186,7 +187,7 @@ class ServingEmbeddingTestCase(unittest.TestCase):
 
     def test_convert_multimodal_request(self):
         """Test converting multimodal request to internal format."""
-        adapted_request, processed_request = (
+        adapted_request, processed_request = asyncio.run(
             self.serving_embedding._convert_to_internal_request(self.multimodal_req)
         )
 
@@ -209,8 +210,8 @@ class ServingEmbeddingTestCase(unittest.TestCase):
             ]
         )
 
-        adapted_request, _ = self.serving_embedding._convert_to_internal_request(
-            self.multimodal_req
+        adapted_request, _ = asyncio.run(
+            self.serving_embedding._convert_to_internal_request(self.multimodal_req)
         )
 
         self.assertEqual(
@@ -248,8 +249,12 @@ class ServingEmbeddingTestCase(unittest.TestCase):
             return_value="<prompt><image></prompt>"
         )
 
-        adapted_request, _ = self.serving_embedding._convert_to_internal_request(
-            self.image_only_multimodal_req
+        adapted_request, _ = asyncio.run(
+            asyncio.run(
+                self.serving_embedding._convert_to_internal_request(
+                    self.image_only_multimodal_req
+                )
+            )
         )
 
         self.assertEqual(adapted_request.text, "<prompt><image></prompt>")
@@ -266,8 +271,10 @@ class ServingEmbeddingTestCase(unittest.TestCase):
             return_value="<prompt>Describe<video></prompt>"
         )
 
-        adapted_request, _ = self.serving_embedding._convert_to_internal_request(
-            self.video_multimodal_req
+        adapted_request, _ = asyncio.run(
+            self.serving_embedding._convert_to_internal_request(
+                self.video_multimodal_req
+            )
         )
 
         self.assertEqual(adapted_request.text, "<prompt>Describe<video></prompt>")
@@ -283,8 +290,12 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         """Without any chat template the raw-text fallback must run without raising."""
         self.tokenizer_manager.tokenizer.chat_template = None
 
-        adapted_request, _ = self.serving_embedding._convert_to_internal_request(
-            self.image_only_multimodal_req
+        adapted_request, _ = asyncio.run(
+            asyncio.run(
+                self.serving_embedding._convert_to_internal_request(
+                    self.image_only_multimodal_req
+                )
+            )
         )
 
         # text=None on an image-only input falls back to the "padding" literal.
@@ -295,8 +306,8 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         """Missing tokenizer should not crash the Jinja branch check."""
         self.tokenizer_manager.tokenizer = None
 
-        adapted_request, _ = self.serving_embedding._convert_to_internal_request(
-            self.multimodal_req
+        adapted_request, _ = asyncio.run(
+            self.serving_embedding._convert_to_internal_request(self.multimodal_req)
         )
 
         self.assertEqual(adapted_request.text, ["Hello", "World"])
@@ -309,8 +320,10 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, "bad template"):
-            self.serving_embedding._convert_to_internal_request(
-                self.image_only_multimodal_req
+            asyncio.run(
+                self.serving_embedding._convert_to_internal_request(
+                    self.image_only_multimodal_req
+                )
             )
 
     def test_jinja_template_syntax_error_includes_location(self):
@@ -320,8 +333,10 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         self.tokenizer_manager.tokenizer.apply_chat_template = Mock(side_effect=err)
 
         with self.assertRaises(ValueError) as ctx:
-            self.serving_embedding._convert_to_internal_request(
-                self.image_only_multimodal_req
+            asyncio.run(
+                self.serving_embedding._convert_to_internal_request(
+                    self.image_only_multimodal_req
+                )
             )
         message = str(ctx.exception)
         self.assertIn("mock.jinja", message)
@@ -335,8 +350,10 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, "missing_field"):
-            self.serving_embedding._convert_to_internal_request(
-                self.image_only_multimodal_req
+            asyncio.run(
+                self.serving_embedding._convert_to_internal_request(
+                    self.image_only_multimodal_req
+                )
             )
 
 

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from openai.types.responses import (
     ResponseOutputMessage,
@@ -165,7 +165,7 @@ class ChatToolForwardingTestCase(unittest.TestCase):
                 tool_call_constraint=("json_schema", {"type": "object"}),
             )
 
-        serving._process_messages = Mock(side_effect=fake_process)
+        serving._process_messages = AsyncMock(side_effect=fake_process)
         request = ResponsesRequest(
             model="x",
             input="call the tool",
@@ -307,7 +307,7 @@ class MultimodalRequestTestCase(unittest.TestCase):
         serving = make_serving(is_multimodal=True)
         captured = {}
 
-        serving._process_messages = Mock(
+        serving._process_messages = AsyncMock(
             return_value=MessageProcessingResult(
                 prompt="rendered multimodal prompt",
                 prompt_ids=[9, 9, 9],


### PR DESCRIPTION
## Summary

Tokenizes chat prompts once instead of twice by splitting apply_chat_template(tokenize=True) into render(tokenize=False) + a separate encode that runs through the dynamic batch tokenizer. Text-only multimodal requests pass prompt_ids straight through, skipping the re-encode in _tokenize_one_request.

This requires making the _convert_to_internal_request / _process_messages / _apply_jinja_template chain async, with all entrypoints updated to await it.

## Changes

### Core (serving_chat.py)
- _encode_text(): uses async_dynamic_batch_tokenizer, falls back to native tokenizer.encode.
- _multimodal_prompt_kwargs(): text when media is present, input_ids for text-only to skip re-encode.
- _forces_mm_processor flag for MossVL (always needs the mm processor).
- Default-template encode sites now await self._encode_text(...); input_ids fast path, dsv4/dsv32, custom encoding, and Mistral/jinja2 fallbacks preserved.

### Async propagation
- serving_responses.py: uses _multimodal_prompt_kwargs (str → text, list → input_ids).
- serving_base / classify / completions / embedding / rerank / score / tokenize / transcription.py: methods made async.
- anthropic/serving.py: await added at 3 call sites.

### Tests
- Mock → AsyncMock; sync coroutine calls wrapped in run_until_complete / asyncio.run.

## Compatibility

- Default behavior unchanged — without the dynamic batch tokenizer, _encode_text falls back to native encode.
- Multimodal requests with real media still take the text path (input_ids stays None).
- All local encoding paths preserved; no capability removed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29648835570](https://github.com/sgl-project/sglang/actions/runs/29648835570)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29648835381](https://github.com/sgl-project/sglang/actions/runs/29648835381)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->