### PR TITLE
[AMD] ci: detect and recover hung GPUs in MI35x pre-flight

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -557,6 +557,9 @@ jobs:
       - name: Ensure VRAM is clear
         run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
 
+      - name: Probe GPU health
+        run: bash scripts/ci/amd/check_gpu_health.sh
+
       - name: Start CI container
         run: bash scripts/ci/amd/amd_ci_start_container.sh
         env:
@@ -1146,6 +1149,9 @@ jobs:
       - name: Ensure VRAM is clear
         run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
 
+      - name: Probe GPU health
+        run: bash scripts/ci/amd/check_gpu_health.sh
+
       - name: Start CI container
         run: bash scripts/ci/amd/amd_ci_start_container.sh
         env:
@@ -1187,6 +1193,9 @@ jobs:
 
       - name: Ensure VRAM is clear
         run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Probe GPU health
+        run: bash scripts/ci/amd/check_gpu_health.sh
 
       - name: Check Host RDMA Environment
         id: rdma_detect

--- a/scripts/ci/amd/check_gpu_health.sh
+++ b/scripts/ci/amd/check_gpu_health.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+#
+# Detect and (optionally) recover *hung / unresponsive* AMD GPUs during CI
+# pre-flight.
+#
+# Relationship to ensure_vram_clear.sh:
+#   * ensure_vram_clear.sh targets *leaked VRAM* -- memory allocated with no
+#     owning process (the ROCm/aiter#2061 zombie-KFD signature).
+#   * THIS script targets a *hung* GPU -- one that is unresponsive or has logged
+#     a hardware fault -- which can wedge a node even when VRAM reads clean.
+#     A hung GPU is the usual cause of the exit-134 "HW Exception ... reason:
+#     GPU Hang" failures seen on the MI35x runners; landing a job on such a GPU
+#     just fails again until the device is reset or the node is rebooted.
+#
+# Detection is host-level (no container / HIP runtime required):
+#   1. rocm-smi responsiveness -- a per-device query that times out or errors is
+#      a strong signal the GPU/driver is not responding. Repeated to avoid
+#      transient false positives under load.
+#   2. Kernel log (dmesg) signatures -- best-effort, node-level: recent amdgpu
+#      ring timeouts / GPU reset / page faults / "GPU hang". Used only to
+#      corroborate / bias toward recovery, never as the sole gate (dmesg lines
+#      map to PCI/DRM ids, not rocm-smi indices, and may be unreadable in a pod).
+#
+# Recovery: a scoped `rocm-smi --gpureset -d <idx>`, applied ONLY to a GPU that
+#   (a) looks hung AND (b) has no process holding its device files. The
+#   device-file guard means we never reset a GPU another tenant is actively
+#   using -- a GPU running someone else's job always has a holder. (A hung GPU
+#   whose stuck process is still attached is intentionally NOT auto-reset here;
+#   we warn and let the operator / ensure_vram_clear kill the holder first.)
+#
+# Behaviour is gated by AMD_CI_GPU_HANG_RESET:
+#   auto (default) : detect + attempt guarded reset; abort (exit 1) only if a
+#                    confirmed hang could not be recovered.
+#   warn           : detect + report only, never reset, never fail the job.
+#   0/off/false    : disable entirely (no-op, exit 0).
+#
+# Exit codes:
+#   0 - all target GPUs healthy, or a hung GPU was recovered, or disabled/warn.
+#   1 - a GPU is hung and could not be recovered (node needs drain / reboot).
+
+set -uo pipefail
+
+# ------------------------------------------------------------------ config ----
+SMI_QUERY_TIMEOUT="${SMI_QUERY_TIMEOUT:-20}"   # per rocm-smi probe, seconds
+GPU_RESET_TIMEOUT="${GPU_RESET_TIMEOUT:-90}"   # per rocm-smi --gpureset, seconds
+PROBE_RETRIES="${PROBE_RETRIES:-3}"            # confirmations before "hung"
+PROBE_RETRY_WAIT="${PROBE_RETRY_WAIT:-5}"      # seconds between probe retries
+DMESG_TAIL_LINES="${DMESG_TAIL_LINES:-2000}"
+
+# --------------------------------------------------------------- utilities ----
+log() { echo "[gpu-health] $*"; }
+
+# All GPU indices rocm-smi knows about (one per line).
+_all_gpu_indices() {
+    command -v rocm-smi >/dev/null 2>&1 || return 0
+    timeout "$SMI_QUERY_TIMEOUT" rocm-smi --showid 2>/dev/null \
+        | grep -oE 'GPU\[[0-9]+\]' | grep -oE '[0-9]+' | sort -un
+}
+
+# Probe a single GPU's responsiveness once.
+# Returns 0 if the device answered a lightweight query, non-zero otherwise
+# (124 = rocm-smi itself timed out => strongly suggests a wedged device/driver).
+_probe_gpu_once() {
+    local idx="$1" out rc
+    out=$(timeout "$SMI_QUERY_TIMEOUT" rocm-smi -d "$idx" --showuse --showmemuse 2>&1)
+    rc=$?
+    if [ "$rc" -eq 124 ]; then
+        return 124   # timed out -> unresponsive
+    fi
+    if [ "$rc" -ne 0 ]; then
+        return 1     # rocm-smi errored for this device
+    fi
+    # A responsive device reports a numeric "GPU use (%)" and/or VRAM% line.
+    # Treat explicit error strings as unhealthy even on rc==0.
+    if echo "$out" | grep -qiE 'unable to|not responding|error|failed'; then
+        return 1
+    fi
+    if ! echo "$out" | grep -qE 'GPU (use|Memory Allocated)'; then
+        return 1     # no usable telemetry came back
+    fi
+    return 0
+}
+
+# Confirm a GPU is hung across PROBE_RETRIES attempts (avoids transient blips).
+_gpu_is_hung() {
+    local idx="$1" attempt rc
+    for attempt in $(seq 1 "$PROBE_RETRIES"); do
+        if _probe_gpu_once "$idx"; then
+            return 1   # answered at least once -> not hung
+        fi
+        rc=$?
+        log "GPU ${idx}: unresponsive probe ${attempt}/${PROBE_RETRIES} (rc=${rc})"
+        [ "$attempt" -lt "$PROBE_RETRIES" ] && sleep "$PROBE_RETRY_WAIT"
+    done
+    return 0   # never answered -> hung
+}
+
+# Best-effort: does the kernel log show recent GPU-hang/reset signatures?
+# Node-level only (not per-index). Returns 0 if signatures are present.
+_dmesg_shows_hang() {
+    command -v dmesg >/dev/null 2>&1 || return 1
+    dmesg 2>/dev/null | tail -n "$DMESG_TAIL_LINES" \
+        | grep -qiE 'ring .*timeout|gpu reset|GPU hang|amdgpu.*(reset|fault)|VM_L2.*fault|MES.*failed'
+}
+
+# PIDs (host namespace) holding any GPU device file. Empty => no host holder.
+# NOTE: cannot see into container PID namespaces; in CI the container is stopped
+# before this runs, so an empty result means the GPU is genuinely unowned.
+_gpu_device_holders() {
+    local pids=""
+    if command -v fuser >/dev/null 2>&1; then
+        pids+=" $(fuser /dev/kfd 2>/dev/null || true)"
+        for dev in /dev/dri/renderD*; do
+            [ -e "$dev" ] || continue
+            pids+=" $(fuser "$dev" 2>/dev/null || true)"
+        done
+    elif command -v lsof >/dev/null 2>&1; then
+        pids+=" $(lsof -t /dev/kfd 2>/dev/null || true)"
+        for dev in /dev/dri/renderD*; do
+            [ -e "$dev" ] || continue
+            pids+=" $(lsof -t "$dev" 2>/dev/null || true)"
+        done
+    fi
+    echo "$pids" | tr ' ' '\n' | grep -E '^[0-9]+$' | sort -u || true
+}
+
+# --------------------------------------------------------------- main flow ----
+check_gpu_health() {
+    local mode="${AMD_CI_GPU_HANG_RESET:-auto}"
+    case "${mode,,}" in
+        0|false|off|no|disable|disabled)
+            log "GPU hang probe disabled (AMD_CI_GPU_HANG_RESET=${mode}); skipping."
+            return 0
+            ;;
+    esac
+
+    if ! command -v rocm-smi >/dev/null 2>&1; then
+        log "rocm-smi not available; cannot probe GPU health (skipping)."
+        return 0
+    fi
+
+    log "=== GPU health probe on $(hostname) ($(date -u +%FT%TZ)) ==="
+
+    local gpus
+    gpus=$(_all_gpu_indices)
+    if [ -z "$gpus" ]; then
+        log "No GPUs enumerated by rocm-smi; nothing to probe."
+        return 0
+    fi
+
+    if _dmesg_shows_hang; then
+        log "NOTE: kernel log shows recent GPU hang/reset/fault signatures on this node."
+    fi
+
+    # Phase 1: identify hung GPUs.
+    local hung=() idx
+    for idx in $gpus; do
+        if _gpu_is_hung "$idx"; then
+            log "GPU ${idx}: HUNG (unresponsive after ${PROBE_RETRIES} probes)."
+            hung+=("$idx")
+        fi
+    done
+
+    if [ "${#hung[@]}" -eq 0 ]; then
+        log "All GPUs responsive; no hang detected."
+        return 0
+    fi
+
+    # warn mode: report only.
+    if [ "${mode,,}" = "warn" ]; then
+        log "WARN mode: hung GPU(s) [${hung[*]}] detected; not resetting."
+        log "Set AMD_CI_GPU_HANG_RESET=auto to enable scoped recovery."
+        return 1
+    fi
+
+    # Phase 2: attempt guarded, scoped recovery.
+    local holders unrecovered=()
+    for idx in "${hung[@]}"; do
+        holders=$(_gpu_device_holders)
+        if [ -n "$holders" ]; then
+            # A stuck process still owns a GPU device file. Resetting now could
+            # disturb it (or another tenant). Leave it to the operator /
+            # ensure_vram_clear to clear holders first.
+            log "GPU ${idx}: hung but device-file holders still present (PIDs: $(echo "$holders" | tr '\n' ' ')); NOT resetting."
+            unrecovered+=("$idx")
+            continue
+        fi
+
+        log "GPU ${idx}: hung with no owning process -> rocm-smi --gpureset -d ${idx}"
+        if timeout "$GPU_RESET_TIMEOUT" rocm-smi --gpureset -d "$idx" 2>&1; then
+            sleep 10
+            if _gpu_is_hung "$idx"; then
+                log "GPU ${idx}: still hung after reset."
+                unrecovered+=("$idx")
+            else
+                log "GPU ${idx}: recovered after scoped reset."
+            fi
+        else
+            log "GPU ${idx}: reset command failed/timed out."
+            unrecovered+=("$idx")
+        fi
+    done
+
+    if [ "${#unrecovered[@]}" -gt 0 ]; then
+        log "=== FAILED: GPU(s) [${unrecovered[*]}] hung and NOT recovered ==="
+        log "Node needs to be drained/rebooted before it can run jobs reliably."
+        return 1
+    fi
+
+    log "=== All hung GPUs recovered via scoped reset ==="
+    return 0
+}
+
+# Run when executed directly (not when sourced, so tests can import helpers).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    check_gpu_health "$@"
+fi


