### PR TITLE
[CI] Fix SGLANG_JIT_KERNEL_RUN_FULL_TESTS never activating the nightly full jit-kernel sweep

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -145,7 +145,9 @@ jobs:
         timeout-minutes: 90
         run: |
           cd test
-          python3 run_suite.py --hw cuda --suite nightly-kernel-8-gpu-h200 --nightly --continue-on-error
+          # Full grids run ~7x the in-CI parametrizations per world size; the
+          # default 1200s per-file budget only fits the reduced PR sweep.
+          python3 run_suite.py --hw cuda --suite nightly-kernel-8-gpu-h200 --nightly --continue-on-error --timeout-per-file 3600
 
       - uses: ./.github/actions/upload-cuda-coredumps
         if: failure()

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -24,19 +24,19 @@ from typing import (
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.utils import is_in_ci
 
 if TYPE_CHECKING:
     from tvm_ffi import Module
 
 F = TypeVar("F", bound=Callable[..., Any])
-_FULL_TEST_ENV_VAR = "SGLANG_JIT_KERNEL_RUN_FULL_TESTS"
 
 logger = logging.getLogger(__name__)
 
 
 def should_run_full_tests() -> bool:
-    return os.getenv(_FULL_TEST_ENV_VAR, "false").lower() == "true"
+    return envs.SGLANG_JIT_KERNEL_RUN_FULL_TESTS.get()
 
 
 def get_ci_test_range(full_range: List[Any], ci_range: List[Any]) -> List[Any]:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -234,6 +234,8 @@ class Envs:
     # else /tmp); see debug_utils/cuda_coredump.py.
     SGLANG_CUDA_COREDUMP_DIR = EnvStr(None)
     SGLANG_TEST_MAX_RETRY = EnvInt(None)
+    # Expand jit_kernel test grids to their full parameter ranges (nightly).
+    SGLANG_JIT_KERNEL_RUN_FULL_TESTS = EnvBool(False)
 
     # Constrained Decoding (Grammar)
     SGLANG_GRAMMAR_POLL_INTERVAL = EnvFloat(0.005)


### PR DESCRIPTION
## Motivation

Found while investigating the `test_custom_all_reduce.py` nightly timeout in #30999: `nightly-test-nvidia.yml` sets `SGLANG_JIT_KERNEL_RUN_FULL_TESTS: "1"` for the two "JIT kernel full unit tests" jobs, but `should_run_full_tests()` compared the raw string against `"true"` only:

```python
def should_run_full_tests() -> bool:
    return os.getenv(_FULL_TEST_ENV_VAR, "false").lower() == "true"   # "1" -> False
```

So the nightly full-sweep expansion has **never actually been active** — those jobs have silently run the same reduced grids as PR CI since they were added.

## Modifications

- `python/sglang/srt/environ.py`: register `SGLANG_JIT_KERNEL_RUN_FULL_TESTS = EnvBool(False)` in the `# SGLang CI` section, per env-var conventions.
- `python/sglang/jit_kernel/utils.py`: `should_run_full_tests()` reads it via `envs....get()` — `EnvBool` accepts `1/true/yes` (case-insensitive), and a malformed value now raises instead of silently meaning "false". Removes the last raw `os.getenv` read of this variable.
- `.github/workflows/nightly-test-nvidia.yml`: since this genuinely activates the expanded grids, give the 8-GPU nightly kernel suite an explicit `--timeout-per-file 3600`. The full custom-all-reduce sweep runs ~7x the in-CI parametrizations per world size, which cannot fit the 1200s default (measured reduced sweep on a slow H200 runner: 98s @ 2 GPUs / 209s @ 4 GPUs / ~620s @ 8 GPUs — data from #30999's logging). The 1-gpu suite keeps the default budget; job-level `timeout-minutes` are unchanged and remain the backstop.

## Heads-up for reviewers

This makes the two nightly kernel jobs actually do what their name says, so their wall-clock will increase accordingly (that was the stated intent when they were added — it just never fired). #30999 additionally scales `test_custom_all_reduce`'s per-torchrun budget when the full sweep is active, and its cache/phase-timing logs will attribute any remaining nightly timeout. If the expanded runtime turns out to be more than the nightly capacity wants to pay, dialing back is a one-line change to the job env — but that should be an explicit decision rather than a string-parsing accident.

## Validation

```
$ SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 python -c 'from sglang.jit_kernel.utils import should_run_full_tests, get_ci_test_range; print(should_run_full_tests(), get_ci_test_range([1,2,3,4,5],[1,2]))'
True [1, 2, 3, 4, 5]
# 'true'/'TRUE' -> True; '0'/'false'/unset -> False; reduced range still returned in CI when unset
```

## Checklist

- [x] Format your code with pre-commit
- [x] Add unit tests (N/A — 3-line env-var registration + parsing fix, exercised by every jit-kernel CI job)
- [x] Update documentation (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29302992107](https://github.com/sgl-project/sglang/actions/runs/29302992107)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29302991987](https://github.com/sgl-project/sglang/actions/runs/29302991987)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->