### PR TITLE
[CI] Use torch.testing.assert_close in custom-all-reduce test (~1400x faster compare)

### DIFF
--- a/test/registered/jit/test_custom_all_reduce.py
+++ b/test/registered/jit/test_custom_all_reduce.py
@@ -28,7 +28,6 @@ from typing import List
 import pytest
 import torch
 import torch.distributed as dist
-import triton
 
 import sglang.srt.distributed.parallel_state as ps
 from sglang.jit_kernel.all_reduce import (
@@ -224,7 +223,7 @@ def test_custom_all_reduce(
         dist.all_reduce(out_ref, group=nccl_group)
         out_jit = run(inp)
         # Exact equality, since values are small integers within bf16 precision.
-        triton.testing.assert_close(out_ref, out_jit, atol=0, rtol=0)
+        torch.testing.assert_close(out_ref, out_jit, atol=0, rtol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`triton.testing.assert_close` copies both tensors to CPU (bf16→fp32 upcast + `.cpu().numpy()`) and compares with single-threaded numpy. This test runs it 16x per parametrization on every rank, on tensors up to 4x2M — measured **142.9 ms vs 0.1 ms** per compare against `torch.testing.assert_close` on an idle H100 (worse under 8-rank CPU contention). A major contributor to this file's CI slowness and its super-linear scaling with world size (98s @ 2 GPUs → 209s @ 4 → ~625s @ 8).

## Modification

Swap to `torch.testing.assert_close` (on-GPU compare). Drop-in: `atol=0, rtol=0` exact equality, same dtype/device, no NaNs. Credit to Ziyi Xu for the diagnosis.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29293184294](https://github.com/sgl-project/sglang/actions/runs/29293184294)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29293192894](https://github.com/sgl-project/sglang/actions/runs/29293192894)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->