### PR TITLE
[Bugfix] Support gated ModelOpt NVFP4 MoE intermediate padding

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1885,6 +1885,61 @@ def _compute_gemm1_alphas(
     return g1_alphas, g1_alphas_up
 
 
+def _pad_nvfp4_gated_moe_weights_for_swizzle(
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w2_weight_scale: torch.Tensor,
+    *,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pad each logical w13 half and the matching w2 input channels.
+
+    ``swizzle_blockscale`` aligns the fused w13 row dimension to 128. Gated
+    activations split those rows into two equal projections, so each half must
+    be aligned to 64 before swizzling to keep the gate/up boundary intact.
+    """
+    total_rows = w13_weight.shape[1]
+    if total_rows % 2 != 0:
+        raise ValueError(f"Expected an even gated w13 row count, got {total_rows}.")
+    if w13_weight_scale.shape[1] != total_rows:
+        raise ValueError(
+            "w13 weight and block-scale rows must match before NVFP4 padding, "
+            f"got {total_rows} and {w13_weight_scale.shape[1]}."
+        )
+
+    intermediate_size = total_rows // 2
+    if w2_weight.shape[-1] * 2 != intermediate_size:
+        raise ValueError(
+            "w2 packed-weight width does not match the w13 intermediate size: "
+            f"{w2_weight.shape[-1]} * 2 != {intermediate_size}."
+        )
+    if w2_weight_scale.shape[-1] * group_size != intermediate_size:
+        raise ValueError(
+            "w2 block-scale width does not match the w13 intermediate size: "
+            f"{w2_weight_scale.shape[-1]} * {group_size} != {intermediate_size}."
+        )
+
+    padded_intermediate_size = round_up(intermediate_size, 64)
+    pad_size = padded_intermediate_size - intermediate_size
+    if pad_size == 0:
+        return w13_weight, w13_weight_scale, w2_weight, w2_weight_scale
+
+    def _pad_w13_halves(tensor: torch.Tensor) -> torch.Tensor:
+        halves = tensor.split(intermediate_size, dim=1)
+        return torch.cat(
+            [torch.nn.functional.pad(half, (0, 0, 0, pad_size)) for half in halves],
+            dim=1,
+        )
+
+    return (
+        _pad_w13_halves(w13_weight),
+        _pad_w13_halves(w13_weight_scale),
+        torch.nn.functional.pad(w2_weight, (0, pad_size // 2)),
+        torch.nn.functional.pad(w2_weight_scale, (0, pad_size // group_size)),
+    )
+
+
 class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
     """
        MoE Method for FP4 Quantization with Blockscales and PerTensorScales
@@ -2245,6 +2300,27 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 )
             }
         )
+
+        if layer.moe_runner_config.is_gated and not self.enable_flashinfer_trtllm_moe:
+            padded_weights = _pad_nvfp4_gated_moe_weights_for_swizzle(
+                layer.w13_weight,
+                layer.w13_weight_scale,
+                layer.w2_weight,
+                layer.w2_weight_scale,
+                group_size=self.quant_config.group_size,
+            )
+            for name, padded_weight in zip(
+                (
+                    "w13_weight",
+                    "w13_weight_scale",
+                    "w2_weight",
+                    "w2_weight_scale",
+                ),
+                padded_weights,
+            ):
+                if padded_weight is not getattr(layer, name):
+                    copy_or_rebind_param(layer, name, padded_weight)
+
         block_size = 16
         # Validate weight scales
         assert_dim = 2 if layer.moe_runner_config.is_gated else 1
@@ -2327,11 +2403,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             w13_weight = layer.w13_weight
             intermediate_size_pad = w13_blockscale_swizzled.size(1) - w13_weight.size(1)
             if intermediate_size_pad:
