### PR TITLE
[docs] Note the default dsa-topk-backend on all DSA-model cookbook pages

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-Math-V2.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-Math-V2.mdx
@@ -39,7 +39,7 @@ This section provides deployment configurations optimized for different hardware
 <DeepSeekMathV2Deployment />
 
 <Warning>
-  DeepSeek-Math-V2 is built on DeepSeek-V3.2 and uses DSA sparse attention. All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on this model, so we recommend keeping the default.
+  DeepSeek-Math-V2 is built on DeepSeek-V3.2 and uses DSA sparse attention. All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on this model.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-Math-V2.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-Math-V2.mdx
@@ -38,6 +38,10 @@ This section provides deployment configurations optimized for different hardware
 
 <DeepSeekMathV2Deployment />
 
+<Warning>
+  DeepSeek-Math-V2 is built on DeepSeek-V3.2 and uses DSA sparse attention. All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our accuracy and benchmark runs cover, so we recommend keeping the default.
+</Warning>
+
 ### 3.2 Configuration Tips
 
 **Hardware Requirements:**

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-Math-V2.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-Math-V2.mdx
@@ -39,7 +39,7 @@ This section provides deployment configurations optimized for different hardware
 <DeepSeekMathV2Deployment />
 
 <Warning>
-  DeepSeek-Math-V2 is built on DeepSeek-V3.2 and uses DSA sparse attention. All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our accuracy and benchmark runs cover, so we recommend keeping the default.
+  DeepSeek-Math-V2 is built on DeepSeek-V3.2 and uses DSA sparse attention. All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on this model, so we recommend keeping the default.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
@@ -58,7 +58,7 @@ import { DeepSeekV32Deployment } from "/src/snippets/autoregressive/deepseek-v32
 <DeepSeekV32Deployment />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our DeepSeek-V3.2 accuracy and benchmark runs cover, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on DeepSeek-V3.2, so we recommend keeping the default.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
@@ -58,7 +58,7 @@ import { DeepSeekV32Deployment } from "/src/snippets/autoregressive/deepseek-v32
 <DeepSeekV32Deployment />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on DeepSeek-V3.2, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on DeepSeek-V3.2.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
@@ -57,6 +57,10 @@ import { DeepSeekV32Deployment } from "/src/snippets/autoregressive/deepseek-v32
 
 <DeepSeekV32Deployment />
 
+<Warning>
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our DeepSeek-V3.2 accuracy and benchmark runs cover, so we recommend keeping the default.
+</Warning>
+
 ### 3.2 Configuration Tips
 
 - **Short-sequence MHA prefill (adaptive):** For prefill sequences shorter than 2048 tokens (default threshold), the DSA backend automatically switches to standard MHA (using FlashAttention variable-length on SM90, TRT-LLM ragged MHA on SM100). To extend this to longer sequences set env var `SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD` to a larger value (potential minor accuracy trade-off).

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
@@ -31,7 +31,7 @@ import { GLM51Deployment } from '/src/snippets/autoregressive/glm-51-deployment.
 <GLM51Deployment />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our GLM-5.1 accuracy and benchmark runs cover, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5.1, so we recommend keeping the default.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
@@ -31,7 +31,7 @@ import { GLM51Deployment } from '/src/snippets/autoregressive/glm-51-deployment.
 <GLM51Deployment />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5.1, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5.1.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.1.mdx
@@ -30,6 +30,10 @@ import { GLM51Deployment } from '/src/snippets/autoregressive/glm-51-deployment.
 
 <GLM51Deployment />
 
+<Warning>
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our GLM-5.1 accuracy and benchmark runs cover, so we recommend keeping the default.
+</Warning>
+
 ### 3.2 Configuration Tips
 
 - Speculative decoding (MTP) can significantly reduce latency for interactive use cases.

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
@@ -52,6 +52,10 @@ import { benchmarks } from "/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
 
 <Deployment config={config} benchmarks={benchmarks} />
 
+<Warning>
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. The other backend choices (`flashinfer`, `torch`) are not fully verified for GLM-5.2 — keep the default unless you have validated the alternative yourself.
+</Warning>
+
 <Note>
   Speed numbers are measured with `--random-range-ratio 1.0`, `--flush-cache`, on `main @ 09ca4fc`. Spec cells pin the EAGLE acceptance length via the serve env `SGLANG_SIMULATE_ACC_LEN` (low-latency 5-1-6 = 3.5, balanced 2-1-3 = 2); high-throughput has no spec.
 </Note>

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
@@ -53,7 +53,7 @@ import { benchmarks } from "/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
 <Deployment config={config} benchmarks={benchmarks} />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our GLM-5.2 accuracy and benchmark runs cover, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5.2, so we recommend keeping the default.
 </Warning>
 
 <Note>

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
@@ -53,7 +53,7 @@ import { benchmarks } from "/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
 <Deployment config={config} benchmarks={benchmarks} />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. The other backend choices (`flashinfer`, `torch`) are not fully verified for GLM-5.2 — keep the default unless you have validated the alternative yourself.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`, which is what our GLM-5.2 accuracy and benchmark runs cover. The other choices (`flashinfer`, `torch`) haven't been validated as extensively on GLM-5.2 yet, so we recommend starting with the default.
 </Warning>
 
 <Note>

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
@@ -53,7 +53,7 @@ import { benchmarks } from "/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
 <Deployment config={config} benchmarks={benchmarks} />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`, which is what our GLM-5.2 accuracy and benchmark runs cover. The other choices (`flashinfer`, `torch`) haven't been validated as extensively on GLM-5.2 yet, so we recommend starting with the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our GLM-5.2 accuracy and benchmark runs cover, so we recommend keeping the default.
 </Warning>
 
 <Note>

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.2.mdx
@@ -53,7 +53,7 @@ import { benchmarks } from "/src/snippets/configs/zai-org/glm-5.2-benchmarks.jsx
 <Deployment config={config} benchmarks={benchmarks} />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5.2, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5.2.
 </Warning>
 
 <Note>

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
@@ -41,6 +41,10 @@ import { GLM5Deployment } from '/src/snippets/autoregressive/glm-5-deployment.js
 
 <GLM5Deployment />
 
