### PR TITLE
[MLX] Fix SchedulerProfilerManager MPS capture mocks

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
+++ b/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
@@ -204,7 +204,7 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
         return mgr
 
     def test_start_profile_failure_does_not_crash(self):
-        import mlx.core as mx
+        import torch
 
         from sglang.srt.hardware_backend.mlx.profiler import (
             apply_metal_profiler_patches,
@@ -214,10 +214,16 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             mgr = self._make_manager(tmp)
-            with patch.object(
-                mx.metal,
-                "start_capture",
-                side_effect=RuntimeError("Capture layer is not inserted"),
+            with (
+                patch(
+                    "sglang.srt.hardware_backend.mlx.profiler.use_mlx",
+                    return_value=False,
+                ),
+                patch.object(
+                    torch.mps.profiler,
+                    "metal_capture",
+                    side_effect=RuntimeError("Capture layer is not inserted"),
+                ),
             ):
                 result = mgr._start_profile()
 
@@ -226,9 +232,7 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
         self.assertIsNone(mgr.torch_profiler)
 
     def test_start_profile_success_with_mock_capture(self):
-        from unittest.mock import patch as mock_patch
-
-        import mlx.core as mx
+        import torch
 
         from sglang.srt.hardware_backend.mlx.profiler import (
             apply_metal_profiler_patches,
@@ -238,14 +242,25 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             mgr = self._make_manager(tmp)
-            with mock_patch.object(mx.metal, "start_capture"), mock_patch.object(
-                mx.metal, "stop_capture"
-            ), mock_patch("torch.distributed.barrier"):
+            mock_ctx = MagicMock()
+            with (
+                patch(
+                    "sglang.srt.hardware_backend.mlx.profiler.use_mlx",
+                    return_value=False,
+                ),
+                patch.object(
+                    torch.mps.profiler, "metal_capture", return_value=mock_ctx
+                ),
+                patch("torch.distributed.barrier"),
+            ):
                 result = mgr._start_profile()
                 self.assertTrue(result.success)
                 self.assertTrue(mgr.profile_in_progress)
                 mgr._stop_profile()
                 self.assertFalse(mgr.profile_in_progress)
+
+            mock_ctx.__enter__.assert_called_once_with()
+            mock_ctx.__exit__.assert_called_once_with(None, None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The two `SchedulerProfilerManager` MPS tests mock
`mx.metal.start_capture`/`stop_capture`, but the patched profiler takes the MPS
path and calls `torch.mps.profiler.metal_capture`. The success test can
therefore start a real Metal capture and fail unless `MTL_CAPTURE_ENABLED` is
set, while the failure test can pass for the wrong reason.

Fixes #30550.

## Modifications

- Force both manager tests to select the MPS path even when the MLX CI lane
  exports `SGLANG_USE_MLX=1`.
- Mock the actual `torch.mps.profiler.metal_capture` call.
- Verify that the successful capture context is entered and exited.

## Accuracy Tests

N/A - test-only change; no model or runtime behavior is changed.

## Speed Tests and Profiling

N/A.

## Validation

- `python -m py_compile test/registered/unit/hardware_backend/mlx/test_metal_profiler.py`
- `uvx --from isort==7.0.0 isort --check-only --diff test/registered/unit/hardware_backend/mlx/test_metal_profiler.py`
- `uvx --from ruff==0.15.1 ruff check --select=F401,F821,UP037 test/registered/unit/hardware_backend/mlx/test_metal_profiler.py`
- `uvx --from black==26.1.0 black --check test/registered/unit/hardware_backend/mlx/test_metal_profiler.py`
- `git diff --check`

The target MLX unit test was not run locally because this host is not Apple
Silicon. The `stage-a-unit-test-mlx` lane on `macos-26` is the authoritative
runtime check.

## Checklist

- [x] Format your code according to the Format code with pre-commit guidance.
- [x] Add or update unit tests according to the unit test guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29159094576](https://github.com/sgl-project/sglang/actions/runs/29159094576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29159094439](https://github.com/sgl-project/sglang/actions/runs/29159094439)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->