### PR TITLE
[AMD] Pin cmake==4.3.4 in ROCm Dockerfile to fix MoRI gtest_discover build break

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -357,8 +357,11 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   cp -v /tmp/build-gtest/lib/*.a /usr/lib/x86_64-linux-gnu/ && \
   rm -rf /tmp/build-gtest; \
   \
-  # Keep setuptools < 80 (compat with base image)
-  "$VENV_PIP" install --upgrade "setuptools>=77.0.3,<80" wheel cmake ninja scikit-build-core && \
+  # Keep setuptools < 80 (compat with base image). Pin cmake to the last known-good
+  # 4.3.4: cmake 4.4's gtest_discover_tests breaks the (pinned) MoRI build with a
+  # JSON parse error. This image is rebuilt daily, so pin the exact version for
+  # reproducible builds rather than letting cmake drift.
+  "$VENV_PIP" install --upgrade "setuptools>=77.0.3,<80" wheel "cmake==4.3.4" ninja scikit-build-core && \
   "$VENV_PIP" cache purge || true; \
   \
   # Locate ROCm llvm-config; fallback to installing LLVM 18 if missing


### PR DESCRIPTION
## Motivation
Both AMD nightly ROCm image builds started failing on 2026-07-11, which also
breaks the AMD PR-CI **Install dependencies** step (it reinstalls MoRI from the
Dockerfile-pinned commit). Both variants share `docker/rocm.Dockerfile`.
| Nightly image | Last green (07-10) | First red |
| ------------- | ------------------ | --------- |
| ROCm 7.0 (`release-docker-amd-nightly.yml`)        | `29093958349` | `29152576569` (07-11) |
| ROCm 7.2 (`release-docker-amd-rocm720-nightly.yml`) | `29093667269` | `29152436775` (07-11) |
### Root cause
`docker/rocm.Dockerfile` installed cmake **unpinned**
(`pip install --upgrade ... cmake ...`), so every daily build pulled the latest
cmake. Between 07-10 and 07-11 cmake drifted **4.3.4 → 4.4**. CMake 4.4's
`gtest_discover_tests` fails to parse the JSON test list of MoRI's `umbp` unit
tests (parallel discovery), aborting the MoRI cmake build:
```
.../cmake-4.4/Modules/GoogleTest/ParseTestList.cmake:96 (string): string sub-command JSON failed parsing json string ninja: build stopped: subcommand failed. CalledProcessError: Command '['cmake', '--build', '.', '-j', '128']' returned non-zero exit status 1
```
MoRI itself did not change — `MORI_COMMIT` is pinned (`e31d426...`) — so cmake is
the only differing input.
## Modifications
Pin **`cmake==4.3.4`** (last known-good) on the Dockerfile dependency-upgrade
line. Since this image is rebuilt daily and is the base for all downstream CI, an
exact pin gives reproducible builds and eliminates the version drift that caused
this break (rather than a floating range). This also protects the other in-image
cmake builds (TileLang, sgl-kernel) from the same 4.4 regression.
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29203466056](https://github.com/sgl-project/sglang/actions/runs/29203466056)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29203465971](https://github.com/sgl-project/sglang/actions/runs/29203465971)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->