### PR TITLE
[PD] Enable mooncake TCP connection pool by default for mooncake_tcp backend

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -19,11 +19,19 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
     # mooncake, and skip RDMA HCA selection. Must run before backend-name checks.
     if server_args.disaggregation_transfer_backend == "mooncake_tcp":
         os.environ.setdefault("MC_FORCE_TCP", "1")
+        # Without the connection pool, TcpTransport opens a fresh TCP
+        # connection per transfer; under concurrent load the client side
+        # exhausts ephemeral ports (EADDRNOTAVAIL, default range is only
+        # ~28K ports with TIME_WAIT held for 60s) and prefill/decode each
+        # conclude the peer is dead. Pooling keeps a bounded set of live
+        # connections instead.
+        os.environ.setdefault("MC_TCP_ENABLE_CONNECTION_POOL", "true")
         server_args.disaggregation_transfer_backend = "mooncake"
         server_args.disaggregation_ib_device = None
         logger.info(
             "disaggregation transfer backend 'mooncake_tcp' -> mooncake "
-            "with MC_FORCE_TCP=1 (TCP transport, no RDMA)"
+            "with MC_FORCE_TCP=1 (TCP transport, no RDMA), "
+            "MC_TCP_ENABLE_CONNECTION_POOL=true"
         )
 
     if server_args.disaggregation_mode == "decode":


### PR DESCRIPTION
## Motivation

When `--disaggregation-transfer-backend mooncake_tcp` is used, mooncake's `TcpTransport` opens a **fresh TCP connection per transfer** (its connection pool defaults to off). Under a concurrency sweep this exhausts the client-side ephemeral port range: each finished transfer leaves a socket in TIME_WAIT for 60s, the default `ip_local_port_range` is only ~28K ports, and once they run out every new transfer fails with:

```text
TcpTransport::getConnection failed to create connection to <decode>:<port>. Error: connect: Cannot assign requested address
```

after which prefill logs `remote mooncake session ... is not alive` and decode logs `Failed to get kvcache from prefill instance, it might be dead` — both sides look dead while both are healthy. In our aiperf concurrency search (DeepSeek-V4, 1P1D, 8×B300) this reproducibly collapsed every trial above a small concurrency.

Mooncake already ships the fix behind an env: `MC_TCP_ENABLE_CONNECTION_POOL=true`. With it enabled we measured a bounded set of ~hundreds of ESTABLISHED connections reused across transfers, single-digit TIME_WAIT, zero `EADDRNOTAVAIL` across a full search (thousands of transferred requests).

## Modification

`handle_pd_disaggregation` already sets `MC_FORCE_TCP=1` when mapping `mooncake_tcp` → `mooncake`. This PR additionally `setdefault`s `MC_TCP_ENABLE_CONNECTION_POOL=true` in the same place, so the TCP transport is usable under load out of the box. Users can still opt out by exporting `MC_TCP_ENABLE_CONNECTION_POOL=false`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-writing-documentation). (env-only change; covered by existing disaggregation fixtures which already set this env in tests)
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35581253660](https://github.com/sgl-project/sglang/actions/runs/35581253660)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35581253110](https://github.com/sgl-project/sglang/actions/runs/35581253110)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35581253920](https://github.com/sgl-project/sglang/actions/runs/35581253920)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->