### PR TITLE
Fix defensive getattr/hasattr usage per no-getattr-defensive.md (#29871)

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -599,8 +599,8 @@ class CommonKVManager(BaseKVManager):
             "page_size": self.kv_args.page_size,
             "kv_cache_dtype": self.server_args.kv_cache_dtype,
             "load_balance_method": self.server_args.load_balance_method,
-            "enable_dsa_cache_layer_split": getattr(
-                self.server_args, "enable_dsa_cache_layer_split", False
+            "enable_dsa_cache_layer_split": (
+                self.server_args.enable_dsa_cache_layer_split
             ),
             # Self-register the HTTP API port so the decode can derive the PD
             # retract rebootstrap /generate URL from bootstrap info instead of a

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -463,7 +463,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             self.token_to_kv_pool,
             self.draft_token_to_kv_pool,
             total_kv_layers=self.scheduler.model_config.num_hidden_layers,
-            req_to_token_pool=getattr(self, "req_to_token_pool", None),
+            req_to_token_pool=self.req_to_token_pool,
         )
 
         kv_args.ib_device = self.scheduler.server_args.disaggregation_ib_device
@@ -905,7 +905,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
             if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
-                if not getattr(decode_req.req, "finished_output", False):
+                if not decode_req.req.finished_output:
                     self.scheduler.output_streamer.stream_output(
                         [decode_req.req],
                         decode_req.req.return_logprob,
@@ -1154,11 +1154,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             state_types = self.kv_manager.kv_args.state_types
             state_indices: Optional[List] = []
             if StateType.C128_STATE in state_types:
-                clear_c128_state = getattr(
-                    self.token_to_kv_pool, "clear_c128_req_state", None
-                )
-                if clear_c128_state is not None:
-                    clear_c128_state(int(decode_req.req.req_pool_idx))
+                if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                    self.token_to_kv_pool.clear_c128_req_state(
+                        int(decode_req.req.req_pool_idx)
+                    )
             for st in state_types:
                 if st == StateType.MAMBA:
                     state_indices.append(_mamba_payload())

--- a/python/sglang/srt/disaggregation/encode_receiver.py
+++ b/python/sglang/srt/disaggregation/encode_receiver.py
@@ -784,7 +784,7 @@ class WaitingImageRequest:
                 # No data available yet, wait a bit and retry
                 return
             recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
-            if getattr(recv_obj, "error_msg", None) is not None:
+            if recv_obj.error_msg is not None:
                 logger.warning(
                     f"Received error signal from encoder for {self.rid}: {recv_obj.error_msg} {recv_obj.error_code = }"
                 )
@@ -1123,7 +1123,7 @@ class WaitingImageRDMARequest(WaitingImageRequest):
                 return
 
             recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
-            if getattr(recv_obj, "error_msg", None) is not None:
+            if recv_obj.error_msg is not None:
                 logger.warning(f"Received error for {self.rid}: {recv_obj.error_msg}")
                 self.error_msg = recv_obj.error_msg
                 self.error_code = recv_obj.error_code
@@ -1442,9 +1442,7 @@ class MMReceiverBase(ABC):
         self.wait_timeout = envs.SGLANG_ENCODER_RECV_TIMEOUT.get()
 
         self.model_type = (
-            getattr(hf_config, "model_type", "").lower()
-            if hf_config is not None
-            else None
+            hf_config.model_type.lower() if hf_config is not None else None
         )
         if self.encoder_transfer_backend == "mooncake":
             self.dtype = dtype
@@ -1465,7 +1463,7 @@ class MMReceiverBase(ABC):
             self.embedding_pool = None
             pool_mb = envs.SGLANG_EMBEDDING_POOL_SIZE_MB.get()
             if pool_mb and pool_mb > 0 and scheduler is not None:
-                gpu_id = getattr(scheduler, "gpu_id", 0)
+                gpu_id = scheduler.ps.gpu_id
                 try:
                     self.embedding_pool = MooncakeEmbeddingPool(
                         self.embeddings_engine, gpu_id, pool_mb * 1024 * 1024
@@ -1484,7 +1482,7 @@ class MMReceiverBase(ABC):
                     server_args,
                     hf_config,
                     model_config=(
-                        getattr(self.scheduler, "model_config", None)
+                        self.scheduler.model_config
                         if self.scheduler is not None
                         else None
                     ),
@@ -1501,7 +1499,7 @@ class MMReceiverBase(ABC):
         import_processors("sglang.srt.multimodal.processors")
 
         extra_kwargs = {}
-        if getattr(server_args, "tokenizer_backend", None) is not None:
+        if server_args.tokenizer_backend is not None:
             extra_kwargs["tokenizer_backend"] = server_args.tokenizer_backend
 
         _processor = None
@@ -1627,10 +1625,10 @@ class MMReceiverBase(ABC):
                 if not parts:
                     continue
                 recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
-                if getattr(recv_obj, "error_msg", None) is not None:
+                if recv_obj.error_msg is not None:
                     logger.warning(
                         f"Encoder error for req_id={req_id}: {recv_obj.error_msg} "
-                        f"error_code={getattr(recv_obj, 'error_code', None)}"
+                        f"error_code={recv_obj.error_code}"
                     )
                     self._cleanup_mooncake_buffer(req_id)
                     return None
@@ -1900,7 +1898,7 @@ class MMReceiverBase(ABC):
             f"Pre-allocating GPU buffer for mooncake RDMA: "
             f"req_id={req_id}, size={total_bytes} bytes"
         )
-        gpu_id = getattr(self.scheduler, "gpu_id", 0)
+        gpu_id = self.scheduler.ps.gpu_id
         embeddings = torch.empty(total_bytes, dtype=torch.uint8, device=gpu_id)
         self.embeddings_engine.register(
             embeddings.data_ptr(),
@@ -2021,7 +2019,7 @@ class MMReceiverHTTP(MMReceiverBase):
     # For zmq_to_scheduler and mooncake
     def process_waiting_requests(self, recv_reqs):
         if self.encoder_transfer_backend == "mooncake":
-            gpu_id = getattr(self.scheduler, "gpu_id", 0)
+            gpu_id = self.scheduler.ps.gpu_id
             return self._process_waiting_requests(
                 recv_reqs,
                 WaitingImageRDMARequest,

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -281,9 +281,7 @@ class MMEncoder:
             remote_instance_weight_loader_seed_instance_service_port=server_args.remote_instance_weight_loader_seed_instance_service_port,
             remote_instance_weight_loader_send_weights_group_ports=server_args.remote_instance_weight_loader_send_weights_group_ports,
         )
-        self.model_type = getattr(
-            self.model_config.hf_config, "model_type", "unknown"
-        ).lower()
+        self.model_type = self.model_config.hf_config.model_type.lower()
 
         self.device = server_args.device
         self.gpu_id = server_args.base_gpu_id + rank

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -209,7 +209,7 @@ class PrefillBootstrapQueue:
         kv_args.ib_device = self.scheduler.server_args.disaggregation_ib_device
         kv_args.gpu_id = self.scheduler.ps.gpu_id
 
-        req_to_token_pool = getattr(self.scheduler, "req_to_token_pool", None)
+        req_to_token_pool = self.scheduler.req_to_token_pool
         setup_state_kv_args(
             kv_args,
             self.token_to_kv_pool,
@@ -431,7 +431,7 @@ class SchedulerDisaggregationPrefillMixin:
         if prefetch is None:
             return
         for req in batch.reqs:
-            room = getattr(req, "bootstrap_room", None)
+            room = req.bootstrap_room
             if room is not None and room in kv_mgr.transfer_infos:
                 prefetch(room)
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -816,7 +816,7 @@ def setup_state_kv_args(
                         ring_lens,
                         ring_item_lens,
                     )
-            if hasattr(token_to_kv_pool, "get_c128_state_buf_infos"):
+            if isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool):
                 c128_ptrs, c128_lens, c128_item_lens = (
                     token_to_kv_pool.get_c128_state_buf_infos()
                 )

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -93,10 +93,7 @@ def _get_logical_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
     # from a reused/padded ForwardBatch turn an empty rank into TARGET_VERIFY.
     if forward_batch.forward_mode.is_idle():
         return forward_batch.forward_mode
-    return (
-        getattr(forward_batch, "_original_forward_mode", None)
-        or forward_batch.forward_mode
-    )
+    return forward_batch._original_forward_mode or forward_batch.forward_mode
 
 
 def _get_target_verify_bs(forward_batch: ForwardBatch) -> int:
@@ -106,7 +103,7 @@ def _get_target_verify_bs(forward_batch: ForwardBatch) -> int:
     if actual_forward_mode.is_idle():
         return 0
 
-    spec_info = getattr(forward_batch, "spec_info", None)
+    spec_info = forward_batch.spec_info
     draft_token_num = getattr(spec_info, "draft_token_num", 0)
     draft_token = getattr(spec_info, "draft_token", None)
     if draft_token is None:
@@ -2030,14 +2027,14 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
             actual_forward_mode=getattr(
                 forward_batch, "actual_forward_mode", forward_batch.forward_mode
             ),
-            input_ids=getattr(forward_batch, "input_ids", None),
-            positions=getattr(forward_batch, "positions", None),
+            input_ids=forward_batch.input_ids,
+            positions=forward_batch.positions,
             req_pool_indices=forward_batch.req_pool_indices,
             seq_lens=forward_batch.seq_lens,
             seq_lens_sum=forward_batch.seq_lens_sum,
             seq_lens_cpu=forward_batch.seq_lens_cpu,
             encoder_lens=None,
-            out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
+            out_cache_loc=forward_batch.out_cache_loc,
             spec_info=forward_batch.spec_info,
         )
         if in_capture:

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -1687,14 +1687,14 @@ class DeepseekV4MultiStepBackend(DeepseekV4HipRadixBackend):
             actual_forward_mode=getattr(
                 forward_batch, "actual_forward_mode", forward_batch.forward_mode
             ),
-            input_ids=getattr(forward_batch, "input_ids", None),
-            positions=getattr(forward_batch, "positions", None),
+            input_ids=forward_batch.input_ids,
+            positions=forward_batch.positions,
             req_pool_indices=forward_batch.req_pool_indices,
             seq_lens=forward_batch.seq_lens,
             seq_lens_sum=forward_batch.seq_lens_sum,
             seq_lens_cpu=forward_batch.seq_lens_cpu,
             encoder_lens=None,
-            out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
+            out_cache_loc=forward_batch.out_cache_loc,
             spec_info=forward_batch.spec_info,
         )
         if in_capture:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -716,7 +716,7 @@ class DeepseekSparseAttnBackend(
             seq_lens_cpu=seq_lens_cpu,
             forward_mode=forward_batch.forward_mode,
             spec_info=forward_batch.spec_info,
-            out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
+            out_cache_loc=forward_batch.out_cache_loc,
             actual_forward_mode=getattr(forward_batch, "actual_forward_mode", None),
         )
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -547,9 +547,7 @@ class CompressorBackendMixin:
                 layer_id=layer_id,
                 compressor=compressor,
                 kv_score_input=kv_score_input,
-                logical_forward_mode=getattr(
-                    forward_batch, "_original_forward_mode", None
-                )
+                logical_forward_mode=forward_batch._original_forward_mode
                 or forward_batch.forward_mode,
             )
 

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -213,7 +213,7 @@ class FlashAttentionBackend(AttentionBackend):
             self.sliding_window_size is not None and self.sliding_window_size > -1
         )
 
