### PR TITLE
glm 5.2 lora fp8 rollout fix

### DIFF
--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -441,6 +441,46 @@ class LoRAMemoryPool:
         q_per_rank = divide(q_dim_total, effective_tp_size)
         return q_per_rank + 2 * head_dim
 
+    def _column_parallel_out_partition(
+        self, module_name: str, base_model: torch.nn.Module, layer_idx: int
+    ) -> Optional[int]:
+        """actual per-rank output dim of a non-MoE column-parallel base module.
+
+        """
+        cache = getattr(self, "_col_parallel_out_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_col_parallel_out_cache", cache)
+        key = (module_name, layer_idx)
+        if key in cache:
+            return cache[key]
+
+        layer_markers = (f".layers.{layer_idx}.", f"layers.{layer_idx}.")
+
+        def _probe(m):
+            ops = getattr(m, "output_size_per_partition", None)
+            if ops is not None and ops > 0:
+                return ops
+            inner = getattr(m, "base_layer", None)
+            if inner is not None and inner is not m:
+                return _probe(inner)
+            return None
+
+        suffix = f".{module_name}"
+        found = None
+        for _name, module in base_model.named_modules():
+            if not _name.endswith(suffix):
+                continue
+            if not any(marker in _name for marker in layer_markers):
+                continue
+            r = _probe(module)
+            if r is not None:
+                found = r
+                break
+
+        cache[key] = found
+        return found
+
     def get_lora_B_shape(
         self,
         module_name: str,
@@ -463,10 +503,27 @@ class LoRAMemoryPool:
             self.moe_tp_size if self.is_moe_module(module_name) else self.tp_size
         )
         if (
+            module_name not in ROW_PARALLELISM_LINEAR_LORA_NAMES
+            and module_name not in REPLICATED_LINEAR_LORA_NAMES
+            and not self.is_moe_module(module_name)
+        ):
+            # prefer base module's actual per-rank output dim over based on global tp_size
+            # column-parallel bases may be fully replicated (dense/shared gate_up if --moe-dense-tp-size 1)
+            probed_out = self._column_parallel_out_partition(
+                module_name, base_model, layer_idx
+            )
+            if probed_out is not None:
+                output_dim = probed_out
+            elif effective_tp_size > 1:
+                output_dim = self._column_parallel_lora_b_per_rank_dim(
+                    module_name, output_dim, effective_tp_size
+                )
+        elif (
             effective_tp_size > 1
             and module_name not in ROW_PARALLELISM_LINEAR_LORA_NAMES
             and module_name not in REPLICATED_LINEAR_LORA_NAMES
         ):
+            # MoE modules keep the moe_tp_size sharding path.
             output_dim = self._column_parallel_lora_b_per_rank_dim(
                 module_name, output_dim, effective_tp_size
             )


### PR DESCRIPTION
Fix LoRA-B buffer sizing for quantized column-parallel layers

## Motivation
Serving a LoRA adapter on an FP8-quantized base (--quantization fp8 --lora-paths ...) crashes at engine init when the adapter targets a fused column-parallel module:

`ValueError: LoRA B output dim 4096 does not match base partition prefix dim 2048 for 2 slices`

I encountered this error when trying to train GLM-5.2 with LoRA on gate_proj/up_proj, TP > 1 with sglang fp8 rollouts (--quantization fp8). The identical configuration works in bf16 with no fp8 rollout. 

## Root cause
LoRAMemoryPool.get_lora_B_shape sizes the per-rank LoRA-B buffer by dividing get_hidden_dim()'s full output dim by the TP degree, gated on heuristics that probe base-layer attributes to detect non-standard sharding (e.g. replicated dense/shared-expert gate_up_proj under --moe-dense-tp-size 1).

The probe reads input_size // input_size_per_partition. UnquantizedLinearMethod never sets input_size_per_partition, so on bf16 the probe fails and the fallback path computes the correct per-rank dim. Fp8LinearMethod.create_weights does set layer.input_size_per_partition — and for a column-parallel layer input is unsharded, so the ratio is 1. The probe then reports "unsharded", the split is skipped, and B is allocated at the full output dim against a TP-sharded base. Then the error arises when set_lora_info correctly rejects the mismatch (shared_experts.gate_up_proj: B = 4096 vs per-rank output_partition_sizes = [1024, 1024]).

## Modifications
Add _column_parallel_out_partition(): Resolve matching base modele per (module_name, layer_idx) and read output_size_per_partition (same quantity validated against in set_lora_info). 

In get_lora_B_shape, for non-MoE column-parallel modules, use the probed per-rank dim directly, and fall back to the existing _column_parallel_lora_b_per_rank_dim arithmetic (which retains the qkv_proj KV-head-replication special case) only when no base module can be probed. MoE modules keep the moe_tp_size path unchanged. For bf16, the probed value equals what previous path computed in all preexisting working configs. 

## Validation
Pre-fix: crash at lora/layers.py set_lora_info on GLM-5.2 5-layer, TP2, FP8 (module mlp.shared_experts.gate_up_proj, Fp8LinearMethod, B=(4096,16) vs partitions [1024,1024]); same crash at TP32 ([64,64], prefix 128).
Post-fix: same configs load, attach, serve, and run RL rollout + LoRA weight-sync end-to-end at 4-GPU and 64-GPU scale; bf16 runs unchanged.

The training scripts are separate and run Miles on top of Modal -- if necessary I can create a repro of serving GLM5.2 Lora via sglang with and without this fix. Thanks!



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #29280640163](https://github.com/sgl-project/sglang/actions/runs/29280640163)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #29280639826](https://github.com/sgl-project/sglang/actions/runs/29280639826)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->