### PR TITLE
Synchronize before releasing saved GPU memory

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -330,6 +330,11 @@ class SchedulerWeightUpdaterManager:
         if tags is None or len(tags) == 0:
             tags = GPU_MEMORY_ALL_TYPES
 
+        # During RL, the following calls to memory_saver_adapter.pause() may pause
+        # inference allocations to make room for training while asynchronous GPU work
+        # is still in flight. Synchronize before their backing memory is unmapped.
+        torch.get_device_module().synchronize()
+
         for tag in tags:
             self.offload_tags.add(tag)
 
@@ -360,8 +365,6 @@ class SchedulerWeightUpdaterManager:
 
         if GPU_MEMORY_TYPE_CUDA_GRAPH in tags:
             self.memory_saver_adapter.pause(GPU_MEMORY_TYPE_CUDA_GRAPH)
-
-        torch.get_device_module().synchronize()
 
         return ReleaseMemoryOccupationReqOutput()
 


### PR DESCRIPTION
## Summary

- Synchronize outstanding device work before torch-memory-saver `pause()`
  unmaps KV-cache, weight, or CUDA-graph allocations.
- Move the existing synchronization to the correct side of the release
  boundary; this does not add another synchronization.

## Problem

During RL, `release_memory_occupation()` can observe an idle CPU-side scheduler
while the last decode or CUDA-graph replay is still executing asynchronously
on the GPU. The previous ordering allowed torch-memory-saver to unmap an
allocation before that GPU work had finished using it.

### Before

```text
CPU
enqueue final decode / graph replay
        |
        v
is_fully_idle = True
        |
        v
TMS pause()
unmap weights / KV / graph memory
        |
        v
device synchronize()              <-- too late


GPU
final decode / graph replay is still running
-------------------X
                    accesses memory that has already been unmapped
                    -> hang or illegal memory access
```

CPU-side idleness only means that SGLang has no active requests. It does not
guarantee that all asynchronously submitted GPU work has completed.

## Fix

```text
CPU
enqueue final decode / graph replay
        |
        v
is_fully_idle = True
        |
        v
device synchronize()
wait for the GPU to finish
        |
        v
TMS pause()
safely unmap weights / KV / graph memory


GPU
final decode / graph replay completes
-------------------+ idle
                    memory can now be released safely
```

This change only fixes the release ordering. It does not change the subsequent
resume or weight-update sequence.

## Validation

- Exercised by two successful two-node GB200 online weight-update runs with
  CUDA-graph release, resume, and recapture.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
