### PR TITLE
Fix diffusion cookbook overview cards

### DIFF
--- a/docs_new/cards/logos/joyai-echo.svg
+++ b/docs_new/cards/logos/joyai-echo.svg
@@ -1,0 +1,9 @@
+<svg width="940" height="525" viewBox="0 0 940 525" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="JoyAI-Echo logo">
+  <rect width="940" height="525" rx="28" fill="none"/>
+  <circle cx="354" cy="262" r="86" fill="#FF4D2E"/>
+  <circle cx="410" cy="262" r="86" fill="#111111" fill-opacity="0.92"/>
+  <path d="M345 231C362 213 393 213 410 231" stroke="white" stroke-width="16" stroke-linecap="round"/>
+  <path d="M345 293C362 311 393 311 410 293" stroke="white" stroke-width="16" stroke-linecap="round"/>
+  <text x="494" y="249" fill="#111111" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="700" letter-spacing="0">JoyAI</text>
+  <text x="494" y="318" fill="#FF4D2E" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="700" letter-spacing="0">Echo</text>
+</svg>

--- a/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
+++ b/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
@@ -1,5 +1,5 @@
 ---
-title: JoyEcho
+title: JoyAI-Echo
 description: Run JoyAI-Echo multi-shot audio–video generation with SGLang Diffusion.
 metatags:
     description: "Deploy and use JoyAI-Echo long-form audio–video generation with SGLang Diffusion, including single-shot and multi-shot memory-bank workflows."

--- a/docs_new/cookbook/diffusion/intro.mdx
+++ b/docs_new/cookbook/diffusion/intro.mdx
@@ -69,16 +69,22 @@ Video models denoise a bounded latent video sequence for each request. Use these
     img="/cards/logos/wan.png"
   />
   <Card
+    title="LongLive 2.0"
+    mode="card"
+    href="/cookbook/diffusion/LongLive/LongLive-2.0"
+    img="/cards/logos/nvidia.png"
+  />
+  <Card
     title="LTX"
     mode="card"
     href="/cookbook/diffusion/LTX/LTX2 & LTX2.3"
     img="/cards/logos/ltx.svg"
   />
   <Card
-    title="JoyEcho"
+    title="JoyAI-Echo"
     mode="card"
     href="/cookbook/diffusion/JoyEcho/JoyEcho"
-    img="/cards/logos/ltx.svg"
+    img="/cards/logos/joyai-echo.svg"
   />
   <Card
     title="MOVA"

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1218,7 +1218,7 @@
                     ]
                   },
                   {
-                    "group": "JoyEcho",
+                    "group": "JoyAI-Echo",
                     "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/JoyEcho/JoyEcho"


### PR DESCRIPTION
## Summary
- Add the missing LongLive 2.0 card to the diffusion cookbook overview
- Rename the JoyEcho display label to the official JoyAI-Echo name
- Replace the JoyAI-Echo overview card logo so it no longer reuses the LTX logo

## Test Plan
- pre-commit run --files docs_new/cookbook/diffusion/intro.mdx docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx docs_new/docs.json docs_new/cards/logos/joyai-echo.svg







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29301027388](https://github.com/sgl-project/sglang/actions/runs/29301027388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29301027232](https://github.com/sgl-project/sglang/actions/runs/29301027232)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->