### PR TITLE
Validate PD top logprobs metadata limit

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -32,6 +32,17 @@ if TYPE_CHECKING:
 FAKE_BOOTSTRAP_HOST = "2.2.2.2"
 _IS_HIP = is_hip()
 
+# MetadataBuffers allocates fixed top-logprob slots per token for PD transfer.
+MAX_PD_TOP_LOGPROBS_NUM = 128
+
+
+def validate_pd_top_logprobs_num(top_logprobs_num: int) -> None:
+    if top_logprobs_num > MAX_PD_TOP_LOGPROBS_NUM:
+        raise ValueError(
+            f"top_logprobs_num {top_logprobs_num} exceeds the maximum "
+            f"{MAX_PD_TOP_LOGPROBS_NUM} supported by PD metadata buffers."
+        )
+
 
 def is_dsv4_c128_online_enabled() -> bool:
     """Return whether DSV4 C128 uses request-scoped online state."""
@@ -225,7 +236,7 @@ class MetadataBuffers:
         size: int,
         hidden_size: int,
         hidden_states_dtype: torch.dtype,
-        max_top_logprobs_num: int = 128,
+        max_top_logprobs_num: int = MAX_PD_TOP_LOGPROBS_NUM,
         custom_mem_pool: torch.cuda.MemPool = None,
     ):
         self.custom_mem_pool = custom_mem_pool
@@ -246,8 +257,6 @@ class MetadataBuffers:
             if self.custom_mem_pool
             else nullcontext()
         ):
-            # TODO: abort top_logprobs_num > 128 in PD
-
             # We transfer the metadata of first output token to decode
             # The minimal size for RDMA is 64Bytes, so we pad it to > 64Bytes
             self.output_ids = torch.zeros((size, 16), dtype=torch.int32, device=device)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -62,6 +62,7 @@ from sglang.srt.disaggregation.utils import (
     ReqToMetadataIdxAllocator,
     TransferBackend,
     prepare_abort,
+    validate_pd_top_logprobs_num,
 )
 from sglang.srt.distributed import get_pp_group, get_world_group
 from sglang.srt.distributed.parallel_state import get_tp_group
@@ -2112,6 +2113,22 @@ class Scheduler(
                 multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
             )
             req.tokenizer = self.tokenizer
+
+            if (
+                self.disaggregation_mode == DisaggregationMode.PREFILL
+                and recv_req.return_logprob
+            ):
+                try:
+                    validate_pd_top_logprobs_num(recv_req.top_logprobs_num)
+                except ValueError as exc:
+                    error_msg = str(exc)
+                    logger.error(error_msg)
+                    recv_req.time_stats.trace_ctx.abort(
+                        abort_info={"reason": error_msg}
+                    )
+                    prepare_abort(req, error_msg, status_code=HTTPStatus.BAD_REQUEST)
+                    self.output_streamer.stream_output([req], req.return_logprob)
+                    return
 
             if self.disaggregation_mode != DisaggregationMode.NULL:
                 # Invalid request for disaggregated mode

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -46,7 +46,10 @@ from fastapi import BackgroundTasks
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.disaggregation.encode_receiver import create_mm_receiver
-from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.disaggregation.utils import (
+    DisaggregationMode,
+    validate_pd_top_logprobs_num,
+)
 from sglang.srt.environ import envs
 from sglang.srt.lora.lora_registry import LoRARef, LoRARegistry
 from sglang.srt.managers.async_dynamic_batch_tokenizer import AsyncDynamicbatchTokenizer
@@ -1016,6 +1019,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
+            self._validate_pd_top_logprobs_num(obj)
             if (
                 obj.return_hidden_states
                 and not self.server_args.enable_return_hidden_states
@@ -1032,6 +1036,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     "The server is not configured to enable custom logit processor. "
                     "Please set `--enable-custom-logit-processor` to enable this feature."
                 )
