### PR TITLE
[DSA] Skip building the Indexer on skip_topk (shared) layers

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -49,14 +49,15 @@ def forward_mha_prepare_npu(
         if m.use_dsa:
             q_lora = m.q_a_layernorm(q)
             q = m.q_b_proj(q_lora)[0].view(-1, m.num_local_heads, m.qk_head_dim)
-            _ = m.indexer(
-                x=hidden_states,
-                q_lora=q_lora,
-                positions=positions,
-                forward_batch=forward_batch,
-                layer_id=m.layer_id,
-                return_indices=False,
-            )
+            if m.should_run_indexer():
+                _ = m.indexer(
+                    x=hidden_states,
+                    q_lora=q_lora,
+                    positions=positions,
+                    forward_batch=forward_batch,
+                    layer_id=m.layer_id,
+                    return_indices=False,
+                )
 
         else:
             q = m.q_a_layernorm(q)
@@ -253,7 +254,7 @@ def forward_mla_prepare_npu(
                 latent_cache, forward_batch, k_nope, k_pe
             )
         topk_indices = None
-        if q_lora is not None:
+        if q_lora is not None and m.should_run_indexer():
             topk_indices = m.indexer(
                 x=hidden_states,
                 q_lora=q_lora,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1637,26 +1637,6 @@ class DeepseekV2AttentionMLA(
         self.skip_topk = None
         self.next_skip_topk = None
         if self.use_dsa:
-            is_neox_style = not getattr(config, "indexer_rope_interleave", False)
-            self.indexer = Indexer(
-                hidden_size=hidden_size,
-                index_n_heads=get_dsa_index_n_heads(config),
-                index_head_dim=get_dsa_index_head_dim(config),
-                rope_head_dim=qk_rope_head_dim,
-                index_topk=get_dsa_index_topk(config),
-                q_lora_rank=q_lora_rank,
-                max_position_embeddings=max_position_embeddings,
-                rope_theta=rope_theta,
-                scale_fmt="ue8m0",
-                block_size=128,
-                rope_scaling=rope_scaling,
-                is_neox_style=is_neox_style,
-                prefix=add_prefix("indexer", prefix),
-                quant_config=quant_config,
-                layer_id=layer_id,
-                alt_stream=alt_stream,
-                config=config,
-            )
             # Refer: https://arxiv.org/abs/2603.12201 for more details.
             # skip_topk: when True, this layer will skip computation and reuse previous layer's topk indices.
             # next_skip_topk: when True, the next layer will skip computation and reuse this layer's topk indices.
@@ -1671,6 +1651,35 @@ class DeepseekV2AttentionMLA(
                 else:
                     self.skip_topk = dsa_layer_skips_topk(config, layer_id)
                     self.next_skip_topk = dsa_layer_skips_topk(config, layer_id + 1)
+            # skip_topk (shared) layers carry no indexer weights in the
+            # checkpoint and never run the indexer (see should_run_indexer),
+            # so skip building it to avoid holding uninitialized weights
+            # (mirrors DeepSeek-V4, where self.indexer is None on non-C4
+            # layers). The NextN layer keeps its indexer: it has checkpoint
+            # weights and runs them when no carried top-k is available.
+            if is_nextn or not self.skip_topk:
+                is_neox_style = not getattr(config, "indexer_rope_interleave", False)
+                self.indexer = Indexer(
+                    hidden_size=hidden_size,
+                    index_n_heads=get_dsa_index_n_heads(config),
+                    index_head_dim=get_dsa_index_head_dim(config),
+                    rope_head_dim=qk_rope_head_dim,
+                    index_topk=get_dsa_index_topk(config),
+                    q_lora_rank=q_lora_rank,
+                    max_position_embeddings=max_position_embeddings,
+                    rope_theta=rope_theta,
+                    scale_fmt="ue8m0",
+                    block_size=128,
+                    rope_scaling=rope_scaling,
+                    is_neox_style=is_neox_style,
+                    prefix=add_prefix("indexer", prefix),
+                    quant_config=quant_config,
+                    layer_id=layer_id,
+                    alt_stream=alt_stream,
+                    config=config,
+                )
+            else:
+                self.indexer = None
 
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,


### PR DESCRIPTION
## Motivation

DSA models with cross-layer index-top-k sharing (e.g. GLM-5.2: `index_topk_freq=4`, `index_skip_topk_offset=3` → 21 full / 57 shared of 78 layers) never run the indexer on `skip_topk` (shared) layers, and the checkpoint carries no indexer weights for them — yet `DeepseekV2AttentionMLA` builds an `Indexer` module on every layer. The shared layers' indexers hold **uninitialized weights that are never used**: ~18.7 MB/layer in bf16 (`wq_b [4096, 2048]` + `wk [128, 6144]` + `weights_proj [32, 6144]`), all `ReplicatedLinear`, so the waste is **per-GPU and does not shard with TP** (~1.07 GB bf16 / ~0.55 GB FP8 per GPU on GLM-5.2).

Keeping never-run modules with uninitialized weights is also a footgun: the `should_run_indexer` docstring already documents a garbling bug from accidentally running them, and the NPU path currently has two ungated call sites that do exactly that on shared layers.

TensorRT-LLM's DSA sharing implementation builds the indexer only on full layers (NVIDIA/TensorRT-LLM#15574), and SGLang's own DeepSeek-V4 code sets `self.indexer = None` on non-C4 layers — this PR applies the same pattern to DSA.

## Modifications

- `deepseek_v2.py`: compute `skip_topk` before constructing the `Indexer`; build it only for `is_nextn or not skip_topk`, else `self.indexer = None`. The NextN layer keeps its indexer (it has checkpoint weights and `should_run_indexer` runs it when no carried top-k is available). The weight loader needs no changes: shared layers have no indexer weights in the checkpoint.
- `deepseek_v2_attention_mla_npu.py`: gate the two previously ungated `m.indexer(...)` call sites with `should_run_indexer()`, mirroring the CUDA `forward_mha`/`forward_mla` paths. Previously these ran **uninitialized** indexer weights on shared layers (fill-only dead work in the MHA path; garbage top-k in the MLA-prepare path).

All CUDA call sites were audited: `forward_mla.py` (2) and `forward_mha.py` (1) are already gated by `should_run_indexer`, and `maybe_capture_indexer_topk` mirroring for shared layers is unchanged.

## Accuracy Tests

8-layer GLM-5.2 config (`indexer_types = F F F S S S F S`, real dims, dummy weights, B200):

| | main | this PR |
|---|---|---|
| Load weight mem usage | 13.63 GB | **13.56 GB** (−70 MB = 4 shared indexers × 18.7 MB) |
| Greedy output ids | `[40472, 76288, 138027, ...]` | **identical** |

Dense-DSA regression (same config without `index_topk_freq`, i.e. DeepSeek-V3.2-style per-layer indexer): 13.63 GB load mem — identical to main, all indexers built, generation OK.

Full GLM-5.2 (78 layers): saves ~0.55 GB (FP8) per GPU, every TP rank.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) (existing GLM-5.2 / DeepSeek-V3.2 registered tests cover both construction paths; a hermetic unit test for the layer-placement helper lands with the follow-up compact-cache PR).
- [x] Provide accuracy and speed benchmark results.

cc @mattteochen @zRzRzRzRzRzRzR







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29185108004](https://github.com/sgl-project/sglang/actions/runs/29185108004)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29185107929](https://github.com/sgl-project/sglang/actions/runs/29185107929)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->