### PR TITLE
[HiCache]fix: hybrid-mamba final snapshot is unmatchable for chunk-aligned prompts

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2414,6 +2414,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # so we need to add 1 to the seqlen to retrieve the correct mamba state from h.
                 mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)
 
+            is_last_prefill_chunk = req.extend_range.end == len(
+                req.full_untruncated_fill_ids
+            )
+            if (
+                is_last_prefill_chunk
+                and req.extend_range.length % mamba_cache_chunk_size == 0
+                and req.extend_range.length > mamba_cache_chunk_size
+            ):
+                # Prefix matching looks up at most page_aligned(input_len - 1),
+                # so a final snapshot at the exact end position can never be
+                # matched by a later request; track one chunk earlier instead.
+                mamba_track_seqlen_aligned -= mamba_cache_chunk_size
+                mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)
+
             # In lazy mode, skip the swap — the second ping-pong slot is not
             # allocated yet; it will be allocated on demand at the track boundary
             # in mamba_lazy_prealloc_at_boundary during prepare_for_decode.

--- a/test/registered/unit/managers/test_schedule_batch_mamba_track_alignment.py
+++ b/test/registered/unit/managers/test_schedule_batch_mamba_track_alignment.py
@@ -1,0 +1,88 @@
+"""Regression test: the final Mamba snapshot must land on a matchable position.
+
+Prefix matching looks up at most page_aligned(input_len - 1). When the final
+prefill chunk length is an exact multiple of mamba_cache_chunk_size, a snapshot
+at the end position is therefore one chunk past what any later request can
+match, and the whole prefix silently degrades to the last chunk-boundary
+snapshot (or zero). The final track must move one chunk earlier in that case,
+and only in that case.
+"""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_MCS = 64
+
+
+class TestMambaFinalTrackAlignment(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        server_args = ServerArgs(model_path="dummy", page_size=_MCS)
+        server_args._mamba_cache_chunk_size = _MCS
+        set_global_server_args_for_scheduler(server_args)
+        cls.batch = SimpleNamespace(req_to_token_pool=MagicMock())
+        cls.batch.req_to_token_pool.get_mamba_ping_pong_other_idx.return_value = 1
+
+    def _prepare(self, prefix_len, extend_len, fill_len):
+        req = Req(
+            rid="r",
+            origin_input_text="",
+            origin_input_ids=array("q"),
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        req.prefix_indices = torch.zeros(prefix_len, dtype=torch.int64)
+        req.full_untruncated_fill_ids = array("q", range(fill_len))
+        req.set_extend_range(prefix_len, prefix_len + extend_len)
+        req.mamba_ping_pong_track_buffer = torch.tensor([3, 7], dtype=torch.int64)
+        req.mamba_next_track_idx = 0
+        req.mamba_branching_seqlen = None
+        entry = ScheduleBatch._mamba_radix_cache_v2_req_prepare_for_extend(
+            self.batch, req
+        )
+        return entry, req
+
+    def test_final_chunk_aligned_moves_one_chunk_earlier(self):
+        entry, req = self._prepare(prefix_len=0, extend_len=5120, fill_len=5120)
+        self.assertTrue(entry.track_mask)
+        self.assertEqual(req.mamba_last_track_seqlen, 5056)
+        self.assertEqual(entry.track_seqlen, 5057)
+
+    def test_final_chunk_aligned_with_prefix(self):
+        entry, req = self._prepare(prefix_len=8192, extend_len=8192, fill_len=16384)
+        self.assertEqual(req.mamba_last_track_seqlen, 16320)
+        self.assertEqual(entry.track_seqlen, 16321)
+
+    def test_final_chunk_unaligned_unchanged(self):
+        entry, req = self._prepare(prefix_len=0, extend_len=5121, fill_len=5121)
+        self.assertEqual(req.mamba_last_track_seqlen, 5120)
+        self.assertEqual(entry.track_seqlen, 5121)
+
+    def test_final_chunk_single_chunk_guard(self):
+        entry, req = self._prepare(prefix_len=8192, extend_len=_MCS, fill_len=8256)
+        self.assertEqual(req.mamba_last_track_seqlen, 8256)
+        self.assertEqual(entry.track_seqlen, 8256)
+
+    def test_intermediate_chunk_unchanged(self):
+        entry, req = self._prepare(prefix_len=0, extend_len=8192, fill_len=16385)
+        self.assertEqual(req.mamba_last_track_seqlen, 8192)
+        self.assertEqual(entry.track_seqlen, 8192)
+
+    def test_below_chunk_not_tracked(self):
+        entry, req = self._prepare(prefix_len=8192, extend_len=63, fill_len=8255)
+        self.assertFalse(entry.track_mask)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

For hybrid-Mamba models with the radix cache, any prompt whose token count is an **exact multiple of `mamba_cache_chunk_size`** silently loses prefix-cache reuse — both **same-instance device radix-tree reuse** (repeating the exact same prompt on one instance) and **cross-instance reuse** through a shared storage backend. The reusable prefix collapses to the last chunk-prefill boundary, or to zero for prompts shorter than `chunked_prefill_size`. All cells measured on main:

| prompt tokens | expected reusable prefix | reused, same instance | reused, cross-instance |
|---|---|---|---|
| 5120 | 5056 | **0** | **0** |
| 6144 | 6080 | **0** | **0** |
| 8192 | 8128 | **0** | **0** |
| 12288 | 12224 | **8192** | **8192** |
| 16384 | 16320 | **8192** | **8192** |
| 20480 | 20416 | **16384** | **16384** |
| 5121 (control, +1 token) | 5120 | 5120 | 5120 |

The `5120 → 0` vs `5121 → 5120` contrast shows this is a boundary defect, not a design limitation. No error is raised; the only symptoms are TTFT jitter and low cache-hit rates for these lengths.

### Root cause

Write `c = mamba_cache_chunk_size` and `p = page_size`. `c >= p` and `c` is always a multiple of `p`.

1. **Read side**: prefix matching looks up at most `input_len - 1` tokens (`Req._compute_max_prefix_len`, needed so at least one token is always forwarded), then page-aligns down, so the deepest reachable position is `R = floor((L - 1) / p) * p`.
2. **Write side**: the final Mamba snapshot is tracked at `S = prefix + floor(extend_len / c) * c`, and `cache_finished_req` inserts the node with that key length. When the final chunk length is a multiple of `c`, `S` is exactly `L`.

For `L % c != 0` we get `S <= L - 1`, and `S` is a multiple of `p`, hence `S <= R`: the snapshot is reachable and reuse works. For `L % c == 0` we get `S = L` but `R = L - p < L` — the snapshot sits one page beyond anything a later request can ever match, including the same request replayed on the same instance. The match then falls back to the previous node that has a state: the last chunk-prefill boundary (multiples of `chunked_prefill_size`), or nothing at all for prompts shorter than one chunk-prefill.

## Modifications

`python/sglang/srt/managers/schedule_batch.py` (+14 lines, `_mamba_radix_cache_v2_req_prepare_for_extend`):

- On the **final prefill chunk only**, when `extend_len % mamba_cache_chunk_size == 0` and `extend_len > mamba_cache_chunk_size`, move the tracked snapshot one chunk earlier (`-mamba_cache_chunk_size`) and retrieve it through the existing `_force_track_h` path (intermediate `h` states, the same mechanism every non-aligned length already uses).
- `extend_len == mamba_cache_chunk_size` keeps today's behavior: for those prompts the read-side lookup lands exactly on the previous chunk boundary, which already has a snapshot, so nothing needs to change.
- Intermediate chunk boundaries, non-multiple lengths, and decode paths are untouched.

`test/registered/unit/managers/test_schedule_batch_mamba_track_alignment.py` (new, 6 cases):

- Asserts the tracked position for: final aligned chunk (moves one chunk earlier — **red on main**, green here), final aligned chunk with prefix (red on main), final unaligned chunk (unchanged), single-chunk guard (unchanged), intermediate chunk (unchanged), below-chunk extend (not tracked). CPU-only.

## Accuracy Tests

Setup identical to the companion backup fix PR: 2 hosts × (2× RTX 5090, TP=2), hybrid-Mamba model (Qwen3.6-35B-A3B) fp8, `page_size=64`, `chunked_prefill_size=8192`, `mamba_cache_chunk_size=64`, mooncake storage shared over TCP, `hicache write_through`. Writer A / reader B cross-instance protocol; `A backed-up` normalized per TP rank; expected hit = `page_aligned(ptok - 1)`.

### Affected lengths: the fix restores full reuse

| ptok | expected | A backed-up: main | B cached: main | A backed-up: fixed | B cached: fixed |
|---|---|---|---|---|---|
| 5120 | 5056 | 5120 * | 0 | **5056** | **5056** |
| 6144 | 6080 | 6144 * | 0 | **6080** | **6080** |
| 8192 | 8128 | 8192 * | 0 | **8128** | **8128** |
| 16384 | 16320 | 16384 * | 8192 | **16320** | **16320** |
| 12288 | 12224 | 12288 * | 8192 | **12224** | **12224** |
| 20480 | 20416 | 20480 * | 16384 | **20416** | **20416** |

\* On main the writer backs up a prefix ending at `L` — which no reader (including the writer itself on a repeated request) can ever match. Same-instance reuse is equally repaired: repeated prompts of these six lengths hit 0/0/0/8192/8192/16384 cached tokens locally on main, and the full expected prefix (5056/6080/8128/12224/16320/20416) after the fix.

### Control lengths: the fix changes nothing

| ptok | expected | B cached: main | B cached: fixed |
|---|---|---|---|
| 5121 | 5120 | 5120 | 5120 |
| 12289 | 12288 | 12288 | 12288 |
| 8256 (guard) | 8192 | 8192 | 8192 |
| 16448 (guard) | 16384 | 16384 | 16384 |

The `+1` rows are the two affected lengths with one extra token: that alone moves `S` off the end position, so reuse is already correct on main and must stay untouched. The guard rows have a final chunk of exactly `mamba_cache_chunk_size` (`k * chunked_prefill_size + c`), the case the fix deliberately skips — there the read-side lookup already lands on the previous chunk boundary, which has a snapshot. Both groups being identical across branches shows that this fix only affects the intended edge cases and has no impact on cases that already behave correctly.

## Speed Tests and Profiling

The change adds two integer comparisons per prefill-chunk preparation on the CPU side and redirects one single-slot snapshot copy (`h` read instead of `last_recurrent_state` read) — no extra copies, no kernel change, nothing on the hot path. Cold prefill wall time from 4k to 24k tokens shows no regression, and neither does a concurrent throughput smoke test.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations. (no doc change needed)
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30426360964](https://github.com/sgl-project/sglang/actions/runs/30426360964)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30426360737](https://github.com/sgl-project/sglang/actions/runs/30426360737)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->