### PR TITLE
Guard ROCm imports without visible GPUs

### DIFF
--- a/python/sglang/kernels/ops/attention/rocm_mla_decode_rope.py
+++ b/python/sglang/kernels/ops/attention/rocm_mla_decode_rope.py
@@ -20,6 +20,7 @@ It supports page size = 1.
 # https://github.com/ModelTC/lightllm/blob/96353e868a840db4d103138caf15ed9dbea8c186/lightllm/models/deepseek2/triton_kernel/gqa_flash_decoding_stage1.py
 # https://github.com/ModelTC/lightllm/blob/96353e868a840db4d103138caf15ed9dbea8c186/lightllm/models/deepseek2/triton_kernel/gqa_flash_decoding_stage2.py
 
+import torch
 import triton
 import triton.language as tl
 
@@ -29,7 +30,12 @@ from sglang.kernels.ops.attention.decode_attention import (
 
 
 def is_hip():
-    return triton.runtime.driver.active.get_current_target().backend == "hip"
+    if torch.version.hip is None or not torch.cuda.is_available():
+        return False
+    try:
+        return triton.runtime.driver.active.get_current_target().backend == "hip"
+    except RuntimeError:
+        return False
 
 
 _is_hip = is_hip()

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -53,7 +53,8 @@ _is_cpu = is_cpu()
 _is_musa = is_musa()
 _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _has_visible_hip_device
 
 if _is_cuda or _is_musa:
     from sglang.jit_kernel.per_tensor_quant_fp8 import (
@@ -78,7 +79,7 @@ if _is_cuda or _is_musa:
         per_token_group_quant_8bit_v2 as sgl_per_token_group_quant_8bit_jit_v2,
     )
 
-if _is_hip:
+if _has_visible_hip_device:
     _has_vllm = False
     if _use_aiter:
         try:
@@ -122,8 +123,15 @@ logger = logging.getLogger(__name__)
 @lru_cache()
 def is_fp8_fnuz() -> bool:
     if _is_hip:
+        if not torch.cuda.is_available():
+            return False
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+        try:
+            return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+        except RuntimeError as err:
+            if "No HIP GPUs are available" in str(err):
+                return False
+            raise
     return False
 
 

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -64,8 +64,9 @@ _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
 _is_gfx95_supported = is_gfx95_supported()
 _is_musa = is_musa()
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
 
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _has_visible_hip_device
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
 # ROCm 7.0 hipcc miscompiles gemm_a8w8_blockscale_bpreshuffle on gfx95 (#23319).
 _use_aiter_bpreshuffle_gfx95 = _use_aiter_gfx95 and get_hip_version() >= (7, 2, 0)
@@ -190,7 +191,15 @@ def use_rowwise_torch_scaled_mm():
         # torch._scaled_mm rowwise feature.
         # The condition is determined once as the operations
         # are time consuming.
-        return get_device_capability() >= (9, 4) and torch_release >= (2, 7)
+        device_capability = get_device_capability()
+        if (
+            device_capability is None
+            or len(device_capability) < 2
+            or device_capability[0] is None
+            or device_capability[1] is None
+        ):
+            return False
+        return device_capability >= (9, 4) and torch_release >= (2, 7)
     return False
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -145,11 +145,32 @@ if TYPE_CHECKING:
 
 _is_cpu = is_cpu()
 _is_hip = is_hip()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
-_is_shuffle_moe_mxfp4 = is_gfx95_supported()
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _has_visible_hip_device
+_is_shuffle_moe_mxfp4 = _has_visible_hip_device and is_gfx95_supported()
 _is_cpu_amx_available = cpu_has_amx_support()
 
-if _is_hip:
+
+def _raise_aiter_mxfp4_requires_visible_hip(*args, **kwargs):
+    del args, kwargs
+    raise NotImplementedError(
+        "AITer MXFP4 kernels require an AMD ROCm device visible at import time."
+    )
+
+
+def _raise_aiter_mxfp4_import_error(*args, _err: ImportError, **kwargs):
+    del args, kwargs
+    raise ImportError("Failed to import AITer MXFP4 kernels.") from _err
+
+
+def _make_aiter_mxfp4_import_error(err: ImportError):
+    def _raise(*args, **kwargs):
+        return _raise_aiter_mxfp4_import_error(*args, _err=err, **kwargs)
+
+    return _raise
+
+
+if _has_visible_hip_device:
     # import aiter
     try:
         from aiter.ops.shuffle import (
@@ -161,7 +182,20 @@ if _is_hip:
         from aiter.ops.triton.quant import dynamic_mxfp4_quant
         from aiter.utility.fp4_utils import e8m0_shuffle
     except ImportError as err:
-        dynamic_mxfp4_quant = e8m0_shuffle = err
+        _raise_import_error = _make_aiter_mxfp4_import_error(err)
+        dynamic_mxfp4_quant = _raise_import_error
+        e8m0_shuffle = _raise_import_error
+        shuffle_scale = _raise_import_error
+        shuffle_scale_a16w4 = _raise_import_error
+        shuffle_weight = _raise_import_error
+        shuffle_weight_a16w4 = _raise_import_error
+else:
+    dynamic_mxfp4_quant = _raise_aiter_mxfp4_requires_visible_hip
+    e8m0_shuffle = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_scale = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_scale_a16w4 = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_weight = _raise_aiter_mxfp4_requires_visible_hip
+    shuffle_weight_a16w4 = _raise_aiter_mxfp4_requires_visible_hip
 
 
 def _swizzle_mxfp4(quant_tensor, scale, num_warps):

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -11,7 +11,8 @@ from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import direct_register_custom_op, mxfp_supported
 
 _is_hip = is_hip()
-if _is_hip:
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
+if _has_visible_hip_device:
     from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
         fused_gemm_afp4wfp4_split_cat as _fused_gemm_afp4wfp4_split_cat_orig,
     )
@@ -147,6 +148,19 @@ if _is_hip:
         return torch.ops.sglang.aiter_fused_gemm_split_cat(
             x, w, y, x_scale, w_scale, S1, S2
         )
+
+else:
+
+    def _raise_mxfp4_requires_visible_hip(*args, **kwargs):
+        del args, kwargs
+        raise NotImplementedError(
+            "Quark MXFP4 kernels require an AMD ROCm device visible at import time."
+        )
+
+    gemm_afp4wfp4 = _raise_mxfp4_requires_visible_hip
+    gemm_afp4wfp4_pre_quant = _raise_mxfp4_requires_visible_hip
+    dynamic_mxfp4_quant = _raise_mxfp4_requires_visible_hip
+    fused_gemm_afp4wfp4_split_cat = _raise_mxfp4_requires_visible_hip
 
 
 __all__ = ["QuarkW4A4MXFP4"]

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -31,12 +31,16 @@ _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 __all__ = ["QuarkW4A4MXFp4MoE"]
 
 _is_hip = is_hip()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _has_visible_hip_device
 if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
     from aiter.utility.fp4_utils import e8m0_shuffle
+else:
+    shuffle_weight = None
+    e8m0_shuffle = None
 
-if _is_hip:
+if _has_visible_hip_device:
     from aiter.ops.triton.quant import dynamic_mxfp4_quant
 else:
     dynamic_mxfp4_quant = None
@@ -218,6 +222,17 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         return online_mxfp4_moe_weight_loader
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if e8m0_shuffle is None:
+            raise NotImplementedError(
+                "Quark MXFP4 MoE post-load scale shuffle requires AITer with "
+                "an AMD ROCm device visible."
+            )
+        if _is_shuffle_moe_mxfp4 and shuffle_weight is None:
+            raise NotImplementedError(
+                "Quark MXFP4 MoE weight shuffle requires AITer with an AMD ROCm "
+                "device visible."
+            )
+
         # Pre-shuffle weight scales
         s0, s1, _ = layer.w13_weight_scale.shape
         w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -7,15 +7,26 @@ from typing import Any, Optional
 
 import torch
 
-try:
-    from aiter.ops.triton.quant import dynamic_mxfp4_quant
-except ImportError:
 
-    def raise_aiter_import_error(*args, **kwargs):
+def raise_aiter_import_error(*args, _err: Optional[ImportError] = None, **kwargs):
+    del args, kwargs
+    if _err is not None:
         raise ImportError(
-            "Failed to import aiter. Make sure AITER is installed and accessible."
-        )
+            "Failed to import AITer MXFP4 quantization kernels."
+        ) from _err
+    raise ImportError("AITer MXFP4 quantization requires an AMD ROCm device visible.")
 
