### PR TITLE
Auto-select DeepSeek V4 FP4 MoE backends

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -700,7 +700,6 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
     arg_groups/deepseek_v4_hook.py). The kv-cache dtype and NPU split-backend
     writes, the max_running_requests fill and the validations stay in the
     hook at its legacy slot."""
-    from sglang.srt.environ import envs
     from sglang.srt.server_args import ServerArgs
 
     model_arch = hf_config.architectures[0]
@@ -734,19 +733,6 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
                 "Use flashinfer_trtllm_routed as MoE runner backend for "
                 f"{model_arch} hybrid FP8+NVFP4 checkpoint."
             )
-        elif model_config.is_fp4_experts and not envs.SGLANG_DSV4_FP4_DEQUANT.get():
-            if is_sm100_supported():
-                overrides["moe_runner_backend"] = "flashinfer_mxfp4"
-                logger.info(
-                    "Use flashinfer_mxfp4 as MoE runner backend for "
-                    f"{model_arch} packed-FP4 checkpoint on SM100."
-                )
-            elif is_sm90_supported() or is_sm120_supported():
-                overrides["moe_runner_backend"] = "marlin"
-                logger.info(
-                    "Use marlin as MoE runner backend for "
-                    f"{model_arch} packed-FP4 checkpoint on SM90/SM120."
-                )
     return overrides
 
 
@@ -1977,6 +1963,53 @@ def _a2a_backend_overrides(view: Any) -> dict:
         )
     if moe_a2a_backend != view.moe_a2a_backend:
         return {"moe_a2a_backend": moe_a2a_backend}
+    return {}
+
+
+@register_post_process
+def _deepseek_v4_fp4_moe_runner(view: Any) -> dict:
+    """Resolve packed-FP4 DeepSeek-V4 runners after A2A normalization.
+
+    Any non-``none`` A2A backend owns its runner selection: keeping the
+    user-requested ``auto`` lets DeepEP select DeepGEMM internally and lets
+    MegaMoE bypass the regular runner. The hardware-specific runners are only
+    valid for the standard no-A2A path.
+    """
+    from sglang.srt.environ import envs
+
+    model_config = view.get_model_config()
+    if model_config.hf_config.architectures[0] != "DeepseekV4ForCausalLM":
+        return {}
+    if view._server_args.moe_runner_backend != "auto":
+        return {}
+    if (
+        model_config.nvfp4_moe_meta is not None
+        or not model_config.is_fp4_experts
+        or envs.SGLANG_DSV4_FP4_DEQUANT.get()
+    ):
+        return {}
+
+    if view.moe_a2a_backend != "none":
+        # The SM120 pass runs before A2A normalization. Restore auto when its
+        # provisional Marlin override would otherwise mask distributed A2A.
+        if view.moe_runner_backend == "marlin":
+            return {"moe_runner_backend": "auto"}
+        return {}
+
+    if view.moe_runner_backend != "auto":
+        return {}
+    if is_sm100_supported():
+        logger.info(
+            "Use flashinfer_mxfp4 as MoE runner backend for "
+            "DeepseekV4ForCausalLM packed-FP4 checkpoint on SM100."
+        )
+        return {"moe_runner_backend": "flashinfer_mxfp4"}
+    if is_sm90_supported() or is_sm120_supported():
+        logger.info(
+            "Use marlin as MoE runner backend for "
+            "DeepseekV4ForCausalLM packed-FP4 checkpoint on SM90/SM120."
+        )
+        return {"moe_runner_backend": "marlin"}
     return {}
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -700,6 +700,7 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
     arg_groups/deepseek_v4_hook.py). The kv-cache dtype and NPU split-backend
     writes, the max_running_requests fill and the validations stay in the
     hook at its legacy slot."""
+    from sglang.srt.environ import envs
     from sglang.srt.server_args import ServerArgs
 
     model_arch = hf_config.architectures[0]
@@ -724,16 +725,28 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
         overrides["swa_full_tokens_ratio"] = 0.1
         logger.info(f"Setting swa_full_tokens_ratio to 0.1 for {model_arch}.")
 
