### PR TITLE
[PP&Spec] enable speculative decoding (eagle_worker_v2) under PP

### DIFF
--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -105,11 +105,17 @@ def init_torch_distributed(
                 tp_size=ps.tp_size, pp_size=ps.pp_size, moe_ep_size=ps.moe_ep_size
             )
 
+    # When pipeline parallelism is enabled, the draft model should use the TP
+    # communication group of its PP rank rather than the world group.
+    if is_draft_worker and ps.pp_size > 1:
+        sync_group = get_tp_group()
+    else:
+        sync_group = get_world_group()
     pre_model_load_memory = get_available_gpu_memory(
         device,
         ps.gpu_id,
-        distributed=get_world_group().world_size > 1,
-        cpu_group=get_world_group().cpu_group,
+        distributed=sync_group.world_size > 1,
+        cpu_group=sync_group.cpu_group,
     )
     tp_group = get_tp_group()
     pp_group = get_pp_group()

--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -129,11 +129,17 @@ def init_torch_distributed(
         ):
             _prewarm_tp_lm_head_all_to_all()
 
+    # When pipeline parallelism is enabled, the draft model should use the TP
+    # communication group of its PP rank rather than the world group.
+    if is_draft_worker and ps.pp_size > 1:
+        sync_group = get_tp_group()
+    else:
+        sync_group = get_world_group()
     pre_model_load_memory = get_available_gpu_memory(
         device,
         ps.gpu_id,
-        distributed=get_world_group().world_size > 1,
-        cpu_group=get_world_group().cpu_group,
+        distributed=sync_group.world_size > 1,
+        cpu_group=sync_group.cpu_group,
     )
     tp_group = get_tp_group()
     pp_group = get_pp_group()

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -116,12 +116,17 @@ class P2PWork:
 
 
 def _split_tensor_dict(
-    tensor_dict: Dict[str, Union[torch.Tensor, Any]],
+    tensor_dict: Dict[str, Union[torch.Tensor, Any]], prefix: str = ""
 ) -> Tuple[List[Tuple[str, Any]], List[torch.Tensor]]:
     """Split the tensor dictionary into two parts:
     1. A list of (key, value) pairs. If the value is a tensor, it is replaced
          by its metadata.
     2. A list of tensors.
+
+    If the tensor is nested under ``tensor_dict["key1"]["key2"]``, the key of
+    its metadata is flattened to "key1%key2" (see ``_update_nested_dict`` for
+    the reverse), so nested tensors also travel over the GPU channel instead
+    of being pickled through CPU.
     """
     metadata_list: List[Tuple[str, Any]] = []
     tensor_list: List[torch.Tensor] = []
@@ -133,12 +138,31 @@ def _split_tensor_dict(
             # receiving side will set the device index.
             device = value.device.type
             metadata_list.append(
-                (key, TensorMetadata(device, value.dtype, value.size()))
+                (prefix + key, TensorMetadata(device, value.dtype, value.size()))
             )
             tensor_list.append(value)
+        elif isinstance(value, dict):
+            if len(value) == 0:
+                metadata_list.append((prefix + key, value))
+            inner_metadata_list, inner_tensor_list = _split_tensor_dict(
+                value, prefix + key + "%"
+            )
+            metadata_list.extend(inner_metadata_list)
+            tensor_list.extend(inner_tensor_list)
         else:
-            metadata_list.append((key, value))
+            metadata_list.append((prefix + key, value))
     return metadata_list, tensor_list
+
+
+def _update_nested_dict(nested_dict, flattened_key, value):
+    """Rebuild a nested dict from a "%"-flattened key (see _split_tensor_dict)."""
+    key_splits = flattened_key.split("%")
+    cur_dict = nested_dict
+    for k in key_splits[:-1]:
+        if k not in cur_dict:
+            cur_dict[k] = {}
+        cur_dict = cur_dict[k]
+    cur_dict[key_splits[-1]] = value
 
 
 _group_name_counter: Dict[str, int] = {}
@@ -1663,7 +1687,7 @@ class GroupCoordinator:
                     )
                     if tensor.numel() == 0:
                         # Skip broadcasting empty tensors.
-                        tensor_dict[key] = tensor
+                        _update_nested_dict(tensor_dict, key, tensor)
                         continue
                     if tensor.is_cpu:
                         # use metadata_group for CPU tensors
@@ -1679,9 +1703,9 @@ class GroupCoordinator:
                             tensor, src=self.ranks[src], group=group, async_op=True
                         )
                     async_handles.append(handle)
-                    tensor_dict[key] = tensor
+                    _update_nested_dict(tensor_dict, key, tensor)
                 else:
-                    tensor_dict[key] = value
+                    _update_nested_dict(tensor_dict, key, value)
             for async_handle in async_handles:
                 async_handle.wait()
         return tensor_dict
@@ -1771,8 +1795,8 @@ class GroupCoordinator:
             if isinstance(value, TensorMetadata):
                 tensor = torch.empty(value.size, dtype=value.dtype, device=value.device)
                 if tensor.numel() == 0:
-                    # Skip broadcasting empty tensors.
-                    tensor_dict[key] = tensor
+                    # Skip receiving empty tensors.
+                    _update_nested_dict(tensor_dict, key, tensor)
                     continue
 
                 # send-allgather: send only a slice, then do allgather.
@@ -1796,9 +1820,9 @@ class GroupCoordinator:
                     tensor = all_gather_group.all_gather(tensor, dim=0)
                     tensor = tensor.reshape(orig_shape)
 
-                tensor_dict[key] = tensor
+                _update_nested_dict(tensor_dict, key, tensor)
             else:
-                tensor_dict[key] = value
+                _update_nested_dict(tensor_dict, key, value)
         return tensor_dict
 
     def barrier(self):

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -302,7 +302,11 @@ class FutureMap:
 
         # Spec extras are gated by spec_algo, not by the payload's shape, so a
         # non-spec stash allocates no extra bufs (only output_tokens_buf).
