### PR TITLE
fix: skip unsafe automatic prefill graph capture

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -40,6 +40,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Measured immediately before prefill graph construction, after model weights,
+# KV cache, and the eager runner's static buffers have been allocated.  Below
+# this budget, compiling/capturing a multi-bucket prefill graph is likely to
+# OOM or make no forward progress for large models.  Keep an explicitly chosen
+# backend untouched: an operator may intentionally trade KV capacity for it.
+_MIN_AUTO_PREFILL_CUDA_GRAPH_FREE_MEMORY_GB = 4.0
+
+
+def should_skip_auto_prefill_cuda_graph_for_memory(
+    available_memory_gb: float,
+    cuda_graph_config_locked: set[tuple[str, str]],
+) -> bool:
+    """Return whether an auto-selected prefill graph lacks capture headroom."""
+    return (
+        (Phase.PREFILL, "backend") not in cuda_graph_config_locked
+        and available_memory_gb < _MIN_AUTO_PREFILL_CUDA_GRAPH_FREE_MEMORY_GB
+    )
+
 
 class DecodeGraphCapture(msgspec.Struct, frozen=True, kw_only=True):
     runner: Optional[BaseRunner]
@@ -217,6 +235,20 @@ def capture_prefill_graph(
     tic = time.perf_counter()
     before_mem = get_available_gpu_memory(model_runner.device, model_runner.gpu_id)
     prefill_backend = model_runner.server_args.cuda_graph_config.prefill.backend
+    if should_skip_auto_prefill_cuda_graph_for_memory(
+        before_mem,
+        getattr(model_runner.server_args, "_cuda_graph_config_locked", set()),
+    ):
+        logger.warning(
+            "Disabling auto-selected prefill CUDA graph: only %.2f GiB is free "
+            "after model/KV/eager-buffer allocation; at least %.2f GiB is "
+            "required for capture. Set an explicit prefill CUDA graph backend "
+            "to override this safety gate.",
+            before_mem,
+            _MIN_AUTO_PREFILL_CUDA_GRAPH_FREE_MEMORY_GB,
+        )
+        return eager_runner
+
     role = "draft" if model_runner.is_draft_worker else "target"
     capture_name = f"{role} prefill"
     capture_num_tokens = sorted(model_runner.server_args.cuda_graph_config.prefill.bs)

--- a/test/registered/unit/model_executor/model_runner_components/test_cuda_graph_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_cuda_graph_setup.py
@@ -1,0 +1,26 @@
+import sys
+
+import pytest
+
+from sglang.srt.model_executor.cuda_graph_config import Phase
+from sglang.srt.model_executor.model_runner_components.cuda_graph_setup import (
+    should_skip_auto_prefill_cuda_graph_for_memory,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_auto_prefill_cuda_graph_memory_gate():
+    assert should_skip_auto_prefill_cuda_graph_for_memory(3.99, set())
+    assert not should_skip_auto_prefill_cuda_graph_for_memory(4.0, set())
+
+
+def test_explicit_prefill_backend_bypasses_memory_gate():
+    assert not should_skip_auto_prefill_cuda_graph_for_memory(
+        0.0, {(Phase.PREFILL, "backend")}
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Prevent an automatically selected prefill CUDA graph from trying multi-bucket capture when there is insufficient physical GPU headroom after model weights, KV cache, and eager static buffers are allocated.

The gate applies only to the automatic backend selection. An explicitly chosen prefill backend remains an operator override and retains the existing behavior.

## NVIDIA Kimi-K2.7-Code result

Hardware: 8x NVIDIA H100 80GB, TP=8, `--mem-fraction-static 0.97`.

Before this change, automatic TC prefill graph capture began with only 2.05--2.28 GiB free per rank and failed to make reliable startup progress. With this change, the server logs the reason, skips automatic capture, and completes launch/serving normally.

The threshold is 4 GiB. This is intentionally conservative: the matching `.945` configuration consumes 1.75--1.79 GiB/GPU for the TC graph alone and has little remaining safety margin. This is a startup/reliability fix, not a claimed online-throughput improvement.

## Validation

- `ruff check` on changed source and test
- `python3 -m pytest -q test/registered/unit/model_executor/model_runner_components/test_cuda_graph_setup.py`
- direct-file invocation also passes for CI runner compatibility
- NVIDIA H100 TP8 Kimi-K2.7-Code launch validation verifies automatic skip; the unit test verifies the explicit-backend override











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29350755600](https://github.com/sgl-project/sglang/actions/runs/29350755600)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29350755456](https://github.com/sgl-project/sglang/actions/runs/29350755456)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->