-    # nvidia/DeepSeek-V4-Pro-NVFP4 uses flashinfer_trtllm_routed MoE runner backend.
-    if (
-        server_args.moe_runner_backend == "auto"
-        and server_args.get_model_config().nvfp4_moe_meta is not None
-    ):
-        overrides["moe_runner_backend"] = "flashinfer_trtllm_routed"
-        logger.info(
-            "Use flashinfer_trtllm_routed as MoE runner backend for "
-            f"{model_arch} hybrid FP8+NVFP4 checkpoint."
-        )
+    if server_args.moe_runner_backend == "auto":
+        model_config = server_args.get_model_config()
+        # nvidia/DeepSeek-V4-Pro-NVFP4 uses flashinfer_trtllm_routed MoE runner backend.
+        if model_config.nvfp4_moe_meta is not None:
+            overrides["moe_runner_backend"] = "flashinfer_trtllm_routed"
+            logger.info(
+                "Use flashinfer_trtllm_routed as MoE runner backend for "
+                f"{model_arch} hybrid FP8+NVFP4 checkpoint."
+            )
+        elif model_config.is_fp4_experts and not envs.SGLANG_DSV4_FP4_DEQUANT.get():
+            if is_sm100_supported():
+                overrides["moe_runner_backend"] = "flashinfer_mxfp4"
+                logger.info(
+                    "Use flashinfer_mxfp4 as MoE runner backend for "
+                    f"{model_arch} packed-FP4 checkpoint on SM100."
+                )
+            elif is_sm90_supported() or is_sm120_supported():
+                overrides["moe_runner_backend"] = "marlin"
+                logger.info(
+                    "Use marlin as MoE runner backend for "
+                    f"{model_arch} packed-FP4 checkpoint on SM90/SM120."
+                )
     return overrides
 
 
@@ -1353,10 +1366,17 @@ def _deepseek_v4_sm120_moe(view: Any) -> dict:
     tcgen05/TMEM, fall back to the marlin MoE runner (reads the
     mid-resolution moe_runner_backend, after the dispatch-time nvfp4
     default)."""
-    hf_config = view.get_model_config().hf_config
+    from sglang.srt.environ import envs
+
+    model_config = view.get_model_config()
+    hf_config = model_config.hf_config
     if hf_config.architectures[0] != "DeepseekV4ForCausalLM":
         return {}
-    if is_sm120_supported() and view.moe_runner_backend == "auto":
+    if (
+        is_sm120_supported()
+        and view.moe_runner_backend == "auto"
+        and not (model_config.is_fp4_experts and envs.SGLANG_DSV4_FP4_DEQUANT.get())
+    ):
         logger.info("Use marlin as MoE runner backend on SM120 for DeepseekV4")
         return {"moe_runner_backend": "marlin"}
     return {}

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5388,11 +5388,13 @@ class ServerArgs:
             _a2a_backend_overrides,
             _a2a_ep_size,
             _a2a_fusion_adjustments,
+            _deepseek_v4_fp4_moe_runner,
             resolved_view,
             run_post_process_pass,
         )
 
         run_post_process_pass(self, _a2a_backend_overrides)
+        run_post_process_pass(self, _deepseek_v4_fp4_moe_runner)
         run_post_process_pass(self, _a2a_ep_size)
 
         # The a2a-driven shared-experts fusion adjustments moved to the

--- a/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
@@ -56,8 +56,6 @@ class TestDSV4FlashFP4B200(
                 "--trust-remote-code",
                 "--tp",
                 "4",
-                "--moe-runner-backend",
-                "flashinfer_mxfp4",
                 "--speculative-algorithm",
                 "EAGLE",
                 "--speculative-num-steps",

--- a/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
@@ -1,6 +1,6 @@
 """B200 per-commit CI: DeepSeek-V4-Flash FP4 (LowLatency recipe).
 
-Launches TP=4 with flashinfer_mxfp4 MoE runner + EAGLE speculative decoding.
+Launches TP=4 with the auto-selected MXFP4 MoE runner + EAGLE speculative decoding.
 Runs 12 ServerSanity probes (correctness, streaming, concurrency, determinism)
 plus a GSM8K accuracy gate.
 

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -814,35 +814,13 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         )
         from sglang.srt.environ import envs
 