-        self.need_topk = self.spec_algo.is_some() and self.spec_algo.need_topk()
+        self.need_topk = (
+            self.spec_algo.is_some()
+            and self.spec_algo.need_topk()
+            and payload.topk_p is not None
+        )
         self.need_hidden_states = (
             self.spec_algo.is_some()
             and spec_need_hidden_states()

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -320,7 +320,11 @@ class FutureMap:
 
         # Spec extras are gated by spec_algo, not by the payload's shape, so a
         # non-spec stash allocates no extra bufs (only output_tokens_buf).
-        self.need_topk = self.spec_algo.is_some() and self.spec_algo.need_topk()
+        self.need_topk = (
+            self.spec_algo.is_some()
+            and self.spec_algo.need_topk()
+            and payload.topk_p is not None
+        )
         self.need_hidden_states = (
             self.spec_algo.is_some()
             and spec_need_hidden_states()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1180,6 +1180,13 @@ class Scheduler(
         self.is_mixed_chunk = (
             self.chunked_prefill_size is not None and get_schedule().enable_mixed_chunk
         )
+        # Under PP + spec, prefill reqs run as EXTEND and decode reqs as
+        # TARGET_VERIFY, so they cannot be merged into a single MIXED batch.
+        assert not (
+            self.is_mixed_chunk
+            and self.ps.pp_size > 1
+            and not self.spec_algorithm.is_none()
+        ), "PP + spec-v2 does not support mixed-chunk prefill; disable --enable-mixed-chunk."
 
         # Init the dynamic chunking predictor for PP
         self.enable_dynamic_chunking = (
@@ -1316,9 +1323,13 @@ class Scheduler(
             else None
         )
 
-        if self.spec_algorithm.carries_draft_hidden_states():
+        if (
+            self.spec_algorithm.carries_draft_hidden_states()
+            and self.draft_worker.draft_worker is not None
+        ):
             # `draft_runner` aliases `draft_runner_list[0]` in the multi-layer
-            # worker, so a single accessor covers both shapes.
+            # worker, so a single accessor covers both shapes. Non-last PP
+            # ranks have no draft worker, so fall through to the default.
             draft_runner = self.draft_worker.draft_worker.draft_runner
             disagg_hidden_size, disagg_hidden_states_dtype = (
                 get_draft_recurrent_hidden_state_spec(draft_runner)
@@ -3755,6 +3766,18 @@ class Scheduler(
                 batch_result = self.tp_worker.forward_batch_split_prefill(batch)
                 self._relay_forward_payload(batch.req_pool_indices, batch_result)
                 batch.input_ids = None
+            elif not batch.spec_algorithm.is_none() and self.ps.pp_size > 1:
+                # PP + spec non-overlap path: forward receives pp_proxy_tensors
+                # and returns batch_result whose post-processing (KV move,
+                # seq_lens advance) is handled by process_batch_result on every
+                # PP rank. Non-last ranks get EaglePPVerifyInputRaw via spec_info
+                # from _pp_prep_batch_result.
+                resolve_forward_inputs(batch, self.future_map)
+                with self._forward_isolation(batch, overlap=False):
+                    batch_result = self.model_worker.forward_batch_generation(
+                        batch, pp_proxy_tensors=pp_proxy_tensors
+                    )
+                self.update_cache_from_scheduler(batch, batch_result)
             elif not batch.spec_algorithm.is_none():
                 # Non-overlap: drive the V2 worker synchronously (no
                 # future_map relay / on_publish).

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1067,6 +1067,13 @@ class Scheduler(
             self.chunked_prefill_size is not None
             and self.server_args.enable_mixed_chunk
         )
+        # Under PP + spec, prefill reqs run as EXTEND and decode reqs as
+        # TARGET_VERIFY, so they cannot be merged into a single MIXED batch.
+        assert not (
+            self.is_mixed_chunk
+            and self.ps.pp_size > 1
+            and not self.spec_algorithm.is_none()
+        ), "PP + spec-v2 does not support mixed-chunk prefill; disable --enable-mixed-chunk."
 
         # Init the dynamic chunking predictor for PP
         self.enable_dynamic_chunking = (
@@ -1189,9 +1196,13 @@ class Scheduler(
             server_args=self.server_args,
         )
 
-        if self.spec_algorithm.carries_draft_hidden_states():
+        if (
+            self.spec_algorithm.carries_draft_hidden_states()
+            and self.draft_worker.draft_worker is not None
+        ):
             # `draft_runner` aliases `draft_runner_list[0]` in the multi-layer
-            # worker, so a single accessor covers both shapes.
+            # worker, so a single accessor covers both shapes. Non-last PP
+            # ranks have no draft worker, so fall through to the default.
             draft_runner = self.draft_worker.draft_worker.draft_runner
             disagg_hidden_size, disagg_hidden_states_dtype = (
                 get_draft_recurrent_hidden_state_spec(draft_runner)
@@ -3497,6 +3508,18 @@ class Scheduler(
                 batch_result = self.tp_worker.forward_batch_split_prefill(batch)
                 self._relay_forward_payload(batch.req_pool_indices, batch_result)
                 batch.input_ids = None
+            elif not batch.spec_algorithm.is_none() and self.ps.pp_size > 1:
+                # PP + spec non-overlap path: forward receives pp_proxy_tensors
+                # and returns batch_result whose post-processing (KV move,
+                # seq_lens advance) is handled by process_batch_result on every
+                # PP rank. Non-last ranks get EaglePPVerifyInputRaw via spec_info
+                # from _pp_prep_batch_result.
+                resolve_forward_inputs(batch, self.future_map)
+                with self._forward_isolation(batch, overlap=False):
+                    batch_result = self.model_worker.forward_batch_generation(
+                        batch, pp_proxy_tensors=pp_proxy_tensors
+                    )
+                self.update_cache_from_scheduler(batch, batch_result)
             elif not batch.spec_algorithm.is_none():
                 # Non-overlap: drive the V2 worker synchronously (no
                 # future_map relay / on_publish).

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -29,6 +29,8 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.srt.speculative.eagle_info import EaglePPVerifyInputRaw
+from sglang.srt.speculative.spec_utils import move_accept_tokens_to_target_kvcache
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.state_capturer.routed_experts import get_global_experts_capturer
 
@@ -761,6 +763,25 @@ class SchedulerBatchResultProcessor:
                 value=can_run_cuda_graph
             )
 
+        accept_lens = None
+        accept_lens_cpu = None
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            pp_raw = batch.spec_info
+            accept_lens_cpu = torch.tensor(pp_raw.accept_lens, dtype=torch.int64)
+            accept_lens = accept_lens_cpu.to(batch.seq_lens.device)
+            if pp_raw.accept_index is not None:
+                accept_index = torch.tensor(
+                    pp_raw.accept_index,
+                    dtype=torch.long,
+                    device=batch.seq_lens.device,
+                )
+                move_accept_tokens_to_target_kvcache(
+                    batch,
+                    accept_index,
+                    accept_lens - 1,
+                    self.model_worker.token_to_kv_pool_allocator,
+                )
+
         self.token_to_kv_pool_allocator.free_group_begin()
 
         for i, req in enumerate(batch.reqs):
@@ -823,6 +844,12 @@ class SchedulerBatchResultProcessor:
 
         self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
         self.token_to_kv_pool_allocator.free_group_end()
+
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            batch.seq_lens = batch.seq_lens + accept_lens
+            if batch.seq_lens_cpu is not None:
+                batch.seq_lens_cpu = batch.seq_lens_cpu + accept_lens_cpu
+            batch.seq_lens_sum = None
 
         self.metrics_reporter.forward_ct_decode = (
             self.metrics_reporter.forward_ct_decode + 1

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -848,14 +848,10 @@ class SchedulerBatchResultProcessor:
         accept_lens_cpu = None
         if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
             pp_raw = batch.spec_info
-            accept_lens_cpu = torch.tensor(pp_raw.accept_lens, dtype=torch.int64)
-            accept_lens = accept_lens_cpu.to(batch.seq_lens.device)
+            accept_lens = pp_raw.accept_lens.to(torch.int64)
+            accept_lens_cpu = accept_lens.cpu()
             if pp_raw.accept_index is not None:
-                accept_index = torch.tensor(
-                    pp_raw.accept_index,
-                    dtype=torch.long,
-                    device=batch.seq_lens.device,
-                )
+                accept_index = pp_raw.accept_index.to(torch.long)
                 move_accept_tokens_to_target_kvcache(
                     batch,
                     accept_index,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -41,6 +41,8 @@ from sglang.srt.runtime_context import (
     max_speculative_num_draft_tokens,
 )
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.srt.speculative.eagle_info import EaglePPVerifyInputRaw
+from sglang.srt.speculative.spec_utils import move_accept_tokens_to_target_kvcache
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.state_capturer.routed_experts import get_global_experts_capturer
 
@@ -842,6 +844,25 @@ class SchedulerBatchResultProcessor:
                 value=can_run_cuda_graph
             )
 
+        accept_lens = None
+        accept_lens_cpu = None
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            pp_raw = batch.spec_info
+            accept_lens_cpu = torch.tensor(pp_raw.accept_lens, dtype=torch.int64)
+            accept_lens = accept_lens_cpu.to(batch.seq_lens.device)
+            if pp_raw.accept_index is not None:
+                accept_index = torch.tensor(
+                    pp_raw.accept_index,
+                    dtype=torch.long,
+                    device=batch.seq_lens.device,
+                )
+                move_accept_tokens_to_target_kvcache(
+                    batch,
+                    accept_index,
+                    accept_lens - 1,
+                    self.model_worker.token_to_kv_pool_allocator,
+                )
+
         self.token_to_kv_pool_allocator.free_group_begin()
 
         for i, req in enumerate(batch.reqs):
@@ -905,6 +926,12 @@ class SchedulerBatchResultProcessor:
 
         self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
         self.token_to_kv_pool_allocator.free_group_end()
+
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            batch.seq_lens = batch.seq_lens + accept_lens
+            if batch.seq_lens_cpu is not None:
+                batch.seq_lens_cpu = batch.seq_lens_cpu + accept_lens_cpu
+            batch.seq_lens_sum = None
 
         self.metrics_reporter.forward_ct_decode = (
             self.metrics_reporter.forward_ct_decode + 1

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1011,6 +1011,13 @@ class SchedulerPPMixin:
                 **tensor_dict,
                 **logprob_dict,
             }
+
+        # PP + spec: the last PP rank serializes the draft tree so non-last ranks
+        # can rebuild EagleVerifyInput on the next iter. Carried as plain Python
+        # lists alongside the tensor payload.
+        if result.pp_verify_input_raw:
+            tensor_dict.update(result.pp_verify_input_raw.to_tensor_dict())
+
         return tensor_dict
 
     def _pp_send_dict_to_next_stage(
@@ -1124,6 +1131,7 @@ class SchedulerPPMixin:
         pp_outputs: PPProxyTensors,
     ):
         from sglang.srt.managers.scheduler import GenerationBatchResult
+        from sglang.srt.speculative.eagle_info import EaglePPVerifyInputRaw
 
         logits_output = None
         extend_input_len_per_req = None
@@ -1136,13 +1144,35 @@ class SchedulerPPMixin:
                 extend_logprob_start_len_per_req,
             ) = get_logprob_from_pp_outputs(pp_outputs)
         next_token_ids = pp_outputs["next_token_ids"].to(torch.int64)
-        # PP rank 0 also relays into output_tokens_buf so the next iter's
-        # resolve_forward_inputs finds these tokens for the decode portion
-        # of mixed-chunk batches (which gather via mix_running_indices).
-        self.future_map.stash(
-            batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
-        )
-        batch.input_ids = None
+        batch.input_ids = next_token_ids
+
+        if not self.spec_algorithm.is_none() and "pp_spec_output" in pp_outputs.tensors:
+            # Spec-v2 decode path: the last PP rank produced draft tokens for
+            # this iter; rebuild the raw draft tree so _build_verify_input_from_pp_raw
+            # can construct EagleVerifyInput on this rank.
+            batch.spec_info = EaglePPVerifyInputRaw.from_pp_outputs(pp_outputs)
+        elif not self.spec_algorithm.is_none() and batch.forward_mode.is_extend():
+            if batch.contains_last_prefill_chunk:
+                # The last PP rank produces no draft tokens for prefill batches;
+                # build a dummy draft for the first decode step.
+                batch.spec_info = EaglePPVerifyInputRaw.build_dummy_for_decode(
+                    batch, self.server_args.speculative_num_draft_tokens
+                )
+            else:
+                # Chunked prefill middle chunk: its next_token_ids is a
+                # placeholder that no consumer reads (the next iter is another
+                # extend and resolve_forward_inputs sources input_ids from the
+                # prefill staging copy). Do nothing here.
+                pass
+        else:
+            # PP rank 0 also relays into output_tokens_buf so the next iter's
+            # resolve_forward_inputs finds these tokens for the decode portion
+            # of mixed-chunk batches (which gather via mix_running_indices).
+            self.future_map.stash(
+                batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
+            )
+            batch.input_ids = None
+
         output_result = GenerationBatchResult(
             logits_output=logits_output,
             pp_hidden_states_proxy_tensors=None,
@@ -1151,6 +1181,23 @@ class SchedulerPPMixin:
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
         )
+
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            output_result.accept_lens = torch.tensor(
+                batch.spec_info.accept_lens, dtype=torch.int64
+            )
+            output_result.speculative_num_draft_tokens = (
+                self.server_args.speculative_num_draft_tokens
+            )
+
+        # Async copy the CPU-bound fields ahead of time; d2h_event in the
+        # caller guarantees completion before the result is consumed.
+        output_result.copy_done = self.device_module.Event()
+        output_result.copy_to_cpu(
+            return_logprob=batch.return_logprob,
+            return_hidden_states=False,
+        )
+
         return output_result
 
     def _pp_process_batch_result(

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -39,7 +39,7 @@ from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.runtime_context import get_disagg, get_parallel
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import DynamicGradMode, broadcast_pyobj, point_to_point_pyobj
-from sglang.srt.utils.common import get_device_module, is_xpu
+from sglang.srt.utils.common import get_device_module
 
 logger = logging.getLogger(__name__)
 
@@ -1028,8 +1028,9 @@ class SchedulerPPMixin:
             }
 
         # PP + spec: the last PP rank serializes the draft tree so non-last ranks
-        # can rebuild EagleVerifyInput on the next iter. Carried as plain Python
-        # lists alongside the tensor payload.
+        # can rebuild EagleVerifyInput on the next iter. Nested under
+        # 'pp_spec_output' and flattened by _split_tensor_dict so the tensors
+        # travel over the GPU channel.
         if result.pp_verify_input_raw:
             tensor_dict.update(result.pp_verify_input_raw.to_tensor_dict())
 
@@ -1198,9 +1199,7 @@ class SchedulerPPMixin:
         )
 
         if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
-            output_result.accept_lens = torch.tensor(
-                batch.spec_info.accept_lens, dtype=torch.int64
-            )
+            output_result.accept_lens = batch.spec_info.accept_lens.to(torch.int64)
             output_result.speculative_num_draft_tokens = (
                 self.server_args.speculative_num_draft_tokens
             )
@@ -1274,18 +1273,13 @@ class SchedulerPPMixin:
         batch_result = None
         send_output_work = []
 
-        # On CUDA, isend is async: it enqueues to the stream and returns,
-        # so every rank can send first safely. On some backends isend is
-        # effectively blocking and does not return until the peer posts a
-        # matching recv; if every PP rank sends first, all ranks block
-        # waiting for a receiver and the ring deadlocks. Order send/recv
-        # by pp_rank parity (even: send->recv, odd: recv->send) so each
-        # adjacent pair has one sender and one receiver posted at the
-        # same time.
-
-        # CUDA: send first
-        # XPU: even ranks send first, odd ranks recv first.
-        send_first = (not is_xpu()) or ((self.ps.pp_rank % 2) == 0)
+        # isend only makes the CPU call asynchronous. Device P2P work is still
+        # ordered on the CUDA stream, so enqueueing several sends before any
+        # recv on every PP rank can form a ring wait. This happens when output
+        # metadata contains multiple GPU tensors (for example speculative
+        # verify state). Pair adjacent stages by parity so one side posts recv
+        # while the other posts send.
+        send_first = (self.ps.pp_rank % 2) == 0
 
         def _do_send():
             return self._pp_send_output_to_next_stage(

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1026,6 +1026,13 @@ class SchedulerPPMixin:
                 **tensor_dict,
                 **logprob_dict,
             }
+
+        # PP + spec: the last PP rank serializes the draft tree so non-last ranks
+        # can rebuild EagleVerifyInput on the next iter. Carried as plain Python
+        # lists alongside the tensor payload.
+        if result.pp_verify_input_raw:
+            tensor_dict.update(result.pp_verify_input_raw.to_tensor_dict())
+
         return tensor_dict
 
     def _pp_send_dict_to_next_stage(
@@ -1139,6 +1146,7 @@ class SchedulerPPMixin:
         pp_outputs: PPProxyTensors,
     ):
         from sglang.srt.managers.scheduler import GenerationBatchResult
+        from sglang.srt.speculative.eagle_info import EaglePPVerifyInputRaw
 
         logits_output = None
         extend_input_len_per_req = None
@@ -1151,13 +1159,35 @@ class SchedulerPPMixin:
                 extend_logprob_start_len_per_req,
             ) = get_logprob_from_pp_outputs(pp_outputs)
         next_token_ids = pp_outputs["next_token_ids"].to(torch.int64)
-        # PP rank 0 also relays into output_tokens_buf so the next iter's
-        # resolve_forward_inputs finds these tokens for the decode portion
-        # of mixed-chunk batches (which gather via mix_running_indices).
-        self.future_map.stash(
-            batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
-        )
-        batch.input_ids = None
+        batch.input_ids = next_token_ids
+
+        if not self.spec_algorithm.is_none() and "pp_spec_output" in pp_outputs.tensors:
+            # Spec-v2 decode path: the last PP rank produced draft tokens for
+            # this iter; rebuild the raw draft tree so _build_verify_input_from_pp_raw
+            # can construct EagleVerifyInput on this rank.
+            batch.spec_info = EaglePPVerifyInputRaw.from_pp_outputs(pp_outputs)
+        elif not self.spec_algorithm.is_none() and batch.forward_mode.is_extend():
+            if batch.contains_last_prefill_chunk:
+                # The last PP rank produces no draft tokens for prefill batches;
+                # build a dummy draft for the first decode step.
+                batch.spec_info = EaglePPVerifyInputRaw.build_dummy_for_decode(
+                    batch, self.server_args.speculative_num_draft_tokens
+                )
+            else:
+                # Chunked prefill middle chunk: its next_token_ids is a
+                # placeholder that no consumer reads (the next iter is another
+                # extend and resolve_forward_inputs sources input_ids from the
+                # prefill staging copy). Do nothing here.
+                pass
+        else:
+            # PP rank 0 also relays into output_tokens_buf so the next iter's
+            # resolve_forward_inputs finds these tokens for the decode portion
+            # of mixed-chunk batches (which gather via mix_running_indices).
+            self.future_map.stash(
+                batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
+            )
+            batch.input_ids = None
+
         output_result = GenerationBatchResult(
             logits_output=logits_output,
             pp_hidden_states_proxy_tensors=None,
@@ -1166,6 +1196,23 @@ class SchedulerPPMixin:
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
         )
+
+        if isinstance(batch.spec_info, EaglePPVerifyInputRaw):
+            output_result.accept_lens = torch.tensor(
+                batch.spec_info.accept_lens, dtype=torch.int64
+            )
+            output_result.speculative_num_draft_tokens = (
+                self.server_args.speculative_num_draft_tokens
+            )
+
+        # Async copy the CPU-bound fields ahead of time; d2h_event in the
+        # caller guarantees completion before the result is consumed.
+        output_result.copy_done = self.device_module.Event()
+        output_result.copy_to_cpu(
+            return_logprob=batch.return_logprob,
+            return_hidden_states=False,
+        )
+
         return output_result
 
     def _pp_process_batch_result(

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -38,8 +38,9 @@ from sglang.srt.model_executor.forward_batch_info import (
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.runtime_context import get_disagg, get_parallel
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import DynamicGradMode, broadcast_pyobj, point_to_point_pyobj
-from sglang.srt.utils.common import get_device_module
+from sglang.srt.utils.common import get_device_module, is_xpu
 
 logger = logging.getLogger(__name__)
 
@@ -1273,13 +1274,23 @@ class SchedulerPPMixin:
         batch_result = None
         send_output_work = []
 
-        # isend only makes the CPU call asynchronous. Device P2P work is still
-        # ordered on the CUDA stream, so enqueueing several sends before any
-        # recv on every PP rank can form a ring wait. This happens when output
-        # metadata contains multiple GPU tensors (for example speculative
-        # verify state). Pair adjacent stages by parity so one side posts recv
-        # while the other posts send.
-        send_first = (self.ps.pp_rank % 2) == 0
+        # On CUDA, isend is async: it enqueues to the stream and returns,
+        # so every rank can send first safely. On some backends isend is
+        # effectively blocking and does not return until the peer posts a
+        # matching recv; if every PP rank sends first, all ranks block
+        # waiting for a receiver and the ring deadlocks. Order send/recv
+        # by pp_rank parity (even: send->recv, odd: recv->send) so each
+        # adjacent pair has one sender and one receiver posted at the
+        # same time.
+
+        if self.spec_algorithm == SpeculativeAlgorithm.EAGLE:
+            # PP+MTP: every rank sending first deadlocks on CUDA, so even
+            # ranks send first instead.
+            send_first = (self.ps.pp_rank % 2) == 0
+        else:
+            # CUDA: send first
+            # XPU: even ranks send first, odd ranks recv first.
+            send_first = (not is_xpu()) or ((self.ps.pp_rank % 2) == 0)
 
         def _do_send():
             return self._pp_send_output_to_next_stage(

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -312,6 +312,7 @@ class TpModelWorker(BaseTpWorker):
         is_multi_layer_eagle: bool = False,
         context_length: Optional[int] = None,
         draft_attention_backend: Optional[str] = None,
+        pp_global_random_seed: Optional[int] = None,
     ):
         # Parse args
         self.server_args = server_args
@@ -371,8 +372,16 @@ class TpModelWorker(BaseTpWorker):
         self.world_group = get_world_group()
 
         # Sync random seed across TP workers.
+        # Under PP the draft worker's TP worker is created on only one PP rank
+        # (the last), so it cannot join the launch-time WORLD broadcast; reuse
+        # the target worker's resolved seed directly.
         # Elastic joiners cannot enter the launch-time WORLD broadcast.
-        if server_args.is_ep_joiner:
+        if self.is_draft_worker and server_args.pp_size > 1:
+            assert (
+                pp_global_random_seed is not None
+            ), "pp_global_random_seed must be provided for the draft worker under PP"
+            self.random_seed = pp_global_random_seed
+        elif server_args.is_ep_joiner:
             self.random_seed = server_args.random_seed
         else:
             self.random_seed = broadcast_pyobj(

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -288,6 +288,7 @@ class TpModelWorker(BaseTpWorker):
         memory_pool_config: Optional[MemoryPoolConfig] = None,
         is_multi_layer_eagle: bool = False,
         context_length: Optional[int] = None,
+        pp_global_random_seed: Optional[int] = None,
     ):
         # Parse args
         self.server_args = server_args
@@ -345,8 +346,16 @@ class TpModelWorker(BaseTpWorker):
         self.world_group = get_world_group()
 
         # Sync random seed across TP workers.
+        # Under PP the draft worker's TP worker is created on only one PP rank
+        # (the last), so it cannot join the launch-time WORLD broadcast; reuse
+        # the target worker's resolved seed directly.
         # Elastic joiners cannot enter the launch-time WORLD broadcast.
-        if server_args.is_ep_joiner:
+        if self.is_draft_worker and server_args.pp_size > 1:
+            assert (
+                pp_global_random_seed is not None
+            ), "pp_global_random_seed must be provided for the draft worker under PP"
+            self.random_seed = pp_global_random_seed
+        elif server_args.is_ep_joiner:
             self.random_seed = server_args.random_seed
         else:
             self.random_seed = broadcast_pyobj(

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -15,8 +15,10 @@ from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 if TYPE_CHECKING:
-    from sglang.srt.managers.scheduler import GenerationBatchResult
-    from sglang.srt.speculative.eagle_info import EagleDraftInput
+    from sglang.srt.speculative.eagle_info import (
+        EagleDraftInput,
+        EaglePPVerifyInputRaw,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -76,6 +78,7 @@ class GenerationBatchResult:
     # FIXME(lsyin): maybe move to a better place?
     # sync path: forward stream -> output processor
     accept_lens: Optional[torch.Tensor] = None
+    accept_index: Optional[torch.Tensor] = None
 
     block_accept_lens: Optional[torch.Tensor] = None
 
@@ -102,6 +105,11 @@ class GenerationBatchResult:
     # Forward pass metrics (FPM) — GPU-accurate timing via CUDA events
     fpm_start_event: Optional[torch.cuda.Event] = None
     fpm_end_event: Optional[torch.cuda.Event] = None
+
+    # PP + Spec: produced by the last PP rank after draft/draft_extend_for_decode,
+    # consumed by _pp_prepare_tensor_dict for PP ring transmission so non-last PP
+    # ranks can rebuild EagleVerifyInput on the next iteration.
+    pp_verify_input_raw: Optional[EaglePPVerifyInputRaw] = None
 
     @property
     def has_sampled_token_ids(self) -> bool:

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -21,7 +21,10 @@ from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import GenerationBatchResult
-    from sglang.srt.speculative.eagle_info import EagleDraftInput
+    from sglang.srt.speculative.eagle_info import (
+        EagleDraftInput,
+        EaglePPVerifyInputRaw,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -81,6 +84,7 @@ class GenerationBatchResult:
     # FIXME(lsyin): maybe move to a better place?
     # sync path: forward stream -> output processor
     accept_lens: Optional[torch.Tensor] = None
+    accept_index: Optional[torch.Tensor] = None
 
     block_accept_lens: Optional[torch.Tensor] = None
 
@@ -107,6 +111,11 @@ class GenerationBatchResult:
     # Forward pass metrics (FPM) — GPU-accurate timing via CUDA events
     fpm_start_event: Optional[torch.cuda.Event] = None
     fpm_end_event: Optional[torch.cuda.Event] = None
+
+    # PP + Spec: produced by the last PP rank after draft/draft_extend_for_decode,
+    # consumed by _pp_prepare_tensor_dict for PP ring transmission so non-last PP
+    # ranks can rebuild EagleVerifyInput on the next iteration.
+    pp_verify_input_raw: Optional[EaglePPVerifyInputRaw] = None
 
     @property
     def has_sampled_token_ids(self) -> bool:

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -62,6 +62,12 @@ def get_draft_kv_pool(
     if draft_worker is None or spec_algorithm.is_ngram():
         return None
 
+    # Under PP the draft model only runs on its host PP rank (the last one);
+    # other ranks have no draft worker and thus no draft KV pool.
+    parallel = get_parallel()
+    if parallel.pp_size > 1 and parallel.pp_rank != parallel.pp_size - 1:
+        return None
+
     # V2 workers nest the draft runner under `.draft_worker`.
     if server_args.enable_multi_layer_eagle:
         draft_runner = draft_worker.draft_worker.draft_runner_list[0]

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -60,6 +60,31 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
+def get_draft_kv_pool(
+    *,
+    draft_worker: BaseTpWorker,
+    spec_algorithm: SpeculativeAlgorithm,
+    server_args: ServerArgs,
+):
+    """Return the draft token-to-KV pool for the current draft worker,
+    or None when no draft KV pool is available."""
+    if draft_worker is None or spec_algorithm.is_ngram():
+        return None
+
+    # Under PP the draft model only runs on its host PP rank (the last one);
+    # other ranks have no draft worker and thus no draft KV pool.
+    parallel = get_parallel()
+    if parallel.pp_size > 1 and parallel.pp_rank != parallel.pp_size - 1:
+        return None
+
+    # V2 workers nest the draft runner under `.draft_worker`.
+    if server_args.enable_multi_layer_eagle:
+        draft_runner = draft_worker.draft_worker.draft_runner_list[0]
+    else:
+        draft_runner = draft_worker.draft_worker.draft_runner
+    return draft_runner.token_to_kv_pool
+
+
 def maybe_register_hicache_draft(
     *,
     tree_cache,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -446,7 +446,7 @@ class ModelRunner:
             "pp_proxy_tensors" in inspect.signature(self.model.forward).parameters
         )
 
-        if self.ps.pp_size > 1:
+        if self.ps.pp_size > 1 and not self.is_draft_worker:
             assert (
                 self.support_pp
             ), "Pipeline Parallel is not compatible with this model."

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -387,7 +387,7 @@ class ModelRunner:
             "pp_proxy_tensors" in inspect.signature(self.model.forward).parameters
         )
 
-        if self.ps.pp_size > 1:
+        if self.ps.pp_size > 1 and not self.is_draft_worker:
             assert (
                 self.support_pp
             ), "Pipeline Parallel is not compatible with this model."

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -193,14 +193,19 @@ def _assert_pp_mtp_compat(
     num_effective_layers: int,
     model_num_layers: int,
 ) -> None:
+    # PP partitions layers across ranks, so each rank holds only a slice
+    # (num_effective_layers < model_num_layers). PP+EAGLE and PP+DSpark
+    # explicitly support MTP draft models on the last PP rank, so the
+    # per-rank slice must not trigger the "PP incompatible with MTP" guard.
     assert (
         (not model_has_mtp_layers)
         or (spec_algorithm.is_none())
+        or (num_effective_layers == model_num_layers)
         or (
-            (not spec_algorithm.is_none())
-            and (num_effective_layers == model_num_layers)
+            (num_effective_layers != model_num_layers)
+            and (spec_algorithm.is_eagle() or spec_algorithm.is_dspark())
         )
-    ), "PP is not compatible with MTP models."
+    ), "PP is not compatible with MTP models except when using EAGLE or DSpark speculative decoding."
 
 
 def adjust_hybrid_swa_layer_ids(

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -197,14 +197,19 @@ def _assert_pp_mtp_compat(
     num_effective_layers: int,
     model_num_layers: int,
 ) -> None:
+    # PP partitions layers across ranks, so each rank holds only a slice
+    # (num_effective_layers < model_num_layers). PP+EAGLE and PP+DSpark
+    # explicitly support MTP draft models on the last PP rank, so the
+    # per-rank slice must not trigger the "PP incompatible with MTP" guard.
     assert (
         (not model_has_mtp_layers)
         or (spec_algorithm.is_none())
+        or (num_effective_layers == model_num_layers)
         or (
-            (not spec_algorithm.is_none())
-            and (num_effective_layers == model_num_layers)
+            (num_effective_layers != model_num_layers)
+            and (spec_algorithm.is_eagle() or spec_algorithm.is_dspark())
         )
-    ), "PP is not compatible with MTP models."
+    ), "PP is not compatible with MTP models except when using EAGLE or DSpark speculative decoding."
 
 
 def adjust_hybrid_swa_layer_ids(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -199,8 +199,10 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                             get_glm_dsa_layer_split_effective_num_layers,
                         )
 
-                        target_kv_num_layers = get_glm_dsa_layer_split_effective_num_layers(
-                            kvc, num_layers
+                        target_kv_num_layers = (
+                            get_glm_dsa_layer_split_effective_num_layers(
+                                kvc, num_layers
+                            )
                         )
                         draft_kv_size = int(
                             target_kv_size * draft_num_layers / target_kv_num_layers

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -171,66 +171,70 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             else kvc.server_args.max_total_tokens or kvc.model_config.context_len
         )
 
-        # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
-        # Assumes draft and target share the same per-layer KV size (head_dim,
-        # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
-        # reuse the target architecture's attention config.
-        if (
-            kvc.spec_algorithm.is_eagle() or kvc.spec_algorithm.is_standalone()
-        ) and not kvc.is_draft_worker:
-            eagle_draft_num_layers = kvc.spec_aux_config.eagle_draft_num_layers
+        # Under pipeline parallelism the draft worker lives on a single PP rank
+        # (the last one); only that rank's target pool needs to reserve draft
+        # KV. Matches DSV4PoolConfigurator's (pp_size==1 or is_last_rank).
+        if kvc.ps.pp_size == 1 or kvc.pp_group.is_last_rank:
+            # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
+            # Assumes draft and target share the same per-layer KV size (head_dim,
+            # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
+            # reuse the target architecture's attention config.
             if (
-                eagle_draft_num_layers is not None
-                and int(eagle_draft_num_layers) > 0
-                and int(num_layers) > 0
-            ):
-                draft_num_layers = int(eagle_draft_num_layers)
-                if is_deepseek_dsa(kvc.model_config.hf_config):
-                    target_indexer_size = self._compute_dsa_indexer_cell_size(
-                        kvc=kvc,
-                        num_layers=num_layers,
-                    )
-                    target_kv_size = self._cell_size - target_indexer_size
-                    from sglang.srt.layers.cp.utils import (
-                        get_glm_dsa_layer_split_effective_num_layers,
-                    )
+                kvc.spec_algorithm.is_eagle() or kvc.spec_algorithm.is_standalone()
+            ) and not kvc.is_draft_worker:
+                eagle_draft_num_layers = kvc.spec_aux_config.eagle_draft_num_layers
+                if (
+                    eagle_draft_num_layers is not None
+                    and int(eagle_draft_num_layers) > 0
+                    and int(num_layers) > 0
+                ):
+                    draft_num_layers = int(eagle_draft_num_layers)
+                    if is_deepseek_dsa(kvc.model_config.hf_config):
+                        target_indexer_size = self._compute_dsa_indexer_cell_size(
+                            kvc=kvc,
+                            num_layers=num_layers,
+                        )
+                        target_kv_size = self._cell_size - target_indexer_size
+                        from sglang.srt.layers.cp.utils import (
+                            get_glm_dsa_layer_split_effective_num_layers,
+                        )
 
-                    target_kv_num_layers = get_glm_dsa_layer_split_effective_num_layers(
-                        kvc, num_layers
-                    )
-                    draft_kv_size = int(
-                        target_kv_size * draft_num_layers / target_kv_num_layers
-                    )
-                    draft_indexer_size = self._compute_dsa_indexer_cell_size(
-                        kvc=kvc,
-                        num_layers=draft_num_layers,
-                        allocate_all_layers=True,
-                    )
-                    self._cell_size += draft_kv_size + draft_indexer_size
-                else:
-                    self._cell_size = int(
-                        self._cell_size * (1 + draft_num_layers / int(num_layers))
-                    )
+                        target_kv_num_layers = get_glm_dsa_layer_split_effective_num_layers(
+                            kvc, num_layers
+                        )
+                        draft_kv_size = int(
+                            target_kv_size * draft_num_layers / target_kv_num_layers
+                        )
+                        draft_indexer_size = self._compute_dsa_indexer_cell_size(
+                            kvc=kvc,
+                            num_layers=draft_num_layers,
+                            allocate_all_layers=True,
+                        )
+                        self._cell_size += draft_kv_size + draft_indexer_size
+                    else:
+                        self._cell_size = int(
+                            self._cell_size * (1 + draft_num_layers / int(num_layers))
+                        )
 
-        # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
-        if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
-            from sglang.srt.speculative.dflash_utils import (
-                scale_kv_cell_size_per_token_for_dflash,
-            )
-
-            draft_num_layers = kvc.spec_aux_config.dflash_draft_num_layers
-            if (
-                draft_num_layers is not None
-                and int(draft_num_layers) > 0
-                and int(num_layers) > 0
-            ):
-                self._cell_size = scale_kv_cell_size_per_token_for_dflash(
-                    target_cell_size_per_token=self._cell_size,
-                    target_num_layers=int(num_layers),
-                    draft_num_layers=int(draft_num_layers)
-                    * get_parallel().attn_dcp_size,
-                    draft_cell_size_per_token=_dflash_draft_cell_size(kvc) or None,
+            # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
+            if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
+                from sglang.srt.speculative.dflash_utils import (
+                    scale_kv_cell_size_per_token_for_dflash,
                 )
+
+                draft_num_layers = kvc.spec_aux_config.dflash_draft_num_layers
+                if (
+                    draft_num_layers is not None
+                    and int(draft_num_layers) > 0
+                    and int(num_layers) > 0
+                ):
+                    self._cell_size = scale_kv_cell_size_per_token_for_dflash(
+                        target_cell_size_per_token=self._cell_size,
+                        target_num_layers=int(num_layers),
+                        draft_num_layers=int(draft_num_layers)
+                        * get_parallel().attn_dcp_size,
+                        draft_cell_size_per_token=_dflash_draft_cell_size(kvc) or None,
+                    )
 
     def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
         """Compute per-token KV cache cost in bytes. Subclasses can override."""
@@ -778,11 +782,13 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             )
 
         self.bytes_per_full_token = self._get_bytes_per_full_token()
-        if self.is_speculative:
+        if self.is_speculative and (kvc.ps.pp_size == 1 or kvc.pp_group.is_last_rank):
             # Reserve memory for the speculative draft worker by inflating
             # per-token bytes by (target+draft)/target. Equivalent to dflash's
             # scale_kv_cell_size_per_token_for_dflash but applied to
             # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
+            # Under pipeline parallelism, only the draft-host PP rank (the last one)
+            # needs this: the draft model's KV pool lives only there.
             draft_layers = 1
             target_layers = self.num_layers_total
             self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -143,41 +143,45 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             else kvc.server_args.max_total_tokens or kvc.model_config.context_len
         )
 
-        # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
-        # Assumes draft and target share the same per-layer KV size (head_dim,
-        # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
-        # reuse the target architecture's attention config.
-        if (
-            kvc.spec_algorithm.is_eagle() or kvc.spec_algorithm.is_standalone()
-        ) and not kvc.is_draft_worker:
-            eagle_draft_num_layers = kvc.spec_aux_config.eagle_draft_num_layers
+        # Under pipeline parallelism the draft worker lives on a single PP rank
+        # (the last one); only that rank's target pool needs to reserve draft
+        # KV. Matches DSV4PoolConfigurator's (pp_size==1 or is_last_rank).
+        if kvc.ps.pp_size == 1 or kvc.pp_group.is_last_rank:
+            # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
+            # Assumes draft and target share the same per-layer KV size (head_dim,
+            # num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
+            # reuse the target architecture's attention config.
             if (
-                eagle_draft_num_layers is not None
-                and int(eagle_draft_num_layers) > 0
-                and int(num_layers) > 0
-            ):
-                self._cell_size = int(
-                    self._cell_size
-                    * (1 + int(eagle_draft_num_layers) / int(num_layers))
+                kvc.spec_algorithm.is_eagle() or kvc.spec_algorithm.is_standalone()
+            ) and not kvc.is_draft_worker:
+                eagle_draft_num_layers = kvc.spec_aux_config.eagle_draft_num_layers
+                if (
+                    eagle_draft_num_layers is not None
+                    and int(eagle_draft_num_layers) > 0
+                    and int(num_layers) > 0
+                ):
+                    self._cell_size = int(
+                        self._cell_size
+                        * (1 + int(eagle_draft_num_layers) / int(num_layers))
+                    )
+
+            # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
+            if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
+                from sglang.srt.speculative.dflash_utils import (
+                    scale_kv_cell_size_per_token_for_dflash,
                 )
 
-        # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
-        if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
-            from sglang.srt.speculative.dflash_utils import (
-                scale_kv_cell_size_per_token_for_dflash,
-            )
-
-            draft_num_layers = kvc.spec_aux_config.dflash_draft_num_layers
-            if (
-                draft_num_layers is not None
-                and int(draft_num_layers) > 0
-                and int(num_layers) > 0
-            ):
-                self._cell_size = scale_kv_cell_size_per_token_for_dflash(
-                    target_cell_size_per_token=self._cell_size,
-                    target_num_layers=int(num_layers),
-                    draft_num_layers=int(draft_num_layers),
-                )
+                draft_num_layers = kvc.spec_aux_config.dflash_draft_num_layers
+                if (
+                    draft_num_layers is not None
+                    and int(draft_num_layers) > 0
+                    and int(num_layers) > 0
+                ):
+                    self._cell_size = scale_kv_cell_size_per_token_for_dflash(
+                        target_cell_size_per_token=self._cell_size,
+                        target_num_layers=int(num_layers),
+                        draft_num_layers=int(draft_num_layers),
+                    )
 
     def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
         """Compute per-token KV cache cost in bytes. Subclasses can override."""
@@ -663,11 +667,13 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.num_layers_ca128 = sum(1 for r in self.compression_ratios if r == 128)
 
         self.bytes_per_full_token = self._get_bytes_per_full_token()
-        if self.is_speculative:
+        if self.is_speculative and (kvc.ps.pp_size == 1 or kvc.pp_group.is_last_rank):
             # Reserve memory for the speculative draft worker by inflating
             # per-token bytes by (target+draft)/target. Equivalent to dflash's
             # scale_kv_cell_size_per_token_for_dflash but applied to
             # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
+            # Under pipeline parallelism, only the draft-host PP rank (the last one)
+            # needs this: the draft model's KV pool lives only there.
             draft_layers = 1
             target_layers = self.num_layers_total
             self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1095,6 +1095,15 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 self.buffers.input_embeds[: self.raw_num_token].copy_(
                     forward_batch.input_embeds
                 )
+            # Under speculative decoding + PP, pp_proxy_tensors also
+            # need to be copied here
+            if pp_proxy_tensors is not None and hasattr(
+                self.buffers, "pp_proxy_tensors"
+            ):
+                for key, dst in self.buffers.pp_proxy_tensors.items():
+                    src = pp_proxy_tensors.tensors.get(key)
+                    if src is not None:
+                        dst[: src.shape[0]].copy_(src)
             variant_label = self._resolve_lora_variant(forward_batch)
             stream_idx = get_current_stream_idx() if self.enable_pdmux else None
             self._replay_graph_key = self._make_graph_key(
@@ -1288,7 +1297,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
         else:
             assert isinstance(output, PPProxyTensors)
-            return PPProxyTensors({k: v[: self.bs] for k, v in output.tensors.items()})
+            return PPProxyTensors(
+                {k: v[: self.raw_num_token] for k, v in output.tensors.items()}
+            )
 
     def get_spec_info(self, num_tokens: int):
         spec_info = None

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1276,6 +1276,15 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 self.buffers.input_embeds[: self.raw_num_token].copy_(
                     forward_batch.input_embeds
                 )
+            # Under speculative decoding + PP, pp_proxy_tensors also
+            # need to be copied here
+            if pp_proxy_tensors is not None and hasattr(
+                self.buffers, "pp_proxy_tensors"
+            ):
+                for key, dst in self.buffers.pp_proxy_tensors.items():
+                    src = pp_proxy_tensors.tensors.get(key)
+                    if src is not None:
+                        dst[: src.shape[0]].copy_(src)
             variant_label = self._resolve_lora_variant(forward_batch)
             dsa_variant = self._resolve_dsa_variant(forward_batch)
             stream_idx = get_current_stream_idx() if self.enable_pdmux else None
@@ -1447,7 +1456,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             )
         else:
             assert isinstance(output, PPProxyTensors)
-            return PPProxyTensors({k: v[: self.bs] for k, v in output.tensors.items()})
+            return PPProxyTensors(
+                {k: v[: self.raw_num_token] for k, v in output.tensors.items()}
+            )
 
     def get_spec_info(self, num_tokens: int):
         spec_info = None

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -132,11 +132,11 @@ class DecodeInputBuffers(ForwardInputBuffers):
                 is_mhc = hc_hidden_size is not None
                 hs = hc_hidden_size if is_mhc else hidden_size
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                    "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
                 }
                 if not is_mhc:
                     pp_proxy_tensors["residual"] = torch.zeros(
-                        (max_bs, hidden_size), dtype=dtype
+                        (max_num_token, hidden_size), dtype=dtype
                     )
                 if pp_proxy_topk_size is not None:
                     pp_proxy_tensors["topk_indices"] = torch.zeros(

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -133,15 +133,17 @@ class DecodeInputBuffers(ForwardInputBuffers):
                 is_mhc = hc_hidden_size is not None
                 hs = hc_hidden_size if is_mhc else hidden_size
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                    "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
                 }
                 if not is_mhc:
                     # Only Kimi K3 supplies num_blocks: its PP bank is token-major
-                    # [T, blocks, H]. Other models keep the legacy [max_bs, H].
+                    # [T, blocks, H]. Other models keep the legacy token-major
+                    # [max_num_token, H] (token dim, not max_bs: spec decoding
+                    # runs more tokens than requests per step).
                     residual_shape = (
                         (max_num_token, pp_proxy_residual_num_blocks, hidden_size)
                         if pp_proxy_residual_num_blocks is not None
-                        else (max_bs, hidden_size)
+                        else (max_num_token, hidden_size)
                     )
                     pp_proxy_tensors["residual"] = torch.zeros(
                         residual_shape, dtype=dtype

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -230,11 +230,20 @@ class DeepseekV2WeightLoaderMixin:
                         nextn_layer_prefix=layer_prefix,
                         nextn_spec_weight_names=spec_weight_names,
                     ):
-                        if not name.startswith(layer_prefix):
+                        # lm_head is always shared from the target model.
+                        if "shared_head.head" in name:
                             continue
 
-                        # Use shared head and embed weights from target model
-                        if "shared_head.head" in name or "embed_tokens" in name:
+                        # Under PP the draft model loads its own embed_tokens on
+                        # the last rank; otherwise embed is shared from target.
+                        is_embed = "embed_tokens" in name
+                        if is_embed and (
+                            self.pp_group.world_size == 1
+                            or not self.pp_group.is_last_rank
+                        ):
+                            continue
+
+                        if not name.startswith(layer_prefix) and not is_embed:
                             continue
 
                         # Transform name: NextN-specific → "model.*", decoder → "model.decoder.*"
@@ -330,8 +339,14 @@ class DeepseekV2WeightLoaderMixin:
                         # Skip loading extra bias for GPTQ models.
                         if name.endswith(".bias") and name not in params_dict:
                             continue
-                        # Skip loading embed_tokens if not first rank in pipeline parallelism
-                        if ".embed_tokens." in name and not self.pp_group.is_first_rank:
+                        # Skip loading embed_tokens if not first rank in pipeline parallelism.
+                        # For the nextn draft, embed_tokens is already handled above (loaded
+                        # on the last rank under PP), so do not skip it here.
+                        if (
+                            ".embed_tokens." in name
+                            and not is_nextn
+                            and not self.pp_group.is_first_rank
+                        ):
                             continue
                         # Skip loading norm if not last rank in pipeline parallelism
                         if ".norm." in name and not self.pp_group.is_last_rank:
@@ -468,6 +483,7 @@ class DeepseekV2WeightLoaderMixin:
                 "eh_proj",
                 "enorm",
                 "hnorm",
+                "embed_tokens",
             ],
         )
 

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -234,11 +234,20 @@ class DeepseekV2WeightLoaderMixin:
                         nextn_layer_prefix=layer_prefix,
                         nextn_spec_weight_names=spec_weight_names,
                     ):
-                        if not name.startswith(layer_prefix):
+                        # lm_head is always shared from the target model.
+                        if "shared_head.head" in name:
                             continue
 
-                        # Use shared head and embed weights from target model
-                        if "shared_head.head" in name or "embed_tokens" in name:
+                        # Under PP the draft model loads its own embed_tokens on
+                        # the last rank; otherwise embed is shared from target.
+                        is_embed = "embed_tokens" in name
+                        if is_embed and (
+                            self.pp_group.world_size == 1
+                            or not self.pp_group.is_last_rank
+                        ):
+                            continue
+
+                        if not name.startswith(layer_prefix) and not is_embed:
                             continue
 
                         # Transform name: NextN-specific → "model.*", decoder → "model.decoder.*"
@@ -339,8 +348,14 @@ class DeepseekV2WeightLoaderMixin:
                         # Skip loading extra bias for GPTQ models.
                         if name.endswith(".bias") and name not in params_dict:
                             continue
-                        # Skip loading embed_tokens if not first rank in pipeline parallelism
-                        if ".embed_tokens." in name and not self.pp_group.is_first_rank:
+                        # Skip loading embed_tokens if not first rank in pipeline parallelism.
+                        # For the nextn draft, embed_tokens is already handled above (loaded
+                        # on the last rank under PP), so do not skip it here.
+                        if (
+                            ".embed_tokens." in name
+                            and not is_nextn
+                            and not self.pp_group.is_first_rank
+                        ):
                             continue
                         # Skip loading norm if not last rank in pipeline parallelism
                         if ".norm." in name and not self.pp_group.is_last_rank:
@@ -477,6 +492,7 @@ class DeepseekV2WeightLoaderMixin:
                 "eh_proj",
                 "enorm",
                 "hnorm",
+                "embed_tokens",
             ],
         )
 

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -225,16 +225,24 @@ class DeepseekModelNextN(nn.Module):
             else:
                 hidden_states = input_embeds
 
+            # CP-v2 shards/gathers at the eager-runner boundary instead.
+            spec_hidden = forward_batch.spec_info.hidden_states
+            use_cp_v1 = (
+                dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
+                or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+            ) and not is_cp_v2_active(forward_batch)
+            if use_cp_v1:
+                hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
+                positions = cp_split_and_rebuild_position(forward_batch, positions)
+                spec_hidden = cp_split_and_rebuild_data(forward_batch, spec_hidden)
+
             if hidden_states.shape[0] > 0:
-                previous_hidden_states = forward_batch.spec_info.hidden_states
                 if self.rot_weight is not None:
-                    previous_hidden_states = torch.matmul(
-                        previous_hidden_states, self.rot_weight
-                    )
+                    spec_hidden = torch.matmul(spec_hidden, self.rot_weight)
                 if _is_cuda:
                     eh_input = fused_eh_norm(
                         hidden_states,
-                        previous_hidden_states,
+                        spec_hidden,
                         self.enorm.weight,
                         self.hnorm.weight,
                         self.enorm.variance_epsilon,
@@ -243,7 +251,7 @@ class DeepseekModelNextN(nn.Module):
                     eh_input = torch.cat(
                         (
                             self.enorm(hidden_states),
-                            self.hnorm(previous_hidden_states),
+                            self.hnorm(spec_hidden),
                         ),
                         dim=-1,
                     )
@@ -252,14 +260,6 @@ class DeepseekModelNextN(nn.Module):
                 else:
                     hidden_states = self.eh_proj(eh_input)
 
-            # CP-v2 shards/gathers at the eager-runner boundary instead.
-            use_cp_v1 = (
-                dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
-                or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
-            ) and not is_cp_v2_active(forward_batch)
-            if use_cp_v1:
-                hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
-                positions = cp_split_and_rebuild_position(forward_batch, positions)
             residual = None
             seed_buf = (
                 forward_batch.spec_info.dsa_seed_topk_capture

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -225,34 +225,8 @@ class DeepseekModelNextN(nn.Module):
             else:
                 hidden_states = input_embeds
 
-            if hidden_states.shape[0] > 0:
-                previous_hidden_states = forward_batch.spec_info.hidden_states
-                if self.rot_weight is not None:
-                    previous_hidden_states = torch.matmul(
-                        previous_hidden_states, self.rot_weight
-                    )
-                if _is_cuda:
-                    eh_input = fused_eh_norm(
-                        hidden_states,
-                        previous_hidden_states,
-                        self.enorm.weight,
-                        self.hnorm.weight,
-                        self.enorm.variance_epsilon,
-                    )
-                else:
-                    eh_input = torch.cat(
-                        (
-                            self.enorm(hidden_states),
-                            self.hnorm(previous_hidden_states),
-                        ),
-                        dim=-1,
-                    )
-                if isinstance(self.eh_proj, ReplicatedLinear):
-                    hidden_states, _ = self.eh_proj(eh_input)
-                else:
-                    hidden_states = self.eh_proj(eh_input)
-
-            # CP-v2 shards/gathers hidden states at the eager-runner boundary.
+            # CP-v2 shards/gathers at the eager-runner boundary instead.
+            spec_hidden = forward_batch.spec_info.hidden_states
             cp_v2_active = is_cp_v2_active(forward_batch)
             use_cp_v1 = (
                 dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
@@ -261,6 +235,32 @@ class DeepseekModelNextN(nn.Module):
             if use_cp_v1:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
                 positions = cp_split_and_rebuild_position(forward_batch, positions)
+                spec_hidden = cp_split_and_rebuild_data(forward_batch, spec_hidden)
+
+            if hidden_states.shape[0] > 0:
+                if self.rot_weight is not None:
+                    spec_hidden = torch.matmul(spec_hidden, self.rot_weight)
+                if _is_cuda:
+                    eh_input = fused_eh_norm(
+                        hidden_states,
+                        spec_hidden,
+                        self.enorm.weight,
+                        self.hnorm.weight,
+                        self.enorm.variance_epsilon,
+                    )
+                else:
+                    eh_input = torch.cat(
+                        (
+                            self.enorm(hidden_states),
+                            self.hnorm(spec_hidden),
+                        ),
+                        dim=-1,
+                    )
+                if isinstance(self.eh_proj, ReplicatedLinear):
+                    hidden_states, _ = self.eh_proj(eh_input)
+                else:
+                    hidden_states = self.eh_proj(eh_input)
+
             residual = None
             index_topk_share = IndexTopKShareState.from_mtp_carry(forward_batch)
             with get_global_expert_distribution_recorder().disable_this_region():

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -3147,6 +3147,9 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
+    def get_head(self):
+        return self.lm_head.weight
+
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
         del self.lm_head.weight
@@ -3154,6 +3157,12 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         self.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+    def set_head(self, head):
+        del self.lm_head.weight
+        self.lm_head.weight = head
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2941,6 +2941,9 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
+    def get_head(self):
+        return self.lm_head.weight
+
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
         del self.lm_head.weight
@@ -2948,6 +2951,12 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         self.lm_head.weight = head
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
+
+    def set_head(self, head):
+        del self.lm_head.weight
+        self.lm_head.weight = head
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3399,10 +3399,18 @@ class DeepseekV4ForCausalLM(nn.Module):
                             if name.startswith("mtp"):
                                 continue
                     else:
-                        if "shared_head.head" in name or "embed_tokens" in name:
+                        if "shared_head.head" in name:
+                            continue
+                        is_embed = "embed_tokens" in name
+                        # Under PP the draft model loads its own embed_tokens on
+                        # the last rank; otherwise embed is shared from target.
+                        if is_embed and (
+                            self.pp_group.world_size == 1
+                            or not self.pp_group.is_last_rank
+                        ):
                             continue
 
-                        if not name.startswith(nextn_layer_prefix):
+                        if not name.startswith(nextn_layer_prefix) and not is_embed:
                             continue
 
                         in_decoder = True
@@ -3478,6 +3486,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                                 continue
                             if (
                                 ".embed_tokens." in name
+                                and not is_nextn
                                 and not self.pp_group.is_first_rank
                             ):
                                 continue
@@ -3605,7 +3614,11 @@ class DeepseekV4ForCausalLM(nn.Module):
             skipped_checking_patterns.append("model.norm.")
             skipped_checking_patterns.extend(["lm_head", "hc_head_"])
         if is_nextn:
-            skipped_checking_patterns.extend(["lm_head", "embed_tokens"])
+            skipped_checking_patterns.extend(["lm_head"])
+            # Under PP the draft loads embed_tokens itself, so do not skip it here;
+            # under non-PP it is still shared from target by eagle_worker, so skip it.
+            if self.pp_group.world_size == 1:
+                skipped_checking_patterns.extend(["embed_tokens"])
         unloaded_params = {
             p
             for p in unloaded_params
@@ -3627,6 +3640,9 @@ class DeepseekV4ForCausalLM(nn.Module):
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
+    def get_head(self):
+        return self.lm_head.weight
+
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
         del self.lm_head.weight
@@ -3634,6 +3650,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         self.lm_head.weight = head
         # Hot weight reload (RL workflows). Use the device-agnostic module
         # accessor so this works on both CUDA/HIP and NPU.
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
+
+    def set_head(self, head):
+        del self.lm_head.weight
+        self.lm_head.weight = head
         torch.get_device_module().empty_cache()
         torch.get_device_module().synchronize()
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2925,10 +2925,18 @@ class DeepseekV4ForCausalLM(nn.Module):
                             if name.startswith("mtp"):
                                 continue
                     else:
-                        if "shared_head.head" in name or "embed_tokens" in name:
+                        if "shared_head.head" in name:
+                            continue
+                        is_embed = "embed_tokens" in name
+                        # Under PP the draft model loads its own embed_tokens on
+                        # the last rank; otherwise embed is shared from target.
+                        if is_embed and (
+                            self.pp_group.world_size == 1
+                            or not self.pp_group.is_last_rank
+                        ):
                             continue
 
-                        if not name.startswith(nextn_layer_prefix):
+                        if not name.startswith(nextn_layer_prefix) and not is_embed:
                             continue
 
                         in_decoder = True
@@ -3004,6 +3012,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                                 continue
                             if (
                                 ".embed_tokens." in name
+                                and not is_nextn
                                 and not self.pp_group.is_first_rank
                             ):
                                 continue
@@ -3129,7 +3138,11 @@ class DeepseekV4ForCausalLM(nn.Module):
             skipped_checking_patterns.append("model.norm.")
             skipped_checking_patterns.extend(["lm_head", "hc_head_"])
         if is_nextn:
-            skipped_checking_patterns.extend(["lm_head", "embed_tokens"])
+            skipped_checking_patterns.extend(["lm_head"])
+            # Under PP the draft loads embed_tokens itself, so do not skip it here;
+            # under non-PP it is still shared from target by eagle_worker, so skip it.
+            if self.pp_group.world_size == 1:
+                skipped_checking_patterns.extend(["embed_tokens"])
         unloaded_params = {
             p
             for p in unloaded_params
@@ -3151,6 +3164,9 @@ class DeepseekV4ForCausalLM(nn.Module):
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
+    def get_head(self):
+        return self.lm_head.weight
+
     def set_embed_and_head(self, embed, head):
         del self.model.embed_tokens.weight
         del self.lm_head.weight
@@ -3158,6 +3174,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         self.lm_head.weight = head
         # Hot weight reload (RL workflows). Use the device-agnostic module
         # accessor so this works on both CUDA/HIP and NPU.
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
+
+    def set_head(self, head):
+        del self.lm_head.weight
+        self.lm_head.weight = head
         torch.get_device_module().empty_cache()
         torch.get_device_module().synchronize()
 

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.attention.dsa.utils import (
 )
 from sglang.srt.layers.dp_attention import (
     dp_gather_partial,
+    get_attention_dp_size,
     get_global_dp_buffer_len,
     is_dp_attention_enabled,
 )
@@ -142,12 +143,22 @@ class DeepseekV4ModelNextN(nn.Module):
         else:
             hidden_states = input_embeds
 
+        spec_hidden = forward_batch.spec_info.hidden_states
+
+        if dsa_use_prefill_cp(forward_batch):
+            assert get_attention_dp_size() == 1
+            hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
+            positions = cp_split_and_rebuild_position(forward_batch, positions)
+            input_ids = cp_round_robin_input_ids(input_ids)
+            spec_hidden = cp_split_and_rebuild_data(
+                forward_batch,
+                spec_hidden.view(-1, self.hc_mult, self.config.hidden_size),
+            )
+
         if hidden_states.shape[0] > 0:
             n_tokens = hidden_states.shape[0]
             d = self.config.hidden_size
-            hc_flat = forward_batch.spec_info.hidden_states.view(
-                n_tokens * self.hc_mult, d
-            )
+            hc_flat = spec_hidden.view(n_tokens * self.hc_mult, d)
             h_proj_out, _ = self.h_proj(self.hnorm(hc_flat))
             h_proj_hidden_states = h_proj_out.view(n_tokens, self.hc_mult, d)
 
@@ -165,12 +176,6 @@ class DeepseekV4ModelNextN(nn.Module):
             dp_gather_partial(input_ids_global, input_ids[:, None], forward_batch)
             input_ids_global = input_ids_global.squeeze(-1)
         else:
-            input_ids_global = input_ids
-
-        if dsa_use_prefill_cp(forward_batch):
-            hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
-            positions = cp_split_and_rebuild_position(forward_batch, positions)
-            input_ids = cp_round_robin_input_ids(input_ids)
             input_ids_global = input_ids
 
         hidden_states, residual, post, comb = self.decoder(

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -19,6 +19,7 @@ from sglang.srt.layers.cp.utils import (
 )
 from sglang.srt.layers.dp_attention import (
     dp_gather_replicate,
+    get_attention_dp_size,
     get_global_dp_buffer_len,
     is_dp_attention_enabled,
 )
@@ -151,12 +152,22 @@ class DeepseekV4ModelNextN(nn.Module):
         else:
             hidden_states = input_embeds
 
+        spec_hidden = forward_batch.spec_info.hidden_states
+
+        if use_prefill_cp and not cp_v2_active:
+            assert get_attention_dp_size() == 1
+            hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
+            positions = cp_split_and_rebuild_position(forward_batch, positions)
+            input_ids = cp_round_robin_input_ids(input_ids)
+            spec_hidden = cp_split_and_rebuild_data(
+                forward_batch,
+                spec_hidden.view(-1, self.hc_mult, self.config.hidden_size),
+            )
+
         if hidden_states.shape[0] > 0:
             n_tokens = hidden_states.shape[0]
             d = self.config.hidden_size
-            hc_flat = forward_batch.spec_info.hidden_states.view(
-                n_tokens * self.hc_mult, d
-            )
+            hc_flat = spec_hidden.view(n_tokens * self.hc_mult, d)
             h_proj_out, _ = self.h_proj(self.hnorm(hc_flat))
             h_proj_hidden_states = h_proj_out.view(n_tokens, self.hc_mult, d)
 
@@ -184,10 +195,6 @@ class DeepseekV4ModelNextN(nn.Module):
         if use_prefill_cp:
             if cp_v2_active:
                 input_ids = cp_round_robin_input_ids_v2(input_ids, forward_batch)
-            else:
-                hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
-                positions = cp_split_and_rebuild_position(forward_batch, positions)
-                input_ids = cp_round_robin_input_ids(input_ids)
             input_ids_global = input_ids
 
         hidden_states, residual, post, comb = self.decoder(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9157,8 +9157,8 @@ class ServerArgs:
 
         if self.pp_size > 1:
             assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
-            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+                self.disable_overlap_schedule
+            ), "Pipeline parallelism is not compatible with overlap schedule"
             assert self.min_free_slots_delay is None, (
                 "--min-free-slots-delay is not supported with pipeline "
                 "parallelism: allocatable slots per microbatch are bounded by "

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8344,8 +8344,8 @@ class ServerArgs:
 
         if self.pp_size > 1:
             assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
-            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+                self.disable_overlap_schedule
+            ), "Pipeline parallelism is not compatible with overlap schedule"
 
         assert not (
             self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -84,6 +84,13 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             "enable_pdmux=True is not supported "
             "(adaptive state swap does not update decode_attn_backend_group)"
         )
+    if server_args.pp_size > 1:
+        return (
+            "pipeline_parallel_size>1 is not supported "
+            "(adaptive state switching only happens on the last PP rank; "
+            "an extra synchronization mechanism would be needed to keep all "
+            "PP ranks in sync)"
+        )
     return None
 
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -1,10 +1,11 @@
 import logging
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import asdict, dataclass
+from typing import List, Optional, Tuple
 
 import torch
 
 from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_spec
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
@@ -387,3 +388,107 @@ class EagleDraftExtendInput(SpecInput):
             req_to_token.size(1),
         )
         return kv_indices, cum_kv_seq_len, qo_indptr, None
+
+
+@dataclass
+class EaglePPVerifyInputRaw(SpecInput):
+    """CPU-side draft tree produced by the PP last rank and relayed across PP
+    stages so non-last ranks can rebuild an EagleVerifyInput on the next iter.
+
+    Carries the raw (pre-tree-mask) fields rather than a built EagleVerifyInput
+    because the tree mask / positions must be rebuilt against each rank's own
+    attention backend buffers.
+    """
+
+    draft_tokens: List[List[int]]
+    bonus_tokens: List[int]
+    top_scores_index: List[List[int]]
+    parent_list: List[List[int]]
+    accept_lens: List[int]
+    accept_index: Optional[List] = None
+
+    def __post_init__(self):
+        super().__init__(SpecInputType.EAGLE_PP_VERIFY_INPUT_RAW)
+
+    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
+        num_draft = (
+            len(self.draft_tokens[0])
+            if self.draft_tokens and isinstance(self.draft_tokens[0], list)
+            else 1
+        )
+        return num_draft, num_draft
+
+    def to_tensor_dict(self) -> dict:
+        return {"pp_spec_output": asdict(self)}
+
+    @classmethod
+    def from_pp_outputs(cls, pp_outputs):
+        return cls(**pp_outputs["pp_spec_output"])
+
+    @classmethod
+    def build_dummy_for_decode(
+        cls, batch: ScheduleBatch, num_draft: int
+    ) -> "EaglePPVerifyInputRaw":
+        """Build a dummy draft spec for the first decode step after prefill.
+
+        The last PP rank produces no draft tokens for prefill batches, so a
+        placeholder tree (each req's bonus token replicated num_draft times)
+        is constructed here.
+        """
+        bs = len(batch.reqs)
+        parent_width = max(num_draft - 1, 0)
+
+        bonus_tokens = batch.input_ids.tolist()
+        draft_tokens = [bonus_tokens[i : i + 1] * num_draft for i in range(bs)]
+        parent_row = list(range(-1, parent_width - 1))
+        parent_list = [parent_row[:] for _ in range(bs)]
+        score_row = list(range(parent_width))
+        top_scores_index = [score_row[:] for _ in range(bs)]
+
+        return cls(
+            draft_tokens=draft_tokens,
+            bonus_tokens=bonus_tokens,
+            top_scores_index=top_scores_index,
+            parent_list=parent_list,
+            accept_lens=[1] * bs,
+            accept_index=None,
+        )
+
+    def filter_batch(
+        self, new_indices: torch.Tensor, new_indices_cpu: Optional[List[int]] = None
+    ):
+        idx = new_indices.tolist()
+
+        def pick(lst):
+            return [lst[i] for i in idx]
+
+        try:
+            self.bonus_tokens = pick(self.bonus_tokens)
+            self.draft_tokens = pick(self.draft_tokens)
+            self.top_scores_index = pick(self.top_scores_index)
+            self.parent_list = pick(self.parent_list)
+            self.accept_lens = pick(self.accept_lens)
+            if self.accept_index is not None:
+                self.accept_index = [self.accept_index[i] for i in idx]
+        except TypeError as e:
+            raise RuntimeError(
+                "EaglePPVerifyInputRaw.filter_batch: a required field was None. "
+                "Under PP + EAGLE, every batch must carry the draft tree relayed "
+                "via pp_outputs, or be given a dummy tree for its first decode."
+            ) from e
+
+    def merge_batch(self, other: "EaglePPVerifyInputRaw"):
+        try:
+            if self.accept_index is not None and other.accept_index is not None:
+                self.accept_index = self.accept_index + other.accept_index
+            self.draft_tokens = self.draft_tokens + other.draft_tokens
+            self.bonus_tokens = self.bonus_tokens + other.bonus_tokens
+            self.top_scores_index = self.top_scores_index + other.top_scores_index
+            self.parent_list = self.parent_list + other.parent_list
+            self.accept_lens = self.accept_lens + other.accept_lens
+        except TypeError as e:
+            raise RuntimeError(
+                "EaglePPVerifyInputRaw.merge_batch: a required field was None. "
+                "Under PP + EAGLE, every batch must carry the draft tree relayed "
+                "via pp_outputs, or be given a dummy tree for its first decode."
+            ) from e

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -392,33 +392,35 @@ class EagleDraftExtendInput(SpecInput):
 
 @dataclass
 class EaglePPVerifyInputRaw(SpecInput):
-    """CPU-side draft tree produced by the PP last rank and relayed across PP
+    """Draft tree produced by the PP last rank and relayed across PP
     stages so non-last ranks can rebuild an EagleVerifyInput on the next iter.
 
     Carries the raw (pre-tree-mask) fields rather than a built EagleVerifyInput
     because the tree mask / positions must be rebuilt against each rank's own
     attention backend buffers.
+
+    All fields are GPU tensors so the PP ring relays them over the GPU
+    channel instead of pickling Python lists through CPU.
     """
 
-    draft_tokens: List[List[int]]
-    bonus_tokens: List[int]
-    top_scores_index: List[List[int]]
-    parent_list: List[List[int]]
-    accept_lens: List[int]
-    accept_index: Optional[List] = None
+    draft_tokens: torch.Tensor  # [bs, num_draft], col 0 is the bonus token
+    bonus_tokens: torch.Tensor  # [bs]
+    top_scores_index: torch.Tensor  # [bs, num_draft - 1]
+    parent_list: torch.Tensor  # [bs, num_draft - 1]
+    accept_lens: Optional[torch.Tensor] = None  # [bs]
+    # Accepted tree path, [bs, max_tree_depth]; None when topk == 1.
+    accept_index: Optional[torch.Tensor] = None
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_PP_VERIFY_INPUT_RAW)
 
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
-        num_draft = (
-            len(self.draft_tokens[0])
-            if self.draft_tokens and isinstance(self.draft_tokens[0], list)
-            else 1
-        )
+        num_draft = self.draft_tokens.shape[1] if self.draft_tokens.dim() == 2 else 1
         return num_draft, num_draft
 
     def to_tensor_dict(self) -> dict:
+        # Nested tensors are flattened by _split_tensor_dict, so the whole
+        # dataclass dict still travels over the GPU channel.
         return {"pp_spec_output": asdict(self)}
 
     @classmethod
@@ -437,39 +439,38 @@ class EaglePPVerifyInputRaw(SpecInput):
         """
         bs = len(batch.reqs)
         parent_width = max(num_draft - 1, 0)
+        device = batch.input_ids.device
 
-        bonus_tokens = batch.input_ids.tolist()
-        draft_tokens = [bonus_tokens[i : i + 1] * num_draft for i in range(bs)]
-        parent_row = list(range(-1, parent_width - 1))
-        parent_list = [parent_row[:] for _ in range(bs)]
-        score_row = list(range(parent_width))
-        top_scores_index = [score_row[:] for _ in range(bs)]
+        # repeat (not expand): the relayed tensors must stay contiguous.
+        bonus_tokens = batch.input_ids.to(torch.int64)
+        draft_tokens = bonus_tokens.unsqueeze(1).repeat(1, num_draft)
+        parent_list = torch.arange(-1, parent_width - 1, device=device).repeat(bs, 1)
+        top_scores_index = torch.arange(parent_width, device=device).repeat(bs, 1)
 
         return cls(
             draft_tokens=draft_tokens,
             bonus_tokens=bonus_tokens,
             top_scores_index=top_scores_index,
             parent_list=parent_list,
-            accept_lens=[1] * bs,
+            accept_lens=torch.ones(bs, dtype=torch.int64, device=device),
             accept_index=None,
         )
 
     def filter_batch(
         self, new_indices: torch.Tensor, new_indices_cpu: Optional[List[int]] = None
     ):
-        idx = new_indices.tolist()
-
-        def pick(lst):
-            return [lst[i] for i in idx]
-
         try:
-            self.bonus_tokens = pick(self.bonus_tokens)
-            self.draft_tokens = pick(self.draft_tokens)
-            self.top_scores_index = pick(self.top_scores_index)
-            self.parent_list = pick(self.parent_list)
-            self.accept_lens = pick(self.accept_lens)
+            self.bonus_tokens = self.bonus_tokens[new_indices]
+            if self.draft_tokens is not None:
+                self.draft_tokens = self.draft_tokens[new_indices]
+            if self.top_scores_index is not None:
+                self.top_scores_index = self.top_scores_index[new_indices]
+            if self.parent_list is not None:
+                self.parent_list = self.parent_list[new_indices]
+            if self.accept_lens is not None:
+                self.accept_lens = self.accept_lens[new_indices]
             if self.accept_index is not None:
-                self.accept_index = [self.accept_index[i] for i in idx]
+                self.accept_index = self.accept_index[new_indices]
         except TypeError as e:
             raise RuntimeError(
                 "EaglePPVerifyInputRaw.filter_batch: a required field was None. "
@@ -479,13 +480,29 @@ class EaglePPVerifyInputRaw(SpecInput):
 
     def merge_batch(self, other: "EaglePPVerifyInputRaw"):
         try:
+            if other.bonus_tokens.numel() == 0:
+                return
+            if self.bonus_tokens.numel() == 0:
+                self.draft_tokens = other.draft_tokens
+                self.bonus_tokens = other.bonus_tokens
+                self.top_scores_index = other.top_scores_index
+                self.parent_list = other.parent_list
+                self.accept_lens = other.accept_lens
+                self.accept_index = other.accept_index
+                return
+            if other.draft_tokens is not None:
+                self.draft_tokens = torch.cat([self.draft_tokens, other.draft_tokens])
+            self.bonus_tokens = torch.cat([self.bonus_tokens, other.bonus_tokens])
+            if other.top_scores_index is not None:
+                self.top_scores_index = torch.cat(
+                    [self.top_scores_index, other.top_scores_index]
+                )
+            if self.parent_list is not None and other.parent_list is not None:
+                self.parent_list = torch.cat([self.parent_list, other.parent_list])
+            if self.accept_lens is not None and other.accept_lens is not None:
+                self.accept_lens = torch.cat([self.accept_lens, other.accept_lens])
             if self.accept_index is not None and other.accept_index is not None:
-                self.accept_index = self.accept_index + other.accept_index
-            self.draft_tokens = self.draft_tokens + other.draft_tokens
-            self.bonus_tokens = self.bonus_tokens + other.bonus_tokens
-            self.top_scores_index = self.top_scores_index + other.top_scores_index
-            self.parent_list = self.parent_list + other.parent_list
-            self.accept_lens = self.accept_lens + other.accept_lens
+                self.accept_index = torch.cat([self.accept_index, other.accept_index])
         except TypeError as e:
             raise RuntimeError(
                 "EaglePPVerifyInputRaw.merge_batch: a required field was None. "

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -1,10 +1,11 @@
 import logging
-from dataclasses import dataclass
-from typing import List, Optional
+from dataclasses import asdict, dataclass
+from typing import List, Optional, Tuple
 
 import torch
 
 from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
@@ -387,3 +388,107 @@ class EagleDraftExtendInput(SpecInput):
             req_to_token.size(1),
         )
         return kv_indices, cum_kv_seq_len, qo_indptr, None
+
+
+@dataclass
+class EaglePPVerifyInputRaw(SpecInput):
+    """CPU-side draft tree produced by the PP last rank and relayed across PP
+    stages so non-last ranks can rebuild an EagleVerifyInput on the next iter.
+
+    Carries the raw (pre-tree-mask) fields rather than a built EagleVerifyInput
+    because the tree mask / positions must be rebuilt against each rank's own
+    attention backend buffers.
+    """
+
+    draft_tokens: List[List[int]]
+    bonus_tokens: List[int]
+    top_scores_index: List[List[int]]
+    parent_list: List[List[int]]
+    accept_lens: List[int]
+    accept_index: Optional[List] = None
+
+    def __post_init__(self):
+        super().__init__(SpecInputType.EAGLE_PP_VERIFY_INPUT_RAW)
+
+    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
+        num_draft = (
+            len(self.draft_tokens[0])
+            if self.draft_tokens and isinstance(self.draft_tokens[0], list)
+            else 1
+        )
+        return num_draft, num_draft
+
+    def to_tensor_dict(self) -> dict:
+        return {"pp_spec_output": asdict(self)}
+
+    @classmethod
+    def from_pp_outputs(cls, pp_outputs):
+        return cls(**pp_outputs["pp_spec_output"])
+
+    @classmethod
+    def build_dummy_for_decode(
+        cls, batch: ScheduleBatch, num_draft: int
+    ) -> "EaglePPVerifyInputRaw":
+        """Build a dummy draft spec for the first decode step after prefill.
+
+        The last PP rank produces no draft tokens for prefill batches, so a
+        placeholder tree (each req's bonus token replicated num_draft times)
+        is constructed here.
+        """
+        bs = len(batch.reqs)
+        parent_width = max(num_draft - 1, 0)
+
+        bonus_tokens = batch.input_ids.tolist()
+        draft_tokens = [bonus_tokens[i : i + 1] * num_draft for i in range(bs)]
+        parent_row = list(range(-1, parent_width - 1))
+        parent_list = [parent_row[:] for _ in range(bs)]
+        score_row = list(range(parent_width))
+        top_scores_index = [score_row[:] for _ in range(bs)]
+
+        return cls(
+            draft_tokens=draft_tokens,
+            bonus_tokens=bonus_tokens,
+            top_scores_index=top_scores_index,
+            parent_list=parent_list,
+            accept_lens=[1] * bs,
+            accept_index=None,
+        )
+
+    def filter_batch(
+        self, new_indices: torch.Tensor, new_indices_cpu: Optional[List[int]] = None
+    ):
+        idx = new_indices.tolist()
+
+        def pick(lst):
+            return [lst[i] for i in idx]
+
+        try:
+            self.bonus_tokens = pick(self.bonus_tokens)
+            self.draft_tokens = pick(self.draft_tokens)
+            self.top_scores_index = pick(self.top_scores_index)
+            self.parent_list = pick(self.parent_list)
+            self.accept_lens = pick(self.accept_lens)
+            if self.accept_index is not None:
+                self.accept_index = [self.accept_index[i] for i in idx]
+        except TypeError as e:
+            raise RuntimeError(
+                "EaglePPVerifyInputRaw.filter_batch: a required field was None. "
+                "Under PP + EAGLE, every batch must carry the draft tree relayed "
+                "via pp_outputs, or be given a dummy tree for its first decode."
+            ) from e
+
+    def merge_batch(self, other: "EaglePPVerifyInputRaw"):
+        try:
+            if self.accept_index is not None and other.accept_index is not None:
+                self.accept_index = self.accept_index + other.accept_index
+            self.draft_tokens = self.draft_tokens + other.draft_tokens
+            self.bonus_tokens = self.bonus_tokens + other.bonus_tokens
+            self.top_scores_index = self.top_scores_index + other.top_scores_index
+            self.parent_list = self.parent_list + other.parent_list
+            self.accept_lens = self.accept_lens + other.accept_lens
+        except TypeError as e:
+            raise RuntimeError(
+                "EaglePPVerifyInputRaw.merge_batch: a required field was None. "
+                "Under PP + EAGLE, every batch must carry the draft tree relayed "
+                "via pp_outputs, or be given a dummy tree for its first decode."
+            ) from e

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -15,6 +15,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_utils import (
     TreeMaskMode,
@@ -418,10 +419,15 @@ def _finalize_accept_tree_path(
     hidden_states -- to the contiguous front of each per-req block, which the
     downstream chain-layout code (draft-extend select_index, committed-KV reads)
     assumes. Returns compacted predict; mutates logits_output.hidden_states
-    (moved only when present)."""
-    move_accept_tokens_to_target_kvcache(
-        batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
-    )
+    (moved only when present).
+
+    Under PP the KV move runs per-rank in the scheduler's batch_result_processor
+    (it needs each rank's own seq_lens / accept_index), so skip it here.
+    """
+    if get_parallel().pp_size == 1:
+        move_accept_tokens_to_target_kvcache(
+            batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
+        )
     predict = _compact_accept_to_front(
         predict, accept_index, bs, num_draft_tokens=num_draft_tokens
     )
@@ -472,6 +478,7 @@ def run_eagle_verify(
     metadata_ready_pre_pad: bool,
     finalize_tree_path: bool,
     grammar_barrier=None,
+    pp_proxy_tensors=None,
 ) -> GenerationBatchResult:
     """Shared verify step: target-verify forward, sampling, acceptance bookkeeping.
 
@@ -563,8 +570,16 @@ def run_eagle_verify(
         batch=None,
         forward_batch=verify_forward_batch,
         is_verify=True,
+        pp_proxy_tensors=pp_proxy_tensors,
     )
     logits_output = forward_batch_output.logits_output
+
+    # Non-last PP rank: only proxy hidden states, no logits — skip the
+    # sample/accept/grammar post-processing below.
+    pp_enabled = target_worker.server_args.pp_size > 1
+    pp_is_last_rank = target_worker.pp_group.is_last_rank
+    if pp_enabled and not pp_is_last_rank:
+        return forward_batch_output
 
     # Generate vocab mask for constrained decoding
     grammar_mask = None
@@ -653,6 +668,7 @@ def run_eagle_verify(
         speculative_num_draft_tokens=num_draft_tokens,
         next_draft_input=next_draft_input,
         accept_lens=accept_lens,
+        accept_index=accept_index,
         new_seq_lens=new_seq_lens,
         routed_experts_output=forward_batch_output.routed_experts_output,
         indexer_topk_output=forward_batch_output.indexer_topk_output,

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -15,6 +15,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_utils import (
     TreeMaskMode,
@@ -414,10 +415,15 @@ def _finalize_accept_tree_path(
     hidden_states -- to the contiguous front of each per-req block, which the
     downstream chain-layout code (draft-extend select_index, committed-KV reads)
     assumes. Returns compacted predict; mutates logits_output.hidden_states
-    (moved only when present)."""
-    move_accept_tokens_to_target_kvcache(
-        batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
-    )
+    (moved only when present).
+
+    Under PP the KV move runs per-rank in the scheduler's batch_result_processor
+    (it needs each rank's own seq_lens / accept_index), so skip it here.
+    """
+    if get_parallel().pp_size == 1:
+        move_accept_tokens_to_target_kvcache(
+            batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
+        )
     predict = _compact_accept_to_front(
         predict, accept_index, bs, num_draft_tokens=num_draft_tokens
     )
@@ -469,6 +475,7 @@ def run_eagle_verify(
     metadata_ready_pre_pad: bool,
     finalize_tree_path: bool,
     grammar_barrier=None,
+    pp_proxy_tensors=None,
 ) -> GenerationBatchResult:
     """Shared verify step: target-verify forward, sampling, acceptance bookkeeping.
 
@@ -560,8 +567,16 @@ def run_eagle_verify(
         batch=None,
         forward_batch=verify_forward_batch,
         is_verify=True,
+        pp_proxy_tensors=pp_proxy_tensors,
     )
     logits_output = forward_batch_output.logits_output
+
+    # Non-last PP rank: only proxy hidden states, no logits — skip the
+    # sample/accept/grammar post-processing below.
+    pp_enabled = target_worker.server_args.pp_size > 1
+    pp_is_last_rank = target_worker.pp_group.is_last_rank
+    if pp_enabled and not pp_is_last_rank:
+        return forward_batch_output
 
     # Generate vocab mask for constrained decoding
     grammar_mask = None
@@ -650,6 +665,7 @@ def run_eagle_verify(
         speculative_num_draft_tokens=num_draft_tokens,
         next_draft_input=next_draft_input,
         accept_lens=accept_lens,
+        accept_index=accept_index,
         new_seq_lens=new_seq_lens,
         routed_experts_output=forward_batch_output.routed_experts_output,
         indexer_topk_output=forward_batch_output.indexer_topk_output,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -37,7 +37,11 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner import (
     DecodeCudaGraphRunner,
@@ -60,10 +64,13 @@ from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
 from sglang.srt.speculative.eagle_info import (
     EagleDraftExtendInput,
     EagleDraftInput,
+    EaglePPVerifyInputRaw,
     EagleVerifyInput,
 )
 from sglang.srt.speculative.eagle_utils import (
+    TreeMaskMode,
     _eagle_prefill_tail_tokens,
+    build_tree_kernel_efficient,
     default_tree_mask_mode,
     get_draft_recurrent_hidden_state_spec,
     organize_draft_results,
@@ -125,6 +132,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         ps: ParallelState,
         nccl_port: int,
         target_worker: TpModelWorker,
+        tree_mask_mode: TreeMaskMode,
     ):
         # copy args
         self.server_args = server_args
@@ -164,6 +172,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 ps=replace(ps, pp_rank=0),
                 nccl_port=nccl_port,
                 is_draft_worker=True,
+                pp_global_random_seed=target_worker.random_seed,
             )
 
         # Alias for better readability
@@ -174,7 +183,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
-        self.tree_mask_mode = default_tree_mask_mode()
+        self.tree_mask_mode = tree_mask_mode
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
@@ -305,7 +314,14 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.hot_token_id = None
 
     def init_lm_head(self):
-        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
+        pp_size = self.target_worker.pp_group.world_size
+
+        if pp_size > 1:
+            # Under PP, the draft embedding is loaded from the draft checkpoint
+            # in load_weights already; here we only take the target lm_head.
+            head = self.target_worker.model_runner.model.get_head()
+        else:
+            embed, head = self.target_worker.model_runner.model.get_embed_and_head()
         target_lm_head = getattr(self.target_worker.model_runner.model, "lm_head", None)
 
         def maybe_share_target_lm_head():
@@ -324,16 +340,18 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 hasattr(self.draft_runner.model, "load_lm_head_from_target")
                 and self.draft_runner.model.load_lm_head_from_target
             ):
-                self.draft_runner.model.set_embed_and_head(embed, head)
+                if pp_size > 1:
+                    self.draft_runner.model.set_head(head)
+                else:
+                    self.draft_runner.model.set_embed_and_head(embed, head)
                 maybe_share_target_lm_head()
             else:
-                self.draft_runner.model.set_embed(embed)
+                if pp_size == 1:
+                    self.draft_runner.model.set_embed(embed)
 
             # grab hot token ids
             if self.draft_runner.model.hot_token_id is not None:
-                self.hot_token_id = self.draft_runner.model.hot_token_id.to(
-                    embed.device
-                )
+                self.hot_token_id = self.draft_runner.model.hot_token_id.to(head.device)
 
         else:
             if self.hot_token_id is not None:
@@ -341,8 +359,12 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 self.hot_token_id = self.hot_token_id.to(head.device)
                 head.data = head.data[self.hot_token_id]
 
-            # Share the embedding and lm_head
-            self.draft_runner.model.set_embed_and_head(embed, head)
+            if pp_size > 1:
+                # Under PP the embed is already loaded by the draft; only set the head.
+                self.draft_runner.model.set_head(head)
+            else:
+                # Share the embedding and lm_head
+                self.draft_runner.model.set_embed_and_head(embed, head)
             maybe_share_target_lm_head()
 
     def init_attention_backend(self):
@@ -369,7 +391,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_runner.draft_attn_backend = self.draft_attn_backend
         if self.draft_extend_attn_backend is not None:
             self.draft_runner.attn_backend = self.draft_extend_attn_backend
-        self.tree_mask_mode = default_tree_mask_mode()
 
     def _capture_cuda_graphs(self):
         """Capture the draft worker's own cuda graphs (decode + draft-extend)."""
@@ -544,6 +565,31 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 parent_list, top_scores_index, draft_tokens, draft_probs = (
                     self.draft_forward(forward_batch)
                 )
+
+        if self.server_args.pp_size > 1:
+            # PP path: return the raw draft tree (flattened draft_tokens with
+            # bonus prepended, parent_list, top_scores_index) so the last PP
+            # rank can serialize it into EaglePPVerifyInputRaw for cross-rank relay.
+            if batch.forward_mode.is_idle():
+                num_draft = self.speculative_num_draft_tokens
+                parent_width = max(num_draft - 1, 0)
+                return (
+                    torch.empty((0, num_draft), dtype=torch.long, device="cpu"),
+                    torch.empty((0, parent_width), dtype=torch.long, device="cpu"),
+                    torch.empty((0, parent_width), dtype=torch.long, device="cpu"),
+                )
+
+            # CUDA Graph buffers are reused; clone before flattening so the
+            # relayed raw tokens survive the next replay.
+            if can_cuda_graph:
+                parent_list = parent_list.clone()
+                top_scores_index = top_scores_index.clone()
+                draft_tokens = draft_tokens.clone()
+
+            draft_tokens = torch.cat(
+                (draft_input.bonus_tokens.unsqueeze(1), draft_tokens), dim=1
+            ).flatten()
+            return draft_tokens, parent_list, top_scores_index
 
         return build_eagle_verify_input(
             batch,
@@ -1041,23 +1087,36 @@ class EAGLEWorkerV2(BaseSpecWorker):
             server_args.speculative_algorithm
         )
 
-        # Override the context length of the draft model to be the same as the target model.
-        server_args.override(
-            "spec_worker.match_target_context_length",
-            context_length=target_worker.model_runner.model_config.context_len,
-        )
+        self._pp_is_last_rank = target_worker.pp_group.is_last_rank
+        self._pp_enabled = server_args.pp_size > 1
 
-        self._draft_worker = EagleDraftWorker(
-            server_args,
-            gpu_id,
-            ps,
-            nccl_port,
-            target_worker,
-        )
+        # Defined on every rank so PP non-last ranks (which have no draft
+        # worker) still resolve the mask mode in _build_verify_input_from_pp_raw.
+        self.tree_mask_mode = default_tree_mask_mode()
+
+        # The draft model is only created on the last PP rank. PP + spec v2
+        # currently only supports hosting the draft worker on the last rank.
+        if not self._pp_enabled or self._pp_is_last_rank:
+            # Override the context length of the draft model to be the same as the target model.
+            server_args.override(
+                "spec_worker.match_target_context_length",
+                context_length=target_worker.model_runner.model_config.context_len,
+            )
+
+            self._draft_worker = EagleDraftWorker(
+                server_args,
+                gpu_id,
+                ps,
+                nccl_port,
+                target_worker,
+                tree_mask_mode=self.tree_mask_mode,
+            )
+        else:
+            self._draft_worker = None
 
         # Adaptive speculative
         self.adaptive_controller: Optional[AdaptiveController] = None
-        if server_args.speculative_adaptive:
+        if server_args.speculative_adaptive and self._draft_worker is not None:
             self.adaptive_controller = AdaptiveController(
                 self,
                 config_path=server_args.speculative_adaptive_config,
@@ -1081,6 +1140,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
     def spec_v2_attn_backends(self) -> tuple:
         # Every attn backend a spec_v2 forward touches; consumed by
         # decide_needs_cpu_seq_lens to gate the seq_lens_cpu D2H.
+        # Non-last PP ranks have no draft model (_draft_worker is None) and
+        # only run the target forward, so only the target backend matters.
+        if self._draft_worker is None:
+            return (self._target_worker.model_runner.attn_backend,)
         return (
             self._target_worker.model_runner.attn_backend,
             self._draft_worker.draft_attn_backend,
@@ -1089,7 +1152,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
         )
 
     def init_cuda_graphs(self):
-        super().init_cuda_graphs()
+        # The draft model only exists on the last PP rank; non-last PP ranks
+        # have no draft worker and skip the draft cuda graph / adaptive init.
+        if not self._pp_enabled or self._pp_is_last_rank:
+            self._draft_worker.init_cuda_graphs()
         # Build adaptive runtime states after target and draft backends exist.
         if self.adaptive_controller is not None:
             with (
@@ -1120,18 +1186,32 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
 
     def forward_batch_generation(
-        self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
     ):
-        if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
-            # Target prefill
-            target_capture_mode = (
-                CaptureHiddenMode.NULL
-                if self.speculative_algorithm.is_standalone()
-                else CaptureHiddenMode.FULL
-            )
+        if batch.forward_mode.is_extend():
+            # Target prefill. Only the last PP rank needs to capture hidden
+            # states for the draft; non-last ranks relay upstream without capture.
+            if not self._pp_enabled or self._pp_is_last_rank:
+                target_capture_mode = (
+                    CaptureHiddenMode.NULL
+                    if self.speculative_algorithm.is_standalone()
+                    else CaptureHiddenMode.FULL
+                )
+            else:
+                target_capture_mode = CaptureHiddenMode.NULL
             batch_output = self.target_worker.forward_batch_generation(
-                batch, capture_hidden_mode=target_capture_mode
+                batch,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=target_capture_mode,
             )
+
+            # Non-last PP ranks only relay the target forward upstream.
+            if self._pp_enabled and not self._pp_is_last_rank:
+                return batch_output
 
             # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
             # Extend processed L prompt tokens; next verify iter expects same L.
@@ -1157,7 +1237,20 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
-                return batch_output
+            return batch_output
+
+        # Decode
+        if batch.forward_mode.is_idle():
+            verify_input = EagleVerifyInput.create_idle_input(
+                self.topk,
+                self.speculative_num_steps,
+                self.speculative_num_draft_tokens,
+                device=self.device,
+            )
+        elif self._pp_enabled:
+            # Under PP the verify input is built from the raw draft tree relayed
+            # from the last PP rank of the previous iteration.
+            verify_input = self._build_verify_input_from_pp_raw(batch)
         else:
             self.activate_step_by_batch(batch.seq_lens.shape[0])
 
@@ -1192,29 +1285,152 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     spec_stage_span("draft"),
                 ):
                     verify_input: EagleVerifyInput = self.draft_worker.draft(batch)
-            assert verify_input.is_verify_input()
-            batch.spec_info = verify_input
-            batch_output = self.verify(batch, grammar_barrier=grammar_barrier)
-            # Publish before draft_extend so the fence is at verify-end.
-            if on_publish is not None:
-                on_publish(batch_output.new_seq_lens)
-            if (
-                self.speculative_num_steps == 0
-                and envs.SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND.get()
-            ):
-                self._stub_skipped_draft_extend(batch, batch_output)
-            else:
-                with (
-                    self.draft_worker.draft_tp_context(
-                        self.draft_worker.draft_runner.tp_group
-                    ),
-                    speculative_moe_backend_context(),
-                    speculative_moe_a2a_backend_context(),
-                    spec_stage_span("draft_extend"),
-                ):
-                    self.draft_worker._draft_extend_for_decode(batch, batch_output)
 
+        assert verify_input.is_verify_input()
+        batch.spec_info = verify_input
+        batch_output = self.verify(
+            batch, grammar_barrier=grammar_barrier, pp_proxy_tensors=pp_proxy_tensors
+        )
+
+        # Non-last PP ranks only relay the target verify forward upstream.
+        if self._pp_enabled and not self._pp_is_last_rank:
             return batch_output
+
+        # Publish before draft_extend so the fence is at verify-end.
+        if on_publish is not None:
+            on_publish(batch_output.new_seq_lens)
+
+        # All paths run draft-extend for decode; non-PP may skip it when
+        # drafting is disabled (num_steps == 0) and the env opt-in is set.
+        if (
+            not self._pp_enabled
+            and self.speculative_num_steps == 0
+            and envs.SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND.get()
+        ):
+            self._stub_skipped_draft_extend(batch, batch_output)
+        else:
+            with (
+                self.draft_worker.draft_tp_context(
+                    self.draft_worker.draft_runner.tp_group
+                ),
+                speculative_moe_backend_context(),
+                speculative_moe_a2a_backend_context(),
+                spec_stage_span("draft_extend"),
+            ):
+                self.draft_worker._draft_extend_for_decode(batch, batch_output)
+
+                # PP last rank: produce next-iter draft raw for cross-rank relay.
+                if self._pp_enabled and self._pp_is_last_rank:
+                    batch.forward_mode = ForwardMode.DECODE
+                    batch.spec_info = batch_output.next_draft_input
+                    # Use post-accept seq_lens so draft/draft_extend write KV
+                    # at the correct slots.
+                    batch.seq_lens = batch_output.new_seq_lens
+                    pp_draft_tokens, pp_parent_list, pp_top_scores_index = (
+                        self.draft_worker.draft(batch)
+                    )
+
+        # PP last rank: serialize the draft tree for PP relay.
+        if self._pp_enabled and self._pp_is_last_rank:
+            batch_output.pp_verify_input_raw = EaglePPVerifyInputRaw(
+                draft_tokens=pp_draft_tokens.reshape(
+                    batch.batch_size(), self.speculative_num_draft_tokens
+                ).tolist(),
+                bonus_tokens=batch_output.next_draft_input.bonus_tokens.to(
+                    torch.int64
+                ).tolist(),
+                top_scores_index=pp_top_scores_index.tolist(),
+                parent_list=pp_parent_list.tolist(),
+                accept_lens=batch_output.accept_lens.tolist(),
+                accept_index=(
+                    batch_output.accept_index.tolist() if self.topk > 1 else None
+                ),
+            )
+
+        return batch_output
+
+    def _build_verify_input_from_pp_raw(self, batch: ScheduleBatch):
+        """Build EagleVerifyInput from EaglePPVerifyInputRaw (PP non-last rank).
+
+        The last PP rank serialized the draft tree into EaglePPVerifyInputRaw;
+        non-last ranks rebuild the tree mask / positions against their own
+        attention backend buffers here.
+        """
+        raw: EaglePPVerifyInputRaw = batch.spec_info
+        device = batch.seq_lens.device
+
+        topk = self.topk
+        spec_steps = self.speculative_num_steps
+        num_draft = self.speculative_num_draft_tokens
+
+        bonus_tokens = torch.tensor(raw.bonus_tokens, dtype=torch.long, device=device)
+        draft_tokens = torch.tensor(raw.draft_tokens, dtype=torch.long, device=device)
+        parent_list = torch.tensor(raw.parent_list, dtype=torch.long, device=device)
+        top_scores_index = torch.tensor(
+            raw.top_scores_index, dtype=torch.long, device=device
+        )
+
+        # draft_tokens is [bs, num_draft_tokens] with bonus as col 0.
+        # build_tree_kernel_efficient expects draft_tokens without bonus.
+        draft_tokens_no_bonus = draft_tokens[:, 1:]
+
+        # Directly write to cuda graph buffers for verify attn.
+        tree_mask_buf, position_buf = (
+            self.target_worker.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
+        )
+
+        seq_lens_sum = batch.seq_lens_sum
+        if seq_lens_sum is None:
+            if batch.seq_lens_cpu is not None:
+                seq_lens_sum = int(batch.seq_lens_cpu.sum())
+            else:
+                seq_lens_sum = int(batch.seq_lens.sum())
+
+        bs = batch.seq_lens.shape[0]
+        assert parent_list.shape == (
+            bs,
+            num_draft - 1,
+        ), f"topology shape mismatch: {parent_list.shape} vs ({bs}, {num_draft - 1})"
+
+        (
+            tree_mask,
+            positions,
+            retrieve_index,
+            retrieve_next_token,
+            retrieve_next_sibling,
+            draft_tokens_arranged,
+        ) = build_tree_kernel_efficient(
+            bonus_tokens,
+            parent_list,
+            top_scores_index,
+            draft_tokens_no_bonus,
+            batch.seq_lens,
+            seq_lens_sum,
+            topk,
+            spec_steps,
+            num_draft,
+            self.tree_mask_mode,
+            tree_mask_buf,
+            position_buf,
+        )
+
+        draft_tokens_arranged = draft_tokens_arranged.to(torch.int64)
+        batch.input_ids = draft_tokens_arranged
+        return EagleVerifyInput(
+            draft_token=draft_tokens_arranged,
+            custom_mask=tree_mask,
+            positions=positions,
+            retrieve_index=retrieve_index,
+            retrieve_next_token=retrieve_next_token,
+            retrieve_next_sibling=retrieve_next_sibling,
+            retrieve_cum_len=None,
+            spec_steps=spec_steps,
+            topk=topk,
+            draft_token_num=num_draft,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            seq_lens_sum=batch.seq_lens_sum,
+            seq_lens_cpu=batch.seq_lens_cpu,
+        )
 
     def _build_trivial_verify_input(self, batch: ScheduleBatch) -> EagleVerifyInput:
         """Build a 1-node EagleVerifyInput rooted at the previous bonus token.
@@ -1497,7 +1713,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
             dw._rebuild_topk1_chain_buffers()
 
-    def verify(self, batch: ScheduleBatch, grammar_barrier=None):
+    def verify(self, batch: ScheduleBatch, grammar_barrier=None, pp_proxy_tensors=None):
         return run_eagle_verify(
             batch,
             target_worker=self.target_worker,
@@ -1512,6 +1728,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             metadata_ready_pre_pad=False,
             finalize_tree_path=True,
             grammar_barrier=grammar_barrier,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1192,7 +1192,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
         grammar_barrier=None,
         pp_proxy_tensors=None,
     ):
-        if batch.forward_mode.is_extend():
+        # Under PP + DP attention, a rank with no local requests must still run
+        # in lockstep with the DP peers that are prefilling. On a global prefill
+        # step (some peer is extending, so the dp-attn all-gather sets
+        # is_extend_in_batch) the idle batch has to follow the *prefill* path so
+        # every DP rank emits the same MoE cross-DP collective sequence (target
+        # forward + a single draft_extend). Falling into the verify path below
+        # would add speculative_num_steps extra draft-decode collectives on the
+        # idle rank and desync the MoE all-gather -> hang. _draft_extend_for_prefill
+        # already short-circuits its input_ids build for idle batches.
+        run_as_prefill = batch.forward_mode.is_extend() or (
+            self._pp_enabled
+            and batch.forward_mode.is_idle()
+            and batch.is_extend_in_batch
+        )
+        if run_as_prefill:
             # Target prefill. Only the last PP rank needs to capture hidden
             # states for the draft; non-last ranks relay upstream without capture.
             if not self._pp_enabled or self._pp_is_last_rank:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1178,7 +1178,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
         grammar_barrier=None,
         pp_proxy_tensors=None,
     ):
-        if batch.forward_mode.is_extend():
+        # Under PP + DP attention, a rank with no local requests must still run
+        # in lockstep with the DP peers that are prefilling. On a global prefill
+        # step (some peer is extending, so the dp-attn all-gather sets
+        # is_extend_in_batch) the idle batch has to follow the *prefill* path so
+        # every DP rank emits the same MoE cross-DP collective sequence (target
+        # forward + a single draft_extend). Falling into the verify path below
+        # would add speculative_num_steps extra draft-decode collectives on the
+        # idle rank and desync the MoE all-gather -> hang. _draft_extend_for_prefill
+        # already short-circuits its input_ids build for idle batches.
+        run_as_prefill = batch.forward_mode.is_extend() or (
+            self._pp_enabled
+            and batch.forward_mode.is_idle()
+            and batch.is_extend_in_batch
+        )
+        if run_as_prefill:
             # Target prefill. Only the last PP rank needs to capture hidden
             # states for the draft; non-last ranks relay upstream without capture.
             if not self._pp_enabled or self._pp_is_last_rank:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -578,7 +578,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
             # CUDA Graph buffers are reused; clone before flattening so the
             # relayed raw tokens survive the next replay.
-            if can_cuda_graph:
+            if can_run_decode_cuda_graph:
                 parent_list = parent_list.clone()
                 top_scores_index = top_scores_index.clone()
                 draft_tokens = draft_tokens.clone()
@@ -1330,20 +1330,23 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         self.draft_worker.draft(batch)
                     )
 
-        # PP last rank: serialize the draft tree for PP relay.
+        # PP last rank: serialize the draft tree for PP relay. Tensors stay on
+        # GPU so the PP ring relays them over the GPU channel.
         if self._pp_enabled and self._pp_is_last_rank:
             batch_output.pp_verify_input_raw = EaglePPVerifyInputRaw(
                 draft_tokens=pp_draft_tokens.reshape(
                     batch.batch_size(), self.speculative_num_draft_tokens
-                ).tolist(),
+                ).to(self.device, torch.int64),
                 bonus_tokens=batch_output.next_draft_input.bonus_tokens.to(
-                    torch.int64
-                ).tolist(),
-                top_scores_index=pp_top_scores_index.tolist(),
-                parent_list=pp_parent_list.tolist(),
-                accept_lens=batch_output.accept_lens.tolist(),
+                    self.device, torch.int64
+                ),
+                top_scores_index=pp_top_scores_index.to(self.device, torch.int64),
+                parent_list=pp_parent_list.to(self.device, torch.int64),
+                accept_lens=batch_output.accept_lens.to(self.device, torch.int64),
                 accept_index=(
-                    batch_output.accept_index.tolist() if self.topk > 1 else None
+                    batch_output.accept_index.to(self.device, torch.int64)
+                    if self.topk > 1
+                    else None
                 ),
             )
 
@@ -1357,27 +1360,19 @@ class EAGLEWorkerV2(BaseSpecWorker):
         attention backend buffers here.
         """
         raw: EaglePPVerifyInputRaw = batch.spec_info
-        device = batch.seq_lens.device
 
         topk = self.topk
         spec_steps = self.speculative_num_steps
         num_draft = self.speculative_num_draft_tokens
 
-        bonus_tokens = torch.tensor(raw.bonus_tokens, dtype=torch.long, device=device)
-        draft_tokens = torch.tensor(raw.draft_tokens, dtype=torch.long, device=device)
-        parent_list = torch.tensor(raw.parent_list, dtype=torch.long, device=device)
-        top_scores_index = torch.tensor(
-            raw.top_scores_index, dtype=torch.long, device=device
-        )
+        bonus_tokens = raw.bonus_tokens.to(torch.long)
+        draft_tokens = raw.draft_tokens.to(torch.long)
+        parent_list = raw.parent_list.to(torch.long)
+        top_scores_index = raw.top_scores_index.to(torch.long)
 
         # draft_tokens is [bs, num_draft_tokens] with bonus as col 0.
         # build_tree_kernel_efficient expects draft_tokens without bonus.
         draft_tokens_no_bonus = draft_tokens[:, 1:]
-
-        # Directly write to cuda graph buffers for verify attn.
-        tree_mask_buf, position_buf = (
-            self.target_worker.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
-        )
 
         seq_lens_sum = batch.seq_lens_sum
         if seq_lens_sum is None:
@@ -1391,6 +1386,18 @@ class EAGLEWorkerV2(BaseSpecWorker):
             bs,
             num_draft - 1,
         ), f"topology shape mismatch: {parent_list.shape} vs ({bs}, {num_draft - 1})"
+
+        # Write straight into the backend's verify-mask buffer when it owns one
+        # and this batch fits; an eager batch past the captured max_bs falls
+        # back to allocating. Mode and fill stay paired with the buffer, same
+        # contract as the shared draft tail in eagle_worker_common.
+        target_attn_backend = self.target_worker.model_runner.attn_backend
+        verify_mask = target_attn_backend.verify_mask
+        if verify_mask is None:
+            tree_mask_buf, mask_mode, fill_mask = None, self.tree_mask_mode, True
+        else:
+            mask_mode, fill_mask = verify_mask.mode, verify_mask.is_read
+            tree_mask_buf = verify_mask.buffer if verify_mask.fits(bs) else None
 
         (
             tree_mask,
@@ -1409,9 +1416,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
             topk,
             spec_steps,
             num_draft,
-            self.tree_mask_mode,
+            mask_mode,
             tree_mask_buf,
-            position_buf,
+            fill_prefix_mask=fill_mask,
         )
 
         draft_tokens_arranged = draft_tokens_arranged.to(torch.int64)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -39,7 +39,11 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner import (
     DecodeCudaGraphRunner,
@@ -69,10 +73,13 @@ from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
 from sglang.srt.speculative.eagle_info import (
     EagleDraftExtendInput,
     EagleDraftInput,
+    EaglePPVerifyInputRaw,
     EagleVerifyInput,
 )
 from sglang.srt.speculative.eagle_utils import (
+    TreeMaskMode,
     _eagle_prefill_tail_tokens,
+    build_tree_kernel_efficient,
     default_tree_mask_mode,
     get_draft_recurrent_hidden_state_spec,
     organize_draft_results,
@@ -134,6 +141,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         ps: ParallelState,
         nccl_port: int,
         target_worker: TpModelWorker,
+        tree_mask_mode: TreeMaskMode,
     ):
         super().__init__()
 
@@ -177,6 +185,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 is_draft_worker=True,
                 # The draft runs at absolute target positions.
                 context_length=target_worker.model_runner.model_config.context_len,
+                pp_global_random_seed=target_worker.random_seed,
             )
 
         # Alias for better readability
@@ -187,7 +196,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_tp_context = (
             draft_tp_context if get_parallel().enable_dp_attention else empty_context
         )
-        self.tree_mask_mode = default_tree_mask_mode()
+        self.tree_mask_mode = tree_mask_mode
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
@@ -278,7 +287,14 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.hot_token_id = None
 
     def init_lm_head(self):
-        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
+        pp_size = self.target_worker.pp_group.world_size
+
+        if pp_size > 1:
+            # Under PP, the draft embedding is loaded from the draft checkpoint
+            # in load_weights already; here we only take the target lm_head.
+            head = self.target_worker.model_runner.model.get_head()
+        else:
+            embed, head = self.target_worker.model_runner.model.get_embed_and_head()
         target_lm_head = getattr(self.target_worker.model_runner.model, "lm_head", None)
 
         def maybe_share_target_lm_head():
@@ -297,16 +313,18 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 hasattr(self.draft_runner.model, "load_lm_head_from_target")
                 and self.draft_runner.model.load_lm_head_from_target
             ):
-                self.draft_runner.model.set_embed_and_head(embed, head)
+                if pp_size > 1:
+                    self.draft_runner.model.set_head(head)
+                else:
+                    self.draft_runner.model.set_embed_and_head(embed, head)
                 maybe_share_target_lm_head()
             else:
-                self.draft_runner.model.set_embed(embed)
+                if pp_size == 1:
+                    self.draft_runner.model.set_embed(embed)
 
             # grab hot token ids
             if self.draft_runner.model.hot_token_id is not None:
-                self.hot_token_id = self.draft_runner.model.hot_token_id.to(
-                    embed.device
-                )
+                self.hot_token_id = self.draft_runner.model.hot_token_id.to(head.device)
 
         else:
             if self.hot_token_id is not None:
@@ -314,8 +332,12 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 self.hot_token_id = self.hot_token_id.to(head.device)
                 head.data = head.data[self.hot_token_id]
 
-            # Share the embedding and lm_head
-            self.draft_runner.model.set_embed_and_head(embed, head)
+            if pp_size > 1:
+                # Under PP the embed is already loaded by the draft; only set the head.
+                self.draft_runner.model.set_head(head)
+            else:
+                # Share the embedding and lm_head
+                self.draft_runner.model.set_embed_and_head(embed, head)
             maybe_share_target_lm_head()
 
     def init_attention_backend(self):
@@ -341,7 +363,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_runner.draft_attn_backend = self.draft_attn_backend
         if self.draft_extend_attn_backend is not None:
             self.draft_runner.attn_backend = self.draft_extend_attn_backend
-        self.tree_mask_mode = default_tree_mask_mode()
 
     def _capture_cuda_graphs(self):
         """Capture the draft worker's own cuda graphs (decode + draft-extend)."""
@@ -541,6 +562,31 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 parent_list, top_scores_index, draft_tokens, draft_probs = (
                     self.draft_forward(forward_batch)
                 )
+
+        if self.server_args.pp_size > 1:
+            # PP path: return the raw draft tree (flattened draft_tokens with
+            # bonus prepended, parent_list, top_scores_index) so the last PP
+            # rank can serialize it into EaglePPVerifyInputRaw for cross-rank relay.
+            if batch.forward_mode.is_idle():
+                num_draft = self.speculative_num_draft_tokens
+                parent_width = max(num_draft - 1, 0)
+                return (
+                    torch.empty((0, num_draft), dtype=torch.long, device="cpu"),
+                    torch.empty((0, parent_width), dtype=torch.long, device="cpu"),
+                    torch.empty((0, parent_width), dtype=torch.long, device="cpu"),
+                )
+
+            # CUDA Graph buffers are reused; clone before flattening so the
+            # relayed raw tokens survive the next replay.
+            if can_cuda_graph:
+                parent_list = parent_list.clone()
+                top_scores_index = top_scores_index.clone()
+                draft_tokens = draft_tokens.clone()
+
+            draft_tokens = torch.cat(
+                (draft_input.bonus_tokens.unsqueeze(1), draft_tokens), dim=1
+            ).flatten()
+            return draft_tokens, parent_list, top_scores_index
 
         return build_eagle_verify_input(
             batch,
@@ -1033,17 +1079,30 @@ class EAGLEWorkerV2(BaseSpecWorker):
             server_args.speculative_algorithm
         )
 
-        self._draft_worker = EagleDraftWorker(
-            server_args,
-            gpu_id,
-            ps,
-            nccl_port,
-            target_worker,
-        )
+        self._pp_is_last_rank = target_worker.pp_group.is_last_rank
+        self._pp_enabled = server_args.pp_size > 1
+
+        # Defined on every rank so PP non-last ranks (which have no draft
+        # worker) still resolve the mask mode in _build_verify_input_from_pp_raw.
+        self.tree_mask_mode = default_tree_mask_mode()
+
+        # The draft model is only created on the last PP rank. PP + spec v2
+        # currently only supports hosting the draft worker on the last rank.
+        if not self._pp_enabled or self._pp_is_last_rank:
+            self._draft_worker = EagleDraftWorker(
+                server_args,
+                gpu_id,
+                ps,
+                nccl_port,
+                target_worker,
+                tree_mask_mode=self.tree_mask_mode,
+            )
+        else:
+            self._draft_worker = None
 
         # Adaptive speculative
         self.adaptive_controller: Optional[AdaptiveController] = None
-        if server_args.speculative_adaptive:
+        if server_args.speculative_adaptive and self._draft_worker is not None:
             self.adaptive_controller = AdaptiveController(
                 self,
                 config_path=server_args.speculative_adaptive_config,
@@ -1067,6 +1126,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
     def spec_v2_attn_backends(self) -> tuple:
         # Every attn backend a spec_v2 forward touches; consumed by
         # decide_needs_cpu_seq_lens to gate the seq_lens_cpu D2H.
+        # Non-last PP ranks have no draft model (_draft_worker is None) and
+        # only run the target forward, so only the target backend matters.
+        if self._draft_worker is None:
+            return (self._target_worker.model_runner.attn_backend,)
         return (
             self._target_worker.model_runner.attn_backend,
             self._draft_worker.draft_attn_backend,
@@ -1075,7 +1138,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
         )
 
     def init_cuda_graphs(self):
-        super().init_cuda_graphs()
+        # The draft model only exists on the last PP rank; non-last PP ranks
+        # have no draft worker and skip the draft cuda graph / adaptive init.
+        if not self._pp_enabled or self._pp_is_last_rank:
+            self._draft_worker.init_cuda_graphs()
         # Build adaptive runtime states after target and draft backends exist.
         if self.adaptive_controller is not None:
             with (
@@ -1106,18 +1172,32 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
 
     def forward_batch_generation(
-        self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
+        self,
+        batch: ScheduleBatch,
+        on_publish=None,
+        grammar_barrier=None,
+        pp_proxy_tensors=None,
     ):
-        if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
-            # Target prefill
-            target_capture_mode = (
-                CaptureHiddenMode.NULL
-                if self.speculative_algorithm.is_standalone()
-                else CaptureHiddenMode.FULL
-            )
+        if batch.forward_mode.is_extend():
+            # Target prefill. Only the last PP rank needs to capture hidden
+            # states for the draft; non-last ranks relay upstream without capture.
+            if not self._pp_enabled or self._pp_is_last_rank:
+                target_capture_mode = (
+                    CaptureHiddenMode.NULL
+                    if self.speculative_algorithm.is_standalone()
+                    else CaptureHiddenMode.FULL
+                )
+            else:
+                target_capture_mode = CaptureHiddenMode.NULL
             batch_output = self.target_worker.forward_batch_generation(
-                batch, capture_hidden_mode=target_capture_mode
+                batch,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=target_capture_mode,
             )
+
+            # Non-last PP ranks only relay the target forward upstream.
+            if self._pp_enabled and not self._pp_is_last_rank:
+                return batch_output
 
             # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
             # Extend processed L prompt tokens; next verify iter expects same L.
@@ -1143,7 +1223,20 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
-                return batch_output
+            return batch_output
+
+        # Decode
+        if batch.forward_mode.is_idle():
+            verify_input = EagleVerifyInput.create_idle_input(
+                self.topk,
+                self.speculative_num_steps,
+                self.speculative_num_draft_tokens,
+                device=self.device,
+            )
+        elif self._pp_enabled:
+            # Under PP the verify input is built from the raw draft tree relayed
+            # from the last PP rank of the previous iteration.
+            verify_input = self._build_verify_input_from_pp_raw(batch)
         else:
             self.activate_step_by_batch(batch.seq_lens.shape[0])
 
@@ -1178,29 +1271,152 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     spec_stage_span("draft"),
                 ):
                     verify_input: EagleVerifyInput = self.draft_worker.draft(batch)
-            assert verify_input.is_verify_input()
-            batch.spec_info = verify_input
-            batch_output = self.verify(batch, grammar_barrier=grammar_barrier)
-            # Publish before draft_extend so the fence is at verify-end.
-            if on_publish is not None:
-                on_publish(batch_output.new_seq_lens)
-            if (
-                self.speculative_num_steps == 0
-                and envs.SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND.get()
-            ):
-                self._stub_skipped_draft_extend(batch, batch_output)
-            else:
-                with (
-                    self.draft_worker.draft_tp_context(
-                        self.draft_worker.draft_runner.tp_group
-                    ),
-                    speculative_moe_backend_context(),
-                    speculative_moe_a2a_backend_context(),
-                    spec_stage_span("draft_extend"),
-                ):
-                    self.draft_worker._draft_extend_for_decode(batch, batch_output)
 
+        assert verify_input.is_verify_input()
+        batch.spec_info = verify_input
+        batch_output = self.verify(
+            batch, grammar_barrier=grammar_barrier, pp_proxy_tensors=pp_proxy_tensors
+        )
+
+        # Non-last PP ranks only relay the target verify forward upstream.
+        if self._pp_enabled and not self._pp_is_last_rank:
             return batch_output
+
+        # Publish before draft_extend so the fence is at verify-end.
+        if on_publish is not None:
+            on_publish(batch_output.new_seq_lens)
+
+        # All paths run draft-extend for decode; non-PP may skip it when
+        # drafting is disabled (num_steps == 0) and the env opt-in is set.
+        if (
+            not self._pp_enabled
+            and self.speculative_num_steps == 0
+            and envs.SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND.get()
+        ):
+            self._stub_skipped_draft_extend(batch, batch_output)
+        else:
+            with (
+                self.draft_worker.draft_tp_context(
+                    self.draft_worker.draft_runner.tp_group
+                ),
+                speculative_moe_backend_context(),
+                speculative_moe_a2a_backend_context(),
+                spec_stage_span("draft_extend"),
+            ):
+                self.draft_worker._draft_extend_for_decode(batch, batch_output)
+
+                # PP last rank: produce next-iter draft raw for cross-rank relay.
+                if self._pp_enabled and self._pp_is_last_rank:
+                    batch.forward_mode = ForwardMode.DECODE
+                    batch.spec_info = batch_output.next_draft_input
+                    # Use post-accept seq_lens so draft/draft_extend write KV
+                    # at the correct slots.
+                    batch.seq_lens = batch_output.new_seq_lens
+                    pp_draft_tokens, pp_parent_list, pp_top_scores_index = (
+                        self.draft_worker.draft(batch)
+                    )
+
+        # PP last rank: serialize the draft tree for PP relay.
+        if self._pp_enabled and self._pp_is_last_rank:
+            batch_output.pp_verify_input_raw = EaglePPVerifyInputRaw(
+                draft_tokens=pp_draft_tokens.reshape(
+                    batch.batch_size(), self.speculative_num_draft_tokens
+                ).tolist(),
+                bonus_tokens=batch_output.next_draft_input.bonus_tokens.to(
+                    torch.int64
+                ).tolist(),
+                top_scores_index=pp_top_scores_index.tolist(),
+                parent_list=pp_parent_list.tolist(),
+                accept_lens=batch_output.accept_lens.tolist(),
+                accept_index=(
+                    batch_output.accept_index.tolist() if self.topk > 1 else None
+                ),
+            )
+
+        return batch_output
+
+    def _build_verify_input_from_pp_raw(self, batch: ScheduleBatch):
+        """Build EagleVerifyInput from EaglePPVerifyInputRaw (PP non-last rank).
+
+        The last PP rank serialized the draft tree into EaglePPVerifyInputRaw;
+        non-last ranks rebuild the tree mask / positions against their own
+        attention backend buffers here.
+        """
+        raw: EaglePPVerifyInputRaw = batch.spec_info
+        device = batch.seq_lens.device
+
+        topk = self.topk
+        spec_steps = self.speculative_num_steps
+        num_draft = self.speculative_num_draft_tokens
+
+        bonus_tokens = torch.tensor(raw.bonus_tokens, dtype=torch.long, device=device)
+        draft_tokens = torch.tensor(raw.draft_tokens, dtype=torch.long, device=device)
+        parent_list = torch.tensor(raw.parent_list, dtype=torch.long, device=device)
+        top_scores_index = torch.tensor(
+            raw.top_scores_index, dtype=torch.long, device=device
+        )
+
+        # draft_tokens is [bs, num_draft_tokens] with bonus as col 0.
+        # build_tree_kernel_efficient expects draft_tokens without bonus.
+        draft_tokens_no_bonus = draft_tokens[:, 1:]
+
+        # Directly write to cuda graph buffers for verify attn.
+        tree_mask_buf, position_buf = (
+            self.target_worker.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
+        )
+
+        seq_lens_sum = batch.seq_lens_sum
+        if seq_lens_sum is None:
+            if batch.seq_lens_cpu is not None:
+                seq_lens_sum = int(batch.seq_lens_cpu.sum())
+            else:
+                seq_lens_sum = int(batch.seq_lens.sum())
+
+        bs = batch.seq_lens.shape[0]
+        assert parent_list.shape == (
+            bs,
+            num_draft - 1,
+        ), f"topology shape mismatch: {parent_list.shape} vs ({bs}, {num_draft - 1})"
+
+        (
+            tree_mask,
+            positions,
+            retrieve_index,
+            retrieve_next_token,
+            retrieve_next_sibling,
+            draft_tokens_arranged,
+        ) = build_tree_kernel_efficient(
+            bonus_tokens,
+            parent_list,
+            top_scores_index,
+            draft_tokens_no_bonus,
+            batch.seq_lens,
+            seq_lens_sum,
+            topk,
+            spec_steps,
+            num_draft,
+            self.tree_mask_mode,
+            tree_mask_buf,
+            position_buf,
+        )
+
+        draft_tokens_arranged = draft_tokens_arranged.to(torch.int64)
+        batch.input_ids = draft_tokens_arranged
+        return EagleVerifyInput(
+            draft_token=draft_tokens_arranged,
+            custom_mask=tree_mask,
+            positions=positions,
+            retrieve_index=retrieve_index,
+            retrieve_next_token=retrieve_next_token,
+            retrieve_next_sibling=retrieve_next_sibling,
+            retrieve_cum_len=None,
+            spec_steps=spec_steps,
+            topk=topk,
+            draft_token_num=num_draft,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            seq_lens_sum=batch.seq_lens_sum,
+            seq_lens_cpu=batch.seq_lens_cpu,
+        )
 
     def _build_trivial_verify_input(self, batch: ScheduleBatch) -> EagleVerifyInput:
         """Build a 1-node EagleVerifyInput rooted at the previous bonus token.
@@ -1497,7 +1713,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
             dw._rebuild_topk1_chain_buffers()
 
-    def verify(self, batch: ScheduleBatch, grammar_barrier=None):
+    def verify(self, batch: ScheduleBatch, grammar_barrier=None, pp_proxy_tensors=None):
         return run_eagle_verify(
             batch,
             target_worker=self.target_worker,
@@ -1511,6 +1727,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             metadata_ready_pre_pad=False,
             finalize_tree_path=True,
             grammar_barrier=grammar_barrier,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -312,6 +312,7 @@ class SpecInputType(IntEnum):
     EAGLE_DRAFT = auto()
     EAGLE_DRAFT_EXTEND = auto()
     EAGLE_VERIFY = auto()
+    EAGLE_PP_VERIFY_INPUT_RAW = auto()
     FROZEN_KV_MTP_DRAFT = auto()
     FROZEN_KV_MTP_VERIFY = auto()
     DFLASH_DRAFT = auto()

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -306,6 +306,7 @@ class SpecInputType(IntEnum):
     EAGLE_DRAFT = auto()
     EAGLE_DRAFT_EXTEND = auto()
     EAGLE_VERIFY = auto()
+    EAGLE_PP_VERIFY_INPUT_RAW = auto()
     FROZEN_KV_MTP_DRAFT = auto()
     FROZEN_KV_MTP_VERIFY = auto()
     DFLASH_DRAFT = auto()


### PR DESCRIPTION
Roadmap: https://github.com/sgl-project/sglang/issues/11857

PP+Dspark is supported base on this PR, the link is https://github.com/sgl-project/sglang/pull/32281

## Motivation

`server_args.py` previously asserted that `pp_size > 1` and a speculative algorithm could not be enabled together. This PR removes that restriction and enables EAGLE speculative decoding to run under pipeline parallelism, tested on GLM52 and Deepseek-V4-Flash.

## Modifications

The draft worker is created only on the last PP rank; every rank runs its own target forward and verify, the draft tree is carried across stages and rebuilt locally per rank, and the accepted-token KV bookkeeping is moved out of the verify epilogue into a per-rank post-processing step.

1. Draft worker created only on the last PP rank. Non-last ranks have no draft worker, draft KV pool, or draft `lm_head`; they forward target layers and relay hidden states / proxy tensors downstream. All draft-accessing paths are null-guarded.

2. Target hidden capture (`capture_hidden = FULL`) enabled only on the last rank; upstream ranks capture nothing and pass the hidden/proxy along.

3. The draft tree produced on the last rank (draft/bonus/parent indices, accept info) is serialized as plain lists, added to the existing PP tensor dict, and reconstructed on every other pp rank into a verify input matching that rank's own KV layout and attention buffers, so each rank builds its tree mask / positions locally.

4. Sampling / acceptance / grammar run only on the last rank; non-last ranks skip that epilogue and execute only the target-layer forward for the verified tokens.

5. Accept-token write-back and sequence-length update are moved into the scheduler's `batch_result_processor`, which runs on every PP rank; the old single-point finalize path is skipped under PP.

6. The scheduler takes a dedicated non-overlap path that threads `pp_proxy_tensors` through generation and triggers the per-rank cache update afterwards.

Other changes:

- MTP/nextn model layer: the context-parallel split is applied to the spec hidden states under PP + MTP. On GLM-5.2 (chunked-prefill-size 8192) this lowers per-step `draft_extend_for_prefill` time on the last PP rank from 27 ms to 20 ms (The data is profiled on 2 8*H20 nodes).
- Weight loading: the nextn draft's `embed_tokens` is loaded on the last rank directly rather than recycled from the target; non-last ranks keep skipping it. `lm_head` / `embed` access is split into separate hooks so the PP draft shares only `lm_head`.
- CUDA graph compatibility: the static `pp_proxy_tensors` buffers are sized by max token count (not batch size); the decode graph runner copies the proxy tensors into the graph buffer before replay.

Limitations asserted: PP + spec disables `mixed-chunk` prefill and `speculative_adaptive`; only EAGLE algorithm are permitted under PP for now.

## Accuracy Tests

Setup: DeepSeek-V4-Flash-FP8, single 8*H20 node;

GSM8K accuracy (200 examples, 5-shot, temperature=0)

| Configuration | GSM8K Accuracy (%) |
|---|---|
| PP2-TP4 (no spec) | 98.50 |
| PP2-TP4 + MTP314 (this PR) | 98.50 |
| TP8 + MTP314 | 98.50 |

## Speed Tests

Setup: DeepSeek-V4-Flash-FP8, single 8*H20 node; EAGLE draft with `speculative-num-steps=3`, `speculative-eagle-topk=1`, `speculative-num-draft-tokens=4`. Three configs sweep the input length (16k / 32k / 64k):

**TTFT (ms)**

| Configuration | 16k | 32k | 64k |
|---|---|---|---|
| PP2-TP4 (no spec) | 653.59 | 1142.21 | 2197.28 |
| PP2-TP4 + MTP314  | 658.30 | 1135.22 | 2124.52 |
| TP8 + MTP314 | 534.70 | 1080.04 | 2212.80 |

**TPOT (ms)**

| Configuration | 16k | 32k | 64k |
|---|---|---|---|
| PP2-TP4 | 11.67 | 11.71 | 11.68 |
| PP2-TP4 + MTP314 (this PR) | 5.42 | 5.53 | 5.65 |
| TP8 + MTP314 | 4.19 | 4.26 | 4.45 |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32382552977](https://github.com/sgl-project/sglang/actions/runs/32382552977)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32382552472](https://github.com/sgl-project/sglang/actions/runs/32382552472)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32382552886](https://github.com/sgl-project/sglang/actions/runs/32382552886)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->