-        self.is_prefill_aware_swa = getattr(model_runner, "prefill_aware_swa", False)
+        self.is_prefill_aware_swa = model_runner.prefill_aware_swa
         if self.is_prefill_aware_swa:
             assert self.page_size == 1, (
                 "Prefill-aware SWA requires page_size=1, "
@@ -354,7 +354,7 @@ class FlashAttentionBackend(AttentionBackend):
         encoder_lens = forward_batch.encoder_lens
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
-        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        out_cache_loc = forward_batch.out_cache_loc
 
         if in_capture:
             num_tokens = forward_batch.positions.numel()

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -560,8 +560,8 @@ class FlashInferAttnBackend(AttentionBackend):
         if precomputed_indices is None:
             return MultiItemScoringParams()
 
-        prefix_cache_lens = getattr(forward_batch, "extend_prefix_lens_cpu", None)
-        extend_seq_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+        prefix_cache_lens = forward_batch.extend_prefix_lens_cpu
+        extend_seq_lens = forward_batch.extend_seq_lens_cpu
         prefix_len_ptr, token_pos_in_items_ptr = [], []
         token_pos_in_items_len = 0
         device = forward_batch.input_ids.device

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -202,7 +202,7 @@ class MambaAttnBackendBase(AttentionBackend):
             mamba_cache_indices=mamba_cache_indices,
             # Physical track destinations (None when tracking off); cuda-graph
             # supplies this via the static backend buffer in _replay_metadata.
-            mamba_track_indices=getattr(forward_batch, "mamba_track_indices", None),
+            mamba_track_indices=forward_batch.mamba_track_indices,
             retrieve_next_token=retrieve_next_token,
             retrieve_next_sibling=retrieve_next_sibling,
             retrieve_parent_token=retrieve_parent_token,
@@ -231,7 +231,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 0 if in_capture else getattr(forward_batch, "num_padding", None)
             ),
             in_capture=in_capture,
