### PR TITLE
fix(completion): treat None suffix as empty in FIM prompt builder

### DIFF
--- a/python/sglang/srt/parser/code_completion_parser.py
+++ b/python/sglang/srt/parser/code_completion_parser.py
@@ -82,7 +82,9 @@ def is_completion_template_defined() -> bool:
 
 def generate_completion_prompt_from_request(request: CompletionRequest) -> str:
     global completion_template_name
-    if request.suffix == "":
+    # suffix defaults to None; treat it like an empty suffix so the FIM
+    # template isn't fed the literal string "None" via the f-string below.
+    if not request.suffix:
         return request.prompt
 
     return generate_completion_prompt(

--- a/test/registered/unit/parser/test_code_completion_parser.py
+++ b/test/registered/unit/parser/test_code_completion_parser.py
@@ -123,6 +123,16 @@ class TestGenerateCompletionPromptFromRequest(CustomTestCase):
         result = generate_completion_prompt_from_request(request)
         self.assertEqual(result, "just code")
 
+    def test_none_suffix_returns_prompt_directly(self):
+        """A None suffix (the default) must bypass FIM, not inject 'None'."""
+        with patch(
+            "sglang.srt.parser.code_completion_parser.completion_template_name",
+            "deepseek_coder",
+        ):
+            request = CompletionRequest(prompt="just code", suffix=None)
+            result = generate_completion_prompt_from_request(request)
+            self.assertEqual(result, "just code")
+
     def test_nonempty_suffix_uses_fim_template(self):
         """Test that non-empty suffix triggers FIM formatting."""
         with patch(


### PR DESCRIPTION
### Problem
`CompletionRequest.suffix` defaults to `None`, but `generate_completion_prompt_from_request` only bypasses FIM formatting when `suffix == ""`. A completion request with no suffix sent to a code model (FIM template configured) falls through to the f-string builder, which stringifies `None` and injects the literal `"None"` where the suffix belongs:

```
suffix=None  -> "<|fim_prefix|>def foo():<|fim_suffix|>None<|fim_middle|>"   # bug
suffix=""    -> "<|fim_prefix|>def foo():<|fim_suffix|><|fim_middle|>"       # correct
```
So the model gets a poisoned prompt (a stray `None` token) for the very common "prefix only, no suffix" completion.

### Fix
Guard with `if not request.suffix` so `None` is treated like an empty suffix (returns the raw prompt), matching the existing `suffix == ""` intent.

### Tests
Added `test_none_suffix_returns_prompt_directly` alongside the existing empty-suffix test. Verified None -> raw prompt, "" -> raw prompt, real suffix -> FIM (no `None`). Ran directly (local env can't load the full server stack for the pytest harness).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29243918135](https://github.com/sgl-project/sglang/actions/runs/29243918135)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29243917986](https://github.com/sgl-project/sglang/actions/runs/29243917986)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->