### PR TITLE
[Bug] Fix DP-attention state-capturer crash on cuda_graph_batch=None (#30712)

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -325,6 +325,10 @@ class RankZeroFilter(logging.Filter):
 class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]
     can_run_graph: bool
+    # Padded per-rank buffer extent of the cuda graph runner that actually ran
+    # the forward pass, or None for the eager path. When can_run_graph is True
+    # this is never None, so DP-attention state capturers can slice safely.
+    cuda_graph_padded_extent: Optional[int] = None
     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
     routed_experts_output: Optional[TopkCaptureOutput] = None
     indexer_topk_output: Optional[TopkCaptureOutput] = None
@@ -3063,7 +3067,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             output.routed_experts_output = experts_capturer.on_forward_end(
                 forward_batch=forward_batch,
                 can_run_graph=output.can_run_graph,
-                cuda_graph_batch=getattr(self.decode_cuda_graph_runner, "bs", None),
+                cuda_graph_batch=output.cuda_graph_padded_extent,
                 no_copy_to_cpu=no_copy_to_cpu,
             )
 
@@ -3071,7 +3075,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             output.indexer_topk_output = indexer_capturer.on_forward_end(
                 forward_batch=forward_batch,
                 can_run_graph=output.can_run_graph,
-                cuda_graph_batch=getattr(self.decode_cuda_graph_runner, "bs", None),
+                cuda_graph_batch=output.cuda_graph_padded_extent,
                 no_copy_to_cpu=no_copy_to_cpu,
             )
 
@@ -3175,7 +3179,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     forward_batch,
                     pp_proxy_tensors=pp_proxy_tensors,
                 )
-                return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
+                return ModelRunnerOutput(
+                    logits_output=ret,
+                    can_run_graph=can_run_graph,
+                    cuda_graph_padded_extent=self.decode_cuda_graph_runner.bs,
+                )
 
             # DP / MLP-sync padding + attn-tp normalization. Only the decode
             # cuda-graph path above pre-pads its static buffers and returns
@@ -3188,6 +3196,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             # Deferred mamba COW/clear on the forward stream, before the extend
             # dispatch below reads the pool.
             self._maybe_execute_deferred_mamba_cow_and_clear(forward_batch)
+
+            # Padded per-rank buffer extent of the runner that runs below.
+            # Only the prefill cuda graph path sets can_run_graph=True here and
+            # thus needs it; eager / split prefill leave it None.
+            cuda_graph_padded_extent: Optional[int] = None
 
             if forward_batch.forward_mode.is_split_prefill():
                 # Layer-split mode; stays on ModelRunner, not the eager runner.
@@ -3223,6 +3236,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                         forward_batch, **kwargs
                     )
                 can_run_graph = True
+                cuda_graph_padded_extent = (
+                    self.prefill_cuda_graph_runner.padded_num_tokens
+                )
             else:
                 # Eager: decode / extend / idle dispatched inside the runner.
                 ret = self.eager_runner.execute(
@@ -3235,7 +3251,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             ):
                 forward_batch.post_forward_mlp_sync_batch(ret)
 
