### PR TITLE
fix(function_call): strip think tags split across stream chunks in Trinity

### DIFF
--- a/python/sglang/srt/function_call/trinity_detector.py
+++ b/python/sglang/srt/function_call/trinity_detector.py
@@ -18,6 +18,15 @@ class TrinityDetector(Qwen25Detector):
     Reference: https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct?chat_template=default
     """
 
+    _think_tokens = ("<think>", "</think>")
+
+    def __init__(self):
+        super().__init__()
+        # Carries a trailing partial `<think>`/`</think>` tag that split across
+        # a streaming chunk boundary, so it can be completed and stripped on the
+        # next increment instead of leaking into normal_text.
+        self._think_tag_carry = ""
+
     def _strip_think_tags(self, text: str) -> str:
         """Remove <think> and </think> tags, keeping the content inside."""
         return text.replace("<think>", "").replace("</think>", "")
@@ -37,7 +46,22 @@ class TrinityDetector(Qwen25Detector):
     ) -> StreamingParseResult:
         """
         Streaming incremental parsing for tool calls.
+
+        Stripping per-increment is unsafe: a `<think>`/`</think>` tag can split
+        across chunk boundaries (`"<thi"` + `"nk>"`), and neither half contains
+        the full tag, so it leaks through raw. Strip on the carried buffer and
+        hold back a trailing partial tag until the next increment completes it —
+        matching the one-shot `detect_and_parse` behavior.
         """
-        return super().parse_streaming_increment(
-            self._strip_think_tags(new_text), tools
+        stripped = self._strip_think_tags(self._think_tag_carry + new_text)
+        holdback = max(
+            (self._ends_with_partial_token(stripped, tok) or 0)
+            for tok in self._think_tokens
         )
+        if holdback:
+            self._think_tag_carry = stripped[-holdback:]
+            forward = stripped[:-holdback]
+        else:
+            self._think_tag_carry = ""
+            forward = stripped
+        return super().parse_streaming_increment(forward, tools)

--- a/test/registered/unit/function_call/test_trinity_detector.py
+++ b/test/registered/unit/function_call/test_trinity_detector.py
@@ -1,0 +1,79 @@
+"""Unit tests for TrinityDetector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.trinity_detector import TrinityDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestTrinityDetector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+        ]
+
+    def _stream(self, chunks):
+        detector = TrinityDetector()
+        normal = ""
+        calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal += result.normal_text
+            calls.extend(result.calls)
+        return normal, calls
+
+    def test_streaming_whole_think_tag(self):
+        """A think tag arriving in one chunk is stripped, content kept."""
+        normal, _ = self._stream(["<think>reasoning</think>hello"])
+        self.assertEqual(normal, "reasoninghello")
+
+    def test_streaming_split_think_tag(self):
+        """A think tag split across chunk boundaries must still be stripped.
+
+        Regression: stripping per-increment left `<think>`/`</think>` intact
+        when the tag straddled two chunks (neither half held the full tag), so
+        the raw tags leaked into normal_text.
+        """
+        normal, _ = self._stream(["<thi", "nk>reasoning</thi", "nk>hello"])
+        self.assertEqual(normal, "reasoninghello")
+
+    def test_streaming_char_by_char(self):
+        """The tightest possible split (one char per chunk) is handled."""
+        normal, _ = self._stream(list("<think>abc</think>hi"))
+        self.assertEqual(normal, "abchi")
+
+    def test_streaming_tag_lookalike_not_eaten(self):
+        """Text that merely starts like `<think>` (e.g. `<thing>`) is preserved."""
+        normal, _ = self._stream(["<thi", "ng>data"])
+        self.assertEqual(normal, "<thing>data")
+
+    def test_streaming_tool_call_inside_think_split(self):
+        """A tool call inside a split think section still parses."""
+        chunks = [
+            "<thi",
+            'nk><tool_call>\n{"name": "get_weather", ',
+            '"arguments": {"city": "Paris"}}\n</tool_call></thi',
+            "nk>",
+        ]
+        _, calls = self._stream(chunks)
+        names = [c.name for c in calls if c.name]
+        self.assertIn("get_weather", names)
+        joined = "".join(c.parameters or "" for c in calls)
+        self.assertIn("Paris", joined)

--- a/test/registered/unit/function_call/test_trinity_detector.py
+++ b/test/registered/unit/function_call/test_trinity_detector.py
@@ -1,7 +1,5 @@
 """Unit tests for TrinityDetector — no server, no model loading."""
 
-import json
-
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
 from sglang.srt.function_call.trinity_detector import TrinityDetector
 from sglang.test.ci.ci_register import register_cpu_ci


### PR DESCRIPTION
### Problem
`TrinityDetector` strips `<think>`/`</think>` per streaming increment, so a tag split across chunk boundaries leaks through raw. Neither half of `"<thi"` + `"nk>"` contains the full tag, so nothing gets stripped.

Repro (streaming the same text in one chunk vs. split):
```
whole  ["<think>reasoning</think>hello"]              -> "reasoninghello"   ✓
split  ["<thi", "nk>reasoning</thi", "nk>hello"]      -> "<think>reasoning</think>hello"   ✗ (tags leak)
```

### Fix
Buffer a trailing partial tag across increments and strip on the carried buffer, holding it back until the next chunk completes it — same result the one-shot `detect_and_parse` already gives. Reuses the base `_ends_with_partial_token` helper for the holdback.

After: split case -> `"reasoninghello"`, and `<thing>` (a look-alike that isn't a think tag) is still emitted intact.

### Tests
Added `test_trinity_detector.py`: whole-tag, split, char-by-char, tag-lookalike, and a tool call inside a split think section. All pass locally (ran the detector directly — my local env can't load the full server stack for the pytest harness, but the assertions run clean against the detector).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29233028387](https://github.com/sgl-project/sglang/actions/runs/29233028387)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29233028255](https://github.com/sgl-project/sglang/actions/runs/29233028255)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->