### PR TITLE
fix(tokenizer): configure Rust server special tokens at load time

### DIFF
--- a/rust/sglang-server/Cargo.lock
+++ b/rust/sglang-server/Cargo.lock
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.3.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801685a07cfbc87d5e3f3ed55b920707b67f31dd660c62d1b3532a651fc9d013"
+checksum = "8618ea35c99831eb8f41a1d239b6f5c009e5f647f118f9c20267c51b7415dab8"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1081,6 +1081,12 @@ checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1738,6 +1744,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,6 +1904,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokenizers",
  "tokio",
@@ -2064,6 +2084,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"

--- a/rust/sglang-server/Cargo.toml
+++ b/rust/sglang-server/Cargo.toml
@@ -44,12 +44,14 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# tokenizer: dynamo for the incremental decode stream (detok); the HuggingFace
-# `tokenizers` lib for encode, because dynamo hard-codes `add_special_tokens=false`
-# and we must prepend BOS to match the Python server (see `tokenizer::HfEncoder`).
-dynamo-tokenizers = "1.3.2"
-tokenizers = "0.21"
+# Tokenizer: one default-configured instance for incremental decode and one
+# `add_special_tokens=true` HuggingFace instance for the encode pool.
+dynamo-tokenizers = "1.5.1"
 
 # Offline HF Hub cache lookup only (no `tokio`/`ureq`/TLS features) — resolves a
 # repo id to its already-downloaded local tokenizer.json without network/openssl.
 hf-hub = { version = "0.5.0", default-features = false }
+
+[dev-dependencies]
+tempfile = "3"
+tokenizers = "0.21"

