### PR TITLE
[Bugfix] Avoid CUDA grid overflow in recurrent linear attention

### DIFF
--- a/python/sglang/srt/layers/attention/fla/fused_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_recurrent.py
@@ -432,8 +432,7 @@ def fused_recurrent_kda_packed_decode_kernel(
     """KDA packed decode: same shape as the GDN packed decode kernel, but
     with a per-K gate (``a`` is ``[B, HV*K]`` and ``dt_bias`` is ``[HV*K]``),
     so the state decay is a per-K vector ``exp(g)`` rather than a scalar."""
-    i_v, i_nh = tl.program_id(0), tl.program_id(1)
-    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_v, i_n, i_hv = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_h = i_hv // (HV // H)
 
     o_k = tl.arange(0, BK)
@@ -629,7 +628,7 @@ def fused_recurrent_kda_packed_decode(
     stride_indices_seq = ssm_state_indices.stride(0)
 
     NV = triton.cdiv(V, BV)
-    grid = (NV, B * HV)
+    grid = (NV, B, HV)
     fused_recurrent_kda_packed_decode_kernel[grid](
         mixed_qkv=mixed_qkv,
         a=a,

--- a/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -47,6 +47,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     IS_KDA: tl.constexpr,
+    SPLIT_N_HV_GRID: tl.constexpr = False,
     # Optional flags for target_verify support (default False for decode)
     DISABLE_STATE_UPDATE: tl.constexpr = False,
     CACHE_INTERMEDIATE_STATES: tl.constexpr = False,
@@ -55,8 +56,12 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     """
     Fused kernel that combines sigmoid gating computation with recurrent delta rule update.
     """
-    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    i_n, i_hv = i_nh // HV, i_nh % HV
+    if SPLIT_N_HV_GRID:
+        i_v, i_n, i_hv = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_k = 0
+    else:
+        i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_n, i_hv = i_nh // HV, i_nh % HV
     i_h = i_hv // (HV // H)
 
     if IS_VARLEN:
@@ -307,7 +312,8 @@ def fused_sigmoid_gating_delta_rule_update(
 
     NP2_T = triton.next_power_of_2(T)
 
-    grid = (NK, NV, N * HV)
+    split_n_hv_grid = q.device.type == "cuda"
+    grid = (NV, N, HV) if split_n_hv_grid else (NK, NV, N * HV)
 
     # Per-req stride must match the buffer's allocated dim, not runtime steps
     # (they can differ under --speculative-adaptive).
@@ -356,6 +362,7 @@ def fused_sigmoid_gating_delta_rule_update(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_VARLEN=cu_seqlens is not None,
         IS_KDA=is_kda,
+        SPLIT_N_HV_GRID=split_n_hv_grid,
         DISABLE_STATE_UPDATE=disable_state_update,
         CACHE_INTERMEDIATE_STATES=intermediate_states_buffer is not None,
         HAS_EAGLE_TREE_CUSTOM_ATTN_MASK=retrieve_parent_token is not None,

--- a/test/registered/attention/test_kda_kernels.py
+++ b/test/registered/attention/test_kda_kernels.py
@@ -420,6 +420,41 @@ class TestKDAPackedDecode(unittest.TestCase):
     def test_b128(self):
         self._check(B=128, H=16, HV=16, K=128, V=128)
 
+    def test_large_grid(self):
+        device = get_device()
+        B, H, HV, K, V = 4096, 20, 20, 64, 64
+        self.assertGreater(B * HV, 65535)
+        dtype = torch.bfloat16
+
+        mixed_qkv = torch.zeros(B, 2 * H * K + HV * V, dtype=dtype, device=device)
+        a = torch.zeros(B, HV * K, dtype=dtype, device=device)
+        b = torch.zeros(B, HV, dtype=dtype, device=device)
+        A_log = torch.zeros(HV, dtype=torch.float32, device=device)
+        dt_bias = torch.zeros(HV * K, dtype=torch.float32, device=device)
+        initial_state = torch.randn(1, HV, V, K, dtype=dtype, device=device)
+        initial_state_ref = initial_state.clone()
+        out = torch.empty(B, 1, HV, V, dtype=dtype, device=device)
+        cache_indices = torch.full((B,), -1, dtype=torch.int32, device=device)
+        cache_indices[-1] = 0
+
+        fused_recurrent_kda_packed_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=K**-0.5,
+            initial_state=initial_state,
+            out=out,
+            ssm_state_indices=cache_indices,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+        torch.testing.assert_close(out, torch.zeros_like(out))
+        torch.testing.assert_close(
+            initial_state.float(), initial_state_ref.float() * 0.5, rtol=1e-3, atol=1e-3
+        )
+
     def test_asymmetric_heads(self):
         # Common KDA config with HV > H (grouped query).
         self._check(B=8, H=8, HV=16, K=128, V=128)

--- a/test/registered/attention/test_kda_kernels.py
+++ b/test/registered/attention/test_kda_kernels.py
@@ -150,6 +150,67 @@ class TestKDAFusedSigmoidGatingRecurrent(unittest.TestCase):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+class TestFusedSigmoidGatingLargeGrid(unittest.TestCase):
+    def _run_case(self, is_kda):
+        N, H, HV, K, V = 2048, 1, 32, 4, 4
+        self.assertEqual(N * HV, 65536)
+        torch.manual_seed(44 + is_kda)
+
+        q = torch.randn(1, N, H, K, dtype=torch.float32, device="cuda")
+        k = torch.randn(1, N, H, K, dtype=torch.float32, device="cuda")
+        v = torch.randn(1, N, HV, V, dtype=torch.float32, device="cuda")
+        a_width = HV * K if is_kda else HV
+        a = torch.randn(1, N, a_width, dtype=torch.float32, device="cuda")
+        b = torch.randn(1, N, HV, dtype=torch.float32, device="cuda")
+        A_log = torch.randn(HV, dtype=torch.float32, device="cuda") * 0.2
+        dt_bias = torch.randn(a_width, dtype=torch.float32, device="cuda") * 0.1
+        state = torch.randn(N, HV, V, K, dtype=torch.float32, device="cuda") * 0.01
+        state_ref = state.clone()
+        cache_indices = torch.arange(N, dtype=torch.int32, device="cuda")
+        cu_seqlens = torch.arange(N + 1, dtype=torch.int32, device="cuda")
+
+        output = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            dt_bias=dt_bias,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            q=q,
+            k=k,
+            v=v,
+            a=a,
+            b=b,
+            initial_state_source=state,
+            initial_state_indices=cache_indices,
+            cu_seqlens=cu_seqlens,
+            is_kda=is_kda,
+        )
+
+        q_ref = q[0, :, 0] * (K**-0.5)
+        k_ref = k[0, :, 0]
+        if is_kda:
+            x = a.reshape(N, HV, K) + dt_bias.reshape(1, HV, K)
+            g = -torch.exp(A_log).reshape(1, HV, 1) * torch.nn.functional.softplus(x)
+            state_ref *= torch.exp(g.unsqueeze(-2))
+        else:
+            x = a[0] + dt_bias
+            g = -torch.exp(A_log) * torch.nn.functional.softplus(x)
+            state_ref *= torch.exp(g[..., None, None])
+        delta = v[0] - torch.sum(state_ref * k_ref[:, None, None, :], dim=-1)
+        delta *= torch.sigmoid(b[0]).unsqueeze(-1)
+        state_ref += delta.unsqueeze(-1) * k_ref[:, None, None, :]
+        output_ref = torch.sum(state_ref * q_ref[:, None, None, :], dim=-1).unsqueeze(0)
+
+        torch.testing.assert_close(output, output_ref, rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(state, state_ref, rtol=1e-4, atol=1e-4)
+
+    def test_kda(self):
+        self._run_case(is_kda=True)
+
+    def test_gdn(self):
+        self._run_case(is_kda=False)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
 class TestKDAGateChunkCumsum(unittest.TestCase):
     """Test kda_gate_chunk_cumsum against torch reference (gate activation + cumsum)."""
 


### PR DESCRIPTION
## Summary

- split request and value-head dimensions across independent CUDA launch-grid axes
- avoid both gridDim.z overflow in the generic recurrent update and gridDim.y overflow in KDA packed decode
- preserve the existing non-CUDA launch mapping

## Validation

- pre-commit on all changed files
- old PR head reproduces `Triton Error [CUDA]: invalid argument` for KDA packed decode at `B=4096, HV=20`; updated head passes
- full `test_kda_kernels.py`: 16/16 pass, including exact 65,536-boundary KDA/GDN reference parity
- public Kimi-Linear TP2 `no_buffer` full GSM8K: 91.51% accuracy, 1,284/1,319 stop (97.35%), 35 length-limited, 0 request errors
- the added packed-decode fix preserves the prior PR head's 97.35% stop rate; upstream-main control was 97.73% stop and 90.75% accuracy







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29254350904](https://github.com/sgl-project/sglang/actions/runs/29254350904)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29254350609](https://github.com/sgl-project/sglang/actions/runs/29254350609)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->