### PR TITLE
[Bugfix] Fix DeepSeek ForwardFlags across custom op boundary

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -871,9 +871,12 @@ class DeepseekV2MoE(nn.Module):
         if not self._enable_a2a_moe:
             server_args = get_server_args()
             if self._can_dual_stream_graph(hidden_states, server_args):
+                fwd = get_forward()
                 return dsv2_flashinfer_moe_dual_stream_graph(
                     hidden_states,
                     self.layer_id,
+                    fwd.fuse_mlp_allreduce,
+                    fwd.mlp_reduce_scatter,
                 )
             elif (
                 self.alt_stream is not None
@@ -2976,6 +2979,8 @@ class DeepseekV32ForCausalLM(DeepseekV2ForCausalLM):
 def dsv2_flashinfer_moe_dual_stream_graph(
     hidden_states: torch.Tensor,
     layer_id: int,
+    fuse_mlp_allreduce: bool,
+    mlp_reduce_scatter: bool,
 ) -> torch.Tensor:
     forward_context = get_tc_piecewise_forward_context()
     assert forward_context is not None
@@ -2983,7 +2988,14 @@ def dsv2_flashinfer_moe_dual_stream_graph(
 
     moe_fusion = forward_context.moe_fusions[layer_id]
     assert moe_fusion is not None
-    with get_forward().scoped(flashinfer_trtllm_bypass=True):
+    # Custom-op execution happens outside the caller's Python scope under
+    # torch.compile. Carry graph-varying control state as scalar operands and
+    # republish it for the nested MoE/linear consumers.
+    with get_forward().scoped(
+        fuse_mlp_allreduce=fuse_mlp_allreduce,
+        mlp_reduce_scatter=mlp_reduce_scatter,
+        flashinfer_trtllm_bypass=True,
+    ):
         return moe_fusion.forward_normal_dual_stream(hidden_states)
 
 


### PR DESCRIPTION
## Summary

#30802 caused the same `ForwardFlags` custom-op boundary bug that #30968 fixed for Nemotron, this time in DeepSeek's `tc_piecewise` dual-stream MoE path. We pass `fuse_mlp_allreduce` and `mlp_reduce_scatter` into the custom op and set them again inside.

## Accuracy

With `SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM=1`, the fix improves the full 1,319-example single-shot GSM8K score by 3.11 percentage points, or 41 more correct answers.

| Metric | Before | After |
|---|---:|---:|
| Score | 92.49% | 95.60% |
| Stop rate | 96.82% | 99.01% |
| Truncated rate | 3.18% | 0.99% |
| Error rate | 0.00% | 0.00% |

```bash
sgl-eval run gsm8k \
  --base-url http://127.0.0.1:30000/v1 \
  --max-tokens 512 \
  --num-threads 512

# Before
gsm8k: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:52<00:00, 24.98it/s, acc=92.49%]
== gsm8k ==
1319 examples (single-shot)  |  52.8s  |  5416 tok/s  |  286K tokens

* score           =  92.49%
  stop_rate       =  96.82%
  truncated_rate  =  3.18%  [warn: hitting max_tokens]
  error_rate      =  0.00%

# After
gsm8k: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:43<00:00, 30.24it/s, acc=95.60%]
== gsm8k ==
1319 examples (single-shot)  |  43.6s  |  6406 tok/s  |  279K tokens

* score           =  95.60%
  stop_rate       =  99.01%
  truncated_rate  =  0.99%
  error_rate      =  0.00%
```

## Profiler

| Kernel | Before per TP rank | After per TP rank |
|---|---:|---:|
| `moe::dev::routing::routingDeepSeek::routingMainKernel` | 58 | 58 |
| `moe::dev::routing::routingDeepSeek::routingIndicesClusterKernel` | 58 | 58 |
| `moe::dev::finalize::finalizeKernelVecLoad` | 58 | 58 |
| `(anonymous namespace)::all_reduce_one_shot_kernel` | 59 | 2 |
| `flashinfer::trtllm_mnnvl_allreduce::twoshotAllreduceKernel` | 121 | 121 |
| `flashinfer::trtllm_mnnvl_allreduce::rmsNormLamport` | 121 | 121 |

The `all_reduce_one_shot_kernel` count drops from 59 to 2 per TP rank.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29230081489](https://github.com/sgl-project/sglang/actions/runs/29230081489)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29230081352](https://github.com/sgl-project/sglang/actions/runs/29230081352)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->