### PR TITLE
`page_blob_direct` layout for HiCache

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -609,7 +609,8 @@ class HiCacheController:
             # TODO(hzh): Rename is_mla_model to is_rank_replicated.
             is_mla_model=is_rank_replicated,
             enable_storage_metrics=self.enable_storage_metrics,
-            is_page_first_layout=self.mem_pool_host.layout == "page_first",
+            is_page_first_layout=self.mem_pool_host.layout
+            in ["page_first", "page_blob_direct"],
             model_name=model_name,
             tp_lcm_size=tp_lcm_size,
             should_split_heads=should_split_heads,
@@ -743,7 +744,7 @@ class HiCacheController:
                 device_indices = device_indices.cpu()
                 host_indices, idx = host_indices.sort()
                 return host_indices, device_indices.index_select(0, idx)
-            elif self.mem_pool_host.layout == "page_first_direct":
+            elif self.mem_pool_host.layout in ["page_first_direct", "page_blob_direct"]:
                 return host_indices, device_indices.cpu()
             else:
                 raise ValueError(

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -107,13 +107,22 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
             # This swaps strides without copying data
             transposed = self.kv_buffer.transpose(0, 1)
             self.data_refs = [transposed[i] for i in range(self.layer_num)]
+        elif self.layout == "page_blob_direct":
+            # page_blob_direct keeps each page as one contiguous outer slice; the
+            # per-layer refs below would slice the page dimension instead.
+            self.data_refs = []
         else:
             self.data_refs = [self.kv_buffer[i] for i in range(self.layer_num)]
-        self.data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.data_refs],
-            dtype=torch.uint64,
-            device=self.device_pool.device,
-        )
+        if self.data_refs:
+            self.data_ptrs = torch.tensor(
+                [x.data_ptr() for x in self.data_refs],
+                dtype=torch.uint64,
+                device=self.device_pool.device,
+            )
+        else:
+            self.data_ptrs = torch.empty(
+                (0,), dtype=torch.uint64, device=self.device_pool.device
+            )
         self._init_write_back_staging_buffers()
 
     def get_contiguous_buf_infos(self):
@@ -151,7 +160,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 1,
                 self.kv_cache_dim,
             )
-        elif self.layout == "page_first_direct":
+        elif self.layout in ["page_first_direct", "page_blob_direct"]:
             dims = (
                 self.page_num,
                 self.layer_num,
@@ -296,7 +305,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                     dst_indices=device_indices,
                     page_size=self.page_size,
                 )
-            elif self.layout == "page_first_direct":
+            elif self.layout in ["page_first_direct", "page_blob_direct"]:
                 transfer_kv_per_layer_direct_pf_lf(
                     src_ptrs=[self.kv_buffer],
                     dst_ptrs=[device_pool.kv_buffer[layer_id]],
@@ -449,7 +458,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                     dst_indices=host_indices,
                     page_size=self.page_size,
                 )
-            elif self.layout == "page_first_direct":
+            elif self.layout in ["page_first_direct", "page_blob_direct"]:
                 transfer_kv_all_layer_direct_lf_pf(
                     src_ptrs=device_pool.kv_buffer,
                     dst_ptrs=[self.kv_buffer],
@@ -483,7 +492,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
             data_page = self.kv_buffer[:, index : index + self.page_size, :, :]
         elif self.layout == "page_first":
             data_page = self.kv_buffer[index : index + self.page_size, :, :, :]
-        elif self.layout == "page_first_direct":
+        elif self.layout in ["page_first_direct", "page_blob_direct"]:
             real_index = index // self.page_size
             data_page = self.kv_buffer[real_index : real_index + 1, :, :, :, :]
         else:
@@ -520,7 +529,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 1,
                 self.kv_cache_dim,
             )
