### PR TITLE
benchmark: MI300X FP8 speed + accuracy data for MiniMax-M2.7

### DIFF
--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7-benchmarks.jsx
@@ -53,6 +53,9 @@ export const benchmarks = [
       { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 16, num_prompts: 256 },
         ttft_ms: 167, tpot_ms: 31.80, tokens_per_sec_per_gpu: 243 },
     ],
+    // sgl-eval GSM8K, --no-thinking, --max-tokens 8192, tp=2 ep=2.
+    // 1319 examples, 94.31% correct, 7.43% truncated (hitting max_tokens), 0% errors.
+    accuracy: { gsm8k_pct: 94.31 },
   },
   {
     // MI300X ×4 / MiniMax-M2.7 / FP8 KV cache (fp8_e4m3) / tp=4 ep=4 / balanced.

--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7-benchmarks.jsx
@@ -37,4 +37,43 @@ export const benchmarks = [
     // MMLU-Pro pass@1 greedy (18.75% no-answer at the 32K cap); GSM8K 8-shot CoT.
     accuracy: { gpqa_pct: 84.91, aime25_pct: 92.50, mmlu_pro_pct: 69.41, gsm8k_pct: 92.34 },
   },
+  {
+    // MI300X ×2 / MiniMax-M2.7 / FP8 KV cache (fp8_e4m3) / tp=2 ep=2 / low-latency.
+    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.13.post1,
+    // docker lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x.
+    // Server flags: --attention-backend triton --mem-fraction-static 0.85
+    //   --kv-cache-dtype fp8_e4m3.
+    // Benchmark: sglang.bench_serving --dataset-name random --random-input-len 1000
+    //   --random-output-len 1000 --warmup-requests 64 --request-rate inf.
+    match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+    sglang_version: "0.5.13.post1",
+    speed: [
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1, num_prompts: 64 },
+        ttft_ms: 210, tpot_ms: 14.94, tokens_per_sec_per_gpu: 33 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 16, num_prompts: 256 },
+        ttft_ms: 167, tpot_ms: 31.80, tokens_per_sec_per_gpu: 243 },
+    ],
+  },
+  {
+    // MI300X ×4 / MiniMax-M2.7 / FP8 KV cache (fp8_e4m3) / tp=4 ep=4 / balanced.
+    match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" },
+    sglang_version: "0.5.13.post1",
+    speed: [
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 64, num_prompts: 512 },
+        ttft_ms: 419, tpot_ms: 42.48, tokens_per_sec_per_gpu: 351 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 256, num_prompts: 1024 },
+        ttft_ms: 337, tpot_ms: 71.72, tokens_per_sec_per_gpu: 809 },
+    ],
+  },
+  {
+    // MI300X ×8 / MiniMax-M2.7 / FP8 KV cache (fp8_e4m3) / tp=8 ep=8 / high-throughput.
+    match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+    sglang_version: "0.5.13.post1",
+    speed: [
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1024, num_prompts: 2048 },
+        ttft_ms: 3547, tpot_ms: 239.18, tokens_per_sec_per_gpu: 538 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 4096, num_prompts: 4096 },
+        ttft_ms: 18251, tpot_ms: 431.16, tokens_per_sec_per_gpu: 1043 },
+    ],
+  },
 ];

--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7-benchmarks.jsx
@@ -39,19 +39,19 @@ export const benchmarks = [
   },
   {
     // MI300X ×2 / MiniMax-M2.7 / FP8 KV cache (fp8_e4m3) / tp=2 ep=2 / low-latency.
-    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.13.post1,
-    // docker lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x.
+    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.16,
+    // docker lmsysorg/sglang:v0.5.16-rocm700-mi30x.
     // Server flags: --attention-backend triton --mem-fraction-static 0.85
     //   --kv-cache-dtype fp8_e4m3.
-    // Benchmark: sglang.bench_serving --dataset-name random --random-input-len 1000
-    //   --random-output-len 1000 --warmup-requests 64 --request-rate inf.
+    // Benchmark: sglang.bench_serving --dataset-name random --random-input-len 8192
+    //   --random-output-len 1024 --flush-cache --request-rate inf.
     match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
-    sglang_version: "0.5.13.post1",
+    sglang_version: "0.5.16",
     speed: [
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1, num_prompts: 64 },
-        ttft_ms: 210, tpot_ms: 14.94, tokens_per_sec_per_gpu: 33 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 16, num_prompts: 256 },
-        ttft_ms: 167, tpot_ms: 31.80, tokens_per_sec_per_gpu: 243 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1, num_prompts: 32 },
+        ttft_ms: 751, tpot_ms: 15.11, tokens_per_sec_per_gpu: 30 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16, num_prompts: 32 },
+        ttft_ms: 1704, tpot_ms: 35.48, tokens_per_sec_per_gpu: 191 },
     ],
     // sgl-eval GSM8K, --no-thinking, --max-tokens 8192, tp=2 ep=2.
     // 1319 examples, 94.31% correct, 7.43% truncated (hitting max_tokens), 0% errors.
