### PR TITLE
Fix Mamba CUDA graph padding outputs

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -14,6 +14,7 @@ from sglang.srt.distributed import (
 from sglang.srt.layers.attention.mamba.mamba2_metadata import Mamba2Metadata
 from sglang.srt.layers.attention.mamba.mixer2_rms_norm_gated import Mixer2RMSNormGated
 from sglang.srt.layers.attention.mamba.ops import (
+    PAD_SLOT_ID,
     mamba_chunk_scan_combined,
     selective_state_update,
 )
@@ -685,6 +686,12 @@ class MambaMixer2(torch.nn.Module):
                     self.conv1d.bias,
                     self.activation,
                     conv_state_indices=state_indices_tensor_d,
+                )
+                # The Triton convolution skips padding slots without writing
+                # their output rows. Zero them before they enter the SSM.
+                hidden_states_B_C_d = hidden_states_B_C_d.masked_fill(
+                    (state_indices_tensor_d == PAD_SLOT_ID).unsqueeze(-1),
+                    0,
                 )
 
             hidden_states_d, B_d, C_d = split_hidden_states_B_C_fn(hidden_states_B_C_d)

--- a/test/registered/unit/layers/test_mamba_padding.py
+++ b/test/registered/unit/layers/test_mamba_padding.py
@@ -1,0 +1,108 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.attention.mamba.mamba as mamba_module
+from sglang.srt.layers.attention.mamba.mamba import MambaMixer2
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMambaCudaGraphPadding(unittest.TestCase):
+    def test_decode_zeroes_skipped_convolution_rows_before_ssm(self):
+        num_tokens = 4
+        state_indices = torch.tensor([0, 1, -1, -1], dtype=torch.int32)
+        projected_states = torch.zeros(num_tokens, 8)
+        ssm_inputs = {}
+
+        def fake_causal_conv1d_update(hidden_states, *args, **kwargs):
+            return torch.full_like(hidden_states, 7.0)
+
+        def fake_selective_state_update(*args, **kwargs):
+            ssm_inputs["hidden_states"] = args[1].detach().clone()
+            ssm_inputs["B"] = args[4].detach().clone()
+            ssm_inputs["C"] = args[5].detach().clone()
+            kwargs["out"].zero_()
+
+        mixer = SimpleNamespace(
+            in_proj=lambda hidden_states: (projected_states.clone(), None),
+            intermediate_size=2,
+            conv_dim=4,
+            num_heads=2,
+            tp_size=1,
+            conv1d=SimpleNamespace(
+                weight=torch.ones(4, 1, 1),
+                bias=torch.zeros(4),
+            ),
+            activation="silu",
+            groups_ssm_state_size=1,
+            head_dim=1,
+            n_groups=1,
+            ssm_state_size=1,
+            A=torch.ones(2),
+            dt_bias=torch.ones(2),
+            D=torch.ones(2),
+            norm=lambda hidden_states, gate: hidden_states,
+            out_proj=lambda hidden_states: (hidden_states, None),
+        )
+        layer_cache = SimpleNamespace(
+            conv=(torch.zeros(2, 4, 1),),
+            temporal=torch.zeros(2, 2, 1, 1),
+        )
+        metadata = SimpleNamespace(
+            mamba_cache_indices=state_indices,
+            query_start_loc=torch.tensor([0], dtype=torch.int32),
+            num_prefills=0,
+            num_decodes=num_tokens,
+            draft_token_num=1,
+            is_target_verify=False,
+            num_prefill_tokens=0,
+        )
+
+        with (
+            patch.object(
+                mamba_module,
+                "causal_conv1d_update_triton",
+                side_effect=fake_causal_conv1d_update,
+                create=True,
+            ),
+            patch.object(
+                mamba_module,
+                "selective_state_update",
+                side_effect=fake_selective_state_update,
+            ),
+        ):
+            MambaMixer2.forward(
+                mixer,
+                hidden_states=torch.zeros(num_tokens, 2),
+                layer_cache=layer_cache,
+                metadata=metadata,
+                forward_batch=SimpleNamespace(mamba_track_mask=None),
+                use_triton_causal_conv=True,
+            )
+
+        combined_ssm_input = torch.cat(
+            [
+                ssm_inputs["hidden_states"].flatten(1),
+                ssm_inputs["B"].flatten(1),
+                ssm_inputs["C"].flatten(1),
+            ],
+            dim=-1,
+        )
+        torch.testing.assert_close(
+            combined_ssm_input[:2],
+            torch.full((2, 4), 7.0),
+        )
+        self.assertTrue(
+            torch.equal(
+                combined_ssm_input[2:],
+                torch.zeros_like(combined_ssm_input[2:]),
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This fixes Mamba CUDA graph padding by zeroing convolution outputs for `PAD_SLOT_ID` rows before they enter the SSM; `causal_conv1d_update_triton` skips those rows and otherwise leaves `torch.empty` data uninitialized. A CPU regression test is included, and the fix completed two two-node GB200 OPD runs with power-of-two captures through 512, including the previously hanging second padded rollout.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29225148097](https://github.com/sgl-project/sglang/actions/runs/29225148097)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29225147952](https://github.com/sgl-project/sglang/actions/runs/29225147952)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->