### PR TITLE
[Bugfix] Fix Qwen MoE CUDA graph padding rows

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -125,6 +125,21 @@ _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
+def _zero_moe_padding_tail(
+    hidden_states: torch.Tensor,
+    num_token_non_padded: Optional[torch.Tensor],
+) -> None:
+    """Keep CUDA-graph-only rows out of residuals and TP collectives."""
+    if num_token_non_padded is None:
+        return
+
+    token_indices = torch.arange(hidden_states.shape[0], device=hidden_states.device)
+    hidden_states.masked_fill_(
+        token_indices[:, None] >= num_token_non_padded,
+        0,
+    )
+
+
 def get_num_shared_experts(config: PretrainedConfig) -> int:
     n_shared_experts = getattr(config, "n_shared_experts", None)
     if n_shared_experts is not None:
@@ -485,10 +500,22 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
 
         return final_hidden_states
 
-    def _forward_router_experts(self, hidden_states: torch.Tensor):
+    def _forward_router_experts(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: Optional[ForwardBatch] = None,
+    ):
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        topk_output = self.topk(hidden_states, router_logits)
+        topk_output = self.topk(
+            hidden_states,
+            router_logits,
+            num_token_non_padded=(
+                forward_batch.num_token_non_padded
+                if forward_batch is not None
+                else None
+            ),
+        )
         if self.enable_shared_expert_fusion and TopKOutputChecker.format_is_standard(
             topk_output
         ):
@@ -499,6 +526,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         self,
         hidden_states: torch.Tensor,
         use_fused_gate: bool = False,
+        forward_batch: Optional[ForwardBatch] = None,
     ) -> torch.Tensor:
         current_stream = torch.cuda.current_stream()
         self.alt_stream.wait_stream(current_stream)
@@ -527,7 +555,10 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         # ===== END TO BE REFACTORED ====
 
         with torch.cuda.stream(self.alt_stream):
-            router_output = self._forward_router_experts(hidden_states)
+            router_output = self._forward_router_experts(
+                hidden_states,
+                forward_batch,
+            )
 
         current_stream.wait_stream(self.alt_stream)
 
@@ -563,13 +594,18 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             final_hidden_states = self.experts(hidden_states, topk_output)
         elif self.alt_stream is not None and get_is_capture_mode():
             final_hidden_states, shared_output = self.forward_normal_dual_stream(
-                hidden_states, use_fused_gate=use_fused_gate
+                hidden_states,
+                use_fused_gate=use_fused_gate,
+                forward_batch=forward_batch,
             )
         else:
             shared_output = self._forward_shared_experts(
                 hidden_states, apply_gate=not use_fused_gate
             )
-            final_hidden_states = self._forward_router_experts(hidden_states)
+            final_hidden_states = self._forward_router_experts(
+                hidden_states,
+                forward_batch,
+            )
 
         if shared_output is not None:
             if use_fused_gate:
@@ -581,6 +617,11 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 )
             else:
                 final_hidden_states += shared_output
