### PR TITLE
[Bugfix] fix(hicache): wait for decode offload before retraction

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -198,21 +198,30 @@ class DecodeKVCacheOffloadManager:
         """Check the progress of offload from device to host and backup from host to storage."""
         cc = self.cache_controller
 
-        qsizes = torch.tensor(
-            [
-                len(cc.ack_write_queue),
-                cc.ack_backup_queue.qsize(),
-            ],
-            dtype=torch.int,
+        n_write, n_backup = self._collective_min_queue_sizes(
+            len(cc.ack_write_queue),
+            cc.ack_backup_queue.qsize(),
         )
-        if self.tp_world_size > 1:
-            torch.distributed.all_reduce(
-                qsizes, op=torch.distributed.ReduceOp.MIN, group=self.tp_group
-            )
-
-        n_write, n_backup = map(int, qsizes.tolist())
         self._check_offload_progress(n_write)
         self._check_backup_progress(n_backup)
+
+    def _collective_min_queue_sizes(self, *queue_sizes):
+        queue_sizes = torch.tensor(queue_sizes, dtype=torch.int)
+        if getattr(self, "tp_world_size", 1) > 1:
+            torch.distributed.all_reduce(
+                queue_sizes, op=torch.distributed.ReduceOp.MIN, group=self.tp_group
+            )
+        return map(int, queue_sizes.tolist())
+
+    def prepare_retraction(self, req: Req):
+        if not self._has_inflight_offload(req.rid):
+            return
+
+        (n_write,) = self._collective_min_queue_sizes(
+            len(self.cache_controller.ack_write_queue)
+        )
+        self._check_offload_progress(n_write)
+        assert not self._has_inflight_offload(req.rid)
 
     def _check_offload_progress(self, finish_count):
         """Check the progress of offload from device to host."""

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -206,22 +206,30 @@ class DecodeKVCacheOffloadManager:
         self._check_backup_progress(n_backup)
 
     def _collective_min_queue_sizes(self, *queue_sizes):
-        queue_sizes = torch.tensor(queue_sizes, dtype=torch.int)
+        queue_sizes = torch.tensor(queue_sizes, dtype=torch.int, device="cpu")
         if getattr(self, "tp_world_size", 1) > 1:
             torch.distributed.all_reduce(
                 queue_sizes, op=torch.distributed.ReduceOp.MIN, group=self.tp_group
             )
         return map(int, queue_sizes.tolist())
 
+    def _collective_any(self, value: bool) -> bool:
+        result = torch.tensor(int(value), dtype=torch.int, device="cpu")
+        if getattr(self, "tp_world_size", 1) > 1:
+            torch.distributed.all_reduce(
+                result, op=torch.distributed.ReduceOp.MAX, group=self.tp_group
+            )
+        return bool(result.item())
+
     def prepare_retraction(self, req: Req):
-        if not self._has_inflight_offload(req.rid):
+        if not self._collective_any(self._has_inflight_offload(req.rid)):
             return
 
-        (n_write,) = self._collective_min_queue_sizes(
-            len(self.cache_controller.ack_write_queue)
-        )
-        self._check_offload_progress(n_write)
-        assert not self._has_inflight_offload(req.rid)
+        self.check_offload_progress()
+        if self._collective_any(self._has_inflight_offload(req.rid)):
+            raise RuntimeError(
+                f"Cannot retract request {req.rid} with inflight decode KV offload"
+            )
 
     def _check_offload_progress(self, finish_count):
         """Check the progress of offload from device to host."""

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -209,6 +209,7 @@ class SchedulerDllmMixin:
             self.priority_scheduling_preemption_threshold,
             prefill_max_requests=self.server_args.prefill_max_requests,
             dllm_config=self.dllm_config,
+            prepare_kv_release=self.prepare_kv_release,
         )
 
     def _process_dllm_batches(self: Scheduler, adder: PrefillAdder) -> ForwardMode:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -49,6 +49,7 @@ from http import HTTPStatus
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     List,
     NamedTuple,
@@ -1669,6 +1670,7 @@ def release_req(
     tree_cache: BasePrefixCache,
     hisparse_coordinator: Optional[HiSparseCoordinator],
     offload_kv: bool = True,
+    prepare_kv_release: Optional[Callable[[Req], None]] = None,
 ) -> None:
     if hisparse_coordinator is not None and not req.finished():
         hisparse_coordinator.retract_req(req)
