### PR TITLE
ci: pin jlumbroso/free-disk-space to a full commit SHA

### DIFF
--- a/.github/workflows/_docker-build-and-publish.yml
+++ b/.github/workflows/_docker-build-and-publish.yml
@@ -81,7 +81,7 @@ jobs:
           done
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: true
           docker-images: true


### PR DESCRIPTION
### What

Pin `jlumbroso/free-disk-space@main` → `54081f1…` in `_docker-build-and-publish.yml` (tag kept in a
trailing comment).

### Why

`@main` is a moving reference — whatever it points to at run time runs in the job. This one sits in the
[docker build-and-publish job](https://github.com/sgl-project/sglang/blob/2cf2920d070f88f0ec40cfdcb1c677291db46541/.github/workflows/_docker-build-and-publish.yml#L84-L107), which logs in to DockerHub (`DOCKERHUB_TOKEN`) and pushes images. If the action's
`main` were moved (compromise or an accidental change), the new code would run in a job holding registry
push credentials — the class of issue behind the 2025 `tj-actions/changed-files` incident. Pinning to a
SHA removes that.

### Scope / safety

- Behaviour unchanged — the SHA is the current tip of the action's `main`.
- Renovate/Dependabot can still bump a SHA pin (the tag comment keeps it readable). Signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29262605293](https://github.com/sgl-project/sglang/actions/runs/29262605293)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29262603355](https://github.com/sgl-project/sglang/actions/runs/29262603355)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->