### PR TITLE
Fix --moe-a2a-backend silently ignored for LongCat-2.0 (moe_topk missing from gate)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -726,12 +726,14 @@ class Scheduler(
         )
 
         # Different MoE architectures expose the per-token expert count under
-        # different attribute names (e.g. Gemma4 uses ``top_k_experts``).
+        # different attribute names (e.g. Gemma4 uses ``top_k_experts``,
+        # LongCat-2.0 uses ``moe_topk``).
         moe_topk_attrs = (
             "num_experts_per_tok",
             "num_experts_per_token",
             "top_k_experts",
             "moe_top_k",
+            "moe_topk",
         )
         if any(hasattr(config_to_check, attr) for attr in moe_topk_attrs):
             initialize_moe_config(self.server_args)


### PR DESCRIPTION
## Motivation

When serving **LongCat-2.0** with `--moe-a2a-backend deepep`, the flag is **silently ignored**: the model runs with `StandardDispatcher` instead of the requested DeepEP expert-parallel all-to-all.

Root cause is in `Scheduler`: `initialize_moe_config()` (the only place that sets the global `MOE_A2A_BACKEND` from `server_args`) is called only when the model config exposes one of a fixed tuple of top-k attribute names (`moe_topk_attrs`). LongCat-2.0 names its attribute **`moe_topk`** (see `configs/longcat_flash.py`), which is **not** in that tuple — note `moe_top_k` *with* an underscore is present, but LongCat uses `moe_topk` without one.

Consequently, for LongCat-2.0:
- `initialize_moe_config()` is never called → global `MOE_A2A_BACKEND` stays `None`
- `get_moe_a2a_backend()` falls back to `MoeA2ABackend.NONE` even though the user passed `--moe-a2a-backend deepep`
- `get_moe_impl_class()` sees `is_deepep()==False` → builds `FusedMoE` + `StandardDispatcher` instead of `DeepEPMoE`

So the requested DeepEP/EP backend never takes effect. (This was confirmed at runtime on H200: `get_moe_a2a_backend()==NONE`, `dispatcher==StandardDispatcher`, despite `--moe-a2a-backend deepep` and the "DeepEP MoE is enabled" log line.)

## Modifications

Add `"moe_topk"` to the `moe_topk_attrs` tuple in `Scheduler` (`python/sglang/srt/managers/scheduler.py`) so LongCat-2.0 is recognized as a MoE model and `initialize_moe_config()` runs, honoring `--moe-a2a-backend`.

## Accuracy Tests

No change to model math. The change only controls whether `initialize_moe_config()` runs; it does not alter dispatch/compute for models already recognized (all existing names are kept). Verified on 4x p5en H200 (tp16/ep16) that with this change LongCat-2.0 correctly resolves `get_moe_a2a_backend()==DEEPEP` and builds `DeepEPMoE`, whereas without it the backend was `NONE`.

## Speed Tests and Profiling

Not applicable to the gating fix itself. Note: enabling the DeepEP path for LongCat-2.0 (top-k=12) additionally requires UCCL/DeepEP `kNumMaxTopK >= 12` in the low-latency internode launcher; the stock value 9 will otherwise abort. That is a separate concern in the EP backend, not in this PR.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29225960769](https://github.com/sgl-project/sglang/actions/runs/29225960769)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29225960627](https://github.com/sgl-project/sglang/actions/runs/29225960627)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->