### PR TITLE
[Fix] Disable FlashInfer allreduce fusion in Nemotron-3-Nano lm-eval test

### DIFF
--- a/test/registered/models_e2e/test_nvidia_nemotron_3_nano.py
+++ b/test/registered/models_e2e/test_nvidia_nemotron_3_nano.py
@@ -27,6 +27,11 @@ class TestNvidiaNemotron3Nano30BFP8(LMEvalMixin, DefaultServerBase):
     other_args = [
         "--tp-size",
         "2",
+        # FlashInfer trtllm allreduce fusion on flashinfer 0.6.14 degrades
+        # gsm8k for this model (strict-match 0.84 -> 0.78); the ground truth
+        # was calibrated with fusion disabled. Keep it off until the fusion
+        # numerics regression is resolved.
+        "--enforce-disable-flashinfer-allreduce-fusion",
     ] + NEMOTRON_3_NANO_THINKING_ARGS
 
 


### PR DESCRIPTION
## Summary
- Add `--enforce-disable-flashinfer-allreduce-fusion` to `test_nvidia_nemotron_3_nano.py` so the lm-eval gsm8k check runs with the same fusion-off numerics its ground truth was calibrated against.

## Background
- FlashInfer trtllm allreduce fusion on flashinfer 0.6.14 degrades gsm8k for this model on TP2 (strict-match 0.84 -> 0.78, flexible-extract 0.55 -> 0.44), failing the lm-eval threshold on every PR run since #30580 landed.
- The regression came with the flashinfer 0.6.12 -> 0.6.14 upgrade (#29910) but was masked at the time: the same upgrade also broke the fusion workspace init (#30875), silently disabling fusion everywhere. #30580 fixed the init and re-enabled the fusion path, exposing the numerics regression.
- The fusion wiring itself is not at fault: this test passed with fusion enabled on flashinfer 0.6.12.

## Verification
| flashinfer | fusion | gsm8k strict / flexible | result |
|---|---|---|---|
| 0.6.12 | on | 0.845 / 0.544 | pass ([run](https://github.com/sgl-project/sglang/actions/runs/29010339282)) |
| 0.6.14 | off (init broken) | 0.844 / 0.548 | pass ([run](https://github.com/sgl-project/sglang/actions/runs/29171938366)) |
| 0.6.14 | on | ~0.78 / ~0.44 | fail ([run](https://github.com/sgl-project/sglang/actions/runs/29187564045)) |
| 0.6.14 | off (this PR) | 0.845 / 0.560 | pass ([rerun-test](https://github.com/sgl-project/sglang/actions/runs/29207618094)) |

This is a CI workaround; the flashinfer 0.6.14 fusion numerics regression should be tracked and fixed separately.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29207287812](https://github.com/sgl-project/sglang/actions/runs/29207287812)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29207287719](https://github.com/sgl-project/sglang/actions/runs/29207287719)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
