### PR TITLE
[sglang] Fix DSA indexer page/token granularity in move_kv_cache

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -3221,10 +3221,50 @@ class DSATokenToKVPool(MLATokenToKVPool):
         if tgt_loc.numel() == 0:
             return
 
-        tgt_loc_flat = tgt_loc.view(-1).long()
-        src_loc_flat = src_loc.view(-1).long()
+        # index_k_with_scale_buffer is page-indexed: each row holds a whole page
+        # of `page_size` tokens laid out as
+        #   [page_size * index_head_dim fp8-K bytes | page_size * 4 fp32-scale bytes].
+        # tgt_loc/src_loc are per-token slot indices, so a token at slot `loc`
+        # lives in row `loc // page_size` at within-page offset `loc % page_size`
+        # (matching index_buf_accessor.SetK/SetS). Indexing the buffer's row axis
+        # with the raw token slot would move the wrong rows and corrupt the
+        # indexer relative to the latent KV, so translate each token to its
+        # (page, offset) byte range and move the per-token K and scale slices.
+        tgt_byte_indices = self._indexer_byte_gather_indices(tgt_loc.view(-1).long())
+        src_byte_indices = self._indexer_byte_gather_indices(src_loc.view(-1).long())
         for index_k in self.index_k_with_scale_buffer:
-            index_k[tgt_loc_flat] = index_k[src_loc_flat]
+            flat_buf = index_k.view(-1)
+            flat_buf[tgt_byte_indices] = flat_buf[src_byte_indices]
+
+    def _indexer_byte_gather_indices(self, loc: torch.Tensor) -> torch.Tensor:
+        """Flat byte indices into a single index_k_with_scale_buffer layer for the
+        per-token K and scale slices of the tokens in `loc`.
+
+        Returns a 1-D int64 tensor addressing, for every token, its
+        `index_head_dim` K bytes followed by its `num_s_bytes_per_token` scale
+        bytes within the token's page row.
+        """
+        num_k_bytes_per_token = self.index_head_dim
+        num_s_bytes_per_token = self.index_head_dim // self.quant_block_size * 4
+        buf_numel_per_page = (
+            self.page_size * num_k_bytes_per_token
+            + self.page_size * num_s_bytes_per_token
+        )
+        s_offset_in_page = self.page_size * num_k_bytes_per_token
+
+        page_index = loc // self.page_size
+        offset_in_page = loc % self.page_size
+        page_base = page_index * buf_numel_per_page
+
+        k_start = page_base + offset_in_page * num_k_bytes_per_token
+        k_bytes = k_start[:, None] + torch.arange(
+            num_k_bytes_per_token, device=loc.device
+        )
+        s_start = page_base + s_offset_in_page + offset_in_page * num_s_bytes_per_token
+        s_bytes = s_start[:, None] + torch.arange(
+            num_s_bytes_per_token, device=loc.device
+        )
+        return torch.cat([k_bytes, s_bytes], dim=1).view(-1)
 
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layer_transfer_counter is not None:

