### PR TITLE
[AMD][DI][CI] Pin Kimi-K2.6 disagg to known-good image (mitigate non-MTP GSM8K regression)

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -145,6 +145,9 @@ jobs:
           # Manual dispatch input wins; otherwise use the latest image resolved
           # by the setup job; otherwise the launcher falls back to the recipe default.
           IMAGE_OVERRIDE: ${{ inputs.image != '' && inputs.image || needs.setup.outputs.image }}
+          # 1 only when a human passed an explicit image; lets that force-win over
+          # a recipe's `pin_image`, while a resolved-latest does not.
+          IMAGE_INPUT_EXPLICIT: ${{ inputs.image != '' && '1' || '0' }}
           # Keep the scheduler off mia1-p01-g20: its ionic RDMA driver ABI
           # mismatches the container, so MORI reports "no active RDMA device"
           # and the disagg server dies on init. Remove once the node is fixed.

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -168,15 +168,21 @@ fi
 eval "$RECIPE_VARS"
 # Optional image override from workflow_dispatch input / setup-resolved latest.
 # A recipe with `runtime.pin_image: true` keeps its pinned image (a known-good
-# pin wins over the dynamically resolved latest). An explicit manual
-# workflow_dispatch `image` input still wins over everything, so a human can
-# force any image for a one-off run.
-if [[ -n "${IMAGE_OVERRIDE:-}" ]]; then
-    if [[ "${PIN_IMAGE:-0}" == "1" && "${IMAGE_INPUT_EXPLICIT:-0}" != "1" ]]; then
+# pin wins over the dynamically resolved latest) AND runs that image's coherent
+# baked sglang (checkout-runtime forced off): an OLD pinned image's kernels
+# won't match the checked-out (newer) python, so reinstalling the checkout would
+# ABI-crash the server. An explicit manual workflow_dispatch `image` input still
+# wins over everything (and leaves checkout-runtime as-is), so a human can force
+# any image for a one-off run.
+if [[ "${PIN_IMAGE:-0}" == "1" && "${IMAGE_INPUT_EXPLICIT:-0}" != "1" ]]; then
+    [[ -n "${IMAGE_OVERRIDE:-}" ]] && \
         echo "recipe pins image=$IMAGE; ignoring resolved override $IMAGE_OVERRIDE"
-    else
-        IMAGE="$IMAGE_OVERRIDE"
+    if [[ "$SGLANG_USE_CHECKOUT_RUNTIME" == "1" ]]; then
+        echo "pin_image: forcing SGLANG_USE_CHECKOUT_RUNTIME=0 to use the pinned image's coherent baked sglang"
+        SGLANG_USE_CHECKOUT_RUNTIME=0
     fi
+elif [[ -n "${IMAGE_OVERRIDE:-}" ]]; then
+    IMAGE="$IMAGE_OVERRIDE"
 fi
 echo "recipe: image=$IMAGE attn=${ATTN:-$PATTN/$DATTN} ib=$IB ptp=$PTP dtp=$DTP concs=$CONCS isl=$ISL osl=$OSL"
 

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -107,6 +107,11 @@ rt = r["runtime"]; b = r["backend"]["sglang_config"]; bn = r["bench"]
 res = r.get("resources", {})
 def emit(k, v): print(f"{k}={v}")
 emit("IMAGE", rt["image"])
+# When true, the recipe's pinned image wins over the workflow's dynamically
+# resolved "latest" image (IMAGE_OVERRIDE). Used to hold a model on a known-good
+# image while a newer-image regression is investigated. Absent/false = prior
+# behavior (dynamic latest wins).
+emit("PIN_IMAGE", 1 if rt.get("pin_image") else 0)
 # Attention backend: single (`attention_backend`) or split
 # (`prefill_attention_backend`/`decode_attention_backend`). Empty when absent so
 # the flag is dropped for a model that omits it.
@@ -161,9 +166,17 @@ if [[ -z "$RECIPE_VARS" ]]; then
     exit 1
 fi
 eval "$RECIPE_VARS"
-# Optional image override from workflow_dispatch input.
+# Optional image override from workflow_dispatch input / setup-resolved latest.
+# A recipe with `runtime.pin_image: true` keeps its pinned image (a known-good
+# pin wins over the dynamically resolved latest). An explicit manual
+# workflow_dispatch `image` input still wins over everything, so a human can
+# force any image for a one-off run.
 if [[ -n "${IMAGE_OVERRIDE:-}" ]]; then
-    IMAGE="$IMAGE_OVERRIDE"
+    if [[ "${PIN_IMAGE:-0}" == "1" && "${IMAGE_INPUT_EXPLICIT:-0}" != "1" ]]; then
+        echo "recipe pins image=$IMAGE; ignoring resolved override $IMAGE_OVERRIDE"
+    else
+        IMAGE="$IMAGE_OVERRIDE"
+    fi
 fi
 echo "recipe: image=$IMAGE attn=${ATTN:-$PATTN/$DATTN} ib=$IB ptp=$PTP dtp=$DTP concs=$CONCS isl=$ISL osl=$OSL"
 

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp.yaml
@@ -54,6 +54,12 @@ mtp:
 
 runtime:
   image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  # MITIGATION: hold Kimi-K2.6 on this known-good image. The newer (dynamically
