### PR TITLE
UnifiedRadixCache: implement query_storage_hit_length for decode-side HiCache

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -174,14 +174,25 @@ def build_kv_cache(
             "Transformers backend to avoid multimodal prefix-cache mismatches."
         )
 
-    # Decode radix cache is unsupported with hybrid SWA/SSM models —
-    # these use specialized memory pools incompatible with the
-    # prefix-match-and-lock allocation path.
+    # Decode radix cache is unsupported with hybrid SSM/Mamba models, and with
+    # hybrid SWA models whose allocator cannot preallocate the sliding-window
+    # tail. When the allocator exposes ``alloc_extend_swa_tail`` (page_size > 1),
+    # disaggregation/decode.py drives a full SWA-tail-prealloc decode-radix path
+    # (DecodeTransferQueue._uses_swa_tail_prealloc): decode receives the full KV
+    # for full-attention layers and only the sliding-window tail for SWA layers,
+    # which is compatible with the prefix-match-and-lock allocation path. So
+    # decode radix IS supported on those SWA pools (e.g. SWAKVPool /
+    # DeepSeekV4TokenToKVPool); only reject SWA models whose allocator lacks that
+    # capability.
     if (
         server_args.disaggregation_decode_enable_radix_cache
         and server_args.disaggregation_mode == "decode"
     ):
-        if is_hybrid_swa:
+        swa_tail_prealloc_supported = (
+            hasattr(token_to_kv_pool_allocator, "alloc_extend_swa_tail")
+            and getattr(token_to_kv_pool_allocator, "page_size", 1) > 1
+        )
+        if is_hybrid_swa and not swa_tail_prealloc_supported:
             raise ValueError(
                 "--disaggregation-decode-enable-radix-cache is incompatible "
                 "with sliding window attention (SWA) models"

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -871,10 +871,15 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 if full_data.value is None:
                     break
                 matched = child.key.match(remaining_key, page_size=self.page_size)
-                value = full_data.value
                 if matched < len(child.key):
-                    value = value[:matched]
-                full_values.append(value)
+                    # Partial match: the divergence is inside this node, so we
+                    # cannot descend into its children (they extend past this
+                    # node's full key). Take the matched span and stop, mirroring
+                    # _match_prefix_helper.
+                    full_values.append(full_data.value[:matched])
+                    full_last_node = child
+                    break
+                full_values.append(full_data.value)
                 full_last_node = child
                 walk_node = child
                 remaining_key = remaining_key[matched:]

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -847,10 +847,46 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         insert_params.value = values
         result = self.insert(insert_params)
 
-        # Match prefix
+        # Match prefix.
+        #
+        # match_prefix() gates the returned device indices on ALL components. For
+        # a hybrid-SWA tree the SWA validator stops at the first out-of-window
+        # tombstone, so device_indices collapses to length 0 for a long prefix
+        # even though the FULL-attention KV for the whole prefix is still
+        # device-resident. That makes the len(new_indices) assert below fatal on
+        # decode radix (new_prefix_len is the full-attention prefix length). Walk
+        # the just-inserted path read-only to collect the ungated FULL-component
+        # indices and re-point the request onto them, protecting the deepest full
+        # node from eviction. SWA reuse stays correctly window-gated elsewhere.
         match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
-        new_indices = match_result.device_indices
-        new_last_node = match_result.last_device_node
+        full_values = []
+        full_last_node = self.root_node
+        remaining_key = radix_key
+        walk_node = self.root_node
+        if len(remaining_key) > 0:
+            child_key = remaining_key.child_key(self.page_size)
+            while len(remaining_key) > 0 and child_key in walk_node.children:
+                child = walk_node.children[child_key]
+                full_data = child.component_data[BASE_COMPONENT_TYPE]
+                if full_data.value is None:
+                    break
+                matched = child.key.match(remaining_key, page_size=self.page_size)
+                value = full_data.value
+                if matched < len(child.key):
+                    value = value[:matched]
+                full_values.append(value)
+                full_last_node = child
+                walk_node = child
+                remaining_key = remaining_key[matched:]
+                if len(remaining_key) == 0:
+                    break
+                child_key = remaining_key.child_key(self.page_size)
+        if full_values:
+            new_indices = torch.cat(full_values)
+            new_last_node = full_last_node
+        else:
+            new_indices = match_result.device_indices
+            new_last_node = match_result.last_device_node
         new_prefix_len = result.prefix_len
         assert (
             req.cache_protected_len <= len(new_indices) + self.page_size - 1

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -36,6 +36,7 @@ from sglang.srt.mem_cache.hicache_storage import (
 )
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
+    PrefetchOperation,
 )
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache_components import (
@@ -67,9 +68,6 @@ from sglang.srt.session.streaming_session import StreamingSession
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-    from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
-        PrefetchOperation,
-    )
     from sglang.srt.server_args import ServerArgs
 
 
@@ -1909,6 +1907,56 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             node,
             self.inc_host_lock_ref(node).to_dec_params(),
         )
