### PR TITLE
[Cherry-pick to release/v0.5.15] Stabilize GLM-5.2 MTP IndexShare across PD and CUDA graph replay (#30839)

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -737,7 +737,7 @@ class TboForwardBatchPreparer:
             "split_index",  # for split prefill
             "orig_seq_lens",  # only used by qwen-1m, thus not care
             "return_pooled_hidden_states",
-            "reuse_mtp_topk_indices",  # forward-level flag, inherited by both child batches
+            "reuse_dsa_topk_indices",  # forward-level flag, inherited by both child batches
         ]:
             output_dict[key] = getattr(batch, key)
 

--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -27,12 +27,8 @@ patches:
   - target: sglang.srt.speculative.eagle_draft_cuda_graph_runner.EAGLEDraftCudaGraphRunner.capture_one_shape
     edits:
       - match: |
-          forward_batch.spec_info.hidden_states = hidden_states_backup
           forward_batch.positions.sub_(self.eagle_worker.speculative_num_steps - 1)
-          return ret
-        replacement: |
-          forward_batch.spec_info.hidden_states = hidden_states_backup
-          return ret
+        replacement: ""
 """
 
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1520,6 +1520,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             output_topk_p,
             output_topk_index,
             output_hidden_states,
+            output_dsa_topk_indices,
             output_bootstrap_room,
         ) = self.metadata_buffers.get_buf(idx)
 
@@ -1595,6 +1596,12 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             decode_req.req.output_topk_p = output_topk_p
             decode_req.req.output_topk_index = output_topk_index
             decode_req.req.hidden_states_tensor = output_hidden_states
+            if (
+                output_dsa_topk_indices is not None
+                and torch.all(output_dsa_topk_indices < 0).item()
+            ):
+                output_dsa_topk_indices = None
+            decode_req.req.output_dsa_topk_indices = output_dsa_topk_indices
 
         if decode_req.req.return_logprob:
             decode_req.req.logprob.output_token_logprobs_val.append(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -637,8 +637,14 @@ class SchedulerDisaggregationPrefillMixin:
                     req.hidden_states_tensor = (
                         batch.spec_info.hidden_states[i].cpu().clone()
                     )
+                    dsa_topk_indices = batch.spec_info.dsa_topk_indices
+                    if dsa_topk_indices is not None:
+                        req.output_dsa_topk_indices = dsa_topk_indices[i].cpu().clone()
+                    else:
+                        req.output_dsa_topk_indices = None
                 else:
                     req.hidden_states_tensor = None
+                    req.output_dsa_topk_indices = None
                 if req.return_logprob:
                     assert extend_logprob_start_len_per_req is not None
                     assert extend_input_len_per_req is not None
@@ -1114,6 +1120,7 @@ class SchedulerDisaggregationPrefillMixin:
         req.start_send_idx = 0
         req.tmp_end_idx = -1
         req.hidden_states_tensor = None
+        req.output_dsa_topk_indices = None
         req.pending_bootstrap = True
         req.time_stats.reset_prefill_retry_time()
         if req.time_stats.prefill_retry_count >= max_retries:

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -11,6 +11,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
+from sglang.srt.configs.model_config import get_dsa_index_topk
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.environ import envs
 from sglang.srt.utils import is_hip, is_npu
@@ -31,6 +32,13 @@ if TYPE_CHECKING:
 #########################
 FAKE_BOOTSTRAP_HOST = "2.2.2.2"
 _IS_HIP = is_hip()
+
+
+def get_dsa_seed_metadata_dim(hf_config) -> int:
+    """Return the model-defined PD seed width, independent of local spec mode."""
+    if not getattr(hf_config, "index_share_for_mtp_iteration", False):
+        return 0
+    return get_dsa_index_topk(hf_config)
 
 
 def is_dsv4_c128_online_enabled() -> bool:
@@ -227,8 +235,10 @@ class MetadataBuffers:
         hidden_states_dtype: torch.dtype,
         max_top_logprobs_num: int = 128,
         custom_mem_pool: torch.cuda.MemPool = None,
+        output_dsa_topk_indices_dim: int = 0,
     ):
         self.custom_mem_pool = custom_mem_pool
+        self.output_dsa_topk_indices_dim = output_dsa_topk_indices_dim
         bootstrap_room_dtype = torch.uint64
         device = "cpu"
         if is_npu():
@@ -276,6 +286,15 @@ class MetadataBuffers:
             self.output_hidden_states = torch.zeros(
                 (size, hidden_size), dtype=hidden_states_dtype, device=device
             )
+            if self.output_dsa_topk_indices_dim > 0:
+                self.output_dsa_topk_indices = torch.full(
+                    (size, self.output_dsa_topk_indices_dim),
+                    -1,
+                    dtype=torch.int32,
+                    device=device,
+                )
+            else:
+                self.output_dsa_topk_indices = None
             # Request validation: store bootstrap_room to detect metadata corruption
             self.bootstrap_room = torch.zeros(
                 (size, 8), dtype=bootstrap_room_dtype, device=device
@@ -318,6 +337,10 @@ class MetadataBuffers:
             self.output_hidden_states[0].nbytes,
             self.bootstrap_room[0].nbytes,
         ]
+        if self.output_dsa_topk_indices is not None:
+            ptrs.insert(-1, self.output_dsa_topk_indices.data_ptr())
+            data_lens.insert(-1, self.output_dsa_topk_indices.nbytes)
+            item_lens.insert(-1, self.output_dsa_topk_indices[0].nbytes)
         return ptrs, data_lens, item_lens
 
     def get_buf(self, idx: int):
@@ -331,6 +354,11 @@ class MetadataBuffers:
             self.output_topk_p[idx].clone(),
             self.output_topk_index[idx].clone(),
             self.output_hidden_states[idx].clone(),
+            (
+                self.output_dsa_topk_indices[idx].clone()
+                if self.output_dsa_topk_indices is not None
+                else None
+            ),
             self.bootstrap_room[idx].clone(),
         )
 
@@ -395,6 +423,14 @@ class MetadataBuffers:
             self.output_hidden_states[req.metadata_buffer_index].copy_(
                 req.hidden_states_tensor
             )
+            if self.output_dsa_topk_indices is not None:
+                dsa_topk_indices = req.output_dsa_topk_indices
+                if dsa_topk_indices is not None:
+                    self.output_dsa_topk_indices[req.metadata_buffer_index].copy_(
+                        dsa_topk_indices
+                    )
+                else:
+                    self.output_dsa_topk_indices[req.metadata_buffer_index].fill_(-1)
         # Store bootstrap_room for validation on decode side
         self.bootstrap_room[req.metadata_buffer_index, 0] = (
             req.bootstrap_room if req.bootstrap_room is not None else 0

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -68,6 +68,17 @@ def compute_dsa_seqlens(original_seq_lens, dsa_index_topk: int):
     return original_seq_lens.clamp(max=dsa_index_topk)
 
 
+def should_use_dsa_fused_topk(
+    server_args, seed_dsa_topk_from_draft_extend: bool
+) -> bool:
+    pd_index_share_seed = (
+        server_args.disaggregation_mode != "null" and seed_dsa_topk_from_draft_extend
+    )
+    # TODO(kpham-sgl): Transfer request-relative IndexShare seeds and remap them
+    # to decode-local KV slots so fused top-k can remain enabled under PD.
+    return envs.SGLANG_DSA_FUSE_TOPK.get() and not pd_index_share_seed
+
+
 def is_dsa_enable_prefill_cp():
     return get_global_server_args().enable_dsa_prefill_context_parallel
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -45,6 +45,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_enable_prefill_cp,
     is_dsa_prefill_cp_in_seq_split,
     pad_dsa_cache_seqlens,
+    should_use_dsa_fused_topk,
 )
 from sglang.srt.layers.attention.utils import (
     concat_mla_absorb_q_general,
@@ -62,6 +63,7 @@ from sglang.srt.utils import (
     is_gfx95_supported,
     is_hip,
     is_sm100_supported,
+    print_warning_once,
 )
 
 # Opt-in (default off): route the fp8 sparse-MLA prefill path through the Triton
@@ -343,6 +345,7 @@ class DeepseekSparseAttnBackend(
         speculative_step_id=0,
         topk=0,
         speculative_num_steps=0,
+        seed_dsa_topk_from_draft_extend: bool = False,
     ):
         super().__init__()
         self.forward_metadata: DSAMetadata
@@ -436,6 +439,13 @@ class DeepseekSparseAttnBackend(
             model_runner.server_args.speculative_num_draft_tokens
         )
         self.speculative_step_id = speculative_step_id
+        self.use_fused_topk = should_use_dsa_fused_topk(
+            model_runner.server_args, seed_dsa_topk_from_draft_extend
+        )
+        if envs.SGLANG_DSA_FUSE_TOPK.get() and not self.use_fused_topk:
+            print_warning_once(
+                "Disabling fused DSA top-k for IndexShare under PD disaggregation."
+            )
 
         self.device_capability = torch.cuda.get_device_capability()
         self.device_sm_major = self.device_capability[0]
@@ -1110,7 +1120,7 @@ class DeepseekSparseAttnBackend(
             and self.real_page_size > 1
             and self.hisparse_coordinator is None
             and not self.speculative_num_draft_tokens
-            and envs.SGLANG_DSA_FUSE_TOPK.get()
+            and self.use_fused_topk
             and envs.SGLANG_OPT_USE_TOPK_V2.get()
             and self.dsa_index_topk is not None
             and self.dsa_index_topk <= 2048
@@ -1900,7 +1910,7 @@ class DeepseekSparseAttnBackend(
         topk_transform_method = self.get_topk_transform_method(
             forward_batch.forward_mode
         )
-        if envs.SGLANG_DSA_FUSE_TOPK.get():
+        if self.use_fused_topk:
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         else:
             if topk_transform_method == TopkTransformMethod.RAGGED:
@@ -2115,7 +2125,7 @@ class DeepseekSparseAttnBackend(
                 topk_indices,
                 layer.layer_id,
             )
-        elif envs.SGLANG_DSA_FUSE_TOPK.get():
+        elif self.use_fused_topk:
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         else:
             page_table_1 = transform_index_page_table_decode(
@@ -2672,7 +2682,7 @@ class DeepseekSparseAttnBackend(
         if topk_indices is not None:
             topk_indices = self._pad_topk_indices(topk_indices, q.shape[0])
 
-        if envs.SGLANG_DSA_FUSE_TOPK.get():
+        if self.use_fused_topk:
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         elif is_prefill:
             page_table_1 = transform_index_page_table_prefill(
@@ -2838,7 +2848,7 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
-        force_unfused = (
+        force_unfused = not self.use_fused_topk or (
             self.hisparse_coordinator is not None
             and forward_batch.forward_mode.is_decode_or_idle()
         )
@@ -2882,7 +2892,11 @@ class DeepseekSparseAttnMultiStepBackend:
     needs_cpu_seq_lens: bool = False
 
     def __init__(
-        self, model_runner: ModelRunner, topk: int, speculative_num_steps: int
+        self,
+        model_runner: ModelRunner,
+        topk: int,
+        speculative_num_steps: int,
+        seed_dsa_topk_from_draft_extend: bool = False,
     ):
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
@@ -2894,6 +2908,7 @@ class DeepseekSparseAttnMultiStepBackend:
                     speculative_step_id=i,
                     topk=self.topk,
                     speculative_num_steps=self.speculative_num_steps,
+                    seed_dsa_topk_from_draft_extend=seed_dsa_topk_from_draft_extend,
                 )
             )
 

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -121,7 +121,7 @@ class RelayPayload:
             topk_index=draft_input.topk_index,
             hidden_states=draft_input.hidden_states,
             draft_probs=getattr(draft_input, "draft_probs", None),
-            dsa_topk_indices=getattr(draft_input, "dsa_topk_indices", None),
+            dsa_topk_indices=draft_input.dsa_topk_indices,
         )
 
 
@@ -170,6 +170,7 @@ class FutureMap:
             self.fwd_prepare_d2h_stream = None
         # Lazy-inited on the first non-empty stash (peeks tensor shapes); non-spec's is a no-op.
         self._forward_buf_initialized = False
+        self.dsa_topk_indices_buf = None
 
         self.publish_ready = None  # lazy device.Event(); only spec_v2 needs it
 
@@ -218,14 +219,15 @@ class FutureMap:
                 device=self.device,
             )
 
-        self.dsa_topk_indices_buf = None
-        if payload.dsa_topk_indices is not None:
-            seed0 = payload.dsa_topk_indices[0]
-            self.dsa_topk_indices_buf = torch.empty(
-                (self.req_pool_size, *seed0.shape),
-                dtype=payload.dsa_topk_indices.dtype,
-                device=self.device,
-            )
+    def _maybe_init_dsa_topk_indices_buf(self, payload: RelayPayload) -> None:
+        if self.dsa_topk_indices_buf is not None or payload.dsa_topk_indices is None:
+            return
+        seed0 = payload.dsa_topk_indices[0]
+        self.dsa_topk_indices_buf = torch.empty(
+            (self.req_pool_size, *seed0.shape),
+            dtype=payload.dsa_topk_indices.dtype,
+            device=self.device,
+        )
 
     def _resolve_spec_extras(self, batch: ScheduleBatch) -> None:
         if self.spec_algo.is_ngram():
@@ -266,8 +268,11 @@ class FutureMap:
             draft_input.bonus_tokens = self.output_tokens_buf[indices]
         if self.need_hidden_states and not self.need_topk:
             draft_input.hidden_states = self.hidden_states_buf[indices]
-        if self.dsa_topk_indices_buf is not None:
+        if draft_input.future_dsa_topk_indices_available:
+            assert self.dsa_topk_indices_buf is not None
             draft_input.dsa_topk_indices = self.dsa_topk_indices_buf[indices]
+        else:
+            draft_input.dsa_topk_indices = None
         if _DEBUG_ASSERT:
             _assert_nonneg_and_invalidate(
                 draft_input.bonus_tokens, self.output_tokens_buf, indices
@@ -336,6 +341,7 @@ class FutureMap:
             return
         if not self._forward_buf_initialized:
             self._lazy_init_forward_buf(payload)
+        self._maybe_init_dsa_topk_indices_buf(payload)
         self.output_tokens_buf[indices] = payload.bonus_tokens.to(
             self.output_tokens_buf.dtype
         )

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -111,6 +111,7 @@ class RelayPayload:
     topk_index: Optional[torch.Tensor] = None
     hidden_states: Optional[torch.Tensor] = None
     draft_probs: Optional[torch.Tensor] = None
+    dsa_topk_indices: Optional[torch.Tensor] = None
 
     @classmethod
     def from_draft_input(cls, draft_input: EagleDraftInput) -> RelayPayload:
@@ -120,6 +121,7 @@ class RelayPayload:
             topk_index=draft_input.topk_index,
             hidden_states=draft_input.hidden_states,
             draft_probs=getattr(draft_input, "draft_probs", None),
+            dsa_topk_indices=getattr(draft_input, "dsa_topk_indices", None),
         )
 
 
@@ -216,6 +218,15 @@ class FutureMap:
                 device=self.device,
             )
 
+        self.dsa_topk_indices_buf = None
+        if payload.dsa_topk_indices is not None:
+            seed0 = payload.dsa_topk_indices[0]
+            self.dsa_topk_indices_buf = torch.empty(
+                (self.req_pool_size, *seed0.shape),
+                dtype=payload.dsa_topk_indices.dtype,
+                device=self.device,
+            )
+
     def _resolve_spec_extras(self, batch: ScheduleBatch) -> None:
         if self.spec_algo.is_ngram():
             # FIXME: remove once precomputed draft is supported.
@@ -255,6 +266,8 @@ class FutureMap:
             draft_input.bonus_tokens = self.output_tokens_buf[indices]
         if self.need_hidden_states and not self.need_topk:
             draft_input.hidden_states = self.hidden_states_buf[indices]
+        if self.dsa_topk_indices_buf is not None:
+            draft_input.dsa_topk_indices = self.dsa_topk_indices_buf[indices]
         if _DEBUG_ASSERT:
             _assert_nonneg_and_invalidate(
                 draft_input.bonus_tokens, self.output_tokens_buf, indices
@@ -338,3 +351,10 @@ class FutureMap:
             )
         if self.draft_probs_buf is not None and payload.draft_probs is not None:
             self.draft_probs_buf[indices] = payload.draft_probs
+        if (
+            self.dsa_topk_indices_buf is not None
+            and payload.dsa_topk_indices is not None
+        ):
+            self.dsa_topk_indices_buf[indices] = payload.dsa_topk_indices.to(
+                self.dsa_topk_indices_buf.dtype
+            )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -920,6 +920,7 @@ class Req(ReqDllmMixin):
         self.hidden_states_tensor = None  # Note: use tensor instead of list to transfer hidden_states when PD + MTP
         self.output_topk_p = None
         self.output_topk_index = None
+        self.output_dsa_topk_indices = None
 
         # capture routed experts
         self.return_routed_experts = return_routed_experts

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -61,6 +61,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    get_dsa_seed_metadata_dim,
     prepare_abort,
 )
 from sglang.srt.distributed import get_pp_group, get_world_group
@@ -1152,6 +1153,12 @@ class Scheduler(
             disagg_hidden_size = 16  # minimal padding size for RDMA
             disagg_hidden_states_dtype = torch.float32
 
+        # The PD metadata wire schema must match on P and D even when only D
+        # enables spec decoding; a seedless prefill writes the invalid sentinel.
+        output_dsa_topk_indices_dim = get_dsa_seed_metadata_dim(
+            self.model_config.hf_config
+        )
+
         if (
             self.disaggregation_mode == DisaggregationMode.DECODE
         ):  # *2 for the headroom.
@@ -1164,6 +1171,7 @@ class Scheduler(
                 hidden_size=disagg_hidden_size,
                 hidden_states_dtype=disagg_hidden_states_dtype,
                 custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),
+                output_dsa_topk_indices_dim=output_dsa_topk_indices_dim,
             )
 
             # The decode requests polling kv cache
@@ -1209,6 +1217,7 @@ class Scheduler(
                 hidden_size=disagg_hidden_size,
                 hidden_states_dtype=disagg_hidden_states_dtype,
                 custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),
+                output_dsa_topk_indices_dim=output_dsa_topk_indices_dim,
             )
 
             self.disagg_prefill_bootstrap_queue = PrefillBootstrapQueue(
@@ -3302,6 +3311,9 @@ class Scheduler(
 
                 if not batch.spec_algorithm.is_none():
                     batch.spec_info = batch_result.next_draft_input
+                    batch.spec_info.future_dsa_topk_indices_available = (
+                        batch.spec_info.dsa_topk_indices is not None
+                    )
                     batch.spec_info.future_indices = future_indices
             elif self.enable_pdmux and batch.forward_mode.is_split_prefill():
                 resolve_forward_inputs(batch, self.future_map)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -431,8 +431,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     return_hidden_states_before_norm: bool = False
 
     # Gate for reusing the first MTP draft step's indexer topk across steps;
-    # the carried topk lives on spec_info (see EagleDraftInput.mtp_topk_indices).
-    reuse_mtp_topk_indices: Optional[bool] = False
+    # the carried topk lives on spec_info (see EagleDraftInput.dsa_topk_indices).
+    reuse_dsa_topk_indices: Optional[bool] = False
 
     # === Forward-derived (built in init_new on the forward stream; FB-owned) ===
     # Position information

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -62,6 +62,36 @@ def _resolve_attn_backend(forward_batch: ForwardBatch):
     return backend
 
 
+def _forward_dsa_indexer_for_mha(
+    indexer,
+    *,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    positions: torch.Tensor,
+    forward_batch: ForwardBatch,
+    layer_id: int,
+) -> None:
+    """Fill the indexer K cache and publish an MTP seed when requested."""
+    spec_info = forward_batch.spec_info
+    seed_buf = spec_info.dsa_seed_topk_capture if spec_info is not None else None
+    topk_indices = indexer(
+        x=hidden_states,
+        q_lora=q_lora,
+        positions=positions,
+        forward_batch=forward_batch,
+        layer_id=layer_id,
+        return_indices=seed_buf is not None,
+    )
+    if seed_buf is None:
+        return
+    if topk_indices is None:
+        raise RuntimeError("DSA MHA indexer did not produce the requested MTP seed")
+
+    select = spec_info.dsa_seed_topk_select
+    src = topk_indices if select is None else topk_indices[select]
+    seed_buf[: src.shape[0]].copy_(src)
+
+
 # Configs for DeepSeek-V3:
 # num_local_heads = 128
 # qk_nope_head_dim = 128
@@ -175,13 +205,13 @@ class DeepseekMHAForwardMixin:
                         -1, self.num_local_heads, self.qk_head_dim
                     )
                 if self.should_run_indexer():
-                    _ = self.indexer(
-                        x=hidden_states,
+                    _forward_dsa_indexer_for_mha(
+                        self.indexer,
+                        hidden_states=hidden_states,
                         q_lora=q_lora,
                         positions=positions,
                         forward_batch=forward_batch,
                         layer_id=self.layer_id,
-                        return_indices=False,
                     )
             elif _use_aiter_gfx95 and self.q_b_proj.weight.dtype == torch.uint8:
                 # MXFP4: fused RMSNorm + quant

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -237,13 +237,22 @@ class DeepseekModelNextN(nn.Module):
                     residual,
                     zero_allocator,
                     prev_topk_indices=(
-                        forward_batch.spec_info.mtp_topk_indices
-                        if forward_batch.reuse_mtp_topk_indices
+                        forward_batch.spec_info.dsa_topk_indices
+                        if forward_batch.reuse_dsa_topk_indices
                         else None
                     ),
                 )
-                if forward_batch.reuse_mtp_topk_indices:
-                    forward_batch.spec_info.mtp_topk_indices = topk_indices
+                if forward_batch.reuse_dsa_topk_indices:
+                    forward_batch.spec_info.dsa_topk_indices = topk_indices
+
+                # MTP IndexShare: on draft-extend, publish the last-token DSA
+                # indexer top-k to seed (avoid recomputing in) the draft-decode loop.
+                if forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
+                    seed_buf = forward_batch.spec_info.dsa_seed_topk_capture
+                    if seed_buf is not None and topk_indices is not None:
+                        sel = forward_batch.spec_info.dsa_seed_topk_select
+                        src = topk_indices if sel is None else topk_indices[sel]
+                        seed_buf[: src.shape[0]].copy_(src)
 
             if not forward_batch.forward_mode.is_idle():
                 if residual is not None:

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -13,11 +13,13 @@ class DraftBackendFactory:
         draft_model_runner,
         topk: int,
         speculative_num_steps: int,
+        seed_dsa_topk_from_draft_extend: bool = False,
     ):
         self.server_args = server_args
         self.draft_model_runner = draft_model_runner
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
+        self.seed_dsa_topk_from_draft_extend = seed_dsa_topk_from_draft_extend
         self.draft_attn_backend = server_args.speculative_draft_attention_backend
 
     def _create_backend(
@@ -109,13 +111,20 @@ class DraftBackendFactory:
         )
 
         return DeepseekSparseAttnMultiStepBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_model_runner,
+            self.topk,
+            self.speculative_num_steps,
+            seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
         )
 
     def _create_dsa_prefill_backend(self):
         from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
 
-        return DeepseekSparseAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return DeepseekSparseAttnBackend(
+            self.draft_model_runner,
+            skip_prefill=False,
+            seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
+        )
 
     def _create_flashinfer_decode_backend(self):
         if not self.draft_model_runner.use_mla_backend:

--- a/python/sglang/srt/speculative/eagle_disaggregation.py
+++ b/python/sglang/srt/speculative/eagle_disaggregation.py
@@ -51,15 +51,24 @@ def build_eagle_disagg_draft_input(
         [req.hidden_states_tensor for req in batch.reqs], dim=0
     ).to(batch.device)
 
+    dsa_topk_indices = None
+    dsa_indices_list = [req.output_dsa_topk_indices for req in batch.reqs]
+    if dsa_indices_list and all(t is not None for t in dsa_indices_list):
+        dsa_topk_indices = torch.stack(dsa_indices_list, dim=0).to(batch.device)
+        if torch.any(torch.all(dsa_topk_indices < 0, dim=1)).item():
+            dsa_topk_indices = None
+
     spec_info = EagleDraftInput(
         topk_p=topk_p,
         topk_index=topk_index,
         hidden_states=hidden_states,
         bonus_tokens=last_tokens_tensor,
+        dsa_topk_indices=dsa_topk_indices,
     )
     spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
 
     if batch.enable_overlap:
+        spec_info.future_dsa_topk_indices_available = dsa_topk_indices is not None
         spec_info.future_indices = batch.req_pool_indices
         future_map.publish(spec_info.future_indices, batch.seq_lens)
         future_map.stash(

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -441,11 +441,13 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
 
             output_cache_loc_backup = forward_batch.out_cache_loc
             hidden_states_backup = forward_batch.spec_info.hidden_states
+            dsa_topk_indices_backup = forward_batch.spec_info.dsa_topk_indices
 
             ret = self.eagle_worker.draft_forward(forward_batch)
 
             forward_batch.out_cache_loc = output_cache_loc_backup
             forward_batch.spec_info.hidden_states = hidden_states_backup
+            forward_batch.spec_info.dsa_topk_indices = dsa_topk_indices_backup
             forward_batch.positions.sub_(self.eagle_worker.speculative_num_steps - 1)
             return ret
 
@@ -644,6 +646,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
         )
         with timer_ctx:
             out = self._replay_graph(shape_key, forward_batch)
+        if self.buffers.dsa_seed_topk is not None:
+            forward_batch.spec_info.dsa_topk_indices = None
 
         if bs != raw_bs:
             out = self._postprocess_output_to_raw_bs(out, raw_bs)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -69,6 +69,7 @@ class EagleDraftInputBuffers(ForwardInputBuffers):
     hidden_states: Optional[torch.Tensor]
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
+    dsa_seed_topk: Optional[torch.Tensor] = None
 
 
 class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
@@ -228,6 +229,16 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             (self.max_bs,), self.seq_len_fill_value, dtype=torch.int64, device="cpu"
         )
 
+        dsa_seed_topk = (
+            torch.zeros(
+                (self.max_bs, self.eagle_worker.dsa_index_topk),
+                dtype=torch.int32,
+                device=model_runner.device,
+            )
+            if self.eagle_worker.seed_dsa_topk_from_draft_extend
+            else None
+        )
+
         self.buffers = EagleDraftInputBuffers(
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,
@@ -245,6 +256,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             hidden_states=hidden_states,
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+            dsa_seed_topk=dsa_seed_topk,
         )
         self.buffers.share_buffers()
 
@@ -372,6 +384,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             hidden_states=hidden_states,
             capture_hidden_mode=capture_mode,
         )
+        if self.buffers.dsa_seed_topk is not None:
+            spec_info.dsa_topk_indices = self.buffers.dsa_seed_topk[:num_seqs]
 
         sampling_info = SamplingBatchInfo(
             temperatures=self.temperatures[:num_seqs],
@@ -504,6 +518,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
                 buffers.draft_probs.zero_()
             if buffers.hidden_states is not None:
                 buffers.hidden_states.zero_()
+            if buffers.dsa_seed_topk is not None:
+                buffers.dsa_seed_topk.zero_()
             buffers.req_pool_indices.zero_()
 
         num_tokens = bs * self.num_tokens_per_bs
@@ -563,6 +579,12 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             and forward_batch.spec_info.hidden_states is not None
         ):
             buffers.hidden_states[:raw_bs].copy_(forward_batch.spec_info.hidden_states)
+        if buffers.dsa_seed_topk is not None:
+            seed = forward_batch.spec_info.dsa_topk_indices
+            if seed is not None:
+                buffers.dsa_seed_topk[:raw_bs].copy_(seed)
+            else:
+                buffers.dsa_seed_topk[:raw_bs].zero_()
         # Only rejection sampling reads temperatures (renorm_draft_probs); skip
         # the copy otherwise to keep the non-RS path free of extra work.
         if (

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -69,6 +69,7 @@ class EagleDraftExtendInputBuffers(ForwardInputBuffers):
     next_token_logits_buffer: torch.Tensor
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
+    dsa_seed_topk_capture: Optional[torch.Tensor] = None
 
 
 class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
@@ -234,6 +235,17 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             (self.max_bs,), self.seq_len_fill_value, dtype=torch.int64, device="cpu"
         )
 
+        dsa_seed_topk_capture = (
+            torch.full(
+                (self.max_num_token, self.eagle_worker.dsa_index_topk),
+                -1,
+                dtype=torch.int32,
+                device=model_runner.device,
+            )
+            if self.eagle_worker.seed_dsa_topk_from_draft_extend
+            else None
+        )
+
         self.buffers = EagleDraftExtendInputBuffers(
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,
@@ -249,6 +261,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             next_token_logits_buffer=next_token_logits_buffer,
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+            dsa_seed_topk_capture=dsa_seed_topk_capture,
         )
         self.buffers.share_buffers()
 
@@ -384,6 +397,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             capture_hidden_mode=CaptureHiddenMode.LAST,
             padded_static_len=self.padded_static_len,
         )
+
+        if self.buffers.dsa_seed_topk_capture is not None:
+            spec_info.dsa_seed_topk_capture = self.buffers.dsa_seed_topk_capture[
+                :num_tokens
+            ]
 
         def run_once():
             self.draft_extend_attn_backend.init_forward_metadata_in_graph(forward_batch)

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -176,6 +176,7 @@ class EagleDraftInput(SpecInput):
 
     # V2 overlap worker only: req_pool_indices used as buf slot keys.
     future_indices: Optional[torch.Tensor] = None
+    future_dsa_topk_indices_available: bool = False
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT)
@@ -252,6 +253,10 @@ class EagleDraftInput(SpecInput):
             assert spec_info.future_indices is not None
             self.future_indices = torch.cat(
                 [self.future_indices, spec_info.future_indices]
+            )
+            self.future_dsa_topk_indices_available = (
+                self.future_dsa_topk_indices_available
+                and spec_info.future_dsa_topk_indices_available
             )
             return
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -161,7 +161,7 @@ class EagleDraftInput(SpecInput):
 
     # Survives across draft steps: spec_info is shared by reference across the
     # per-step forwards (each runs on a copied ForwardBatch, dropping writebacks).
-    mtp_topk_indices: Optional[torch.Tensor] = None
+    dsa_topk_indices: Optional[torch.Tensor] = None
 
     # Per-req bonus token (the "+1" target prediction at end of each accept
     # chain); the worker copies it here post-extend for next iter's draft.
@@ -233,6 +233,8 @@ class EagleDraftInput(SpecInput):
             if self.hidden_states is not None:
                 self.hidden_states = self.hidden_states[: len(new_indices)]
             self.bonus_tokens = self.bonus_tokens[: len(new_indices)]
+            if self.dsa_topk_indices is not None:
+                self.dsa_topk_indices = self.dsa_topk_indices[: len(new_indices)]
         else:
             # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
             self.topk_p = self.topk_p[new_indices]
@@ -242,6 +244,8 @@ class EagleDraftInput(SpecInput):
             if self.hidden_states is not None:
                 self.hidden_states = self.hidden_states[new_indices]
             self.bonus_tokens = self.bonus_tokens[new_indices]
+            if self.dsa_topk_indices is not None:
+                self.dsa_topk_indices = self.dsa_topk_indices[new_indices]
 
     def merge_batch(self, spec_info: "EagleDraftInput"):
         if self.future_indices is not None:
@@ -260,6 +264,7 @@ class EagleDraftInput(SpecInput):
             self.topk_p = spec_info.topk_p
             self.topk_index = spec_info.topk_index
             self.draft_probs = spec_info.draft_probs
+            self.dsa_topk_indices = spec_info.dsa_topk_indices
             return
         if len(spec_info.topk_index) == 0:
             return
@@ -272,6 +277,12 @@ class EagleDraftInput(SpecInput):
         )
         self.topk_p = torch.cat([self.topk_p, spec_info.topk_p])
         self.topk_index = torch.cat([self.topk_index, spec_info.topk_index])
+        if self.dsa_topk_indices is not None and spec_info.dsa_topk_indices is not None:
+            self.dsa_topk_indices = torch.cat(
+                [self.dsa_topk_indices, spec_info.dsa_topk_indices]
+            )
+        else:
+            self.dsa_topk_indices = None
         if self.draft_probs is not None and spec_info.draft_probs is not None:
             self.draft_probs = torch.cat([self.draft_probs, spec_info.draft_probs])
 
@@ -316,6 +327,9 @@ class EagleDraftExtendInput(SpecInput):
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.LAST
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = 1
+
+    dsa_seed_topk_capture: Optional[torch.Tensor] = None
+    dsa_seed_topk_select: Optional[torch.Tensor] = None
 
     # None for draft-extend's idle batch; attention backends fall back to
     # rebuilding plain metadata from seq_lens when this is None.

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -14,6 +14,7 @@ from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner i
 )
 from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import NPUGraphRunner
 from sglang.srt.kv_canary.runner.canary_manager import context_tuple
+from sglang.srt.layers.attention.dsa.utils import dsa_use_prefill_cp
 from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
 from sglang.srt.layers.attention.tokenspeed_mla_backend import TokenspeedMLABackend
 from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
@@ -191,16 +192,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         # Alias for better readability
         self.draft_runner = self.draft_worker.model_runner
-        # Reuse the first draft step's NSA/DSA indexer topk across the rest;
-        # topk == 1 only (select_top_k_tokens reorders rows, desyncing indices).
-        self.index_share_for_mtp_iteration = (
-            getattr(
-                self.draft_runner.model_config.hf_config,
-                "index_share_for_mtp_iteration",
-                False,
-            )
-            and self.topk == 1
-        )
+        self._init_dsa_index_share_state()
+        # Eager draft-extend seed buffer (graph paths use their own static ones).
+        self.dsa_extend_topk_buf: Optional[torch.Tensor] = None
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
@@ -263,6 +257,23 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         if (c := self.draft_runner.canary_manager) is not None:
             c.mark_init_finished()
+
+    def _init_dsa_index_share_state(self) -> None:
+        # Populate DSA index-share fields from the draft runner's hf_config.
+        # Reused by the attention unit-test harnesses, which skip __init__.
+        hf_config = self.draft_runner.model_config.hf_config
+        # Reuse the first draft step's DSA indexer topk across the rest;
+        # topk == 1 only (select_top_k_tokens reorders rows, desyncing indices).
+        self.index_share_for_mtp_iteration = (
+            getattr(hf_config, "index_share_for_mtp_iteration", False)
+            and self.topk == 1
+        )
+        # GLM-5.2 MTP IndexShare: seed reused indexer top-k from draft-extend
+        # (last verified token), not draft-decode step 0.
+        self.dsa_index_topk = getattr(hf_config, "index_topk", None)
+        self.seed_dsa_topk_from_draft_extend = (
+            self.index_share_for_mtp_iteration and self.dsa_index_topk is not None
+        )
 
     def _rebuild_topk1_chain_buffers(self) -> None:
         # For topk=1 the draft tree degenerates to a chain, so parent_list and
@@ -629,8 +640,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         # Forward multiple steps
         scores = None
         if self.index_share_for_mtp_iteration:
-            forward_batch.reuse_mtp_topk_indices = True
-            spec_info.mtp_topk_indices = None
+            forward_batch.reuse_dsa_topk_indices = True
+            # Keep the draft-extend seed so step 0 reuses it; else recompute it.
+            if not (
+                self.seed_dsa_topk_from_draft_extend
+                and spec_info.dsa_topk_indices is not None
+            ):
+                spec_info.dsa_topk_indices = None
         for i in range(self.speculative_num_steps):
             input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
                 i, topk_p, topk_index, hidden_states, scores, self.topk
@@ -706,8 +722,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             forward_batch.positions.add_(1)
 
         if self.index_share_for_mtp_iteration:
-            spec_info.mtp_topk_indices = None
-            forward_batch.reuse_mtp_topk_indices = False
+            spec_info.dsa_topk_indices = None
+            forward_batch.reuse_dsa_topk_indices = False
 
         # Organize the results
         if (
@@ -794,6 +810,23 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         if mm_input_embeds is not None:
             forward_batch.mm_input_embeds = mm_input_embeds
 
+        # Seed the first draft-decode loop from each request's last prefill
+        # position. Gather last-per-req before the copy (prefill can be long).
+        # Skipped under context-parallel prefill (token layout wouldn't match).
+        seed_from_extend = (
+            self.seed_dsa_topk_from_draft_extend
+            and not forward_batch.forward_mode.is_idle()
+            and not dsa_use_prefill_cp(forward_batch)
+        )
+        if seed_from_extend:
+            bs = forward_batch.batch_size
+            forward_batch.spec_info.dsa_seed_topk_capture = (
+                self._get_dsa_extend_topk_buf(bs)
+            )
+            forward_batch.spec_info.dsa_seed_topk_select = (
+                torch.cumsum(forward_batch.extend_seq_lens, dim=0) - 1
+            ).long()
+
         canary_ctx = (
             context_tuple(
                 c.with_ops_outside_graph(
@@ -809,6 +842,10 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             logits_output = self.draft_runner.forward(forward_batch).logits_output
         maybe_detect_nan(logits_output.next_token_logits, "draft_extend_for_prefill")
         maybe_detect_inf(logits_output.next_token_logits, "draft_extend_for_prefill")
+
+        prefill_dsa_topk = None
+        if seed_from_extend:
+            prefill_dsa_topk = self.dsa_extend_topk_buf[:bs].clone()
 
         # Assemble the next-iter draft spec_info from the extend output.
         use_rejection_sampling = self.server_args.speculative_use_rejection_sampling
@@ -829,7 +866,21 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             bonus_tokens=next_token_ids,
             num_tokens_per_req=1,
             num_tokens_for_logprob_per_req=1,
+            dsa_topk_indices=prefill_dsa_topk,
         )
+
+    def _get_dsa_extend_topk_buf(self, num_tokens: int) -> torch.Tensor:
+        """Lazily-grown int32 [num_tokens, index_topk] eager draft-extend seed buffer."""
+        buf = self.dsa_extend_topk_buf
+        if buf is None or buf.shape[0] < num_tokens:
+            buf = torch.full(
+                (num_tokens, self.dsa_index_topk),
+                -1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self.dsa_extend_topk_buf = buf
+        return buf[:num_tokens]
 
     def _draft_extend_for_decode(
         self, batch: ScheduleBatch, batch_result: GenerationBatchResult
@@ -882,6 +933,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             and self.cuda_graph_runner_for_draft_extend.can_run_graph(forward_batch)
         )
 
+        # Eager path publishes the indexer top-k into a worker buffer (the graph
+        # path uses the runner's static buffer). Gathered at select_index below.
+        if self.seed_dsa_topk_from_draft_extend and not can_cuda_graph:
+            forward_batch.spec_info.dsa_seed_topk_capture = (
+                self._get_dsa_extend_topk_buf(forward_batch.input_ids.shape[0])
+            )
+
         canary_ctx = (
             context_tuple(
                 c.with_ops_outside_graph(
@@ -911,6 +969,19 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             draft_logits_output.next_token_logits,
             f"draft_extend_for_decode (cuda_graph={can_cuda_graph})",
         )
+
+        # Gather the per-request last-position indexer top-k as the next loop's
+        # seed (select_index already picks the last accepted position per req).
+        dsa_seed_topk_indices = None
+        if self.seed_dsa_topk_from_draft_extend:
+            if can_cuda_graph:
+                dsa_extend_topk_capture = (
+                    self.cuda_graph_runner_for_draft_extend.buffers.dsa_seed_topk_capture
+                )
+            else:
+                dsa_extend_topk_capture = forward_batch.spec_info.dsa_seed_topk_capture
+            # Fancy indexing returns a fresh tensor (detached from the buffer).
+            dsa_seed_topk_indices = dsa_extend_topk_capture[select_index]
 
         # Reorganize the spec info for the next batch
         draft_logits_output.next_token_logits = draft_logits_output.next_token_logits[
@@ -961,6 +1032,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         )
         if self.server_args.speculative_use_rejection_sampling:
             next_draft_input.draft_probs = ret_draft_probs
+        if self.seed_dsa_topk_from_draft_extend:
+            next_draft_input.dsa_topk_indices = dsa_seed_topk_indices
 
 
 class EAGLEWorkerV2(BaseSpecWorker):

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -376,6 +376,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.draft_runner,
             self.topk,
             self.speculative_num_steps,
+            seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
         )
 
         # Initialize decode attention backend
@@ -513,6 +514,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.topk,
             self.speculative_num_steps,
         )
+        if (
+            can_cuda_graph
+            and not forward_batch.forward_mode.is_idle()
+            and self.seed_dsa_topk_from_draft_extend
+            and draft_input.dsa_topk_indices is None
+        ):
+            can_cuda_graph = False
 
         n_inner = self.speculative_num_steps - 1
         canary_outside_ctx = (

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -227,9 +227,7 @@ class SpeculativeAlgorithm(Enum):
 
             return EAGLEWorkerV2
         elif self.is_standalone():
-            from sglang.srt.speculative.standalone_worker_v2 import (
-                StandaloneWorkerV2,
-            )
+            from sglang.srt.speculative.standalone_worker_v2 import StandaloneWorkerV2
 
             return StandaloneWorkerV2
         elif self.is_ngram():
@@ -254,6 +252,15 @@ class SpecInputType(IntEnum):
 
 
 class SpecInput(ABC):
+    # DSA MTP IndexShare seed relay. Class-level defaults so scheduler/relay/
+    # attention code reads them uniformly on any SpecInput; only the
+    # EAGLE-family inputs override them. Class-level (not __init__) because
+    # dataclass subclasses run __post_init__ -> super().__init__ after field
+    # assignment, so an init-time default would clobber a passed value.
+    dsa_topk_indices: Optional[torch.Tensor] = None
+    future_dsa_topk_indices_available: bool = False
+    dsa_seed_topk_capture: Optional[torch.Tensor] = None
+
     def __init__(self, spec_input_type: SpecInputType):
         self.spec_input_type = spec_input_type
 

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -113,6 +113,9 @@ class StandaloneDraftWorker(EagleDraftWorker):
             )
             and self.topk == 1
         )
+        self.dsa_index_topk = None
+        self.seed_dsa_topk_from_draft_extend = False
+        self.dsa_extend_topk_buf = None
 
     def alloc_memory_pool(
         self,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
@@ -20,6 +20,7 @@ from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
 )
 from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import fast_topk
 
@@ -496,6 +497,7 @@ class _EagleDraftExtendV2WorkerHarness:
         self.eagle_use_aux_hidden_state = False
         self.hot_token_id = None
         self.draft_runner.model = model_forward
+        EagleDraftWorker._init_dsa_index_share_state(self)
 
 
 def _build_eagle_draft_extend_fixture(

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -188,15 +188,7 @@ class _EagleDraftWorkerHarness:
         self._topk1_parents_prealloc = None
         self._topk1_score_indices_prealloc = None
         EagleDraftWorker._rebuild_topk1_chain_buffers(self)
-        # draft_forward reads this (set in EagleDraftWorker.__init__, skipped here).
-        self.index_share_for_mtp_iteration = (
-            getattr(
-                self.model_config.hf_config,
-                "index_share_for_mtp_iteration",
-                False,
-            )
-            and self.topk == 1
-        )
+        EagleDraftWorker._init_dsa_index_share_state(self)
 
     @property
     def draft_model_runner(self):

--- a/test/registered/kernels/test_dsa_indexer.py
+++ b/test/registered/kernels/test_dsa_indexer.py
@@ -261,6 +261,7 @@ class MockModelRunner:
                 "dsa_decode_backend": "fa3",
                 "dsa_topk_backend": "sgl-kernel",
                 "dsa_paged_mqa_logits_backend": "auto",
+                "disaggregation_mode": "null",
             },
         )()
         self.hisparse_coordinator = None

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -1,7 +1,10 @@
 import unittest
+from types import SimpleNamespace
 
 import numpy as np
+import torch
 
+from sglang.srt.disaggregation.base.conn import KVArgs, StateType
 from sglang.srt.disaggregation.common.utils import (
     group_concurrent_contiguous,
     pack_int_lists,
@@ -9,7 +12,16 @@ from sglang.srt.disaggregation.common.utils import (
     unpack_int_lists,
     unpack_list_of_buffers,
 )
-from sglang.srt.disaggregation.utils import get_dsv4_c128_state_indices
+from sglang.srt.disaggregation.utils import (
+    MetadataBuffers,
+    get_dsv4_c128_state_indices,
+    setup_state_kv_args,
+)
+from sglang.srt.managers.overlap_utils import FutureMap, RelayPayload
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.srt.speculative.eagle_disaggregation import (
+    build_eagle_disagg_draft_input,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
@@ -68,11 +80,6 @@ class TestGroupConcurrentContiguous(unittest.TestCase):
             ([[10, 11], [20]], [[5, 6], [7]]),
         )
 
-    def test_both_empty(self):
-        self.assertEqual(
-            group_concurrent_contiguous(self._arr([]), self._arr([])), ([], [])
-        )
-
     def test_empty_src_nonempty_dst(self):
         self.assertEqual(
             group_concurrent_contiguous(self._arr([]), self._arr([1, 2])), ([], [])
@@ -89,6 +96,97 @@ class TestGroupConcurrentContiguous(unittest.TestCase):
     def test_mismatched_nonempty_lengths_raise(self):
         with self.assertRaises(ValueError):
             group_concurrent_contiguous(self._arr([1, 2, 3]), self._arr([1, 2]))
+
+
+class TestEagleDsaSeedTransfer(unittest.TestCase):
+    @staticmethod
+    def _make_req(seed, metadata_buffer_index=0):
+        return SimpleNamespace(
+            metadata_buffer_index=metadata_buffer_index,
+            output_ids=[101],
+            cached_tokens=0,
+            cached_tokens_device=0,
+            cached_tokens_host=0,
+            cached_tokens_storage=0,
+            multimodal_inputs=None,
+            return_logprob=False,
+            return_sampling_mask=False,
+            hidden_states_tensor=torch.tensor([1.0, 2.0]),
+            output_topk_p=torch.tensor([1.0]),
+            output_topk_index=torch.tensor([7]),
+            output_dsa_topk_indices=seed,
+            bootstrap_room=9,
+        )
+
+    def test_metadata_buffer_copies_seed_and_uses_invalid_sentinel(self):
+        buffers = MetadataBuffers(
+            size=2,
+            hidden_size=2,
+            hidden_states_dtype=torch.float32,
+            output_dsa_topk_indices_dim=3,
+        )
+        seed = torch.tensor([4, 5, 6], dtype=torch.int32)
+        buffers.set_buf(self._make_req(seed))
+        buffers.set_buf(self._make_req(None, metadata_buffer_index=1))
+
+        self.assertTrue(torch.equal(buffers.output_dsa_topk_indices[0], seed))
+        self.assertEqual(buffers.output_dsa_topk_indices[1].tolist(), [-1, -1, -1])
+        ptrs, data_lens, item_lens = buffers.get_buf_infos()
+        self.assertEqual(ptrs[-2], buffers.output_dsa_topk_indices.data_ptr())
+        self.assertEqual(data_lens[-2], buffers.output_dsa_topk_indices.nbytes)
+        self.assertEqual(item_lens[-2], buffers.output_dsa_topk_indices[0].nbytes)
+
+    def test_decode_input_requires_valid_seed_for_every_request(self):
+        seeds = (
+            torch.tensor([1, 2, 3], dtype=torch.int32),
+            torch.tensor([4, 5, 6], dtype=torch.int32),
+        )
+        batch = SimpleNamespace(
+            reqs=[self._make_req(seed) for seed in seeds],
+            device="cpu",
+            enable_overlap=False,
+        )
+        server_args = SimpleNamespace(
+            speculative_eagle_topk=1,
+            speculative_num_steps=5,
+            enable_multi_layer_eagle=False,
+        )
+        last_tokens = torch.tensor([11, 12], dtype=torch.int64)
+
+        draft_input = build_eagle_disagg_draft_input(
+            batch, server_args, last_tokens, None
+        )
+        self.assertTrue(torch.equal(draft_input.dsa_topk_indices, torch.stack(seeds)))
+
+        for invalid_seed in (
+            None,
+            torch.full((3,), -1, dtype=torch.int32),
+        ):
+            batch.reqs[1].output_dsa_topk_indices = invalid_seed
+            draft_input = build_eagle_disagg_draft_input(
+                batch, server_args, last_tokens, None
+            )
+            self.assertIsNone(draft_input.dsa_topk_indices)
+
+    def test_future_map_initializes_seed_buffer_after_seedless_payload(self):
+        future_map = object.__new__(FutureMap)
+        future_map.dsa_topk_indices_buf = None
+        future_map.req_pool_size = 4
+        future_map.device = "cpu"
+        future_map._maybe_init_dsa_topk_indices_buf(
+            RelayPayload(bonus_tokens=torch.zeros((2,), dtype=torch.int64))
+        )
+        self.assertIsNone(future_map.dsa_topk_indices_buf)
+
+        seeds = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int32)
+        future_map._maybe_init_dsa_topk_indices_buf(
+            RelayPayload(
+                bonus_tokens=torch.zeros((2,), dtype=torch.int64),
+                dsa_topk_indices=seeds,
+            )
+        )
+        self.assertEqual(future_map.dsa_topk_indices_buf.shape, (4, 3))
+        self.assertEqual(future_map.dsa_topk_indices_buf.dtype, torch.int32)
 
 
 class TestDSV4C128StateIndices(unittest.TestCase):
@@ -115,6 +213,88 @@ class TestDSV4C128StateIndices(unittest.TestCase):
             get_dsv4_c128_state_indices(7, 129, online=False, ring_size=256),
             np.array([15], dtype=np.int32),
         )
+
+
+def _buf_infos(*ptrs):
+    return list(ptrs), [ptr + 100 for ptr in ptrs], [ptr + 200 for ptr in ptrs]
+
+
+def _make_dsv4_target(*, unified, mapping=None):
+    pool = object.__new__(DeepSeekV4TokenToKVPool)
+    pool._unified_kv = unified
+    pool.page_size = 256
+    pool.sliding_window = 128
+    pool.full_to_swa_index_mapping = mapping
+    pool.unified_swa_window = 128
+    pool.unified_swa_ring_size = 131
+    pool.unified_swa_pages = 524
+    pool.get_state_buf_infos = lambda: _buf_infos(11)
+    pool.get_unified_swa_ring_buf_infos = lambda: (
+        _buf_infos(12) if unified else ([], [], [])
+    )
+    pool.get_c128_state_buf_infos = lambda: ([], [], [])
+    return pool
+
+
+def _make_dsv4_draft(*, unified, mapping=None):
+    pool = object.__new__(DeepSeekV4TokenToKVPool)
+    pool._unified_kv = unified
+    pool.compression_ratios = [0]
+    pool.page_size = 256
+    pool.sliding_window = 128
+    pool.full_to_swa_index_mapping = mapping
+    pool.unified_swa_window = 128
+    pool.unified_swa_ring_size = 131
+    pool.unified_swa_pages = 524
+    pool.compress_state_pools = [None]
+    pool.indexer_compress_state_pools = [None]
+    if unified:
+        pool.unified_kv_pool = SimpleNamespace(
+            swa_pages=524,
+            kv_buffer=[torch.empty((524, 16), dtype=torch.uint8)],
+        )
+    else:
+        pool.swa_kv_pool = SimpleNamespace(
+            kv_buffer=[torch.empty((2, 16), dtype=torch.uint8)]
+        )
+    return pool
+
+
+class TestDSV4DraftStateRegistration(unittest.TestCase):
+    def test_draft_state_is_a_separate_component(self):
+        mapping = torch.arange(16)
+        cases = [
+            (
+                "paged",
+                _make_dsv4_target(unified=False, mapping=mapping),
+                _make_dsv4_draft(unified=False, mapping=mapping),
+                [StateType.SWA, StateType.SWA],
+                [[11]],
+            ),
+            (
+                "unified",
+                _make_dsv4_target(unified=True),
+                _make_dsv4_draft(unified=True),
+                [StateType.SWA, StateType.SWA_RING, StateType.SWA_RING],
+                [[11], [12]],
+            ),
+        ]
+
+        for name, target, draft, expected_types, target_ptrs in cases:
+            with self.subTest(name=name):
+                if draft._unified_kv:
+                    expected_infos = draft.get_unified_swa_ring_buf_infos()
+                else:
+                    expected_infos = draft.get_state_buf_infos()
+                kv_args = KVArgs()
+
+                setup_state_kv_args(kv_args, target, draft)
+
+                self.assertEqual(kv_args.state_types, expected_types)
+                self.assertEqual(kv_args.state_data_ptrs[:-1], target_ptrs)
+                self.assertEqual(kv_args.state_data_ptrs[-1], expected_infos[0])
+                self.assertEqual(kv_args.state_data_lens[-1], expected_infos[1])
+                self.assertEqual(kv_args.state_item_lens[-1], expected_infos[2])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_eagle_draft_cuda_graph_runner.py
+++ b/test/registered/unit/spec/test_eagle_draft_cuda_graph_runner.py
@@ -74,6 +74,7 @@ class TestEagleDraftCudaGraphRunner(CustomTestCase):
             hidden_states=torch.empty(CAPTURE_BS, 2, dtype=torch.float32),
             req_pool_indices=torch.empty(CAPTURE_BS, dtype=torch.int32),
             seq_lens_cpu=torch.empty(CAPTURE_BS, dtype=torch.int32),
+            dsa_seed_topk=None,
         )
         runner.capture_bs = [1, CAPTURE_BS]
         runner.num_tokens_per_bs = 1

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -8,10 +8,11 @@ slow path (`organize_draft_results`) for num_steps in {1, 2, 3, 4}.
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.speculative.adaptive_runtime_state import SpecRuntimeState
 from sglang.srt.speculative.eagle_utils import organize_draft_results
 from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker, EAGLEWorkerV2
@@ -59,10 +60,11 @@ def _make_worker(num_steps: int, num_draft_tokens: int):
     return worker
 
 
-def _make_backend_factory(decode_backend, draft_extend_backend):
+def _make_backend_factory(decode_backend, draft_extend_backend, captured_kwargs=None):
     class FakeDraftBackendFactory:
         def __init__(self, *args, **kwargs):
-            pass
+            if captured_kwargs is not None:
+                captured_kwargs.update(kwargs)
 
         def create_decode_backend(self):
             return decode_backend
@@ -110,6 +112,78 @@ class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
 
 
 class TestEagleWorkerV2BackendFallback(CustomTestCase):
+    def test_missing_seed_cuda_graph_fallback(self):
+        graph_result = (
+            [],
+            torch.zeros((1, 1), dtype=torch.long, device=DEVICE),
+            torch.zeros((1, 1), dtype=torch.long, device=DEVICE),
+            None,
+        )
+        tree_result = (
+            torch.empty((0,), dtype=torch.bool, device=DEVICE),
+            torch.zeros((1,), dtype=torch.long, device=DEVICE),
+            torch.zeros((1, 2), dtype=torch.long, device=DEVICE),
+            torch.zeros((1, 2), dtype=torch.long, device=DEVICE),
+            torch.zeros((1, 2), dtype=torch.long, device=DEVICE),
+            torch.zeros((2,), dtype=torch.long, device=DEVICE),
+        )
+
+        for seed_enabled, seed_present, expect_graph in (
+            (True, False, False),
+            (True, True, True),
+            (False, False, True),
+        ):
+            with self.subTest(
+                seed_enabled=seed_enabled,
+                seed_present=seed_present,
+            ):
+                worker = object.__new__(EagleDraftWorker)
+                worker.req_to_token_pool = None
+                worker.cuda_graph_runner = SimpleNamespace(
+                    execute=MagicMock(return_value=graph_result)
+                )
+                worker.draft_runner = SimpleNamespace(canary_manager=None)
+                worker.topk = 1
+                worker.speculative_num_steps = 1
+                worker.speculative_num_draft_tokens = 2
+                worker.device = DEVICE
+                worker.tree_mask_mode = None
+                worker.seed_dsa_topk_from_draft_extend = seed_enabled
+                worker.index_share_for_mtp_iteration = True
+                forward_batch = SimpleNamespace(forward_mode=ForwardMode.DECODE)
+                worker.prepare_for_draft = MagicMock(return_value=(forward_batch, True))
+                worker.draft_forward = MagicMock(return_value=graph_result)
+                attn_backend = SimpleNamespace(
+                    get_verify_buffers_to_fill_after_draft=lambda: (None, None),
+                    max_context_len=1,
+                )
+                worker.target_worker = SimpleNamespace(
+                    model_runner=SimpleNamespace(attn_backend=attn_backend)
+                )
+                draft_input = SimpleNamespace(
+                    bonus_tokens=torch.zeros((1,), dtype=torch.long, device=DEVICE),
+                    dsa_topk_indices=(
+                        torch.ones((1, 1), dtype=torch.int32, device=DEVICE)
+                        if seed_present
+                        else None
+                    ),
+                )
+                batch = SimpleNamespace(
+                    spec_info=draft_input,
+                    forward_mode=ForwardMode.DECODE,
+                    seq_lens_sum=1,
+                    seq_lens=torch.ones((1,), dtype=torch.int32, device=DEVICE),
+                )
+
+                with patch(
+                    "sglang.srt.speculative.eagle_worker_v2.build_tree_kernel_efficient",
+                    return_value=tree_result,
+                ):
+                    worker.draft(batch)
+
+                self.assertEqual(worker.cuda_graph_runner.execute.called, expect_graph)
+                self.assertEqual(worker.draft_forward.called, not expect_graph)
+
     def test_preserves_initialized_backend_when_draft_extend_backend_is_unset(self):
         worker = object.__new__(EagleDraftWorker)
         existing_backend = object()
@@ -118,6 +192,7 @@ class TestEagleWorkerV2BackendFallback(CustomTestCase):
         worker.draft_runner = SimpleNamespace(attn_backend=existing_backend)
         worker.topk = 1
         worker.speculative_num_steps = 2
+        worker.seed_dsa_topk_from_draft_extend = False
 
         with patch(
             "sglang.srt.speculative.eagle_worker_v2.DraftBackendFactory",
@@ -139,10 +214,14 @@ class TestEagleWorkerV2BackendFallback(CustomTestCase):
         worker.draft_runner = SimpleNamespace(attn_backend=existing_backend)
         worker.topk = 1
         worker.speculative_num_steps = 2
+        worker.seed_dsa_topk_from_draft_extend = True
+        factory_kwargs = {}
 
         with patch(
             "sglang.srt.speculative.eagle_worker_v2.DraftBackendFactory",
-            _make_backend_factory(decode_backend, draft_extend_backend),
+            _make_backend_factory(
+                decode_backend, draft_extend_backend, captured_kwargs=factory_kwargs
+            ),
         ):
             worker.init_attention_backend()
 
@@ -150,6 +229,7 @@ class TestEagleWorkerV2BackendFallback(CustomTestCase):
         self.assertIs(worker.draft_extend_attn_backend, draft_extend_backend)
         self.assertIs(worker.draft_runner.draft_attn_backend, decode_backend)
         self.assertIs(worker.draft_runner.attn_backend, draft_extend_backend)
+        self.assertTrue(factory_kwargs["seed_dsa_topk_from_draft_extend"])
 
     def _make_adaptive_worker(self, runner_attn_backend):
         """An EAGLEWorkerV2 with a draft worker whose state-machine fields are


