### PR TITLE
[PD] Fix optimistic prefill inflight-queue hangs on parked/aborted reqs

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -158,6 +158,18 @@ class BaseKVSender(ABC):
         """
         ...
 
+    def clear(self):
+        """
+        Clear any internal states.
+        """
+        pass
+
+    def abort(self):
+        """
+        Abort the current transfer.
+        """
+        pass
+
 
 class BaseKVReceiver(ABC):
     @abstractmethod

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -788,52 +788,32 @@ class SchedulerDisaggregationPrefillMixin:
                     undone_reqs.append(req)
                     continue
 
-            if req.pending_bootstrap and poll != KVPoll.Failed:
-                # prefill finished before bootstrap
-                if poll == KVPoll.WaitingForInput:
-                    assert self.disagg_prefill_bootstrap_queue.finalize_bootstrap(req)
+            if req.pending_bootstrap:
+                # Parked: prefill finished before bootstrap completed.
+                if self.handle_pending_bootstrap(req, poll):
                     self.send_kv_chunk(req, last_chunk=True)
-                undone_reqs.append(req)
-            elif poll in [KVPoll.WaitingForInput, KVPoll.Transferring]:
+                    undone_reqs.append(req)
+                elif poll != KVPoll.Failed:
+                    undone_reqs.append(req)
+                continue
+
+            if poll in [KVPoll.WaitingForInput, KVPoll.Transferring]:
+                # todo: set Transferring correctly in backend
                 undone_reqs.append(req)
             elif poll == KVPoll.Success:  # transfer done
                 release_kv_cache(req, self.tree_cache)  # unlock the tree
                 req.finished_reason = FINISH_LENGTH(length=0)
                 # FIXME: clean up req's data in transfer engine
-                if hasattr(req.disagg_kv_sender, "clear"):
-                    req.disagg_kv_sender.clear()
+                req.disagg_kv_sender.clear()
                 done_reqs.append(req)
                 req.time_stats.set_prefill_kv_transfer_finish_time()
             elif poll == KVPoll.Failed:
-                error_message = f"Prefill transfer failed for request rank={self.ps.tp_rank} {req.rid=} {req.bootstrap_room=}"
-                is_propagated = False
-                try:
-                    req.disagg_kv_sender.failure_exception()
-                except Exception as e:
-                    error_message += f" with exception {e}"
-                    is_propagated = getattr(e, "is_from_another_rank", False)
-                # Mute error message for propagated exceptions to avoid duplicate logging
-                if is_propagated:
-                    logger.debug(error_message)
-                else:
-                    logger.warning(error_message)
-                req.time_stats.trace_ctx.abort(abort_info={"reason": error_message})
-                release_kv_cache(req, self.tree_cache)  # unlock the tree
-                prepare_abort(
-                    req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-                )
+                self.handle_inflight_transfer_failure(req)
                 done_reqs.append(req)
-                if self.metrics_reporter.enable_metrics:
-                    if req.pending_bootstrap:
-                        self.metrics_collector.increment_bootstrap_failed_reqs()
-                    else:
-                        self.metrics_collector.increment_transfer_failed_reqs()
             else:
-                logger.warning_once(
-                    f"Unexpected polling state {poll} for rid {req.rid} in inflight queue; "
-                    f"treating as undone",
+                raise RuntimeError(
+                    f"Unexpected poll state {poll} for req {req.rid} in inflight queue"
                 )
-                undone_reqs.append(req)
 
         for req in done_reqs:
             req.time_stats.set_completion_time()
@@ -872,6 +852,32 @@ class SchedulerDisaggregationPrefillMixin:
         self.disagg_prefill_inflight_queue = undone_reqs
 
         return done_reqs
+
+    def handle_inflight_transfer_failure(
+        self: Scheduler, req: Req
+    ) -> Optional[Exception]:
+        """Conclude an inflight request whose KV transfer failed."""
+        error_message = (
+            f"Prefill transfer failed for request rank={self.ps.tp_rank} "
+            f"{req.rid=} {req.bootstrap_room=}"
+        )
+        exc: Optional[Exception] = None
+        try:
+            req.disagg_kv_sender.failure_exception()
+        except Exception as e:
+            exc = e
+            error_message += f" with exception {e}"
+        # Mute error message for propagated exceptions to avoid duplicate logging
+        if getattr(exc, "is_from_another_rank", False):
+            logger.debug(error_message)
+        else:
+            logger.warning(error_message)
+        req.time_stats.trace_ctx.abort(abort_info={"reason": error_message})
+        release_kv_cache(req, self.tree_cache)  # unlock the tree
+        prepare_abort(req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+        if self.metrics_reporter.enable_metrics:
+            self.metrics_collector.increment_transfer_failed_reqs()
+        return exc
 
     def get_transferred_rids(self: Scheduler) -> List[str]:
         """


### PR DESCRIPTION
## Problem

Optimistic prefill parks a request in the prefill inflight queue when its prefill finishes before bootstrap completes. Two paths never drove such requests to a terminal state, so PD prefill could hang / spin the inflight queue:

- A parked (`pending_bootstrap`) request that had already reached `KVPoll.WaitingForInput` was re-appended to the inflight queue indefinitely instead of finalizing bootstrap, sending its KV, and progressing to transfer. Aborted/failed parked requests were likewise never terminated.
- A request polling a genuinely unexpected state (e.g. a non-pending request seeing `KVPoll.Bootstrapping`) hit the fallthrough branch, which logged `warning_once` and re-queued the request forever.

## Fix

- Route parked requests through the existing `handle_pending_bootstrap` helper in `process_disagg_prefill_inflight_queue`, so they finalize, retry, or terminate deterministically (same state machine already used elsewhere).
- Replace the silent re-queue fallthrough with a hard `RuntimeError` on truly unexpected poll states, so the queue can no longer spin.
- Factor the transfer-failure handling into `handle_inflight_transfer_failure`.
- Add no-op `clear()` / `abort()` to the `BaseKVSender` interface (`BaseKVReceiver` already has them) so the success path can call `clear()` unconditionally instead of an `hasattr` guard.

## Test

Covered by `test/registered/disaggregation/test_disaggregation_optimistic_prefill.py` (`TestOptimisticPrefill`, `TestOptimisticPrefillFailure`), which exercise the retry/abort inflight paths.

Follow-up to #30951.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29290461955](https://github.com/sgl-project/sglang/actions/runs/29290461955)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29290461793](https://github.com/sgl-project/sglang/actions/runs/29290461793)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->