+
+    def query_storage_hit_length(
+        self,
+        last_host_node: UnifiedTreeNode,
+        new_input_tokens: list[int],
+        last_hash: Optional[str] = None,
+        prefix_keys: Optional[list[str]] = None,
+    ) -> int:
+        """Return how many suffix tokens are resident in the L3 storage backend.
+
+        Mirrors ``HiRadixCache.query_storage_hit_length`` so ``UnifiedRadixCache``
+        is a drop-in for the decode-side HiCache prefix-match path
+        (``disaggregation/decode_hicache_mixin._build_decode_prefix_match``),
+        which calls this unconditionally on the tree cache. When no L3 storage
+        backend is configured (L2-only: GPU + host DRAM) this returns 0 exactly
+        like ``HiRadixCache``, so decode-side hierarchical cache works without an
+        external store and transparently gains storage-hit prefetch when one is
+        configured.
+        """
+        if (
+            not self.enable_storage
+            or self.cache_controller is None
+            or self.cache_controller.prefetch_rate_limited()
+        ):
+            return 0
+
+        extra_key = last_host_node.key.extra_key if last_host_node.key else None
+        prefetch_key = RadixKey(
+            new_input_tokens,
+            extra_key=extra_key,
+            is_bigram=self.is_eagle,
+        ).page_aligned(self.page_size)
+        if len(prefetch_key) < self.prefetch_threshold:
+            return 0
+
+        operation = PrefetchOperation(
+            "__storage_hit_query__",
+            self.cache_controller.mem_pool_host.get_dummy_flat_data_page()[:0],
+            prefetch_key,
+            last_hash,
+            prefix_keys,
+        )
+        _, storage_hit_count = self.cache_controller._storage_hit_query(operation)
+        storage_hit_count_tensor = torch.tensor(storage_hit_count, dtype=torch.int)
+        self._all_reduce_attn_groups(
+            storage_hit_count_tensor, torch.distributed.ReduceOp.MIN
+        )
+        storage_hit_count = storage_hit_count_tensor.item()
+        storage_hit_count = storage_hit_count - (storage_hit_count % self.page_size)
+        return storage_hit_count
 
     def prefetch_from_storage(
         self,

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -31,6 +31,7 @@ from sglang.srt.mem_cache.hicache_storage import (
 )
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
+    PrefetchOperation,
 )
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache.cache_action import (
@@ -75,9 +76,6 @@ if TYPE_CHECKING:
     from sglang.srt.managers.cache_controller import HiCacheAck
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-    from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
-        PrefetchOperation,
-    )
     from sglang.srt.mem_cache.memory_pool_host import PoolEntry
     from sglang.srt.server_args import ServerArgs
 
@@ -1217,6 +1215,61 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def get_prefix_hash_values(self, node_id: NodeId) -> list[str]:
         return self.tree_core.get_prefix_hash_values(node_id)
