### PR TITLE
Support any exact v/k head ratio in the fused GDN qkvzba split

### DIFF
--- a/python/sglang/jit_kernel/triton/gdn_fused_proj.py
+++ b/python/sglang/jit_kernel/triton/gdn_fused_proj.py
@@ -194,26 +194,6 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
         + i_qk * HEAD_QK
         + tl.arange(0, HEAD_QK)
     )
-    # v for head group i_qk: in the all_v region
-    blk_v_ptr = (
-        mixed_qkvz
-        + i_bs * TOTAL_QKVZ
-        + TOTAL_Q
-        + TOTAL_K
-        + i_qk * V_PER_GROUP * HEAD_V
-        + tl.arange(0, V_PER_GROUP * HEAD_V)
-    )
-    # z for head group i_qk: in the all_z region
-    blk_z_ptr = (
-        mixed_qkvz
-        + i_bs * TOTAL_QKVZ
-        + TOTAL_Q
-        + TOTAL_K
-        + TOTAL_V
-        + i_qk * V_PER_GROUP * HEAD_V
-        + tl.arange(0, V_PER_GROUP * HEAD_V)
-    )
-
     # ── Write to output (identical layout to the interleaved kernel) ──
     blk_q_st_ptr = mixed_qkv + i_bs * QKV_DIM_T + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
     blk_k_st_ptr = (
@@ -223,24 +203,83 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
         + i_qk * HEAD_QK
         + tl.arange(0, HEAD_QK)
     )
-    blk_v_st_ptr = (
-        mixed_qkv
-        + i_bs * QKV_DIM_T
-        + NUM_HEADS_QK * HEAD_QK * 2
-        + i_qk * V_PER_GROUP * HEAD_V
-        + tl.arange(0, V_PER_GROUP * HEAD_V)
-    )
-    blk_z_st_ptr = (
-        z
-        + i_bs * NUM_HEADS_V * HEAD_V
-        + i_qk * V_PER_GROUP * HEAD_V
-        + tl.arange(0, V_PER_GROUP * HEAD_V)
-    )
 
     tl.store(blk_q_st_ptr, tl.load(blk_q_ptr))
     tl.store(blk_k_st_ptr, tl.load(blk_k_ptr))
-    tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
-    tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
+
+    # tl.arange requires power-of-2 ranges: copy the v/z group as one wide
+    # block when V_PER_GROUP * HEAD_V is a power of two, else one v-head per
+    # static_range step (matching the b/a loops below).
+    V_GROUP_DIM: tl.constexpr = V_PER_GROUP * HEAD_V
+    V_GROUP_IS_POW2: tl.constexpr = (V_GROUP_DIM & (V_GROUP_DIM - 1)) == 0
+    if V_GROUP_IS_POW2:
+        blk_v_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + TOTAL_K
+            + i_qk * V_GROUP_DIM
+            + tl.arange(0, V_GROUP_DIM)
+        )
+        blk_z_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + TOTAL_K
+            + TOTAL_V
+            + i_qk * V_GROUP_DIM
+            + tl.arange(0, V_GROUP_DIM)
+        )
+        blk_v_st_ptr = (
+            mixed_qkv
+            + i_bs * QKV_DIM_T
+            + NUM_HEADS_QK * HEAD_QK * 2
+            + i_qk * V_GROUP_DIM
+            + tl.arange(0, V_GROUP_DIM)
+        )
+        blk_z_st_ptr = (
+            z
+            + i_bs * NUM_HEADS_V * HEAD_V
+            + i_qk * V_GROUP_DIM
+            + tl.arange(0, V_GROUP_DIM)
+        )
+        tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
+        tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
+    else:
+        for i in tl.static_range(V_PER_GROUP):
+            blk_v_ptr = (
+                mixed_qkvz
+                + i_bs * TOTAL_QKVZ
+                + TOTAL_Q
+                + TOTAL_K
+                + (i_qk * V_PER_GROUP + i) * HEAD_V
+                + tl.arange(0, HEAD_V)
+            )
+            blk_v_st_ptr = (
+                mixed_qkv
+                + i_bs * QKV_DIM_T
+                + NUM_HEADS_QK * HEAD_QK * 2
+                + (i_qk * V_PER_GROUP + i) * HEAD_V
+                + tl.arange(0, HEAD_V)
+            )
+            tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
+
+            blk_z_ptr = (
+                mixed_qkvz
+                + i_bs * TOTAL_QKVZ
+                + TOTAL_Q
+                + TOTAL_K
+                + TOTAL_V
+                + (i_qk * V_PER_GROUP + i) * HEAD_V
+                + tl.arange(0, HEAD_V)
+            )
+            blk_z_st_ptr = (
+                z
+                + i_bs * NUM_HEADS_V * HEAD_V
+                + (i_qk * V_PER_GROUP + i) * HEAD_V
+                + tl.arange(0, HEAD_V)
+            )
+            tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
 
     # ── b and a from contiguous [all_b | all_a] ──
     for i in tl.static_range(V_PER_GROUP):
