### PR TITLE
Don't fail server startup when psutil can't parse /proc/meminfo (GB300 ShadowCallStack)

### DIFF
--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -227,12 +227,6 @@ def config_socket(socket, socket_type: zmq.SocketType):
         total_mem = mem.total / 1024**3
         available_mem = mem.available / 1024**3
     except Exception as e:
-        # psutil chokes on malformed /proc/meminfo lines. Seen on GB300
-        # (arm64) kernels: the value of "ShadowCallStack:" is printed with a
-        # fixed 8-char width, so once it reaches 8 digits the separating
-        # space disappears ("ShadowCallStack:10006144 kB") and psutil raises
-        # ValueError parsing "kB". Sizing the ZMQ buffers is a heuristic --
-        # fall back to OS defaults instead of failing server startup.
         logger.warning(
             "psutil.virtual_memory() failed (%s); using default ZMQ buffer size", e
         )

--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -222,9 +222,21 @@ def get_zmq_socket_on_host(
 
 
 def config_socket(socket, socket_type: zmq.SocketType):
-    mem = psutil.virtual_memory()
-    total_mem = mem.total / 1024**3
-    available_mem = mem.available / 1024**3
+    try:
+        mem = psutil.virtual_memory()
+        total_mem = mem.total / 1024**3
+        available_mem = mem.available / 1024**3
+    except Exception as e:
+        # psutil chokes on malformed /proc/meminfo lines. Seen on GB300
+        # (arm64) kernels: the value of "ShadowCallStack:" is printed with a
+        # fixed 8-char width, so once it reaches 8 digits the separating
+        # space disappears ("ShadowCallStack:10006144 kB") and psutil raises
+        # ValueError parsing "kB". Sizing the ZMQ buffers is a heuristic --
+        # fall back to OS defaults instead of failing server startup.
+        logger.warning(
+            "psutil.virtual_memory() failed (%s); using default ZMQ buffer size", e
+        )
+        total_mem = available_mem = 0
     if total_mem > 32 and available_mem > 16:
         buf_size = int(0.5 * 1024**3)
     else:


### PR DESCRIPTION
## Problem

Every `sglang serve` launch on the GB300 CI runner dies at startup ([example](https://github.com/sgl-project/sglang/actions/runs/29292733629/job/86961435781)):

```
File .../srt/utils/network.py, line 225, in config_socket
    mem = psutil.virtual_memory()
File .../psutil/_pslinux.py, line 319, in virtual_memory
    mems[fields[0]] = int(fields[1]) * 1024
ValueError: invalid literal for int() with base 10: b'kB'
```

## Root cause

The arm64 kernel prints the `ShadowCallStack` meminfo field with a fixed 8-char width. Its value grows with every thread on the node; once it crosses 10,000,000 kB (8 digits) the separating space disappears:

```
ShadowCallStack:10006144 kB
```

psutil splits this into `['ShadowCallStack:10006144', 'kB']` and crashes on `int('kB')`. The node oscillates around the boundary as threads come and go (observed 10,006,144 → 9,962,496 kB across a runner restart), which is why the failure is intermittent and why node reboots "fix" it temporarily.

## Fix

`config_socket` only uses the memory reading to pick a ZMQ buffer-size heuristic — wrap the call and fall back to OS-default buffers with a warning instead of failing startup.

## Validation (on the affected GB300 runner, label pulled)

Reproduced the exact crash deterministically by pointing `psutil.PROCFS_PATH` at a meminfo copy with the malformed line, then ran `config_socket` on this branch in the runner container:

```
REPRO_CONFIRMED ValueError: invalid literal for int() with base 10: b'kB'
psutil.virtual_memory() failed (invalid literal for int() with base 10: b'kB'); using default ZMQ buffer size
CONFIG_SOCKET_OK_WITH_FIX
```



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29537792760](https://github.com/sgl-project/sglang/actions/runs/29537792760)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29537792672](https://github.com/sgl-project/sglang/actions/runs/29537792672)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->