### PR TITLE
[Feature] Enable a16w4 MXFP4 MoE on the aiter fp4_bf16 FlyDSL path

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -162,23 +162,28 @@ class AiterRunnerCore(MoeRunnerCore):
             extra["num_local_tokens"] = runner_input.num_local_tokens
         if runner_input.output_dtype is not None:
             extra["dtype"] = runner_input.output_dtype
-        if quant_info.swiglu_limit > 0:
-            # GateMode is only needed for the gpt-oss MXFP4 swiglu_limit path.
-            # Import lazily so models that don't use it (e.g. DeepSeek-V3 fp8,
-            # swiglu_limit==0) still run on aiter builds where this module
-            # lives elsewhere / is absent.
-            from aiter.ops.flydsl.moe_common import GateMode
+        # Weights tagged gate/up-interleaved (the a16w4 fp4_bf16 layout) only work
+        # under INTERLEAVE, so take gate_mode from the layout itself. aiter derives
+        # the same thing from is_guinterleave, but only in eager mode -- the
+        # attribute does not survive its torch_compile_guard boundary -- so pass it
+        # explicitly. Cache the guarded import: this is a per-forward hot path and
+        # older aiter builds may not ship the module.
+        _gu_interleave = getattr(quant_info.w13_weight, "is_guinterleave", False)
+        if _gu_interleave or quant_info.swiglu_limit > 0:
+            if not hasattr(self, "_gate_mode_class"):
+                try:
+                    from aiter.ops.flydsl.moe_common import GateMode
 
-            # Default (INTERLEAVE) preserves the pre-fix behavior for paths
-            # that prepare weights in the gate/up-interleaved layout. Set
-            # `SGLANG_USE_AITER_MOE_GU_ITLV=0` to switch to SEPARATED, which
-            # matches the layout produced by `Mxfp4MoEMethod` (gpt-oss
-            # MXFP4) and the gptoss_fp4 tuned FlyDSL kernels.
-            extra["gate_mode"] = (
-                GateMode.INTERLEAVE.value
-                if envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
-                else GateMode.SEPARATED.value
-            )
+                    self._gate_mode_class = GateMode
+                except ImportError:
+                    self._gate_mode_class = None
+            if self._gate_mode_class is not None:
+                extra["gate_mode"] = (
+                    self._gate_mode_class.INTERLEAVE.value
+                    if _gu_interleave or envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
+                    else self._gate_mode_class.SEPARATED.value
+                )
+        if quant_info.swiglu_limit > 0:
             extra["swiglu_limit"] = quant_info.swiglu_limit
         if self.config.no_combine:
             extra["no_combine"] = True

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -44,6 +44,14 @@ if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
     from aiter.utility.fp4_utils import e8m0_shuffle
 
+    # a16w4 (bf16 activations + fp4 weights) fp4_bf16 FlyDSL path. Uses the
+    # unified aiter shuffle API (finalized aiter #4398): klane_inner is tied to
+    # INTERLEAVE mode. Guarded so older aiter builds fall back to a4w4.
+    try:
+        from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+    except ImportError:
+        shuffle_scale_a16w4 = shuffle_weight_a16w4 = None
+
 if _is_hip:
     from aiter.ops.triton.quant import dynamic_mxfp4_quant
 else:
@@ -574,6 +582,46 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             assert layer.w13_weight_scale.dtype == torch.uint8
             assert layer.w2_weight_scale.dtype == torch.uint8
 