### PR DESCRIPTION
## Summary

The MI35x runners intermittently hit **GPU hangs** (`HW Exception … reason: GPU Hang`, exit 134) — e.g. during aiter kernel builds or model weight loading. A hung GPU can wedge a node **even when VRAM reads clean**, so `ensure_vram_clear.sh` (which targets *leaked VRAM*) doesn't catch it, and the next job just fails again until the device is reset or the node is rebooted.

This adds a host-level pre-flight **GPU-health probe** that detects a hung/unresponsive GPU and recovers it with a **scoped, guarded** `rocm-smi --gpureset`.

> Complementary to — and independent of — the VRAM-leak self-heal in #30431. That PR handles *leaked VRAM* (allocated, no owner); this one handles a *hung* GPU (unresponsive / HW-faulted), which is the exit-134 signature yc flagged on MI35x.

## Changes
- **New `scripts/ci/amd/check_gpu_health.sh`**:
  - **Detect**: repeated `rocm-smi` per-device queries (retries to avoid transient false positives under load), corroborated best-effort by kernel-log (`dmesg`) hang/reset/fault signatures.
  - **Recover**: scoped `rocm-smi --gpureset -d <idx>`, applied **only** to a GPU that is hung **AND** has no process holding its device files — so a GPU another tenant is actively using is never reset. A hung GPU whose stuck process is still attached is not auto-reset (warned instead).
  - **Gating** via `AMD_CI_GPU_HANG_RESET`: `auto` (detect+recover, default), `warn` (report only), `0` (disabled). Exits non-zero only when a confirmed hang can't be recovered, so the job aborts instead of running on a wedged GPU.
