### PR TITLE
Add optional uint16/uint8 routed-experts wire encoding

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -409,6 +409,7 @@ class SglExt(BaseModel):
     """
 
     routed_experts: Optional[str] = None
+    routed_experts_dtype: Optional[str] = None
     cached_tokens_details: Optional[CachedTokensDetails] = None
 
     @model_serializer(mode="wrap")

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -53,6 +53,7 @@ from sglang.srt.entrypoints.openai.utils import (
     cached_tokens_details_from_dict,
     process_cached_tokens_details_from_ret,
     process_hidden_states_from_ret,
+    process_routed_experts_dtype_from_ret,
     process_routed_experts_from_ret,
     should_include_usage,
     to_openai_style_logprobs,
@@ -1064,6 +1065,7 @@ class OpenAIServingChat(OpenAIServingBase):
         cached_tokens = {}
         hidden_states = {}
         routed_experts = {}
+        routed_experts_dtype = {}
         cached_tokens_details = {}
         image_tokens = {}
         audio_tokens = {}
@@ -1091,6 +1093,9 @@ class OpenAIServingChat(OpenAIServingBase):
                 cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)
+                routed_experts_dtype[index] = content["meta_info"].get(
+                    "routed_experts_dtype", None
+                )
                 cached_tokens_details[index] = content["meta_info"].get(
                     "cached_tokens_details", None
                 )
@@ -1212,8 +1217,9 @@ class OpenAIServingChat(OpenAIServingBase):
 
             sglext_routed = None
             if request.return_routed_experts and routed_experts:
-                sglext_routed = next(
-                    (v for v in routed_experts.values() if v is not None), None
+                # Get first non-None routed_experts value
+                first_routed_experts = next(
+                    ((i, v) for i, v in routed_experts.items() if v is not None), None
                 )
 
             sglext_details = None
@@ -1224,14 +1230,23 @@ class OpenAIServingChat(OpenAIServingBase):
                 if first_details is not None:
                     sglext_details = cached_tokens_details_from_dict(first_details)
 
-            if sglext_routed is not None or sglext_details is not None:
+            if first_routed_experts is not None or sglext_details is not None:
+                routed_experts_index = None
+                routed_experts_value = None
+                if first_routed_experts is not None:
+                    routed_experts_index, routed_experts_value = first_routed_experts
                 sglext_chunk = ChatCompletionStreamResponse(
                     id=content["meta_info"]["id"],
                     created=int(time.time()),
                     choices=[],  # sglext is at response level
                     model=request.model,
                     sglext=SglExt(
-                        routed_experts=sglext_routed,
+                        routed_experts=routed_experts_value,
+                        routed_experts_dtype=(
+                            routed_experts_dtype.get(routed_experts_index)
+                            if routed_experts_index is not None
+                            else None
+                        ),
                         cached_tokens_details=sglext_details,
                     ),
                 )
@@ -1315,13 +1330,15 @@ class OpenAIServingChat(OpenAIServingBase):
         # Build sglext at response level (from first ret_item, as these are per-request)
         first_ret = ret[0]
         routed_experts = process_routed_experts_from_ret(first_ret, request)
+        routed_experts_dtype = process_routed_experts_dtype_from_ret(first_ret, request)
         cached_tokens_details = process_cached_tokens_details_from_ret(
             first_ret, request
         )
         response_sglext = None
-        if routed_experts or cached_tokens_details:
+        if routed_experts or routed_experts_dtype or cached_tokens_details:
             response_sglext = SglExt(
                 routed_experts=routed_experts,
+                routed_experts_dtype=routed_experts_dtype,
                 cached_tokens_details=cached_tokens_details,
             )
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -23,6 +23,7 @@ from sglang.srt.entrypoints.openai.utils import (
     cached_tokens_details_from_dict,
     process_cached_tokens_details_from_ret,
     process_hidden_states_from_ret,
+    process_routed_experts_dtype_from_ret,
     process_routed_experts_from_ret,
     should_include_usage,
     to_openai_style_logprobs,
@@ -232,6 +233,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
         cached_tokens = {}
         hidden_states = {}
         routed_experts = {}
+        routed_experts_dtype = {}
         cached_tokens_details = {}
 
         stream_started = False
@@ -257,6 +259,9 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)
+                routed_experts_dtype[index] = content["meta_info"].get(
+                    "routed_experts_dtype", None
+                )
                 cached_tokens_details[index] = content["meta_info"].get(
                     "cached_tokens_details", None
                 )
@@ -393,8 +398,9 @@ class OpenAIServingCompletion(OpenAIServingBase):
 
             sglext_routed = None
             if request.return_routed_experts and routed_experts:
-                sglext_routed = next(
-                    (v for v in routed_experts.values() if v is not None), None
+                # Get first non-None routed_experts value
+                first_routed_experts = next(
+                    ((i, v) for i, v in routed_experts.items() if v is not None), None
                 )
 
             sglext_details = None
@@ -405,7 +411,11 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 if first_details is not None:
                     sglext_details = cached_tokens_details_from_dict(first_details)
 
-            if sglext_routed is not None or sglext_details is not None:
+            if first_routed_experts is not None or sglext_details is not None:
+                routed_experts_index = None
+                routed_experts_value = None
+                if first_routed_experts is not None:
+                    routed_experts_index, routed_experts_value = first_routed_experts
                 sglext_chunk = CompletionStreamResponse(
                     id=content["meta_info"]["id"],
                     created=created,
@@ -413,7 +423,12 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     choices=[],  # sglext is at response level
                     model=request.model,
                     sglext=SglExt(
-                        routed_experts=sglext_routed,
+                        routed_experts=routed_experts_value,
+                        routed_experts_dtype=(
+                            routed_experts_dtype.get(routed_experts_index)
+                            if routed_experts_index is not None
+                            else None
+                        ),
                         cached_tokens_details=sglext_details,
                     ),
                 )
@@ -492,13 +507,15 @@ class OpenAIServingCompletion(OpenAIServingBase):
         # Build sglext at response level (from first ret_item, as these are per-request)
         first_ret = ret[0]
         routed_experts = process_routed_experts_from_ret(first_ret, request)
+        routed_experts_dtype = process_routed_experts_dtype_from_ret(first_ret, request)
         cached_tokens_details = process_cached_tokens_details_from_ret(
             first_ret, request
         )
         response_sglext = None
-        if routed_experts or cached_tokens_details:
+        if routed_experts or routed_experts_dtype or cached_tokens_details:
             response_sglext = SglExt(
                 routed_experts=routed_experts,
+                routed_experts_dtype=routed_experts_dtype,
                 cached_tokens_details=cached_tokens_details,
             )
 

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -106,10 +106,27 @@ def process_routed_experts_from_ret(
     return ret_item["meta_info"].get("routed_experts", None)
 
 
+def process_routed_experts_dtype_from_ret(
+    ret_item: Dict[str, Any],
+    request: Union[
+        ChatCompletionRequest,
+        CompletionRequest,
+    ],
+) -> Optional[str]:
+    """Process routed experts dtype from a ret item in non-streaming response."""
+    if not getattr(request, "return_routed_experts", False):
+        return None
+    meta_info = ret_item["meta_info"]
+    if meta_info.get("routed_experts", None) is None:
+        return None
+    return meta_info.get("routed_experts_dtype", None)
+
+
 def cached_tokens_details_from_dict(
     details: Dict[str, Any],
 ) -> CachedTokensDetails:
     """Convert a raw cached_tokens_details dict to a CachedTokensDetails object."""
+    # Check if L3 storage fields are present
     if "storage" in details:
         return CachedTokensDetails(
             device=details.get("device", 0),

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -40,6 +40,9 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.multi_tokenizer_mixin import MultiHttpWorkerDetokenizerMixin
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
 from sglang.srt.server_args import PortArgs, ServerArgs
+from sglang.srt.state_capturer.routed_experts import (
+    encode_routed_experts_for_wire,
+)
 from sglang.srt.utils import configure_logger, freeze_gc, kill_itself_when_parent_died
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.srt.utils.network import get_zmq_socket
@@ -403,6 +406,18 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             for item in data_list
         ]
 
+    @staticmethod
+    def _encode_routed_experts_per_request(
+        data_list: Optional[List[Optional[torch.Tensor]]],
+    ) -> Optional[List[Optional[str]]]:
+        """Encode routed experts per request using the configured wire dtype."""
+        if data_list is None:
+            return None
+        return [
+            (encode_routed_experts_for_wire(item) if item is not None else None)
+            for item in data_list
+        ]
+
     def handle_batch_token_id_out(self, recv_obj: BatchTokenIDOutput):
         # If handling idle batch, set output_strs to [].
         output_strs = (
@@ -410,7 +425,9 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             if len(recv_obj.rids) > 0
             else []
         )
-        routed_experts = self._b64_encode_per_request(recv_obj.routed_experts)
+        routed_experts = self._encode_routed_experts_per_request(
+            recv_obj.routed_experts
+        )
         indexer_topk = self._b64_encode_per_request(recv_obj.indexer_topk)
         return BatchStrOutput(
             rids=recv_obj.rids,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1250,8 +1250,10 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     # Hidden states
     output_hidden_states: OutputHiddenStates
 
-    # Per-request routed experts (input + output tokens), shape
-    # (token, layer, top_k). DetokenizerManager encodes to base64 into
+    # The routed experts for each position that produced the next token.
+    # routed_experts[i] is a tensor of shape (position, layer, top_k) for request i.
+    # The wire payload is a flat row-major buffer with shape
+    # (position, layer * top_k). DetokenizerManager encodes to base64 into
     # BatchStrOutput; on the skip_tokenizer_init path the scheduler sends this
     # straight to TokenizerManager, which encodes on demand.
     routed_experts: Optional[List[Optional[torch.Tensor]]]
@@ -1334,8 +1336,9 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
     output_hidden_states: OutputHiddenStates
 
     # Per-request routed experts, base64-encoded by DetokenizerManager off the
-    # tokenizer hot path. Underlying tensor shape is (token, layer, top_k);
-    # see BatchTokenIDOutput.routed_experts.
+    # tokenizer hot path. routed_experts[i] is a base64 flat row-major buffer
+    # with shape (position, layer * top_k) after decoding. Underlying tensor
+    # shape is (token, layer, top_k); see BatchTokenIDOutput.routed_experts.
     routed_experts: Optional[List[Optional[str]]]
 
     indexer_topk: Optional[List[Optional[str]]]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -977,7 +977,7 @@ class Req(ReqDllmMixin):
         self.return_routed_experts = return_routed_experts
         self.routed_experts_start_len = routed_experts_start_len
         self.routed_experts: Optional[torch.Tensor] = (
-            None  # cpu tensor: shape (seqlen, topk)
+            None  # cpu tensor: shape (position, layer, topk)
         )
 
         self.return_indexer_topk = return_indexer_topk

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -114,6 +114,9 @@ from sglang.srt.server_args import (
     set_global_server_args_for_tokenizer,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.state_capturer.routed_experts import (
+    get_routed_experts_wire_dtype_name,
+)
 from sglang.srt.utils import (
     configure_gc_warning,
     freeze_gc,
@@ -2003,6 +2006,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     if isinstance(val, torch.Tensor):
                         val = pybase64.b64encode(val.numpy().tobytes()).decode("utf-8")
                     meta_info["routed_experts"] = val
+                    meta_info["routed_experts_dtype"] = (
+                        get_routed_experts_wire_dtype_name()
+                    )
             if getattr(recv_obj, "indexer_topk", None):
                 val = recv_obj.indexer_topk[i]
                 if val is not None:

--- a/python/sglang/srt/state_capturer/routed_experts.py
+++ b/python/sglang/srt/state_capturer/routed_experts.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Optional
 
 import numpy as np
@@ -14,6 +15,64 @@ from sglang.srt.layers.moe import get_moe_a2a_backend
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import get_parallel, get_server_args
 from sglang.srt.state_capturer.base import BaseTopkCapturer
+
+_ROUTED_EXPERTS_DTYPE_ENV = "SGLANG_ROUTED_EXPERTS_DTYPE"
+_ROUTED_EXPERTS_WIRE_DTYPES = {
+    "int32": np.dtype(np.int32),
+    "uint16": np.dtype(np.uint16),
+    "uint8": torch.uint8,
+}
+
+
+def get_routed_experts_wire_dtype():
+    dtype_name = get_routed_experts_wire_dtype_name()
+    return _ROUTED_EXPERTS_WIRE_DTYPES[dtype_name]
+
+
+def get_routed_experts_wire_dtype_name():
+    dtype_name = os.environ.get(_ROUTED_EXPERTS_DTYPE_ENV, "int32").strip().lower()
+    if dtype_name not in _ROUTED_EXPERTS_WIRE_DTYPES:
+        raise ValueError(
+            f"Unsupported {_ROUTED_EXPERTS_DTYPE_ENV}={dtype_name!r}. "
+            f"Supported values are: {', '.join(_ROUTED_EXPERTS_WIRE_DTYPES)}."
+        )
+    return dtype_name
+
+
+def _get_routed_experts_wire_dtype_from_meta_info(meta_info: dict):
+    dtype_name = meta_info.get("routed_experts_dtype")
+    if dtype_name is None:
+        return get_routed_experts_wire_dtype()
+
+    if not isinstance(dtype_name, str):
+        raise ValueError("routed_experts_dtype must be a string when provided.")
+
+    dtype_name = dtype_name.strip().lower()
+    if dtype_name not in _ROUTED_EXPERTS_WIRE_DTYPES:
+        raise ValueError(
+            f"Unsupported routed_experts_dtype={dtype_name!r}. "
+            f"Supported values are: {', '.join(_ROUTED_EXPERTS_WIRE_DTYPES)}."
+        )
+    return _ROUTED_EXPERTS_WIRE_DTYPES[dtype_name]
+
+
+def encode_routed_experts_for_wire(routed_experts: torch.Tensor) -> str:
+    """Encode row-major routings as a flat base64 wire payload."""
+    routed_experts_np = routed_experts.numpy().reshape(-1)
+    wire_dtype = get_routed_experts_wire_dtype()
+    dtype_name = get_routed_experts_wire_dtype_name()
+
+    if dtype_name in ("uint16", "uint8") and routed_experts_np.size:
+        np_dtype = np.dtype(np.uint16) if dtype_name == "uint16" else np.dtype(np.uint8)
+        info = np.iinfo(np_dtype)
+        if routed_experts_np.min() < info.min or routed_experts_np.max() > info.max:
+            raise ValueError(
+                f"Cannot encode routed experts as {dtype_name} because at least one "
+                f"expert id is outside [{info.min}, {info.max}]."
+            )
+
+    routed_experts_np = routed_experts_np.astype(wire_dtype, copy=False)
+    return pybase64.b64encode(routed_experts_np.tobytes()).decode("utf-8")
 
 
 class RoutedExpertsCapturer(BaseTopkCapturer):
@@ -145,15 +204,36 @@ def set_global_experts_capturer(capturer: Optional[RoutedExpertsCapturer]):
     get_resources().experts_capturer = capturer
 
 
-def extract_routed_experts_from_meta_info(data):
-    # To solve the performance issue, we return the experts_ids in base64
-    # We left this function for user to change it back to normal int32
-    # See detokenizer_manager::_extract_routed_experts
-    routed_experts_base64 = data["meta_info"].get("routed_experts", None)
+def extract_routed_experts_from_meta_info(
+    data,
+    num_layers: Optional[int] = None,
+    topk: Optional[int] = None,
+):
+    """Decode routed experts from response metadata.
+
+    SGLang returns a flat row-major buffer where row p contains the routing that
+    produced token p + 1. When num_layers and topk are provided, the return value
+    is reshaped to (positions, num_layers * topk) using the advertised wire dtype.
+    """
+    meta_info = data["meta_info"]
+    routed_experts_base64 = meta_info.get("routed_experts", None)
+    wire_dtype = _get_routed_experts_wire_dtype_from_meta_info(meta_info)
     routed_experts = np.frombuffer(
-        pybase64.b64decode(routed_experts_base64.encode("utf-8")), dtype=np.int32
+        pybase64.b64decode(routed_experts_base64.encode("utf-8")), dtype=wire_dtype
     )
-    return routed_experts
+
+    if num_layers is None and topk is None:
+        return routed_experts
+    if num_layers is None or topk is None:
+        raise ValueError("num_layers and topk must be provided together.")
+
+    row_width = num_layers * topk
+    if row_width <= 0:
+        raise ValueError(
+            f"Expected positive routed experts row width, got {row_width}."
+        )
+
+    return routed_experts.reshape(-1, row_width)
 
 
 def disable_routed_experts_capture_for_draft(model: Any) -> None:

--- a/test/registered/rl/test_return_routed_experts.py
+++ b/test/registered/rl/test_return_routed_experts.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 import logging
 import unittest
@@ -318,7 +319,12 @@ def extract_routed_experts_from_openai_response(response):
     if routed_experts is None:
         raise ValueError("OpenAI response sglext missing routed_experts.")
     return extract_routed_experts_from_meta_info(
-        {"meta_info": {"routed_experts": routed_experts}}
+        {
+            "meta_info": {
+                "routed_experts": routed_experts,
+                "routed_experts_dtype": sglext.get("routed_experts_dtype", None),
+            }
+        }
     )
 
 
@@ -537,6 +543,48 @@ class TestRoutedExpertsStartLen(CustomTestCase):
         else:
             self.assertGreaterEqual(resp.status_code, 400)
             self.assertIn(expected_substring, resp.text)
+
+
+class TestRoutedExpertsWireDecoder(unittest.TestCase):
+    def test_decode_uint16_wire_dtype_to_flat_rows(self):
+        payload = np.arange(12, dtype=np.uint16)
+        decoded = extract_routed_experts_from_meta_info(
+            {
+                "meta_info": {
+                    "routed_experts": base64.b64encode(payload.tobytes()).decode(
+                        "utf-8"
+                    ),
+                    "routed_experts_dtype": "uint16",
+                }
+            },
+            num_layers=2,
+            topk=3,
+        )
+
+        self.assertIsNotNone(decoded)
+        self.assertEqual(decoded.dtype, np.dtype(np.uint16))
+        self.assertEqual(decoded.shape, (2, 6))
+        np.testing.assert_array_equal(decoded, payload.reshape(2, 6))
+
+    def test_decode_uint8_wire_dtype_to_flat_rows(self):
+        payload = np.arange(12, dtype=np.uint8)
+        decoded = extract_routed_experts_from_meta_info(
+            {
+                "meta_info": {
+                    "routed_experts": base64.b64encode(payload.tobytes()).decode(
+                        "utf-8"
+                    ),
+                    "routed_experts_dtype": "uint8",
+                }
+            },
+            num_layers=2,
+            topk=3,
+        )
+
+        self.assertIsNotNone(decoded)
+        self.assertEqual(decoded.dtype, np.dtype(np.uint8))
+        self.assertEqual(decoded.shape, (2, 6))
+        np.testing.assert_array_equal(decoded, payload.reshape(2, 6))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

DType Compression of Routed Expert Buffer for low Bandwidth Network. Especially useful for non-collocated multi-step agent interactions where the expert buffer has to pass between the generation and the agent environment multiple times.

## Changes

### `python/sglang/srt/state_capturer/routed_experts.py`
- Add `_ROUTED_EXPERTS_DTYPE_ENV` + `_ROUTED_EXPERTS_WIRE_DTYPES` dict (`int32`, `uint16`, `uint8`)
- Add `get_routed_experts_wire_dtype()` / `get_routed_experts_wire_dtype_name()`
- Add `_get_routed_experts_wire_dtype_from_meta_info(meta_info)` for decode-side dtype resolution
- Add `encode_routed_experts_for_wire()` — flat row-major base64 wire payload, with range validation for `uint16` and `uint8`
- Update `extract_routed_experts_from_meta_info(data, num_layers, topk)` to reshape to `(-1, num_layers * topk)` using the advertised wire dtype

### `python/sglang/srt/managers/detokenizer_manager.py`
- Import `encode_routed_experts_for_wire` from `state_capturer.routed_experts`
- Encode `routed_experts` via the wire encoder (keep `pybase64` for `indexer_topk`)

### `python/sglang/srt/managers/tokenizer_manager.py`
- Record `routed_experts_dtype` in `meta_info` alongside existing `routed_experts`, `indexer_topk`, and `dp_rank`

### OpenAI serving path
- Add `process_routed_experts_dtype_from_ret()`
- Surface `routed_experts_dtype` in chat/completions `sglext`

### Tests
- Add wire decoder coverage for `uint16` and `uint8`

## Base
Rebased onto current `main` (`1f34911de7`).

## Validation
- `PYTHONPATH=python python -m py_compile` on touched Python files
- Full routed-experts runtime tests were not run locally because this environment lacks required test dependencies such as `torch`/`aiohttp`.







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29529204148](https://github.com/sgl-project/sglang/actions/runs/29529204148)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29529203942](https://github.com/sgl-project/sglang/actions/runs/29529203942)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->