+        # a16w4 (bf16 activations, fp4 weights). The fp4_bf16 FlyDSL kernels unpack
+        # the weights with v_cvt_scalef32_pk_bf16_fp4, which needs the
+        # fp4-cvt-scale-insts target feature -- gfx950 only -- so the hardware check
+        # is the gate. Layout follows the aiter #4398 recipe: w13 gate/up-interleaved
+        # with klane_inner=True, w2 on the default layout, scales through
+        # shuffle_scale_a16w4 rather than e8m0_shuffle.
+        _use_a16w4 = (
+            _use_aiter and is_gfx95_supported() and shuffle_weight_a16w4 is not None
+        )
+        if _use_a16w4:
+            E = layer.w13_weight.shape[0]
+            logger.info("[quark a16w4] INTERLEAVE fp4_bf16 (klane_inner) weight prep")
+
+            s0, s1, _ = layer.w13_weight_scale.shape
+            layer.w13_weight_scale.data = shuffle_scale_a16w4(
+                layer.w13_weight_scale.view(s0 * s1, -1), E, True, klane_inner=True
+            ).view(s0, s1, -1)
+            s0, s1, _ = layer.w2_weight_scale.shape
+            # w2 keeps the default layout: klane_inner is a stage1 gate/up-interleave
+            # concept, and aiter rejects it on stage2 (ROCm/aiter#4548).
+            layer.w2_weight_scale.data = shuffle_scale_a16w4(
+                layer.w2_weight_scale.view(s0 * s1, -1), E, False, klane_inner=False
+            ).view(s0, s1, -1)
+
+            layer.w13_weight.data = shuffle_weight_a16w4(
+                layer.w13_weight.contiguous(), 16, True, klane_inner=True
+            )
+            layer.w2_weight.data = shuffle_weight_a16w4(
+                layer.w2_weight.contiguous(), 16, False, klane_inner=False
+            )
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+            layer.w13_weight.is_guinterleave = True
+
+            if hasattr(layer, "dispatcher"):
+                layer.dispatcher.set_quant_config(
+                    {"weight_dtype": torch.float4_e2m1fn_x2}
+                )
+            return
+
         # Pre-shuffle weight scales
         s0, s1, _ = layer.w13_weight_scale.shape
         w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
@@ -639,6 +687,12 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         if hasattr(layer.w13_weight, "is_shuffled"):
             w13_weight.is_shuffled = True
             w2_weight.is_shuffled = True
