### PR TITLE
[Refactor] Unify HiSparse device-pool mapping internals

### DIFF
--- a/python/sglang/srt/mem_cache/base_hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/base_hisparse_memory_pool.py
@@ -1,0 +1,19 @@
+import torch
+
+
+class HiSparseDevicePoolMappingMixin:
+    def register_mapping(self, full_to_hisparse_device_index_mapping: torch.Tensor):
+        self.full_to_hisparse_device_index_mapping = (
+            full_to_hisparse_device_index_mapping
+        )
+
+    def _translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
+        return self.full_to_hisparse_device_index_mapping[compressed_indices]
+
+    def translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
+        return self.full_to_hisparse_device_index_mapping[compressed_indices]
+
+    def translate_loc_from_full_to_hisparse_device(self, full_indices: torch.Tensor):
+        return self._translate_loc_to_hisparse_device(
+            self.translate_loc_from_full_to_compressed(full_indices)
+        )

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -18,6 +18,9 @@ from sglang.srt.layers.attention.dsv4 import (
     index_buf_accessor as dsv4_index_buf_accessor,
 )
 from sglang.srt.layers.attention.dsv4.index_buf_accessor import NopeFp8RopeBf16Pack
+from sglang.srt.mem_cache.base_hisparse_memory_pool import (
+    HiSparseDevicePoolMappingMixin,
+)
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
@@ -166,8 +169,7 @@ class DeepSeekV4SingleKVPool(KVCache):
         raise NotImplementedError("Use get_key_buffer instead.")
 
 
-class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
-
+class HiSparseC4DevicePool(HiSparseDevicePoolMappingMixin, DeepSeekV4SingleKVPool):
     def __init__(
         self,
         size: int,
@@ -201,27 +203,14 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         )
         self.compress_ratio = 4
 
-    def register_mapping(self, full_to_hisparse_device_index_mapping: torch.Tensor):
-        self.full_to_hisparse_device_index_mapping = (
-            full_to_hisparse_device_index_mapping
-        )
-
     def translate_loc_from_full_to_compressed(self, full_indices: torch.Tensor):
         mask = (full_indices + 1) % self.compress_ratio == 0
         compressed_indices = full_indices[mask] // self.compress_ratio
         return compressed_indices
 
     def translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices].to(
-            torch.int32
-        )
-
-    def _translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices]
-
-    def translate_loc_from_full_to_hisparse_device(self, full_indices: torch.Tensor):
-        return self._translate_loc_to_hisparse_device(
-            self.translate_loc_from_full_to_compressed(full_indices)
+        return (
+            super().translate_loc_to_hisparse_device(compressed_indices).to(torch.int32)
         )
 
     def set_key_buffer(
@@ -453,7 +442,6 @@ class DeepSeekV4UnifiedKVPool:
 
 
 class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
-
     def __init__(
         self,
         max_num_reqs: int,

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -18,6 +18,9 @@ from sglang.kernels.ops.attention.dsv4 import (
 from sglang.kernels.ops.attention.dsv4.index_buf_accessor import NopeFp8RopeBf16Pack
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
+from sglang.srt.mem_cache.base_hisparse_memory_pool import (
+    HiSparseDevicePoolMappingMixin,
+)
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
@@ -181,7 +184,7 @@ class DeepSeekV4SingleKVPool(KVCache):
         raise NotImplementedError("Use get_key_buffer instead.")
 
 
-class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
+class HiSparseC4DevicePool(HiSparseDevicePoolMappingMixin, DeepSeekV4SingleKVPool):
     def __init__(
         self,
         size: int,
@@ -215,27 +218,14 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         )
         self.compress_ratio = 4
 
-    def register_mapping(self, full_to_hisparse_device_index_mapping: torch.Tensor):
-        self.full_to_hisparse_device_index_mapping = (
-            full_to_hisparse_device_index_mapping
-        )
-
     def translate_loc_from_full_to_compressed(self, full_indices: torch.Tensor):
         mask = (full_indices + 1) % self.compress_ratio == 0
         compressed_indices = full_indices[mask] // self.compress_ratio
         return compressed_indices
 
     def translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices].to(
-            torch.int32
-        )
-
-    def _translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices]
-
-    def translate_loc_from_full_to_hisparse_device(self, full_indices: torch.Tensor):
-        return self._translate_loc_to_hisparse_device(
-            self.translate_loc_from_full_to_compressed(full_indices)
+        return (
+            super().translate_loc_to_hisparse_device(compressed_indices).to(torch.int32)
         )
 
     def set_key_buffer(

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -6,6 +6,9 @@ from typing import Optional
 import torch
 
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.base_hisparse_memory_pool import (
+    HiSparseDevicePoolMappingMixin,
+)
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.utils import is_cuda, is_hip
 
@@ -25,7 +28,7 @@ else:
         )
 
 
-class HiSparseDSATokenToKVPool(DSATokenToKVPool):
+class HiSparseDSATokenToKVPool(HiSparseDevicePoolMappingMixin, DSATokenToKVPool):
     def __init__(
         self,
         size: int,
@@ -58,20 +61,6 @@ class HiSparseDSATokenToKVPool(DSATokenToKVPool):
             index_buf_size=size * host_to_device_ratio,
         )
         self.bytes_per_token = self.kv_cache_dim * self.dtype.itemsize
-
-    def register_mapping(self, full_to_hisparse_device_index_mapping: torch.Tensor):
-        self.full_to_hisparse_device_index_mapping = (
-            full_to_hisparse_device_index_mapping
-        )
-
-    def translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices]
-
-    def _translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices]
-
-    def translate_loc_from_full_to_hisparse_device(self, full_indices: torch.Tensor):
-        return self._translate_loc_to_hisparse_device(full_indices)
 
     def translate_loc_from_full_to_compressed(self, full_indices: torch.Tensor):
         return full_indices

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -6,6 +6,9 @@ from typing import Optional
 import torch
 
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.base_hisparse_memory_pool import (
+    HiSparseDevicePoolMappingMixin,
+)
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.utils import is_cuda, is_hip
 
@@ -25,7 +28,7 @@ else:
         )
 
 