+    def query_storage_hit_length(
+        self,
+        last_host_node: NodeId,
+        new_input_tokens: list[int],
+        last_hash: Optional[str] = None,
+        prefix_keys: Optional[list[str]] = None,
+    ) -> int:
+        """Return how many suffix tokens are resident in the L3 storage backend.
+
+        Mirrors ``HiRadixCache.query_storage_hit_length`` so ``UnifiedRadixCache``
+        is a drop-in for the decode-side HiCache prefix-match path
+        (``disaggregation/decode_hicache_mixin._build_decode_prefix_match``),
+        which calls this unconditionally on the tree cache. When no L3 storage
+        backend is configured (L2-only: GPU + host DRAM) this returns 0 exactly
+        like ``HiRadixCache``, so decode-side hierarchical cache works without an
+        external store and transparently gains storage-hit prefetch when one is
+        configured.
+
+        ``HiRadixCache`` takes a ``TreeNode`` here, but a ``UnifiedRadixCache``
+        caller holds a ``NodeId`` handle: `_build_decode_prefix_match` resolves
+        one for its own use and then passes the *unresolved* handle to this
+        method. ``NodeId`` is an ``int``, so the node has to be resolved here.
+        """
+        if (
+            not self.enable_storage
+            or self.cache_controller is None
+            or self.cache_controller.prefetch_rate_limited()
+        ):
+            return 0
+
+        node = self.resolve_node_handle(last_host_node)
+        extra_key = node.key.extra_key if node.key else None
+        prefetch_key = RadixKey(
+            new_input_tokens,
+            extra_key=extra_key,
+            is_bigram=self.is_eagle,
+        ).page_aligned(self.page_size)
+        if len(prefetch_key) < self.prefetch_threshold:
+            return 0
+
+        operation = PrefetchOperation(
+            "__storage_hit_query__",
+            self.cache_controller.mem_pool_host.get_dummy_flat_data_page()[:0],
+            prefetch_key,
+            last_hash,
+            prefix_keys,
+        )
+        _, storage_hit_count = self.cache_controller._storage_hit_query(operation)
+        storage_hit_count_tensor = torch.tensor(storage_hit_count, dtype=torch.int)
+        self._all_reduce_attn_groups(
+            storage_hit_count_tensor, torch.distributed.ReduceOp.MIN
+        )
+        storage_hit_count = storage_hit_count_tensor.item()
+        storage_hit_count = storage_hit_count - (storage_hit_count % self.page_size)
+        return storage_hit_count
 
     def prefetch_from_storage(
         self,


### PR DESCRIPTION
## Motivation

Follow-up to #30929 (decode radix cache on DeepSeek-V4, hybrid-SWA). That PR
lets DeepSeek-V4 use `UnifiedRadixCache` as the decode radix tree. However, the
decode-side HiCache prefix-match path calls `query_storage_hit_length()`
unconditionally on the tree cache:

```
File ".../srt/disaggregation/decode.py", pop_preallocated
  -> _match_prefix_and_lock
    -> _build_decode_prefix_match
      -> .../srt/disaggregation/decode_hicache_mixin.py:84
         l3_storage_hit_length = self.tree_cache.query_storage_hit_length(...)
AttributeError: 'UnifiedRadixCache' object has no attribute 'query_storage_hit_length'
```

`query_storage_hit_length` is part of the hierarchical tree-cache interface but
is currently only implemented on `HiRadixCache`. So enabling
`--disaggregation-decode-enable-radix-cache` together with
`--enable-hierarchical-cache` on the **decode** server (DeepSeek-V4, 1P1D,
mori PD-disagg) crashes every decode TP worker at the first prealloc, tearing
the job down. Decode-side HiCache is therefore unavailable on DeepSeek-V4 even
though the decode host pool allocates fine and the tree initializes with
`hierarchical=True`.

## Modifications

`mem_cache/unified_radix_cache.UnifiedRadixCache.query_storage_hit_length` —
implement the method, mirroring `HiRadixCache.query_storage_hit_length`:

- Return `0` when there is no L3 storage backend (L2-only: GPU + host DRAM),
  when the cache controller is absent, or when prefetch is rate-limited —
  exactly matching `HiRadixCache` (whose first line is
  `if not self.enable_storage or self.cache_controller.prefetch_rate_limited(): return 0`).
- Otherwise page-align the suffix key, gate on `prefetch_threshold`, issue a
  storage-hit query through the `HybridCacheController`, and MIN-reduce the hit
  count across the attention TP groups.

This makes `UnifiedRadixCache` a drop-in for the decode HiCache path
(`decode_hicache_mixin`), consistent with how `HiRadixCache`-backed models
already behave: L2-only decode hierarchical cache works without an external
store, and L3 storage-hit prefetch is picked up transparently when a storage
backend is configured.

Note: stacks on #30929 (contains its 2 commits until that PR merges).

## Validation

- Without this change, a DeepSeek-V4 1P1D agentic run with decode radix +
  `--enable-hierarchical-cache` on decode reproduces the `AttributeError` above
  on all 8 decode TP workers immediately after `Tree cache initialized:
  ... hierarchical=True`, tearing the job down.
- The L2-only path now short-circuits to `0` (same as `HiRadixCache`), so the
  decode prealloc prefix-match no longer crashes; end-to-end decode-HiCache
  sweep validation to follow.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Provide a description and validation for this change.
- [ ] (Maintainers) Run/extend CI for the decode-radix + decode-HiCache path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32248375708](https://github.com/sgl-project/sglang/actions/runs/32248375708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32248375384](https://github.com/sgl-project/sglang/actions/runs/32248375384)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->