### PR TITLE
[DSA] Compact indexer K cache: drop slots for skip_topk (shared) layers (+15.8% KV capacity on GLM-5.2)

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1042,6 +1042,20 @@ class MooncakeKVManager(CommonKVManager):
                     raise RuntimeError(
                         f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
                     )
+                if (
+                    st == StateType.DSA
+                    and dst_data_ptrs
+                    and len(src_data_ptrs) != len(dst_data_ptrs)
+                ):
+                    # Positional pairing: a buffer-count mismatch means the two
+                    # sides disagree on the indexer layout (e.g. compact vs
+                    # dense across versions) -- pairing would corrupt KV.
+                    raise RuntimeError(
+                        f"DSA indexer state buffer count mismatch between "
+                        f"prefill ({len(src_data_ptrs)}) and decode "
+                        f"({len(dst_data_ptrs)}); both sides must run the same "
+                        f"sglang version and indexer cache layout."
+                    )
                 src_indices = list(indices)
                 dst_indices_local = list(dst_indices)
                 if (

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -643,6 +643,11 @@ class Envs:
         True, deprecated_name="SGLANG_NSA_FUSE_TOPK"
     )
     SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC = EnvBool(False)
+    # Allocate DSA indexer K-cache slots only for layers that own an indexer
+    # (skip_topk/shared layers reuse the previous full layer's top-k and
+    # never read their own indexer cache). Escape hatch: set to false to
+    # restore the dense one-slot-per-layer layout.
+    SGLANG_DSA_COMPACT_INDEXER_CACHE = EnvBool(True)
     SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK = EnvStr(None)
     SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD = EnvIntWithAlias(
         2048, deprecated_name="SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD"

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -49,14 +49,15 @@ def forward_mha_prepare_npu(
         if m.use_dsa:
             q_lora = m.q_a_layernorm(q)
             q = m.q_b_proj(q_lora)[0].view(-1, m.num_local_heads, m.qk_head_dim)
-            _ = m.indexer(
-                x=hidden_states,
-                q_lora=q_lora,
-                positions=positions,
-                forward_batch=forward_batch,
-                layer_id=m.layer_id,
-                return_indices=False,
-            )
+            if m.should_run_indexer():
+                _ = m.indexer(
+                    x=hidden_states,
+                    q_lora=q_lora,
+                    positions=positions,
+                    forward_batch=forward_batch,
+                    layer_id=m.layer_id,
+                    return_indices=False,
+                )
 
         else:
             q = m.q_a_layernorm(q)
@@ -253,7 +254,7 @@ def forward_mla_prepare_npu(
                 latent_cache, forward_batch, k_nope, k_pe
             )
         topk_indices = None
-        if q_lora is not None:
+        if q_lora is not None and m.should_run_indexer():
             topk_indices = m.indexer(
                 x=hidden_states,
                 q_lora=q_lora,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -3136,6 +3136,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         start_layer: Optional[int] = None,
         end_layer: Optional[int] = None,
         index_buf_size: Optional[int] = None,
+        indexer_layer_ids: Optional[List[int]] = None,
     ):
         override_dim = (
             kv_cache_dim if kv_cache_dim != kv_lora_rank + qk_rope_head_dim else None
@@ -3161,6 +3162,19 @@ class DSATokenToKVPool(MLATokenToKVPool):
         if index_buf_size is None:
             index_buf_size = size
         self.index_buf_size = index_buf_size
+        # Compact indexer layout: only these (absolute) layer ids own an
+        # index_k slot. skip_topk (shared) layers reuse the previous full
+        # layer's top-k and never read their own indexer cache (see
+        # should_run_indexer), so with sharing enabled their slots are
+        # dropped. None keeps the dense one-slot-per-layer layout.
+        if indexer_layer_ids is None:
+            indexer_layer_ids = list(
+                range(self.start_layer, self.start_layer + layer_num)
+            )
+        self.indexer_layer_ids = list(indexer_layer_ids)
+        self._indexer_slot_by_layer = {
+            lid: slot for slot, lid in enumerate(self.indexer_layer_ids)
+        }
         # num head == 1 and head dim == 128 for index_k in DSA
         assert index_head_dim == 128
 
@@ -3204,8 +3218,16 @@ class DSATokenToKVPool(MLATokenToKVPool):
                     dtype=self.index_k_with_scale_buffer_dtype,
                     device=self.device,
                 )
-                for _ in range(self.layer_num)
+                for _ in self.indexer_layer_ids
             ]
+
+    def _get_index_buf(self, layer_id: int) -> torch.Tensor:
+        slot = self._indexer_slot_by_layer.get(layer_id)
+        assert slot is not None, (
+            f"DSA indexer K cache accessed for layer {layer_id}, which owns no "
+            f"indexer slot (skip_topk/shared layer under the compact layout)"
+        )
+        return self.index_k_with_scale_buffer[slot]
 
     def _clear_buffers(self):
         super()._clear_buffers()
@@ -3226,7 +3248,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        return self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        return self._get_index_buf(layer_id)
 
     def get_index_k_continuous(
         self,
@@ -3236,7 +3258,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
     ):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        buf = self._get_index_buf(layer_id)
         return index_buf_accessor.GetK.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -3249,7 +3271,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
     ):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        buf = self._get_index_buf(layer_id)
         return index_buf_accessor.GetS.execute(
             self, buf, seq_len=seq_len, page_indices=page_indices
         )
