### PR TITLE
[AMD] sgl-kernel: enable gfx1151 (RDNA3.5 / Strix Halo) for single-GPU

### DIFF
--- a/sgl-kernel/csrc/common_extension_rocm.cc
+++ b/sgl-kernel/csrc/common_extension_rocm.cc
@@ -67,8 +67,12 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.impl("dsv4_fused_q_indexer_rope_hadamard_quant", torch::kCUDA, &dsv4_fused_q_indexer_rope_hadamard_quant);
 
   /*
-   * From csrc/allreduce
+   * From csrc/allreduce -- custom/deterministic/quick all-reduce are CDNA-only
+   * (cross-GPU peer-IPC + wave64). Guarded out on RDNA (single-GPU); the .hip
+   * sources are also omitted from the RDNA build in setup_rocm.py, and multi-GPU
+   * all-reduce falls back to RCCL.
    */
+#ifndef SGL_IS_RDNA
   m.def(
       "init_custom_ar(Tensor meta, Tensor rank_data, "
       "str[] handles, int[] offsets, int rank, "
@@ -128,6 +132,7 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
 
   // Max input size in bytes
   m.def("qr_max_size", &qr_max_size);
+#endif  // !SGL_IS_RDNA
 
   /*
    * From csrc/moe

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -52,6 +52,9 @@ using fptr_t = int64_t;
  * From csrc/allreduce
  */
 #ifdef USE_ROCM
+// ROCM custom/deterministic/quick all-reduce: CDNA-only, guarded out on RDNA
+// (single-GPU). The .hip sources are also omitted from the RDNA build.
+#ifndef SGL_IS_RDNA
 // ROCM custom allreduce
 fptr_t init_custom_ar(
     torch::Tensor& meta,
@@ -78,6 +81,7 @@ torch::Tensor qr_get_handle(fptr_t _fa);
 void qr_open_handles(fptr_t _fa, const std::vector<torch::Tensor>& handles);
 void qr_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out, int64_t quant_level, bool cast_bf2half = false);
 int64_t qr_max_size();
+#endif  // !SGL_IS_RDNA
 #else
 // custom allreduce
 fptr_t

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -342,7 +342,13 @@ inline bool getEnvEnablePDL() {
 #ifndef USE_ROCM
 #define WARP_SIZE 32
 #else
-#if defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
+// ROCm: host and device passes must agree on the logical warp width. Historically
+// host code (__HIP_DEVICE_COMPILE__ undefined) always saw 64 while RDNA device code
+// saw 32, mismatching grid/block math in the MoE topk launchers. setup_rocm.py passes
+// SGL_ROCM_WARP_SIZE (64 on CDNA, 32 on RDNA) so both passes agree.
+#ifdef SGL_ROCM_WARP_SIZE
+#define WARP_SIZE SGL_ROCM_WARP_SIZE
+#elif defined(__GFX9__) || !defined(__HIP_DEVICE_COMPILE__)
 #define WARP_SIZE 64
 #else
 #define WARP_SIZE 32

--- a/sgl-kernel/python/sgl_kernel/allreduce.py
+++ b/sgl-kernel/python/sgl_kernel/allreduce.py
@@ -3,25 +3,29 @@ from typing import List, Optional, Tuple
 import torch
 
 
-def _is_rdna() -> bool:
-    """True if the current AMD GPU is RDNA (gfx11xx/gfx12xx).
+def _has_custom_ar() -> bool:
+    """True if the custom all-reduce operators are compiled and registered.
 
     The custom/deterministic/quick all-reduce ops are CDNA-only and are omitted
-    from the RDNA build (see sgl-kernel/setup_rocm.py), so their Python wrappers
-    are skipped here too. Multi-GPU all-reduce on RDNA falls back to RCCL.
+    from the RDNA build (see sgl-kernel/setup_rocm.py). Probing the registered
+    ops instead of the device arch avoids initializing CUDA at import time:
+    eagerly calling torch.cuda.get_device_properties(0) here would force CUDA
+    init on device 0, which breaks fork-based multiprocessing and pins the
+    process to device 0 before CUDA_VISIBLE_DEVICES is honored. common_ops is
+    loaded before this module, so the registry is already populated.
     """
-    if torch.version.hip is None or not torch.cuda.is_available():
-        return False
     try:
-        arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
-        return arch.startswith("gfx11") or arch.startswith("gfx12")
+        return hasattr(torch.ops.sgl_kernel, "init_custom_ar")
     except Exception:
         return False
 
 
-_HIP_IS_RDNA = _is_rdna()
+# CDNA ROCm builds compile the custom all-reduce ops; RDNA builds omit them
+# (multi-GPU all-reduce falls back to RCCL). CUDA always has them and is handled
+# by the final `else` branch, so gate the ROCm wrappers on hip + op presence.
+_HAS_CUSTOM_AR = torch.version.hip is not None and _has_custom_ar()
 
-if torch.version.hip is not None and not _HIP_IS_RDNA:
+if _HAS_CUSTOM_AR:
     # ROCM custom allreduce
     def init_custom_ar(
         meta: torch.Tensor,

--- a/sgl-kernel/python/sgl_kernel/allreduce.py
+++ b/sgl-kernel/python/sgl_kernel/allreduce.py
@@ -2,7 +2,26 @@ from typing import List, Optional, Tuple
 
 import torch
 
-if torch.version.hip is not None:
+
+def _is_rdna() -> bool:
+    """True if the current AMD GPU is RDNA (gfx11xx/gfx12xx).
+
+    The custom/deterministic/quick all-reduce ops are CDNA-only and are omitted
+    from the RDNA build (see sgl-kernel/setup_rocm.py), so their Python wrappers
+    are skipped here too. Multi-GPU all-reduce on RDNA falls back to RCCL.
+    """
+    if torch.version.hip is None or not torch.cuda.is_available():
+        return False
+    try:
+        arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+        return arch.startswith("gfx11") or arch.startswith("gfx12")
+    except Exception:
+        return False
+
+
+_HIP_IS_RDNA = _is_rdna()
+
+if torch.version.hip is not None and not _HIP_IS_RDNA:
     # ROCM custom allreduce
     def init_custom_ar(
         meta: torch.Tensor,
@@ -91,6 +110,12 @@ if torch.version.hip is not None:
 
     def qr_max_size() -> int:
         return torch.ops.sgl_kernel.qr_max_size.default()
+
+elif torch.version.hip is not None:
+    # RDNA (e.g. gfx1151 / Strix Halo): the CDNA-only custom/deterministic/quick
+    # all-reduce ops are not built, so no wrappers are exposed here. Multi-GPU
+    # all-reduce falls back to RCCL; single-GPU never calls all-reduce.
+    pass
 
 else:
 

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -40,10 +40,11 @@ include_dirs = [
     root / "csrc",
 ]
 
+# The custom multi-GPU all-reduce collectives (custom/deterministic/quick) are
+# CDNA-only (cross-GPU peer-IPC + wave64). They are appended below for CDNA
+# targets only; on RDNA they are omitted from the build and #ifdef'd out of
+# registration via -DSGL_IS_RDNA, so multi-GPU all-reduce falls back to RCCL.
 sources = [
-    "csrc/allreduce/custom_all_reduce.hip",
-    "csrc/allreduce/deterministic_all_reduce.hip",
-    "csrc/allreduce/quick_all_reduce.cu",
     "csrc/common_extension_rocm.cc",
     "csrc/elementwise/activation.cu",
     "csrc/elementwise/deepseek_v4_topk.cu",
@@ -74,21 +75,39 @@ if torch.cuda.is_available():
 else:
     print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
 
-if amdgpu_target not in ["gfx942", "gfx950"]:
+# Supported architectures:
+#   CDNA3  (gfx942, MI300X/MI325X) and CDNA3+ (gfx950, MI350X)
+#   RDNA3.5 (gfx1151, Strix Halo / Ryzen AI Max) -- single-GPU only
+CDNA_TARGETS = ["gfx942", "gfx950"]
+RDNA_TARGETS = ["gfx1151"]
+SUPPORTED_TARGETS = CDNA_TARGETS + RDNA_TARGETS
+
+if amdgpu_target not in SUPPORTED_TARGETS:
     print(
-        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
+        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. "
+        f"Supported: {SUPPORTED_TARGETS}."
     )
     sys.exit(1)
+
+is_cdna = amdgpu_target in CDNA_TARGETS
+is_rdna = amdgpu_target in RDNA_TARGETS
 
 fp8_macro = (
     "-DHIP_FP8_TYPE_FNUZ" if amdgpu_target == "gfx942" else "-DHIP_FP8_TYPE_E4M3"
 )
 
 # Dynamic shared-memory budget for the TopK kernels.
-# - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
-#   (leaves room for static shared allocations in the kernel).
-# - gfx95x (MI350): LDS is larger (e.g. 160KB per CU) -> allow the original 128KB dynamic smem.
-topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
+# - gfx950 (MI350): large LDS (~160KB/CU) -> allow the 128KB dynamic smem path.
+# - gfx942 (MI300/MI325) and RDNA (gfx1151): 64KB LDS/workgroup -> cap at 48KB.
+topk_dynamic_smem_bytes = 32 * 1024 * 4 if amdgpu_target == "gfx950" else 48 * 1024
+
+# CDNA-only custom multi-GPU all-reduce kernels (see the sources note above).
+if is_cdna:
+    sources += [
+        "csrc/allreduce/custom_all_reduce.hip",
+        "csrc/allreduce/deterministic_all_reduce.hip",
+        "csrc/allreduce/quick_all_reduce.cu",
+    ]
 
 hipcc_flags = [
     "-DNDEBUG",
@@ -103,6 +122,17 @@ hipcc_flags = [
     fp8_macro,
     f"-DSGL_TOPK_DYNAMIC_SMEM_BYTES={topk_dynamic_smem_bytes}",
 ]
+
+# Host and device passes must agree on the logical warp/wave width (CDNA=64,
+# RDNA=32); WARP_SIZE in include/utils.h reads SGL_ROCM_WARP_SIZE. On RDNA,
+# SGL_IS_RDNA additionally #ifdef's the CDNA-only all-reduce ops out of the
+# cxx-compiled registration TU (common_extension_rocm.cc) so it links against
+# exactly the objects that were built.
+_rocm_arch_flags = [f"-DSGL_ROCM_WARP_SIZE={64 if is_cdna else 32}"]
+if is_rdna:
+    _rocm_arch_flags.append("-DSGL_IS_RDNA")
+hipcc_flags += _rocm_arch_flags
+cxx_flags += _rocm_arch_flags
 
 ext_modules = [
     CUDAExtension(


### PR DESCRIPTION
## Motivation

`sgl-kernel` currently `sys.exit(1)`s on any architecture other than gfx942/gfx950, so AMD **Strix Halo (gfx1151, RDNA3.5)** cannot build it. gfx1151 is also the first **wave32** target `sgl-kernel` would support (all prior AMD targets are wave64 CDNA), which surfaces two latent bugs:

- The host compile pass hardcodes `WARP_SIZE = 64`, so on wave32 the host launch geometry (64) mismatches the device `__launch_bounds__` (32) — **every MoE `topk_softmax` launch fails with `hipErrorLaunchFailure`**.
- The TopK kernels request a 128 KB dynamic-shared-memory budget only gfx950 has (RDNA has 64 KB per workgroup).

This makes `sgl-kernel` build and launch correctly on **single-GPU** gfx1151, validated on real Strix Halo silicon. It consolidates the existing (stalled, partly-conflicting) RDNA PRs — #24158, #28097, #28518 — into one coherent change, and adds the piece none of them cover for gfx1151: guarding the multi-GPU collectives that can't be validated on a single APU. Part of the consumer-RDNA (gfx1151) enablement tracked in #30599.

---

## ⭐ TL;DR — build this series from source, and 12 mainstream models run on gfx1151 today

This PR is the base of a small, self-contained series that together makes a **from-source build serve the current mainstream model families on Strix Halo (gfx1151), no hand-patching**. Every model in the matrix below was served on **real gfx1151 silicon** with the branches in the index applied, **zero `hipError` across all 12**, correct generation verified.

**The claim, stated so it can be checked:** *build `sgl-kernel` from source with this PR, add the merged/open companion PRs listed in the index, launch with `--attention-backend triton`, and these 12 models run.*

---

## 📇 The gfx1151 enablement series (this PR is the index)

| PR | Title | What it does for gfx1151 | Status |
|---|---|---|---|
| **#31137** *(this PR)* | sgl-kernel gfx1151 build | wave32 `WARP_SIZE`; TopK LDS cap; single-GPU collective guard | **OPEN** |
| #31143 | jit_kernel HIP-compat | JIT KV-cache kernel missing HIP enum mappings; stock `main` can't serve without it | ✅ **MERGED** |
| #31403 | HIP RMSNorm fallback (RMSNorm **+ GemmaRMSNorm**) | vllm 4-arg vs AITER 6-arg `TypeError` on every residual norm without AITER; both classes | **OPEN** |
| #31246 | MoE `no_grad` cuda-graph fix | Triton MoE sum-reduce blocked decode-graph capture on gfx1151 | **OPEN** |
| #31421 | Optional aiter imports at startup | 3 quant modules imported AITER unconditionally → server couldn't start at all without AITER | **OPEN** |
| #31259 | Default RDNA → Triton attention | Auto-selects Triton; **ease-of-life, not required** — matrix passes the flag explicitly | **OPEN** |

> Validation used **#31137 + #31143 (merged) + #31403 + #31246 + #31421**, launching with `--attention-backend triton` explicitly (**without** relying on #31259).

---

## Modifications

All changes under `sgl-kernel/` (single component):

- **`setup_rocm.py`** — add `gfx1151`; classify `is_cdna`/`is_rdna`; `-DSGL_ROCM_WARP_SIZE` (64 CDNA / 32 RDNA); cap TopK smem to 48 KB off gfx950; on RDNA omit the three `csrc/allreduce/*` sources + `-DSGL_IS_RDNA`.
- **`include/utils.h`** — host-pass `WARP_SIZE` follows `SGL_ROCM_WARP_SIZE`; **CDNA byte-for-byte unchanged**.
- **`common_extension_rocm.cc`, `sgl_kernel_ops.h`, `allreduce.py`** — `#ifndef SGL_IS_RDNA` guards around the three collectives (mechanism follows #24158, extended to all three).

**wave32 fix — before/after:**

| build | OLMoE (MoE) serve |
|---|---|
| without | ❌ `topk_softmax launch error: unspecified launch failure` |
| with | ✅ serves, correct, 0 hipError |

---

## ✅ Validation — 12 mainstream models served on real gfx1151

**HW:** Ryzen AI Max+ 395 / **Radeon 8060S (gfx1151, RDNA3.5, wave32)**, 88 GB GTT, ROCm 7.2.4.
**Stack:** this PR + #31143 (merged) + #31403 + #31246 + #31421, `--attention-backend triton`.
**Bench:** `sglang.bench_serving`, random 1024-in/256-out; 1-stream = 8 prompts @ conc 1; 8-way = 32 @ conc 8.
**Every row: `triton`, 0 `hipError`, generation verified** (chat template for instruction/reasoning models).

| # | Model | Size | Quant / Arch | Runs | tok/s (1) | tok/s (8) |
|---|---|---|---|:---:|---:|---:|
| 1 | `Qwen2.5-7B-Instruct-AWQ` | 4.5 GB | AWQ 4-bit | ✅ | 6.64 | 43.66 |
| 2 | `Phi-4-mini-instruct` | 7.7 GB | bf16 dense | ✅ | 21.70 | 127.54 |
| 3 | `Mistral-7B-Instruct-v0.3` | 14.5 GB | bf16 dense | ✅ | 11.25 | 67.93 |
| 4 | `Llama-3.1-8B-Instruct` | 16 GB | bf16 dense | ✅ | 10.78 | 65.45 |
| 5 | `Qwen3.5-9B` | 19 GB | bf16 dense (reasoning) | ✅ | 9.94 | 57.44 |
| 6 | `lmsys/gpt-oss-20b-bf16` | 22.7 GB | **MoE** (4/32) | ✅ | 24.72 | 60.64 |
| 7 | `google/gemma-4-12B-it` | 23.9 GB | bf16 dense, mm + SWA | ✅ | 8.61 | 50.73 |
| 8 | `DeepSeek-V2-Lite-Chat` | 31 GB | **MoE + MLA** (64) | ✅ | 15.29 | 42.78 |
| 9 | `Mistral-Small-24B-Base` | 47 GB | bf16 dense | ✅ | 4.41 | 26.56 |
| 10 | `Qwen3.6-27B` | 55.6 GB | bf16 dense | ✅ | 4.15 | 23.54 |
| 11 | `google/gemma-4-31B-it` | 62.5 GB | bf16 dense, mm + SWA | ✅ | 3.30 | 20.02 |
| 12 | `Qwen3.6-35B-A3B` | 64 GB | **Mamba + MoE** (~3B active) | ✅ | 9.69 | 31.76 |

**Families:** dense · MoE · MLA · Mamba-hybrid · multimodal · 4-bit AWQ · bf16 · reasoning.

> ⚠️ Throughput is an **UNTUNED BASELINE** — gfx1151 has zero tuned fused-MoE Triton configs in-tree (359 shipped, all CDNA). Floors, not ceilings.

---

## 🔍 Findings

**1. MoE is the architecture that wins on a big-memory APU.** Decode is memory-bandwidth-bound in the weights it actually reads, and a MoE reads only its **active** parameters per token — a small fraction of the total. So a MoE decodes at roughly the speed of a *dense model its active size*, while holding the capacity of its *total size*:

| Model | Total | Active / token | tok/s (1 stream) |
|---|---|---|---|
| gpt-oss-20b (MoE) | 21 B | ~3.6 B | 24.72 |
| DeepSeek-V2-Lite (MoE+MLA) | 16 B | ~2.4 B | 15.29 |
| Qwen3.6-35B-A3B (Mamba+MoE) | 35 B | ~3 B | 9.69 |

The cleanest evidence is a same-family, dense-vs-MoE pair from this matrix:

| Qwen3.6 family | Total params | tok/s (1) |
|---|---|---|
| Qwen3.6-27B (**dense**) | 27 B | 4.15 |
| Qwen3.6-35B-A3B (**MoE**) | 35 B | **9.69** |

**The MoE has more total parameters than the dense model, yet decodes 2.3× faster** — because it activates only ~3 B per token while the dense model reads all 27 B. That is the headline: a **35B-class model at conversational speed on a laptop APU**, where a dense 35B would be roughly 2–3 tok/s. On gfx1151 — abundant unified memory, limited bandwidth — **MoE is the sweet spot: the memory holds the whole model, and only a slice is read per token. Spend capacity on MoE, not on 4-bit.**

**2. 4-bit buys capacity, not speed** — control-measured, same family/params:

| | AWQ 4-bit | bf16 |
|---|---|---|
| Qwen2.5-7B, tok/s (1) | 6.64 | **15.53** (2.34× faster) |

**3. This validation found a real bug in the series.** Serving Qwen3.5-9B crashed on the exact `TypeError` #31403 fixes — because #31403 patched `RMSNorm` but missed `GemmaRMSNorm`, which backs Gemma/Gemma2/Qwen3.5/Qwen3.6/Qwen3-Next/MiniMax/Step3.5 (rows 5, 10, 11, 12). Folded into #31403: verified vs `forward_native` at cos ≥ 0.999994, red/green regression test, proven end-to-end.

---

## Reproduction — exact commands

```bash
# 1. build sgl-kernel from source for gfx1151 (this PR)
cd sgl-kernel && AMDGPU_TARGET=gfx1151 python setup_rocm.py install

# 2. small/medium models (rows 1-8) — defaults:
python -m sglang.launch_server --model-path <MODEL> \
  --attention-backend triton --mem-fraction-static 0.5 --trust-remote-code

# 3. large models (rows 9-12, ~47-64 GB) — two documented flags for the
#    Strix Halo GTT accounting, else CUDA-graph capture OOMs:
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
python -m sglang.launch_server --model-path <MODEL> \
  --attention-backend triton --mem-fraction-static 0.80 --context-length 8192 \
  --trust-remote-code
```

- `--attention-backend triton` required until #31259 lands (AITER is CDNA-only).
- Instruction/reasoning models (Gemma-4, GPT-OSS, Qwen3.5/3.6) must be prompted via the **chat template**; raw completion is not a correctness signal for these families.
- The large-model memory flags are a real gfx1151 requirement (torch reports the ~47 GB VRAM carve-out as "capacity" while the model allocates into the ~88 GB GTT pool).

---

## Accuracy

No numerics change on CDNA targets. On gfx1151, **full 1319-question GSM8K** (5-shot, greedy) across the two biggest architecture buckets — dense and MoE:

| Model | Path exercised | GSM8K (1319q) | Invalid | hipError |
|---|---|---|---|---|
| `Llama-3.1-8B-Instruct` | dense bf16 attention + RMSNorm + sampling | **75.5%** | 0.1% | 0 |
| `lmsys/gpt-oss-20b-bf16` | MoE fused kernel + expert routing + reasoning | **92.1%** | 0.0% | 0 |

The **near-zero invalid rate** (a well-formed numeric answer on 99.9–100% of questions) is the correctness signal: a numerical fault on the wave32 path would surface as garbage, not a clean answer. The accuracies sit in each model's expected range for this 5-shot greedy harness — confirming the math is *right*, not merely non-crashing. gpt-oss is scored through its chat template (`--enable-thinking`), so the harmony reasoning format is parsed correctly.

Scope: a **representative subset** — dense + MoE, the two paths where "wrong but plausible" is the real risk — not the full 12-model matrix, and not a same-harness CUDA comparison. The defensible claim is "correct math at each model's expected accuracy, with 0–0.1% invalid," which the numbers support.

## No-CDNA-regression

Cross-compiled for gfx942 (wave64) and gfx950 (wave64) — both build, all collectives kept, no `SGL_IS_RDNA`; existing CUDA/CDNA CI covers the untouched path.

## Checklist

- [x] Format with pre-commit (all green).
- [ ] Unit tests — N/A here (build-script + preprocessor gate, matches #7092); companion PRs ship their own.
- [ ] Docs — N/A this PR; serving guide follows once the series merges.
- [x] Accuracy/speed — matrix above; no change on existing targets.
- [x] Code style.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29318338348](https://github.com/sgl-project/sglang/actions/runs/29318338348)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29318338208](https://github.com/sgl-project/sglang/actions/runs/29318338208)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->