### PR TITLE
Extract load_model helpers into a load_model_utils module

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -129,6 +129,9 @@ from sglang.srt.model_executor.forward_context import (
 )
 from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
 from sglang.srt.model_executor.hook_manager import register_forward_hooks
+from sglang.srt.model_executor.model_runner_components.load_model_utils import (
+    maybe_downgrade_dtype_for_legacy_gpu,
+)
 from sglang.srt.model_executor.model_runner_components.ngram_embedding_manager import (
     NgramEmbeddingManager,
 )
@@ -2382,32 +2385,3 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             load_format=load_format,
         )
         self.load_config = load_config
-
-
-import logging
-from typing import TYPE_CHECKING
-
-import torch
-
-if TYPE_CHECKING:
-    from sglang.srt.configs.model_config import ModelConfig
-    from sglang.srt.server_args import ServerArgs
-
-logger = logging.getLogger(__name__)
-
-
-def maybe_downgrade_dtype_for_legacy_gpu(
-    *, server_args: ServerArgs, model_config: ModelConfig
-) -> None:
-    if torch.cuda.get_device_capability()[0] < 8:
-        logger.info(
-            "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
-        )
-        from sglang.srt.arg_groups.overrides import declare_load_time_override
-
-        declare_load_time_override(
-            "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
-        )
-        model_config.dtype = torch.float16
-        if torch.cuda.get_device_capability()[1] < 5:
-            raise RuntimeError("SGLang only supports sm75 and above.")

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -128,6 +128,7 @@ from sglang.srt.model_executor.forward_context import (
 from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
 from sglang.srt.model_executor.hook_manager import register_forward_hooks
 from sglang.srt.model_executor.model_runner_components.load_model_utils import (
+    load_kv_cache_scales,
     maybe_downgrade_dtype_for_legacy_gpu,
     maybe_trigger_remote_instance_nccl_send_group,
 )
@@ -1139,7 +1140,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             pyt_hooks = PytHooks()
             pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        ModelRunner.load_kv_cache_scales(model=self.model, server_args=self.server_args)
+        load_kv_cache_scales(model=self.model, server_args=self.server_args)
 
         self._resolve_sliding_window_size()
 
@@ -1330,29 +1331,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if _is_npu:
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
-
-    @staticmethod
-    def load_kv_cache_scales(*, model, server_args: ServerArgs) -> None:
-        if server_args.kv_cache_dtype == "fp8_e4m3":
-            if server_args.quantization_param_path is not None:
-                if callable(getattr(model, "load_kv_cache_scales", None)):
-                    model.load_kv_cache_scales(server_args.quantization_param_path)
-                    logger.info(
-                        "Loaded KV cache scaling factors from %s",
-                        server_args.quantization_param_path,
-                    )
-                else:
-                    raise RuntimeError(
-                        "Using FP8 KV cache and scaling factors provided but "
-                        "model %s does not support loading scaling factors.",
-                        model.__class__,
-                    )
-            else:
-                logger.warning(
-                    "Using FP8 KV cache but no scaling factors "
-                    "provided. Defaulting to scaling factors of 1.0. "
-                    "This may lead to less accurate results!"
-                )
 
     def _resolve_sliding_window_size(self) -> None:
         # Parse other args

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1166,20 +1166,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"mem usage={self.weight_load_mem_usage:.2f} GB."
         )
 
-        # TODO: Make sure all models have `quant_config` attribute, and all online quantization methods register which layers they actually quantize.
-        # TODO: Move this online-quantization reporting out of ModelRunner.
-        quantized_layers = getattr(
-            getattr(self.model, "quant_config", None), "quantized_layers", None
+        ModelRunner.report_online_quantization(
+            model=self.model, server_args=self.server_args
         )
-        if (
-            self.server_args.quantization is not None
-            and isinstance(quantized_layers, tuple)
-            and len(quantized_layers) == 2
-        ):
-            layer_types, quantized_layers_count = quantized_layers
-            logger.info(
-                f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
-            )
 
         maybe_register_debug_tensor_dump_hook(
             model=self.model,
@@ -1204,6 +1193,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
 
         self._dist_barrier_after_load()
+
+    @staticmethod
+    def report_online_quantization(*, model, server_args: ServerArgs) -> None:
+        # TODO: Make sure all models have `quant_config` attribute, and all online quantization methods register which layers they actually quantize.
+        quantized_layers = getattr(
+            getattr(model, "quant_config", None), "quantized_layers", None
+        )
+        if (
+            server_args.quantization is not None
+            and isinstance(quantized_layers, tuple)
+            and len(quantized_layers) == 2
+        ):
+            layer_types, quantized_layers_count = quantized_layers
+            logger.info(
+                f"Online {server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
+            )
 
     def _prepare_moe_topk(self):
         balancer_cls = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -131,6 +131,7 @@ from sglang.srt.model_executor.model_runner_components.load_model_utils import (
     load_kv_cache_scales,
     maybe_downgrade_dtype_for_legacy_gpu,
     maybe_trigger_remote_instance_nccl_send_group,
+    resolve_sliding_window_size,
 )
 from sglang.srt.model_executor.model_runner_components.ngram_embedding_manager import (
     NgramEmbeddingManager,
@@ -1142,7 +1143,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         load_kv_cache_scales(model=self.model, server_args=self.server_args)
 
-        self.sliding_window_size = ModelRunner.resolve_sliding_window_size(
+        self.sliding_window_size = resolve_sliding_window_size(
             self.model, self.model_config
         )
 
@@ -1333,24 +1334,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if _is_npu:
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
-
-    @staticmethod
-    def resolve_sliding_window_size(model, model_config: ModelConfig) -> Optional[int]:
-        # Parse other args
-        sliding_window_size = None
-        if hasattr(model, "get_attention_sliding_window_size"):
-            sliding_window_size = model.get_attention_sliding_window_size()
-        elif (
-            model_config.is_hybrid_swa and model_config.sliding_window_size is not None
-        ):
-            # sliding window field in model config may have different meaning for different kinds of models (e.g., dllm), here we only consider the sliding window in SWA model
-            sliding_window_size = model_config.sliding_window_size
-        elif model_config.attention_chunk_size is not None:
-            sliding_window_size = model_config.attention_chunk_size
-            logger.info(
-                f"Setting sliding_window_size to be attention_chunk_size: {sliding_window_size}"
-            )
-        return sliding_window_size
 
     def _maybe_register_debug_tensor_dump_hook(self) -> None:
         if self.server_args.debug_tensor_dump_output_folder is not None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -128,6 +128,7 @@ from sglang.srt.model_executor.model_runner_components.load_model_utils import (
     maybe_downgrade_dtype_for_legacy_gpu,
     maybe_register_debug_tensor_dump_hook,
     maybe_trigger_remote_instance_nccl_send_group,
+    report_online_quantization,
     resolve_sliding_window_size,
 )
 from sglang.srt.model_executor.model_runner_components.ngram_embedding_manager import (
@@ -1166,9 +1167,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             f"mem usage={self.weight_load_mem_usage:.2f} GB."
         )
 
-        ModelRunner.report_online_quantization(
-            model=self.model, server_args=self.server_args
-        )
+        report_online_quantization(model=self.model, server_args=self.server_args)
 
         maybe_register_debug_tensor_dump_hook(
             model=self.model,
@@ -1193,22 +1192,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
 
         self._dist_barrier_after_load()
-
-    @staticmethod
-    def report_online_quantization(*, model, server_args: ServerArgs) -> None:
-        # TODO: Make sure all models have `quant_config` attribute, and all online quantization methods register which layers they actually quantize.
-        quantized_layers = getattr(
-            getattr(model, "quant_config", None), "quantized_layers", None
-        )
-        if (
-            server_args.quantization is not None
-            and isinstance(quantized_layers, tuple)
-            and len(quantized_layers) == 2
-        ):
-            layer_types, quantized_layers_count = quantized_layers
-            logger.info(
-                f"Online {server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
-            )
 
     def _prepare_moe_topk(self):
         balancer_cls = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1125,23 +1125,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.model_config, self.load_config, self.tp_size
             )
 
-        if (
-            self.server_args.load_format == LoadFormat.REMOTE_INSTANCE
-            and self.server_args.remote_instance_weight_loader_backend
-            == RemoteInstanceWeightLoaderBackend.NCCL
-        ):
-            if self.tp_rank == 0:
-                instance_ip = NetworkAddress.resolve_host(socket.gethostname())
-                t = threading.Thread(
-                    target=trigger_init_weights_send_group_for_remote_instance_request,
-                    args=(
-                        self.server_args.remote_instance_weight_loader_seed_instance_ip,
-                        self.server_args.remote_instance_weight_loader_seed_instance_service_port,
-                        self.server_args.remote_instance_weight_loader_send_weights_group_ports,
-                        instance_ip,
-                    ),
-                )
-                t.start()
+        self._maybe_trigger_remote_instance_nccl_send_group()
 
         # Load the model
         # Remove monkey_patch when linear.py quant remove dependencies with vllm
@@ -1420,6 +1404,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             rl_quant_profile=self.server_args.rl_quant_profile,
             draft_model_idx=self.draft_model_idx,
         )
+
+    def _maybe_trigger_remote_instance_nccl_send_group(self) -> None:
+        if (
+            self.server_args.load_format == LoadFormat.REMOTE_INSTANCE
+            and self.server_args.remote_instance_weight_loader_backend
+            == RemoteInstanceWeightLoaderBackend.NCCL
+        ):
+            if self.tp_rank == 0:
+                instance_ip = NetworkAddress.resolve_host(socket.gethostname())
+                t = threading.Thread(
+                    target=trigger_init_weights_send_group_for_remote_instance_request,
+                    args=(
+                        self.server_args.remote_instance_weight_loader_seed_instance_ip,
+                        self.server_args.remote_instance_weight_loader_seed_instance_service_port,
+                        self.server_args.remote_instance_weight_loader_send_weights_group_ports,
+                        instance_ip,
+                    ),
+                )
+                t.start()
 
     def maybe_recover_ep_ranks(self):
         # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1119,7 +1119,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         set_cuda_arch()
 
-        self.load_config = self._build_load_config()
+        self.load_config = self.build_load_config()
         if self.device == "cpu":
             self.model_config = adjust_config_with_unaligned_cpu_tp(
                 self.model_config, self.load_config, self.tp_size
@@ -1129,7 +1129,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             server_args=self.server_args, tp_rank=self.tp_rank
         )
 
-        self._load_model_with_memory_saver()
+        self.load_model_with_memory_saver()
 
         if not self.is_draft_worker:
             get_offloader().post_init()
@@ -1191,7 +1191,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger,
         )
 
-        self._dist_barrier_after_load()
+        self.dist_barrier_after_load()
 
     def _prepare_moe_topk(self):
         balancer_cls = None
@@ -1268,7 +1268,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             set_global_lplb_solver(lid, solver)
         logger.info(f"Initialized LPLB solvers for {metadata.num_layers} layers")
 
-    def _build_load_config(self) -> LoadConfig:
+    def build_load_config(self) -> LoadConfig:
         # Prepare the model config
         from sglang.srt.configs.modelopt_config import ModelOptConfig
 
@@ -1298,7 +1298,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             draft_model_idx=self.draft_model_idx,
         )
 
-    def _load_model_with_memory_saver(self) -> None:
+    def load_model_with_memory_saver(self) -> None:
         # Load the model
         # Remove monkey_patch when linear.py quant remove dependencies with vllm
         monkey_patch_vllm_parallel_state()
@@ -1328,7 +1328,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
 
-    def _dist_barrier_after_load(self) -> None:
+    def dist_barrier_after_load(self) -> None:
         if self.server_args.elastic_ep_backend == "mooncake":
             # Mooncake does not support `monitored_barrier`
             dist.barrier(group=get_tp_group().cpu_group)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1130,7 +1130,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.model_config, self.load_config, self.tp_size
             )
 
