### PR TITLE
[WIP][PD+PP] Fix prefill deadlock due to /abort_request 

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -333,13 +333,15 @@ class PrefillBootstrapQueue:
     def pop_bootstrapped(
         self,
         return_failed_reqs: bool = False,
-        rids_to_check: Optional[List[str]] = None,
-    ) -> List[Req]:
+        pp_good_rids: Optional[List[str]] = None,
+        pp_bad_rids: Optional[List[str]] = None,
+    ) -> List[Req] | tuple[List[Req], List[Req]]:
         """
         pop the reqs which has finished bootstrapping
 
         return_failed_reqs: For PP, on rank 0, also return the failed reqs to notify the next rank
-        rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
+        pp_good_rids: For PP, the rids that PP consensus determined as good (WaitingForInput)
+        pp_bad_rids: For PP, the rids that PP consensus determined as bad (Failed)
         """
 
         bootstrapped_reqs = []
@@ -352,21 +354,33 @@ class PrefillBootstrapQueue:
             else:
                 return [], []
 
-        polls = poll_and_all_reduce_attn_cp_tp_group(
-            [req.disagg_kv_sender for req in self.queue],
-            self.scheduler.attn_cp_cpu_group,
-            self.scheduler.attn_tp_cpu_group,
-        )
+        # In PP mode with consensus results, skip local polling and use PP consensus
+        # This prevents divergence when abort notifications arrive between consensus
+        # and pop_bootstrapped execution on different PP ranks.
+        is_pp_mode = pp_good_rids is not None and pp_bad_rids is not None
+
+        if is_pp_mode:
+            # Fake polls based on PP consensus - no need to poll local state
+            # which may have changed due to abort notifications arriving at different times
+            polls = []
+            for req in self.queue:
+                if req.rid in pp_good_rids:
+                    polls.append(KVPoll.WaitingForInput)
+                elif req.rid in pp_bad_rids:
+                    polls.append(KVPoll.Failed)
+                else:
+                    # Request not in consensus - skip it
+                    polls.append(None)
+        else:
+            polls = poll_and_all_reduce_attn_cp_tp_group(
+                [req.disagg_kv_sender for req in self.queue],
+                self.scheduler.attn_cp_cpu_group,
+                self.scheduler.attn_tp_cpu_group,
+            )
 
         for i, (req, poll) in enumerate(zip(self.queue, polls)):
-            if (
-                rids_to_check is not None
-                and req.rid not in rids_to_check
-                and poll != KVPoll.Failed
-            ):
-                # In PP mode, successful bootstrap still requires cross-rank
-                # consensus. Local failures are terminal and must be drained
-                # even if an earlier PP rank has already removed the request.
+            if poll is None:
+                # In PP mode, skip requests not in consensus
                 continue
 
             if poll == KVPoll.Failed:

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -804,8 +804,8 @@ class SchedulerPPMixin:
             good_reqs, failed_reqs = (
                 self.disagg_prefill_bootstrap_queue.pop_bootstrapped(
                     return_failed_reqs=True,
-                    rids_to_check=good_consensus_bootstrapped_rids
-                    + bad_consensus_bootstrapped_rids,
+                    pp_good_rids=good_consensus_bootstrapped_rids,
+                    pp_bad_rids=bad_consensus_bootstrapped_rids,
                 )
             )
             self.waiting_queue.extend(good_reqs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes #30476.

## Modifications

This PR changes the PP path of `PrefillBootstrapQueue::pop_bootstrapped`. 

Let us illustrate the root cause of #30476 with an example of pp_size=2.  The following events happens, causing PP0 and PP1 diverge.

- [Initial] A request passes the first round of bootstrap ring-consensus. Both PP0 and PP1 has local state KVPoll.WaitingForInput for that request.  The request is still in bootstrap_queue.
- [t1][PP0] In the second round of bootstrap ring-consensus，The request is moved from bootstrap_queue to waiting_queue.
- [t2][PP0 & PP1] Received zmq abort. `KVPoll.WaitingForInput` -> `KVPoll::Failed`.
- [t3][PP1] In the second round of bootstrap ring-consensus, the request is pop from bootstrap_queue and considered failure, because of the local state `KVPoll.Failed`.
- Now, PP0 and PP1 diverge!  PP0 continues to schedule that request for forward, while PP1 does not.

The fix is to make `pop_bootstrapped` not look at local state at all.  When `pop_bootstrapped` is called, PP0 and PP1 have been agreed on which rids are successful and which are failed.  We just follow the decision resulted by first round of ring-consensus.

This function `pop_bootstrapped` is used by both PP and non-PP prefill node.  The non-PP path is left unchanged.

Thanks @whybeyoung for advices and reproduction.

TODO(stepinto):  Let me add a test case.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29250460052](https://github.com/sgl-project/sglang/actions/runs/29250460052)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29250459853](https://github.com/sgl-project/sglang/actions/runs/29250459853)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->