-                # padding gated activations will require to split w1 and w3
-                # and pad them individually
                 assert not layer.moe_runner_config.is_gated, (
-                    "The intermediate size required padding, "
-                    "but padding is also implemented for gated activations"
+                    "Unexpected NVFP4 gated MoE padding remained after aligning "
+                    "the gate and up projections independently."
                 )
 
                 copy_or_rebind_param(

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_padding.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_padding.py
@@ -1,0 +1,94 @@
+"""CPU unit tests for ModelOpt NVFP4 MoE intermediate padding."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.modelopt_quant import (
+    _pad_nvfp4_gated_moe_weights_for_swizzle,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _row_values(rows: int) -> torch.Tensor:
+    return torch.arange(1, rows + 1, dtype=torch.int32).view(1, rows, 1)
+
+
+def _column_values(columns: int) -> torch.Tensor:
+    return torch.arange(1, columns + 1, dtype=torch.int32).view(1, 1, columns)
+
+
+class TestNvfp4MoeIntermediatePadding(CustomTestCase):
+    def test_gated_gemma4_tp2_pads_each_half_and_scales(self):
+        # Gemma-4 has moe_intermediate_size=704. TP=2 produces 352 channels per
+        # rank, while the fused gated w13 row layout must align to 128 overall.
+        intermediate = 352
+        w13_weight = _row_values(2 * intermediate)
+        w13_weight_scale = _row_values(2 * intermediate) * 10
+        w2_weight = _column_values(intermediate // 2)
+        w2_weight_scale = _column_values(intermediate // 16)
+
+        padded = _pad_nvfp4_gated_moe_weights_for_swizzle(
+            w13_weight,
+            w13_weight_scale,
+            w2_weight,
+            w2_weight_scale,
+            group_size=16,
+        )
+        padded_w13, padded_w13_scale, padded_w2, padded_w2_scale = padded
+
+        padded_intermediate = 384
+        self.assertEqual(padded_w13.shape, (1, 2 * padded_intermediate, 1))
+        self.assertEqual(padded_w13_scale.shape, (1, 2 * padded_intermediate, 1))
+        self.assertEqual(padded_w2.shape, (1, 1, padded_intermediate // 2))
+        self.assertEqual(padded_w2_scale.shape, (1, 1, padded_intermediate // 16))
+
+        for source, result in (
+            (w13_weight, padded_w13),
+            (w13_weight_scale, padded_w13_scale),
+        ):
+            torch.testing.assert_close(
+                result[:, :intermediate], source[:, :intermediate]
+            )
+            torch.testing.assert_close(
+                result[:, padded_intermediate : padded_intermediate + intermediate],
+                source[:, intermediate:],
+            )
+            self.assertEqual(
+                torch.count_nonzero(result[:, intermediate:padded_intermediate]).item(),
+                0,
+            )
+            self.assertEqual(torch.count_nonzero(result[:, -32:]).item(), 0)
+
+        torch.testing.assert_close(padded_w2[..., : intermediate // 2], w2_weight)
+        torch.testing.assert_close(
+            padded_w2_scale[..., : intermediate // 16], w2_weight_scale
+        )
+        self.assertEqual(
+            torch.count_nonzero(padded_w2[..., intermediate // 2 :]).item(), 0
+        )
+        self.assertEqual(
+            torch.count_nonzero(padded_w2_scale[..., intermediate // 16 :]).item(),
+            0,
+        )
+
+    def test_aligned_gated_layout_is_not_reallocated(self):
+        intermediate = 384
+        tensors = (
+            torch.zeros(1, 2 * intermediate, 2, dtype=torch.uint8),
+            torch.zeros(1, 2 * intermediate, 4, dtype=torch.float8_e4m3fn),
+            torch.zeros(1, 8, intermediate // 2, dtype=torch.uint8),
+            torch.zeros(1, 8, intermediate // 16, dtype=torch.float8_e4m3fn),
+        )
+
+        padded = _pad_nvfp4_gated_moe_weights_for_swizzle(*tensors, group_size=16)
+
+        for source, result in zip(tensors, padded):
+            self.assertIs(result, source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_padding.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_padding.py
@@ -1,90 +1,294 @@
-"""CPU unit tests for ModelOpt NVFP4 MoE intermediate padding."""
+"""CPU regression tests for ModelOpt NVFP4 gated-MoE TP padding.
+
+The regression test drives the real ``process_weights_after_loading`` path used
+by ``flashinfer_cutlass``. It keeps Gemma-4's relevant dimensions exactly as
+observed in the TP=2 failure: 704 fused rows, 352 channels per rank, hidden size
+2816, and a 22-column w2 block scale. Only the expert count is reduced to keep
+CPU CI small.
+
+The GPU-only block-scale swizzle is replaced with a CPU test double that keeps
+its padding contract. This makes the test fail at the original gated-padding
+assertion if per-half padding is removed or moved after swizzling, while marker
+values catch a naive tail pad that shifts the two logical w13 projections.
+"""
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.srt.layers.quantization.modelopt_quant import (
-    _pad_nvfp4_gated_moe_weights_for_swizzle,
-)
+from sglang.srt.layers.quantization import modelopt_quant
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+GROUP_SIZE = 16
+GEMMA4_MOE_INTERMEDIATE_SIZE = 704
+TP_SIZE = 2
+TP_INTERMEDIATE_SIZE = GEMMA4_MOE_INTERMEDIATE_SIZE // TP_SIZE
+PADDED_INTERMEDIATE_SIZE = 384
+GEMMA4_HIDDEN_SIZE = 2816
+NUM_TEST_EXPERTS = 1
 
 
-def _row_values(rows: int) -> torch.Tensor:
-    return torch.arange(1, rows + 1, dtype=torch.int32).view(1, rows, 1)
+def _parameter(tensor: torch.Tensor) -> torch.nn.Parameter:
+    return torch.nn.Parameter(tensor, requires_grad=False)
 
 
-def _column_values(columns: int) -> torch.Tensor:
-    return torch.arange(1, columns + 1, dtype=torch.int32).view(1, 1, columns)
+def _make_gemma4_tp2_layer():
+    projection_shape = (
+        NUM_TEST_EXPERTS,
+        TP_INTERMEDIATE_SIZE,
+        GEMMA4_HIDDEN_SIZE // 2,
+    )
+    projection_scale_shape = (
+        NUM_TEST_EXPERTS,
+        TP_INTERMEDIATE_SIZE,
+        GEMMA4_HIDDEN_SIZE // GROUP_SIZE,
+    )
+
+    layer = torch.nn.Module()
+    layer.w13_weight = _parameter(
+        torch.cat(
+            (
+                torch.full(projection_shape, 0x11, dtype=torch.uint8),
+                torch.full(projection_shape, 0x77, dtype=torch.uint8),
+            ),
+            dim=1,
+        )
+    )
+    layer.w13_weight_scale = _parameter(
+        torch.cat(
+            (
+                torch.full(projection_scale_shape, 1.0, dtype=torch.float8_e4m3fn),
+                torch.full(projection_scale_shape, 2.0, dtype=torch.float8_e4m3fn),
+            ),
+            dim=1,
+        )
+    )
+
+    w2_columns = torch.arange(1, TP_INTERMEDIATE_SIZE // 2 + 1, dtype=torch.uint8).view(
+        1, 1, -1
+    )
+    layer.w2_weight = _parameter(
+        w2_columns.expand(NUM_TEST_EXPERTS, GEMMA4_HIDDEN_SIZE, -1).contiguous()
+    )
+    w2_scale_columns = torch.arange(
+        1, TP_INTERMEDIATE_SIZE // GROUP_SIZE + 1, dtype=torch.float32
+    ).to(torch.float8_e4m3fn)
+    layer.w2_weight_scale = _parameter(
+        w2_scale_columns.view(1, 1, -1)
+        .expand(NUM_TEST_EXPERTS, GEMMA4_HIDDEN_SIZE, -1)
+        .contiguous()
+    )
+
+    layer.w13_input_scale = _parameter(torch.full((NUM_TEST_EXPERTS, 2), 0.5))
+    layer.w2_input_scale = _parameter(torch.full((NUM_TEST_EXPERTS,), 0.25))
+    layer.w13_weight_scale_2 = _parameter(
+        torch.tensor([[0.125, 0.25]]).expand(NUM_TEST_EXPERTS, -1).contiguous()
+    )
+    layer.w2_weight_scale_2 = _parameter(torch.full((NUM_TEST_EXPERTS,), 0.5))
+
+    layer.moe_runner_config = SimpleNamespace(
+        is_gated=True,
+        swiglu_limit=None,
+        intermediate_size_per_partition=TP_INTERMEDIATE_SIZE,
+    )
+    layer.num_experts = NUM_TEST_EXPERTS
+    layer.dispatcher = MagicMock()
+
+    original_params = {
+        name: getattr(layer, name)
+        for name in (
+            "w13_weight",
+            "w13_weight_scale",
+            "w2_weight",
+            "w2_weight_scale",
+        )
+    }
+    return layer, original_params
 
 
 class TestNvfp4MoeIntermediatePadding(CustomTestCase):
-    def test_gated_gemma4_tp2_pads_each_half_and_scales(self):
-        # Gemma-4 has moe_intermediate_size=704. TP=2 produces 352 channels per
-        # rank, while the fused gated w13 row layout must align to 128 overall.
-        intermediate = 352
-        w13_weight = _row_values(2 * intermediate)
-        w13_weight_scale = _row_values(2 * intermediate) * 10
-        w2_weight = _column_values(intermediate // 2)
-        w2_weight_scale = _column_values(intermediate // 16)
-
-        padded = _pad_nvfp4_gated_moe_weights_for_swizzle(
-            w13_weight,
-            w13_weight_scale,
-            w2_weight,
-            w2_weight_scale,
-            group_size=16,
+    def test_process_weights_after_loading_pads_gemma4_tp2_before_swizzle(self):
+        """Exercise the exact flashinfer_cutlass post-load regression path."""
+        layer, original_params = _make_gemma4_tp2_layer()
+        method = modelopt_quant.ModelOptNvFp4FusedMoEMethod.__new__(
+            modelopt_quant.ModelOptNvFp4FusedMoEMethod
         )
-        padded_w13, padded_w13_scale, padded_w2, padded_w2_scale = padded
+        method.quant_config = SimpleNamespace(
+            group_size=GROUP_SIZE,
+            use_per_token_activation=False,
+        )
+        method.enable_flashinfer_trtllm_moe = False
+        backend = modelopt_quant.MoeRunnerBackend.FLASHINFER_CUTLASS
+        swizzle_inputs = []
 
-        padded_intermediate = 384
-        self.assertEqual(padded_w13.shape, (1, 2 * padded_intermediate, 1))
-        self.assertEqual(padded_w13_scale.shape, (1, 2 * padded_intermediate, 1))
-        self.assertEqual(padded_w2.shape, (1, 1, padded_intermediate // 2))
-        self.assertEqual(padded_w2_scale.shape, (1, 1, padded_intermediate // 16))
+        def record_swizzle_input(scale):
+            swizzle_inputs.append(scale.detach().clone())
+            padded_rows = (scale.shape[1] + 127) // 128 * 128
+            padded_columns = (scale.shape[2] + 3) // 4 * 4
+            return torch.zeros(
+                scale.shape[0],
+                padded_rows,
+                padded_columns,
+                dtype=scale.dtype,
+                device=scale.device,
+            )
 
-        for source, result in (
-            (w13_weight, padded_w13),
-            (w13_weight_scale, padded_w13_scale),
+        with (
+            patch.object(
+                modelopt_quant, "get_moe_runner_backend", return_value=backend
+            ),
+            patch(
+                "sglang.srt.layers.moe.get_moe_runner_backend",
+                return_value=backend,
+            ),
+            patch.object(modelopt_quant, "MOE_NVFP4_DISPATCH", False),
+            patch.object(
+                modelopt_quant,
+                "should_use_flashinfer_cutlass_moe_fp4_allgather",
+                return_value=False,
+            ),
+            patch.object(
+                modelopt_quant,
+                "swizzle_blockscale",
+                side_effect=record_swizzle_input,
+            ),
         ):
-            torch.testing.assert_close(
-                result[:, :intermediate], source[:, :intermediate]
-            )
-            torch.testing.assert_close(
-                result[:, padded_intermediate : padded_intermediate + intermediate],
-                source[:, intermediate:],
-            )
-            self.assertEqual(
-                torch.count_nonzero(result[:, intermediate:padded_intermediate]).item(),
-                0,
-            )
-            self.assertEqual(torch.count_nonzero(result[:, -32:]).item(), 0)
+            method.process_weights_after_loading(layer)
 
-        torch.testing.assert_close(padded_w2[..., : intermediate // 2], w2_weight)
-        torch.testing.assert_close(
-            padded_w2_scale[..., : intermediate // 16], w2_weight_scale
+        self.assertEqual(len(swizzle_inputs), 2)
+        self.assertEqual(
+            swizzle_inputs[0].shape,
+            (1, 768, 176),
         )
         self.assertEqual(
-            torch.count_nonzero(padded_w2[..., intermediate // 2 :]).item(), 0
+            swizzle_inputs[1].shape,
+            (1, 2816, 24),
         )
-        self.assertEqual(
-            torch.count_nonzero(padded_w2_scale[..., intermediate // 16 :]).item(),
-            0,
+        self.assertEqual(layer.w13_weight.shape, (1, 768, 1408))
+        self.assertEqual(layer.w2_weight.shape, (1, 2816, 192))
+
+        for name, padded, first_marker, second_marker in (
+            ("w13_weight", layer.w13_weight, 0x11, 0x77),
+            ("w13_weight_scale", swizzle_inputs[0], 1.0, 2.0),
+        ):
+            with self.subTest(tensor=name):
+                self.assertTrue(
+                    torch.equal(
+                        padded[:, :TP_INTERMEDIATE_SIZE],
+                        torch.full_like(padded[:, :TP_INTERMEDIATE_SIZE], first_marker),
+                    )
+                )
+                first_padding = padded[:, TP_INTERMEDIATE_SIZE:PADDED_INTERMEDIATE_SIZE]
+                self.assertTrue(
+                    torch.equal(first_padding, torch.zeros_like(first_padding))
+                )
+                self.assertTrue(
+                    torch.equal(
+                        padded[
+                            :,
+                            PADDED_INTERMEDIATE_SIZE : PADDED_INTERMEDIATE_SIZE
+                            + TP_INTERMEDIATE_SIZE,
+                        ],
+                        torch.full_like(
+                            padded[
+                                :,
+                                PADDED_INTERMEDIATE_SIZE : PADDED_INTERMEDIATE_SIZE
+                                + TP_INTERMEDIATE_SIZE,
+                            ],
+                            second_marker,
+                        ),
+                    )
+                )
+                second_padding = padded[
+                    :, PADDED_INTERMEDIATE_SIZE + TP_INTERMEDIATE_SIZE :
+                ]
+                self.assertTrue(
+                    torch.equal(second_padding, torch.zeros_like(second_padding))
+                )
+
+        expected_w2 = torch.arange(1, 177, dtype=torch.uint8).view(1, 1, -1)
+        self.assertTrue(
+            torch.equal(
+                layer.w2_weight[..., : TP_INTERMEDIATE_SIZE // 2],
+                expected_w2.expand(1, GEMMA4_HIDDEN_SIZE, -1),
+            )
+        )
+        w2_padding = layer.w2_weight[..., TP_INTERMEDIATE_SIZE // 2 :]
+        self.assertTrue(torch.equal(w2_padding, torch.zeros_like(w2_padding)))
+
+        padded_w2_scale = swizzle_inputs[1]
+        expected_w2_scale = torch.arange(1, 23, dtype=torch.float32).to(
+            torch.float8_e4m3fn
+        )
+        self.assertTrue(
+            torch.equal(
+                padded_w2_scale[..., : TP_INTERMEDIATE_SIZE // GROUP_SIZE],
+                expected_w2_scale.view(1, 1, -1).expand(1, GEMMA4_HIDDEN_SIZE, -1),
+            )
+        )
+        w2_scale_padding = padded_w2_scale[..., TP_INTERMEDIATE_SIZE // GROUP_SIZE :]
+        self.assertTrue(
+            torch.equal(w2_scale_padding, torch.zeros_like(w2_scale_padding))
         )
 
-    def test_aligned_gated_layout_is_not_reallocated(self):
-        intermediate = 384
+        for name, original_param in original_params.items():
+            with self.subTest(parameter_identity=name):
+                self.assertIs(getattr(layer, name), original_param)
+
+        for source_name, derived_name, expected_shape in (
+            (
+                "w13_weight_scale",
+                "w13_blockscale_swizzled",
+                (1, 768, 176),
+            ),
+            ("w2_weight_scale", "w2_blockscale_swizzled", (1, 2816, 24)),
+        ):
+            source = getattr(layer, source_name)
+            derived = getattr(layer, derived_name)
+            with self.subTest(blockscale_alias=derived_name):
+                self.assertIs(derived, source)
+                self.assertEqual(derived.shape, expected_shape)
+                self.assertEqual(derived.dtype, torch.float8_e4m3fn)
+
+        self.assertEqual(
+            layer.moe_runner_config.intermediate_size_per_partition,
+            TP_INTERMEDIATE_SIZE,
+        )
+        self.assertEqual(
+            layer.cutlass_moe_params.intermediate_size_per_partition,
+            PADDED_INTERMEDIATE_SIZE,
+        )
+        self.assertEqual(layer.cutlass_moe_params.hidden_size, GEMMA4_HIDDEN_SIZE)
+
+    def test_gemma4_tp1_intermediate_padding_is_noop(self):
+        """Each TP=1 projection has 704 rows, already a multiple of 64."""
+        hidden_size = 16
+        intermediate_size = GEMMA4_MOE_INTERMEDIATE_SIZE
         tensors = (
-            torch.zeros(1, 2 * intermediate, 2, dtype=torch.uint8),
-            torch.zeros(1, 2 * intermediate, 4, dtype=torch.float8_e4m3fn),
-            torch.zeros(1, 8, intermediate // 2, dtype=torch.uint8),
-            torch.zeros(1, 8, intermediate // 16, dtype=torch.float8_e4m3fn),
+            torch.zeros(1, 2 * intermediate_size, hidden_size // 2, dtype=torch.uint8),
+            torch.zeros(
+                1,
+                2 * intermediate_size,
+                hidden_size // GROUP_SIZE,
+                dtype=torch.float8_e4m3fn,
+            ),
+            torch.zeros(1, hidden_size, intermediate_size // 2, dtype=torch.uint8),
+            torch.zeros(
+                1,
+                hidden_size,
+                intermediate_size // GROUP_SIZE,
+                dtype=torch.float8_e4m3fn,
+            ),
         )
 
-        padded = _pad_nvfp4_gated_moe_weights_for_swizzle(*tensors, group_size=16)
+        padded = modelopt_quant._pad_nvfp4_gated_moe_weights_for_swizzle(
+            *tensors, group_size=GROUP_SIZE
+        )
 
         for source, result in zip(tensors, padded):
             self.assertIs(result, source)


### PR DESCRIPTION
## Motivation

ModelOpt NVFP4 gated MoE models cannot load with tensor parallel sizes that
leave a per-rank intermediate size requiring block-scale swizzle padding.

For `nvidia/Gemma-4-26B-A4B-NVFP4`, TP=2 splits the 704-channel MoE
intermediate size into 352 channels per rank. The fused gate/up `w13` layout
must be padded to 384 channels per half, but the current post-load path rejects
gated padding with an assertion.

This is the NVFP4 counterpart of the gated ModelOpt FP8 padding handled in
https://github.com/sgl-project/sglang/pull/22627.

Fixes #30887

## Modifications

- Pad each logical half of gated NVFP4 `w13` independently to the 64-row
  swizzle alignment, preserving the gate/up boundary.
- Pad the matching `w13` block scales, packed `w2` input columns, and `w2`
  block scales before validation, CuteDSL interleaving, and swizzling.
- Keep aligned layouts as a no-op and retain an invariant assertion for any
  unexpected post-swizzle gated padding.
- Add a CPU regression test that drives the real `flashinfer_cutlass`
  `process_weights_after_loading` path with the Gemma-4 TP=2 dimensions,
  checks both logical w13 boundaries, matching w2 padding, parameter identity,
  derived block-scale aliases, CUTLASS metadata, and the aligned TP=1 control.

## Accuracy Tests

- Unpatched `lmsysorg/sglang:v0.5.15`, TP=2: reproduced the load-time
  assertion on both ranks.
- Patched v0.5.15, TP=2 on 2 x NVIDIA B300: both ranks completed weight loading,
  the server became healthy, and generation requests returned HTTP 200.
- Patched TP=1 and TP=2 produced identical first-token IDs for five greedy
  prompts: `[506, 236743, 506, 3425, 5122]`. The TP=2 batch was repeated with
  the same result.
- Focused CPU tests. The TP=2 post-load test was also run against the parent
  commit and failed at the original assertion, immediately after reporting
  `w2_weight_scale shape=(1, 2816, 22)`:

```text
patched test_modelopt_nvfp4_moe_padding.py: 2 passed
pre-fix TP=2 post-load test: original gated-padding AssertionError
test_modelopt_nvfp4_moe_scales.py: 12 passed
```

## Speed Tests and Profiling

A short functionality smoke was run with AIPerf 0.11.0 on the patched TP=2
server (`ISL=128`, `OSL=16`, concurrency=1, 2 warmups, 10 measured requests):

```text
Requests:             10 completed, 0 errors
Mean TTFT:            46.30 ms
Mean inter-token:      3.95 ms
Mean request latency: 105.52 ms
Output throughput:    150.86 tokens/s
```

This small run is a load/generation smoke, not a performance comparison.

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add unit tests according to the unit test guide.
- [x] Documentation changes are not required for this internal loading fix.
- [x] Provide accuracy and smoke benchmark results above.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

The branch is ready for CI and maintainer review.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29164574940](https://github.com/sgl-project/sglang/actions/runs/29164574940)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29164574833](https://github.com/sgl-project/sglang/actions/runs/29164574833)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->