+
+if torch.version.hip is not None and torch.cuda.is_available():
+    try:
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    except ImportError as err:
+        dynamic_mxfp4_quant = (
+            lambda *args, _err=err, **kwargs: raise_aiter_import_error(
+                *args, _err=_err, **kwargs
+            )
+        )
+else:
     dynamic_mxfp4_quant = raise_aiter_import_error
 from torch import nn
 

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -24,12 +24,16 @@ if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import DispatchOutput
 
 _is_hip = is_hip()
+_has_visible_hip_device = _is_hip and torch.cuda.is_available()
 
 
-if _is_hip:
+if _has_visible_hip_device:
     from aiter.ops.shuffle import shuffle_weight
 
     ON_GFX950 = "gfx950" in torch.cuda.get_device_properties("cuda").gcnArchName
+else:
+    shuffle_weight = None
+    ON_GFX950 = False
 
 logger = logging.getLogger(__name__)
 
@@ -349,6 +353,12 @@ class QuarkInt4Fp8MoEMethod(FusedMoEMethodBase):
         tqdm_reset_no_print(self.online_quant_progress_bar, total=total)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if shuffle_weight is None:
+            raise NotImplementedError(
+                "Quark INT4-FP8 MoE weight shuffling requires AITer with a "
+                "visible AMD ROCm device."
+            )
+
         if _is_hip and not ON_GFX950:
             # CDNA3 does not support OCP FP8E4M3FN, but uses FP8E4M3FNUZ.
             # CDNA4 supports OCP FP8E4M3FN.

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -104,6 +104,7 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
+_HIP_GCN_ARCH_NAME_CACHE = None
 torch_release = pkg_version.parse(torch.__version__).release
 
 
