### PR TITLE
[misc] Debug dev branch

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2174,6 +2174,32 @@ def _execute_server_warmup(server_args: ServerArgs):
     return success
 
 
+def _freeze_gc_after_warmup(server_args: ServerArgs):
+    """Broadcast gc.freeze() to all server processes via /freeze_gc.
+
+    Called once right after warmup, so the long-lived startup heap (imports,
+    weights metadata, CUDA graph bookkeeping) is moved out of gen2 GC scan
+    scope before real traffic arrives. Requests in flight at freeze time would
+    be frozen too and never reclaimed, hence warmup time only.
+    """
+    headers = {}
+    if server_args.api_key:
+        headers["Authorization"] = f"Bearer {server_args.api_key}"
+    try:
+        res = requests.post(
+            server_args.url() + "/freeze_gc",
+            timeout=120,
+            headers=headers,
+            verify=server_args.ssl_verify(),
+        )
+        assert res.status_code == 200, f"{res=}, {res.text=}"
+        logger.info("Froze GC in all server processes after warmup.")
+    except Exception:
+        logger.error(
+            f"freeze_gc after warmup failed (non-fatal): {get_exception_traceback()}"
+        )
+
+
 def _wait_and_warmup(
     server_args: ServerArgs,
     launch_callback: Optional[Callable[[], None]] = None,
@@ -2188,6 +2214,9 @@ def _wait_and_warmup(
             return
     else:
         _global_state.tokenizer_manager.server_status = ServerStatus.Up
+
+    if envs.SGLANG_GC_FREEZE_AFTER_WARMUP.get():
+        _freeze_gc_after_warmup(server_args)
 
     # The server is ready for requests
     logger.info("The server is fired up and ready to roll!")

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -211,9 +211,27 @@ class Envs:
     SGLANG_ENABLE_REQUEST_DECOMPRESSION = EnvBool(False)
     # Override parsed request fields from headers.
     SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES = EnvBool(False)
+    # Broadcast gc.freeze() to tokenizer manager, schedulers, and detokenizer
+    # once after warmup, so gen2 GC stops scanning the long-lived startup heap.
+    SGLANG_GC_FREEZE_AFTER_WARMUP = EnvBool(False)
+
+    # Scheduler GC management (see managers/scheduler_gc_manager.py):
+    # defer automatic gen-2 collections and run full GC at idle instead, so a
+    # stop-the-world pause in one TP rank cannot stall the whole TP group
+    # mid-batch.
+    # NOTE: upstream PR #28067 defaults this to True; flipped to False here so
+    # every GC-related change in this patch set is opt-in.
+    SGLANG_ENABLE_SCHEDULER_GC_MANAGEMENT = EnvBool(False)
+    SGLANG_SCHEDULER_IDLE_GC_INTERVAL = EnvFloat(300.0)
+    SGLANG_SCHEDULER_GC_GEN2_THRESHOLD = EnvInt(10000)
 
     # Logging Options
     SGLANG_LOG_GC = EnvBool(False)
+    # Log a warning when the tokenizer manager event loop wakes up later than
+    # this many seconds past its deadline (0 = disabled). A late wakeup means
+    # the loop was blocked by synchronous work or a GC pause, during which
+    # finished responses could not be dispatched.
+    SGLANG_LOG_TOKENIZER_LOOP_LAG_SECS = EnvFloat(0.0)
     SGLANG_LOG_FORWARD_ITERS = EnvBool(False)
     SGLANG_LOG_DECODE_GRAPH_KEY = EnvBool(False)
     SGLANG_LOG_MS = EnvBool(False)

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -40,7 +40,13 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.multi_tokenizer_mixin import MultiHttpWorkerDetokenizerMixin
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import configure_logger, freeze_gc, kill_itself_when_parent_died
+from sglang.srt.utils import (
+    configure_gc_logger,
+    configure_gc_warning,
+    configure_logger,
+    freeze_gc,
+    kill_itself_when_parent_died,
+)
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.srt.utils.network import get_zmq_socket
 from sglang.srt.utils.patch_tokenizer import decode_without_hf_kwargs
@@ -144,6 +150,11 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             soft=True,
             test_stuck_time=envs.SGLANG_TEST_STUCK_DETOKENIZER.get(),
         )
+
+        if envs.SGLANG_LOG_GC.get():
+            configure_gc_logger()
+        if server_args.gc_warning_threshold_secs > 0.0:
+            configure_gc_warning(server_args.gc_warning_threshold_secs)
 
         if server_args.enable_metrics:
             start_cpu_monitor_thread("detokenizer")
@@ -492,6 +503,11 @@ def run_detokenizer_process(
     setproctitle.setproctitle("sglang::detokenizer")
     configure_logger(server_args)
     parent_process = psutil.Process().parent()
+
+    if server_args.gc_threshold:
+        import gc
+
+        gc.set_threshold(*server_args.gc_threshold)
 
     manager = None
     try:

--- a/python/sglang/srt/managers/idle_gc.py
+++ b/python/sglang/srt/managers/idle_gc.py
@@ -1,0 +1,53 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Only freeze after the process has been continuously idle this long,
+# so sub-second gaps in a live request stream never trigger it.
+MIN_IDLE_DURATION_S = 5.0
+# Do not freeze more often than this. gc.freeze() itself costs
+# milliseconds; the interval only bounds how much recently-created
+# state an ill-timed freeze can pin.
+MIN_FREEZE_INTERVAL_S = 60.0
+
+
+class IdleGCFreezeGate:
+    """Decide when to broadcast gc.freeze() across the server processes.
+
+    The long-lived heap is live by design (import-graph objects), so
+    freezing at sustained-idle moments — not collecting — is what keeps
+    full collections from re-scanning it during serving. Pure decision
+    logic: the owner observes busy/idle, calls note(), and performs the
+    freeze broadcast when it returns True.
+    """
+
+    def __init__(
+        self,
+        min_idle_duration_s: float = MIN_IDLE_DURATION_S,
+        min_freeze_interval_s: float = MIN_FREEZE_INTERVAL_S,
+    ):
+        self.min_idle_duration_s = min_idle_duration_s
+        self.min_freeze_interval_s = min_freeze_interval_s
+        self.idle_since = None
+        self.seen_work = False
+        self.last_freeze_time = -float("inf")
+
+    def note(self, busy: bool, now: float) -> bool:
+        """Record the current busy/idle state; True means freeze now."""
+        if busy:
+            self.idle_since = None
+            self.seen_work = True
+            return False
+        if self.idle_since is None:
+            self.idle_since = now
+        if not self.seen_work:
+            return False
+        if now - self.idle_since < self.min_idle_duration_s:
+            return False
+        if now - self.last_freeze_time < self.min_freeze_interval_s:
+            return False
+        return True
+
+    def mark_frozen(self, now: float) -> None:
+        self.last_freeze_time = now
+        self.seen_work = False

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -215,6 +215,7 @@ from sglang.srt.managers.scheduler_components.request_receiver import (
 from sglang.srt.managers.scheduler_components.weight_updater import (
     SchedulerWeightUpdaterManager,
 )
+from sglang.srt.managers.scheduler_gc_manager import SchedulerGCManager
 from sglang.srt.managers.scheduler_input_blocker import SchedulerInputBlocker
 from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
 from sglang.srt.managers.scheduler_recv_skipper import SchedulerRecvSkipper
@@ -248,6 +249,7 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
     DynamicGradMode,
     configure_gc_logger,
+    configure_gc_warning,
     configure_logger,
     freeze_gc,
     get_available_gpu_memory,
@@ -1105,6 +1107,12 @@ class Scheduler(
         # Configure GC logger
         if envs.SGLANG_LOG_GC.get():
             configure_gc_logger()
+        if self.server_args.gc_warning_threshold_secs > 0.0:
+            configure_gc_warning(self.server_args.gc_warning_threshold_secs)
+
+        # Keep stop-the-world GC pauses away from the batch critical path
+        # (a gen-2 pause in one TP rank stalls every rank).
+        self.gc_manager = SchedulerGCManager()
 
     def init_disaggregation(self):
         self.mm_receiver = None
@@ -3602,6 +3610,9 @@ class Scheduler(
         # Publish the idle state so /get_loads and DP balancing do not see stale load.
         self.publish_load_snapshot(force=True)
 
+        # reclaim cyclic garbage while a pause cannot stall in-flight batches
+        self.gc_manager.on_idle()
+
         # sleep until next event
         self.maybe_sleep_on_idle()
 
@@ -4397,6 +4408,11 @@ def run_scheduler_process(
         dp_rank,
     )
     parent_process = psutil.Process().parent()
+
+    if server_args.gc_threshold:
+        import gc
+
+        gc.set_threshold(*server_args.gc_threshold)
 
     # Set up tracing
     if server_args.enable_trace:

--- a/python/sglang/srt/managers/scheduler_gc_manager.py
+++ b/python/sglang/srt/managers/scheduler_gc_manager.py
@@ -1,0 +1,112 @@
+"""GC management for the scheduler process.
+
+CPython's automatic generation-2 garbage collection is a stop-the-world pause
+whose cost is O(live heap), and it triggers at arbitrary allocation sites. In
+a tensor-parallel server this is a correctness-adjacent problem, not just a
+latency one: a multi-second GC pause in ONE scheduler rank stalls ALL ranks,
+because the paused rank stops launching kernels while the peer GPUs spin
+inside a TP collective that needs its next launch. If anything in the process
+slowly accumulates live objects (e.g. a leaking dependency), pause duration
+grows with uptime until it exceeds the /health_generate window and the pod is
+killed by its liveness probe mid-pause — which looks like a permanent silent
+hang ("Server couldn't get a response from detokenizer") even though the
+process would have recovered.
+
+This was observed in production with sglang v0.5.12 on 8xB300 serving a
+DeepSeek-V3-family model: a flashinfer autotuner leak (TuningConfig objects
+retained by an unbounded lru_cache, see
+https://github.com/flashinfer-ai/flashinfer/issues/2139) grew the scheduler
+heap to ~75M tracked objects in ~6.5 hours, at which point a single gen-2
+collection measured 41 s while freeing nothing. Pauses crossed the 20 s
+health-check threshold after ~3.5 h and the pod was recycled several times a
+day.
+
+Strategy (all knobs env-gated):
+  * Raise the gen-2 threshold so automatic full collections become rare
+    (they remain as a fallback under sustained load that never goes idle).
+  * On the first fully-idle tick — i.e. right after warmup — run one full
+    collection and ``gc.freeze()`` the startup heap (model/module metadata,
+    several million objects) into the permanent generation so subsequent
+    collections never traverse it again.
+  * While idle, periodically run ``gc.collect()`` so cyclic garbage is
+    reclaimed at a moment when a pause cannot stall in-flight batches.
+
+We deliberately do NOT re-freeze periodically: objects frozen while alive are
+never collected if they later become cyclic garbage (e.g. evicted radix-tree
+nodes, which hold parent<->child cycles), so repeated freezing would convert
+ordinary churn into a permanent leak. The one-time startup freeze is safe
+because the startup heap is stable for the process lifetime.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import time
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerGCManager:
+    def __init__(self):
+        self.enabled = envs.SGLANG_ENABLE_SCHEDULER_GC_MANAGEMENT.get()
+        self.idle_gc_interval_s = envs.SGLANG_SCHEDULER_IDLE_GC_INTERVAL.get()
+        self._did_initial_freeze = False
+        self._last_idle_gc_time = 0.0
+
+        if not self.enabled:
+            return
+
+        gen0, gen1, gen2 = gc.get_threshold()
+        new_gen2 = max(gen2, envs.SGLANG_SCHEDULER_GC_GEN2_THRESHOLD.get())
+        gc.set_threshold(gen0, gen1, new_gen2)
+        logger.info(
+            "Scheduler GC management enabled: gen-2 threshold %d -> %d, "
+            "idle GC interval %.0fs (disable with SGLANG_ENABLE_SCHEDULER_GC_MANAGEMENT=0)",
+            gen2,
+            new_gen2,
+            self.idle_gc_interval_s,
+        )
+
+    def on_idle(self):
+        """Run from the scheduler's idle housekeeping path.
+
+        First call (right after warmup): full collect + freeze of the startup
+        heap. Later calls: throttled full collect so cyclic garbage is
+        reclaimed while a pause is harmless.
+        """
+        if not self.enabled:
+            return
+
+        now = time.perf_counter()
+        if self._did_initial_freeze and (
+            now < self._last_idle_gc_time + self.idle_gc_interval_s
+        ):
+            return
+
+        tic = now
+        collected = gc.collect()
+        if not self._did_initial_freeze:
+            frozen_before = gc.get_freeze_count()
+            gc.freeze()
+            self._did_initial_freeze = True
+            logger.info(
+                "Initial post-warmup GC freeze: collected %d, froze %d objects "
+                "(%.3fs)",
+                collected,
+                gc.get_freeze_count() - frozen_before,
+                time.perf_counter() - tic,
+            )
+        else:
+            duration = time.perf_counter() - tic
+            if duration > 0.1:
+                logger.info(
+                    "Idle GC: collected %d objects in %.3fs "
+                    "(a growing duration here indicates a heap leak; "
+                    "see scheduler_gc_manager.py)",
+                    collected,
+                    duration,
+                )
+        self._last_idle_gc_time = time.perf_counter()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -53,6 +53,7 @@ from sglang.srt.lora.lora_registry import LoRARef, LoRARegistry
 from sglang.srt.managers.async_dynamic_batch_tokenizer import AsyncDynamicbatchTokenizer
 from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.idle_gc import IdleGCFreezeGate
 from sglang.srt.managers.io_struct import (
     AbortReq,
     ActiveRanksOutput,
@@ -115,6 +116,7 @@ from sglang.srt.server_args import (
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
+    configure_gc_logger,
     configure_gc_warning,
     freeze_gc,
     get_bool_env_var,
@@ -311,6 +313,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Init metric collector and watchdog
         self.init_metric_collector_watchdog()
+        self.maybe_init_idle_gc()
 
         # Init request dispatcher
         self.init_request_dispatcher()
@@ -543,6 +546,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 encode_urls=self.encoder_urls,
             )
 
+    def maybe_init_idle_gc(self) -> None:
+        if self.server_args.gc_freeze_on_idle:
+            self.idle_gc_gate = IdleGCFreezeGate()
+        else:
+            self.idle_gc_gate = None
+
     def init_metric_collector_watchdog(self):
         # Metrics
         if self.enable_metrics:
@@ -578,6 +587,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         if self.server_args.gc_warning_threshold_secs > 0.0:
             configure_gc_warning(self.server_args.gc_warning_threshold_secs)
+        if envs.SGLANG_LOG_GC.get():
+            configure_gc_logger()
         self.soft_watchdog = Watchdog.create(
             debug_name="TokenizerManager",
             watchdog_timeout=self.server_args.soft_watchdog_timeout,
@@ -1823,6 +1834,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         freeze_gc("Tokenizer Manager")
         return None
 
+    async def idle_gc_freeze_watcher(self):
+        """Broadcast gc.freeze() after sustained idle (see IdleGCFreezeGate)."""
+        while True:
+            await asyncio.sleep(2.0)
+            now = time.monotonic()
+            if self.idle_gc_gate.note(busy=bool(self.rid_to_state), now=now):
+                await self.freeze_gc()
+                self.idle_gc_gate.mark_frozen(now)
+
     def create_abort_task(self, obj: GenerateReqInput):
         # Abort the request if the client is disconnected.
         async def abort_request():
@@ -1861,6 +1881,38 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.asyncio_tasks.add(
             loop.create_task(print_exception_wrapper(self.sigterm_watchdog))
         )
+
+        if envs.SGLANG_LOG_TOKENIZER_LOOP_LAG_SECS.get() > 0:
+            self.asyncio_tasks.add(
+                loop.create_task(print_exception_wrapper(self.watch_loop_lag))
+            )
+
+        if self.idle_gc_gate is not None:
+            self.asyncio_tasks.add(
+                loop.create_task(print_exception_wrapper(self.idle_gc_freeze_watcher))
+            )
+
+    async def watch_loop_lag(self):
+        """Log when this process's event loop is starved.
+
+        A wakeup later than SGLANG_LOG_TOKENIZER_LOOP_LAG_SECS means the loop
+        was blocked that long by synchronous work (e.g. tokenization,
+        chat-template rendering) or a stop-the-world GC pause; while blocked,
+        finished responses from the detokenizer cannot be dispatched.
+        """
+        threshold = envs.SGLANG_LOG_TOKENIZER_LOOP_LAG_SECS.get()
+        interval = 1.0
+        while True:
+            start = time.monotonic()
+            await asyncio.sleep(interval)
+            lag = time.monotonic() - start - interval
+            if lag > threshold:
+                logger.warning(
+                    f"TokenizerManager event loop wakeup was {lag:.2f}s late "
+                    f"(threshold {threshold:.2f}s). The loop was blocked by "
+                    f"synchronous work or a GC pause; output dispatch was "
+                    f"stalled for at least this long."
+                )
 
     async def handle_loop(self):
         """The event loop that handles requests"""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1030,6 +1030,10 @@ class ServerArgs:
         Optional[List[int]],
         "Set the garbage collection thresholds (the collection frequency). Accepts 1 to 3 integers.",
     ] = None
+    gc_freeze_on_idle: A[
+        bool,
+        "Broadcast gc.freeze() to the tokenizer manager, scheduler, and detokenizer after sustained idle periods. Serving accumulates millions of live long-lived objects in GC generation 2 in each process; full collections over them cost hundreds of milliseconds each and can fire during serving. Freezing at idle moments moves that population out of GC scan scope.",
+    ] = False
 
     # -------------------------------------------------------------------------
     # HTTP server

--- a/test/registered/unit/managers/test_idle_gc.py
+++ b/test/registered/unit/managers/test_idle_gc.py
@@ -1,0 +1,57 @@
+"""Unit tests for the idle GC freeze gate."""
+
+import unittest
+
+from sglang.srt.managers.idle_gc import IdleGCFreezeGate
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestIdleGCFreezeGate(CustomTestCase):
+    def test_freezes_after_sustained_idle_following_work(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=5.0, min_freeze_interval_s=60.0)
+        self.assertFalse(gate.note(busy=True, now=100.0))
+        self.assertFalse(gate.note(busy=False, now=101.0))  # idle 0s
+        self.assertFalse(gate.note(busy=False, now=104.0))  # idle 3s
+        self.assertTrue(gate.note(busy=False, now=107.0))  # idle 6s
+        gate.mark_frozen(107.0)
+
+    def test_never_freezes_without_prior_work(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=5.0, min_freeze_interval_s=0.0)
+        self.assertFalse(gate.note(busy=False, now=0.0))
+        self.assertFalse(gate.note(busy=False, now=100.0))
+
+    def test_short_idle_gaps_in_live_traffic_never_freeze(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=5.0, min_freeze_interval_s=0.0)
+        now = 0.0
+        for _ in range(50):
+            self.assertFalse(gate.note(busy=True, now=now))
+            now += 0.5
+            self.assertFalse(gate.note(busy=False, now=now))  # sub-second gap
+            now += 0.5
+
+    def test_min_interval_between_freezes(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=1.0, min_freeze_interval_s=60.0)
+        gate.note(busy=True, now=0.0)
+        gate.note(busy=False, now=1.0)  # idle observed from t=1
+        self.assertTrue(gate.note(busy=False, now=2.5))
+        gate.mark_frozen(2.5)
+        gate.note(busy=True, now=3.0)  # new work
+        gate.note(busy=False, now=4.0)
+        self.assertFalse(gate.note(busy=False, now=10.0))  # interval not passed
+        self.assertTrue(gate.note(busy=False, now=70.0))
+
+    def test_no_refreeze_without_new_work(self):
+        gate = IdleGCFreezeGate(min_idle_duration_s=1.0, min_freeze_interval_s=0.0)
+        gate.note(busy=True, now=0.0)
+        gate.note(busy=False, now=1.0)
+        self.assertTrue(gate.note(busy=False, now=2.5))
+        gate.mark_frozen(2.5)
+        self.assertFalse(gate.note(busy=False, now=100.0))
+        self.assertFalse(gate.note(busy=False, now=200.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_gc_manager.py
+++ b/test/registered/unit/managers/test_scheduler_gc_manager.py
@@ -25,8 +25,13 @@ from sglang.srt.managers.scheduler_gc_manager import SchedulerGCManager
 class TestSchedulerGCManager(unittest.TestCase):
     def setUp(self):
         self._saved_threshold = gc.get_threshold()
+        # SGLANG_ENABLE_SCHEDULER_GC_MANAGEMENT defaults to off; enable it
+        # explicitly so these tests exercise the managed behavior.
+        self._enable_ctx = envs.SGLANG_ENABLE_SCHEDULER_GC_MANAGEMENT.override(True)
+        self._enable_ctx.__enter__()
 
     def tearDown(self):
+        self._enable_ctx.__exit__(None, None, None)
         gc.set_threshold(*self._saved_threshold)
 
     def test_disabled_is_a_strict_noop(self):

--- a/test/registered/unit/managers/test_scheduler_gc_manager.py
+++ b/test/registered/unit/managers/test_scheduler_gc_manager.py
@@ -1,0 +1,120 @@
+"""Unit tests for srt/managers/scheduler_gc_manager.py.
+
+SchedulerGCManager keeps stop-the-world GC pauses off the scheduler's batch
+critical path: it defers automatic gen-2 collections, freezes the startup
+heap once on the first idle tick after warmup, and thereafter runs full
+collections only while the scheduler is idle (throttled).
+
+Note: ``gc.freeze()`` moves currently tracked objects into the permanent
+generation and cannot be undone. That is harmless for test correctness (the
+permanent generation is simply skipped by traversal), but tests below assert
+on freeze-count deltas rather than absolute values.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import gc
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.scheduler_gc_manager import SchedulerGCManager
+
+
+class TestSchedulerGCManager(unittest.TestCase):
+    def setUp(self):
+        self._saved_threshold = gc.get_threshold()
+
+    def tearDown(self):
+        gc.set_threshold(*self._saved_threshold)
+
+    def test_disabled_is_a_strict_noop(self):
+        before = gc.get_threshold()
+        with envs.SGLANG_ENABLE_SCHEDULER_GC_MANAGEMENT.override(False):
+            manager = SchedulerGCManager()
+            self.assertFalse(manager.enabled)
+            self.assertEqual(gc.get_threshold(), before)
+
+            frozen_before = gc.get_freeze_count()
+            manager.on_idle()
+            self.assertEqual(gc.get_freeze_count(), frozen_before)
+            self.assertFalse(manager._did_initial_freeze)
+
+    def test_gen2_threshold_raised_but_never_lowered(self):
+        with envs.SGLANG_SCHEDULER_GC_GEN2_THRESHOLD.override(10000):
+            gc.set_threshold(700, 10, 10)
+            SchedulerGCManager()
+            self.assertEqual(gc.get_threshold(), (700, 10, 10000))
+
+            # An operator-configured larger threshold must not be lowered.
+            gc.set_threshold(700, 10, 50000)
+            SchedulerGCManager()
+            self.assertEqual(gc.get_threshold(), (700, 10, 50000))
+
+    def test_gen0_gen1_thresholds_untouched(self):
+        gc.set_threshold(123, 45, 10)
+        SchedulerGCManager()
+        gen0, gen1, _ = gc.get_threshold()
+        self.assertEqual((gen0, gen1), (123, 45))
+
+    def test_first_idle_tick_collects_and_freezes_once(self):
+        manager = SchedulerGCManager()
+        self.assertFalse(manager._did_initial_freeze)
+
+        frozen_before = gc.get_freeze_count()
+        manager.on_idle()
+        self.assertTrue(manager._did_initial_freeze)
+        self.assertGreater(
+            gc.get_freeze_count(),
+            frozen_before,
+            "first idle tick must freeze the startup heap",
+        )
+
+        # Subsequent idle ticks must not freeze again (only collect, and
+        # only when the throttle interval has elapsed).
+        frozen_after_first = gc.get_freeze_count()
+        manager._last_idle_gc_time = 0.0  # force the throttle open
+        manager.on_idle()
+        self.assertEqual(
+            gc.get_freeze_count(),
+            frozen_after_first,
+            "periodic idle GC must not re-freeze (frozen-then-garbage "
+            "objects would leak permanently)",
+        )
+
+    def test_idle_gc_is_throttled_by_interval(self):
+        with envs.SGLANG_SCHEDULER_IDLE_GC_INTERVAL.override(3600.0):
+            manager = SchedulerGCManager()
+            manager.on_idle()  # initial freeze
+            stamp = manager._last_idle_gc_time
+
+            manager.on_idle()  # immediately again: throttled, must no-op
+            self.assertEqual(manager._last_idle_gc_time, stamp)
+
+            manager._last_idle_gc_time -= 7200.0  # pretend interval elapsed
+            manager.on_idle()
+            self.assertGreater(manager._last_idle_gc_time, stamp - 7200.0)
+
+    def test_idle_gc_reclaims_reference_cycles(self):
+        manager = SchedulerGCManager()
+        manager.on_idle()  # initial freeze (cycles created after this)
+
+        class Node:
+            pass
+
+        a, b = Node(), Node()
+        a.other, b.other = b, a  # unreachable cycle once dropped
+        del a, b
+
+        manager._last_idle_gc_time = 0.0  # open the throttle
+        gc.set_threshold(*self._saved_threshold)  # restore for isolation
+        before = gc.get_count()[0]
+        manager.on_idle()
+        # The cycle objects were created after the freeze, so the idle
+        # collect must be able to reclaim them (no exception, gen0 drained).
+        self.assertLessEqual(gc.get_count()[0], before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Debug dev branch for CI testing.

All changes are guarded by switches and are no-ops by default:

| Switch | Default | Effect when enabled |
|---|---|---|
| `SGLANG_LOG_GC=1` (env) | off | Log every GC pass (generation, duration, collected count). Previously wired into the scheduler only; now also the tokenizer manager and detokenizer |
| `--gc-warning-threshold-secs <s>` (flag) | off | Warn on GC passes longer than `<s>` seconds, with a gen0/1/2 object census. Previously tokenizer manager only; now all three processes |
| `SGLANG_LOG_TOKENIZER_LOOP_LAG_SECS=<s>` (env, new) | off | Warn when the tokenizer manager event loop wakes up more than `<s>` seconds late, i.e. the loop was blocked by synchronous work or a GC pause and could not dispatch outputs |
| `SGLANG_GC_FREEZE_AFTER_WARMUP=1` (env, new) | off | Broadcast the existing `/freeze_gc` once right after warmup, so gen2 GC stops scanning the long-lived startup heap before traffic arrives |
| `--gc-threshold g0 g1 g2` (existing flag) | unchanged | Now also applied in the scheduler and detokenizer processes (previously only the engine / tokenizer manager process) |
| `SGLANG_ENABLE_SCHEDULER_GC_MANAGEMENT=1` (env) | off | Port of #28067: defer automatic gen2 collections in scheduler ranks, one-time post-warmup heap freeze, full collect only at idle. Upstream defaults this on; defaulted off here |
| `--gc-freeze-on-idle` (flag) | off | Port of #30693: broadcast `/freeze_gc` after sustained idle (>= 5s, at most once per 60s) |

The same change set as a single patch file against the `v0.5.15` tag (apply with `git apply`): https://gist.github.com/hnyls2002/45d1c3f26ef2c44dda5b892df04748cf

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29294702575](https://github.com/sgl-project/sglang/actions/runs/29294702575)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29294702479](https://github.com/sgl-project/sglang/actions/runs/29294702479)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

