### PR TITLE
Revert "[Tiny] Enable Full Cuda Graph with Page size = 1"

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1796,9 +1796,6 @@ def _fa4_page_constraint(view: Any) -> dict:
         # CUTLASS kernel aborts on at page_size>1. That path only works at
         # page_size==1, so skip the 128 auto-force for it and keep the default.
         and (view.speculative_eagle_topk or 0) <= 1
-        # The full prefill CUDA graph runs the FA backend at page_size==1 only
-        # (#27988), so skip the 128 auto-force for it and keep the default.
-        and view.cuda_graph_config.prefill.backend != Backend.FULL
     ):
         logger.warning(
             f"FA4 backend only supports page size 128 for non-MLA model architectures, changing page_size from {view.page_size} to 128."


### PR DESCRIPTION
Reverts sgl-project/sglang#30835. It breaks CI: https://github.com/sgl-project/sglang/actions/runs/29276578199/job/86907146007?pr=29981











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29277303971](https://github.com/sgl-project/sglang/actions/runs/29277303971)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29277303840](https://github.com/sgl-project/sglang/actions/runs/29277303840)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->