### PR TITLE
fix(rocm): don't attempt CUDA IPC handle creation on ROCm tensors; document the pitfall

### DIFF
--- a/docs_new/docs/developer_guide/contribution_guide.mdx
+++ b/docs_new/docs/developer_guide/contribution_guide.mdx
@@ -161,6 +161,7 @@ Users listed in [CI_PERMISSIONS.json](https://github.com/sgl-project/sglang/blob
   - Do not drastically change existing code.
   - Always prefer new files to introduce specific components for your new hardware (e.g., `allocator_ascend.py`).
   - If you write multiple if/else blocks for new features, ensure the common path (e.g., NVIDIA hardware or the existing code path) is the first branch.
+  - Do not use `tensor.is_cuda` (or any other raw PyTorch device-namespace property/name) to mean "this is running on NVIDIA CUDA." PyTorch's ROCm build exposes HIP tensors under the `cuda` device type for API compatibility, so `tensor.is_cuda` is also True on AMD/ROCm. Use `sglang.srt.utils.is_cuda()` (checks `torch.version.cuda is not None`) or `is_hip()` (checks `torch.version.hip is not None`) instead — see [#30926](https://github.com/sgl-project/sglang/pull/30926) for a real bug this distinction would have caught: CUDA IPC handle creation (`storage._share_cuda_()`) being attempted on ROCm tensors because the gate only checked `tensor.is_cuda`.
 
 ## How to update sgl-kernel
 Since sglang and the `sglang-kernel` (prior `sgl-kernel`) distribution are separate Python packages, our current GitHub CI infrastructure does not support updating a kernel and using it immediately within the same pull request (PR).

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -34,7 +34,7 @@ from sglang.srt.mem_cache.multimodal_cache import EmbeddingResult, MultiModalSta
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.multimodal.evs import EVSEmbeddingResult
 from sglang.srt.runtime_context import get_parallel, get_server_args
-from sglang.srt.utils import flatten_nested_list, is_hip, is_npu, print_warning_once
+from sglang.srt.utils import flatten_nested_list, is_cuda, is_hip, is_npu, print_warning_once
 from sglang.srt.utils.stale_shm_cleanup import make_shm_name
 from sglang.utils import logger
 
@@ -150,7 +150,13 @@ class TransportProxyTensor(torch.Tensor):
         }
         transport_mode = self._metadata.get("transport_mode", "default")
 
-        if transport_mode == "cuda_ipc" and self.is_cuda:
+        # `self.is_cuda` is torch.Tensor's own device-namespace check, which is True
+        # on both real CUDA and ROCm/HIP builds (PyTorch exposes HIP tensors under
+        # the "cuda" device type for API compatibility). `storage._share_cuda_()`
+        # below does real CUDA IPC handle creation, which isn't valid on ROCm — gate
+        # on `is_cuda()` too, which checks `torch.version.cuda is not None` and is
+        # only true on an actual CUDA build.
+        if transport_mode == "cuda_ipc" and self.is_cuda and is_cuda():
             try:
                 storage = self.untyped_storage()
                 handle = storage._share_cuda_()

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -201,7 +201,13 @@ class BaseMultimodalProcessor(ABC):
             if configured_mm_feature_transport in ("cpu", "cuda_ipc")
             else "cpu"
         )
-        self.use_cuda_ipc = self.mm_feature_transport == "cuda_ipc"
+        # storage._share_cuda_() (called downstream when use_cuda_ipc is True)
+        # is only valid on a real CUDA build -- upstream's own server_args
+        # validation already rejects `--mm-feature-transport=cuda_ipc` on
+        # non-CUDA hardware at config time, but gate it here too so this
+        # attribute can never resolve True on a non-CUDA build even if this
+        # processor is constructed directly, bypassing that validation.
+        self.use_cuda_ipc = self.mm_feature_transport == "cuda_ipc" and is_cuda()
         self.disable_fast_image_processor = server_args.disable_fast_image_processor
         self.skip_tokenizer_init = server_args.skip_tokenizer_init
 


### PR DESCRIPTION
## What
Two related bugs, same root cause: code assumed `torch.Tensor.is_cuda` (or an env-var flag with no device check) meant *real CUDA*, when it's also True on ROCm/HIP builds — PyTorch exposes HIP tensors under the `cuda` device type for API compatibility. Both paths then called `storage._share_cuda_()`, which does real CUDA IPC handle creation and isn't valid on ROCm.

**Commit 1:** `TransportProxyTensor.__getstate__` gated CUDA-IPC pickling on `self.is_cuda` alone.

**Commit 2:** `SGL_USE_CUDA_IPC` (env var `SGLANG_USE_CUDA_IPC_TRANSPORT`) had no device check at all — if set on a ROCm box it would construct `MmItemMemoryPool` (unconditional `_share_cuda_()` in its constructor) and `CudaIpcTensorTransportProxy.get_proxy_state` (same call, same problem).

**Commit 3:** documents the pitfall in the contribution guide (both `docs/` and `docs_new/`, kept in sync) so it doesn't recur — this exact mistake happened in two independent places in the same codebase.

## Fix
Gate both code paths on sglang's own `is_cuda()` helper (`sglang.srt.utils`), which checks `torch.version.cuda is not None` — true only on an actual CUDA build. For the flag, fixed at its 2 source definitions (`base_processor.py`, `ernie45_vl.py`) rather than each of the 6+ downstream call sites, so every consumer inherits the exclusion.

## Context
Commit 1 is a re-submission of #30576 — that PR's source fork was deleted before a maintainer could review it (tooling issue on my end, not a withdrawal). Re-verified the bug is still present in current `main`. Commits 2 and 3 are new — found and written while investigating the same feature area for this re-submission.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35512600188](https://github.com/sgl-project/sglang/actions/runs/35512600188)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35512600084](https://github.com/sgl-project/sglang/actions/runs/35512600084)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35512600186](https://github.com/sgl-project/sglang/actions/runs/35512600186)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->