-class HiSparseDSATokenToKVPool(DSATokenToKVPool):
+class HiSparseDSATokenToKVPool(HiSparseDevicePoolMappingMixin, DSATokenToKVPool):
     def __init__(
         self,
         size: int,
@@ -68,20 +71,6 @@ class HiSparseDSATokenToKVPool(DSATokenToKVPool):
             skip_topk_layers=skip_topk_layers,
         )
         self.bytes_per_token = self.kv_cache_dim * self.dtype.itemsize
-
-    def register_mapping(self, full_to_hisparse_device_index_mapping: torch.Tensor):
-        self.full_to_hisparse_device_index_mapping = (
-            full_to_hisparse_device_index_mapping
-        )
-
-    def translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices]
-
-    def _translate_loc_to_hisparse_device(self, compressed_indices: torch.Tensor):
-        return self.full_to_hisparse_device_index_mapping[compressed_indices]
-
-    def translate_loc_from_full_to_hisparse_device(self, full_indices: torch.Tensor):
-        return self._translate_loc_to_hisparse_device(full_indices)
 
     def translate_loc_from_full_to_compressed(self, full_indices: torch.Tensor):
         return full_indices


### PR DESCRIPTION
## Motivation

This implements the **Unify HiSparse pool internals** item in #23602.

`HiSparseC4DevicePool` and `HiSparseDSATokenToKVPool` independently owned the
same full-to-HiSparse mapping registration and translation operations. Keeping
those APIs in two model-specific pools makes allocator and coordinator changes
easy to drift.

## Changes

- Add `HiSparseDevicePoolMappingMixin` for mapping registration, raw lookup,
  public lookup, and full-to-compressed-to-device composition.
- Compose the mixin into the C4 and DSA device pools.
- Keep compression model-specific: C4 selects every fourth token, while DSA is
  identity-compressed.
- Preserve the current dtype contract:
  - DSA public/private/composed translation keeps the mapping dtype.
  - C4 private/composed translation keeps the mapping dtype.
  - C4 public translation still converts to `int32`.

No allocation, buffer I/O, or transfer behavior changes.

## Validation

- `test/registered/unit/mem_cache/test_hisparse_allocator.py`: **3 passed**
- `test/registered/unit/managers/test_hisparse_unit.py`: imported and collected;
  **11 skipped** because the local host has no GPU
- CPU contract check for DSA/C4 mapping identity, compression, dtype behavior,
  method annotations, and mixin-first MRO: **passed**
- Black, configured Ruff checks, and `git diff --check`: **passed**
- Mechanical transform reproduced the rebased target commit exactly: **passed**

## Mechanical Move

Transform script: https://gist.github.com/anencore94/68bfa1e2933875f1c0870ee58c618a93

### One-click verification

Run from the SGLang repository root:

```bash
uv run --no-project python <(curl -sL https://gist.githubusercontent.com/anencore94/68bfa1e2933875f1c0870ee58c618a93/raw/f37018e22e8c6fe84c0b6be07a68a9e2df9c563b/transform_hisparse_pool_mapping.py)
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34141987148](https://github.com/sgl-project/sglang/actions/runs/34141987148)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34141986924](https://github.com/sgl-project/sglang/actions/runs/34141986924)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34141987107](https://github.com/sgl-project/sglang/actions/runs/34141987107)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->