### PR TITLE
[Feature] Skip Qwen3 Omni multimodal towers when disabled

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -163,10 +163,10 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
         <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-multimodal`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable the multimodal functionality for the served model. If the model being served is not multimodal, nothing will happen.</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-multimodal` / `--disable-multimodal`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Explicitly enable or disable multimodal functionality for the served model. When disabled, supported models can avoid constructing their multimodal components.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>` None`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>mutually exclusive bool flags</td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--revision`</td>

--- a/docs_new/docs/advanced_features/server_arguments.mdx
+++ b/docs_new/docs/advanced_features/server_arguments.mdx
@@ -163,10 +163,10 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
         <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-multimodal`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable the multimodal functionality for the served model. If the model being served is not multimodal, nothing will happen.</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-multimodal` / `--disable-multimodal`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Explicitly enable or disable multimodal functionality for the served model. When disabled, supported models can avoid constructing their multimodal components.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>` None`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>mutually exclusive bool flags</td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--revision`</td>

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -322,6 +322,9 @@ class ModelConfig:
             else:
                 enable_multimodal = True
 
+        self.enable_multimodal = enable_multimodal
+        self.hf_config.enable_multimodal = enable_multimodal
+
         # Config draft model
         self._config_draft_model()
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -318,7 +318,9 @@ class ModelConfig:
         rope_scaling = getattr(self.hf_text_config, "rope_parameters", None) or getattr(
             self.hf_text_config, "rope_scaling", {}
         )
-        self.is_lm_only = getattr(self.hf_config, "language_model_only", False)
+        self.is_lm_only = language_model_only or getattr(
+            self.hf_config, "language_model_only", False
+        )
         self.model_is_mrope = (
             not self.is_lm_only
             and rope_scaling is not None
@@ -360,6 +362,9 @@ class ModelConfig:
                 )
             else:
                 enable_multimodal = True
+
+        self.enable_multimodal = enable_multimodal
+        self.hf_config.enable_multimodal = enable_multimodal
 
         # Config draft model
         self._config_draft_model()
@@ -539,7 +544,7 @@ class ModelConfig:
         # Checkpoints declare this one themselves (hf_transformers/processor.py),
         # so the flag may only turn it on: writing the default back would build a
         # vision tower with no weights to fill.
