### PR TITLE
Support GLM-5.2 DSpark config and block correctness

### DIFF
--- a/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
@@ -408,6 +408,7 @@ def _compact_verify_ids_gather_kernel(
     draft_tokens_ptr,
     out_ptr,
     bs,
+    draft_block_stride,
     gamma,
     n,
     BLOCK: tl.constexpr,
@@ -419,7 +420,9 @@ def _compact_verify_ids_gather_kernel(
     within = tl.load(within_ptr + offs, mask=mask, other=0)
     valid = req < bs
     safe_req = tl.minimum(req, bs - 1)
-    anchor = tl.load(draft_block_ids_ptr + safe_req * gamma, mask=mask, other=0)
+    anchor = tl.load(
+        draft_block_ids_ptr + safe_req * draft_block_stride, mask=mask, other=0
+    )
     wcol = tl.maximum(within - 1, 0)
     draft = tl.load(draft_tokens_ptr + safe_req * gamma + wcol, mask=mask, other=0)
     v = tl.where(within == 0, anchor, draft)
@@ -443,12 +446,22 @@ def compact_verify_ids_triton(
     gamma = draft_tokens.shape[1]
     draft_block_ids = draft_block_ids.to(device=device, dtype=torch.int64).contiguous()
     draft_tokens = draft_tokens.to(device=device, dtype=torch.int64).contiguous()
+    draft_block_stride = draft_block_ids.shape[1]
     n = layout.graph_num_tokens
     out = torch.empty(n, dtype=torch.int64, device=device)
     BLOCK = 256
     grid = (triton.cdiv(n, BLOCK),)
     _compact_verify_ids_gather_kernel[grid](
-        req, within, draft_block_ids, draft_tokens, out, bs, gamma, n, BLOCK=BLOCK
+        req,
+        within,
+        draft_block_ids,
+        draft_tokens,
+        out,
+        bs,
+        draft_block_stride,
+        gamma,
+        n,
+        BLOCK=BLOCK,
     )
     return out
 

--- a/python/sglang/srt/speculative/dflash_info_v2.py
+++ b/python/sglang/srt/speculative/dflash_info_v2.py
@@ -172,6 +172,14 @@ class DFlashDraftInputV2(SpecInput):
         self.max_top_k = max(max_top_k, 1)
         self.uniform_top_k_value = uniform_top_k_value if uniform_top_k else None
 
+        row_width = batch.req_to_token_pool.req_to_token.shape[1]
+        max_reserved_len = int(nxt_kv_lens_cpu_t.max().item())
+        assert max_reserved_len <= row_width, (
+            f"DFLASH/DSPARK draft over-allocation ({max_reserved_len}) exceeds "
+            f"req_to_token row width ({row_width}); widen the row to hold committed "
+            f"+ get_alloc_reserve_per_decode()."
+        )
+
         caller_stream = None
         if plan_stream is not None:
             caller_stream = torch.get_device_module(batch.device).current_stream()

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -335,10 +335,19 @@ def _get_text_config(config: Any) -> Any:
     if config is None:
         return None
     if isinstance(config, dict):
-        return config.get("text_config", config)
+        text_config = config.get("text_config", None)
+        if text_config is not None:
+            return text_config
+        transformer_layer_config = config.get("transformer_layer_config", None)
+        return (
+            transformer_layer_config if transformer_layer_config is not None else config
+        )
     text_config = getattr(config, "text_config", None)
     if text_config is not None:
         return text_config
+    transformer_layer_config = getattr(config, "transformer_layer_config", None)
+    if transformer_layer_config is not None:
+        return transformer_layer_config
     get_text_config = getattr(config, "get_text_config", None)
     if callable(get_text_config):
         try:
@@ -446,6 +455,7 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
         field_name="DFLASH draft num_hidden_layers",
         min_value=1,
     )
+    aux_layer_ids = _cfg_get(draft_hf_config, "aux_hidden_state_layer_ids", None)
     raw_num_target_layers = dflash_cfg.get(
         "num_target_layers",
         _cfg_get(draft_hf_config, "num_target_layers", None),
@@ -469,7 +479,7 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
 
     layer_ids = dflash_cfg.get(
         "target_layer_ids",
-        _cfg_get(draft_hf_config, "target_layer_ids", None),
+        _cfg_get(draft_hf_config, "target_layer_ids", aux_layer_ids),
     )
     parsed_target_layer_ids: Optional[List[int]]
     if layer_ids is None:

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -55,6 +55,21 @@ _is_npu = is_npu()
 
 logger = logging.getLogger(__name__)
 
+
+def _copy_prefix_seq_lens_cpu(
+    dst: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    seq_lens_cpu: Optional[torch.Tensor],
+) -> int:
+    src = seq_lens_cpu
+    if src is None:
+        src = prefix_lens.detach().to(device=dst.device, dtype=dst.dtype)
+    elif src.dtype != dst.dtype:
+        src = src.to(dtype=dst.dtype)
+    dst.copy_(src)
+    return int(dst.sum().item())
+
+
 _FusedKVMaterializeHelper = None
 
 
@@ -1576,22 +1591,14 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_seq_lens = draft_prefix_lens
             draft_seq_lens_sum = int(seq_lens_cpu.sum().item())
         else:
-            # Non-windowed path uses the shared overallocated mapping directly.
-            # Backend planning only needs a safe upper bound for the committed
-            # prefix lengths, not the full allocator reservation length.
+            # TARGET_VERIFY attention backends interpret seq_lens_cpu as the
+            # committed prefix and add the fixed draft width internally when
+            # planning metadata. Keep this mirror prefix-only; using allocator
+            # reservation or prefix + block double-counts the verify width.
             draft_seq_lens = prefix_lens
-            if batch.seq_lens_cpu is not None:
-                # Host bound = committed prefix + one verify block.
-                seq_lens_cpu.copy_(batch.seq_lens_cpu)
-                seq_lens_cpu.add_(block_size)
-                draft_seq_lens_sum = int(seq_lens_cpu.sum())
-            elif draft_input.reserved_seq_lens_cpu is not None:
-                # GPU-only backend: reserved is a safe over-estimate.
-                seq_lens_cpu.copy_(draft_input.reserved_seq_lens_cpu)
-                draft_seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
-            else:
-                seq_lens_cpu.copy_(prefix_lens.to("cpu", dtype=torch.int32))
-                draft_seq_lens_sum = int(prefix_lens.sum().item())
+            draft_seq_lens_sum = _copy_prefix_seq_lens_cpu(
+                seq_lens_cpu, prefix_lens, batch.seq_lens_cpu
+            )
 
         forward_batch = ForwardBatch(
             forward_mode=ForwardMode.TARGET_VERIFY,
@@ -1654,14 +1661,13 @@ class DFlashWorkerV2(BaseSpecWorker):
         )
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
-        if seq_lens_cpu_backup is not None:
-            # Verify host bound = committed prefix + one verify block (matches draft).
-            verify_host_seq_lens = seq_lens_cpu_backup + block_size
-            batch.seq_lens_cpu = verify_host_seq_lens
-            batch.seq_lens_sum = int(verify_host_seq_lens.sum())
-        elif draft_input.reserved_seq_lens_cpu is not None:
-            batch.seq_lens_cpu = draft_input.reserved_seq_lens_cpu
-            batch.seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
+        base_seq_lens_cpu = (
+            seq_lens_cpu_backup
+            if seq_lens_cpu_backup is not None
+            else batch.seq_lens.cpu()
+        )
+        batch.seq_lens_cpu = base_seq_lens_cpu
+        batch.seq_lens_sum = int(base_seq_lens_cpu.sum())
 
         verify_forward_batch, _ = verify_input.prepare_for_verify(
             batch, self.target_worker

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -165,10 +165,19 @@ def _get_text_config(config: Any) -> Any:
     if config is None:
         return None
     if isinstance(config, dict):
-        return config.get("text_config", config)
+        text_config = config.get("text_config", None)
+        if text_config is not None:
+            return text_config
+        transformer_layer_config = config.get("transformer_layer_config", None)
+        return (
+            transformer_layer_config if transformer_layer_config is not None else config
+        )
     text_config = getattr(config, "text_config", None)
     if text_config is not None:
         return text_config
+    transformer_layer_config = getattr(config, "transformer_layer_config", None)
+    if transformer_layer_config is not None:
+        return transformer_layer_config
     return config
 
 
@@ -178,10 +187,70 @@ def _get_dspark_config(config: Any) -> dict:
         return {}
     if isinstance(cfg, dict):
         return cfg
+    if hasattr(cfg, "__dict__"):
+        return vars(cfg)
     try:
         return dict(cfg)
     except Exception:
         return {}
+
+
+def _get_speculators_config(config: Any) -> dict:
+    cfg = _cfg_get(config, "speculators_config", None)
+    if cfg is None:
+        return {}
+    if isinstance(cfg, dict):
+        return cfg
+    if hasattr(cfg, "__dict__"):
+        return vars(cfg)
+    try:
+        return dict(cfg)
+    except Exception:
+        return {}
+
+
+def _get_speculators_gamma(config: Any) -> Optional[int]:
+    speculators_cfg = _get_speculators_config(config)
+    proposal_methods = speculators_cfg.get("proposal_methods") or []
+    default_method = speculators_cfg.get("default_proposal_method")
+
+    selected_method = None
+    for method in proposal_methods:
+        if not isinstance(method, dict) and not hasattr(method, "__dict__"):
+            continue
+        if (
+            default_method is None
+            or _cfg_get(method, "proposal_type", None) == default_method
+        ):
+            selected_method = method
+            break
+    if selected_method is None and default_method is not None:
+        raise ValueError(
+            "DSpark speculators_config default_proposal_method "
+            f"{default_method!r} does not match any proposal_type."
+        )
+    if selected_method is None and proposal_methods:
+        selected_method = next(
+            (
+                method
+                for method in proposal_methods
+                if isinstance(method, dict) or hasattr(method, "__dict__")
+            ),
+            None,
+        )
+    if selected_method is None:
+        return None
+
+    speculative_tokens = _cfg_get(selected_method, "speculative_tokens", None)
+    if speculative_tokens is None:
+        return None
+    gamma = int(speculative_tokens)
+    if gamma < 1:
+        raise ValueError(
+            "DSpark speculators_config speculative_tokens must be positive, "
+            f"got {gamma}."
+        )
+    return gamma
 
 
 def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
@@ -265,9 +334,13 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
             f"DSpark mask_token_id must be non-negative, got {mask_token_id}."
         )
 
-    gamma = (
-        int(prefixed_block_size) if prefixed_block_size is not None else base.block_size
-    )
+    speculators_gamma = _get_speculators_gamma(draft_hf_config)
+    if prefixed_block_size is not None:
+        gamma = int(prefixed_block_size)
+    elif speculators_gamma is not None:
+        gamma = speculators_gamma
+    else:
+        gamma = base.block_size
 
     if prefixed_target_layer_ids is not None:
         if not isinstance(prefixed_target_layer_ids, (list, tuple)) or not len(

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -405,13 +405,20 @@ class DraftBlockProposer:
             draft_input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
 
         if batch.seq_lens_cpu is not None:
-            draft_seq_lens_cpu = batch.seq_lens_cpu + gamma
-            draft_seq_lens_sum = int(draft_seq_lens_cpu.sum())
-        elif draft_input.reserved_seq_lens_cpu is not None:
-            draft_seq_lens_cpu = draft_input.reserved_seq_lens_cpu
-            draft_seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
+            # TARGET_VERIFY attention backends interpret seq_lens_cpu as the
+            # committed prefix and add the fixed draft width internally when
+            # sizing cache/page-table metadata. Passing prefix + gamma here
+            # makes verifier metadata longer than the real committed row.
+            draft_seq_lens_cpu = batch.seq_lens_cpu
+            seq_lens_sum = getattr(batch, "seq_lens_sum", None)
+            draft_seq_lens_sum = (
+                int(seq_lens_sum)
+                if seq_lens_sum is not None
+                else int(batch.seq_lens_cpu.sum().item())
+            )
         else:
-            raise RuntimeError("DSpark decode expected batch.seq_lens_cpu, got None")
+            draft_seq_lens_cpu = prefix_lens.detach().to("cpu")
+            draft_seq_lens_sum = int(draft_seq_lens_cpu.sum().item())
 
         draft_forward_batch = ForwardBatch(
             forward_mode=ForwardMode.TARGET_VERIFY,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -97,20 +97,34 @@ class DsparkDraftSampler:
         )
 
     def __call__(self, hidden_states, input_ids):
-        bs = hidden_states.shape[0] // self.gamma
-        base_logits, confidence_tap = self.model.compute_base_logits(hidden_states)
+        draft_width = self.gamma + 1
+        if hidden_states.shape[0] % draft_width != 0:
+            raise RuntimeError(
+                "DSpark folded draft sampler expects full blocks with "
+                f"anchor + gamma tokens, got {hidden_states.shape[0]} rows "
+                f"for gamma={self.gamma}."
+            )
+        bs = hidden_states.shape[0] // draft_width
+        hidden_3d = hidden_states.view(bs, draft_width, -1)
+        ids_2d = input_ids.view(bs, draft_width)
+        anchor = ids_2d[:, 0]
+        # Slot 0 conditions the block. Slots 1..gamma are the draft tokens
+        # used by the verifier and confidence scheduler.
+        draft_hidden = hidden_3d[:, 1:, :].contiguous()
+        hidden_for_logits = draft_hidden.reshape(bs * self.gamma, -1)
+
+        base_logits, confidence_tap = self.model.compute_base_logits(hidden_for_logits)
         base_logits = base_logits.view(bs, self.gamma, -1)
-        anchor = input_ids.view(bs, self.gamma)[:, 0]
         draft_tokens, _ = self.markov_head.sample_block(
             base_logits,
             first_prev_tokens=anchor,
-            hidden_states=hidden_states.view(bs, self.gamma, -1),
+            hidden_states=draft_hidden,
             sampler=greedy_step_sampler,
         )
         self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
         if self.confidence_out is not None:
             confidence = self.confidence_fn(
-                draft_hidden=hidden_states.view(bs, self.gamma, -1),
+                draft_hidden=draft_hidden,
                 anchor_tokens=anchor,
                 draft_tokens=draft_tokens,
                 confidence_tap=confidence_tap,
@@ -369,16 +383,20 @@ class DraftBlockProposer:
         embed_module,
     ) -> DraftForwardResult:
         gamma = self.gamma
+        draft_width = gamma + 1
         prefix_lens = batch.seq_lens
         positions_2d = verify_window.positions_2d
         verify_cache_loc_2d = verify_window.verify_cache_loc_2d
 
         draft_block_ids = torch.full(
-            (bs, gamma), int(self._mask_token_id), dtype=torch.long, device=device
+            (bs, draft_width),
+            int(self._mask_token_id),
+            dtype=torch.long,
+            device=device,
         )
         draft_block_ids[:, 0].copy_(draft_input.bonus_tokens.view(-1))
-        draft_positions = positions_2d[:, :gamma].reshape(-1)
-        draft_cache_loc = verify_cache_loc_2d[:, :gamma].reshape(-1)
+        draft_positions = positions_2d[:, :draft_width].reshape(-1)
+        draft_cache_loc = verify_cache_loc_2d[:, :draft_width].reshape(-1)
 
         draft_owns_embed = hasattr(self.draft_model, "forward_embed")
         draft_input_embeds: Optional[torch.Tensor] = None
@@ -417,7 +435,11 @@ class DraftBlockProposer:
         raw_hidden = logits_output.hidden_states
         if raw_hidden is None:
             raise RuntimeError("DSpark draft model returned no hidden states.")
-        draft_hidden_3d = raw_hidden.view(bs, gamma, -1)
+        # Slot 0 is the anchor token used to condition semi-autoregressive
+        # drafting. Only slots 1..gamma are speculative token hidden states.
+        raw_hidden_3d = raw_hidden.view(bs, draft_width, -1)
+        draft_hidden_3d = raw_hidden_3d[:, 1:, :].contiguous()
+        raw_hidden = draft_hidden_3d.reshape(bs * gamma, -1)
         return DraftForwardResult(
             draft_block_ids=draft_block_ids,
             raw_hidden=raw_hidden,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -236,12 +236,13 @@ class TargetVerifyExecutor:
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
         if not self._verify_backend_self_adds_seq_lens():
-            if seq_lens_cpu_backup is not None:
-                batch.seq_lens_cpu = seq_lens_cpu_backup + verify_w
-                batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
-            elif draft_input.reserved_seq_lens_cpu is not None:
-                batch.seq_lens_cpu = draft_input.reserved_seq_lens_cpu
-                batch.seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
+            base_seq_lens_cpu = (
+                seq_lens_cpu_backup
+                if seq_lens_cpu_backup is not None
+                else batch.seq_lens.cpu()
+            )
+            batch.seq_lens_cpu = base_seq_lens_cpu
+            batch.seq_lens_sum = int(base_seq_lens_cpu.sum())
 
         result = self._forward_prepared_verify(
             batch=batch,
@@ -336,16 +337,14 @@ class TargetVerifyExecutor:
         batch.out_cache_loc = ragged_window.verify_cache_loc
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
-        if seq_lens_cpu_backup is not None:
-            verify_lens_cpu = (
-                layout.verify_lens_cpu
-                if layout.verify_lens_cpu is not None
-                else layout.verify_lens.cpu().tolist()
+        if not self._verify_backend_self_adds_seq_lens():
+            base_seq_lens_cpu = (
+                seq_lens_cpu_backup
+                if seq_lens_cpu_backup is not None
+                else batch.seq_lens.cpu()
             )
-            batch.seq_lens_cpu = seq_lens_cpu_backup + torch.tensor(
-                verify_lens_cpu, dtype=seq_lens_cpu_backup.dtype
-            )
-            batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
+            batch.seq_lens_cpu = base_seq_lens_cpu
+            batch.seq_lens_sum = int(base_seq_lens_cpu.sum())
 
         return self._forward_prepared_verify(
             batch=batch,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -136,7 +136,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             length=self.verify_num_draft_tokens, device=self.device
         )
         self._draft_block_spec_info = make_draft_block_spec_info(
-            draft_token_num=int(self.gamma), device=self.device
+            draft_token_num=int(self.verify_num_draft_tokens), device=self.device
         )
 
         target_model = self.target_worker.model_runner.model

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -413,7 +413,7 @@ def create_dummy_verify_input(
         spec_info = DFlashVerifyInput(
             draft_token=None,
             positions=None,
-            draft_token_num=server_args.speculative_num_draft_tokens,
+            draft_token_num=num_tokens_per_req,
             custom_mask=None,
             capture_hidden_mode=(
                 CaptureHiddenMode.NULL if is_draft_worker else CaptureHiddenMode.FULL

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -227,8 +227,6 @@ class SpeculativeAlgorithm(Enum):
         # graph support. We can use it for target verify, or we can use it for
         # other cases which is not target verify but fixed length prefill.
         # Here, we expose this interface to allow the other use cases.
-        if self.is_dspark() and is_draft_worker:
-            return num_draft_tokens - 1
         return num_draft_tokens
 
     def get_num_tokens_per_bs_for_target_verify(

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -58,6 +58,52 @@ _LONGCAT_ARCHS = {
     "LongcatFlashNgramForCausalLM",
 }
 
+_DSPARK_DRAFT_ARCHS = {
+    "DSparkDraftModel",
+    "Qwen3DSparkModel",
+}
+
+
+def _looks_like_dspark_draft_config(config_dict: dict) -> bool:
+    architectures = config_dict.get("architectures") or []
+    if any(arch in _DSPARK_DRAFT_ARCHS for arch in architectures):
+        return True
+
+    speculators_config = config_dict.get("speculators_config") or {}
+    return (
+        isinstance(speculators_config, dict)
+        and speculators_config.get("algorithm") == "dspark"
+        and isinstance(config_dict.get("transformer_layer_config"), dict)
+    )
+
+
+def _lift_dspark_transformer_layer_config(config, config_dict: dict) -> None:
+    transformer_layer_config = config_dict.get("transformer_layer_config")
+    if not isinstance(transformer_layer_config, dict):
+        return
+
+    for key, value in transformer_layer_config.items():
+        if key == "model_type" or value is None:
+            continue
+        current = getattr(config, key, None)
+        if current is None:
+            setattr(config, key, value)
+
+
+def _try_load_dspark_draft_config(model, revision: Optional[str], **kwargs):
+    config_dict, _ = PretrainedConfig.get_config_dict(
+        model, revision=revision, **kwargs
+    )
+    if config_dict.get("model_type") is not None:
+        return None
+    if not _looks_like_dspark_draft_config(config_dict):
+        return None
+
+    config = PretrainedConfig.from_dict(config_dict)
+    _lift_dspark_transformer_layer_config(config, config_dict)
+    config._name_or_path = model
+    return config
+
 
 def _try_load_longcat_config(model, revision: Optional[str], **kwargs):
     config_dict, _ = PretrainedConfig.get_config_dict(
@@ -82,6 +128,8 @@ class HfModelConfigParser(ModelConfigParserBase):
         **kwargs,
     ):
         config = _try_load_longcat_config(model, revision, **kwargs)
+        if config is None:
+            config = _try_load_dspark_draft_config(model, revision, **kwargs)
         if config is None:
             config = AutoConfig.from_pretrained(
                 model,

--- a/test/registered/spec/dspark/test_dspark_draft_anchor_layout.py
+++ b/test/registered/spec/dspark/test_dspark_draft_anchor_layout.py
@@ -1,0 +1,107 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.speculative.dspark_components.dspark_draft import (
+    DraftBlockProposer,
+    DsparkDraftSampler,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSparkDraftAnchorLayout(CustomTestCase):
+    def test_draft_forward_runs_anchor_plus_gamma_and_crops_anchor_hidden(self):
+        seen = {}
+        bs = 2
+        gamma = 4
+        draft_width = gamma + 1
+        hidden_size = 8
+
+        class FakeDraftRunner:
+            device = "cpu"
+
+            def forward(self, forward_batch):
+                seen["input_ids"] = forward_batch.input_ids.clone()
+                seen["positions"] = forward_batch.positions.clone()
+                seen["out_cache_loc"] = forward_batch.out_cache_loc.clone()
+                hidden = torch.arange(
+                    bs * draft_width * hidden_size, dtype=torch.float32
+                ).view(bs * draft_width, hidden_size)
+                return SimpleNamespace(
+                    logits_output=SimpleNamespace(hidden_states=hidden),
+                    can_run_graph=False,
+                )
+
+        proposer = DraftBlockProposer(
+            draft_model=SimpleNamespace(),
+            draft_model_runner=FakeDraftRunner(),
+            gamma=gamma,
+            mask_token_id=0,
+            draft_block_spec_info=SimpleNamespace(),
+        )
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_sum=30,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+        )
+        draft_input = SimpleNamespace(
+            bonus_tokens=torch.tensor([7, 8], dtype=torch.int64),
+        )
+        verify_window = SimpleNamespace(
+            positions_2d=torch.arange(bs * draft_width, dtype=torch.int64).view(
+                bs, draft_width
+            ),
+            verify_cache_loc_2d=torch.arange(
+                100, 100 + bs * draft_width, dtype=torch.int64
+            ).view(bs, draft_width),
+        )
+
+        out = proposer._run_forward(
+            batch=batch,
+            draft_input=draft_input,
+            verify_window=verify_window,
+            bs=bs,
+            device="cpu",
+            embed_module=torch.nn.Embedding(16, hidden_size),
+        )
+
+        self.assertEqual(tuple(out.draft_block_ids.shape), (bs, draft_width))
+        self.assertEqual(out.draft_block_ids[:, 0].tolist(), [7, 8])
+        self.assertEqual(seen["input_ids"].numel(), bs * draft_width)
+        self.assertEqual(seen["positions"].tolist(), list(range(bs * draft_width)))
+        self.assertEqual(
+            seen["out_cache_loc"].tolist(),
+            list(range(100, 100 + bs * draft_width)),
+        )
+        self.assertEqual(tuple(out.draft_hidden_3d.shape), (bs, gamma, hidden_size))
+        self.assertEqual(tuple(out.raw_hidden.shape), (bs * gamma, hidden_size))
+        self.assertEqual(out.raw_hidden[0].tolist(), list(range(hidden_size, 16)))
+
+    def test_folded_sampler_requires_full_anchor_plus_gamma_blocks(self):
+        class FakeModel:
+            def __init__(self):
+                self.markov_head = SimpleNamespace()
+
+            def compute_base_logits(self, hidden_states):
+                vocab_size = 16
+                logits = torch.zeros((hidden_states.shape[0], vocab_size))
+                return logits, None
+
+        sampler = DsparkDraftSampler(
+            model=FakeModel(),
+            gamma=4,
+            max_bs=2,
+            device=torch.device("cpu"),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "anchor \\+ gamma"):
+            sampler(torch.empty((8, 8)), torch.empty((8,), dtype=torch.int64))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/dspark/test_dspark_kernel_parity.py
+++ b/test/registered/spec/dspark/test_dspark_kernel_parity.py
@@ -136,7 +136,7 @@ def _case_build_ragged_verify_window(tc):
             dspark_verify_window.BuildRaggedVerifyWindow,
             batch=batch,
             layout=_layout(verify_lens, graph_num_tokens),
-            draft_block_ids=_ri(0, VOCAB, (bs, gamma)),
+            draft_block_ids=_ri(0, VOCAB, (bs, t)),
             draft_tokens=_ri(0, VOCAB, (bs, gamma)),
             bs=bs,
             device=DEVICE,
@@ -269,7 +269,7 @@ def _case_compact_layout(tc):
         )
         tc._parity(
             dspark_verify_window.CompactVerifyIds,
-            draft_block_ids=_ri(0, VOCAB, (bs, gamma)),
+            draft_block_ids=_ri(0, VOCAB, (bs, t)),
             draft_tokens=_ri(0, VOCAB, (bs, gamma)),
             layout=_layout(verify_lens, padded_total),
             device=DEVICE,

--- a/test/registered/spec/dspark/test_glm52_dspark_config.py
+++ b/test/registered/spec/dspark/test_glm52_dspark_config.py
@@ -1,0 +1,185 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from sglang.srt.models.dspark import EntryClass
+from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
+from sglang.srt.speculative.dspark_components.dspark_config import (
+    parse_dspark_draft_config,
+)
+from sglang.srt.utils.hf_transformers import get_config
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _glm52_redhat_dspark_config_dict() -> dict:
+    return {
+        "architectures": ["DSparkDraftModel"],
+        "aux_hidden_state_layer_ids": [8, 23, 39, 55, 70],
+        "block_size": 8,
+        "markov_head_type": "vanilla",
+        "markov_rank": 256,
+        "mask_token_id": 154856,
+        "speculators_config": {
+            "algorithm": "dspark",
+            "default_proposal_method": "greedy",
+            "proposal_methods": [
+                {
+                    "proposal_type": "greedy",
+                    "speculative_tokens": 7,
+                    "verifier_accept_k": 1,
+                }
+            ],
+        },
+        "transformer_layer_config": {
+            "hidden_size": 6144,
+            "model_type": "qwen3",
+            "num_hidden_layers": 5,
+            "vocab_size": 154880,
+        },
+    }
+
+
+def _to_namespace(value):
+    if isinstance(value, dict):
+        return SimpleNamespace(
+            **{key: _to_namespace(nested) for key, nested in value.items()}
+        )
+    if isinstance(value, list):
+        return [_to_namespace(nested) for nested in value]
+    return value
+
+
+def _glm52_redhat_dspark_config() -> SimpleNamespace:
+    return _to_namespace(_glm52_redhat_dspark_config_dict())
+
+
+class TestGLM52RedHatDSparkConfig(CustomTestCase):
+    def test_dflash_parser_reads_nested_transformer_config_and_aux_layers(self):
+        parsed = parse_dflash_draft_config(
+            draft_hf_config=_glm52_redhat_dspark_config()
+        )
+
+        self.assertEqual(parsed.num_hidden_layers, 5)
+        self.assertEqual(parsed.block_size, 8)
+        self.assertEqual(parsed.target_layer_ids, [8, 23, 39, 55, 70])
+        self.assertIsNone(parsed.num_target_layers)
+
+    def test_dspark_parser_prefers_speculators_tokens_for_gamma(self):
+        parsed = parse_dspark_draft_config(
+            draft_hf_config=_glm52_redhat_dspark_config()
+        )
+
+        self.assertEqual(parsed.gamma, 7)
+        self.assertEqual(parsed.target_layer_ids, [8, 23, 39, 55, 70])
+        self.assertEqual(parsed.markov_rank, 256)
+        self.assertEqual(parsed.markov_head_type, "vanilla")
+        self.assertEqual(parsed.mask_token_id, 154856)
+
+    def test_dspark_parser_selects_default_proposal_method(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+        raw_config["block_size"] = 8
+        raw_config["speculators_config"]["default_proposal_method"] = "sample"
+        raw_config["speculators_config"]["proposal_methods"] = [
+            {
+                "proposal_type": "greedy",
+                "speculative_tokens": 7,
+                "verifier_accept_k": 1,
+            },
+            {
+                "proposal_type": "sample",
+                "speculative_tokens": 5,
+                "verifier_accept_k": 1,
+            },
+        ]
+
+        parsed = parse_dspark_draft_config(draft_hf_config=_to_namespace(raw_config))
+
+        self.assertEqual(parsed.gamma, 5)
+
+    def test_dspark_parser_rejects_missing_default_proposal_method(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+        raw_config["speculators_config"]["default_proposal_method"] = "missing"
+        raw_config["speculators_config"]["proposal_methods"] = [
+            {
+                "proposal_type": "greedy",
+                "speculative_tokens": 4,
+                "verifier_accept_k": 1,
+            },
+            {
+                "proposal_type": "sample",
+                "speculative_tokens": 6,
+                "verifier_accept_k": 1,
+            },
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError, "default_proposal_method 'missing' does not match"
+        ):
+            parse_dspark_draft_config(draft_hf_config=raw_config)
+
+    def test_dspark_parser_rejects_invalid_speculative_tokens(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+        raw_config["speculators_config"]["proposal_methods"][0][
+            "speculative_tokens"
+        ] = 0
+
+        with self.assertRaisesRegex(ValueError, "speculative_tokens must be positive"):
+            parse_dspark_draft_config(draft_hf_config=raw_config)
+
+    def test_dict_text_config_none_falls_back_to_transformer_layer_config(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+        raw_config["text_config"] = None
+
+        parsed = parse_dflash_draft_config(draft_hf_config=raw_config)
+
+        self.assertEqual(parsed.num_hidden_layers, 5)
+        self.assertEqual(parsed.target_layer_ids, [8, 23, 39, 55, 70])
+
+    def test_dflash_parser_rejects_empty_aux_layer_ids(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+        raw_config["aux_hidden_state_layer_ids"] = []
+
+        with self.assertRaisesRegex(ValueError, "target_layer_ids must be non-empty"):
+            parse_dflash_draft_config(draft_hf_config=raw_config)
+
+    def test_prefixed_dspark_block_size_overrides_speculators_gamma(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+        raw_config["dspark_block_size"] = 3
+
+        parsed = parse_dspark_draft_config(draft_hf_config=raw_config)
+
+        self.assertEqual(parsed.gamma, 3)
+
+    def test_prefixed_target_layer_ids_must_be_non_empty(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+        raw_config["dspark_target_layer_ids"] = []
+
+        with self.assertRaisesRegex(ValueError, "must be a non-empty list"):
+            parse_dspark_draft_config(draft_hf_config=raw_config)
+
+    def test_generic_dspark_draft_model_is_not_registered_yet(self):
+        self.assertNotIn("DSparkDraftModel", {cls.__name__ for cls in EntryClass})
+
+    def test_hf_loader_falls_back_for_missing_top_level_model_type(self):
+        raw_config = _glm52_redhat_dspark_config_dict()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = Path(tmp_dir) / "config.json"
+            config_path.write_text(json.dumps(raw_config), encoding="utf-8")
+
+            loaded = get_config(str(config_path.parent), trust_remote_code=True)
+
+        self.assertEqual(loaded.architectures, ["DSparkDraftModel"])
+        self.assertEqual(loaded.hidden_size, 6144)
+        self.assertEqual(loaded.num_hidden_layers, 5)
+        self.assertEqual(loaded.vocab_size, 154880)
+        self.assertEqual(parse_dspark_draft_config(draft_hf_config=loaded).gamma, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_dspark_verify_lengths.py
+++ b/test/registered/unit/spec/test_dflash_dspark_verify_lengths.py
@@ -1,0 +1,342 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.speculative.dflash_info import DFlashVerifyInput
+from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+from sglang.srt.speculative.dflash_worker_v2 import _copy_prefix_seq_lens_cpu
+from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockProposer
+from sglang.srt.speculative.dspark_components.dspark_verify import TargetVerifyExecutor
+from sglang.srt.speculative.spec_info import (
+    SpeculativeAlgorithm,
+    create_dummy_verify_input,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _spec_args(*, draft_tokens: int = 8, algorithm: str = "DSPARK") -> ServerArgs:
+    args = ServerArgs(model_path="dummy")
+    args.speculative_algorithm = algorithm
+    args.speculative_num_draft_tokens = draft_tokens
+    args.speculative_num_steps = 1
+    args.speculative_eagle_topk = 1
+    args.page_size = 1
+    return args
+
+
+class _FakeBatch:
+    def __init__(self, *, committed_lens, allocated_lens, row_width: int):
+        self.device = torch.device("cpu")
+        self.reqs = [
+            SimpleNamespace(
+                kv_committed_len=committed_len,
+                kv=SimpleNamespace(kv_allocated_len=allocated_len),
+                sampling_params=SimpleNamespace(top_k=1),
+            )
+            for committed_len, allocated_len in zip(committed_lens, allocated_lens)
+        ]
+        self.token_to_kv_pool_allocator = SimpleNamespace(page_size=1)
+        self.req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.empty((len(self.reqs), row_width), dtype=torch.int32)
+        )
+        self.req_pool_indices = torch.arange(len(self.reqs), dtype=torch.int64)
+        self.tree_cache = SimpleNamespace()
+
+    def batch_size(self):
+        return len(self.reqs)
+
+
+class _FakeTargetWorker:
+    def __init__(self):
+        self.model_runner = SimpleNamespace(attn_backend=SimpleNamespace())
+
+    def forward_batch_generation(self, **kwargs):
+        return SimpleNamespace(
+            logits_output=SimpleNamespace(next_token_logits=torch.empty(0)),
+            can_run_cuda_graph=False,
+        )
+
+
+class TestDFlashDSparkVerifyLengths(CustomTestCase):
+    def test_prepare_for_decode_keeps_committed_and_reserved_lengths_separate(self):
+        args = _spec_args(draft_tokens=4)
+        set_global_server_args_for_scheduler(args)
+        draft_input = DFlashDraftInputV2.create_idle_input(torch.device("cpu"))
+        batch = _FakeBatch(
+            committed_lens=[10, 20],
+            allocated_lens=[18, 28],
+            row_width=64,
+        )
+
+        with patch(
+            "sglang.srt.speculative.dflash_info_v2.alloc_for_spec_decode"
+        ) as alloc_mock:
+            with envs.SGLANG_ENABLE_OVERLAP_PLAN_STREAM.override(False):
+                draft_input.prepare_for_decode(batch)
+
+        alloc_mock.assert_called_once()
+        self.assertEqual(
+            alloc_mock.call_args.kwargs["cur_kv_lens_cpu"].tolist(), [18, 28]
+        )
+        self.assertEqual(
+            alloc_mock.call_args.kwargs["nxt_kv_lens_cpu"].tolist(), [18, 28]
+        )
+        self.assertEqual(batch.seq_lens_cpu.tolist(), [10, 20])
+        self.assertEqual(batch.seq_lens_sum, 30)
+        self.assertEqual(draft_input.reserved_seq_lens_cpu.tolist(), [18, 28])
+        self.assertEqual(draft_input.reserved_seq_lens_sum, 46)
+
+    def test_prepare_for_decode_fails_before_req_to_token_oob(self):
+        args = _spec_args(draft_tokens=8)
+        set_global_server_args_for_scheduler(args)
+        draft_input = DFlashDraftInputV2.create_idle_input(torch.device("cpu"))
+        batch = _FakeBatch(committed_lens=[8], allocated_lens=[24], row_width=23)
+
+        with envs.SGLANG_ENABLE_OVERLAP_PLAN_STREAM.override(False):
+            with self.assertRaisesRegex(AssertionError, "over-allocation"):
+                draft_input.prepare_for_decode(batch)
+
+    def test_dflash_draft_block_uses_prefix_seq_lens_cpu(self):
+        dst = torch.empty((2,), dtype=torch.int32)
+        prefix_lens = torch.tensor([10, 20], dtype=torch.int32)
+        host_lens = torch.tensor([10, 20], dtype=torch.int64)
+
+        seq_lens_sum = _copy_prefix_seq_lens_cpu(dst, prefix_lens, host_lens)
+        self.assertEqual(dst.tolist(), [10, 20])
+        self.assertEqual(seq_lens_sum, 30)
+
+        dst.fill_(-1)
+        seq_lens_sum = _copy_prefix_seq_lens_cpu(dst, prefix_lens, None)
+        self.assertEqual(dst.tolist(), [10, 20])
+        self.assertEqual(seq_lens_sum, 30)
+
+    def test_dspark_draft_proposer_passes_prefix_seq_lens_cpu(self):
+        seen = {}
+        gamma = 4
+        bs = 2
+        draft_width = gamma + 1
+
+        class FakeDraftRunner:
+            device = "cpu"
+
+            def forward(self, forward_batch):
+                seen["seq_lens"] = forward_batch.seq_lens.clone()
+                seen["seq_lens_cpu"] = forward_batch.seq_lens_cpu.clone()
+                seen["seq_lens_sum"] = forward_batch.seq_lens_sum
+                return SimpleNamespace(
+                    logits_output=SimpleNamespace(
+                        hidden_states=torch.empty((bs * draft_width, 16))
+                    ),
+                    can_run_graph=False,
+                )
+
+        proposer = DraftBlockProposer(
+            draft_model=SimpleNamespace(),
+            draft_model_runner=FakeDraftRunner(),
+            gamma=gamma,
+            mask_token_id=0,
+            draft_block_spec_info=SimpleNamespace(),
+        )
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_sum=30,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+        )
+        draft_input = SimpleNamespace(
+            bonus_tokens=torch.tensor([7, 8], dtype=torch.int64),
+        )
+        verify_window = SimpleNamespace(
+            positions_2d=torch.arange(bs * draft_width, dtype=torch.int64).view(
+                bs, draft_width
+            ),
+            verify_cache_loc_2d=torch.arange(bs * draft_width, dtype=torch.int64).view(
+                bs, draft_width
+            ),
+        )
+
+        proposer._run_forward(
+            batch=batch,
+            draft_input=draft_input,
+            verify_window=verify_window,
+            bs=bs,
+            device="cpu",
+            embed_module=torch.nn.Embedding(16, 16),
+        )
+
+        self.assertEqual(seen["seq_lens"].tolist(), [10, 20])
+        self.assertEqual(seen["seq_lens_cpu"].tolist(), [10, 20])
+        self.assertEqual(seen["seq_lens_sum"], 30)
+
+    def test_dspark_draft_proposer_derives_cpu_lens_from_gpu_only_batch(self):
+        seen = {}
+        gamma = 4
+        bs = 2
+        draft_width = gamma + 1
+
+        class FakeDraftRunner:
+            device = "cpu"
+
+            def forward(self, forward_batch):
+                seen["seq_lens"] = forward_batch.seq_lens.clone()
+                seen["seq_lens_cpu"] = forward_batch.seq_lens_cpu.clone()
+                seen["seq_lens_sum"] = forward_batch.seq_lens_sum
+                return SimpleNamespace(
+                    logits_output=SimpleNamespace(
+                        hidden_states=torch.empty((bs * draft_width, 16))
+                    ),
+                    can_run_graph=False,
+                )
+
+        proposer = DraftBlockProposer(
+            draft_model=SimpleNamespace(),
+            draft_model_runner=FakeDraftRunner(),
+            gamma=gamma,
+            mask_token_id=0,
+            draft_block_spec_info=SimpleNamespace(),
+        )
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_cpu=None,
+            seq_lens_sum=None,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+        )
+        draft_input = SimpleNamespace(
+            bonus_tokens=torch.tensor([7, 8], dtype=torch.int64),
+            reserved_seq_lens_cpu=torch.tensor([18, 28], dtype=torch.int32),
+            reserved_seq_lens_sum=46,
+        )
+        verify_window = SimpleNamespace(
+            positions_2d=torch.arange(bs * draft_width, dtype=torch.int64).view(
+                bs, draft_width
+            ),
+            verify_cache_loc_2d=torch.arange(bs * draft_width, dtype=torch.int64).view(
+                bs, draft_width
+            ),
+        )
+
+        proposer._run_forward(
+            batch=batch,
+            draft_input=draft_input,
+            verify_window=verify_window,
+            bs=bs,
+            device="cpu",
+            embed_module=torch.nn.Embedding(16, 16),
+        )
+
+        self.assertEqual(seen["seq_lens"].tolist(), [10, 20])
+        self.assertEqual(seen["seq_lens_cpu"].tolist(), [10, 20])
+        self.assertEqual(seen["seq_lens_sum"], 30)
+
+    def test_dspark_target_verify_passes_prefix_seq_lens_cpu_not_reserved(self):
+        target_worker = _FakeTargetWorker()
+        executor = TargetVerifyExecutor(
+            target_worker=target_worker,
+            gamma=3,
+            verify_num_draft_tokens=4,
+            model_runner=target_worker.model_runner,
+            kv_injector=SimpleNamespace(),
+        )
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_cpu=None,
+            seq_lens_sum=None,
+            out_cache_loc=None,
+        )
+        draft_input = SimpleNamespace(
+            reserved_seq_lens_cpu=torch.tensor([18, 28], dtype=torch.int32),
+            reserved_seq_lens_sum=46,
+        )
+        verify_window = SimpleNamespace(
+            positions_2d=torch.arange(8, dtype=torch.int64).view(2, 4),
+            verify_cache_loc=torch.arange(8, dtype=torch.int64),
+        )
+        seen = {}
+
+        def capture_prepare(_verify_input, verify_batch, _target_worker):
+            seen["seq_lens_cpu"] = verify_batch.seq_lens_cpu.clone()
+            seen["seq_lens_sum"] = verify_batch.seq_lens_sum
+            return SimpleNamespace(), False
+
+        with patch.object(DFlashVerifyInput, "prepare_for_verify", new=capture_prepare):
+            executor.run_non_compact(
+                batch=batch,
+                draft_input=draft_input,
+                verify_ids_2d=torch.ones((2, 4), dtype=torch.int64),
+                verify_window=verify_window,
+                sampling_info=None,
+            )
+
+        self.assertEqual(seen["seq_lens_cpu"].tolist(), [10, 20])
+        self.assertEqual(seen["seq_lens_sum"], 30)
+        self.assertIsNone(batch.seq_lens_cpu)
+        self.assertIsNone(batch.seq_lens_sum)
+
+    def test_dspark_ragged_verify_passes_prefix_seq_lens_cpu(self):
+        target_worker = _FakeTargetWorker()
+        executor = TargetVerifyExecutor(
+            target_worker=target_worker,
+            gamma=3,
+            verify_num_draft_tokens=4,
+            model_runner=target_worker.model_runner,
+            kv_injector=SimpleNamespace(),
+        )
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_sum=30,
+            out_cache_loc=None,
+        )
+        layout = SimpleNamespace(
+            verify_lens_cpu=[1, 3],
+            verify_lens=torch.tensor([1, 3], dtype=torch.int32),
+        )
+        ragged_window = SimpleNamespace(
+            verify_ids=torch.arange(4, dtype=torch.int64),
+            positions=torch.arange(4, dtype=torch.int64),
+            verify_cache_loc=torch.arange(4, dtype=torch.int64),
+        )
+        seen = {}
+
+        def capture_prepare(_verify_input, verify_batch, _target_worker):
+            seen["seq_lens_cpu"] = verify_batch.seq_lens_cpu.clone()
+            seen["seq_lens_sum"] = verify_batch.seq_lens_sum
+            return SimpleNamespace(), False
+
+        with patch.object(DFlashVerifyInput, "prepare_for_verify", new=capture_prepare):
+            executor._run_ragged(
+                batch=batch,
+                layout=layout,
+                ragged_window=ragged_window,
+                sampling_info=None,
+            )
+
+        self.assertEqual(seen["seq_lens_cpu"].tolist(), [10, 20])
+        self.assertEqual(seen["seq_lens_sum"], 30)
+        self.assertEqual(batch.seq_lens_cpu.tolist(), [10, 20])
+        self.assertEqual(batch.seq_lens_sum, 30)
+
+    def test_dflash_family_dummy_verify_input_uses_caller_width(self):
+        args = _spec_args(draft_tokens=8)
+        spec_algorithm = SpeculativeAlgorithm.DSPARK
+
+        spec_info = create_dummy_verify_input(
+            spec_algorithm=spec_algorithm,
+            server_args=args,
+            custom_mask=torch.empty(0, dtype=torch.bool),
+            num_tokens_per_req=5,
+            is_draft_worker=True,
+        )
+
+        self.assertEqual(spec_info.draft_token_num, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR does

- Load the RedHat GLM-5.2 DSpark config format: `DSparkDraftModel`, nested `transformer_layer_config`, auxiliary hidden-state layers, and proposal gamma.
- Align dense DSpark drafting with the checkpoint contract: one anchor token plus `gamma` proposed tokens.
- Keep committed prefix lengths separate from reserved KV lengths during draft and target verify.
- Fix compact verify anchor indexing when requests use different verify lengths.

## Commit order

1. `Support GLM-5.2 DSpark draft config`
2. `Align DSpark draft block with anchor slot`
3. `Fix DFlash DSpark verify length metadata`
4. `Fix DSpark compact anchor stride`

Each commit has its focused regression tests.

## Validation

Validated at `fc09f91be`, rebased on upstream `f5155d960`, using one MI350 GPU:

```bash
python3 -m pytest -q \
  test/registered/spec/dspark/test_glm52_dspark_config.py \
  test/registered/spec/dspark/test_dspark_draft_anchor_layout.py \
  test/registered/unit/spec/test_dflash_dspark_verify_lengths.py \
  test/registered/spec/dspark/test_dspark_kernel_parity.py
```

```text
22 passed, 22 subtests passed
```

Also passed `git diff --check` and `py_compile` for every changed Python file.

## Scope

- This PR intentionally does **not** register the generic `DSparkDraftModel` entry class.
- GLM/ROCm target-verify activation remains in #31260.
- CUDA graph coverage, SPS/STS, zero-overhead scheduling, and performance tuning are out of scope here.

## Acceptance rate

The current RedHat checkpoint is workload-sensitive. UltraChat-like prompts work reasonably well, while random, long-context, and code traffic can be much worse.

This PR validates the config/runtime contract so improved GLM speculators can be plugged in later. It does not claim workload-independent speedup from the current checkpoint.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30148542704](https://github.com/sgl-project/sglang/actions/runs/30148542704)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30148542580](https://github.com/sgl-project/sglang/actions/runs/30148542580)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->