@@ -1677,6 +1679,8 @@ def release_req(
     # restored later without recompute (see resume_retracted_reqs/load_kv_cache).
     # Callers that will recompute the KV instead (PD true-retraction rebootstrap)
     # pass offload_kv=False to skip the wasteful device->host copy.
+    if prepare_kv_release is not None:
+        prepare_kv_release(req)
     if server_args.disaggregation_mode == "decode" and offload_kv:
         req.offload_kv_cache(req_to_token_pool, token_to_kv_pool_allocator)
     # TODO (csy): for preempted requests, we may want to insert into the tree
@@ -1697,6 +1701,7 @@ def retract_all(
     tree_cache: BasePrefixCache,
     hisparse_coordinator: Optional[HiSparseCoordinator],
     offload_kv: bool = True,
+    prepare_kv_release: Optional[Callable[[Req], None]] = None,
 ) -> List[Req]:
     retracted_reqs = reqs
     for idx in range(len(reqs)):
@@ -1709,6 +1714,7 @@ def retract_all(
             tree_cache=tree_cache,
             hisparse_coordinator=hisparse_coordinator,
             offload_kv=offload_kv,
+            prepare_kv_release=prepare_kv_release,
         )
     return retracted_reqs
 
@@ -2539,7 +2545,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         evict_from_tree_cache(self.tree_cache, num_tokens)
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens
 
-    def retract_all(self, server_args: ServerArgs, offload_kv: bool = True):
+    def retract_all(
+        self,
+        server_args: ServerArgs,
+        offload_kv: bool = True,
+        prepare_kv_release: Optional[Callable[[Req], None]] = None,
+    ):
         retracted_reqs = retract_all(
             reqs=self.reqs,
             server_args=server_args,
@@ -2548,12 +2559,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             tree_cache=self.tree_cache,
             hisparse_coordinator=self.hisparse_coordinator,
             offload_kv=offload_kv,
+            prepare_kv_release=prepare_kv_release,
         )
         self.reqs = []
         return retracted_reqs
 
     def retract_decode(
-        self, server_args: ServerArgs
+        self,
+        server_args: ServerArgs,
+        prepare_kv_release: Optional[Callable[[Req], None]] = None,
     ) -> Tuple[List[Req], float, List[Req]]:
         """Retract the decoding requests when there is not enough memory."""
         sorted_indices = self._get_decode_retraction_order(
@@ -2578,7 +2592,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req = self.reqs[idx]
             retracted_reqs.append(req)
             # release memory and don't insert into the tree because we need the space instantly
-            self.release_req(idx, len(sorted_indices), server_args)
+            self.release_req(
+                idx,
+                len(sorted_indices),
+                server_args,
+                prepare_kv_release=prepare_kv_release,
+            )
 
         reqs_to_abort: List[Req] = []
         if len(sorted_indices) <= 1 and not self.check_decode_mem(
@@ -2594,7 +2613,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
             reqs_to_abort.append(last_req)
-            self.release_req(last_idx, 0, server_args)
+            self.release_req(
+                last_idx,
+                0,
+                server_args,
+                prepare_kv_release=prepare_kv_release,
+            )
             logger.warning(
                 "retract_decode: aborted last request %s due to OOM", last_req.rid
             )
@@ -2654,7 +2678,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         )
         return sorted_indices
 
-    def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
+    def release_req(
+        self,
+        idx: int,
+        remaing_req_count: int,
+        server_args: ServerArgs,
+        prepare_kv_release: Optional[Callable[[Req], None]] = None,
+    ):
         release_req(
             req=self.reqs[idx],
             remaing_req_count=remaing_req_count,
@@ -2663,6 +2693,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             tree_cache=self.tree_cache,
             hisparse_coordinator=self.hisparse_coordinator,
+            prepare_kv_release=prepare_kv_release,
         )
 
     def prepare_encoder_info_decode(self):

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -30,7 +30,7 @@ import random
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Union
 
 import torch
 
@@ -456,6 +456,7 @@ class PrefillAdder:
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor] = None,
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
+        prepare_kv_release: Optional[Callable[[Req], None]] = None,
     ):
         self.page_size = page_size
         self.tree_cache = tree_cache
