### PR TITLE
[Test] Add unit tests for srt/utils/common.py AMD arch-detection helpers

### DIFF
--- a/test/registered/unit/utils/test_common_arch_detection.py
+++ b/test/registered/unit/utils/test_common_arch_detection.py
@@ -1,0 +1,99 @@
+"""CPU unit tests for the AMD architecture-detection helpers in srt/utils/common.py.
+
+These helpers read the AMD GPU's ``gcnArchName`` and gate a numerics-affecting
+dispatch: ``mxfp8_block_convert_required`` decides, in
+``layers/quantization/fp8.py``, whether an MXFP8 checkpoint runs the native
+MX-scaled matmul (gfx950 / CDNA4) or is first converted to block-FP8
+(gfx942 / CDNA3, which has no hardware MX-scaled matmul). No server, no GPU,
+no model loading. Ref: #20865.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.utils.common import (
+    is_gfx95_supported,
+    is_gfx942_supported,
+    mxfp8_block_convert_required,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _clear_arch_caches():
+    is_gfx942_supported.cache_clear()
+    is_gfx95_supported.cache_clear()
+    mxfp8_block_convert_required.cache_clear()
+
+
+def _set_amd_arch(mock_torch, gcn_arch):
+    mock_torch.version.hip = "6.0"
+    mock_torch.cuda.get_device_properties.return_value.gcnArchName = gcn_arch
+
+
+class TestMxfp8BlockConvertRequired(CustomTestCase):
+    """``mxfp8_block_convert_required`` picks the fp8.py MXFP8 dispatch: True
+    converts to block-FP8 (gfx942, no HW MX matmul); False keeps the native MX
+    path (gfx950). Non-CDNA and non-HIP devices never convert."""
+
+    def setUp(self):
+        _clear_arch_caches()
+
+    def tearDown(self):
+        _clear_arch_caches()
+
+    @patch("sglang.srt.utils.common.torch")
+    def test_arch_dispatch_matrix(self, mock_torch):
+        # gcnArchName -> mxfp8_block_convert_required(); the negative branches
+        # (native-MX gfx950 and the RDNA archs) are the point of the guard.
+        cases = [
+            ("gfx942:sramecc+:xnack-", True),
+            ("gfx950:sramecc+:xnack-", False),
+            ("gfx1151", False),
+            ("gfx1100", False),
+        ]
+        for gcn_arch, expected in cases:
+            with self.subTest(gcn_arch=gcn_arch):
+                _clear_arch_caches()
+                _set_amd_arch(mock_torch, gcn_arch)
+                self.assertIs(mxfp8_block_convert_required(), expected)
+
+    @patch("sglang.srt.utils.common.torch")
+    def test_non_hip_never_converts(self, mock_torch):
+        mock_torch.version.hip = None
+        self.assertIs(mxfp8_block_convert_required(), False)
+
+
+class TestGfxArchDetection(CustomTestCase):
+    """``is_gfx942_supported`` / ``is_gfx95_supported`` substring-match the
+    suffixed gcnArchName and are mutually exclusive on a single device."""
+
+    def setUp(self):
+        _clear_arch_caches()
+
+    def tearDown(self):
+        _clear_arch_caches()
+
+    @patch("sglang.srt.utils.common.torch")
+    def test_gfx942_matches_suffixed_arch(self, mock_torch):
+        _set_amd_arch(mock_torch, "gfx942:sramecc+:xnack-")
+        self.assertIs(is_gfx942_supported(), True)
+        self.assertIs(is_gfx95_supported(), False)
+
+    @patch("sglang.srt.utils.common.torch")
+    def test_gfx95_matches_suffixed_arch(self, mock_torch):
+        _set_amd_arch(mock_torch, "gfx950:sramecc+:xnack-")
+        self.assertIs(is_gfx95_supported(), True)
+        self.assertIs(is_gfx942_supported(), False)
+
+    @patch("sglang.srt.utils.common.torch")
+    def test_non_hip_returns_false(self, mock_torch):
+        mock_torch.version.hip = None
+        self.assertIs(is_gfx942_supported(), False)
+        self.assertIs(is_gfx95_supported(), False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds CPU-only unit tests for the AMD architecture-detection helpers in `srt/utils/common.py`. No server, no GPU, no model loading. Ref: #20865

## Motivation
`srt/utils/common.py` exposes AMD arch-detection helpers that gate a numerics-affecting dispatch but had no unit coverage. `mxfp8_block_convert_required()` decides, in `layers/quantization/fp8.py`, whether an MXFP8 checkpoint runs the native MX-scaled matmul (gfx950 / CDNA4) or is first converted to block-FP8 (gfx942 / CDNA3, which has no hardware MX-scaled matmul). A wrong result silently changes the AMD execution path, and the helper was refactored recently in #28715 with no guarding test.

This coverage is also timely for the ongoing consumer-AMD RDNA enablement (tracked in #30599 — `gfx1100`/`gfx1101`/`gfx1151`/`gfx1201`), which introduces new architectures into exactly these detection paths. Pinning the current CDNA-only behavior — `gfx942` converts, `gfx950` stays on the native MX path, and RDNA / non-HIP don't convert — means any intended change to MXFP8 routing as those archs land surfaces as a *deliberate* test update rather than a silent shift, so the new arch handling can't accidentally mix up the existing CDNA path.

## Modifications
New file `test/registered/unit/utils/test_common_arch_detection.py`, CPU-only (`register_cpu_ci(est_time=5, suite="base-a-test-cpu")`), mocking `torch` / `gcnArchName`:
- **`mxfp8_block_convert_required`** — pins the arch → dispatch decision: `gfx942` → convert (True); `gfx950` → native MX (False); RDNA (`gfx1151`/`gfx1100`) and non-HIP → False. Clears the three delegated `lru_cache`s between cases.
- **`is_gfx942_supported` / `is_gfx95_supported`** — verify they substring-match suffixed real arch strings (`gfx950:sramecc+:xnack-`), are mutually exclusive on a single device, and return False when non-HIP.

## Accuracy Tests
N/A — test-only; no model/kernel/forward changes, so model outputs are unaffected.

## Speed Tests and Profiling
N/A — test-only; no runtime path is touched.

## Checklist
- [x] Format your code according to Format code with pre-commit.
- [x] Add unit tests according to Run and add unit tests.
- [ ] Update documentation — N/A (test-only).
- [ ] Provide accuracy and speed benchmark results — N/A (test-only; no output/perf change).
- [x] Follow the SGLang code style guidance.

## Test plan
```
$ python3 -m pytest -v test/registered/unit/utils/test_common_arch_detection.py
  TestMxfp8BlockConvertRequired::test_arch_dispatch_matrix PASSED
  TestMxfp8BlockConvertRequired::test_non_hip_never_converts PASSED
  TestGfxArchDetection::test_gfx942_matches_suffixed_arch PASSED
  TestGfxArchDetection::test_gfx95_matches_suffixed_arch PASSED
  TestGfxArchDetection::test_non_hip_returns_false PASSED
  ===== 5 passed, 4 subtests passed =====
  ```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29299712142](https://github.com/sgl-project/sglang/actions/runs/29299712142)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29299712054](https://github.com/sgl-project/sglang/actions/runs/29299712054)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->