### PR TITLE
[Bugfix] Guard Humming probe against missing quant_method

### DIFF
--- a/python/sglang/srt/layers/quantization/humming.py
+++ b/python/sglang/srt/layers/quantization/humming.py
@@ -227,7 +227,7 @@ class HummingConfig(QuantizationConfig):
 
     @classmethod
     def override_quantization_method(cls, hf_quant_cfg, user_quant) -> str | None:
-        if hf_quant_cfg["quant_method"] == "mxfp4":
+        if hf_quant_cfg.get("quant_method") == "mxfp4":
             # NOTE: gpt-oss has a special weight loading logic, so we don't support it now.
             # TODO: integrate humming kernels to mxfp4.py
             return None

--- a/test/registered/unit/layers/quantization/test_humming.py
+++ b/test/registered/unit/layers/quantization/test_humming.py
@@ -1,0 +1,21 @@
+"""Unit tests for Humming quantization config detection."""
+
+import unittest
+
+from sglang.srt.layers.quantization.humming import HummingConfig
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHummingQuantizationOverride(unittest.TestCase):
+    def test_override_ignores_config_without_quant_method(self):
+        self.assertIsNone(
+            HummingConfig.override_quantization_method(
+                {"group_size": 64, "bits": 4}, None
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`HummingConfig.override_quantization_method()` is called while SGLang probes
all registered quantization methods.

It currently accesses `hf_quant_cfg["quant_method"]` directly. A quantization
config belonging to another backend may legitimately omit this key, causing
Humming to raise `KeyError: 'quant_method'` before the remaining backends can
inspect the config.

Minimal reproduction:

```python
from sglang.srt.layers.quantization.humming import HummingConfig

HummingConfig.override_quantization_method(
    {"group_size": 64, "bits": 4},
    None,
)
```

Fixes #31183



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29327773535](https://github.com/sgl-project/sglang/actions/runs/29327773535)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29327773319](https://github.com/sgl-project/sglang/actions/runs/29327773319)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->