-            mamba_track_indices=getattr(forward_batch, "mamba_track_indices", None),
+            mamba_track_indices=forward_batch.mamba_track_indices,
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
@@ -715,7 +715,7 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
                 0 if in_capture else getattr(forward_batch, "num_padding", None)
             ),
             in_capture=in_capture,
-            mamba_track_indices=getattr(forward_batch, "mamba_track_indices", None),
+            mamba_track_indices=forward_batch.mamba_track_indices,
         )
         spec_info = forward_batch.spec_info
         draft_token_num = spec_info.draft_token_num if spec_info is not None else 1

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -215,7 +215,7 @@ class Mamba2Metadata(ForwardMetadata):
                 if forward_batch.spec_info is not None
                 else 1
             )
-            num_decodes = getattr(forward_batch, "_original_batch_size", None)
+            num_decodes = forward_batch._original_batch_size
             if num_decodes is None:
                 num_decodes = len(forward_batch.seq_lens)
             return cls.prepare_decode(
@@ -234,7 +234,7 @@ class Mamba2Metadata(ForwardMetadata):
             num_prefill_tokens = int(sum(extend_seq_lens_cpu))
         else:
             num_prefill_tokens = int(forward_batch.extend_num_tokens)
-        batch_size = getattr(forward_batch, "_original_batch_size", None)
+        batch_size = forward_batch._original_batch_size
         if batch_size is None:
             batch_size = len(forward_batch.seq_lens)
         num_decodes = batch_size - num_prefills

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -167,7 +167,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         # cuda-graph replay views are a SimpleNamespace without extend_seq_lens_cpu,
         # and TARGET_VERIFY sets it to None despite is_extend() — getattr covers both.
         self._msa_dec_meta = None
-        extend_lens = forward_batch.extend_seq_lens_cpu
+        extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
         if extend_lens is not None:
             self._max_seqlen_q = int(max(extend_lens))
         else:

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -167,7 +167,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         # cuda-graph replay views are a SimpleNamespace without extend_seq_lens_cpu,
         # and TARGET_VERIFY sets it to None despite is_extend() — getattr covers both.
         self._msa_dec_meta = None
-        extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+        extend_lens = forward_batch.extend_seq_lens_cpu
         if extend_lens is not None:
             self._max_seqlen_q = int(max(extend_lens))
         else:

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -165,9 +165,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         self, forward_batch: ForwardBatch, in_capture: bool = False
     ):
         # cuda-graph replay views are a SimpleNamespace without extend_seq_lens_cpu,
-        # and TARGET_VERIFY sets it to None despite is_extend() — getattr covers both.
+        # and TARGET_VERIFY sets it to None despite is_extend().
         self._msa_dec_meta = None
-        extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+        extend_lens = (
+            forward_batch.extend_seq_lens_cpu
+            if isinstance(forward_batch, ForwardBatch)
+            else None
+        )
         if extend_lens is not None:
             self._max_seqlen_q = int(max(extend_lens))
         else:

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -49,7 +49,7 @@ class TboAttnBackend(AttentionBackend):
         )
         if not self._children_use_cuda_graph():
             return
