### PR TITLE
Fix MXFP4 expert zero weight loading

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -727,7 +727,7 @@ class FusedMoE(torch.nn.Module):
         # if expert_id is None, then
         # all the experts are loaded at the same time
         if (
-            not expert_id
+            expert_id is None
             and self.quant_config is not None
             and self.quant_config.get_name() == "mxfp4"
             and self.quant_config.is_static_cfg()

--- a/test/registered/unit/layers/moe/test_mxfp4_expert_weight_loader.py
+++ b/test/registered/unit/layers/moe/test_mxfp4_expert_weight_loader.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _StaticMxfp4Config:
+    @staticmethod
+    def get_name():
+        return "mxfp4"
+
+    @staticmethod
+    def is_static_cfg():
+        return True
+
+
+def test_static_mxfp4_expert_zero_uses_per_expert_loader():
+    load_impl = Mock()
+    layer = SimpleNamespace(
+        quant_config=_StaticMxfp4Config(),
+        _map_global_expert_id_to_local_expert_id=lambda expert_id: expert_id,
+        _weight_loader_impl=load_impl,
+    )
+    param = torch.nn.Parameter(torch.empty(1))
+    loaded_weight = torch.empty((4, 8))
+
+    with patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer."
+        "get_global_expert_location_metadata",
+        return_value=None,
+    ):
+        FusedMoE.weight_loader(
+            layer,
+            param,
+            loaded_weight,
+            "experts.w1.weight",
+            "w1",
+            expert_id=0,
+        )
+
+    load_impl.assert_called_once_with(
+        param=param,
+        loaded_weight=loaded_weight,
+        weight_name="experts.w1.weight",
+        shard_id="w1",
+        expert_id=0,
+    )


### PR DESCRIPTION
## Summary

- distinguish the all-expert `None` sentinel from valid expert ID `0` in the static MXFP4 weight loader
- add a focused CPU regression for a 2-D per-expert MXFP4 weight with expert ID `0`

## Root cause

`FusedMoE.weight_loader` used `not expert_id` to detect an all-expert tensor. That condition is also true for expert ID `0`, so the loader entered the 3-D all-expert path and indexed `loaded_weight.shape[2]` on a 2-D per-expert tensor.

This small fix is also present in the broader open #21529; this PR splits the loader correctness change and its regression test into an independently reviewable patch.

## Impact

Static MXFP4 checkpoints loaded one expert at a time can fail while loading expert zero with `IndexError: tuple index out of range`.

## Validation

- `python3 -m pytest -q test/registered/unit/layers/moe/test_mxfp4_expert_weight_loader.py`
- `python3 -m ruff check python/sglang/srt/layers/moe/fused_moe_triton/layer.py test/registered/unit/layers/moe/test_mxfp4_expert_weight_loader.py`























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29341502637](https://github.com/sgl-project/sglang/actions/runs/29341502637)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29341502576](https://github.com/sgl-project/sglang/actions/runs/29341502576)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->