### PR TITLE
[Intel][XPU] Add pyxccl: direct Intel oneCCL communicator for XPU

### DIFF
--- a/docs_new/docs/hardware-platforms/xpu.pyxccl.md
+++ b/docs_new/docs/hardware-platforms/xpu.pyxccl.md
@@ -1,0 +1,257 @@
+# pyxccl + oneCCL Setup for SGLang XPU (Intel GPU)
+
+`PyXcclCommunicator` is the XPU counterpart of `PyNcclCommunicator` — a
+direct-binding communicator for Intel's oneCCL library that bypasses
+`torch.distributed` for collective operations (AllReduce, AllGather,
+ReduceScatter, Broadcast, Send/Recv). It lives at
+`python/sglang/srt/distributed/device_communicators/pyxccl.py`. The ctypes layer
+that binds oneCCL's `oneccl*` C API is vendored in
+`pyxccl_wrapper.py` (the XPU analogue of `pynccl_wrapper.py`) — no third-party
+Python binding is required, only the oneCCL runtime library `libccl.so`.
+
+By default, tensor-parallel (`--tp > 1`) collectives on Intel GPU go through
+torch's XCCL backend. **pyxccl is opt-in**: set `SGLANG_ENABLE_PYXCCL=1` to route
+them through oneCCL directly instead. This is the path to use when your torch
+build has no usable XCCL backend. When `SGLANG_ENABLE_PYXCCL=1` is set but pyxccl
+cannot initialize, SGLang raises at startup for `tp>1` rather than silently
+falling back — since you opted in precisely because torch.distributed may be
+unavailable.
+
+---
+
+## Quick Checklist
+
+```text
+[ ] 0. Install one-time system prerequisites
+[ ] 1. Source Intel oneAPI compiler environment
+[ ] 2. Build oneCCL-v2 XPU library (libccl.so.1)
+[ ] 3. Point SGLANG_PYXCCL_SO_PATH / LD_LIBRARY_PATH at libccl.so.1
+[ ] 4. Source the SGLang-XPU activation script before every run
+```
+
+---
+
+## Step 0 — One-time system prerequisites
+
+Install these packages once on the machine:
+
+```bash
+apt-get install -y gcc g++ libopenmpi-dev
+```
+
+Set up a dedicated Python environment for build tools (cmake, ninja). This
+environment is used only during the oneCCL build, not at runtime:
+
+```bash
+uv venv /work/.build-env --python 3.12
+uv pip install --python /work/.build-env/bin/python cmake ninja
+```
+
+---
+
+## Step 1 — Source the Intel oneAPI compiler
+
+```bash
+source /work/compiler/setvars.sh
+```
+
+This must be run **in the same shell** before building or running anything.
+Verify it works:
+
+```bash
+icpx -v   # should print: Intel(R) oneAPI DPC++/C++ Compiler 2026.x.x
+```
+
+> **Note:** Sourcing oneAPI gives you the compiler and the `libccl.so` runtime.
+> It does **not** install the Python `pyxccl` binding (Step 3), and a stock
+> oneCCL runtime may predate the NCCL-compatible `oneccl*` C shim or be built
+> without SYCL/XPU device code. Build oneCCL-v2 from source (Step 2) to
+> guarantee a `libccl.so.1` that has both.
+
+---
+
+## Step 2 — Build oneCCL-v2 XPU library
+
+oneCCL must be built from source with SYCL/dpcpp support to produce
+`libccl.so.1` (the XPU-capable shim used by pyxccl).
+
+### 2a. Clone and patch the repo
+
+Two source patches are required for the SYCL build to work correctly:
+
+**Patch 1** — `CMakeLists.txt` (top-level): pass `-DCMAKE_CXX_STANDARD=17` to
+the inner libccl ExternalProject so that `FindIntelSYCL_level_zero.cmake` can
+detect `-fsycl` support (SYCL requires C++17).
+
+**Patch 2** — `deps/libccl/CMakeLists.txt`: guard `set(CMAKE_CXX_STANDARD 11)`
+with `if(NOT CMAKE_CXX_STANDARD)` so the C++17 override is not clobbered by the
+libccl default.
+
+### 2b. Run the build script
+
+```bash
+# Standard Release build (recommended):
+bash scripts/build_oneccl_xpu.sh --install
+
+# Clean rebuild from scratch:
+bash scripts/build_oneccl_xpu.sh --install --clean
+
+# Debug build:
+bash scripts/build_oneccl_xpu.sh --install --debug
+
+# Also build tests and examples:
+bash scripts/build_oneccl_xpu.sh --install --with-tests --with-examples
+
+# Faster device-code for inner-loop development (larger binary, not for deploy):
+bash scripts/build_oneccl_xpu.sh --install --device-code per_source
+```
+
+The script automatically sources the compiler, locates cmake/ninja, initializes
+git submodules, configures with `-DCOMPUTE_BACKEND=dpcpp
+-DCMAKE_CXX_COMPILER=icpx`, and installs into
+`<repo>/build-xpu-release/_install/`.
+
+### 2c. Verify the build
+
+```bash
+CCL_INSTALL=/work/libraries.performance.communication.oneccl-v2/build-xpu-release/_install
+ls -lh $CCL_INSTALL/lib/libccl.so*
+# Expected output:
+#   libccl.so  -> libccl.so.2
+#   libccl.so.1.0   (~258 MB, XPU SYCL device code)
+#   libccl.so.2.0   (~128 KB, oneCCL v2 core)
+```
+
+---
+
+## Step 3 — Point SGLang at the oneCCL runtime
+
+The ctypes binding is vendored in SGLang (`pyxccl_wrapper.py`), so there is no
+separate Python package to install — you only need the oneCCL runtime library
+(`libccl.so`) on the loader path. Use the SYCL library you built in Step 2 by
+either putting its directory on `LD_LIBRARY_PATH` or pointing
+`SGLANG_PYXCCL_SO_PATH` directly at `libccl.so.1`:
+
+```bash
+CCL_INSTALL=/work/libraries.performance.communication.oneccl-v2/build-xpu-release/_install
+export LD_LIBRARY_PATH=${CCL_INSTALL}/lib:$LD_LIBRARY_PATH
+export SGLANG_PYXCCL_SO_PATH=${CCL_INSTALL}/lib/libccl.so.1
+```
+
+Verify (the binding is importable directly from SGLang):
+
+```bash
+source /work/compiler/setvars.sh
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/work/compiler/lib/
+CCL_INSTALL=/work/libraries.performance.communication.oneccl-v2/build-xpu-release/_install
+python -c "
+from sglang.srt.distributed.device_communicators.pyxccl_wrapper import ONECCLLibrary
+lib = ONECCLLibrary('$CCL_INSTALL/lib/libccl.so.1')
+print('oneCCL version:', lib.onecclGetVersion())
+"
+```
+
+---
+
+## Step 4 — Activation script
+
+Source `scripts/activate-xpu-sglang.sh` before every SGLang run. Its contents:
+
+```bash
+#!/bin/bash
+# activate-xpu-sglang.sh — source this before running SGLang on XPU with pyxccl
+#
+# Usage:  source scripts/activate-xpu-sglang.sh
+
+# 1. Intel oneAPI compiler & SYCL runtime
+source /work/compiler/setvars.sh
+
+# 2. Runtime shared libraries
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/work/compiler/lib/
+
+_CCL=/work/libraries.performance.communication.oneccl-v2/build-xpu-release/_install
+export LD_LIBRARY_PATH=${_CCL}/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${_CCL}/opt/mpi/libfabric/lib:$LD_LIBRARY_PATH
+
+# 3. oneCCL / OFI transport
+export FI_PROVIDER_PATH=${_CCL}/opt/mpi/libfabric/lib/prov
+export CCL_ATL_TRANSPORT=ofi
+export CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0
+
+# 4. SGLang pyxccl integration
+# Opt into the direct-oneCCL path (pyxccl is off by default).
+export SGLANG_ENABLE_PYXCCL=1
+export SGLANG_PYXCCL_SO_PATH=${_CCL}/lib/libccl.so.1
+
+unset _CCL
+```
+
+Run SGLang with tensor parallelism:
+
+```bash
+source scripts/activate-xpu-sglang.sh
+python -m sglang.launch_server \
+    --model-path facebook/opt-125m --device xpu --tp 2 \
+    --attention-backend intel_xpu
+```
+
+---
+
+## OFI transport notes
+
+oneCCL needs a transport backend for inter-process communication. The bundled
+libfabric providers shipped with oneCCL support:
+
+| Provider | Use case |
+| --- | --- |
+| `shm` | Single-node, shared-memory (lowest latency) |
+| `tcp` | Single/multi-node, TCP fallback |
+| `verbs` | InfiniBand / RoCE (HPC clusters) |
+
+Without `CCL_ATL_TRANSPORT=ofi` and `FI_PROVIDER_PATH`, oneCCL cannot initialize
+any transport. `PyXcclCommunicator` logs a warning, marks itself disabled, and
+SGLang raises a `RuntimeError` at `tp>1` — set these variables before starting
+SGLang workers.
+
+---
+
+## Diagnosing tp>1 failures
+
+### libccl.so.1 not found
+
+```text
+Failed to load oneCCL library from libccl.so.1
+```
+
+**Fix**: Check `SGLANG_PYXCCL_SO_PATH` and `LD_LIBRARY_PATH`.
+
+### OFI transport not configured
+
+```text
+CCL_ERROR: could not initialize any transport library
+oneCCL communicator initialization failed
+```
+
+**Fix**: Set `CCL_ATL_TRANSPORT=ofi` and `FI_PROVIDER_PATH`.
+
+### oneCCL runtime not installed
+
+```text
+PyXcclCommunicator failed to initialize
+Failed to load oneCCL library from libccl.so.1
+```
+
+**Fix**: Build the oneCCL runtime (Step 2) and set `SGLANG_PYXCCL_SO_PATH` to a
+valid `libccl.so.1` (or put its directory on `LD_LIBRARY_PATH`).
+
+---
+
+## Environment variable reference
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SGLANG_ENABLE_PYXCCL` | `0` | Set to `1` to route XPU `tp>1` collectives through oneCCL directly; otherwise torch's XCCL backend is used |
+| `SGLANG_PYXCCL_SO_PATH` | (unset) | Explicit path to `libccl.so.1` |
+| `CCL_ATL_TRANSPORT` | (auto) | Must be `ofi` for XPU |
+| `FI_PROVIDER_PATH` | (system) | Path to OFI provider `.so` files |
+| `CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK` | `1` | Set to `0` to suppress PCIe topology warnings |

--- a/docs_new/docs/hardware-platforms/xpu.pyxccl.md
+++ b/docs_new/docs/hardware-platforms/xpu.pyxccl.md
@@ -17,6 +17,13 @@ cannot initialize, SGLang raises at startup for `tp>1` rather than silently
 falling back — since you opted in precisely because torch.distributed may be
 unavailable.
 
+pyxccl replaces the *collectives*; the process group itself is still bootstrapped
+by `torch.distributed`. On a torch build that does have XCCL, that bootstrap uses
+`xccl` as before. On a build without it, `SGLANG_ENABLE_PYXCCL=1` makes SGLang
+bootstrap over `gloo` instead, so the missing backend is not fatal — see
+[torch built without the XCCL backend](#torch-built-without-the-xccl-backend)
+for the caveats.
+
 ---
 
 ## Quick Checklist
@@ -243,6 +250,46 @@ Failed to load oneCCL library from libccl.so.1
 
 **Fix**: Build the oneCCL runtime (Step 2) and set `SGLANG_PYXCCL_SO_PATH` to a
 valid `libccl.so.1` (or put its directory on `LD_LIBRARY_PATH`).
+
+### torch built without the XCCL backend
+
+```text
+RuntimeError: Distributed package doesn't have XCCL built in
+  ... in _create_xccl_process_group
+```
+
+pyxccl replaces the XPU *collectives*, but the process group is still
+bootstrapped by `torch.distributed`. Whether XCCL exists is a compile-time
+property of the torch wheel — no environment variable changes it. Check with:
+
+```bash
+python -c "import torch.distributed as d; print(d.is_xccl_available())"
+```
+
+**Fix**: Set `SGLANG_ENABLE_PYXCCL=1`. SGLang then bootstraps the process group
+over `gloo` — which registers itself for the CPU device only, leaving the XPU
+device slot empty — and runs the XPU collectives on oneCCL directly. This mirrors
+CUDA, where pynccl owns the data plane and rendezvouses over the gloo
+`cpu_group`. Alternatively, install a torch XPU build that includes XCCL.
+
+Because no XPU backend is registered, any XPU collective pyxccl does *not*
+implement raises `No backend type associated with device type xpu` rather than
+silently degrading to a CPU round-trip. Covered by pyxccl: `all_reduce`,
+`all_gather`, `reduce_scatter`, `broadcast`, `send`, `recv`, `all_to_all_single`,
+and `gather` (emulated via all-gather). Not covered: `reduce_scatter` with a
+tensor *list*, `all_gatherv`/`reduce_scatterv`, and object-based collectives
+(which use the CPU group and are unaffected).
+
+### CPU-only oneCCL plugin
+
+```text
+|WARN| [onecclSetDevice:732] Plugin does not implement onecclSetDevice (INIT_DEVICE)
+oneCCL communicator initialization failed: oneCCL error: Not implemented.
+```
+
+The loaded `libccl.so` is a CPU-only build (common for the `oneccl` conda/pip
+package). **Fix**: Point `SGLANG_PYXCCL_SO_PATH` at a SYCL-built oneCCL v2
+library from Step 2.
 
 ---
 

--- a/python/sglang/srt/distributed/device_communicators/pyxccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pyxccl.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from vLLM's vllm/distributed/device_communicators/pyxccl_comm.py
+
+# ``PyXcclCommunicator`` is the XPU counterpart of ``PyNcclCommunicator``: a
+# direct binding to Intel's oneCCL library that bypasses ``torch.distributed``
+# for collective operations (AllReduce, AllGather, ReduceScatter, Broadcast,
+# Send/Recv).  It mirrors the ``pynccl.py`` pattern for CUDA, adapted for Intel
+# XPU + oneCCL so that ``GroupCoordinator`` can drive it beside ``pynccl_comm``.
+#
+# The ctypes/library-loading layer lives in the vendored ``pyxccl_wrapper``
+# module (the XPU analogue of ``pynccl_wrapper``), which binds the ``oneccl*``
+# NCCL-compatible C API exported by ``libccl.so``.  This module only
+# orchestrates rendezvous, device binding, and buffer/stream marshalling.  When
+# the oneCCL library cannot be loaded the communicator marks itself disabled and
+# the caller falls back to ``torch.distributed``.
+
+import logging
+from typing import Optional, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup, ReduceOp
+
+from sglang.srt.distributed.device_communicators.pyxccl_wrapper import (
+    ONECCLLibrary,
+    buffer_type,
+    onecclComm_t,
+    onecclDataTypeEnum,
+    onecclRedOpTypeEnum,
+    onecclUniqueId,
+    xpuStream_t,
+)
+from sglang.srt.distributed.utils import StatelessProcessGroup
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+
+class PyXcclCommunicator:
+    """oneCCL-backed communicator for Intel XPU devices.
+
+    Mirrors the interface of :class:`PyNcclCommunicator` so that
+    ``GroupCoordinator`` can use it as a drop-in replacement for the
+    ``torch.distributed`` XPU collective calls. It is opt-in
+    (``SGLANG_ENABLE_PYXCCL=1``) and intended for environments where the torch
+    build has no usable XCCL backend.
+
+    Unlike ``PyNcclCommunicator`` (which starts ``disabled`` and is only enabled
+    inside CUDA-graph capture via ``change_state``), pyxccl is enabled as soon as
+    it initializes: it is the live collective path in both eager and graph modes
+    on XPU, replacing the ``torch.distributed`` calls.
+    """
+
+    def __init__(
+        self,
+        group: Union[ProcessGroup, StatelessProcessGroup],
+        device: Union[int, str, torch.device],
+        library_path: Optional[str] = None,
+    ):
+        """
+        Args:
+            group: the process group to work on. pyxccl broadcasts the oneCCL
+                unique id over this group during rendezvous, so it should be a
+                CPU (gloo) group or a StatelessProcessGroup, mirroring how
+                PyNcclCommunicator is attached to ``cpu_group``.
+            device: the XPU device this communicator is bound to.
+            library_path: optional explicit path to ``libccl.so.1``. When None,
+                ``SGLANG_PYXCCL_SO_PATH`` is tried first, then the dynamic-linker
+                default (``"libccl.so.1"``).
+        """
+        if isinstance(group, StatelessProcessGroup):
+            self.rank = group.rank
+            self.world_size = group.world_size
+        else:
+            assert dist.is_initialized()
+            self.rank = dist.get_rank(group)
+            self.world_size = dist.get_world_size(group)
+
+        self.group = group
+
+        if isinstance(device, int):
+            device = torch.device(f"xpu:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        assert isinstance(device, torch.device)
+        self.device = device
+
+        # pyxccl is opt-in (off by default); skip when world_size == 1 or when it
+        # has not been explicitly enabled via SGLANG_ENABLE_PYXCCL.
+        if self.world_size == 1 or not envs.SGLANG_ENABLE_PYXCCL.get():
+            self.available = False
+            self.disabled = True
+            return
+
+        # Resolve library path: explicit arg > env var > ldconfig default.
+        so_path = library_path or envs.SGLANG_PYXCCL_SO_PATH.get() or "libccl.so.1"
+
+        try:
+            self.oneccl = ONECCLLibrary(so_path)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load oneCCL library from %s: %s. "
+                "The XPU oneCCL fast-path communicator is disabled.",
+                so_path,
+                exc,
+            )
+            self.available = False
+            self.disabled = True
+            return
+
+        self.available = True
+        self.disabled = False
+        # Opt-in per-collective logging (SGLANG_DEBUG_PYXCCL=1) to confirm at
+        # runtime that collectives are dispatched through this oneCCL path.
+        self._debug = envs.SGLANG_DEBUG_PYXCCL.get()
+
+        if self.rank == 0:
+            logger.info(
+                "sglang XPU is using oneCCL==%s from %s",
+                self.oneccl.onecclGetVersion(),
+                so_path,
+            )
+
+        try:
+            self._init_comm()
+        except Exception as exc:
+            logger.warning(
+                "oneCCL communicator initialization failed: %s. This is often "
+                "caused by missing transport configuration; check that "
+                "CCL_ATL_TRANSPORT=ofi and FI_PROVIDER_PATH are set correctly "
+                "(see docs/platforms/xpu.pyxccl.md).",
+                exc,
+            )
+            self.available = False
+            self.disabled = True
+
+    def _init_comm(self) -> None:
+        """Rendezvous + bind the oneCCL communicator (called from __init__)."""
+        # --- broadcast unique_id so all ranks share the same rendezvous ---
+        if self.rank == 0:
+            self.unique_id = self.oneccl.onecclGetUniqueId()
+        else:
+            self.unique_id = onecclUniqueId()
+
+        if isinstance(self.group, StatelessProcessGroup):
+            self.unique_id = self.group.broadcast_obj(self.unique_id, src=0)
+        else:
+            # Pack the opaque id into a ByteTensor for torch.distributed.
+            tensor = torch.ByteTensor(list(self.unique_id.internal))
+            ranks = dist.get_process_group_ranks(self.group)
+            # arg `src` in `broadcast` is the global rank
+            dist.broadcast(tensor, src=ranks[0], group=self.group)
+            byte_list = tensor.tolist()
+            for i, byte in enumerate(byte_list):
+                self.unique_id.internal[i] = byte
+
+        # Bind the communicator to the correct XPU device.
+        self.oneccl.onecclSetDevice(self.device.index)
+
+        self.comm: onecclComm_t = self.oneccl.onecclCommInitRank(
+            self.world_size, self.unique_id, self.rank
+        )
+
+        # Warmup: a tiny all_reduce to force runtime init before first use, and
+        # to fail fast (→ disabled, torch.distributed fallback) if the transport
+        # is misconfigured.
+        data = torch.zeros(1, device=self.device)
+        self.all_reduce(data)
+        torch.xpu.synchronize()
+        del data
+
+    def _stream(self) -> "xpuStream_t":
+        """Return the current XPU SYCL queue as the oneCCL stream handle."""
+        return xpuStream_t(torch.xpu.current_stream().sycl_queue)
+
+    def _debug_log(self, coll: str, tensor: torch.Tensor, **extra) -> None:
+        """When SGLANG_DEBUG_PYXCCL=1, log that a collective went via oneCCL."""
+        if not self._debug:
+            return
+        detail = "".join(f" {k}={v}" for k, v in extra.items())
+        logger.info(
+            "[pyxccl] rank=%d/%d oneCCL.%s numel=%d dtype=%s dev=%s%s",
+            self.rank,
+            self.world_size,
+            coll,
+            tensor.numel(),
+            tensor.dtype,
+            tensor.device,
+            detail,
+        )
+
+    def all_reduce(self, tensor: torch.Tensor, op: ReduceOp = ReduceOp.SUM):
+        """In-place all-reduce (send buffer == recv buffer)."""
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this pyxccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}"
+        )
+        self._debug_log("AllReduce", tensor, op=op)
+        self.oneccl.onecclAllReduce(
+            buffer_type(tensor.data_ptr()),
+            buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            onecclDataTypeEnum.from_torch(tensor.dtype),
+            onecclRedOpTypeEnum.from_torch(op),
+            self.comm,
+            self._stream(),
+        )
+
+    def all_gather(self, output_tensor: torch.Tensor, input_tensor: torch.Tensor):
+        if self.disabled:
+            return
+        assert input_tensor.device == self.device, (
+            f"this pyxccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {input_tensor.device}"
+        )
+        self._debug_log("AllGather", input_tensor)
+        self.oneccl.onecclAllGather(
+            buffer_type(input_tensor.data_ptr()),
+            buffer_type(output_tensor.data_ptr()),
+            input_tensor.numel(),
+            onecclDataTypeEnum.from_torch(input_tensor.dtype),
+            self.comm,
+            self._stream(),
+        )
+
+    def reduce_scatter(
+        self,
+        output_tensor: torch.Tensor,
+        input_tensor: torch.Tensor,
+        op: ReduceOp = ReduceOp.SUM,
+    ):
+        if self.disabled:
+            return
+        assert input_tensor.device == self.device, (
+            f"this pyxccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {input_tensor.device}"
+        )
+        self._debug_log("ReduceScatter", input_tensor, op=op)
+        self.oneccl.onecclReduceScatter(
+            buffer_type(input_tensor.data_ptr()),
+            buffer_type(output_tensor.data_ptr()),
+            output_tensor.numel(),
+            onecclDataTypeEnum.from_torch(input_tensor.dtype),
+            onecclRedOpTypeEnum.from_torch(op),
+            self.comm,
+            self._stream(),
+        )
+
+    def broadcast(self, tensor: torch.Tensor, src: int):
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this pyxccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}"
+        )
+        self._debug_log("Broadcast", tensor, src=src)
+        self.oneccl.onecclBroadcast(
+            buffer_type(tensor.data_ptr()),
+            buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            onecclDataTypeEnum.from_torch(tensor.dtype),
+            src,
+            self.comm,
+            self._stream(),
+        )
+
+    def send(self, tensor: torch.Tensor, dst: int):
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this pyxccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}"
+        )
+        self._debug_log("Send", tensor, dst=dst)
+        self.oneccl.onecclSend(
+            buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            onecclDataTypeEnum.from_torch(tensor.dtype),
+            dst,
+            self.comm,
+            self._stream(),
+        )
+
+    def recv(self, tensor: torch.Tensor, src: int):
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this pyxccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}"
+        )
+        self._debug_log("Recv", tensor, src=src)
+        self.oneccl.onecclRecv(
+            buffer_type(tensor.data_ptr()),
+            tensor.numel(),
+            onecclDataTypeEnum.from_torch(tensor.dtype),
+            src,
+            self.comm,
+            self._stream(),
+        )
+
+    def destroy(self):
+        """Release the oneCCL communicator handle."""
+        if self.available and not self.disabled:
+            try:
+                self.oneccl.onecclCommDestroy(self.comm)
+            except Exception as exc:
+                logger.debug("onecclCommDestroy raised: %s", exc)
+            self.available = False
+            self.disabled = True

--- a/python/sglang/srt/distributed/device_communicators/pyxccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pyxccl.py
@@ -129,7 +129,7 @@ class PyXcclCommunicator:
                 "oneCCL communicator initialization failed: %s. This is often "
                 "caused by missing transport configuration; check that "
                 "CCL_ATL_TRANSPORT=ofi and FI_PROVIDER_PATH are set correctly "
-                "(see docs/platforms/xpu.pyxccl.md).",
+                "(see docs_new/docs/hardware-platforms/xpu.pyxccl.md).",
                 exc,
             )
             self.available = False
@@ -221,6 +221,35 @@ class PyXcclCommunicator:
             buffer_type(input_tensor.data_ptr()),
             buffer_type(output_tensor.data_ptr()),
             input_tensor.numel(),
+            onecclDataTypeEnum.from_torch(input_tensor.dtype),
+            self.comm,
+            self._stream(),
+        )
+
+    def all_to_all_single(
+        self, output_tensor: torch.Tensor, input_tensor: torch.Tensor
+    ):
+        """Even-split all-to-all: each rank sends an equal chunk to every rank.
+
+        Mirrors ``torch.distributed.all_to_all_single`` without split lists;
+        oneCCL takes the *per-rank* element count.
+        """
+        if self.disabled:
+            return
+        assert input_tensor.device == self.device, (
+            f"this pyxccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {input_tensor.device}"
+        )
+        assert input_tensor.numel() % self.world_size == 0, (
+            f"all_to_all_single requires an even split, but numel "
+            f"({input_tensor.numel()}) is not divisible by world_size "
+            f"({self.world_size})"
+        )
+        self._debug_log("AllToAll", input_tensor)
+        self.oneccl.onecclAllToAll(
+            buffer_type(input_tensor.data_ptr()),
+            buffer_type(output_tensor.data_ptr()),
+            input_tensor.numel() // self.world_size,
             onecclDataTypeEnum.from_torch(input_tensor.dtype),
             self.comm,
             self._stream(),

--- a/python/sglang/srt/distributed/device_communicators/pyxccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pyxccl_wrapper.py
@@ -1,0 +1,462 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from sglang's pynccl_wrapper.py for Intel oneCCL.
+
+# This file is a pure Python (ctypes) wrapper for Intel's oneCCL library,
+# binding its NCCL-compatible C API (the ``oneccl*`` symbols exported by
+# ``libccl.so``). It is the XPU counterpart of ``pynccl_wrapper.py`` and is used
+# by ``PyXcclCommunicator`` (``pyxccl.py``) to call oneCCL directly instead of
+# routing collectives through ``torch.distributed``'s XCCL backend.
+#
+# A pure Python wrapper (rather than a compiled C/C++ binding) keeps oneCCL
+# version-agnostic: the library is selected at runtime via the
+# ``SGLANG_PYXCCL_SO_PATH`` environment variable or the dynamic-linker default,
+# with no recompilation needed to switch oneCCL builds.
+#
+# For the oneCCL C API definitions, see
+# ``<oneapi>/include/oneapi/ccl.h`` and ``ccl/v2/types.h``.
+
+import ctypes
+import logging
+import os
+import platform
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.distributed import ReduceOp
+
+logger = logging.getLogger(__name__)
+
+
+def find_ccl_library() -> str:
+    """
+    Locate the oneCCL shared library. Uses ``SGLANG_PYXCCL_SO_PATH`` when set,
+    otherwise falls back to the dynamic-linker default ``libccl.so.1``.
+    """
+    so_file = os.environ.get("SGLANG_PYXCCL_SO_PATH", None)
+    if so_file:
+        logger.info(
+            "Found oneCCL from environment variable SGLANG_PYXCCL_SO_PATH=%s", so_file
+        )
+    else:
+        so_file = "libccl.so.1"
+        logger.debug("Using default oneCCL library %s", so_file)
+    return so_file
+
+
+# === export types and functions from oneCCL to Python ===
+# for the original oneCCL definitions, see include/oneapi/ccl.h and
+# include/oneapi/ccl/v2/types.h.
+
+onecclResult_t = ctypes.c_int
+onecclComm_t = ctypes.c_void_p
+
+# oneCCL's unique id is 4096 bytes (ONECCL_UNIQUE_ID_BYTES), unlike NCCL's 128.
+ONECCL_UNIQUE_ID_BYTES = 4096
+
+
+class onecclUniqueId(ctypes.Structure):
+    _fields_ = [("internal", ctypes.c_byte * ONECCL_UNIQUE_ID_BYTES)]
+
+
+# oneCCL takes a ``void *stream`` that is a pointer to a SYCL queue on XPU.
+xpuStream_t = ctypes.c_void_p
+buffer_type = ctypes.c_void_p
+
+onecclDataType_t = ctypes.c_int
+
+
+class onecclDataTypeEnum:
+    # Values from onecclDataType_t in ccl/v2/types.h.
+    onecclInt8 = 0
+    onecclChar = 0
+    onecclUint8 = 1
+    onecclInt32 = 2
+    onecclInt = 2
+    onecclUint32 = 3
+    onecclInt64 = 4
+    onecclUint64 = 5
+    onecclFloat16 = 6
+    onecclHalf = 6
+    onecclFloat32 = 7
+    onecclFloat = 7
+    onecclFloat64 = 8
+    onecclDouble = 8
+    onecclBfloat16 = 9
+
+    @classmethod
+    def from_torch(cls, dtype: torch.dtype) -> int:
+        if dtype == torch.int8:
+            return cls.onecclInt8
+        if dtype == torch.uint8:
+            return cls.onecclUint8
+        if dtype == torch.int32:
+            return cls.onecclInt32
+        if dtype == torch.int64:
+            return cls.onecclInt64
+        if dtype == torch.float16:
+            return cls.onecclFloat16
+        if dtype == torch.float32:
+            return cls.onecclFloat32
+        if dtype == torch.float64:
+            return cls.onecclFloat64
+        if dtype == torch.bfloat16:
+            return cls.onecclBfloat16
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+onecclRedOp_t = ctypes.c_int
+
+
+class onecclRedOpTypeEnum:
+    # Values from onecclRedOp_t in ccl/v2/types.h.
+    onecclSum = 0
+    onecclProd = 1
+    onecclMax = 2
+    onecclMin = 3
+    onecclAvg = 4
+
+    @classmethod
+    def from_torch(cls, op: ReduceOp) -> int:
+        if op == ReduceOp.SUM:
+            return cls.onecclSum
+        if op == ReduceOp.PRODUCT:
+            return cls.onecclProd
+        if op == ReduceOp.MAX:
+            return cls.onecclMax
+        if op == ReduceOp.MIN:
+            return cls.onecclMin
+        if op == ReduceOp.AVG:
+            return cls.onecclAvg
+        raise ValueError(f"Unsupported op: {op}")
+
+
+@dataclass
+class Function:
+    name: str
+    restype: Any
+    argtypes: List[Any]
+
+
+class ONECCLLibrary:
+    exported_functions = [
+        # const char* onecclGetErrorString(onecclResult_t result);
+        Function("onecclGetErrorString", ctypes.c_char_p, [onecclResult_t]),
+        # onecclResult_t onecclGetVersion(int *version);
+        Function("onecclGetVersion", onecclResult_t, [ctypes.POINTER(ctypes.c_int)]),
+        # onecclResult_t onecclGetUniqueId(onecclUniqueId *uniqueId);
+        Function("onecclGetUniqueId", onecclResult_t, [ctypes.POINTER(onecclUniqueId)]),
+        # onecclResult_t onecclSetDevice(uint32_t index);
+        Function("onecclSetDevice", onecclResult_t, [ctypes.c_uint32]),
+        # onecclResult_t onecclCommInitRank(
+        #   onecclComm_t *comm, size_t nranks, onecclUniqueId commId, int rank);
+        # note that onecclComm_t is a pointer type, so the first argument
+        # is a pointer to a pointer, and nranks is size_t (not int).
+        Function(
+            "onecclCommInitRank",
+            onecclResult_t,
+            [
+                ctypes.POINTER(onecclComm_t),
+                ctypes.c_size_t,
+                onecclUniqueId,
+                ctypes.c_int,
+            ],
+        ),
+        # onecclResult_t onecclAllReduce(
+        #   void *sendbuff, void *recvbuff, size_t count,
+        #   onecclDataType_t datatype, onecclRedOp_t reduction_op,
+        #   onecclComm_t comm, void *stream);
+        Function(
+            "onecclAllReduce",
+            onecclResult_t,
+            [
+                buffer_type,
+                buffer_type,
+                ctypes.c_size_t,
+                onecclDataType_t,
+                onecclRedOp_t,
+                onecclComm_t,
+                xpuStream_t,
+            ],
+        ),
+        # onecclResult_t onecclAllGather(
+        #   const void *sendbuff, void *recvbuff, size_t sendcount,
+        #   onecclDataType_t datatype, onecclComm_t comm, void *stream);
+        Function(
+            "onecclAllGather",
+            onecclResult_t,
+            [
+                buffer_type,
+                buffer_type,
+                ctypes.c_size_t,
+                onecclDataType_t,
+                onecclComm_t,
+                xpuStream_t,
+            ],
+        ),
+        # onecclResult_t onecclReduceScatter(
+        #   const void *sendbuff, void *recvbuff, size_t recvcount,
+        #   onecclDataType_t datatype, onecclRedOp_t redop,
+        #   onecclComm_t comm, void *stream);
+        Function(
+            "onecclReduceScatter",
+            onecclResult_t,
+            [
+                buffer_type,
+                buffer_type,
+                ctypes.c_size_t,
+                onecclDataType_t,
+                onecclRedOp_t,
+                onecclComm_t,
+                xpuStream_t,
+            ],
+        ),
+        # onecclResult_t onecclBroadcast(
+        #   const void *sendbuff, void *recvbuff, size_t count,
+        #   onecclDataType_t datatype, int root, onecclComm_t comm,
+        #   void *stream);
+        Function(
+            "onecclBroadcast",
+            onecclResult_t,
+            [
+                buffer_type,
+                buffer_type,
+                ctypes.c_size_t,
+                onecclDataType_t,
+                ctypes.c_int,
+                onecclComm_t,
+                xpuStream_t,
+            ],
+        ),
+        # onecclResult_t onecclSend(
+        #   const void *sendbuff, size_t count, onecclDataType_t datatype,
+        #   int peer, onecclComm_t comm, void *stream);
+        Function(
+            "onecclSend",
+            onecclResult_t,
+            [
+                buffer_type,
+                ctypes.c_size_t,
+                onecclDataType_t,
+                ctypes.c_int,
+                onecclComm_t,
+                xpuStream_t,
+            ],
+        ),
+        # onecclResult_t onecclRecv(
+        #   void *recvbuff, size_t count, onecclDataType_t datatype,
+        #   int peer, onecclComm_t comm, void *stream);
+        Function(
+            "onecclRecv",
+            onecclResult_t,
+            [
+                buffer_type,
+                ctypes.c_size_t,
+                onecclDataType_t,
+                ctypes.c_int,
+                onecclComm_t,
+                xpuStream_t,
+            ],
+        ),
+        # be cautious! onecclCommDestroy is a collective call; because Python
+        # object destruction can happen in random order, it is better not to
+        # rely on __del__ to call it.
+        # onecclResult_t onecclCommDestroy(onecclComm_t comm);
+        Function("onecclCommDestroy", onecclResult_t, [onecclComm_t]),
+        # onecclResult_t onecclGroupStart();
+        Function("onecclGroupStart", onecclResult_t, []),
+        # onecclResult_t onecclGroupEnd();
+        Function("onecclGroupEnd", onecclResult_t, []),
+    ]
+
+    # class attribute to store the mapping from the path to the library
+    # to avoid loading the same library multiple times
+    path_to_library_cache: Dict[str, Any] = {}
+
+    # class attribute to store the mapping from library path
+    #  to the corresponding dictionary
+    path_to_dict_mapping: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(self, so_file: Optional[str] = None):
+
+        so_file = so_file or find_ccl_library()
+
+        try:
+            if so_file not in ONECCLLibrary.path_to_dict_mapping:
+                lib = ctypes.CDLL(so_file)
+                ONECCLLibrary.path_to_library_cache[so_file] = lib
+            self.lib = ONECCLLibrary.path_to_library_cache[so_file]
+        except Exception as e:
+            logger.error(
+                "Failed to load oneCCL library from %s . "
+                "It is expected if you are not running on Intel XPUs. "
+                "Otherwise, the oneCCL library might not exist, be corrupted, "
+                "or it does not support the current platform %s. "
+                "If you already have the library, please set the "
+                "environment variable SGLANG_PYXCCL_SO_PATH"
+                " to point to the correct oneCCL library path.",
+                so_file,
+                platform.platform(),
+            )
+            raise e
+
+        if so_file not in ONECCLLibrary.path_to_dict_mapping:
+            _funcs: Dict[str, Any] = {}
+            for func in ONECCLLibrary.exported_functions:
+                f = getattr(self.lib, func.name)
+                f.restype = func.restype
+                f.argtypes = func.argtypes
+                _funcs[func.name] = f
+            ONECCLLibrary.path_to_dict_mapping[so_file] = _funcs
+        self._funcs = ONECCLLibrary.path_to_dict_mapping[so_file]
+
+    def onecclGetErrorString(self, result: onecclResult_t) -> str:
+        return self._funcs["onecclGetErrorString"](result).decode("utf-8")
+
+    def ONECCL_CHECK(self, result: onecclResult_t) -> None:
+        if result != 0:
+            error_str = self.onecclGetErrorString(result)
+            raise RuntimeError(f"oneCCL error: {error_str}")
+
+    def onecclGetRawVersion(self) -> int:
+        version = ctypes.c_int()
+        self.ONECCL_CHECK(self._funcs["onecclGetVersion"](ctypes.byref(version)))
+        # e.g. 20211702 for oneCCL 2021.17.2
+        return version.value
+
+    def onecclGetVersion(self) -> str:
+        # ONECCL_VERSION_CODE = major*10000 + minor*100 + suffix
+        code = self.onecclGetRawVersion()
+        major = code // 10000
+        minor = (code % 10000) // 100
+        patch = code % 100
+        return f"{major}.{minor}.{patch}"
+
+    def onecclGetUniqueId(self) -> onecclUniqueId:
+        unique_id = onecclUniqueId()
+        self.ONECCL_CHECK(self._funcs["onecclGetUniqueId"](ctypes.byref(unique_id)))
+        return unique_id
+
+    def onecclSetDevice(self, index: int) -> None:
+        self.ONECCL_CHECK(self._funcs["onecclSetDevice"](index))
+
+    def onecclCommInitRank(
+        self, world_size: int, unique_id: onecclUniqueId, rank: int
+    ) -> onecclComm_t:
+        comm = onecclComm_t()
+        self.ONECCL_CHECK(
+            self._funcs["onecclCommInitRank"](
+                ctypes.byref(comm), world_size, unique_id, rank
+            )
+        )
+        return comm
+
+    def onecclAllReduce(
+        self,
+        sendbuff: buffer_type,
+        recvbuff: buffer_type,
+        count: int,
+        datatype: int,
+        op: int,
+        comm: onecclComm_t,
+        stream: xpuStream_t,
+    ) -> None:
+        self.ONECCL_CHECK(
+            self._funcs["onecclAllReduce"](
+                sendbuff, recvbuff, count, datatype, op, comm, stream
+            )
+        )
+
+    def onecclReduceScatter(
+        self,
+        sendbuff: buffer_type,
+        recvbuff: buffer_type,
+        count: int,
+        datatype: int,
+        op: int,
+        comm: onecclComm_t,
+        stream: xpuStream_t,
+    ) -> None:
+        self.ONECCL_CHECK(
+            self._funcs["onecclReduceScatter"](
+                sendbuff, recvbuff, count, datatype, op, comm, stream
+            )
+        )
+
+    def onecclAllGather(
+        self,
+        sendbuff: buffer_type,
+        recvbuff: buffer_type,
+        count: int,
+        datatype: int,
+        comm: onecclComm_t,
+        stream: xpuStream_t,
+    ) -> None:
+        self.ONECCL_CHECK(
+            self._funcs["onecclAllGather"](
+                sendbuff, recvbuff, count, datatype, comm, stream
+            )
+        )
+
+    def onecclSend(
+        self,
+        sendbuff: buffer_type,
+        count: int,
+        datatype: int,
+        dest: int,
+        comm: onecclComm_t,
+        stream: xpuStream_t,
+    ) -> None:
+        self.ONECCL_CHECK(
+            self._funcs["onecclSend"](sendbuff, count, datatype, dest, comm, stream)
+        )
+
+    def onecclRecv(
+        self,
+        recvbuff: buffer_type,
+        count: int,
+        datatype: int,
+        src: int,
+        comm: onecclComm_t,
+        stream: xpuStream_t,
+    ) -> None:
+        self.ONECCL_CHECK(
+            self._funcs["onecclRecv"](recvbuff, count, datatype, src, comm, stream)
+        )
+
+    def onecclBroadcast(
+        self,
+        sendbuff: buffer_type,
+        recvbuff: buffer_type,
+        count: int,
+        datatype: int,
+        root: int,
+        comm: onecclComm_t,
+        stream: xpuStream_t,
+    ) -> None:
+        self.ONECCL_CHECK(
+            self._funcs["onecclBroadcast"](
+                sendbuff, recvbuff, count, datatype, root, comm, stream
+            )
+        )
+
+    def onecclCommDestroy(self, comm: onecclComm_t) -> None:
+        self.ONECCL_CHECK(self._funcs["onecclCommDestroy"](comm))
+
+    def onecclGroupStart(self) -> None:
+        self.ONECCL_CHECK(self._funcs["onecclGroupStart"]())
+
+    def onecclGroupEnd(self) -> None:
+        self.ONECCL_CHECK(self._funcs["onecclGroupEnd"]())
+
+
+__all__ = [
+    "ONECCLLibrary",
+    "onecclDataTypeEnum",
+    "onecclRedOpTypeEnum",
+    "onecclUniqueId",
+    "onecclComm_t",
+    "xpuStream_t",
+    "buffer_type",
+]

--- a/python/sglang/srt/distributed/device_communicators/pyxccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pyxccl_wrapper.py
@@ -195,6 +195,22 @@ class ONECCLLibrary:
                 xpuStream_t,
             ],
         ),
+        # onecclResult_t onecclAllToAll(
+        #   const void *sendbuff, void *recvbuff, size_t count,
+        #   onecclDataType_t datatype, onecclComm_t comm, void *stream);
+        # NOTE: `count` is the per-rank element count (not the total).
+        Function(
+            "onecclAllToAll",
+            onecclResult_t,
+            [
+                buffer_type,
+                buffer_type,
+                ctypes.c_size_t,
+                onecclDataType_t,
+                onecclComm_t,
+                xpuStream_t,
+            ],
+        ),
         # onecclResult_t onecclReduceScatter(
         #   const void *sendbuff, void *recvbuff, size_t recvcount,
         #   onecclDataType_t datatype, onecclRedOp_t redop,
@@ -381,6 +397,22 @@ class ONECCLLibrary:
         self.ONECCL_CHECK(
             self._funcs["onecclReduceScatter"](
                 sendbuff, recvbuff, count, datatype, op, comm, stream
+            )
+        )
+
+    def onecclAllToAll(
+        self,
+        sendbuff: buffer_type,
+        recvbuff: buffer_type,
+        count: int,
+        datatype: int,
+        comm: onecclComm_t,
+        stream: xpuStream_t,
+    ) -> None:
+        """`count` is the per-rank element count, not the buffer total."""
+        self.ONECCL_CHECK(
+            self._funcs["onecclAllToAll"](
+                sendbuff, recvbuff, count, datatype, comm, stream
             )
         )
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -250,6 +250,7 @@ class GroupCoordinator:
     )
     # communicators are only created for world size > 1
     pynccl_comm: Optional[Any]  # PyNccl communicator
+    pyxccl_comm: Optional[Any]  # PyXccl (XPU oneCCL) communicator
     ca_comm: Optional[Any]  # Custom allreduce communicator
     torch_symm_mem_comm: Optional[Any]  # Torch symm mem communicator
     mq_broadcaster: Optional[Any]  # shared memory broadcaster
@@ -359,6 +360,9 @@ class GroupCoordinator:
         from sglang.srt.distributed.device_communicators.pymscclpp import (
             PyMscclppCommunicator,
         )
+        from sglang.srt.distributed.device_communicators.pyxccl import (
+            PyXcclCommunicator,
+        )
         from sglang.srt.distributed.device_communicators.pynccl import (
             PyNcclCommunicator,
         )
@@ -388,6 +392,41 @@ class GroupCoordinator:
                 group=self.cpu_group,
                 device=self.device,
             )
+
+        # pyxccl is the XPU counterpart of pynccl: it calls Intel oneCCL directly
+        # instead of routing collectives through torch.distributed's XCCL
+        # backend. It is OFF by default (XPU uses torch.distributed / XCCL) and
+        # opted into via SGLANG_ENABLE_PYXCCL=1 — the path to use when the torch
+        # build has no usable XCCL backend. Once initialized it is the live
+        # collective path in both eager and graph modes (so, unlike pynccl, it
+        # is not gated behind graph_capture's change_state toggle).
+        self.pyxccl_comm: Optional[PyXcclCommunicator] = None
+        if (
+            _is_xpu
+            and use_xpu_communicator
+            and self.world_size > 1
+            and envs.SGLANG_ENABLE_PYXCCL.get()
+        ):
+            self.pyxccl_comm = PyXcclCommunicator(
+                group=self.cpu_group,
+                device=self.device,
+            )
+            if self.pyxccl_comm.disabled:
+                # The user explicitly opted into pyxccl (SGLANG_ENABLE_PYXCCL=1),
+                # typically because torch.distributed / XCCL is unavailable, so
+                # a silent fallback is not appropriate. Fail loudly with setup
+                # guidance instead.
+                raise RuntimeError(
+                    "SGLANG_ENABLE_PYXCCL=1 was set but PyXcclCommunicator "
+                    "failed to initialize, so XPU tensor parallelism (tp>1) "
+                    "cannot run. Set up pyxccl + oneCCL correctly (see "
+                    "docs/platforms/xpu.pyxccl.md), point SGLANG_PYXCCL_SO_PATH "
+                    "at a SYCL-built libccl.so.1, and ensure the required OFI "
+                    "environment variables (CCL_ATL_TRANSPORT=ofi, "
+                    "FI_PROVIDER_PATH) are set. To use torch.distributed "
+                    "instead, unset SGLANG_ENABLE_PYXCCL (requires a torch build "
+                    "with a working XCCL backend)."
+                )
 
         self.pymscclpp_comm: Optional[PyMscclppCommunicator] = None
         if use_pymscclpp and self.world_size > 1:
@@ -610,9 +649,9 @@ class GroupCoordinator:
             # an opaque call and does not decompose it into _c10d_functional primitives
             # (which invoke sycl_event.wait() and break XPU graph capture).
             # Keeps the operation in-place; the all-reduce is performed by
-            # _all_reduce_in_place, which for XPU falls through to
-            # torch.distributed.all_reduce on self.device_group (the same group
-            # used by xpu_communicator).
+            # _all_reduce_in_place, which for XPU uses torch.distributed on
+            # self.device_group by default and only calls pyxccl_comm.all_reduce
+            # (direct oneCCL) when it is enabled (SGLANG_ENABLE_PYXCCL=1).
             inplace_all_reduce(input_, group_name=self.unique_name)
             return input_
 
@@ -771,6 +810,10 @@ class GroupCoordinator:
         return out
 
     def _all_reduce_in_place(self, input_: torch.Tensor) -> None:
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            pyxccl_comm.all_reduce(input_)
+            return
         pynccl_comm = self.pynccl_comm
         torch_symm_mem_comm = self.torch_symm_mem_comm
         if pynccl_comm is not None and not pynccl_comm.disabled:
@@ -826,6 +869,10 @@ class GroupCoordinator:
         output: torch.Tensor,
         input: torch.Tensor,
     ) -> torch.Tensor:
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            pyxccl_comm.reduce_scatter(output, input)
+            return output
         pynccl_comm = self.pynccl_comm
         if pynccl_comm is not None and (
             not pynccl_comm.disabled or self.is_symmetric_memory_enabled()
@@ -980,6 +1027,11 @@ class GroupCoordinator:
             else:
                 ca_comm.all_gather_unreg(input, out=output, dim=0)
                 return
+
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            pyxccl_comm.all_gather(output, input)
+            return
 
         pynccl_comm = self.pynccl_comm
         if pynccl_comm is not None and (
@@ -1228,6 +1280,10 @@ class GroupCoordinator:
         if self.world_size == 1:
             return input_
         # Broadcast.
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            pyxccl_comm.broadcast(input_, src=src)
+            return input_
         torch.distributed.broadcast(
             input_, src=self.ranks[src], group=self.device_group
         )
@@ -1580,6 +1636,10 @@ class GroupCoordinator:
         if dst is None:
             dst = (self.rank_in_group + 1) % self.world_size
 
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            pyxccl_comm.send(tensor, dst)
+            return
         pynccl_comm = self.pynccl_comm
         if pynccl_comm is not None and not pynccl_comm.disabled:
             pynccl_comm.send(tensor, dst)
@@ -1595,6 +1655,10 @@ class GroupCoordinator:
             src = (self.rank_in_group - 1) % self.world_size
 
         tensor = torch.empty(size, dtype=dtype, device=self.device)
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            pyxccl_comm.recv(tensor, src)
+            return tensor
         pynccl_comm = self.pynccl_comm
         if pynccl_comm is not None and not pynccl_comm.disabled:
             pynccl_comm.recv(tensor, src)
@@ -1611,6 +1675,9 @@ class GroupCoordinator:
             self.cpu_group = None
         if self.pynccl_comm is not None:
             self.pynccl_comm = None
+        if self.pyxccl_comm is not None:
+            self.pyxccl_comm.destroy()
+            self.pyxccl_comm = None
         if self.pymscclpp_comm is not None:
             self.pymscclpp_comm.destroy()
         if self.ca_comm is not None:

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -360,9 +360,6 @@ class GroupCoordinator:
         from sglang.srt.distributed.device_communicators.pymscclpp import (
             PyMscclppCommunicator,
         )
-        from sglang.srt.distributed.device_communicators.pyxccl import (
-            PyXcclCommunicator,
-        )
         from sglang.srt.distributed.device_communicators.pynccl import (
             PyNcclCommunicator,
         )
@@ -370,6 +367,9 @@ class GroupCoordinator:
             debug_check_symmetric_mempool,
             is_symmetric_memory_enabled,
             use_symmetric_memory,
+        )
+        from sglang.srt.distributed.device_communicators.pyxccl import (
+            PyXcclCommunicator,
         )
         from sglang.srt.distributed.device_communicators.torch_symm_mem import (
             TorchSymmMemCommunicator,

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1921,7 +1921,7 @@ def set_torch_symm_mem_all_reduce(enable: bool):
     _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = enable
 
 
-def xccl_is_available() -> bool:
+def is_xccl_available() -> bool:
     """Whether this torch build has the XCCL backend compiled in.
 
     Not every XPU torch build ships XCCL; when it is missing,
@@ -1955,7 +1955,7 @@ def get_default_distributed_backend(device: str) -> str:
     if (
         backend == "xccl"
         and envs.SGLANG_ENABLE_PYXCCL.get()
-        and not xccl_is_available()
+        and not is_xccl_available()
     ):
         logger.warning(
             "This torch build has no XCCL backend; bootstrapping the process "
@@ -2074,7 +2074,7 @@ def init_distributed_environment(
         else:
             pg_options = get_torch_distributed_pg_options()
 
-        if backend == "xccl" and not xccl_is_available():
+        if backend == "xccl" and not is_xccl_available():
             # torch would raise a bare "Distributed package doesn't have XCCL
             # built in" here, which gives no hint about the way out.
             raise RuntimeError(

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -420,7 +420,7 @@ class GroupCoordinator:
                     "SGLANG_ENABLE_PYXCCL=1 was set but PyXcclCommunicator "
                     "failed to initialize, so XPU tensor parallelism (tp>1) "
                     "cannot run. Set up pyxccl + oneCCL correctly (see "
-                    "docs/platforms/xpu.pyxccl.md), point SGLANG_PYXCCL_SO_PATH "
+                    "docs_new/docs/hardware-platforms/xpu.pyxccl.md), point SGLANG_PYXCCL_SO_PATH "
                     "at a SYCL-built libccl.so.1, and ensure the required OFI "
                     "environment variables (CCL_ATL_TRANSPORT=ofi, "
                     "FI_PROVIDER_PATH) are set. To use torch.distributed "
@@ -944,6 +944,10 @@ class GroupCoordinator:
         return True
 
     def _all_to_all_single(self, output: torch.Tensor, input: torch.Tensor) -> None:
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            pyxccl_comm.all_to_all_single(output, input)
+            return
         torch.distributed.all_to_all_single(output, input, group=self.device_group)
 
     def all_to_all_single(self, output: torch.Tensor, input: torch.Tensor):
@@ -1253,6 +1257,25 @@ class GroupCoordinator:
         if dim < 0:
             # Convert negative dim to positive.
             dim += input_.dim()
+        pyxccl_comm = self.pyxccl_comm
+        if pyxccl_comm is not None and not pyxccl_comm.disabled:
+            # oneCCL has no gather primitive, so emulate it exactly as
+            # XpuCommunicator.gather does (all-gather, then keep the result on
+            # `dst` only) -- but over oneCCL, so it works without an XPU
+            # torch.distributed backend.
+            input_size = input_.size()
+            output_tensor = torch.empty(
+                (world_size,) + input_size, dtype=input_.dtype, device=input_.device
+            )
+            pyxccl_comm.all_gather(output_tensor, input_)
+            if self.rank_in_group != dst:
+                return None
+            output_tensor = output_tensor.movedim(0, dim)
+            return output_tensor.reshape(
+                input_size[:dim]
+                + (world_size * input_size[dim],)
+                + input_size[dim + 1 :]
+            )
         if self.xpu_communicator is not None and not self.xpu_communicator.disabled:
             return self.xpu_communicator.gather(input_, self.rank_in_group, dst, dim)
         # Allocate output tensor.
@@ -1898,6 +1921,17 @@ def set_torch_symm_mem_all_reduce(enable: bool):
     _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = enable
 
 
+def xccl_is_available() -> bool:
+    """Whether this torch build has the XCCL backend compiled in.
+
+    Not every XPU torch build ships XCCL; when it is missing,
+    ``init_process_group(backend="xccl")`` raises "Distributed package doesn't
+    have XCCL built in". No environment variable can change that -- it is a
+    compile-time property of the wheel.
+    """
+    return torch.distributed.is_xccl_available()
+
+
 # TODO: refactor in-tree platforms to get rid of this wrapper
 def get_default_distributed_backend(device: str) -> str:
     # We deliberately go through ``platforms.current_platform`` (rather than
@@ -1905,8 +1939,33 @@ def get_default_distributed_backend(device: str) -> str:
     # platforms package's lazy ``__getattr__`` and picks up runtime overrides
     # of ``_current_platform`` (e.g. in tests).
     if device == platforms.current_platform.device_type:
-        return platforms.current_platform.get_torch_distributed_backend_str()
-    return _DEVICE_TO_DISTRIBUTED_BACKEND.get(device, "gloo")
+        backend = platforms.current_platform.get_torch_distributed_backend_str()
+    else:
+        backend = _DEVICE_TO_DISTRIBUTED_BACKEND.get(device, "gloo")
+
+    # pyxccl replaces the XPU *collectives*, but the process group itself is
+    # still bootstrapped by torch.distributed, and on a build without XCCL that
+    # bootstrap raises before pyxccl is ever constructed. Bootstrap over gloo
+    # instead: pyxccl owns the XPU data plane, exactly as pynccl owns it on CUDA
+    # (pynccl likewise rendezvouses over the gloo ``cpu_group``). gloo registers
+    # itself for the CPU device only, so the XPU device slot stays empty and any
+    # XPU collective pyxccl does *not* implement raises "No backend type
+    # associated with device type xpu" instead of silently degrading to a CPU
+    # round-trip. See docs_new/docs/hardware-platforms/xpu.pyxccl.md.
+    if (
+        backend == "xccl"
+        and envs.SGLANG_ENABLE_PYXCCL.get()
+        and not xccl_is_available()
+    ):
+        logger.warning(
+            "This torch build has no XCCL backend; bootstrapping the process "
+            "group over gloo so SGLANG_ENABLE_PYXCCL=1 can drive XPU "
+            "collectives on oneCCL directly. Collectives pyxccl does not "
+            "implement (group gather, MoE all-to-all) are unsupported here and "
+            "will raise rather than fall back."
+        )
+        return "gloo"
+    return backend
 
 
 def _create_global_tcp_store(rank: int, world_size: int) -> None:
@@ -2014,6 +2073,19 @@ def init_distributed_environment(
             pg_options = MooncakeBackendOptions(active_ranks, recovered_rank)
         else:
             pg_options = get_torch_distributed_pg_options()
+
+        if backend == "xccl" and not xccl_is_available():
+            # torch would raise a bare "Distributed package doesn't have XCCL
+            # built in" here, which gives no hint about the way out.
+            raise RuntimeError(
+                "This PyTorch build does not have the XCCL backend compiled in "
+                "(torch.distributed.is_xccl_available() is False), so XPU "
+                "distributed cannot be initialized with backend='xccl'. Either "
+                "install a torch XPU build that includes XCCL, or set "
+                "SGLANG_ENABLE_PYXCCL=1 to run XPU collectives directly on "
+                "Intel oneCCL (which bootstraps over gloo instead). See "
+                "docs_new/docs/hardware-platforms/xpu.pyxccl.md."
+            )
 
         # this backend is used for WORLD
         torch.distributed.init_process_group(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1003,6 +1003,20 @@ class Envs:
     # Symmetric Memory
     SGLANG_SYMM_MEM_PREALLOC_GB_SIZE = EnvInt(-1)
     SGLANG_DEBUG_SYMM_MEM = EnvBool(False)
+    # XPU oneCCL (pyxccl) direct-binding communicator. pyxccl is the XPU
+    # counterpart of pynccl: it calls Intel oneCCL directly, bypassing
+    # torch.distributed. It is OFF by default (XPU collectives use
+    # torch.distributed's XCCL backend); set SGLANG_ENABLE_PYXCCL=1 to route XPU
+    # tp>1 collectives through oneCCL directly. This is the path to use when the
+    # torch build has no usable XCCL backend. SGLANG_PYXCCL_SO_PATH points at an
+    # explicit libccl.so.1 (SYCL-built oneCCL v2 with the oneccl* C shim),
+    # otherwise the loader falls back to the dynamic-linker default.
+    SGLANG_ENABLE_PYXCCL = EnvBool(False)
+    SGLANG_PYXCCL_SO_PATH = EnvStr(None)
+    # Debug: when set, PyXcclCommunicator logs every collective call
+    # (all_reduce/all_gather/reduce_scatter/broadcast/send/recv) so you can
+    # confirm at runtime that collectives flow through the oneCCL path.
+    SGLANG_DEBUG_PYXCCL = EnvBool(False)
 
     # Aiter
     SGLANG_USE_AITER_FP8_PER_TOKEN = EnvBool(False)

--- a/scripts/activate-xpu-sglang.sh
+++ b/scripts/activate-xpu-sglang.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# activate-xpu-sglang.sh — source this before running SGLang on XPU with pyxccl
+#
+# Usage:
+#   source scripts/activate-xpu-sglang.sh
+#   python -m sglang.launch_server \
+#       --model-path facebook/opt-125m --device xpu --tp 2 \
+#       --attention-backend intel_xpu
+#
+# See docs/platforms/xpu.pyxccl.md for the full setup guide.
+
+# ---------------------------------------------------------------------------
+# 1. Intel oneAPI compiler & SYCL runtime
+# ---------------------------------------------------------------------------
+source /work/compiler/setvars.sh
+
+# ---------------------------------------------------------------------------
+# 2. Runtime shared libraries
+# ---------------------------------------------------------------------------
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/work/compiler/lib/
+
+_CCL=/work/libraries.performance.communication.oneccl-v2/build-xpu-release/_install
+export LD_LIBRARY_PATH=${_CCL}/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${_CCL}/opt/mpi/libfabric/lib:$LD_LIBRARY_PATH
+
+# ---------------------------------------------------------------------------
+# 3. oneCCL / OFI transport
+# ---------------------------------------------------------------------------
+export FI_PROVIDER_PATH=${_CCL}/opt/mpi/libfabric/lib/prov
+export CCL_ATL_TRANSPORT=ofi
+export CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0
+
+# ---------------------------------------------------------------------------
+# 4. SGLang pyxccl integration
+# ---------------------------------------------------------------------------
+# Opt into the direct-oneCCL path (pyxccl is off by default; XPU otherwise uses
+# torch.distributed / XCCL).
+export SGLANG_ENABLE_PYXCCL=1
+export SGLANG_PYXCCL_SO_PATH=${_CCL}/lib/libccl.so.1
+
+unset _CCL

--- a/scripts/activate-xpu-sglang.sh
+++ b/scripts/activate-xpu-sglang.sh
@@ -7,7 +7,7 @@
 #       --model-path facebook/opt-125m --device xpu --tp 2 \
 #       --attention-backend intel_xpu
 #
-# See docs/platforms/xpu.pyxccl.md for the full setup guide.
+# See docs_new/docs/hardware-platforms/xpu.pyxccl.md for the full setup guide.
 
 # ---------------------------------------------------------------------------
 # 1. Intel oneAPI compiler & SYCL runtime

--- a/scripts/build_oneccl_xpu.sh
+++ b/scripts/build_oneccl_xpu.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# =============================================================================
+# build_oneccl_xpu.sh — Build oneCCL-v2 with XPU (SYCL/dpcpp) support
+#
+# Produces the SYCL-built libccl.so.1 that SGLang's PyXcclCommunicator loads
+# (via SGLANG_PYXCCL_SO_PATH) to call Intel oneCCL directly for XPU tensor-
+# parallel collectives. See docs/platforms/xpu.pyxccl.md.
+#
+# USAGE
+#   ./build_oneccl_xpu.sh [OPTIONS]
+#
+# OPTIONS
+#   -j N            Parallel jobs (default: nproc)
+#   --build-dir DIR Build directory (default: <repo>/build-xpu-release)
+#   --debug         Debug build instead of Release
+#   --install       Run cmake --install after build
+#   --clean         Wipe build directory before configure
+#   --with-tests    Also build functional/regression tests (slower)
+#   --with-examples Also build examples (slower)
+#   --device-code MODE
+#                   SYCL device-code-split: per_kernel|per_source|off
+#                   default: per_kernel (best for deployment)
+#   -h, --help      Show this message
+#
+# WHAT IT BUILDS
+#   libccl.so.2  — oneCCL v2 XPU library (SYCL/dpcpp, via icpx)
+#   libccl.so.1  — legacy CCL shim (XPU path, links libccl.so.2)
+#   libccl.so    — symlink -> libccl.so.2
+#
+#   CPU plugin is disabled by default (XPU-only build).
+#
+# COMPILER
+#   Activates Intel oneAPI compiler via: source /work/compiler/setvars.sh
+#
+# ENVIRONMENT PREREQUISITES (first run only)
+#   1. System packages:
+#        apt-get install -y gcc g++ libopenmpi-dev
+#   2. Build-tools uv environment (cmake + ninja):
+#        uv venv /work/.build-env --python 3.12
+#        uv pip install --python /work/.build-env/bin/python cmake ninja
+#
+# SOURCE PATCHES APPLIED TO THE oneCCL-v2 REPO
+#   1. CMakeLists.txt (top-level):
+#        LIBCCL_CMAKE_ARGS gets -DCMAKE_CXX_STANDARD=17 so the inner
+#        ExternalProject's FindIntelSYCL_level_zero.cmake check_cxx_compiler_flag
+#        test for -fsycl compiles with C++17 (SYCL requires C++17).
+#   2. deps/libccl/CMakeLists.txt:
+#        set(CMAKE_CXX_STANDARD 11) guarded with if(NOT CMAKE_CXX_STANDARD)
+#        so the dpcpp -DCMAKE_CXX_STANDARD=17 override is not clobbered.
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+REPO_ROOT="${ONECCL_REPO_ROOT:-/work/libraries.performance.communication.oneccl-v2}"
+BUILD_TYPE="Release"
+BUILD_DIR=""          # resolved below after parsing args
+JOBS="$(nproc)"
+DO_INSTALL=0
+DO_CLEAN=0
+BUILD_TESTS=0
+BUILD_EXAMPLES=0
+DEVICE_CODE="per_kernel"
+BUILD_CPU_PLUGIN=OFF
+SETVARS="${ONEAPI_SETVARS:-/work/compiler/setvars.sh}"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+usage() {
+    sed -n '/^# USAGE/,/^# =/p' "${BASH_SOURCE[0]}" | head -n -1 | sed 's/^# \{0,1\}//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -j)          JOBS="$2"; shift 2 ;;
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        --debug)     BUILD_TYPE="Debug"; shift ;;
+        --install)   DO_INSTALL=1; shift ;;
+        --clean)     DO_CLEAN=1; shift ;;
+        --with-tests)    BUILD_TESTS=1; shift ;;
+        --with-examples) BUILD_EXAMPLES=1; shift ;;
+        --device-code)   DEVICE_CODE="$2"; shift 2 ;;
+        -h|--help)   usage ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Default build dir: inside the repo
+[[ -z "$BUILD_DIR" ]] && BUILD_DIR="${REPO_ROOT}/build-xpu-$(echo "$BUILD_TYPE" | tr '[:upper:]' '[:lower:]')"
+INSTALL_DIR="${BUILD_DIR}/_install"
+
+# ---------------------------------------------------------------------------
+# Activate compiler
+# ---------------------------------------------------------------------------
+echo "[build_oneccl_xpu] Activating Intel oneAPI compiler..."
+# setvars.sh references variables that may be unset; temporarily relax -u/-e
+set +euo pipefail
+# shellcheck source=/dev/null
+source "$SETVARS"
+set -euo pipefail
+
+# Locate cmake — prefer the build-tools venv, then fall back to known locations
+CMAKE_BIN=""
+for _cmake_candidate in \
+    /work/.build-env/lib/python3.12/site-packages/cmake/data/bin/cmake \
+    /work/.venv/lib/python3.12/site-packages/cmake/data/bin/cmake \
+    /usr/local/bin/cmake /usr/bin/cmake; do
+    if [[ -x "$_cmake_candidate" ]]; then
+        CMAKE_BIN="$_cmake_candidate"
+        break
+    fi
+done
+
+if [[ -z "$CMAKE_BIN" ]]; then
+    echo "[build_oneccl_xpu] ERROR: cmake not found. Install it via:" >&2
+    echo "  uv pip install --python /work/.build-env/bin/python cmake ninja" >&2
+    exit 1
+fi
+echo "[build_oneccl_xpu] cmake: $("$CMAKE_BIN" --version | head -1)  [$CMAKE_BIN]"
+
+# Locate ninja — prefer the build-tools venv
+NINJA_BIN=""
+for _ninja_candidate in \
+    /work/.build-env/bin/ninja \
+    /work/.venv/bin/ninja \
+    /usr/local/bin/ninja /usr/bin/ninja; do
+    if [[ -x "$_ninja_candidate" ]]; then
+        NINJA_BIN="$_ninja_candidate"
+        break
+    fi
+done
+
+if [[ -n "$NINJA_BIN" ]]; then
+    CMAKE_GENERATOR="-GNinja -DCMAKE_MAKE_PROGRAM=$NINJA_BIN"
+    # Also add to PATH so ExternalProject sub-builds inherit it
+    export PATH="$(dirname "$NINJA_BIN"):$PATH"
+    echo "[build_oneccl_xpu] ninja: $("$NINJA_BIN" --version)  [$NINJA_BIN]"
+else
+    CMAKE_GENERATOR=""
+    echo "[build_oneccl_xpu] WARNING: ninja not found, falling back to Unix Makefiles"
+fi
+
+# Verify icpx is available
+if ! command -v icpx &>/dev/null; then
+    echo "[build_oneccl_xpu] ERROR: icpx not found after sourcing $SETVARS" >&2
+    exit 1
+fi
+ICPX_VER=$(icpx --version 2>&1 | head -1)
+echo "[build_oneccl_xpu] Compiler: $ICPX_VER"
+
+# Ensure the Intel compiler's bundled linker (ld.lld) is on PATH so that
+# icpx can resolve 'ld' when linking. The oneAPI package ships ld.lld in
+# compiler/latest/bin/compiler/ but does not always install a system 'ld'.
+INTEL_COMPILER_BIN="$(dirname "$(command -v icpx)")"/compiler
+if [[ -x "$INTEL_COMPILER_BIN/ld.lld" ]]; then
+    # Create a temp dir with an 'ld' symlink so the system linker path resolves
+    _LD_SHIM_DIR="$(mktemp -d)"
+    ln -sf "$INTEL_COMPILER_BIN/ld.lld" "$_LD_SHIM_DIR/ld"
+    export PATH="$INTEL_COMPILER_BIN:$_LD_SHIM_DIR:$PATH"
+    echo "[build_oneccl_xpu] linker: $INTEL_COMPILER_BIN/ld.lld (shimmed as ld)"
+fi
+
+# ---------------------------------------------------------------------------
+# Initialize git submodules (idempotent)
+# ---------------------------------------------------------------------------
+echo "[build_oneccl_xpu] Checking git submodules..."
+cd "$REPO_ROOT"
+git submodule update --init --recursive
+
+# ---------------------------------------------------------------------------
+# Optional clean
+# ---------------------------------------------------------------------------
+if [[ $DO_CLEAN -eq 1 && -d "$BUILD_DIR" ]]; then
+    echo "[build_oneccl_xpu] Cleaning build dir: $BUILD_DIR"
+    rm -rf "$BUILD_DIR"
+fi
+
+mkdir -p "$BUILD_DIR"
+
+# ---------------------------------------------------------------------------
+# cmake configure
+# ---------------------------------------------------------------------------
+ON_OFF_TESTS=$([ "$BUILD_TESTS" -eq 1 ] && echo ON || echo OFF)
+ON_OFF_EXAMPLES=$([ "$BUILD_EXAMPLES" -eq 1 ] && echo ON || echo OFF)
+
+echo "[build_oneccl_xpu] Configuring..."
+echo "[build_oneccl_xpu]   BUILD_TYPE    = $BUILD_TYPE"
+echo "[build_oneccl_xpu]   DEVICE_CODE   = $DEVICE_CODE"
+echo "[build_oneccl_xpu]   CPU_PLUGIN    = $BUILD_CPU_PLUGIN"
+echo "[build_oneccl_xpu]   TESTS         = $ON_OFF_TESTS"
+echo "[build_oneccl_xpu]   EXAMPLES      = $ON_OFF_EXAMPLES"
+echo "[build_oneccl_xpu]   BUILD_DIR     = $BUILD_DIR"
+echo "[build_oneccl_xpu]   INSTALL_DIR   = $INSTALL_DIR"
+echo "[build_oneccl_xpu]   JOBS          = $JOBS"
+
+"$CMAKE_BIN" \
+    ${CMAKE_GENERATOR} \
+    -S "$REPO_ROOT" \
+    -B "$BUILD_DIR" \
+    -DCMAKE_CXX_COMPILER=icpx \
+    -DCMAKE_C_COMPILER=icx \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+    -DONECCL_LIBCCL_BUILD_FT="$ON_OFF_TESTS" \
+    -DONECCL_LIBCCL_BUILD_REG_TESTS="$ON_OFF_TESTS" \
+    -DONECCL_LIBCCL_BUILD_EXAMPLES="$ON_OFF_EXAMPLES" \
+    -DONECCL_BUILD_TESTS="$ON_OFF_TESTS" \
+    -DONECCL_LIBCCL_SYCL_DEVICE_CODE_SPLIT="$DEVICE_CODE" \
+    -DONECCL_LIBCCL_EXTERN_TEMPLATE_INST=ON \
+    -DONECCL_BUILD_CPU_PLUGIN="$BUILD_CPU_PLUGIN" \
+    -DONECCL_ENABLE_ITT=ON
+
+# Sanity check: ensure SYCL support was detected
+if grep -q '^COMPILER_SUPPORTS_SYCL:INTERNAL=FALSE' "$BUILD_DIR/CMakeCache.txt" 2>/dev/null; then
+    echo "[build_oneccl_xpu] ERROR: COMPILER_SUPPORTS_SYCL=FALSE — icpx does not support -fsycl!" >&2
+    echo "[build_oneccl_xpu] Check that setvars.sh was sourced correctly and icpx supports SYCL." >&2
+    exit 1
+fi
+echo "[build_oneccl_xpu] SYCL support confirmed"
+
+# ---------------------------------------------------------------------------
+# cmake build
+# ---------------------------------------------------------------------------
+echo "[build_oneccl_xpu] Building (jobs=$JOBS)..."
+"$CMAKE_BIN" --build "$BUILD_DIR" --parallel "$JOBS"
+
+# ---------------------------------------------------------------------------
+# cmake install (optional)
+# ---------------------------------------------------------------------------
+if [[ $DO_INSTALL -eq 1 ]]; then
+    echo "[build_oneccl_xpu] Installing to $INSTALL_DIR..."
+    "$CMAKE_BIN" --install "$BUILD_DIR"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "[build_oneccl_xpu] ========================================="
+echo "[build_oneccl_xpu] Build complete!"
+echo "[build_oneccl_xpu]   Build dir:   $BUILD_DIR"
+if [[ $DO_INSTALL -eq 1 ]]; then
+    echo "[build_oneccl_xpu]   Install dir: $INSTALL_DIR"
+fi
+echo ""
+echo "[build_oneccl_xpu] Key outputs (build dir):"
+find "$BUILD_DIR" -maxdepth 4 \( -name "libccl.so*" -o -name "libccl.so.2*" \) \
+    ! -name "*.cmake" 2>/dev/null | sort | sed 's/^/  /'
+echo ""
+echo "[build_oneccl_xpu] To use in your environment:"
+echo "  export CCL_ROOT=$INSTALL_DIR"
+echo "  export LD_LIBRARY_PATH=\$CCL_ROOT/lib:\$LD_LIBRARY_PATH"
+echo "  export SGLANG_PYXCCL_SO_PATH=\$CCL_ROOT/lib/libccl.so.1"
+echo "[build_oneccl_xpu] ========================================="

--- a/scripts/build_oneccl_xpu.sh
+++ b/scripts/build_oneccl_xpu.sh
@@ -4,7 +4,7 @@
 #
 # Produces the SYCL-built libccl.so.1 that SGLang's PyXcclCommunicator loads
 # (via SGLANG_PYXCCL_SO_PATH) to call Intel oneCCL directly for XPU tensor-
-# parallel collectives. See docs/platforms/xpu.pyxccl.md.
+# parallel collectives. See docs_new/docs/hardware-platforms/xpu.pyxccl.md.
 #
 # USAGE
 #   ./build_oneccl_xpu.sh [OPTIONS]

--- a/test/registered/xpu/test_pyxccl_collectives.py
+++ b/test/registered/xpu/test_pyxccl_collectives.py
@@ -95,8 +95,10 @@ def all_gather_fn(rank: int, world_size: int):
         comm.all_gather(out, inp)
         torch.xpu.synchronize()
         expected = torch.cat(
-            [torch.full((chunk,), float(r + 1), dtype=dtype, device=dev)
-             for r in range(world_size)]
+            [
+                torch.full((chunk,), float(r + 1), dtype=dtype, device=dev)
+                for r in range(world_size)
+            ]
         )
         torch.testing.assert_close(out, expected)
     comm.destroy()
@@ -109,14 +111,19 @@ def reduce_scatter_fn(rank: int, world_size: int):
     for dtype in DTYPES:
         per_rank = 4
         # Full input on every rank: value (r+1) contributed by rank r.
-        full = torch.full((per_rank * world_size,), float(rank + 1),
-                          dtype=dtype, device=dev)
+        full = torch.full(
+            (per_rank * world_size,), float(rank + 1), dtype=dtype, device=dev
+        )
         out = torch.empty((per_rank,), dtype=dtype, device=dev)
         comm.reduce_scatter(out, full)
         torch.xpu.synchronize()
         # Each output element is the sum over ranks of (r+1).
-        expected = torch.full((per_rank,), float(sum(r + 1 for r in range(world_size))),
-                              dtype=dtype, device=dev)
+        expected = torch.full(
+            (per_rank,),
+            float(sum(r + 1 for r in range(world_size))),
+            dtype=dtype,
+            device=dev,
+        )
         torch.testing.assert_close(out, expected)
     comm.destroy()
     dist.destroy_process_group()
@@ -154,9 +161,9 @@ def sglang_tp_collectives_fn(rank: int, world_size: int):
 
     tp = get_tp_group()
     # The whole point of this port: on XPU tp>1 the TP group drives pyxccl.
-    assert tp.pyxccl_comm is not None and not tp.pyxccl_comm.disabled, (
-        "TP group is not using the pyxccl (direct oneCCL) path"
-    )
+    assert (
+        tp.pyxccl_comm is not None and not tp.pyxccl_comm.disabled
+    ), "TP group is not using the pyxccl (direct oneCCL) path"
 
     dev = f"xpu:{rank}"
 
@@ -174,8 +181,10 @@ def sglang_tp_collectives_fn(rank: int, world_size: int):
     gathered = tensor_model_parallel_all_gather(g, dim=0)
     torch.xpu.synchronize()
     expected_gather = torch.cat(
-        [torch.full((3, 4), float(r + 1), device=dev, dtype=torch.float32)
-         for r in range(world_size)],
+        [
+            torch.full((3, 4), float(r + 1), device=dev, dtype=torch.float32)
+            for r in range(world_size)
+        ],
         dim=0,
     )
     torch.testing.assert_close(gathered, expected_gather)

--- a/test/registered/xpu/test_pyxccl_collectives.py
+++ b/test/registered/xpu/test_pyxccl_collectives.py
@@ -1,0 +1,261 @@
+"""
+Numeric correctness tests for the direct-oneCCL XPU communicator
+(PyXcclCommunicator). Each test spawns ``world_size`` ranks, binds each to its
+own Intel XPU, drives a collective through oneCCL directly, and compares the
+result against the ``torch.distributed`` reference (or a closed-form expected
+value).
+
+Requires >= 2 Intel XPUs; skips otherwise. pyxccl is opt-in, so the workers set
+SGLANG_ENABLE_PYXCCL=1; oneCCL needs an OFI transport, so CCL_ATL_TRANSPORT=ofi
+is set too.
+
+Follows the multi-process pattern in test/manual/cpu/test_comm.py: module-level
+worker/collective functions (picklable for the "spawn" start method) plus a Pipe
+that reports per-rank success back to the parent.
+
+Usage:
+python3 -m unittest test_pyxccl_collectives.TestPyXcclCollectives.test_all_reduce
+"""
+
+import multiprocessing
+import os
+import traceback
+import unittest
+from multiprocessing import Process
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from sglang.test.ci.ci_register import register_xpu_ci
+from sglang.test.test_utils import CustomTestCase, find_available_port
+
+register_xpu_ci(est_time=120, suite="stage-a-test-2-gpu-xpu")
+
+WORLD_SIZE = 2
+# oneCCL supports these element types via onecclDataTypeEnum.from_torch.
+DTYPES = [torch.float32, torch.bfloat16, torch.float16]
+
+
+def _make_comm(rank: int, world_size: int):
+    """Init a gloo world + a PyXcclCommunicator bound to xpu:{rank}."""
+    from sglang.srt.distributed.device_communicators.pyxccl import PyXcclCommunicator
+
+    torch.xpu.set_device(rank)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    # pyxccl broadcasts its oneCCL unique id over the CPU (gloo) group, mirroring
+    # how GroupCoordinator attaches pynccl/pyxccl to cpu_group.
+    cpu_group = dist.new_group(ranks=list(range(world_size)), backend="gloo")
+    comm = PyXcclCommunicator(group=cpu_group, device=torch.device(f"xpu:{rank}"))
+    assert not comm.disabled, "PyXcclCommunicator unexpectedly disabled"
+    return comm, cpu_group
+
+
+def all_reduce_fn(rank: int, world_size: int):
+    comm, _ = _make_comm(rank, world_size)
+    dev = f"xpu:{rank}"
+    for dtype in DTYPES:
+        # Deterministic per-rank input so the reference is exact.
+        base = torch.arange(2 * 10, dtype=dtype, device=dev).reshape(2, 10)
+        tensor = base + rank
+
+        comm.all_reduce(tensor)  # oneCCL, in-place
+        torch.xpu.synchronize()
+
+        # Sum over ranks of (base + r) == world_size*base + sum(range(world_size)).
+        expected = world_size * base + sum(range(world_size))
+        torch.testing.assert_close(tensor, expected)
+    comm.destroy()
+    dist.destroy_process_group()
+
+
+def broadcast_fn(rank: int, world_size: int):
+    comm, _ = _make_comm(rank, world_size)
+    dev = f"xpu:{rank}"
+    for dtype in DTYPES:
+        if rank == 0:
+            tensor = torch.arange(12, dtype=dtype, device=dev)
+        else:
+            tensor = torch.full((12,), -1.0, dtype=dtype, device=dev)
+        comm.broadcast(tensor, src=0)
+        torch.xpu.synchronize()
+        expected = torch.arange(12, dtype=dtype, device=dev)
+        torch.testing.assert_close(tensor, expected)
+    comm.destroy()
+    dist.destroy_process_group()
+
+
+def all_gather_fn(rank: int, world_size: int):
+    comm, _ = _make_comm(rank, world_size)
+    dev = f"xpu:{rank}"
+    for dtype in DTYPES:
+        chunk = 4
+        inp = torch.full((chunk,), float(rank + 1), dtype=dtype, device=dev)
+        out = torch.empty((chunk * world_size,), dtype=dtype, device=dev)
+        comm.all_gather(out, inp)
+        torch.xpu.synchronize()
+        expected = torch.cat(
+            [torch.full((chunk,), float(r + 1), dtype=dtype, device=dev)
+             for r in range(world_size)]
+        )
+        torch.testing.assert_close(out, expected)
+    comm.destroy()
+    dist.destroy_process_group()
+
+
+def reduce_scatter_fn(rank: int, world_size: int):
+    comm, _ = _make_comm(rank, world_size)
+    dev = f"xpu:{rank}"
+    for dtype in DTYPES:
+        per_rank = 4
+        # Full input on every rank: value (r+1) contributed by rank r.
+        full = torch.full((per_rank * world_size,), float(rank + 1),
+                          dtype=dtype, device=dev)
+        out = torch.empty((per_rank,), dtype=dtype, device=dev)
+        comm.reduce_scatter(out, full)
+        torch.xpu.synchronize()
+        # Each output element is the sum over ranks of (r+1).
+        expected = torch.full((per_rank,), float(sum(r + 1 for r in range(world_size))),
+                              dtype=dtype, device=dev)
+        torch.testing.assert_close(out, expected)
+    comm.destroy()
+    dist.destroy_process_group()
+
+
+def sglang_tp_collectives_fn(rank: int, world_size: int):
+    """End-to-end: drive SGLang's public TP-collective API through the real
+    initialize_model_parallel() -> GroupCoordinator -> pyxccl_comm path on XPU.
+
+    This exercises the wiring added to GroupCoordinator (the pyxccl_comm branches
+    in _all_reduce_in_place / _all_gather_into_tensor / broadcast), not just the
+    raw communicator.
+    """
+    from sglang.srt.distributed.communication_op import (
+        tensor_model_parallel_all_gather,
+        tensor_model_parallel_all_reduce,
+    )
+    from sglang.srt.distributed.parallel_state import (
+        get_default_distributed_backend,
+        get_tp_group,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    torch.xpu.set_device(rank)
+    backend = get_default_distributed_backend("xpu")  # -> "xccl"
+    init_distributed_environment(
+        backend=backend,
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method="env://",
+    )
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    tp = get_tp_group()
+    # The whole point of this port: on XPU tp>1 the TP group drives pyxccl.
+    assert tp.pyxccl_comm is not None and not tp.pyxccl_comm.disabled, (
+        "TP group is not using the pyxccl (direct oneCCL) path"
+    )
+
+    dev = f"xpu:{rank}"
+
+    # all_reduce via the public API -> get_tp_group().all_reduce -> inplace_all_reduce
+    # custom op -> _all_reduce_in_place -> pyxccl_comm.all_reduce.
+    x = torch.full((2, 8), float(rank + 1), device=dev, dtype=torch.float32)
+    out = tensor_model_parallel_all_reduce(x)
+    torch.xpu.synchronize()
+    expected_sum = float(world_size * (world_size + 1) // 2)
+    torch.testing.assert_close(out, torch.full_like(out, expected_sum))
+
+    # all_gather via the public API -> get_tp_group().all_gather ->
+    # _all_gather_into_tensor -> pyxccl_comm.all_gather. dim=0 concatenation.
+    g = torch.full((3, 4), float(rank + 1), device=dev, dtype=torch.float32)
+    gathered = tensor_model_parallel_all_gather(g, dim=0)
+    torch.xpu.synchronize()
+    expected_gather = torch.cat(
+        [torch.full((3, 4), float(r + 1), device=dev, dtype=torch.float32)
+         for r in range(world_size)],
+        dim=0,
+    )
+    torch.testing.assert_close(gathered, expected_gather)
+
+    dist.barrier()
+    tp.destroy()
+    dist.destroy_process_group()
+
+
+def _run(rank, world_size, master_port, output_writer, fn):
+    try:
+        os.environ.setdefault("CCL_ATL_TRANSPORT", "ofi")
+        # These tests exercise the direct-oneCCL path, which is opt-in.
+        os.environ["SGLANG_ENABLE_PYXCCL"] = "1"
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(master_port)
+        fn(rank, world_size)
+        ok = True
+    except Exception as e:  # surface the traceback to the parent
+        print(f"subprocess[rank={rank}] error: {e}", flush=True)
+        traceback.print_exc()
+        ok = False
+    output_writer.send(ok)
+    output_writer.close()
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+class TestPyXcclCollectives(CustomTestCase):
+    def _spawn_and_check(self, fn, world_size=WORLD_SIZE):
+        if not (hasattr(torch, "xpu") and torch.xpu.is_available()):
+            self.skipTest("XPU not available")
+        if torch.xpu.device_count() < world_size:
+            self.skipTest(f"need >= {world_size} XPUs")
+
+        mp.set_start_method("spawn", force=True)
+        master_port = find_available_port(23456)
+        output_reader, output_writer = multiprocessing.Pipe(duplex=False)
+
+        processes = []
+        for rank in range(world_size):
+            p = Process(
+                target=_run,
+                kwargs=dict(
+                    rank=rank,
+                    world_size=world_size,
+                    master_port=master_port,
+                    output_writer=output_writer,
+                    fn=fn,
+                ),
+            )
+            p.start()
+            processes.append(p)
+
+        for _ in range(world_size):
+            self.assertTrue(
+                output_reader.recv(), "Subprocess failed. Check logs above."
+            )
+        for p in processes:
+            p.join()
+
+    def test_all_reduce(self):
+        self._spawn_and_check(all_reduce_fn)
+
+    def test_broadcast(self):
+        self._spawn_and_check(broadcast_fn)
+
+    def test_all_gather(self):
+        self._spawn_and_check(all_gather_fn)
+
+    def test_reduce_scatter(self):
+        self._spawn_and_check(reduce_scatter_fn)
+
+    def test_sglang_tp_collectives(self):
+        # End-to-end: SGLang's public TP-collective API through the real
+        # initialize_model_parallel -> GroupCoordinator -> pyxccl path.
+        self._spawn_and_check(sglang_tp_collectives_fn)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/xpu/test_pyxccl_collectives.py
+++ b/test/registered/xpu/test_pyxccl_collectives.py
@@ -149,7 +149,9 @@ def sglang_tp_collectives_fn(rank: int, world_size: int):
     )
 
     torch.xpu.set_device(rank)
-    backend = get_default_distributed_backend("xpu")  # -> "xccl"
+    # -> "xccl", or "gloo" when this torch build has no XCCL compiled in (pyxccl
+    # then owns the XPU collectives; see get_default_distributed_backend).
+    backend = get_default_distributed_backend("xpu")
     init_distributed_environment(
         backend=backend,
         world_size=world_size,


### PR DESCRIPTION
## Motivation

On Intel XPU, tensor-parallel (`--tp > 1`) collectives currently dispatch through 
`torch.distributed`'s XCCL backend. This is useful when we want to do some quick 
prototype on the latest oneccl releases without the full torch/xccl package. Some 
torch XPU builds may ship **without a usable XCCL backend** , which leaves 
tensor parallelism with no working collective path.

This PR adds `pyxccl` — the XPU counterpart of the existing CUDA `pynccl` — a
direct binding to Intel oneCCL's NCCL-compatible C API (`libccl.so`) that
bypasses `torch.distributed`. It gives XPU an in-tree collective path that does
not depend on torch shipping XCCL, mirroring how CUDA uses `pynccl` to call
NCCL directly.

## Modifications

**New**
- `python/sglang/srt/distributed/device_communicators/pyxccl_wrapper.py` —
  vendored `ctypes` binding of oneCCL's `oneccl*` C API from `libccl.so` (the
  XPU analogue of `pynccl_wrapper.py`). No third-party Python package is
  required; only the oneCCL runtime library.
- `python/sglang/srt/distributed/device_communicators/pyxccl.py` —
  `PyXcclCommunicator` (all_reduce / all_gather / reduce_scatter / broadcast /
  send / recv / destroy), analogous to `PyNcclCommunicator`. Uses the XPU SYCL
  queue (`torch.xpu.current_stream().sycl_queue`) as the oneCCL stream handle.
- `test/registered/xpu/test_pyxccl_collectives.py` — 2-XPU numeric tests for all
  four collectives (× float32/bfloat16/float16) plus an end-to-end SGLang
  TP-collective integration test.
- `docs_new/docs/hardware-platforms/xpu.pyxccl.md` — setup guide.
- `scripts/build_oneccl_xpu.sh`, `scripts/activate-xpu-sglang.sh` — SYCL oneCCL
  build + runtime activation helpers.

**Wiring** (`parallel_state.py`)
- `pyxccl_comm` added as a sibling of `pynccl_comm` on `GroupCoordinator`,
  branched **before** the `torch.distributed` fallback in `_all_reduce_in_place`,
  `_reduce_scatter_tensor`, `_all_gather_into_tensor`, `broadcast`, `send`,
  `recv`, and released in `destroy()`.
- Only constructed for XPU model-parallel groups, so CUDA / ROCm / NPU / CPU
  paths are byte-for-byte unchanged.

**Env vars** (`environ.py`)
- `SGLANG_ENABLE_PYXCCL` (default `False`) — opt in to the direct-oneCCL path.
- `SGLANG_PYXCCL_SO_PATH` — explicit path to `libccl.so.1` (else the dynamic
  linker resolves it).
- `SGLANG_DEBUG_PYXCCL` — log every collective call to confirm the oneCCL path.

**Behavior**
- Off by default; XPU `tp>1` uses `torch.distributed` / XCCL exactly as before.
- With `SGLANG_ENABLE_PYXCCL=1`, if oneCCL cannot initialize at `tp>1`, SGLang
  raises at startup with setup guidance rather than silently falling back
  (the opt-in usually means XCCL is unavailable, so a silent fallback would be
  wrong).

## Accuracy Tests

Verified on 2× Intel Arc Pro B60 (oneCCL 2021.17.2), `torch 2.12.0+xpu`:

- `test/registered/xpu/test_pyxccl_collectives.py` — **5 passed**:
  `all_reduce`, `all_gather`, `broadcast`, `reduce_scatter` (numerically checked
  against closed-form expected values across float32/bfloat16/float16 at tp=2),
  plus `test_sglang_tp_collectives` (public TP API →
  `initialize_model_parallel` → `GroupCoordinator` → pyxccl).
- End-to-end `bench_one_batch` (Qwen2.5-1.5B-Instruct, `--device xpu --tp 2`):
  - `SGLANG_ENABLE_PYXCCL=1` → generation completes; `SGLANG_DEBUG_PYXCCL=1`
    shows collectives routed through oneCCL (930 calls: 914 AllReduce +
    16 AllGather).
  - flag unset → same run completes via `torch.distributed` (0 pyxccl calls),
    confirming the fallback path is unaffected.

## Speed Tests and Profiling

Not a perf-oriented change (adds an alternative communicator; default path
unchanged). Functional throughput sanity on Qwen2.5-1.5B tp=2 was comparable
between the pyxccl and torch.distributed paths; no rigorous benchmarking was
performed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->