### PR TITLE
[Fix] Check paged allocator capacity before kernel launch

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -190,6 +190,15 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         ):
             self.merge_and_sort_free()
 
+        if num_new_pages is None:
+            num_new_pages = get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=self.page_size,
+                prefix_lens=prefix_lens_cpu,
+            )
+        if num_new_pages > len(self.free_pages):
+            return None
+
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
@@ -206,15 +215,6 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
-
-        if num_new_pages is None:
-            num_new_pages = get_num_new_pages(
-                seq_lens=seq_lens_cpu,
-                page_size=self.page_size,
-                prefix_lens=prefix_lens_cpu,
-            )
-        if num_new_pages > len(self.free_pages):
-            return None
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices
@@ -234,6 +234,14 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if self.need_sort and bs > len(self.free_pages):
             self.merge_and_sort_free()
 
+        num_new_pages = get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=self.page_size,
+            decode=True,
+        )
+        if num_new_pages > len(self.free_pages):
+            return None
+
         out_indices = torch.empty((bs,), dtype=torch.int64, device=self.device)
         alloc_decode_kernel[(bs,)](
             seq_lens,
@@ -246,14 +254,6 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
-
-        num_new_pages = get_num_new_pages(
-            seq_lens=seq_lens_cpu,
-            page_size=self.page_size,
-            decode=True,
-        )
-        if num_new_pages > len(self.free_pages):
-            return None
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices

--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -184,18 +184,21 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 (last_loc + 1) % self.page_size == prefix_lens % self.page_size
             )
 
-        bs = len(prefix_lens)
-        if self.need_sort and extend_num_tokens // self.page_size + bs + 1 > len(
-            self.free_pages
-        ):
-            self.merge_and_sort_free()
-
         if num_new_pages is None:
             num_new_pages = get_num_new_pages(
                 seq_lens=seq_lens_cpu,
                 page_size=self.page_size,
                 prefix_lens=prefix_lens_cpu,
             )
+        if num_new_pages > len(self.free_pages) + len(self.release_pages):
+            return None
+
+        bs = len(prefix_lens)
+        if self.need_sort and extend_num_tokens // self.page_size + bs + 1 > len(
+            self.free_pages
+        ):
+            self.merge_and_sort_free()
+
         if num_new_pages > len(self.free_pages):
             return None
 
@@ -230,15 +233,18 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 (last_loc + 2) % self.page_size == seq_lens % self.page_size
             )
 
-        bs = len(seq_lens)
-        if self.need_sort and bs > len(self.free_pages):
-            self.merge_and_sort_free()
-
         num_new_pages = get_num_new_pages(
             seq_lens=seq_lens_cpu,
             page_size=self.page_size,
             decode=True,
         )
+        if num_new_pages > len(self.free_pages) + len(self.release_pages):
+            return None
+
+        bs = len(seq_lens)
+        if self.need_sort and bs > len(self.free_pages):
+            self.merge_and_sort_free()
+
         if num_new_pages > len(self.free_pages):
             return None
 

