### PR TITLE
Fix: pp_proxy_tensors oversized at SCATTERED PP boundary breaks all_gather in CUDA graph capture

### DIFF
--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -448,6 +448,11 @@ class BaseRunner(ABC):
                 and mr.attn_cp_size > 1
             ):
                 pp_hidden_tokens = num_tokens // mr.attn_cp_size
+            # When the previous PP stage's output is SCATTERED (DeepEP or
+            # moe_dense_tp_size=1), hidden states at the PP boundary have
+            # num_tokens / attn_tp_size rows per rank, not num_tokens.
+            if require_attn_tp_gather(mr.server_args):
+                pp_hidden_tokens = pp_hidden_tokens // get_parallel().attn_tp_size
             pp_proxy_tensors = PPProxyTensors(
                 {k: v[:pp_hidden_tokens] for k, v in buffers.pp_proxy_tensors.items()}
             )

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -565,8 +565,14 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         pp_proxy_tensors = None
         # pipeline parallelism
         if self.pp_size > 1:
+            # When the previous PP stage's output is SCATTERED (DeepEP or
+            # moe_dense_tp_size=1), hidden states at the PP boundary have
+            # num_tokens / attn_tp_size rows per rank, not num_tokens.
+            pp_hidden_tokens = num_tokens
+            if self.require_attn_tp_gather:
+                pp_hidden_tokens = num_tokens // self.attn_tp_size
             pp_proxy_tensors = PPProxyTensors(
-                {k: v[:num_tokens] for k, v in buffers.pp_proxy_tensors.items()}
+                {k: v[:pp_hidden_tokens] for k, v in buffers.pp_proxy_tensors.items()}
             )
 
         if self.require_mlp_tp_gather:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix pp_proxy_tensors sizing for SCATTERED PP boundary in CUDA graph capture

When PP > 1 and DeepEP/moe_dense_tp_size=1 are used, the previous PP
stage's output is in ScatterMode.SCATTERED — each rank holds only
num_tokens / attn_tp_size rows, not num_tokens.

During CUDA graph capture, pp_proxy_tensors was unconditionally sliced
to num_tokens, causing the subsequent all_gather_into_tensor to fail:
  RuntimeError: output tensor size must be equal to world_size times
  input tensor size

The bug only manifests with all of: PP > 1, DeepEP backend, moe_dense_tp_size=1,
CUDA graph enabled, and attn_tp_size > 1.

original issue: https://gitcode.com/Ascend/slime-ascend/issues/17

## Modifications

Fix: slice pp_proxy_tensors to num_tokens // attn_tp_size when
require_attn_tp_gather is True, in both the decode CUDA graph capture
path (capture_prepare) and the eager warmup path (get_dummy_forward_batch).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29235190808](https://github.com/sgl-project/sglang/actions/runs/29235190808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29235190614](https://github.com/sgl-project/sglang/actions/runs/29235190614)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->