### PR TITLE
[AMD] Gate TP4 o_proj/qkv CK block-FP8 GEMM shapes to Triton (ROCm 7.0 Qwen-3.5)

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -70,13 +70,16 @@ _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
 _use_aiter_bpreshuffle_gfx95 = _use_aiter_gfx95 and get_hip_version() >= (7, 2, 0)
 # gfx95 + ROCm < 7.2: bpreshuffle CK is disabled (above), and the non-bpreshuffle
 # fallback ck_gemm_a8w8_blockscale returns NaN above a per-shape M for some shapes
-# (measured NaN onset: (2560,4096)@M>=4096, (4096,1024)@M>=8192), corrupting prefill.
+# (measured NaN onset: (2560,4096)@M>=4096, (4096,1024)@M>=8192 at TP8; at TP4 the
+# attn proj (4608,4096)@M>=2048 and o_proj (4096,2048)@M>=4096), corrupting prefill.
 # Map each affected (n, k) to the largest M for which CK is confirmed correct
 # (conservative = last verified-safe M). Keep the faster CK path at/below that M and
 # fall back to the numerically-correct Triton FP8 GEMM above it. Fixed in ROCm 7.2.
 _AITER_GFX95_CK_W8A8_MAX_SAFE_M = {
     (2560, 4096): 2048,
     (4096, 1024): 4096,
+    (4096, 2048): 2048,  # TP4 o_proj (TP8 shape was (4096, 1024))
+    (4608, 4096): 512,  # TP4 attn qkv/gate proj: CK NaN at M>=2048 on ROCm 7.0
 }
 
 


### PR DESCRIPTION


## Motivation

Follow-up to #29918. Qwen3.5-397B-A17B-FP8 accuracy on **AMD gfx95 (MI35x) with
ROCm 7.0** drops to ~0 (GSM8K 0.001) at **TP4**, while the same model/args pass
on ROCm 7.2 (~0.95).

### Root cause

On gfx95 the bpreshuffle CK block-scale FP8 GEMM is disabled for ROCm < 7.2
(ROCm 7.0 hipcc miscompiles it, PR23319). The dense FP8 linear path then falls
back to `ck_gemm_a8w8_blockscale`, which **returns NaN above a per-shape M
threshold** on ROCm 7.0 gfx95, corrupting prefill (chunked up to 8192).

\#29918 gated this for the **TP8** shapes, but at **TP4** the per-shard weight
shapes differ and were not covered, so the NaN slipped through. A minimal probe
(same fp8 inputs -> CK vs Triton vs fp32 ref) on the TP4 dense attention
projections actually used by the model:

| Shape (n, k) | Proj | CK correct up to | NaN at | Triton / ROCm 7.2 |
| ------------ | ---- | ---------------- | ------- | ----------------- |
| (4608, 4096) | qkv/gate | M = 512  | M >= 2048 | correct |
| (4096, 2048) | o_proj   | M = 2048 | M >= 4096 | correct |
| (5120, 4096) | qkv      | all M    | -         | correct (not gated) |

Triton matches the fp32 reference for all M; CK returns NaN above the listed M
on ROCm 7.0 and is correct for all M on ROCm 7.2.

## Modifications

Only on the affected environment (gfx95 + ROCm < 7.2), add the two broken TP4
shapes to `_AITER_GFX95_CK_W8A8_MAX_SAFE_M` (conservative = last verified-safe
M), so they fall back to the numerically-correct Triton FP8 GEMM above that M
while keeping the faster CK path below it (decode / small prefill). Unlisted
shapes and ROCm >= 7.2 / non-gfx95 are untouched.

* `(4608, 4096): 512`
* `(4096, 2048): 2048`

## Accuracy Results

Qwen3.5-397B-A17B-FP8, TP4, `--attention-backend aiter`
`--enable-aiter-allreduce-fusion --kv-cache-dtype fp8_e4m3`, GSM8K (1319),
MI35x + ROCm 7.0:

| Config              | ROCm    | Accuracy  | Invalid |
| ------------------- | ------- | --------- | ------- |
| Before (CK)         | 7.0     | 0.001     | 0.195   |
| **After (this PR)** | **7.0** | **0.950** | 0.011   |
| Reference           | 7.2     | ~0.95     | ~0.01   |

## Checklist

* [ ] Format code with pre-commit
* [ ] Add/adjust unit tests
* [ ] Provide accuracy benchmark results (above)
* [ ] Follow the SGLang code style

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29202069756](https://github.com/sgl-project/sglang/actions/runs/29202069756)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29202069644](https://github.com/sgl-project/sglang/actions/runs/29202069644)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->