### PR TITLE
docs(sgl-model-gateway): add DaoXE OpenAI-compatible upstream example

### DIFF
--- a/docs_new/docs/advanced_features/sgl_model_gateway.mdx
+++ b/docs_new/docs/advanced_features/sgl_model_gateway.mdx
@@ -262,6 +262,35 @@ python -m sglang_router.launch_router \
   --history-backend memory
 ```
 
+Any OpenAI-compatible upstream works the same way. For example, [DaoXE](https://daoxe.com) is a multi-protocol multi-model API gateway (OpenAI-compatible base URL `https://daoxe.com/v1`). The router appends `/v1/...` to `--worker-urls`, so pass the host without the `/v1` suffix (same pattern as `https://api.openai.com`). Use `--api-key` for upstream worker authorization, and an exact account-scoped model ID in client requests:
+
+```bash Command
+export DAOXE_API_KEY=your-daoxe-api-key
+
+python -m sglang_router.launch_router \
+  --backend openai \
+  --worker-urls https://daoxe.com \
+  --api-key "$DAOXE_API_KEY" \
+  --history-backend memory
+```
+
+Then call the router with the OpenAI Python client. Model IDs are account-scoped — copy them from your DaoXE dashboard or `GET https://daoxe.com/v1/models`:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:30000/v1",
+    api_key=os.environ["DAOXE_API_KEY"],
+)
+completion = client.chat.completions.create(
+    model="your-account-model-id",
+    messages=[{"role": "user", "content": "Hello from SGLang + DaoXE"}],
+)
+print(completion.choices[0].message.content)
+```
+
 OpenAI backend mode expects exactly one `--worker-urls` entry per router instance.
 
 ### Multi-Model Inference Gateway


### PR DESCRIPTION
## Description

Adds a short example under **OpenAI Backend Proxy** in the SGLang Model Gateway docs showing how to use [DaoXE](https://daoxe.com) as an OpenAI-compatible upstream (`--backend openai`).

DaoXE is a multi-protocol multi-model API gateway with OpenAI-compatible base URL `https://daoxe.com/v1`. The router appends `/v1/...` to `--worker-urls` (same pattern as `https://api.openai.com`), so the example uses `https://daoxe.com` as the worker base. Model IDs are account-scoped.

## Changes

- `docs_new/docs/advanced_features/sgl_model_gateway.mdx` — DaoXE example next to the existing `api.openai.com` proxy snippet

## Checklist

- [x] Docs only; no code/runtime changes
- [x] Follows existing OpenAI Backend Proxy style
- [x] English







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29353801800](https://github.com/sgl-project/sglang/actions/runs/29353801800)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29353801809](https://github.com/sgl-project/sglang/actions/runs/29353801809)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->