-        # Original FP4 checkpoints need a packed-FP4-capable backend. The
-        # preferred backend is architecture-specific.
+        # Original FP4 backend selection is deferred until A2A resolution so
+        # the selected runner can remain auto for distributed dispatch.
         with (
             patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
             patch.object(overrides_module, "is_sm100_supported", return_value=True),
         ):
-            self.assertEqual(
-                _deepseek_v4_overrides(fp4_args, hf)["moe_runner_backend"],
-                "flashinfer_mxfp4",
-            )
-        with (
-            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
-            patch.object(overrides_module, "is_sm100_supported", return_value=False),
-            patch.object(overrides_module, "is_sm90_supported", return_value=True),
-        ):
-            self.assertEqual(
-                _deepseek_v4_overrides(fp4_args, hf)["moe_runner_backend"],
-                "marlin",
-            )
-        with (
-            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
-            patch.object(overrides_module, "is_sm100_supported", return_value=False),
-            patch.object(overrides_module, "is_sm90_supported", return_value=False),
-            patch.object(overrides_module, "is_sm120_supported", return_value=True),
-        ):
-            self.assertEqual(
-                _deepseek_v4_overrides(fp4_args, hf)["moe_runner_backend"],
-                "marlin",
-            )
+            self.assertNotIn("moe_runner_backend", _deepseek_v4_overrides(fp4_args, hf))
         with (
             patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=True),
             patch.object(overrides_module, "is_sm100_supported", return_value=True),
@@ -858,6 +836,134 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 hf,
             ),
         )
+
+    def test_deepseek_v4_fp4_moe_runner_after_a2a_resolution(self):
+        from sglang.srt.arg_groups.overrides import (
+            ResolvedView,
+            _a2a_backend_overrides,
+            _deepseek_v4_fp4_moe_runner,
+            resolved_view,
+            run_post_process_pass,
+        )
+        from sglang.srt.environ import envs
+
+        hf = SimpleNamespace(architectures=["DeepseekV4ForCausalLM"])
+
+        def _view(
+            *,
+            moe_runner_backend="auto",
+            moe_a2a_backend="none",
+            is_fp4_experts=True,
+            nvfp4_moe_meta=None,
+            overlay=None,
+        ):
+            return ResolvedView(
+                SimpleNamespace(
+                    moe_runner_backend=moe_runner_backend,
+                    moe_a2a_backend=moe_a2a_backend,
+                    get_model_config=lambda: SimpleNamespace(
+                        hf_config=hf,
+                        is_fp4_experts=is_fp4_experts,
+                        nvfp4_moe_meta=nvfp4_moe_meta,
+                    ),
+                ),
+                overlay=overlay,
+            )
+
+        with patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False):
+            with patch.object(
+                overrides_module, "is_sm100_supported", return_value=True
+            ):
+                self.assertEqual(
+                    _deepseek_v4_fp4_moe_runner(_view()),
+                    {"moe_runner_backend": "flashinfer_mxfp4"},
+                )
+            with (
+                patch.object(
+                    overrides_module, "is_sm100_supported", return_value=False
+                ),
+                patch.object(overrides_module, "is_sm90_supported", return_value=True),
+            ):
+                self.assertEqual(
+                    _deepseek_v4_fp4_moe_runner(_view()),
+                    {"moe_runner_backend": "marlin"},
+                )
+            with (
+                patch.object(
+                    overrides_module, "is_sm100_supported", return_value=False
+                ),
+                patch.object(overrides_module, "is_sm90_supported", return_value=False),
+                patch.object(overrides_module, "is_sm120_supported", return_value=True),
+            ):
+                self.assertEqual(
+                    _deepseek_v4_fp4_moe_runner(_view()),
+                    {"moe_runner_backend": "marlin"},
+                )
+            for a2a_backend in (
+                "deepep",
+                "mooncake",
+                "nixl",
+                "mori",
+                "ascend_fuseep",
+                "flashinfer",
+                "megamoe",
+            ):
+                self.assertEqual(
+                    _deepseek_v4_fp4_moe_runner(_view(moe_a2a_backend=a2a_backend)),
+                    {},
+                )
+            self.assertEqual(
+                _deepseek_v4_fp4_moe_runner(
+                    _view(
+                        moe_a2a_backend="deepep",
+                        overlay={"moe_runner_backend": "marlin"},
+                    )
+                ),
+                {"moe_runner_backend": "auto"},
+            )
+        with patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=True):
+            self.assertEqual(_deepseek_v4_fp4_moe_runner(_view()), {})
+        self.assertEqual(
+            _deepseek_v4_fp4_moe_runner(_view(moe_runner_backend="triton")), {}
+        )
+        self.assertEqual(
+            _deepseek_v4_fp4_moe_runner(_view(nvfp4_moe_meta=object())), {}
+        )
+
+        def _run_late_a2a_override(enable_deepep_waterfill):
+            server_args = SimpleNamespace(
+                moe_runner_backend="auto",
+                moe_a2a_backend="none",
+                enable_deepep_waterfill=enable_deepep_waterfill,
+                _resolved_overrides=[],
+                get_model_config=lambda: SimpleNamespace(
+                    hf_config=hf,
+                    is_fp4_experts=True,
+                    nvfp4_moe_meta=None,
+                ),
+            )
+            run_post_process_pass(server_args, _a2a_backend_overrides)
+            run_post_process_pass(server_args, _deepseek_v4_fp4_moe_runner)
+            return resolved_view(server_args)
+
+        with (
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
+            patch.object(
+                envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE, "get", return_value=False
+            ),
+        ):
+            waterfill_view = _run_late_a2a_override(enable_deepep_waterfill=True)
+            self.assertEqual(waterfill_view.moe_a2a_backend, "deepep")
+            self.assertEqual(waterfill_view.moe_runner_backend, "auto")
+        with (
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
+            patch.object(
+                envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE, "get", return_value=True
+            ),
+        ):
+            megamoe_view = _run_late_a2a_override(enable_deepep_waterfill=False)
+            self.assertEqual(megamoe_view.moe_a2a_backend, "megamoe")
+            self.assertEqual(megamoe_view.moe_runner_backend, "auto")
 
     def test_deepseek_v4_sm120_moe_pass(self):
         from sglang.srt.arg_groups.overrides import (

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -770,7 +770,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 device="cuda",
                 swa_full_tokens_ratio=ServerArgs.swa_full_tokens_ratio,
                 moe_runner_backend="auto",
-                get_model_config=lambda: SimpleNamespace(nvfp4_moe_meta=None),
+                get_model_config=lambda: SimpleNamespace(
+                    nvfp4_moe_meta=None, is_fp4_experts=False
+                ),
             )
             defaults.update(kw)
             return SimpleNamespace(**defaults)
