### PR TITLE
[BugFix] Clamp HiCache prefetch prefix to sidecar-indexer hits

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -6,7 +6,7 @@ import threading
 import time
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, List, Optional, Set
 
@@ -121,7 +121,11 @@ class PoolTransferResult:
     """Tracks how many pages were successfully processed per pool."""
 
     kv_hit_pages: int
+    # Total hits per pool (sum). For TRAILING_PAGES consumers (SWA/mamba).
     extra_pool_hit_pages: dict[str, int]
+    # Contiguous hit prefix (up to first miss) per pool. For ALL_PAGES consumers
+    # (DSA indexer) that must not commit past a miss; != sum for a hole [T,F,T].
+    extra_pool_hit_prefix: dict[str, int] = field(default_factory=dict)
 
     @classmethod
     def empty(cls) -> PoolTransferResult:
@@ -132,9 +136,15 @@ class PoolTransferResult:
         self.kv_hit_pages = max(self.kv_hit_pages, kv_hit_pages)
 
     def update_extra_pool_hit_pages(self, results: dict[str, List[bool]]) -> None:
-        """Record actual load/write success counts per extra pool."""
+        """Record per-pool hit stats: the total count and the contiguous prefix."""
         self.extra_pool_hit_pages.update(
             {name: sum(rs) for name, rs in results.items()}
+        )
+        self.extra_pool_hit_prefix.update(
+            {
+                name: next((i for i, ok in enumerate(rs) if not ok), len(rs))
+                for name, rs in results.items()
+            }
         )
 
 

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1505,6 +1505,19 @@ class HiRadixCache(RadixCache):
         logger.debug(f"Prefetch {req_id} completed with {completed_tokens} tokens")
 
         min_completed_tokens = completed_tokens
