### PR TITLE
[Intel GPU] Fix topk_softmax wrapper to match XPU sgl-kernel signature 

### DIFF
--- a/python/sglang/kernels/ops/moe/__init__.py
+++ b/python/sglang/kernels/ops/moe/__init__.py
@@ -103,13 +103,19 @@ def topk_softmax(
     correction_bias: Optional[torch.Tensor] = None,
 ) -> None:
     """Compute top-k softmax routing weights/ids for MoE."""
+    # The XPU sgl-kernel build (sgl-kernel-xpu) exposes
+    # topk_softmax(topk_weights, topk_ids, gating_output, renormalize=False) and
+    # does not accept moe_softcapping / correction_bias. Forward only the args the
+    # kernel supports; guard so a caller that actually needs the extras fails loudly
+    # instead of having them silently dropped.
+    assert (
+        moe_softcapping == 0.0 and correction_bias is None
+    ), "moe_softcapping / correction_bias are not supported by the XPU topk_softmax kernel"
     return get_kernel("moe.topk_softmax", KernelBackend.CUDA_AOT)(
         topk_weights,
         topk_ids,
         gating_output,
         renormalize,
-        moe_softcapping,
-        correction_bias,
     )
 
 


### PR DESCRIPTION
## Motivation
<!-- Describe the purpose and goals of this pull request. -->

The `topk_softmax` wrapper in `sglang/kernels/ops/moe/__init__.py` calls the AOT MoE kernel with **6 arguments** (`topk_weights, topk_ids, gating_output, renormalize, moe_softcapping, correction_bias`). This matches the CUDA `sgl-kernel` signature, but the Intel XPU build (`sgl-kernel-xpu`) exposes only **4 arguments**: `topk_softmax(topk_weights, topk_ids, gating_output, renormalize)` — it has no `moe_softcapping` / `correction_bias` parameters.

As a result, ungrouped-softmax MoE routing that dispatches through this wrapper fails on XPU with an arity mismatch when calling the kernel. This blocks the fused `topk_softmax` path for Mixtral / Qwen-MoE-style models (`use_grouped_topk=False`) on Intel GPUs.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
`python/sglang/kernels/ops/moe/__init__.py` — `topk_softmax()`:

- Forward only the four arguments the XPU kernel accepts (`topk_weights`, `topk_ids`, `gating_output`, `renormalize`); drop `moe_softcapping` and `correction_bias` from the kernel call.
- Add an assertion so a caller that actually needs the extras (`moe_softcapping != 0.0` or `correction_bias is not None`) **fails loudly** instead of having those arguments silently dropped, preserving CUDA-path semantics for anyone relying on them.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29312946627](https://github.com/sgl-project/sglang/actions/runs/29312946627)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29312946568](https://github.com/sgl-project/sglang/actions/runs/29312946568)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->