-        tbo_children = getattr(forward_batch, "tbo_children", None)
+        tbo_children = forward_batch.tbo_children
         if tbo_children is not None:
             for child, forward_batch_child in zip(
                 self.children, tbo_children, strict=True
@@ -115,7 +115,7 @@ class TboAttnBackend(AttentionBackend):
         self.primary.init_forward_metadata_in_graph(forward_batch=forward_batch)
         if not self._children_use_cuda_graph():
             return
-        tbo_children = getattr(forward_batch, "tbo_children", None)
+        tbo_children = forward_batch.tbo_children
         if tbo_children is not None:
             for child, forward_batch_child in zip(
                 self.children, tbo_children, strict=True

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -1,11 +1,9 @@
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Callable, List
+from typing import Callable, List
 
 from sglang.srt.batch_overlap import two_batch_overlap
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-
-if TYPE_CHECKING:
-    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
 class TboAttnBackend(AttentionBackend):
@@ -41,7 +39,7 @@ class TboAttnBackend(AttentionBackend):
 
     def init_forward_metadata_out_graph(
         self,
-        forward_batch: "ForwardBatch",
+        forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
         self.primary.init_forward_metadata_out_graph(
@@ -49,7 +47,11 @@ class TboAttnBackend(AttentionBackend):
         )
         if not self._children_use_cuda_graph():
             return
-        tbo_children = getattr(forward_batch, "tbo_children", None)
+        tbo_children = (
+            forward_batch.tbo_children
+            if isinstance(forward_batch, ForwardBatch)
+            else None
+        )
         if tbo_children is not None:
             for child, forward_batch_child in zip(
                 self.children, tbo_children, strict=True
@@ -111,7 +113,7 @@ class TboAttnBackend(AttentionBackend):
                 forward_batch=child_fb_view, in_capture=False
             )
 
-    def init_forward_metadata_in_graph(self, forward_batch: "ForwardBatch"):
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
         self.primary.init_forward_metadata_in_graph(forward_batch=forward_batch)
         if not self._children_use_cuda_graph():
             return
@@ -125,7 +127,7 @@ class TboAttnBackend(AttentionBackend):
                         forward_batch=forward_batch_child
                     )
 
-    def init_forward_metadata(self, forward_batch: "ForwardBatch"):
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
         self.primary.init_forward_metadata(forward_batch=forward_batch)
         if forward_batch.tbo_children is not None:
             for child, forward_batch_child in zip(
@@ -166,7 +168,7 @@ class TboAttnBackend(AttentionBackend):
     def forward_decode(self, *args, **kwargs):
         return self.primary.forward_decode(*args, **kwargs)
 
-    def get_indexer_metadata(self, layer_id: int, forward_batch: "ForwardBatch"):
+    def get_indexer_metadata(self, layer_id: int, forward_batch: ForwardBatch):
         return self.primary.get_indexer_metadata(layer_id, forward_batch)
 
     def __getattr__(self, name):

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -49,7 +49,7 @@ class TboAttnBackend(AttentionBackend):
         )
         if not self._children_use_cuda_graph():
             return
-        tbo_children = forward_batch.tbo_children
+        tbo_children = getattr(forward_batch, "tbo_children", None)
         if tbo_children is not None:
             for child, forward_batch_child in zip(
                 self.children, tbo_children, strict=True

--- a/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
+++ b/python/sglang/srt/layers/attention/tokenspeed_mla_backend.py
@@ -240,7 +240,7 @@ class TokenspeedMLABackend(TRTLLMMLABackend):
             k_pe=k_pe,
             cos_sin_cache=layer.rotary_emb.cos_sin_cache,
             positions=positions,
-            is_neox=getattr(layer.rotary_emb, "is_neox_style", True),
+            is_neox=layer.rotary_emb.is_neox_style,
             qk_nope_head_dim=layer.qk_nope_head_dim,
             qk_rope_head_dim=layer.qk_rope_head_dim,
         )

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -153,7 +153,7 @@ class TritonAttnBackend(AttentionBackend):
         self.use_sliding_window_kv_pool = isinstance(self.token_to_kv_pool, SWAKVPool)
         # Lets the Triton wrappers specialize on PAGE_SIZE; page_size=1 is
         # byte-identical to the slot-based envelope.
-        self.page_size = getattr(model_runner, "page_size", 1) or 1
+        self.page_size = model_runner.page_size or 1
         # Unified pool v2p hook (None = no-op): req_to_token holds VIRTUAL ids but
         # kernels need PHYSICAL. Applied eagerly so the captured graph has no translate.
         self._translate_kv_loc = getattr(

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -513,7 +513,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             ):
                 self.forward_prefill_metadata = None
             # Get maximum sequence length.
-            if getattr(forward_batch, "seq_lens_cpu", None) is not None:
+            if forward_batch.seq_lens_cpu is not None:
                 max_seq = forward_batch.seq_lens_cpu.max().item()
             else:
                 max_seq = forward_batch.seq_lens.max().item()

--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -1058,7 +1058,7 @@ class XPUAttentionBackend(AttentionBackend):
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
-        seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+        seq_lens_cpu = forward_batch.seq_lens_cpu
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
 

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -396,11 +396,11 @@ class HiCacheController:
             except Exception:
                 pass
 
-        alive = [t for t in threads if getattr(t, "is_alive", lambda: False)()]
+        alive = [t for t in threads if t.is_alive()]
         if alive:
             logger.error(
                 "Failed to stop HiCache storage threads cleanly: %s",
-                [getattr(t, "name", repr(t)) for t in alive],
+                [t.name for t in alive],
             )
             raise RuntimeError("Failed to stop HiCache storage threads cleanly.")
 

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -940,9 +940,7 @@ def _embed_mm_inputs_with_split(
     non_precomputed_req_indices = []
     for idx, mm_input in enumerate(mm_inputs_list):
         items = [item for item in mm_input.mm_items if item is not None]
-        if items and all(
-            getattr(item, "precomputed_embeddings", None) is not None for item in items
-        ):
+        if items and all(item.precomputed_embeddings is not None for item in items):
             precomputed_req_indices.append(idx)
         else:
             non_precomputed_req_indices.append(idx)
@@ -1120,13 +1118,11 @@ def general_mm_embed_routine(
                 for mm_input_obj in mm_inputs_list:
                     if mm_input_obj and hasattr(mm_input_obj, "mm_items"):
                         for mm_item in mm_input_obj.mm_items:
-                            feature = getattr(mm_item, "feature", None)
+                            feature = mm_item.feature
                             if isinstance(feature, torch.Tensor) and feature.is_cuda:
                                 mm_item.feature = feature.to("cpu", non_blocking=True)
                             if get_server_args().language_only:
-                                precomputed_embeddings = getattr(
-                                    mm_item, "precomputed_embeddings", None
-                                )
+                                precomputed_embeddings = mm_item.precomputed_embeddings
                                 if (
                                     isinstance(precomputed_embeddings, torch.Tensor)
                                     and precomputed_embeddings.is_cuda

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -145,7 +145,7 @@ class RelayPayload:
             topk_p=draft_input.topk_p,
             topk_index=draft_input.topk_index,
             hidden_states=draft_input.hidden_states,
-            draft_probs=getattr(draft_input, "draft_probs", None),
+            draft_probs=draft_input.draft_probs,
             dsa_topk_indices=draft_input.dsa_topk_indices,
         )
 

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -1025,7 +1025,7 @@ class SchedulerMetricsReporter:
                 for batch in self.scheduler.running_mbs:
                     if batch:
                         for req in batch.reqs:
-                            if hasattr(req, "lora_id") and req.lora_id is not None:
+                            if req.lora_id is not None:
                                 active_lora_ids.add(req.lora_id)
             # For normal mode, check running_batch
             elif self.scheduler.running_batch:

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -130,7 +130,7 @@ class SchedulerMetricsReporter:
             "cpu": "cpu graph",
             "npu": "npu graph",
             "musa": "musa graph",
-        }.get(getattr(self.scheduler, "device", ""), "cuda graph")
+        }.get(self.scheduler.device, "cuda graph")
 
         # Cumulative spec-decoding counters (reset every decode_log_interval).
         # Each update adds (num_correct_drafts + bs, bs).
@@ -370,8 +370,8 @@ class SchedulerMetricsReporter:
         hf_text_config = model_config.hf_text_config
 
         hidden_size = float(model_config.hidden_size)
-        num_layers = float(getattr(model_config, "num_attention_layers", 0))
-        head_dim = float(getattr(model_config, "head_dim", 0))
+        num_layers = float(model_config.num_attention_layers)
+        head_dim = float(model_config.head_dim)
         num_attn_heads = float(
             model_config.get_num_attention_heads(self.scheduler.ps.tp_size)
         )
@@ -1023,16 +1023,15 @@ class SchedulerMetricsReporter:
             # For PP mode, check all running micro batches
             if self.scheduler.server_args.pp_size > 1:
                 for batch in self.scheduler.running_mbs:
-                    if batch and hasattr(batch, "reqs"):
+                    if batch:
                         for req in batch.reqs:
                             if hasattr(req, "lora_id") and req.lora_id is not None:
                                 active_lora_ids.add(req.lora_id)
             # For normal mode, check running_batch
             elif self.scheduler.running_batch:
-                if hasattr(self.scheduler.running_batch, "reqs"):
-                    for req in self.scheduler.running_batch.reqs:
-                        if hasattr(req, "lora_id") and req.lora_id is not None:
-                            active_lora_ids.add(req.lora_id)
+                for req in self.scheduler.running_batch.reqs:
+                    if req.lora_id is not None:
+                        active_lora_ids.add(req.lora_id)
 
             # Count active adapters (excluding None for base model)
             slots_used = len(active_lora_ids)

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -38,7 +38,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.page_size = page_size
 
         full_kv_pool = getattr(kvcache, "full_kv_pool", None)
-        swa_kv_pool = getattr(kvcache, "swa_kv_pool", None)
+        swa_kv_pool = kvcache.swa_kv_pool
 
         if page_size == 1:
             self.full_attn_allocator = TokenToKVPoolAllocator(

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -78,7 +78,7 @@ def free_swa_out_of_window_slots(
     assert (
         req.cache_protected_len % page_size == 0
     ), "cache_protected_len must be page aligned"
-    evict_floor = max(req.cache_protected_len, getattr(req, "swa_evict_floor", 0))
+    evict_floor = max(req.cache_protected_len, req.swa_evict_floor)
     if page_size > 1 and evict_floor > req.cache_protected_len:
         evict_floor = -(-evict_floor // page_size) * page_size
     req.swa_evicted_seqlen = max(req.swa_evicted_seqlen, evict_floor)
@@ -113,7 +113,7 @@ def free_swa_out_of_window_slots(
 
 
 def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
-    if getattr(req, "skip_radix_cache_insert", False):
+    if req.skip_radix_cache_insert:
         return
 
     tree_cache.cache_unfinished_req(req, **kwargs)
@@ -646,7 +646,7 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
 
     tree_cache.cache_finished_req(
         req,
-        is_insert=is_insert and not getattr(req, "skip_radix_cache_insert", False),
+        is_insert=is_insert and not req.skip_radix_cache_insert,
     )
 
     # StreamingSession.cache_finished_req handles speculative tail trim

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -665,7 +665,7 @@ class HiCacheFile(HiCacheStorage):
         for transfer in transfers:
             host_pool = self.registered_pools[transfer.name]
             keys = transfer.keys or []
-            page_size = getattr(host_pool, "page_size", 1) or 1
+            page_size = host_pool.page_size or 1
             expected = len(keys) * page_size
             host_indices = transfer.host_indices
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2551,11 +2551,11 @@ class HybridLinearKVPool(KVCache):
 
     @property
     def post_capture_active(self) -> bool:
-        return getattr(self.full_kv_pool, "post_capture_active", False)
+        return self.full_kv_pool.post_capture_active
 
     @property
     def post_capture_backed_bytes(self) -> int:
-        return getattr(self.full_kv_pool, "post_capture_backed_bytes", 0)
+        return self.full_kv_pool.post_capture_backed_bytes
 
     def finalize_backing(self, config) -> None:
         # Only the attention KV is resized; the mamba state cache is fixed pre-capture.

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -461,7 +461,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
 
         # Radix Cache takes one ref in memory pool
         if is_insert:
-            priority = getattr(req, "priority", 0) or 0
+            priority = req.priority or 0
             result = self.insert(
                 InsertParams(key=radix_key, value=values, priority=priority)
             )

--- a/python/sglang/srt/mem_cache/session_radix_cache.py
+++ b/python/sglang/srt/mem_cache/session_radix_cache.py
@@ -58,7 +58,7 @@ class SessionRadixCacheMixin:
         if not self.enable_session_radix_cache:
             return
         self._ensure_session_radix_state()
-        sid = getattr(req, "session_id", None)
+        sid = req.session_id
         if sid is None or sid in self._closed_session_ids:
             return
         if node is None:

--- a/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
@@ -580,7 +580,7 @@ class HiCacheHF3FS(HiCacheStorage):
             return
         super().register_mem_host_pool_v2(host_pool, host_pool_name)
 
-        pool_page_size = getattr(host_pool, "page_size", 1) or 1
+        pool_page_size = host_pool.page_size or 1
         pool_bytes_per_page = host_pool.get_ksize_per_token() * pool_page_size
         pool_num_pages = self.file_size // pool_bytes_per_page
         pool_file_path = f"{self.file_path}.{host_pool_name}"
@@ -727,7 +727,7 @@ class HiCacheHF3FS(HiCacheStorage):
         host_pool = self.registered_pools[pool_name]
         keys = transfer.keys
         host_indices = transfer.host_indices
-        page_size = getattr(host_pool, "page_size", 1) or 1
+        page_size = host_pool.page_size or 1
         page_num = len(keys)
 
         component_keys = [f"{key}_{pool_name}" for key in keys]
@@ -785,7 +785,7 @@ class HiCacheHF3FS(HiCacheStorage):
         host_pool = self.registered_pools[pool_name]
         keys = transfer.keys
         host_indices = transfer.host_indices
-        page_size = getattr(host_pool, "page_size", 1) or 1
+        page_size = host_pool.page_size or 1
         page_num = len(keys)
 
         component_keys = [f"{key}_{pool_name}" for key in keys]

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -829,7 +829,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         for transfer in transfers:
             host_pool = getattr(self, "registered_pools", {}).get(transfer.name)
             keys = transfer.keys
-            page_size = getattr(host_pool, "page_size", 1) or 1
+            page_size = host_pool.page_size or 1
             host_indices = transfer.host_indices
             assert len(keys) > 0
             assert len(keys) == len(host_indices) // page_size

--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -351,7 +351,7 @@ class HiCacheNixl(HiCacheStorage):
             self.is_zero_copy = False
             self._logical_anchor = True
             marker_numel = 4096 if self.needs_page_alignment else 1
-            pin_memory = bool(getattr(mem_pool_host, "pin_memory", False))
+            pin_memory = bool(mem_pool_host.pin_memory)
             self._bounce_page_bytes = marker_numel
             self._bounce_set = self._alloc_registered(
                 marker_numel, torch.uint8, pin_memory, "logical_anchor_set"
@@ -394,7 +394,7 @@ class HiCacheNixl(HiCacheStorage):
             page_numel = sample.numel()
             self._bounce_page_bytes = page_numel * sample.element_size()
             del sample
-            pin_memory = bool(getattr(mem_pool_host, "pin_memory", False))
+            pin_memory = bool(mem_pool_host.pin_memory)
             self._bounce_set = self._alloc_registered(
                 page_numel, mem_pool_host.dtype, pin_memory, "bounce_set"
             )
@@ -429,7 +429,7 @@ class HiCacheNixl(HiCacheStorage):
             page_bytes = page_numel * sample.element_size()
             del sample
 
-            pin_memory = bool(getattr(host_pool, "pin_memory", False))
+            pin_memory = bool(host_pool.pin_memory)
             bounce_set = self._alloc_registered(
                 page_numel, host_pool.dtype, pin_memory, f"{host_pool_name}_bounce_set"
             )
@@ -532,7 +532,7 @@ class HiCacheNixl(HiCacheStorage):
         host_pool = ctx.host_pool
         keys = transfer.keys or []
         host_indices = transfer.host_indices
-        page_size = getattr(host_pool, "page_size", 1) or 1
+        page_size = host_pool.page_size or 1
         expected = len(keys) * page_size
         if host_indices is None or host_indices.numel() != expected:
             logger.error(

--- a/python/sglang/srt/mem_cache/storage/umbp/umbp_store.py
+++ b/python/sglang/srt/mem_cache/storage/umbp/umbp_store.py
@@ -884,7 +884,7 @@ class UMBPStore(HiCacheStorage):
             return
         if not hasattr(self.client, "register_memory"):
             return
-        if getattr(self, "_disable_zero_copy_register", False):
+        if self._disable_zero_copy_register:
             logger.info(
                 "UMBPStore: skipping host KV buffer RDMA registration because "
                 "disable_zero_copy_register=true (UMBP_DISABLE_ZERO_COPY_REGISTER). "
@@ -1215,13 +1215,13 @@ class UMBPStore(HiCacheStorage):
         return bool(self.client.flush())
 
     def close(self) -> None:
-        if getattr(self, "_kv_events_subscriber", None) is not None:
+        if self._kv_events_subscriber is not None:
             try:
                 self._kv_events_subscriber.stop()
             except Exception:
                 logger.exception("KVEventsSubscriber stop during close failed")
             self._kv_events_subscriber = None
-        if getattr(self, "client", None) is None:
+        if self.client is None:
             return
         try:
             self.flush()

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -738,7 +738,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         if is_insert:
             insert_params = InsertParams(
                 prev_prefix_len=req.cache_protected_len,
-                priority=getattr(req, "priority", 0) or 0,
+                priority=req.priority or 0,
             )
 
             # components prepare insert data + return effective cache_len
@@ -777,8 +777,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
         self.dec_lock_ref(
             req.last_node,
-            DecLockRefParams(swa_uuid_for_lock=getattr(req, "swa_uuid_for_lock", None)),
-            skip_swa=getattr(req, "swa_prefix_lock_released", False),
+            DecLockRefParams(swa_uuid_for_lock=req.swa_uuid_for_lock),
+            skip_swa=req.swa_prefix_lock_released,
         )
 
         # cleanup
@@ -808,7 +808,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         insert_params = InsertParams(
             prev_prefix_len=req.cache_protected_len,
             chunked=chunked,
-            priority=getattr(req, "priority", 0) or 0,
+            priority=req.priority or 0,
         )
         effective_cache_len = len(token_ids)
         for comp in self._components_tuple:
@@ -867,7 +867,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
         self.dec_lock_ref(
             req.last_node,
-            DecLockRefParams(swa_uuid_for_lock=getattr(req, "swa_uuid_for_lock", None)),
+            DecLockRefParams(swa_uuid_for_lock=req.swa_uuid_for_lock),
         )
         lock_result = self.inc_lock_ref(new_last_node)
 
@@ -2913,7 +2913,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         if x is None:
             errors.append(
                 f"[{label}][{ct}] broken chain: lru_next is None "
-                f"after node {prev.id if hasattr(prev, 'id') else 'head'}"
+                f"after node {prev.id if prev.id is not None else 'head'}"
             )
         if len(visited) != len(lru.cache):
             errors.append(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -876,11 +876,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
             model_runner.lora_manager.prepare_lora_batch(ret)
 
-        if (
-            getattr(model_runner, "dcp_size", 1) > 1
-            and ret.out_cache_loc is not None
-            and is_hip()
-        ):
+        if model_runner.dcp_size > 1 and ret.out_cache_loc is not None and is_hip():
             ret.dcp_kv_mask = (
                 ret.positions % model_runner.dcp_size == model_runner.dcp_rank
             )
@@ -1534,15 +1530,15 @@ def build_inner_fb_view(
         batch_size=bs,
         forward_mode=forward_mode,
         actual_forward_mode=forward_batch.forward_mode,
-        input_ids=getattr(forward_batch, "input_ids", None),
-        positions=getattr(forward_batch, "positions", None),
+        input_ids=forward_batch.input_ids,
+        positions=forward_batch.positions,
         req_pool_indices=forward_batch.req_pool_indices,
         seq_lens=forward_batch.seq_lens,
         seq_lens_sum=forward_batch.seq_lens_sum,
         seq_lens_cpu=forward_batch.seq_lens_cpu,
         encoder_lens=encoder_lens,
-        out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
-        out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),
+        out_cache_loc=forward_batch.out_cache_loc,
+        out_cache_loc_dsv4=forward_batch.out_cache_loc_dsv4,
         spec_info=forward_batch.spec_info,
     )
 

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -317,7 +317,7 @@ class BaseRunner(ABC):
                 if mr.ngram_embedding_manager.enabled
                 else None
             ),
-            hc_hidden_size=getattr(mr.model_config, "hc_hidden_size", None),
+            hc_hidden_size=mr.model_config.hc_hidden_size,
             pp_proxy_topk_size=mr.get_pp_proxy_topk_size(),
         )
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -165,8 +165,8 @@ def build_replay_fb_view(
         seq_lens_cpu=buffers.seq_lens_cpu[:bs],
         num_padding=bs - raw_bs,
         encoder_lens=buffers.encoder_lens[:bs] if is_encoder_decoder else None,
-        out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
-        out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),
+        out_cache_loc=forward_batch.out_cache_loc,
+        out_cache_loc_dsv4=forward_batch.out_cache_loc_dsv4,
         # The mamba-track registry slot (VIRTUAL ids) is the v2p translate SOURCE
         # for the backend, which copies the result into its own static buffer and
         # reads THAT in the decode track-save — this slot is never mutated. None
@@ -366,9 +366,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 if self.use_ngram_embedding
                 else None
             ),
-            hc_hidden_size=getattr(
-                self.model_runner.model_config, "hc_hidden_size", None
-            ),
+            hc_hidden_size=self.model_runner.model_config.hc_hidden_size,
             pp_proxy_topk_size=self.model_runner.get_pp_proxy_topk_size(),
         )
         self.buffers.share_buffers()

--- a/python/sglang/srt/model_executor/runner_backend/cuda_graph_dedup_mixin.py
+++ b/python/sglang/srt/model_executor/runner_backend/cuda_graph_dedup_mixin.py
@@ -304,7 +304,7 @@ class DedupedCudaGraphMixin:
 
     def _memory_saver_cuda_graph_enabled(self) -> bool:
         adapter = getattr(self, "_memory_saver_adapter", None)
-        if adapter is not None and getattr(adapter, "enabled", False):
+        if adapter is not None and adapter.enabled:
             return True
 
         model_runner = getattr(self, "model_runner", None)
@@ -313,7 +313,7 @@ class DedupedCudaGraphMixin:
         server_args = getattr(model_runner, "server_args", None)
         return bool(
             server_args is not None
-            and getattr(server_args, "enable_memory_saver", False)
+            and server_args.enable_memory_saver
             and get_bool_env_var("SGLANG_MEMORY_SAVER_CUDA_GRAPH")
         )
 

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -581,7 +581,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                     "SGLang does not support resizing target embeddings for DFLASH yet."
                 )
 
-            tokenizer = getattr(self.target_worker, "tokenizer", None)
+            tokenizer = self.target_worker.tokenizer
             if tokenizer is not None:
                 token_id_from_vocab = tokenizer.get_vocab().get(mask_token, None)
                 if (
@@ -595,7 +595,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                     )
             return resolved_id
 
-        tokenizer = getattr(self.target_worker, "tokenizer", None)
+        tokenizer = self.target_worker.tokenizer
         if tokenizer is None:
             raise RuntimeError(
                 "DFLASH requires tokenizer initialization when dflash_config.mask_token_id is not set "
@@ -603,8 +603,8 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
 
         resolved_id = None
-        if getattr(tokenizer, "mask_token", None) == mask_token:
-            resolved_id = getattr(tokenizer, "mask_token_id", None)
+        if tokenizer.mask_token == mask_token:
+            resolved_id = tokenizer.mask_token_id
 
         if resolved_id is None:
             # Prefer checking the explicit vocab mapping first.
@@ -615,7 +615,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             # Mirror the reference DFlash HF demo by adding the mask token to the tokenizer.
             # This is safe only when the resulting id stays within the target model vocab size.
             added = tokenizer.add_special_tokens({"mask_token": mask_token})
-            resolved_id = getattr(tokenizer, "mask_token_id", None)
+            resolved_id = tokenizer.mask_token_id
             if resolved_id is None:
                 resolved_id = tokenizer.convert_tokens_to_ids(mask_token)
 
@@ -1218,7 +1218,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         on_publish=None,
     ) -> GenerationBatchResult:
-        if getattr(batch, "return_logprob", False):
+        if batch.return_logprob:
             raise ValueError(
                 "DFLASH speculative decoding does not support return_logprob yet."
             )

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -359,7 +359,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         on_publish=None,
     ) -> GenerationBatchResult:
-        if getattr(batch, "return_logprob", False):
+        if batch.return_logprob:
             raise ValueError(
                 "DSpark speculative decoding does not support return_logprob yet."
             )

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -37,6 +37,7 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     Phase,
@@ -1609,18 +1610,15 @@ class EAGLEWorkerV2(BaseSpecWorker):
             accept_index,
         ) = eagle_sample(verify_input, batch, logits_output, vocab_mask)
         new_seq_lens = batch.seq_lens + accept_lens
-        clear_unaccepted_c128 = getattr(
-            self.token_to_kv_pool_allocator.get_kvcache(),
-            "clear_unaccepted_c128_draft_states",
-            None,
-        )
-        if clear_unaccepted_c128 is not None and not batch.forward_mode.is_idle():
-            clear_unaccepted_c128(
-                batch.req_pool_indices,
-                batch.seq_lens,
-                accept_lens,
-                self.speculative_num_draft_tokens,
-            )
+        if not batch.forward_mode.is_idle():
+            kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
+            if isinstance(kv_cache, DeepSeekV4TokenToKVPool):
+                kv_cache.clear_unaccepted_c128_draft_states(
+                    batch.req_pool_indices,
+                    batch.seq_lens,
+                    accept_lens,
+                    self.speculative_num_draft_tokens,
+                )
 
         # Update mamba state for hybrid GDN models after verification
         commit_mamba_states_after_verify(


### PR DESCRIPTION
## Motivation

Fix defensive `getattr`/`hasattr` usage across the codebase as defined in [#29871](https://github.com/sgl-project/sglang/pull/29871) ([`no-getattr-defensive.md`](https://github.com/sgl-project/sglang/blob/main/.claude/rules/no-getattr-defensive.md)). Each case replaces `getattr(obj, "field", default)` / `hasattr(obj, "field")` with either `isinstance` type-narrowing or direct attribute access, for fields that always exist on the object type.

**Includes one bugfix**: `encode_receiver.py` had 3 sites of `getattr(scheduler, "gpu_id", 0)` that always returned the default 0 — `Scheduler` stores gpu_id as `self.ps.gpu_id`, not `self.gpu_id`.

## Changes by subsystem

### disaggregation/ (6 files)
- `decode.py`: `isinstance` check for `clear_c128_req_state`; `req.finished_output`
- `utils.py`: `isinstance` check for `get_c128_state_buf_infos`
- `encode_receiver.py`: **BUGFIX** `scheduler.ps.gpu_id`; `server_args.tokenizer_backend`; `recv_obj.error_msg/error_code`; `hf_config.model_type`; `scheduler.model_config`
- `prefill.py`: `scheduler.req_to_token_pool`; `req.bootstrap_room`
- `common/conn.py`: `server_args.enable_dsa_cache_layer_split`
- `encode_server.py`: `hf_config.model_type`

### mem_cache/ (11 files)
- Req fields (always set in `__init__`): `priority`, `swa_evict_floor`, `skip_radix_cache_insert`, `swa_uuid_for_lock`, `swa_prefix_lock_released`, `session_id`
- `HostKVCache` fields: `page_size` (5 sites), `pin_memory` (3 sites)
- `memory_pool`: `post_capture_active`/`backed_bytes` on `KVCache`/`BaseKVPool`
- `allocator/swa`: `swa_kv_pool` on `BaseSWAKVPool`
- `umbp_store`: `_disable_zero_copy_register`, `_kv_events_subscriber`, `client`

### speculative/ (3 files)
- `eagle_worker_v2.py`: `isinstance(kv_cache, DeepSeekV4TokenToKVPool)` for `clear_unaccepted_c128_draft_states`
- `dflash_worker_v2.py`: `batch.return_logprob`; `target_worker.tokenizer`; `tokenizer.mask_token/mask_token_id`
- `dspark_worker_v2.py`: `batch.return_logprob`

### layers/attention/ (14 files)
- ForwardBatch `@dataclass` fields: `input_ids`, `positions`, `out_cache_loc`, `out_cache_loc_dsv4`, `spec_info`, `_original_forward_mode`, `_original_batch_size`, `seq_lens_cpu`, `extend_prefix_lens_cpu`, `extend_seq_lens_cpu`, `mamba_track_indices`, `tbo_children`
- `model_runner.page_size`/`prefill_aware_swa`
- `RotaryEmbedding.is_neox_style`

### model_executor/ (4 files)
- `model_config.hc_hidden_size`, `model_runner.dcp_size`
- `ForwardBatch` dataclass fields
- `server_args.enable_memory_saver`
- `adapter.enabled` (TorchMemorySaverAdapter property)

### managers/ (4 files)
- `model_config.num_attention_layers`/`head_dim`
- `scheduler.device`; redundant `hasattr(batch, "reqs")`; `req.lora_id`
- `Thread.is_alive`/`name`; `MultimodalDataItem.feature`/`precomputed_embeddings`
- `EagleDraftInput.draft_probs`























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29384409590](https://github.com/sgl-project/sglang/actions/runs/29384409590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29384409489](https://github.com/sgl-project/sglang/actions/runs/29384409489)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->