-        self._maybe_trigger_remote_instance_nccl_send_group()
+        ModelRunner.maybe_trigger_remote_instance_nccl_send_group(
+            server_args=self.server_args, tp_rank=self.tp_rank
+        )
 
         self._load_model_with_memory_saver()
 
@@ -1304,20 +1306,23 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             draft_model_idx=self.draft_model_idx,
         )
 
-    def _maybe_trigger_remote_instance_nccl_send_group(self) -> None:
+    @staticmethod
+    def maybe_trigger_remote_instance_nccl_send_group(
+        *, server_args: ServerArgs, tp_rank: int
+    ) -> None:
         if (
-            self.server_args.load_format == LoadFormat.REMOTE_INSTANCE
-            and self.server_args.remote_instance_weight_loader_backend
+            server_args.load_format == LoadFormat.REMOTE_INSTANCE
+            and server_args.remote_instance_weight_loader_backend
             == RemoteInstanceWeightLoaderBackend.NCCL
         ):
-            if self.tp_rank == 0:
+            if tp_rank == 0:
                 instance_ip = NetworkAddress.resolve_host(socket.gethostname())
                 t = threading.Thread(
                     target=trigger_init_weights_send_group_for_remote_instance_request,
                     args=(
-                        self.server_args.remote_instance_weight_loader_seed_instance_ip,
-                        self.server_args.remote_instance_weight_loader_seed_instance_service_port,
-                        self.server_args.remote_instance_weight_loader_send_weights_group_ports,
+                        server_args.remote_instance_weight_loader_seed_instance_ip,
+                        server_args.remote_instance_weight_loader_seed_instance_service_port,
+                        server_args.remote_instance_weight_loader_send_weights_group_ports,
                         instance_ip,
                     ),
                 )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1115,7 +1115,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self.device != "cpu":
             torch.set_num_threads(1)
         if self.device == "cuda":
-            self._maybe_downgrade_dtype_for_legacy_gpu()
+            maybe_downgrade_dtype_for_legacy_gpu(
+                server_args=self.server_args, model_config=self.model_config
+            )
 
         set_cuda_arch()
 
@@ -1268,22 +1270,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             set_global_lplb_solver(lid, solver)
         logger.info(f"Initialized LPLB solvers for {metadata.num_layers} layers")
-
-    def _maybe_downgrade_dtype_for_legacy_gpu(self) -> None:
-        if torch.cuda.get_device_capability()[0] < 8:
-            logger.info(
-                "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
-            )
-            from sglang.srt.arg_groups.overrides import (
-                declare_load_time_override,
-            )
-
-            declare_load_time_override(
-                "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
-            )
-            self.model_config.dtype = torch.float16
-            if torch.cuda.get_device_capability()[1] < 5:
-                raise RuntimeError("SGLang only supports sm75 and above.")
 
     def _build_load_config(self) -> LoadConfig:
         # Prepare the model config
@@ -2396,3 +2382,32 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             load_format=load_format,
         )
         self.load_config = load_config
+
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def maybe_downgrade_dtype_for_legacy_gpu(
+    *, server_args: ServerArgs, model_config: ModelConfig
+) -> None:
+    if torch.cuda.get_device_capability()[0] < 8:
+        logger.info(
+            "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
+        )
+        from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+        declare_load_time_override(
+            "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
+        )
+        model_config.dtype = torch.float16
+        if torch.cuda.get_device_capability()[1] < 5:
+            raise RuntimeError("SGLang only supports sm75 and above.")

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1192,23 +1192,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger,
         )
 
-        if self.server_args.elastic_ep_backend == "mooncake":
-            # Mooncake does not support `monitored_barrier`
-            dist.barrier(group=get_tp_group().cpu_group)
-        else:
-            # Handle the case where some ranks do not finish loading.
-            try:
-                dist.monitored_barrier(
-                    group=get_tp_group().cpu_group,
-                    timeout=datetime.timedelta(
-                        seconds=UNBALANCED_MODEL_LOADING_TIMEOUT_S
-                    ),
-                    wait_all_ranks=True,
-                )
-            except RuntimeError:
-                raise ValueError(
-                    f"TP rank {self.tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
-                ) from None
+        self._dist_barrier_after_load()
 
     def _prepare_moe_topk(self):
         balancer_cls = None
@@ -1435,6 +1419,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.tp_rank,
                 self.pp_rank,
             )
+
+    def _dist_barrier_after_load(self) -> None:
+        if self.server_args.elastic_ep_backend == "mooncake":
+            # Mooncake does not support `monitored_barrier`
+            dist.barrier(group=get_tp_group().cpu_group)
+        else:
+            # Handle the case where some ranks do not finish loading.
+            try:
+                dist.monitored_barrier(
+                    group=get_tp_group().cpu_group,
+                    timeout=datetime.timedelta(
+                        seconds=UNBALANCED_MODEL_LOADING_TIMEOUT_S
+                    ),
+                    wait_all_ranks=True,
+                )
+            except RuntimeError:
+                raise ValueError(
+                    f"TP rank {self.tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
+                ) from None
 
     def maybe_recover_ep_ranks(self):
         # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1119,34 +1119,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         set_cuda_arch()
 