@@ -546,6 +547,7 @@ class PrefillAdder:
         # Snapshot of scheduler waiting_queue length at the start of this
         # prefill pass. Used by PrefillDelayer's queue-based trigger.
         self.waiting_queue_len = waiting_queue_len
+        self.prepare_kv_release = prepare_kv_release
 
     def _init_dllm_meta(self, dllm_config: DllmConfig):
         self.dllm_block_size = dllm_config.block_size
@@ -1212,7 +1214,10 @@ class PrefillAdder:
                 )
                 release_counter += 1
                 self.running_batch.release_req(
-                    i, len(self.running_batch.reqs) - release_counter, server_args
+                    i,
+                    len(self.running_batch.reqs) - release_counter,
+                    server_args,
+                    prepare_kv_release=self.prepare_kv_release,
                 )
             else:
                 keep_indices.append(i)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -480,6 +480,11 @@ class Scheduler(
             )
         else:
             self.decode_offload_manager = None
+        self.prepare_kv_release = (
+            self.decode_offload_manager.prepare_retraction
+            if self.decode_offload_manager is not None
+            else None
+        )
 
         # Register draft KV pool (when spec + HiCache co-enabled).
         kv_cache_builder.maybe_register_hicache_draft(
@@ -2851,6 +2856,7 @@ class Scheduler(
             prefill_delayer_single_pass=prefill_delayer_single_pass,
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
+            prepare_kv_release=self.prepare_kv_release,
         )
 
         if self.chunked_req is not None:
@@ -3088,7 +3094,8 @@ class Scheduler(
                 else None
             )
             retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode(
-                self.server_args
+                self.server_args,
+                prepare_kv_release=self.prepare_kv_release,
             )
             new_available_tokens = self.token_to_kv_pool_allocator.available_size()
             new_token_gained = new_available_tokens - old_available_tokens
@@ -4053,7 +4060,9 @@ class Scheduler(
                 # would otherwise do; the offloaded copy would be immediately
                 # discarded. Non-decode modes ignore offload_kv (they never offload).
                 retracted_reqs = self.running_batch.retract_all(
-                    self.server_args, offload_kv=False
+                    self.server_args,
+                    offload_kv=False,
+                    prepare_kv_release=self.prepare_kv_release,
                 )
                 for req in retracted_reqs:
                     if self.disaggregation_mode == DisaggregationMode.DECODE:

--- a/test/registered/disaggregation/test_specv2_kvcache_offloading.py
+++ b/test/registered/disaggregation/test_specv2_kvcache_offloading.py
@@ -8,7 +8,7 @@ Requires: torch, sglang (run in an environment with sglang installed)
 """
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -16,6 +16,7 @@ from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
     DecodeKVCacheOffloadManager,
 )
 from sglang.srt.disaggregation.kv_events import OffloadedState
+from sglang.srt.managers import schedule_batch
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
@@ -87,8 +88,11 @@ def _make_manager(pool_size: int, page_size: int = 1):
 
 
 class _FinishedEvent:
+    def __init__(self):
+        self.synchronized = False
+
     def synchronize(self):
-        pass
+        self.synchronized = True
 
 
 class TestReleaseFinishedReq(unittest.TestCase):
@@ -301,6 +305,120 @@ class TestReleaseFinishedReq(unittest.TestCase):
         self.assertEqual(freed, [])
         manager.req_to_token_pool.free.assert_not_called()
         self.assertNotIn(req.rid, manager.offload_inflight)
+
+    def test_prepare_retraction_drains_inflight_offload(self):
+        manager, _ = _make_manager(pool_size=32)
+        req = _make_mock_req(
+            req_pool_idx=0, kv_committed_len=20, kv_allocated_len=20, rid=6
+        )
+        req.finished.return_value = False
+        manager.offloaded_state[req.rid] = OffloadedState(
+            prefill_len=4, inc_len=4, last_hash="prior_hash"
+        )
+        manager.offload_inflight[req.rid] = 1
+        host_indices = object()
+        incremental_tokens = [10, 11, 12, 13]
+        start_time = 123.0
+        manager.ongoing_offload[10] = (
+            req,
+            host_indices,
+            incremental_tokens,
+            start_time,
+            4,
+            8,
+        )
+        finish_event = _FinishedEvent()
+        manager.cache_controller = MagicMock()
+        manager.cache_controller.ack_write_queue = [(None, finish_event, [10])]
+        manager.cache_controller.ack_backup_queue.qsize.return_value = 0
+        manager._trigger_backup = MagicMock(return_value="next_hash")
+
+        manager.prepare_retraction(req)
+
+        self.assertTrue(finish_event.synchronized)
+        self.assertNotIn(req.rid, manager.offload_inflight)
+        self.assertNotIn(10, manager.ongoing_offload)
+        manager._trigger_backup.assert_called_once_with(
+            req,
+            host_indices,
+            incremental_tokens,
+            start_time,
+            "prior_hash",
+        )
+        self.assertEqual(manager.offloaded_state[req.rid].last_hash, "next_hash")
+
+    def test_prepare_retraction_fails_closed_when_only_peer_is_inflight(self):
+        manager, _ = _make_manager(pool_size=32)
+        req = _make_mock_req(
+            req_pool_idx=0, kv_committed_len=20, kv_allocated_len=20, rid=7
+        )
+        manager.tp_world_size = 2
+        manager.tp_group = object()
+        manager.cache_controller = MagicMock()
+        manager.cache_controller.ack_write_queue = []
+        manager.cache_controller.ack_backup_queue.qsize.return_value = 0
+        collectives = []
+
+        def simulate_peer_inflight(tensor, op, group):
+            self.assertIs(group, manager.tp_group)
+            collectives.append((tensor.numel(), op))
+            if op == torch.distributed.ReduceOp.MAX:
+                tensor.fill_(1)
+
+        with (
+            patch.object(
+                torch.distributed,
+                "all_reduce",
+                side_effect=simulate_peer_inflight,
+            ),
+            self.assertRaisesRegex(RuntimeError, "inflight decode KV offload"),
+        ):
+            manager.prepare_retraction(req)
+
+        self.assertEqual(
+            collectives,
+            [
+                (1, torch.distributed.ReduceOp.MAX),
+                (2, torch.distributed.ReduceOp.MIN),
+                (1, torch.distributed.ReduceOp.MAX),
+            ],
+        )
+
+    def test_release_req_prepares_kv_before_offload_and_release(self):
+        events = []
+        req = object.__new__(schedule_batch.Req)
+        req.finished_reason = None
+        req.reset_for_retract = lambda: None
+
+        def prepare_kv_release(released_req):
+            self.assertIs(released_req, req)
+            events.append("prepare")
+
+        with (
+            patch.object(
+                req,
+                "offload_kv_cache",
+                side_effect=lambda *args, **kwargs: events.append("offload"),
+            ),
+            patch.object(
+                schedule_batch,
+                "release_kv_cache",
+                side_effect=lambda *args, **kwargs: events.append("release"),
+            ),
+            patch.object(schedule_batch, "evict_from_tree_cache"),
+        ):
+            schedule_batch.release_req(
+                req=req,
+                remaing_req_count=0,
+                server_args=MagicMock(disaggregation_mode="decode"),
+                req_to_token_pool=MagicMock(),
+                token_to_kv_pool_allocator=MagicMock(),
+                tree_cache=MagicMock(),
+                hisparse_coordinator=None,
+                prepare_kv_release=prepare_kv_release,
+            )
+
+        self.assertEqual(events, ["prepare", "offload", "release"])
 
     def test_offload_kv_cache_tracks_inflight_write_until_ack(self):
         manager, freed = _make_manager(pool_size=32, page_size=4)

--- a/test/registered/disaggregation/test_specv2_kvcache_offloading.py
+++ b/test/registered/disaggregation/test_specv2_kvcache_offloading.py
@@ -8,6 +8,7 @@ Requires: torch, sglang (run in an environment with sglang installed)
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -85,6 +86,16 @@ def _make_manager(pool_size: int, page_size: int = 1):
     manager.offload_inflight = {}
 
     return manager, freed_indices
+
+
+def _make_release_batch(reqs):
+    batch = object.__new__(schedule_batch.ScheduleBatch)
+    batch.reqs = reqs
+    batch.req_to_token_pool = MagicMock()
+    batch.token_to_kv_pool_allocator = MagicMock()
+    batch.tree_cache = MagicMock()
+    batch.hisparse_coordinator = None
+    return batch
 
 
 class _FinishedEvent:
@@ -419,6 +430,71 @@ class TestReleaseFinishedReq(unittest.TestCase):
             )
 
         self.assertEqual(events, ["prepare", "offload", "release"])
+
+    def test_retract_decode_propagates_prepare_callback_to_release(self):
+        events = []
+        keep_req = _make_mock_req(0, 20, 20, rid=8)
+        retract_req = _make_mock_req(0, 20, 20, rid=9)
+        retract_req.offload_kv_cache.side_effect = lambda *args: events.append(
+            "offload"
+        )
+        batch = _make_release_batch([keep_req, retract_req])
+        batch.spec_algorithm = MagicMock()
+        batch.spec_algorithm.is_none.return_value = True
+        batch._get_decode_retraction_order = MagicMock(return_value=[0, 1])
+        batch.check_decode_mem = MagicMock(return_value=True)
+        batch.filter_batch = MagicMock()
+        for req in batch.reqs:
+            req.output_ids = []
+            req.sampling_params.max_new_tokens = 10
+
+        def prepare_kv_release(req):
+            self.assertIs(req, retract_req)
+            events.append("prepare")
+
+        with (
+            patch.object(
+                schedule_batch,
+                "release_kv_cache",
+                side_effect=lambda *args, **kwargs: events.append("release"),
+            ),
+            patch.object(schedule_batch, "evict_from_tree_cache"),
+        ):
+            retracted, _, aborted = batch.retract_decode(
+                SimpleNamespace(disaggregation_mode="decode"),
+                prepare_kv_release=prepare_kv_release,
+            )
+
+        self.assertEqual(retracted, [retract_req])
+        self.assertEqual(aborted, [])
+        self.assertEqual(events, ["prepare", "offload", "release"])
+
+    def test_retract_all_propagates_prepare_callback_to_release(self):
+        events = []
+        req = _make_mock_req(0, 20, 20, rid=10)
+        batch = _make_release_batch([req])
+
+        def prepare_kv_release(released_req):
+            self.assertIs(released_req, req)
+            events.append("prepare")
+
+        with (
+            patch.object(
+                schedule_batch,
+                "release_kv_cache",
+                side_effect=lambda *args, **kwargs: events.append("release"),
+            ),
+            patch.object(schedule_batch, "evict_from_tree_cache"),
+        ):
+            retracted = batch.retract_all(
+                SimpleNamespace(disaggregation_mode="decode"),
+                offload_kv=False,
+                prepare_kv_release=prepare_kv_release,
+            )
+
+        self.assertEqual(retracted, [req])
+        self.assertEqual(batch.reqs, [])
+        self.assertEqual(events, ["prepare", "release"])
 
     def test_offload_kv_cache_tracks_inflight_write_until_ack(self):
         manager, freed = _make_manager(pool_size=32, page_size=4)

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -1,7 +1,8 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from sglang.srt.managers import schedule_batch
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.mem_cache.base_prefix_cache import (
@@ -133,6 +134,51 @@ class TestPrefillAdder(CustomTestCase):
         self.assertIn(running_reqs[0], adder.preempt_list)
         self.assertEqual(adder.rem_total_token_offset, 175)  # 50 + 75 + 100 - 50 = 175
         running_batch.release_req.assert_called_once()
+
+    def test_preemption_propagates_prepare_callback_to_release(self):
+        events = []
+        running_req = self.create_mock_req("run", 0, 50)
+        running_req.offload_kv_cache.side_effect = lambda *args: events.append(
+            "offload"
+        )
+        running_batch = object.__new__(schedule_batch.ScheduleBatch)
+        running_batch.reqs = [running_req]
+        running_batch.req_to_token_pool = MagicMock()
+        running_batch.token_to_kv_pool_allocator = self.mock_token_allocator
+        running_batch.tree_cache = self.mock_tree_cache
+        running_batch.hisparse_coordinator = None
+        running_batch.filter_batch = MagicMock()
+
+        def prepare_kv_release(req):
+            self.assertIs(req, running_req)
+            events.append("prepare")
+
+        adder = self.create_adder(
+            running_batch,
+            prepare_kv_release=prepare_kv_release,
+        )
+        self.mock_token_allocator.full_available_size.return_value = 50
+        self.mock_token_allocator.available_size.return_value = 50
+        new_req = self.create_mock_req("new", priority=1, max_new_tokens=49)
+
+        with (
+            patch.object(
+                schedule_batch,
+                "release_kv_cache",
+                side_effect=lambda *args, **kwargs: events.append("release"),
+            ),
+            patch.object(schedule_batch, "evict_from_tree_cache"),
+        ):
+            success = adder.preempt_to_schedule(
+                new_req,
+                SimpleNamespace(
+                    schedule_low_priority_values_first=False,
+                    disaggregation_mode="decode",
+                ),
+            )
+
+        self.assertTrue(success)
+        self.assertEqual(events, ["prepare", "offload", "release"])
 
     def test_preempt_success_low_priority_values_first(self):
         params = [

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -1,12 +1,16 @@
+import sys
 import unittest
 from collections import deque
+from contextlib import ExitStack
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
+sys.modules.setdefault("mlx", MagicMock())
+sys.modules.setdefault("mlx.core", MagicMock())
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import (
@@ -15,6 +19,7 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.scheduler_components.pool_stats_observer import PoolStats
+from sglang.srt.server_args import ServerArgs
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 register_cpu_ci(est_time=9, suite="base-c-test-cpu")
@@ -37,6 +42,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         scheduler.req_to_token_pool = MagicMock()
         scheduler.result_queue = deque()
         scheduler.disaggregation_mode = DisaggregationMode.NULL
+        scheduler.prepare_kv_release = MagicMock()
         # Support _kv_snap diagnostic logging in patched schedulers
         scheduler.token_to_kv_pool_allocator = MagicMock()
         scheduler.token_to_kv_pool_allocator.available_size.return_value = 1000
@@ -163,7 +169,147 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         # Rebootstrap recomputes the KV from the prefill, so the retract must skip
         # the device->host KV offload rather than offload-then-delete it.
         scheduler.running_batch.retract_all.assert_called_once_with(
-            scheduler.server_args, offload_kv=False
+            scheduler.server_args,
+            offload_kv=False,
+            prepare_kv_release=scheduler.prepare_kv_release,
+        )
+
+    def test_oom_retraction_forwards_prepare_callback(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = False
+        scheduler.forward_ct = 1
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.token_to_kv_pool_allocator.available_size.return_value = 0
+        scheduler.tree_cache = MagicMock()
+        scheduler.tree_cache.req_to_token_pool.mamba_allocator = None
+        scheduler.new_token_ratio_tracker = SimpleNamespace(current=1.0)
+        scheduler.server_args = MagicMock()
+        scheduler.prepare_kv_release = MagicMock()
+
+        batch = MagicMock()
+        batch.batch_size.return_value = 2
+        batch.is_empty.return_value = False
+        batch.check_decode_mem.return_value = False
+
+        class StopAfterRetraction(Exception):
+            pass
+
+        batch.retract_decode.side_effect = StopAfterRetraction
+
+        with self.assertRaises(StopAfterRetraction):
+            scheduler.update_running_batch(batch)
+
+        batch.retract_decode.assert_called_once_with(
+            scheduler.server_args,
+            prepare_kv_release=scheduler.prepare_kv_release,
+        )
+
+    def test_decode_offload_manager_provisions_prepare_callback(self):
+        class StopAfterProvisioning(Exception):
+            pass
+
+        scheduler = Scheduler.__new__(Scheduler)
+        server_args = ServerArgs(
+            model_path="dummy",
+            disaggregation_mode="decode",
+            disaggregation_decode_enable_offload_kvcache=True,
+        )
+        pool_result = SimpleNamespace(
+            is_hybrid_swa=False,
+            is_hybrid_ssm=False,
+            sliding_window_size=None,
+            full_tokens_per_layer=None,
+            swa_tokens_per_layer=None,
+            req_to_token_pool=MagicMock(),
+            token_to_kv_pool_allocator=MagicMock(),
+            disable_radix_cache=False,
+            tree_cache=MagicMock(),
+        )
+        offload_manager = MagicMock()
+
+        def init_model_config(instance):
+            instance.model_config = MagicMock()
+
+        def init_model_worker(instance):
+            instance.tp_worker = MagicMock()
+            instance.tp_worker.model_runner.canary_manager = None
+            instance.draft_worker = None
+            instance.attn_tp_cpu_group = MagicMock()
+            instance.tp_cpu_group = MagicMock()
+            instance.attn_cp_cpu_group = MagicMock()
+            instance.tp_group = MagicMock()
+            instance.pp_group = MagicMock()
+
+        no_op_initializers = (
+            "init_soft_watchdog",
+            "init_metrics_collector",
+            "init_ipc_channels",
+            "init_idle_sleeper",
+            "init_zbal_on_npu",
+            "init_tokenizer",
+            "init_moe_gemm_config",
+            "init_mamba_backend",
+            "init_hisparse_coordinator",
+        )
+        with ExitStack() as stack:
+            for name in no_op_initializers:
+                stack.enter_context(patch.object(Scheduler, name, autospec=True))
+            stack.enter_context(
+                patch.object(
+                    Scheduler,
+                    "init_model_config",
+                    autospec=True,
+                    side_effect=init_model_config,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    Scheduler,
+                    "init_model_worker",
+                    autospec=True,
+                    side_effect=init_model_worker,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.managers.scheduler.kv_cache_builder.build_kv_cache",
+                    return_value=pool_result,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.managers.scheduler.DecodeKVCacheOffloadManager",
+                    return_value=offload_manager,
+                )
+            )
+            stack.enter_context(
+                patch("sglang.srt.managers.scheduler.maybe_revert_pr_fix")
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.managers.scheduler.kv_cache_builder.maybe_register_hicache_draft",
+                    side_effect=StopAfterProvisioning,
+                )
+            )
+
+            with self.assertRaises(StopAfterProvisioning):
+                Scheduler.__init__(
+                    scheduler,
+                    server_args=server_args,
+                    port_args=SimpleNamespace(nccl_port=12345),
+                    gpu_id=0,
+                    tp_rank=0,
+                    moe_ep_rank=0,
+                    pp_rank=0,
+                    attn_cp_rank=0,
+                    moe_dp_rank=0,
+                    dp_rank=0,
+                )
+
+        self.assertIs(scheduler.decode_offload_manager, offload_manager)
+        self.assertIs(
+            scheduler.prepare_kv_release,
+            offload_manager.prepare_retraction,
         )
 
     def test_pd_decode_continue_releases_held_rebootstrap(self):


### PR DESCRIPTION
## Motivation

Decode-side HiCache offload copies incremental KV from device to host asynchronously. Request retraction currently bypasses the offload manager and can return those KV pages to the allocator while the D2H copy is still reading them. A subsequent request can reuse the pages, allowing the old offload to persist unrelated KV under the retracted request's cache keys.

## Modifications

- Add a collective retraction barrier to `DecodeKVCacheOffloadManager` that drains the existing D2H acknowledgement path before KV release.
- Fail closed across TP ranks if any rank still has an inflight offload after progress processing.
- Propagate the release-preparation callback through OOM retraction, pause/retract-all, and priority preemption paths.
- Add unit coverage for acknowledgement processing, release ordering, asymmetric TP state, and callback propagation through each retraction path.

## Accuracy Tests

This change does not alter model forward or sampling behavior. The affected unit suites pass:

```text
41 passed
```

Command:

```bash
PYTHONPATH=/var/folders/nn/833fm1k13_sb8hxhf8yxr5gm0000gn/T/opencode/sglang-verify:python python -m pytest test/registered/disaggregation/test_specv2_kvcache_offloading.py test/registered/unit/managers/test_prefill_adder.py test/registered/unit/managers/test_scheduler_pause_generation.py
```

## Speed Tests and Profiling

No benchmark was run. The normal decode path remains asynchronous. Only retraction with an active D2H offload waits for completion before releasing pages.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: no user-facing API or configuration changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable: no model-forward change; retraction-only synchronization.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29170944405](https://github.com/sgl-project/sglang/actions/runs/29170944405)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29170944350](https://github.com/sgl-project/sglang/actions/runs/29170944350)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #29170944381](https://github.com/sgl-project/sglang/actions/runs/29170944381)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->