### PR TITLE
[Bugfix] Fix Nemotron ForwardFlags across custom op boundary

### DIFF
--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -550,11 +550,13 @@ class NemotronHMambaDecoderLayer(NemotronHAttnLikeDecoderLayer):
             if is_in_breakable_cuda_graph():
                 output = torch.empty_like(hidden_states)
                 breakable_nemotron_mamba2_with_output(
-                    hidden_states, output, self.layer_id
+                    hidden_states, output, self.layer_id, fuse_mlp_allreduce
                 )
             elif is_in_tc_piecewise_cuda_graph():
                 output = torch.empty_like(hidden_states)
-                nemotron_mamba2_with_output(hidden_states, output, self.layer_id)
+                nemotron_mamba2_with_output(
+                    hidden_states, output, self.layer_id, fuse_mlp_allreduce
+                )
             else:
                 output = self._forward_mamba(hidden_states, forward_batch)
 
@@ -1189,6 +1191,7 @@ def nemotron_mamba2_with_output(
     hidden_states: torch.Tensor,
     output: torch.Tensor,
     layer_id: int,
+    fuse_mlp_allreduce: bool = False,
 ) -> None:
     """Split op for Mamba2 forward in piecewise CUDA graph mode."""
     context = get_tc_piecewise_forward_context()
@@ -1208,7 +1211,12 @@ def nemotron_mamba2_with_output(
     if hidden_states.shape[0] != num_actual_tokens:
         hidden_states = hidden_states[:num_actual_tokens]
 
-    ret = mamba_layer._forward_mamba(hidden_states, forward_batch)
+    # This function is an opaque custom op under torch.compile. The caller's
+    # ForwardFlags scope is Python control-plane state and is no longer active
+    # when the compiled graph invokes this implementation. Carry the scalar
+    # across the graph boundary and republish it for RowParallelLinear.
+    with get_forward().scoped(fuse_mlp_allreduce=fuse_mlp_allreduce):
+        ret = mamba_layer._forward_mamba(hidden_states, forward_batch)
 
     # Copy result back; output may be larger (padded) so only fill actual tokens
     output[:num_actual_tokens].view(ret.shape).copy_(ret)

--- a/test/registered/models_e2e/test_nvidia_nemotron_3_nano.py
+++ b/test/registered/models_e2e/test_nvidia_nemotron_3_nano.py
@@ -27,11 +27,6 @@ class TestNvidiaNemotron3Nano30BFP8(LMEvalMixin, DefaultServerBase):
     other_args = [
         "--tp-size",
         "2",
-        # FlashInfer trtllm allreduce fusion on flashinfer 0.6.14 degrades
-        # gsm8k for this model (strict-match 0.84 -> 0.78); the ground truth
-        # was calibrated with fusion disabled. Keep it off until the fusion
-        # numerics regression is resolved.
-        "--enforce-disable-flashinfer-allreduce-fusion",
     ] + NEMOTRON_3_NANO_THINKING_ARGS
 
 


### PR DESCRIPTION
## Summary

#30802 moved the Nemotron all-reduce fusion flag into `ForwardFlags`. That works for normal calls, but the Mamba custom op can run after the flag's scope is gone. It then reads the wrong value, runs an extra all-reduce, and hurts accuracy.

CI did not catch this because a FlashInfer workspace error silently disabled fusion. #30580 fixed that error and exposed the bug. The fix is small. We pass the flag into the custom op and set it again inside.

## Accuracy

```bash
CI=true PYTHONUNBUFFERED=1 python registered/models_e2e/test_nvidia_nemotron_3_nano.py -v

gsm8k | exact_match,strict-match: ground_truth=0.847 | measured=0.845 | rtol=0.08
[METRIC] gsm8k_exact_match,strict-match=0.8453373768006065 labels={"model": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8", "eval": "lm-eval", "task": "gsm8k"}
gsm8k | exact_match,flexible-extract: ground_truth=0.556 | measured=0.558 | rtol=0.08
[METRIC] gsm8k_exact_match,flexible-extract=0.5579984836997726 labels={"model": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8", "eval": "lm-eval", "task": "gsm8k"}
```



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29222775887](https://github.com/sgl-project/sglang/actions/runs/29222775887)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29222775748](https://github.com/sgl-project/sglang/actions/runs/29222775748)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->