@@ -796,30 +798,92 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self.assertEqual(
             _deepseek_v4_overrides(
                 _args(
-                    get_model_config=lambda: SimpleNamespace(nvfp4_moe_meta=object())
+                    get_model_config=lambda: SimpleNamespace(
+                        nvfp4_moe_meta=object(), is_fp4_experts=True
+                    )
                 ),
                 hf,
             )["moe_runner_backend"],
             "flashinfer_trtllm_routed",
         )
 
+        fp4_args = _args(
+            get_model_config=lambda: SimpleNamespace(
+                nvfp4_moe_meta=None, is_fp4_experts=True
+            )
+        )
+        from sglang.srt.environ import envs
+
+        # Original FP4 checkpoints need a packed-FP4-capable backend. The
+        # preferred backend is architecture-specific.
+        with (
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+        ):
+            self.assertEqual(
+                _deepseek_v4_overrides(fp4_args, hf)["moe_runner_backend"],
+                "flashinfer_mxfp4",
+            )
+        with (
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm90_supported", return_value=True),
+        ):
+            self.assertEqual(
+                _deepseek_v4_overrides(fp4_args, hf)["moe_runner_backend"],
+                "marlin",
+            )
+        with (
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm90_supported", return_value=False),
+            patch.object(overrides_module, "is_sm120_supported", return_value=True),
+        ):
+            self.assertEqual(
+                _deepseek_v4_overrides(fp4_args, hf)["moe_runner_backend"],
+                "marlin",
+            )
+        with (
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=True),
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+        ):
+            self.assertNotIn("moe_runner_backend", _deepseek_v4_overrides(fp4_args, hf))
+        self.assertNotIn(
+            "moe_runner_backend",
+            _deepseek_v4_overrides(
+                _args(
+                    moe_runner_backend="triton",
+                    get_model_config=fp4_args.get_model_config,
+                ),
+                hf,
+            ),
+        )
+
     def test_deepseek_v4_sm120_moe_pass(self):
         from sglang.srt.arg_groups.overrides import (
             ResolvedView,
             _deepseek_v4_sm120_moe,
+            run_post_process_pass,
         )
