### PR TITLE
[docker] cu13: restore NVIDIA CUDA compiler components dropped by flashinfer 0.6.14 dependency change

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -470,6 +470,19 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Copy flashinfer cubin (always) and jit-cache (if installed) packages
 COPY --from=flashinfer_cache /flashinfer_jit_output/ /usr/local/lib/python3.12/dist-packages/
 
+# flashinfer>=0.6.14 no longer pulls the NVIDIA CUDA compiler components
+# (previously via its cuda-tile[tileiras] extra); CuTe-DSL runtime codegen needs
+# them at serving time. Pin them directly: cuda-tile>=1.5.0 routes the extra
+# through the cuda-toolkit metapackage, which conflicts with torch's pin.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+        python3 -m pip install \
+            "nvidia-cuda-crt>=13.2,<13.4" \
+            "nvidia-cuda-nvcc>=13.2,<13.4" \
+            "nvidia-cuda-tileiras>=13.2,<13.4" \
+            "nvidia-nvvm>=13.2,<13.4"; \
+    fi
+
 # Copy dev tools
 COPY --from=devtools_builder /tools/diff-so-fancy /usr/local/bin/
 COPY --from=devtools_builder /tools/clang-format /usr/local/bin/


### PR DESCRIPTION
## Motivation

Starting with the `nightly-dev-cu13-20260711` image, the NVIDIA CUDA compiler components (`nvidia-cuda-crt`, `nvidia-cuda-nvcc`, `nvidia-cuda-tileiras`, `nvidia-nvvm`) are no longer present in the cu13 image: flashinfer >= 0.6.14 stopped declaring the `cuda-tile[tileiras]` extra, which was the only thing pulling them in. CuTe-DSL runtime codegen needs these components at serving time; with them missing, hybrid GDN model serving (e.g. Qwen3.5) hangs on Blackwell.

This pins the four component packages directly in the cu13 image.

Direct pins are used instead of `cuda-tile[tileiras]` because cuda-tile >= 1.5.0 routes that extra through the `cuda-toolkit` metapackage (>=13.2), which conflicts with torch 2.11's `cuda-toolkit==13.0.2` pin.

## Verification

Installing exactly these four packages on the affected `20260711` image restores healthy serving (2/2 full benchmark runs vs 5/5 hangs on the stock image). Image rebuild with this Dockerfile change has not been run yet — keeping as draft.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29216651306](https://github.com/sgl-project/sglang/actions/runs/29216651306)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29216651167](https://github.com/sgl-project/sglang/actions/runs/29216651167)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->