### PR TITLE
[Debug] Add per-request lifecycle tracing (SGLANG_DEBUG_REQUEST_TRACE)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -221,6 +221,12 @@ class Envs:
     SGLANG_LOG_REQUEST_HEADERS = EnvTuple(tuple())
     SGLANG_LOG_SCHEDULER_STATUS_TARGET = EnvStr("")
     SGLANG_LOG_SCHEDULER_STATUS_INTERVAL = EnvFloat(60.0)
+    # When on, every request emits per-stage lifecycle lines tagged with rid(s):
+    # received/tokenize/dispatch/postprocess (TokenizerManager) and detokenize
+    # (DetokenizerManager). Grep the logs for [RTRACE]. The scheduler
+    # prefill/decode stages instead append rids=[...] to their existing stats
+    # line (not an [RTRACE] line). See sglang.srt.utils.req_trace.
+    SGLANG_DEBUG_REQUEST_TRACE = EnvBool(False)
 
     # IPC
     SGLANG_USE_PICKLE_IPC = EnvBool(True)

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -44,6 +44,7 @@ from sglang.srt.utils import configure_logger, freeze_gc, kill_itself_when_paren
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.srt.utils.network import get_zmq_socket
 from sglang.srt.utils.patch_tokenizer import decode_without_hf_kwargs
