### PR TITLE
Fix hashtopk empty return annotation

### DIFF
--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -95,7 +95,7 @@ class HashTopK(nn.Module):
 
     def empty_topk_output(
         self, device: torch.device, *, layer_id: Optional[int] = None
-    ):
+    ) -> StandardTopKOutput:
         # self.topk includes any fused shared-expert columns.
         topk = self.topk
         if layer_id is not None:

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -96,7 +96,8 @@ class HashTopK(nn.Module):
     def empty_topk_output(
         self, device: torch.device, *, layer_id: Optional[int] = None
     ):
-        topk = self.topk - self.num_fused_shared_experts
+        # self.topk includes any fused shared-expert columns.
+        topk = self.topk
         if layer_id is not None:
             from sglang.srt.eplb.lplb_solver import get_global_lplb_solver
 
@@ -107,18 +108,10 @@ class HashTopK(nn.Module):
                 )
         topk_weights = torch.empty((0, topk), dtype=torch.float32, device=device)
         topk_ids = torch.full((0, topk), -1, dtype=torch.int32, device=device)
-        router_logits = torch.empty((0, topk), dtype=torch.float32, device=device)
+        router_logits = torch.empty(
+            (0, self.num_experts), dtype=torch.float32, device=device
+        )
         topk_output = StandardTopKOutput(topk_weights, topk_ids, router_logits)
-        if has_per_rank_fused_shared_slots(self.num_fused_shared_experts):
-            n = self.num_fused_shared_experts
-            topk_output = topk_output._replace(
-                topk_ids=topk_output.topk_ids.new_empty(
-                    (0, topk_output.topk_ids.shape[-1] + n)
-                ),
-                topk_weights=topk_output.topk_weights.new_empty(
-                    (0, topk_output.topk_weights.shape[-1] + n)
-                ),
-            )
         return self._apply_deepep_waterfill(topk_output, num_tokens=0)
 
     def _apply_deepep_waterfill(

--- a/test/registered/moe/test_hash_topk.py
+++ b/test/registered/moe/test_hash_topk.py
@@ -80,9 +80,14 @@ def test_hash_topk_remaps_per_rank_fused_shared_slots(monkeypatch):
     assert recorded["topk_ids"].tolist() == [[0, 65], [63, 127]]
 
 
-def test_hash_topk_empty_output_keeps_per_rank_shared_slot(monkeypatch):
+@pytest.mark.parametrize("uses_per_rank_shared_slots", [False, True])
+def test_hash_topk_empty_output_matches_zero_token_forward(
+    monkeypatch, uses_per_rank_shared_slots
+):
     monkeypatch.setattr(
-        hash_topk_module, "has_per_rank_fused_shared_slots", lambda *_args: True
+        hash_topk_module,
+        "has_per_rank_fused_shared_slots",
+        lambda *_args: uses_per_rank_shared_slots,
     )
 
     topk = HashTopK(
@@ -93,11 +98,19 @@ def test_hash_topk_empty_output_keeps_per_rank_shared_slot(monkeypatch):
         scoring_func="softmax",
     )
 
-    output = topk.empty_topk_output(torch.device("cpu"))
+    with hash_topk_module.envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.override(False):
+        forward_output = topk(
+            hidden_states=torch.empty((0, 4)),
+            router_logits=torch.empty((0, 256)),
+            input_ids=torch.empty((0,), dtype=torch.int64),
+        )
+    empty_output = topk.empty_topk_output(torch.device("cpu"))
 
-    assert output.topk_ids.shape == (0, 7)
-    assert output.topk_weights.shape == (0, 7)
-    assert output.router_logits.shape == (0, 6)
+    expected_shapes = ((0, 7), (0, 7), (0, 256))
+    for output in (forward_output, empty_output):
+        assert output.topk_ids.shape == expected_shapes[0]
+        assert output.topk_weights.shape == expected_shapes[1]
+        assert output.router_logits.shape == expected_shapes[2]
 
 
 def test_deepep_empty_forward_does_not_append_shared_slot_twice():


### PR DESCRIPTION
## Motivation

Address the `gemini-code-assist` review comment on sgl-project/sglang#30939 by adding the missing return type annotation to `HashTopK.empty_topk_output`.

## Modifications

- Add `-> StandardTopKOutput` to `HashTopK.empty_topk_output`.
This PR is intended as a small helper PR into `glaziermag:agent/fix-hash-topk-empty-output` so the commit can be cherry-picked into sgl-project/sglang#30939.

Commit to cherry-pick: `7867e6b621b68d079a60657128a0b932a23901f5`

## Accuracy Tests

Not applicable.

## Speed Tests and Profiling

Not applicable. 







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29203264315](https://github.com/sgl-project/sglang/actions/runs/29203264315)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29203264283](https://github.com/sgl-project/sglang/actions/runs/29203264283)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->