+        # An ALL_PAGES sidecar (DSA indexer) can load shorter than KV; committing
+        # past its hit prefix pairs fresh KV with a stale sidecar page. Clamp to
+        # the prefix here (commit thread), so a best_effort terminate can't race.
+        pool_transfers = getattr(operation, "pool_transfers", None)
+        if pool_transfers:
+            hit_prefix = operation.pool_storage_result.extra_pool_hit_prefix
+            for transfer in pool_transfers:
+                if transfer.hit_policy != PoolHitPolicy.ALL_PAGES:
+                    continue
+                min_completed_tokens = min(
+                    min_completed_tokens,
+                    hit_prefix.get(transfer.name, 0) * self.page_size,
+                )
         # Synchronize workers before mutating host cache tree state.
         completed_tokens_tensor = torch.tensor(min_completed_tokens, dtype=torch.int)
         self._all_reduce_attn_groups(

--- a/test/srt/mem_cache/test_hicache_indexer_prefix_clamp.py
+++ b/test/srt/mem_cache/test_hicache_indexer_prefix_clamp.py
@@ -1,0 +1,63 @@
+"""Tests that update_extra_pool_hit_pages records both the total hit count and
+the contiguous hit prefix, so an ALL_PAGES sidecar (DSA indexer) clamps to the
+prefix (not sum) and never commits past a mid-run miss like [T, F, T]."""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.hicache_storage import PoolTransferResult  # noqa: E402
+
+register_cpu_ci(est_time=10, suite="stage-a-test-cpu")
+
+
+class TestExtraPoolHitPrefix(unittest.TestCase):
+    """update_extra_pool_hit_pages records sum AND contiguous prefix separately."""
+
+    def test_full_hit_prefix_equals_count(self):
+        r = PoolTransferResult.empty()
+        r.update_extra_pool_hit_pages({"indexer": [True, True, True, True]})
+        self.assertEqual(r.extra_pool_hit_pages["indexer"], 4)
+        self.assertEqual(r.extra_pool_hit_prefix["indexer"], 4)
+
+    def test_trailing_miss_prefix_stops_before_miss(self):
+        r = PoolTransferResult.empty()
+        r.update_extra_pool_hit_pages({"indexer": [True, True, False, False]})
+        self.assertEqual(r.extra_pool_hit_pages["indexer"], 2)
+        self.assertEqual(r.extra_pool_hit_prefix["indexer"], 2)
+
+    def test_mid_hole_prefix_diverges_from_sum(self):
+        """The whole point: a non-prefix-fail hole [T,F,T,T] sums to 3 but the
+        usable contiguous prefix is 1."""
+        r = PoolTransferResult.empty()
+        r.update_extra_pool_hit_pages({"indexer": [True, False, True, True]})
+        self.assertEqual(r.extra_pool_hit_pages["indexer"], 3)  # sum (SWA/mamba view)
+        self.assertEqual(r.extra_pool_hit_prefix["indexer"], 1)  # prefix (DSA view)
+
+    def test_leading_miss_prefix_zero(self):
+        r = PoolTransferResult.empty()
+        r.update_extra_pool_hit_pages({"indexer": [False, True, True, True]})
+        self.assertEqual(r.extra_pool_hit_prefix["indexer"], 0)
+
+    def test_empty_result_list_prefix_zero(self):
+        r = PoolTransferResult.empty()
+        r.update_extra_pool_hit_pages({"indexer": []})
+        self.assertEqual(r.extra_pool_hit_prefix["indexer"], 0)
+
+    def test_multiple_pools_tracked_independently(self):
+        r = PoolTransferResult.empty()
+        r.update_extra_pool_hit_pages(
+            {"indexer": [True, False, True], "swa": [True, True, True]}
+        )
+        self.assertEqual(r.extra_pool_hit_prefix["indexer"], 1)
+        self.assertEqual(r.extra_pool_hit_prefix["swa"], 3)
+        # sum view preserved for both
+        self.assertEqual(r.extra_pool_hit_pages["indexer"], 2)
+        self.assertEqual(r.extra_pool_hit_pages["swa"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Partial fix for #30321 ("GLM-5.2 with MTP+Hicache+Mooncake occasionally produces garbled output") for reporters running an **L3 storage backend** (Mooncake or any `--hicache-storage-backend`).

GLM-5.2's DSA-indexer sidecar is an `ALL_PAGES` pool co-loaded 1:1 with KV, but it evicts independently and is read by a **separate `batch_get_v2`** on the prefetch IO thread, after `batch_exists_v2` has already mined the usable prefix across pools. So on an L3 prefetch restore the indexer can come back **shorter than KV** (a page present at the exists check is evicted before the get). `HiRadixCache.check_prefetch_progress` committed the full KV prefix regardless, pairing fresh KV with a **stale/unloaded indexer page** for the tail. DSA then scores tokens against garbage indexer state → wrong top-k selection → garbled/runaway output. It only appears after a long run under memory backpressure (when L3 eviction is active) and is **silent** (the miss is logged and swallowed on the storage thread; no crash).

This matches the #30321 symptom profile for the Mooncake/L3 reporters. It does **not** explain the reporter's L2-only reproduction after bisecting — that points to a separate bug in the L2 host path — but this is a real, independent correctness bug on the L3 path.

## Modification

`PoolTransferResult` now records two per-pool stats from `batch_get_v2`:

- **`extra_pool_hit_pages`** (unchanged): `sum()` of the per-page hit list. Used by `TRAILING_PAGES` consumers (SWA/mamba), which only need a threshold count — so their behavior is unchanged.
- **`extra_pool_hit_prefix`** (new): the leading contiguous hit run (up to the first miss). Used by `ALL_PAGES` consumers (the DSA indexer), which must not commit past a miss. This is correct even for backends without prefix-fail (mooncake, hf3fs) that can return a hole like `[T, F, T]` — sum is 2 but the usable prefix is 1.

`HiRadixCache.check_prefetch_progress` clamps `completed_tokens` to the `ALL_PAGES` sidecar's prefix **at commit time**, on the same thread as the commit — so it cannot be raced by a `best_effort` terminate. This matches how `UnifiedRadixCache` and `HiMambaRadixCache` reconcile their (`TRAILING_PAGES`) sidecars at commit. No change to `hybrid_cache_controller.py` or `can_terminate_prefetch`.

## Accuracy Tests

`test/srt/mem_cache/test_hicache_indexer_prefix_clamp.py` (6 cases) covers `update_extra_pool_hit_pages` recording both stats: full hit (prefix == count); trailing miss `[T,T,F,F]` → prefix 2; **mid-hole `[T,F,T,T]` → sum 3 but prefix 1** (the corruption case + sum/prefix divergence); leading miss → 0; empty list → 0; multiple pools tracked independently with the sum view preserved.

Not yet load-tested on B200 under real L3 eviction pressure — happy to coordinate a repro with anyone who has the loadgen setup from #30321.

## Checklist

- [x] Add unit tests
- [x] Follow the SGLang code style guidance
- [ ] pre-commit (run locally before merge)
- [ ] accuracy/speed benchmark (recommend a B200 L3 load test)