### PR TITLE
[ROCm] Fix EAGLE spec-decode verify silently sampling greedy on HIP

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -573,6 +573,28 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
                 "trtllm_mha backend only supports topk = 1 for speculative decoding."
             )
 
+    # ROCm/HIP lacks the CUDA/MUSA sampling-verify kernels, so EAGLE verify would
+    # otherwise silently fall back to greedy (argmax), ignoring temperature/top_p.
+    # Default rejection sampling on (routes verify through the Triton chain sampler)
+    # for configs that support it, unless the user opted in or picked an incompatible
+    # option. Conditions mirror the validation below so the flip never triggers a raise.
+    from sglang.srt.utils import is_hip
+
+    if (
+        is_hip()
+        and not server_args.speculative_use_rejection_sampling
+        and server_args.speculative_algorithm in ("EAGLE", "EAGLE3")
+        and server_args.speculative_eagle_topk == 1
+        and server_args.speculative_accept_threshold_single == 1.0
+        and server_args.speculative_accept_threshold_acc == 1.0
+        and not server_args.enable_deterministic_inference
+    ):
+        server_args.speculative_use_rejection_sampling = True
+        logger.info(
+            "ROCm requires rejection sampling for correct EAGLE spec-decode "
+            "sampling; enabling speculative_use_rejection_sampling by default."
+        )
+
     if server_args.speculative_use_rejection_sampling:
         # Resolved alias by now: NEXTN -> EAGLE, Gemma4 draft -> FROZEN_KV_MTP.
         # Only the EAGLE/EAGLE3 draft workers emit a target-vocab proposal that

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -764,6 +764,30 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
                 "trtllm_mha backend only supports topk = 1 for speculative decoding."
             )
 
