### PR TITLE
fix: cap CUDA IPC multimodal pool budget

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -35,6 +35,7 @@ from sglang.srt.utils.cuda_ipc_transport_utils import (
     MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL,
     CudaIpcTensorTransportProxy,
     MmItemMemoryPool,
+    get_mm_feature_pool_size_per_worker,
 )
 
 _is_cpu = is_cpu()
@@ -272,16 +273,19 @@ class BaseMultimodalProcessor(ABC):
             # tokenizer workers. Each worker gets an equal share so that adding
             # workers doesn't multiply the GPU-side footprint.
             worker_num = self.server_args.tokenizer_worker_num
-            per_worker_pool_size = max(
-                MM_FEATURE_CACHE_SIZE // worker_num,
-                128 * 1024 * 1024,
+            per_worker_pool_size = get_mm_feature_pool_size_per_worker(
+                MM_FEATURE_CACHE_SIZE, worker_num
             )
+            total_pool_size = per_worker_pool_size * worker_num
             logger.info(
-                "MmItemMemoryPool size per tokenizer worker: %.0f MiB "
-                "(budget %.0f MiB / %d worker(s))",
+                "CUDA IPC multimodal feature pools reserve %.0f MiB total on "
+                "GPU %d (%.0f MiB per tokenizer worker × %d; configured "
+                "budget %.0f MiB).",
+                total_pool_size / (1024 * 1024),
+                self.server_args.base_gpu_id,
                 per_worker_pool_size / (1024 * 1024),
-                MM_FEATURE_CACHE_SIZE / (1024 * 1024),
                 worker_num,
+                MM_FEATURE_CACHE_SIZE / (1024 * 1024),
             )
             self.cudaipc_mmfeature_pool = MmItemMemoryPool(
                 per_worker_pool_size,

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -23,6 +23,25 @@ MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL = (
 SHM_LOCK_FILE = "/tmp/shm_wr_lock.lock"
 
 
+def get_mm_feature_pool_size_per_worker(
+    total_pool_size: int, tokenizer_worker_num: int
+) -> int:
+    """Split the CUDA IPC feature-pool budget without exceeding it.
+
+    Each tokenizer worker owns a distinct CUDA allocation, even though all pools
+    are created on ``base_gpu_id``.  Therefore a minimum per-worker allocation
+    would make the aggregate HBM reservation larger than the configured budget.
+    Keep the configured value as a hard per-node cap and leave at most
+    ``tokenizer_worker_num - 1`` bytes unused when it is not evenly divisible.
+    """
+    if total_pool_size <= 0:
+        raise ValueError("total_pool_size must be positive")
+    if tokenizer_worker_num <= 0:
+        raise ValueError("tokenizer_worker_num must be positive")
+
+    return total_pool_size // tokenizer_worker_num
+
+
 # Cache for pool-level IPC handles on the consumer side.
 # Key: the pool CUDA IPC handle tuple. Value: opened UntypedStorage.
 _pool_storage_cache: dict = {}

--- a/test/registered/unit/multimodal/test_cuda_ipc_pool_budget.py
+++ b/test/registered/unit/multimodal/test_cuda_ipc_pool_budget.py
@@ -1,0 +1,35 @@
+"""CPU-only regression tests for CUDA IPC multimodal pool budgeting."""
+
+import unittest
+
+from sglang.srt.utils.cuda_ipc_transport_utils import (
+    get_mm_feature_pool_size_per_worker,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestCudaIpcPoolBudget(unittest.TestCase):
+    def test_budget_is_not_multiplied_by_tokenizer_workers(self):
+        budget = 1_024 * 1024 * 1024
+        worker_num = 16
+
+        per_worker = get_mm_feature_pool_size_per_worker(budget, worker_num)
+
+        self.assertEqual(per_worker, 64 * 1024 * 1024)
+        self.assertLessEqual(per_worker * worker_num, budget)
+
+    def test_remainder_is_not_overallocated(self):
+        self.assertEqual(get_mm_feature_pool_size_per_worker(1_001, 8), 125)
+        self.assertLessEqual(get_mm_feature_pool_size_per_worker(1_001, 8) * 8, 1_001)
+
+    def test_rejects_invalid_budget_or_worker_count(self):
+        with self.assertRaisesRegex(ValueError, "total_pool_size"):
+            get_mm_feature_pool_size_per_worker(0, 1)
+        with self.assertRaisesRegex(ValueError, "tokenizer_worker_num"):
+            get_mm_feature_pool_size_per_worker(1, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- treat `SGLANG_MM_FEATURE_CACHE_MB` as a hard per-node CUDA IPC pool budget across tokenizer workers
- report the actual total and per-worker HBM reservation at startup
- add CPU-only regression coverage for budget splitting

## Root cause

Each tokenizer worker owns a distinct allocation on `base_gpu_id`. The previous 128 MiB per-worker floor could make the aggregate reservation larger than the configured budget (for example, a 1 GiB budget with 16 workers reserved 2 GiB).

## Behavior

The pool now splits the configured budget exactly across workers. A pool miss retains the existing CPU-transport fallback, so SGLang does not allocate additional CUDA memory to preserve IPC.

## Validation

- `PYTHONPATH=$PWD/python uv run python -m pytest test/registered/unit/multimodal/test_cuda_ipc_pool_budget.py -v`
- direct-file `unittest` invocation
- pre-commit hooks (including registered-test CI validation)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29174721443](https://github.com/sgl-project/sglang/actions/runs/29174721443)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29174721370](https://github.com/sgl-project/sglang/actions/runs/29174721370)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->