### PR TITLE
feat: enable piecewise prefill graph for Kimi K2.5/K2.7

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1726,6 +1726,7 @@ piecewise_cuda_graph_disabled_model_archs = [
 # cleanly (vision encoder runs eagerly outside the graph via general_mm_embed_routine).
 multimodal_piecewise_cuda_graph_supported_model_archs = [
     "Cohere2VisionForConditionalGeneration",
+    "KimiK25ForConditionalGeneration",
     "MiniMaxM3SparseForCausalLM",
     "MiniMaxM3SparseForConditionalGeneration",
 ]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3447,6 +3447,21 @@ class ServerArgs:
         """
         if (Phase.PREFILL, "backend") in self._cuda_graph_config_locked:
             return
+
+        # Breakable is the general CUDA default, but it is not compatible with
+        # multimodal prefill. Models on this allowlist have had their decoder
+        # prefill validated under tc_piecewise; the vision encoder remains
+        # eager outside the captured LM forward.
+        if (
+            self.cuda_graph_config.prefill.backend == Backend.BREAKABLE
+            and self.get_model_config().is_multimodal_piecewise_cuda_graph_supported
+        ):
+            logger.info(
+                "Using tc_piecewise CUDA graph for validated multimodal "
+                "decoder prefill."
+            )
+            self.cuda_graph_config.prefill.backend = Backend.TC_PIECEWISE
+
         if self.cuda_graph_config.prefill.backend == Backend.TC_PIECEWISE:
             self._disable_tc_piecewise_cudagraph_if_incompatible()
         elif self.cuda_graph_config.prefill.backend == Backend.BREAKABLE:

--- a/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
+++ b/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
@@ -1,10 +1,18 @@
 """Regression tests for multimodal piecewise CUDA graph opt-ins."""
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from sglang.srt.configs.model_config import (
     is_multimodal_piecewise_cuda_graph_supported,
 )
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
+from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -25,6 +33,24 @@ class TestMultimodalPiecewiseCudaGraph(CustomTestCase):
                 ["UnknownVisionForConditionalGeneration"]
             )
         )
+
+    def test_supported_multimodal_model_upgrades_default_to_tc_piecewise(self):
+        args = ServerArgs(model_path="dummy")
+        args.model_config = SimpleNamespace(
+            is_multimodal_piecewise_cuda_graph_supported=True
+        )
+        args.cuda_graph_config = CudaGraphConfig(
+            prefill=PhaseConfig(backend=Backend.BREAKABLE)
+        )
+        args._cuda_graph_config_locked = set()
+
+        with patch.object(
+            ServerArgs, "_disable_tc_piecewise_cudagraph_if_incompatible"
+        ) as disable_if_incompatible:
+            args._apply_cuda_graph_compatibility()
+
+        self.assertEqual(args.cuda_graph_config.prefill.backend, Backend.TC_PIECEWISE)
+        disable_if_incompatible.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
+++ b/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
@@ -1,0 +1,31 @@
+"""Regression tests for multimodal piecewise CUDA graph opt-ins."""
+
+import unittest
+
+from sglang.srt.configs.model_config import (
+    is_multimodal_piecewise_cuda_graph_supported,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMultimodalPiecewiseCudaGraph(CustomTestCase):
+    def test_kimi_k25_lm_prefill_is_opted_in(self):
+        self.assertTrue(
+            is_multimodal_piecewise_cuda_graph_supported(
+                ["KimiK25ForConditionalGeneration"]
+            )
+        )
+
+    def test_unknown_multimodal_arch_is_not_opted_in(self):
+        self.assertFalse(
+            is_multimodal_piecewise_cuda_graph_supported(
+                ["UnknownVisionForConditionalGeneration"]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- opt `KimiK25ForConditionalGeneration` into multimodal `tc_piecewise` prefill CUDA graph
- upgrade the default CUDA prefill backend from incompatible `breakable` to `tc_piecewise` for validated multimodal models only
- retain eager vision encoding: only the LM prefill forward is captured
- add a CPU regression test so unsupported multimodal architectures remain opted out

## Validation

- CPU: `PYTHONPATH=python python3 -m pytest test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py -q` — **3 passed**.
- NVIDIA H200 TP8, `moonshotai/Kimi-K2.7-Code`, native compressed-tensors int4, FA3 for LM and vision, DP MM encoder, CUDA IPC enabled:
  - candidate PR automatically resolved to `prefill.backend=tc_piecewise` with no explicit CUDA-graph flag
  - captured 42 prefill sizes (4…2048) in 109.39s, using 1.33 GiB additional memory per GPU
  - server passed `/health` and completed the seeded random-image r1/r8/r32 matrix
  - K2.7 TP8 eager itself is not token-exact across repeated int4 runs (5/16 short prefixes differ); PCG repeats differ 3/16, so this manual validation checks service health and output behavior rather than claiming token-exact equality

## Performance (before → after)

Strict A/B on one NVIDIA H200 TP8 host: `origin/main` `32cb89d` versus this PR `f3d3195`; native compressed-tensors int4, FA3 LM/vision attention, DP MM encoder, CUDA IPC enabled, radix cache disabled. The seeded `bench_serving` trace contains 16 requests, one random JPEG each, `random:256x256-1024x1024`, 32 text input tokens, and 16 output tokens. Each rate has its own one-request warmup. `r32` uses the repeat result for the PCG side.

| Request rate | Output tok/s (main → PCG) | TTFT p50 / p99 ms (main → PCG) | E2E p50 / p99 ms (main → PCG) |
| --- | ---: | ---: | ---: |
| 1/s | 13.34 → 13.34 (0.0%) | 140 / 273 → 96 / 152 (-31% / -44%) | 215 / 351 → 160 / 242 (-26% / -31%) |
| 8/s | 85.92 → 95.85 (+11.5%) | 476 / 896 → 153 / 255 (-68% / -72%) | 760 / 1029 → 496 / 1194 (-35% / +16%) |
| 32/s | 139.61 → 142.75 (+2.3%) | 641 / 782 → 589 / 712 (-8% / -9%) | 830 / 1012 → 806 / 988 (-3% / -2%) |

PCG resolves the incompatible default (`breakable` disables MLA prefill graphs) and moves heterogeneous-shape capture to startup. The explicit cost is the 109.39s / 1.33 GiB-per-GPU capture noted above. At 8/s, the first high-concurrency eager shape stalls materially; PCG removes that stall, but its E2E p99 is still worse in this small trace. Thus this PR improves the documented cold-shape and median-latency path, but does not claim to solve every saturated-tail bottleneck.

This measurement still has the known TileLang CUDA-runtime-stub issue, which disables SGLang FlashInfer all-reduce fusion. That dependency issue is separate and leaves the high-load SGLang/vLLM gap conservative.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29160274313](https://github.com/sgl-project/sglang/actions/runs/29160274313)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29160842701](https://github.com/sgl-project/sglang/actions/runs/29160842701)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->