-        self.hf_config.language_model_only = language_model_only or self.is_lm_only
+        self.hf_config.language_model_only = self.is_lm_only
 
         # matryoshka embeddings
         self.matryoshka_dimensions = getattr(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -618,6 +618,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Normalize the request
         obj.normalize_batch_and_arguments()
+        if obj.contains_mm_input() and not self.model_config.enable_multimodal:
+            raise ValueError(
+                "Multimodal inputs are disabled. Restart with --enable-multimodal "
+                "to process images, video, or audio."
+            )
         self._set_default_priority(obj)
 
         if isinstance(obj, GenerateReqInput) and obj.routed_dp_rank is not None:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -761,6 +761,18 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Normalize the request
         obj.normalize_batch_and_arguments()
+        if obj.contains_mm_input() and not self.model_config.is_multimodal:
+            if self.model_config.is_lm_only:
+                raise ValueError(
+                    "Multimodal inputs are not supported in language-model-only "
+                    "mode because the encoder is not loaded."
+                )
+            if not self.model_config.enable_multimodal:
+                raise ValueError(
+                    "Multimodal inputs are disabled. Restart with "
+                    "--enable-multimodal to process images, video, or audio."
+                )
+            raise ValueError("The served model does not support multimodal inputs.")
         self._set_default_priority(obj)
         if (
             isinstance(obj, GenerateReqInput)
@@ -1024,11 +1036,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 )
 
         contains_mm_input = obj.contains_mm_input()
-        if contains_mm_input and self.server_args.language_model_only:
-            raise ValueError(
-                "Multimodal inputs are not supported when --language-model-only "
-                "is set; the encoder is not loaded. Restart without the flag."
-            )
         is_mossvl = (
             "MossVLForConditionalGeneration"
             in self.model_config.hf_config.architectures

--- a/python/sglang/srt/models/interns2_mobius.py
+++ b/python/sglang/srt/models/interns2_mobius.py
@@ -199,6 +199,7 @@ def _load_mobius_weights_strict(
     expected_slots = _expected_mobius_load_slots(params_dict, config.num_experts)
     loaded_slots: set[tuple[str, object, int | None]] = set()
     loaded_sources: set[str] = set()
+    skip_visual_sources = owner.visual is None
 
     def record_slot(name, shard_id=None, expert_id=None):
         slot = (name, shard_id, expert_id)
@@ -207,6 +208,8 @@ def _load_mobius_weights_strict(
         loaded_slots.add(slot)
 
     for source_name, loaded_weight in weights:
+        if skip_visual_sources and source_name.startswith(("model.visual.", "visual.")):
+            continue
         if _is_intentional_mobius_skip(source_name, config.tie_word_embeddings):
             continue
         if source_name in loaded_sources:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1655,7 +1655,8 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
         self.is_mrope_enabled = "mrope_section" in rope_config
 
-        self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+        if self.visual is not None:
+            self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
 
     def get_hidden_dim(self, module_name: str, layer_idx: int):
         return self.model.get_hidden_dim(module_name, layer_idx)
@@ -1713,6 +1714,10 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         loaded_params: Set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            if not self.enable_multimodal and name.startswith(
+                ("model.visual.", "visual.")
+            ):
+                continue
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:
@@ -1812,7 +1817,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         )
         self.is_mrope_enabled = "mrope_section" in rope_config
 
-        self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+        if self.visual is not None:
+            self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
         self.num_fused_shared_experts = 0
         if _use_aiter and not _disable_shared_experts_fusion():
             self.num_fused_shared_experts = self._get_num_fused_shared_experts()
@@ -1964,6 +1970,10 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            if not self.enable_multimodal and name.startswith(
+                ("model.visual.", "visual.")
+            ):
+                continue
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1781,9 +1781,8 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
             not self.language_model_only and "mrope_section" in rope_config
         )
 
-        self.deepstack_visual_indexes = (
-            self.visual.deepstack_visual_indexes if self.visual is not None else []
-        )
+        if self.visual is not None:
+            self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
 
     def get_hidden_dim(self, module_name: str, layer_idx: int):
         return self.model.get_hidden_dim(module_name, layer_idx)
@@ -1842,6 +1841,10 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         loaded_params: Set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            if not self.enable_multimodal and name.startswith(
+                ("model.visual.", "visual.")
+            ):
+                continue
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:
@@ -1943,9 +1946,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             not self.language_model_only and "mrope_section" in rope_config
         )
 
-        self.deepstack_visual_indexes = (
-            self.visual.deepstack_visual_indexes if self.visual is not None else []
-        )
+        if self.visual is not None:
+            self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
 
         self.num_fused_shared_experts = 0
         if _use_aiter and not _disable_shared_experts_fusion():
@@ -2099,6 +2101,10 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            if not self.enable_multimodal and name.startswith(
+                ("model.visual.", "visual.")
+            ):
+                continue
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:

--- a/python/sglang/srt/models/qwen3_omni_moe.py
+++ b/python/sglang/srt/models/qwen3_omni_moe.py
@@ -437,13 +437,15 @@ class Qwen3OmniMoeVisionEncoder(Qwen3VLMoeVisionModel):
         self,
         config: Qwen3OmniMoeVisionEncoderConfig,
         quant_config: Optional[QuantizationConfig] = None,
+        *,
+        norm_eps: float,
         prefix: str = None,
         **kwargs,
     ):
         super().__init__(
             vision_config=config,
             quant_config=quant_config,
-            norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+            norm_eps=norm_eps,
         )
 
         self.merger = Qwen3OmniMoeVisionPatchMerger(
@@ -494,13 +496,17 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(Qwen3VLMoeForConditionalGenera
         super().__init__(
             config, quant_config, prefix, language_model_cls=Qwen3MoeLLMModel
         )
-        self.audio_tower = Qwen3OmniMoeAudioEncoder(config.audio_config, quant_config)
-        self.visual = Qwen3OmniMoeVisionEncoder(
-            config.vision_config,
-            quant_config=quant_config,
-            norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-            prefix=add_prefix("visual", prefix),
-        )
+        self.audio_tower = None
+        if self.enable_multimodal:
+            self.audio_tower = Qwen3OmniMoeAudioEncoder(
+                config.audio_config, quant_config
+            )
+            self.visual = Qwen3OmniMoeVisionEncoder(
+                config.vision_config,
+                quant_config=quant_config,
+                norm_eps=config.text_config.rms_norm_eps,
+                prefix=add_prefix("visual", prefix),
+            )
         self.pad_token_id = (
             self.config.pad_token_id if self.config.pad_token_id is not None else -1
         )
@@ -548,9 +554,17 @@ class Qwen3OmniMoeForConditionalGeneration(PreTrainedModel):
     ):
         super().__init__(config)
         self.config = config
+        self.enable_multimodal = getattr(config, "enable_multimodal", True)
+        encoder_only = getattr(config, "encoder_only", False)
+        language_only = getattr(config, "language_only", False)
+
+        thinker_config = config.thinker_config
+        thinker_config.enable_multimodal = self.enable_multimodal
+        thinker_config.encoder_only = encoder_only
+        thinker_config.language_only = language_only
 
         self.thinker = Qwen3OmniMoeThinkerForConditionalGeneration(
-            config.thinker_config, quant_config=quant_config, prefix=prefix
+            thinker_config, quant_config=quant_config, prefix=prefix
         )
         self.enable_talker = False
         self.pad_input_ids = self.thinker.pad_input_ids
@@ -599,6 +613,13 @@ class Qwen3OmniMoeForConditionalGeneration(PreTrainedModel):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            if not self.enable_multimodal and name.startswith(
+                (
+                    "thinker.visual.",
+                    "thinker.audio_tower.",
+                )
+            ):
+                continue
             name = name.replace(r"model.language_model.", r"model.")
 
             if ("talker" in name or "code2wav" in name) and not self.enable_talker:

--- a/python/sglang/srt/models/qwen3_omni_moe.py
+++ b/python/sglang/srt/models/qwen3_omni_moe.py
@@ -437,13 +437,15 @@ class Qwen3OmniMoeVisionEncoder(Qwen3VLMoeVisionModel):
         self,
         config: Qwen3OmniMoeVisionEncoderConfig,
         quant_config: Optional[QuantizationConfig] = None,
+        *,
+        norm_eps: float,
         prefix: str = None,
         **kwargs,
     ):
         super().__init__(
             vision_config=config,
             quant_config=quant_config,
-            norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+            norm_eps=norm_eps,
         )
 
         self.merger = Qwen3OmniMoeVisionPatchMerger(
@@ -494,13 +496,17 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(Qwen3VLMoeForConditionalGenera
         super().__init__(
             config, quant_config, prefix, language_model_cls=Qwen3MoeLLMModel
         )
-        self.audio_tower = Qwen3OmniMoeAudioEncoder(config.audio_config, quant_config)
-        self.visual = Qwen3OmniMoeVisionEncoder(
-            config.vision_config,
-            quant_config=quant_config,
-            norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-            prefix=add_prefix("visual", prefix),
-        )
+        self.audio_tower = None
+        if self.enable_multimodal and not self.language_model_only:
+            self.audio_tower = Qwen3OmniMoeAudioEncoder(
+                config.audio_config, quant_config
+            )
+            self.visual = Qwen3OmniMoeVisionEncoder(
+                config.vision_config,
+                quant_config=quant_config,
+                norm_eps=config.text_config.rms_norm_eps,
+                prefix=add_prefix("visual", prefix),
+            )
         self.pad_token_id = (
             self.config.pad_token_id if self.config.pad_token_id is not None else -1
         )
@@ -548,9 +554,19 @@ class Qwen3OmniMoeForConditionalGeneration(PreTrainedModel):
     ):
         super().__init__(config)
         self.config = config
+        self.enable_multimodal = getattr(config, "enable_multimodal", True)
+        self.language_model_only = getattr(config, "language_model_only", False)
+        encoder_only = getattr(config, "encoder_only", False)
+        language_only = getattr(config, "language_only", False)
+
+        thinker_config = config.thinker_config
+        thinker_config.enable_multimodal = self.enable_multimodal
+        thinker_config.language_model_only = self.language_model_only
+        thinker_config.encoder_only = encoder_only
+        thinker_config.language_only = language_only
 
         self.thinker = Qwen3OmniMoeThinkerForConditionalGeneration(
-            config.thinker_config, quant_config=quant_config, prefix=prefix
+            thinker_config, quant_config=quant_config, prefix=prefix
         )
         self.enable_talker = False
         self.pad_input_ids = self.thinker.pad_input_ids
@@ -599,6 +615,15 @@ class Qwen3OmniMoeForConditionalGeneration(PreTrainedModel):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            if (
+                not self.enable_multimodal or self.language_model_only
+            ) and name.startswith(
+                (
+                    "thinker.visual.",
+                    "thinker.audio_tower.",
+                )
+            ):
+                continue
             name = name.replace(r"model.language_model.", r"model.")
 
             if ("talker" in name or "code2wav" in name) and not self.enable_talker:

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1233,15 +1233,20 @@ class Qwen3VLForConditionalGeneration(nn.Module):
 
         self.use_data_parallel = get_server_args().mm_enable_dp_encoder
 
-        self.visual = Qwen3VLMoeVisionModel(
-            config.vision_config,
-            # NOTE: Qwen3-VL vision encoder currently supports BitsAndBytes 4-bit quantization.
-            # Other quantization methods (e.g., GPTQ, AWQ) are untested and may not be supported.
-            quant_config=None,
-            norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-            prefix=add_prefix("model.visual", prefix),
-            use_data_parallel=self.use_data_parallel,
-        )
+        self.enable_multimodal = getattr(config, "enable_multimodal", True)
+        self.visual = None
+        if self.enable_multimodal:
+            self.visual = Qwen3VLMoeVisionModel(
+                config.vision_config,
+                # NOTE: Qwen3-VL vision encoder currently supports BitsAndBytes 4-bit quantization.
+                # Other quantization methods (e.g., GPTQ, AWQ) are untested and may not be supported.
+                quant_config=None,
+                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                prefix=add_prefix("model.visual", prefix),
+                use_data_parallel=self.use_data_parallel,
+            )
+        else:
+            logger.info("Skipping the vision tower because multimodal is disabled")
 
         # TODO: make it more elegant
         if language_model_cls is Qwen3LLMModel:

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1241,9 +1241,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         self.use_data_parallel = get_mm().mm_enable_dp_encoder
 
         self.language_model_only = getattr(config, "language_model_only", False)
-        if self.language_model_only:
-            self.visual = None
-        else:
+        self.enable_multimodal = getattr(config, "enable_multimodal", True)
+        self.visual = None
+        if self.enable_multimodal and not self.language_model_only:
             self.visual = Qwen3VLMoeVisionModel(
                 config.vision_config,
                 # NOTE: Qwen3-VL vision encoder currently supports BitsAndBytes 4-bit quantization.
@@ -1253,6 +1253,8 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 prefix=add_prefix("model.visual", prefix),
                 use_data_parallel=self.use_data_parallel,
             )
+        elif not self.enable_multimodal:
+            logger.info("Skipping the vision tower because multimodal is disabled")
 
         # TODO: make it more elegant
         if language_model_cls is Qwen3LLMModel:

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -230,6 +230,10 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            if not self.enable_multimodal and name.startswith(
+                ("model.visual.", "visual.")
+            ):
+                continue
             name = name.replace(r"model.language_model.", r"model.")
             layer_id = get_layer_id(name)
             if (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -520,7 +520,10 @@ class ServerArgs:
     is_embedding: A[bool, "Whether to use a CausalLM as an embedding model."] = False
     enable_multimodal: A[
         Optional[bool],
-        "Enable the multimodal functionality for the served model. If the model being served is not multimodal, nothing will happen",
+        Arg(
+            help="Whether to enable multimodal functionality for the served model.",
+            no_cli=True,
+        ),
     ] = None
     revision: A[
         Optional[str],
@@ -6557,6 +6560,22 @@ class ServerArgs:
 
         # Auto-derived from Annotated[..., Arg(...)] field metadata.
         add_cli_args_from_dataclass(parser, ServerArgs)
+
+        multimodal_group = parser.add_mutually_exclusive_group()
+        multimodal_group.add_argument(
+            "--enable-multimodal",
+            dest="enable_multimodal",
+            action="store_true",
+            default=ServerArgs.enable_multimodal,
+            help="Enable multimodal functionality for the served model.",
+        )
+        multimodal_group.add_argument(
+            "--disable-multimodal",
+            dest="enable_multimodal",
+            action="store_false",
+            help="Disable multimodal functionality for text-only deployment. "
+            "Supported models can avoid constructing their multimodal components.",
+        )
 
         # --- Fields with dynamic choices (computed at add_cli_args time) ---
         reasoning_parser_choices = list(ReasoningParser.DetectorMap.keys())

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -588,7 +588,10 @@ class ServerArgs:
     ] = False
     enable_multimodal: A[
         Optional[bool],
-        "Enable the multimodal functionality for the served model. If the model being served is not multimodal, nothing will happen",
+        Arg(
+            help="Whether to enable multimodal functionality for the served model.",
+            no_cli=True,
+        ),
         NS("mm"),
     ] = None
     revision: A[
@@ -8517,6 +8520,22 @@ class ServerArgs:
 
         # Auto-derived from Annotated[..., Arg(...)] field metadata.
         add_cli_args_from_dataclass(parser, ServerArgs)
+
+        multimodal_group = parser.add_mutually_exclusive_group()
+        multimodal_group.add_argument(
+            "--enable-multimodal",
+            dest="enable_multimodal",
+            action="store_true",
+            default=ServerArgs.enable_multimodal,
+            help="Enable multimodal functionality for the served model.",
+        )
+        multimodal_group.add_argument(
+            "--disable-multimodal",
+            dest="enable_multimodal",
+            action="store_false",
+            help="Disable multimodal functionality for text-only deployment. "
+            "Supported models can avoid constructing their multimodal components.",
+        )
 
         # --- Fields with dynamic choices (computed at add_cli_args time) ---
         reasoning_parser_choices = list(ReasoningParser.DetectorMap.keys())

--- a/python/sglang/srt/server_args_config_parser.py
+++ b/python/sglang/srt/server_args_config_parser.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -22,20 +22,26 @@ class ConfigArgumentMerger:
         parser: argparse.ArgumentParser = None,
         boolean_actions: List[str] = None,
     ):
-        """Initialize with list of store_true action names."""
-        # NOTE: The current code does not support actions other than "store_true" and "store".
+        """Initialize with the parser's supported boolean actions."""
         if parser is not None:
             self.parser = parser
-            self.store_true_actions = [
-                action.dest
-                for action in parser._actions
-                if isinstance(action, argparse._StoreTrueAction)
-            ]
+            self.boolean_options = {}
+            for action in parser._actions:
+                if isinstance(action, argparse._StoreTrueAction):
+                    value = True
+                elif isinstance(action, argparse._StoreFalseAction):
+                    value = False
+                else:
+                    continue
+                self.boolean_options.setdefault(action.dest, {})[value] = (
+                    action.option_strings[0]
+                )
             self.unsupported_actions = {
                 a.dest: a
                 for a in parser._actions
                 if a.option_strings
                 and not isinstance(a, argparse._StoreTrueAction)
+                and not isinstance(a, argparse._StoreFalseAction)
                 and not isinstance(a, argparse._StoreAction)
                 and "--config" not in a.option_strings
                 and "--help" not in a.option_strings
@@ -43,10 +49,14 @@ class ConfigArgumentMerger:
             }
         elif boolean_actions is not None:
             # Legacy interface for compatibility
-            self.store_true_actions = boolean_actions
+            self.boolean_options = {
+                name: {True: f"--{name.replace('_', '-')}"} for name in boolean_actions
+            }
+            self.parser = None
             self.unsupported_actions = {}
         else:
-            self.store_true_actions = []
+            self.boolean_options = {}
+            self.parser = None
             self.unsupported_actions = {}
 
     def merge_config_with_args(self, cli_args: List[str]) -> List[str]:
@@ -70,7 +80,6 @@ class ConfigArgumentMerger:
             return cli_args
 
         config_data = self._parse_yaml_config(config_file_path)
-        config_args = self._convert_config_to_args(config_data)
 
         # Merge config args into CLI args
         config_index = cli_args.index("--config")
@@ -79,8 +88,35 @@ class ConfigArgumentMerger:
         before_config = cli_args[:config_index]
         after_config = cli_args[config_index + 2 :]  # Skip --config and file path
 
+        cli_boolean_dests = {
+            dest
+            for arg in before_config + after_config
+            if (dest := self._boolean_dest(arg)) is not None
+        }
+        config_data = {
+            key: value
+            for key, value in config_data.items()
+            if key.replace("-", "_") not in cli_boolean_dests
+        }
+        config_args = self._convert_config_to_args(config_data)
+
         # Simple merge: config args + CLI args
         return config_args + before_config + after_config
+
+    def _boolean_dest(self, arg: str) -> Optional[str]:
+        if self.parser is None or not arg.startswith("-") or arg == "--":
+            return None
+        action = self.parser._option_string_actions.get(arg)
+        if action is None:
+            actions = {option[0] for option in self.parser._get_option_tuples(arg)}
+            if len(actions) != 1:
+                return None
+            action = actions.pop()
+        if not isinstance(
+            action, (argparse._StoreTrueAction, argparse._StoreFalseAction)
+        ):
+            return None
+        return action.dest
 
     def _extract_config_file_path(self, args: List[str]) -> str:
         """Extract the config file path from arguments."""
@@ -163,16 +199,18 @@ class ConfigArgumentMerger:
         """
         Add boolean argument to the list.
 
-        Only store_true flags:
-            - value True -> add flag
-            - value False -> skip
+        Boolean flags:
+            - store_true: value True adds the flag
+            - store_false: value False adds the flag
+            - paired actions use the flag matching the configured value
         Regular booleans:
             - always add --key true/false
         """
         key_norm = key.replace("-", "_")
-        if key_norm in self.store_true_actions:
-            if value:
-                args.append(f"--{key}")
+        if key_norm in self.boolean_options:
+            option = self.boolean_options[key_norm].get(value)
+            if option is not None:
+                args.append(option)
         else:
             args.extend([f"--{key}", str(value).lower()])
 

--- a/test/registered/unit/configs/test_disable_multimodal.py
+++ b/test/registered/unit/configs/test_disable_multimodal.py
@@ -8,12 +8,16 @@ import torch.nn as nn
 
 from sglang.srt.managers.io_struct import EmbeddingReqInput
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
-from sglang.srt.models import qwen3_vl, qwen3_vl_moe
+from sglang.srt.models import qwen3_omni_moe, qwen3_vl, qwen3_vl_moe
 from sglang.srt.models.interns1pro import InternS1ProForConditionalGeneration
 from sglang.srt.models.interns2preview import InternS2PreviewForConditionalGeneration
 from sglang.srt.models.qwen3_5 import (
     Qwen3_5ForConditionalGeneration,
     Qwen3_5MoeForConditionalGeneration,
+)
+from sglang.srt.models.qwen3_omni_moe import (
+    Qwen3OmniMoeForConditionalGeneration,
+    Qwen3OmniMoeThinkerForConditionalGeneration,
 )
 from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
 from sglang.srt.server_args import ServerArgs
@@ -29,6 +33,10 @@ class _FakeLanguageModel(nn.Module):
         super().__init__()
 
 
+class _FakeOmniThinker(nn.Module):
+    pad_input_ids = None
+
+
 def _qwen35_config(*, enable_multimodal: bool):
     return SimpleNamespace(
         enable_multimodal=enable_multimodal,
@@ -40,7 +48,9 @@ def _qwen35_config(*, enable_multimodal: bool):
             rope_parameters={"mrope_section": [16, 24, 24]},
             rope_scaling={},
             tie_word_embeddings=False,
+            pad_token_id=None,
         ),
+        audio_config=SimpleNamespace(),
         vision_config=SimpleNamespace(deepstack_visual_indexes=[8, 16, 24]),
     )
 
@@ -194,6 +204,111 @@ class TestMultimodalConfiguration(CustomTestCase):
                 )
 
                 self.assertEqual(loaded, set())
