### PR TITLE
Clean up ModelRunner by renaming effective-token property and remove dead code

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -140,7 +140,7 @@ class PrefillBootstrapQueue:
         self.gloo_group = gloo_group
         self.scheduler = scheduler
         self.max_total_num_tokens = (
-            self.scheduler.tp_worker.model_runner.max_token_pool_size
+            self.scheduler.tp_worker.model_runner.effective_max_total_num_tokens
         )
         self.transfer_backend = transfer_backend
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get() and self.is_mla_backend:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -342,7 +342,7 @@ class TpModelWorker(BaseTpWorker):
         assert self.model_runner.max_running_requests > 0, "max_running_request is zero"
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.max_token_pool_size - 1,
+            self.model_runner.effective_max_total_num_tokens - 1,
         )
         assert max_req_len > 0, "Memory pool size is too small"
 
@@ -454,7 +454,7 @@ class TpModelWorker(BaseTpWorker):
     def get_worker_info(self):
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.max_token_pool_size - 1,
+            self.model_runner.effective_max_total_num_tokens - 1,
         )
         return (
             self.model_runner.max_total_num_tokens,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -256,36 +256,12 @@ if _is_npu:
 elif current_platform.is_out_of_tree():
     current_platform.init_backend()
 
-MLA_ATTENTION_BACKENDS = [
-    "aiter",
-    "flashinfer",
-    "fa3",
-    "fa4",
-    "triton",
-    "flashmla",
-    "cutedsl_mla",
-    "cutlass_mla",
-    "trtllm_mla",
-    "tokenspeed_mla",
-    "ascend",
-    "dsa",
-    "nsa",  # Deprecated alias for "dsa"
-    "intel_xpu",
-]
-
-
 TORCH_DTYPE_TO_KV_CACHE_STR = {
     torch.float8_e4m3fn: "fp8_e4m3",
     torch.float8_e4m3fnuz: "fp8_e4m3",
     torch.float8_e5m2: "fp8_e5m2",
     torch.bfloat16: "bf16",
 }
-
-
-def add_mla_attention_backend(backend_name):
-    if backend_name not in MLA_ATTENTION_BACKENDS:
-        MLA_ATTENTION_BACKENDS.append(backend_name)
-        logger.info(f"Added {backend_name} to MLA_ATTENTION_BACKENDS.")
 
 
 # Detect stragger ranks in model loading

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2362,7 +2362,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         return None
 
     @property
-    def max_token_pool_size(self):
+    def effective_max_total_num_tokens(self):
         """Return the max token pool size considering hybrid swa settings."""
         if self.is_hybrid_swa:
             return self.full_max_total_num_tokens or self.swa_max_total_num_tokens

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -884,12 +884,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.init_routed_experts_capturer()
         self.init_indexer_capturer()
 
-        self.attn_backend = None
-        self.decode_attn_backend = None
-        self.decode_attn_backend_group = []
-        self.decode_cuda_graph_runner = None
-        self.graph_mem_usage = 0
-        self.prefill_cuda_graph_runner = None
         self.graph_shared_output = None
 
     def init_attention_backends(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -284,19 +284,6 @@ def resolve_language_model(model: nn.Module) -> nn.Module:
     return model.model
 
 
-class RankZeroFilter(logging.Filter):
-    """Filter that only allows INFO level logs from rank 0, but allows all other levels from any rank."""
-
-    def __init__(self, is_rank_zero):
-        super().__init__()
-        self.is_rank_zero = is_rank_zero
-
-    def filter(self, record):
-        if record.levelno == logging.INFO:
-            return self.is_rank_zero
-        return True
-
-
 @dataclass
 class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]


### PR DESCRIPTION
### mrc-misc-cleanups(effective-max-total-num-tokens,non_mechanical_provable): Rename the max_token_pool_size property to effective_max_total_num_tokens and route prefill/tp_worker through it

### mrc-misc-cleanups(remove-unused-mla-attention-backends,non_mechanical_provable): Remove unused MLA_ATTENTION_BACKENDS and add_mla_attention_backend

Both the MLA_ATTENTION_BACKENDS list and its add_mla_attention_backend
mutator had no readers anywhere under python/sglang/srt (only the
definition existed). Delete the dead pair.

### mrc-misc-cleanups(drop-vestigial-alloc-memory-pool-defaults,non_mechanical_provable): Drop vestigial backend/graph None-defaults from alloc_memory_pool

The six self.attn_backend / decode_attn_backend / decode_attn_backend_group /
decode_cuda_graph_runner / graph_mem_usage / prefill_cuda_graph_runner = None defaults
at the end of alloc_memory_pool were a leftover fallback for an old
disable_cuda_graph early-skip path. init_model_worker now unconditionally calls
init_attention_backends (assigns the attn trio) and init_cuda_graphs (assigns the
cuda-graph trio, always returning all fields even when capture is disabled), both
before any forward, and nothing probes these fields with hasattr/getattr. Remove the
dead defaults.

### mrc-misc-cleanups(drop-rank-zero-filter,non_mechanical_provable): Remove unused RankZeroFilter class from model_runner.py











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29315896354](https://github.com/sgl-project/sglang/actions/runs/29315896354)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29315896240](https://github.com/sgl-project/sglang/actions/runs/29315896240)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->