-        elif self.layout == "page_first_direct":
+        elif self.layout in ["page_first_direct", "page_blob_direct"]:
             real_index = index // self.page_size
             self.kv_buffer[real_index : real_index + 1, :, :, :, :] = data_page.reshape(
                 1,
@@ -551,7 +560,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                     ptr_list.append(k_ptr)
             element_size = self.dtype.itemsize * self.page_size * self.kv_cache_dim
             element_size_list = [element_size] * len(ptr_list)
-        elif self.layout in ["page_first", "page_first_direct"]:
+        elif self.layout in ["page_first", "page_first_direct", "page_blob_direct"]:
             for index in range(0, len(indices), self.page_size):
                 k_ptr = (
                     kv_buffer_data_ptr
@@ -584,7 +593,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         For this to be page-aligned (given a page-aligned ``base_ptr``) the per-page
         stride must itself be a multiple of the OS page size.
         """
-        if self.layout not in ("page_first", "page_first_direct"):
+        if self.layout not in ("page_first", "page_first_direct", "page_blob_direct"):
             return False
         stride = (
             self.page_size * self.layer_num * self.kv_cache_dim * self.dtype.itemsize
@@ -609,11 +618,12 @@ class MambaPoolHost(HostKVCache):
         self.page_size = 1
 
         # TODO: Mamba pool is currently incompatible with write-back staging
-        # kernel; only allow 'page_first_direct' + 'direct' for now.
+        # kernel; only allow direct page-first layouts + direct IO for now.
         # Relax this restriction once the staging bug is fixed.
-        if layout != "page_first_direct":
+        if layout not in ("page_first_direct", "page_blob_direct"):
             raise ValueError(
-                f"MambaPoolHost only supports layout='page_first_direct', "
+                "MambaPoolHost only supports layout='page_first_direct' or "
+                f"'page_blob_direct', "
                 f"got '{layout}'."
             )
 
@@ -696,7 +706,7 @@ class MambaPoolHost(HostKVCache):
     def init_kv_buffer(self):
         alloc_func = ALLOC_MEMORY_FUNCS[self.device_pool.device]
 
-        if self.layout in ["page_first", "page_first_direct"]:
+        if self.layout in ["page_first", "page_first_direct", "page_blob_direct"]:
             # page-first: (page_num, num_layers, 1, *shape) — per-page data is contiguous
             temporal_dims = (
                 self.size,
@@ -801,7 +811,7 @@ class MambaPoolHost(HostKVCache):
         return [self.temporal_buffer, *self.conv_buffer]
 
     def _iter_page_tensors(self, index: int):
-        if self.layout in ["page_first", "page_first_direct"]:
+        if self.layout in ["page_first", "page_first_direct", "page_blob_direct"]:
             yield self.temporal_buffer[index]
             for conv_buf in self.conv_buffer:
                 yield conv_buf[index]
@@ -985,7 +995,7 @@ class MambaPoolHost(HostKVCache):
                 f"MambaPoolHost only supports io_backend='direct', "
                 f"got '{io_backend}'."
             )
-        if self.layout in ["page_first", "page_first_direct"]:
+        if self.layout in ["page_first", "page_first_direct", "page_blob_direct"]:
             self._copy_tensor_pf_lf(
                 src=self.temporal_buffer,
                 dst=device_pool.mamba_cache.temporal[layer_id],
@@ -1030,7 +1040,7 @@ class MambaPoolHost(HostKVCache):
                 f"MambaPoolHost only supports io_backend='direct', "
                 f"got '{io_backend}'."
             )
-        if self.layout in ["page_first", "page_first_direct"]:
+        if self.layout in ["page_first", "page_first_direct", "page_blob_direct"]:
             self._copy_tensor_all_layers_lf_pf(
                 src_layers=device_pool.mamba_cache.temporal,
                 dst=self.temporal_buffer,
@@ -1110,7 +1120,7 @@ class MambaPoolHost(HostKVCache):
         each page slot in temporal/conv buffers is directly addressable.
         """
         assert len(indices) % self.page_size == 0
-        if self.layout not in ["page_first", "page_first_direct"]:
+        if self.layout not in ["page_first", "page_first_direct", "page_blob_direct"]:
             raise ValueError(
                 f"Mamba storage zero-copy requires page_first layout, got {self.layout}"
             )

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -103,19 +103,32 @@ class MHATokenToKVPoolHost(HostKVCache):
             v_transposed = self.v_buffer.transpose(0, 1)
             self.k_data_refs = [k_transposed[i] for i in range(self.layer_num)]
             self.v_data_refs = [v_transposed[i] for i in range(self.layer_num)]
+        elif self.layout == "page_blob_direct":
+            # page_blob_direct keeps each page as one contiguous outer slice; the
+            # per-layer refs below would slice the page dimension instead.
+            self.k_data_refs = []
+            self.v_data_refs = []
         else:
             self.k_data_refs = [self.k_buffer[i] for i in range(self.layer_num)]
             self.v_data_refs = [self.v_buffer[i] for i in range(self.layer_num)]
-        self.k_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.k_data_refs],
-            dtype=torch.uint64,
-            device=self.device_pool.device,
-        )
-        self.v_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.v_data_refs],
-            dtype=torch.uint64,
-            device=self.device_pool.device,
-        )
+        if self.k_data_refs:
+            self.k_data_ptrs = torch.tensor(
+                [x.data_ptr() for x in self.k_data_refs],
+                dtype=torch.uint64,
+                device=self.device_pool.device,
+            )
+            self.v_data_ptrs = torch.tensor(
+                [x.data_ptr() for x in self.v_data_refs],
+                dtype=torch.uint64,
+                device=self.device_pool.device,
+            )
+        else:
+            self.k_data_ptrs = torch.empty(
+                (0,), dtype=torch.uint64, device=self.device_pool.device
+            )
+            self.v_data_ptrs = torch.empty(
+                (0,), dtype=torch.uint64, device=self.device_pool.device
+            )
         self._init_write_back_staging_buffers()
 
     def get_size_per_token(self):