+  # resolved "latest") MI35x images regressed non-MTP disagg GSM8K to ~0.88
+  # (this Jun-23 image = 0.941; see the image-vs-code bisect). pin_image makes
+  # this pinned image win over the workflow's resolved-latest so the scheduled
+  # nightly is green; remove once the image regression is fixed upstream.
+  pin_image: true
   # Kimi uses split attention backends (aiter prefill / triton decode), not a
   # single --attention-backend.
   prefill_attention_backend: aiter

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d.yaml
@@ -44,6 +44,12 @@ model:
 
 runtime:
   image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260623
+  # MITIGATION: hold Kimi-K2.6 on this known-good image. The newer (dynamically
+  # resolved "latest") MI35x images regressed non-MTP disagg GSM8K to ~0.88
+  # (this Jun-23 image = 0.941; see the image-vs-code bisect). pin_image makes
+  # this pinned image win over the workflow's resolved-latest so the scheduled
+  # nightly is green; remove once the image regression is fixed upstream.
+  pin_image: true
   # Kimi uses split attention backends (aiter prefill / triton decode), not a
   # single --attention-backend.
   prefill_attention_backend: aiter


### PR DESCRIPTION
## Summary

> ✅ **Verified green**: scheduled-style dispatch on this branch passed at **GSM8K 0.939** (> 0.92 gate) — [run 29282616011](https://github.com/sgl-project/sglang/actions/runs/29282616011).

The `Nightly Test (AMD MI355X 2N 1P1D Disagg)` Kimi-K2.6 **non-MTP** GSM8K regressed to **~0.88** (< 0.92 gate); MTP stays ~0.95 and single-node is **0.947**.

A code-vs-image bisect (diagnostic PR #30433) isolated the regression to the **docker image, not sglang code**:

| python | image | GSM8K |
| --- | --- | --- |
| main | resolved-latest | 0.887 |
| srt @67361ff | resolved-latest | 0.879 |
| full @67361ff | **Jun-23 (`v0.5.13.post1-...-20260623`)** | **0.941** |

So the same code on the Jun-23 image = 0.941, but on newer images = ~0.88. The drop is disagg-specific (single-node unaffected) and lives in the image (aiter / ROCm / sgl-kernel).

## Why a launcher change is needed

The disagg workflow's `setup` job resolves the *latest* MI35x image and passes it as `IMAGE_OVERRIDE`, which the launcher applies over each recipe's `runtime.image`. So pinning the recipe image alone does nothing for the scheduled nightly — the override always wins.

## Modifications

- `launch_mi355x.sh`: add opt-in `runtime.pin_image`. When true, the recipe's pinned image wins over the resolved-latest `IMAGE_OVERRIDE`. An **explicit** `workflow_dispatch` `image` input still force-wins (via `IMAGE_INPUT_EXPLICIT`), so humans can still test any image.
- `nightly-amd-mi355x-disagg.yml`: pass `IMAGE_INPUT_EXPLICIT` (1 only when a human supplied `image`).
- Kimi-K2.6 `1p1d.yaml` + `1p1d-mtp.yaml`: set `pin_image: true`, pinned to the Jun-23 known-good image.

Override truth table (verified): `pin=0` → latest (DSV4 etc. unchanged); `pin=1` + scheduled → recipe Jun-23 (mitigation); `pin=1` + explicit input → human image wins.

## Scope / follow-up

- Stopgap only — **revert once the image regression is fixed upstream**.
- DSV4 recipes are unaffected (no `pin_image`; still track latest).
- Image-tag bisect (Jun-23 good → latest bad) to find the first bad build is in progress; the `v0.5.13.post1 → v0.5.14` bump at Jun-26 is the prime suspect.

## Note: pin_image also disables checkout-runtime

The disagg CI reinstalls the checked-out (main) python into the container via checkout-runtime. A pinned **old** image's kernels (sgl-kernel/aiter) don't match main python, so the reinstall ABI-crashes the server at init (first verify attempt hit exactly this: `server exited early before bench`). Since the regression is in the image's baked kernels — and those are what newer python requires — the only coherent known-good is the **old image + its own baked python** (the Jun-23 build that scored 0.941, run with no checkout-runtime). So when `pin_image` wins, the launcher now also forces `SGLANG_USE_CHECKOUT_RUNTIME=0` to run that image's coherent baked sglang.

Trade-off: the pinned Kimi legs test the Jun-23 baked build, not current main — an acceptable stopgap to keep the nightly green until the image regression is fixed; DSV4 legs still track latest + checkout-runtime unchanged.

## Test plan

- [x] Launcher override truth table verified locally for all `pin_image`/explicit combinations.
- [x] Recipe + workflow YAML parse.
- [x] Dispatched scheduled-style (no `image` input) on this branch: pin_image held Kimi non-MTP on the Jun-23 image (checkout-runtime auto-off) and **passed at GSM8K 0.939** ([run 29282616011](https://github.com/sgl-project/sglang/actions/runs/29282616011)). Nightly is green again.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29282593870](https://github.com/sgl-project/sglang/actions/runs/29282593870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29282593600](https://github.com/sgl-project/sglang/actions/runs/29282593600)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


