### PR TITLE
[Bug Fix][Compilation] Use a deterministic computation_graph dump filename to stop unbounded per-startup accumulation

### DIFF
--- a/python/sglang/srt/compilation/backend.py
+++ b/python/sglang/srt/compilation/backend.py
@@ -456,7 +456,7 @@ class SGLangBackend:
 
         rank = torch.distributed.get_rank()
 
-        if rank == 0:
+        if rank == 0 and self.compile_config.get_enable_debug_mode():
             graph_path = os.path.join(local_cache_dir, "computation_graph.py")
             if not os.path.exists(graph_path):
                 # code adapted from https://github.com/thuml/depyf/blob/dab831108a752d1facc00acdd6d4243891845c37/depyf/explain/patched_lazy_format_graph_code.py#L30 # noqa

--- a/python/sglang/srt/compilation/backend.py
+++ b/python/sglang/srt/compilation/backend.py
@@ -457,9 +457,7 @@ class SGLangBackend:
         rank = torch.distributed.get_rank()
 
         if rank == 0:
-            graph_path = os.path.join(
-                local_cache_dir, f"computation_graph_{time.time()}.py"
-            )
+            graph_path = os.path.join(local_cache_dir, "computation_graph.py")
             if not os.path.exists(graph_path):
                 # code adapted from https://github.com/thuml/depyf/blob/dab831108a752d1facc00acdd6d4243891845c37/depyf/explain/patched_lazy_format_graph_code.py#L30 # noqa
                 # use `print_readable` because it can include submodules


### PR DESCRIPTION
## Motivation

When piecewise `torch.compile` is enabled, `SGLangBackend.__call__` dumps a human-readable copy of the split graph module for debugging (a depyf-style dump). Two issues:

**1. The filename embedded a wall-clock timestamp, so the dump accumulated without bound.**

```python
if rank == 0:
    graph_path = os.path.join(
        local_cache_dir, f"computation_graph_{time.time()}.py"
    )
    if not os.path.exists(graph_path):
        ...
        with open(graph_path, "w") as f:
            f.write(src)
```

Because `time.time()` changes on every process, the filename is unique on every startup, so `os.path.exists(graph_path)` is always `False` and the guard never skips anything. Each startup writes a brand-new `computation_graph_<timestamp>.py` into `local_cache_dir`, and nothing ever removes them.

`SGLangBackend.__call__` asserts it runs at most once per instance (`assert not self._called`), so the intent of the `if not os.path.exists(...)` guard is clearly "write once, don't rewrite". The timestamp defeats that intent:

```text
1. First boot writes computation_graph_1700000000.1234.py.
2. The exists-check passed only because that exact path was new.
3. Next boot computes a different timestamp, so the check passes again.
4. Over N restarts the cache dir accumulates N copies of essentially the same dump, never garbage-collected.
```

The file is a pure debug artifact: `git grep computation_graph` shows the write site is the only reference in the tree — nothing reads, globs, or cleans these files — so the filename can be made deterministic without breaking any consumer.

**2. The dump ran on every compile-enabled startup, even in production.**

It was gated only by `rank == 0`, not by any debug flag, so a multi-KB readable `.py` was written on every compile-enabled boot regardless of whether anyone was debugging.

## Modifications

In `python/sglang/srt/compilation/backend.py`:

- Change the graph dump filename from `f"computation_graph_{time.time()}.py"` to a fixed `"computation_graph.py"`. The dump already lives under a `local_cache_dir` scoped by cache hash + rank + `model_tag`, so a fixed name is unique per compiled region and simply overwrites/skips on subsequent boots instead of accumulating. This also restores the existing `os.path.exists` guard to its evident "write-once" meaning.
- Gate the dump behind the existing `compile_config.get_enable_debug_mode()` flag (wired from `--enable-torch-compile-debug-mode`, already used in `cuda_piecewise_backend.py`), so it is only produced when debugging and incurs no disk I/O in production. This addresses the review suggestion on the filename change; I used an explicit `if rank == 0 and ...debug_mode()` gate rather than overloading `graph_path` for readability.
- No import changes: `time` is still used elsewhere in the file (`compilation_start_time = time.time()`, elapsed-time logging).

## Tests

- Ran `pre-commit run --files python/sglang/srt/compilation/backend.py` locally — all hooks pass.
- Ran `python3 -m compileall -q python/sglang/srt/compilation/backend.py`.
- No focused `pytest` was added/run: the dump is emitted from `SGLangBackend.__call__`, which requires a real Dynamo-produced `fx.GraphModule`, an initialized `torch.distributed` group, and the CUDA `torch.compile` path — i.e. GPU + a full compile pass — so it is not practically reachable from a CPU-only unit test. The changes are a static filename fix plus a boolean gate, both verifiable by inspection.
- Verified the leak reasoning statically: `git grep -n computation_graph` returns only the write site, confirming no reader/cleaner depends on the timestamped name.

## Speed Tests and Profiling

N/A. This is a correctness/hygiene fix that removes unbounded disk growth in the compile cache directory and avoids the debug dump write entirely in production. It does not change compiled kernels, cache hit behavior, or the serving hot path.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [ ] Add unit tests as outlined in the Running Unit Tests. (Not practical — dump path requires GPU + full compile pass; see Tests.)
- [ ] Update documentation as needed, including docstrings or example tutorials. (N/A)
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (N/A — static hygiene fix)
- [ ] For reviewer assignment, see the Reviewer Assignment Guide.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29154804734](https://github.com/sgl-project/sglang/actions/runs/29154804734)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29154804650](https://github.com/sgl-project/sglang/actions/runs/29154804650)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->