+from sglang.srt.utils.req_trace import req_trace
 from sglang.srt.utils.watchdog import Watchdog
 from sglang.utils import (
     TypeBasedDispatcher,
@@ -276,6 +277,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
         for i in range(bs):
             rid = recv_obj.rids[i]
             if rid not in self.decode_status:
+                req_trace("detokenize", "first", rid)
                 s = DecodeStatus(
                     decoded_text=recv_obj.decoded_texts[i],
                     decode_ids=list(recv_obj.decode_ids[i]),
@@ -286,6 +288,8 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             else:
                 s = self.decode_status[rid]
                 s.decode_ids.extend(recv_obj.decode_ids[i])
+            if recv_obj.finished_reasons[i] is not None:
+                req_trace("detokenize", "finished", rid)
 
             read_ids.append(
                 self.trim_matched_stop(

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -27,6 +27,7 @@ from sglang.srt.observability.metrics_collector import (
     compute_routing_key_stats,
 )
 from sglang.srt.utils.device_timer import DeviceTimer
+from sglang.srt.utils.req_trace import req_trace_enabled
 from sglang.srt.utils.scheduler_status_logger import SchedulerStatusLogger
 
 if TYPE_CHECKING:
@@ -602,6 +603,13 @@ class SchedulerMetricsReporter:
         if ENABLE_METRICS_DEVICE_TIMER:
             msg += f", fwd occupancy: {self.fwd_occupancy:.2f}%"
 
+        # Per-request trace: append the rids in this prefill batch so the batch
+        # can be correlated with the tokenize/detokenize/postprocess [RTRACE]
+        # lines. Gated by SGLANG_DEBUG_REQUEST_TRACE; enriches the existing line
+        # instead of emitting a duplicate one.
+        if req_trace_enabled() and batch is not None:
+            msg += f", rids={[req.rid for req in batch.reqs]}"
+
         if self.is_stats_logging_rank:
             logger.info(msg)
         if self.current_scheduler_metrics_enabled:
@@ -845,6 +853,13 @@ class SchedulerMetricsReporter:
 
         if ENABLE_METRICS_DEVICE_TIMER:
             msg += f", fwd occupancy: {self.fwd_occupancy:.2f}%"
+
+        # Per-request trace: append the rids in this decode batch (see the
+        # matching note in report_prefill_stats). NOTE: the decode line is
+        # throttled by decode_log_interval, so rids are shown once per interval,
+        # not every decode step; lower the interval for per-step rid visibility.
+        if req_trace_enabled():
+            msg += f", rids={[req.rid for req in batch.reqs]}"
 
         if self.is_stats_logging_rank:
             logger.info(msg)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -133,6 +133,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_tokenizer_from_processor,
 )
 from sglang.srt.utils.network import get_zmq_socket
+from sglang.srt.utils.req_trace import req_trace, req_trace_enabled
 from sglang.srt.utils.request_logger import RequestLogger
 from sglang.srt.utils.watchdog import Watchdog
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
@@ -814,6 +815,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         obj: Union[GenerateReqInput, EmbeddingReqInput],
     ):
         """Tokenize one request."""
+        req_trace("tokenize", "start", obj.rid)
         # Tokenize
         input_embeds = None
         input_text = obj.text
@@ -960,6 +962,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             mm_inputs = None
 
         self._validate_one_request(obj, input_ids)
+        if req_trace_enabled():
+            req_trace(
+                "tokenize",
+                "end",
+                obj.rid,
+                extra=f"n_input_ids={len(input_ids) if input_ids is not None else 'NA'}",
+            )
         return self._create_tokenized_object(
             obj, input_text, input_ids, input_embeds, mm_inputs, token_type_ids
         )
@@ -1356,6 +1365,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         time_stats = tokenized_obj.time_stats
         tokenized_obj.wrap_pickle_fields()
         self._dispatch_to_scheduler(tokenized_obj)
+        req_trace("dispatch", "start", tokenized_obj.rid)
         tokenized_obj.time_stats = time_stats
         tokenized_obj.time_stats.set_api_server_dispatch_finish_time()
 
@@ -1377,6 +1387,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             batch_req = BatchTokenizedEmbeddingReqInput(batch=tokenized_objs)
 
         self._dispatch_to_scheduler(batch_req)
+        if req_trace_enabled():
+            req_trace(
+                "dispatch",
+                "start",
+                [tokenized_obj.rid for tokenized_obj in tokenized_objs],
+            )
         for tokenized_obj, time_stat in zip(tokenized_objs, time_stats):
             tokenized_obj.time_stats = time_stat
         set_time_batch(tokenized_objs, "set_api_server_dispatch_finish_time")
@@ -2094,8 +2110,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # This is the single write point for first_token_time.
             if state.time_stats.first_token_time == 0.0:
                 state.time_stats.set_first_token_time()
+                req_trace("postprocess", "first", rid)
 
             if state.finished:
+                req_trace("postprocess", "finished", rid)
                 if state.time_stats.trace_ctx.tracing_enable:
                     state.time_stats.trace_ctx.trace_set_root_attrs(
                         self.convert_to_span_attrs(state, recv_obj, i)
@@ -2928,6 +2946,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             time_stats = APIServerReqTimeStats(disagg_mode=self.disaggregation_mode)
             state = ReqState([], False, asyncio.Event(), sub_obj, time_stats)
             self.rid_to_state[rid] = state
+            req_trace("received", "start", rid)
             if self.enable_trace:
                 time_stats.init_trace_ctx(rid, bootstrap_room, external_trace_header)
             time_stats.set_created_time(created_time)

--- a/python/sglang/srt/utils/req_trace.py
+++ b/python/sglang/srt/utils/req_trace.py
@@ -1,0 +1,87 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Lightweight per-request stage tracing for latency debugging.
+
+Enable with ``SGLANG_DEBUG_REQUEST_TRACE=1``. When on, each request emits a
+line at the following lifecycle points, tagged with the request id(s) and a
+high-resolution wall-clock timestamp, in whichever process the stage runs:
+
+    received / tokenize / dispatch / postprocess -> TokenizerManager process
+    detokenize                                   -> DetokenizerManager process
+
+The ``phase`` field marks the point within a stage; the values differ by
+stage rather than being a uniform start/end pair:
+
+    received     start
+    tokenize     start, end
+    dispatch     start            (fire-and-forget send; no end)
+    postprocess  first, finished  (first output batch; request finished)
+    detokenize   first, finished
+
+These lines are prefixed with ``[RTRACE]`` and emitted at INFO level, so they
+show up whenever the process log level is INFO or lower (the default). The
+Scheduler ``prefill``/``decode`` stages do NOT emit ``[RTRACE]`` lines; they
+instead append ``rids=[...]`` to the existing scheduler stats line (gated by
+the same env var), which correlates a batch with the ``[RTRACE]`` lines by
+``rid``. Join everything across processes on ``rid`` in the combined logs.
+This is a debug-only tool; it is a no-op unless the env var is set.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Iterable, Union
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+
+def req_trace_enabled() -> bool:
+    """Whether request tracing is turned on."""
+    return envs.SGLANG_DEBUG_REQUEST_TRACE.get()
+
+
+def req_trace(
+    stage: str,
+    phase: str,
+    rids: Union[str, Iterable[str]],
+    extra: str = "",
+) -> None:
+    """Emit one trace line for ``stage``.
+
+    Args:
+        stage: lifecycle stage name, e.g. "received", "tokenize", "dispatch",
+            "postprocess", "detokenize".
+        phase: the point within the stage, e.g. "start", "end", "first",
+            "finished" (which values apply depends on the stage).
+        rids: a single request id, or an iterable of request ids (used by the
+            batched dispatch path).
+        extra: optional extra key=value context appended to the line.
+
+    No-op unless ``SGLANG_DEBUG_REQUEST_TRACE`` is set.
+    """
+    if not envs.SGLANG_DEBUG_REQUEST_TRACE.get():
+        return
+    if isinstance(rids, str):
+        rid_list = [rids]
+    else:
+        rid_list = list(rids)
+    ts = time.time()
+    suffix = f" {extra}" if extra else ""
+    logger.info(
+        f"[RTRACE] stage={stage} phase={phase} ts={ts:.6f} "
+        f"n={len(rid_list)} rids={rid_list}{suffix}"
+    )


### PR DESCRIPTION
## Motivation

Debugging per-request latency across SGLang's multi-process pipeline (TokenizerManager → Scheduler → DetokenizerManager) is hard because there's no single, greppable trail of *where a request's time goes*, keyed by request id. This adds an opt-in, env-gated tracer that emits one line at each lifecycle point of a request, tagged with `rid` and a wall-clock timestamp, so the full lifecycle can be reconstructed by grepping the combined logs.

## What this does

Set `SGLANG_DEBUG_REQUEST_TRACE=1` to enable. When on, each request emits `[RTRACE]` lines at these points:

| Stage (`phase`) | Process |
|---|---|
| `received` (start) | TokenizerManager |
| `tokenize` (start, end) | TokenizerManager |
| `dispatch` (start — fire-and-forget send, no end) | TokenizerManager |
| `postprocess` (first = first output batch, finished) | TokenizerManager |
| `detokenize` (first, finished) | DetokenizerManager |

The scheduler `prefill`/`decode` stages don't emit standalone `[RTRACE]` lines — they append `rids=[...]` to their **existing** stats line (gated by the same env var), so a batch correlates to the `[RTRACE]` lines by `rid`.

Example trace for one request:

```
[RTRACE] stage=received    phase=start    ts=... rids=['abc']
[RTRACE] stage=tokenize    phase=start    ts=... rids=['abc']
[RTRACE] stage=tokenize    phase=end      ts=... rids=['abc'] n_input_ids=5
[RTRACE] stage=dispatch    phase=start    ts=... rids=['abc']
[RTRACE] stage=detokenize  phase=first    ts=... rids=['abc']
[RTRACE] stage=detokenize  phase=finished ts=... rids=['abc']
[RTRACE] stage=postprocess phase=first    ts=... rids=['abc']
[RTRACE] stage=postprocess phase=finished ts=... rids=['abc']
```

## Design notes

- **Zero cost when off.** Every `req_trace(...)` early-returns on the env read; every call site that builds a non-trivial argument (list comprehensions, `extra=` strings) is additionally guarded by `req_trace_enabled()` so nothing is constructed when disabled.
- **Purely additive.** No control flow is changed and no errors are caught/masked — enabling the trace cannot alter serving behavior.
- **Wall-clock `time.time()`** is intentional: timestamps must be comparable across the three processes (monotonic clocks are per-process).
- **Multi-worker safe.** The traced TokenizerManager methods are inherited unchanged by `TokenizerWorker` (multi-tokenizer mode), and the detokenizer edit lives in the shared `handle_batch_token_id_out` dispatcher target (multi-detokenizer mode), so coverage holds there too.

## Testing

Ran a single-GPU server (`Qwen2.5-0.5B-Instruct`, H200) with `SGLANG_DEBUG_REQUEST_TRACE=1` and confirmed the full ordered lifecycle trace for a request with a known `rid`. Default `--log-level` is INFO, so lines appear without extra config; with the env var unset, all calls are no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DnHnHWds9AcK3FyBUUEMm







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29290961625](https://github.com/sgl-project/sglang/actions/runs/29290961625)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29290961535](https://github.com/sgl-project/sglang/actions/runs/29290961535)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->