+
+    def test_qwen3_omni_propagates_runtime_config_to_thinker(self):
+        for runtime_config, expected_enable_multimodal in (
+            ({}, True),
+            (
+                {
+                    "enable_multimodal": False,
+                    "encoder_only": False,
+                    "language_only": False,
+                },
+                False,
+            ),
+        ):
+            with self.subTest(runtime_config=runtime_config):
+                thinker_config = SimpleNamespace()
+                config = SimpleNamespace(
+                    thinker_config=thinker_config,
+                    **runtime_config,
+                )
+
+                with (
+                    patch.object(
+                        qwen3_omni_moe.PreTrainedModel,
+                        "__init__",
+                        lambda self, config: nn.Module.__init__(self),
+                    ),
+                    patch.object(
+                        qwen3_omni_moe,
+                        "Qwen3OmniMoeThinkerForConditionalGeneration",
+                        return_value=_FakeOmniThinker(),
+                    ),
+                ):
+                    model = Qwen3OmniMoeForConditionalGeneration(config)
+
+                self.assertIs(model.enable_multimodal, expected_enable_multimodal)
+                self.assertIs(
+                    thinker_config.enable_multimodal, expected_enable_multimodal
+                )
+                self.assertFalse(thinker_config.encoder_only)
+                self.assertFalse(thinker_config.language_only)
+
+    def test_qwen3_omni_enabled_towers_use_text_norm_eps(self):
+        config = _qwen35_config(enable_multimodal=True)
+        config.text_config.rms_norm_eps = 1e-5
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        server_args = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_server_args", return_value=server_args),
+            patch.object(qwen3_omni_moe, "Qwen3MoeLLMModel", _FakeLanguageModel),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel"),
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+            patch.object(qwen3_omni_moe, "Qwen3OmniMoeAudioEncoder") as audio_model,
+            patch.object(qwen3_omni_moe, "Qwen3OmniMoeVisionEncoder") as vision_model,
+        ):
+            model = Qwen3OmniMoeThinkerForConditionalGeneration(config)
+
+        audio_model.assert_called_once_with(config.audio_config, None)
+        vision_model.assert_called_once_with(
+            config.vision_config,
+            quant_config=None,
+            norm_eps=config.text_config.rms_norm_eps,
+            prefix="visual",
+        )
+        self.assertIs(model.visual, vision_model.return_value)
+
+    def test_qwen3_omni_skips_disabled_multimodal_towers_and_weights(self):
+        config = _qwen35_config(enable_multimodal=False)
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        server_args = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_server_args", return_value=server_args),
+            patch.object(qwen3_omni_moe, "Qwen3MoeLLMModel", _FakeLanguageModel),
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+            patch.object(qwen3_omni_moe, "Qwen3OmniMoeAudioEncoder") as audio_model,
+            patch.object(qwen3_omni_moe, "Qwen3OmniMoeVisionEncoder") as vision_model,
+        ):
+            model = Qwen3OmniMoeThinkerForConditionalGeneration(config)
+
+        audio_model.assert_not_called()
+        vision_model.assert_not_called()
+        self.assertIsNone(model.audio_tower)
+        self.assertIsNone(model.visual)
+
+        outer_model = Qwen3OmniMoeForConditionalGeneration.__new__(
+            Qwen3OmniMoeForConditionalGeneration
+        )
+        nn.Module.__init__(outer_model)
+        outer_model.config = SimpleNamespace(num_experts=1)
+        outer_model.enable_talker = False
+        outer_model.enable_multimodal = False
+        weights = [
+            ("thinker.visual.patch_embed.proj.weight", None),
+            ("thinker.audio_tower.conv1.weight", None),
+        ]
+
+        with patch.object(qwen3_omni_moe.logger, "warning") as warning:
+            outer_model.load_weights(weights)
+
+        warning.assert_not_called()
 
 
 class TestDisabledMultimodalRequests(CustomTestCase):

