### PR TITLE
fix(sampling): handle NOT_LITERAL token in stop_regex max-length bound

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -292,6 +292,7 @@ def _max_length_from_subpattern(subpattern: sre_parse.SubPattern):
     for token, value in subpattern:
         if token in {
             sre_parse.LITERAL,  # `value` is any one character
+            sre_parse.NOT_LITERAL,  # `[^a]` - a negated single character
             sre_parse.IN,  # Any character within `value`
             sre_parse.ANY,  # "."
         }:

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -454,6 +454,15 @@ class TestRegexMaxLength(CustomTestCase):
         """Test that character class '[a-z]' gives max length 1."""
         self.assertEqual(get_max_seq_length("[a-z]"), 1)
 
+    def test_negated_single_char_class(self):
+        """Test that a single-char negated class '[^a]' gives max length 1,
+        matching the multi-char negated form '[^ab]' rather than falling
+        into the unhandled-token MAX_LEN fallback (sre_parse emits a
+        distinct NOT_LITERAL token for the single-char case)."""
+        self.assertEqual(get_max_seq_length("[^a]"), 1)
+        self.assertEqual(get_max_seq_length("[^ab]"), 1)
+        self.assertEqual(get_max_seq_length("a[^b]c"), 3)
+
     def test_dot_any(self):
         """Test that dot wildcard '.' gives max length 1."""
         self.assertEqual(get_max_seq_length("."), 1)


### PR DESCRIPTION
Fixes #30932.

`_max_length_from_subpattern` computes a strict upper bound on how many characters a `stop_regex` can match, used to size the tail-buffer re-decoded on each generation step. It special-cased `LITERAL`, `IN`, and `ANY` as single-character tokens, but `sre_parse`/`re._parser` emits a distinct `NOT_LITERAL` token for a negated class containing exactly one character (`[^a]`) - separate from `IN`, which is what multi-char negated classes like `[^ab]` parse to. `NOT_LITERAL` fell through to the unhandled-token fallback and got treated as unbounded (`MAX_LEN = 2**30`):

```python
>>> get_max_seq_length(r'[^a]')
1073741824          # before this fix; should be 1
>>> get_max_seq_length(r'[^ab]')
1                    # already correct - two-char negated class hits IN instead
```

Since `_stop_match_tail_len` (in `managers/schedule_batch.py`) clamps to `len(self.output_ids)`, this didn't cause an actual oversized allocation - but it did silently disable the tail-buffering optimization for any `stop_regex` containing a single-char negated class (e.g. `[^,]+`), forcing a full-output re-decode on every step instead of just the recent tail.

Fix is the one-line addition the comment on `LITERAL` already implies applies here too - `NOT_LITERAL` matches exactly one character, same as `LITERAL`/`IN`/`ANY`.

## Testing

Added `test_negated_single_char_class` to the existing `TestRegexMaxLength` suite in `test/registered/unit/sampling/test_sampling_params.py`, covering the single-char case, the already-working multi-char case, and a mixed pattern.

I wasn't able to run the full test file through pytest in my sandbox - importing `sglang.test.test_utils` pulls in the full package init chain, which hit an unrelated environment issue (a `transformers` version already registering `qwen3_asr` as a config, from a different local checkout on my `PYTHONPATH`), not anything caused by this change. I verified the fix and all of `TestRegexMaxLength`'s existing assertions directly against the patched module via `importlib`, bypassing the package `__init__` entirely:

```python
import importlib.util
spec = importlib.util.spec_from_file_location(
    "sampling_params", "python/sglang/srt/sampling/sampling_params.py"
)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)

# every existing TestRegexMaxLength case, plus the new ones:
assert mod.get_max_seq_length("abc") == 3
assert mod.get_max_seq_length("[a-z]") == 1
assert mod.get_max_seq_length(".") == 1
assert mod.get_max_seq_length("a{5}") == 5
assert mod.get_max_seq_length("a{2,4}") == 4
assert mod.get_max_seq_length("abc|de") == 3
assert mod.get_max_seq_length("(abc)") == 3
assert mod.get_max_seq_length("^abc$") == 3
assert mod.get_max_seq_length("((ab))") == 2
assert mod.get_max_seq_length("a?") == 1
assert mod.get_max_seq_length("") == 0
assert mod.get_max_seq_length("[^a]") == 1       # new
assert mod.get_max_seq_length("[^ab]") == 1      # new
assert mod.get_max_seq_length("a[^b]c") == 3     # new
```

All pass. Happy to re-run through the real CI harness if a maintainer can confirm the `qwen3_asr` collision is just my local environment (I'm fairly confident it is, since it traces back to a `transformers` checkout that isn't part of this repo).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29194696983](https://github.com/sgl-project/sglang/actions/runs/29194696983)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29194696877](https://github.com/sgl-project/sglang/actions/runs/29194696877)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->