### PR TITLE
[SM120] Allow fused MHC opt-in with standalone TileLang pre disabled

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -205,12 +205,9 @@ DEEPSEEK_V4_STACKED_PARAMS_MAPPING: List[Tuple[str, str, int]] = [
 
 
 def _is_fused_mhc_post_pre_enabled() -> bool:
-    # SM120 post-processing clears SGLANG_OPT_USE_TILELANG_MHC_PRE and
-    # SGLANG_OPT_DEEPGEMM_HC_PRENORM. mhc_fused_post_pre selects its GEMM on
-    # SGLANG_OPT_DEEPGEMM_HC_PRENORM alone and never reads the pre flag, so with both
-    # clear it runs mhc_fused_post_pre_fma_tilelang (built with TL_DISABLE_TMA_LOWER
-    # and TL_DISABLE_WARP_SPECIALIZED). The pre flag must not veto this opt-in.
-    # Whether the standalone pre path runs stays a server_args decision.
+    # SM120 disables the standalone TileLang pre path. mhc_fused_post_pre does
+    # not read that flag and dispatches independently for both small and large
+    # token batches, so the standalone pre flag must not veto the fused opt-in.
     return (
         envs.SGLANG_OPT_FUSE_MHC_POST_PRE.get()
         and envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get()

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -153,6 +153,7 @@ from sglang.srt.utils import (
     log_info_on_rank0,
     make_layers,
 )
+from sglang.srt.utils.common import is_sm120_supported
 from sglang.srt.utils.custom_op import register_custom_op
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
@@ -204,12 +205,17 @@ DEEPSEEK_V4_STACKED_PARAMS_MAPPING: List[Tuple[str, str, int]] = [
 
 
 def _is_fused_mhc_post_pre_enabled() -> bool:
-    # The fused path directly reuses TileLang mhc_post/mhc_pre kernels and their
-    # tensor layout assumptions, so keep it disabled when either dependency is off.
+    # SM120 disables the standalone TileLang mhc_pre path because its split-K
+    # kernel is unsupported there. The fused post/pre kernel has a separate FMA
+    # implementation that is supported on SM120, so do not let the standalone
+    # pre-path override silently disable this explicit opt-in.
     return (
         envs.SGLANG_OPT_FUSE_MHC_POST_PRE.get()
-        and envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get()
         and envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get()
+        and (
+            envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get()
+            or is_sm120_supported()
+        )
     )
 
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -205,10 +205,12 @@ DEEPSEEK_V4_STACKED_PARAMS_MAPPING: List[Tuple[str, str, int]] = [
 
 
 def _is_fused_mhc_post_pre_enabled() -> bool:
-    # SM120 disables the standalone TileLang mhc_pre path because its split-K
-    # kernel is unsupported there. The fused post/pre kernel has a separate FMA
-    # implementation that is supported on SM120, so do not let the standalone
-    # pre-path override silently disable this explicit opt-in.
+    # SM120 post-processing clears SGLANG_OPT_USE_TILELANG_MHC_PRE and
+    # SGLANG_OPT_DEEPGEMM_HC_PRENORM. mhc_fused_post_pre selects its GEMM on
+    # SGLANG_OPT_DEEPGEMM_HC_PRENORM alone and never reads the pre flag, so with both
+    # clear it runs mhc_fused_post_pre_fma_tilelang (built with TL_DISABLE_TMA_LOWER
+    # and TL_DISABLE_WARP_SPECIALIZED). The pre flag must not veto this opt-in.
+    # Whether the standalone pre path runs stays a server_args decision.
     return (
         envs.SGLANG_OPT_FUSE_MHC_POST_PRE.get()
         and envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get()

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -212,10 +212,7 @@ def _is_fused_mhc_post_pre_enabled() -> bool:
     return (
         envs.SGLANG_OPT_FUSE_MHC_POST_PRE.get()
         and envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get()
-        and (
-            envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get()
-            or is_sm120_supported()
-        )
+        and (envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get() or is_sm120_supported())
     )
 
 

--- a/test/registered/unit/models/test_deepseek_v4_fused_mhc_policy.py
+++ b/test/registered/unit/models/test_deepseek_v4_fused_mhc_policy.py
@@ -1,0 +1,74 @@
+"""Unit tests for the DeepSeek-V4 fused-MHC enable policy."""
+
+from unittest.mock import patch
+
+import sglang.srt.models.deepseek_v4 as deepseek_v4
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDeepseekV4FusedMHCPolicy(CustomTestCase):
+    def _is_enabled(
+        self,
+        *,
+        fuse: bool,
+        tilelang_pre: bool,
+        tilelang_post: bool,
+        sm120: bool,
+    ) -> bool:
+        with (
+            envs.SGLANG_OPT_FUSE_MHC_POST_PRE.override(fuse),
+            envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.override(tilelang_pre),
+            envs.SGLANG_OPT_USE_TILELANG_MHC_POST.override(tilelang_post),
+            patch.object(deepseek_v4, "is_sm120_supported", return_value=sm120),
+        ):
+            return deepseek_v4._is_fused_mhc_post_pre_enabled()
+
+    def test_sm120_allows_fused_opt_in_with_standalone_pre_disabled(self):
+        self.assertTrue(
+            self._is_enabled(
+                fuse=True,
+                tilelang_pre=False,
+                tilelang_post=True,
+                sm120=True,
+            )
+        )
+
+    def test_other_platform_still_requires_tilelang_pre(self):
+        self.assertFalse(
+            self._is_enabled(
+                fuse=True,
+                tilelang_pre=False,
+                tilelang_post=True,
+                sm120=False,
+            )
+        )
+        self.assertTrue(
+            self._is_enabled(
+                fuse=True,
+                tilelang_pre=True,
+                tilelang_post=True,
+                sm120=False,
+            )
+        )
+
+    def test_fusion_opt_in_and_tilelang_post_remain_required(self):
+        self.assertFalse(
+            self._is_enabled(
+                fuse=False,
+                tilelang_pre=False,
+                tilelang_post=True,
+                sm120=True,
+            )
+        )
+        self.assertFalse(
+            self._is_enabled(
+                fuse=True,
+                tilelang_pre=False,
+                tilelang_post=False,
+                sm120=True,
+            )
+        )

--- a/test/registered/unit/models/test_deepseek_v4_fused_mhc_policy.py
+++ b/test/registered/unit/models/test_deepseek_v4_fused_mhc_policy.py
@@ -1,5 +1,6 @@
 """Unit tests for the DeepSeek-V4 fused-MHC enable policy."""
 
+import unittest
 from unittest.mock import patch
 
 import sglang.srt.models.deepseek_v4 as deepseek_v4
@@ -72,3 +73,7 @@ class TestDeepseekV4FusedMHCPolicy(CustomTestCase):
                 sm120=True,
             )
         )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SM120 model post-processing sets `SGLANG_OPT_USE_TILELANG_MHC_PRE=False`. `_is_fused_mhc_post_pre_enabled()` also required that flag, so `SGLANG_OPT_FUSE_MHC_POST_PRE=1` had no effect on SM120.

A 60-step C1 trace with the fusion flag set contained, per decode cycle, 86 `mhc_post`, 86 `hc_split_sinkhorn`, and 86 `hc_combine` launches, and zero `mhc_fused_post_pre_fma_tilelang` launches.

`mhc_fused_post_pre` never reads `SGLANG_OPT_USE_TILELANG_MHC_PRE`. It dispatches on its own token-count threshold, taking `mhc_fused_post_pre_fma_tilelang` for small batches and a separate branch for large ones, selecting the GEMM there on `SGLANG_OPT_DEEPGEMM_HC_PRENORM`. Both regimes are handled independently of the standalone pre path, so that flag should not gate the fusion opt-in.

## Modifications

- Allow the fused-MHC opt-in to bypass the standalone TileLang-pre flag on SM120.
- Keep standalone TileLang pre disabled on SM120.
- Keep TileLang post required.
- Keep the gate unchanged on other architectures.
- Add a registered CPU unit test covering SM120, non-SM120, fusion opt-in, and TileLang-post policy.

This follows the fused path added in #25976. It does not change the fused kernel or its numerical behavior.

## Accuracy Tests

- Registered CPU unit test (`test/registered/unit/models/test_deepseek_v4_fused_mhc_policy.py`): 3 cases pass.
- Isolated fused-op reference checks: M=1, 2, 8, 32, 384, and 8192 passed.
- GSM8K smoke: 20/20.

## Effect

Hardware: 2x RTX PRO 6000 Blackwell Max-Q at 300 W, TP2, DeepSeek-V4-Flash, FP8 KV, FlashInfer MXFP4 MoE, full decode CUDA graphs, EAGLE MTP2.

With `SGLANG_OPT_USE_TILELANG_MHC_PRE` at its SM120 default (off), the non-fused path falls back to `hc_pre_torch_impl`, a torch-level `F.linear`/`rsqrt` implementation. The fusion opt-in replaces it. Median target-verify decode graph:

| | fused off | fused on |
|---|---:|---:|
| Kernel nodes | 3,306 | 2,796 |
| Summed kernel time | 16.230 ms | 14.587 ms |

The 510-node difference is the `hc_pre_torch_impl` fallback. Per-category (fused minus non-fused): gemm_cutlass -767 us (492 -> 407 kernels), other -434 us, gemm_other -320 us (148 -> 63), norm -165 us (130 -> 45), fill -97 us, quant +68 us, sparse_attention +74 us.

Kernel-node counts are structural and do not vary run to run. Throughput is not reported here: the available A/B ran with EAGLE MTP2, whose acceptance rate drifts run to run, and the fused cell spanned 6.9% across five 30 s samples. A non-speculative re-measurement under the settled harness is pending.

## Checklist

- [x] `pre-commit run --files` passed on both changed files.
- [x] Added and registered a CPU unit test under `test/registered/unit/models/`.
- [x] Existing environment variable and interface are unchanged.
- [x] Followed the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30159293986](https://github.com/sgl-project/sglang/actions/runs/30159293986)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30159293903](https://github.com/sgl-project/sglang/actions/runs/30159293903)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->