+
+        # `.view()` above returns fresh tensors, so re-tag the gate/up-interleaved
+        # layout. The aiter runner reads this to pick gate_mode, and aiter itself
+        # only sees it when the call stays in eager mode.
+        if getattr(layer.w13_weight, "is_guinterleave", False):
+            w13_weight.is_guinterleave = True
 
         quant_info = AiterMoeQuantInfo(
             w13_weight=w13_weight,


### PR DESCRIPTION
## Motivation

Qwen3.5-397B-A17B-MXFP4 runs its MoE through **a4w4**: bf16 activations are quantized to fp4 on every forward, then multiplied by fp4 weights. aiter has a **fp4_bf16 (a16w4)** two-stage path that keeps activations in bf16 and dequantizes only the weights — it drops two quant kernels per layer and is the more accurate path.

This PR reaches that path. Two things were in the way:

1. `moe_runner/aiter.py` passed `gate_mode` **only when `swiglu_limit > 0`**, so a model without a clamped swiglu (Qwen3.5 MXFP4, `swiglu_limit == 0`) never selected INTERLEAVE and never reached the fp4_bf16 kernels.
2. Nothing produced the a16w4 weight layout those kernels need.

## Modifications

**`moe_runner/aiter.py`** — send `gate_mode` when the weights are tagged gate/up-interleaved, not only when `swiglu_limit > 0`. That old condition is why Qwen3.5 (no clamped swiglu) never reached the fp4_bf16 kernels. The guarded import is cached on the instance: this runs on every forward, and older aiter builds may not ship the module.

**`quark/schemes/quark_w4a4_mxfp4_moe.py`** — prepare the a16w4 layout in `process_weights_after_loading`:

- `w13` → `shuffle_weight_a16w4(..., gate_up=True, klane_inner=True)` + matching `shuffle_scale_a16w4`, giving the faster `_gui` stage1 kernel, and `is_guinterleave = True`
- `w2` → default layout (`gate_up=False, klane_inner=False`). Stage2 is the down projection; it has no gate/up split to interleave, and the klane_inner w2 layout is measurably wrong (cosine 0.225 / 0.049 vs 0.999990 on real weights).
- scales go through `shuffle_scale_a16w4`, not `e8m0_shuffle`

### The gate is the hardware, not an env var

These kernels unpack weights with `v_cvt_scalef32_pk_bf16_fp4`, which requires the **`fp4-cvt-scale-insts`** target feature, and the aiter MoE path always takes the hardware convert (`unpack_b_mxfp4_bf16(..., use_hw_cvt=True)`) with no software fallback. Probing the builtin across targets with this toolchain:

| target | `__builtin_amdgcn_cvt_scalef32_pk_bf16_fp4` |
|---|---|
| gfx90a (MI200) | rejected — needs `fp4-cvt-scale-insts` |
| gfx942 (MI300X / MI325X) | rejected — needs `fp4-cvt-scale-insts` |
| **gfx950 (MI350X / MI355X)** | **supported** |
| gfx1200 | rejected |
| gfx1250 | rejected |

So a16w4 turns on exactly when `is_gfx95_supported()` and the aiter build exports the shuffle helpers — no `SGLANG_USE_AITER_MOE_GU_ITLV` dependency. Everything else keeps a4w4 unchanged. This matches aiter's own gate (`skipif get_gfx() not in ["gfx950"]`).

`gate_mode` then follows the weight layout rather than a global: `apply()` re-tags `is_guinterleave` onto the `float4_e2m1fn_x2` view (that view drops python attributes — the same reason `is_shuffled` is re-set there), and the runner reads it. aiter derives the flag itself, but only in eager mode: it does not survive the `torch_compile_guard` boundary, so the runner passes `gate_mode` explicitly.

### Rewritten since the first revision

The earlier version of this PR called `shuffle_weight_a16w4_sep_fp4` / `shuffle_weight_a16w4_gui_fp4`, carried an `AITER_FP4BF16_USE_ITLV` toggle, and gated the feature on `SGLANG_USE_AITER_MOE_GU_ITLV`. Those helpers do not exist in aiter — the shipped API is the unified `shuffle_weight_a16w4(src, NLane, gate_up, klane_inner=...)` — so that revision would have silently taken the `is not None` fallback and never enabled a16w4. It also offered a SEPARATED a16w4 variant, which aiter does not implement: the fp4_bf16 stage1 kernel is INTERLEAVE-only. Both are gone.

### aiter dependency

Targets the finalized API in **ROCm/aiter#4398** plus the follow-up **ROCm/aiter#4548**. Relevant to review here: #4548 makes aiter *reject* the layouts this file must not produce (`klane_inner=True` on stage2, SEPARATED `gate_mode` on fp4_bf16 stage1) instead of returning corrupt output — so a future drift between these two files fails loudly rather than degrading accuracy.

## Accuracy Tests

Replaying this exact weight-prep recipe through `aiter.fused_moe` on **real Qwen3.5-397B-A17B-MXFP4 checkpoint weights** (layer 0, TP2 shard, E=512, topk=10, 32 tokens), versus the torch reference:

```
ref |.|=3.1473e-06   out |.|=3.1472e-06
cosine=0.999989      rel_rms=4.6447e-03      PASS
```

The same recipe validated on the aiter side (`aiter/ops/flydsl/test_flydsl_moe_a16w4.py --spread-exponents`, E=512 / topk=10 / tokens 1–128): 12/12, cosine 0.999988–0.999990.

Not yet re-run on this revision: a full served GSM8K. Earlier measurement on this path gave a16w4 **0.97** vs a4w4 **0.87** under an instruction prompt.

## Benchmarking and Profiling

Profiling `fused_moe` at the Qwen3.5 TP2 MoE shape (4096×512, E=512, topk=10), INTERLEAVE, confirms the intended kernels dispatch — `moe_gemm1_0` / `moe_gemm2_0`, not a CK fallback — at 23.5 µs / 15.7 µs per iteration at 4 tokens and 200.5 µs / 146.4 µs at 128 tokens.

## Checklist

- [x] Format: `[Feature]` tag, no trailers
- [x] Validated against real checkpoint weights
- [x] Guarded so older aiter builds fall back to a4w4

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30896366280](https://github.com/sgl-project/sglang/actions/runs/30896366280)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30896366537](https://github.com/sgl-project/sglang/actions/runs/30896366537)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->