-        # Prepare the model config
-        from sglang.srt.configs.modelopt_config import ModelOptConfig
-
-        modelopt_config = ModelOptConfig(
-            quant=self.server_args.modelopt_quant,
-            checkpoint_restore_path=self.server_args.modelopt_checkpoint_restore_path,
-            checkpoint_save_path=self.server_args.modelopt_checkpoint_save_path,
-            export_path=self.server_args.modelopt_export_path,
-            quantize_and_serve=self.server_args.quantize_and_serve,
-        )
-
-        self.load_config = LoadConfig(
-            load_format=self.server_args.load_format,
-            download_dir=self.server_args.download_dir,
-            model_loader_extra_config=self.server_args.model_loader_extra_config,
-            tp_rank=self.tp_rank,
-            remote_instance_weight_loader_seed_instance_ip=self.server_args.remote_instance_weight_loader_seed_instance_ip,
-            remote_instance_weight_loader_seed_instance_service_port=self.server_args.remote_instance_weight_loader_seed_instance_service_port,
-            remote_instance_weight_loader_send_weights_group_ports=self.server_args.remote_instance_weight_loader_send_weights_group_ports,
-            remote_instance_weight_loader_backend=self.server_args.remote_instance_weight_loader_backend,
-            remote_instance_weight_loader_transfer_engine=self.remote_instance_weight_transporter.engine,
-            remote_instance_weight_loader_transfer_engine_session_id=self.remote_instance_weight_transporter.session_id,
-            modelexpress_url=self.server_args.modelexpress_url,
-            modelexpress_transport=self.server_args.modelexpress_transport,
-            modelopt_config=modelopt_config,
-            rl_quant_profile=self.server_args.rl_quant_profile,
-            draft_model_idx=self.draft_model_idx,
-        )
+        self.load_config = self._build_load_config()
         if self.device == "cpu":
             self.model_config = adjust_config_with_unaligned_cpu_tp(
                 self.model_config, self.load_config, self.tp_size
@@ -1417,6 +1390,36 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.model_config.dtype = torch.float16
             if torch.cuda.get_device_capability()[1] < 5:
                 raise RuntimeError("SGLang only supports sm75 and above.")
+
+    def _build_load_config(self) -> LoadConfig:
+        # Prepare the model config
+        from sglang.srt.configs.modelopt_config import ModelOptConfig
+
+        modelopt_config = ModelOptConfig(
+            quant=self.server_args.modelopt_quant,
+            checkpoint_restore_path=self.server_args.modelopt_checkpoint_restore_path,
+            checkpoint_save_path=self.server_args.modelopt_checkpoint_save_path,
+            export_path=self.server_args.modelopt_export_path,
+            quantize_and_serve=self.server_args.quantize_and_serve,
+        )
+
+        return LoadConfig(
+            load_format=self.server_args.load_format,
+            download_dir=self.server_args.download_dir,
+            model_loader_extra_config=self.server_args.model_loader_extra_config,
+            tp_rank=self.tp_rank,
+            remote_instance_weight_loader_seed_instance_ip=self.server_args.remote_instance_weight_loader_seed_instance_ip,
+            remote_instance_weight_loader_seed_instance_service_port=self.server_args.remote_instance_weight_loader_seed_instance_service_port,
+            remote_instance_weight_loader_send_weights_group_ports=self.server_args.remote_instance_weight_loader_send_weights_group_ports,
+            remote_instance_weight_loader_backend=self.server_args.remote_instance_weight_loader_backend,
+            remote_instance_weight_loader_transfer_engine=self.remote_instance_weight_transporter.engine,
+            remote_instance_weight_loader_transfer_engine_session_id=self.remote_instance_weight_transporter.session_id,
+            modelexpress_url=self.server_args.modelexpress_url,
+            modelexpress_transport=self.server_args.modelexpress_transport,
+            modelopt_config=modelopt_config,
+            rl_quant_profile=self.server_args.rl_quant_profile,
+            draft_model_idx=self.draft_model_idx,
+        )
 
     def maybe_recover_ep_ranks(self):
         # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1139,7 +1139,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             pyt_hooks = PytHooks()
             pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        self._load_kv_cache_scales()
+        ModelRunner.load_kv_cache_scales(model=self.model, server_args=self.server_args)
 
         self._resolve_sliding_window_size()
 
@@ -1331,22 +1331,21 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
 
-    def _load_kv_cache_scales(self) -> None:
-        if self.server_args.kv_cache_dtype == "fp8_e4m3":
-            if self.server_args.quantization_param_path is not None:
-                if callable(getattr(self.model, "load_kv_cache_scales", None)):
-                    self.model.load_kv_cache_scales(
-                        self.server_args.quantization_param_path
-                    )
+    @staticmethod
+    def load_kv_cache_scales(*, model, server_args: ServerArgs) -> None:
+        if server_args.kv_cache_dtype == "fp8_e4m3":
+            if server_args.quantization_param_path is not None:
+                if callable(getattr(model, "load_kv_cache_scales", None)):
+                    model.load_kv_cache_scales(server_args.quantization_param_path)
                     logger.info(
                         "Loaded KV cache scaling factors from %s",
-                        self.server_args.quantization_param_path,
+                        server_args.quantization_param_path,
                     )
                 else:
                     raise RuntimeError(
                         "Using FP8 KV cache and scaling factors provided but "
                         "model %s does not support loading scaling factors.",
-                        self.model.__class__,
+                        model.__class__,
                     )
             else:
                 logger.warning(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import contextlib
-import datetime
 import inspect
 import logging
 import time
@@ -25,9 +24,7 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 import torch
-import torch.distributed as dist
 
-from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig
 from sglang.srt.configs.model_config import (
     AttentionArch,
@@ -38,17 +35,14 @@ from sglang.srt.configs.model_config import (
     is_deepseek_dsa,
 )
 from sglang.srt.configs.update_config import adjust_config_with_unaligned_cpu_tp
-from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
 from sglang.srt.debug_utils.dumper import dumper
 from sglang.srt.distributed import (
     bootstrap,
-    get_tp_group,
     get_world_group,
 )
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     prealloc_symmetric_memory_pool,
 )
-from sglang.srt.distributed.parallel_state import monkey_patch_vllm_parallel_state
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.elastic_ep.elastic_ep import (
     ElasticEPStateManager,
@@ -124,7 +118,10 @@ from sglang.srt.model_executor.forward_context import (
 from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
 from sglang.srt.model_executor.hook_manager import register_forward_hooks
 from sglang.srt.model_executor.model_runner_components.load_model_utils import (
+    build_load_config,
+    dist_barrier_after_load,
     load_kv_cache_scales,
+    load_model_with_memory_saver,
     maybe_downgrade_dtype_for_legacy_gpu,
     maybe_register_debug_tensor_dump_hook,
     maybe_trigger_remote_instance_nccl_send_group,
@@ -152,7 +149,6 @@ from sglang.srt.model_executor.runner import (
     PrefillCudaGraphRunner,
     get_batch_sizes_to_capture,
 )
-from sglang.srt.model_loader.loader import get_model_loader
 from sglang.srt.model_loader.utils import resolve_language_model
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_flags, get_server_args
@@ -220,7 +216,6 @@ elif current_platform.is_out_of_tree():
     current_platform.init_backend()
 
 # Detect stragger ranks in model loading
-UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data processing
 
 
 logger = logging.getLogger(__name__)
@@ -1119,7 +1114,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         set_cuda_arch()
 
-        self.load_config = ModelRunner.build_load_config(
+        self.load_config = build_load_config(
             server_args=self.server_args,
             tp_rank=self.tp_rank,
             remote_instance_weight_transporter_engine=self.remote_instance_weight_transporter.engine,
@@ -1135,7 +1130,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             server_args=self.server_args, tp_rank=self.tp_rank
         )
 
-        loaded = ModelRunner.load_model_with_memory_saver(
+        loaded = load_model_with_memory_saver(
             server_args=self.server_args,
             model_config=self.model_config,
             load_config=self.load_config,
@@ -1211,7 +1206,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger,
         )
 
-        ModelRunner.dist_barrier_after_load(
+        dist_barrier_after_load(
             elastic_ep_backend=self.server_args.elastic_ep_backend,
             tp_rank=self.tp_rank,
         )
@@ -1290,111 +1285,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             set_global_lplb_solver(lid, solver)
         logger.info(f"Initialized LPLB solvers for {metadata.num_layers} layers")
-
-    @staticmethod
-    def build_load_config(
-        *,
-        server_args: ServerArgs,
-        tp_rank: int,
-        remote_instance_weight_transporter_engine: Any,
-        remote_instance_weight_transporter_session_id: str,
-        draft_model_idx: Optional[int],
-    ) -> LoadConfig:
-        from sglang.srt.configs.modelopt_config import ModelOptConfig
-
-        modelopt_config = ModelOptConfig(
-            quant=server_args.modelopt_quant,
-            checkpoint_restore_path=server_args.modelopt_checkpoint_restore_path,
-            checkpoint_save_path=server_args.modelopt_checkpoint_save_path,
-            export_path=server_args.modelopt_export_path,
-            quantize_and_serve=server_args.quantize_and_serve,
-        )
-
-        return LoadConfig(
-            load_format=server_args.load_format,
-            download_dir=server_args.download_dir,
-            model_loader_extra_config=server_args.model_loader_extra_config,
-            tp_rank=tp_rank,
-            remote_instance_weight_loader_seed_instance_ip=server_args.remote_instance_weight_loader_seed_instance_ip,
-            remote_instance_weight_loader_seed_instance_service_port=server_args.remote_instance_weight_loader_seed_instance_service_port,
-            remote_instance_weight_loader_send_weights_group_ports=server_args.remote_instance_weight_loader_send_weights_group_ports,
-            remote_instance_weight_loader_backend=server_args.remote_instance_weight_loader_backend,
-            remote_instance_weight_loader_transfer_engine=remote_instance_weight_transporter_engine,
-            remote_instance_weight_loader_transfer_engine_session_id=remote_instance_weight_transporter_session_id,
-            modelexpress_url=server_args.modelexpress_url,
-            modelexpress_transport=server_args.modelexpress_transport,
-            modelopt_config=modelopt_config,
-            rl_quant_profile=server_args.rl_quant_profile,
-            draft_model_idx=draft_model_idx,
-        )
-
-    @staticmethod
-    def load_model_with_memory_saver(
-        *,
-        server_args: ServerArgs,
-        model_config: ModelConfig,
-        load_config: LoadConfig,
-        device: str,
-        gpu_id: int,
-        memory_saver_adapter: Any,
-        is_draft_worker: bool,
-    ) -> LoadedModel:
-        # Remove monkey_patch when linear.py quant remove dependencies with vllm
-        monkey_patch_vllm_parallel_state()
-
-        enable_cpu_backup = server_args.enable_weights_cpu_backup or (
-            is_draft_worker and server_args.enable_draft_weights_cpu_backup
-        )
-        remote_instance_weight_info = None
-        with memory_saver_adapter.region(
-            GPU_MEMORY_TYPE_WEIGHTS,
-            enable_cpu_backup=enable_cpu_backup,
-        ):
-            loader = get_model_loader(
-                load_config=load_config,
-                model_config=model_config,
-            )
-            model = loader.load_model(
-                model_config=model_config,
-                device_config=DeviceConfig(device, gpu_id),
-            )
-            if hasattr(loader, "remote_instance_transfer_engine_weight_info"):
-                remote_instance_weight_info = (
-                    loader.remote_instance_transfer_engine_weight_info
-                )
-        # Cache needs to be cleared after loading model weights (in the loader.load_model function).
-        # To avoid conflict with memory_saver_adapter.region, empty_cache operation is now moved here.
-        if _is_npu:
-            torch.npu.empty_cache()
-        monkey_patch_vllm_parallel_state(reverse=True)
-
-        return LoadedModel(
-            loader=loader,
-            model=model,
-            remote_instance_weight_info=remote_instance_weight_info,
-        )
-
-    @staticmethod
-    def dist_barrier_after_load(
-        *, elastic_ep_backend: Optional[str], tp_rank: int
-    ) -> None:
-        if elastic_ep_backend == "mooncake":
-            # Mooncake does not support `monitored_barrier`
-            dist.barrier(group=get_tp_group().cpu_group)
-        else:
-            # Handle the case where some ranks do not finish loading.
-            try:
-                dist.monitored_barrier(
-                    group=get_tp_group().cpu_group,
-                    timeout=datetime.timedelta(
-                        seconds=UNBALANCED_MODEL_LOADING_TIMEOUT_S
-                    ),
-                    wait_all_ranks=True,
-                )
-            except RuntimeError:
-                raise ValueError(
-                    f"TP rank {tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
-                ) from None
 
     def maybe_recover_ep_ranks(self):
         # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -20,8 +20,6 @@ import datetime
 import inspect
 import logging
 import os
-import socket
-import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -31,7 +29,7 @@ import torch
 import torch.distributed as dist
 
 from sglang.srt.configs.device_config import DeviceConfig
-from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+from sglang.srt.configs.load_config import LoadConfig
 from sglang.srt.configs.model_config import (
     AttentionArch,
     ModelConfig,
@@ -131,6 +129,7 @@ from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
 from sglang.srt.model_executor.hook_manager import register_forward_hooks
 from sglang.srt.model_executor.model_runner_components.load_model_utils import (
     maybe_downgrade_dtype_for_legacy_gpu,
+    maybe_trigger_remote_instance_nccl_send_group,
 )
 from sglang.srt.model_executor.model_runner_components.ngram_embedding_manager import (
     NgramEmbeddingManager,
@@ -154,10 +153,6 @@ from sglang.srt.model_executor.runner import (
     get_batch_sizes_to_capture,
 )
 from sglang.srt.model_loader.loader import get_model_loader
-from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
-    RemoteInstanceWeightLoaderBackend,
-    trigger_init_weights_send_group_for_remote_instance_request,
-)
 from sglang.srt.model_loader.utils import resolve_language_model
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_flags, get_server_args
@@ -199,7 +194,7 @@ from sglang.srt.utils import (
     set_cuda_arch,
     slow_rank_detector,
 )
-from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
+from sglang.srt.utils.network import get_local_ip_auto
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.nvtx_utils import profile_range
 from sglang.srt.utils.offloader import (
@@ -1130,7 +1125,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.model_config, self.load_config, self.tp_size
             )
 
-        ModelRunner.maybe_trigger_remote_instance_nccl_send_group(
+        maybe_trigger_remote_instance_nccl_send_group(
             server_args=self.server_args, tp_rank=self.tp_rank
         )
 
@@ -1305,28 +1300,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             rl_quant_profile=self.server_args.rl_quant_profile,
             draft_model_idx=self.draft_model_idx,
         )
-
-    @staticmethod
-    def maybe_trigger_remote_instance_nccl_send_group(
-        *, server_args: ServerArgs, tp_rank: int
-    ) -> None:
-        if (
-            server_args.load_format == LoadFormat.REMOTE_INSTANCE
-            and server_args.remote_instance_weight_loader_backend
-            == RemoteInstanceWeightLoaderBackend.NCCL
-        ):
-            if tp_rank == 0:
-                instance_ip = NetworkAddress.resolve_host(socket.gethostname())
-                t = threading.Thread(
-                    target=trigger_init_weights_send_group_for_remote_instance_request,
-                    args=(
-                        server_args.remote_instance_weight_loader_seed_instance_ip,
-                        server_args.remote_instance_weight_loader_seed_instance_service_port,
-                        server_args.remote_instance_weight_loader_send_weights_group_ports,
-                        instance_ip,
-                    ),
-                )
-                t.start()
 
     def _load_model_with_memory_saver(self) -> None:
         # Load the model

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1137,44 +1137,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             pyt_hooks = PytHooks()
             pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        if self.server_args.kv_cache_dtype == "fp8_e4m3":
-            if self.server_args.quantization_param_path is not None:
-                if callable(getattr(self.model, "load_kv_cache_scales", None)):
-                    self.model.load_kv_cache_scales(
-                        self.server_args.quantization_param_path
-                    )
-                    logger.info(
-                        "Loaded KV cache scaling factors from %s",
-                        self.server_args.quantization_param_path,
-                    )
-                else:
-                    raise RuntimeError(
-                        "Using FP8 KV cache and scaling factors provided but "
-                        "model %s does not support loading scaling factors.",
-                        self.model.__class__,
-                    )
-            else:
-                logger.warning(
-                    "Using FP8 KV cache but no scaling factors "
-                    "provided. Defaulting to scaling factors of 1.0. "
-                    "This may lead to less accurate results!"
-                )
+        self._load_kv_cache_scales()
 
-        # Parse other args
-        self.sliding_window_size = None
-        if hasattr(self.model, "get_attention_sliding_window_size"):
-            self.sliding_window_size = self.model.get_attention_sliding_window_size()
-        elif (
-            self.model_config.is_hybrid_swa
-            and self.model_config.sliding_window_size is not None
-        ):
-            # sliding window field in model config may have different meaning for different kinds of models (e.g., dllm), here we only consider the sliding window in SWA model
-            self.sliding_window_size = self.model_config.sliding_window_size
-        elif self.model_config.attention_chunk_size is not None:
-            self.sliding_window_size = self.model_config.attention_chunk_size
-            logger.info(
-                f"Setting sliding_window_size to be attention_chunk_size: {self.sliding_window_size}"
-            )
+        self._resolve_sliding_window_size()
 
         self.prefill_aware_swa = (
             hasattr(self.model, "is_prefill_aware_swa")
@@ -1426,6 +1391,47 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if _is_npu:
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
+
+    def _load_kv_cache_scales(self) -> None:
+        if self.server_args.kv_cache_dtype == "fp8_e4m3":
+            if self.server_args.quantization_param_path is not None:
+                if callable(getattr(self.model, "load_kv_cache_scales", None)):
+                    self.model.load_kv_cache_scales(
+                        self.server_args.quantization_param_path
+                    )
+                    logger.info(
+                        "Loaded KV cache scaling factors from %s",
+                        self.server_args.quantization_param_path,
+                    )
+                else:
+                    raise RuntimeError(
+                        "Using FP8 KV cache and scaling factors provided but "
+                        "model %s does not support loading scaling factors.",
+                        self.model.__class__,
+                    )
+            else:
+                logger.warning(
+                    "Using FP8 KV cache but no scaling factors "
+                    "provided. Defaulting to scaling factors of 1.0. "
+                    "This may lead to less accurate results!"
+                )
+
+    def _resolve_sliding_window_size(self) -> None:
+        # Parse other args
+        self.sliding_window_size = None
+        if hasattr(self.model, "get_attention_sliding_window_size"):
+            self.sliding_window_size = self.model.get_attention_sliding_window_size()
+        elif (
+            self.model_config.is_hybrid_swa
+            and self.model_config.sliding_window_size is not None
+        ):
+            # sliding window field in model config may have different meaning for different kinds of models (e.g., dllm), here we only consider the sliding window in SWA model
+            self.sliding_window_size = self.model_config.sliding_window_size
+        elif self.model_config.attention_chunk_size is not None:
+            self.sliding_window_size = self.model_config.attention_chunk_size
+            logger.info(
+                f"Setting sliding_window_size to be attention_chunk_size: {self.sliding_window_size}"
+            )
 
     def maybe_recover_ep_ranks(self):
         # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -19,7 +19,6 @@ import contextlib
 import datetime
 import inspect
 import logging
-import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -41,9 +40,6 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.configs.update_config import adjust_config_with_unaligned_cpu_tp
 from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
 from sglang.srt.debug_utils.dumper import dumper
-from sglang.srt.debug_utils.tensor_dump_forward_hook import (
-    register_forward_hook_for_model,
-)
 from sglang.srt.distributed import (
     bootstrap,
     get_tp_group,
@@ -130,6 +126,7 @@ from sglang.srt.model_executor.hook_manager import register_forward_hooks
 from sglang.srt.model_executor.model_runner_components.load_model_utils import (
     load_kv_cache_scales,
     maybe_downgrade_dtype_for_legacy_gpu,
+    maybe_register_debug_tensor_dump_hook,
     maybe_trigger_remote_instance_nccl_send_group,
     resolve_sliding_window_size,
 )
@@ -1184,7 +1181,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
             )
 
-        ModelRunner.maybe_register_debug_tensor_dump_hook(
+        maybe_register_debug_tensor_dump_hook(
             model=self.model,
             server_args=self.server_args,
             spec_algorithm=self.spec_algorithm,
@@ -1342,31 +1339,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if _is_npu:
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
-
-    @staticmethod
-    def maybe_register_debug_tensor_dump_hook(
-        *,
-        model,
-        server_args: ServerArgs,
-        spec_algorithm: SpeculativeAlgorithm,
-        is_draft_worker: bool,
-        tp_size: int,
-        tp_rank: int,
-        pp_rank: int,
-    ) -> None:
-        if server_args.debug_tensor_dump_output_folder is not None:
-            dump_folder = server_args.debug_tensor_dump_output_folder
-            if spec_algorithm.is_eagle():
-                role = "draft" if is_draft_worker else "target"
-                dump_folder = os.path.join(dump_folder, role)
-            register_forward_hook_for_model(
-                model,
-                dump_folder,
-                server_args.debug_tensor_dump_layers,
-                tp_size,
-                tp_rank,
-                pp_rank,
-            )
 
     def _dist_barrier_after_load(self) -> None:
         if self.server_args.elastic_ep_backend == "mooncake":

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1119,7 +1119,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         set_cuda_arch()
 
-        self.load_config = self.build_load_config()
+        self.load_config = ModelRunner.build_load_config(
+            server_args=self.server_args,
+            tp_rank=self.tp_rank,
+            remote_instance_weight_transporter_engine=self.remote_instance_weight_transporter.engine,
+            remote_instance_weight_transporter_session_id=self.remote_instance_weight_transporter.session_id,
+            draft_model_idx=self.draft_model_idx,
+        )
         if self.device == "cpu":
             self.model_config = adjust_config_with_unaligned_cpu_tp(
                 self.model_config, self.load_config, self.tp_size
@@ -1129,7 +1135,21 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             server_args=self.server_args, tp_rank=self.tp_rank
         )
 
-        self.load_model_with_memory_saver()
+        loaded = ModelRunner.load_model_with_memory_saver(
+            server_args=self.server_args,
+            model_config=self.model_config,
+            load_config=self.load_config,
+            device=self.device,
+            gpu_id=self.gpu_id,
+            memory_saver_adapter=self.memory_saver_adapter,
+            is_draft_worker=self.is_draft_worker,
+        )
+        self.loader = loaded.loader
+        self.model = loaded.model
+        if loaded.remote_instance_weight_info is not None:
+            self.remote_instance_weight_transporter.weight_info = (
+                loaded.remote_instance_weight_info
+            )
 
         if not self.is_draft_worker:
             get_offloader().post_init()
@@ -1191,7 +1211,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger,
         )
 
-        self.dist_barrier_after_load()
+        ModelRunner.dist_barrier_after_load(
+            elastic_ep_backend=self.server_args.elastic_ep_backend,
+            tp_rank=self.tp_rank,
+        )
 
     def _prepare_moe_topk(self):
         balancer_cls = None
@@ -1268,68 +1291,94 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             set_global_lplb_solver(lid, solver)
         logger.info(f"Initialized LPLB solvers for {metadata.num_layers} layers")
 
-    def build_load_config(self) -> LoadConfig:
-        # Prepare the model config
+    @staticmethod
+    def build_load_config(
+        *,
+        server_args: ServerArgs,
+        tp_rank: int,
+        remote_instance_weight_transporter_engine: Any,
+        remote_instance_weight_transporter_session_id: str,
+        draft_model_idx: Optional[int],
+    ) -> LoadConfig:
         from sglang.srt.configs.modelopt_config import ModelOptConfig
 
         modelopt_config = ModelOptConfig(
-            quant=self.server_args.modelopt_quant,
-            checkpoint_restore_path=self.server_args.modelopt_checkpoint_restore_path,
-            checkpoint_save_path=self.server_args.modelopt_checkpoint_save_path,
-            export_path=self.server_args.modelopt_export_path,
-            quantize_and_serve=self.server_args.quantize_and_serve,
+            quant=server_args.modelopt_quant,
+            checkpoint_restore_path=server_args.modelopt_checkpoint_restore_path,
+            checkpoint_save_path=server_args.modelopt_checkpoint_save_path,
+            export_path=server_args.modelopt_export_path,
+            quantize_and_serve=server_args.quantize_and_serve,
         )
 
         return LoadConfig(
-            load_format=self.server_args.load_format,
-            download_dir=self.server_args.download_dir,
-            model_loader_extra_config=self.server_args.model_loader_extra_config,
-            tp_rank=self.tp_rank,
-            remote_instance_weight_loader_seed_instance_ip=self.server_args.remote_instance_weight_loader_seed_instance_ip,
-            remote_instance_weight_loader_seed_instance_service_port=self.server_args.remote_instance_weight_loader_seed_instance_service_port,
-            remote_instance_weight_loader_send_weights_group_ports=self.server_args.remote_instance_weight_loader_send_weights_group_ports,
-            remote_instance_weight_loader_backend=self.server_args.remote_instance_weight_loader_backend,
-            remote_instance_weight_loader_transfer_engine=self.remote_instance_weight_transporter.engine,
-            remote_instance_weight_loader_transfer_engine_session_id=self.remote_instance_weight_transporter.session_id,
-            modelexpress_url=self.server_args.modelexpress_url,
-            modelexpress_transport=self.server_args.modelexpress_transport,
+            load_format=server_args.load_format,
+            download_dir=server_args.download_dir,
+            model_loader_extra_config=server_args.model_loader_extra_config,
+            tp_rank=tp_rank,
+            remote_instance_weight_loader_seed_instance_ip=server_args.remote_instance_weight_loader_seed_instance_ip,
+            remote_instance_weight_loader_seed_instance_service_port=server_args.remote_instance_weight_loader_seed_instance_service_port,
+            remote_instance_weight_loader_send_weights_group_ports=server_args.remote_instance_weight_loader_send_weights_group_ports,
+            remote_instance_weight_loader_backend=server_args.remote_instance_weight_loader_backend,
+            remote_instance_weight_loader_transfer_engine=remote_instance_weight_transporter_engine,
+            remote_instance_weight_loader_transfer_engine_session_id=remote_instance_weight_transporter_session_id,
+            modelexpress_url=server_args.modelexpress_url,
+            modelexpress_transport=server_args.modelexpress_transport,
             modelopt_config=modelopt_config,
-            rl_quant_profile=self.server_args.rl_quant_profile,
-            draft_model_idx=self.draft_model_idx,
+            rl_quant_profile=server_args.rl_quant_profile,
+            draft_model_idx=draft_model_idx,
         )
 
-    def load_model_with_memory_saver(self) -> None:
-        # Load the model
+    @staticmethod
+    def load_model_with_memory_saver(
+        *,
+        server_args: ServerArgs,
+        model_config: ModelConfig,
+        load_config: LoadConfig,
+        device: str,
+        gpu_id: int,
+        memory_saver_adapter: Any,
+        is_draft_worker: bool,
+    ) -> LoadedModel:
         # Remove monkey_patch when linear.py quant remove dependencies with vllm
         monkey_patch_vllm_parallel_state()
 
-        enable_cpu_backup = self.server_args.enable_weights_cpu_backup or (
-            self.is_draft_worker and self.server_args.enable_draft_weights_cpu_backup
+        enable_cpu_backup = server_args.enable_weights_cpu_backup or (
+            is_draft_worker and server_args.enable_draft_weights_cpu_backup
         )
-        with self.memory_saver_adapter.region(
+        remote_instance_weight_info = None
+        with memory_saver_adapter.region(
             GPU_MEMORY_TYPE_WEIGHTS,
             enable_cpu_backup=enable_cpu_backup,
         ):
-            self.loader = get_model_loader(
-                load_config=self.load_config,
-                model_config=self.model_config,
+            loader = get_model_loader(
+                load_config=load_config,
+                model_config=model_config,
             )
-            self.model = self.loader.load_model(
-                model_config=self.model_config,
-                device_config=DeviceConfig(self.device, self.gpu_id),
+            model = loader.load_model(
+                model_config=model_config,
+                device_config=DeviceConfig(device, gpu_id),
             )
-            if hasattr(self.loader, "remote_instance_transfer_engine_weight_info"):
-                self.remote_instance_weight_transporter.weight_info = (
-                    self.loader.remote_instance_transfer_engine_weight_info
+            if hasattr(loader, "remote_instance_transfer_engine_weight_info"):
+                remote_instance_weight_info = (
+                    loader.remote_instance_transfer_engine_weight_info
                 )
-        # Cache needs to be cleared after loading model weights (in the self.loader.load_model function).
+        # Cache needs to be cleared after loading model weights (in the loader.load_model function).
         # To avoid conflict with memory_saver_adapter.region, empty_cache operation is now moved here.
         if _is_npu:
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
 
-    def dist_barrier_after_load(self) -> None:
-        if self.server_args.elastic_ep_backend == "mooncake":
+        return LoadedModel(
+            loader=loader,
+            model=model,
+            remote_instance_weight_info=remote_instance_weight_info,
+        )
+
+    @staticmethod
+    def dist_barrier_after_load(
+        *, elastic_ep_backend: Optional[str], tp_rank: int
+    ) -> None:
+        if elastic_ep_backend == "mooncake":
             # Mooncake does not support `monitored_barrier`
             dist.barrier(group=get_tp_group().cpu_group)
         else:
@@ -1344,7 +1393,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
             except RuntimeError:
                 raise ValueError(
-                    f"TP rank {self.tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
+                    f"TP rank {tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
                 ) from None
 
     def maybe_recover_ep_ranks(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1127,34 +1127,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         self._maybe_trigger_remote_instance_nccl_send_group()
 
-        # Load the model
-        # Remove monkey_patch when linear.py quant remove dependencies with vllm
-        monkey_patch_vllm_parallel_state()
-
-        enable_cpu_backup = self.server_args.enable_weights_cpu_backup or (
-            self.is_draft_worker and self.server_args.enable_draft_weights_cpu_backup
-        )
-        with self.memory_saver_adapter.region(
-            GPU_MEMORY_TYPE_WEIGHTS,
-            enable_cpu_backup=enable_cpu_backup,
-        ):
-            self.loader = get_model_loader(
-                load_config=self.load_config,
-                model_config=self.model_config,
-            )
-            self.model = self.loader.load_model(
-                model_config=self.model_config,
-                device_config=DeviceConfig(self.device, self.gpu_id),
-            )
-            if hasattr(self.loader, "remote_instance_transfer_engine_weight_info"):
-                self.remote_instance_weight_transporter.weight_info = (
-                    self.loader.remote_instance_transfer_engine_weight_info
-                )
-        # Cache needs to be cleared after loading model weights (in the self.loader.load_model function).
-        # To avoid conflict with memory_saver_adapter.region, empty_cache operation is now moved here.
-        if _is_npu:
-            torch.npu.empty_cache()
-        monkey_patch_vllm_parallel_state(reverse=True)
+        self._load_model_with_memory_saver()
 
         if not self.is_draft_worker:
             get_offloader().post_init()
@@ -1423,6 +1396,36 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     ),
                 )
                 t.start()
+
+    def _load_model_with_memory_saver(self) -> None:
+        # Load the model
+        # Remove monkey_patch when linear.py quant remove dependencies with vllm
+        monkey_patch_vllm_parallel_state()
+
+        enable_cpu_backup = self.server_args.enable_weights_cpu_backup or (
+            self.is_draft_worker and self.server_args.enable_draft_weights_cpu_backup
+        )
+        with self.memory_saver_adapter.region(
+            GPU_MEMORY_TYPE_WEIGHTS,
+            enable_cpu_backup=enable_cpu_backup,
+        ):
+            self.loader = get_model_loader(
+                load_config=self.load_config,
+                model_config=self.model_config,
+            )
+            self.model = self.loader.load_model(
+                model_config=self.model_config,
+                device_config=DeviceConfig(self.device, self.gpu_id),
+            )
+            if hasattr(self.loader, "remote_instance_transfer_engine_weight_info"):
+                self.remote_instance_weight_transporter.weight_info = (
+                    self.loader.remote_instance_transfer_engine_weight_info
+                )
+        # Cache needs to be cleared after loading model weights (in the self.loader.load_model function).
+        # To avoid conflict with memory_saver_adapter.region, empty_cache operation is now moved here.
+        if _is_npu:
+            torch.npu.empty_cache()
+        monkey_patch_vllm_parallel_state(reverse=True)
 
     def maybe_recover_ep_ranks(self):
         # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1184,7 +1184,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
             )
 
-        self._maybe_register_debug_tensor_dump_hook()
+        ModelRunner.maybe_register_debug_tensor_dump_hook(
+            model=self.model,
+            server_args=self.server_args,
+            spec_algorithm=self.spec_algorithm,
+            is_draft_worker=self.is_draft_worker,
+            tp_size=self.tp_size,
+            tp_rank=self.tp_rank,
+            pp_rank=self.pp_rank,
+        )
 
         if dumper.may_enable:
             dumper.apply_source_patches()
@@ -1335,19 +1343,29 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
 
-    def _maybe_register_debug_tensor_dump_hook(self) -> None:
-        if self.server_args.debug_tensor_dump_output_folder is not None:
-            dump_folder = self.server_args.debug_tensor_dump_output_folder
-            if self.spec_algorithm.is_eagle():
-                role = "draft" if self.is_draft_worker else "target"
+    @staticmethod
+    def maybe_register_debug_tensor_dump_hook(
+        *,
+        model,
+        server_args: ServerArgs,
+        spec_algorithm: SpeculativeAlgorithm,
+        is_draft_worker: bool,
+        tp_size: int,
+        tp_rank: int,
+        pp_rank: int,
+    ) -> None:
+        if server_args.debug_tensor_dump_output_folder is not None:
+            dump_folder = server_args.debug_tensor_dump_output_folder
+            if spec_algorithm.is_eagle():
+                role = "draft" if is_draft_worker else "target"
                 dump_folder = os.path.join(dump_folder, role)
             register_forward_hook_for_model(
-                self.model,
+                model,
                 dump_folder,
-                self.server_args.debug_tensor_dump_layers,
-                self.tp_size,
-                self.tp_rank,
-                self.pp_rank,
+                server_args.debug_tensor_dump_layers,
+                tp_size,
+                tp_rank,
+                pp_rank,
             )
 
     def _dist_barrier_after_load(self) -> None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1142,7 +1142,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         load_kv_cache_scales(model=self.model, server_args=self.server_args)
 
-        self._resolve_sliding_window_size()
+        self.sliding_window_size = ModelRunner.resolve_sliding_window_size(
+            self.model, self.model_config
+        )
 
         self.prefill_aware_swa = (
             hasattr(self.model, "is_prefill_aware_swa")
@@ -1332,22 +1334,23 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             torch.npu.empty_cache()
         monkey_patch_vllm_parallel_state(reverse=True)
 
-    def _resolve_sliding_window_size(self) -> None:
+    @staticmethod
+    def resolve_sliding_window_size(model, model_config: ModelConfig) -> Optional[int]:
         # Parse other args
-        self.sliding_window_size = None
-        if hasattr(self.model, "get_attention_sliding_window_size"):
-            self.sliding_window_size = self.model.get_attention_sliding_window_size()
+        sliding_window_size = None
+        if hasattr(model, "get_attention_sliding_window_size"):
+            sliding_window_size = model.get_attention_sliding_window_size()
         elif (
-            self.model_config.is_hybrid_swa
-            and self.model_config.sliding_window_size is not None
+            model_config.is_hybrid_swa and model_config.sliding_window_size is not None
         ):
             # sliding window field in model config may have different meaning for different kinds of models (e.g., dllm), here we only consider the sliding window in SWA model
-            self.sliding_window_size = self.model_config.sliding_window_size
-        elif self.model_config.attention_chunk_size is not None:
-            self.sliding_window_size = self.model_config.attention_chunk_size
+            sliding_window_size = model_config.sliding_window_size
+        elif model_config.attention_chunk_size is not None:
+            sliding_window_size = model_config.attention_chunk_size
             logger.info(
-                f"Setting sliding_window_size to be attention_chunk_size: {self.sliding_window_size}"
+                f"Setting sliding_window_size to be attention_chunk_size: {sliding_window_size}"
             )
+        return sliding_window_size
 
     def _maybe_register_debug_tensor_dump_hook(self) -> None:
         if self.server_args.debug_tensor_dump_output_folder is not None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1115,20 +1115,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self.device != "cpu":
             torch.set_num_threads(1)
         if self.device == "cuda":
-            if torch.cuda.get_device_capability()[0] < 8:
-                logger.info(
-                    "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
-                )
-                from sglang.srt.arg_groups.overrides import (
-                    declare_load_time_override,
-                )
-
-                declare_load_time_override(
-                    "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
-                )
-                self.model_config.dtype = torch.float16
-                if torch.cuda.get_device_capability()[1] < 5:
-                    raise RuntimeError("SGLang only supports sm75 and above.")
+            self._maybe_downgrade_dtype_for_legacy_gpu()
 
         set_cuda_arch()
 
@@ -1414,6 +1401,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             set_global_lplb_solver(lid, solver)
         logger.info(f"Initialized LPLB solvers for {metadata.num_layers} layers")
+
+    def _maybe_downgrade_dtype_for_legacy_gpu(self) -> None:
+        if torch.cuda.get_device_capability()[0] < 8:
+            logger.info(
+                "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
+            )
+            from sglang.srt.arg_groups.overrides import (
+                declare_load_time_override,
+            )
+
+            declare_load_time_override(
+                "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
+            )
+            self.model_config.dtype = torch.float16
+            if torch.cuda.get_device_capability()[1] < 5:
+                raise RuntimeError("SGLang only supports sm75 and above.")
 
     def maybe_recover_ep_ranks(self):
         # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1178,19 +1178,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
             )
 
-        if self.server_args.debug_tensor_dump_output_folder is not None:
-            dump_folder = self.server_args.debug_tensor_dump_output_folder
-            if self.spec_algorithm.is_eagle():
-                role = "draft" if self.is_draft_worker else "target"
-                dump_folder = os.path.join(dump_folder, role)
-            register_forward_hook_for_model(
-                self.model,
-                dump_folder,
-                self.server_args.debug_tensor_dump_layers,
-                self.tp_size,
-                self.tp_rank,
-                self.pp_rank,
-            )
+        self._maybe_register_debug_tensor_dump_hook()
 
         if dumper.may_enable:
             dumper.apply_source_patches()
@@ -1431,6 +1419,21 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.sliding_window_size = self.model_config.attention_chunk_size
             logger.info(
                 f"Setting sliding_window_size to be attention_chunk_size: {self.sliding_window_size}"
+            )
+
+    def _maybe_register_debug_tensor_dump_hook(self) -> None:
+        if self.server_args.debug_tensor_dump_output_folder is not None:
+            dump_folder = self.server_args.debug_tensor_dump_output_folder
+            if self.spec_algorithm.is_eagle():
+                role = "draft" if self.is_draft_worker else "target"
+                dump_folder = os.path.join(dump_folder, role)
+            register_forward_hook_for_model(
+                self.model,
+                dump_folder,
+                self.server_args.debug_tensor_dump_layers,
+                self.tp_size,
+                self.tp_rank,
+                self.pp_rank,
             )
 
     def maybe_recover_ep_ranks(self):

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import socket
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -81,3 +81,19 @@ def load_kv_cache_scales(*, model, server_args: ServerArgs) -> None:
                 "provided. Defaulting to scaling factors of 1.0. "
                 "This may lead to less accurate results!"
             )
+
+
+def resolve_sliding_window_size(model, model_config: ModelConfig) -> Optional[int]:
+    # Parse other args
+    sliding_window_size = None
+    if hasattr(model, "get_attention_sliding_window_size"):
+        sliding_window_size = model.get_attention_sliding_window_size()
+    elif model_config.is_hybrid_swa and model_config.sliding_window_size is not None:
+        # sliding window field in model config may have different meaning for different kinds of models (e.g., dllm), here we only consider the sliding window in SWA model
+        sliding_window_size = model_config.sliding_window_size
+    elif model_config.attention_chunk_size is not None:
+        sliding_window_size = model_config.attention_chunk_size
+        logger.info(
+            f"Setting sliding_window_size to be attention_chunk_size: {sliding_window_size}"
+        )
+    return sliding_window_size

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -1,21 +1,30 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 import socket
 import threading
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
+import msgspec
 import torch
+import torch.distributed as dist
 
-from sglang.srt.configs.load_config import LoadFormat
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
 from sglang.srt.debug_utils.tensor_dump_forward_hook import (
     register_forward_hook_for_model,
 )
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.distributed.parallel_state import monkey_patch_vllm_parallel_state
+from sglang.srt.model_loader.loader import get_model_loader
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
     trigger_init_weights_send_group_for_remote_instance_request,
 )
+from sglang.srt.utils.common import is_npu
 from sglang.srt.utils.network import NetworkAddress
 
 if TYPE_CHECKING:
@@ -24,6 +33,14 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 logger = logging.getLogger(__name__)
+
+_is_npu = is_npu()
+
+
+class LoadedModel(msgspec.Struct, frozen=True, kw_only=True):
+    loader: Any
+    model: Any
+    remote_instance_weight_info: Optional[Any]
 
 
 def maybe_downgrade_dtype_for_legacy_gpu(

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def maybe_downgrade_dtype_for_legacy_gpu(
+    *, server_args: ServerArgs, model_config: ModelConfig
+) -> None:
+    if torch.cuda.get_device_capability()[0] < 8:
+        logger.info(
+            "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
+        )
+        from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+        declare_load_time_override(
+            "ModelRunner._sm80_dtype_fallback", {"dtype": "float16"}
+        )
+        model_config.dtype = torch.float16
+        if torch.cuda.get_device_capability()[1] < 5:
+            raise RuntimeError("SGLang only supports sm75 and above.")

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import socket
 import threading
 from typing import TYPE_CHECKING, Optional
@@ -8,6 +9,9 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from sglang.srt.configs.load_config import LoadFormat
+from sglang.srt.debug_utils.tensor_dump_forward_hook import (
+    register_forward_hook_for_model,
+)
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
     trigger_init_weights_send_group_for_remote_instance_request,
@@ -17,6 +21,7 @@ from sglang.srt.utils.network import NetworkAddress
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.server_args import ServerArgs
+    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 logger = logging.getLogger(__name__)
 
@@ -97,3 +102,28 @@ def resolve_sliding_window_size(model, model_config: ModelConfig) -> Optional[in
             f"Setting sliding_window_size to be attention_chunk_size: {sliding_window_size}"
         )
     return sliding_window_size
+
+
+def maybe_register_debug_tensor_dump_hook(
+    *,
+    model,
+    server_args: ServerArgs,
+    spec_algorithm: SpeculativeAlgorithm,
+    is_draft_worker: bool,
+    tp_size: int,
+    tp_rank: int,
+    pp_rank: int,
+) -> None:
+    if server_args.debug_tensor_dump_output_folder is not None:
+        dump_folder = server_args.debug_tensor_dump_output_folder
+        if spec_algorithm.is_eagle():
+            role = "draft" if is_draft_worker else "target"
+            dump_folder = os.path.join(dump_folder, role)
+        register_forward_hook_for_model(
+            model,
+            dump_folder,
+            server_args.debug_tensor_dump_layers,
+            tp_size,
+            tp_rank,
+            pp_rank,
+        )

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 import logging
+import socket
+import threading
 from typing import TYPE_CHECKING
 
 import torch
+
+from sglang.srt.configs.load_config import LoadFormat
+from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
+    RemoteInstanceWeightLoaderBackend,
+    trigger_init_weights_send_group_for_remote_instance_request,
+)
+from sglang.srt.utils.network import NetworkAddress
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -27,3 +36,25 @@ def maybe_downgrade_dtype_for_legacy_gpu(
         model_config.dtype = torch.float16
         if torch.cuda.get_device_capability()[1] < 5:
             raise RuntimeError("SGLang only supports sm75 and above.")
+
+
+def maybe_trigger_remote_instance_nccl_send_group(
+    *, server_args: ServerArgs, tp_rank: int
+) -> None:
+    if (
+        server_args.load_format == LoadFormat.REMOTE_INSTANCE
+        and server_args.remote_instance_weight_loader_backend
+        == RemoteInstanceWeightLoaderBackend.NCCL
+    ):
+        if tp_rank == 0:
+            instance_ip = NetworkAddress.resolve_host(socket.gethostname())
+            t = threading.Thread(
+                target=trigger_init_weights_send_group_for_remote_instance_request,
+                args=(
+                    server_args.remote_instance_weight_loader_seed_instance_ip,
+                    server_args.remote_instance_weight_loader_seed_instance_service_port,
+                    server_args.remote_instance_weight_loader_send_weights_group_ports,
+                    instance_ip,
+                ),
+            )
+            t.start()

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -58,3 +58,26 @@ def maybe_trigger_remote_instance_nccl_send_group(
                 ),
             )
             t.start()
+
+
+def load_kv_cache_scales(*, model, server_args: ServerArgs) -> None:
+    if server_args.kv_cache_dtype == "fp8_e4m3":
+        if server_args.quantization_param_path is not None:
+            if callable(getattr(model, "load_kv_cache_scales", None)):
+                model.load_kv_cache_scales(server_args.quantization_param_path)
+                logger.info(
+                    "Loaded KV cache scaling factors from %s",
+                    server_args.quantization_param_path,
+                )
+            else:
+                raise RuntimeError(
+                    "Using FP8 KV cache and scaling factors provided but "
+                    "model %s does not support loading scaling factors.",
+                    model.__class__,
+                )
+        else:
+            logger.warning(
+                "Using FP8 KV cache but no scaling factors "
+                "provided. Defaulting to scaling factors of 1.0. "
+                "This may lead to less accurate results!"
+            )

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -104,6 +104,22 @@ def resolve_sliding_window_size(model, model_config: ModelConfig) -> Optional[in
     return sliding_window_size
 
 
+def report_online_quantization(*, model, server_args: ServerArgs) -> None:
+    # TODO: Make sure all models have `quant_config` attribute, and all online quantization methods register which layers they actually quantize.
+    quantized_layers = getattr(
+        getattr(model, "quant_config", None), "quantized_layers", None
+    )
+    if (
+        server_args.quantization is not None
+        and isinstance(quantized_layers, tuple)
+        and len(quantized_layers) == 2
+    ):
+        layer_types, quantized_layers_count = quantized_layers
+        logger.info(
+            f"Online {server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
+        )
+
+
 def maybe_register_debug_tensor_dump_hook(
     *,
     model,

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -37,6 +37,9 @@ logger = logging.getLogger(__name__)
 _is_npu = is_npu()
 
 
+UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data processing
+
+
 class LoadedModel(msgspec.Struct, frozen=True, kw_only=True):
     loader: Any
     model: Any
@@ -160,3 +163,104 @@ def maybe_register_debug_tensor_dump_hook(
             tp_rank,
             pp_rank,
         )
+
+
+def build_load_config(
+    *,
+    server_args: ServerArgs,
+    tp_rank: int,
+    remote_instance_weight_transporter_engine: Any,
+    remote_instance_weight_transporter_session_id: str,
+    draft_model_idx: Optional[int],
+) -> LoadConfig:
+    from sglang.srt.configs.modelopt_config import ModelOptConfig
+
+    modelopt_config = ModelOptConfig(
+        quant=server_args.modelopt_quant,
+        checkpoint_restore_path=server_args.modelopt_checkpoint_restore_path,
+        checkpoint_save_path=server_args.modelopt_checkpoint_save_path,
+        export_path=server_args.modelopt_export_path,
+        quantize_and_serve=server_args.quantize_and_serve,
+    )
+
+    return LoadConfig(
+        load_format=server_args.load_format,
+        download_dir=server_args.download_dir,
+        model_loader_extra_config=server_args.model_loader_extra_config,
+        tp_rank=tp_rank,
+        remote_instance_weight_loader_seed_instance_ip=server_args.remote_instance_weight_loader_seed_instance_ip,
+        remote_instance_weight_loader_seed_instance_service_port=server_args.remote_instance_weight_loader_seed_instance_service_port,
+        remote_instance_weight_loader_send_weights_group_ports=server_args.remote_instance_weight_loader_send_weights_group_ports,
+        remote_instance_weight_loader_backend=server_args.remote_instance_weight_loader_backend,
+        remote_instance_weight_loader_transfer_engine=remote_instance_weight_transporter_engine,
+        remote_instance_weight_loader_transfer_engine_session_id=remote_instance_weight_transporter_session_id,
+        modelexpress_url=server_args.modelexpress_url,
+        modelexpress_transport=server_args.modelexpress_transport,
+        modelopt_config=modelopt_config,
+        rl_quant_profile=server_args.rl_quant_profile,
+        draft_model_idx=draft_model_idx,
+    )
+
+
+def load_model_with_memory_saver(
+    *,
+    server_args: ServerArgs,
+    model_config: ModelConfig,
+    load_config: LoadConfig,
+    device: str,
+    gpu_id: int,
+    memory_saver_adapter: Any,
+    is_draft_worker: bool,
+) -> LoadedModel:
+    # Remove monkey_patch when linear.py quant remove dependencies with vllm
+    monkey_patch_vllm_parallel_state()
+
+    enable_cpu_backup = server_args.enable_weights_cpu_backup or (
+        is_draft_worker and server_args.enable_draft_weights_cpu_backup
+    )
+    remote_instance_weight_info = None
+    with memory_saver_adapter.region(
+        GPU_MEMORY_TYPE_WEIGHTS,
+        enable_cpu_backup=enable_cpu_backup,
+    ):
+        loader = get_model_loader(
+            load_config=load_config,
+            model_config=model_config,
+        )
+        model = loader.load_model(
+            model_config=model_config,
+            device_config=DeviceConfig(device, gpu_id),
+        )
+        if hasattr(loader, "remote_instance_transfer_engine_weight_info"):
+            remote_instance_weight_info = (
+                loader.remote_instance_transfer_engine_weight_info
+            )
+    # Cache needs to be cleared after loading model weights (in the loader.load_model function).
+    # To avoid conflict with memory_saver_adapter.region, empty_cache operation is now moved here.
+    if _is_npu:
+        torch.npu.empty_cache()
+    monkey_patch_vllm_parallel_state(reverse=True)
+
+    return LoadedModel(
+        loader=loader,
+        model=model,
+        remote_instance_weight_info=remote_instance_weight_info,
+    )
+
+
+def dist_barrier_after_load(*, elastic_ep_backend: Optional[str], tp_rank: int) -> None:
+    if elastic_ep_backend == "mooncake":
+        # Mooncake does not support `monitored_barrier`
+        dist.barrier(group=get_tp_group().cpu_group)
+    else:
+        # Handle the case where some ranks do not finish loading.
+        try:
+            dist.monitored_barrier(
+                group=get_tp_group().cpu_group,
+                timeout=datetime.timedelta(seconds=UNBALANCED_MODEL_LOADING_TIMEOUT_S),
+                wait_all_ranks=True,
+            )
+        except RuntimeError:
+            raise ValueError(
+                f"TP rank {tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
+            ) from None


### PR DESCRIPTION
### mrc-load-model-utils(loadmodel-extract-downgrade-dtype,non_mechanical_provable): Extract _maybe_downgrade_dtype_for_legacy_gpu

### mrc-load-model-utils(loadmodel-extract-build-load-config,non_mechanical_provable): Extract _build_load_config -> LoadConfig

### mrc-load-model-utils(loadmodel-extract-trigger-remote-nccl,non_mechanical_provable): Extract _maybe_trigger_remote_instance_nccl_send_group

### mrc-load-model-utils(loadmodel-extract-load-with-memory-saver,non_mechanical_provable): Extract _load_model_with_memory_saver

### mrc-load-model-utils(loadmodel-extract-post-load-derivations,non_mechanical_provable): Extract _load_kv_cache_scales + _resolve_sliding_window_size

### mrc-load-model-utils(loadmodel-extract-debug-tensor-dump,non_mechanical_provable): Extract _maybe_register_debug_tensor_dump_hook

### mrc-load-model-utils(loadmodel-extract-dist-barrier,non_mechanical_provable): Extract _dist_barrier_after_load

### mrc-load-model-utils(extract-downgrade-dtype-prep,non_mechanical_provable): inline maybe_downgrade_dtype_for_legacy_gpu into model_runner before move

### mrc-load-model-utils(extract-downgrade-dtype-move,mechanical_provable): move maybe_downgrade_dtype_for_legacy_gpu to load_model_utils module (cut+paste)

### mrc-load-model-utils(extract-trigger-remote-nccl-prep,non_mechanical_provable): de-self _maybe_trigger_remote_instance_nccl_send_group to @staticmethod

### mrc-load-model-utils(extract-trigger-remote-nccl-move,mechanical_provable): move maybe_trigger_remote_instance_nccl_send_group to load_model_utils module (cut+paste)

### mrc-load-model-utils(extract-load-kv-cache-scales-prep,non_mechanical_provable): de-self _load_kv_cache_scales to @staticmethod

### mrc-load-model-utils(extract-load-kv-cache-scales-move,mechanical_provable): move load_kv_cache_scales to load_model_utils module (cut+paste)

### mrc-load-model-utils(extract-resolve-sliding-window-prep,non_mechanical_provable): de-self _resolve_sliding_window_size to @staticmethod

### mrc-load-model-utils(extract-resolve-sliding-window-move,mechanical_provable): move resolve_sliding_window_size to load_model_utils module

### mrc-load-model-utils(extract-debug-tensor-dump-hook-prep,non_mechanical_provable): de-self _maybe_register_debug_tensor_dump_hook to @staticmethod

### mrc-load-model-utils(extract-debug-tensor-dump-hook-move,mechanical_provable): move maybe_register_debug_tensor_dump_hook to load_model_utils module (cut+paste)

PR-Title: Extract load-model helpers into load_model_utils

### mrc-load-model-utils(online-quant-report-prep,non_mechanical_provable): Extract online-quantization reporting into a de-self'd report_online_quantization @staticmethod in place

The inline reporting block in load_model becomes a kwargs @staticmethod next
to it; the block is replaced by the class-qualified call.

### mrc-load-model-utils(online-quant-report-move,mechanical_provable): Move report_online_quantization to load_model_utils (cut+paste)

### mrc-load-model-utils(load-model-fns-rename,non_mechanical_provable): Privacy-flip the three load_model helpers to their public move names

_build_load_config / _load_model_with_memory_saver / _dist_barrier_after_load
become build_load_config / load_model_with_memory_saver /
dist_barrier_after_load in place, ahead of the module move.

### mrc-load-model-utils(load-model-fns-inplace-prep,non_mechanical_provable): Prep build_load_config / load_model_with_memory_saver / dist_barrier_after_load for extraction: @staticmethod + kwargs + LoadedModel

De-self the three helpers in place as kwargs @staticmethods (bodies stay at
their original class positions); load_model calls them class-qualified and
unpacks the LoadedModel result. Stage the LoadedModel struct and the header
additions in load_model_utils so the moves land in an existing module.

### mrc-load-model-utils(load-model-fns-move,mechanical_provable): Move build_load_config / load_model_with_memory_saver / dist_barrier_after_load + UNBALANCED_MODEL_LOADING_TIMEOUT_S to load_model_utils (cut+paste)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29316378028](https://github.com/sgl-project/sglang/actions/runs/29316378028)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29316377855](https://github.com/sgl-project/sglang/actions/runs/29316377855)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->