+        from sglang.srt.environ import envs
 
         def _view(arch="DeepseekV4ForCausalLM", **kw):
             hf = SimpleNamespace(architectures=[arch])
-            defaults = dict(moe_runner_backend="auto")
+            defaults = dict(moe_runner_backend="auto", is_fp4_experts=False)
             defaults.update(kw)
             return ResolvedView(
                 SimpleNamespace(
-                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
+                    get_model_config=lambda: SimpleNamespace(
+                        hf_config=hf, is_fp4_experts=defaults.pop("is_fp4_experts")
+                    ),
+                    **defaults,
                 )
             )
 
-        with patch.object(overrides_module, "is_sm120_supported", return_value=True):
+        with (
+            patch.object(overrides_module, "is_sm120_supported", return_value=True),
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=False),
+        ):
             self.assertEqual(
                 _deepseek_v4_sm120_moe(_view()), {"moe_runner_backend": "marlin"}
             )
@@ -827,6 +891,14 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 _deepseek_v4_sm120_moe(_view(moe_runner_backend="triton")), {}
             )
             self.assertEqual(_deepseek_v4_sm120_moe(_view(arch="LlamaForCausalLM")), {})
+        with (
+            patch.object(overrides_module, "is_sm120_supported", return_value=True),
+            patch.object(envs.SGLANG_DSV4_FP4_DEQUANT, "get", return_value=True),
+        ):
+            server_args = _view(is_fp4_experts=True)._server_args
+            server_args._resolved_overrides = []
+            run_post_process_pass(server_args, _deepseek_v4_sm120_moe)
+            self.assertEqual(server_args._resolved_overrides, [])
         with patch.object(overrides_module, "is_sm120_supported", return_value=False):
             self.assertEqual(_deepseek_v4_sm120_moe(_view()), {})
 


### PR DESCRIPTION
## Summary
- defer DeepSeek-V4 packed-FP4 MoE runner selection until A2A normalization finishes
- when the final `--moe-a2a-backend` is `none`, select `flashinfer_mxfp4` on SM100/B200 and Marlin on SM90/Hopper or SM120
- when the final A2A backend is non-`none`, retain the user-requested `auto`: DeepEP then selects DeepGEMM internally, while MegaMoE prepares its own weights and bypasses the ordinary runner
- preserve explicit runner selections, NVFP4 routed selection, and FP4-to-FP8 dequantization; restore `auto` if SM120 provisionally selected Marlin before a non-`none` A2A backend was finalized
- retain the B200 E2E coverage with automatic selection, and add regression coverage for every supported A2A backend plus DeepEP Waterfill and environment-enabled MegaMoE

## Root cause
Original DeepSeek-V4 has packed FP4 routed-expert weights. With an `auto` runner, the Triton FP8 MoE path can interpret the packed final dimension as the full hidden dimension and fail during CUDA-graph capture with `AssertionError: Hidden size mismatch`. The initial fix selected a hardware backend too early; that could force `flashinfer_mxfp4` before DeepEP/MegaMoE A2A resolution. This update makes the final A2A backend authoritative for automatic runner selection.

## Validation
- `python3 -m py_compile` for all modified Python files
- `uvx pre-commit run --files ...` (all hooks passed)
- resolver coverage for SM100, SM90, SM120, every supported non-`none` A2A backend, SM120 reset, explicit selection, NVFP4, dequantization, Waterfill, and MegaMoE env resolution

The focused unit command could not run in this macOS checkout because its SGLang dependency stack requires Linux-only serving wheels; the B200 devbox used for reproduction was released before this branch could be rerun.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29211202512](https://github.com/sgl-project/sglang/actions/runs/29211202512)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29211202440](https://github.com/sgl-project/sglang/actions/runs/29211202440)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->