### PR TITLE
[ROCm] Add DeepSeek-V4 DSpark speculative decoding support for  AMD GPU(MI350X / MI355X, gfx950)

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -590,6 +590,7 @@ class DeepseekV4HipRadixBackend(
         extend_seq_lens: Optional[torch.Tensor] = None,
         use_prefill_cuda_graph: bool = False,
         seq_lens_cpu: Optional[List[int]] = None,
+        num_draft_tokens: Optional[int] = None,
     ) -> Union[DSV4Metadata, DSV4RawVerifyMetadata]:
         # HIP path: build target-verify metadata eagerly even when
         # SGLANG_PREP_IN_CUDA_GRAPH is enabled. The raw/lazy-upgrade route can
@@ -603,6 +604,7 @@ class DeepseekV4HipRadixBackend(
             seq_lens_cpu=seq_lens_cpu,
             out_cache_loc=out_cache_loc,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
+            num_draft_tokens=num_draft_tokens,
         )
 
     def init_forward_metadata_target_verify_old(
@@ -613,13 +615,15 @@ class DeepseekV4HipRadixBackend(
         seq_lens_cpu: Optional[List[int]] = None,
         out_cache_loc: Optional[torch.Tensor] = None,
         use_prefill_cuda_graph: bool = False,
+        num_draft_tokens: Optional[int] = None,
     ) -> DSV4Metadata:
         batch_size = len(seq_lens)
-        seq_lens = seq_lens + self.speculative_num_draft_tokens
-        seq_lens_cpu = [x + self.speculative_num_draft_tokens for x in seq_lens_cpu]
-        extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
+        num_draft_tokens = int(num_draft_tokens or self.speculative_num_draft_tokens)
+        seq_lens = seq_lens + num_draft_tokens
+        seq_lens_cpu = [x + num_draft_tokens for x in seq_lens_cpu]
+        extend_seq_lens_cpu = [num_draft_tokens] * batch_size
         extend_seq_lens = self._move_to_device(extend_seq_lens_cpu)
-        num_tokens = self.speculative_num_draft_tokens * batch_size
+        num_tokens = num_draft_tokens * batch_size
         if out_cache_loc is None:
             out_cache_loc = seq_lens.new_zeros(num_tokens)
         return self.init_forward_metadata_prefill(
@@ -971,6 +975,11 @@ class DeepseekV4HipRadixBackend(
                 extend_seq_lens=forward_batch.extend_seq_lens,
                 seq_lens_cpu=(
                     seq_lens_cpu.tolist() if seq_lens_cpu is not None else None
+                ),
+                num_draft_tokens=getattr(
+                    getattr(forward_batch, "spec_info", None),
+                    "draft_token_num",
+                    None,
                 ),
             )
         elif forward_batch.forward_mode.is_prefill(include_draft_extend_v2=True):

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -390,6 +390,25 @@ class DSparkWorkerV2(BaseSpecWorker):
                 self.target_worker.forward_batch_generation(batch)
             return self._decode_idle_result(on_publish=on_publish)
 
+        if batch.extend_lens is None or batch.prefix_lens is None:
+            raise RuntimeError(
+                "DSpark expected extend_lens / prefix_lens in extend mode, got None."
+            )
+        if batch.out_cache_loc is None:
+            raise RuntimeError("DSpark prefill expected out_cache_loc, but got None.")
+
+        device = self.model_runner.device
+        ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
+        draft_seq_lens = torch.tensor(
+            batch.prefix_lens, dtype=torch.int32, device=device
+        )
+        positions, _ = compute_position(
+            self.model_runner.server_args.attention_backend,
+            draft_seq_lens,
+            ctx_lens,
+            int(sum(batch.extend_lens)),
+        )
+
         batch.capture_hidden_mode = CaptureHiddenMode.FULL
         batch_output = self.target_worker.forward_batch_generation(batch)
         logits_output = batch_output.logits_output
@@ -403,24 +422,6 @@ class DSparkWorkerV2(BaseSpecWorker):
                 "DSpark requires target aux hidden capture for prefill, but got None. "
                 "Make sure the target model has DFlash layers-to-capture configured."
             )
-        if batch.extend_lens is None or batch.prefix_lens is None:
-            raise RuntimeError(
-                "DSpark expected extend_lens / prefix_lens in extend mode, got None."
-            )
-        if batch.out_cache_loc is None:
-            raise RuntimeError("DSpark prefill expected out_cache_loc, but got None.")
-
-        device = next_token_ids.device
-        ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
-        draft_seq_lens = torch.tensor(
-            batch.prefix_lens, dtype=torch.int32, device=device
-        )
-        positions, _ = compute_position(
-            self.model_runner.server_args.attention_backend,
-            draft_seq_lens,
-            ctx_lens,
-            int(sum(batch.extend_lens)),
-        )
         self._kv_injector.inject_target_hidden(
             target_hidden=logits_output.hidden_states,
             cache_loc=batch.out_cache_loc,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -398,10 +398,17 @@ class DSparkWorkerV2(BaseSpecWorker):
             raise RuntimeError("DSpark prefill expected out_cache_loc, but got None.")
 
         device = self.model_runner.device
-        ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
-        draft_seq_lens = torch.tensor(
-            batch.prefix_lens, dtype=torch.int32, device=device
+        pin_memory = is_cuda()
+        ctx_lens_cpu = torch.empty(
+            (len(batch.extend_lens),), dtype=torch.int32, pin_memory=pin_memory
         )
+        draft_seq_lens_cpu = torch.empty(
+            (len(batch.prefix_lens),), dtype=torch.int32, pin_memory=pin_memory
+        )
+        ctx_lens_cpu.copy_(torch.tensor(batch.extend_lens, dtype=torch.int32))
+        draft_seq_lens_cpu.copy_(torch.tensor(batch.prefix_lens, dtype=torch.int32))
+        ctx_lens = ctx_lens_cpu.to(device, non_blocking=True)
+        draft_seq_lens = draft_seq_lens_cpu.to(device, non_blocking=True)
         positions, _ = compute_position(
             self.model_runner.server_args.attention_backend,
             draft_seq_lens,


### PR DESCRIPTION
## Summary
This PR is now a small follow-up on top of the DSpark implementation that already landed in `main` via #30261. It keeps the ROCm/AMD DeepSeek V4 DSpark fixes that were still missing after rebasing the branch onto current `main`.

- Fix DeepSeek V4 HIP target-verify metadata to use the active DSpark draft token count instead of the static configured speculative token count.
- Prepare DSpark KV-injection prefill position metadata before the target prefill forward so the correct cache locations and hidden states are used.
- Stage DSpark prefill `extend_lens` / `prefix_lens` through pinned CPU tensors before non-blocking transfer to the AMD GPU device, avoiding extra synchronization in the prefill path.

The earlier large DSpark implementation commit was dropped from this PR because the equivalent newer implementation is already present on `main`.

## Test plan
- `python3 -m compileall -q python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py`
- Docker environment used for validation: `sglang-rocm-v0514` with AMD MI350X/ROCm.
- Verified DeepSeek V4 Flash DSpark server startup and `/health` readiness.
- Ran ShareGPT DSpark benchmark successfully for 10 requests and compared against baseline; DSpark showed about 1.57x output throughput improvement in the validated run.

## Reproduce

### DSpark Enabled
```shell
unset SGLANG_HACK_FLASHMLA_BACKEND
export SGLANG_DEFAULT_THINKING=1
export SGLANG_DSV4_REASONING_EFFORT=max
export SGLANG_USE_ROCM700A=0
export AITER_BF16_FP8_MOE_BOUND=0

sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-DSpark \
  --speculative-algorithm DSPARK \
  --tp 8 \
  --attention-backend dsv4 \
  --page-size 256 \
  --mem-fraction-static 0.8 \
  --disable-radix-cache \
  --swa-full-tokens-ratio 0.05 \
  --speculative-moe-runner-backend triton \
  --disable-shared-experts-fusion \
  --kv-cache-dtype fp8_e4m3 \
  --cuda-graph-backend-decode=disabled \
  --max-running-requests 128 \
  --host 0.0.0.0 \
  --port 8888
```

### Baseline
```shell
export SGLANG_DEFAULT_THINKING=1
export SGLANG_DSV4_REASONING_EFFORT=max
export SGLANG_USE_ROCM700A=0
export SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton
export AITER_BF16_FP8_MOE_BOUND=0

sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash \
  --tp 8 \
  --attention-backend dsv4 \
  --page-size 256 \
  --mem-fraction-static 0.80 \
  --swa-full-tokens-ratio 0.05 \
  --disable-shared-experts-fusion \
  --kv-cache-dtype fp8_e4m3 \
  --cuda-graph-backend-decode=disabled \
  --max-running-requests 128 \
  --host 0.0.0.0 \
  --port 8888
```

### Benchmark Command
```shell
python3 -m sglang.bench_serving \
  --backend sglang \
  --base-url http://0.0.0.0:8888 \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --num-prompts 10 \
  --request-rate inf \
  --max-concurrency 8 \
  --sharegpt-output-len 128 \
  --warmup-requests 5 \
  --disable-ignore-eos
```

### DSpark Results
```text
Successful requests: 10
Benchmark duration: 19.84 s
Request throughput: 0.50 req/s
Output token throughput: 64.53 tok/s
Total token throughput: 218.64 tok/s
Mean TTFT: 1559.49 ms
Mean TPOT: 70.84 ms
Accept length: 2.02
```

### Baseline Results
```text
Successful requests: 10
Benchmark duration: 31.21 s
Request throughput: 0.32 req/s
Output token throughput: 41.01 tok/s
Total token throughput: 138.94 tok/s
Mean TTFT: 2118.59 ms
Mean TPOT: 107.23 ms
```



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29302344043](https://github.com/sgl-project/sglang/actions/runs/29302344043)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29302343884](https://github.com/sgl-project/sglang/actions/runs/29302343884)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->