### PR TITLE
Guard ROCm imports without visible GPUs

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -122,8 +122,15 @@ logger = logging.getLogger(__name__)
 @lru_cache()
 def is_fp8_fnuz() -> bool:
     if _is_hip:
+        if not torch.cuda.is_available():
+            return False
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+        try:
+            return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+        except RuntimeError as err:
+            if "No HIP GPUs are available" in str(err):
+                return False
+            raise
     return False
 
 

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -190,7 +190,15 @@ def use_rowwise_torch_scaled_mm():
         # torch._scaled_mm rowwise feature.
         # The condition is determined once as the operations
         # are time consuming.
-        return get_device_capability() >= (9, 4) and torch_release >= (2, 7)
+        device_capability = get_device_capability()
+        if (
+            device_capability is None
+            or len(device_capability) < 2
+            or device_capability[0] is None
+            or device_capability[1] is None
+        ):
+            return False
+        return device_capability >= (9, 4) and torch_release >= (2, 7)
     return False
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -145,11 +145,20 @@ if TYPE_CHECKING:
 
 _is_cpu = is_cpu()
 _is_hip = is_hip()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
-_is_shuffle_moe_mxfp4 = is_gfx95_supported()
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _has_visible_hip_device
+_is_shuffle_moe_mxfp4 = _has_visible_hip_device and is_gfx95_supported()
 _is_cpu_amx_available = cpu_has_amx_support()
 