--- a/test/registered/unit/mem_cache/test_paged_allocator_capacity.py
+++ b/test/registered/unit/mem_cache/test_paged_allocator_capacity.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.mem_cache.allocator.paged as paged
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def make_allocator(*, free_pages, release_pages=(), need_sort=False):
+    allocator = object.__new__(PagedTokenToKVPoolAllocator)
+    allocator.page_size = 8
+    allocator.device = "cpu"
+    allocator.debug_mode = False
+    allocator.need_sort = need_sort
+    allocator.free_pages = torch.tensor(free_pages, dtype=torch.int64)
+    allocator.release_pages = torch.tensor(release_pages, dtype=torch.int64)
+    return allocator
+
+
+class TestPagedAllocatorCapacity(CustomTestCase):
+    def test_alloc_extend_does_not_launch_kernel_when_capacity_is_insufficient(self):
+        allocator = make_allocator(free_pages=[7])
+        free_pages = allocator.free_pages.clone()
+
+        with patch.object(paged, "alloc_extend_kernel") as kernel:
+            result = allocator.alloc_extend(
+                prefix_lens=torch.tensor([8, 8]),
+                prefix_lens_cpu=torch.tensor([8, 8]),
+                seq_lens=torch.tensor([9, 9]),
+                seq_lens_cpu=torch.tensor([9, 9]),
+                last_loc=torch.tensor([7, 7]),
+                extend_num_tokens=2,
+            )
+
+        self.assertIsNone(result)
+        kernel.__getitem__.assert_not_called()
+        self.assertTrue(torch.equal(allocator.free_pages, free_pages))
+
+    def test_alloc_decode_does_not_launch_kernel_when_capacity_is_insufficient(self):
+        allocator = make_allocator(free_pages=[7])
+        free_pages = allocator.free_pages.clone()
+
+        with patch.object(paged, "alloc_decode_kernel") as kernel:
+            result = allocator.alloc_decode(
+                seq_lens=torch.tensor([9, 9]),
+                seq_lens_cpu=torch.tensor([9, 9]),
+                last_loc=torch.tensor([7, 7]),
+            )
+
+        self.assertIsNone(result)
+        kernel.__getitem__.assert_not_called()
+        self.assertTrue(torch.equal(allocator.free_pages, free_pages))
+
+    def test_alloc_extend_launches_at_exact_capacity(self):
+        allocator = make_allocator(free_pages=[3, 7])
+
+        with patch.object(paged, "alloc_extend_kernel") as kernel:
+            result = allocator.alloc_extend(
+                prefix_lens=torch.tensor([8, 8]),
+                prefix_lens_cpu=torch.tensor([8, 8]),
+                seq_lens=torch.tensor([9, 9]),
+                seq_lens_cpu=torch.tensor([9, 9]),
+                last_loc=torch.tensor([7, 7]),
+                extend_num_tokens=2,
+            )
+
+        self.assertIsNotNone(result)
+        kernel.__getitem__.assert_called_once_with((2,))
+        self.assertEqual(len(allocator.free_pages), 0)
+
+    def test_allocations_launch_when_no_new_page_is_required(self):
+        extend_allocator = make_allocator(free_pages=[])
+        decode_allocator = make_allocator(free_pages=[])
+
+        with patch.object(paged, "alloc_extend_kernel") as extend_kernel:
+            extend_result = extend_allocator.alloc_extend(
+                prefix_lens=torch.tensor([5]),
+                prefix_lens_cpu=torch.tensor([5]),
+                seq_lens=torch.tensor([6]),
+                seq_lens_cpu=torch.tensor([6]),
+                last_loc=torch.tensor([4]),
+                extend_num_tokens=1,
+            )
+
+        with patch.object(paged, "alloc_decode_kernel") as decode_kernel:
+            decode_result = decode_allocator.alloc_decode(
+                seq_lens=torch.tensor([2]),
+                seq_lens_cpu=torch.tensor([2]),
+                last_loc=torch.tensor([0]),
+            )
+
+        self.assertIsNotNone(extend_result)
+        self.assertIsNotNone(decode_result)
+        extend_kernel.__getitem__.assert_called_once_with((1,))
+        decode_kernel.__getitem__.assert_called_once_with((1,))
+
+    def test_alloc_extend_merges_released_pages_before_capacity_check(self):
+        allocator = make_allocator(free_pages=[7], release_pages=[3], need_sort=True)
+
+        with patch.object(paged, "alloc_extend_kernel") as kernel:
+            result = allocator.alloc_extend(
+                prefix_lens=torch.tensor([8, 8]),
+                prefix_lens_cpu=torch.tensor([8, 8]),
+                seq_lens=torch.tensor([9, 9]),
+                seq_lens_cpu=torch.tensor([9, 9]),
+                last_loc=torch.tensor([7, 7]),
+                extend_num_tokens=2,
+            )
+
+        self.assertIsNotNone(result)
+        launched_free_pages = kernel.__getitem__.return_value.call_args.args[3]
+        self.assertTrue(torch.equal(launched_free_pages, torch.tensor([3, 7])))
+        self.assertEqual(len(allocator.free_pages), 0)
+        self.assertEqual(len(allocator.release_pages), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_paged_allocator_capacity.py
+++ b/test/registered/unit/mem_cache/test_paged_allocator_capacity.py
@@ -56,8 +56,45 @@ class TestPagedAllocatorCapacity(CustomTestCase):
         kernel.__getitem__.assert_not_called()
         self.assertTrue(torch.equal(allocator.free_pages, free_pages))
 
+    def test_alloc_extend_does_not_merge_released_pages_on_oom(self):
+        allocator = make_allocator(free_pages=[7], release_pages=[3], need_sort=True)
+        free_pages = allocator.free_pages.clone()
+        release_pages = allocator.release_pages.clone()
+
+        with patch.object(paged, "alloc_extend_kernel") as kernel:
+            result = allocator.alloc_extend(
+                prefix_lens=torch.tensor([8, 8, 8]),
+                prefix_lens_cpu=torch.tensor([8, 8, 8]),
+                seq_lens=torch.tensor([9, 9, 9]),
+                seq_lens_cpu=torch.tensor([9, 9, 9]),
+                last_loc=torch.tensor([7, 7, 7]),
+                extend_num_tokens=3,
+            )
+
+        self.assertIsNone(result)
+        kernel.__getitem__.assert_not_called()
+        self.assertTrue(torch.equal(allocator.free_pages, free_pages))
+        self.assertTrue(torch.equal(allocator.release_pages, release_pages))
+
+    def test_alloc_decode_does_not_merge_released_pages_on_oom(self):
+        allocator = make_allocator(free_pages=[7], release_pages=[3], need_sort=True)
+        free_pages = allocator.free_pages.clone()
+        release_pages = allocator.release_pages.clone()
+
+        with patch.object(paged, "alloc_decode_kernel") as kernel:
+            result = allocator.alloc_decode(
+                seq_lens=torch.tensor([9, 9, 9]),
+                seq_lens_cpu=torch.tensor([9, 9, 9]),
+                last_loc=torch.tensor([7, 7, 7]),
+            )
+
+        self.assertIsNone(result)
+        kernel.__getitem__.assert_not_called()
+        self.assertTrue(torch.equal(allocator.free_pages, free_pages))
+        self.assertTrue(torch.equal(allocator.release_pages, release_pages))
+
     def test_alloc_extend_launches_at_exact_capacity(self):
-        allocator = make_allocator(free_pages=[3, 7])
+        allocator = make_allocator(free_pages=[9, 3, 7])
 
         with patch.object(paged, "alloc_extend_kernel") as kernel:
             result = allocator.alloc_extend(
@@ -71,6 +108,24 @@ class TestPagedAllocatorCapacity(CustomTestCase):
 
         self.assertIsNotNone(result)
         kernel.__getitem__.assert_called_once_with((2,))
+        launched_free_pages = kernel.__getitem__.return_value.call_args.args[3]
+        self.assertTrue(torch.equal(launched_free_pages, torch.tensor([9, 3, 7])))
+        self.assertTrue(torch.equal(allocator.free_pages, torch.tensor([7])))
+
+    def test_alloc_decode_launches_at_exact_capacity(self):
+        allocator = make_allocator(free_pages=[9, 3])
+
+        with patch.object(paged, "alloc_decode_kernel") as kernel:
+            result = allocator.alloc_decode(
+                seq_lens=torch.tensor([9, 9]),
+                seq_lens_cpu=torch.tensor([9, 9]),
+                last_loc=torch.tensor([7, 7]),
+            )
+
+        self.assertIsNotNone(result)
+        kernel.__getitem__.assert_called_once_with((2,))
+        launched_free_pages = kernel.__getitem__.return_value.call_args.args[2]
+        self.assertTrue(torch.equal(launched_free_pages, torch.tensor([9, 3])))
         self.assertEqual(len(allocator.free_pages), 0)
 
     def test_allocations_launch_when_no_new_page_is_required(self):


### PR DESCRIPTION
## Motivation

`PagedTokenToKVPoolAllocator.alloc_extend()` and `alloc_decode()` launch their allocator kernels before checking whether `free_pages` contains the required number of pages. On genuine KV-cache exhaustion, those kernels can read beyond the free-page array before the allocator returns `None`, turning a controlled OOM into an illegal GPU access or poisoned CUDA context.

## Modifications

- Compute the exact CPU-side page requirement before allocator kernel dispatch.
- Return `None` before output allocation or kernel launch when capacity is insufficient.
- Preserve both active and deferred free-page lists on definite OOM.
- Retain the existing merge and consumption order for successful allocations.
- Add CPU regression coverage for extend and decode OOM ordering, exact capacity, zero-new-page allocations, deferred-page merging, state preservation, and free-list consumption order.

## Accuracy Tests

No model-output behavior changes for successful allocations. The change only moves existing capacity checks ahead of kernel dispatch.

## Speed Tests and Profiling

No new calculation is introduced; the existing CPU page-count calculation runs earlier. Definite OOM avoids unnecessary output allocation, free-list sorting, and allocator kernel dispatch. No performance benchmark was run.

## Checklist

- [x] Format code according to the repository pre-commit configuration.
- [x] Add unit tests for the changed allocator behavior.
- [x] Documentation is not required for this internal ordering fix.
- [x] Accuracy impact assessed: no successful-allocation output change.
- [x] Speed impact assessed: no added hot-path calculation.

## Tests

- `PYTHONPATH=python .venv/bin/python -m pytest test/registered/unit/mem_cache/test_paged_allocator_capacity.py test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py -q` (15 passed)
- `.venv/bin/pre-commit run --files python/sglang/srt/mem_cache/allocator/paged.py test/registered/unit/mem_cache/test_paged_allocator_capacity.py` (passed)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29163989557](https://github.com/sgl-project/sglang/actions/runs/29163989557)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29163989420](https://github.com/sgl-project/sglang/actions/runs/29163989420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->