### PR TITLE
[Spec] Add kill-switch env for draft-extend CUDA graph capture

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -709,6 +709,11 @@ class Envs:
     # Saves the per-step draft forward, but the draft KV goes stale: an upshift
     # back to steps>0 starts from a cold draft state (low accept until it recovers).
     SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND = EnvBool(False)
+    # Kill-switch for the draft-extend cuda graph. Draft extend then always runs
+    # eager. Escape hatch for setups where the capture's memory pool costs more
+    # than the graph saves (e.g. DeepEP MoE workspace captured at full dispatch
+    # capacity).
+    SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH = EnvBool(False)
     # Use the split-KV (flash-decode) kernel for EAGLE target-verify on the
     # Triton backend (ROCm). Only active at speculative topk == 1; falls back to
     # extend_attention_fwd for unsupported cases or when set false (e.g. for

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -486,11 +486,15 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         ) and graph_supported_backend
         # Capture extend
         # TODO: support draft extend cuda graph for more attention backends
-        if self.draft_extend_attn_backend and (
-            _is_npu
-            or _is_xpu
-            or supports_cuda_draft_extend_graph
-            or supports_hip_aiter_draft_extend_graph
+        if (
+            self.draft_extend_attn_backend
+            and not envs.SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH.get()
+            and (
+                _is_npu
+                or _is_xpu
+                or supports_cuda_draft_extend_graph
+                or supports_hip_aiter_draft_extend_graph
+            )
         ):
             tic = time.perf_counter()
             before_mem = get_available_gpu_memory(self.device, self.gpu_id)

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -237,6 +237,9 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         if _is_cpu or check_cuda_graph_backend(Phase.DECODE, Backend.DISABLED):
             return
 
+        if envs.SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH.get():
+            return
+
         if not _is_npu:
             self.cuda_graph_runner_for_draft_extend = (
                 MultiLayerEagleMultiStepDraftExtendCudaGraphRunner(self)

--- a/test/registered/cp/test_deepseek_v4_flash_fp4_b200_cp.py
+++ b/test/registered/cp/test_deepseek_v4_flash_fp4_b200_cp.py
@@ -30,6 +30,11 @@ DEEPEP_CONFIG = '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":9
 
 _DEEPEP_ENV = {
     "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "1024",
+    # The draft-extend graph pool costs ~4.5 GB here (DeepEP MoE workspace is
+    # captured at full dispatch capacity), which starves the eager prefill
+    # draft extend and OOMs. Run draft extend eager until the capture-time
+    # footprint is fixed.
+    "SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH": "1",
 }
 
 


### PR DESCRIPTION
Adds `SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH` to force draft extend to run eager, and sets it in `test_deepseek_v4_flash_fp4_b200_cp.py` where the draft-extend graph pool costs ~4.5 GB and OOMs the eager prefill draft extend (see https://github.com/sgl-project/sglang/pull/30853#issuecomment-4951235511).

## Follow-up

The draft-extend graph enablement logic is fragmented and should be unified:

- The capture decision is duplicated across two workers (`eagle_worker_v2.py` and `multi_layer_eagle_worker_v2.py`), each hardcoding its own platform / supported-backend checks; this PR's kill-switch had to be wired into both sites separately.
- Draft-extend graphs live entirely outside the `cuda_graph_config` phase framework: there is no per-phase `backend` / `bs` / `max_bs` control for them, and the capture bs list is borrowed from the decode phase.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29206097067](https://github.com/sgl-project/sglang/actions/runs/29206097067)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29206096970](https://github.com/sgl-project/sglang/actions/runs/29206096970)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