@@ -1001,15 +1002,33 @@ def set_cuda_arch():
         )
 
 
+def _clear_hip_gcn_arch_name_cache():
+    global _HIP_GCN_ARCH_NAME_CACHE
+    _HIP_GCN_ARCH_NAME_CACHE = None
+
+
+def _hip_gcn_arch_name_or_none():
+    global _HIP_GCN_ARCH_NAME_CACHE
+    if _HIP_GCN_ARCH_NAME_CACHE is not None:
+        return _HIP_GCN_ARCH_NAME_CACHE
+    if not torch.version.hip or not torch.cuda.is_available():
+        return None
+    try:
+        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+    except RuntimeError as err:
+        if "No HIP GPUs are available" in str(err):
+            return None
+        raise
+    _HIP_GCN_ARCH_NAME_CACHE = gcn_arch
+    return gcn_arch
+
+
 def mxfp_supported():
     """
     Returns whether the current platform supports MX types.
     """
-    if torch.version.hip:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        return any(gfx in gcn_arch for gfx in ["gfx95"])
-    else:
-        return False
+    gcn_arch = _hip_gcn_arch_name_or_none()
+    return gcn_arch is not None and any(gfx in gcn_arch for gfx in ["gfx95"])
 
 
 @lru_cache(maxsize=1)