@@ -252,6 +291,22 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
         blk_a_ptr = mixed_ba + i_bs * TOTAL_BA + NUM_HEADS_V + i_qk * V_PER_GROUP + i
         blk_a_st_ptr = a + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
         tl.store(blk_a_st_ptr, tl.load(blk_a_ptr))
+
+
+def fused_qkvzba_split_contiguous_supported(
+    num_heads_qk,
+    num_heads_v,
+    head_qk,
+    head_v,
+):
+    """Shapes the contiguous split kernel can compile: v heads must divide
+    evenly into k-head groups, and the q/k and per-head v/z copies need
+    power-of-2 tl.arange widths."""
+
+    def _is_pow2(n):
+        return n > 0 and (n & (n - 1)) == 0
+
+    return num_heads_v % num_heads_qk == 0 and _is_pow2(head_qk) and _is_pow2(head_v)
 
 
 def fused_qkvzba_split_reshape_cat_contiguous(

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -23,6 +23,7 @@ import torch.nn as nn
 import triton
 
 from sglang.jit_kernel.triton.gdn_fused_proj import (
+    fused_qkvzba_split_contiguous_supported,
     fused_qkvzba_split_reshape_cat_contiguous,
 )
 
@@ -518,7 +519,9 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         )
 
         if (
-            self.num_v_heads // self.num_k_heads in [1, 2, 4]
+            fused_qkvzba_split_contiguous_supported(
+                self.num_k_heads, self.num_v_heads, self.head_k_dim, self.head_v_dim
+            )
             and not _is_cpu
             and not _is_npu
         ):