--- a/rust/sglang-server/src/detokenizer/mod.rs
+++ b/rust/sglang-server/src/detokenizer/mod.rs
@@ -393,7 +393,7 @@ mod tests {
         handle_chunk(&mut table, ev, &DetokenizerBackend::Skip, &tm_tx);
 
         // Request removed (no lingering state to be mistaken for success)...
-        assert!(table.get(&RequestId(1)).is_none());
+        assert!(!table.contains_key(&RequestId(1)));
         // ...and the scheduler was told to abort it.
         assert!(matches!(
             tm_rx.try_recv(),

--- a/rust/sglang-server/src/runtime/mod.rs
+++ b/rust/sglang-server/src/runtime/mod.rs
@@ -317,10 +317,10 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
     // tokenizer is loaded, and the egress emits raw `output_ids` (no decode).
     let skip_tokenizer_init = cfg.server_args.skip_tokenizer_init();
 
-    // Two tokenizers over the same `tokenizer.json`: dynamo for the detok shards'
-    // incremental decode, and the HuggingFace `tokenizers` lib for the encode pool
-    // (dynamo can't add BOS — see `tokenizer::HfEncoder`). Both `None` only under
-    // `skip_tokenizer_init`, so their Some/None state stays in lockstep.
+    // Two tokenizer instances over the same `tokenizer.json`: default options for
+    // the detok shards' incremental decode, and `add_special_tokens=true` for the
+    // encode pool. Both `None` only under `skip_tokenizer_init`, so their Some/None
+    // state stays in lockstep.
     let dyn_tokenizer = tokenizer::load_tokenizer(
         cfg.tokenizer_path.as_deref(),
         cfg.revision.as_deref(),
@@ -360,8 +360,8 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
     // Only spawned when a real tokenizer is loaded; under `skip_tokenizer_init`
     // there is none and ingress never routes to the pool, so we skip it.
     if let Some(enc) = hf_encoder {
-        // HF encoder (adds BOS), independent of the dynamo tokenizer the detok
-        // shards use; both are present together (same `skip_tokenizer_init` gate).
+        // HF encoder (adds BOS), independently configured from the tokenizer the
+        // detok shards use; both are present together (same skip-init gate).
         let tokenizer = Arc::new(tokenizer::HfEncoder::new(enc));
         let tok_cores = plan.as_ref().map(|p| p.tok.clone());
         // Workers share the MPMC inbox (`tok_rx`) and the read-only backend, so

--- a/rust/sglang-server/src/tokenizer/mod.rs
+++ b/rust/sglang-server/src/tokenizer/mod.rs
@@ -2,8 +2,8 @@
 //! executor). Each worker pulls a `Request` from the shared `flume` receiver,
 //! fills `input_ids`, and moves the request back to the TokenizerManager inbox.
 //!
-//! The text→ids step is behind [`TextTokenizer`], implemented by
-//! [`DynamoTokenizer`] (dynamo-tokenizers: HuggingFace / tiktoken / fastokens).
+//! The text→ids step is behind [`TextTokenizer`], implemented by [`HfEncoder`]
+//! over dynamo-tokenizers' HuggingFace backend.
 //! A non-skip server requires a real tokenizer (enforced at startup); under
 //! `skip_tokenizer_init` the pool isn't spawned at all.
 //!
@@ -51,17 +51,16 @@ pub fn load_tokenizer(
     Ok(Some(tokenizer))
 }
 
-/// Load the HuggingFace `tokenizers` tokenizer used by the encode pool. Separate
-/// from [`load_tokenizer`] (dynamo) because the two libraries differ on special
-/// tokens: dynamo hard-codes `add_special_tokens=false`, so it drops the BOS the
-/// prompt's post-processor would add, whereas [`HfEncoder`] passes `true` to match
-/// the Python server's `tokenizer.encode(text)`. Loads the same `tokenizer.json`;
+/// Load the plain HuggingFace tokenizer used by the encode pool, configured once
+/// with `add_special_tokens=true` to match the Python server's
+/// `tokenizer.encode(text)`. This construction path intentionally does not select
+/// fastokens or add a `CachedTokenizer` wrapper. Loads the same `tokenizer.json`;
 /// `None` under `skip_tokenizer_init`.
 pub fn load_encoder(
     tokenizer_path: Option<&str>,
     revision: Option<&str>,
     skip_tokenizer_init: bool,
-) -> Result<Option<tokenizers::Tokenizer>, String> {
+) -> Result<Option<dynamo_tokenizers::Tokenizer>, String> {
     if skip_tokenizer_init {
         return Ok(None);
     }
@@ -71,8 +70,13 @@ pub fn load_encoder(
 
     let file = resolve_model_file(path, revision, "tokenizer.json")
         .ok_or_else(|| format!("tokenizer.json not found for '{path}'"))?;
-    let tokenizer = tokenizers::Tokenizer::from_file(&file)
-        .map_err(|e| format!("encoder load failed ({file}): {e}"))?;
+    let tokenizer = dynamo_tokenizers::Tokenizer::from_file_with_options(
+        &file,
+        dynamo_tokenizers::TokenizerOptions {
+            add_special_tokens: true,
+        },
+    )
+    .map_err(|e| format!("encoder load failed ({file}): {e}"))?;
     tracing::info!(%path, "loaded encoder (add_special_tokens=true)");
     Ok(Some(tokenizer))
 }
@@ -110,18 +114,19 @@ fn resolve_from_hub_cache(repo_id: &str, revision: Option<&str>, filename: &str)
         .map(|p| p.to_string_lossy().into_owned())
 }
 
-/// Real encoder over the HuggingFace `tokenizers` library. Encodes with
-/// `add_special_tokens=true` so the prompt gets its BOS / post-processor special
-/// tokens — matching the Python server's `tokenizer.encode(text)`. dynamo's encoder
-/// passes `false`, dropping BOS; on models that prepend one (Llama, gemma, …) that
-/// silently changed the prompt and measurably cut accuracy (GSM8K gemma-2: 0.44 →
-/// 0.29). Decode still runs through dynamo's `DecodeStream` (see the detok shard).
+/// Real encoder over dynamo-tokenizers' plain HuggingFace backend. The inner
+/// tokenizer is constructed with `add_special_tokens=true`, so the prompt gets
+/// its BOS / post-processor special tokens — matching the Python server's
+/// `tokenizer.encode(text)`. On models that prepend one (Llama, Gemma, …), dropping
+/// BOS silently changed the prompt and measurably cut accuracy (GSM8K Gemma-2:
+/// 0.44 → 0.29). Decode still runs through the default-configured tokenizer used
+/// by the detok shard.
 pub struct HfEncoder {
-    inner: tokenizers::Tokenizer,
+    inner: dynamo_tokenizers::Tokenizer,
 }
 
 impl HfEncoder {
-    pub fn new(inner: tokenizers::Tokenizer) -> Self {
+    pub fn new(inner: dynamo_tokenizers::Tokenizer) -> Self {
         Self { inner }
     }
 }
@@ -135,10 +140,10 @@ impl TextTokenizer for HfEncoder {
         }
         let encoding = self
             .inner
-            .encode(text, true) // add_special_tokens=true → BOS etc., as Python does
+            .encode(text)
             .map_err(|e| Error::Tokenize(e.to_string()))?;
         // Vocab ids are non-negative and fit in i32.
-        Ok(encoding.get_ids().iter().map(|&id| id as i32).collect())
+        Ok(encoding.token_ids().iter().map(|&id| id as i32).collect())
     }
 }
 
@@ -184,5 +189,127 @@ impl Runnable for TokenizerWorker {
                 break;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dynamo_tokenizers::Encoding;
+    use tokenizers::{
+        AddedToken, Tokenizer as DirectHfTokenizer, models::wordlevel::WordLevel,
+        pre_tokenizers::whitespace::WhitespaceSplit, processors::template::TemplateProcessing,
+    };
+
+    use super::*;
+
+    struct TokenizerFixture {
+        _dir: tempfile::TempDir,
+        path: String,
+    }
+
+    fn tokenizer_fixture() -> TokenizerFixture {
+        let vocab = [
+            ("[UNK]", 0),
+            ("<s>", 1),
+            ("</s>", 2),
+            ("<|im_start|>", 3),
+            ("<|im_end|>", 4),
+            ("system", 5),
+            ("user", 6),
+            ("hello", 7),
+            ("world", 8),
+            ("again", 9),
+        ]
+        .into_iter()
+        .map(|(token, id)| (token.to_string(), id))
+        .collect();
+        let model = WordLevel::builder()
+            .vocab(vocab)
+            .unk_token("[UNK]".to_string())
+            .build()
+            .expect("build word-level model");
+        let mut tokenizer = DirectHfTokenizer::new(model);
+        tokenizer.with_pre_tokenizer(Some(WhitespaceSplit));
+        tokenizer.add_special_tokens(&[
+            AddedToken::from("<s>", true),
+            AddedToken::from("</s>", true),
+            AddedToken::from("<|im_start|>", true),
+            AddedToken::from("<|im_end|>", true),
+        ]);
+        tokenizer.with_post_processor(Some(
+            TemplateProcessing::builder()
+                .try_single("<s> $A </s>")
+                .expect("single-sequence template")
+                .special_tokens(vec![("<s>", 1), ("</s>", 2)])
+                .build()
+                .expect("build template processor"),
+        ));
+
+        let dir = tempfile::tempdir().expect("create fixture directory");
+        let path = dir.path().join("tokenizer.json");
+        tokenizer
+            .save(&path, false)
+            .expect("save tokenizer fixture");
+        TokenizerFixture {
+            _dir: dir,
+            path: path.to_string_lossy().into_owned(),
+        }
+    }
+
+    #[test]
+    fn add_special_tokens_encoder_matches_direct_hf() {
+        let fixture = tokenizer_fixture();
+        let selected = load_encoder(Some(&fixture.path), None, false)
+            .expect("load encoder")
+            .expect("encoder enabled");
+        let direct = DirectHfTokenizer::from_file(&fixture.path).expect("load direct HF tokenizer");
+
+        let prompts = [
+            "<|im_start|> system <|im_end|> <|im_start|> user hello world <|im_end|>",
+            "<|im_start|> user hello again <|im_end|>",
+        ];
+
+        for prompt in prompts {
+            let expected = direct.encode(prompt, true).expect("direct HF encode");
+            for _ in 0..3 {
+                let actual = selected.encode(prompt).expect("selected encode");
+                assert!(
+                    matches!(actual, Encoding::Hf(_)),
+                    "add_special_tokens=true must select the plain HF backend"
+                );
+                assert_eq!(actual.token_ids(), expected.get_ids());
+            }
+        }
+
+        let expected_batch = direct
+            .encode_batch(prompts.to_vec(), true)
+            .expect("direct HF batch encode");
+        let actual_batch = selected
+            .encode_batch(&prompts)
+            .expect("selected batch encode");
+        assert_eq!(actual_batch.len(), expected_batch.len());
+        for (actual, expected) in actual_batch.iter().zip(&expected_batch) {
+            assert!(matches!(actual, Encoding::Hf(_)));
+            assert_eq!(actual.token_ids(), expected.get_ids());
+        }
+
+        let ids = actual_batch[0].token_ids();
+        let bos = direct.token_to_id("<s>").expect("BOS id");
+        let eos = direct.token_to_id("</s>").expect("EOS id");
+        assert_eq!(ids.first(), Some(&bos));
+        assert_eq!(ids.last(), Some(&eos));
+        assert_eq!(ids.iter().filter(|&&id| id == bos).count(), 1);
+        assert_eq!(ids.iter().filter(|&&id| id == eos).count(), 1);
+
+        let worker_encoder = HfEncoder::new(selected);
+        let worker_ids = worker_encoder.encode(prompts[0]).expect("worker encode");
+        assert_eq!(
+            worker_ids,
+            expected_batch[0]
+                .get_ids()
+                .iter()
+                .map(|&id| id as i32)
+                .collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- upgrade the Rust server to dynamo-tokenizers 1.5.1
- construct the encode-pool tokenizer once with add_special_tokens=true, which selects the plain HuggingFace backend without a CachedTokenizer wrapper
- keep the detokenizer on default tokenizer options and leave CachedTokenizer unchanged
- add offline SGLang coverage for HF backend selection, repeated scalar parity, batch parity, and exactly-once BOS/EOS around multiple chat-boundary tokens

## Test Plan

- cargo test tokenizer::tests::add_special_tokens_encoder_matches_direct_hf --lib
- cargo test --lib
- cargo test --doc
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29266332621](https://github.com/sgl-project/sglang/actions/runs/29266332621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29266333260](https://github.com/sgl-project/sglang/actions/runs/29266333260)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->