### PR TITLE
Fix deterministic inference test coverage

### DIFF
--- a/python/sglang/test/test_deterministic_utils.py
+++ b/python/sglang/test/test_deterministic_utils.py
@@ -10,18 +10,18 @@ from sglang.test.test_utils import (
 )
 
 DEFAULT_MODEL = "Qwen/Qwen3-8B"
-COMMON_SERVER_ARGS = [
+COMMON_SERVER_ARGS = (
     "--trust-remote-code",
     "--cuda-graph-max-bs-decode",
     "32",
     "--enable-deterministic-inference",
-]
+)
 
 
 class TestDeterministicBase(CustomTestCase):
     @classmethod
     def get_server_args(cls):
-        return COMMON_SERVER_ARGS
+        return list(COMMON_SERVER_ARGS)
 
     @classmethod
     def get_model(cls):
@@ -31,19 +31,21 @@ class TestDeterministicBase(CustomTestCase):
     def setUpClass(cls):
         cls.model = cls.get_model()
         cls.base_url = DEFAULT_URL_FOR_TEST
-        if "--attention-backend" not in cls.get_server_args():
+        server_args = cls.get_server_args()
+        if "--attention-backend" not in server_args:
             raise unittest.SkipTest("Skip the base test class")
 
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.get_server_args(),
+            other_args=server_args,
         )
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
 
     def _extract_host_and_port(self, url):
         return url.split("://")[-1].split(":")[0], int(url.split(":")[-1])
@@ -55,8 +57,8 @@ class TestDeterministicBase(CustomTestCase):
         args.test_mode = "single"
         args.n_start = 10
         args.n_trials = 20
-        results = test_deterministic(args)
         args.temperature = 0.5  # test for deterministic sampling
+        results = test_deterministic(args)
         for result in results:
             assert result == 1
 

--- a/python/sglang/test/test_deterministic_utils.py
+++ b/python/sglang/test/test_deterministic_utils.py
@@ -10,18 +10,18 @@ from sglang.test.test_utils import (
 )
 
 DEFAULT_MODEL = "Qwen/Qwen3-8B"
-COMMON_SERVER_ARGS = [
+COMMON_SERVER_ARGS = (
     "--trust-remote-code",
     "--cuda-graph-max-bs-decode",
     "32",
     "--enable-deterministic-inference",
-]
+)
 
 
 class TestDeterministicBase(CustomTestCase):
     @classmethod
     def get_server_args(cls):
-        return COMMON_SERVER_ARGS
+        return list(COMMON_SERVER_ARGS)
 
     @classmethod
     def get_model(cls):
@@ -36,16 +36,18 @@ class TestDeterministicBase(CustomTestCase):
         if cls is TestDeterministicBase:
             raise unittest.SkipTest("Skip the base test class")
 
+        server_args = cls.get_server_args()
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.get_server_args(),
+            other_args=server_args,
         )
 
     @classmethod
     def tearDownClass(cls):
-        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
+        if hasattr(cls, "process") and cls.process:
+            terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
     def _extract_host_and_port(self, url):
         return url.split("://")[-1].split(":")[0], int(url.split(":")[-1])
@@ -57,8 +59,8 @@ class TestDeterministicBase(CustomTestCase):
         args.test_mode = "single"
         args.n_start = 10
         args.n_trials = 20
-        results = test_deterministic(args)
         args.temperature = 0.5  # test for deterministic sampling
+        results = test_deterministic(args)
         for result in results:
             assert result == 1
 

--- a/test/registered/attention/test_deepseek_v3_deterministic.py
+++ b/test/registered/attention/test_deepseek_v3_deterministic.py
@@ -25,14 +25,10 @@ class TestFa3Deterministic(TestDeterministicBase):
     # Test with fa3 attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
-        args.extend(
-            [
-                "--attention-backend",
-                "fa3",
-            ]
-        )
-        return args
+        return list(COMMON_SERVER_ARGS) + [
+            "--attention-backend",
+            "fa3",
+        ]
 
 
 class TestTritonDeterministic(TestDeterministicBase):
@@ -43,14 +39,10 @@ class TestTritonDeterministic(TestDeterministicBase):
     # Test with triton attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
-        args.extend(
-            [
-                "--attention-backend",
-                "triton",
-            ]
-        )
-        return args
+        return list(COMMON_SERVER_ARGS) + [
+            "--attention-backend",
+            "triton",
+        ]
 
 
 if __name__ == "__main__":

--- a/test/registered/attention/test_deterministic.py
+++ b/test/registered/attention/test_deterministic.py
@@ -25,14 +25,10 @@ class TestFlashinferDeterministic(TestDeterministicBase):
     # Test with flashinfer attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
-        args.extend(
-            [
-                "--attention-backend",
-                "flashinfer",
-            ]
-        )
-        return args
+        return list(COMMON_SERVER_ARGS) + [
+            "--attention-backend",
+            "flashinfer",
+        ]
 
 
 @unittest.skipIf(is_in_amd_ci(), "Skip for AMD CI.")
@@ -40,28 +36,20 @@ class TestFa3Deterministic(TestDeterministicBase):
     # Test with fa3 attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