--- a/test/registered/jit/test_gdn_fused_proj.py
+++ b/test/registered/jit/test_gdn_fused_proj.py
@@ -1,0 +1,80 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.jit_kernel.triton.gdn_fused_proj import (
+    fused_qkvzba_split_contiguous_supported,
+    fused_qkvzba_split_reshape_cat_contiguous,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+# (num_k_heads, num_v_heads, head_k_dim, head_v_dim): pow2 group widths
+# (ratios 1/2/4) take the kernel's wide-block path, non-pow2 (3/5/6) the
+# per-head loop. Ratio 3 is Qwen3.6-27B's GDN (48/16).
+SHAPES = [
+    (8, 8, 64, 32),
+    (8, 16, 64, 64),
+    (16, 48, 128, 128),
+    (4, 16, 128, 128),
+    (4, 20, 64, 64),
+    (4, 24, 128, 128),
+]
+
+
+def _reference_split(qkvz, ba, num_k_heads, num_v_heads, head_k_dim, head_v_dim):
+    q, k, v, z = qkvz.split(
+        [
+            num_k_heads * head_k_dim,
+            num_k_heads * head_k_dim,
+            num_v_heads * head_v_dim,
+            num_v_heads * head_v_dim,
+        ],
+        dim=-1,
+    )
+    b, a = ba.split([num_v_heads, num_v_heads], dim=-1)
+    mixed_qkv = torch.cat([q, k, v], dim=-1)
+    return mixed_qkv, z, b, a
+
+
+@pytest.mark.parametrize("num_k_heads,num_v_heads,head_k_dim,head_v_dim", SHAPES)
+@pytest.mark.parametrize("seq_len", [1, 7, 64, 333])
+def test_fused_qkvzba_split_contiguous(
+    num_k_heads: int, num_v_heads: int, head_k_dim: int, head_v_dim: int, seq_len: int
+) -> None:
+    torch.manual_seed(0)
+    qkvz_dim = 2 * num_k_heads * head_k_dim + 2 * num_v_heads * head_v_dim
+    qkvz = torch.randn(seq_len, qkvz_dim, dtype=torch.bfloat16, device="cuda")
+    ba = torch.randn(seq_len, 2 * num_v_heads, dtype=torch.bfloat16, device="cuda")
+
+    mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat_contiguous(
+        qkvz, ba, num_k_heads, num_v_heads, head_k_dim, head_v_dim
+    )
+    ref_qkv, ref_z, ref_b, ref_a = _reference_split(
+        qkvz, ba, num_k_heads, num_v_heads, head_k_dim, head_v_dim
+    )
+
+    # The kernel is a pure copy/reshape — outputs must be bit-exact.
+    assert torch.equal(mixed_qkv.reshape(seq_len, -1), ref_qkv)
+    assert torch.equal(z.reshape(seq_len, -1), ref_z)
+    assert torch.equal(b.reshape(seq_len, -1), ref_b)
+    assert torch.equal(a.reshape(seq_len, -1), ref_a)
+
+
+def test_supported_shapes() -> None:
+    for num_k_heads, num_v_heads, head_k_dim, head_v_dim in SHAPES:
+        assert fused_qkvzba_split_contiguous_supported(
+            num_k_heads, num_v_heads, head_k_dim, head_v_dim
+        )
+    # inexact ratio
+    assert not fused_qkvzba_split_contiguous_supported(16, 40, 128, 128)
+    # non-power-of-2 head dims need the torch fallback (tl.arange widths)
+    assert not fused_qkvzba_split_contiguous_supported(16, 48, 128, 96)
+    assert not fused_qkvzba_split_contiguous_supported(16, 48, 96, 128)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

The contiguous GDN qkvzba split kernel (`fused_qkvzba_split_reshape_cat_contiguous`) copies each head group's v/z block with `tl.arange(0, V_PER_GROUP * HEAD_V)`, and `tl.arange` rejects non-power-of-2 ranges. That is the (undocumented) reason the call site in `qwen3_5.py` whitelists v/k head ratios `{1, 2, 4}`.

The Qwen3.6-27B architecture uses **48 v-heads / 16 k-heads (ratio 3)** in its GDN layers (`linear_num_value_heads=48`, `linear_num_key_heads=16` — any variant of the checkpoint), so every GDN layer silently falls back to `torch.split` + two `.contiguous()` copies + `torch.cat` on every forward pass.

## Modifications

- `jit_kernel/triton/gdn_fused_proj.py`: when `V_PER_GROUP * HEAD_V` is a power of two, keep the existing single wide-block copy (unchanged codegen for the currently-supported ratios). Otherwise copy one v-head per `tl.static_range` step (power-of-2 `HEAD_V` blocks), mirroring the kernel's existing b/a loops. Both branches are `tl.constexpr`-pruned per shape.
- `srt/models/qwen3_5.py`: the ratio whitelist reduces to its real precondition, `num_v_heads % num_k_heads == 0`.
- `test/registered/jit/test_gdn_fused_proj.py` (new): bit-exactness vs a torch reference for ratios 1/2/3/4/5/6 across seq lens 1/7/64/333 (24 cases, covering both compile-time paths), registered for `base-b-kernel-unit-test-1-gpu-large`.

## Accuracy Tests

The kernel is a pure copy/reshape, so outputs must be — and are — **bit-exact**:
- New registered test: 24/24 cases pass (`torch.equal` against the split/cat reference).
- End-to-end on `nvidia/Qwen3.6-27B-NVFP4` with EAGLE MTP: 16/16 greedy 128-token generations byte-identical before/after, gsm8k unchanged.

## Speed Tests and Profiling

Kernel microbench (RTX PRO 6000 Blackwell / SM120, bf16, `triton.testing.do_bench`):

Ratio 3 — Qwen3.6-27B GDN shape (nk=16, nv=48, dk=dv=128), fused kernel vs the current fallback path:

| seq | fallback (split+contiguous+cat) | fused | speedup |
|---:|---:|---:|---:|
| 1 | 5.5 µs | 8.3 µs | 0.66× |
| 16 | 28.7 µs | 11.0 µs | 2.6× |
| 256 | 56.3 µs | 18.1 µs | 3.1× |

(seq 1 in isolation is slightly slower than the fallback, but real decode with speculative verify runs seq ≥ topk·draft-tokens, and prefill runs far larger seq; e2e is a clear win — below.)

Previously-supported pow2 ratios take the identical wide-block path; interleaved microbench confirms parity within noise (e.g. ratio 2, nk=8, dv=64, seq 256: 8.0–8.4 µs before vs 8.1–8.5 µs after).

End-to-end single-user decode, `nvidia/Qwen3.6-27B-NVFP4` + EAGLE tree MTP (steps 4 / topk 8 / draft 16), 512-token generations, 1× RTX PRO 6000 Blackwell: **142.2 → 144.7 tok/s**.

Note: benchmarked on SM120 (no upstream CI for this arch); the change itself is arch-independent Triton block-shape restructuring, and the registered test runs on the standard CI runners.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29297418131](https://github.com/sgl-project/sglang/actions/runs/29297418131)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29297417855](https://github.com/sgl-project/sglang/actions/runs/29297417855)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->