### PR TITLE
[Feature] Release PyNccl communicator memory in sleep mode

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/pynccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl.py
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/distributed/device_communicators/pynccl.py
 
 import logging
+import weakref
 from contextlib import contextmanager
 from typing import Optional, Union
 
@@ -25,6 +26,26 @@ from sglang.srt.utils.common import get_current_device_stream_fast
 
 logger = logging.getLogger(__name__)
 
+_NCCL_SUSPEND_MEM = 0x01
+_NCCL_SUSPEND_MIN_VERSION = 22907
+
+# Includes the standalone communicator used by DSA layer sharding.
+_pynccl_communicators: list[weakref.ReferenceType] = []
+
+
+def get_pynccl_communicators() -> list["PyNcclCommunicator"]:
+    return [comm for ref in _pynccl_communicators if (comm := ref()) is not None]
+
+
+def suspend_pynccl_comms() -> None:
+    for comm in get_pynccl_communicators():
+        comm.suspend()
+
+
+def resume_pynccl_comms() -> None:
+    for comm in get_pynccl_communicators():
+        comm.resume()
+
 
 class PyNcclCommunicator:
 
@@ -45,6 +66,7 @@ class PyNcclCommunicator:
         It is the caller's responsibility to make sure each communicator
         is bind to a unique device.
         """
+        self._is_suspended = False
         if not isinstance(group, StatelessProcessGroup):
             assert dist.is_initialized()
             assert (
@@ -124,6 +146,7 @@ class PyNcclCommunicator:
         # to use it, use under `with obj.change_state(enable=True)`, usually
         # when we are using CUDA graph.
         self.disabled = True
+        _pynccl_communicators.append(weakref.ref(self))
 
     def _resolve_stream(self) -> torch.cuda.Stream:
         """Return the current device stream used for NCCL calls."""
@@ -361,6 +384,30 @@ class PyNcclCommunicator:
 
     def deregister_comm_window(self, window):
         return self.nccl.ncclCommWindowDeregister(self.comm, window)
+
+    def suspend(self) -> None:
+        """Release dynamic GPU memory while preserving communicator state."""
+        if (
+            not self.available
+            or self.nccl_version < _NCCL_SUSPEND_MIN_VERSION
+            or not self.nccl.supports_comm_suspend
+            or self._is_suspended
+        ):
+            return
+        self.nccl.ncclCommSuspend(self.comm, _NCCL_SUSPEND_MEM)
+        self._is_suspended = True
+
+    def resume(self) -> None:
+        """Restore dynamic GPU memory released by :meth:`suspend`."""
+        if (
+            not self.available
+            or self.nccl_version < _NCCL_SUSPEND_MIN_VERSION
+            or not self.nccl.supports_comm_suspend
+            or not self._is_suspended
+        ):
+            return
+        self.nccl.ncclCommResume(self.comm)
+        self._is_suspended = False
 
     def group_start(self):
         self.nccl.ncclGroupStart()

--- a/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
@@ -302,6 +302,10 @@ class NCCLLibrary:
         # it is better not to call it at all.
         # ncclResult_t  ncclCommDestroy(ncclComm_t comm);
         Function("ncclCommDestroy", ncclResult_t, [ncclComm_t]),
+        # ncclResult_t ncclCommSuspend(ncclComm_t comm, int flags);
+        Function("ncclCommSuspend", ncclResult_t, [ncclComm_t, ctypes.c_int]),
+        # ncclResult_t ncclCommResume(ncclComm_t comm);
+        Function("ncclCommResume", ncclResult_t, [ncclComm_t]),
         # ncclResult_t ncclGroupStart();
         Function("ncclGroupStart", ncclResult_t, []),
         # ncclResult_t ncclGroupEnd();
@@ -358,16 +362,33 @@ class NCCLLibrary:
 
         if so_file not in NCCLLibrary.path_to_dict_mapping:
             _funcs: Dict[str, Any] = {}
-            exported_functions = NCCLLibrary.exported_functions
+            exported_functions = list(NCCLLibrary.exported_functions)
             if hasattr(self.lib, "ncclCommWindowRegister"):
                 exported_functions.extend(NCCLLibrary.exported_functions_symm_mem)
+            missing_comm_suspend = False
             for func in exported_functions:
-                f = getattr(self.lib, func.name)
+                try:
+                    f = getattr(self.lib, func.name)
+                except AttributeError:
+                    if func.name in ("ncclCommSuspend", "ncclCommResume"):
+                        missing_comm_suspend = True
+                        continue
+                    raise
                 f.restype = func.restype
                 f.argtypes = func.argtypes
                 _funcs[func.name] = f
+            if missing_comm_suspend and torch.version.cuda is not None:
+                logger.warning(
+                    "NCCL communicator suspend/resume is unavailable in %s "
+                    "(requires NCCL >= 2.29.7); communicator memory offload "
+                    "is disabled.",
+                    so_file,
+                )
             NCCLLibrary.path_to_dict_mapping[so_file] = _funcs
         self._funcs = NCCLLibrary.path_to_dict_mapping[so_file]
+        self.supports_comm_suspend = all(
+            name in self._funcs for name in ("ncclCommSuspend", "ncclCommResume")
+        )
 
     def ncclGetErrorString(self, result: ncclResult_t) -> str:
         return self._funcs["ncclGetErrorString"](result).decode("utf-8")
@@ -534,6 +555,12 @@ class NCCLLibrary:
 
     def ncclCommDestroy(self, comm: ncclComm_t) -> None:
         self.NCCL_CHECK(self._funcs["ncclCommDestroy"](comm))
+
+    def ncclCommSuspend(self, comm: ncclComm_t, flags: int) -> None:
+        self.NCCL_CHECK(self._funcs["ncclCommSuspend"](comm, flags))
+
+    def ncclCommResume(self, comm: ncclComm_t) -> None:
+        self.NCCL_CHECK(self._funcs["ncclCommResume"](comm))
 
     def ncclCommWindowRegister(
         self, comm: ncclComm_t, buff: buffer_type, size: int, win_flags: int

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -17,6 +17,10 @@ from sglang.srt.constants import (
     GPU_MEMORY_TYPE_WEIGHTS,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.distributed.device_communicators.pynccl import (
+    resume_pynccl_comms,
+    suspend_pynccl_comms,
+)
 from sglang.srt.managers.io_struct import (
     CheckWeightsReqInput,
     CheckWeightsReqOutput,
@@ -222,7 +226,10 @@ class SchedulerWeightUpdaterManager:
         if GPU_MEMORY_TYPE_CUDA_GRAPH in tags:
             self.memory_saver_adapter.pause(GPU_MEMORY_TYPE_CUDA_GRAPH)
 
+        # ncclCommSuspend requires all communicator operations to be complete.
         torch.get_device_module().synchronize()
+        if any(tag in tags for tag in GPU_MEMORY_ALL_TYPES):
+            suspend_pynccl_comms()
 
         return ReleaseMemoryOccupationReqOutput()
 
@@ -249,6 +256,13 @@ class SchedulerWeightUpdaterManager:
 
         if GPU_MEMORY_TYPE_KV_CACHE in tags:
             self.memory_saver_adapter.resume(GPU_MEMORY_TYPE_KV_CACHE)
+
+        # Restore communicator allocations after memory-saver regions but
+        # before any subsystem can communicate again.
+        if any(tag in tags for tag in GPU_MEMORY_ALL_TYPES):
+            resume_pynccl_comms()
+
+        if GPU_MEMORY_TYPE_KV_CACHE in tags:
             scheduler = self.scheduler
             if scheduler is not None:
                 if scheduler.disaggregation_mode == DisaggregationMode.DECODE:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

NCCL >= 2.29.7 supports dynamic memory offload, so add this feature to sleep mode.

## Modifications

- Offload all live PyNccl communicators during SGLang sleep mode using `ncclCommSuspend`, and restore them with `ncclCommResume`.
- Enable this automatically for NCCL >= 2.29.7; older NCCL versions retain the existing behavior.
- Integrate communicator suspend/resume into the existing staged memory release/resume flow without adding a new option.

## Validation

Tested on 8x GB200 with NCCL 2.30.4:

| Model / topology | PyNccl communicators suspended per rank | Additional memory released |
|---|---:|---:|
| Qwen3-30B-A3B, TP8/EP8 | 1 | ~576 MiB/GPU, 4.5 GiB total |
| Qwen3-235B-A22B-FP8, world size 8 / attention TP4 / DP2 / EP8 | 1 | ~576 MiB/GPU, ~4.5 GiB total |

In both topologies, SGLang has **one** suspendable PyNccl communicator per rank: EP8 reuses the global TP8 communicator, while attention TP4 uses a torch NCCL process group by default. Both models produced the same output before sleep, and communicator collectives continued working after resume. A raw NCCL test with two PyNccl communicators per rank released 1,152 MiB/GPU, confirming that the saving scales with communicator count.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29177989152](https://github.com/sgl-project/sglang/actions/runs/29177989152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29177989075](https://github.com/sgl-project/sglang/actions/runs/29177989075)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->