+
+        _zero_moe_padding_tail(
+            final_hidden_states,
+            (forward_batch.num_token_non_padded if forward_batch is not None else None),
+        )
         if (
             self.tp_size > 1
             and not should_skip_post_experts_all_reduce(

--- a/test/registered/unit/models/test_qwen2_moe_padding.py
+++ b/test/registered/unit/models/test_qwen2_moe_padding.py
@@ -1,0 +1,80 @@
+import unittest
+from types import MethodType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.models.qwen2_moe as qwen2_moe
+from sglang.srt.models.qwen2_moe import Qwen2MoeSparseMoeBlock
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _RecordingTopK:
+    def __init__(self):
+        self.num_token_non_padded = None
+
+    def __call__(
+        self,
+        hidden_states,
+        router_logits,
+        *,
+        num_token_non_padded=None,
+    ):
+        self.num_token_non_padded = num_token_non_padded
+        return object()
+
+
+class TestQwen2MoeCudaGraphPadding(unittest.TestCase):
+    def test_standard_moe_path_masks_and_zeroes_padded_rows(self):
+        num_tokens, hidden_size, num_valid = 8, 4, 5
+        hidden_states = torch.ones(num_tokens, hidden_size)
+        num_token_non_padded = torch.tensor(num_valid, dtype=torch.int32)
+        forward_batch = SimpleNamespace(
+            num_token_non_padded=num_token_non_padded,
+        )
+
+        topk = _RecordingTopK()
+        block = SimpleNamespace(
+            alt_stream=None,
+            enable_shared_expert_fusion=False,
+            experts=lambda hidden_states, topk_output: torch.full_like(
+                hidden_states, 2.0
+            ),
+            gate=lambda hidden_states: (
+                torch.zeros(hidden_states.shape[0], 2),
+                None,
+            ),
+            shared_expert_gate=None,
+            topk=topk,
+            tp_size=1,
+        )
+        block._forward_router_experts = MethodType(
+            Qwen2MoeSparseMoeBlock._forward_router_experts,
+            block,
+        )
+        block._forward_shared_experts = (
+            lambda hidden_states, apply_gate: torch.ones_like(hidden_states)
+        )
+
+        backend = SimpleNamespace(is_deepep=lambda: False)
+        with patch.object(qwen2_moe, "get_moe_a2a_backend", return_value=backend):
+            output = Qwen2MoeSparseMoeBlock.forward(
+                block,
+                hidden_states,
+                forward_batch,
+            )
+
+        self.assertIs(topk.num_token_non_padded, num_token_non_padded)
+        torch.testing.assert_close(
+            output[:num_valid],
+            torch.full((num_valid, hidden_size), 3.0),
+        )
+        self.assertTrue(
+            torch.equal(output[num_valid:], torch.zeros_like(output[num_valid:]))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

CUDA graph decode can pad a real batch to a captured batch size. In the
standard (non-DeepEP) Qwen2/Qwen3.5 MoE path, the real token count was not
forwarded to `TopK`, and the shared-expert merge could leave non-zero output in
graph-only rows. Those synthetic rows then entered the post-expert TP
collective.

With online weight updates and post-resume graph recapture, this caused a
multi-rank decode hang after a padded graph replay. Disabling CUDA graph
padding avoided the failure, but also gave up the intended graph coverage.

## Modifications

- Thread `ForwardBatch` through the standard and dual-stream routed-expert
  paths.
- Pass `num_token_non_padded` to `TopK`, matching the existing DeepEP path.
- Zero graph-only rows after routed and shared experts are merged and before
  the post-expert TP all-reduce.
- Add a deterministic CPU regression test for both the TopK metadata and the
  final padded output rows.

## Accuracy Tests

Pure SGLang model-level regression:

```text
python3 test/registered/unit/models/test_qwen2_moe_padding.py -v

test_standard_moe_path_masks_and_zeroes_padded_rows ... ok
Ran 1 test in 0.001s
OK
```

The test invokes the real `Qwen2MoeSparseMoeBlock.forward` control flow with
lightweight test doubles. It verifies that `TopK` receives the same
`num_token_non_padded` tensor and that only the graph-only output tail is zero.

Two-node GB200 integration A/B, using 8 SGLang ranks with padding-enabled
decode graphs and online weight updates:

| Variant | Result |
| --- | --- |
| TopK padded-row masking only | Second rollout hung at 51 real requests replaying the size-64 graph |
| TopK masking + output-tail zeroing | Two rollouts and two training updates completed |

Successful two-update metrics:

| Metric | Update 0 | Update 1 |
| --- | ---: | ---: |
| Mean response length | 18,736.00 | 6,699.26 |
| OPD reverse-KL | 0.044982 | 0.013613 |
| Grad norm | 0.313641 | 0.154027 |
| OIS | 1.0000002 | 1.0000001 |
| ESS | 0.9999980 | 0.9999998 |
| TIS | 1.0000207 | 0.9999925 |

The successful run crossed padded graph buckets at 255, 127, 65, 52, 51, and
50 real requests after the first weight update, then completed the second
update. No FlashInfer source change was used.

## Speed Tests and Profiling

No standalone microbenchmark was run. The added tail mask is device-side and
is captured as part of the decode CUDA graph when padded-token metadata is
enabled.

## Checklist

- [x] Format code with Black and isort; run Ruff checks.
- [x] Add a registered CPU unit test.
- [ ] Documentation update (not needed for this model-forward bug fix).
- [x] Provide accuracy/integration results above.
- [x] Follow the SGLang code style guidance.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29168512812](https://github.com/sgl-project/sglang/actions/runs/29168512812)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29168512737](https://github.com/sgl-project/sglang/actions/runs/29168512737)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->