### PR TITLE
[kernel] Add opt-in deterministic CuTe-DSL DSA top-k backend (--dsa-topk-backend cutedsl)

### DIFF
--- a/python/sglang/jit_kernel/cutedsl_topk.py
+++ b/python/sglang/jit_kernel/cutedsl_topk.py
@@ -1,0 +1,958 @@
+"""Deterministic DSA top-k selector — CuTe DSL SIMT (SM90 / SM100).
+
+Implements the DSA top-k backend contract (`DSATopKBackend.topk_func`):
+
+    cute_topk_func(score (B, L) fp32, lengths (B) i32, topk,
+                   row_starts (B) i32 | None) -> (B, topk) int32
+
+Candidates for row r: columns c in [row_starts[r], row_starts[r] + lengths[r])
+with score[r, c] != -inf (exact -inf excluded — matches the torch backend's
+masked-fill convention; finite scores are never excluded). Returned indices
+are LOCAL (column - row_starts[r]), front-packed, -1 padded — same as
+sgl_kernel.fast_topk_v2 / the torch fallback — and emitted in ASCENDING
+INDEX order (the slot order is part of this backend's determinism
+contract; no sglang consumer depends on any particular slot order, the
+default kernel's is arrival-nondeterministic).
+
+Why this kernel (vs the default sgl-kernel CUDA radix top-k):
+
+1. DETERMINISM: bitwise-identical output for identical input, always, in
+   canonical order (INDEX ASCENDING; the selected set is an exact top-k
+   with smallest-index tie-breaking, see 3.). The default kernel emits
+   winners in smem-atomic ARRIVAL order and resolves the k-th-boundary tie
+   set by arrival order, so equal logits can produce different index
+   sets/orders run to run. No atomic in this kernel can affect any output
+   bit: histogram atomics only ADD (commutative counts); staging atomics
+   only permute buffers that feed order-independent histograms or the
+   canonical index sort; the scan-emit output stage has no atomics at all.
+   Both output stages (below) emit the same canonical output bit-for-bit.
+2. EXACTNESS under adversarial distributions: the default kernel stages
+   threshold-bin candidates into a fixed 4K-entry smem window and silently
+   skips overflow (see sgl-project/sglang#17747), leaving uninitialized
+   output slots; this kernel falls back to full-row rescans instead —
+   identical results, just slower.
+3. Tie policy is well-defined: at the k-th boundary the selected tie subset
+   is the SMALLEST indices among bitwise-equal scores.
+
+Algorithm (one CTA per row, 512 threads):
+  ukey  = monotonic uint32 of the fp32 bits (b < 0 ? ~b : b | 0x80000000)
+  * pass 1: 256-bucket histogram of ukey byte3 over the window (full-row
+    scan #1), suffix-scan -> threshold bucket b*, count above s_above,
+    bucket population c1, n_valid.
+  * scan #2: elements in bucket b* are staged to a survivor buffer
+    (composite int64) when c1 <= _SURV_CAP; on the index-sort output stage
+    (below) elements in buckets > b* are definitively selected and go
+    straight to the sort buffer. Refinement never touches gmem again on
+    the staged path.
+  * MSB-first 8-bit radix refinement over the survivors (<=3 passes with
+    early exit) -> exact threshold key K_th and t_rem, the number of slots
+    left for ukey == K_th elements.
+  * If the tie set is larger than t_rem: 8-bit radix select over
+    nidx24 = (~idx) & 0xFFFFFF among ukey == K_th (<=3 passes) -> N_th.
+    Selection is then a pure per-element predicate:
+        sel = ukey > K_th || (ukey == K_th && nidx >= N_th)
+    which selects EXACTLY min(topk, n_valid) elements, smallest-index
+    preferred at the boundary.
+  * OUTPUT STAGE — two shape-selected variants, SAME canonical output
+    (ascending index, front-packed, -1 padded), both bitwise deterministic:
+    - scan-emit (grids that saturate the GPU, or short rows): one more
+      ordered full-window pass; per element the pure predicate above; warp
+      ballot+popc gives the lane prefix, a 16-warp smem scan plus a running
+      cross-chunk base gives the global slot. The slot of each winner is
+      its rank in index order among winners — a pure function of the
+      input. No sort buffer, no output-affecting atomic.
+    - index-sort collect (long rows at small B, small k): winners are
+      staged to a sort buffer in (arbitrary) arrival order as int64 keys
+      ~idx, then a bitonic sort canonicalizes to index-ascending order.
+      Unique keys => ONE canonical permutation regardless of staging
+      arrival order. Costs the k-slot sort but skips the third full-row
+      scan — cheaper exactly where rows are long and the grid is small.
+    The variant is chosen per shape at launch (compile-time constant, see
+    _pick_scanemit); SGLANG_DSA_TOPK_CUTEDSL_STAGE={auto,scanemit,sort}
+    overrides for perf work (output is identical either way).
+  * c1 > _SURV_CAP (near-degenerate rows, e.g. all-equal) falls back to
+    full-row scans for refinement — identical results, just slower.
+
+smem: 512-entry i32 histogram + SURV_CAP int64 survivor buffer + vars
+(+ NSORT = next_pow2(topk) int64 sort buffer on the index-sort stage
+only). SURV_CAP is occupancy-aware: 4096 (~34KB scan-emit / ~50KB
+index-sort at topk=2048) for grids that fill the GPU, 20480 (~162KB,
+1 CTA/SM — free when B <= #SMs, e.g. decode) so wide/tie-heavy rows stay
+on the staged path instead of the full-row-rescan fallback. No
+KV-dependent smem: any row width up to 2^24-1 (nidx24 domain) with
+B*L < 2^31 (flat int32 indexing) is supported; topk <= 4096 (production
+DSA topk = 2048).
+
+SGLANG_DSA_TOPK_CUTEDSL_SURVCAP overrides the survivor-stage capacity
+(perf tuning only; results are identical for any capacity that fits in
+shared memory). SGLANG_DSA_TOPK_CUTEDSL_STAGE={auto,scanemit,sort}
+overrides the output-stage choice (perf tuning only; output is
+identical).
+
+Input contract notes: row_starts/lengths are trusted metadata (same as the
+default kernel) — windows are clamped to [0, L) so out-of-range values can
+never fault, but invalid metadata (e.g. negative row_starts) yields
+window-clamped results rather than an error. NaN scores are not excluded:
+they rank in the same bitwise-monotone total order (positive NaN above
++inf, negative NaN below all finite values), which is deterministic but
+differs from torch.topk's NaN-maximal convention; DSA indexer logits are
+expected NaN-free.
+"""
+
+import os
+import threading
+
+import torch
+
+HAVE_CUTE_TOPK = False
+_IMPORT_ERROR = None
+try:
+    import cuda.bindings.driver as cuda_driver
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.utils as utils
+    from cutlass.cute.runtime import make_ptr
+
+    HAVE_CUTE_TOPK = torch.cuda.is_available()
+except Exception as e:  # pragma: no cover - import guard
+    _IMPORT_ERROR = e
+
+
+_NT = 512  # threads per CTA (also histogram zero-stride; keep 512)
+_NW = _NT // 32  # warps per CTA (scan-emit ballot+scan output stage)
+_RADIX = 256
+_MAX_TOPK = 4096  # sort smem cap (8B * 4096 = 32KB; production DSA = 2048)
+_SURV_CAP_SMALL = 4096  # big grids: 32KB stage
+_SURV_CAP_LARGE = 20480  # small grids (B <= #SMs): 160KB stage, 1 CTA/SM is
+# free when the grid can't fill the GPU anyway;
+# keeps wide rows staged (worst observed coarse-bin
+# population ~18.7K on randn 64k rows) instead of
+# the full-row-rescan fallback.
+_I64_MIN = -(1 << 63)
+
+_CAP_OK = {}  # device index -> compute capability >= 9.0
+
+
+def _sm90(device: torch.device) -> bool:
+    """Per-device capability gate (the tensor's device, not the current one)."""
+    idx = device.index
+    if idx is None:
+        idx = torch.cuda.current_device()
+    ok = _CAP_OK.get(idx)
+    if ok is None:
+        ok = torch.cuda.get_device_capability(idx)[0] >= 9
+        _CAP_OK[idx] = ok
+    return ok
+
+
+def supports(score: torch.Tensor, topk: int) -> bool:
+    """CuTe path constraints; call sites fall back to the default otherwise."""
+    if not HAVE_CUTE_TOPK:
+        return False
+    if not (score.is_cuda and score.dtype == torch.float32 and score.dim() == 2):
+        return False
+    if not _sm90(score.device):
+        return False
+    b, kv = score.shape
+    if b <= 0 or kv <= 0:
+        return False
+    return (
+        0 < topk <= _MAX_TOPK
+        and kv < (1 << 24)  # nidx24 tie-select domain
+        and b * kv < (1 << 31)  # flat int32 indexing (input)
+        and b * topk < (1 << 31)
+    )  # flat int32 indexing (output)
+
+
+def _next_pow2(n: int) -> int:
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+def _pick_scanemit(b: int, kv: int, topk: int) -> bool:
+    """Output-stage heuristic (B200-measured crossover; see PR perf table).
+
+    scan-emit wins when rows are short enough that one extra ordered row
+    scan is cheaper than the k-slot bitonic sort — decisively so when the
+    grid saturates the GPU (prefill-scale B, where the sort is the
+    bottleneck at full occupancy: 2.6-3.8x) and for k >> 512 at any B.
+    index-sort wins on long rows (the third full-row scan and its
+    per-chunk CTA barriers dominate) and at small k where the sort is
+    cheap. Output is bit-identical either way; this is perf-only.
+    """
+    return kv <= 16384 and (b >= 512 or topk > 512)
+
+
+if HAVE_CUTE_TOPK:
+
+    _EXT = (1 << 31) - 1  # flat extent placeholder (no bounds checks)
+
+    def _warp_scan_pick(sHist, sVar, lane, k_rem):
+        """Single-warp suffix-scan + threshold pick over the 256-bucket
+        histogram (branchless; module-level so loops stay python). Lane l
+        owns buckets [8l, 8l+8). Computes, for suffix-inclusive sums
+        S[b] = sum_{u >= b} hist[u], the unique b* with
+        S[b*] >= k_rem > S[b*+1], and writes (b*, S[b*+1], hist[b*],
+        n_valid=S[0]) to sVar[0..2] and sVar[5] — every lane writes the same
+        value (benign duplicate stores). Histogram is left untouched."""
+        vals = [sHist[lane * 8 + b] for b in range(8)]
+        suf = [None] * 8
+        acc = vals[7]
+        suf[7] = acc
+        for b in (6, 5, 4, 3, 2, 1, 0):
+            acc = acc + vals[b]
+            suf[b] = acc
+        tot = acc
+        # incl_from_me = sum of lane totals for lanes >= me (shfl.down scan,
+        # branchless OOB guard: shfl.down with clamp returns own value)
+        x = tot
+        for off in (1, 2, 4, 8, 16):
+            y = cute.arch.shuffle_sync_down(x, off)
+            x = x + y * cutlass.Int32(lane + off < 32)
+        above = x - tot  # totals of lanes strictly above
+        n_valid = cute.arch.warp_reduction_sum(tot, threads_in_group=32)
+        bacc = cutlass.Int32(0)
+        sacc = cutlass.Int32(0)
+        cacc = cutlass.Int32(0)
+        for b in range(8):
+            s_here = suf[b] + above
+            s_next = (suf[b + 1] + above) if b < 7 else above
+            ind = cutlass.Int32(s_here >= k_rem) * cutlass.Int32(s_next < k_rem)
+            bacc = bacc + (lane * 8 + b) * ind
+            sacc = sacc + s_next * ind
+            cacc = cacc + vals[b] * ind
+        bacc = cute.arch.warp_reduction_sum(bacc, threads_in_group=32)
+        sacc = cute.arch.warp_reduction_sum(sacc, threads_in_group=32)
+        cacc = cute.arch.warp_reduction_sum(cacc, threads_in_group=32)
+        sVar[0] = bacc
+        sVar[1] = sacc
+        sVar[2] = cacc
+        sVar[5] = n_valid
+
+    # ----------------------------------------------------------------------
+    # Sort emission helpers (index-sort output stage). These are PLAIN
+    # module-level python functions: the DSL AST rewrite only applies to
+    # @cute.kernel/@cute.jit bodies (and their nested defs), so loops here
+    # stay python-unrolled and may index python lists of register values.
+    # Consequence: NO dynamic `if` allowed here — every compare-exchange is
+    # branchless select arithmetic. The dynamic short-row guards live in
+    # the kernel body.
+    # ----------------------------------------------------------------------
+
+    def _cmpx_reg_local(regs, tidx, k, j, E):
+        # in-register pairs (e, e|j), j < E
+        for e in range(E):
+            if e & j == 0:
+                a = regs[e]
+                b = regs[e | j]
+                d = b - a
+                s = cutlass.Int64(b > a)
+                m = a + d * s  # max(a, b)
+                n = b - d * s  # min(a, b)
+                desc = ((tidx * E + e) & k) == 0
+                dI = cutlass.Int64(desc)
+                lo_v = n + (m - n) * dI  # lo slot: desc -> max
+                regs[e] = lo_v
+                regs[e | j] = (m + n) - lo_v
+
+    def _cmpx_reg_shfl(regs, tidx, k, j, E):
+        # cross-lane pairs, E <= j < 32E: partner lane = t ^ (j//E)
+        xm = j // E
+        desc = ((tidx * E) & k) == 0  # k >= 2E: e-invariant
+        i_lo = (tidx & xm) == 0
+        km = cutlass.Int64(cutlass.Boolean(i_lo == desc))
+        for e in range(E):
+            a = regs[e]
+            hi = cutlass.Int32(a >> 32)
+            lo = cutlass.Int32((a << 32) >> 32)
+            ph = cute.arch.shuffle_sync_bfly(hi, xm)
+            pl = cute.arch.shuffle_sync_bfly(lo, xm)
+            b = (cutlass.Int64(ph) << 32) | (
+                cutlass.Int64(pl) & cutlass.Int64(0xFFFFFFFF)
+            )
+            d = b - a
+            s = cutlass.Int64(b > a)
+            m = a + d * s
+            n = b - d * s
+            regs[e] = n + (m - n) * km
+
+    # NOTE: tail smem stages (npairs < NT, i.e. nsort = 512) need a dynamic
+    # thread predicate — a wrap-alias (p &= npairs-1) would let two threads
+    # in different warps rewrite the same pair unsynchronized. Dynamic `if`
+    # requires the DSL AST rewrite, so the stage function is @cute.jit with
+    # Constexpr shape params (python loops in the PLAIN helpers around it
+    # stay python-unrolled).
+
+    def _cmpx_smem_pair(sBuf, p, k, j):
+        # one compare-exchange (branchless select arithmetic; plain helper)
+        lo = ((p & ~(j - 1)) << 1) | (p & (j - 1))
+        hi_i = lo | j
+        a = sBuf[lo]
+        b = sBuf[hi_i]
+        d = b - a
+        s = cutlass.Int64(b > a)
+        m = a + d * s
+        n = b - d * s
+        dI = cutlass.Int64((lo & k) == 0)  # descending segment
+        lo_v = n + (m - n) * dI
+        sBuf[lo] = lo_v
+        sBuf[hi_i] = (m + n) - lo_v
+
+    @cute.jit
+    def _cmpx_smem_stage(
+        sBuf: cute.Tensor,
+        tidx: cutlass.Int32,
+        k: cutlass.Constexpr,
+        j: cutlass.Constexpr,
+        npairs: cutlass.Constexpr,
+    ):
+        # smem pairs, j >= 32E; surplus threads predicated off on tail
+        # stages, npairs >= NT stages keep the unpredicated codegen.
+        # Caller adds the barrier.
+        for i in range(max(npairs // _NT, 1)):
+            p = tidx + i * _NT
+            if cutlass.const_expr(npairs < _NT):
+                if p < npairs:
+                    _cmpx_smem_pair(sBuf, p, k, j)
+            else:
+                _cmpx_smem_pair(sBuf, p, k, j)
+
+    def _sort_phase_b_group(sBuf, tidx, nsort, kk):
+        # one k-group with k = kk > 32E: high-j stages in smem, tail in regs
+        E = nsort // _NT
+        wspan = 32 * E
+        npairs = nsort // 2
+        j = kk // 2
+        while j >= wspan:
+            _cmpx_smem_stage(sBuf, tidx, kk, j, npairs)
+            cute.arch.sync_threads()
+            j //= 2
+        regs = [sBuf[tidx * E + e] for e in range(E)]
+        while j >= 1:
+            if j >= E:
+                _cmpx_reg_shfl(regs, tidx, kk, j, E)
+            else:
+                _cmpx_reg_local(regs, tidx, kk, j, E)
+            j //= 2
+        for e in range(E):
+            sBuf[tidx * E + e] = regs[e]
+
+    def _sort_phase_a(sBuf, tidx, nsort):
+        # k = 2 .. 32E in registers/shuffles only; zero barriers
+        E = nsort // _NT
+        wspan = 32 * E
+        regs = [sBuf[tidx * E + e] for e in range(E)]
+        kk = 2
+        while kk <= wspan:
+            j = kk // 2
+            while j >= 1:
+                if j >= E:
+                    _cmpx_reg_shfl(regs, tidx, kk, j, E)
+                else:
+                    _cmpx_reg_local(regs, tidx, kk, j, E)
+                j //= 2
+            kk *= 2
+        for e in range(E):
+            sBuf[tidx * E + e] = regs[e]
+
+    @cute.kernel
+    def _topk_kernel(
+        mIn: cute.Tensor,  # flat [b * kv] fp32
+        mKs: cute.Tensor,  # [b] int32 (row_starts)
+        mLen: cute.Tensor,  # [b] int32 (lengths)
+        mOut: cute.Tensor,  # flat [b * topk] int32
+        kv: cutlass.Int32,
+        topk_c: cutlass.Constexpr,  # int
+        nsort_c: cutlass.Constexpr,  # int, pow2 >= topk_c (index-sort stage)
+        surv_cap_c: cutlass.Constexpr,  # survivor-stage capacity (smem)
+        scanemit_c: cutlass.Constexpr,  # bool: scan-emit output stage
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        row, _, _ = cute.arch.block_idx()
+
+        smem = utils.SmemAllocator()
+        hist_p = smem.allocate_array(cutlass.Int32, 2 * _RADIX, byte_alignment=4)
+        var_p = smem.allocate_array(cutlass.Int32, 8, byte_alignment=4)
+        sBuf = None
+        if cutlass.const_expr(not scanemit_c):
+            buf_p = smem.allocate_array(cutlass.Int64, nsort_c, byte_alignment=8)
+            sBuf = cute.make_tensor(buf_p, cute.make_layout(nsort_c))
+        surv_p = smem.allocate_array(cutlass.Int64, surv_cap_c, byte_alignment=8)
+        sHist = cute.make_tensor(hist_p, cute.make_layout(2 * _RADIX))
+        sVar = cute.make_tensor(var_p, cute.make_layout(8))
+        sSurv = cute.make_tensor(surv_p, cute.make_layout(surv_cap_c))
+
+        ks = mKs[row]
+        ln = mLen[row]
+        if ks < 0:
+            ks = cutlass.Int32(0)
+        if ln < 0:
+            ln = cutlass.Int32(0)
+        ke = ks + ln
+        if ke > kv:
+            ke = kv
+        base = row * kv
+        span = ke - ks
+        iters = cutlass.Int32(0)
+        if span > 0:
+            iters = (span + _NT - 1) // _NT
+
+        # ------------------------------------------------------------------
+        # traced helpers (nested defs; all traced values passed explicitly —
+        # the DSL forbids closure capture inside dynamic control flow)
+        # ------------------------------------------------------------------
+        def hist_zero(sHist, tidx):
+            # 512 threads x 512 entries: exactly one store per thread
+            sHist[tidx] = 0
+
+        def elem(it, tidx, ks, ke, base, mIn):
+            """Load element it*NT+tidx of the window; returns
+            (valid, idx, ukey, nidx24)."""
+            idx = ks + it * _NT + tidx
+            inw = idx < ke
+            v = cutlass.Float32(0.0)
+            if inw:
+                v = mIn[base + idx]
+            b = v.bitcast(cutlass.Int32)
+            bu = b.bitcast(cutlass.Uint32)
+            ukey = bu | cutlass.Uint32(0x80000000)
+            if b < 0:
+                ukey = ~bu
+            # -inf (bits 0xFF800000) excluded (torch-backend parity)
+            valid = inw and (b != cutlass.Int32(-8388608))
+            nidx = (~idx).bitcast(cutlass.Uint32) & cutlass.Uint32(0xFFFFFF)
+            return valid, idx, ukey, nidx
+
+        def comp_of(idx, ukey):
+            """Unique canonical-order composite: (skey << 32) | (~idx)."""
+            skey = (ukey ^ cutlass.Uint32(0x80000000)).bitcast(cutlass.Int32)
+            return (cutlass.Int64(skey) << 32) | (
+                cutlass.Int64(~idx) & cutlass.Int64(0xFFFFFFFF)
+            )
+
+        def surv_decode(comp):
+            """Recover (ukey, nidx24) from a staged composite."""
+            hi = cutlass.Int32(comp >> 32)
+            ukey = hi.bitcast(cutlass.Uint32) ^ cutlass.Uint32(0x80000000)
+            nidx = cutlass.Int32(comp).bitcast(cutlass.Uint32) & cutlass.Uint32(
+                0xFFFFFF
+            )
+            return ukey, nidx
+
+        def suffix_scan_and_pick(sHist, sVar, tidx, k_rem):
+            """Warp-0 suffix-scan + pick over hist[0:256] (see
+            _warp_scan_pick). Returns (bstar, s_above, c_bucket),
+            CTA-uniform; row candidate total lands in sVar[5]."""
+            if tidx < 32:
+                _warp_scan_pick(sHist, sVar, tidx, k_rem)
+            cute.arch.sync_threads()
+            return sVar[0], sVar[1], sVar[2]
+
+        # ------------------------------------------------------------------
+        # init: counters, sort-buffer sentinel padding (index-sort stage),
+        # pass-1 histogram (ukey byte3 over all valid candidates; full-row
+        # scan #1)
+        # ------------------------------------------------------------------
+        hist_zero(sHist, tidx)
+        if tidx < 8:
+            sVar[tidx] = 0
+        if cutlass.const_expr(not scanemit_c):
+            for i in range(nsort_c // _NT):
+                sBuf[tidx + i * _NT] = cutlass.Int64(_I64_MIN)
+        cute.arch.sync_threads()
+        for it in cutlass.range(iters):
+            valid, idx, ukey, nidx = elem(it, tidx, ks, ke, base, mIn)
+            if valid:
+                byte = (ukey >> 24).bitcast(cutlass.Int32)
+                cute.arch.atomic_add(
+                    sHist.iterator + byte, cutlass.Int32(1), scope="cta"
+                )
+        cute.arch.sync_threads()
+
+        # pass-0 pick; row candidate total (S[0]) comes back in sVar[5]
+        bstar, s_above, c_bkt = suffix_scan_and_pick(
+            sHist, sVar, tidx, cutlass.Int32(topk_c)
+        )
+        n_valid = sVar[5]
+        cute.arch.sync_threads()
+
+        kth = cutlass.Uint32(0)
+        nth = cutlass.Uint32(0)
+        out_v = n_valid
+        if n_valid <= topk_c:
+            # short row: every valid candidate is selected (kth=nth=0).
+            # Index-sort staging only — scan-emit handles short rows
+            # entirely in the ordered emission pass below. Sort keys are
+            # int64 ~idx: unique, and descending-sorting them yields
+            # ascending index order.
+            if cutlass.const_expr(not scanemit_c):
+                for it in cutlass.range(iters):
+                    valid, idx, ukey, nidx = elem(it, tidx, ks, ke, base, mIn)
+                    if valid:
+                        pos = cute.arch.atomic_add(
+                            sVar.iterator + 3, cutlass.Int32(1), scope="cta"
+                        )
+                        if pos < nsort_c:
+                            sBuf[pos] = cutlass.Int64(~idx)
+        else:
+            out_v = cutlass.Int32(topk_c)
+            # pass-1 pick is valid (S[0] = n_valid > topk)
+            bstar_u = bstar.bitcast(cutlass.Uint32)
+            prefix = cutlass.Uint32(bstar_u << 24)
+            k_rem = cutlass.Int32(topk_c) - s_above
+            c1 = c_bkt
+            done = c_bkt == k_rem
+            staged = c1 <= surv_cap_c
+            # scan #2 (full-row): winners above bucket b* go straight to
+            # the sort buffer (index-sort stage only — scan-emit re-finds
+            # them in the ordered emission pass); bucket-b* members are
+            # staged to the smem survivor buffer for refinement.
+            for it in cutlass.range(iters):
+                valid, idx, ukey, nidx = elem(it, tidx, ks, ke, base, mIn)
+                if valid:
+                    byte3 = ukey >> 24
+                    if cutlass.const_expr(not scanemit_c):
+                        if byte3 > bstar_u:
+                            pos = cute.arch.atomic_add(
+                                sVar.iterator + 3, cutlass.Int32(1), scope="cta"
+                            )
+                            if pos < nsort_c:
+                                sBuf[pos] = cutlass.Int64(~idx)
+                        elif staged and byte3 == bstar_u:
+                            sp = cute.arch.atomic_add(
+                                sVar.iterator + 4, cutlass.Int32(1), scope="cta"
+                            )
+                            if sp < surv_cap_c:
+                                sSurv[sp] = comp_of(idx, ukey)
+                    else:
+                        if staged and byte3 == bstar_u:
+                            sp = cute.arch.atomic_add(
+                                sVar.iterator + 4, cutlass.Int32(1), scope="cta"
+                            )
+                            if sp < surv_cap_c:
+                                sSurv[sp] = comp_of(idx, ukey)
+            cute.arch.sync_threads()
+            iters_s = (c1 + _NT - 1) // _NT
+
+            # MSB-first radix refinement to the exact threshold key
+            for shift in (16, 8, 0):
+                if not done:
+                    hist_zero(sHist, tidx)
+                    cute.arch.sync_threads()
+                    if staged:
+                        for it in cutlass.range(iters_s):
+                            si = it * _NT + tidx
+                            if si < c1:
+                                ukey, nidx = surv_decode(sSurv[si])
+                                if (ukey >> (shift + 8)) == (prefix >> (shift + 8)):
+                                    byte = (
+                                        (ukey >> shift) & cutlass.Uint32(0xFF)
+                                    ).bitcast(cutlass.Int32)
+                                    cute.arch.atomic_add(
+                                        sHist.iterator + byte,
+                                        cutlass.Int32(1),
+                                        scope="cta",
+                                    )
+                    else:
+                        for it in cutlass.range(iters):
+                            valid, idx, ukey, nidx = elem(it, tidx, ks, ke, base, mIn)
+                            if valid and (ukey >> (shift + 8)) == (
+                                prefix >> (shift + 8)
+                            ):
+                                byte = ((ukey >> shift) & cutlass.Uint32(0xFF)).bitcast(
+                                    cutlass.Int32
+                                )
+                                cute.arch.atomic_add(
+                                    sHist.iterator + byte, cutlass.Int32(1), scope="cta"
+                                )
+                    cute.arch.sync_threads()
+                    bstar, s_above, c_bkt = suffix_scan_and_pick(
+                        sHist, sVar, tidx, k_rem
+                    )
+                    prefix = prefix | (bstar.bitcast(cutlass.Uint32) << shift)
+                    k_rem = k_rem - s_above
+                    if shift != 0:
+                        done = c_bkt == k_rem
+            kth = prefix
+            # tie boundary: need k_rem smallest indices among ukey == kth,
+            # i.e. the k_rem LARGEST nidx24 = (~idx) & 0xFFFFFF
+            if (not done) and c_bkt > k_rem:
+                nprefix = cutlass.Uint32(0)
+                done2 = cutlass.Boolean(False)
+                for shift in (16, 8, 0):
+                    if not done2:
+                        hist_zero(sHist, tidx)
+                        cute.arch.sync_threads()
+                        if staged:
+                            for it in cutlass.range(iters_s):
+                                si = it * _NT + tidx
+                                if si < c1:
+                                    ukey, nidx = surv_decode(sSurv[si])
+                                    if ukey == kth and (nidx >> (shift + 8)) == (
+                                        nprefix >> (shift + 8)
+                                    ):
+                                        byte = (
+                                            (nidx >> shift) & cutlass.Uint32(0xFF)
+                                        ).bitcast(cutlass.Int32)
+                                        cute.arch.atomic_add(
+                                            sHist.iterator + byte,
+                                            cutlass.Int32(1),
+                                            scope="cta",
+                                        )
+                        else:
+                            for it in cutlass.range(iters):
+                                valid, idx, ukey, nidx = elem(
+                                    it, tidx, ks, ke, base, mIn
+                                )
+                                if (
+                                    valid
+                                    and ukey == kth
+                                    and (nidx >> (shift + 8))
+                                    == (nprefix >> (shift + 8))
+                                ):
+                                    byte = (
+                                        (nidx >> shift) & cutlass.Uint32(0xFF)
+                                    ).bitcast(cutlass.Int32)
+                                    cute.arch.atomic_add(
+                                        sHist.iterator + byte,
+                                        cutlass.Int32(1),
+                                        scope="cta",
+                                    )
+                        cute.arch.sync_threads()
+                        bstar, s_above, c_bkt = suffix_scan_and_pick(
+                            sHist, sVar, tidx, k_rem
+                        )
+                        nprefix = nprefix | (bstar.bitcast(cutlass.Uint32) << shift)
+                        k_rem = k_rem - s_above
+                        if shift != 0:
+                            done2 = c_bkt == k_rem
+                nth = nprefix
+
+            # final selection within bucket b* (index-sort stage only):
+            # pure predicate; arrival order only permutes the buffer the
+            # index sort canonicalizes. Scan-emit applies the same
+            # predicate inside the ordered emission pass instead.
+            if cutlass.const_expr(not scanemit_c):
+                if staged:
+                    for it in cutlass.range(iters_s):
+                        si = it * _NT + tidx
+                        if si < c1:
+                            comp = sSurv[si]
+                            ukey, nidx = surv_decode(comp)
+                            sel = ukey > kth
+                            if ukey == kth and nidx >= nth:
+                                sel = cutlass.Boolean(True)
+                            if sel:
+                                pos = cute.arch.atomic_add(
+                                    sVar.iterator + 3, cutlass.Int32(1), scope="cta"
+                                )
+                                if pos < nsort_c:
+                                    # low 32 bits of the composite are ~idx
+                                    sBuf[pos] = cutlass.Int64(cutlass.Int32(comp))
+                else:
+                    for it in cutlass.range(iters):
+                        valid, idx, ukey, nidx = elem(it, tidx, ks, ke, base, mIn)
+                        if valid and (ukey >> 24) == bstar_u:
+                            sel = ukey > kth
+                            if ukey == kth and nidx >= nth:
+                                sel = cutlass.Boolean(True)
+                            if sel:
+                                pos = cute.arch.atomic_add(
+                                    sVar.iterator + 3, cutlass.Int32(1), scope="cta"
+                                )
+                                if pos < nsort_c:
+                                    sBuf[pos] = cutlass.Int64(~idx)
+        cute.arch.sync_threads()
+
+        if cutlass.const_expr(scanemit_c):
+            # --------------------------------------------------------------
+            # scan-emit output stage (scan #3): deterministic ORDERED
+            # emission. Selection is the pure predicate on (kth, nth); the
+            # output slot of each winner is the exclusive count of winners
+            # before it in index order (warp ballot + 16-warp scan +
+            # running cross-chunk base). No sort, no arrival-order atomic
+            # anywhere near the output => bitwise deterministic, canonical
+            # (index ascending).
+            # --------------------------------------------------------------
+            if tidx == 0:
+                sVar[3] = 0
+            cute.arch.sync_threads()
+            obase = row * topk_c
+            lane = tidx % 32
+            wid = tidx // 32
+            for it in cutlass.range(iters):
+                valid, idx, ukey, nidx = elem(it, tidx, ks, ke, base, mIn)
+                sel = cutlass.Boolean(False)
+                if valid:
+                    if n_valid <= topk_c:
+                        sel = cutlass.Boolean(True)
+                    elif ukey > kth:
+                        sel = cutlass.Boolean(True)
+                    elif ukey == kth and nidx >= nth:
+                        sel = cutlass.Boolean(True)
+                mask = cute.arch.vote_ballot_sync(sel)
+                lpre = cute.arch.popc(mask & cute.arch.lanemask_lt())
+                if lane == 0:
+                    sHist[_RADIX + wid] = cute.arch.popc(mask)
+                cute.arch.sync_threads()
+                if tidx < 32:
+                    t_w = cutlass.Int32(0)
+                    if tidx < _NW:
+                        t_w = sHist[_RADIX + tidx]
+                    run0 = sVar[3]
+                    x = t_w
+                    for off in (1, 2, 4, 8):
+                        # DSL gotcha: shuffle_sync_up's default
+                        # mask_and_clamp (31) is the DOWN clamp; up MUST
+                        # pass 0 or every lane silently reads itself back.
+                        y = cute.arch.shuffle_sync_up(x, off, mask_and_clamp=0)
+                        x = x + y * cutlass.Int32(tidx >= off)
+                    if tidx < _NW:
+                        sHist[_RADIX + 32 + tidx] = run0 + x - t_w
+                        if tidx == _NW - 1:
+                            sVar[6] = run0 + x
+                cute.arch.sync_threads()
+                if sel:
+                    pos = sHist[_RADIX + 32 + wid] + lpre
+                    if pos < topk_c:
+                        mOut[obase + pos] = idx - ks  # LOCAL index
+                if tidx == 0:
+                    sVar[3] = sVar[6]
+                cute.arch.sync_threads()
+
+            # -1 fill beyond out_v (selected count is analytic:
+            # min(topk, n_valid))
+            for i in range(max((topk_c + _NT - 1) // _NT, 1)):
+                o = tidx + i * _NT
+                if o < topk_c:
+                    if o >= out_v:
+                        mOut[obase + o] = cutlass.Int32(-1)
+        else:
+            # --------------------------------------------------------------
+            # index-sort output stage: descending bitonic sort of nsort_c
+            # int64 keys ~idx (unique; descending ~idx == ascending idx —
+            # the SAME canonical order the scan-emit stage produces) via
+            # the module-level emission helpers above. Short rows skip
+            # k-groups under CTA-uniform guards: with out_v real elements
+            # compacted into [0, out_v) and INT64_MIN sentinels elsewhere,
+            # the k <= next_pow2(out_v) prefix of the network fully sorts
+            # block 0 (larger-k stages only permute sentinel blocks).
+            # Phase B is always exactly 4 groups: kk = NSORT/8, /4, /2,
+            # NSORT (32E = NSORT/16).
+            # --------------------------------------------------------------
+            if out_v > 1:
+                _sort_phase_a(sBuf, tidx, nsort_c)
+            cute.arch.sync_threads()
+            if out_v * 2 > nsort_c // 8:
+                _sort_phase_b_group(sBuf, tidx, nsort_c, nsort_c // 8)
+            cute.arch.sync_threads()
+            if out_v * 2 > nsort_c // 4:
+                _sort_phase_b_group(sBuf, tidx, nsort_c, nsort_c // 4)
+            cute.arch.sync_threads()
+            if out_v * 2 > nsort_c // 2:
+                _sort_phase_b_group(sBuf, tidx, nsort_c, nsort_c // 2)
+            cute.arch.sync_threads()
+            if out_v * 2 > nsort_c:
+                _sort_phase_b_group(sBuf, tidx, nsort_c, nsort_c)
+            cute.arch.sync_threads()
+
+            # emit: slot i -> LOCAL index (~key - row_start) if i < out_v
+            # else -1
+            obase = row * topk_c
+            for i in range(max((topk_c + _NT - 1) // _NT, 1)):
+                o = tidx + i * _NT
+                if o < topk_c:
+                    res = cutlass.Int32(-1)
+                    if o < out_v:
+                        low = cutlass.Int32((~sBuf[o]) & cutlass.Int64(0xFFFFFFFF))
+                        res = low - ks
+                    mOut[obase + o] = res
+
+    @cute.jit
+    def _topk_launch(
+        in_ptr: cute.Pointer,
+        ks_ptr: cute.Pointer,
+        len_ptr: cute.Pointer,
+        out_ptr: cute.Pointer,
+        b_rows: cutlass.Int32,
+        kv: cutlass.Int32,
+        stream: cuda_driver.CUstream,
+        topk_c: cutlass.Constexpr,
+        nsort_c: cutlass.Constexpr,
+        surv_cap_c: cutlass.Constexpr,
+        scanemit_c: cutlass.Constexpr,
+    ):
+        mIn = cute.make_tensor(in_ptr, cute.make_layout(_EXT))
+        mKs = cute.make_tensor(ks_ptr, cute.make_layout(_EXT))
+        mLen = cute.make_tensor(len_ptr, cute.make_layout(_EXT))
+        mOut = cute.make_tensor(out_ptr, cute.make_layout(_EXT))
+        _topk_kernel(
+            mIn, mKs, mLen, mOut, kv, topk_c, nsort_c, surv_cap_c, scanemit_c
+        ).launch(grid=(b_rows, 1, 1), block=(_NT, 1, 1), stream=stream)
+
+    _COMPILED = {}
+    _COMPILE_LOCK = threading.Lock()
+    _ZEROS = {}
+    _SM_COUNTS = {}
+
+    def _sm_count(device):
+        idx = device.index
+        n = _SM_COUNTS.get(idx)
+        if n is None:
+            n = torch.cuda.get_device_properties(device).multi_processor_count
+            _SM_COUNTS[idx] = n
+        return n
+
+    def _f32_ptr(t):
+        return make_ptr(
+            cutlass.Float32, t.data_ptr(), cute.AddressSpace.gmem, assumed_align=4
+        )
+
+    def _i32_ptr(t):
+        return make_ptr(
+            cutlass.Int32, t.data_ptr(), cute.AddressSpace.gmem, assumed_align=4
+        )
+
+    def _zeros_i32(n, device):
+        key = (device.index,)
+        z = _ZEROS.get(key)
+        if z is None or z.numel() < n:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "cute_topk_func: the default row_starts buffer would be "
+                    "allocated under CUDA graph capture; run one eager "
+                    "warmup step first."
+                )
+            z = torch.zeros(max(n, 8192), dtype=torch.int32, device=device)
+            # one-time: make the zero-fill visible to any stream that later
+            # reads this cached buffer
+            torch.cuda.current_stream(device).synchronize()
+            _ZEROS[key] = z
+        return z
+
+
+def cute_topk_func(
+    score: torch.Tensor,
+    lengths: torch.Tensor,
+    topk: int,
+    row_starts: torch.Tensor = None,
+) -> torch.Tensor:
+    """sglang DSATopKBackend.topk_func-compatible entry (see module doc).
+
+    score (B, L) fp32 CUDA; lengths (B) int32; optional row_starts (B) int32.
+    Returns (B, topk) int32 LOCAL indices, -1 padded, in ascending index
+    order (canonical; see module docstring). Bitwise deterministic.
+    """
+    if not HAVE_CUTE_TOPK:
+        raise RuntimeError(
+            "cute_topk_func requires a CUDA SM90+ device and nvidia-cutlass-dsl"
+            + (
+                f" (import failed: {_IMPORT_ERROR!r})"
+                if _IMPORT_ERROR is not None
+                else ""
+            )
+        )
+    if not (score.is_cuda and score.dtype == torch.float32 and score.dim() == 2):
+        raise ValueError(
+            "cute_topk_func: score must be a CUDA (B, L) float32 tensor, got "
+            f"{score.device} {tuple(score.shape)} {score.dtype}"
+        )
+    if not _sm90(score.device):
+        raise RuntimeError(
+            f"cute_topk_func: device {score.device} has compute capability "
+            f"{torch.cuda.get_device_capability(score.device)}, needs SM90+"
+        )
+    score = score.contiguous()
+    b, kv = score.shape
+    # validate the full documented envelope BEFORE the empty-shape early
+    # returns, so out-of-envelope arguments fail loudly even on B=0/L=0
+    if not (
+        0 <= topk <= _MAX_TOPK
+        and kv < (1 << 24)
+        and b * kv < (1 << 31)
+        and b * topk < (1 << 31)
+    ):
+        raise ValueError(
+            f"cute_topk_func: unsupported shape B={b}, L={kv}, topk={topk} "
+            f"(requires topk <= {_MAX_TOPK}, L < 2**24, B*L < 2**31, "
+            "B*topk < 2**31; see supports())"
+        )
+    if lengths.numel() < b:
+        raise ValueError(
+            f"cute_topk_func: lengths has {lengths.numel()} elements, needs {b}"
+        )
+    if row_starts is not None and row_starts.numel() < b:
+        raise ValueError(
+            f"cute_topk_func: row_starts has {row_starts.numel()} elements, "
+            f"needs {b}"
+        )
+    out = torch.empty((b, topk), dtype=torch.int32, device=score.device)
+    if b == 0 or topk == 0:
+        return out
+    if kv == 0:
+        return out.fill_(-1)
+    lengths = lengths.to(device=score.device, dtype=torch.int32).contiguous()
+    if row_starts is None:
+        row_starts = _zeros_i32(b, score.device)
+    else:
+        row_starts = row_starts.to(device=score.device, dtype=torch.int32).contiguous()
+    stream = cuda_driver.CUstream(torch.cuda.current_stream(score.device).cuda_stream)
+    args = (
+        _f32_ptr(score),
+        _i32_ptr(row_starts),
+        _i32_ptr(lengths),
+        _i32_ptr(out),
+        cutlass.Int32(b),
+        cutlass.Int32(kv),
+        stream,
+    )
+    cap_env = os.environ.get("SGLANG_DSA_TOPK_CUTEDSL_SURVCAP", "")
+    if cap_env:
+        try:
+            surv_cap = int(cap_env)
+        except ValueError:
+            raise ValueError(
+                f"SGLANG_DSA_TOPK_CUTEDSL_SURVCAP={cap_env!r} is not an integer"
+            ) from None
+        if surv_cap <= 0:
+            raise ValueError(
+                f"SGLANG_DSA_TOPK_CUTEDSL_SURVCAP must be > 0, got {surv_cap}"
+            )
+    else:
+        # occupancy-aware: grids that cannot fill the GPU (1 CTA/SM anyway)
+        # take the large stage for free; full grids keep the small stage.
+        surv_cap = _SURV_CAP_LARGE if b <= _sm_count(score.device) else _SURV_CAP_SMALL
+    stage_env = os.environ.get("SGLANG_DSA_TOPK_CUTEDSL_STAGE", "auto")
+    if stage_env == "scanemit":
+        scanemit = True
+    elif stage_env == "sort":
+        scanemit = False
+    elif stage_env in ("auto", ""):
+        scanemit = _pick_scanemit(b, kv, topk)
+    else:
+        raise ValueError(
+            "SGLANG_DSA_TOPK_CUTEDSL_STAGE must be one of 'auto', 'scanemit', "
+            f"'sort', got {stage_env!r}"
+        )
+    nsort = max(_next_pow2(topk), _NT)
+    key = (topk, nsort, surv_cap, scanemit, score.get_device())
+    fn = _COMPILED.get(key)
+    if fn is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "cute_topk_func: first call for config "
+                f"{key} happened under CUDA graph capture; run one eager "
+                "warmup step first."
+            )
+        with torch.cuda.nvtx.range("cute_topk_compile"):
+            with torch.cuda.device(score.device), _COMPILE_LOCK:
+                fn = _COMPILED.get(key)
+                if fn is None:
+                    fn = cute.compile(
+                        _topk_launch, *args, topk, nsort, surv_cap, scanemit
+                    )
+                    _COMPILED[key] = fn
+    fn(*args)
+    return out

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -24,6 +24,7 @@ class DSATopKBackend(Enum):
     SGL_KERNEL = "sgl-kernel"
     TORCH = "torch"
     FLASHINFER = "flashinfer"
+    CUTEDSL = "cutedsl"
 
     def is_sgl_kernel(self) -> bool:
         return self == DSATopKBackend.SGL_KERNEL
@@ -33,6 +34,9 @@ class DSATopKBackend(Enum):
 
     def is_flashinfer(self) -> bool:
         return self == DSATopKBackend.FLASHINFER
+
+    def is_cutedsl(self) -> bool:
+        return self == DSATopKBackend.CUTEDSL
 
     def topk_func(
         self,
@@ -54,6 +58,10 @@ class DSATopKBackend(Enum):
                 topk_op=torch.topk,
                 topk_op_kwargs={"dim": -1},
             )
+        if self.is_cutedsl():
+            from sglang.jit_kernel.cutedsl_topk import cute_topk_func
+
+            return cute_topk_func(score, lengths, topk, row_starts=row_starts)
         if self.is_flashinfer():
             import flashinfer
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -332,7 +332,7 @@ DSA_CHOICES = [
 ]
 NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
-DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
+DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer", "cutedsl"]
 
 DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
 
@@ -1474,7 +1474,7 @@ class ServerArgs:
     dsa_topk_backend: A[
         str,
         Arg(
-            help="DSA indexer top-k backend. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            help="DSA indexer top-k backend. Options: 'sgl-kernel' (default), 'torch', 'flashinfer', 'cutedsl' (deterministic: bitwise-reproducible canonical top-k, SM90+). The 'torch' and 'cutedsl' backends currently require SGLANG_DSA_FUSE_TOPK=false.",
             choices=DSA_TOPK_BACKEND_CHOICES,
         ),
     ] = "sgl-kernel"

--- a/test/registered/jit/test_cutedsl_topk.py
+++ b/test/registered/jit/test_cutedsl_topk.py
@@ -1,0 +1,270 @@
+"""Tests for the CuTe DSL deterministic DSA top-k kernel."""
+
+import sys
+import zlib
+
+import pytest
+import torch
+
+from sglang.jit_kernel.utils import get_jit_cuda_arch, is_hip_runtime
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from sglang.jit_kernel.cutedsl_topk import (  # noqa: E402
+    HAVE_CUTE_TOPK,
+    cute_topk_func,
+    supports,
+)
+
+NEG_INF = float("-inf")
+
+
+def _skip_if_unsupported():
+    if is_hip_runtime() or get_jit_cuda_arch().major < 9 or not HAVE_CUTE_TOPK:
+        pytest.skip("SM90+ with nvidia-cutlass-dsl required")
+
+
+def _make_case(kind, batch, width, topk, seed, with_row_starts):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    if kind == "randn":
+        score = torch.randn(batch, width, device="cuda", generator=g)
+    elif kind == "relu":
+        # Realistic DSA indexer logits: sum_h relu(q.k) * w produces an
+        # exact-0.0 tie plateau covering most of the row.
+        score = (
+            torch.relu(torch.randn(batch, width, device="cuda", generator=g) - 1.28)
+            * 11.3
+        )
+    elif kind == "quant":
+        score = torch.randint(0, 64, (batch, width), device="cuda", generator=g).float()
+    elif kind == "neginf":
+        score = torch.randn(batch, width, device="cuda", generator=g)
+        mask = torch.rand(batch, width, device="cuda", generator=g) < 0.3
+        score = score.masked_fill(mask, NEG_INF)
+        score[0, :] = NEG_INF
+        if batch > 3:
+            # all -inf with a nonzero window (row 0's length is zeroed below):
+            # n_valid == 0 -> all -1 output
+            score[3, :] = NEG_INF
+    else:
+        raise ValueError(kind)
+    if with_row_starts:
+        row_starts = torch.randint(
+            0, max(width // 4, 1), (batch,), device="cuda", generator=g
+        ).to(torch.int32)
+    else:
+        row_starts = None
+    max_len = width - (
+        row_starts.to(torch.int64)
+        if row_starts is not None
+        else torch.zeros(batch, dtype=torch.int64, device="cuda")
+    )
+    lengths = (torch.rand(batch, device="cuda", generator=g) * max_len.float()).to(
+        torch.int32
+    )
+    # edge lengths
+    lengths[0] = 0
+    if batch > 1:
+        lengths[1] = torch.minimum(
+            torch.tensor(topk, dtype=torch.int32, device="cuda"),
+            max_len[1].to(torch.int32),
+        )
+    if batch > 2:
+        lengths[2] = max_len[2].to(torch.int32)
+    return score, lengths, row_starts
+
+
+def _check_contract(score, lengths, topk, idx, row_starts):
+    """Tie-robust exact top-k check.
+
+    Per row: index range/uniqueness, count == min(topk, n_valid), selected
+    score multiset bitwise-equals the reference top multiset (unique answer
+    even under exact fp32 ties), canonical order (strictly ascending
+    indices), -1 tail-packed.
+    """
+    batch, _ = score.shape
+    starts = (
+        torch.zeros(batch, dtype=torch.int64, device=score.device)
+        if row_starts is None
+        else row_starts.to(torch.int64)
+    )
+    for r in range(batch):
+        ln = int(lengths[r])
+        st = int(starts[r])
+        row = idx[r].to(torch.int64)
+        sel = row[row >= 0]
+        n_out = sel.numel()
+        assert bool((row >= -1).all()) and bool((row < ln).all())
+        assert torch.unique(sel).numel() == n_out
+        w = score[r, st : st + ln] if ln > 0 else score[r, :0]
+        finite = w != NEG_INF
+        n_valid = int(finite.sum())
+        assert n_out == min(topk, n_valid)
+        neg = row == -1
+        if bool(neg.any()):
+            first = int(torch.argmax(neg.int()))
+            assert bool(neg[first:].all())  # -1 strictly tail-packed
+        if n_out == 0:
+            continue
+        got = torch.sort(w[sel], descending=True).values
+        ref = torch.sort(w[finite], descending=True).values[:n_out]
+        assert torch.equal(got.view(torch.int32), ref.view(torch.int32))
+        # canonical order: strictly ascending indices (the scan-emit output
+        # stage's slot order; part of the determinism contract)
+        assert bool((row[1:n_out] > row[: n_out - 1]).all())
+        # smallest-index tie subset at the k-th boundary: among candidates
+        # whose score bitwise-equals the k-th (minimum selected) score, the
+        # selected ones must be exactly the smallest indices
+        sb = w[sel].view(torch.int32).to(torch.int64)
+        uk = torch.where(sb < 0, ~sb & 0xFFFFFFFF, sb | 0x80000000)
+        kth_bits = sb[torch.argmin(uk)]
+        wb = w.view(torch.int32).to(torch.int64)
+        finite_idx = finite.nonzero().flatten()
+        tie_all = finite_idx[wb[finite_idx] == kth_bits]
+        tie_sel = sel[sb == kth_bits]
+        assert torch.equal(torch.sort(tie_sel).values, tie_all[: tie_sel.numel()])
+
+
+@pytest.mark.parametrize("kind", ["randn", "relu", "quant", "neginf"])
+@pytest.mark.parametrize("with_row_starts", [False, True])
+def test_cutedsl_topk_contract(kind, with_row_starts):
+    _skip_if_unsupported()
+    topk = 2048
+    score, lengths, row_starts = _make_case(
+        kind,
+        64,
+        16384,
+        topk,
+        seed=zlib.crc32(f"{kind}:{with_row_starts}".encode()) & 0xFFFF,
+        with_row_starts=with_row_starts,
+    )
+    assert supports(score, topk)
+    out = cute_topk_func(score, lengths, topk, row_starts)
+    assert out.shape == (64, topk) and out.dtype == torch.int32
+    _check_contract(score, lengths, topk, out, row_starts)
+
+
+@pytest.mark.parametrize("topk", [512, 2048])
+def test_cutedsl_topk_deterministic(topk):
+    _skip_if_unsupported()
+    # exact-tie-heavy input: the regime where arrival-order kernels return a
+    # different index set run to run. NB: topk=512 exercises the index-sort
+    # output stage, topk=2048 the scan-emit stage (see _pick_scanemit).
+    score, lengths, _ = _make_case(
+        "relu", 64, 16384, topk, seed=7, with_row_starts=False
+    )
+    ref = cute_topk_func(score, lengths, topk)
+    for _ in range(10):
+        out = cute_topk_func(score, lengths, topk)
+        assert torch.equal(out, ref)  # bitwise, including slot order
+
+
+@pytest.mark.parametrize("kind", ["relu", "quant"])
+def test_cutedsl_topk_stage_equivalence(kind, monkeypatch):
+    """The two output stages emit the identical canonical output
+    bit-for-bit (ascending index), including on tie-heavy inputs and
+    short/empty rows."""
+    _skip_if_unsupported()
+    topk = 2048
+    score, lengths, row_starts = _make_case(
+        kind, 64, 16384, topk, seed=11, with_row_starts=True
+    )
+    monkeypatch.setenv("SGLANG_DSA_TOPK_CUTEDSL_STAGE", "scanemit")
+    a = cute_topk_func(score, lengths, topk, row_starts)
+    monkeypatch.setenv("SGLANG_DSA_TOPK_CUTEDSL_STAGE", "sort")
+    b = cute_topk_func(score, lengths, topk, row_starts)
+    assert torch.equal(a, b)
+    _check_contract(score, lengths, topk, a, row_starts)
+
+
+def test_cutedsl_topk_cuda_graph():
+    _skip_if_unsupported()
+    topk = 2048
+    score, lengths, _ = _make_case(
+        "randn", 32, 8192, topk, seed=3, with_row_starts=False
+    )
+    ref_warm = cute_topk_func(score, lengths, topk)  # eager warmup (compiles)
+    torch.cuda.synchronize()
+    del ref_warm
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        cute_topk_func(score, lengths, topk)
+    torch.cuda.current_stream().wait_stream(stream)
+    with torch.cuda.graph(graph):
+        out = cute_topk_func(score, lengths, topk)
+    g = torch.Generator(device="cuda").manual_seed(9)
+    score.copy_(torch.randn(score.shape, device="cuda", generator=g))
+    graph.replay()
+    torch.cuda.synchronize()
+    ref = cute_topk_func(score, lengths, topk)
+    torch.cuda.synchronize()
+    assert torch.equal(out, ref)
+
+
+def test_cutedsl_topk_empty():
+    _skip_if_unsupported()
+    out = cute_topk_func(
+        torch.empty(0, 128, device="cuda"),
+        torch.empty(0, dtype=torch.int32, device="cuda"),
+        2048,
+    )
+    assert out.shape == (0, 2048)
+
+
+def test_cutedsl_topk_survcap_fallback(monkeypatch):
+    """c1 > SURV_CAP forces the full-row-rescan refinement fallback; the
+    result must be bit-identical to the staged path on both output stages."""
+    _skip_if_unsupported()
+    topk = 2048
+    # quantized scores: every coarse histogram bucket holds thousands of
+    # candidates, so SURVCAP=64 cannot stage bucket b* -> fallback path
+    score, lengths, _ = _make_case(
+        "quant", 8, 16384, topk, seed=5, with_row_starts=False
+    )
+    ref = cute_topk_func(score, lengths, topk)
+    monkeypatch.setenv("SGLANG_DSA_TOPK_CUTEDSL_SURVCAP", "64")
+    for stage in ("scanemit", "sort"):
+        monkeypatch.setenv("SGLANG_DSA_TOPK_CUTEDSL_STAGE", stage)
+        out = cute_topk_func(score, lengths, topk)
+        assert torch.equal(out, ref)
+
+
+def test_cutedsl_topk_envelope_errors(monkeypatch):
+    """The wrapper enforces the documented envelope with actionable errors,
+    including on empty shapes, and validates its env overrides."""
+    _skip_if_unsupported()
+    score = torch.randn(2, 128, device="cuda")
+    lengths = torch.full((2,), 128, dtype=torch.int32, device="cuda")
+    with pytest.raises(ValueError):
+        cute_topk_func(score, lengths, 4097)  # topk > cap
+    with pytest.raises(ValueError):
+        cute_topk_func(score, lengths, -1)  # negative topk
+    with pytest.raises(ValueError):  # L >= 2**24 rejected even at B=0
+        cute_topk_func(
+            torch.empty(0, 1 << 24, device="cuda"),
+            torch.empty(0, dtype=torch.int32, device="cuda"),
+            2048,
+        )
+    with pytest.raises(ValueError):
+        cute_topk_func(score, lengths[:1], 128)  # undersized lengths
+    with pytest.raises(ValueError):
+        cute_topk_func(score, lengths, 128, row_starts=lengths[:1])
+    with pytest.raises(ValueError):
+        cute_topk_func(score.half(), lengths, 128)  # wrong dtype
+    monkeypatch.setenv("SGLANG_DSA_TOPK_CUTEDSL_SURVCAP", "zero")
+    with pytest.raises(ValueError):
+        cute_topk_func(score, lengths, 128)
+    monkeypatch.delenv("SGLANG_DSA_TOPK_CUTEDSL_SURVCAP")
+    monkeypatch.setenv("SGLANG_DSA_TOPK_CUTEDSL_STAGE", "bogus")
+    with pytest.raises(ValueError):
+        cute_topk_func(score, lengths, 128)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
# [kernel] Opt-in deterministic CuTe-DSL DSA top-k backend (`--dsa-topk-backend cutedsl`)

Adds an opt-in, bitwise-deterministic top-k backend for the DSA/lightning-indexer selection stage, implemented in CuTe DSL (SM90/SM100). This description is self-contained: it folds in the earlier thread discussion (tie semantics, 0.0-plateau structure, topk_v2 safety data) and the scan-emit output-stage optimization added after the initial review round.

## Problem

The DSA indexer scores are `sum_h w_h * relu(q_h . k_h)` (see `fp8_index`), so every key whose head-dots are all non-positive lands on **exactly 0.0**: real indexer rows carry a large exact-0.0 tie plateau — structural to the ReLU-sum architecture, not a fixture artifact (distribution study: [evidence comment](https://github.com/sgl-project/sglang/pull/31115#issuecomment-4966578547)). Whenever a row's k-th boundary falls inside that plateau (`nnz(row) < k`, common for mid-length rows), the boundary tie set is huge, and the default `sgl_kernel.fast_topk_v2`:

1. **Selects a different index set run to run.** Winners are emitted in smem-atomic arrival order and boundary ties resolve by arrival order: on tie-heavy inputs we measured 21–25/25 replays returning *distinct index sets* (noisy sibling stream; harness in the evidence comment). Same request, same weights — different attended tokens.
2. **Can drop strictly-positive candidates.** On the ReLU-shaped fixture (L=16384, ~1640 nonzero < k=2048) a strictly-positive candidate was replaced by a 0.0 one in 1/256 rows — the #17747 overflow-drop mode, which also bites systematically in narrow-value-range regimes (#17747, #15041 family).
3. **Short rows take a separate, score-blind fill path.** When a row has fewer candidates than `topk` the kernel emits an identity-style fill without reading scores — set-correct, but yet another slot-order regime; combined with (1), the output is not byte-reproducible in any regime.

Practical impact: identical requests are not replayable (debugging), RL rollouts against a served model are not bitwise-reproducible, and the drift enters at *token selection*, where seeding cannot recover it. (2) is a correctness defect independent of determinism.

All data is synthetic and reproducible; no proprietary captures involved.

## Solution

`--dsa-topk-backend cutedsl` — a single-kernel CuTe DSL selector (one CTA per row), opt-in with zero default behavior change:

- **Bitwise determinism, always.** Output is a pure function of the input: histogram atomics are commutative adds; staging atomics only permute buffers that feed order-independent histograms or a canonical index sort. 30/30 replays bitwise-identical under a noisy sibling stream on every input class tested (tie plateaus, quantized, narrow-range, -inf windows, degenerate rows).
- **Exact top-k with a defined tie policy**: smallest-index selection at the k-th boundary (radix select over `~idx`); no candidate is ever dropped — threshold-bin overflow falls back to full-row rescans (identical result, slower) instead of silently skipping (#17747).
- **Canonical output order: ascending index**, front-packed, -1 padded. The kernel has two shape-selected output stages — an ordered ballot+block-scan **scan-emit** pass and an **index-sort** collect — that emit the *identical* canonical output bit-for-bit (asserted directly in tests); an internal heuristic picks the faster one per shape. Ascending order is gather-friendly for the downstream page-table fetch. No sglang consumer depends on any slot order (the default backend's order is arrival-nondeterministic; we audited every consumer of the top-k tensor — all are element-wise `-1`-masked gathers, mask-based compactions, or permutation-invariant attention).
- **Performance**: the scan-emit stage (new in this revision) removes the bitonic sort from the hot path where it dominated. vs the first revision of this backend: up to **3.8x faster** on prefill-scale grids and 1.2–2x on mid-band decode shapes, and no measured band regresses beyond noise (the sort stage is retained exactly where it wins). vs the default radix kernel the picture is now honest and mixed rather than uniformly behind: **faster on realistic (0.0-plateau) prefill-scale rows at L<=4k (1.33x)**, near-parity at small-L decode and dense prefill (0.81–0.94x), while **radix stays 2–4x faster at mid/long L** — see the table.

### Performance (B200, fp32 scores, CUDA-graph replay timing, per-call µs)

`relu` = realistic indexer-shaped scores (exact-0.0 plateau, the distribution the DSA indexer actually produces); `randn` = dense distinct scores. "prev rev" = this backend before the scan-emit stage; "radix" = `sgl_kernel.fast_topk_v2` (default, nondeterministic); "fi/fi-det" = `flashinfer.top_k` with `deterministic=False/True`. k=2048 (production DSA config).

| scores | rows | L | cutedsl | prev rev | radix | fi | fi-det | radix/cutedsl |
|---|---|---|---|---|---|---|---|---|
| relu | 64 | 4096 | 12.9 | 22.7 | 11.1 | 8.8 | 23.8 | 0.86x |
| relu | 64 | 16384 | 36.3 | 43.2 | 15.8 | 18.1 | 40.1 | 0.44x |
| relu | 64 | 131072 | 137.0 | 137.1 | 54.2 | 25.9 | 57.0 | 0.40x |
| relu | 256 | 16384 | 76.5 | 93.9 | 25.4 | 39.9 | 73.7 | 0.33x |
| relu | 512 | 65536 | 199.0 | 199.8 | 87.3 | 98.5 | 143.3 | 0.44x |
| relu | 2048 | 4096 | 74.7 | 202.5 | 99.5 | 85.6 | 257.1 | **1.33x** |
| relu | 2048 | 16384 | 358.2 | 482.1 | 166.2 | 272.3 | 500.0 | 0.46x |
| relu | 8192 | 4096 | 305.0 | 805.4 | 406.8 | 339.2 | 1015.6 | **1.33x** |
| relu | 8192 | 8192 | 673.7 | 1223.3 | 483.8 | 538.7 | 1348.3 | 0.72x |
| relu | 8192 | 16384 | 1319.5 | 1829.7 | 646.2 | 1057.5 | 1979.7 | 0.49x |
| randn | 64 | 4096 | 8.4 | 17.2 | 6.8 | 6.8 | 18.7 | 0.81x |
| randn | 64 | 16384 | 27.1 | 32.4 | 13.7 | 14.6 | 25.5 | 0.51x |
| randn | 256 | 16384 | 57.2 | 82.6 | 20.5 | 20.5 | 45.5 | 0.36x |
| randn | 2048 | 4096 | 43.3 | 162.8 | 40.7 | 55.9 | 158.3 | 0.94x |
| randn | 8192 | 4096 | 190.8 | 656.2 | 163.1 | 221.1 | 617.2 | 0.85x |
| randn | 8192 | 8192 | 386.4 | 811.5 | 303.9 | 329.9 | 855.0 | 0.79x |
| randn | 2048 | 65536 | 1374.1 | 1378.9 | 330.6 | 469.9 | 540.5 | 0.24x |

Honest summary of the bands:
- Tie-plateau (realistic) prefill-scale rows at L<=4096: **cutedsl beats the default radix kernel** (1.33x) — big tie sets are exactly where arrival-order kernels also thrash.
- Small-L decode and dense prefill at L<=8192: near-parity (0.72–0.94x).
- Mid/long L (>=16k) at small/mid batch: **radix remains 2–4x faster**; flashinfer's multi-CTA-per-row split dominates everyone at L>=64k low batch. If you need bitwise determinism there, this backend still costs only low-hundreds of µs absolute.
- vs `flashinfer.top_k(deterministic=True)`: cutedsl is faster on most shapes tested (up to 3.4x at prefill scale), slower at long-L low-batch. (Note also the flashinfer deterministic mode documents reproducibility, not a smallest-index tie policy, and its unfused sglang integration adds a masking pass.)

Numbers are average per-call µs over 30 CUDA-graph replays of a 10-call graph (eager warmup excluded); full-length rows; harness reproducible from the test fixtures.

### Scope / envelope

- Opt-in only; zero default behavior change (`sgl-kernel` remains the default).
- SM90+ with `nvidia-cutlass-dsl`; fp32 scores; `topk <= 4096`, `L < 2^24`, `B*L`, `B*topk < 2^31` — enforced with actionable errors; `supports()` gates call sites.
- Like the `torch` backend, currently requires `SGLANG_DSA_FUSE_TOPK=false` (the fused paged/ragged transform paths keep their existing backends).
- CUDA-graph safe: compile and first-touch allocations refuse graph capture with a clear eager-warmup message; compile cache is device-keyed, compilation serialized.
- NaN ordering documented (deterministic bitwise total order; DSA indexer logits are NaN-free). `SGLANG_DSA_TOPK_CUTEDSL_SURVCAP` / `SGLANG_DSA_TOPK_CUTEDSL_STAGE` are validated perf-only overrides — results are bit-identical for any legal value.

## Review guide

- `python/sglang/jit_kernel/cutedsl_topk.py` — the kernel (single file; module docstring is the full algorithm spec)
- `dsa_topk_backend.py` + `server_args.py` — dispatch/choice registration only (+13 lines)
- `test/registered/jit/test_cutedsl_topk.py` — 16 registered tests: tie-robust exact-contract checks (selected score multiset bitwise vs reference, smallest-index k-th-boundary tie subset asserted directly, canonical ascending order, -1 tail packing), determinism replays covering both output stages, bit-identity between the two output stages, the SURV_CAP overflow fallback (forced, checked bit-identical), envelope/env-override error contracts, CUDA-graph capture/replay, empty/edge shapes
- Evidence for the Problem section: [score-distribution + topk_v2 tie-safety study](https://github.com/sgl-project/sglang/pull/31115#issuecomment-4966578547) (synthetic, reproducible, includes a harness you can run on live captures)

History note: the branch is squashed into 3 logical commits (kernel / dispatch / tests); the pre-review hardening from the earlier 48bce24 push (input-contract enforcement, CUDA-graph guards, seed-stable tests) is retained in full.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29393610563](https://github.com/sgl-project/sglang/actions/runs/29393610563)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29393610429](https://github.com/sgl-project/sglang/actions/runs/29393610429)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->