### PR TITLE
[Test] Add unit tests for msgspec_utils

### DIFF
--- a/test/registered/unit/utils/test_msgspec_utils.py
+++ b/test/registered/unit/utils/test_msgspec_utils.py
@@ -1,0 +1,213 @@
+"""Unit tests for msgspec utilities -- no server, model, or GPU required."""
+
+import base64
+import unittest
+from typing import Annotated, Any
+
+import msgspec
+from pydantic import TypeAdapter, ValidationError
+
+from sglang.srt.utils.msgspec_utils import (
+    Base64Bytes,
+    msgspec_struct_pydantic_core_schema,
+    msgspec_to_builtins,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _ChildStruct(msgspec.Struct):
+    value: int
+
+
+class _NestedStruct(msgspec.Struct):
+    child: _ChildStruct
+    mapping: dict[str, Any]
+    sequence: list[Any]
+    coordinates: tuple[Any, ...]
+    labels: set[str]
+    enabled: bool
+
+
+class _SchemaStruct(msgspec.Struct, kw_only=True):
+    required_count: int
+    name: str = "default-name"
+    items: list[int] = msgspec.field(default_factory=list)
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return msgspec_struct_pydantic_core_schema(cls, handler)
+
+
+class _TensorPayload(msgspec.Struct, kw_only=True):
+    serialized_named_tensors: Annotated[list[bytes], Base64Bytes()]
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return msgspec_struct_pydantic_core_schema(cls, handler)
+
+
+class TestBase64Bytes(CustomTestCase):
+    def test_decodes_scalar_and_list_values(self):
+        scalar_adapter = TypeAdapter(Annotated[bytes, Base64Bytes()])
+        list_adapter = TypeAdapter(Annotated[list[bytes], Base64Bytes()])
+
+        self.assertEqual(
+            scalar_adapter.validate_python(base64.b64encode(b"tensor-data").decode()),
+            b"tensor-data",
+        )
+        self.assertEqual(
+            list_adapter.validate_python(
+                [
+                    base64.b64encode(b"weight-0").decode(),
+                    base64.b64encode(b"weight-1").decode(),
+                ]
+            ),
+            [b"weight-0", b"weight-1"],
+        )
+
+    def test_recurses_through_nested_lists_and_tuples(self):
+        nested_adapter = TypeAdapter(Annotated[list[tuple[bytes, ...]], Base64Bytes()])
+        encoded = base64.b64encode(b"nested").decode()
+
+        self.assertEqual(
+            nested_adapter.validate_python([(encoded,), (encoded, encoded)]),
+            [(b"nested",), (b"nested", b"nested")],
+        )
+
+    def test_rejects_malformed_base64(self):
+        adapter = TypeAdapter(Annotated[bytes, Base64Bytes()])
+
+        for value in ("not-base64!", "abc"):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    ValidationError, "Expected base64-encoded bytes"
+                ):
+                    adapter.validate_python(value)
+
+    def test_preserves_python_bytes(self):
+        adapter = TypeAdapter(Annotated[list[bytes], Base64Bytes()])
+        values = [b"already-decoded", b"\x00\xff"]
+
+        self.assertEqual(adapter.validate_python(values), values)
+
+    def test_decodes_multiple_serialized_tensor_values_from_json(self):
+        adapter = TypeAdapter(_TensorPayload)
+        encoded_values = [
+            base64.b64encode(b"tensor-a").decode(),
+            base64.b64encode(b"tensor-b").decode(),
+        ]
+
+        payload = adapter.validate_json(
+            msgspec.json.encode({"serialized_named_tensors": encoded_values})
+        )
+
+        self.assertEqual(
+            payload.serialized_named_tensors,
+            [b"tensor-a", b"tensor-b"],
+        )
+
+
+class TestMsgspecToBuiltins(CustomTestCase):
+    def test_recursively_converts_realistic_nested_struct(self):
+        value = _NestedStruct(
+            child=_ChildStruct(1),
+            mapping={"child": _ChildStruct(2), "primitive": None},
+            sequence=[_ChildStruct(3), {"deep": _ChildStruct(4)}],
+            coordinates=(_ChildStruct(5), "origin"),
+            labels={"fast", "cpu"},
+            enabled=True,
+        )
+
+        result = msgspec_to_builtins(value)
+
+        self.assertEqual(result["child"], {"value": 1})
+        self.assertEqual(
+            result["mapping"],
+            {"child": {"value": 2}, "primitive": None},
+        )
+        self.assertEqual(
+            result["sequence"],
+            [{"value": 3}, {"deep": {"value": 4}}],
+        )
+        self.assertEqual(result["coordinates"], ({"value": 5}, "origin"))
+        self.assertIsInstance(result["coordinates"], tuple)
+        self.assertCountEqual(result["labels"], ["fast", "cpu"])
+        self.assertIsInstance(result["labels"], list)
+        self.assertIs(result["enabled"], True)
+
+    def test_preserves_dict_keys_and_primitive_leaves(self):
+        key = ("stable", 1)
+        value = {key: _ChildStruct(7), "number": 42}
+
+        result = msgspec_to_builtins(value)
+
+        self.assertIn(key, result)
+        self.assertEqual(result[key], {"value": 7})
+        self.assertEqual(result["number"], 42)
+
+
+class TestMsgspecStructPydanticCoreSchema(CustomTestCase):
+    def setUp(self):
+        self.adapter = TypeAdapter(_SchemaStruct)
+
+    def test_required_field_rejects_missing_input(self):
+        with self.assertRaisesRegex(ValidationError, "required_count"):
+            self.adapter.validate_python({})
+
+    def test_defaults_and_default_factory_are_applied_independently(self):
+        first = self.adapter.validate_python({"required_count": 1})
+        second = self.adapter.validate_python({"required_count": 2})
+
+        self.assertEqual(first.name, "default-name")
+        self.assertEqual(first.items, [])
+        self.assertEqual(second.items, [])
+        self.assertIsNot(first.items, second.items)
+
+    def test_python_dict_and_json_build_structs(self):
+        from_python = self.adapter.validate_python(
+            {"required_count": 3, "name": "python", "items": [1]}
+        )
+        from_json = self.adapter.validate_json(
+            b'{"required_count":4,"name":"json","items":[2,3]}'
+        )
+
+        self.assertEqual(
+            from_python,
+            _SchemaStruct(required_count=3, name="python", items=[1]),
+        )
+        self.assertEqual(
+            from_json,
+            _SchemaStruct(required_count=4, name="json", items=[2, 3]),
+        )
+
+    def test_existing_instance_is_preserved_by_python_path(self):
+        value = _SchemaStruct(required_count=5)
+
+        self.assertIs(self.adapter.validate_python(value), value)
+
+    def test_wrong_field_type_fails_validation(self):
+        with self.assertRaisesRegex(ValidationError, "required_count"):
+            self.adapter.validate_python({"required_count": ["not-an-int"]})
+
+    def test_extra_fields_are_ignored(self):
+        value = self.adapter.validate_python(
+            {"required_count": 6, "unexpected": "ignored"}
+        )
+
+        self.assertEqual(value, _SchemaStruct(required_count=6))
+        self.assertFalse(hasattr(value, "unexpected"))
+
+    def test_json_schema_marks_required_and_default_fields(self):
+        schema = self.adapter.json_schema()
+        definition = schema.get("$defs", {}).get("_SchemaStruct", schema)
+
+        self.assertEqual(definition["required"], ["required_count"])
+        self.assertEqual(definition["properties"]["name"]["default"], "default-name")
+        self.assertNotIn("default", definition["properties"]["items"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Issue #20865 tracks missing unit-test coverage across SGLang. This PR adds focused CPU-only coverage for `python/sglang/srt/utils/msgspec_utils.py` without launching a server, loading a model, or requiring a GPU.

Related to #20865.

## Modifications

- test `Base64Bytes` with scalar, list, nested list/tuple, malformed, existing bytes, and serialized tensor payload inputs
- test recursive `msgspec_to_builtins` conversion for structs, dictionaries, lists, tuples, sets, and primitive leaves
- test `msgspec_struct_pydantic_core_schema` required fields, defaults, independent default factories, Python/JSON validation, existing instances, ignored extras, invalid types, and generated JSON schema
- register the test in `base-a-test-cpu` with an estimated runtime of 5 seconds

## Accuracy Tests

Not applicable. This is a CPU-only unit-test change and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This change does not affect runtime behavior.

## Local Validation

Environment:

```text
Python 3.12.13
msgspec 0.21.1
pydantic 2.12.3
```

The tests were run on Windows. A temporary, untracked import bootstrap bypassed SGLang's Unix-only top-level `resource` import; the committed test uses the repository's normal `CustomTestCase` import.

```powershell
python -m pytest test/registered/unit/utils/test_msgspec_utils.py -v
```

```text
============================= test session starts =============================
platform win32 -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- D:\apps\miniforge\envs\work312\python.exe
cachedir: .pytest_cache
rootdir: D:\project\git_code\sglang_issue_20865\test
configfile: pytest.ini
plugins: anyio-4.13.0, cov-7.1.0
collecting ... collected 14 items

test\registered\unit\utils\test_msgspec_utils.py::TestBase64Bytes::test_decodes_multiple_serialized_tensor_values_from_json PASSED [  7%]
test\registered\unit\utils\test_msgspec_utils.py::TestBase64Bytes::test_decodes_scalar_and_list_values PASSED [ 14%]
test\registered\unit\utils\test_msgspec_utils.py::TestBase64Bytes::test_preserves_python_bytes PASSED [ 21%]
test\registered\unit\utils\test_msgspec_utils.py::TestBase64Bytes::test_recurses_through_nested_lists_and_tuples PASSED [ 28%]
test\registered\unit\utils\test_msgspec_utils.py::TestBase64Bytes::test_rejects_malformed_base64 PASSED [ 35%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecToBuiltins::test_preserves_dict_keys_and_primitive_leaves PASSED [ 42%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecToBuiltins::test_recursively_converts_realistic_nested_struct PASSED [ 50%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecStructPydanticCoreSchema::test_defaults_and_default_factory_are_applied_independently PASSED [ 57%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecStructPydanticCoreSchema::test_existing_instance_is_preserved_by_python_path PASSED [ 64%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecStructPydanticCoreSchema::test_extra_fields_are_ignored PASSED [ 71%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecStructPydanticCoreSchema::test_json_schema_marks_required_and_default_fields PASSED [ 78%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecStructPydanticCoreSchema::test_python_dict_and_json_build_structs PASSED [ 85%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecStructPydanticCoreSchema::test_required_field_rejects_missing_input PASSED [ 92%]
test\registered\unit\utils\test_msgspec_utils.py::TestMsgspecStructPydanticCoreSchema::test_wrong_field_type_fails_validation PASSED [100%]

============================== warnings summary ===============================
PytestConfigWarning: Unknown config option: asyncio_mode

============== 14 passed, 1 warning, 2 subtests passed in 0.54s ===============
```

```powershell
python scripts/ci/check_registered_tests.py
```

```text
exit code 0; no output
```

```powershell
python -m pytest test/registered/unit/utils/test_msgspec_utils.py test/registered/unit/utils/test_field_validators.py -v
```

```text
============== 32 passed, 1 warning, 15 subtests passed in 0.49s ==============
```

```powershell
python -m pytest test/registered/unit/utils/test_msgspec_utils.py --cov --cov-config=.coveragerc --cov-report=term-missing -v
```

```text
python\sglang\srt\utils\msgspec_utils.py    48    0    100%
============== 14 passed, 1 warning, 2 subtests passed in 6.55s ===============
```

```powershell
pre-commit run --files test/registered/unit/utils/test_msgspec_utils.py
```

```text
All applicable formatting, AST, lint, spelling, secret, and file checks passed.
The registered-test hook could not launch its `python3` entry on Windows (`WinError 3`); running the same script with the active Python interpreter passed with exit code 0 as shown above.
```

```powershell
git diff origin/main...HEAD --check
```

```text
exit code 0; no output
```

## Checklist

- [x] Format the changed test and run the applicable pre-commit checks.
- [x] Add and locally run the focused CPU unit tests.
- [x] Follow the SGLang code style guidance.
- [x] Confirm documentation changes are not required for this test-only PR.
- [x] Confirm accuracy and speed benchmarks are not applicable.

## Review and Merge Process

1. Request review from Merge Oncalls and relevant code owners.
2. Ask an authorized maintainer to trigger CI with `/tag-and-rerun-ci`.
3. Address review and CI feedback before merge.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29304120834](https://github.com/sgl-project/sglang/actions/runs/29304120834)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29304120666](https://github.com/sgl-project/sglang/actions/runs/29304120666)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->