### PR TITLE
Move LoRA cuda-graph buffers and logging into LoRAManager

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -856,3 +856,36 @@ class LoRAManager:
                 lora_module.experts_shared_outer_loras = self.experts_shared_outer_loras
                 lora_module.lora_use_virtual_experts = self.lora_use_virtual_experts
                 self.lora_modules[layer_id][module_name] = lora_module
+
+
+def _init_lora_cuda_graph_moe_buffers(
+    *,
+    server_args: ServerArgs,
+    model: torch.nn.Module,
+    lora_manager: LoRAManager,
+    dtype: torch.dtype,
+):
+    """Phase 1 of LoRA CUDA graph init: pre-allocate MoE intermediate buffers.
+
+    Must be called before init_memory_pool() so that memory profiling
+    sees the reduced available memory and sizes KV cache correctly.
+    All MoE LoRA layers share one set of buffers (managed by the
+    lora_backend) since they execute sequentially during forward.
+
+    Phase 2 (dense LoRA batch metadata) is handled later in
+    CudaGraphRunner.__init__() via lora_manager.init_cuda_graph_batch_info(),
+    because it needs capture-time parameters (max_bs, num_tokens_per_req)
+    that are only available at that stage.
+    """
+    from sglang.srt.lora.layers import FusedMoEWithLoRA
+
+    max_bs = server_args.cuda_graph_config.decode.max_bs
+    max_loras = server_args.max_loras_per_batch
+    for module in model.modules():
+        if isinstance(module, FusedMoEWithLoRA):
+            lora_manager.init_cuda_graph_moe_buffers(max_bs, max_loras, dtype, module)
+            logger.info(
+                f"Pre-allocated shared MoE LoRA CUDA graph buffers "
+                f"(max_bs={max_bs}, max_loras={max_loras})"
+            )
+            break

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -46,7 +46,7 @@ from sglang.srt.lora.utils import (
 from sglang.srt.managers.io_struct import LoRAUpdateOutput
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import replace_submodule
+from sglang.srt.utils import get_available_gpu_memory, replace_submodule
 from sglang.srt.utils.hf_transformers_utils import AutoConfig
 
 _SGLANG_EXPERIMENTAL_LORA_OPTI = envs.SGLANG_EXPERIMENTAL_LORA_OPTI.get()
@@ -164,6 +164,18 @@ class LoRAManager:
         )
 
     def load_lora_adapter(self, lora_ref: LoRARef) -> LoRAUpdateOutput:
+        logger.info(
+            f"LoRA adapter loading starts: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device.type, self.device.index):.2f} GB"
+        )
+        result = self._load_lora_adapter(lora_ref)
+        logger.info(
+            f"LoRA adapter loading completes: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device.type, self.device.index):.2f} GB"
+        )
+        return result
+
+    def _load_lora_adapter(self, lora_ref: LoRARef) -> LoRAUpdateOutput:
         """
         Load a single LoRA adapter from the specified path.
 
@@ -246,6 +258,18 @@ class LoRAManager:
             )
 
     def unload_lora_adapter(self, lora_ref: LoRARef) -> LoRAUpdateOutput:
+        logger.info(
+            f"LoRA adapter unloading starts: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device.type, self.device.index):.2f} GB"
+        )
+        result = self._unload_lora_adapter(lora_ref)
+        logger.info(
+            f"LoRA adapter unloading completes: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device.type, self.device.index):.2f} GB"
+        )
+        return result
+
+    def _unload_lora_adapter(self, lora_ref: LoRARef) -> LoRAUpdateOutput:
         """
         Unload LoRA adapters by their names. This will remove the adapters from the memory pool and
         delete the corresponding LoRA modules.
@@ -484,7 +508,7 @@ class LoRAManager:
 
         if lora_paths:
             for lora_ref in lora_paths:
