### PR TITLE
Fix custom all-reduce deadlock when one communicator is issued from two CUDA streams

### DIFF
--- a/python/sglang/jit_kernel/csrc/distributed/custom_all_reduce_pull.cuh
+++ b/python/sglang/jit_kernel/csrc/distributed/custom_all_reduce_pull.cuh
@@ -24,11 +24,13 @@ namespace {
 using device::distributed::PullController;
 using host::distributed::AllReduceData;
 using host::distributed::CustomAllReduceBase, host::distributed::CustomAllReduceRef;
+using host::distributed::get_spin_timeout_ns;
 
 struct AllReduceParams {
   void* __restrict__ output;
   uint32_t rank;
   uint32_t num_items;  // NOTE: support at most 4G, but that's too much
+  uint64_t spin_timeout_ns;
 };
 
 [[maybe_unused]]
@@ -45,7 +47,7 @@ SGL_DEVICE void all_reduce_impl(const AllReduceParams& params, DType* (&input)[k
   constexpr uint32_t kVecSize = 16 / (sizeof(DType) * 2);
   using DType2 = packed_t<DType>;
   using Storage = AlignedVector<DType2, kVecSize>;
-  const auto& [output, rank, num_items] = params;
+  const auto& [output, rank, num_items, spin_timeout_ns] = params;
 
   for (auto i = blockIdx.x;; i += gridDim.x) {
     const auto offset = i * blockDim.x + threadIdx.x;
@@ -81,11 +83,11 @@ CUSTOM_AR_KERNEL void all_reduce_one_shot_kernel(
     input[i] = static_cast<DType*>(data->input[i]);
   device::PDLWaitPrimary<kUsePDL>();
 
-  ctrl.sync</*kFence=*/0, /*kStart=*/1>(params.rank, kNumGPU);
+  ctrl.sync</*kFence=*/0, /*kStart=*/1>(params.rank, kNumGPU, params.spin_timeout_ns);
   all_reduce_impl</*kBroadcast=*/false>(params, input);
 
   device::PDLTriggerSecondary<kUsePDL>();
-  ctrl.sync</*kFence=*/0, /*kStart=*/0>(params.rank, kNumGPU);
+  ctrl.sync</*kFence=*/0, /*kStart=*/0>(params.rank, kNumGPU, params.spin_timeout_ns);
 }
 
 template <typename DType, uint32_t kNumGPU, bool kUsePDL>
@@ -114,6 +116,7 @@ CUSTOM_AR_KERNEL void all_reduce_two_shot_kernel(
       .output = nullptr,  // this is not used for 2-shot all reduce
       .rank = params.rank,
       .num_items = local_length,
+      .spin_timeout_ns = params.spin_timeout_ns,
   };
 
 #pragma unroll
@@ -122,11 +125,11 @@ CUSTOM_AR_KERNEL void all_reduce_two_shot_kernel(
 
   device::PDLWaitPrimary<kUsePDL>();
 
-  ctrl.sync</*kFence=*/0, /*kStart=*/1>(params.rank, kNumGPU);
+  ctrl.sync</*kFence=*/0, /*kStart=*/1>(params.rank, kNumGPU, params.spin_timeout_ns);
   all_reduce_impl</*kBroadcast=*/true>(local_params, input);
 
   device::PDLTriggerSecondary<kUsePDL>();
-  ctrl.sync</*kFence=*/1, /*kStart=*/0>(params.rank, kNumGPU);
+  ctrl.sync</*kFence=*/1, /*kStart=*/0>(params.rank, kNumGPU, params.spin_timeout_ns);
 }
 
 template <typename DType, uint32_t kNumGPU, bool kUsePDL>
@@ -154,6 +157,7 @@ struct CustomAllReducePull : public CustomAllReduceBase {
         .output = use_2shot ? nullptr : output.data_ptr(),
         .rank = m_rank,
         .num_items = num_items,
+        .spin_timeout_ns = get_spin_timeout_ns(),
     };
 
     RuntimeCheck(input.IsContiguous(), "Input tensor must be contiguous");

--- a/python/sglang/jit_kernel/csrc/distributed/custom_all_reduce_push.cuh
+++ b/python/sglang/jit_kernel/csrc/distributed/custom_all_reduce_push.cuh
@@ -19,6 +19,7 @@ namespace {
 
 using device::distributed::PushController;
 using host::distributed::CustomAllReduceBase, host::distributed::CustomAllReduceRef;
+using host::distributed::get_spin_timeout_ns;
 
 struct AllReducePushData {
   void* __restrict__ buffer[device::distributed::kMaxNumGPU];
@@ -28,6 +29,7 @@ struct AllReducePushData {
   uint32_t num_items;
   uint32_t buffer_bytes;
   uint32_t epoch_bytes;
+  uint64_t spin_timeout_ns;
 };
 
 #define CUSTOM_AR_KERNEL __global__ __launch_bounds__(1024, 1)
@@ -128,10 +130,14 @@ SGL_DEVICE void push_impl(DType* (&push_buf)[kNumGPU], const void* data, uint32_
 }
 
 template <typename DType, uint32_t kNumGPU>
-SGL_DEVICE void poll_impl(DType* (&poll_buf)[kNumGPU], void* data, uint32_t num_items) {
+SGL_DEVICE void poll_impl(DType* (&poll_buf)[kNumGPU], void* data, uint32_t num_items, uint64_t spin_timeout_ns) {
   using namespace device;
   constexpr uint32_t kVecSize = 16 / (sizeof(DType) * 2);
   using Storage = AlignedVector<packed_t<DType>, kVecSize>;
+
+  // Bounds the wait below: a peer that never arrives is a bug, not a slow peer.
+  // See `device::distributed::SpinDeadline`.
+  distributed::SpinDeadline deadline(spin_timeout_ns);
 
   for (auto i = blockIdx.x;; i += gridDim.x) {
     const auto offset = i * blockDim.x + threadIdx.x;
@@ -150,6 +156,7 @@ SGL_DEVICE void poll_impl(DType* (&poll_buf)[kNumGPU], void* data, uint32_t num_
         }
       }
       if (!has_pos_zero) break;
+      deadline.tick();
     }
 
     const Storage result = distributed::reduce_impl(storage);
@@ -170,7 +177,7 @@ CUSTOM_AR_KERNEL void all_reduce_one_shot_push_kernel(
     const PushController __grid_constant__ ctrl) {
   using namespace device;
 
-  const auto [buffer, input, output, rank, num_items, buffer_bytes, epoch_bytes] = params;
+  const auto [buffer, input, output, rank, num_items, buffer_bytes, epoch_bytes, spin_timeout_ns] = params;
 
   PDLWaitPrimary<kUsePDL>();
 
@@ -191,7 +198,7 @@ CUSTOM_AR_KERNEL void all_reduce_one_shot_push_kernel(
   for (uint32_t i = 0; i < kNumGPU; ++i) {
     poll_buf[i] = static_cast<DType*>(pointer::offset(buffer[rank], i * buffer_bytes, epoch_offset));
   }
-  poll_impl(poll_buf, output, num_items);
+  poll_impl(poll_buf, output, num_items, spin_timeout_ns);
   ctrl.exit();
 }
 
@@ -224,6 +231,7 @@ struct CustomAllReducePush : public CustomAllReduceBase {
     params.num_items = num_items;
     params.buffer_bytes = m_push_buffer_bytes;
     params.epoch_bytes = kNumGPU * params.buffer_bytes;
+    params.spin_timeout_ns = get_spin_timeout_ns();
 
     RuntimeCheck(input.IsContiguous(), "Input must be contiguous");
     RuntimeCheck(m_num_gpu == kNumGPU, "Number of GPUs mismatch");

--- a/python/sglang/jit_kernel/include/sgl_kernel/distributed/common.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/distributed/common.cuh
@@ -1,9 +1,95 @@
 #pragma once
 #include <sgl_kernel/utils.cuh>
 
+#include <cstdint>
+#include <cstdio>
+
 namespace device::distributed {
 
 inline constexpr uint32_t kMaxNumGPU = 8;
+
+/// Device-wide nanosecond wall clock. Unlike `clock64()` this is independent of
+/// the SM clock, so it can be used to express a real time bound.
+SGL_DEVICE uint64_t global_timer_ns() {
+  uint64_t ns;
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(ns));
+  return ns;
+}
+
+/// A time bound for the cross-rank rendezvous spins below.
+///
+/// Both custom all-reduce protocols assume that the all-reduces of one
+/// communicator are *totally ordered*, i.e. at most one is in flight at a time,
+/// which is exactly what issuing them on a single stream provides. The state
+/// that encodes "has my peer arrived?" is per communicator and per block -- a
+/// two-stage counter here, and in the push kernel the push buffer itself -- so
+/// two all-reduces of one communicator that execute concurrently (e.g. issued
+/// from two CUDA streams) alias that state: one kernel's poll phase re-arms the
+/// buffer slice the other one is still waiting for, and the non-atomic epoch
+/// update can leave the ranks permanently out of step. The rendezvous then never
+/// completes. Since these loops spin, that used to manifest as a silent,
+/// permanent, unkillable 100%-utilization hang (issue #31117).
+///
+/// The host side now serializes a second stream's issue behind the first, which
+/// removes the hazard for every issue it can see. It cannot see two CUDA graphs
+/// replayed concurrently on two streams -- a replay makes no host call -- so this
+/// deadline is the backstop for that case: on expiry the kernel traps, turning
+/// the hang into an immediate, attributable CUDA error. Override the bound with
+/// `SGLANG_CUSTOM_ALL_REDUCE_SPIN_TIMEOUT` (seconds; 0 disables it).
+struct SpinDeadline {
+ public:
+  /// Spin iterations between two clock reads. A healthy rendezvous completes in
+  /// far fewer than this, so the common path never reads `%globaltimer` at all:
+  /// the clock is only started once a wait is already long enough to be
+  /// suspicious. (Reading it eagerly, once per thread, was measurable -- ~1% of
+  /// the one-shot push kernel at small message sizes.)
+  static constexpr uint32_t kCheckInterval = 4096;
+
+  SGL_DEVICE explicit SpinDeadline(uint64_t timeout_ns)
+      : m_timeout_ns(timeout_ns), m_start_ns(0), m_countdown(kCheckInterval) {}
+
+  /// Call once per spin iteration. Never returns once the deadline has passed.
+  SGL_DEVICE void tick() {
+    if (m_timeout_ns == 0) return;   // bound disabled
+    if (--m_countdown != 0) return;  // amortize the clock read
+    m_countdown = kCheckInterval;
+    const uint64_t now = global_timer_ns();
+    if (m_start_ns == 0) {
+      m_start_ns = now;  // first suspiciously long wait: start the clock
+    } else if (now - m_start_ns > m_timeout_ns) {
+      expire();
+    }
+  }
+
+ private:
+  /// Cold path: `noinline` + `noreturn` so the hot loop keeps no state alive
+  /// across the call. The trap tears the context down, so the message above it
+  /// is the only diagnosis the user gets; one line per stuck warp keeps it
+  /// readable.
+  ///
+  /// NOTE: the message deliberately takes no printf arguments. Passing any would
+  /// make the kernel allocate a per-thread stack frame for the varargs buffer
+  /// (`STACK:8` in `cuobjdump -res-usage`), and setting that local-memory window
+  /// up costs ~45ns on *every* launch of this kernel -- ~1.5% of a small
+  /// all-reduce, for a buffer only the dead path ever writes.
+  [[noreturn]] __noinline__ __device__ void expire() const {
+    const uint32_t lane = threadIdx.x % kWarpThreads;
+    if (lane == static_cast<uint32_t>(__ffs(__activemask()) - 1)) {
+      printf(
+          "[sglang] custom all-reduce timed out waiting for its peers. Two all-reduces of the "
+          "SAME communicator were in flight at once -- e.g. two CUDA graphs replayed concurrently "
+          "on two streams. The protocol supports only one in-flight all-reduce per communicator; "
+          "use one communicator per concurrent stream. (Bound: "
+          "SGLANG_CUSTOM_ALL_REDUCE_SPIN_TIMEOUT seconds, 0 disables.)\n");
+    }
+    __trap();
+    __builtin_unreachable();
+  }
+
+  uint64_t m_timeout_ns;
+  uint64_t m_start_ns;
+  uint32_t m_countdown;
+};
 
 struct alignas(128) Semaphore {
  public:
@@ -59,8 +145,9 @@ struct PullController {
   /// Synchronize all GPUs.
   /// When kFence is true, establishes happens-before across GPUs using
   /// release/acquire semantics, ensuring prior writes are visible system-wide.
+  /// `spin_timeout_ns` bounds the wait for the peers (see `SpinDeadline`).
   template <bool kFence, bool kStart>
-  SGL_DEVICE void sync(uint32_t rank, uint32_t num_gpu) const {
+  SGL_DEVICE void sync(uint32_t rank, uint32_t num_gpu, uint64_t spin_timeout_ns) const {
     // For fenced sync: ensure all threads in this block have completed their writes,
     // so the signaling thread's release carries them transitively.
     static_assert(!(kFence && kStart), "Start stage does not need to wait fence");
@@ -76,8 +163,9 @@ struct PullController {
         /// NOTE: correctness here:
         /// - base is only read/updated locally by the owning GPU
         const auto base = signal.get_counter();
+        SpinDeadline deadline(spin_timeout_ns);
         while (signal.get<kFence>() - base < target)
-          ;
+          deadline.tick();
         if constexpr (!kStart) {
           signal.set_counter(base + target);
         }

--- a/python/sglang/jit_kernel/include/sgl_kernel/distributed/custom_all_reduce.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/distributed/custom_all_reduce.cuh
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <numeric>
@@ -24,6 +25,25 @@
 namespace host::distributed {
 
 using device::distributed::PullController, device::distributed::PushController;
+
+/// Wall-clock bound (nanoseconds) on the kernels' wait for their peers, from
+/// `SGLANG_CUSTOM_ALL_REDUCE_SPIN_TIMEOUT` (seconds; 0 disables the bound).
+///
+/// The rendezvous takes microseconds once both peers have launched, so this only
+/// has to be above the worst *launch* skew between the ranks -- a peer stalled on
+/// the host by a JIT compile, a debugger, or a profiler. The default matches the
+/// NCCL watchdog's (`TORCH_NCCL_TIMEOUT`, 600s): a collective that has not landed
+/// after ten minutes is not slow, it is dead, and here it is dead in a way no
+/// amount of waiting recovers from (see `device::distributed::SpinDeadline`).
+inline uint64_t get_spin_timeout_ns() {
+  static const uint64_t value = [] {
+    constexpr double kDefaultSeconds = 600.0;
+    const char* env = std::getenv("SGLANG_CUSTOM_ALL_REDUCE_SPIN_TIMEOUT");
+    const double seconds = env == nullptr ? kDefaultSeconds : std::strtod(env, nullptr);
+    return seconds <= 0.0 ? uint64_t{0} : static_cast<uint64_t>(seconds * 1e9);
+  }();
+  return value;
+}
 
 struct AllReduceData {
   constexpr AllReduceData() {}

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -15,6 +15,7 @@ from torch.distributed import ProcessGroup
 import sglang.srt.distributed.device_communicators.custom_all_reduce_ops as ops
 from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import (
+    SingleStreamGuard,
     can_use_custom_all_reduce_with_nvlink,
     is_weak_contiguous,
 )
@@ -84,6 +85,8 @@ class CustomAllreduce:
         # now `device` is a `torch.device` object
         assert isinstance(device, torch.device)
         self.device = device
+        # One in-flight all-reduce per communicator; see SingleStreamGuard.
+        self.stream_guard = SingleStreamGuard(device)
         full_nvlink = can_use_custom_all_reduce_with_nvlink(
             group=group,
             device=device,
@@ -284,6 +287,11 @@ class CustomAllreduce:
 
     def _all_reduce_impl(self, inp: torch.Tensor, registered: bool):
         out = torch.empty_like(inp)
+        # The kernel's per-communicator barrier state (`multi_gpu_barrier`)
+        # assumes one in-flight all-reduce per communicator: if this issue comes
+        # from a different stream than the previous one, order it behind that
+        # one rather than let the two kernels corrupt each other's counters.
+        self.stream_guard.maybe_serialize()
         if not _is_hip:  # CUDA-like
             if registered:
                 ops.all_reduce(self._ptr, inp, out, 0, 0)

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
@@ -398,6 +398,85 @@ def is_weak_contiguous(inp: torch.Tensor):
     )
 
 
+# torch._C._cuda_getCurrentRawStream returns the raw cudaStream_t as an int. It
+# is ~20x cheaper than torch.cuda.current_stream() (which builds a Stream
+# object), which matters because the guard below runs on every all-reduce.
+_get_raw_stream = getattr(torch._C, "_cuda_getCurrentRawStream", None)
+
+
+class SingleStreamGuard:
+    """Serializes the all-reduces of one custom all-reduce communicator.
+
+    Both custom all-reduce implementations keep per-communicator, per-block
+    rendezvous state: a two-stage counter, and -- for the JIT one-shot push
+    kernel -- the push buffer itself, which the poll phase re-arms for the next
+    all-reduce. The protocol is correct only while the all-reduces of a
+    communicator are *totally ordered*, i.e. at most one is in flight at a time,
+    which is exactly what issuing them on a single stream provides.
+
+    Two all-reduces of one communicator that execute concurrently -- e.g. issued
+    from two CUDA streams -- alias that state: one kernel's poll phase overwrites
+    (re-arms) the buffer slice the other kernel is still waiting for, and the
+    non-atomic epoch update can leave the ranks permanently out of step. Neither
+    is recoverable, and since the kernels spin-wait, the result is a silent,
+    permanent, 100%-utilization hang that survives SIGTERM (issue #31117).
+
+    This guard makes the second issue *wait* instead of corrupting the first:
+    when the stream changes, it records an event on the previous stream and has
+    the new stream wait on it, which restores the total order. The normal path --
+    one stream forever -- pays only a raw-stream-pointer compare.
+
+    Not covered: two CUDA graphs replayed concurrently on two streams, because a
+    replay makes no host call at all. The kernels bound their own wait for that
+    case and fail with an error instead of hanging (see ``SpinDeadline`` in
+    ``jit_kernel/include/sgl_kernel/distributed/common.cuh``).
+
+    Assumes the all-reduces of one communicator are issued from one host thread,
+    which is how every SGLang path uses them (the model runner owns its group).
+    Two threads racing to issue on one communicator would need a lock here, and
+    that lock would have to span the launch; it is not worth the cost on a path
+    this hot, and the kernels' bound turns that race into an error, not a hang.
+    """
+
+    def __init__(self, device: torch.device) -> None:
+        self.device_index = 0 if device.index is None else device.index
+        # Bound once: an attribute lookup, not a branch, on the fast path.
+        self._raw_stream = _get_raw_stream or (
+            lambda index: torch.cuda.current_stream(index).cuda_stream
+        )
+        self._last_stream: Optional[torch.cuda.Stream] = None
+        self._last_raw_stream: Optional[int] = None
+        self._event: Optional[torch.cuda.Event] = None
+
+    def maybe_serialize(self) -> None:
+        """Order this all-reduce behind the previous one if the stream changed.
+
+        Call immediately before issuing. The steady state (one stream forever) is
+        a raw-pointer compare; everything else is in the cold path below.
+        """
+        if self._raw_stream(self.device_index) != self._last_raw_stream:
+            self._switch_stream()
+
+    def _switch_stream(self) -> None:
+        if torch.cuda.is_current_stream_capturing():
+            # CUDA-graph capture records a dependency graph; it does not execute
+            # anything, so there is nothing in flight to serialize against, and a
+            # dependency on work outside the capture cannot be expressed in the
+            # graph anyway. Leave the eager bookkeeping untouched.
+            return
+        stream = torch.cuda.current_stream(self.device_index)
+        if self._last_stream is not None:
+            if self._event is None:
+                self._event = torch.cuda.Event()
+            # Everything already issued on the previous stream -- in particular
+            # the previous all-reduce of this communicator -- must complete
+            # before this stream may start its own.
+            self._event.record(self._last_stream)
+            stream.wait_event(self._event)
+        self._last_stream = stream
+        self._last_raw_stream = stream.cuda_stream
+
+
 def can_p2p(rank: int, world_size: int) -> bool:
     # SGLANG_SKIP_P2P_CHECK can be set to False in sglang
     SGLANG_SKIP_P2P_CHECK = os.getenv("SGLANG_SKIP_P2P_CHECK", "0") == "1"

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -9,6 +9,7 @@ from torch.distributed import ProcessGroup
 
 from sglang.jit_kernel.all_reduce import AllReduceAlgo, get_custom_all_reduce_cls
 from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import (
+    SingleStreamGuard,
     can_use_custom_all_reduce_with_nvlink,
     is_weak_contiguous,
 )
@@ -47,6 +48,8 @@ class CustomAllReduceV2:
     ) -> None:
         _maybe_init_config()
         self.disabled = True
+        # One in-flight all-reduce per communicator; see SingleStreamGuard.
+        self.stream_guard = SingleStreamGuard(device)
         if not can_use_custom_all_reduce_v2(group=group, device=device):
             return
 
@@ -161,6 +164,11 @@ class CustomAllReduceV2:
     def _all_reduce(self, input: torch.Tensor) -> torch.Tensor:
         """Perform the actual all-reduce via JIT kernel."""
         algo = self._determine_algo(input)
+        # The kernels support exactly one in-flight all-reduce per communicator:
+        # if this issue comes from a different stream than the previous one, order
+        # it behind that one instead of letting the two kernels corrupt the
+        # communicator's shared rendezvous state.
+        self.stream_guard.maybe_serialize()
         return torch.from_dlpack(self.obj.all_reduce(input, algo))
 
     def _determine_algo(self, input: torch.Tensor) -> AllReduceAlgo:

--- a/test/registered/jit/test_custom_all_reduce.py
+++ b/test/registered/jit/test_custom_all_reduce.py
@@ -18,12 +18,15 @@ Usage::
 from __future__ import annotations
 
 import atexit
+import contextlib
 import itertools
 import logging
 import multiprocessing
 import os
+import sys
+import threading
 from multiprocessing.context import SpawnProcess
-from typing import List
+from typing import Iterator, List
 
 import pytest
 import torch
@@ -224,6 +227,113 @@ def test_custom_all_reduce(
         out_jit = run(inp)
         # Exact equality, since values are small integers within bf16 precision.
         torch.testing.assert_close(out_ref, out_jit, atol=0, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Regression test: concurrent issue on one communicator (issue #31117)
+# ---------------------------------------------------------------------------
+
+CONCURRENT_ITERS = 32
+CONCURRENT_NUMEL = 64 * 1024  # 128 KB in bf16
+# Long enough that a merely slow machine never trips it, short enough to leave
+# room in the per-file CI budget. It is only ever reached by the bug: the
+# healthy path finishes in well under a second.
+DEADLOCK_TIMEOUT_S = 120
+DEADLOCK_EXIT_CODE = 87
+
+
+@contextlib.contextmanager
+def _deadlock_watchdog(what: str) -> Iterator[None]:
+    """Turn a wedged custom all-reduce into a hard, attributable failure.
+
+    The kernels spin-wait on their peers, so a rank whose all-reduce can no
+    longer complete is stuck inside a CUDA call forever: it cannot be
+    interrupted from Python, `pytest.fail()` could not run (and its teardown
+    would hang on the same GPU), and even SIGTERM does not free the device.
+    Hard-exiting the worker is the only reliable escape; torchrun then fails the
+    run with the message printed here.
+    """
+
+    def _fire() -> None:
+        print(
+            f"\nDEADLOCK: {what} made no progress for {DEADLOCK_TIMEOUT_S}s. The "
+            f"custom all-reduce kernels are resident and spinning (the GPU is "
+            f"pinned at 100%): two all-reduces of one communicator were in flight "
+            f"at once and corrupted its rendezvous state (issue #31117).",
+            file=sys.stderr,
+            flush=True,
+        )
+        os._exit(DEADLOCK_EXIT_CODE)
+
+    timer = threading.Timer(DEADLOCK_TIMEOUT_S, _fire)
+    timer.daemon = True
+    timer.start()
+    try:
+        yield
+    finally:
+        timer.cancel()
+
+
+@pytest.mark.parametrize("algo", TEST_ALGOS)
+@torch.inference_mode()
+def test_concurrent_issue_on_two_streams(algo: AllReduceAlgo) -> None:
+    """Two streams issue on the SAME communicator with both all-reduces in flight.
+
+    The kernels keep their rendezvous state per communicator and per block (a
+    two-stage counter, and for the one-shot push kernel the push buffer itself,
+    which the poll phase re-arms). The protocol is therefore correct only while
+    the all-reduces of a communicator are totally ordered, which a single stream
+    guarantees and two concurrent streams do not: the kernels alias that state,
+    one poll phase re-arms the buffer the other is still waiting on, and the
+    rendezvous never completes -- a permanent, unkillable, 100%-utilization hang
+    (issue #31117).
+
+    The communicator must serialize the second issue behind the first, so the
+    concurrent issue both terminates and still matches NCCL.
+    """
+    nccl_group = _init_nccl_group_once()
+    comm = _init_comm_once()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    dtype = torch.bfloat16
+
+    # NOTE: 15 * 8 < 128, which is the precision limit for bf16.
+    inputs = [
+        torch.randint(0, 16, (CONCURRENT_NUMEL,), dtype=dtype, device=device)
+        for _ in range(2)
+    ]
+    refs = [inp.clone() for inp in inputs]
+    for ref in refs:
+        dist.all_reduce(ref, group=nccl_group)
+
+    streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    for stream in streams:
+        stream.wait_stream(torch.cuda.current_stream())
+
+    previous_algo = comm.override_algo
+    comm.override_algo = algo
+    try:
+        outs: list[list[torch.Tensor]] = []
+        with _deadlock_watchdog(f"concurrent custom all-reduce ({algo.name})"):
+            for _ in range(CONCURRENT_ITERS):
+                # Both all-reduces are issued back-to-back with no dependency
+                # between their streams, so without serialization the kernels do
+                # overlap on the device.
+                step = []
+                for inp, stream in zip(inputs, streams):
+                    with torch.cuda.stream(stream):
+                        step.append(comm.custom_all_reduce(inp.clone()))
+                outs.append(step)
+            for stream in streams:
+                torch.cuda.current_stream().wait_stream(stream)
+            torch.cuda.synchronize()  # never returns once the kernels have wedged
+    finally:
+        comm.override_algo = previous_algo
+
+    # Serialized, not just unwedged: a buffer that another kernel re-armed under
+    # us would come back with holes even when the rendezvous happened to finish.
+    for step in outs:
+        for out, ref in zip(step, refs):
+            torch.testing.assert_close(out, ref, atol=0, rtol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### Motivation

Fixes #31117.

Custom all-reduce hangs permanently — kernels resident, GPU pinned at 100%, no
error, no timeout, immune to `SIGTERM` — when two CUDA streams issue an
all-reduce on the **same** communicator with both in flight at once. It affects
both implementations (the JIT `CustomAllReduceV2`, which is the CUDA default, and
the legacy AOT `CustomAllreduce`), and it needs nothing exotic to hit: two
ordinary `torch.cuda.Stream()`s reproduce it. Custom all-reduce is on by default
whenever NVLink P2P is available, and `--enable-pdmux` makes issuing from two
streams easy to do.

### Root cause

The protocols are **single-in-flight-per-communicator by construction**, but
nothing enforces it.

1. **The push buffer *is* the "has my peer arrived?" flag.**
   `all_reduce_one_shot_push_kernel` has no flag array: positive zero is the
   "not here yet" sentinel. Block `b` pushes its slice into every peer's buffer
   and then spin-polls that same slice in its own buffer until no positive zero
   remains (`poll_impl`). After reducing, it writes the sentinel back over the
   buffer — **the poll phase is also the re-arm for the next all-reduce**
   (`custom_all_reduce_push.cuh`). Two concurrent all-reduces of one communicator
   read the same epoch and therefore land in the same buffer half, so one
   kernel's poll re-arms the slice the other kernel's block is still waiting on.
   That block then spins forever on data that has already been consumed.

2. **The epoch counter is a non-atomic read-modify-write.** Which half is used
   comes from `PushController::epoch()` = `m_local_signal[blockIdx.x]`, advanced
   by `signal = (signal + 1) % kNumStages` from thread 0 (`common.cuh`). Two
   concurrent kernels can lose an update; if the ranks lose it differently their
   epochs are permanently out of step — one rank polls the half the other is not
   pushing into.

Either one is sufficient on its own. The same shape exists in the pull path
(`PullController::sync` keeps per-communicator, per-block counters and spins on
an exact value) and in the legacy AOT `multi_gpu_barrier`.

Nothing detects it from inside the kernel, because **both spin loops are
unbounded**. A spinning block never retires, so it holds its SM for the life of
the process — hence 100% utilization forever and immunity to `SIGTERM`.

Two all-reduces on **distinct** communicators are fine: the state is per
communicator (verified, 220/220 iterations, including one custom-AR communicator
per green-context partition).

### Fix

Two parts, one for each way a second all-reduce can get in flight.

**1. Host side — `SingleStreamGuard`** (`custom_all_reduce_utils.py`, used by
both `CustomAllReduceV2._all_reduce` and `CustomAllreduce._all_reduce_impl`).

Remember the stream the communicator's last all-reduce was issued on. When the
next one arrives on a *different* stream, record an event on the previous stream
and `wait_event` it on the new one, so the second all-reduce is **serialized
behind** the first instead of aliasing its buffer. Restores the total order the
protocol already assumes; no kernel change, no semantic change for anyone
already using one stream.

The steady state (one stream forever) is a raw-stream-pointer compare — the
event is only recorded when a second stream is actually seen. Graph *capture* is
skipped (it records a dependency DAG, it does not execute anything).

**2. Device side — `SpinDeadline`** (`common.cuh`).

Bound both peer-rendezvous spins by `SGLANG_CUSTOM_ALL_REDUCE_SPIN_TIMEOUT`
seconds (default **600**, matching the NCCL watchdog's `TORCH_NCCL_TIMEOUT`; `0`
disables) and `__trap()` with a message naming the cause.

This covers the case the host guard *cannot* see: **two CUDA graphs replayed
concurrently on two streams** — a replay makes no host call at all. It turns an
unkillable, silent, 100%-GPU hang into an immediate, attributable CUDA error:

```
[sglang] custom all-reduce timed out waiting for its peers. Two all-reduces of the
SAME communicator were in flight at once -- e.g. two CUDA graphs replayed concurrently
on two streams. The protocol supports only one in-flight all-reduce per communicator;
use one communicator per concurrent stream. (Bound: SGLANG_CUSTOM_ALL_REDUCE_SPIN_TIMEOUT
seconds, 0 disables.)
RuntimeError: CUDA error: unspecified launch failure
```

Two details keep this free on the healthy path (both measured, see below):
* the clock is read **lazily** — only after 4096 spin iterations, which a healthy
  rendezvous never reaches — so the common path never touches `%globaltimer`;
* the message takes **no printf arguments**. Passing any makes the kernel
  allocate a per-thread stack frame for the varargs buffer (`STACK:8` in
  `cuobjdump -res-usage`), and setting that local-memory window up costs ~45 ns
  on *every* launch (~1.5% of a small all-reduce), for a buffer only the dead
  path ever writes.

Net kernel resources (bf16, world size 2, sm80): `REG 30 → 31`, `STACK 0 → 0`,
kernel params `456 → 464 B`.

### The contract

Documented on the guard and in the kernel comment: **one in-flight all-reduce per
communicator.** Concurrency must come from *distinct* communicators — one per
concurrently-issuing stream.

### Test

`test/registered/jit/test_custom_all_reduce.py::test_concurrent_issue_on_two_streams`
(existing multi-GPU harness; runs at world size 2/4/8, all three algos).

It issues on the same communicator from two streams with both all-reduces in
flight, then asserts the run *terminates* and that every result matches NCCL
(serialized, not merely un-wedged — an aliased buffer comes back with holes even
when the rendezvous happens to finish).

It has to be a deadlock *detector*: the kernels spin, so a wedged rank cannot be
interrupted from Python, `pytest.fail()` could not run, and its teardown would
hang on the same GPU. A watchdog thread hard-exits the worker with an explanatory
message, which fails the torchrun run.

* on **unpatched** code: fails (both ranks hard-exit via the watchdog);
* on **patched** code: `3 passed in 0.4s`.

### Benchmark

`test/registered/jit/benchmark/bench_custom_all_reduce.py`, world size 2, bf16,
`jit` provider, 2× A100-SXM4-40GB NVLink. **Interleaved A/B** (unpatched/patched
alternating in one time window, 3 pairs, median), so environmental drift cancels.
The `aot` provider is untouched by this PR and is shown as the noise floor.

| message | algo | before (µs) | after (µs) | delta | aot control |
|---:|---|---:|---:|---:|---:|
| 4 KB | one-shot push | 3.000 | 3.031 | +1.02% | −0.25% |
| 16 KB | one-shot push | 3.164 | 3.185 | +0.64% | +0.00% |
| 64 KB | one-shot push | 3.758 | 3.809 | +1.36% | +0.00% |
| 128 KB | one-shot push | 4.618 | 4.659 | +0.89% | −0.18% |
| 192 KB | one-shot push | 5.509 | 5.550 | +0.74% | −0.15% |
| 256 KB | one-shot push | 6.339 | 6.390 | +0.81% | +0.00% |
| 384 KB | one-shot push | 8.038 | 8.079 | +0.51% | −0.11% |
| 512 KB | one-shot push | 9.626 | 9.656 | +0.32% | +0.00% |
| 640 KB | one-shot push | 11.264 | 11.295 | +0.27% | −0.08% |
| 768 KB | one-shot push | 12.974 | 12.995 | +0.16% | +0.00% |
| 896 KB | one-shot push | 14.633 | 14.613 | −0.14% | +0.00% |
| 1 MB | one-shot push | 16.251 | 16.230 | −0.13% | +0.00% |
| 2 MB | one-shot push | 30.013 | 29.931 | −0.27% | +0.00% |
| 3 MB | one-shot pull | 45.508 | 45.583 | +0.17% | −0.02% |
| 4 MB | one-shot pull | 59.422 | 59.513 | +0.15% | +0.00% |
| 8 MB | one-shot pull | 115.230 | 115.299 | +0.06% | +0.00% |
| 16 MB | one-shot pull | 226.661 | 226.670 | +0.00% | −0.01% |
| 32 MB | one-shot pull | 448.286 | 449.073 | +0.18% | −0.00% |

`jit` mean **+0.37%**, median +0.22%, max +1.36%; `aot` (untouched) max 0.25%.
In absolute terms the residual is a **fixed ~30–50 ns per launch** (one extra
register, 8 bytes of kernel params, and the bounded-spin counter), which is
~1% of the smallest all-reduce and ~0% from 896 KB up.

**Host side.** The kernel benchmark captures CUDA graphs, so the guard never runs
in it (replay makes no host call — it is exactly 0 there). Measured separately on
the *eager* path, A/B inside one process (real guard vs. a no-op, interleaved,
9×2000 calls): **+0.36 µs on a 31 µs enqueue, +1.2%.**

### Notes / things a reviewer may want to weigh in on

1. **Default bound (600 s).** Chosen to match `TORCH_NCCL_TIMEOUT` and to be far
   above any legitimate *launch* skew (a peer stalled on the host by a JIT
   compile, a debugger, or a profiler — the rendezvous itself is microseconds).
   Lower is more useful for debugging, higher is safer against false trips.
   Env-tunable; `0` disables.
2. **`__trap()` surfaces on the host as `unspecified launch failure`.** The
   diagnosis is the device-side message printed immediately above it. A
   `__assertfail`-based variant would give `device-side assert triggered` instead,
   which is arguably a better host-side error; happy to switch.
3. **The remaining ~30–50 ns/launch** could be taken to zero by making the
   timeout a compile-time template argument of the JIT kernels (it would drop the
   kernel param and the register). That adds JIT-arg plumbing, so I left it out —
   say the word if you want it.
4. **The AOT (`sgl-kernel`) V1 kernel's spin is still unbounded.** Its *host*
   wrapper gets the same guard (so the reported bug is fixed for it too), but
   bounding its device loop would need a wheel rebuild, which I could not
   validate here. Happy to add it in a follow-up.
5. **The guard assumes a communicator's all-reduces are issued from one host
   thread**, which is true of every SGLang path. A lock spanning the launch would
   make it unconditional; it is not worth ~200 ns on this path, and the kernel
   bound turns that race into an error rather than a hang.
6. **The pull path deadlocks too**, not just the push kernel the issue was filed
   against — the regression test covers all three algos, and the bound is applied
   to both spin loops.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29314190804](https://github.com/sgl-project/sglang/actions/runs/29314190804)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29314190501](https://github.com/sgl-project/sglang/actions/runs/29314190501)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->