### PR TITLE
[AMD] Register 3 CPU-bound / triton unit + light-integration tests for AMD 1-GPU PR CI

### DIFF
--- a/test/registered/attention/test_chunk_gated_delta_rule.py
+++ b/test/registered/attention/test_chunk_gated_delta_rule.py
@@ -6,7 +6,7 @@ from sglang.srt.layers.attention.fla.chunk import chunk_gated_delta_rule
 from sglang.srt.layers.attention.fla.fused_recurrent import (
     fused_recurrent_gated_delta_rule,
 )
-from sglang.srt.utils import get_device
+from sglang.srt.utils import get_device, is_hip
 from sglang.test.ci.ci_register import (
     register_amd_ci,
     register_cuda_ci,
@@ -188,6 +188,11 @@ class TestChunkGatedDeltaRule(unittest.TestCase):
     def test_dim_k_gt_v(self):
         self._check_shape(B=4, T_per_seq=128, H=16, K=128, V=64, pool_size=32)
 
+    @unittest.skipIf(
+        is_hip(),
+        "K=V=256 head dim exceeds the FLA chunk triton kernel's shared-memory "
+        "budget on ROCm (out-of-resource at launch); smaller head dims pass.",
+    )
     def test_dim_256x256(self):
         self._check_shape(B=4, T_per_seq=128, H=16, K=256, V=256, pool_size=32)
 

--- a/test/registered/attention/test_chunk_gated_delta_rule.py
+++ b/test/registered/attention/test_chunk_gated_delta_rule.py
@@ -7,9 +7,14 @@ from sglang.srt.layers.attention.fla.fused_recurrent import (
     fused_recurrent_gated_delta_rule,
 )
 from sglang.srt.utils import get_device
-from sglang.test.ci.ci_register import register_cuda_ci, register_xpu_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cuda_ci,
+    register_xpu_ci,
+)
 
 register_cuda_ci(est_time=11, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=11, stage="stage-b", runner_config="1-gpu-large-amd")
 register_xpu_ci(est_time=900, suite="stage-b-test-1-gpu-xpu")
 
 