@@ -59,24 +59,26 @@ export const benchmarks = [
   },
   {
     // MI300X ×4 / MiniMax-M2.7 / FP8 KV cache (fp8_e4m3) / tp=4 ep=4 / balanced.
+    // Same server and benchmark config as low-latency entry above (tp=4 ep=4 instead).
     match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" },
-    sglang_version: "0.5.13.post1",
+    sglang_version: "0.5.16",
     speed: [
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 64, num_prompts: 512 },
-        ttft_ms: 419, tpot_ms: 42.48, tokens_per_sec_per_gpu: 351 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 256, num_prompts: 1024 },
-        ttft_ms: 337, tpot_ms: 71.72, tokens_per_sec_per_gpu: 809 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 3026, tpot_ms: 74.01, tokens_per_sec_per_gpu: 212 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
+        ttft_ms: 9296, tpot_ms: 168.73, tokens_per_sec_per_gpu: 390 },
     ],
   },
   {
     // MI300X ×8 / MiniMax-M2.7 / FP8 KV cache (fp8_e4m3) / tp=8 ep=8 / high-throughput.
+    // Same server and benchmark config as low-latency entry above (tp=8 ep=8 instead).
     match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
-    sglang_version: "0.5.13.post1",
+    sglang_version: "0.5.16",
     speed: [
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1024, num_prompts: 2048 },
-        ttft_ms: 3547, tpot_ms: 239.18, tokens_per_sec_per_gpu: 538 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 4096, num_prompts: 4096 },
-        ttft_ms: 18251, tpot_ms: 431.16, tokens_per_sec_per_gpu: 1043 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1024, num_prompts: 2048 },
+        ttft_ms: 23261, tpot_ms: 508.06, tokens_per_sec_per_gpu: 322 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 4096, num_prompts: 4096 },
+        ttft_ms: 218886, tpot_ms: 536.96, tokens_per_sec_per_gpu: 462 },
     ],
   },
 ];

--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7.jsx
@@ -440,6 +440,7 @@ ns eval \\
     },
     {
       match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",
@@ -455,6 +456,7 @@ ns eval \\
     },
     {
       match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" },
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",
@@ -470,6 +472,7 @@ ns eval \\
     },
     {
       match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",

--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m2.7.jsx
@@ -84,7 +84,8 @@ export const config = {
   --model {{MODEL_NAME}} \\
   --dataset-name {{DATASET}} \\
   --random-input-len {{ISL}} --random-output-len {{OSL}} \\
-  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}}`,
+  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}} \\
+  --flush-cache`,
     accuracy: {
       gpqa_pct:
 `ns prepare_data gpqa
@@ -127,7 +128,7 @@ ns eval \\
   --parallel 32 \\
   --host {{CURL_HOST}} --port {{CURL_PORT}}`,
     },
-    numPromptsByConc: { 1: 10, 100: 500 },
+    numPromptsByConc: { 1: 32, 16: 32, 64: 128, 256: 512, 1024: 2048, 4096: 4096 },
   },
 
   accuracyLabels: [
@@ -144,7 +145,7 @@ ns eval \\
     h200:   "lmsysorg/sglang:v0.5.10.post1",
     b200:   "lmsysorg/sglang:v0.5.10.post1",
     gb300:  "lmsysorg/sglang:v0.5.10.post1-cu130",
-    mi300x: "lmsysorg/sglang:v0.5.10.post1-rocm720-mi30x",
+    mi300x: "lmsysorg/sglang:v0.5.16-rocm700-mi30x",
     mi325x: "lmsysorg/sglang:v0.5.10.post1-rocm720-mi30x",
     mi355x: "lmsysorg/sglang:v0.5.10.post1-rocm720-mi35x",
     // xeon: no docker mapping — install from source (CPU build); falls back to :dev.


### PR DESCRIPTION
## What this PR does

Adds verified MI300X benchmark data for MiniMax-M2.7 across all 3 deployment strategies.

### Hardware and Software
- **GPU**: AMD Instinct MI300X (8x192 GB HBM3)
- **SGLang**: 0.5.13.post1
- **Docker**: lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x
- **Quantization**: FP8 KV cache (fp8_e4m3)

### Speed Benchmarks (ISL/OSL 1000/1000)

| Strategy | TP x EP | Concurrency | TTFT (ms) | TPOT (ms) | Throughput (tok/s) | tok/s/GPU |
|----------|---------|-------------|-----------|-----------|-------------------|-----------|
| Low-latency | 2x2 | 1 | 210 | 14.94 | 65 | 33 |
| Low-latency | 2x2 | 16 | 167 | 31.80 | 486 | 243 |
| Balanced | 4x4 | 64 | 419 | 42.48 | 1403 | 351 |
| Balanced | 4x4 | 256 | 337 | 71.72 | 3236 | 809 |
| High-throughput | 8x8 | 1024 | 3547 | 239.18 | 4301 | 538 |
| High-throughput | 8x8 | 4096 | 18251 | 431.16 | 8344 | 1043 |

### Accuracy (GSM8K)
- GSM8K eval in progress (sgl-eval run gsm8k --no-thinking --max-tokens 8192), will update when complete.

### Changes
- minimax-m2.7-benchmarks.jsx: Added 3 MI300X benchmark entries (low-latency, balanced, high-throughput)
- minimax-m2.7.jsx: Marked 3 MI300X cells as verified: true

### Server flags (all strategies)
--trust-remote-code --kv-cache-dtype fp8_e4m3 --attention-backend triton --mem-fraction-static 0.85

CC @nicchenn @zijiexia

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828411165](https://github.com/sgl-project/sglang/actions/runs/34828411165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828410701](https://github.com/sgl-project/sglang/actions/runs/34828410701)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->