### PR TITLE
[DSA] Guard move_kv_cache against page-indexed corruption for page_size>1

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -3216,6 +3216,18 @@ class DSATokenToKVPool(MLATokenToKVPool):
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         """Move latent KV and the DSA indexer cache (key + scale) in lockstep."""
+        # index_k_with_scale_buffer is page-indexed (dim-0 = num_pages; see
+        # _index_buffer_shape) while tgt_loc/src_loc are per-token locations, so the
+        # per-token copy below is correct only for page_size == 1. Guard fail-fast
+        # (before any move) until the topk>1 tree-draft path needs a page-aware move.
+        if self.page_size != 1:
+            raise NotImplementedError(
+                "DSATokenToKVPool.move_kv_cache does not support page_size > 1 "
+                f"(got page_size={self.page_size}): index_k_with_scale_buffer is "
+                "page-indexed while tgt_loc/src_loc are token locations. Implement a "
+                "page-aware move before enabling tree-drafting (topk>1) on DSA."
+            )
+
         super().move_kv_cache(tgt_loc, src_loc)
 
         if tgt_loc.numel() == 0:

--- a/test/registered/unit/mem_cache/test_dsa_move_kv_cache_guard.py
+++ b/test/registered/unit/mem_cache/test_dsa_move_kv_cache_guard.py
@@ -1,0 +1,80 @@
+"""Unit tests for the DSATokenToKVPool.move_kv_cache page-index guard.
+
+Regression guard for the DSA index-K move bug: ``index_k_with_scale_buffer`` is
+PAGE-indexed (dim-0 is ``num_pages``, with ``page_size`` tokens packed along
+dim-1), but ``move_kv_cache`` receives per-TOKEN locations. The per-token row
+copy is correct only for ``page_size == 1``; for ``page_size > 1`` (all CUDA DSA
+uses ``page_size == 64``, HIP preshuffle uses a multiple of 16) it would index
+the wrong rows / go out of bounds and silently corrupt the indexer cache. The
+fix guards that path with an explicit ``NotImplementedError`` for
+``page_size != 1``.
+
+These tests pin the behavior without a GPU by bypassing the heavy
+(GPU/allocator) ``__init__`` and stubbing the base MLA move (which is
+token-indexed and correct), so only the DSA-specific guard is exercised.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool, MLATokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+# The base MLA move (super().move_kv_cache) is token-indexed and correct, but it
+# touches self.kv_buffer / self.size, which the bypassed __init__ never set.
+# Stub it to a no-op so the tests isolate the DSA index-K guard on the CPU.
+def _no_base_move(self, tgt_loc, src_loc):
+    return None
+
+
+class TestDSAMoveKVCacheGuard(CustomTestCase):
+    @staticmethod
+    def _make_pool(page_size: int) -> DSATokenToKVPool:
+        # __new__ gives a real DSATokenToKVPool instance (so the zero-arg super()
+        # call inside move_kv_cache resolves) without running the GPU __init__.
+        pool = DSATokenToKVPool.__new__(DSATokenToKVPool)
+        pool.page_size = page_size
+        return pool
+
+    def test_move_kv_cache_raises_for_page_size_gt_1(self):
+        """page_size > 1 must raise instead of doing a corrupting per-token move.
+
+        Covers the real configs: 64 (all CUDA DSA) and 16 (a HIP preshuffle
+        page_size, which must be a multiple of 16). A guard written as
+        ``== 64`` instead of ``!= 1`` would wrongly pass page_size 16 through.
+        """
+        tgt_loc = torch.tensor([0, 1], dtype=torch.int64)
+        src_loc = torch.tensor([2, 3], dtype=torch.int64)
+        for page_size in (16, 64):
+            with self.subTest(page_size=page_size):
+                pool = self._make_pool(page_size)
+                with patch.object(MLATokenToKVPool, "move_kv_cache", _no_base_move):
+                    with self.assertRaises(NotImplementedError):
+                        pool.move_kv_cache(tgt_loc, src_loc)
+
+    def test_move_kv_cache_page_size_1_moves_without_guard(self):
+        """page_size == 1 (HIP legacy): token index == page index, so the guard
+        must NOT fire and the per-token move must still copy the right row."""
+        pool = self._make_pool(1)
+        # (num_tokens=4, packed_dim=6); with page_size==1 a "page" is one token.
+        buf = torch.arange(4 * 6, dtype=torch.uint8).view(4, 6)
+        pool.index_k_with_scale_buffer = [buf]
+        expected_row = buf[2].clone()
+
+        tgt_loc = torch.tensor([0], dtype=torch.int64)
+        src_loc = torch.tensor([2], dtype=torch.int64)
+        with patch.object(MLATokenToKVPool, "move_kv_cache", _no_base_move):
+            pool.move_kv_cache(tgt_loc, src_loc)  # must not raise
+
+        # Row 0 now holds the old contents of row 2: the per-token move ran.
+        self.assertTrue(torch.equal(buf[0], expected_row))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`DSATokenToKVPool.move_kv_cache` (`srt/mem_cache/memory_pool.py`) moves the DSA indexer cache with:

```python
for index_k in self.index_k_with_scale_buffer:   # PAGE-indexed: (num_pages, page_size*(...))
    index_k[tgt_loc_flat] = index_k[src_loc_flat]  # tgt/src are per-TOKEN locations
```

`index_k_with_scale_buffer` is **page-indexed** (dim-0 is `num_pages`, with `page_size` tokens packed along
dim-1), but `tgt_loc/src_loc` are **token** locations. This is correct only for `page_size == 1`; for
`page_size == 64` (all CUDA DSA) it indexes the page dimension with token indices → wrong rows / OOB → silent
indexer-cache corruption. It is reached only via `move_accept_tokens_to_target_kvcache` on the **topk>1
tree-draft** path (`srt/speculative/spec_utils.py`); the topk==1 chain (e.g. GLM-5.2) never hits it, so it is
latent today.

## Fix
Add a fail-fast guard at the top of the method: for `page_size != 1`, raise `NotImplementedError` (before any
move, preserving the method's all-or-nothing contract) explaining that a page-aware move is required before
tree-drafting (topk>1) is enabled on DSA. The `page_size == 1` path and the base MLA `super().move_kv_cache`
(token-indexed, correct) are unchanged. A page-aware rewrite is deliberately out of scope — this stops silent
corruption cheaply until tree-drafting on DSA is actually wired up.

## Testing (all pass)

**`test/registered/unit/mem_cache/test_dsa_move_kv_cache_guard.py`** — GPU-free, **2/2 PASSED**:
| method | asserts |
|---|---|
| `test_move_kv_cache_raises_for_page_size_gt_1` | `page_size` ∈ {16, 64} raises `NotImplementedError` (fails on pre-fix code, which silently mis-moves); the 16 case pins `!= 1` vs a wrong `== 64` |
| `test_move_kv_cache_page_size_1_moves_without_guard` | `page_size == 1` does not raise and moves the correct row |







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29354807603](https://github.com/sgl-project/sglang/actions/runs/29354807603)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29354807313](https://github.com/sgl-project/sglang/actions/runs/29354807313)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->