--- a/test/registered/unit/mem_cache/test_dsa_indexer_move.py
+++ b/test/registered/unit/mem_cache/test_dsa_indexer_move.py
@@ -1,0 +1,117 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Regression tests for DSA-indexer token moves in a page-indexed buffer."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool, MLATokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+PAGE_SIZE = 64
+INDEX_HEAD_DIM = 128
+QUANT_BLOCK_SIZE = 128
+S_BYTES = INDEX_HEAD_DIM // QUANT_BLOCK_SIZE * 4
+PER_PAGE = PAGE_SIZE * INDEX_HEAD_DIM + PAGE_SIZE * S_BYTES
+S_OFFSET_IN_PAGE = PAGE_SIZE * INDEX_HEAD_DIM
+
+
+def _pool_stub(num_pages: int) -> DSATokenToKVPool:
+    pool = object.__new__(DSATokenToKVPool)
+    pool.page_size = PAGE_SIZE
+    pool.index_head_dim = INDEX_HEAD_DIM
+    pool.quant_block_size = QUANT_BLOCK_SIZE
+
+    buf = torch.zeros((num_pages, PER_PAGE), dtype=torch.uint8)
+    for row in range(num_pages):
+        for offset in range(PAGE_SIZE):
+            slot = row * PAGE_SIZE + offset
+            buf[row, offset * INDEX_HEAD_DIM : (offset + 1) * INDEX_HEAD_DIM] = (
+                slot % 256
+            )
+            scale_start = S_OFFSET_IN_PAGE + offset * S_BYTES
+            buf[row, scale_start : scale_start + S_BYTES] = (slot % 256) ^ 0xA5
+    pool.index_k_with_scale_buffer = [buf]
+    return pool
+
+
+def _token_bytes(buf: torch.Tensor, loc: int) -> torch.Tensor:
+    row, offset = divmod(loc, PAGE_SIZE)
+    key = buf[row, offset * INDEX_HEAD_DIM : (offset + 1) * INDEX_HEAD_DIM]
+    scale_start = S_OFFSET_IN_PAGE + offset * S_BYTES
+    scale = buf[row, scale_start : scale_start + S_BYTES]
+    return torch.cat([key, scale])
+
+
+def _move_indexer(
+    pool: DSATokenToKVPool, target: torch.Tensor, source: torch.Tensor
+) -> None:
+    with patch.object(MLATokenToKVPool, "move_kv_cache"):
+        pool.move_kv_cache(target, source)
+
+
+class TestDSAIndexerMove(CustomTestCase):
+    def test_scattered_non_page_aligned_tokens_are_relocated(self):
+        pool = _pool_stub(num_pages=10)
+        before = pool.index_k_with_scale_buffer[0].clone()
+        source = torch.tensor([200, 5, 130, 511, 64, 383, 7, 448])
+        target = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        expected = {
+            int(target_loc): _token_bytes(before, int(source_loc))
+            for source_loc, target_loc in zip(source, target)
+        }
+
+        _move_indexer(pool, target, source)
+
+        after = pool.index_k_with_scale_buffer[0]
+        for target_loc in target:
+            self.assertTrue(
+                torch.equal(
+                    _token_bytes(after, int(target_loc)), expected[int(target_loc)]
+                )
+            )
+
+    def test_tokens_sharing_target_pages_are_not_corrupted(self):
+        pool = _pool_stub(num_pages=10)
+        before = pool.index_k_with_scale_buffer[0].clone()
+        source = torch.tensor([200, 5, 130, 511, 64, 383, 7, 448])
+        target = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        moved = {int(target_loc) for target_loc in target}
+
+        _move_indexer(pool, target, source)
+
+        after = pool.index_k_with_scale_buffer[0]
+        for slot in range(10 * PAGE_SIZE):
+            if slot not in moved:
+                self.assertTrue(
+                    torch.equal(_token_bytes(after, slot), _token_bytes(before, slot))
+                )
+
+    def test_empty_move_is_noop(self):
+        pool = _pool_stub(num_pages=2)
+        before = pool.index_k_with_scale_buffer[0].clone()
+        empty = torch.empty(0, dtype=torch.long)
+
+        _move_indexer(pool, empty, empty)
+
+        self.assertTrue(torch.equal(pool.index_k_with_scale_buffer[0], before))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DSATokenToKVPool.move_kv_cache` moves the DSA indexer buffer while the main KV cache move is expressed in token slots. The DSA indexer buffer is page-indexed and stores per-token key bytes plus per-token scale bytes inside each page, so using token locations directly can move the wrong byte ranges for non-page-aligned or scattered tokens.

## Modifications

- Translate source and target token locations into page rows and page-local offsets before moving the DSA indexer buffer.
- Move both the key bytes and scale bytes for each token slot without overwriting neighboring tokens that share a target page.
- Add CPU unit coverage for scattered non-page-aligned moves, target-page neighbor preservation, and empty moves.

## Accuracy Tests

Not applicable. This fixes DSA indexer cache relocation bookkeeping and does not change model forward computation or expected model outputs.

## Speed Tests and Profiling

Not run. The change is scoped to cache movement correctness and adds unit coverage; no inference-speed-sensitive kernel path is changed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Local verification note: attempted `python3 -m pytest test/registered/unit/mem_cache/test_dsa_indexer_move.py -q`, but the local environment does not have `pytest` installed (`No module named pytest`).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29276483799](https://github.com/sgl-project/sglang/actions/runs/29276483799)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29276483596](https://github.com/sgl-project/sglang/actions/runs/29276483596)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->