### PR TITLE
[BugFix][DSA] Harden top-k v1/v2 kernels against negative padded seq_lens

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v1.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v1.cuh
@@ -53,10 +53,10 @@ SGL_DEVICE void naive_transform(
     const int32_t* __restrict__ page_table,
     int32_t* __restrict__ indices,
     int32_t* __restrict__ raw_indices,  // optional: output raw abs position indices
-    const uint32_t length,
+    const int32_t length,               // signed: negative (padded row) fills everything with -1
     const uint32_t page_bits) {
   static_assert(kTopK <= kTopKBlockSize);
-  if (const auto tx = threadIdx.x; tx < length) {
+  if (const auto tx = threadIdx.x; static_cast<int32_t>(tx) < length) {
     indices[tx] = page_to_indices(page_table, tx, page_bits);
     if (raw_indices != nullptr) {
       raw_indices[tx] = tx;
@@ -236,7 +236,11 @@ __global__ void topk_transform_kernel(const __grid_constant__ TopKParams params)
   const uint32_t work_id = blockIdx.x;
 
   /// NOTE: dangerous prefetch seq_len before PDL wait
-  const uint32_t seq_len = seq_lens[work_id];
+  // Kept signed: a negative length (DP-padded / idle-companion row) must not
+  // be reinterpreted as a ~4e9-token row (illegal memory access). The signed
+  // trivial-path comparison below routes it to naive_transform, which fills
+  // the whole row with -1 (no non-negative index qualifies).
+  const int32_t seq_len = seq_lens[work_id];
   const auto score_ptr = scores + work_id * score_stride;
   const auto page_ptr = page_table + work_id * page_table_stride;
   const auto indices_ptr = page_indices + work_id * kTopK;
@@ -244,11 +248,11 @@ __global__ void topk_transform_kernel(const __grid_constant__ TopKParams params)
 
   device::PDLWaitPrimary<kUsePDL>();
 
-  if (seq_len <= kTopK) {
+  if (seq_len <= static_cast<int32_t>(kTopK)) {
     naive_transform(score_ptr, page_ptr, indices_ptr, raw_indices_ptr, seq_len, page_bits);
   } else {
     __shared__ int32_t s_topk_indices[kTopK];
-    radix_topk(score_ptr, s_topk_indices, seq_len);
+    radix_topk(score_ptr, s_topk_indices, static_cast<uint32_t>(seq_len));
     static_assert(kTopK <= kTopKBlockSize);
     const auto tx = threadIdx.x;
     if (kTopK == kTopKBlockSize || tx < kTopK) {

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v2.cuh
@@ -97,6 +97,12 @@ struct TopKLaunchParams {
     };
   }
   SGL_DEVICE TopKProblem problem(uint32_t batch_id) const {
+    // The bit pattern of a negative length (DP-padded / idle-companion row)
+    // is preserved here; the trivial-path dispatch compares it as SIGNED, so
+    // such rows fall into trivial_transform and yield the all-(-1) output
+    // instead of being reinterpreted as a ~4e9-token row (illegal memory
+    // access, or a silently corrupted output row when the unsigned chunk
+    // arithmetic happens to wrap).
     return this->problem(batch_id, static_cast<uint32_t>(seq_lens[batch_id]));
   }
 };
@@ -133,12 +139,21 @@ SGL_DEVICE void for_each_item(uint32_t topk, const F& f) {
   }
 }
 
+/// Trivial (seq_len <= topk) dispatch, compared as SIGNED so that negative
+/// (DP-padded / idle-companion) lengths also land here and fill the row with
+/// -1 -- every non-negative candidate index compares >= -1, i.e. none wins.
+SGL_DEVICE bool is_trivial(const TopKProblem& problem) {
+  return static_cast<int32_t>(problem.seq_len) <= static_cast<int32_t>(problem.topk);
+}
+
 template <bool kPDL>
 SGL_DEVICE void trivial_transform(const TopKProblem& problem) {
   device::PDLWaitPrimary<kPDL>();
   device::PDLTriggerSecondary<kPDL>();
   for_each_item(problem.topk, [&](uint32_t tx, uint32_t) {
-    problem.transform_output(tx, tx < problem.seq_len ? static_cast<int32_t>(tx) : -1);
+    // signed compare: for a negative seq_len no index qualifies -> all -1
+    const bool valid = static_cast<int32_t>(tx) < static_cast<int32_t>(problem.seq_len);
+    problem.transform_output(tx, valid ? static_cast<int32_t>(tx) : -1);
   });
 }
 
@@ -166,7 +181,7 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKLaunchParams param
   auto problem = params.problem(blockIdx.x);
   constexpr uint32_t kU32Max = std::numeric_limits<uint32_t>::max();
   __shared__ impl::MaxSmem<Register2::Smem, Register4::Smem, Streaming::Smem> smem;
-  if (problem.seq_len <= problem.topk) return trivial_transform<kPDL>(problem);
+  if (is_trivial(problem)) return trivial_transform<kPDL>(problem);
   __shared__ int32_t topk_indices[kMaxTopK];
   problem.out = topk_indices;
 
@@ -206,7 +221,7 @@ CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKLau
   device::enable_smem_spilling();
   auto problem = params.problem(blockIdx.x);
   __shared__ impl::MaxSmem<Streaming::Smem, Cluster::Smem> smem;
-  if (problem.seq_len <= problem.topk) return trivial_transform<kPDL>(problem);
+  if (is_trivial(problem)) return trivial_transform<kPDL>(problem);
   __shared__ int32_t topk_indices[kMaxTopK];
   problem.out = topk_indices;
 
@@ -232,7 +247,7 @@ CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKLau
 
 // --- Plan: choose cluster_threshold from the seq_len distribution -----------
 __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
-    const uint32_t* __restrict__ seq_lens,
+    const int32_t* __restrict__ seq_lens,
     PlanItem* __restrict__ metadata,  // [0]=GlobalMetadata, [1+i]=PlanItem
     const uint32_t batch_size,
     const uint32_t static_cluster_threshold) {
@@ -272,11 +287,13 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
     if (tx == 0) s_threshold = static_cluster_threshold;
   } else {
     for (uint32_t i = tx; i < batch_size; i += kBlockSize) {
-      const uint32_t sl = seq_lens[i];
+      // signed compare: negative (DP-padded / idle-companion) lengths never
+      // count toward any candidate threshold
+      const int32_t sl = seq_lens[i];
       uint32_t count = 0;
 #pragma unroll
       for (uint32_t j = 0; j < kNumCandidates; ++j) {
-        count += (sl > kCandidates[j].threshold ? 1 : 0);
+        count += (sl > static_cast<int32_t>(kCandidates[j].threshold) ? 1 : 0);
       }
       if (count > 0) atomicAdd(&s_counts[count - 1], 1);
     }
@@ -300,10 +317,14 @@ __global__ __launch_bounds__(kBlockSize, 1) void topk_plan(
   // Compact items with seq_len > threshold into metadata[1..N]: their batch ids
   // are the work list the persistent cluster pool fetches.
   for (uint32_t i = tx; i < batch_size; i += kBlockSize) {
-    const uint32_t sl = seq_lens[i];
-    if (sl > cluster_threshold) {
+    // signed guard first: negative (padded) rows are never routed to the pool
+    // as ~4e9-token items. The threshold compare itself stays unsigned so a
+    // full-uint32 static_cluster_threshold (> INT32_MAX) keeps its meaning --
+    // for a proven-positive sl this pair is exactly the old unsigned compare.
+    const int32_t sl = seq_lens[i];
+    if (sl > 0 && static_cast<uint32_t>(sl) > cluster_threshold) {
       const auto pos = atomicAdd(&s_count, 1);
-      metadata[1 + pos] = {i, sl};
+      metadata[1 + pos] = {i, static_cast<uint32_t>(sl)};
     }
   }
   __syncthreads();
@@ -338,7 +359,7 @@ struct TopKKernel {
     const auto device = device_.unwrap();
     LaunchKernel(1, kBlockSize, device)(  //
         topk_plan,
-        static_cast<const uint32_t*>(seq_lens.data_ptr()),
+        static_cast<const int32_t*>(seq_lens.data_ptr()),
         static_cast<PlanItem*>(metadata.data_ptr()),
         batch_size,
         static_cluster_threshold);

--- a/python/sglang/jit_kernel/dsv4/topk.py
+++ b/python/sglang/jit_kernel/dsv4/topk.py
@@ -69,12 +69,15 @@ _PLAN_METADATA_INTS_PER_BATCH = 2
 def plan_topk_v2(seq_lens: torch.Tensor, static_threshold: int = 0) -> torch.Tensor:
     """Preprocess the per-batch routing plan for :func:`topk_transform_512_v2`.
 
-    IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE. The device
-    kernel reads the int32 buffer as ``uint32_t``, so a negative length (e.g.
-    -4 from a DP-padded / idle-companion row) reinterprets as ~4e9, poisons
-    the plan, and drives the transform kernel into an illegal memory access.
-    Producers of padded rows must clamp their lengths to 0 (0 selects the
-    trivial all-(-1) output path, which is safe).
+    Entries of ``seq_lens`` should be non-negative; a length of 0 expresses
+    "no tokens" (the row takes the trivial path and the output is all -1).
+    Negative lengths (e.g. -4 from a DP-padded / idle-companion row) are
+    compared as signed on device and are never counted toward a candidate
+    threshold nor routed to the persistent cluster pool -- historically they
+    were read as ``uint32_t`` (~4e9), poisoned the plan, and drove the
+    transform kernel into an illegal memory access. Producers of padded rows
+    should still clamp to 0 themselves so every consumer sees consistent
+    lengths.
     """
     module = _jit_topk_v2_module()
     bs = seq_lens.shape[0]
@@ -94,14 +97,17 @@ def topk_transform_512_v2(
 ) -> None:
     """Fused top-k + page-table transform (DeepSeek-V4 top-k v2 kernel).
 
-    IMPORTANT: every entry of ``seq_lens`` must be NON-NEGATIVE, and
     ``metadata`` must come from :func:`plan_topk_v2` over the same ``seq_lens``
-    values. The kernel reads lengths as ``uint32_t``: a negative entry
-    reinterprets as a ~4e9-token sequence, sending the row down the cluster
-    path over garbage scores and crashing with an illegal memory access
-    (GLM 5.2 MTP DP-idle companion rows hit exactly this). A length of 0 is
-    the valid way to express "no tokens": the row takes the trivial path and
-    the output is all -1.
+    values. Entries of ``seq_lens`` should be non-negative; 0 is the valid way
+    to express "no tokens" (the row takes the trivial path and the output is
+    all -1). Negative lengths (DP-padded / idle-companion rows, e.g. GLM 5.2
+    MTP hit exactly this) are handled via signed comparisons on device: such
+    rows take the same trivial path and come back all -1 -- historically they
+    were read as ``uint32_t``, sending the row down the cluster/streaming
+    path over garbage scores and crashing with an illegal memory access (or,
+    when the unsigned chunk arithmetic happened to wrap, silently emitting a
+    garbage top-k row). Producers should still clamp to 0 themselves so every
+    consumer sees consistent lengths.
     """
     module = _jit_topk_v2_module()
     module.topk_transform(

--- a/test/registered/jit/deepseek_v4/test_topk_v2.py
+++ b/test/registered/jit/deepseek_v4/test_topk_v2.py
@@ -29,7 +29,11 @@ import sys
 import pytest
 import torch
 
-from sglang.jit_kernel.dsv4.topk import plan_topk_v2, topk_transform_512_v2
+from sglang.jit_kernel.dsv4.topk import (
+    plan_topk_v2,
+    topk_transform_512,
+    topk_transform_512_v2,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -293,6 +297,124 @@ def test_topk_v2_output_indices(batch: int, seq: int, k: int) -> None:
     our_raw = _run_raw(scores, seq_lens, page_table, k)
     ref_raw = _reference(scores, seq_lens, k)
     _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, seq_lens.cpu(), k)
+
+
+# Negative lengths model DP-padded / idle-companion rows (e.g. -4 from GLM 5.2
+# MTP draft-extend metadata, see #30378; DP-attention idle rows are the same
+# class -- issue #25574). The kernels must treat them as empty (trivial
+# all-(-1) output, via signed length comparisons) instead of reinterpreting
+# them as ~4e9-token rows -- which was an illegal memory access, or a silently
+# garbage output row when the unsigned chunk arithmetic happened to wrap. One
+# config per dispatch shape so every device-side seq_len read (main kernel,
+# fused small-batch cluster kernel, and the plan kernel's pool routing) is
+# exercised.
+NEGATIVE_LENGTH_CONFIGS = [
+    [4096, 4096, -4, 400],  # level 0 (Register2)
+    [9000, 9000, 9000, -4],  # level 1 (Register4)
+    [40000] * 16 + [-1048576, 400],  # level 2 (Streaming; batch > 15 => floor 65536)
+    [131072, 9000, 9000, -1],  # fused small-batch cluster
+    [131072, 9000, 9000, -4],  # fused small-batch cluster
+    [131072, 9000, 9000, -1048576],  # fused small-batch cluster
+    [131072] * 20 + [400] * 10 + [-4],  # persistent pool + main<3>
+    [131072] * 20 + [400] * 10 + [-1048576],  # persistent pool + main<3>
+]
+
+
+@pytest.mark.parametrize("k", [512, 2048])
+@pytest.mark.parametrize("lens", NEGATIVE_LENGTH_CONFIGS)
+@torch.inference_mode()
+def test_topk_v2_negative_lengths(lens: list, k: int) -> None:
+    """Negative rows -> all-(-1) out AND raw; non-negative rows unaffected."""
+    torch.manual_seed(abs(sum(lens)) + k)
+    device = "cuda"
+    batch = len(lens)
+    width = (max(lens) + 3) & ~3
+    scores = torch.randn(batch, width, dtype=torch.float32, device=device)
+    seq_lens = torch.tensor(lens, dtype=torch.int32, device=device)
+    num_pages = (width + PAGE_SIZE - 1) // PAGE_SIZE
+    page_table, inv_cpu = _make_page_table(batch, num_pages, "perm", device)
+    out = torch.full((batch, k), 7, dtype=torch.int32, device=device)  # poison
+    raw = torch.full((batch, k), 7, dtype=torch.int32, device=device)  # poison
+
+    metadata = plan_topk_v2(seq_lens)
+    topk_transform_512_v2(scores, seq_lens, page_table, out, PAGE_SIZE, metadata, raw)
+    torch.cuda.synchronize()
+
+    # Every row is fully written by the kernel (trivial rows pad with -1), so
+    # the poison also proves the negative rows were actually processed.
+    for i, L in enumerate(lens):
+        if L < 0:
+            assert (out[i] == -1).all(), f"row {i} (len={L}): out not all -1"
+            assert (raw[i] == -1).all(), f"row {i} (len={L}): raw not all -1"
+
+    # Non-negative rows must still match torch.topk (negative rows reference
+    # as length 0, which _assert_topk_close checks as "no valid entries").
+    clamped = torch.tensor([max(L, 0) for L in lens], dtype=torch.int32)
+    out_cpu = out.cpu().tolist()
+    our_raw = [_invert(out_cpu[i], inv_cpu[i]) for i in range(batch)]
+    ref_raw = _reference(scores, clamped, k)
+    _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, clamped, k)
+
+
+@torch.inference_mode()
+def test_topk_v2_plan_negative_lengths() -> None:
+    """A negative row must not be counted by the plan's threshold heuristic.
+
+    30 rows just above the 65536 candidate sit exactly at its cap (30). If the
+    plan's counting loop read the negative row unsigned (~4e9 > every
+    candidate), the count would become 31 > 30 and cluster_threshold would be
+    lifted to the next candidate (98304); it must stay at the floor, and the
+    negative row must not be routed to the persistent pool.
+    """
+    device = "cuda"
+    lens = [98000] * 30 + [-4]
+    seq_lens = torch.tensor(lens, dtype=torch.int32, device=device)
+    metadata = plan_topk_v2(seq_lens)
+    torch.cuda.synchronize()
+    threshold, num_items = metadata[0].tolist()
+    assert threshold == FLOOR, f"cluster_threshold {threshold} != {FLOOR}"
+    assert num_items == 30, f"num_cluster_items {num_items} != 30"
+
+    # A full-uint32 static threshold (> INT32_MAX) must not resurrect the
+    # unsigned routing: the compaction loop proves rows positive (signed)
+    # before the unsigned threshold compare, so nothing is routed here --
+    # neither the negative row nor the 98000-token rows.
+    metadata = plan_topk_v2(seq_lens, static_threshold=2**31)
+    torch.cuda.synchronize()
+    threshold_u32 = metadata[0, 0].item() & 0xFFFFFFFF
+    assert threshold_u32 == 2**31, f"static threshold not honored: {threshold_u32}"
+    assert metadata[0, 1].item() == 0, "rows routed past a 2^31 threshold"
+
+
+@torch.inference_mode()
+def test_topk_v1_negative_lengths() -> None:
+    """The v1 kernel dispatches on the same per-row lengths; negative
+    (padded) rows must take the same trivial all-(-1) path as in v2."""
+    k = 512
+    torch.manual_seed(20260714)
+    device = "cuda"
+    lens = [9000, 9000, -4, -1048576]
+    batch = len(lens)
+    width = (max(lens) + 3) & ~3
+    scores = torch.randn(batch, width, dtype=torch.float32, device=device)
+    seq_lens = torch.tensor(lens, dtype=torch.int32, device=device)
+    num_pages = (width + PAGE_SIZE - 1) // PAGE_SIZE
+    page_table, inv_cpu = _make_page_table(batch, num_pages, "perm", device)
+    out = torch.full((batch, k), 7, dtype=torch.int32, device=device)  # poison
+
+    topk_transform_512(scores, seq_lens, page_table, out, PAGE_SIZE)
+    torch.cuda.synchronize()
+
+    # naive_transform fills every slot >= length with -1, so the poison also
+    # proves the negative rows were actually processed (not skipped).
+    for i, L in enumerate(lens):
+        if L < 0:
+            assert (out[i] == -1).all(), f"row {i} (len={L}): out not all -1"
+    clamped = torch.tensor([max(L, 0) for L in lens], dtype=torch.int32)
+    out_cpu = out.cpu().tolist()
+    our_raw = [_invert(out_cpu[i], inv_cpu[i]) for i in range(batch)]
+    ref_raw = _reference(scores, clamped, k)
+    _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, clamped, k)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Related to #25574 (`topk_transform_512_v2` illegal memory access on SM100 under DP-attention). We set out to reproduce and fix that issue on B200 (SM100) and found the following:

1. **The code quoted in #25574 no longer exists.** #26788 rewrote `topk_v2.cuh`; the old `topk_fused_transform` SMALL/TRIVIAL early-return branches are gone, and the rewritten fused small-batch kernel already has cluster-uniform fall-through control flow. Note the branch condition is per-`blockIdx.x` and all 8 blocks of a cluster share `blockIdx.x`, so even in the old kernel every block of a cluster took the same branch — there was never a *divergent* cluster barrier (`compute-sanitizer --tool synccheck` on the pre-#26788 kernel reports 0 errors, and 24k+ stress iterations over mixed TRIVIAL/SMALL/LARGE batches, eager + CUDA-graph replay, never faulted on B200). The B300-specific crash could not be reproduced at kernel level on B200, and its proposed patch (#25575) targets the deleted code.

2. **What does reproduce — deterministically, at current `main` — is the negative-`seq_lens` crash class.** Negative per-row lengths (DP-padded / idle-companion rows; #30378 observed `-4` from GLM 5.2 MTP draft-extend metadata, and DP-attention idle rows are the same class) are read through unsigned conversions in **both** top-k kernels and become ~4e9-token rows:
   - v1 (`topk_v1.cuh`): illegal memory access for **any** negative length (notably, the `SGLANG_OPT_USE_TOPK_V2=0` fallback is equally exposed);
   - v2 (`topk_v2.cuh`): illegal memory access (e.g. `-1048576`, on every dispatch shape: fused small-batch cluster, persistent pool, streaming) or — worse — a **silently garbage top-k row** (`-1`/`-4`, where the unsigned chunk arithmetic happens to wrap to a zero-length chunk and `handle_tie` pads the row with bogus indices).

   #30378 clamped two DSA triton *producers* caller-side, but the kernels stay exposed to every other caller — e.g. the DSv4 DP-attention path (`dsv4/metadata.py` feeds `c4_seq_lens` to `plan_topk_v2` unclamped).

## Modifications

Per review feedback, negative lengths are handled with **signed comparisons** (no arithmetic clamp) so a negative row takes the documented trivial all-`(-1)` "no tokens" path -- every non-negative candidate index compares `>= -1`, so none qualifies:

- `topk_v1.cuh`: `seq_len` stays `int32_t`; the signed trivial dispatch (`seq_len <= (int32_t)kTopK`) routes negative rows into `naive_transform`, whose fill comparison is signed; the radix path casts to `uint32_t` only after the `> kTopK` guard proves the value positive;
- `topk_v2.cuh`: a signed `is_trivial()` (`(int32_t)seq_len <= (int32_t)topk`) used by the main and fused small-batch kernels; `trivial_transform`'s per-element comparison is signed;
- `topk_v2.cuh` `topk_plan` (parameter type fixed to `const int32_t*` to match the tensor dtype): the threshold-count loop compares signed against the candidate thresholds (all int32-exact); the pool-compaction predicate proves a row positive (signed) before the unsigned threshold compare, so negative rows are never routed to the persistent pool as ~4e9-token items while a full-uint32 `static_cluster_threshold` keeps its meaning.

Python docstrings updated (producers should still clamp to 0 themselves; the kernel no longer turns a producer bug into an illegal address or silent corruption). Cost is unchanged -- paired timing below.

New tests: `test_topk_v2_negative_lengths` (8 configs x k in {512, 2048}, one config per dispatch shape: level 0/1/2, fused small-batch cluster with `-1`/`-4`/`-1048576`, persistent pool), `test_topk_v2_plan_negative_lengths` (pins the plan kernel's counting loop via a candidate-cap-boundary distribution and the plan metadata, plus a full-uint32 static-threshold boundary check), and `test_topk_v1_negative_lengths`. Output buffers are poison-prefilled; each test asserts negative rows come back all-`(-1)` (both `out` and `raw`) and non-negative rows in the same batch still match `torch.topk`.

## Accuracy Tests

On B200 (CUDA 13.3), before this patch (current `main`):

- `[40000]*16 + [-1048576, 400]` (streaming), `[131072, 9000, 9000, -1048576]` (fused cluster), `[131072]*20 + [400]*10 + [-1048576]` (persistent pool): `CUDA error: an illegal memory access was encountered` — deterministic;
- `[131072, 9000, 9000, -4]` / `[..., -1]`: padded row returns 512 garbage indices (silent corruption);
- v1 with `[9000, 9000, 9000, -4]`: illegal memory access;
- on the pre-#26788 kernel (the code #25574 was filed against), `[131072, 9000, 9000, -4]` reproduces the exact reported failure signature (illegal address surfacing at the fused-kernel launch).

After this patch:

- all of the above complete, negative rows = all `(-1)`;
- full registered suite `test/registered/jit/deepseek_v4/test_topk_v2.py`: **262 passed** (244 pre-existing + 18 new);
- stress: 14 scenarios (branch mixes, batch-15 boundary, zero rows, negative rows) x eager + CUDA-graph replay: pass;
- `compute-sanitizer` memcheck + synccheck on negative-row and mixed-branch cluster scenarios: 0 errors.

## Speed Tests and Profiling

Paired A/B timing (median of 5x50 launches, 4 interleaved rounds, B200), `main` vs this PR, us/launch:

| shape (batch x seq) | dispatch | main | this PR |
|---|---|---:|---:|
| 128 x 8192 | level 0 (Register2) | 5.41-5.72 | 5.24-5.45 |
| 64 x 16384 | level 1 (Register4) | 6.19-6.37 | 6.20-6.24 |
| 100 x 65536 | level 2 (Streaming) | 13.85-14.16 | 13.84-13.86 |
| 8 x 131072 | fused small-batch cluster | 10.82-10.96 | 10.80-10.83 |
| 64 x 131072 | persistent pool + main | 23.95-24.06 | 24.07-24.10 |
| 4 x 9000 | decode-like level 1 | 5.07-5.09 | 5.04-5.09 |

All deltas within run-to-run noise on a shared machine.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29328239541](https://github.com/sgl-project/sglang/actions/runs/29328239541)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29328239210](https://github.com/sgl-project/sglang/actions/runs/29328239210)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->