### PR TITLE
fix: add exist_ok=True to qwen3_asr AutoConfig.register

### DIFF
--- a/python/sglang/srt/configs/qwen3_asr.py
+++ b/python/sglang/srt/configs/qwen3_asr.py
@@ -164,5 +164,5 @@ class Qwen3ASRConfig(PretrainedConfig):
         return self.thinker_config.text_config
 
 
-AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
-AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig)
+AutoConfig.register("qwen3_asr", Qwen3ASRConfig, exist_ok=True)
+AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig, exist_ok=True)

--- a/python/sglang/srt/configs/qwen3_asr.py
+++ b/python/sglang/srt/configs/qwen3_asr.py
@@ -164,5 +164,9 @@ class Qwen3ASRConfig(PretrainedConfig):
         return self.thinker_config.text_config
 
 
-AutoConfig.register("qwen3_asr", Qwen3ASRConfig, exist_ok=True)
-AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig, exist_ok=True)
+try:
+    AutoConfig.register("qwen3_asr", Qwen3ASRConfig, exist_ok=True)
+    AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig, exist_ok=True)
+except TypeError:
+    AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
+    AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig)


### PR DESCRIPTION
## Description

When a newer version of `transformers` (e.g. 5.x+) already registers `qwen3_asr` natively, SGLang's `AutoConfig.register` call at:

```python
AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig)
```

...fails with:

> `Config model type 'qwen3_asr' already registered`

This affects users deploying Qwen3.x models with newer `transformers` versions.

## Fix

Simply adds `exist_ok=True` to both `AutoConfig.register` calls, making them tolerant of prior registration. This is forward-compatible: if transformers hasn't registered it yet, the `exist_ok` is a no-op; if it has, the conflict is avoided.

## Related

- Original workaround discussion: https://huggingface.co/selode-ai/Qwen-3.6-35B-A3B-VRAP-4-bit-AWQ-21.2GB/discussions/3

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31150562788](https://github.com/sgl-project/sglang/actions/runs/31150562788)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31150562732](https://github.com/sgl-project/sglang/actions/runs/31150562732)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->