### PR TITLE
Add dummy forward batch preparation hook

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2896,6 +2896,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def update_decode_attn_backend(self, stream_idx: int):
         self.decode_attn_backend = self.decode_attn_backend_group[stream_idx]
 
+    def prepare_dummy_forward_batch(self, forward_batch: ForwardBatch) -> ForwardBatch:
+        """Customize a runner-created dummy batch before attention metadata initialization."""
+        return forward_batch
+
     def _prepare_eager_forward_batch(self, forward_batch: ForwardBatch) -> None:
         """Pad / normalize a batch for the eager (non-cuda-graph) forward.
 

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -548,6 +548,7 @@ class BaseRunner(ABC):
         if lora_ids is not None:
             mr.lora_manager.prepare_lora_batch(forward_batch)
 
+        forward_batch = mr.prepare_dummy_forward_batch(forward_batch)
         mr.attn_backend.init_forward_metadata(forward_batch)
 
         def run_once():


### PR DESCRIPTION
## Summary

- add a no-op `ModelRunner.prepare_dummy_forward_batch` extension point
- invoke it after the runner constructs a dummy batch and before attention metadata initialization

## Motivation

Custom model runners may need to replace or enrich runner-created dummy `ForwardBatch` objects before attention backends inspect them during CUDA graph capture. Keeping the default implementation as an identity function preserves existing behavior while avoiding model-specific imports in the generic runner package.

## Testing

- focused Ruff checks for the changed files
- Python syntax compilation for the changed files





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29289537343](https://github.com/sgl-project/sglang/actions/runs/29289537343)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29289537172](https://github.com/sgl-project/sglang/actions/runs/29289537172)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->