### PR TITLE
feat(dsa): add SM89 FP8 paged indexer operator

### DIFF
--- a/python/sglang/kernels/ops/attention/__init__.py
+++ b/python/sglang/kernels/ops/attention/__init__.py
@@ -7,7 +7,7 @@ KV-cache index/write kernels went to the ``kvcache`` group instead.
 """
 
 from sglang.kernels.registry import register_kernel
-from sglang.kernels.spec import KernelBackend, KernelSpec
+from sglang.kernels.spec import CapabilityRequirement, KernelBackend, KernelSpec
 
 # (module, public_fn) migrated from layers/attention/triton_ops + model_executor.
 _TRITON_KERNELS = [
@@ -109,6 +109,21 @@ for _mod, _fn in [
         )
     )
 del _mod, _fn
+
+register_kernel(
+    KernelSpec(
+        op="attention.sm89_paged_fp8_index_logits",
+        backend=KernelBackend.TRITON,
+        target=(
+            "sglang.kernels.ops.attention.dsa.sm89_paged_indexer:"
+            "sm89_paged_fp8_index_logits"
+        ),
+        capabilities=frozenset(
+            {CapabilityRequirement.cuda(min_sm=(8, 9), max_sm=(8, 9))}
+        ),
+        description="Exact SM89 paged FP8 DSA index logits for the GLM page-64 layout.",
+    )
+)
 
 # Generic attention kernels migrated in Phase 2.5 (RFC #29630).
 for _mod, _fn in [

--- a/python/sglang/kernels/ops/attention/dsa/sm89_paged_indexer.py
+++ b/python/sglang/kernels/ops/attention/dsa/sm89_paged_indexer.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+_PAGE_SIZE = 64
+_NUM_HEADS = 32
+_HEAD_DIM = 128
+_K_BYTES_PER_PAGE = _PAGE_SIZE * _HEAD_DIM
+_SCALE_BYTES_PER_PAGE = _PAGE_SIZE * torch.float32.itemsize
+_PACKED_BYTES_PER_PAGE = _K_BYTES_PER_PAGE + _SCALE_BYTES_PER_PAGE
+_FP8_DTYPE = torch.float8_e4m3fn
+
+
+@triton.jit
+def _sm89_paged_fp8_index_logits_kernel(
+    q_ptr,
+    q_stride_batch,
+    q_stride_head,
+    q_stride_dim,
+    kv_ptr,
+    kv_stride_page,
+    scale_ptr,
+    scale_stride_page,
+    weights_ptr,
+    weights_stride_batch,
+    seq_lens_ptr,
+    seq_lens_stride_batch,
+    page_table_ptr,
+    page_table_stride_batch,
+    page_table_stride_page,
+    logits_ptr,
+    logits_stride_batch,
+    num_pages,
+    max_seq_len,
+    PAGE_SIZE: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    logical_page = tl.program_id(1)
+
+    seq_len = tl.load(seq_lens_ptr + batch_id * seq_lens_stride_batch)
+    physical_page = tl.load(
+        page_table_ptr
+        + batch_id * page_table_stride_batch
+        + logical_page * page_table_stride_page
+    )
+    page_is_valid = (physical_page >= 0) & (physical_page < num_pages)
+    safe_page = tl.where(page_is_valid, physical_page, 0)
+
+    token_offsets = tl.arange(0, PAGE_SIZE)
+    logical_tokens = logical_page * PAGE_SIZE + token_offsets
+    token_is_valid = (
+        page_is_valid & (logical_tokens < seq_len) & (logical_tokens < max_seq_len)
+    )
+
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    key_offsets = (
+        safe_page * kv_stride_page
+        + token_offsets[:, None] * HEAD_DIM
+        + dim_offsets[None, :]
+    )
+    keys = tl.load(
+        kv_ptr + key_offsets,
+        mask=token_is_valid[:, None],
+        other=0.0,
+    ).to(tl.float16)
+
+    head_offsets = tl.arange(0, NUM_HEADS)
+    query_offsets = (
+        batch_id * q_stride_batch
+        + head_offsets[:, None] * q_stride_head
+        + dim_offsets[None, :] * q_stride_dim
+    )
+    query = tl.load(q_ptr + query_offsets).to(tl.float16)
+    head_weights = tl.load(weights_ptr + batch_id * weights_stride_batch + head_offsets)
+    key_scales = tl.load(
+        scale_ptr + safe_page * scale_stride_page + token_offsets,
+        mask=token_is_valid,
+        other=0.0,
+    )
+
+    per_head_dot = tl.dot(keys, tl.trans(query), out_dtype=tl.float32)
+    scores = (
+        tl.sum(tl.maximum(per_head_dot, 0.0) * head_weights[None, :], axis=1)
+        * key_scales
+    )
+    tl.store(
+        logits_ptr + batch_id * logits_stride_batch + logical_tokens,
+        scores,
+        mask=token_is_valid,
+    )
+
+
+def _validate_inputs(
+    q_fp8: torch.Tensor,
+    kv_cache_u8: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+) -> None:
+    if q_fp8.dtype != _FP8_DTYPE:
+        raise TypeError("q_fp8 must have dtype float8_e4m3fn")
+    if q_fp8.ndim != 4 or q_fp8.shape[1:] != (1, _NUM_HEADS, _HEAD_DIM):
+        raise ValueError("q_fp8 shape must be [B, 1, 32, 128]")
+    if not q_fp8.is_contiguous():
+        raise ValueError("q_fp8 must be contiguous")
+
+    batch_size = q_fp8.shape[0]
+    if kv_cache_u8.dtype != torch.uint8:
+        raise TypeError("kv_cache_u8 must have dtype uint8")
+    if kv_cache_u8.ndim != 2 or kv_cache_u8.shape[1] != _PACKED_BYTES_PER_PAGE:
+        raise ValueError("kv_cache_u8 shape must be [num_pages, 8448]")
+    if not kv_cache_u8.is_contiguous():
+        raise ValueError("kv_cache_u8 must be contiguous")
+
+    if weights.dtype != torch.float32:
+        raise TypeError("weights must have dtype float32")
+    if weights.shape != (batch_size, _NUM_HEADS):
+        raise ValueError("weights shape must be [B, 32]")
+    if not weights.is_contiguous():
+        raise ValueError("weights must be contiguous")
+
+    if seq_lens.dtype != torch.int32:
+        raise TypeError("seq_lens must have dtype int32")
+    if seq_lens.shape not in ((batch_size,), (batch_size, 1)):
+        raise ValueError("seq_lens shape must be [B] or [B, 1]")
+
+    if page_table.dtype != torch.int32:
+        raise TypeError("page_table must have dtype int32")
+    if page_table.ndim != 2 or page_table.shape[0] != batch_size:
+        raise ValueError("page_table shape must be [B, max_pages]")
+
+    if type(max_seq_len) is not int or max_seq_len <= 0:
+        raise TypeError("max_seq_len must be a positive integer")
+    if max_seq_len != page_table.shape[1] * _PAGE_SIZE:
+        raise ValueError("max_seq_len must equal page_table width times 64")
+
+    tensors = (q_fp8, kv_cache_u8, weights, seq_lens, page_table)
+    if q_fp8.device.type != "cuda" or any(
+        tensor.device != q_fp8.device for tensor in tensors[1:]
+    ):
+        raise ValueError("all inputs must be on the same CUDA device")
+
+
+def sm89_paged_fp8_index_logits(
+    q_fp8: torch.Tensor,
+    kv_cache_u8: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+) -> torch.Tensor:
+    """Compute exact GLM DSA index logits from the raw page-64 FP8 cache."""
+    _validate_inputs(
+        q_fp8,
+        kv_cache_u8,
+        weights,
+        seq_lens,
+        page_table,
+        max_seq_len,
+    )
+
+    batch_size = q_fp8.shape[0]
+    num_pages = kv_cache_u8.shape[0]
+    kv_cache_fp8 = kv_cache_u8.view(_FP8_DTYPE)
+    kv_scales = kv_cache_u8[:, _K_BYTES_PER_PAGE:].view(torch.float32)
+    flat_seq_lens = seq_lens.reshape(batch_size)
+    logits = torch.full(
+        (batch_size, max_seq_len),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+
+    grid = (batch_size, triton.cdiv(max_seq_len, _PAGE_SIZE))
+    _sm89_paged_fp8_index_logits_kernel[grid](
+        q_fp8,
+        q_fp8.stride(0),
+        q_fp8.stride(2),
+        q_fp8.stride(3),
+        kv_cache_fp8,
+        kv_cache_fp8.stride(0),
+        kv_scales,
+        kv_scales.stride(0),
+        weights,
+        weights.stride(0),
+        flat_seq_lens,
+        flat_seq_lens.stride(0),
+        page_table,
+        page_table.stride(0),
+        page_table.stride(1),
+        logits,
+        logits.stride(0),
+        num_pages,
+        max_seq_len,
+        PAGE_SIZE=_PAGE_SIZE,
+        NUM_HEADS=_NUM_HEADS,
+        HEAD_DIM=_HEAD_DIM,
+        num_warps=4,
+        num_stages=4,
+    )
+    return logits

--- a/test/registered/kernels/test_kernels_namespace.py
+++ b/test/registered/kernels/test_kernels_namespace.py
@@ -45,9 +45,11 @@ EXPECTED = {
     "moe.moe_align_block_size": {"aot", "jit"},
     "quantization.nvfp4_gemm_swiglu_nvfp4_quant": {"cute_dsl"},
     "kvcache.reshape_and_cache_flash": {"triton"},
+    "attention.sm89_paged_fp8_index_logits": {"triton"},
 }
 
 _CPU = PlatformInfo(device_type="cpu")
+_SM89 = PlatformInfo(device_type="cuda", cuda_arch_major=8, cuda_arch_minor=9)
 _SM90 = PlatformInfo(device_type="cuda", cuda_arch_major=9, cuda_arch_minor=0)
 _SM100 = PlatformInfo(device_type="cuda", cuda_arch_major=10, cuda_arch_minor=0)
 _HIP = PlatformInfo(device_type="hip")
@@ -166,6 +168,15 @@ def test_capabilities_or_semantics():
     assert not K.capabilities_satisfied(both, _CPU)
     assert K.capabilities_satisfied((), _CPU)  # empty = unrestricted
     assert K.capabilities_satisfied(Cap.CUDA, _SM90)  # single tolerated
+
+
+def test_sm89_paged_indexer_capability():
+    spec = K.registry.get_backend(
+        "attention.sm89_paged_fp8_index_logits", KernelBackend.TRITON
+    )
+    assert spec.is_available(_SM89)
+    assert not spec.is_available(_SM90)
+    assert not spec.is_available(_CPU)
 
 
 def test_capability_shortcuts():

--- a/test/registered/kernels/test_sm89_paged_indexer.py
+++ b/test/registered/kernels/test_sm89_paged_indexer.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsa import sm89_paged_indexer
+from sglang.kernels.ops.attention.dsa.sm89_paged_indexer import (
+    sm89_paged_fp8_index_logits,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+PAGE_SIZE = 64
+NUM_HEADS = 32
+HEAD_DIM = 128
+K_BYTES_PER_PAGE = PAGE_SIZE * HEAD_DIM
+SCALE_BYTES_PER_PAGE = PAGE_SIZE * torch.float32.itemsize
+PACKED_BYTES_PER_PAGE = K_BYTES_PER_PAGE + SCALE_BYTES_PER_PAGE
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def _make_q(batch_size: int, *, phase: int = 0) -> torch.Tensor:
+    q = torch.ones(
+        batch_size, 1, NUM_HEADS, HEAD_DIM, device="cuda", dtype=torch.float32
+    )
+    q[:, :, NUM_HEADS // 2 :] = -1
+    if phase % 2:
+        q.neg_()
+    if phase % 3 == 2:
+        q[:, :, :, 1::2].neg_()
+    return q.to(torch.float8_e4m3fn).contiguous()
+
+
+def _make_weights(batch_size: int, *, phase: int = 0) -> torch.Tensor:
+    first_half = torch.tensor(
+        [1.0, -0.5] * (NUM_HEADS // 4), device="cuda", dtype=torch.float32
+    )
+    second_half = torch.tensor(
+        [0.25, -0.75] * (NUM_HEADS // 4),
+        device="cuda",
+        dtype=torch.float32,
+    )
+    weights = torch.cat((first_half, second_half)).repeat(batch_size, 1)
+    if phase:
+        weights = torch.roll(weights, shifts=phase, dims=1)
+        weights[:, ::5].neg_()
+    return weights.contiguous()
+
+
+def _make_raw_cache(num_pages: int, *, phase: int = 0) -> torch.Tensor:
+    cache = torch.zeros(
+        num_pages, PACKED_BYTES_PER_PAGE, device="cuda", dtype=torch.uint8
+    )
+    token_ids = torch.arange(
+        num_pages * PAGE_SIZE, device="cuda", dtype=torch.int64
+    ).view(num_pages, PAGE_SIZE)
+    signs = torch.where(
+        (token_ids + phase) % 3 == 0,
+        torch.tensor(-1.0, device="cuda"),
+        torch.tensor(1.0, device="cuda"),
+    )
+    dimension_signs = torch.ones(HEAD_DIM, device="cuda", dtype=torch.float32)
+    if phase % 3 == 2:
+        dimension_signs[1::2] = -1
+    keys = (signs[..., None] * dimension_signs).to(torch.float8_e4m3fn)
+    cache[:, :K_BYTES_PER_PAGE].view(torch.float8_e4m3fn).view(
+        num_pages, PAGE_SIZE, HEAD_DIM
+    ).copy_(keys)
+
+    scales = 1.25 + (token_ids.to(torch.float32) + phase) / 1024.0
+    cache[:, K_BYTES_PER_PAGE:].view(torch.float32).copy_(scales)
+    return cache
+
+
+def _gather_packed_cache(
+    kv_cache_u8: torch.Tensor, page_table: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_pages = kv_cache_u8.shape[0]
+    keys = (
+        kv_cache_u8[:, :K_BYTES_PER_PAGE]
+        .view(torch.float8_e4m3fn)
+        .view(num_pages, PAGE_SIZE, HEAD_DIM)
+    )
+    scales = kv_cache_u8[:, K_BYTES_PER_PAGE:].view(torch.float32)
+    valid_pages = (page_table >= 0) & (page_table < num_pages)
+    safe_pages = torch.where(valid_pages, page_table, 0).to(torch.long)
+    return keys[safe_pages], scales[safe_pages], valid_pages
+
+
+def _reference_logits(
+    q_fp8: torch.Tensor,
+    kv_cache_u8: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+) -> torch.Tensor:
+    batch_size = q_fp8.shape[0]
+    selected_keys, selected_scales, valid_pages = _gather_packed_cache(
+        kv_cache_u8, page_table
+    )
+    selected_keys = selected_keys.reshape(batch_size, max_seq_len, HEAD_DIM)
+    selected_scales = selected_scales.reshape(batch_size, max_seq_len)
+    dots = torch.matmul(
+        selected_keys.to(torch.float32),
+        q_fp8[:, 0].to(torch.float32).transpose(1, 2),
+    )
+    logits = (torch.relu(dots) * weights[:, None, :]).sum(dim=-1) * selected_scales
+
+    positions = torch.arange(max_seq_len, device=q_fp8.device)[None, :]
+    valid_tokens = (
+        valid_pages[..., None]
+        .expand(-1, -1, PAGE_SIZE)
+        .reshape(batch_size, max_seq_len)
+    )
+    valid_tokens &= positions < seq_lens.reshape(batch_size, 1)
+    return logits.masked_fill(~valid_tokens, float("-inf"))
+
+
+def _sorted_topk(logits: torch.Tensor, k: int = 8) -> torch.Tensor:
+    return torch.topk(logits, k=k, dim=-1).indices.sort(dim=-1).values
+
+
+@pytest.fixture
+def valid_case() -> dict[str, object]:
+    batch_size = 2
+    max_pages = 3
+    return {
+        "q_fp8": _make_q(batch_size),
+        "kv_cache_u8": _make_raw_cache(5),
+        "weights": _make_weights(batch_size),
+        "seq_lens": torch.tensor([130, 159], device="cuda", dtype=torch.int32),
+        "page_table": torch.tensor(
+            [[2, 0, -1], [1, 5, 3]], device="cuda", dtype=torch.int32
+        ),
+        "max_seq_len": max_pages * PAGE_SIZE,
+    }
+
+
+def test_matches_packed_page_reference_and_masks_invalid_positions(valid_case):
+    logits = sm89_paged_fp8_index_logits(**valid_case)
+    expected = _reference_logits(**valid_case)
+
+    assert logits.shape == (2, 3 * PAGE_SIZE)
+    assert logits.dtype == torch.float32
+    torch.testing.assert_close(logits, expected, atol=1e-4, rtol=1e-5)
+    assert torch.equal(_sorted_topk(logits), _sorted_topk(expected))
+
+    assert torch.isfinite(logits[0, : 2 * PAGE_SIZE]).all()
+    assert torch.isneginf(logits[0, 2 * PAGE_SIZE :]).all()
+    assert torch.isfinite(logits[1, :PAGE_SIZE]).all()
+    assert torch.isneginf(logits[1, PAGE_SIZE : 2 * PAGE_SIZE]).all()
+    assert torch.isfinite(logits[1, 2 * PAGE_SIZE : 159]).all()
+    assert torch.isneginf(logits[1, 159:]).all()
+
+
+def test_applies_relu_per_head_before_signed_weight(valid_case):
+    q_fp8 = valid_case["q_fp8"]
+    kv_cache_u8 = valid_case["kv_cache_u8"]
+    weights = valid_case["weights"]
+    page_table = valid_case["page_table"]
+    max_seq_len = valid_case["max_seq_len"]
+    selected_keys, selected_scales, valid_pages = _gather_packed_cache(
+        kv_cache_u8, page_table
+    )
+    dots = torch.matmul(
+        selected_keys.reshape(2, max_seq_len, HEAD_DIM).float(),
+        q_fp8[:, 0].float().transpose(1, 2),
+    )
+
+    assert (dots > 0).any(dim=-1).all()
+    assert (dots < 0).any(dim=-1).all()
+    assert (weights > 0).any() and (weights < 0).any()
+    assert torch.all(selected_scales > 0)
+    assert not torch.any(selected_scales == 1)
+
+    correct = (torch.relu(dots) * weights[:, None, :]).sum(dim=-1)
+    wrong = torch.relu((dots * weights[:, None, :]).sum(dim=-1))
+    valid = valid_pages[..., None].expand(-1, -1, PAGE_SIZE).reshape(2, max_seq_len)
+    assert not torch.allclose(correct[valid], wrong[valid])
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "message"),
+    [
+        ("q_fp8", lambda case: case["q_fp8"].float(), "q_fp8.*float8_e4m3fn"),
+        ("q_fp8", lambda case: case["q_fp8"][:, 0], "q_fp8.*shape"),
+        ("q_fp8", lambda case: case["q_fp8"][:, :, :31], "q_fp8.*shape"),
+        ("q_fp8", lambda case: case["q_fp8"][..., :64], "q_fp8.*shape"),
+        (
+            "q_fp8",
+            lambda case: torch.empty(
+                2,
+                1,
+                NUM_HEADS,
+                HEAD_DIM * 2,
+                device="cuda",
+                dtype=torch.float8_e4m3fn,
+            )[..., ::2],
+            "q_fp8.*contiguous",
+        ),
+        (
+            "kv_cache_u8",
+            lambda case: case["kv_cache_u8"].view(torch.float8_e4m3fn),
+            "kv_cache_u8.*uint8",
+        ),
+        (
+            "kv_cache_u8",
+            lambda case: case["kv_cache_u8"][:, :-1].contiguous(),
+            "kv_cache_u8.*shape",
+        ),
+        (
+            "kv_cache_u8",
+            lambda case: torch.empty(
+                5, PACKED_BYTES_PER_PAGE * 2, device="cuda", dtype=torch.uint8
+            )[:, ::2],
+            "kv_cache_u8.*contiguous",
+        ),
+        (
+            "weights",
+            lambda case: case["weights"].to(torch.bfloat16),
+            "weights.*float32",
+        ),
+        ("weights", lambda case: case["weights"][:, :-1], "weights.*shape"),
+        (
+            "weights",
+            lambda case: torch.empty(
+                2, NUM_HEADS * 2, device="cuda", dtype=torch.float32
+            )[:, ::2],
+            "weights.*contiguous",
+        ),
+        ("seq_lens", lambda case: case["seq_lens"].long(), "seq_lens.*int32"),
+        (
+            "seq_lens",
+            lambda case: case["seq_lens"][:, None].expand(-1, 2).contiguous(),
+            "seq_lens.*shape",
+        ),
+        ("seq_lens", lambda case: case["seq_lens"].cpu(), "same CUDA device"),
+        ("page_table", lambda case: case["page_table"].long(), "page_table.*int32"),
+        ("page_table", lambda case: case["page_table"][:1], "page_table.*shape"),
+        ("page_table", lambda case: case["page_table"].cpu(), "same CUDA device"),
+        ("max_seq_len", lambda case: True, "max_seq_len.*integer"),
+        ("max_seq_len", lambda case: 2 * PAGE_SIZE, "max_seq_len.*page_table"),
+    ],
+)
+def test_rejects_invalid_contract(valid_case, field, replacement, message):
+    invalid_case = dict(valid_case)
+    invalid_case[field] = replacement(valid_case)
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        sm89_paged_fp8_index_logits(**invalid_case)
+
+
+def test_accepts_column_device_lengths(valid_case):
+    valid_case["seq_lens"] = valid_case["seq_lens"][:, None]
+    logits = sm89_paged_fp8_index_logits(**valid_case)
+    expected = _reference_logits(**valid_case)
+    torch.testing.assert_close(logits, expected, atol=1e-4, rtol=1e-5)
+
+
+def test_accepts_noncontiguous_page_table(valid_case):
+    page_table_storage = torch.tensor(
+        [[2, 4, 0, 4, -1, 4], [1, 4, 5, 4, 3, 4]],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    valid_case["page_table"] = page_table_storage[:, ::2]
+    assert not valid_case["page_table"].is_contiguous()
+
+    logits = sm89_paged_fp8_index_logits(**valid_case)
+    expected = _reference_logits(**valid_case)
+    torch.testing.assert_close(logits, expected, atol=1e-4, rtol=1e-5)
+    assert torch.equal(_sorted_topk(logits), _sorted_topk(expected))
+
+
+def test_source_has_no_host_device_reads():
+    source = inspect.getsource(sm89_paged_indexer)
+    for forbidden in (".item(", ".tolist(", ".cpu(", ".numpy("):
+        assert forbidden not in source
+
+
+def test_cuda_graph_replays_short_long_and_long_short_with_stable_pointers():
+    max_seq_len = 2 * PAGE_SIZE
+    static_q = _make_q(1, phase=0)
+    static_cache = _make_raw_cache(4, phase=0)
+    static_weights = _make_weights(1, phase=0)
+    static_seq_lens = torch.tensor([37], device="cuda", dtype=torch.int32)
+    static_page_table = torch.tensor([[0, -1]], device="cuda", dtype=torch.int32)
+    pointers = tuple(
+        tensor.data_ptr()
+        for tensor in (
+            static_q,
+            static_cache,
+            static_weights,
+            static_seq_lens,
+            static_page_table,
+        )
+    )
+
+    states = [
+        {
+            "q_fp8": _make_q(1, phase=1),
+            "kv_cache_u8": _make_raw_cache(4, phase=1),
+            "weights": _make_weights(1, phase=1),
+            "seq_lens": torch.tensor([111], device="cuda", dtype=torch.int32),
+            "page_table": torch.tensor([[2, 1]], device="cuda", dtype=torch.int32),
+        },
+        {
+            "q_fp8": _make_q(1, phase=2),
+            "kv_cache_u8": _make_raw_cache(4, phase=2),
+            "weights": _make_weights(1, phase=2),
+            "seq_lens": torch.tensor([19], device="cuda", dtype=torch.int32),
+            "page_table": torch.tensor([[3, 0]], device="cuda", dtype=torch.int32),
+        },
+    ]
+
+    sm89_paged_fp8_index_logits(
+        static_q,
+        static_cache,
+        static_weights,
+        static_seq_lens,
+        static_page_table,
+        max_seq_len,
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        replay_logits = sm89_paged_fp8_index_logits(
+            static_q,
+            static_cache,
+            static_weights,
+            static_seq_lens,
+            static_page_table,
+            max_seq_len,
+        )
+        replay_topk = torch.topk(replay_logits, k=8, dim=-1).indices
+
+    graph.replay()
+    torch.cuda.synchronize()
+    initial_expected = _reference_logits(
+        static_q,
+        static_cache,
+        static_weights,
+        static_seq_lens,
+        static_page_table,
+        max_seq_len,
+    )
+    torch.testing.assert_close(replay_logits, initial_expected, atol=1e-4, rtol=1e-5)
+    assert torch.equal(
+        replay_topk.sort(dim=-1).values.to(torch.int64),
+        _sorted_topk(initial_expected),
+    )
+
+    replay_snapshots = []
+    for state in states:
+        static_q.copy_(state["q_fp8"])
+        static_cache.copy_(state["kv_cache_u8"])
+        static_weights.copy_(state["weights"])
+        static_seq_lens.copy_(state["seq_lens"])
+        static_page_table.copy_(state["page_table"])
+
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = _reference_logits(
+            static_q,
+            static_cache,
+            static_weights,
+            static_seq_lens,
+            static_page_table,
+            max_seq_len,
+        )
+        actual = replay_logits.clone()
+        replay_snapshots.append(actual)
+        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-5)
+        assert torch.equal(
+            replay_topk.sort(dim=-1).values.to(torch.int64),
+            _sorted_topk(expected),
+        )
+        assert pointers == tuple(
+            tensor.data_ptr()
+            for tensor in (
+                static_q,
+                static_cache,
+                static_weights,
+                static_seq_lens,
+                static_page_table,
+            )
+        )
+
+    assert torch.isfinite(replay_snapshots[0][0, :111]).all()
+    assert torch.isneginf(replay_snapshots[1][0, 19:]).all()


### PR DESCRIPTION
## Motivation

Ada/SM89 cannot use the SM90-only fast DSA indexer paths. GLM DSA also uses a
different raw paged index-cache layout from the DeepSeek V4 work in #28620 and
#25470: each page contains 64 E4M3 key vectors of dimension 128 followed by one
FP32 dynamic scale per token (`8448` bytes total).

This PR adds the exact paged-logits primitive for that layout. It is not a
dense-attention fallback and does not change any runtime default or backend
selection by itself.

## Modifications

- Add a Triton paged FP8 index-logits operator under the unified
  `sglang.kernels.ops.attention.dsa` namespace introduced by #29630 and #30792.
- Register the operator lazily as
  `attention.sm89_paged_fp8_index_logits`, with an exact SM89 capability
  requirement using the current set-valued `KernelSpec.capabilities` API.
- Support page size 64, 32 query heads, and head dimension 128.
- Apply ReLU per head before the signed FP32 head-weight reduction, then apply
  each token's packed FP32 dynamic scale.
- Read logical-to-physical page mappings directly and leave invalid pages and
  tokens at `-inf`.
- Validate dtype, shape, contiguity, device, and page-width contracts at the
  Python boundary.
- Keep the launch graph-safe: the kernel path performs no host reads or tensor
  value-dependent Python control flow.
- Add numerical, contract, non-contiguous page-table, masking, CUDA Graph
  replay, and CPU-only registry tests.

The scope is intentionally operator-only. A follow-up will connect it to the
GLM DSA indexer selector together with the SM89 sparse MLA backend; until then
the operator is not selected by serving code.

## Accuracy Tests

Hardware: RTX 4090 48GB mod (SM89), Torch 2.11.0+cu129.

```bash
PYTHONPATH=python python -m pytest \
  test/registered/kernels/test_sm89_paged_indexer.py -q
```

Result: `25 passed, 5 warnings in 6.30s`.

The tests compare logits and sorted top-k indices against an eager FP32
reference, including signed head weights, non-unit per-token scales, invalid
physical pages, partial final pages, and stride-2 page-table views. CUDA Graph
tests replay short-to-long and long-to-short sequence lengths while checking
stable input pointers and exact masking.

CPU-only namespace and registry validation:

```bash
PYTHONPATH=python python -m pytest \
  test/registered/kernels/test_kernels_namespace.py -q
```

Result: `51 passed, 3 warnings in 10.44s`.

Downstream integration validation, not claimed as functionality of this PR
alone, was also completed on 2x RTX 4090 48GB mod GPUs with GLM-5.2-504B,
exact DSA, FP8 KV, TP=2, and a 262208-token KV budget. A cold 200006-token
prompt plus exact 128 output tokens measured 105.785 tok/s prefill and 9.955
tok/s decode; three cached exact-128 runs had a 9.864 tok/s median and no
detected quality flags.
The stacked integration source is available on the
[`glm52-sm89-fp8-upstream`](https://github.com/mochgolf/sglang/tree/glm52-sm89-fp8-upstream)
branch.

## Speed Tests and Profiling

Standalone CUDA-event timing on one RTX 4090 48GB mod after warmup, batch size
1, all pages valid:

| Sequence length | Eager median | CUDA Graph replay median |
|---:|---:|---:|
| 32768 | 0.068 ms | 0.009 ms |
| 262144 | 0.068 ms | 0.021 ms |

Eager timing includes output allocation/initialization. Graph timing used 50
replays. There is no existing operator for this GLM layout on SM89, so this PR
does not claim a synthetic speedup ratio.

## Additional Checks

- Full repository pre-commit hooks on `origin/main..HEAD`
- `scripts/ci/check_registered_tests.py`
- `scripts/ci/check_no_registered_tests_in_package.py`
- `git diff --check`

## Checklist

- [x] Rebase onto current upstream main.
- [x] Use the unified `sglang.kernels.ops` public namespace and registry.
- [x] Format the changed files according to the repository pre-commit versions.
- [x] Add focused unit, registry, and CUDA Graph tests.
- [x] Provide accuracy and standalone latency results.
- [x] No user-facing configuration is introduced here; serving documentation
      will accompany the integration follow-up.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29725364773](https://github.com/sgl-project/sglang/actions/runs/29725364773)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29725364644](https://github.com/sgl-project/sglang/actions/runs/29725364644)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