-if _is_hip:
+
+def _raise_aiter_mxfp4_requires_visible_hip(*args, **kwargs):
+    del args, kwargs
+    raise NotImplementedError(
+        "AITer MXFP4 kernels require an AMD ROCm device visible at import time."
+    )
+
+
+if _has_visible_hip_device:
     # import aiter
     try:
         from aiter.ops.shuffle import (
@@ -162,6 +171,15 @@ if _is_hip:
         from aiter.utility.fp4_utils import e8m0_shuffle
     except ImportError as err:
         dynamic_mxfp4_quant = e8m0_shuffle = err
+        shuffle_scale = shuffle_scale_a16w4 = err
+        shuffle_weight = shuffle_weight_a16w4 = err
+else:
+    dynamic_mxfp4_quant = _raise_aiter_mxfp4_requires_visible_hip
+    e8m0_shuffle = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_scale = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_scale_a16w4 = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_weight = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_weight_a16w4 = _raise_aiter_mxfp4_requires_visible_hip
 
 
 def _swizzle_mxfp4(quant_tensor, scale, num_warps):
@@ -255,7 +273,7 @@ class Mxfp4Config(QuantizationConfig):
         quant_method = cls.get_from_keys(config, ["quant_method"])
         is_checkpoint_mxfp4_serialized = "mxfp4" in quant_method
 
-        if _is_hip:
+        if _has_visible_hip_device:
             if mxfp_supported():
                 return cls(
                     is_checkpoint_mxfp4_serialized=is_checkpoint_mxfp4_serialized

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -11,7 +11,8 @@ from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import direct_register_custom_op, mxfp_supported
 
 _is_hip = is_hip()
-if _is_hip:
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
+if _has_visible_hip_device:
     from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
         fused_gemm_afp4wfp4_split_cat as _fused_gemm_afp4wfp4_split_cat_orig,
     )
@@ -147,6 +148,19 @@ if _is_hip:
         return torch.ops.sglang.aiter_fused_gemm_split_cat(
             x, w, y, x_scale, w_scale, S1, S2
         )
+
+else:
+
+    def _raise_mxfp4_requires_visible_hip(*args, **kwargs):
+        del args, kwargs
+        raise NotImplementedError(
+            "Quark MXFP4 kernels require an AMD ROCm device visible at import time."
+        )
+
+    gemm_afp4wfp4 = _raise_mxfp4_requires_visible_hip
+    gemm_afp4wfp4_pre_quant = _raise_mxfp4_requires_visible_hip
+    dynamic_mxfp4_quant = _raise_mxfp4_requires_visible_hip
+    fused_gemm_afp4wfp4_split_cat = _raise_mxfp4_requires_visible_hip
 
 
 __all__ = ["QuarkW4A4MXFP4"]

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -31,12 +31,16 @@ _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 __all__ = ["QuarkW4A4MXFp4MoE"]
 
 _is_hip = is_hip()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _has_visible_hip_device
 if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
     from aiter.utility.fp4_utils import e8m0_shuffle
+else:
+    shuffle_weight = None
+    e8m0_shuffle = None
 
-if _is_hip:
+if _has_visible_hip_device:
     from aiter.ops.triton.quant import dynamic_mxfp4_quant
 else:
     dynamic_mxfp4_quant = None
@@ -218,6 +222,12 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         return online_mxfp4_moe_weight_loader
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if e8m0_shuffle is None:
+            raise NotImplementedError(
+                "Quark MXFP4 MoE weight processing requires AITer with a visible "
+                "AMD ROCm device."
+            )
+
         # Pre-shuffle weight scales
         s0, s1, _ = layer.w13_weight_scale.shape
         w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
@@ -231,6 +241,11 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
 
         # Pre-shuffle weight
         if _is_shuffle_moe_mxfp4:
+            if shuffle_weight is None:
+                raise NotImplementedError(
+                    "Quark MXFP4 MoE weight shuffling requires AITer with a "
+                    "visible AMD ROCm device."
+                )
             layer.w13_weight.data = shuffle_weight(
                 layer.w13_weight.contiguous(), (16, 16)
             )

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -7,15 +7,20 @@ from typing import Any, Optional
 
 import torch
 
-try:
-    from aiter.ops.triton.quant import dynamic_mxfp4_quant
-except ImportError:
 
-    def raise_aiter_import_error(*args, **kwargs):
-        raise ImportError(
-            "Failed to import aiter. Make sure AITER is installed and accessible."
-        )
+def raise_aiter_import_error(*args, **kwargs):
+    del args, kwargs
+    raise ImportError(
+        "AITer MXFP4 quantization requires an AMD ROCm device visible at import time."
+    )
 
+
+if torch.version.hip is not None and torch.cuda.is_available():
+    try:
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    except (ImportError, RuntimeError):
+        dynamic_mxfp4_quant = raise_aiter_import_error
+else:
     dynamic_mxfp4_quant = raise_aiter_import_error
 from torch import nn
 

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -24,12 +24,16 @@ if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import DispatchOutput
 
 _is_hip = is_hip()
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
 
 
-if _is_hip:
+if _has_visible_hip_device:
     from aiter.ops.shuffle import shuffle_weight
 
     ON_GFX950 = "gfx950" in torch.cuda.get_device_properties("cuda").gcnArchName
+else:
+    shuffle_weight = None
+    ON_GFX950 = False
 
 logger = logging.getLogger(__name__)
 
@@ -349,6 +353,12 @@ class QuarkInt4Fp8MoEMethod(FusedMoEMethodBase):
         tqdm_reset_no_print(self.online_quant_progress_bar, total=total)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if shuffle_weight is None:
+            raise NotImplementedError(
+                "Quark INT4-FP8 MoE weight shuffling requires AITer with a "
+                "visible AMD ROCm device."
+            )
+
         if _is_hip and not ON_GFX950:
             # CDNA3 does not support OCP FP8E4M3FN, but uses FP8E4M3FNUZ.
             # CDNA4 supports OCP FP8E4M3FN.

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1001,39 +1001,52 @@ def set_cuda_arch():
         )
 
 
+_HIP_GCN_ARCH_NAME_CACHE = None
+
+
+def _clear_hip_gcn_arch_name_cache():
+    global _HIP_GCN_ARCH_NAME_CACHE
+    _HIP_GCN_ARCH_NAME_CACHE = None
+
+
+def _hip_gcn_arch_name_or_none():
+    global _HIP_GCN_ARCH_NAME_CACHE
+    if _HIP_GCN_ARCH_NAME_CACHE is not None:
+        return _HIP_GCN_ARCH_NAME_CACHE
+    if not torch.version.hip or not torch.cuda.is_available():
+        return None
+    try:
+        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+    except RuntimeError as err:
+        if "No HIP GPUs are available" in str(err):
+            return None
+        raise
+    _HIP_GCN_ARCH_NAME_CACHE = gcn_arch
+    return gcn_arch
+
+
 def mxfp_supported():
     """
     Returns whether the current platform supports MX types.
     """
-    if torch.version.hip:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        return any(gfx in gcn_arch for gfx in ["gfx95"])
-    else:
-        return False
+    gcn_arch = _hip_gcn_arch_name_or_none()
+    return gcn_arch is not None and any(gfx in gcn_arch for gfx in ["gfx95"])
 
 
-@lru_cache(maxsize=1)
 def is_gfx95_supported():
     """
     Returns whether the current platform supports MX types.
     """
