### PR TITLE
[LoRA] Fuse absorbed-MLA kv_b_proj LoRA correction (4 kernels → 2)

### DIFF
--- a/python/sglang/kernels/ops/gemm/__init__.py
+++ b/python/sglang/kernels/ops/gemm/__init__.py
@@ -151,6 +151,8 @@ _TRITON_KERNELS = [
     ("kv_b_lora_absorbed", "step_b_q_fwd"),
     ("kv_b_lora_absorbed", "step_a_v_fwd"),
     ("kv_b_lora_absorbed", "step_b_v_fwd"),
+    ("kv_b_lora_absorbed", "q_side_fused_fwd"),
+    ("kv_b_lora_absorbed", "v_side_fused_fwd"),
 ]
 for _mod, _fn in _TRITON_KERNELS:
     register_kernel(

--- a/python/sglang/kernels/ops/gemm/kv_b_lora_absorbed.py
+++ b/python/sglang/kernels/ops/gemm/kv_b_lora_absorbed.py
@@ -44,6 +44,8 @@ over it is acceptable.  ``tl.dot`` itself uses fp32 accumulation internally.
 
 from __future__ import annotations
 
+import os
+
 import torch
 import triton
 import triton.language as tl
@@ -850,4 +852,454 @@ def step_b_v_fwd(
         BLOCK_N=_STEP_B_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
     )
+    return base_output
+
+
+# ===========================================================================
+# Fused variants -- collapse each 2-kernel side into ONE kernel.
+#
+# The split path writes the small ``(S, H, rank)`` step-A intermediate to
+# global memory and step B immediately reads it back. For the decode-shape
+# workload ``rank`` is tiny (16-32), so that global round trip plus the second
+# launch dominate the cost. The fused kernels below keep the per-(token-tile,
+# head) rank intermediate in registers and run the second contraction in the
+# same program: 4 launches -> 2, and no global round trip for the intermediate.
+#
+# Generality matches the split path exactly: per-slot ``weight_indices``
+# routing, ``permutation`` (SORTED_BY_ADAPTER), ``use_cuda_graph`` segment
+# grid, mixed / zero per-slot ranks, per-slot ``scalings``, accumulate in
+# place. Precision matches too -- the rank intermediate is cast back to the
+# input dtype between the two dots, exactly as the split kernels store/reload
+# it -- so the fused path is numerically equivalent, not merely algebraically.
+#
+# Because the whole padded-rank intermediate stays resident, the fused path
+# only wins while that is small. Above ``_fuse_max_rank()`` (or on any launch
+# failure) we fall back to the split kernels, which are correct at any rank.
+# ===========================================================================
+
+_FUSE_BLOCK_S = 32
+_FUSE_BLOCK_K = 64
+_FUSE_BLOCK_N = 128
+_FUSE_MAX_RANK_DEFAULT = 64  # padded rank; covers typical kv_b_proj LoRA (<=32)
+
+
+def _next_pow2(x: int) -> int:
+    return 1 << (max(1, x) - 1).bit_length()
+
+
+def _fuse_max_rank() -> int:
+    """Largest padded rank the fused path attempts before falling back.
+
+    Fusing keeps the ``(BLOCK_S, R_pad)`` rank intermediate resident, so the
+    win fades as rank grows. The default fuses the common kv_b_proj LoRA ranks
+    (<=32, padded to 32) with headroom; ``SGLANG_MLA_LORA_FUSE_MAX_RANK``
+    overrides it (offline sweeps on this kernel put the A100 crossover near 96
+    and H100 near 128). Ranks above the limit use the always-correct split
+    kernels.
+    """
+    env = os.environ.get("SGLANG_MLA_LORA_FUSE_MAX_RANK")
+    if env is not None:
+        try:
+            return int(env)
+        except ValueError:
+            pass
+    return _FUSE_MAX_RANK_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# Fused q-side: step A_q + step B_q in one kernel.
+#
+#     base[t,h,n] += ((q_nope[t,h,:] @ B_kc[slot,h]) @ A[slot])[n] * scaling
+#
+# Compute the (BLOCK_S, R_PAD) rank intermediate once (contract qk_nope), keep
+# it in registers, then contract it against A over the kv_lora_rank output.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit(do_not_specialize=["num_segments"])
+def _fused_q_kernel(
+    q,
+    B,
+    A,
+    base,
+    # dims
+    S,
+    K_qk,  # qk_nope (step-A contraction)
+    N_kv,  # kv_lora_rank (step-B output)
+    # strides
+    q_stride_s,
+    q_stride_h,
+    q_stride_k,
+    B_stride_l,
+    B_stride_n,
+    B_stride_k,
+    A_stride_l,
+    A_stride_r,
+    A_stride_k,
+    b_stride_s,
+    b_stride_h,
+    b_stride_n,
+    # batch info
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    scalings,
+    sorted_token_ids,
+    num_segments,
+    # meta
+    FULL_K: tl.constexpr,  # per-head row stride in B (qk_nope + v_head_dim)
+    SORTED_BY_ADAPTER: tl.constexpr,
+    R_PAD: tl.constexpr,  # padded rank (pow2, >=16) -- the fused intermediate width
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    batch_id = tl.program_id(axis=2)
+    head_id = tl.program_id(axis=1)
+    pid_s = tl.program_id(axis=0)
+
+    if batch_id >= num_segments:
+        return
+
+    w_index = tl.load(weight_indices + batch_id)
+    cur_rank = tl.load(lora_ranks + w_index)
+    if cur_rank == 0:
+        return
+
+    seg_start = tl.load(seg_indptr + batch_id)
+    seg_end = tl.load(seg_indptr + batch_id + 1)
+    seg_len = seg_end - seg_start
+    if seg_len == 0:
+        return
+    if pid_s * BLOCK_S >= seg_len:
+        return
+    scaling = tl.load(scalings + w_index)
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    row_mask = s_offset < seg_len
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+    safe_row = tl.minimum(s_physical, S - 1)
+
+    r_offset = tl.arange(0, R_PAD)
+    r_mask = r_offset < cur_rank
+    head_row_base = head_id * FULL_K
+
+    # --- step A: a[BLOCK_S, R_PAD] = q[:, h, :qk_nope] @ B_kc[h] ---
+    a = tl.zeros((BLOCK_S, R_PAD), dtype=tl.float32)
+    for k_block in range(0, tl.cdiv(K_qk, BLOCK_K)):
+        cur_k = k_block * BLOCK_K + tl.arange(0, BLOCK_K)
+        k_mask = cur_k < K_qk
+        safe_k = tl.minimum(cur_k, K_qk - 1)
+        q_tile = tl.load(
+            q
+            + safe_row[:, None] * q_stride_s
+            + head_id * q_stride_h
+            + safe_k[None, :] * q_stride_k,
+            mask=row_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        # B[slot, h*FULL_K + i, r]: row = i (GEMM K), col = r (GEMM N)
+        B_tile = tl.load(
+            B
+            + w_index * B_stride_l
+            + (head_row_base + safe_k[:, None]) * B_stride_n
+            + r_offset[None, :] * B_stride_k,
+            mask=k_mask[:, None] & r_mask[None, :],
+            other=0.0,
+        )
+        a += tl.dot(q_tile, B_tile)
+    a = a.to(A.dtype.element_ty)  # round-trip through input dtype (matches split path)
+
+    # --- step B: out[:, n] = a @ A[slot][:, n] * scaling, tiled over kv_lora_rank ---
+    for n_start in range(0, N_kv, BLOCK_N):
+        n_offset = n_start + tl.arange(0, BLOCK_N)
+        n_mask = n_offset < N_kv
+        safe_n = tl.minimum(n_offset, N_kv - 1)
+        A_tile = tl.load(
+            A
+            + w_index * A_stride_l
+            + r_offset[:, None] * A_stride_r
+            + safe_n[None, :] * A_stride_k,
+            mask=r_mask[:, None] & n_mask[None, :],
+            other=0.0,
+        )
+        acc = tl.dot(a, A_tile) * scaling
+        base_offs = (
+            safe_row[:, None] * b_stride_s
+            + head_id * b_stride_h
+            + safe_n[None, :] * b_stride_n
+        )
+        out_mask = row_mask[:, None] & n_mask[None, :]
+        acc += tl.load(base + base_offs, mask=out_mask, other=0.0)
+        tl.store(base + base_offs, acc.to(base.dtype.element_ty), mask=out_mask)
+
+
+def q_side_fused_fwd(
+    q_nope: torch.Tensor,
+    B_buf: torch.Tensor,
+    A_buf: torch.Tensor,
+    batch_info: LoRABatchInfo,
+    base_output: torch.Tensor,
+    full_K_per_head: int,
+) -> torch.Tensor:
+    """Fused q-side correction: ``step_a_q_fwd`` + ``step_b_q_fwd`` in one kernel.
+
+    Same result and generality as the split path, accumulating into
+    ``base_output`` (``(S, H, kv_lora_rank)``). Falls back to the split kernels
+    when the padded rank exceeds :func:`_fuse_max_rank` or the launch fails.
+    """
+    S, H, qk_nope_dim = q_nope.shape
+    kv_lora_rank = A_buf.shape[-1]
+    R_pad = max(16, _next_pow2(A_buf.shape[1]))
+    if R_pad > _fuse_max_rank():
+        q_lora_a = step_a_q_fwd(q_nope, B_buf, batch_info, full_K_per_head)
+        return step_b_q_fwd(q_lora_a, A_buf, batch_info, base_output)
+
+    num_segments = _num_segments(batch_info)
+    max_segment_len = _max_segment_len(batch_info)
+    segment_grid = _segment_grid_size(batch_info, num_segments)
+    grid = (triton.cdiv(max_segment_len, _FUSE_BLOCK_S), H, segment_grid)
+    try:
+        _fused_q_kernel[grid](
+            q_nope,
+            B_buf,
+            A_buf,
+            base_output,
+            S,
+            qk_nope_dim,
+            kv_lora_rank,
+            q_nope.stride(0),
+            q_nope.stride(1),
+            q_nope.stride(2),
+            B_buf.stride(0),
+            B_buf.stride(1),
+            B_buf.stride(2),
+            A_buf.stride(0),
+            A_buf.stride(1),
+            A_buf.stride(2),
+            base_output.stride(0),
+            base_output.stride(1),
+            base_output.stride(2),
+            batch_info.seg_indptr,
+            batch_info.weight_indices,
+            batch_info.lora_ranks,
+            batch_info.scalings,
+            batch_info.permutation,
+            segment_grid,
+            FULL_K=full_K_per_head,
+            SORTED_BY_ADAPTER=batch_info.permutation is not None,
+            R_PAD=R_pad,
+            BLOCK_S=_FUSE_BLOCK_S,
+            BLOCK_N=_FUSE_BLOCK_N,
+            BLOCK_K=_FUSE_BLOCK_K,
+        )
+    except Exception:
+        q_lora_a = step_a_q_fwd(q_nope, B_buf, batch_info, full_K_per_head)
+        return step_b_q_fwd(q_lora_a, A_buf, batch_info, base_output)
+    return base_output
+
+
+# ---------------------------------------------------------------------------
+# Fused v-side: step A_v + step B_v in one kernel.
+#
+#     base[t,h,j] += ((attn[t,h,:] @ A[slot].T) @ B_vc[slot,h].T)[j] * scaling
+#
+# Compute the (BLOCK_S, R_PAD) rank intermediate once (contract kv_lora_rank),
+# then contract it against the V-half of B over the v_head_dim output.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit(do_not_specialize=["num_segments"])
+def _fused_v_kernel(
+    x,
+    A,
+    B,
+    base,
+    # dims
+    S,
+    K_kv,  # kv_lora_rank (step-A contraction)
+    N_v,  # v_head_dim (step-B output)
+    # strides
+    x_stride_s,
+    x_stride_h,
+    x_stride_k,
+    A_stride_l,
+    A_stride_r,
+    A_stride_k,
+    B_stride_l,
+    B_stride_n,
+    B_stride_k,
+    b_stride_s,
+    b_stride_h,
+    b_stride_n,
+    # batch info
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    scalings,
+    sorted_token_ids,
+    num_segments,
+    # meta
+    FULL_K: tl.constexpr,  # qk_nope + v_head_dim
+    QK_NOPE_OFFSET: tl.constexpr,  # offset of V-half within each head's row block
+    SORTED_BY_ADAPTER: tl.constexpr,
+    R_PAD: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    batch_id = tl.program_id(axis=2)
+    head_id = tl.program_id(axis=1)
+    pid_s = tl.program_id(axis=0)
+
+    if batch_id >= num_segments:
+        return
+
+    w_index = tl.load(weight_indices + batch_id)
+    cur_rank = tl.load(lora_ranks + w_index)
+    if cur_rank == 0:
+        return
+
+    seg_start = tl.load(seg_indptr + batch_id)
+    seg_end = tl.load(seg_indptr + batch_id + 1)
+    seg_len = seg_end - seg_start
+    if seg_len == 0:
+        return
+    if pid_s * BLOCK_S >= seg_len:
+        return
+    scaling = tl.load(scalings + w_index)
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    row_mask = s_offset < seg_len
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+    safe_row = tl.minimum(s_physical, S - 1)
+
+    r_offset = tl.arange(0, R_PAD)
+    r_mask = r_offset < cur_rank
+
+    # --- step A: a[BLOCK_S, R_PAD] = attn[:, h, :kv] @ A.T (contract kv_lora_rank) ---
+    a = tl.zeros((BLOCK_S, R_PAD), dtype=tl.float32)
+    for k_block in range(0, tl.cdiv(K_kv, BLOCK_K)):
+        cur_k = k_block * BLOCK_K + tl.arange(0, BLOCK_K)
+        k_mask = cur_k < K_kv
+        safe_k = tl.minimum(cur_k, K_kv - 1)
+        x_tile = tl.load(
+            x
+            + safe_row[:, None] * x_stride_s
+            + head_id * x_stride_h
+            + safe_k[None, :] * x_stride_k,
+            mask=row_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        # A[slot, r, k]: read k along contraction (GEMM K), r along output (GEMM N)
+        A_tile = tl.load(
+            A
+            + w_index * A_stride_l
+            + safe_k[:, None] * A_stride_k
+            + r_offset[None, :] * A_stride_r,
+            mask=k_mask[:, None] & r_mask[None, :],
+            other=0.0,
+        )
+        a += tl.dot(x_tile, A_tile)
+    a = a.to(B.dtype.element_ty)
+
+    # --- step B: out[:, j] = a @ B_vc[h].T * scaling, tiled over v_head_dim ---
+    head_row_base = head_id * FULL_K + QK_NOPE_OFFSET
+    for n_start in range(0, N_v, BLOCK_N):
+        n_offset = n_start + tl.arange(0, BLOCK_N)
+        n_mask = n_offset < N_v
+        safe_n = tl.minimum(n_offset, N_v - 1)
+        # B[slot, h*FULL_K + qk_nope + j, r]: row = j (GEMM N), col = r (GEMM K)
+        B_tile = tl.load(
+            B
+            + w_index * B_stride_l
+            + (head_row_base + safe_n[None, :]) * B_stride_n
+            + r_offset[:, None] * B_stride_k,
+            mask=r_mask[:, None] & n_mask[None, :],
+            other=0.0,
+        )  # (R_PAD, BLOCK_N)
+        acc = tl.dot(a, B_tile) * scaling
+        base_offs = (
+            safe_row[:, None] * b_stride_s
+            + head_id * b_stride_h
+            + safe_n[None, :] * b_stride_n
+        )
+        out_mask = row_mask[:, None] & n_mask[None, :]
+        acc += tl.load(base + base_offs, mask=out_mask, other=0.0)
+        tl.store(base + base_offs, acc.to(base.dtype.element_ty), mask=out_mask)
+
+
+def v_side_fused_fwd(
+    attn_output: torch.Tensor,
+    A_buf: torch.Tensor,
+    B_buf: torch.Tensor,
+    batch_info: LoRABatchInfo,
+    base_output: torch.Tensor,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+) -> torch.Tensor:
+    """Fused v-side correction: ``step_a_v_fwd`` + ``step_b_v_fwd`` in one kernel.
+
+    Same result and generality as the split path, accumulating into
+    ``base_output`` (``(S, H, v_head_dim)``). Falls back to the split kernels
+    when the padded rank exceeds :func:`_fuse_max_rank` or the launch fails.
+    """
+    S, H, kv_lora_rank = attn_output.shape
+    full_K_per_head = qk_nope_head_dim + v_head_dim
+    R_pad = max(16, _next_pow2(A_buf.shape[1]))
+    if R_pad > _fuse_max_rank():
+        attn_lora_a = step_a_v_fwd(attn_output, A_buf, batch_info)
+        return step_b_v_fwd(
+            attn_lora_a, B_buf, batch_info, base_output, qk_nope_head_dim, v_head_dim
+        )
+
+    num_segments = _num_segments(batch_info)
+    max_segment_len = _max_segment_len(batch_info)
+    segment_grid = _segment_grid_size(batch_info, num_segments)
+    grid = (triton.cdiv(max_segment_len, _FUSE_BLOCK_S), H, segment_grid)
+    block_n = max(16, _next_pow2(v_head_dim))
+    try:
+        _fused_v_kernel[grid](
+            attn_output,
+            A_buf,
+            B_buf,
+            base_output,
+            S,
+            kv_lora_rank,
+            v_head_dim,
+            attn_output.stride(0),
+            attn_output.stride(1),
+            attn_output.stride(2),
+            A_buf.stride(0),
+            A_buf.stride(1),
+            A_buf.stride(2),
+            B_buf.stride(0),
+            B_buf.stride(1),
+            B_buf.stride(2),
+            base_output.stride(0),
+            base_output.stride(1),
+            base_output.stride(2),
+            batch_info.seg_indptr,
+            batch_info.weight_indices,
+            batch_info.lora_ranks,
+            batch_info.scalings,
+            batch_info.permutation,
+            segment_grid,
+            FULL_K=full_K_per_head,
+            QK_NOPE_OFFSET=qk_nope_head_dim,
+            SORTED_BY_ADAPTER=batch_info.permutation is not None,
+            R_PAD=R_pad,
+            BLOCK_S=_FUSE_BLOCK_S,
+            BLOCK_N=block_n,
+            BLOCK_K=_FUSE_BLOCK_K,
+        )
+    except Exception:
+        attn_lora_a = step_a_v_fwd(attn_output, A_buf, batch_info)
+        return step_b_v_fwd(
+            attn_lora_a, B_buf, batch_info, base_output, qk_nope_head_dim, v_head_dim
+        )
     return base_output

--- a/python/sglang/kernels/ops/gemm/kv_b_lora_absorbed.py
+++ b/python/sglang/kernels/ops/gemm/kv_b_lora_absorbed.py
@@ -870,11 +870,13 @@ def step_b_v_fwd(
 # grid, mixed / zero per-slot ranks, per-slot ``scalings``, accumulate in
 # place. Rounding mirrors the split path too: the rank intermediate is cast to
 # the activation dtype between the two dots (as step-A does), and the scaled
-# delta is rounded to the output dtype *before* it is added to the base value
-# (as step-B does). The only remaining difference is that the low-rank
-# contraction is a single ``tl.dot`` here vs. the split step-B's tiled
-# accumulation, so the two agree to within fp32 reassociation (a few ULPs),
-# not bitwise.
+# delta is rounded to the activation dtype *before* it is added to the base
+# value (as step-B does). These fused kernels use different tile shapes than
+# the split kernels, and the low-rank (rank) contraction is a single ``tl.dot``
+# here vs. the split step-B's tiled accumulation, so the fp32 reduction order
+# differs: the result matches the split path within the per-dtype tolerance and
+# is bit-identical on the tested shapes, but bitwise equality is not guaranteed
+# in general.
 #
 # Because the whole padded-rank intermediate stays resident, the fused path
 # only wins while that is small. Above ``_fuse_max_rank()`` (or on any launch
@@ -1031,9 +1033,11 @@ def _fused_q_kernel(
             mask=r_mask[:, None] & n_mask[None, :],
             other=0.0,
         )
-        # Mirror the split step-B rounding: round the scaled delta to the output
-        # dtype BEFORE adding the base value (step_b_q casts partial_sum then += base).
-        delta = (tl.dot(a, A_tile) * scaling).to(base.dtype.element_ty)
+        # Mirror the split step-B rounding: round the scaled delta to the
+        # activation dtype BEFORE adding the base value (step_b_q casts
+        # partial_sum to x.dtype -- the step-A intermediate / activation dtype --
+        # then += base), which may differ from the base-output dtype.
+        delta = (tl.dot(a, A_tile) * scaling).to(q.dtype.element_ty)
         base_offs = (
             safe_row[:, None] * b_stride_s
             + head_id * b_stride_h
@@ -1231,8 +1235,9 @@ def _fused_v_kernel(
             mask=r_mask[:, None] & n_mask[None, :],
             other=0.0,
         )  # (R_PAD, BLOCK_N)
-        # Mirror the split step-B rounding: round the scaled delta before += base.
-        delta = (tl.dot(a, B_tile) * scaling).to(base.dtype.element_ty)
+        # Mirror the split step-B rounding: round the scaled delta to the
+        # activation dtype (x.dtype) before adding the base value, as step_b_v does.
+        delta = (tl.dot(a, B_tile) * scaling).to(x.dtype.element_ty)
         base_offs = (
             safe_row[:, None] * b_stride_s
             + head_id * b_stride_h

--- a/python/sglang/kernels/ops/gemm/kv_b_lora_absorbed.py
+++ b/python/sglang/kernels/ops/gemm/kv_b_lora_absorbed.py
@@ -868,9 +868,13 @@ def step_b_v_fwd(
 # Generality matches the split path exactly: per-slot ``weight_indices``
 # routing, ``permutation`` (SORTED_BY_ADAPTER), ``use_cuda_graph`` segment
 # grid, mixed / zero per-slot ranks, per-slot ``scalings``, accumulate in
-# place. Precision matches too -- the rank intermediate is cast back to the
-# input dtype between the two dots, exactly as the split kernels store/reload
-# it -- so the fused path is numerically equivalent, not merely algebraically.
+# place. Rounding mirrors the split path too: the rank intermediate is cast to
+# the activation dtype between the two dots (as step-A does), and the scaled
+# delta is rounded to the output dtype *before* it is added to the base value
+# (as step-B does). The only remaining difference is that the low-rank
+# contraction is a single ``tl.dot`` here vs. the split step-B's tiled
+# accumulation, so the two agree to within fp32 reassociation (a few ULPs),
+# not bitwise.
 #
 # Because the whole padded-rank intermediate stays resident, the fused path
 # only wins while that is small. Above ``_fuse_max_rank()`` (or on any launch
@@ -1010,7 +1014,9 @@ def _fused_q_kernel(
             other=0.0,
         )
         a += tl.dot(q_tile, B_tile)
-    a = a.to(A.dtype.element_ty)  # round-trip through input dtype (matches split path)
+    # Cast the rank intermediate to the activation dtype, exactly as the split
+    # step-A kernel does (step_a_q stores partial_sum.to(x.dtype)).
+    a = a.to(q.dtype.element_ty)
 
     # --- step B: out[:, n] = a @ A[slot][:, n] * scaling, tiled over kv_lora_rank ---
     for n_start in range(0, N_kv, BLOCK_N):
@@ -1025,15 +1031,17 @@ def _fused_q_kernel(
             mask=r_mask[:, None] & n_mask[None, :],
             other=0.0,
         )
-        acc = tl.dot(a, A_tile) * scaling
+        # Mirror the split step-B rounding: round the scaled delta to the output
+        # dtype BEFORE adding the base value (step_b_q casts partial_sum then += base).
+        delta = (tl.dot(a, A_tile) * scaling).to(base.dtype.element_ty)
         base_offs = (
             safe_row[:, None] * b_stride_s
             + head_id * b_stride_h
             + safe_n[None, :] * b_stride_n
         )
         out_mask = row_mask[:, None] & n_mask[None, :]
-        acc += tl.load(base + base_offs, mask=out_mask, other=0.0)
-        tl.store(base + base_offs, acc.to(base.dtype.element_ty), mask=out_mask)
+        base_value = tl.load(base + base_offs, mask=out_mask, other=0.0)
+        tl.store(base + base_offs, delta + base_value, mask=out_mask)
 
 
 def q_side_fused_fwd(
@@ -1205,7 +1213,8 @@ def _fused_v_kernel(
             other=0.0,
         )
         a += tl.dot(x_tile, A_tile)
-    a = a.to(B.dtype.element_ty)
+    # Cast to the activation dtype, exactly as the split step_a_v kernel does.
+    a = a.to(x.dtype.element_ty)
 
     # --- step B: out[:, j] = a @ B_vc[h].T * scaling, tiled over v_head_dim ---
     head_row_base = head_id * FULL_K + QK_NOPE_OFFSET
@@ -1222,15 +1231,16 @@ def _fused_v_kernel(
             mask=r_mask[:, None] & n_mask[None, :],
             other=0.0,
         )  # (R_PAD, BLOCK_N)
-        acc = tl.dot(a, B_tile) * scaling
+        # Mirror the split step-B rounding: round the scaled delta before += base.
+        delta = (tl.dot(a, B_tile) * scaling).to(base.dtype.element_ty)
         base_offs = (
             safe_row[:, None] * b_stride_s
             + head_id * b_stride_h
             + safe_n[None, :] * b_stride_n
         )
         out_mask = row_mask[:, None] & n_mask[None, :]
-        acc += tl.load(base + base_offs, mask=out_mask, other=0.0)
-        tl.store(base + base_offs, acc.to(base.dtype.element_ty), mask=out_mask)
+        base_value = tl.load(base + base_offs, mask=out_mask, other=0.0)
+        tl.store(base + base_offs, delta + base_value, mask=out_mask)
 
 
 def v_side_fused_fwd(

--- a/python/sglang/srt/lora/deepseek_mla_correction.py
+++ b/python/sglang/srt/lora/deepseek_mla_correction.py
@@ -20,10 +20,8 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import torch
 
 from sglang.kernels.ops.gemm.kv_b_lora_absorbed import (
-    step_a_q_fwd,
-    step_a_v_fwd,
-    step_b_q_fwd,
-    step_b_v_fwd,
+    q_side_fused_fwd,
+    v_side_fused_fwd,
 )
 
 if TYPE_CHECKING:
@@ -72,6 +70,10 @@ def apply_q_correction(
 
       step A_q : ``(S,H,qk_nope) @ B_kc[slot, h] (qk_nope, rank) -> (S,H,rank)``
       step B_q : ``(S,H,rank)    @ A[slot] (rank, kv_lora_rank)  -> += q_nope_out``
+
+    The two steps are fused into a single kernel (keeping the small rank
+    intermediate in registers); it falls back to the split kernels for large
+    ranks or on any launch failure.
     """
     state = _get_state(attn_module)
     if state is None:
@@ -79,8 +81,9 @@ def apply_q_correction(
     A_buf, B_buf, batch_info = state
 
     full_K_per_head = attn_module.qk_nope_head_dim + attn_module.v_head_dim
-    q_lora_a = step_a_q_fwd(q_nope, B_buf, batch_info, full_K_per_head)
-    return step_b_q_fwd(q_lora_a, A_buf, batch_info, q_nope_out)
+    return q_side_fused_fwd(
+        q_nope, B_buf, A_buf, batch_info, q_nope_out, full_K_per_head
+    )
 
 
 def apply_v_correction(
@@ -100,12 +103,12 @@ def apply_v_correction(
         return attn_bmm_flat
     A_buf, B_buf, batch_info = state
 
-    attn_lora_a = step_a_v_fwd(attn_output, A_buf, batch_info)
     base_view = attn_bmm_flat.view(
         -1, attn_module.num_local_heads, attn_module.v_head_dim
     )
-    step_b_v_fwd(
-        attn_lora_a,
+    v_side_fused_fwd(
+        attn_output,
+        A_buf,
         B_buf,
         batch_info,
         base_view,

--- a/test/registered/lora/test_kv_b_lora_absorbed_fused.py
+++ b/test/registered/lora/test_kv_b_lora_absorbed_fused.py
@@ -1,0 +1,322 @@
+"""GPU regression for the fused absorbed-MLA ``kv_b_proj`` LoRA correction.
+
+Checks that the fused q/v-side kernels (:func:`q_side_fused_fwd` /
+:func:`v_side_fused_fwd`) produce the same result as the split 4-kernel path
+(``step_a_*`` -> ``step_b_*``) across a matrix that stresses the generality both
+paths support:
+
+  * non-uniform and empty segments,
+  * ``permutation`` (adapter-sorted routing),
+  * mixed and zero per-slot ranks,
+  * ``use_cuda_graph`` segment grid,
+  * fp16 / bf16, and a mixed FP16-activation / BF16-base-output case,
+  * large rank (fused path) and a forced fallback to the split kernels,
+  * many heads.
+
+For every config it additionally checks both paths against an fp32 reference, so
+a bug shared by both kernels is caught, not just divergence between them.
+
+The fuse/fallback threshold is forced via ``SGLANG_MLA_LORA_FUSE_MAX_RANK`` so the
+fused path is exercised at every rank (and to 0 for the forced-fallback case).
+"""
+
+import os
+import unittest
+from unittest import mock
+
+import torch
+
+import sglang.kernels.ops.gemm.kv_b_lora_absorbed as kvb
+from sglang.kernels.ops.gemm.kv_b_lora_absorbed import (
+    q_side_fused_fwd,
+    step_a_q_fwd,
+    step_a_v_fwd,
+    step_b_q_fwd,
+    step_b_v_fwd,
+    v_side_fused_fwd,
+)
+from sglang.srt.lora.utils import LoRABatchInfo
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, suite="nightly-1-gpu", nightly=True)
+
+_FUSE_ENV = "SGLANG_MLA_LORA_FUSE_MAX_RANK"
+_DTYPES = {"bf16": torch.bfloat16, "fp16": torch.float16}
+_TOL = {"bf16": 3e-2, "fp16": 1e-2}  # rel-err vs fp32 reference, per dtype
+
+# kv_b_proj dims for the tested model family (DeepSeek/Kimi absorbed MLA).
+_QK_NOPE, _V_HEAD, _KV_LORA = 128, 128, 512
+
+
+def _configs():
+    """Matrix of (name, seg_lens, ranks, slot_of_seg, H, dtype, base_dtype, perm,
+    cuda_graph, fuse_max_rank). ``slot_of_seg`` defaults to round-robin."""
+    return [
+        dict(name="decode_uniform", seg_lens=[1] * 8, ranks=[16]),
+        dict(name="prefill_uniform", seg_lens=[64] * 4, ranks=[16]),
+        dict(name="non_uniform_one_long", seg_lens=[1, 1, 200, 1, 1], ranks=[16]),
+        dict(name="empty_segments", seg_lens=[0, 50, 0, 30, 0], ranks=[16]),
+        dict(
+            name="permutation_non_uniform",
+            seg_lens=[1, 1, 128, 1],
+            ranks=[16],
+            perm=True,
+        ),
+        dict(
+            name="mixed_ranks",
+            seg_lens=[8, 8, 8, 8],
+            ranks=[8, 16, 32],
+            slot_of_seg=[0, 1, 2, 1],
+        ),
+        dict(
+            name="rank0_slot_noop",
+            seg_lens=[16, 16, 16],
+            ranks=[0, 16, 32],
+            slot_of_seg=[0, 1, 2],
+        ),
+        dict(name="cuda_graph_flag", seg_lens=[1] * 16, ranks=[16], cuda_graph=True),
+        dict(name="dtype_fp16", seg_lens=[32] * 4, ranks=[16], dtype="fp16"),
+        dict(name="big_rank_64", seg_lens=[8] * 4, ranks=[64]),
+        dict(name="big_rank_128", seg_lens=[8] * 4, ranks=[128]),
+        dict(name="many_heads_32", seg_lens=[4] * 8, ranks=[16], H=32),
+        dict(
+            name="large_batch",
+            seg_lens=[1, 1, 1, 300, 1, 1, 1, 50] * 2,
+            ranks=[16, 32],
+            perm=True,
+        ),
+        dict(
+            name="forced_fallback", seg_lens=[1, 1, 200, 1], ranks=[16], fuse_max_rank=0
+        ),
+        dict(
+            name="mixed_fp16act_bf16base",
+            seg_lens=[1, 1, 200, 1],
+            ranks=[16],
+            dtype="fp16",
+            base_dtype="bf16",
+        ),
+    ]
+
+
+def _build(cfg, device):
+    seg_lens = cfg["seg_lens"]
+    ranks = cfg["ranks"]
+    H = cfg.get("H", 16)
+    dt = _DTYPES[cfg.get("dtype", "bf16")]
+    base_dt = _DTYPES[cfg.get("base_dtype", cfg.get("dtype", "bf16"))]
+    qk, v, kv = _QK_NOPE, _V_HEAD, _KV_LORA
+    full_K = qk + v
+    nseg = len(seg_lens)
+    S = int(sum(seg_lens))
+    num_lora = len(ranks)
+    R_max = max(1, max(ranks))
+    slot_of_seg = cfg.get("slot_of_seg") or [i % num_lora for i in range(nseg)]
+
+    g = torch.Generator(device=device).manual_seed(1234)
+    rnd = (
+        lambda *shape, d=dt: torch.randn(*shape, generator=g, device=device, dtype=d)
+        * 0.1
+    )
+
+    seg_indptr = torch.tensor(
+        [0] + torch.tensor(seg_lens).cumsum(0).tolist(),
+        device=device,
+        dtype=torch.int32,
+    )
+    weight_indices = torch.tensor(slot_of_seg, device=device, dtype=torch.int32)
+    lora_ranks = torch.tensor(ranks, device=device, dtype=torch.int32)
+    scalings = (0.5 + torch.rand(num_lora, generator=g, device=device)).float()
+    perm = (
+        torch.randperm(S, generator=g, device=device).to(torch.int32)
+        if cfg.get("perm")
+        else None
+    )
+
+    batch_info = LoRABatchInfo(
+        use_cuda_graph=cfg.get("cuda_graph", False),
+        bs=nseg,
+        num_segments=nseg,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        scalings=scalings,
+        max_len=(max(seg_lens) if seg_lens else 0),
+        seg_lens=torch.tensor(seg_lens, device=device, dtype=torch.int32),
+        permutation=perm,
+    )
+    return dict(
+        q_nope=rnd(S, H, qk),
+        attn_output=rnd(S, H, kv),
+        A_buf=rnd(num_lora, R_max, kv),
+        B_buf=rnd(num_lora, H * full_K, R_max),
+        base_q=rnd(S, H, kv, d=base_dt),
+        base_v=rnd(S, H, v, d=base_dt),
+        batch_info=batch_info,
+        perm=perm,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        scalings=scalings,
+        nseg=nseg,
+        H=H,
+        qk=qk,
+        v=v,
+        full_K=full_K,
+    )
+
+
+def _fp32_reference(d):
+    """fp32 ground truth honoring permutation, per-slot rank truncation, scalings."""
+    qk, v, full_K, H = d["qk"], d["v"], d["full_K"], d["H"]
+    q_f, a_f = d["q_nope"].float(), d["attn_output"].float()
+    A_f, B_f = d["A_buf"].float(), d["B_buf"].float()
+    q_out, v_out = d["base_q"].float().clone(), d["base_v"].float().clone()
+    for seg in range(d["nseg"]):
+        s0 = int(d["seg_indptr"][seg])
+        s1 = int(d["seg_indptr"][seg + 1])
+        if s1 <= s0:
+            continue
+        w = int(d["weight_indices"][seg])
+        r = int(d["lora_ranks"][w])
+        if r == 0:
+            continue
+        scaling = float(d["scalings"][w])
+        rows = (
+            d["perm"][s0:s1].long()
+            if d["perm"] is not None
+            else torch.arange(s0, s1, device=q_f.device)
+        )
+        A_slot = A_f[w, :r, :]
+        for h in range(H):
+            b = h * full_K
+            B_kc = B_f[w, b : b + qk, :r]
+            B_vc = B_f[w, b + qk : b + full_K, :r]
+            q_out[rows, h, :] += (q_f[rows, h, :] @ B_kc) @ A_slot * scaling
+            v_out[rows, h, :] += (a_f[rows, h, :] @ A_slot.T) @ B_vc.T * scaling
+    return q_out, v_out
+
+
+def _relerr(a, b):
+    a, b = a.float(), b.float()
+    return (a - b).abs().max().item() / (b.abs().max().item() + 1e-6)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestKvBLoraAbsorbedFused(unittest.TestCase):
+    def test_fused_matches_split_and_reference(self):
+        device = "cuda"
+        for cfg in _configs():
+            with self.subTest(cfg=cfg["name"]):
+                d = _build(cfg, device)
+                bi, full_K, qk, v = d["batch_info"], d["full_K"], d["qk"], d["v"]
+                tol = max(
+                    _TOL[cfg.get("dtype", "bf16")],
+                    _TOL[cfg.get("base_dtype", cfg.get("dtype", "bf16"))],
+                )
+
+                q_ref, v_ref = _fp32_reference(d)
+
+                # Split path (BEFORE). Uses the module-level step_* references
+                # imported into this test namespace, so it is unaffected by the
+                # patches applied to ``kvb`` below.
+                q_split, v_split = d["base_q"].clone(), d["base_v"].clone()
+                step_b_q_fwd(
+                    step_a_q_fwd(d["q_nope"], d["B_buf"], bi, full_K),
+                    d["A_buf"],
+                    bi,
+                    q_split,
+                )
+                step_b_v_fwd(
+                    step_a_v_fwd(d["attn_output"], d["A_buf"], bi),
+                    d["B_buf"],
+                    bi,
+                    v_split,
+                    qk,
+                    v,
+                )
+
+                # Fused path (AFTER). Force fused at every rank (0 => split fallback).
+                forced = cfg.get("fuse_max_rank") == 0
+                prev = os.environ.get(_FUSE_ENV)
+                os.environ[_FUSE_ENV] = str(cfg.get("fuse_max_rank", 1_000_000))
+                q_fused, v_fused = d["base_q"].clone(), d["base_v"].clone()
+                try:
+                    # The fused wrappers catch *any* kernel exception and silently
+                    # run the split kernels instead. Patch the step-A entry points
+                    # (called first on every fallback route) so a fused config that
+                    # secretly falls back is caught rather than passing trivially.
+                    if forced:
+                        # forced_fallback MUST take the split path -- assert it did.
+                        with mock.patch.object(
+                            kvb, "step_a_q_fwd", wraps=kvb.step_a_q_fwd
+                        ) as mq, mock.patch.object(
+                            kvb, "step_a_v_fwd", wraps=kvb.step_a_v_fwd
+                        ) as mv:
+                            q_side_fused_fwd(
+                                d["q_nope"], d["B_buf"], d["A_buf"], bi, q_fused, full_K
+                            )
+                            v_side_fused_fwd(
+                                d["attn_output"],
+                                d["A_buf"],
+                                d["B_buf"],
+                                bi,
+                                v_fused,
+                                qk,
+                                v,
+                            )
+                        self.assertTrue(
+                            mq.called, "forced_fallback did not use split q path"
+                        )
+                        self.assertTrue(
+                            mv.called, "forced_fallback did not use split v path"
+                        )
+                    else:
+                        # Fused configs MUST NOT fall back -- any split call fails here.
+                        with mock.patch.object(
+                            kvb,
+                            "step_a_q_fwd",
+                            side_effect=AssertionError("q fused kernel fell back"),
+                        ), mock.patch.object(
+                            kvb,
+                            "step_a_v_fwd",
+                            side_effect=AssertionError("v fused kernel fell back"),
+                        ):
+                            q_side_fused_fwd(
+                                d["q_nope"], d["B_buf"], d["A_buf"], bi, q_fused, full_K
+                            )
+                            v_side_fused_fwd(
+                                d["attn_output"],
+                                d["A_buf"],
+                                d["B_buf"],
+                                bi,
+                                v_fused,
+                                qk,
+                                v,
+                            )
+                finally:
+                    if prev is None:
+                        os.environ.pop(_FUSE_ENV, None)
+                    else:
+                        os.environ[_FUSE_ENV] = prev
+
+                # Both paths must be correct vs the fp32 reference.
+                self.assertLess(_relerr(q_split, q_ref), tol, "split q vs fp32 ref")
+                self.assertLess(_relerr(v_split, v_ref), tol, "split v vs fp32 ref")
+                self.assertLess(_relerr(q_fused, q_ref), tol, "fused q vs fp32 ref")
+                self.assertLess(_relerr(v_fused, v_ref), tol, "fused v vs fp32 ref")
+
+                # Strict fused-vs-split regression. On the tested GPUs / Triton the
+                # fused output is bit-identical to the split path (the rank-contraction
+                # reduction-order difference is sub-output-ULP). If a future
+                # GPU/Triton produces a ~1-ULP difference, relax these to
+                # torch.testing.assert_close with a tight tolerance.
+                self.assertTrue(
+                    torch.equal(q_fused, q_split), f"[{cfg['name']}] fused q != split q"
+                )
+                self.assertTrue(
+                    torch.equal(v_fused, v_split), f"[{cfg['name']}] fused v != split v"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The absorbed-MLA `kv_b_proj` LoRA correction currently runs as **four** Triton kernels: each
side (q, v) does a step-A SGMM that writes a small `(S, H, rank)` intermediate to global
memory, then a step-B SGMM that immediately reads it back. At decode shapes `rank` is tiny
(16–32), so that global round trip plus the extra launch dominate.

## Modifications

- Adds fused `q_side_fused_fwd` / `v_side_fused_fwd` in
  `python/sglang/kernels/ops/gemm/kv_b_lora_absorbed.py` (exported from the package
  `__init__.py`), which keep the
  per-`(token-tile, head)` rank intermediate **in registers** and run the second contraction
  in the same program — **4 launches → 2**, with no global round trip for the intermediate.
- Switches the two call sites in `deepseek_mla_correction.py` to the fused wrappers.
- The fused kernels mirror the split path on every generality axis: per-slot
  `weight_indices` routing, `permutation` (`SORTED_BY_ADAPTER`), `use_cuda_graph` segment
  grid, mixed / zero per-slot ranks, per-slot `scalings`, accumulate-in-place.
- **Rounding mirrors the split path**: the rank intermediate is cast to the activation dtype
  between the two dots (as step-A does), and the scaled delta is rounded to the
  **activation** dtype *before* it is added to the base value (as step-B does — note the
  activation dtype may differ from the base-output dtype).
- The four split kernels are **kept as an always-correct fallback**. Above
  `_fuse_max_rank()` (default padded-rank 64, `SGLANG_MLA_LORA_FUSE_MAX_RANK`-overridable)
  or on any launch failure, the wrappers call the original `step_a_*`/`step_b_*` path — so
  behavior is unchanged for ranks that don't fuse. This is a strict superset.

## Accuracy Tests

`test/registered/lora/test_kv_b_lora_absorbed_fused.py` (nightly-1-gpu) checks the fused
q/v-side kernels against the split 4-kernel path across the full matrix (non-uniform / empty
segments, permutation, mixed & zero ranks, cuda-graph, fp16/bf16, mixed FP16-act/BF16-base,
large rank, many heads, forced fallback), and both paths against an fp32 reference.

```bash
python -m unittest test.registered.lora.test_kv_b_lora_absorbed_fused
```

Results on **A100-80GB and H100**, fused path engaged:

- **15/15 configs** (incl. a mixed FP16-activation / BF16-base case) are **bit-identical to
  the split path** on the tested shapes (max fused-vs-split rel-err **0.0**) and within
  fp32-reference tolerance.
- The tile shapes and the rank-contraction reduction order differ from the split kernels, so
  bit-identity is an observed property of the tested A100/H100 configurations, **not a
  guarantee**: outside that matrix, equivalence is expected within the stated dtype
  tolerance rather than bitwise.

## Speed Tests and Profiling

Standalone before/after harness (the split path vs. fused, both checked against an fp32
torch reference) over a matrix that stresses every generality axis above: non-uniform /
empty segments, permutation, mixed ranks incl. 0, cuda-graph, fp16/bf16, large rank, many
heads. CUDA-event median, 10 reps.

| GPU | median speedup (fused vs. split) | peak |
|---|---|---|
| A100-80GB | **~1.70×** | ~1.85× |
| H100 | **~1.68×** | ~1.85× |

At decode shapes (qk=v=128, `kv_lora_rank=512`, rank 16–32). Padded-rank 128 is ~parity
(0.99× A100 / 1.06× H100), which is why the fuse threshold falls back above it; offline
sweeps put the crossover near 96 (A100) / 128 (H100).

**Scope of the measurement.** Validated as a standalone kernel microbenchmark on synthetic
inputs (fixed head dims qk=v=128, `kv_lora_rank=512`) — not through a full model run. The
natural end-to-end regression for this path is
`test/registered/lora/test_lora_kimi_k25_logprob_diff.py` (Kimi-K2.5, 8×B200); I don't have
that hardware, so a maintainer run of that suite against this branch would be the ideal
final check.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`pre-commit run --files <changed files>` is clean.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing behavior change; the only new knob is the `SGLANG_MLA_LORA_FUSE_MAX_RANK` escape hatch.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes

Happy to adjust the fuse-threshold policy (env var vs. capability-gated constant) to match
project conventions.

This change was prepared with AI assistance (Claude). A human reviewed every changed line
and ran the tests and benchmarks above on A100 and H100 hardware.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30898692892](https://github.com/sgl-project/sglang/actions/runs/30898692892)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30898692507](https://github.com/sgl-project/sglang/actions/runs/30898692507)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