- **Workflow**: added a `Probe GPU health` step after `Ensure VRAM is clear` in the three **MI35x** jobs (`stage-b-test-1-gpu-small-amd-mi35x`, `stage-c-test-large-8-gpu-amd-mi35x`, `stage-b-test-large-8-gpu-mi35x-disaggregation-amd`) where the hangs occur.

## Validation
- **In CI on real MI35x hardware** — targeted dispatch [`stage-b-test-1-gpu-small-amd-mi35x` — Run #29296172463](https://github.com/sgl-project/sglang/actions/runs/29296172463): the new `Probe GPU health` step ran green in the pre-flight and correctly let the job proceed:
  ```
  [gpu-health] === GPU health probe on linux-mi35x-gpu-1-qxll6-runner-4gt2j ===
  [gpu-health] All GPUs responsive; no hang detected.
  ```
  No false positive, no needless reset. (The job's later `Run test` failure was an unrelated **mid-run** GPU hang at 00:40, ~8 min after the healthy pre-flight probe at 00:32 — see note below.)
- `rocm-smi --gpureset` privileges confirmed on an MI35x host (`Successfully reset GPU 7`, scoped `-d 7`, no impact to other GPUs/containers).
- Local checks: healthy host → `All GPUs responsive; no hang detected`; `AMD_CI_GPU_HANG_RESET=0` correctly no-ops; helper detection functions verified.
- `bash -n`, YAML validation, and `pre-commit` all pass on the changed files.

### Scope note: pre-flight vs. mid-run hangs
A pre-flight probe **cannot prevent a hang that happens during the run** (the GPU is healthy at job start; the workload triggers the hang later). Its value is **breaking the cascade**: once a job leaves a GPU wedged, the *next* job's pre-flight probe detects and resets (or cleanly aborts on) that GPU — stopping the "one hang wedges the node for every subsequent job" pattern that drives the fleet-wide OSSCI-2693 outage. A stronger in-run/in-container hang guard could be layered on later.

## Test plan
- [ ] Probe runs green on healthy MI35x runners (no false-positive resets).
- [ ] On a genuinely hung MI35x GPU with no owning process, the scoped reset recovers it (or aborts cleanly if unrecoverable).
- [ ] Confirm `warn` mode behaves as report-only.

## Notes / future work
- Detection is host-level (no container/HIP needed). A stronger in-container HIP compute smoke test could be added later.
- Once #30431 lands, the device-file-holder helper here and in `ensure_vram_clear.sh` could be de-duplicated into a shared lib.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29282514035](https://github.com/sgl-project/sglang/actions/runs/29282514035)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29358754425](https://github.com/sgl-project/sglang/actions/runs/29358754425)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