@@ -3275,7 +3297,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         """
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        buf = self._get_index_buf(layer_id)
         return index_buf_accessor.GetKAndS.execute(
             self,
             buf,
@@ -3292,7 +3314,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
     ) -> None:
-        buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
+        buf = self._get_index_buf(layer_id)
         index_buf_accessor.SetKAndS.execute(
             pool=self, buf=buf, loc=loc, index_k=index_k, index_k_scale=index_k_scale
         )
@@ -3310,13 +3332,13 @@ class DSATokenToKVPool(MLATokenToKVPool):
         index_k_cpu = []
         chunk_size = self.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.page_size)
-        for layer_id in range(self.layer_num):
+        for slot in range(len(self.index_k_with_scale_buffer)):
             index_k_cpu.append([])
             for i in range(0, len(page_indices), page_chunk_size):
                 chunk_page_indices = page_indices[i : i + page_chunk_size]
-                idx_cpu = self.index_k_with_scale_buffer[layer_id][
-                    chunk_page_indices
-                ].to("cpu", non_blocking=True)
+                idx_cpu = self.index_k_with_scale_buffer[slot][chunk_page_indices].to(
+                    "cpu", non_blocking=True
+                )
                 index_k_cpu[-1].append(idx_cpu)
         torch.cuda.synchronize()
 
@@ -3332,26 +3354,25 @@ class DSATokenToKVPool(MLATokenToKVPool):
         torch.cuda.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         page_chunk_size = max(1, chunk_size // self.page_size)
-        for layer_id in range(self.layer_num):
+        for slot in range(len(self.index_k_with_scale_buffer)):
             for i in range(0, len(page_indices), page_chunk_size):
                 chunk_page_indices = page_indices[i : i + page_chunk_size]
-                idx_cpu = index_k_cpu[layer_id][i // page_chunk_size]
+                idx_cpu = index_k_cpu[slot][i // page_chunk_size]
                 assert idx_cpu.shape[0] == len(chunk_page_indices)
                 idx_chunk = idx_cpu.to(
                     self.index_k_with_scale_buffer[0].device, non_blocking=True
                 )
-                self.index_k_with_scale_buffer[layer_id][chunk_page_indices] = idx_chunk
+                self.index_k_with_scale_buffer[slot][chunk_page_indices] = idx_chunk
         torch.cuda.synchronize()
 
     def get_state_buf_infos(self):
+        num_bufs = len(self.index_k_with_scale_buffer)
         data_ptrs = [
-            self.index_k_with_scale_buffer[i].data_ptr() for i in range(self.layer_num)
+            self.index_k_with_scale_buffer[i].data_ptr() for i in range(num_bufs)
         ]
-        data_lens = [
-            self.index_k_with_scale_buffer[i].nbytes for i in range(self.layer_num)
-        ]
+        data_lens = [self.index_k_with_scale_buffer[i].nbytes for i in range(num_bufs)]
         item_lens = [
-            self.index_k_with_scale_buffer[i][0].nbytes for i in range(self.layer_num)
+            self.index_k_with_scale_buffer[i][0].nbytes for i in range(num_bufs)
         ]
         return data_ptrs, data_lens, item_lens
 

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -972,6 +972,13 @@ class ModelRunnerKVCacheMixin:
                 pool_kwargs["layer_shard_size"] = dsa_cp_layer_shard_size
             else:
                 PoolCls = DSATokenToKVPool
+                from sglang.srt.model_executor.pool_configurator import (
+                    get_dsa_compact_indexer_layer_ids,
+                )
+
+                pool_kwargs["indexer_layer_ids"] = get_dsa_compact_indexer_layer_ids(
+                    self
+                )
             self.token_to_kv_pool = PoolCls(
                 self.max_total_num_tokens,
                 page_size=self.page_size,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -216,9 +216,11 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 element_size = torch._utils._element_size(
                     DSATokenToKVPool.index_k_with_scale_buffer_dtype
                 )
-                cell_size += (
-                    indexer_size_per_token * effective_num_layers * element_size
-                )
+                num_indexer_layers = effective_num_layers
+                compact_indexer_layer_ids = get_dsa_compact_indexer_layer_ids(mr)
+                if compact_indexer_layer_ids is not None:
+                    num_indexer_layers = len(compact_indexer_layer_ids)
+                cell_size += indexer_size_per_token * num_indexer_layers * element_size
         elif is_minimax_sparse(model_config.hf_config):
             # Mirrors MiniMaxSparseKVPool: main pool (K+V all layers) + indexer pool
             # (sparse-only, single-head; kv layers store K+V, k-only layers store K).
@@ -792,3 +794,44 @@ def create_memory_pool_configurator(
         return HybridSWAPoolConfigurator(mr)
     # Future: MambaPoolConfigurator
     return DefaultPoolConfigurator(mr)
+
+
+def get_dsa_compact_indexer_layer_ids(mr) -> Optional[list[int]]:
+    """Absolute layer ids that own a DSA indexer K-cache slot, or None for
+    the dense one-slot-per-layer layout.
+
+    skip_topk (shared) layers reuse the previous full layer's top-k; their
+    indexer cache is never read (see should_run_indexer), so their slots are
+    pure waste (57/78 layers on GLM-5.2 == ~13.6% of the KV pool). Dense
+    layout is kept for: models without shared layers (e.g. DeepSeek-V3.2),
+    draft/NextN workers (the NextN layer owns indexer weights), hisparse and
+    hierarchical cache (their host mirrors assume the dense layout), DSA
+    cache layer split (per-rank shard bookkeeping assumes dense), and when
+    SGLANG_DSA_COMPACT_INDEXER_CACHE is false.
+    """
+    from sglang.srt.configs.model_config import dsa_layer_skips_topk
+    from sglang.srt.environ import envs
+    from sglang.srt.layers.cp.utils import get_glm_dsa_cp_layer_shard_info
+
+    hf_config = mr.model_config.hf_config
+    if not is_deepseek_dsa(hf_config):
+        return None
+    if not envs.SGLANG_DSA_COMPACT_INDEXER_CACHE.get():
+        return None
+    if mr.is_draft_worker:
+        return None
+    if getattr(mr, "enable_hisparse", False):
+        return None
+    if mr.server_args.enable_hierarchical_cache:
+        return None
+    shard_rank, _ = get_glm_dsa_cp_layer_shard_info(mr)
+    if shard_rank is not None:
+        return None
+    layer_ids = [
+        layer_id
+        for layer_id in range(mr.start_layer, mr.end_layer)
+        if not dsa_layer_skips_topk(hf_config, layer_id)
+    ]
+    if len(layer_ids) == mr.end_layer - mr.start_layer:
+        return None
+    return layer_ids

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1637,26 +1637,6 @@ class DeepseekV2AttentionMLA(
         self.skip_topk = None
         self.next_skip_topk = None
         if self.use_dsa:
-            is_neox_style = not getattr(config, "indexer_rope_interleave", False)
-            self.indexer = Indexer(
-                hidden_size=hidden_size,
-                index_n_heads=get_dsa_index_n_heads(config),
-                index_head_dim=get_dsa_index_head_dim(config),
-                rope_head_dim=qk_rope_head_dim,
-                index_topk=get_dsa_index_topk(config),
-                q_lora_rank=q_lora_rank,
-                max_position_embeddings=max_position_embeddings,
-                rope_theta=rope_theta,
-                scale_fmt="ue8m0",
-                block_size=128,
-                rope_scaling=rope_scaling,
-                is_neox_style=is_neox_style,
-                prefix=add_prefix("indexer", prefix),
-                quant_config=quant_config,
-                layer_id=layer_id,
-                alt_stream=alt_stream,
-                config=config,
-            )
             # Refer: https://arxiv.org/abs/2603.12201 for more details.
             # skip_topk: when True, this layer will skip computation and reuse previous layer's topk indices.
             # next_skip_topk: when True, the next layer will skip computation and reuse this layer's topk indices.
@@ -1671,6 +1651,35 @@ class DeepseekV2AttentionMLA(
                 else:
                     self.skip_topk = dsa_layer_skips_topk(config, layer_id)
                     self.next_skip_topk = dsa_layer_skips_topk(config, layer_id + 1)
+            # skip_topk (shared) layers carry no indexer weights in the
+            # checkpoint and never run the indexer (see should_run_indexer),
+            # so skip building it to avoid holding uninitialized weights
+            # (mirrors DeepSeek-V4, where self.indexer is None on non-C4
+            # layers). The NextN layer keeps its indexer: it has checkpoint
+            # weights and runs them when no carried top-k is available.
+            if is_nextn or not self.skip_topk:
+                is_neox_style = not getattr(config, "indexer_rope_interleave", False)
+                self.indexer = Indexer(
+                    hidden_size=hidden_size,
+                    index_n_heads=get_dsa_index_n_heads(config),
+                    index_head_dim=get_dsa_index_head_dim(config),
+                    rope_head_dim=qk_rope_head_dim,
+                    index_topk=get_dsa_index_topk(config),
+                    q_lora_rank=q_lora_rank,
+                    max_position_embeddings=max_position_embeddings,
+                    rope_theta=rope_theta,
+                    scale_fmt="ue8m0",
+                    block_size=128,
+                    rope_scaling=rope_scaling,
+                    is_neox_style=is_neox_style,
+                    prefix=add_prefix("indexer", prefix),
+                    quant_config=quant_config,
+                    layer_id=layer_id,
+                    alt_stream=alt_stream,
+                    config=config,
+                )
+            else:
+                self.indexer = None
 
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,

--- a/test/registered/unit/mem_cache/test_dsa_compact_indexer_cache.py
+++ b/test/registered/unit/mem_cache/test_dsa_compact_indexer_cache.py
@@ -1,0 +1,149 @@
+"""Unit tests for the compact DSA indexer K-cache layout.
+
+Hermetic (no GPU, no server). Guards:
+
+  1. ``dsa_layer_skips_topk`` layer-placement resolution for the three config
+     forms (``index_topk_pattern`` > ``index_topk_freq``/
+     ``index_skip_topk_offset`` > dense), including the GLM-5.2 shipped
+     config (freq=4, offset=3 -> 21 full / 57 shared of 78).
+  2. ``get_dsa_compact_indexer_layer_ids`` gating: dense models, draft
+     workers, hisparse, hierarchical cache, and DSA cache layer split all
+     keep the dense one-slot-per-layer layout (returning None).
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.configs.model_config import dsa_layer_skips_topk
+from sglang.srt.model_executor.pool_configurator import (
+    get_dsa_compact_indexer_layer_ids,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+GLM52_NUM_LAYERS = 78
+# indexer_types from zai-org/GLM-5.2 config.json: full on 0,1,2 then every
+# 4th layer starting at 6; the checkpoint carries indexer weights only there.
+GLM52_FULL_LAYERS = [0, 1, 2] + list(range(6, GLM52_NUM_LAYERS, 4))
+
+
+def _glm52_config():
+    return SimpleNamespace(
+        architectures=["GlmMoeDsaForCausalLM"],
+        index_topk=2048,
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        index_topk_pattern=None,
+    )
+
+
+def _dense_dsa_config():
+    # DeepSeek-V3.2 style: no freq/pattern fields -> indexer on every layer.
+    return SimpleNamespace(
+        architectures=["DeepseekV32ForCausalLM"],
+        index_topk=2048,
+    )
+
+
+def _mock_runner(hf_config, num_layers, **overrides):
+    mr = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=hf_config),
+        start_layer=0,
+        end_layer=num_layers,
+        is_draft_worker=False,
+        enable_hisparse=False,
+        server_args=SimpleNamespace(enable_hierarchical_cache=False),
+    )
+    for k, v in overrides.items():
+        setattr(mr, k, v)
+    return mr
+
+
+def _patch_dsa_env(compact=True):
+    return patch(
+        "sglang.srt.environ.envs.SGLANG_DSA_COMPACT_INDEXER_CACHE.get",
+        return_value=compact,
+    )
+
+
+def _patch_no_layer_split():
+    return patch(
+        "sglang.srt.layers.cp.utils.get_glm_dsa_cp_layer_shard_info",
+        return_value=(None, None),
+    )
+
+
+class TestDsaLayerSkipsTopk(CustomTestCase):
+    def test_glm52_freq_offset_matches_shipped_indexer_types(self):
+        cfg = _glm52_config()
+        full = [l for l in range(GLM52_NUM_LAYERS) if not dsa_layer_skips_topk(cfg, l)]
+        self.assertEqual(full, GLM52_FULL_LAYERS)
+        self.assertEqual(len(full), 21)
+
+    def test_pattern_takes_precedence_over_freq(self):
+        cfg = _glm52_config()
+        cfg.index_topk_pattern = "FSFS"
+        self.assertFalse(dsa_layer_skips_topk(cfg, 0))
+        self.assertTrue(dsa_layer_skips_topk(cfg, 1))
+        self.assertFalse(dsa_layer_skips_topk(cfg, 2))
+        self.assertTrue(dsa_layer_skips_topk(cfg, 3))
+
+    def test_dense_config_never_skips(self):
+        cfg = _dense_dsa_config()
+        self.assertFalse(
+            any(dsa_layer_skips_topk(cfg, l) for l in range(GLM52_NUM_LAYERS))
+        )
+
+
+class TestCompactIndexerLayerIds(CustomTestCase):
+    def test_glm52_compacts_to_full_layers(self):
+        mr = _mock_runner(_glm52_config(), GLM52_NUM_LAYERS)
+        with _patch_dsa_env(), _patch_no_layer_split():
+            ids = get_dsa_compact_indexer_layer_ids(mr)
+        self.assertEqual(ids, GLM52_FULL_LAYERS)
+
+    def test_pp_range_is_respected(self):
+        mr = _mock_runner(
+            _glm52_config(), GLM52_NUM_LAYERS, start_layer=39, end_layer=78
+        )
+        with _patch_dsa_env(), _patch_no_layer_split():
+            ids = get_dsa_compact_indexer_layer_ids(mr)
+        self.assertEqual(ids, [l for l in GLM52_FULL_LAYERS if 39 <= l < 78])
+
+    def test_dense_model_returns_none(self):
+        mr = _mock_runner(_dense_dsa_config(), 61)
+        with _patch_dsa_env(), _patch_no_layer_split():
+            self.assertIsNone(get_dsa_compact_indexer_layer_ids(mr))
+
+    def test_gates_return_none(self):
+        cases = [
+            dict(is_draft_worker=True),
+            dict(enable_hisparse=True),
+            dict(server_args=SimpleNamespace(enable_hierarchical_cache=True)),
+        ]
+        for overrides in cases:
+            mr = _mock_runner(_glm52_config(), GLM52_NUM_LAYERS, **overrides)
+            with _patch_dsa_env(), _patch_no_layer_split():
+                self.assertIsNone(
+                    get_dsa_compact_indexer_layer_ids(mr), msg=str(overrides)
+                )
+
+    def test_layer_split_returns_none(self):
+        mr = _mock_runner(_glm52_config(), GLM52_NUM_LAYERS)
+        with _patch_dsa_env(), patch(
+            "sglang.srt.layers.cp.utils.get_glm_dsa_cp_layer_shard_info",
+            return_value=(0, 2),
+        ):
+            self.assertIsNone(get_dsa_compact_indexer_layer_ids(mr))
+
+    def test_env_escape_hatch(self):
+        mr = _mock_runner(_glm52_config(), GLM52_NUM_LAYERS)
+        with _patch_dsa_env(compact=False), _patch_no_layer_split():
+            self.assertIsNone(get_dsa_compact_indexer_layer_ids(mr))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DSATokenToKVPool` allocates an indexer K-cache slot (132 B/token/layer: 128 B fp8 index-K + 4 B scale) for **every** transformer layer. With cross-layer index-top-k sharing (GLM-5.2: 57 shared of 78 layers), shared layers reuse the previous full layer's top-k and **never read their own indexer cache** (`should_run_indexer`), so 57/78 of the indexer pool — **13.6 % of the entire KV pool, ~7.5 KB/token** — is allocated and never used. Compacting it buys **+15.8 % token capacity** on GLM-5.2 for free.

This follows TensorRT-LLM's approach of materializing indexer state only on full layers (NVIDIA/TensorRT-LLM#15574), and mirrors the compacted sparse-layer sub-pool pattern already used by `MiniMaxSparseKVPool`.

Stacked on #30922 (skip building the `Indexer` module on shared layers).

## Modifications

- **`pool_configurator.py`**: new `get_dsa_compact_indexer_layer_ids(mr)` — the single source of truth for which (absolute) layer ids own an indexer slot. Returns `None` (dense one-slot-per-layer layout, i.e. today's behavior) for: dense-DSA models (DeepSeek-V3.2), draft/NextN workers, hisparse, hierarchical cache (their host mirrors assume the dense layout), DSA cache layer split, and the `SGLANG_DSA_COMPACT_INDEXER_CACHE=false` escape hatch. Cell-size accounting uses the compact count so `max_total_num_tokens` grows accordingly.
- **`memory_pool.py` (`DSATokenToKVPool`)**: optional `indexer_layer_ids` ctor arg; buffers allocated per indexer layer; all five layer-id-based accessors route through a slot lookup that **hard-asserts on shared-layer access** (any missed call site fails loudly instead of reading garbage); cpu-offload copies and `get_state_buf_infos` enumerate the compact buffer list.
- **`model_runner_kv_cache_mixin.py`**: pass `indexer_layer_ids` to the plain `DSATokenToKVPool` only (`HiSparse`/`LayerSplit` subclasses keep the dense layout).
- **`environ.py`**: `SGLANG_DSA_COMPACT_INDEXER_CACHE` (default true).
- **`mooncake/conn.py`**: PD-disagg ships indexer buffers as a positionally-paired `StateType.DSA` ptr list; a buffer-count mismatch (e.g. compact vs dense across versions) previously fell into lenient truncation and would silently mispair layers — now it hard-fails with a clear message. Both P and D compute the layout from the same config + helper, so same-version deployments pair correctly by construction, and the DSA state transfer volume itself drops 73 % on GLM-5.2.

PP is handled: the mapping is computed per rank from `[start_layer, end_layer)`. Unsupported-path bookkeeping (hisparse host mirror, layer-split shard math, hierarchical-cache sidecar) deliberately keeps the dense layout rather than half-supporting it; they can be migrated in follow-ups.

## Accuracy Tests

8-layer GLM-5.2 config (`F F F S S S F S`, real dims, dummy weights, B200, `mem-fraction-static 0.4`):

| | main | this PR | check |
|---|---|---|---|
| KV cell size | 5664 B/token | **5136 B/token** | = 8×576 (MLA) + **4**×132 (indexer) exactly |
| `max_total_num_tokens` | 10,539,968 | **11,638,208** | **+10.4 %** (theory +10.3 %) |
| Greedy output ids | `[40472, 76288, 138027, ...]` | **identical** | full layers read/write their slots correctly |

Dense-DSA regression (same config without `index_topk_freq`): tokens and KV size **bit-identical to main** (10,539,968 / 55.60 GB) — helper returns `None`, stock layout.

Extrapolated to full GLM-5.2 (78 layers): 55,224 → 47,700 B/token ⇒ **+15.8 % KV token capacity** on every rank.

Unit tests: `test/registered/unit/mem_cache/test_dsa_compact_indexer_cache.py` (hermetic, CPU) — layer-placement resolution incl. the shipped GLM-5.2 config reproducing 21 full / 57 shared, pattern-over-freq precedence, PP ranges, and every dense-layout gate. 9/9 pass.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Provide accuracy and speed benchmark results.

cc @mattteochen @zRzRzRzRzRzRzR @mmangkad







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29185114985](https://github.com/sgl-project/sglang/actions/runs/29185114985)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29185114939](https://github.com/sgl-project/sglang/actions/runs/29185114939)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->