@@ -136,6 +149,15 @@ class MHATokenToKVPoolHost(HostKVCache):
             dims = (
                 2,
                 self.page_num,
+                self.layer_num,
+                self.page_size,
+                self.head_num,
+                self.head_dim,
+            )
+        elif self.layout == "page_blob_direct":
+            dims = (
+                self.page_num,
+                2,
                 self.layer_num,
                 self.page_size,
                 self.head_num,
@@ -200,10 +222,14 @@ class MHATokenToKVPoolHost(HostKVCache):
 
     @property
     def k_buffer(self):
+        if self.layout == "page_blob_direct":
+            return self.kv_buffer.select(1, 0)
         return self.kv_buffer[0]
 
     @property
     def v_buffer(self):
+        if self.layout == "page_blob_direct":
+            return self.kv_buffer.select(1, 1)
         return self.kv_buffer[1]
 
     def load_to_device_per_layer(
@@ -290,7 +316,7 @@ class MHATokenToKVPoolHost(HostKVCache):
                     dst_indices=device_indices,
                     page_size=self.page_size,
                 )
-            elif self.layout == "page_first_direct":
+            elif self.layout in ["page_first_direct", "page_blob_direct"]:
                 transfer_kv_per_layer_direct_pf_lf(
                     src_ptrs=[self.k_buffer, self.v_buffer],
                     dst_ptrs=[
@@ -401,7 +427,7 @@ class MHATokenToKVPoolHost(HostKVCache):
                     dst_indices=host_indices,
                     page_size=self.page_size,
                 )
-            elif self.layout == "page_first_direct":
+            elif self.layout in ["page_first_direct", "page_blob_direct"]:
                 transfer_kv_all_layer_direct_lf_pf(
                     src_ptrs=device_pool.k_buffer + device_pool.v_buffer,
                     dst_ptrs=[self.k_buffer, self.v_buffer],
@@ -436,6 +462,9 @@ class MHATokenToKVPoolHost(HostKVCache):
         elif self.layout in ["page_first_direct", "page_head"]:
             real_index = index // self.page_size
             data_page = self.kv_buffer[:, real_index : real_index + 1, :, :, :, :]
+        elif self.layout == "page_blob_direct":
+            real_index = index // self.page_size
+            data_page = self.kv_buffer[real_index : real_index + 1, :, :, :, :, :]
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")
         if flat:
@@ -472,6 +501,13 @@ class MHATokenToKVPoolHost(HostKVCache):
             self.kv_buffer[:, real_index : real_index + 1, :, :, :, :] = (
                 data_page.reshape(
                     2, 1, self.layer_num, self.page_size, self.head_num, self.head_dim
+                )
+            )
+        elif self.layout == "page_blob_direct":
+            real_index = index // self.page_size
+            self.kv_buffer[real_index : real_index + 1, :, :, :, :, :] = (
+                data_page.reshape(
+                    1, 2, self.layer_num, self.page_size, self.head_num, self.head_dim
                 )
             )
         elif self.layout == "page_head":
@@ -569,6 +605,21 @@ class MHATokenToKVPoolHost(HostKVCache):
                 self.dtype.itemsize * self.page_size * self.head_num * self.head_dim
             )
             element_size_list = [element_size] * len(ptr_list)
+        elif self.layout == "page_blob_direct":
+            element_size = (
+                self.layer_num
+                * self.dtype.itemsize
+                * self.page_size
+                * self.head_num
+                * self.head_dim
+            )
+            page_blob_size = 2 * element_size
+            for index in range(0, len(indices), self.page_size):
+                page_index = indices[index] // self.page_size
+                page_base_ptr = kv_buffer_data_ptr + page_index * page_blob_size
+                ptr_list.append(page_base_ptr)
+                ptr_list.append(page_base_ptr + element_size)
+            element_size_list = [element_size] * len(ptr_list)
         elif self.layout in ["page_first", "page_first_direct", "page_head"]:
             for index in range(0, len(indices), self.page_size):
                 k_ptr = (
@@ -606,15 +657,28 @@ class MHATokenToKVPoolHost(HostKVCache):
         For this to be page-aligned (given a page-aligned ``base_ptr``) the per-page
         stride must itself be a multiple of the OS page size.
         """
-        if self.layout not in ("page_first", "page_first_direct", "page_head"):
+        if self.layout not in (
+            "page_first",
+            "page_first_direct",
+            "page_blob_direct",
+            "page_head",
+        ):
             return False
-        stride = (
+        page_bytes = (
             self.page_size
             * self.layer_num
             * self.head_num
             * self.head_dim
             * self.dtype.itemsize
         )
+        if self.layout == "page_blob_direct":
+            stride = 2 * page_bytes
+            return (
+                self.kv_buffer.data_ptr() % page_size_bytes == 0
+                and page_bytes % page_size_bytes == 0
+                and stride % page_size_bytes == 0
+            )
+        stride = page_bytes
         base_aligned = self.kv_buffer.data_ptr() % page_size_bytes == 0
         return base_aligned and stride % page_size_bytes == 0
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2129,6 +2129,7 @@ class ServerArgs:
                 "layer_first",
                 "page_first",
                 "page_first_direct",
+                "page_blob_direct",
                 "page_first_kv_split",
                 "page_head",
             ],
@@ -5760,12 +5761,12 @@ class ServerArgs:
 
     def _resolve_layout_io_compatibility(self):
         if (
-            self.hicache_mem_layout == "page_first_direct"
+            self.hicache_mem_layout in ["page_first_direct", "page_blob_direct"]
             and self.hicache_io_backend == "kernel"
         ):
             self.hicache_io_backend = "direct"
             logger.warning(
-                "Kernel io backend does not support page first direct layout, switching to direct io backend"
+                "Kernel io backend does not support the requested direct page layout, switching to direct io backend"
             )
 
         if (

--- a/test/registered/unit/mem_cache/test_memory_pool_host_page_blob_direct.py
+++ b/test/registered/unit/mem_cache/test_memory_pool_host_page_blob_direct.py
@@ -1,0 +1,153 @@
+"""Unit tests for the page_blob_direct host layout."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool_host import MambaPoolHost, MLATokenToKVPoolHost
+from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class PageBlobDirectLayoutTest(unittest.TestCase):
+    def _build_mha_pool(self) -> MHATokenToKVPoolHost:
+        device_pool = SimpleNamespace(
+            head_num=2,
+            head_dim=3,
+            layer_num=4,
+            layer_shard_enabled=False,
+            store_dtype=torch.float16,
+            size=2,
+            start_layer=0,
+            end_layer=4,
+            device="cpu",
+        )
+        return MHATokenToKVPoolHost(
+            device_pool,
+            host_to_device_ratio=2.0,
+            host_size=0,
+            page_size=2,
+            layout="page_blob_direct",
+            pin_memory=False,
+            device="cpu",
+        )
+
+    def test_mha_page_blob_direct_keeps_page_blob_contiguous(self) -> None:
+        pool = self._build_mha_pool()
+
+        self.assertEqual(
+            tuple(pool.kv_buffer.shape),
+            (
+                pool.page_num,
+                2,
+                pool.layer_num,
+                pool.page_size,
+                pool.head_num,
+                pool.head_dim,
+            ),
+        )
+
+        page = torch.arange(pool.get_dummy_flat_data_page().numel(), dtype=pool.dtype)
+        pool.set_from_flat_data_page(0, page)
+
+        self.assertTrue(torch.equal(pool.get_data_page(0, flat=True), page))
+
+        first_page_indices = torch.tensor([0, 1], dtype=torch.int64)
+        ptrs, sizes = pool.get_page_buffer_meta(first_page_indices)
+        self.assertEqual(len(ptrs), 2)
+        self.assertEqual(sizes, [sizes[0], sizes[0]])
+        self.assertEqual(ptrs[1] - ptrs[0], sizes[0])
+
+        two_page_indices = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+        ptrs, sizes = pool.get_page_buffer_meta(two_page_indices)
+        self.assertEqual(len(ptrs), 4)
+        self.assertEqual(ptrs[2] - ptrs[0], 2 * sizes[0])
+
+    def test_mla_page_blob_direct_matches_direct_page_shape(self) -> None:
+        device_pool = SimpleNamespace(
+            kv_lora_rank=8,
+            qk_rope_head_dim=4,
+            layer_num=3,
+            layer_shard_enabled=False,
+            store_dtype=torch.float16,
+            size=2,
+            start_layer=0,
+            end_layer=3,
+            device="cpu",
+        )
+        pool = MLATokenToKVPoolHost(
+            device_pool,
+            host_to_device_ratio=2.0,
+            host_size=0,
+            page_size=2,
+            layout="page_blob_direct",
+            pin_memory=False,
+            device="cpu",
+        )
+
+        self.assertEqual(
+            tuple(pool.kv_buffer.shape),
+            (
+                pool.page_num,
+                pool.layer_num,
+                pool.page_size,
+                1,
+                pool.kv_cache_dim,
+            ),
+        )
+
+        page = torch.arange(pool.get_dummy_flat_data_page().numel(), dtype=pool.dtype)
+        pool.set_from_flat_data_page(0, page)
+
+        self.assertTrue(torch.equal(pool.get_data_page(0, flat=True), page))
+
+        first_page_indices = torch.tensor([0, 1], dtype=torch.int64)
+        ptrs, sizes = pool.get_page_buffer_meta(first_page_indices)
+        self.assertEqual(len(ptrs), 1)
+        self.assertEqual(len(sizes), 1)
+        self.assertEqual(sizes[0], page.numel() * page.element_size())
+
+        two_page_indices = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+        ptrs, sizes = pool.get_page_buffer_meta(two_page_indices)
+        self.assertEqual(len(ptrs), 2)
+        self.assertEqual(ptrs[1] - ptrs[0], sizes[0])
+
+    def test_mamba_page_blob_direct_uses_direct_page_shape(self) -> None:
+        device_pool = SimpleNamespace(
+            num_mamba_layers=2,
+            size=3,
+            device="cpu",
+            mamba_cache=SimpleNamespace(
+                temporal=torch.zeros((2, 3, 5), dtype=torch.float16),
+                conv=[torch.zeros((2, 3, 4), dtype=torch.float16)],
+            ),
+        )
+        pool = MambaPoolHost(
+            device_pool,
+            host_to_device_ratio=1.0,
+            host_size=0,
+            layout="page_blob_direct",
+            pin_memory=False,
+            device="cpu",
+        )
+
+        self.assertEqual(tuple(pool.temporal_buffer.shape), (pool.size, 2, 1, 5))
+        self.assertEqual(tuple(pool.conv_buffer[0].shape), (pool.size, 2, 1, 4))
+
+        page = torch.arange(pool.get_dummy_flat_data_page().numel(), dtype=torch.uint8)
+        pool.set_from_flat_data_page(0, page)
+
+        self.assertTrue(torch.equal(pool.get_data_page(0, flat=True), page))
+
+        ptrs, sizes = pool.get_page_buffer_meta(torch.tensor([0], dtype=torch.int64))
+        self.assertEqual(len(ptrs), 2)
+        self.assertEqual(len(sizes), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR adds a new HiCache host memory layout: `page_blob_direct`. This is a preparatory PR for the Tensorcast HiCache backend integration https://github.com/sgl-project/sglang/pull/27265. The Tensorcast backend wants a page-major host layout where each logical cache page is represented as one contiguous page blob.  As requested by @hzh0425, splitting this layout support into a separate PR keeps the Tensorcast backend PR focused on the backend itself.

The main advantages of `page_blob_direct` layout are stated in https://github.com/sgl-project/sglang/pull/27265 ("page_blob_direct layout" part). Besides, it becomes a unified HiCache host-layout option across MHA, MLA, and Mamba models, while preserving each cache type's native physical representation.

## Modifications

`page_blob_direct` essentially swaps `(page_num, 2)` positions in `page_first_direct` layout

For MHA KV cache, `page_blob_direct` stores host KV cache as:

  ```text
  kv_buffer shape:

    [page_num, 2, layer_num, page_size, head_num, head_dim]

  Conceptually, each logical page is laid out as one contiguous blob:

  page 0
  +--------------------------------------------------------------+
  | K for all layers/tokens/heads | V for all layers/tokens/heads |
  +--------------------------------------------------------------+

  page 1
  +--------------------------------------------------------------+
  | K for all layers/tokens/heads | V for all layers/tokens/heads |
  +--------------------------------------------------------------+

  page 2
  +--------------------------------------------------------------+
  | K for all layers/tokens/heads | V for all layers/tokens/heads |
  +--------------------------------------------------------------+

  In pointer form:

  page_blob(p) = base + p * (2 * page_bytes)

  K(p) = page_blob(p)
  V(p) = page_blob(p) + page_bytes
```
For MLA or Mamba cache, `page_blob_direct` is interpreted as the closest page-major direct layout for each cache type, one blob per page.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->