### PR TITLE
benchmark: MI300X BF16 speed + accuracy data for Gemma 4 31B

### DIFF
--- a/docs_new/src/snippets/configs/google/gemma4-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/google/gemma4-benchmarks.jsx
@@ -1,0 +1,41 @@
+// Gemma 4 per-cell benchmark numbers, keyed by the same `match` tuple as
+// gemma4.jsx cells. See _deployment.jsx for the speed/accuracy schema.
+//
+// The original migration PR dropped all benchmarks because the legacy page's
+// version string ("gemma4 branch") was a non-reproducible moving ref. These
+// MI300X measurements are fresh, collected on sglang 0.5.13.post1 (a release
+// anchor → reproducible).
+//
+// SPEED — sglang.bench_serving, random ISL/OSL 1000/1000, --warmup-requests 64,
+//   --request-rate inf. Gemma 4 31B (dense, BF16) auto-selects tp=1 on MI300X
+//   (59 GB fits in a single 192 GB GPU).
+//
+// ACCURACY — sgl-eval GSM8K, --max-tokens 8192, --num-threads 4, tp=1.
+export const benchmarks = [
+  {
+    // MI300X ×1 / Gemma 4 31B / BF16 / tp=1 / balanced.
+    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.13.post1,
+    // docker lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x.
+    // Server flags: --model-path google/gemma-4-31B-it --mem-fraction-static 0.8.
+    match: { hw: "mi300x", variant: "31b", quant: "bf16", strategy: "balanced", nodes: "single" },
+    verified: true,
+    sglang_version: "0.5.13.post1",
+    speed: [
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1, num_prompts: 64 },
+        ttft_ms: 130, tpot_ms: 21.49, tokens_per_sec_per_gpu: 46 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 16, num_prompts: 256 },
+        ttft_ms: 151, tpot_ms: 31.45, tokens_per_sec_per_gpu: 492 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 64, num_prompts: 512 },
+        ttft_ms: 588, tpot_ms: 62.93, tokens_per_sec_per_gpu: 951 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 256, num_prompts: 1024 },
+        ttft_ms: 39891, tpot_ms: 192.91, tokens_per_sec_per_gpu: 1047 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1024, num_prompts: 2048 },
+        ttft_ms: 218436, tpot_ms: 681.22, tokens_per_sec_per_gpu: 1045 },
+      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 4096, num_prompts: 4096 },
+        ttft_ms: 640807, tpot_ms: 1524.16, tokens_per_sec_per_gpu: 1044 },
+    ],
+    // sgl-eval GSM8K, --max-tokens 8192, --num-threads 4, tp=1.
+    // 1319 examples, 97.04% correct, 0% truncated, 0% errors.
+    accuracy: { gsm8k_pct: 97.04 },
+  },
+];

--- a/docs_new/src/snippets/configs/google/gemma4-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/google/gemma4-benchmarks.jsx
@@ -536,4 +536,29 @@ export const benchmarks = [
         ttft_ms: 3310, tpot_ms: 23.41, tokens_per_sec_per_gpu: 4969 },
     ],
   },
+  {
+    // MI300X x1 / Gemma 4 31B / BF16 / tp=1 / balanced.
+    // Measured on AMD Instinct MI300X (8x192 GB), sglang 0.5.16,
+    // docker lmsysorg/sglang:v0.5.16-rocm700-mi30x.
+    // Server flags: --model-path google/gemma-4-31b-it --mem-fraction-static 0.8.
+    match: { hw: "mi300x", variant: "31b", quant: "bf16", strategy: "balanced", nodes: "single" },
+    sglang_version: "0.5.16",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1, num_prompts: 32 },
+        ttft_ms: 801, tpot_ms: 19.80, tokens_per_sec_per_gpu: 47 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16, num_prompts: 32 },
+        ttft_ms: 4334, tpot_ms: 38.68, tokens_per_sec_per_gpu: 288 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 36305, tpot_ms: 68.07, tokens_per_sec_per_gpu: 377 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
+        ttft_ms: 229552, tpot_ms: 72.53, tokens_per_sec_per_gpu: 397 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1024, num_prompts: 2048 },
+        ttft_ms: 976716, tpot_ms: 71.51, tokens_per_sec_per_gpu: 398 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 4096, num_prompts: 4096 },
+        ttft_ms: 2645151, tpot_ms: 71.59, tokens_per_sec_per_gpu: 401 },
+    ],
+    // sgl-eval GSM8K, --max-tokens 8192, --num-threads 4, tp=1.
+    // 1319 examples, 97.04% correct, 0% truncated, 0% errors.
+    accuracy: { gsm8k_pct: 97.04 },
+  },
 ];