@@ -1017,11 +1036,8 @@ def is_gfx95_supported():
     """
     Returns whether the current platform supports MX types.
     """
-    if torch.version.hip:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        return any(gfx in gcn_arch for gfx in ["gfx95"])
-    else:
-        return False
+    gcn_arch = _hip_gcn_arch_name_or_none()
+    return gcn_arch is not None and any(gfx in gcn_arch for gfx in ["gfx95"])
 
 
 @lru_cache(maxsize=1)
@@ -1029,11 +1045,8 @@ def is_gfx942_supported():
     """
     Returns whether the current platform is AMD CDNA3 (gfx942 — MI300X / MI325X).
     """
-    if torch.version.hip:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        return any(gfx in gcn_arch for gfx in ["gfx942"])
-    else:
-        return False
+    gcn_arch = _hip_gcn_arch_name_or_none()
+    return gcn_arch is not None and any(gfx in gcn_arch for gfx in ["gfx942"])
 
 
 def get_hip_version():

--- a/test/registered/unit/quantization/test_rocm_no_device_imports.py
+++ b/test/registered/unit/quantization/test_rocm_no_device_imports.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestRocmNoDeviceImports(CustomTestCase):
+    @unittest.skipIf(
+        torch.version.hip is None or torch.cuda.is_available(),
+        "requires a ROCm build without a visible HIP device",
+    )
+    def test_rocm_quant_modules_import_without_visible_device(self):
+        code = textwrap.dedent("""
+            import sglang.kernels.ops.attention.rocm_mla_decode_rope  # noqa: F401
+            import sglang.srt.layers.quantization.fp8_kernel  # noqa: F401
+            import sglang.srt.layers.quantization.fp8_utils  # noqa: F401
+            import sglang.srt.layers.quantization.mxfp4  # noqa: F401
+            import sglang.srt.layers.quantization.quark.utils  # noqa: F401
+            import sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4  # noqa: F401
+            import sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4_moe  # noqa: F401
+            import sglang.srt.layers.quantization.quark_int4fp8_moe  # noqa: F401
+            """)
+        env = os.environ.copy()
+        env["SGLANG_USE_AITER"] = "0"
+
+        subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR makes ROCm/AITer-related imports safe when running a ROCm build without visible HIP devices.

It guards import-time device probes and optional AITer/vLLM extension imports behind visible-device checks, and adds explicit callable error stubs for MXFP4/Quark paths that cannot run without a ROCm device.

## Motivation

CPU-only tests in the ROCm Docker image can fail during import before reaching the actual test logic because some modules probe HIP/Triton/AITer at import time. This is especially visible when validating DSpark/DFLASH config and scheduler tests in a no-GPU container.

## Changes

- Guard `rocm_mla_decode_rope.py` Triton backend probing when no HIP device is visible.
- Gate FP8/MXFP4/Quark AITer and vLLM extension imports on visible HIP devices.
- Replace exception-object/`None` placeholders with explicit callable error stubs where runtime calls may happen later.
- Add a ROCm no-device import regression test.

## Tests

```bash
docker run --rm \
  -v /tmp/sglang-main-rocm-no-device-guards:/workspace/sglang \
  -w /workspace/sglang \
  -e SGLANG_USE_AITER=0 \
  -e PYTHONPATH=/workspace/sglang/python:/workspace/sglang \
  -e PYTHONPYCACHEPREFIX=/tmp/sglang-guard-pycache \
  lmsysorg/sglang:v0.5.14-rocm720-mi35x \
  python3 test/registered/unit/quantization/test_rocm_no_device_imports.py
```

Result:

- `Ran 1 test`
- `OK`

Also checked:

- `git diff --check origin/main`





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29227828609](https://github.com/sgl-project/sglang/actions/runs/29227828609)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29227828526](https://github.com/sgl-project/sglang/actions/runs/29227828526)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->