-                result = self.load_lora_adapter(lora_ref)
+                result = self._load_lora_adapter(lora_ref)
                 if not result.success:
                     raise RuntimeError(
                         f"Failed to load LoRA adapter {lora_ref.lora_name}: {result.error_message}"
@@ -681,6 +705,20 @@ class LoRAManager:
         self.loras[lora_ref.lora_id] = lora_adapter
 
     def load_lora_adapter_from_tensors(
+        self,
+        lora_ref: LoRARef,
+        tensors: Dict[str, torch.Tensor],
+        config_dict: Dict,
+        added_tokens_config: Optional[Dict] = None,
+    ) -> LoRAUpdateOutput:
+        logger.info(f"LoRA adapter loading from tensors starts: {lora_ref}.")
+        result = self._load_lora_adapter_from_tensors(
+            lora_ref, tensors, config_dict, added_tokens_config
+        )
+        logger.info(f"LoRA adapter loading from tensors completes: {lora_ref}.")
+        return result
+
+    def _load_lora_adapter_from_tensors(
         self,
         lora_ref: LoRARef,
         tensors: Dict[str, torch.Tensor],

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -896,7 +896,7 @@ class LoRAManager:
                 self.lora_modules[layer_id][module_name] = lora_module
 
 
-def _init_lora_cuda_graph_moe_buffers(
+def init_lora_cuda_graph_moe_buffers(
     *,
     server_args: ServerArgs,
     model: torch.nn.Module,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -114,7 +114,7 @@ from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.sampler import create_sampler
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
-from sglang.srt.lora.lora_manager import LoRAManager, _init_lora_cuda_graph_moe_buffers
+from sglang.srt.lora.lora_manager import LoRAManager, init_lora_cuda_graph_moe_buffers
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
 from sglang.srt.mem_cache import kv_cache_dtype
@@ -1686,7 +1686,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             lora_paths=self.server_args.lora_paths,
         )
         if not cuda_graph_fully_disabled():
-            _init_lora_cuda_graph_moe_buffers(
+            init_lora_cuda_graph_moe_buffers(
                 server_args=self.server_args,
                 model=self.model,
                 lora_manager=self.lora_manager,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -734,18 +734,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Init lora
         if server_args.enable_lora:
             self.init_lora_manager()
-            if not cuda_graph_fully_disabled():
-                # Phase 1 of LoRA CUDA graph init: pre-allocate large MoE
-                # intermediate buffers before init_memory_pool() so memory
-                # profiling accounts for them. The buffers are reused by
-                # any captured graph (decode today; widen here so any
-                # future prefill capture path also picks them up).
-                _init_lora_cuda_graph_moe_buffers(
-                    server_args=self.server_args,
-                    model=self.model,
-                    lora_manager=self.lora_manager,
-                    dtype=self.dtype,
-                )
 
         # Enable batch invariant mode
         if server_args.enable_deterministic_inference:
@@ -1697,6 +1685,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             target_modules=self.server_args.lora_target_modules,
             lora_paths=self.server_args.lora_paths,
         )
+        if not cuda_graph_fully_disabled():
+            _init_lora_cuda_graph_moe_buffers(
+                server_args=self.server_args,
+                model=self.model,
+                lora_manager=self.lora_manager,
+                dtype=self.dtype,
+            )
 
     def load_lora_adapter(self, lora_ref: LoRARef):
         """Load a new lora adapter from disk or huggingface."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -114,7 +114,7 @@ from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.sampler import create_sampler
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
-from sglang.srt.lora.lora_manager import LoRAManager
+from sglang.srt.lora.lora_manager import LoRAManager, _init_lora_cuda_graph_moe_buffers
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
 from sglang.srt.mem_cache import kv_cache_dtype
@@ -740,7 +740,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 # profiling accounts for them. The buffers are reused by
                 # any captured graph (decode today; widen here so any
                 # future prefill capture path also picks them up).
-                ModelRunner._init_lora_cuda_graph_moe_buffers(
+                _init_lora_cuda_graph_moe_buffers(
                     server_args=self.server_args,
                     model=self.model,
                     lora_manager=self.lora_manager,
@@ -1697,41 +1697,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             target_modules=self.server_args.lora_target_modules,
             lora_paths=self.server_args.lora_paths,
         )
-
-    @staticmethod
-    def _init_lora_cuda_graph_moe_buffers(
-        *,
-        server_args: ServerArgs,
-        model: torch.nn.Module,
-        lora_manager: LoRAManager,
-        dtype: torch.dtype,
-    ):
-        """Phase 1 of LoRA CUDA graph init: pre-allocate MoE intermediate buffers.
-
-        Must be called before init_memory_pool() so that memory profiling
-        sees the reduced available memory and sizes KV cache correctly.
-        All MoE LoRA layers share one set of buffers (managed by the
-        lora_backend) since they execute sequentially during forward.
-
-        Phase 2 (dense LoRA batch metadata) is handled later in
-        CudaGraphRunner.__init__() via lora_manager.init_cuda_graph_batch_info(),
-        because it needs capture-time parameters (max_bs, num_tokens_per_req)
-        that are only available at that stage.
-        """
-        from sglang.srt.lora.layers import FusedMoEWithLoRA
-
-        max_bs = server_args.cuda_graph_config.decode.max_bs
-        max_loras = server_args.max_loras_per_batch
-        for module in model.modules():
-            if isinstance(module, FusedMoEWithLoRA):
-                lora_manager.init_cuda_graph_moe_buffers(
-                    max_bs, max_loras, dtype, module
-                )
-                logger.info(
-                    f"Pre-allocated shared MoE LoRA CUDA graph buffers "
-                    f"(max_bs={max_bs}, max_loras={max_loras})"
-                )
-                break
 
     def load_lora_adapter(self, lora_ref: LoRARef):
         """Load a new lora adapter from disk or huggingface."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -740,7 +740,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 # profiling accounts for them. The buffers are reused by
                 # any captured graph (decode today; widen here so any
                 # future prefill capture path also picks them up).
-                self._init_lora_cuda_graph_moe_buffers()
+                ModelRunner._init_lora_cuda_graph_moe_buffers(
+                    server_args=self.server_args,
+                    model=self.model,
+                    lora_manager=self.lora_manager,
+                    dtype=self.dtype,
+                )
 
         # Enable batch invariant mode
         if server_args.enable_deterministic_inference:
@@ -1693,7 +1698,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             lora_paths=self.server_args.lora_paths,
         )
 
-    def _init_lora_cuda_graph_moe_buffers(self):
+    @staticmethod
+    def _init_lora_cuda_graph_moe_buffers(
+        *,
+        server_args: ServerArgs,
+        model: torch.nn.Module,
+        lora_manager: LoRAManager,
+        dtype: torch.dtype,
+    ):
         """Phase 1 of LoRA CUDA graph init: pre-allocate MoE intermediate buffers.
 
         Must be called before init_memory_pool() so that memory profiling
@@ -1708,12 +1720,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         """
         from sglang.srt.lora.layers import FusedMoEWithLoRA
 
-        max_bs = self.server_args.cuda_graph_config.decode.max_bs
-        max_loras = self.server_args.max_loras_per_batch
-        for module in self.model.modules():
+        max_bs = server_args.cuda_graph_config.decode.max_bs
+        max_loras = server_args.max_loras_per_batch
+        for module in model.modules():
             if isinstance(module, FusedMoEWithLoRA):
-                self.lora_manager.init_cuda_graph_moe_buffers(
-                    max_bs, max_loras, self.dtype, module
+                lora_manager.init_cuda_graph_moe_buffers(
+                    max_bs, max_loras, dtype, module
                 )
                 logger.info(
                     f"Pre-allocated shared MoE LoRA CUDA graph buffers "

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1695,47 +1695,18 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
     def load_lora_adapter(self, lora_ref: LoRARef):
         """Load a new lora adapter from disk or huggingface."""
-
-        logger.info(
-            f"LoRA adapter loading starts: {lora_ref}. "
-            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
-        )
-
-        result = self.lora_manager.load_lora_adapter(lora_ref)
-
-        logger.info(
-            f"LoRA adapter loading completes: {lora_ref}. "
-            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
-        )
-
-        return result
+        return self.lora_manager.load_lora_adapter(lora_ref)
 
     def load_lora_adapter_from_tensors(
         self, lora_ref: LoRARef, tensors, config_dict, added_tokens_config=None
     ):
-        logger.info(f"LoRA adapter loading from tensors starts: {lora_ref}.")
-        result = self.lora_manager.load_lora_adapter_from_tensors(
+        return self.lora_manager.load_lora_adapter_from_tensors(
             lora_ref, tensors, config_dict, added_tokens_config
         )
-        logger.info(f"LoRA adapter loading from tensors completes: {lora_ref}.")
-        return result
 
     def unload_lora_adapter(self, lora_ref: LoRARef):
         """Unload a lora adapter that was previously loaded during initialization or dynamic loading."""
-
-        logger.info(
-            f"LoRA adapter unloading starts: {lora_ref}. "
-            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
-        )
-
-        result = self.lora_manager.unload_lora_adapter(lora_ref)
-
-        logger.info(
-            f"LoRA adapter unloading completes: {lora_ref}. "
-            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
-        )
-
-        return result
+        return self.lora_manager.unload_lora_adapter(lora_ref)
 
     @property
     def effective_max_total_num_tokens(self):


### PR DESCRIPTION
### mrc-lora-extraction(extract-lora-moe-buffers-prep,non_mechanical_provable): Prep _init_lora_cuda_graph_moe_buffers for extraction

### mrc-lora-extraction(extract-lora-moe-buffers-move,mechanical_provable): Move _init_lora_cuda_graph_moe_buffers to lora.lora_manager (cut+paste)

### mrc-lora-extraction(absorb-init-lora-cuda-graph-moe-buffers-into-ini,non_mechanical_provable): Absorb _init_lora_cuda_graph_moe_buffers into init_lora_manager

The MoE buffer pre-allocation was a separate call right after init_lora_manager() in initialize(); fold it into init_lora_manager so the manager owns its own setup. Drops the stale '# Phase 1 of ...' comment in the process; the ordering constraint (run before init_memory_pool) is preserved since init_lora_manager is still called from initialize() ahead of pool init.

### mrc-lora-extraction(move-lora-load-unload-logging-from-modelrunner-i,non_mechanical_provable): Move LoRA load/unload logging from ModelRunner into LoRAManager

The start/complete (and avail-mem) log lines wrapped the lora_manager calls inside
ModelRunner. Push them down into LoRAManager.{load,unload}_lora_adapter[_from_tensors]
so ModelRunner just delegates; the manager logs around its own private impl. The
init-time lora_paths batch-load keeps calling the unlogged private path, preserving
its no-log behavior.

### mrc-lora-extraction(make-init-lora-cuda-graph-moe-buffers-public,non_mechanical_provable): Make init_lora_cuda_graph_moe_buffers public

It is imported and called across modules, so drop the leading underscore.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29316237765](https://github.com/sgl-project/sglang/actions/runs/29316237765)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29316237537](https://github.com/sgl-project/sglang/actions/runs/29316237537)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->