+
+    def _validate_pd_top_logprobs_num(self, obj: GenerateReqInput) -> None:
+        if (
+            self.disaggregation_mode != DisaggregationMode.PREFILL
+            or not obj.return_logprob
+        ):
+            return
+        validate_pd_top_logprobs_num(obj.top_logprobs_num)
 
     def _validate_mm_limits(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/test/registered/unit/disaggregation/test_pd_top_logprobs_validation.py
+++ b/test/registered/unit/disaggregation/test_pd_top_logprobs_validation.py
@@ -1,0 +1,173 @@
+"""Unit tests for PD top-logprobs metadata buffer limits."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.disaggregation.utils import (
+    DisaggregationMode,
+    MAX_PD_TOP_LOGPROBS_NUM,
+    MetadataBuffers,
+    validate_pd_top_logprobs_num,
+)
+from sglang.srt.managers.io_struct import GenerateReqInput, TokenizedGenerateReqInput
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_req_for_set_buf(top_logprobs_count: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata_buffer_index=0,
+        output_ids=[42],
+        cached_tokens=0,
+        cached_tokens_device=0,
+        cached_tokens_host=0,
+        cached_tokens_storage=0,
+        multimodal_inputs=None,
+        return_logprob=True,
+        bootstrap_room=1,
+        logprob=SimpleNamespace(
+            output_token_logprobs_val=[1.0],
+            output_token_logprobs_idx=[1],
+            output_top_logprobs_val=[[0.1] * top_logprobs_count],
+            output_top_logprobs_idx=[[i for i in range(top_logprobs_count)]],
+        ),
+        hidden_states_tensor=None,
+    )
+
+
+def _make_tokenizer_manager(mode: DisaggregationMode) -> TokenizerManager:
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.disaggregation_mode = mode
+    tm.context_len = 4096
+    tm.num_reserved_tokens = 0
+    tm.allow_auto_truncate = False
+    tm.validate_total_tokens = False
+    tm.is_generation = True
+    tm.model_config = MagicMock(vocab_size=32000)
+    tm.server_args = MagicMock(enable_return_hidden_states=False)
+    tm.server_args.enable_custom_logit_processor = False
+    return tm
+
+
+def _make_tokenized_req(top_logprobs_num: int) -> TokenizedGenerateReqInput:
+    recv = TokenizedGenerateReqInput(
+        rid="r1",
+        input_text="hi",
+        input_ids=array("q", [1, 2, 3]),
+        input_embeds=None,
+        mm_inputs=None,
+        token_type_ids=None,
+        sampling_params=SamplingParams(),
+        return_logprob=True,
+        logprob_start_len=0,
+        top_logprobs_num=top_logprobs_num,
+        token_ids_logprob=None,
+        stream=False,
+        bootstrap_host="127.0.0.1",
+        bootstrap_port=8998,
+        bootstrap_room=1,
+    )
+    recv.time_stats = MagicMock()
+    return recv
+
+
+def _make_prefill_scheduler() -> Scheduler:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.disaggregation_mode = DisaggregationMode.PREFILL
+    scheduler.server_args = MagicMock()
+    scheduler.server_args.disaggregation_bootstrap_port = 8998
+    scheduler.server_args.enable_session_radix_cache = False
+    scheduler.model_config = MagicMock()
+    scheduler.model_config.hf_eos_token_id = set()
+    scheduler.model_config.vocab_size = 32000
+    scheduler.metrics_reporter = MagicMock()
+    scheduler.metrics_reporter.enable_metrics = False
+    scheduler.dllm_config = None
+    scheduler.tokenizer = MagicMock()
+    scheduler.output_streamer = MagicMock()
+    scheduler.transfer_backend = MagicMock()
+    return scheduler
+
+
+class TestPdTopLogprobsValidation(CustomTestCase):
+    def test_metadata_buffers_set_buf_overflows_at_limit_plus_one(self):
+        # Documents the fixed PD metadata capacity that validation must protect.
+        bufs = MetadataBuffers(size=1, hidden_size=8, hidden_states_dtype=torch.float32)
+        req = _make_req_for_set_buf(MAX_PD_TOP_LOGPROBS_NUM + 1)
+
+        with self.assertRaises(RuntimeError):
+            bufs.set_buf(req)
+
+    def test_validate_pd_top_logprobs_num_allows_limit(self):
+        validate_pd_top_logprobs_num(MAX_PD_TOP_LOGPROBS_NUM)
+
+    def test_validate_pd_top_logprobs_num_allows_zero(self):
+        validate_pd_top_logprobs_num(0)
+
+    def test_validate_pd_top_logprobs_num_rejects_over_limit(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            f"top_logprobs_num {MAX_PD_TOP_LOGPROBS_NUM + 1} exceeds the maximum "
+            f"{MAX_PD_TOP_LOGPROBS_NUM}",
+        ):
+            validate_pd_top_logprobs_num(MAX_PD_TOP_LOGPROBS_NUM + 1)
+
+    def test_tokenizer_rejects_over_limit_on_pd_prefill(self):
+        tm = _make_tokenizer_manager(DisaggregationMode.PREFILL)
+        obj = GenerateReqInput(
+            text="hello",
+            return_logprob=True,
+            top_logprobs_num=MAX_PD_TOP_LOGPROBS_NUM + 1,
+        )
+        obj.normalize_batch_and_arguments()
+
+        with self.assertRaisesRegex(ValueError, str(MAX_PD_TOP_LOGPROBS_NUM + 1)):
+            tm._validate_one_request(obj, [1, 2, 3])
+
+    def test_tokenizer_allows_limit_on_pd_prefill(self):
+        tm = _make_tokenizer_manager(DisaggregationMode.PREFILL)
+        obj = GenerateReqInput(
+            text="hello",
+            return_logprob=True,
+            top_logprobs_num=MAX_PD_TOP_LOGPROBS_NUM,
+        )
+        obj.normalize_batch_and_arguments()
+        tm._validate_one_request(obj, [1, 2, 3])
+
+    def test_tokenizer_allows_over_limit_on_unified_mode(self):
+        tm = _make_tokenizer_manager(DisaggregationMode.NULL)
+        obj = GenerateReqInput(
+            text="hello",
+            return_logprob=True,
+            top_logprobs_num=MAX_PD_TOP_LOGPROBS_NUM + 1,
+        )
+        obj.normalize_batch_and_arguments()
+        tm._validate_one_request(obj, [1, 2, 3])
+
+    def test_scheduler_prefill_aborts_over_limit(self):
+        scheduler = _make_prefill_scheduler()
+        recv = _make_tokenized_req(MAX_PD_TOP_LOGPROBS_NUM + 1)
+
+        scheduler.handle_generate_request(recv)
+
+        scheduler.output_streamer.stream_output.assert_called_once()
+        req = scheduler.output_streamer.stream_output.call_args[0][0][0]
+        self.assertIsInstance(req.finished_reason, FINISH_ABORT)
+        self.assertEqual(req.finished_reason.status_code, 400)
+        self.assertIn(str(MAX_PD_TOP_LOGPROBS_NUM + 1), req.finished_reason.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Fixes a PD disaggregation prefill crash when a request asks for more top logprobs than the fixed PD metadata buffer supports.
PD prefill stores top-logprob metadata in `MetadataBuffers`, which has a fixed `max_top_logprobs_num` capacity of 128. Before this change, request paths could accept `top_logprobs_num > 128` and only fail later when prefill tried to copy the larger top-logprob list into the fixed-size metadata buffer.
Example failure:
```text
RuntimeError: The expanded size of the tensor (128) must match the existing size (129)
```
This PR rejects unsupported PD prefill logprob requests before scheduler execution.
## Modifications
- Add a canonical `MAX_PD_TOP_LOGPROBS_NUM` limit next to `MetadataBuffers`.
- Add PD top-logprobs validation for tokenizer-managed requests.
- Add the same validation in the scheduler path for skip-tokenizer/direct IPC requests.
- Preserve unified serving behavior, where this PD metadata-buffer limit does not apply.
- Add CPU unit coverage for the buffer overflow case, boundary validation, tokenizer validation, unified-mode behavior, and scheduler abort behavior.
## Accuracy Tests
N/A. This change only rejects invalid PD prefill requests that would otherwise crash the scheduler. Valid requests and model outputs are unchanged.
## Speed Tests and Profiling
N/A. This is request validation and does not affect normal inference execution.
## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A for this internal validation fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A because this change does not affect model outputs or inference speed.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
## Testing
```text
python -m pytest test/registered/unit/disaggregation/test_pd_top_logprobs_validation.py -q
python -m pytest test/registered/unit/test_decode_queue_cleanup.py -q
python -m py_compile python/sglang/srt/disaggregation/utils.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/managers/scheduler.py test/registered/unit/disaggregation/test_pd_top_logprobs_validation.py
python -m ruff check python/sglang/srt/disaggregation/utils.py test/registered/unit/disaggregation/test_pd_top_logprobs_validation.py
python -m ruff format --check test/registered/unit/disaggregation/test_pd_top_logprobs_validation.py
python3 scripts/ci/check_registered_tests.py
git diff --check
```

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29166720254](https://github.com/sgl-project/sglang/actions/runs/29166720254)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29166720172](https://github.com/sgl-project/sglang/actions/runs/29166720172)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->