--- a/test/registered/unit/configs/test_disable_multimodal.py
+++ b/test/registered/unit/configs/test_disable_multimodal.py
@@ -1,0 +1,220 @@
+import argparse
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch.nn as nn
+
+from sglang.srt.managers.io_struct import EmbeddingReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.models import qwen3_vl, qwen3_vl_moe
+from sglang.srt.models.interns1pro import InternS1ProForConditionalGeneration
+from sglang.srt.models.interns2preview import InternS2PreviewForConditionalGeneration
+from sglang.srt.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeLanguageModel(nn.Module):
+    def __init__(self, **kwargs):
+        super().__init__()
+
+
+def _qwen35_config(*, enable_multimodal: bool):
+    return SimpleNamespace(
+        enable_multimodal=enable_multimodal,
+        encoder_only=False,
+        language_only=False,
+        tie_word_embeddings=False,
+        text_config=SimpleNamespace(
+            rms_norm_eps=1e-6,
+            rope_parameters={"mrope_section": [16, 24, 24]},
+            rope_scaling={},
+            tie_word_embeddings=False,
+        ),
+        vision_config=SimpleNamespace(deepstack_visual_indexes=[8, 16, 24]),
+    )
+
+
+class TestMultimodalConfiguration(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(cls.parser)
+
+    def test_enable_multimodal_cli_is_tristate(self):
+        for cli_args, expected in (
+            ([], None),
+            (["--enable-multimodal"], True),
+            (["--disable-multimodal"], False),
+        ):
+            with self.subTest(cli_args=cli_args):
+                parsed = self.parser.parse_args(["--model", "dummy", *cli_args])
+                server_args = ServerArgs.from_cli_args(parsed)
+
+                self.assertIs(server_args.enable_multimodal, expected)
+
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(
+                [
+                    "--model",
+                    "dummy",
+                    "--enable-multimodal",
+                    "--disable-multimodal",
+                ]
+            )
+
+    def test_multimodal_yaml_config_is_tristate_and_cli_wins(self):
+        for config_value, cli_args, expected in (
+            (True, [], True),
+            (False, [], False),
+            (False, ["--enable-multimodal"], True),
+            (True, ["--disable-multimodal"], False),
+            (False, ["--enable-multim"], True),
+            (True, ["--disable-multim"], False),
+        ):
+            with self.subTest(config_value=config_value, cli_args=cli_args):
+                merger = ConfigArgumentMerger(self.parser)
+                with patch.object(
+                    merger,
+                    "_parse_yaml_config",
+                    return_value={"enable-multimodal": config_value},
+                ):
+                    merged = merger.merge_config_with_args(
+                        ["--config", "config.yaml", "--model", "dummy", *cli_args]
+                    )
+
+                parsed = self.parser.parse_args(merged)
+                self.assertIs(parsed.enable_multimodal, expected)
+
+    def test_qwen35_skips_vision_when_multimodal_is_disabled(self):
+        config = _qwen35_config(enable_multimodal=False)
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        server_args = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_server_args", return_value=server_args),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel") as vision_model,
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+        ):
+            model = Qwen3_5ForConditionalGeneration(
+                config,
+                language_model_cls=_FakeLanguageModel,
+            )
+
+        vision_model.assert_not_called()
+        self.assertIsNone(model.visual)
+        self.assertTrue(model.is_mrope_enabled)
+        self.assertEqual(model.deepstack_visual_indexes, [8, 16, 24])
+
+    def test_qwen35_constructs_vision_when_multimodal_is_enabled(self):
+        config = _qwen35_config(enable_multimodal=True)
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        server_args = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_server_args", return_value=server_args),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel") as vision_model,
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+        ):
+            vision_model.return_value.deepstack_visual_indexes = [8, 16, 24]
+            model = Qwen3_5ForConditionalGeneration(
+                config,
+                language_model_cls=_FakeLanguageModel,
+            )
+
+        vision_model.assert_called_once()
+        self.assertIs(model.visual, vision_model.return_value)
+
+    def test_intern_models_inherit_disabled_vision_construction(self):
+        config = _qwen35_config(enable_multimodal=False)
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        server_args = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_server_args", return_value=server_args),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel") as vision_model,
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+        ):
+            for model_cls in (
+                InternS1ProForConditionalGeneration,
+                InternS2PreviewForConditionalGeneration,
+            ):
+                with self.subTest(model_cls=model_cls):
+                    model = model_cls(
+                        config,
+                        language_model_cls=_FakeLanguageModel,
+                    )
+                    self.assertIsNone(model.visual)
+
+        vision_model.assert_not_called()
+
+    def test_qwen3_vl_moe_skips_disabled_visual_weights_without_warnings(self):
+        model = Qwen3VLMoeForConditionalGeneration.__new__(
+            Qwen3VLMoeForConditionalGeneration
+        )
+        nn.Module.__init__(model)
+        model.config = SimpleNamespace(num_experts=1)
+        model.enable_multimodal = False
+
+        with patch.object(qwen3_vl_moe.logger, "warning") as warning:
+            model.load_weights([("model.visual.patch_embed.proj.weight", None)])
+
+        warning.assert_not_called()
+
+    def test_qwen35_loaders_skip_disabled_visual_weights(self):
+        for model_cls in (
+            Qwen3_5ForConditionalGeneration,
+            Qwen3_5MoeForConditionalGeneration,
+        ):
+            with self.subTest(model_cls=model_cls):
+                model = model_cls.__new__(model_cls)
+                nn.Module.__init__(model)
+                model.config = SimpleNamespace(num_experts=1)
+                model.enable_multimodal = False
+                model.enable_shared_expert_fusion = False
+
+                loaded = model.load_weights(
+                    [("model.visual.patch_embed.proj.weight", None)]
+                )
+
+                self.assertEqual(loaded, set())
+
+
+class TestDisabledMultimodalRequests(CustomTestCase):
+    def test_rejects_multimodal_input_at_request_boundary(self):
+        for request in (
+            EmbeddingReqInput(image_data="image.png"),
+            EmbeddingReqInput(
+                text=["first", "second"],
+                image_data=["first.png", "second.png"],
+            ),
+        ):
+            with self.subTest(is_batch=isinstance(request.text, list)):
+                manager = TokenizerManager.__new__(TokenizerManager)
+                manager.auto_create_handle_loop = lambda: None
+                manager.model_config = SimpleNamespace(enable_multimodal=False)
+
+                with self.assertRaisesRegex(
+                    ValueError, "Multimodal inputs are disabled"
+                ):
+                    asyncio.run(manager.generate_request(request).__anext__())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/configs/test_disable_multimodal.py
+++ b/test/registered/unit/configs/test_disable_multimodal.py
@@ -1,0 +1,336 @@
+import argparse
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch.nn as nn
+
+from sglang.srt.configs import model_config as model_config_module
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.configs.qwen3_vl import Qwen3VLConfig
+from sglang.srt.managers.io_struct import EmbeddingReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.models import qwen3_vl, qwen3_vl_moe
+from sglang.srt.models.interns1pro import InternS1ProForConditionalGeneration
+from sglang.srt.models.interns2_mobius import InternS2MobiusForConditionalGeneration
+from sglang.srt.models.interns2preview import InternS2PreviewForConditionalGeneration
+from sglang.srt.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeLanguageModel(nn.Module):
+    def __init__(self, **kwargs):
+        super().__init__()
+
+
+def _qwen35_config(*, enable_multimodal: bool, language_model_only: bool = False):
+    return SimpleNamespace(
+        enable_multimodal=enable_multimodal,
+        language_model_only=language_model_only,
+        encoder_only=False,
+        language_only=False,
+        tie_word_embeddings=False,
+        text_config=SimpleNamespace(
+            rms_norm_eps=1e-6,
+            rope_parameters={"mrope_section": [16, 24, 24]},
+            rope_scaling={},
+            tie_word_embeddings=False,
+        ),
+        vision_config=SimpleNamespace(deepstack_visual_indexes=[8, 16, 24]),
+    )
+
+
+class TestMultimodalConfiguration(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(cls.parser)
+
+    def test_enable_multimodal_cli_is_tristate(self):
+        for cli_args, expected in (
+            ([], None),
+            (["--enable-multimodal"], True),
+            (["--disable-multimodal"], False),
+        ):
+            with self.subTest(cli_args=cli_args):
+                parsed = self.parser.parse_args(["--model", "dummy", *cli_args])
+                server_args = ServerArgs.from_cli_args(parsed)
+
+                self.assertIs(server_args.enable_multimodal, expected)
+
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(
+                [
+                    "--model",
+                    "dummy",
+                    "--enable-multimodal",
+                    "--disable-multimodal",
+                ]
+            )
+
+    def test_multimodal_yaml_config_is_tristate_and_cli_wins(self):
+        for config_value, cli_args, expected in (
+            (True, [], True),
+            (False, [], False),
+            (False, ["--enable-multimodal"], True),
+            (True, ["--disable-multimodal"], False),
+            (False, ["--enable-multim"], True),
+            (True, ["--disable-multim"], False),
+        ):
+            with self.subTest(config_value=config_value, cli_args=cli_args):
+                merger = ConfigArgumentMerger(self.parser)
+                with patch.object(
+                    merger,
+                    "_parse_yaml_config",
+                    return_value={"enable-multimodal": config_value},
+                ):
+                    merged = merger.merge_config_with_args(
+                        ["--config", "config.yaml", "--model", "dummy", *cli_args]
+                    )
+
+                parsed = self.parser.parse_args(merged)
+                self.assertIs(parsed.enable_multimodal, expected)
+
+    def test_language_model_only_resolution_combines_checkpoint_and_cli(self):
+        for checkpoint_value, cli_value, expected in (
+            (False, False, False),
+            (True, False, True),
+            (False, True, True),
+            (True, True, True),
+        ):
+            with self.subTest(
+                checkpoint_value=checkpoint_value,
+                cli_value=cli_value,
+            ):
+                hf_config = Qwen3VLConfig(
+                    architectures=["Qwen3VLForConditionalGeneration"],
+                    language_model_only=checkpoint_value,
+                )
+                with (
+                    patch.object(ModelConfig, "_maybe_pull_model_for_runai"),
+                    patch.object(
+                        ModelConfig,
+                        "_maybe_pull_model_tokenizer_from_remote",
+                    ),
+                    patch.object(
+                        model_config_module,
+                        "get_config",
+                        return_value=hf_config,
+                    ),
+                    patch.object(
+                        model_config_module,
+                        "get_generation_config",
+                        return_value=None,
+                    ),
+                ):
+                    model_config = ModelConfig(
+                        "dummy",
+                        language_model_only=cli_value,
+                    )
+
+                self.assertIs(model_config.is_lm_only, expected)
+                self.assertIs(model_config.is_multimodal, not expected)
+                self.assertIs(model_config.hf_config.language_model_only, expected)
+
+    def test_qwen35_skips_vision_when_multimodal_is_disabled(self):
+        config = _qwen35_config(enable_multimodal=False)
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        mm_config = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_mm", return_value=mm_config),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel") as vision_model,
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+        ):
+            model = Qwen3_5ForConditionalGeneration(
+                config,
+                language_model_cls=_FakeLanguageModel,
+            )
+
+        vision_model.assert_not_called()
+        self.assertIsNone(model.visual)
+        self.assertTrue(model.is_mrope_enabled)
+        self.assertEqual(model.deepstack_visual_indexes, [8, 16, 24])
+
+    def test_qwen35_constructs_vision_when_multimodal_is_enabled(self):
+        config = _qwen35_config(enable_multimodal=True)
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        mm_config = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_mm", return_value=mm_config),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel") as vision_model,
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+        ):
+            vision_model.return_value.deepstack_visual_indexes = [8, 16, 24]
+            model = Qwen3_5ForConditionalGeneration(
+                config,
+                language_model_cls=_FakeLanguageModel,
+            )
+
+        vision_model.assert_called_once()
+        self.assertIs(model.visual, vision_model.return_value)
+
+    def test_qwen35_skips_vision_in_language_model_only_mode(self):
+        config = _qwen35_config(
+            enable_multimodal=True,
+            language_model_only=True,
+        )
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        mm_config = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_mm", return_value=mm_config),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel") as vision_model,
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+        ):
+            model = Qwen3_5ForConditionalGeneration(
+                config,
+                language_model_cls=_FakeLanguageModel,
+            )
+
+        vision_model.assert_not_called()
+        self.assertIsNone(model.visual)
+        self.assertFalse(model.is_mrope_enabled)
+        self.assertEqual(model.deepstack_visual_indexes, [])
+
+    def test_intern_models_inherit_disabled_vision_construction(self):
+        config = _qwen35_config(enable_multimodal=False)
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        mm_config = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_mm", return_value=mm_config),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel") as vision_model,
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+        ):
+            for model_cls in (
+                InternS1ProForConditionalGeneration,
+                InternS2PreviewForConditionalGeneration,
+                InternS2MobiusForConditionalGeneration,
+            ):
+                with self.subTest(model_cls=model_cls):
+                    model = model_cls(
+                        config,
+                        language_model_cls=_FakeLanguageModel,
+                    )
+                    self.assertIsNone(model.visual)
+
+        vision_model.assert_not_called()
+
+    def test_qwen3_vl_moe_skips_disabled_visual_weights_without_warnings(self):
+        model = Qwen3VLMoeForConditionalGeneration.__new__(
+            Qwen3VLMoeForConditionalGeneration
+        )
+        nn.Module.__init__(model)
+        model.config = SimpleNamespace(num_experts=1)
+        model.enable_multimodal = False
+
+        with patch.object(qwen3_vl_moe.logger, "warning") as warning:
+            model.load_weights([("model.visual.patch_embed.proj.weight", None)])
+
+        warning.assert_not_called()
+
+    def test_qwen35_loaders_skip_disabled_visual_weights(self):
+        for model_cls in (
+            Qwen3_5ForConditionalGeneration,
+            Qwen3_5MoeForConditionalGeneration,
+        ):
+            with self.subTest(model_cls=model_cls):
+                model = model_cls.__new__(model_cls)
+                nn.Module.__init__(model)
+                model.config = SimpleNamespace(num_experts=1)
+                model.enable_multimodal = False
+                model.enable_shared_expert_fusion = False
+
+                loaded = model.load_weights(
+                    [("model.visual.patch_embed.proj.weight", None)]
+                )
+
+                self.assertEqual(loaded, set())
+
+    def test_mobius_loader_skips_only_intentionally_absent_visual_tower(self):
+        model = InternS2MobiusForConditionalGeneration.__new__(
+            InternS2MobiusForConditionalGeneration
+        )
+        nn.Module.__init__(model)
+        model.config = SimpleNamespace(num_experts=1, tie_word_embeddings=False)
+        model.visual = None
+
+        loaded = model.load_weights([("model.visual.patch_embed.proj.weight", None)])
+        self.assertEqual(loaded, set())
+
+        with self.assertRaisesRegex(KeyError, "Mobius destination is missing"):
+            model.load_weights([("model.language_model.unknown.weight", None)])
+
+        model.visual = nn.Identity()
+        with self.assertRaisesRegex(KeyError, "Mobius destination is missing"):
+            model.load_weights([("model.visual.patch_embed.proj.weight", None)])
+
+
+class TestDisabledMultimodalRequests(CustomTestCase):
+    def test_rejects_multimodal_input_when_effective_capability_is_disabled(self):
+        for request, enable_multimodal, checkpoint_lm_only, cli_lm_only, error in (
+            (
+                EmbeddingReqInput(image_data="image.png"),
+                False,
+                False,
+                False,
+                "Multimodal inputs are disabled",
+            ),
+            (
+                EmbeddingReqInput(image_data="image.png"),
+                True,
+                True,
+                False,
+                "language-model-only mode",
+            ),
+            (
+                EmbeddingReqInput(
+                    text=["first", "second"],
+                    image_data=["first.png", "second.png"],
+                ),
+                True,
+                False,
+                True,
+                "language-model-only mode",
+            ),
+        ):
+            with self.subTest(
+                enable_multimodal=enable_multimodal,
+                checkpoint_lm_only=checkpoint_lm_only,
+                cli_lm_only=cli_lm_only,
+            ):
+                manager = TokenizerManager.__new__(TokenizerManager)
+                manager.auto_create_handle_loop = lambda: None
+                is_lm_only = checkpoint_lm_only or cli_lm_only
+                manager.model_config = SimpleNamespace(
+                    enable_multimodal=enable_multimodal,
+                    is_lm_only=is_lm_only,
+                    is_multimodal=enable_multimodal and not is_lm_only,
+                )
+
+                with self.assertRaisesRegex(ValueError, error):
+                    asyncio.run(manager.generate_request(request).__anext__())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/configs/test_disable_multimodal.py
+++ b/test/registered/unit/configs/test_disable_multimodal.py
@@ -11,13 +11,17 @@ from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.configs.qwen3_vl import Qwen3VLConfig
 from sglang.srt.managers.io_struct import EmbeddingReqInput
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
-from sglang.srt.models import qwen3_vl, qwen3_vl_moe
+from sglang.srt.models import qwen3_omni_moe, qwen3_vl, qwen3_vl_moe
 from sglang.srt.models.interns1pro import InternS1ProForConditionalGeneration
 from sglang.srt.models.interns2_mobius import InternS2MobiusForConditionalGeneration
 from sglang.srt.models.interns2preview import InternS2PreviewForConditionalGeneration
 from sglang.srt.models.qwen3_5 import (
     Qwen3_5ForConditionalGeneration,
     Qwen3_5MoeForConditionalGeneration,
+)
+from sglang.srt.models.qwen3_omni_moe import (
+    Qwen3OmniMoeForConditionalGeneration,
+    Qwen3OmniMoeThinkerForConditionalGeneration,
 )
 from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
 from sglang.srt.server_args import ServerArgs