--- a/test/registered/model_loading/test_utils_update_weights.py
+++ b/test/registered/model_loading/test_utils_update_weights.py
@@ -9,11 +9,10 @@ from transformers import AutoModelForCausalLM
 
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.weight_sync.utils import update_weights
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 register_cuda_ci(est_time=32, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=32, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 class AsyncEngine(Engine):

--- a/test/registered/model_loading/test_utils_update_weights.py
+++ b/test/registered/model_loading/test_utils_update_weights.py
@@ -9,10 +9,11 @@ from transformers import AutoModelForCausalLM
 
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.weight_sync.utils import update_weights
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 register_cuda_ci(est_time=32, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=32, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 class AsyncEngine(Engine):

--- a/test/registered/observability/test_encoder_server_metrics.py
+++ b/test/registered/observability/test_encoder_server_metrics.py
@@ -13,7 +13,7 @@ from prometheus_client.samples import Sample
 from sglang.srt.disaggregation.encode_server import MINIMUM_PNG_PICTURE_BASE64
 from sglang.srt.utils import kill_process_tree
 from sglang.srt.utils.network import get_zmq_socket_on_host
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -23,6 +23,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(est_time=180, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=180, stage="stage-b", runner_config="1-gpu-small-amd")
 
 _MODEL_NAME = DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST
 

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -15,10 +15,15 @@ import torch
 from sglang.srt.speculative.adaptive_runtime_state import SpecRuntimeState
 from sglang.srt.speculative.eagle_utils import organize_draft_results
 from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker, EAGLEWorkerV2
-from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=20, stage="stage-b", runner_config="1-gpu-small-amd")
 register_cpu_ci(est_time=20, suite="base-a-test-cpu")
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"


### PR DESCRIPTION
## Motivation

Close part of the AMD-vs-NVIDIA per-commit coverage gap surfaced by the [rocm/sglang-ci coverage dashboard](https://rocm.github.io/sglang-ci/coverage/). These tests already run on NVIDIA per-commit CI (`base-b`) and are CPU-only, fully mocked, or use plain `torch` / `triton` ops that work on ROCm. Registering them for AMD is a 2-line edit per file — `register_amd_ci(...)` next to the existing `register_cuda_ci(...)`, mirroring the CUDA call's `stage=`/`runner_config=` shape with `-amd` appended to `runner_config`.

## Modifications

| File | NVIDIA suite | AMD suite | Why it's safe on AMD |
|---|---|---|---|
| `unit/spec/test_eagle_worker_v2_topk1_fastpath.py` | base-b 1-gpu-small | `stage-b-test-1-gpu-small-amd` | Pure tensor-equivalence unit test; `SpecRuntimeState` / `organize_draft_results` mocked, no CUDA-only deps (already has `register_cpu_ci`). |
| `observability/test_encoder_server_metrics.py` | base-b 1-gpu-small | `stage-b-test-1-gpu-small-amd` | Encoder-only server + Prometheus metric-export assertions; default attention backend. |
| `attention/test_chunk_gated_delta_rule.py` | base-b 1-gpu-large | `stage-b-test-1-gpu-large-amd` | Triton FLA `chunk_gated_delta_rule` vs `fused_recurrent` reference. The lone `test_dim_256x256` case is `skipIf(is_hip())`'d (K=V=256 exceeds the FLA chunk triton kernel's LDS budget on ROCm → out-of-resource at launch); all other dim/seqlen/stress cases pass. |

Local AST collector (`test/registered/`) before → after:
- `stage-b-test-1-gpu-small-amd`: **123 → 125**
- `stage-b-test-1-gpu-large-amd`: **26 → 27**

`model_loading/test_utils_update_weights.py` was initially registered too, but the rocm720 CI image is missing `torch_memory_saver` (fails at `Engine` init) — a whole-file environment gap — so its `register_amd_ci` was dropped (stays CUDA-only, no register-and-disable).

## CI Verification — green on both AMD lanes (mi3xx + rocm720)

| Test | mi3xx | rocm720 |
|---|---|---|
| `test_eagle_worker_v2_topk1_fastpath.py` (small) | ✅ | ✅ |
| `test_encoder_server_metrics.py` (small) | ✅ | ✅ |
| `test_chunk_gated_delta_rule.py` (large) | ✅ 9/9, `OK (skipped=1)` | ✅ partition 13/13, `OK (skipped=1)` |

Run links:
- 1-gpu-small — mi3xx: https://github.com/sgl-project/sglang/actions/runs/29295135599 ✅ · rocm720: https://github.com/sgl-project/sglang/actions/runs/29295122831 ✅
- 1-gpu-large — mi3xx: https://github.com/sgl-project/sglang/actions/runs/29358225682 (**all 3 partitions ✅, run green**) · rocm720: https://github.com/sgl-project/sglang/actions/runs/29358228006

The `test_dim_256x256` `skipIf(is_hip())` fix is confirmed on both lanes (`skipped=1`, `chunk_gated` runs in ~36–37s). The **mi3xx `stage-b-test-1-gpu-large-amd` run is fully green** (all 3 partitions passed). The only red on the rocm720 large run is a **pre-existing, unrelated** partition-mate — `perf/test_bench_serving_1gpu_part1.py` throughput threshold (`~3161 < 3500`), which fails on `main` independent of this PR (none of this PR's files are in that partition).

## Checklist

- [x] AMD `stage-b-test-1-gpu-small-amd` green on mi3xx + rocm720.
- [x] AMD `stage-b-test-1-gpu-large-amd` green — mi3xx run fully green (all 3 partitions); this PR's `chunk_gated` file also green on rocm720 (`test_dim_256x256` skipped on ROCm).
- [x] NVIDIA CI (`PR Test`) unaffected — `register_cuda_ci` lines are unchanged.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29358220901](https://github.com/sgl-project/sglang/actions/runs/29358220901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29452442566](https://github.com/sgl-project/sglang/actions/runs/29452442566)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->