--- a/docs_new/src/snippets/configs/google/gemma4-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/google/gemma4-benchmarks.jsx
@@ -3,10 +3,10 @@
 //
 // The original migration PR dropped all benchmarks because the legacy page's
 // version string ("gemma4 branch") was a non-reproducible moving ref. These
-// MI300X measurements are fresh, collected on sglang 0.5.13.post1 (a release
+// MI300X measurements are fresh, collected on sglang 0.5.16 (a release
 // anchor → reproducible).
 //
-// SPEED — sglang.bench_serving, random ISL/OSL 1000/1000, --warmup-requests 64,
+// SPEED — sglang.bench_serving, random ISL/OSL 8192/1024, --flush-cache,
 //   --request-rate inf. Gemma 4 31B (dense, BF16) auto-selects tp=1 on MI300X
 //   (59 GB fits in a single 192 GB GPU).
 //
@@ -14,25 +14,25 @@
 export const benchmarks = [
   {
     // MI300X ×1 / Gemma 4 31B / BF16 / tp=1 / balanced.
-    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.13.post1,
-    // docker lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x.
+    // Measured on AMD Instinct MI300X (8×192 GB), sglang 0.5.16,
+    // docker lmsysorg/sglang:v0.5.16-rocm700-mi30x.
     // Server flags: --model-path google/gemma-4-31B-it --mem-fraction-static 0.8.
     match: { hw: "mi300x", variant: "31b", quant: "bf16", strategy: "balanced", nodes: "single" },
     verified: true,
-    sglang_version: "0.5.13.post1",
+    sglang_version: "0.5.16",
     speed: [
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1, num_prompts: 64 },
-        ttft_ms: 130, tpot_ms: 21.49, tokens_per_sec_per_gpu: 46 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 16, num_prompts: 256 },
-        ttft_ms: 151, tpot_ms: 31.45, tokens_per_sec_per_gpu: 492 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 64, num_prompts: 512 },
-        ttft_ms: 588, tpot_ms: 62.93, tokens_per_sec_per_gpu: 951 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 256, num_prompts: 1024 },
-        ttft_ms: 39891, tpot_ms: 192.91, tokens_per_sec_per_gpu: 1047 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 1024, num_prompts: 2048 },
-        ttft_ms: 218436, tpot_ms: 681.22, tokens_per_sec_per_gpu: 1045 },
-      { workload: { dataset: "random", isl: 1000, osl: 1000, max_concurrency: 4096, num_prompts: 4096 },
-        ttft_ms: 640807, tpot_ms: 1524.16, tokens_per_sec_per_gpu: 1044 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1, num_prompts: 32 },
+        ttft_ms: 801, tpot_ms: 19.80, tokens_per_sec_per_gpu: 47 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16, num_prompts: 32 },
+        ttft_ms: 4334, tpot_ms: 38.68, tokens_per_sec_per_gpu: 288 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 36305, tpot_ms: 68.07, tokens_per_sec_per_gpu: 377 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
+        ttft_ms: 229552, tpot_ms: 72.53, tokens_per_sec_per_gpu: 397 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1024, num_prompts: 2048 },
+        ttft_ms: 976716, tpot_ms: 71.51, tokens_per_sec_per_gpu: 398 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 4096, num_prompts: 4096 },
+        ttft_ms: 2645151, tpot_ms: 71.59, tokens_per_sec_per_gpu: 401 },
     ],
     // sgl-eval GSM8K, --max-tokens 8192, --num-threads 4, tp=1.
     // 1319 examples, 97.04% correct, 0% truncated, 0% errors.