-            return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
+            return ModelRunnerOutput(
+                logits_output=ret,
+                can_run_graph=can_run_graph,
+                cuda_graph_padded_extent=cuda_graph_padded_extent,
+            )
 
     def _preprocess_logits(
         self, logits_output: LogitsProcessorOutput, sampling_info: SamplingBatchInfo

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -363,6 +363,16 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
         self.raw_num_tokens = 0
         self.raw_bs = 0
+        self._static_num_tokens = 0
+
+    @property
+    def padded_num_tokens(self) -> int:
+        """Padded static token count of the most recent replay.
+
+        This is the rank-padded buffer extent used for DP-attention state
+        capturer slicing when the prefill cuda graph runs the forward pass.
+        """
+        return self._static_num_tokens
 
     def _is_mamba_track_enabled(self) -> bool:
         return (

--- a/test/registered/unit/layers/test_dp_attention_local_slice.py
+++ b/test/registered/unit/layers/test_dp_attention_local_slice.py
@@ -1,0 +1,123 @@
+"""Unit tests for the issue #30712 fix.
+
+All tests run on CPU -- no GPU required.
+
+Issue #30712: on the prefill / piecewise CUDA-graph path with DP attention and
+routed-expert return enabled, ``ModelRunner`` fed the DP-attention state
+capturers ``getattr(self.decode_cuda_graph_runner, "bs", None)`` regardless of
+which runner actually ran. When the decode runner had not run (or was absent),
+that resolved to ``None`` and ``get_dp_local_slice_cpu`` computed
+``dp_rank * None`` -> ``TypeError`` for ``dp_rank > 0``.
+
+Two layers are pinned here:
+
+1. ``TestGetDpLocalSliceCpu`` -- the rank-padded slicing invariant the capturer
+   relies on. When a forward pass runs through a CUDA graph each DP rank's data
+   lives in a rank-padded buffer whose per-rank stride is the graph's padded
+   extent, so rank ``r`` starts at ``r * padded_extent`` -- NOT the eager
+   prefix-sum offset. (This function was already correct; these cases guard
+   against a "None-guard" fallback that would silently read the wrong slice.)
+
+2. ``TestModelRunnerOutputCudaGraphExtent`` -- the actual fix wiring. The bug
+   was NOT in ``get_dp_local_slice_cpu`` (unchanged by the fix) but in the
+   ``ModelRunner`` call sites. The fix carries the real padded extent on
+   ``ModelRunnerOutput.cuda_graph_padded_extent`` and reads it at the capturer
+   call sites. These tests FAIL on the stock (unpatched) tree, where the field
+   does not exist.
+"""
+
+import dataclasses
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.dp_attention import get_dp_local_slice_cpu
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+GLOBAL_NUM_TOKENS = [11, 13, 17, 19]
+
+
+class TestGetDpLocalSliceCpu(CustomTestCase):
+    def _slice(self, dp_rank, can_run_graph, cuda_graph_batch):
+        forward_batch = SimpleNamespace(global_num_tokens_cpu=GLOBAL_NUM_TOKENS)
+        with patch(
+            "sglang.srt.layers.dp_attention.get_attention_dp_rank",
+            return_value=dp_rank,
+        ):
+            return get_dp_local_slice_cpu(
+                forward_batch, can_run_graph, cuda_graph_batch
+            )
+
+    def test_cuda_graph_uses_rank_padded_stride(self):
+        # Graph path: start = dp_rank * padded_extent; length = local tokens.
+        self.assertEqual(self._slice(2, True, 32), (64, 17))
+        self.assertEqual(self._slice(0, True, 32), (0, 11))
+
+    def test_eager_uses_prefix_sum(self):
+        # Eager path ignores the graph extent and packs ranks contiguously.
+        self.assertEqual(self._slice(2, False, None), (24, 17))
+
+    def test_graph_and_eager_layouts_diverge_for_nonzero_rank(self):
+        # The two layouts must not coincide for dp_rank > 0 -- this is why the
+        # capturer must receive the actual padded extent (issue #30712), not a
+        # prefix-sum fallback that happens to avoid the crash.
+        graph_start, _ = self._slice(3, True, 32)
+        eager_start, _ = self._slice(3, False, None)
+        self.assertNotEqual(graph_start, eager_start)
+
+    def test_none_extent_on_graph_path_crashes_for_nonzero_rank(self):
+        # The exact #30712 symptom: had the capturer received None on the graph
+        # path (as the stock getattr(self.decode_cuda_graph_runner, "bs", None)
+        # did), the slice math raises for dp_rank > 0. The fix removes the None
+        # at the source so this branch is never taken with a real graph run.
+        with self.assertRaises(TypeError):
+            self._slice(2, True, None)
+
+
+class TestModelRunnerOutputCudaGraphExtent(CustomTestCase):
+    """Regression tests for the fix wiring itself (fail on the stock tree)."""
+
+    def test_output_exposes_cuda_graph_padded_extent(self):
+        from sglang.srt.model_executor.model_runner import ModelRunnerOutput
+
+        field_names = {f.name for f in dataclasses.fields(ModelRunnerOutput)}
+        # Absent on stock -> the capturer could only fall back to the decode
+        # runner's bs (or None). Present on the fix.
+        self.assertIn("cuda_graph_padded_extent", field_names)
+
+    def test_output_defaults_extent_to_none_for_eager(self):
+        from sglang.srt.model_executor.model_runner import ModelRunnerOutput
+
+        # Eager path leaves the extent None (prefix-sum layout is used).
+        out = ModelRunnerOutput(logits_output=None, can_run_graph=False)
+        self.assertIsNone(out.cuda_graph_padded_extent)
+
+    def test_graph_output_extent_feeds_a_valid_slice(self):
+        from sglang.srt.model_executor.model_runner import ModelRunnerOutput
+
+        # End-to-end contract: the value the capturer receives on the graph
+        # path is ModelRunnerOutput.cuda_graph_padded_extent -- a real int, so
+        # get_dp_local_slice_cpu returns the rank-padded slice instead of doing
+        # dp_rank * None.
+        out = ModelRunnerOutput(
+            logits_output=None,
+            can_run_graph=True,
+            cuda_graph_padded_extent=32,
+        )
+        self.assertIsNotNone(out.cuda_graph_padded_extent)
+        forward_batch = SimpleNamespace(global_num_tokens_cpu=GLOBAL_NUM_TOKENS)
+        with patch(
+            "sglang.srt.layers.dp_attention.get_attention_dp_rank",
+            return_value=2,
+        ):
+            start, length = get_dp_local_slice_cpu(
+                forward_batch, out.can_run_graph, out.cuda_graph_padded_extent
+            )
+        self.assertEqual((start, length), (64, 17))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #30712.

On the prefill / piecewise CUDA-graph path with DP attention and routed-expert return enabled, the DP-attention state capturers crash with:

```
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

**Root cause.** The routed-expert and indexer state capturers in `ModelRunner.forward()` were passed:

```python
cuda_graph_batch=getattr(self.decode_cuda_graph_runner, "bs", None)
```

regardless of which runner actually executed the forward pass. On the prefill/piecewise CUDA-graph path (or whenever the decode runner was not the one that ran), that resolves to `None`, so `get_dp_local_slice_cpu` computes `dp_rank * None` and raises for `dp_rank > 0`. `get_dp_local_slice_cpu` itself was already correct — the defect was the caller feeding it the wrong runner's extent.

## Modifications

- Add `ModelRunnerOutput.cuda_graph_padded_extent: Optional[int]`, set at each `_forward_raw` exit to the padded per-rank extent of the runner that **actually executed**:
  - decode graph → `decode_cuda_graph_runner.bs`
  - prefill graph → `prefill_cuda_graph_runner.padded_num_tokens` (new property exposing the padded static token count of the last replay)
  - eager / split-prefill → `None`
- Both capturer call sites now read `output.cuda_graph_padded_extent` instead of the hard-coded `getattr(self.decode_cuda_graph_runner, "bs", None)`.

This makes the invariant **`can_run_graph == True ⇒ extent is not None`** hold *by construction*. I deliberately did **not** add a `None`-guard that falls back to the eager prefix-sum layout: on the graph path that would silently read the **wrong slice** for `dp_rank > 0` (a correctness bug) instead of the loud `TypeError`. The change also removes an over-defensive `getattr`, per the `no-getattr-defensive` convention.

The decode path is byte-identical (it already passed `.bs`; it now passes the same value via the new field).

## Accuracy Tests

New CPU regression test `test/registered/unit/layers/test_dp_attention_local_slice.py`:

- `TestModelRunnerOutputCudaGraphExtent` — exercises the fix wiring: `ModelRunnerOutput` exposes `cuda_graph_padded_extent`, it defaults to `None` on the eager path, and the graph-path extent feeds a valid rank-padded slice (not `dp_rank * None`).
- `TestGetDpLocalSliceCpu` — pins the underlying slicing invariant (graph → `dp_rank * padded_extent`; eager → prefix sum; the two must diverge for `dp_rank > 0`; `None` on the graph path raises).

Verified in the `lmsysorg/sglang:latest` image:

- **Stock tree (fix reverted, test present):** `3 failed, 4 passed` — the three wiring tests fail because the field does not exist.
- **Fixed tree:** `7 passed`.

**On reproducing the live server crash — full transparency:** I attempted an end-to-end server repro on 4× H100 NVL (driver 595 / CUDA 13.2), but could not trigger it on this build for a reason unrelated to this bug: prefill CUDA-graph capture fails during warmup for every MoE/DP model I tried (DeepSeek-V2-Lite: `CUBLAS_STATUS_EXECUTION_FAILED` / MLA shape errors; Qwen1.5-MoE and OLMoE fail elsewhere in capture), on both stock and patched trees, before any request. With prefill-graph capture unavailable, the runtime `dp_rank * None` path is unreachable here. The evidence for this PR is therefore the root-cause analysis plus the deterministic regression test above, which fails on the unpatched tree and passes with the fix. Happy to add a live before/after trace if a maintainer can point me to a build/config where prefill-graph capture with DP attention succeeds.

(Separately, the Qwen capture failure surfaced inside the routed-experts capturer itself — an off-by-`dp_size` shape mismatch — which looks like a distinct defect; I'll file it as its own issue.)

## Speed Tests and Profiling

No performance impact — the change only threads an already-computed integer through `ModelRunnerOutput`; no new work on any hot path.

## Checklist

- [x] Format code with pre-commit (`ruff`/`black`/`isort` clean).
- [x] Add unit tests (CPU regression test above).
- [ ] Update documentation — n/a (bug fix, no API/user-facing surface change).
- [ ] Accuracy/speed benchmarks — n/a (no model-output or perf change; see above).
- [x] Follow the SGLang code style guidance.

---

*Disclosure: developed with AI assistance (Claude). The change is authored and owned by me, and I can defend it in review.*















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29306267159](https://github.com/sgl-project/sglang/actions/runs/29306267159)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29306267055](https://github.com/sgl-project/sglang/actions/runs/29306267055)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->