-    if torch.version.hip:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        return any(gfx in gcn_arch for gfx in ["gfx95"])
-    else:
-        return False
+    gcn_arch = _hip_gcn_arch_name_or_none()
+    return gcn_arch is not None and any(gfx in gcn_arch for gfx in ["gfx95"])
 
 
-@lru_cache(maxsize=1)
 def is_gfx942_supported():
     """
     Returns whether the current platform is AMD CDNA3 (gfx942 — MI300X / MI325X).
     """
-    if torch.version.hip:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        return any(gfx in gcn_arch for gfx in ["gfx942"])
-    else:
-        return False
+    gcn_arch = _hip_gcn_arch_name_or_none()
+    return gcn_arch is not None and any(gfx in gcn_arch for gfx in ["gfx942"])
 
 
 def get_hip_version():

--- a/test/registered/unit/utils/test_rocm_no_gpu_guards.py
+++ b/test/registered/unit/utils/test_rocm_no_gpu_guards.py
@@ -1,0 +1,150 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestRocmNoGpuGuards(CustomTestCase):
+    def tearDown(self):
+        from sglang.srt.layers.quantization import fp8_kernel
+        from sglang.srt.utils import common
+
+        common._clear_hip_gcn_arch_name_cache()
+        fp8_kernel.is_fp8_fnuz.cache_clear()
+
+    def test_common_gfx_helpers_return_false_without_visible_gpu(self):
+        from sglang.srt.utils import common
+
+        common._clear_hip_gcn_arch_name_cache()
+        with patch.object(common.torch.version, "hip", "7.2.0"), patch.object(
+            common.torch.cuda, "is_available", return_value=False
+        ), patch.object(
+            common.torch.cuda,
+            "get_device_properties",
+            side_effect=AssertionError("must not query device properties"),
+        ):
+            self.assertFalse(common.mxfp_supported())
+            self.assertFalse(common.is_gfx95_supported())
+            self.assertFalse(common.is_gfx942_supported())
+
+    def test_common_gfx_helpers_swallow_no_hip_gpu_runtime_error(self):
+        from sglang.srt.utils import common
+
+        common._clear_hip_gcn_arch_name_cache()
+        with patch.object(common.torch.version, "hip", "7.2.0"), patch.object(
+            common.torch.cuda, "is_available", return_value=True
+        ), patch.object(
+            common.torch.cuda,
+            "get_device_properties",
+            side_effect=RuntimeError("No HIP GPUs are available"),
+        ):
+            self.assertFalse(common.mxfp_supported())
+            self.assertFalse(common.is_gfx95_supported())
+            self.assertFalse(common.is_gfx942_supported())
+
+    def test_common_gfx_helpers_preserve_real_gpu_detection(self):
+        from sglang.srt.utils import common
+
+        common._clear_hip_gcn_arch_name_cache()
+        fake_props = SimpleNamespace(gcnArchName="gfx950:sramecc+:xnack-")
+        with patch.object(common.torch.version, "hip", "7.2.0"), patch.object(
+            common.torch.cuda, "is_available", return_value=True
+        ), patch.object(
+            common.torch.cuda, "get_device_properties", return_value=fake_props
+        ):
+            self.assertTrue(common.mxfp_supported())
+            self.assertTrue(common.is_gfx95_supported())
+            self.assertFalse(common.is_gfx942_supported())
+
+    def test_common_gfx_helpers_do_not_cache_no_gpu_false(self):
+        from sglang.srt.utils import common
+
+        common._clear_hip_gcn_arch_name_cache()
+        fake_props = SimpleNamespace(gcnArchName="gfx950:sramecc+:xnack-")
+        with patch.object(common.torch.version, "hip", "7.2.0"):
+            with patch.object(common.torch.cuda, "is_available", return_value=False):
+                self.assertFalse(common.is_gfx95_supported())
+
+            with patch.object(common.torch.cuda, "is_available", return_value=True):
+                with patch.object(
+                    common.torch.cuda, "get_device_properties", return_value=fake_props
+                ):
+                    self.assertTrue(common.is_gfx95_supported())
+
+    def test_fp8_fnuz_returns_false_without_visible_gpu(self):
+        from sglang.srt.layers.quantization import fp8_kernel
+
+        fp8_kernel.is_fp8_fnuz.cache_clear()
+        with patch.object(fp8_kernel, "_is_hip", True), patch.object(
+            fp8_kernel.torch.cuda, "is_available", return_value=False
+        ), patch.object(
+            fp8_kernel.torch.cuda,
+            "get_device_properties",
+            side_effect=AssertionError("must not query device properties"),
+        ):
+            self.assertFalse(fp8_kernel.is_fp8_fnuz())
+
+    def test_fp8_fnuz_preserves_gfx942_detection(self):
+        from sglang.srt.layers.quantization import fp8_kernel
+
+        fp8_kernel.is_fp8_fnuz.cache_clear()
+        fake_props = SimpleNamespace(gcnArchName="gfx942:sramecc+:xnack-")
+        with patch.object(fp8_kernel, "_is_hip", True), patch.object(
+            fp8_kernel.torch.cuda, "is_available", return_value=True
+        ), patch.object(
+            fp8_kernel.torch.cuda, "get_device_properties", return_value=fake_props
+        ):
+            self.assertTrue(fp8_kernel.is_fp8_fnuz())
+
+    def test_rowwise_scaled_mm_returns_false_without_device_capability(self):
+        from sglang.srt.layers.quantization import fp8_utils
+
+        with patch.object(fp8_utils, "_is_hip", True), patch.object(
+            fp8_utils, "get_device_capability", return_value=(None, None)
+        ):
+            self.assertFalse(fp8_utils.use_rowwise_torch_scaled_mm())
+
+    def test_rowwise_scaled_mm_preserves_supported_capability(self):
+        from sglang.srt.layers.quantization import fp8_utils
+
+        with patch.object(fp8_utils, "_is_hip", True), patch.object(
+            fp8_utils, "get_device_capability", return_value=(9, 5)
+        ), patch.object(fp8_utils, "torch_release", (2, 7)):
+            self.assertTrue(fp8_utils.use_rowwise_torch_scaled_mm())
+
+    def test_quark_mxfp4_linear_no_gpu_stub_raises_not_implemented(self):
+        from sglang.srt.layers.quantization.quark.schemes import quark_w4a4_mxfp4
+
+        if getattr(quark_w4a4_mxfp4, "_has_visible_hip_device", False):
+            self.skipTest("visible HIP device imports real AITer kernels")
+
+        with self.assertRaisesRegex(NotImplementedError, "visible at import time"):
+            quark_w4a4_mxfp4.dynamic_mxfp4_quant(None)
+
+    def test_quark_mxfp4_moe_no_gpu_processing_raises_not_implemented(self):
+        from sglang.srt.layers.quantization.quark.schemes import quark_w4a4_mxfp4_moe
+
+        if getattr(quark_w4a4_mxfp4_moe, "_has_visible_hip_device", False):
+            self.skipTest("visible HIP device imports real AITer kernels")
+
+        scheme = object.__new__(quark_w4a4_mxfp4_moe.QuarkW4A4MXFp4MoE)
+        with self.assertRaisesRegex(NotImplementedError, "visible AMD ROCm device"):
+            scheme.process_weights_after_loading(object())
+
+    def test_quark_int4fp8_moe_no_gpu_processing_raises_not_implemented(self):
+        import sglang.srt.layers.quantization.quark_int4fp8_moe as quark_int4fp8_moe
+
+        if getattr(quark_int4fp8_moe, "_has_visible_hip_device", False):
+            self.skipTest("visible HIP device imports real AITer kernels")
+
+        method = object.__new__(quark_int4fp8_moe.QuarkInt4Fp8MoEMethod)
+        with self.assertRaisesRegex(NotImplementedError, "visible AMD ROCm device"):
+            method.process_weights_after_loading(object())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Avoid querying HIP device properties when a ROCm build has no visible GPU.
- Make ROCm gfx/MX helpers and FP8/Quark import paths safe in no-GPU ROCm containers.
- Preserve normal visible-GPU detection; no-GPU negative detection is not cached forever.

## Tests

- Docker ROCm no-GPU focused test: `11 passed, 6 warnings`
- `py_compile` for touched files

## Notes

This is split out as a standalone guard PR because it makes CPU/no-GPU CI usable for the later DSpark GLM-5.2 work without changing runtime behavior when a HIP GPU is visible.







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29182015269](https://github.com/sgl-project/sglang/actions/runs/29182015269)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29182015197](https://github.com/sgl-project/sglang/actions/runs/29182015197)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->