### PR TITLE
Extract kv cache dtype configuration into mem_cache

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_dtype.py
+++ b/python/sglang/srt/mem_cache/kv_cache_dtype.py
@@ -5,7 +5,6 @@ import torch
 from torch import nn
 
 from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
-from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import is_hip
 
 logger = logging.getLogger(__name__)
@@ -22,12 +21,14 @@ TORCH_DTYPE_TO_KV_CACHE_STR = {
 
 def configure_kv_cache_dtype(
     *,
-    server_args: ServerArgs,
+    server_args_kv_cache_dtype: str,
     model: nn.Module,
     model_dtype: torch.dtype,
+    is_draft_worker: bool,
+    is_dflash: bool,
+    speculative_draft_attention_backend: str,
 ) -> tuple[Optional[str], torch.dtype]:
     resolved_kv_cache_dtype: Optional[str] = None
-    server_args_kv_cache_dtype = server_args.kv_cache_dtype
     if server_args_kv_cache_dtype == "auto":
         quant_config = getattr(model, "quant_config", None)
         kv_cache_quant_algo = getattr(quant_config, "kv_cache_quant_algo", None)
@@ -62,4 +63,21 @@ def configure_kv_cache_dtype(
             kv_cache_dtype = model_dtype
     else:
         raise ValueError(f"Unsupported kv_cache_dtype: {server_args_kv_cache_dtype}.")
+
+    # DFLASH: fa4 draft attention can't read the target's fp8 KV (needs K.dtype == Q.dtype),
+    # so give the fa4 draft its own compute-dtype KV. fp8-capable backends keep the target dtype.
+    if (
+        is_draft_worker
+        and is_dflash
+        and speculative_draft_attention_backend == "fa4"
+        and kv_cache_dtype != model_dtype
+    ):
+        logger.info(
+            "DFLASH fa4 draft: overriding KV cache dtype %s -> %s "
+            "(fa4 needs K.dtype == Q.dtype; cannot read the target's quantized KV).",
+            kv_cache_dtype,
+            model_dtype,
+        )
+        kv_cache_dtype = model_dtype
+
     return resolved_kv_cache_dtype, kv_cache_dtype

--- a/python/sglang/srt/mem_cache/kv_cache_dtype.py
+++ b/python/sglang/srt/mem_cache/kv_cache_dtype.py
@@ -4,10 +4,62 @@ from typing import Optional
 import torch
 from torch import nn
 
-from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
+from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import is_hip
 
 logger = logging.getLogger(__name__)
 
 _is_hip = is_hip()
+
+TORCH_DTYPE_TO_KV_CACHE_STR = {
+    torch.float8_e4m3fn: "fp8_e4m3",
+    torch.float8_e4m3fnuz: "fp8_e4m3",
+    torch.float8_e5m2: "fp8_e5m2",
+    torch.bfloat16: "bf16",
+}
+
+
+def configure_kv_cache_dtype(
+    *,
+    server_args: ServerArgs,
+    model: nn.Module,
+    model_dtype: torch.dtype,
+) -> tuple[Optional[str], torch.dtype]:
+    resolved_kv_cache_dtype: Optional[str] = None
+    server_args_kv_cache_dtype = server_args.kv_cache_dtype
+    if server_args_kv_cache_dtype == "auto":
+        quant_config = getattr(model, "quant_config", None)
+        kv_cache_quant_algo = getattr(quant_config, "kv_cache_quant_algo", None)
+        if (
+            isinstance(kv_cache_quant_algo, str)
+            and kv_cache_quant_algo.upper() == "FP8"
+        ):
+            kv_cache_dtype = fp8_dtype if _is_hip else torch.float8_e4m3fn
+            resolved_kv_cache_dtype = TORCH_DTYPE_TO_KV_CACHE_STR[kv_cache_dtype]
+        else:
+            kv_cache_dtype = model_dtype
+    elif server_args_kv_cache_dtype == "fp8_e5m2":
+        if _is_hip:  # Using natively supported format
+            kv_cache_dtype = fp8_dtype
+        else:
+            kv_cache_dtype = torch.float8_e5m2
+    elif server_args_kv_cache_dtype == "fp8_e4m3":
+        if _is_hip:  # Using natively supported format
+            kv_cache_dtype = fp8_dtype
+        else:
+            kv_cache_dtype = torch.float8_e4m3fn
+    elif server_args_kv_cache_dtype in ("bf16", "bfloat16"):
+        kv_cache_dtype = torch.bfloat16
+    elif server_args_kv_cache_dtype == "fp4_e2m1":
+        if hasattr(torch, "float4_e2m1fn_x2"):
+            kv_cache_dtype = torch.float4_e2m1fn_x2
+            logger.warning(f"FP4 (E2M1) KV Cache might lead to a accuracy drop!")
+        else:
+            logger.warning(
+                f"--kv-cache-dtype falls back to 'auto' because this torch version does not support torch.float4_e2m1fn_x2"
+            )
+            kv_cache_dtype = model_dtype
+    else:
+        raise ValueError(f"Unsupported kv_cache_dtype: {server_args_kv_cache_dtype}.")
+    return resolved_kv_cache_dtype, kv_cache_dtype

--- a/python/sglang/srt/mem_cache/kv_cache_dtype.py
+++ b/python/sglang/srt/mem_cache/kv_cache_dtype.py
@@ -1,0 +1,13 @@
+import logging
+from typing import Optional
+
+import torch
+from torch import nn
+
+from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import is_hip
+
+logger = logging.getLogger(__name__)
+
+_is_hip = is_hip()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2358,29 +2358,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def configure_kv_cache_dtype(self):
         resolved_kv_cache_dtype, self.kv_cache_dtype = (
             kv_cache_dtype.configure_kv_cache_dtype(
-                server_args=self.server_args,
+                server_args_kv_cache_dtype=self.server_args.kv_cache_dtype,
                 model=self.model,
                 model_dtype=self.dtype,
+                is_draft_worker=self.is_draft_worker,
+                is_dflash=self.spec_algorithm.is_dflash(),
+                speculative_draft_attention_backend=self.server_args.speculative_draft_attention_backend,
             )
         )
         if resolved_kv_cache_dtype is not None:
             self._record_kv_cache_dtype(resolved_kv_cache_dtype)
-
-        # DFLASH: fa4 draft attention can't read the target's fp8 KV (needs K.dtype == Q.dtype),
-        # so give the fa4 draft its own compute-dtype KV. fp8-capable backends keep the target dtype.
-        if (
-            self.is_draft_worker
-            and self.spec_algorithm.is_dflash()
-            and self.server_args.speculative_draft_attention_backend == "fa4"
-            and self.kv_cache_dtype != self.dtype
-        ):
-            logger.info(
-                "DFLASH fa4 draft: overriding KV cache dtype %s -> %s "
-                "(fa4 needs K.dtype == Q.dtype; cannot read the target's quantized KV).",
-                self.kv_cache_dtype,
-                self.dtype,
-            )
-            self.kv_cache_dtype = self.dtype
 
     def init_attention_backend(self):
         """Init attention kernel backend."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -775,8 +775,31 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
             enable_batch_invariant_mode()
 
-        # Deduce KV cache dtype
-        self.configure_kv_cache_dtype()
+        resolved_kv_cache_dtype, self.kv_cache_dtype = (
+            ModelRunner.configure_kv_cache_dtype(
+                server_args=self.server_args,
+                model=self.model,
+                model_dtype=self.dtype,
+            )
+        )
+        if resolved_kv_cache_dtype is not None:
+            self._record_kv_cache_dtype(resolved_kv_cache_dtype)
+
+        # DFLASH: fa4 draft attention can't read the target's fp8 KV (needs K.dtype == Q.dtype),
+        # so give the fa4 draft its own compute-dtype KV. fp8-capable backends keep the target dtype.
+        if (
+            self.is_draft_worker
+            and self.spec_algorithm.is_dflash()
+            and self.server_args.speculative_draft_attention_backend == "fa4"
+            and self.kv_cache_dtype != self.dtype
+        ):
+            logger.info(
+                "DFLASH fa4 draft: overriding KV cache dtype %s -> %s "
+                "(fa4 needs K.dtype == Q.dtype; cannot read the target's quantized KV).",
+                self.kv_cache_dtype,
+                self.dtype,
+            )
+            self.kv_cache_dtype = self.dtype
 
     def get_pp_proxy_topk_size(self) -> Optional[int]:
         hf_config = self.model_config.hf_text_config
@@ -2364,61 +2387,52 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 "ModelRunner.configure_kv_cache_dtype", kv_cache_dtype=resolved
             )
 
-    def configure_kv_cache_dtype(self):
-        if self.server_args.kv_cache_dtype == "auto":
-            quant_config = getattr(self.model, "quant_config", None)
+    @staticmethod
+    def configure_kv_cache_dtype(
+        *,
+        server_args: ServerArgs,
+        model: nn.Module,
+        model_dtype: torch.dtype,
+    ) -> tuple[Optional[str], torch.dtype]:
+        resolved_kv_cache_dtype: Optional[str] = None
+        server_args_kv_cache_dtype = server_args.kv_cache_dtype
+        if server_args_kv_cache_dtype == "auto":
+            quant_config = getattr(model, "quant_config", None)
             kv_cache_quant_algo = getattr(quant_config, "kv_cache_quant_algo", None)
             if (
                 isinstance(kv_cache_quant_algo, str)
                 and kv_cache_quant_algo.upper() == "FP8"
             ):
-                self.kv_cache_dtype = fp8_dtype if _is_hip else torch.float8_e4m3fn
-                self._record_kv_cache_dtype(
-                    TORCH_DTYPE_TO_KV_CACHE_STR[self.kv_cache_dtype]
-                )
+                kv_cache_dtype = fp8_dtype if _is_hip else torch.float8_e4m3fn
+                resolved_kv_cache_dtype = TORCH_DTYPE_TO_KV_CACHE_STR[kv_cache_dtype]
             else:
-                self.kv_cache_dtype = self.dtype
-        elif self.server_args.kv_cache_dtype == "fp8_e5m2":
+                kv_cache_dtype = model_dtype
+        elif server_args_kv_cache_dtype == "fp8_e5m2":
             if _is_hip:  # Using natively supported format
-                self.kv_cache_dtype = fp8_dtype
+                kv_cache_dtype = fp8_dtype
             else:
-                self.kv_cache_dtype = torch.float8_e5m2
-        elif self.server_args.kv_cache_dtype == "fp8_e4m3":
+                kv_cache_dtype = torch.float8_e5m2
+        elif server_args_kv_cache_dtype == "fp8_e4m3":
             if _is_hip:  # Using natively supported format
-                self.kv_cache_dtype = fp8_dtype
+                kv_cache_dtype = fp8_dtype
             else:
-                self.kv_cache_dtype = torch.float8_e4m3fn
-        elif self.server_args.kv_cache_dtype in ("bf16", "bfloat16"):
-            self.kv_cache_dtype = torch.bfloat16
-        elif self.server_args.kv_cache_dtype == "fp4_e2m1":
+                kv_cache_dtype = torch.float8_e4m3fn
+        elif server_args_kv_cache_dtype in ("bf16", "bfloat16"):
+            kv_cache_dtype = torch.bfloat16
+        elif server_args_kv_cache_dtype == "fp4_e2m1":
             if hasattr(torch, "float4_e2m1fn_x2"):
-                self.kv_cache_dtype = torch.float4_e2m1fn_x2
+                kv_cache_dtype = torch.float4_e2m1fn_x2
                 logger.warning(f"FP4 (E2M1) KV Cache might lead to a accuracy drop!")
             else:
                 logger.warning(
                     f"--kv-cache-dtype falls back to 'auto' because this torch version does not support torch.float4_e2m1fn_x2"
                 )
-                self.kv_cache_dtype = self.dtype
+                kv_cache_dtype = model_dtype
         else:
             raise ValueError(
-                f"Unsupported kv_cache_dtype: {self.server_args.kv_cache_dtype}."
+                f"Unsupported kv_cache_dtype: {server_args_kv_cache_dtype}."
             )
-
-        # DFLASH: fa4 draft attention can't read the target's fp8 KV (needs K.dtype == Q.dtype),
-        # so give the fa4 draft its own compute-dtype KV. fp8-capable backends keep the target dtype.
-        if (
-            self.is_draft_worker
-            and self.spec_algorithm.is_dflash()
-            and self.server_args.speculative_draft_attention_backend == "fa4"
-            and self.kv_cache_dtype != self.dtype
-        ):
-            logger.info(
-                "DFLASH fa4 draft: overriding KV cache dtype %s -> %s "
-                "(fa4 needs K.dtype == Q.dtype; cannot read the target's quantized KV).",
-                self.kv_cache_dtype,
-                self.dtype,
-            )
-            self.kv_cache_dtype = self.dtype
+        return resolved_kv_cache_dtype, kv_cache_dtype
 
     def init_attention_backend(self):
         """Init attention kernel backend."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -138,8 +138,8 @@ from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
 from sglang.srt.lora.lora_manager import LoRAManager
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
+from sglang.srt.mem_cache import kv_cache_dtype
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.kv_cache_dtype import configure_kv_cache_dtype
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
 from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -258,7 +258,6 @@ if _is_npu:
     init_npu_backend()
 elif current_platform.is_out_of_tree():
     current_platform.init_backend()
-
 
 # Detect stragger ranks in model loading
 UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data processing
@@ -768,29 +767,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
             enable_batch_invariant_mode()
 
-        resolved_kv_cache_dtype, self.kv_cache_dtype = configure_kv_cache_dtype(
-            server_args=self.server_args,
-            model=self.model,
-            model_dtype=self.dtype,
-        )
-        if resolved_kv_cache_dtype is not None:
-            self._record_kv_cache_dtype(resolved_kv_cache_dtype)
-
-        # DFLASH: fa4 draft attention can't read the target's fp8 KV (needs K.dtype == Q.dtype),
-        # so give the fa4 draft its own compute-dtype KV. fp8-capable backends keep the target dtype.
-        if (
-            self.is_draft_worker
-            and self.spec_algorithm.is_dflash()
-            and self.server_args.speculative_draft_attention_backend == "fa4"
-            and self.kv_cache_dtype != self.dtype
-        ):
-            logger.info(
-                "DFLASH fa4 draft: overriding KV cache dtype %s -> %s "
-                "(fa4 needs K.dtype == Q.dtype; cannot read the target's quantized KV).",
-                self.kv_cache_dtype,
-                self.dtype,
-            )
-            self.kv_cache_dtype = self.dtype
+        self.configure_kv_cache_dtype()
 
     def get_pp_proxy_topk_size(self) -> Optional[int]:
         hf_config = self.model_config.hf_text_config
@@ -2377,6 +2354,33 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.server_args.override(
                 "ModelRunner.configure_kv_cache_dtype", kv_cache_dtype=resolved
             )
+
+    def configure_kv_cache_dtype(self):
+        resolved_kv_cache_dtype, self.kv_cache_dtype = (
+            kv_cache_dtype.configure_kv_cache_dtype(
+                server_args=self.server_args,
+                model=self.model,
+                model_dtype=self.dtype,
+            )
+        )
+        if resolved_kv_cache_dtype is not None:
+            self._record_kv_cache_dtype(resolved_kv_cache_dtype)
+
+        # DFLASH: fa4 draft attention can't read the target's fp8 KV (needs K.dtype == Q.dtype),
+        # so give the fa4 draft its own compute-dtype KV. fp8-capable backends keep the target dtype.
+        if (
+            self.is_draft_worker
+            and self.spec_algorithm.is_dflash()
+            and self.server_args.speculative_draft_attention_backend == "fa4"
+            and self.kv_cache_dtype != self.dtype
+        ):
+            logger.info(
+                "DFLASH fa4 draft: overriding KV cache dtype %s -> %s "
+                "(fa4 needs K.dtype == Q.dtype; cannot read the target's quantized KV).",
+                self.kv_cache_dtype,
+                self.dtype,
+            )
+            self.kv_cache_dtype = self.dtype
 
     def init_attention_backend(self):
         """Init attention kernel backend."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -31,7 +31,6 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import torch
 import torch.distributed as dist
 
-from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.configs import (
     BailingHybridConfig,
     FalconH1Config,
@@ -140,6 +139,7 @@ from sglang.srt.lora.lora_manager import LoRAManager
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.kv_cache_dtype import configure_kv_cache_dtype
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
 from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -258,13 +258,6 @@ if _is_npu:
     init_npu_backend()
 elif current_platform.is_out_of_tree():
     current_platform.init_backend()
-
-TORCH_DTYPE_TO_KV_CACHE_STR = {
-    torch.float8_e4m3fn: "fp8_e4m3",
-    torch.float8_e4m3fnuz: "fp8_e4m3",
-    torch.float8_e5m2: "fp8_e5m2",
-    torch.bfloat16: "bf16",
-}
 
 
 # Detect stragger ranks in model loading
@@ -775,12 +768,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
             enable_batch_invariant_mode()
 
-        resolved_kv_cache_dtype, self.kv_cache_dtype = (
-            ModelRunner.configure_kv_cache_dtype(
-                server_args=self.server_args,
-                model=self.model,
-                model_dtype=self.dtype,
-            )
+        resolved_kv_cache_dtype, self.kv_cache_dtype = configure_kv_cache_dtype(
+            server_args=self.server_args,
+            model=self.model,
+            model_dtype=self.dtype,
         )
         if resolved_kv_cache_dtype is not None:
             self._record_kv_cache_dtype(resolved_kv_cache_dtype)
@@ -2386,53 +2377,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.server_args.override(
                 "ModelRunner.configure_kv_cache_dtype", kv_cache_dtype=resolved
             )
-
-    @staticmethod
-    def configure_kv_cache_dtype(
-        *,
-        server_args: ServerArgs,
-        model: nn.Module,
-        model_dtype: torch.dtype,
-    ) -> tuple[Optional[str], torch.dtype]:
-        resolved_kv_cache_dtype: Optional[str] = None
-        server_args_kv_cache_dtype = server_args.kv_cache_dtype
-        if server_args_kv_cache_dtype == "auto":
-            quant_config = getattr(model, "quant_config", None)
-            kv_cache_quant_algo = getattr(quant_config, "kv_cache_quant_algo", None)
-            if (
-                isinstance(kv_cache_quant_algo, str)
-                and kv_cache_quant_algo.upper() == "FP8"
-            ):
-                kv_cache_dtype = fp8_dtype if _is_hip else torch.float8_e4m3fn
-                resolved_kv_cache_dtype = TORCH_DTYPE_TO_KV_CACHE_STR[kv_cache_dtype]
-            else:
-                kv_cache_dtype = model_dtype
-        elif server_args_kv_cache_dtype == "fp8_e5m2":
-            if _is_hip:  # Using natively supported format
-                kv_cache_dtype = fp8_dtype
-            else:
-                kv_cache_dtype = torch.float8_e5m2
-        elif server_args_kv_cache_dtype == "fp8_e4m3":
-            if _is_hip:  # Using natively supported format
-                kv_cache_dtype = fp8_dtype
-            else:
-                kv_cache_dtype = torch.float8_e4m3fn
-        elif server_args_kv_cache_dtype in ("bf16", "bfloat16"):
-            kv_cache_dtype = torch.bfloat16
-        elif server_args_kv_cache_dtype == "fp4_e2m1":
-            if hasattr(torch, "float4_e2m1fn_x2"):
-                kv_cache_dtype = torch.float4_e2m1fn_x2
-                logger.warning(f"FP4 (E2M1) KV Cache might lead to a accuracy drop!")
-            else:
-                logger.warning(
-                    f"--kv-cache-dtype falls back to 'auto' because this torch version does not support torch.float4_e2m1fn_x2"
-                )
-                kv_cache_dtype = model_dtype
-        else:
-            raise ValueError(
-                f"Unsupported kv_cache_dtype: {server_args_kv_cache_dtype}."
-            )
-        return resolved_kv_cache_dtype, kv_cache_dtype
 
     def init_attention_backend(self):
         """Init attention kernel backend."""


### PR DESCRIPTION
### mrc-kv-cache-dtype(extract-kv-cache-dtype-prep,non_mechanical_provable): Prep configure_kv_cache_dtype for extraction: @staticmethod + kwargs + 2-tuple return

De-self in place: the method becomes a kwargs @staticmethod returning the
(resolved_kv_cache_dtype, kv_cache_dtype) 2-tuple; the call site unpacks the
tuple, records the resolved string, and keeps the DFLASH fa4 draft override
inline. The body stays at its original position in the class. Stage the
destination module header (imports + logger + _is_hip) so the move lands in
an existing module.

### mrc-kv-cache-dtype(extract-kv-cache-dtype-move,mechanical_provable): Move configure_kv_cache_dtype + TORCH_DTYPE_TO_KV_CACHE_STR to mem_cache.kv_cache_dtype (cut+paste)

### mrc-kv-cache-dtype(kv-cache-dtype-wrapper-postpare,non_mechanical_provable): Reintroduce the configure_kv_cache_dtype orchestration wrapper and requalify through the kv_cache_dtype module import

Wrap the moved function back into the configure_kv_cache_dtype method
(tuple unpack + resolved-dtype recording + the DFLASH fa4 draft override)
and route the call through the kv_cache_dtype module import instead of the
bare function import.

### mrc-kv-cache-dtype(pass-kv-cache-dtype-string,non_mechanical_provable): Pass kv_cache_dtype string into configure_kv_cache_dtype and fold the DFLASH fa4 draft override into it

configure_kv_cache_dtype only ever read server_args.kv_cache_dtype, so take
that field directly and drop the ServerArgs dependency.

Forward-port adaptation for latest upstream/main: the fa4 draft KV-cache dtype
override now flows through the extracted configure_kv_cache_dtype free function.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29316032024](https://github.com/sgl-project/sglang/actions/runs/29316032024)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29316031818](https://github.com/sgl-project/sglang/actions/runs/29316031818)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->