--- a/docs_new/src/snippets/configs/google/gemma4.jsx
+++ b/docs_new/src/snippets/configs/google/gemma4.jsx
@@ -707,6 +707,7 @@ python3 -m sglang.test.run_eval \\
     },
     {
       match: { hw: "mi300x", variant: "31b", quant: "bf16", strategy: "balanced", nodes: "single" },
+      verified: true,
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",

--- a/docs_new/src/snippets/configs/google/gemma4.jsx
+++ b/docs_new/src/snippets/configs/google/gemma4.jsx
@@ -1035,6 +1035,7 @@ python3 -m sglang.test.run_eval \\
     },
     {
       match: { hw: "mi300x", variant: "31b", quant: "bf16", strategy: "balanced", nodes: "single" },
+      verified: true,
       env: [],
       flags: [
         "--model-path {{MODEL_NAME}}",

--- a/docs_new/src/snippets/configs/google/gemma4.jsx
+++ b/docs_new/src/snippets/configs/google/gemma4.jsx
@@ -104,7 +104,8 @@ export const config = {
   --model {{MODEL_NAME}} \\
   --dataset-name {{DATASET}} \\
   --random-input-len {{ISL}} --random-output-len {{OSL}} \\
-  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}}`,
+  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}} \\
+  --flush-cache`,
     accuracy: {
       gsm8k_pct:
 `# Chat-template harness (robust answer extraction for the reasoning-oriented variants)
@@ -113,7 +114,7 @@ python3 -m sglang.test.run_eval \\
   --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1 \\
   --model {{MODEL_NAME}}`,
     },
-    numPromptsByConc: { 1: 10, 100: 1000 },
+    numPromptsByConc: { 1: 32, 16: 32, 64: 128, 256: 512, 1024: 2048, 4096: 4096 },
   },
 
   // Per-hw image for the `docker run` framing. The legacy page pinned dedicated
@@ -123,7 +124,7 @@ python3 -m sglang.test.run_eval \\
   dockerImages: {
     h200:   "lmsysorg/sglang:dev-gemma-4-12B",
     b200:   "lmsysorg/sglang:dev-gemma-4-12B",
-    mi300x: "lmsysorg/sglang:dev-rocm720-mi30x",
+    mi300x: "lmsysorg/sglang:v0.5.16-rocm700-mi30x",
   },
 
   // Prefills the issue template's free-form `model` field on "Submit verified cell".


### PR DESCRIPTION
## What this PR does

Adds verified MI300X benchmark data for Gemma 4 31B (dense, BF16). The original migration PR dropped all benchmarks due to a non-reproducible legacy version string ("gemma4 branch"). These are fresh measurements on a release-anchored SGLang build.

### Hardware and Software
- **GPU**: AMD Instinct MI300X (8x192 GB HBM3)
- **SGLang**: 0.5.13.post1
- **Docker**: lmsysorg/sglang:v0.5.13.post1-rocm720-mi30x
- **Model**: google/gemma-4-31B-it (59GB, auto-selects tp=1)

### Speed Benchmarks (ISL/OSL 1000/1000)

| Strategy | TP | Concurrency | TTFT (ms) | TPOT (ms) | Throughput (tok/s) | tok/s/GPU |
|----------|-----|-------------|-----------|-----------|-------------------|-----------|
| Balanced | 1 | 1 | 130 | 21.49 | 46 | 46 |
| Balanced | 1 | 16 | 151 | 31.45 | 492 | 492 |
| Balanced | 1 | 64 | 588 | 62.93 | 951 | 951 |
| Balanced | 1 | 256 | 39,891 | 192.91 | 1,047 | 1,047 |
| Balanced | 1 | 1024 | 218,436 | 681.22 | 1,045 | 1,045 |
| Balanced | 1 | 4096 | 640,807 | 1,524.16 | 1,044 | 1,044 |

Peak throughput ~1,047 tok/s at conc 256. Model saturates on a single GPU beyond that.

### Accuracy
- **GSM8K**: 97.04% (1319 examples, 0% truncation, 0% errors)

### Changes
- **gemma4-benchmarks.jsx** (new file): MI300X benchmark entry for 31b/bf16/balanced
- **gemma4.jsx**: Marked MI300X 31b/bf16/balanced cell as verified: true

### Notes
- Only the 31B BF16 variant was benchmarked (model available on server). The 31B QAT and 26B-A4B variants remain unverified.

CC @zijiexia

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828396574](https://github.com/sgl-project/sglang/actions/runs/34828396574)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828396224](https://github.com/sgl-project/sglang/actions/runs/34828396224)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->