### PR TITLE
(fix) Prevent unknown HTTP paths from overloading Prometheus metrics generation

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2444,7 +2444,9 @@ def add_prometheus_track_response_middleware(
     async def track_http_status_code(request, call_next):
         # With recording all requests, we have the risk of high cardinality if requests have arbitrary unhandled paths.
         # But given that SGLang engines with metrics enabled are usually behind routers this looks safe.
-        path, is_handled_path = _get_fastapi_request_path(request)
+        path, is_handled_path = _get_normalized_fastapi_request_path_for_metrics(
+            request
+        )
         method = request.method
         routing_key = request.headers.get("x-smg-routing-key")
 
@@ -2482,6 +2484,19 @@ def _get_fastapi_request_path(request) -> Tuple[str, bool]:
             return getattr(route, "path", request.url.path), True
 
     return request.url.path, False
+
+
+def _get_normalized_fastapi_request_path_for_metrics(request) -> Tuple[str, bool]:
+    """Return a route path suitable for metrics labels.
+
+    Handled requests use FastAPI's route template. Unhandled requests are
+    collapsed to a single label to prevent unbounded cardinality growth.
+    """
+    path, is_handled_path = _get_fastapi_request_path(request)
+    if not is_handled_path:
+        # Collapse arbitrary unknown paths to prevent unbounded cardinality growth.
+        path = "__unhandled__"
+    return path, is_handled_path
 
 
 # Copy from pytorch and OpenRLHF to allow creating multiple main groups.

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2626,7 +2626,9 @@ def add_prometheus_track_response_middleware(
     async def track_http_status_code(request, call_next):
         # With recording all requests, we have the risk of high cardinality if requests have arbitrary unhandled paths.
         # But given that SGLang engines with metrics enabled are usually behind routers this looks safe.
-        path, is_handled_path = _get_fastapi_request_path(request)
+        path, is_handled_path = _get_normalized_fastapi_request_path_for_metrics(
+            request
+        )
         method = request.method
         routing_key = request.headers.get("x-smg-routing-key")
 
@@ -2664,6 +2666,19 @@ def _get_fastapi_request_path(request) -> Tuple[str, bool]:
             return getattr(route, "path", request.url.path), True
 
     return request.url.path, False
+
+
+def _get_normalized_fastapi_request_path_for_metrics(request) -> Tuple[str, bool]:
+    """Return a route path suitable for metrics labels.
+
+    Handled requests use FastAPI's route template. Unhandled requests are
+    collapsed to a single label to prevent unbounded cardinality growth.
+    """
+    path, is_handled_path = _get_fastapi_request_path(request)
+    if not is_handled_path:
+        # Collapse arbitrary unknown paths to prevent unbounded cardinality growth.
+        path = "__unhandled__"
+    return path, is_handled_path
 
 
 # Copy from pytorch and OpenRLHF to allow creating multiple main groups.

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -4,6 +4,7 @@ from array import array
 import torch
 
 from sglang.srt.utils.common import (
+    _get_normalized_fastapi_request_path_for_metrics,
     flatten_arrays_to_int64_tensor,
     get_device_sm_nvidia_smi,
     get_nvidia_driver_version_str,
@@ -13,6 +14,59 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small-amd")
+
+
+def _make_request(app, path: str, method: str = "GET"):
+    from starlette.requests import Request
+
+    return Request(
+        {
+            "type": "http",
+            "app": app,
+            "method": method,
+            "path": path,
+            "root_path": "",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+
+class TestGetNormalizedFastapiRequestPathForMetrics(CustomTestCase):
+    def test_handled_path_returns_route_path(self):
+        from fastapi import FastAPI
+
+        app = FastAPI()
+
+        @app.get("/v1/models/{model_id}")
+        def get_model(model_id: str):
+            return {"model_id": model_id}
+
+        path, is_handled_path = _get_normalized_fastapi_request_path_for_metrics(
+            _make_request(app, "/v1/models/test-model")
+        )
+
+        self.assertEqual(path, "/v1/models/{model_id}")
+        self.assertTrue(is_handled_path)
+
+    def test_unhandled_path_collapses_to_single_metric_label(self):
+        from fastapi import FastAPI
+
+        app = FastAPI()
+
+        @app.get("/v1/models")
+        def list_models():
+            return {}
+
+        path, is_handled_path = _get_normalized_fastapi_request_path_for_metrics(
+            _make_request(app, "/scanner/probe-specific-path")
+        )
+
+        self.assertEqual(path, "__unhandled__")
+        self.assertFalse(is_handled_path)
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")


### PR DESCRIPTION
## Motivation

This change prevents unbounded Prometheus cardinality growth caused by arbitrary unknown HTTP paths.

One real-world example is vulnerability scanners, which can probe tens of thousands of unique random endpoints. When the raw request path is used as the endpoint metric label, every unique unknown path creates a new Prometheus time series for the HTTP request/response metrics.

In one production incident, a vulnerability scanner generated approximately **17,700 unique unknown endpoints**, producing metric series such as:

```text
sglang:http_requests_total{endpoint="/.../.../.../.../.../.../.../.../.../.../../../../../../../../../../etc/passwd",method="GET"} 1.0
sglang:http_requests_total{endpoint="/${jndi:ldap://localhost",method="GET"} 2.0
```

This significantly inflated the Prometheus multiprocess metric files:

```
counter_1.db         8 MB
gauge_livesum_1.db   4 MB
histogram_1.db      64 KB
```

The `/metrics` endpoint rebuilds the Prometheus exposition on every scrape. In multiprocess mode, this means scanning and reading the *.db files, merging samples, serializing all metrics, and optionally compressing the response. This work runs in Python on the main ASGI thread and can execute under the GIL.

While reproducing the issue, I continuously sent chat completion requests while sampling the SGLang process with [pyspy](https://github.com/benfred/py-spy). 

Across all samples, the main thread was consistently inside the Prometheus metrics generation path:
for example
```
Thread 1 (active): "MainThread"
    compress (gzip.py:616)
    _bake_output (prometheus_client/exposition.py:116)
    prometheus_app (prometheus_client/asgi.py:24)
    handle (starlette/routing.py:448)
```
or 
```
Thread 1 (active+gil): "MainThread"
    add_sample (prometheus_client/metrics_core.py:35)
    _read_metrics (prometheus_client/multiprocess.py:82)
    merge (prometheus_client/multiprocess.py:43)
    collect (prometheus_client/multiprocess.py:158)
    collect (prometheus_client/registry.py:97)
    generate_latest (prometheus_client/exposition.py:289)
```

Together with the enlarged multiprocess metric files, this explained why the frontend accepted HTTP connections but stopped making progress on completion requests: the main ASGI thread was repeatedly rebuilding and serializing a high-cardinality metrics payload during `/metrics` scrapes.

With this change, even under vulnerability scans or other arbitrary requests, these files remain small:

```
counter_1.db         64 KB
gauge_livesum_1.db   64 KB
histogram_1.db       64 KB
```

Since the metrics endpoint reconstructs the Prometheus exposition by reading and merging these multiprocess files on every scrape, the increased number of time series significantly increased metrics generation cost. In our production incident, the server eventually spent a significant amount of CPU time generating /metrics, reducing its ability to serve completion requests.

## Modifications

Unhandled FastAPI paths are now reported as `endpoint="__unhandled__"` instead of using the raw request path.

Known routes continue to use their normalized route paths, preserving the existing metrics for handled endpoints while preventing unbounded cardinality for unknown paths.

## Accuracy Tests
## Speed Tests and Profiling

Not applicable. This PR only changes HTTP metrics path labeling for unhandled FastAPI routes and does not affect model outputs, kernels, or model forward code.






<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33681213917](https://github.com/sgl-project/sglang/actions/runs/33681213917)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33681213197](https://github.com/sgl-project/sglang/actions/runs/33681213197)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33681213726](https://github.com/sgl-project/sglang/actions/runs/33681213726)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->