@@ -33,6 +37,10 @@ class _FakeLanguageModel(nn.Module):
         super().__init__()
 
 
+class _FakeOmniThinker(nn.Module):
+    pad_input_ids = None
+
+
 def _qwen35_config(*, enable_multimodal: bool, language_model_only: bool = False):
     return SimpleNamespace(
         enable_multimodal=enable_multimodal,
@@ -45,7 +53,9 @@ def _qwen35_config(*, enable_multimodal: bool, language_model_only: bool = False
             rope_parameters={"mrope_section": [16, 24, 24]},
             rope_scaling={},
             tie_word_embeddings=False,
+            pad_token_id=None,
         ),
+        audio_config=SimpleNamespace(),
         vision_config=SimpleNamespace(deepstack_visual_indexes=[8, 16, 24]),
     )
 
@@ -284,6 +294,133 @@ class TestMultimodalConfiguration(CustomTestCase):
         model.visual = nn.Identity()
         with self.assertRaisesRegex(KeyError, "Mobius destination is missing"):
             model.load_weights([("model.visual.patch_embed.proj.weight", None)])
+
+    def test_qwen3_omni_propagates_runtime_config_to_thinker(self):
+        for runtime_config, expected_enable_multimodal, expected_lm_only in (
+            ({}, True, False),
+            (
+                {
+                    "enable_multimodal": False,
+                    "encoder_only": False,
+                    "language_only": False,
+                },
+                False,
+                False,
+            ),
+            ({"language_model_only": True}, True, True),
+        ):
+            with self.subTest(runtime_config=runtime_config):
+                thinker_config = SimpleNamespace()
+                config = SimpleNamespace(
+                    thinker_config=thinker_config,
+                    **runtime_config,
+                )
+
+                with (
+                    patch.object(
+                        qwen3_omni_moe.PreTrainedModel,
+                        "__init__",
+                        lambda self, config: nn.Module.__init__(self),
+                    ),
+                    patch.object(
+                        qwen3_omni_moe,
+                        "Qwen3OmniMoeThinkerForConditionalGeneration",
+                        return_value=_FakeOmniThinker(),
+                    ),
+                ):
+                    model = Qwen3OmniMoeForConditionalGeneration(config)
+
+                self.assertIs(model.enable_multimodal, expected_enable_multimodal)
+                self.assertIs(model.language_model_only, expected_lm_only)
+                self.assertIs(
+                    thinker_config.enable_multimodal, expected_enable_multimodal
+                )
+                self.assertIs(thinker_config.language_model_only, expected_lm_only)
+                self.assertFalse(thinker_config.encoder_only)
+                self.assertFalse(thinker_config.language_only)
+
+    def test_qwen3_omni_enabled_towers_use_text_norm_eps(self):
+        config = _qwen35_config(enable_multimodal=True)
+        config.text_config.rms_norm_eps = 1e-5
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        mm_config = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        with (
+            patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+            patch.object(qwen3_vl, "get_mm", return_value=mm_config),
+            patch.object(qwen3_omni_moe, "Qwen3MoeLLMModel", _FakeLanguageModel),
+            patch.object(qwen3_vl, "Qwen3VLMoeVisionModel"),
+            patch.object(qwen3_vl, "LogitsProcessor", return_value=nn.Identity()),
+            patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+            patch.object(qwen3_omni_moe, "Qwen3OmniMoeAudioEncoder") as audio_model,
+            patch.object(qwen3_omni_moe, "Qwen3OmniMoeVisionEncoder") as vision_model,
+        ):
+            model = Qwen3OmniMoeThinkerForConditionalGeneration(config)
+
+        audio_model.assert_called_once_with(config.audio_config, None)
+        vision_model.assert_called_once_with(
+            config.vision_config,
+            quant_config=None,
+            norm_eps=config.text_config.rms_norm_eps,
+            prefix="visual",
+        )
+        self.assertIs(model.visual, vision_model.return_value)
+
+    def test_qwen3_omni_skips_unneeded_multimodal_towers_and_weights(self):
+        pp_group = SimpleNamespace(is_last_rank=False, world_size=1)
+        mm_config = SimpleNamespace(mm_enable_dp_encoder=False)
+
+        for enable_multimodal, language_model_only in (
+            (False, False),
+            (True, True),
+        ):
+            with self.subTest(
+                enable_multimodal=enable_multimodal,
+                language_model_only=language_model_only,
+            ):
+                config = _qwen35_config(enable_multimodal=enable_multimodal)
+                config.language_model_only = language_model_only
+                with (
+                    patch.object(qwen3_vl, "get_pp_group", return_value=pp_group),
+                    patch.object(qwen3_vl, "get_mm", return_value=mm_config),
+                    patch.object(
+                        qwen3_omni_moe, "Qwen3MoeLLMModel", _FakeLanguageModel
+                    ),
+                    patch.object(
+                        qwen3_vl, "LogitsProcessor", return_value=nn.Identity()
+                    ),
+                    patch.object(qwen3_vl, "Pooler", return_value=nn.Identity()),
+                    patch.object(
+                        qwen3_omni_moe, "Qwen3OmniMoeAudioEncoder"
+                    ) as audio_model,
+                    patch.object(
+                        qwen3_omni_moe, "Qwen3OmniMoeVisionEncoder"
+                    ) as vision_model,
+                ):
+                    model = Qwen3OmniMoeThinkerForConditionalGeneration(config)
+
+                audio_model.assert_not_called()
+                vision_model.assert_not_called()
+                self.assertIsNone(model.audio_tower)
+                self.assertIsNone(model.visual)
+
+                outer_model = Qwen3OmniMoeForConditionalGeneration.__new__(
+                    Qwen3OmniMoeForConditionalGeneration
+                )
+                nn.Module.__init__(outer_model)
+                outer_model.config = SimpleNamespace(num_experts=1)
+                outer_model.enable_talker = False
+                outer_model.enable_multimodal = enable_multimodal
+                outer_model.language_model_only = language_model_only
+                weights = [
+                    ("thinker.visual.patch_embed.proj.weight", None),
+                    ("thinker.audio_tower.conv2d1.weight", None),
+                ]
+
+                with patch.object(qwen3_omni_moe.logger, "warning") as warning:
+                    outer_model.load_weights(weights)
+
+                warning.assert_not_called()
 
 
 class TestDisabledMultimodalRequests(CustomTestCase):

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -405,6 +405,7 @@ class _DummyAsyncCM:
 def _make_tm_for_generate() -> TokenizerManager:
     """Augment the mocked TokenizerManager with what generate_request needs."""
     tm = _make_tokenizer_manager()
