### PR TITLE
fix(reasoning_parser): hold back think tags split across stream chunks

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -194,10 +194,12 @@ class BaseReasoningFormatDetector:
                 # so it isn't emitted as reasoning content (it would otherwise
                 # leak the tag and mis-classify the following normal text).
                 hold = _trailing_partial_token_len(current_text, tokens_to_check)
-                emit = (
-                    current_text[: len(current_text) - hold] if hold else current_text
+                # Guard hold != 0: `[:-0]` is empty, not the whole string.
+                emit, self._buffer = (
+                    (current_text[:-hold], current_text[-hold:])
+                    if hold
+                    else (current_text, "")
                 )
-                self._buffer = current_text[len(current_text) - hold :] if hold else ""
                 if not emit:
                     return StreamingParseResult()
                 return StreamingParseResult(reasoning_text=emit)
@@ -210,8 +212,12 @@ class BaseReasoningFormatDetector:
             # opening that split across this chunk boundary is still detected on
             # the next increment instead of leaking into normal text.
             hold = _trailing_partial_token_len(current_text, tokens_to_check)
-            emit = current_text[: len(current_text) - hold] if hold else current_text
-            self._buffer = current_text[len(current_text) - hold :] if hold else ""
+            # Guard hold != 0: `[:-0]` is empty, not the whole string.
+            emit, self._buffer = (
+                (current_text[:-hold], current_text[-hold:])
+                if hold
+                else (current_text, "")
+            )
             if not emit:
                 return StreamingParseResult()
             return StreamingParseResult(normal_text=emit)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -18,6 +18,25 @@ class StreamingParseResult:
         self.reasoning_text = reasoning_text or ""
 
 
+def _trailing_partial_token_len(text: str, tokens: List[str]) -> int:
+    """Length of the longest suffix of ``text`` that is a proper prefix of any
+    token in ``tokens`` (0 if none).
+
+    Used to hold back a structural token (``<think>`` / ``</think>`` / a tool
+    marker) that split across a streaming chunk boundary, so the partial isn't
+    emitted as content and can be completed on the next increment. This is the
+    end-of-buffer counterpart to the whole-buffer prefix guard.
+    """
+    best = 0
+    for token in tokens:
+        limit = min(len(text), len(token) - 1)
+        for k in range(limit, best, -1):
+            if token.startswith(text[-k:]):
+                best = k
+                break
+    return best
+
+
 class BaseReasoningFormatDetector:
     """Base class providing two sets of interfaces: one-time and streaming incremental."""
 
@@ -170,16 +189,32 @@ class BaseReasoningFormatDetector:
                     normal_text=normal_text, reasoning_text=reasoning_text
                 )
             if self.stream_reasoning:
-                # Stream the content immediately
-                self._buffer = ""
-                return StreamingParseResult(reasoning_text=current_text)
+                # Stream the content immediately, but hold back a trailing
+                # partial end/tool token that split across this chunk boundary
+                # so it isn't emitted as reasoning content (it would otherwise
+                # leak the tag and mis-classify the following normal text).
+                hold = _trailing_partial_token_len(current_text, tokens_to_check)
+                emit = (
+                    current_text[: len(current_text) - hold] if hold else current_text
+                )
+                self._buffer = current_text[len(current_text) - hold :] if hold else ""
+                if not emit:
+                    return StreamingParseResult()
+                return StreamingParseResult(reasoning_text=emit)
             else:
                 return StreamingParseResult()
 
         # If we're not in a reasoning block return as normal text
         if not self._in_reasoning:
-            self._buffer = ""
-            return StreamingParseResult(normal_text=current_text)
+            # Hold back a trailing partial start/tool token so a reasoning block
+            # opening that split across this chunk boundary is still detected on
+            # the next increment instead of leaking into normal text.
+            hold = _trailing_partial_token_len(current_text, tokens_to_check)
+            emit = current_text[: len(current_text) - hold] if hold else current_text
+            self._buffer = current_text[len(current_text) - hold :] if hold else ""
+            if not emit:
+                return StreamingParseResult()
+            return StreamingParseResult(normal_text=emit)
 
         return StreamingParseResult()
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -110,6 +110,29 @@ class TestBaseReasoningFormatDetector(CustomTestCase):
         self.assertEqual(result.normal_text, "normal text")
         self.assertFalse(self.detector._in_reasoning)
 
+    def test_parse_streaming_increment_end_token_split(self):
+        """End token split across chunk boundaries must still be detected.
+
+        Regression: a partial `</think>` at the end of buffered reasoning
+        content (e.g. `"reasoning<"` + `"/think>..."`) was emitted as content,
+        so the tag leaked and the following normal text was mis-classified as
+        reasoning.
+        """
+        self.detector.parse_streaming_increment("<think>")
+        r1 = self.detector.parse_streaming_increment("reasoning<")
+        r2 = self.detector.parse_streaming_increment("/think>normal text")
+        self.assertEqual(r1.reasoning_text + r2.reasoning_text, "reasoning")
+        self.assertEqual(r1.normal_text + r2.normal_text, "normal text")
+        self.assertFalse(self.detector._in_reasoning)
+
+    def test_parse_streaming_increment_lt_in_reasoning_content(self):
+        """A bare `<` in reasoning content is not mistaken for a split tag."""
+        self.detector.parse_streaming_increment("<think>")
+        r1 = self.detector.parse_streaming_increment("a<b ")
+        r2 = self.detector.parse_streaming_increment("more</think>x")
+        self.assertEqual(r1.reasoning_text + r2.reasoning_text, "a<b more")
+        self.assertEqual(r1.normal_text + r2.normal_text, "x")
+
     def test_parse_streaming_increment_no_stream_reasoning(self):
         """Test streaming parse without streaming reasoning."""
         detector = BaseReasoningFormatDetector(


### PR DESCRIPTION
### Problem
`BaseReasoningFormatDetector.parse_streaming_increment` only buffers when the **whole** buffer is a prefix of a structural token. A `</think>` (or `<think>`/tool marker) split across a chunk boundary leaves a partial token at the **end** of buffered content, which gets emitted as `reasoning_text` — the tag leaks and the following normal text is mis-classified as reasoning.

Repro (`stream_reasoning=True`, DeepSeek-R1 style):
```
whole  ["reasoning</think>answer"]           -> reasoning="reasoning", normal="answer"   ✓
split  ["reasoning<", "/think>answer"]        -> reasoning="reasoning</think>answer", normal=""   ✗
```
It only bites when `</think>` isn't emitted as a single token, so it slips past whole-token streaming.

### Fix
Hold back a trailing partial token at the two emit points that clear the buffer (the `stream_reasoning` path and the normal-text path), completing it on the next increment. This is the end-of-buffer counterpart to the existing whole-buffer prefix guard a few lines up — same intent, applied to a partial at the end of content.

After: split case -> `reasoning="reasoning", normal="answer"`; a bare `<` inside reasoning (`"a<b "`) is still emitted, not held.

### Tests
Added two cases to `test_reasoning_parser.py`: end token split across chunks, and a bare `<` in reasoning content. Ran the parser directly (my local env can't load the full server stack for the pytest harness — unrelated transformers config collision); new cases pass and the existing streaming cases still pass.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29240367256](https://github.com/sgl-project/sglang/actions/runs/29240367256)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29240367141](https://github.com/sgl-project/sglang/actions/runs/29240367141)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->