### PR TITLE
Fix MockDSV4ModelRunner missing spec_algorithm

### DIFF
--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
@@ -17,8 +17,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
-from torch import nn
-
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.attention_registry import ATTENTION_BACKENDS
 from sglang.srt.layers.attention.dsv4.quant_k_cache import (
@@ -35,6 +33,8 @@ from sglang.srt.model_executor.cuda_graph_config import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.runtime_context import get_context, get_parallel
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from torch import nn
 
 # DSV4 backend pre-resolves attention TP at construction; pin to single-rank.
 _parallel_override = get_parallel().override(
@@ -410,6 +410,7 @@ class MockDSV4ModelRunner:
         self.sliding_window_size = DSV4_SWA_WINDOW
         self.use_mla_backend = True
         self.is_draft_worker = False
+        self.spec_algorithm = SpeculativeAlgorithm.NONE
         self._kernel_warmed_up = True
 
     @property

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
@@ -17,6 +17,8 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+from torch import nn
+
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.attention_registry import ATTENTION_BACKENDS
 from sglang.srt.layers.attention.dsv4.quant_k_cache import (
@@ -34,7 +36,6 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from torch import nn
 
 # DSV4 backend pre-resolves attention TP at construction; pin to single-rank.
 _parallel_override = get_parallel().override(


### PR DESCRIPTION
## Motivation
DSpark (#30261) switched `DeepseekV4AttnBackend.__init__` from reading
`server_args.speculative_algorithm` to `model_runner.spec_algorithm`, which the
attention-unittest mock runner does not define, so every dsv4 backend construction
through the kit crashes with `AttributeError: 'MockDSV4ModelRunner' object has no
attribute 'spec_algorithm'` (e.g. all `dsv4_c4_*` cases in
`test/registered/attention/unittests/dsv4/test_deepseek_v4.py`). This breaks CI for
every PR based on current main.

## Modifications
Give the mock `SpeculativeAlgorithm.NONE`, matching the pre-DSpark behavior for
non-spec cases: the old gate was `server_args.speculative_algorithm is not None`,
which the mock overrides to `None`, so with `NONE` the new gate resolves identically
(`needs_cpu_seq_lens` unset, `is_dspark_draft` False). One attribute plus its import in
`python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py`;
`is_draft_worker`, the other attribute the new code reads, was already defined.

## Accuracy Tests
N/A — test-kit-only change; no runtime code touched.

## Speed Tests and Profiling
N/A.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (This PR repairs the existing dsv4 attention unit tests themselves.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29281398333](https://github.com/sgl-project/sglang/actions/runs/29281398333)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29281398028](https://github.com/sgl-project/sglang/actions/runs/29281398028)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->