### PR TITLE
[DeepSeek V4] Disable YaRN for uncompressed attention layers

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -479,16 +479,20 @@ class MqaAttentionBase(nn.Module):
         from sglang.srt.layers.deepseek_v4_rope import precompute_freqs_cis
 
         rope_theta, rope_scaling = get_rope_config(config)
-        self.rope_scaling = rope_scaling
-        scaling = rope_scaling or {}
+        # Pure sliding-window layers use base RoPE without YaRN.
+        self.rope_scaling = rope_scaling if self.compress_ratio else None
+        scaling = self.rope_scaling or {}
         self.rope_base = (
             config.compress_rope_theta if self.compress_ratio else rope_theta
         )
-        original_seq_len: int = (
-            rope_original_seq_len
-            if rope_original_seq_len is not None
-            else scaling["original_max_position_embeddings"]
-        )
+        if self.compress_ratio:
+            original_seq_len = (
+                rope_original_seq_len
+                if rope_original_seq_len is not None
+                else scaling["original_max_position_embeddings"]
+            )
+        else:
+            original_seq_len = 0
         freqs_cis = precompute_freqs_cis(
             dim=self.qk_rope_head_dim,
             seqlen=config.max_position_embeddings,


### PR DESCRIPTION
## Motivation

DeepSeek V4 uses different RoPE settings depending on the attention layer:

- Compressed layers use `compress_rope_theta` with YaRN.
- Pure sliding-window layers (`compress_ratio == 0`) use the base `rope_theta` without YaRN.

SGLang currently propagates the model-level `rope_scaling` configuration to every layer. This causes uncompressed layers to use YaRN, differing from the [official DeepSeek V4 reference implementation](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/2b2bebc1776b2cf88ca36f0b5b6f816ae0f5892f/inference/model.py#L475-L479).

## Modifications

- Disable `rope_scaling` for layers with `compress_ratio == 0`.
- Set `original_seq_len = 0` for those layers so the precomputed frequency table also uses plain RoPE.
- Leave compressed layers unchanged.

## Accuracy Tests

- Downstream TP=8 B300 smoke test with DeepSeek-V4-Flash-FP8: server startup and a fixed 4096-token prefill completed successfully.
- Verified uncompressed layers use base RoPE with `original_seq_len = 0`.
- Verified the compressed-layer YaRN configuration is unchanged.

## Speed Tests and Profiling

No performance impact is expected; this only selects the correct RoPE configuration during model initialization.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). A standalone unit test was not added because this path is part of the distributed model constructor.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation changes are needed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29184573901](https://github.com/sgl-project/sglang/actions/runs/29184573901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29184573852](https://github.com/sgl-project/sglang/actions/runs/29184573852)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->