### PR TITLE
[CI] Disable gated Llama-2 EAGLE spec tests to unblock Xeon CPU CI

### DIFF
--- a/test/registered/cpu/test_spec_eagle_cpu.py
+++ b/test/registered/cpu/test_spec_eagle_cpu.py
@@ -18,7 +18,11 @@ from sglang.test.kits.spec_server_kits import (
 from sglang.test.server_fixtures.spec_eagle_fixture import EagleLlama2Base
 
 # Measured 780s all-green on a 40-core GNR socket (1 launch + 18 methods).
-register_cpu_ci(est_time=800, suite="base-b-test-cpu")
+register_cpu_ci(
+    est_time=800,
+    suite="base-b-test-cpu",
+    disabled="EagleLlama2Base needs gated meta-llama/Llama-2-7b-chat-hf",
+)
 
 _KITS = (
     SpecCorrectnessKit,

--- a/test/registered/cpu/test_spec_eagle_topk_cpu.py
+++ b/test/registered/cpu/test_spec_eagle_topk_cpu.py
@@ -19,7 +19,11 @@ from sglang.test.kits.spec_server_kits import (
 from sglang.test.server_fixtures.spec_eagle_fixture import EagleLlama2Base
 
 # Measured 830s all-green on a 40-core GNR socket (1 launch + 14 methods).
-register_cpu_ci(est_time=850, suite="base-b-test-cpu")
+register_cpu_ci(
+    est_time=850,
+    suite="base-b-test-cpu",
+    disabled="EagleLlama2Base needs gated meta-llama/Llama-2-7b-chat-hf",
+)
 
 
 class _Core(EagleLlama2Base):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The Xeon CPU CI (`base-b-test-cpu` on `xeon-gnr`) is currently failing caused by `test_spec_eagle_cpu.py` and `test_spec_eagle_topk_cpu.py` (added in #27862) launch `meta-llama/Llama-2-7b-chat-hf`, a gated Hugging Face checkpoint.

The runner's HF token has no Llama access and the model is not in its local cache, so the download 403s and the suite fails. #27862 was validated locally (the Xeon CI could not build at the time), where a cached copy masked this.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Mark the `register_cpu_ci` registrations of both files `disabled=`.
 - `test_spec_eagle_parity_cpu.py` (EAGLE3, Llama-3.1-8B-Instruct) stays enabled for now.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29232590703](https://github.com/sgl-project/sglang/actions/runs/29232590703)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29298383020](https://github.com/sgl-project/sglang/actions/runs/29298383020)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->