-        args.extend(
-            [
-                "--attention-backend",
-                "fa3",
-            ]
-        )
-        return args
+        return list(COMMON_SERVER_ARGS) + [
+            "--attention-backend",
+            "fa3",
+        ]
 
 
 class TestTritonDeterministic(TestDeterministicBase):
     # Test with triton attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
-        args.extend(
-            [
-                "--attention-backend",
-                "triton",
-            ]
-        )
-        return args
+        return list(COMMON_SERVER_ARGS) + [
+            "--attention-backend",
+            "triton",
+        ]
 
 
 if __name__ == "__main__":

--- a/test/registered/attention/test_glm4_moe_lite_deterministic.py
+++ b/test/registered/attention/test_glm4_moe_lite_deterministic.py
@@ -27,7 +27,7 @@ GLM_MODEL = "zai-org/GLM-4.7-Flash"
 # COMMON_SERVER_ARGS is shared module state; copy it. Extending it in place
 # would leak the fa4 flag into the auto class below and silently make that
 # test a second fa4 test.
-SERVER_ARGS = COMMON_SERVER_ARGS + [
+SERVER_ARGS = list(COMMON_SERVER_ARGS) + [
     "--chunked-prefill-size",
     "2048",
     "--max-prefill-tokens",

--- a/test/registered/attention/test_qwen3_next_deterministic.py
+++ b/test/registered/attention/test_qwen3_next_deterministic.py
@@ -25,9 +25,12 @@ class TestFlashInferDeterministic(TestDeterministicBase):
     # Test with flashinfer attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
-        args.extend(["--attention-backend", "flashinfer", "--tp", "4"])
-        return args
+        return list(COMMON_SERVER_ARGS) + [
+            "--attention-backend",
+            "flashinfer",
+            "--tp",
+            "4",
+        ]
 
 
 class TestTritonDeterministic(TestDeterministicBase):
@@ -38,9 +41,12 @@ class TestTritonDeterministic(TestDeterministicBase):
     # Test with triton attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
-        args.extend(["--attention-backend", "triton", "--tp", "4"])
-        return args
+        return list(COMMON_SERVER_ARGS) + [
+            "--attention-backend",
+            "triton",
+            "--tp",
+            "4",
+        ]
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_deterministic_utils.py
+++ b/test/registered/unit/test_deterministic_utils.py
@@ -1,0 +1,96 @@
+"""Unit tests for the deterministic inference test harness."""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.test import test_deterministic_utils as deterministic_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestDeterministicUtils(CustomTestCase):
+    def test_common_server_args_are_immutable_and_copied(self):
+        first = deterministic_utils.TestDeterministicBase.get_server_args()
+        second = deterministic_utils.TestDeterministicBase.get_server_args()
+
+        self.assertIsInstance(deterministic_utils.COMMON_SERVER_ARGS, tuple)
+        self.assertIsNot(first, second)
+
+        first.extend(["--attention-backend", "fa3"])
+        self.assertNotIn("--attention-backend", second)
+        self.assertNotIn("--attention-backend", deterministic_utils.COMMON_SERVER_ARGS)
+
+    def test_single_configures_sampling_before_running(self):
+        def capture_args(args):
+            self.assertEqual(args.test_mode, "single")
+            self.assertEqual(args.temperature, 0.5)
+            self.assertEqual(args.sampling_seed, 42)
+            return [1]
+
+        case = deterministic_utils.TestDeterministicBase(methodName="test_single")
+
+        with patch.object(
+            deterministic_utils, "test_deterministic", side_effect=capture_args
+        ) as mock_test_deterministic:
+            case.test_single()
+
+        mock_test_deterministic.assert_called_once()
+
+    @patch.object(deterministic_utils, "popen_launch_server")
+    def test_setup_uses_one_server_args_snapshot(self, mock_launch_server):
+        class BackendTest(deterministic_utils.TestDeterministicBase):
+            server_args_calls = 0
+
+            @classmethod
+            def get_model(cls):
+                return "test/model"
+
+            @classmethod
+            def get_server_args(cls):
+                cls.server_args_calls += 1
+                return [
+                    "--attention-backend",
+                    "fa3",
+                    "--snapshot",
+                    str(cls.server_args_calls),
+                ]
+
+        mock_launch_server.return_value.pid = 123
+
+        BackendTest.setUpClass()
+
+        self.assertEqual(BackendTest.server_args_calls, 1)
+        mock_launch_server.assert_called_once_with(
+            "test/model",
+            deterministic_utils.DEFAULT_URL_FOR_TEST,
+            timeout=deterministic_utils.DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=["--attention-backend", "fa3", "--snapshot", "1"],
+        )
+
+        with patch.object(deterministic_utils, "kill_process_tree") as mock_kill:
+            BackendTest.tearDownClass()
+            mock_kill.assert_called_once_with(123)
+
+    def test_teardown_is_safe_after_server_launch_failure(self):
+        class BackendTest(deterministic_utils.TestDeterministicBase):
+            @classmethod
+            def get_server_args(cls):
+                return ["--attention-backend", "fa3"]
+
+        with patch.object(
+            deterministic_utils,
+            "popen_launch_server",
+            side_effect=RuntimeError("launch failed"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "launch failed"):
+                BackendTest.setUpClass()
+
+        with patch.object(deterministic_utils, "kill_process_tree") as mock_kill:
+            BackendTest.tearDownClass()
+            mock_kill.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_deterministic_utils.py
+++ b/test/registered/unit/test_deterministic_utils.py
@@ -1,0 +1,100 @@
+"""Unit tests for the deterministic inference test harness."""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.test import test_deterministic_utils as deterministic_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestDeterministicUtils(CustomTestCase):
+    def test_common_server_args_are_immutable_and_copied(self):
+        first = deterministic_utils.TestDeterministicBase.get_server_args()
+        second = deterministic_utils.TestDeterministicBase.get_server_args()
+
+        self.assertIsInstance(deterministic_utils.COMMON_SERVER_ARGS, tuple)
+        self.assertIsNot(first, second)
+
+        first.extend(["--attention-backend", "fa3"])
+        self.assertNotIn("--attention-backend", second)
+        self.assertNotIn("--attention-backend", deterministic_utils.COMMON_SERVER_ARGS)
+
+    def test_single_configures_sampling_before_running(self):
+        def capture_args(args):
+            self.assertEqual(args.test_mode, "single")
+            self.assertEqual(args.temperature, 0.5)
+            self.assertEqual(args.sampling_seed, 42)
+            return [1]
+
+        case = deterministic_utils.TestDeterministicBase(methodName="test_single")
+
+        with patch.object(
+            deterministic_utils, "test_deterministic", side_effect=capture_args
+        ) as mock_test_deterministic:
+            case.test_single()
+
+        mock_test_deterministic.assert_called_once()
+
+    @patch.object(deterministic_utils, "popen_launch_server")
+    def test_setup_uses_one_server_args_snapshot(self, mock_launch_server):
+        class BackendTest(deterministic_utils.TestDeterministicBase):
+            server_args_calls = 0
+
+            @classmethod
+            def get_model(cls):
+                return "test/model"
+
+            @classmethod
+            def get_server_args(cls):
+                cls.server_args_calls += 1
+                return [
+                    "--attention-backend",
+                    "fa3",
+                    "--snapshot",
+                    str(cls.server_args_calls),
+                ]
+
+        BackendTest.setUpClass()
+
+        self.assertEqual(BackendTest.server_args_calls, 1)
+        mock_launch_server.assert_called_once_with(
+            "test/model",
+            deterministic_utils.DEFAULT_URL_FOR_TEST,
+            timeout=deterministic_utils.DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=["--attention-backend", "fa3", "--snapshot", "1"],
+        )
+
+        with patch.object(
+            deterministic_utils, "terminate_and_kill_process_tree"
+        ) as mock_kill:
+            BackendTest.tearDownClass()
+            mock_kill.assert_called_once_with(
+                mock_launch_server.return_value, wait_timeout=60
+            )
+
+    def test_teardown_is_safe_after_server_launch_failure(self):
+        class BackendTest(deterministic_utils.TestDeterministicBase):
+            @classmethod
+            def get_server_args(cls):
+                return ["--attention-backend", "fa3"]
+
+        with patch.object(
+            deterministic_utils,
+            "popen_launch_server",
+            side_effect=RuntimeError("launch failed"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "launch failed"):
+                BackendTest.setUpClass()
+
+        with patch.object(
+            deterministic_utils, "terminate_and_kill_process_tree"
+        ) as mock_kill:
+            BackendTest.tearDownClass()
+            mock_kill.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The registered deterministic inference tests had several harness issues that weakened their coverage:

- Backend subclasses mutated the shared `COMMON_SERVER_ARGS` list, so repeated calls accumulated flags and test classes polluted one another.
- `test_single` set `temperature=0.5` after calling the deterministic runner, so it exercised greedy decoding instead of deterministic sampling.
- `setUpClass` evaluated `get_server_args()` twice, allowing validation and launch to observe different values.
- `tearDownClass` assumed server launch had completed and could raise a secondary exception after setup failure.

## Changes

- Make common server arguments immutable and return a fresh list from every backend test class.
- Evaluate server arguments once per class setup and reuse the same snapshot for validation and launch.
- Configure sampling before invoking the deterministic runner.
- Make process teardown defensive.
- Add CPU-only regression tests for all four failure modes without launching a server or loading model weights.

## Testing

- `test/registered/unit/test_deterministic_utils.py`: 4/4 passed.
- Applied the same tests to unpatched `origin/main`: all four failed for the intended reasons.
- Ruff lint and format checks passed for all changed files.
- Python bytecode compilation passed.
- `scripts/ci/check_registered_tests.py` passed.
- `scripts/ci/check_no_registered_tests_in_package.py` passed.

GPU-backed deterministic server tests were not run locally and are left to CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32624798856](https://github.com/sgl-project/sglang/actions/runs/32624798856)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32624798602](https://github.com/sgl-project/sglang/actions/runs/32624798602)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32624798871](https://github.com/sgl-project/sglang/actions/runs/32624798871)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->