+    tm.model_config = MagicMock(enable_multimodal=True)
     tm.server_args.language_only = False
     tm.server_args.tokenizer_worker_num = 1
     tm.auto_create_handle_loop = Mock()

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -416,6 +416,7 @@ class _DummyAsyncCM:
 def _make_tm_for_generate() -> TokenizerManager:
     """Augment the mocked TokenizerManager with what generate_request needs."""
     tm = _make_tokenizer_manager()
+    tm.model_config = MagicMock(is_multimodal=True)
     tm.server_args.language_only = False
     tm.server_args.tokenizer_worker_num = 1
     tm.server_args.enable_strict_thinking = False


### PR DESCRIPTION
## Motivation

Qwen3 Omni owns separate audio and vision towers under its nested thinker configuration. #31081 establishes the effective text-only capability contract for Qwen3-derived models; this child applies it to Omni without widening the parent.

## Changes

- Project resolved multimodal/language-only state into `thinker_config` before construction.
- Omit Omni audio and vision towers when capability is disabled.
- Skip exactly `thinker.audio_tower.*` and `thinker.visual.*` checkpoint weights in that mode.
- Preserve default-enabled construction, including explicit vision `norm_eps` from the thinker text config.
- Add focused coverage for nested propagation, tower omission, exact weight omission, default-enabled behavior, and `language_model_only` composition.

## Verification

- The child diff relative to #31081 contains exactly two files: `qwen3_omni_moe.py` and the focused multimodal configuration test.
- The full focused suite previously passed 11 tests plus 20 subtests; exact-tip compilation, Ruff, isort, registered-test validation, and diff checks pass.
- The official checkpoint audio fixture uses `thinker.audio_tower.conv2d1.weight`.
- Fresh independent review found no correctness blockers.
- Replayed onto the repaired/current-main #31081 parent with all parent coverage preserved.

No model-forward or speed claim is made. The default-enabled path is unchanged, and no local Omni checkpoint was available for a GPU parity run.

## Dependency

Depends on #31081. GitHub shows the parent changes because an upstream PR cannot use a fork branch as its base; after #31081 lands, rebasing this branch onto `main` leaves only the two-file Omni diff.

## Checklist

- [x] Format with repo-configured checks.
- [x] Add focused unit coverage.
- [ ] Rebase onto `main` after #31081 lands.
- [x] Keep the Omni child isolated to its two owning files.
- [x] Follow SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31553470812](https://github.com/sgl-project/sglang/actions/runs/31553470812)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31553470681](https://github.com/sgl-project/sglang/actions/runs/31553470681)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->