### PR DESCRIPTION
Backport of #30839 to `release/v0.5.15`.

Structured as two commits to stay conflict-free against the release branch:

1. **Reapply #29787** — reverts the release-branch revert #30842, reinstating the GLM-5.2 MTP IndexShare draft-extend anchor that this fix builds on.
2. **Squashed backport of #30839** — the stabilization work itself.

## Motivation

This PR makes GLM-5.2 MTP IndexShare reliable across PD disaggregation, context parallelism, overlap scheduling, batch splitting, and CUDA graph replay. It preserves the correct draft-extend DSA seed across draft steps, avoiding redundant indexer computation without reusing stale or misaligned indices. This improves proposal consistency, acceptance length stability, and inference performance.

This is a follow-up to #29787. The optimization remains gated to EAGLE with `speculative_eagle_topk == 1`, `index_share_for_mtp_iteration=true`, and a valid `index_topk`.

## Modifications

- Transfer per-request DSA top-k seeds from prefill nodes to decode nodes in PD disaggregation, with explicit invalid sentinels and retry-state cleanup.
- Unify eager and CUDA-graph seed capture through `LogitsProcessorOutput`, including correct last-token extraction after CP gather/reordering.
- Preserve seed alignment across context parallelism and Two-Batch Overlap splitting.
- Keep reusable seed state across copied forward batches and graph capture/replay.
- Track seed validity in `FutureMap` to prevent stale overlap/PD state, and fall back to eager recomputation when no valid seed is available.
- Refresh paged-MQA schedules, top-k-v2 plans, and per-step metadata during multi-step DSA graph replay.
- Resolve DSA context-parallel aliases from the effective attention backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29295651002](https://github.com/sgl-project/sglang/actions/runs/29295651002)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29295650791](https://github.com/sgl-project/sglang/actions/runs/29295650791)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->