### PR TITLE
fix: include OpenSSL headers in runtime image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -805,7 +805,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
     libcurl4 \
     libczmq4 \
     libfabric1 \
-    libssl3 \
+    libssl-dev \
     # RDMA runtime
     rdma-core \
     infiniband-diags \


### PR DESCRIPTION
<!-- codex-pr-description:start -->
The SGLang runtime image now installs `libssl-dev` instead of only `libssl3`. This supplies the OpenSSL headers and linker metadata required when the HiCache native hash extension JIT-compiles at runtime.

### How This Was Implemented

- Replace the runtime-stage `libssl3` package with `libssl-dev`.
- Rely on `libssl-dev`'s exact-version dependency to retain the matching `libssl3` runtime library.
- Leave the builder and unrelated runtime dependencies unchanged.

<details>
<summary>Walkthrough</summary>

#### Mental model

The HiCache native hash loader compiles `hash_binding.cpp` with `torch.utils.cpp_extension.load`. That source includes `openssl/sha.h` and links `-lcrypto`, so the production image needs both the runtime library and its development files.

#### Boundaries and limitations

This only changes the CUDA production runtime image package set. It does not change hashing behavior or precompile the extension.

</details>

### Validation

- `pre-commit run --files docker/Dockerfile`
- `git diff --check`
- Full runtime image build not run locally; it is covered by the repository image CI.
<!-- codex-pr-description:end -->











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29279629183](https://github.com/sgl-project/sglang/actions/runs/29279629183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29279628771](https://github.com/sgl-project/sglang/actions/runs/29279628771)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->