+<Warning>
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our GLM-5 accuracy and benchmark runs cover, so we recommend keeping the default.
+</Warning>
+
 ### 3.2 Configuration Tips
 
 - Speculative decoding (MTP) can significantly reduce latency for interactive use cases.

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
@@ -42,7 +42,7 @@ import { GLM5Deployment } from '/src/snippets/autoregressive/glm-5-deployment.js
 <GLM5Deployment />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our GLM-5 accuracy and benchmark runs cover, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5, so we recommend keeping the default.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
@@ -42,7 +42,7 @@ import { GLM5Deployment } from '/src/snippets/autoregressive/glm-5-deployment.js
 <GLM5Deployment />
 
 <Warning>
-  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5, so we recommend keeping the default.
+  All recipes here run the DSA indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on GLM-5.
 </Warning>
 
 ### 3.2 Configuration Tips

--- a/docs_new/cookbook/autoregressive/Meituan/LongCat-2.0.mdx
+++ b/docs_new/cookbook/autoregressive/Meituan/LongCat-2.0.mdx
@@ -59,6 +59,10 @@ import { benchmarks } from "/src/snippets/configs/meituan-longcat/longcat-2.0-be
 
 <Deployment config={config} benchmarks={benchmarks} />
 
+<Warning>
+  All recipes here run the LongCat sparse-attention indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our LongCat-2.0 accuracy and benchmark runs cover, so we recommend keeping the default.
+</Warning>
+
 <Note>
   The B300 single-node recipe was validated end-to-end with CUDA graph capture enabled. H200, B200, and H20 are shown as 2-node recipes because LongCat-2.0-FP8 needs 16 ranks for those GPU memory profiles.
 </Note>

--- a/docs_new/cookbook/autoregressive/Meituan/LongCat-2.0.mdx
+++ b/docs_new/cookbook/autoregressive/Meituan/LongCat-2.0.mdx
@@ -60,7 +60,7 @@ import { benchmarks } from "/src/snippets/configs/meituan-longcat/longcat-2.0-be
 <Deployment config={config} benchmarks={benchmarks} />
 
 <Warning>
-  All recipes here run the LongCat sparse-attention indexer top-k on the default `--dsa-topk-backend sgl-kernel` — that is the configuration our LongCat-2.0 accuracy and benchmark runs cover, so we recommend keeping the default.
+  All recipes here run the LongCat sparse-attention indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on LongCat-2.0, so we recommend keeping the default.
 </Warning>
 
 <Note>

--- a/docs_new/cookbook/autoregressive/Meituan/LongCat-2.0.mdx
+++ b/docs_new/cookbook/autoregressive/Meituan/LongCat-2.0.mdx
@@ -60,7 +60,7 @@ import { benchmarks } from "/src/snippets/configs/meituan-longcat/longcat-2.0-be
 <Deployment config={config} benchmarks={benchmarks} />
 
 <Warning>
-  All recipes here run the LongCat sparse-attention indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on LongCat-2.0, so we recommend keeping the default.
+  All recipes here run the LongCat sparse-attention indexer top-k on the default `--dsa-topk-backend sgl-kernel`. Other top-k backend choices have not been fully validated on LongCat-2.0.
 </Warning>
 
 <Note>


### PR DESCRIPTION
## Motivation

The cookbook deployment panels for DSA models generate launch commands that are all validated with the default DSA indexer top-k backend (`--dsa-topk-backend sgl-kernel`), while the other top-k backend choices have not been fully validated on these models — but nothing on those pages says so.

## Modifications

Add a `<Warning>` right below the deployment panel of every cookbook model that runs the DSA indexer top-k path (attention backend `dsa`, `--dsa-topk-backend`, default `sgl-kernel`), stating that all recipes run on the default and that other top-k backend choices have not been fully validated on the model:

- `GLM/GLM-5.2.mdx`, `GLM/GLM-5.1.mdx`, `GLM/GLM-5.mdx` (`GlmMoeDsaForCausalLM`)
- `DeepSeek/DeepSeek-V3_2.mdx`, `DeepSeek/DeepSeek-Math-V2.mdx` (`DeepseekV32ForCausalLM`; Math-V2 is V3.2-based, `index_topk=2048`)
- `Meituan/LongCat-2.0.mdx` (LongCat sparse attention runs through the same `dsa` backend, `index_topk=2048`)

Backend name and default verified against `python/sglang/srt/server_args.py` (`dsa_topk_backend`, default `sgl-kernel`) and `python/sglang/srt/layers/attention/dsa_backend.py`; model architectures verified against the HF configs. `mint validate` passes.

## Checklist

- [x] Format your code with `pre-commit run --all-files`
- [ ] Add unit tests (docs-only change)
- [x] Update documentation as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29312260546](https://github.com/sgl-project/sglang/actions/runs/29312260546)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29312260229](https://github.com/sgl-project/sglang/actions/runs/29312260229)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

