### PR TITLE
fix: avoid HF re-sampling video frames when sglang already sampled (Qwen-VL)

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -422,6 +422,18 @@ class BaseMultimodalProcessor(ABC):
             kwargs["videos"] = videos
             if self.video_config:
                 kwargs.setdefault("videos_kwargs", {}).update(self.video_config)
+            # Frames may already be sampled by the sglang processor (e.g. the
+            # Qwen-VL preprocess_video) using mm_process_config; in that case
+            # do_sample_frames=False is passed at the top level. HF's
+            # _merge_kwargs does not route a top-level do_sample_frames into
+            # videos_kwargs, so it gets overridden by the video processor
+            # default (do_sample_frames=True) and HF re-samples using
+            # videos_kwargs["fps"], halving the visual tokens. Move it into
+            # videos_kwargs (and pop the top-level one to avoid HF's
+            # "passed two times" error) so it actually takes effect.
+            if kwargs.get("do_sample_frames") is False:
+                kwargs.pop("do_sample_frames", None)
+                kwargs.setdefault("videos_kwargs", {})["do_sample_frames"] = False
         if audios:
             if self._processor.__class__.__name__ in {
                 "Gemma3nProcessor",


### PR DESCRIPTION
## Motivation

Fixes #31200.

Since v0.5.11 (PR #18467), `BaseMultimodalProcessor.process_mm_data()` forwards the per-modality `--mm-process-config` into the HF processor via `videos_kwargs.update(self.video_config)`. For **Qwen-VL** video models this includes `fps` / `max_frames`.

However the Qwen-VL processor **already samples the video frames itself** in `preprocess_video()` (using the same `fps`/`max_frames`), and passes `do_sample_frames=False` at the top level of the processor call so HF won't sample again.

The bug: the top-level `do_sample_frames=False` is **not** routed into HF's `videos_kwargs` by `_merge_kwargs`, so it is overridden by the video processor's class default (`do_sample_frames=True`). HF's `Qwen3VLVideoProcessor.sample_frames()` then performs a **second** sampling pass using the forwarded `videos_kwargs.fps`. With no proper `video_metadata`, `metadata.fps` falls back to 24, so a pre-sampled 8-frame clip is re-sampled down to 4 frames (`grid_t` 4 -> 2), **halving the visual tokens** vs `<= v0.5.10`.

## Modifications

`python/sglang/srt/multimodal/processors/base_processor.py`, in `process_mm_data()`'s `if videos:` block: when `do_sample_frames=False` was requested at the top level (i.e. the sglang processor already sampled frames), move it into `videos_kwargs` (and pop the top-level one to avoid HF `_merge_kwargs` "passed two times") so HF actually skips re-sampling.

```python
if videos:
    kwargs["videos"] = videos
    if self.video_config:
        kwargs.setdefault("videos_kwargs", {}).update(self.video_config)
    # Frames may already be sampled by the sglang processor (e.g. Qwen-VL
    # preprocess_video) using mm_process_config; there do_sample_frames=False
    # is passed at top level. HF _merge_kwargs does not route it into
    # videos_kwargs, so it is overridden by the processor default
    # (do_sample_frames=True) and HF re-samples using videos_kwargs.fps,
    # halving the visual tokens. Move it into videos_kwargs so it takes effect.
    if kwargs.get("do_sample_frames") is False:
        kwargs.pop("do_sample_frames", None)
        kwargs.setdefault("videos_kwargs", {})["do_sample_frames"] = False
```

This keeps PR #18467's per-modality routing intact and does not change behavior for models that rely on HF-side sampling (they don't pass `do_sample_frames=False`).

## Accuracy Tests

Same Qwen3-VL video-caption request, `--mm-process-config '{"video":{"fps":2,"max_frames":30,"size":{"shortest_edge":3136,"longest_edge":12288000}}}'`:

| | before (v0.5.13.post1) | after this PR | v0.5.10.post1 (reference) |
|---|---|---|---|
| sampled frames | 4 | 8 | 8 |
| `video_grid_thw` | `[2, 36, 64]` | `[4, 36, 64]` | `[4, 36, 64]` |
| visual tokens | 1152 | 2304 | 2304 |
| Prefill `#new-token` | 1216 | 2816 | 2816 |

Verified end-to-end via `/v1/chat/completions` on H20: `prompt_tokens` restored to 2799 / `#new-token=2816`, matching v0.5.10, model output normal. `--mm-process-config` unchanged.

## Checklist

- [ ] Format code with pre-commit
- [ ] Add unit tests (extend `test/registered/core/test_mm_process_config.py` to assert `videos_kwargs["do_sample_frames"] == False` when top-level `do_sample_frames=False` is passed)
- [ ] Update documentation if needed







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29347966378](https://github.com/sgl-project/sglang/actions/runs/29347966378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29347966134](https://github.com/sgl-project/sglang/actions/runs/29347966134)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->