+    # ROCm/HIP lacks the CUDA/MUSA sampling-verify kernels, so EAGLE verify would
+    # otherwise silently fall back to greedy (argmax), ignoring temperature/top_p.
+    # Default rejection sampling on (routes verify through the Triton chain sampler)
+    # for configs that support it, unless the user opted in or picked an incompatible
+    # option. Conditions mirror the validation below so the flip never triggers a raise.
+    # Read through cfg so the algorithm alias is already resolved (NEXTN -> EAGLE);
+    # write back to server_args, which is the object that actually holds the value.
+    from sglang.srt.utils import is_hip
+
+    if (
+        is_hip()
+        and not cfg.speculative_use_rejection_sampling
+        and cfg.speculative_algorithm in ("EAGLE", "EAGLE3")
+        and cfg.speculative_eagle_topk == 1
+        and cfg.speculative_accept_threshold_single == 1.0
+        and cfg.speculative_accept_threshold_acc == 1.0
+        and not cfg.enable_deterministic_inference
+    ):
+        server_args.speculative_use_rejection_sampling = True
+        logger.info(
+            "ROCm requires rejection sampling for correct EAGLE spec-decode "
+            "sampling; enabling speculative_use_rejection_sampling by default."
+        )
+
     if cfg.speculative_use_rejection_sampling:
         # Resolved alias by now: NEXTN -> EAGLE, Gemma4 draft -> FROZEN_KV_MTP.
         # Only the EAGLE/EAGLE3 draft workers emit a target-vocab proposal that

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -7,6 +7,8 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
+import triton
+import triton.language as tl
 
 from sglang.kernels.ops.speculative.spec_tree import (
     sgl_build_tree_kernel_efficient_triton,
@@ -578,6 +580,105 @@ def eagle_prepare_for_verify(
     return verify_forward_batch, can_run_cuda_graph
 
 
+@triton.jit
+def _top_p_renorm_kernel(
+    probs_ptr,
+    out_ptr,
+    top_p_ptr,
+    vocab: tl.constexpr,
+    BLOCK: tl.constexpr,
+    N_ITER: tl.constexpr,
+):
+    # Per-row top-p renorm by pivot binary-search (no sort): keep the largest tau with
+    # sum(p >= tau) >= top_p, then renormalize p >= tau. N_ITER=30 pins tau to
+    # max_prob*2^-30, far below realistic prob gaps, so it matches a sort to <1e-6.
+    row = tl.program_id(0)
+    base = row * vocab
+    tp = tl.load(top_p_ptr + row)
+    offs = tl.arange(0, BLOCK)
+    hi = 0.0
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        hi = tl.maximum(hi, tl.max(p, axis=0))
+    lo = 0.0
+    for _ in range(N_ITER):
+        mid = (lo + hi) * 0.5
+        s = 0.0
+        for start in range(0, vocab, BLOCK):
+            idx = start + offs
+            m = idx < vocab
+            p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+            s += tl.sum(tl.where(p >= mid, p, 0.0), axis=0)
+        take = s >= tp
+        lo = tl.where(take, mid, lo)
+        hi = tl.where(take, hi, mid)
+    Z = 0.0
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        Z += tl.sum(tl.where(p >= lo, p, 0.0), axis=0)
+    Z = tl.maximum(Z, 1e-12)
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        tl.store(out_ptr + base + idx, tl.where(p >= lo, p / Z, 0.0), mask=m)
+
+
+def _renorm_top_k_top_p_hip(
+    probs: torch.Tensor, top_ks: torch.Tensor, top_ps: torch.Tensor
+) -> torch.Tensor:
+    """ROCm replacement for sgl_kernel top_k/top_p_renorm_prob (CUDA/MUSA-only).
+
+    top-p runs the Triton pivot kernel; top-k uses a sort only for rows that actually
+    restrict it (a no-op when top_k >= vocab). Rows with top_p >= 1.0 pass through
+    unchanged to stay bit-exact with CUDA's top_p_renorm_prob(p, 1.0) == p.
+    """
+    vocab = probs.shape[-1]
+    probs = probs.contiguous()
+    if bool((top_ks < vocab).any()):
+        sorted_probs, sorted_indices = probs.sort(dim=-1, descending=True)
+        order = torch.arange(vocab, device=probs.device).view(1, -1)
+        sorted_probs = sorted_probs.masked_fill(order >= top_ks.reshape(-1, 1), 0.0)
+        sorted_probs = sorted_probs / sorted_probs.sum(dim=-1, keepdim=True).clamp_min(
+            1e-12
+        )
+        probs = torch.zeros_like(sorted_probs).scatter_(
+            -1, sorted_indices, sorted_probs
+        )
+    top_ps = top_ps.reshape(-1).to(torch.float32).contiguous()
+    out = torch.empty_like(probs)
+    _top_p_renorm_kernel[(probs.shape[0],)](
+        probs, out, top_ps, vocab, BLOCK=4096, N_ITER=30
+    )
+    return torch.where((top_ps >= 1.0).view(-1, 1), probs, out)
+
+
+def _verify_uses_greedy(
+    *,
+    is_all_greedy: bool,
+    is_cpu: bool,
+    is_npu: bool,
+    is_hip: bool,
+    is_xpu: bool,
+    use_rejection_sampling: bool,
+) -> bool:
+    """Whether EAGLE verify must commit argmax(greedy) instead of the sampling path.
+
+    HIP has no CUDA/MUSA sampling-verify kernels, so it historically forced greedy here;
+    route it through the pure-Triton chain sampler when rejection sampling supplies the
+    draft proposal and the batch isn't all-greedy. Reduces to the original predicate on
+    non-HIP platforms.
+    """
+    hip_can_sample = is_hip and use_rejection_sampling and not is_all_greedy
+    return (
+        is_all_greedy or is_cpu or is_npu or is_xpu or (is_hip and not hip_can_sample)
+    )
+
+
 def eagle_sample(
     verify_input: EagleVerifyInput,
     batch: ScheduleBatch,
@@ -659,7 +760,15 @@ def eagle_sample(
 
     # Sample tokens
     target_predict = None
-    if sampling_info.is_all_greedy or _is_cpu or _is_npu or _is_hip or _is_xpu:
+    _use_rej = get_server_args().speculative_use_rejection_sampling
+    if _verify_uses_greedy(
+        is_all_greedy=sampling_info.is_all_greedy,
+        is_cpu=_is_cpu,
+        is_npu=_is_npu,
+        is_hip=_is_hip,
+        is_xpu=_is_xpu,
+        use_rejection_sampling=_use_rej,
+    ):
         target_predict = torch.argmax(next_token_logits, dim=-1)
         target_predict = target_predict.reshape(bs, verify_input.draft_token_num)
         predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
@@ -674,17 +783,21 @@ def eagle_sample(
             topk=verify_input.tree_topk,
         )
     else:
-        from sgl_kernel import (
-            top_k_renorm_prob,
-            top_p_renorm_prob,
-            tree_speculative_sampling_target_only,
-        )
+        # sgl_kernel renorm/tree-verify ops are CUDA/MUSA-only; import lazily so the HIP
+        # branch never ImportErrors. The gate forces rejection sampling on HIP, so the
+        # CUDA-only tree_speculative_sampling_target_only is never referenced there.
+        if not _is_hip:
+            from sgl_kernel import (
+                top_k_renorm_prob,
+                top_p_renorm_prob,
+                tree_speculative_sampling_target_only,
+            )
 
         from sglang.srt.speculative.reject_sampling import (
             chain_speculative_sampling_triton,
         )
 
-        use_rejection_sampling = get_server_args().speculative_use_rejection_sampling
+        use_rejection_sampling = _use_rej
 
         # Apply temperature and get target probs
         expanded_temperature = torch.repeat_interleave(
@@ -695,20 +808,22 @@ def eagle_sample(
             next_token_logits / expanded_temperature, dim=-1
         )  # (bs * num_draft_tokens, vocab_size)
         maybe_detect_nan(target_probs, "v2 verify: target_probs after softmax")
-        target_probs = top_k_renorm_prob(
-            target_probs,
-            torch.repeat_interleave(
-                sampling_info.top_ks, verify_input.draft_token_num, dim=0
-            ),
-        )  # (bs * num_draft_tokens, vocab_size)
-        maybe_detect_nan(target_probs, "v2 verify: target_probs after top_k_renorm")
-        target_probs = top_p_renorm_prob(
-            target_probs,
-            torch.repeat_interleave(
-                sampling_info.top_ps, verify_input.draft_token_num, dim=0
-            ),
+        _top_ks = torch.repeat_interleave(
+            sampling_info.top_ks, verify_input.draft_token_num, dim=0
         )
-        maybe_detect_nan(target_probs, "v2 verify: target_probs after top_p_renorm")
+        _top_ps = torch.repeat_interleave(
+            sampling_info.top_ps, verify_input.draft_token_num, dim=0
+        )
+        if _is_hip:
+            target_probs = _renorm_top_k_top_p_hip(target_probs, _top_ks, _top_ps)
+            maybe_detect_nan(
+                target_probs, "v2 verify: target_probs after top_k/top_p renorm"
+            )
+        else:
+            target_probs = top_k_renorm_prob(target_probs, _top_ks)
+            maybe_detect_nan(target_probs, "v2 verify: target_probs after top_k_renorm")
+            target_probs = top_p_renorm_prob(target_probs, _top_ps)
+            maybe_detect_nan(target_probs, "v2 verify: target_probs after top_p_renorm")
         target_probs = target_probs.reshape(bs, verify_input.draft_token_num, -1)
         draft_probs = (
             verify_input.draft_probs

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -6,6 +6,8 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
+import triton
+import triton.language as tl
 
 from sglang.kernels.ops.speculative.spec_tree import (
     sgl_build_tree_kernel_efficient_triton,
@@ -650,6 +652,105 @@ def _verify_coins(
     return coins, coins_for_final_sampling
 
 
+@triton.jit
+def _top_p_renorm_kernel(
+    probs_ptr,
+    out_ptr,
+    top_p_ptr,
+    vocab: tl.constexpr,
+    BLOCK: tl.constexpr,
+    N_ITER: tl.constexpr,
+):
+    # Per-row top-p renorm by pivot binary-search (no sort): keep the largest tau with
+    # sum(p >= tau) >= top_p, then renormalize p >= tau. N_ITER=30 pins tau to
+    # max_prob*2^-30, far below realistic prob gaps, so it matches a sort to <1e-6.
+    row = tl.program_id(0)
+    base = row * vocab
+    tp = tl.load(top_p_ptr + row)
+    offs = tl.arange(0, BLOCK)
+    hi = 0.0
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        hi = tl.maximum(hi, tl.max(p, axis=0))
+    lo = 0.0
+    for _ in range(N_ITER):
+        mid = (lo + hi) * 0.5
+        s = 0.0
+        for start in range(0, vocab, BLOCK):
+            idx = start + offs
+            m = idx < vocab
+            p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+            s += tl.sum(tl.where(p >= mid, p, 0.0), axis=0)
+        take = s >= tp
+        lo = tl.where(take, mid, lo)
+        hi = tl.where(take, hi, mid)
+    Z = 0.0
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        Z += tl.sum(tl.where(p >= lo, p, 0.0), axis=0)
+    Z = tl.maximum(Z, 1e-12)
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        tl.store(out_ptr + base + idx, tl.where(p >= lo, p / Z, 0.0), mask=m)
+
+
+def _renorm_top_k_top_p_hip(
+    probs: torch.Tensor, top_ks: torch.Tensor, top_ps: torch.Tensor
+) -> torch.Tensor:
+    """ROCm replacement for sgl_kernel top_k/top_p_renorm_prob (CUDA/MUSA-only).
+
+    top-p runs the Triton pivot kernel; top-k uses a sort only for rows that actually
+    restrict it (a no-op when top_k >= vocab). Rows with top_p >= 1.0 pass through
+    unchanged to stay bit-exact with CUDA's top_p_renorm_prob(p, 1.0) == p.
+    """
+    vocab = probs.shape[-1]
+    probs = probs.contiguous()
+    if bool((top_ks < vocab).any()):
+        sorted_probs, sorted_indices = probs.sort(dim=-1, descending=True)
+        order = torch.arange(vocab, device=probs.device).view(1, -1)
+        sorted_probs = sorted_probs.masked_fill(order >= top_ks.reshape(-1, 1), 0.0)
+        sorted_probs = sorted_probs / sorted_probs.sum(dim=-1, keepdim=True).clamp_min(
+            1e-12
+        )
+        probs = torch.zeros_like(sorted_probs).scatter_(
+            -1, sorted_indices, sorted_probs
+        )
+    top_ps = top_ps.reshape(-1).to(torch.float32).contiguous()
+    out = torch.empty_like(probs)
+    _top_p_renorm_kernel[(probs.shape[0],)](
+        probs, out, top_ps, vocab, BLOCK=4096, N_ITER=30
+    )
+    return torch.where((top_ps >= 1.0).view(-1, 1), probs, out)
+
+
+def _verify_uses_greedy(
+    *,
+    is_all_greedy: bool,
+    is_cpu: bool,
+    is_npu: bool,
+    is_hip: bool,
+    is_xpu: bool,
+    use_rejection_sampling: bool,
+) -> bool:
+    """Whether EAGLE verify must commit argmax(greedy) instead of the sampling path.
+
+    HIP has no CUDA/MUSA sampling-verify kernels, so it historically forced greedy here;
+    route it through the pure-Triton chain sampler when rejection sampling supplies the
+    draft proposal and the batch isn't all-greedy. Reduces to the original predicate on
+    non-HIP platforms.
+    """
+    hip_can_sample = is_hip and use_rejection_sampling and not is_all_greedy
+    return (
+        is_all_greedy or is_cpu or is_npu or is_xpu or (is_hip and not hip_can_sample)
+    )
+
+
 def eagle_sample(
     verify_input: EagleVerifyInput,
     batch: ScheduleBatch,
@@ -727,7 +828,15 @@ def eagle_sample(
 
     # Sample tokens
     target_predict = None
-    if sampling_info.is_all_greedy or _is_cpu or _is_npu or _is_hip or _is_xpu:
+    _use_rej = get_spec().speculative_use_rejection_sampling
+    if _verify_uses_greedy(
+        is_all_greedy=sampling_info.is_all_greedy,
+        is_cpu=_is_cpu,
+        is_npu=_is_npu,
+        is_hip=_is_hip,
+        is_xpu=_is_xpu,
+        use_rejection_sampling=_use_rej,
+    ):
         target_predict = torch.argmax(next_token_logits, dim=-1)
         target_predict = target_predict.reshape(bs, verify_input.draft_token_num)
         predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
@@ -757,17 +866,21 @@ def eagle_sample(
                 tp_group.broadcast(accept_index, src=0)
                 tp_group.broadcast(num_correct_drafts, src=0)
     else:
-        from sgl_kernel import (
-            top_k_renorm_prob,
-            top_p_renorm_prob,
-            tree_speculative_sampling_target_only,
-        )
+        # sgl_kernel renorm/tree-verify ops are CUDA/MUSA-only; import lazily so the HIP
+        # branch never ImportErrors. The gate forces rejection sampling on HIP, so the
+        # CUDA-only tree_speculative_sampling_target_only is never referenced there.
+        if not _is_hip:
+            from sgl_kernel import (
+                top_k_renorm_prob,
+                top_p_renorm_prob,
+                tree_speculative_sampling_target_only,
+            )
 
         from sglang.kernels.ops.speculative.reject_sampling import (
             chain_speculative_sampling_triton,
         )
 
-        use_rejection_sampling = get_spec().speculative_use_rejection_sampling
+        use_rejection_sampling = _use_rej
 
         sampling_fn = (
             chain_speculative_sampling_triton
@@ -787,26 +900,44 @@ def eagle_sample(
                 next_token_logits / expanded_temperature, dim=-1
             )  # (bs * num_draft_tokens, vocab_size)
             maybe_detect_nan(target_probs, "v2 verify: target_probs after softmax")
-            if sampling_info.need_top_k_sampling:
-                target_probs = top_k_renorm_prob(
-                    target_probs,
-                    torch.repeat_interleave(
-                        sampling_info.top_ks, verify_input.draft_token_num, dim=0
-                    ),
-                )  # (bs * num_draft_tokens, vocab_size)
-                maybe_detect_nan(
-                    target_probs, "v2 verify: target_probs after top_k_renorm"
-                )
-            if sampling_info.need_top_p_sampling:
-                target_probs = top_p_renorm_prob(
-                    target_probs,
-                    torch.repeat_interleave(
-                        sampling_info.top_ps, verify_input.draft_token_num, dim=0
-                    ),
-                )
-                maybe_detect_nan(
-                    target_probs, "v2 verify: target_probs after top_p_renorm"
-                )
+            if _is_hip:
+                if (
+                    sampling_info.need_top_k_sampling
+                    or sampling_info.need_top_p_sampling
+                ):
+                    target_probs = _renorm_top_k_top_p_hip(
+                        target_probs,
+                        torch.repeat_interleave(
+                            sampling_info.top_ks, verify_input.draft_token_num, dim=0
+                        ),
+                        torch.repeat_interleave(
+                            sampling_info.top_ps, verify_input.draft_token_num, dim=0
+                        ),
+                    )
+                    maybe_detect_nan(
+                        target_probs, "v2 verify: target_probs after top_k/top_p renorm"
+                    )
+            else:
+                if sampling_info.need_top_k_sampling:
+                    target_probs = top_k_renorm_prob(
+                        target_probs,
+                        torch.repeat_interleave(
+                            sampling_info.top_ks, verify_input.draft_token_num, dim=0
+                        ),
+                    )  # (bs * num_draft_tokens, vocab_size)
+                    maybe_detect_nan(
+                        target_probs, "v2 verify: target_probs after top_k_renorm"
+                    )
+                if sampling_info.need_top_p_sampling:
+                    target_probs = top_p_renorm_prob(
+                        target_probs,
+                        torch.repeat_interleave(
+                            sampling_info.top_ps, verify_input.draft_token_num, dim=0
+                        ),
+                    )
+                    maybe_detect_nan(
+                        target_probs, "v2 verify: target_probs after top_p_renorm"
+                    )
             target_probs = target_probs.reshape(bs, verify_input.draft_token_num, -1)
             draft_probs = (
                 verify_input.draft_probs

--- a/test/registered/spec/eagle/test_rocm_eagle_renorm.py
+++ b/test/registered/spec/eagle/test_rocm_eagle_renorm.py
@@ -1,0 +1,129 @@
+"""Numerical-equivalence tests for the ROCm EAGLE top-k/top-p renorm.
+
+Guards ``eagle_utils._renorm_top_k_top_p_hip`` (the Triton replacement for the
+CUDA/MUSA-only ``sgl_kernel`` ``top_k_renorm_prob`` + ``top_p_renorm_prob``)
+against an independent torch nucleus reference. A regression in the pivot search
+(wrong iteration count, wrong threshold, broken top-k, or a ``top_p == 1.0`` that
+stops being an exact no-op) turns a case red. The kernel is device-agnostic, so
+this runs on any triton-capable GPU (CUDA in CI); skipped without one.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+# Runs on any triton GPU; AMD registration exercises the actual ROCm target path.
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+
+try:
+    import triton  # noqa: F401
+
+    _HAS_TRITON = True
+except Exception:
+    _HAS_TRITON = False
+
+_RUNNABLE = torch.cuda.is_available() and _HAS_TRITON
+
+
+def _torch_nucleus_reference(probs, top_ks, top_ps):
+    """top-k renorm then nucleus (top-p) renorm, mirroring sgl_kernel semantics.
+
+    Always keeps the argmax token (like the pivot kernel and sgl_kernel), so it
+    agrees on the top_p -> 0 edge instead of zeroing the row.
+    """
+    vocab = probs.shape[-1]
+    order = torch.arange(vocab, device=probs.device).view(1, -1)
+    # top-k
+    sorted_probs, sorted_idx = probs.sort(dim=-1, descending=True)
+    sorted_probs = torch.where(
+        order < top_ks.view(-1, 1), sorted_probs, torch.zeros_like(sorted_probs)
+    )
+    sorted_probs = sorted_probs / sorted_probs.sum(-1, keepdim=True).clamp_min(1e-12)
+    p = torch.zeros_like(probs).scatter_(-1, sorted_idx, sorted_probs)
+    # top-p (nucleus)
+    sorted_probs, sorted_idx = p.sort(dim=-1, descending=True)
+    csum = sorted_probs.cumsum(dim=-1)
+    keep = (csum - sorted_probs) < top_ps.view(-1, 1)
+    keep[..., 0] = True
+    sorted_probs = torch.where(keep, sorted_probs, torch.zeros_like(sorted_probs))
+    sorted_probs = sorted_probs / sorted_probs.sum(-1, keepdim=True).clamp_min(1e-12)
+    return torch.zeros_like(p).scatter_(-1, sorted_idx, sorted_probs)
+
+
+@unittest.skipUnless(_RUNNABLE, "requires a triton-capable GPU")
+class TestRocmEagleRenorm(CustomTestCase):
+    VOCAB = 4096
+    ROWS = 16
+
+    def setUp(self):
+        torch.manual_seed(0)
+
+    def _rand_probs(self, rows=None):
+        rows = rows or self.ROWS
+        return torch.softmax(torch.randn(rows, self.VOCAB, device="cuda"), dim=-1)
+
+    def _unrestricted_top_ks(self, rows=None):
+        rows = rows or self.ROWS
+        return torch.full((rows,), self.VOCAB, dtype=torch.int32, device="cuda")
+
+    def test_top_p_matches_nucleus(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs()
+        top_ks = self._unrestricted_top_ks()
+        for top_p in (0.5, 0.9, 0.95):
+            top_ps = torch.full((self.ROWS,), top_p, device="cuda")
+            got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+            ref = _torch_nucleus_reference(probs.clone(), top_ks, top_ps)
+            self.assertLess((got - ref).abs().max().item(), 1e-6, f"top_p={top_p}")
+
+    def test_top_p_one_is_exact_noop(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs()
+        top_ks = self._unrestricted_top_ks()
+        top_ps = torch.ones(self.ROWS, device="cuda")
+        got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+        self.assertEqual((got - probs).abs().max().item(), 0.0)
+
+    def test_top_k_restriction(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs()
+        top_ks = torch.full((self.ROWS,), 8, dtype=torch.int32, device="cuda")
+        top_ps = torch.ones(self.ROWS, device="cuda")  # top_p no-op -> isolate top-k
+        got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+        self.assertTrue(((got > 0).sum(-1) == 8).all().item())
+        ref = _torch_nucleus_reference(probs.clone(), top_ks, top_ps)
+        self.assertLess((got - ref).abs().max().item(), 1e-6)
+
+    def test_edge_top_p_to_zero_keeps_top1(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs(rows=1)
+        top_ks = self._unrestricted_top_ks(rows=1)
+        top_ps = torch.full((1,), 1e-4, device="cuda")
+        got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+        self.assertEqual((got > 0).sum().item(), 1)
+        self.assertEqual(got.argmax().item(), probs.argmax().item())
+
+    def test_edge_single_nonmasked_token(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        one_hot = torch.zeros(1, self.VOCAB, device="cuda")
+        one_hot[0, 123] = 1.0
+        got = _renorm_top_k_top_p_hip(
+            one_hot.clone(),
+            self._unrestricted_top_ks(rows=1),
+            torch.full((1,), 0.9, device="cuda"),
+        )
+        self.assertEqual((got > 0).sum().item(), 1)
+        self.assertAlmostEqual(got[0, 123].item(), 1.0, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_gate_routing.py
+++ b/test/registered/unit/spec/test_eagle_gate_routing.py
@@ -1,0 +1,91 @@
+"""Gate-routing tests for EAGLE verify: sampling vs. greedy (argmax).
+
+Guards the correctness contract of the ROCm fix in
+``eagle_utils._verify_uses_greedy``: on every non-HIP platform the gate must
+reduce byte-for-byte to the pre-patch predicate
+(``is_all_greedy or is_cpu or is_npu or is_hip or is_xpu``), and HIP may take the
+sampling path only when rejection sampling is on and the batch isn't all-greedy.
+A regression that forced greedy on CUDA, or that let HIP sample without rejection
+sampling, would turn a case here red. Pure-boolean logic, so it runs on CPU CI.
+"""
+
+import itertools
+import unittest
+
+from sglang.srt.speculative.eagle_utils import _verify_uses_greedy
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _pre_patch_gate(is_all_greedy, is_cpu, is_npu, is_hip, is_xpu):
+    # eagle_utils.py gate before this PR. Non-HIP behavior must match this exactly.
+    return is_all_greedy or is_cpu or is_npu or is_hip or is_xpu
+
+
+# (name, is_cpu, is_npu, is_hip, is_xpu); CUDA == no platform flag set.
+_PLATFORMS = {
+    "cuda": (False, False, False, False),
+    "hip": (False, False, True, False),
+    "cpu": (True, False, False, False),
+    "npu": (False, True, False, False),
+    "xpu": (False, False, False, True),
+}
+
+
+class TestEagleGateRouting(CustomTestCase):
+    def _gate(self, is_all_greedy, platform, use_rej):
+        is_cpu, is_npu, is_hip, is_xpu = _PLATFORMS[platform]
+        return _verify_uses_greedy(
+            is_all_greedy=is_all_greedy,
+            is_cpu=is_cpu,
+            is_npu=is_npu,
+            is_hip=is_hip,
+            is_xpu=is_xpu,
+            use_rejection_sampling=use_rej,
+        )
+
+    def test_non_hip_is_byte_identical_to_pre_patch(self):
+        for platform, is_all_greedy, use_rej in itertools.product(
+            _PLATFORMS, (False, True), (False, True)
+        ):
+            is_cpu, is_npu, is_hip, is_xpu = _PLATFORMS[platform]
+            if is_hip:
+                continue
+            got = self._gate(is_all_greedy, platform, use_rej)
+            expected = _pre_patch_gate(is_all_greedy, is_cpu, is_npu, is_hip, is_xpu)
+            self.assertEqual(
+                got,
+                expected,
+                f"{platform} greedy={is_all_greedy} rej={use_rej}: gate diverged "
+                f"from pre-patch ({got} != {expected})",
+            )
+
+    def test_hip_samples_only_with_rejection_and_non_greedy(self):
+        # The single new sampling entry: HIP + rejection sampling + not all-greedy.
+        self.assertFalse(self._gate(False, "hip", True))
+        # Every other HIP combination still commits greedy (argmax).
+        self.assertTrue(self._gate(True, "hip", True))
+        self.assertTrue(self._gate(True, "hip", False))
+        self.assertTrue(self._gate(False, "hip", False))
+
+    def test_cuda_keyed_on_all_greedy_only(self):
+        # CUDA samples whenever the batch isn't all-greedy, regardless of the flag.
+        self.assertFalse(self._gate(False, "cuda", False))
+        self.assertFalse(self._gate(False, "cuda", True))
+        self.assertTrue(self._gate(True, "cuda", False))
+        self.assertTrue(self._gate(True, "cuda", True))
+
+    def test_cpu_npu_xpu_always_greedy(self):
+        for platform in ("cpu", "npu", "xpu"):
+            for is_all_greedy in (False, True):
+                for use_rej in (False, True):
+                    self.assertTrue(
+                        self._gate(is_all_greedy, platform, use_rej),
+                        f"{platform} must force greedy",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On ROCm/HIP, EAGLE speculative decoding **always commits `argmax` (greedy) in verify**. It ignores
`temperature` and `top_p`:

```python
if sampling_info.is_all_greedy or _is_cpu or _is_npu or _is_hip or _is_xpu:
    target_predict = torch.argmax(...)   # greedy
```

`_is_hip` is in that list because the sampling-verify ops
(`tree_speculative_sampling_target_only`, `top_k_renorm_prob`, `top_p_renorm_prob`) are only imported
under `is_cuda()/is_musa()`. So **any EAGLE spec-decode run at `temperature>0` on ROCm decodes
greedy**. On long reasoning output that turns into repetition loops. This is not model specific.

## Modifications

1. `eagle_utils.py` — move the check into a small `_verify_uses_greedy(...)` helper, which returns
   exactly the old answer on every non-HIP platform. Add a Triton top-p renorm (pivot binary search)
   and a HIP wrapper to stand in for the CUDA-only sgl_kernel ops, and guard the CUDA-only imports.
   HIP then goes through the pure-Triton `chain_speculative_sampling_triton`.
2. `arg_groups/speculative_hook.py` — turn on `speculative_use_rejection_sampling` by default on HIP
   for EAGLE/EAGLE3 with topk==1, default accept thresholds, and non-deterministic mode, so users do
   not have to know about a flag. These conditions are a strict subset of the checks that raise just
   below, so turning it on can never break a config that used to work.

## Accuracy Tests

Both sides were run on this branch with the same settings. Only the patch differs. GLM-5.2-FP8,
8x MI355X, NEXTN spec decode (`num_steps=1, eagle_topk=1, draft_tokens=2`), GPQA-Diamond 198
questions, `temperature=1.0 / top_p=0.95`, `max_tokens=98304`.

| | old code | this PR |
|---|---|---|
| **GPQA-Diamond** | **0.702 ± 0.033** | **0.904 ± 0.021** |
| answers that used up the whole token budget | **78/198 (39.4%)** | **5/198 (2.5%)** |
| mean response length | 134,921 chars | 7,860 chars |
| accuracy on answers that did finish | 0.9333 | 0.9223 |

**+20.2 points, about 5.2 sigma.** The cause is not model quality. On the questions where the old
code finishes, it scores 0.9333, which matches the patched build. It loses because **39.4% of its
answers never finish**: greedy verify at `temperature>0` falls into repetition loops and burns the
whole budget without giving an answer. You can also see it in wall-clock time (about 2x) and in a
first attempt that died because requests went past the default 1800s per-request timeout.

A probe on a non-greedy batch confirms which branch runs: old code takes `GREEDY(argmax)`, this PR
takes `SAMPLING`. The same run shows the `speculative_hook.py` half working, with the server logging
`enabling speculative_use_rejection_sampling by default` and no error.

## Speed Tests and Profiling

This is a correctness fix; the sampling path costs the same. Throughput under NEXTN spec decode on GSM8K n=200: 740-771 tok/s before, 764 tok/s after.

**GSM8K cannot show this bug** because it runs greedy, so argmax is already the right answer there.
It is only a no-regression check: 0.945-0.960 old vs 0.940 patched at n=200, throughput 740-771 vs
764 tok/s.

## Known gaps (pre-existing, not regressions)

On HIP, EAGLE topk==1 with `--enable-deterministic-inference` or non-default accept thresholds is
left alone on purpose, because rejection sampling really is incompatible there. HIP **tree drafting**
(topk>1) still uses greedy, because the Triton chain sampler only handles chains.

`_renorm_top_k_top_p_hip` decides whether to run the top-k sort with `bool((top_ks < vocab).any())`,
which is a device sync on every verify step. Passing `sampling_info.need_top_k_sampling` and
`need_top_p_sampling` (what the CUDA branch already uses) would remove it. That measured well under
0.5% of a decode step, so I left it out to keep this PR a pure bug fix whose numbers match the code.

<details>
<summary>How to reproduce</summary>

Image `lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260817`, `/data/huggingface/GLM-5.2-FP8`. Use
FP8, **not** MXFP4: on that image `quark.py` imports a name its `overrides.py` does not have, so the
server dies while loading weights.

```bash
# Unit tests. Pass the GPU devices even for CPU-only tests: importing sglang pulls in aiter,
# which runs rocminfo at import time.
docker run --rm --device=/dev/kfd --device=/dev/dri --group-add video \
  --security-opt seccomp=unconfined --shm-size 16g -v "$PWD:/wt" -w /wt -e PYTHONPATH=/wt/python \
  lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260817 \
  bash -lc 'python3 -m pytest test/registered/unit/spec/test_eagle_gate_routing.py \
            test/registered/spec/eagle/test_rocm_eagle_renorm.py -q'

# Serve with spec decode
python3 -m sglang.launch_server --model-path /data/huggingface/GLM-5.2-FP8 --trust-remote-code \
  --tp-size 8 --page-size 64 --kv-cache-dtype fp8_e4m3 \
  --dsa-prefill-backend tilelang --dsa-decode-backend tilelang \
  --speculative-algorithm NEXTN --speculative-num-steps 1 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 \
  --reasoning-parser glm45 --context-length 163840 --mem-fraction-static 0.75 --port 30000

# GPQA-Diamond. lm-eval pinned at b315ef3b05176acc9732bb7fdec116abe1ecc476,
# task gpqa_diamond_cot_n_shot.
python3 -m lm_eval --model local-chat-completions --apply_chat_template \
  --tasks gpqa_diamond.yaml --output_path "$RESULTS" --log_samples \
  --model_args "model=$MODEL,base_url=http://0.0.0.0:30000/v1/chat/completions,api_key=EMPTY,\
eos_string=</s>,max_retries=5,num_concurrent=64,timeout=7200,tokenized_requests=False,max_length=163840" \
  --limit 198 --gen_kwargs "max_tokens=98304,temperature=1.0,top_p=0.95"
```

`--limit 198` takes one permutation per question (`process_docs` uses `n_repeats=2`). You need
`HF_TOKEN`, the dataset is gated. lm-eval has to fall back to `reasoning_content` when `content` is
empty, or every graded answer from a thinking model is an empty string.

Two things to watch when probing the branch. Gate the probe on `not sampling_info.is_all_greedy`:
server warmup sends a greedy request, so a plain one-shot probe tells you nothing. And do not use
output diversity as a test: the old code still returns 8 out of 8 different completions at
`temperature=1.0`, because the bonus token goes through the normal sampler.
</details>

## AI assistance

This PR was developed with AI assistance (Claude). The AI helped with the rebase and conflict
resolution, wrote the unit tests, and ran the measurements reported above. All code and results were
reviewed and verified by the author on real hardware; the commits carry a `Co-authored-by` trailer.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33038846825](https://github.com/sgl-project/sglang/actions/runs/33038846825)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33038846496](https://github.com/sgl-project/sglang/actions/runs/33038846496)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33038846762](https://github.com/sgl-project/sglang/actions/runs/33038846762)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->