### PR TITLE
Qwen3.5-MoE: support modelopt_fp4 checkpoints that quantize attention (+ load baked FP8 KV scales)

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -700,13 +700,14 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
         self.config = config
         self.layer_id = layer_id
 
-        linear_attn_quant_config = (
-            None
-            if quant_config and quant_config.get_name() == "modelopt_fp4"
-            else quant_config
-        )
+        # Pass quant_config through unchanged. ModelOptFp4Config.is_layer_excluded()
+        # already decides per-prefix whether a layer is quantized or kept in BF16,
+        # so forcing this to None here would break checkpoints that DO quantize
+        # linear attention (uniform W4A4). NVIDIA's MoE-only NVFP4 checkpoints list
+        # attention modules in exclude_modules, so is_layer_excluded() returns
+        # UnquantizedLinearMethod for them and behavior is unchanged for those.
         self.linear_attn = Qwen3_5GatedDeltaNet(
-            config, layer_id, linear_attn_quant_config, alt_stream, prefix
+            config, layer_id, quant_config, alt_stream, prefix
         )
 
         # NOTE: Determine the MLP type based on the model type
@@ -886,11 +887,12 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             dtype=torch.get_default_dtype(),
         )
 
-        attn_quant_config = (
-            None
-            if quant_config and quant_config.get_name() == "modelopt_fp4"
-            else quant_config
-        )
+        # Pass quant_config through unchanged. ModelOptFp4Config.is_layer_excluded()
+        # already decides per-prefix whether a layer is quantized or kept in BF16,
+        # so forcing this to None here would break checkpoints that DO quantize
+        # full attention (uniform W4A4). NVIDIA's MoE-only NVFP4 checkpoints list
+        # attention modules in exclude_modules, so is_layer_excluded() returns
+        # UnquantizedLinearMethod for them and behavior is unchanged for those.
 
         self.qkv_proj = QKVParallelLinear(
             config.hidden_size,
@@ -898,7 +900,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             self.total_num_heads * (1 + self.attn_output_gate),
             self.total_num_kv_heads,
             bias=False,
-            quant_config=attn_quant_config,
+            quant_config=quant_config,
             tp_rank=self.attn_tp_rank,
             tp_size=self.attn_tp_size,
             prefix=add_prefix("qkv_proj", prefix),
@@ -908,13 +910,16 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             self.total_num_heads * self.head_dim,
             config.hidden_size,
             bias=False,
-            quant_config=attn_quant_config,
+            quant_config=quant_config,
             reduce_results=False,
             tp_rank=self.attn_tp_rank,
             tp_size=self.attn_tp_size,
             prefix=add_prefix("o_proj", prefix),
         )
 
+        # Also pass quant_config to RadixAttention so a FP8-KV quant method (if
+        # any) registers k_scale/v_scale params here; otherwise baked KV scales
+        # from the checkpoint have nowhere to load into and default to 1.0.
         self.attn = RadixAttention(
             self.num_heads,
             self.head_dim,
@@ -922,6 +927,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             num_kv_heads=self.num_kv_heads,
             layer_id=layer_id,
             prefix=f"{prefix}.attn",
+            quant_config=quant_config,
         )
 
         # Dense MLP for non-MoE variant

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1661,6 +1661,32 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
             ):
                 continue
 
+            if name.endswith(".k_scale") or name.endswith(".v_scale"):
+                # ModelOpt FP4 checkpoints that quantize attention bake per-layer
+                # k_scale/v_scale under q/k_proj, e.g.
+                # "layers.N.self_attn.k_proj.k_scale". The stock
+                # maybe_remap_kv_scale_name() cannot handle this here: it keys off
+                # ".self_attn."/".mixer." still being present in the name, but we
+                # already stripped ".self_attn" a few lines up. Remap directly to
+                # the RadixAttention scale param instead and copy the value; the
+                # non-stacked fallback branch below only loads names that already
+                # match params_dict as-is, so without this the scale would be
+                # silently dropped via ignore_suffixes. This is a no-op for
+                # NVIDIA's MoE-only NVFP4 checkpoints, which do not emit
+                # k_scale/v_scale keys for attention.
+                attn_scale_name = name.replace(
+                    ".k_proj.k_scale", ".attn.k_scale"
+                ).replace(".v_proj.v_scale", ".attn.v_scale")
+                if attn_scale_name in params_dict:
+                    scale_param = params_dict[attn_scale_name]
+                    scale_weight_loader = getattr(scale_param, "weight_loader", None)
+                    if scale_weight_loader is not None:
+                        scale_weight_loader(scale_param, loaded_weight)
+                    else:
+                        scale_param.data.copy_(loaded_weight.to(scale_param.dtype))
+                    loaded_params.add(attn_scale_name)
+                    continue
+
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if "experts.gate_up_proj" in name or "experts.down_proj" in name:
                     is_fused_expert = True
@@ -2126,6 +2152,32 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 and (layer_id < self.start_layer or layer_id >= self.end_layer)
             ):
                 continue
+
+            if name.endswith(".k_scale") or name.endswith(".v_scale"):
+                # ModelOpt FP4 checkpoints that quantize attention bake per-layer
+                # k_scale/v_scale under q/k_proj, e.g.
+                # "layers.N.self_attn.k_proj.k_scale". The stock
+                # maybe_remap_kv_scale_name() cannot handle this here: it keys off
+                # ".self_attn."/".mixer." still being present in the name, but we
+                # already stripped ".self_attn" a few lines up. Remap directly to
+                # the RadixAttention scale param instead and copy the value; the
+                # non-stacked fallback branch below only loads names that already
+                # match params_dict as-is, so without this the scale would be
+                # silently dropped via ignore_suffixes. This is a no-op for
+                # NVIDIA's MoE-only NVFP4 checkpoints, which do not emit
+                # k_scale/v_scale keys for attention.
+                attn_scale_name = name.replace(
+                    ".k_proj.k_scale", ".attn.k_scale"
+                ).replace(".v_proj.v_scale", ".attn.v_scale")
+                if attn_scale_name in params_dict:
+                    scale_param = params_dict[attn_scale_name]
+                    scale_weight_loader = getattr(scale_param, "weight_loader", None)
+                    if scale_weight_loader is not None:
+                        scale_weight_loader(scale_param, loaded_weight)
+                    else:
+                        scale_param.data.copy_(loaded_weight.to(scale_param.dtype))
+                    loaded_params.add(attn_scale_name)
+                    continue
 
             if self.enable_shared_expert_fusion:
                 if "mlp.shared_expert." in name:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -701,12 +701,6 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
         self.config = config
         self.layer_id = layer_id
 
-        # Pass quant_config through unchanged. ModelOptFp4Config.is_layer_excluded()
-        # already decides per-prefix whether a layer is quantized or kept in BF16,
-        # so forcing this to None here would break checkpoints that DO quantize
-        # linear attention (uniform W4A4). NVIDIA's MoE-only NVFP4 checkpoints list
-        # attention modules in exclude_modules, so is_layer_excluded() returns
-        # UnquantizedLinearMethod for them and behavior is unchanged for those.
         self.linear_attn = Qwen3_5GatedDeltaNet(
             config, layer_id, quant_config, alt_stream, prefix
         )
@@ -888,13 +882,6 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             dtype=torch.get_default_dtype(),
         )
 
-        # Pass quant_config through unchanged. ModelOptFp4Config.is_layer_excluded()
-        # already decides per-prefix whether a layer is quantized or kept in BF16,
-        # so forcing this to None here would break checkpoints that DO quantize
-        # full attention (uniform W4A4). NVIDIA's MoE-only NVFP4 checkpoints list
-        # attention modules in exclude_modules, so is_layer_excluded() returns
-        # UnquantizedLinearMethod for them and behavior is unchanged for those.
-
         self.qkv_proj = QKVParallelLinear(
             config.hidden_size,
             self.head_dim,
@@ -918,9 +905,6 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             prefix=add_prefix("o_proj", prefix),
         )
 
-        # Also pass quant_config to RadixAttention so a FP8-KV quant method (if
-        # any) registers k_scale/v_scale params here; otherwise baked KV scales
-        # from the checkpoint have nowhere to load into and default to 1.0.
         self.attn = RadixAttention(
             self.num_heads,
             self.head_dim,
@@ -1243,15 +1227,10 @@ ALL_DECODER_LAYER_TYPES = {
     "linear_attention": Qwen3_5LinearDecoderLayer,
 }
 
-# ModelOpt FP4 checkpoints that quantize attention bake the per-layer KV-cache
-# scales under the HF attention projections ("...self_attn.k_proj.k_scale"); in
-# the sglang module tree they live on RadixAttention ("...attn.k_scale"). Must
-# be applied to the weight stream before load_weights() strips ".self_attn",
-# otherwise the stacked-params qkv_proj matching consumes the name and silently
-# drops the scale. Applied per-load_weights rather than exposed as a
-# hf_to_sglang_mapper class attribute: the loader feeds that attribute into
-# quant_config.apply_weight_name_mapper(), which rewrites exclude_modules --
-# a side effect the VL classes deliberately disable (hf_to_sglang_mapper=None).
+# ModelOpt FP4 checkpoints bake the per-layer KV-cache scales under the HF
+# attention projections; in sglang they live on RadixAttention. Apply this to the
+# weight stream at the top of load_weights(), before ".self_attn" is stripped and
+# before the stacked qkv_proj matching would consume the name.
 QWEN3_5_KV_SCALE_MAPPER = WeightsMapper(
     orig_to_new_substr={
         ".self_attn.k_proj.k_scale": ".attn.k_scale",

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -87,6 +87,7 @@ from sglang.srt.models.qwen2_moe import (
 # Models
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
 from sglang.srt.models.utils import (
+    WeightsMapper,
     fused_qk_gemma_rmsnorm,
     fused_qk_gemma_rmsnorm_with_gate,
 )
@@ -1242,6 +1243,22 @@ ALL_DECODER_LAYER_TYPES = {
     "linear_attention": Qwen3_5LinearDecoderLayer,
 }
 
+# ModelOpt FP4 checkpoints that quantize attention bake the per-layer KV-cache
+# scales under the HF attention projections ("...self_attn.k_proj.k_scale"); in
+# the sglang module tree they live on RadixAttention ("...attn.k_scale"). Must
+# be applied to the weight stream before load_weights() strips ".self_attn",
+# otherwise the stacked-params qkv_proj matching consumes the name and silently
+# drops the scale. Applied per-load_weights rather than exposed as a
+# hf_to_sglang_mapper class attribute: the loader feeds that attribute into
+# quant_config.apply_weight_name_mapper(), which rewrites exclude_modules --
+# a side effect the VL classes deliberately disable (hf_to_sglang_mapper=None).
+QWEN3_5_KV_SCALE_MAPPER = WeightsMapper(
+    orig_to_new_substr={
+        ".self_attn.k_proj.k_scale": ".attn.k_scale",
+        ".self_attn.v_proj.v_scale": ".attn.v_scale",
+    },
+)
+
 
 class Qwen3_5ForCausalLM(nn.Module):
     """Qwen3.5 Model with support for dense variant."""
@@ -1482,6 +1499,7 @@ class Qwen3_5ForCausalLM(nn.Module):
         return hidden_states, aux_hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -1560,44 +1578,6 @@ class Qwen3_5ForCausalLM(nn.Module):
         )
 
 
-def remap_and_load_qwen3_5_kv_scale(
-    name: str, loaded_weight: torch.Tensor, params_dict: dict
-) -> Optional[str]:
-    """Remap a ModelOpt FP4 checkpoint's attention KV-scale name onto the
-    RadixAttention scale param and load it, if the target exists.
-
-    ModelOpt FP4 checkpoints that quantize attention bake per-layer k_scale/
-    v_scale under q/k_proj, e.g. "layers.N.self_attn.k_proj.k_scale". By the time
-    names reach this point in load_weights(), ".self_attn" has already been
-    stripped, so the stock maybe_remap_kv_scale_name() (which keys off
-    ".self_attn."/".mixer." still being present) cannot match. Remap directly to
-    the RadixAttention scale param instead and copy the value.
-
-    No-op (returns None, does not raise) for names that are not a k_scale/v_scale
-    suffix, or whose remapped target is not present in params_dict -- e.g.
-    NVIDIA's MoE-only NVFP4 checkpoints never emit these keys for attention at
-    all, so this function is never meaningfully invoked for them.
-
-    Returns:
-        The remapped, loaded param name (add this to loaded_params), or None if
-        nothing was loaded.
-    """
-    if not (name.endswith(".k_scale") or name.endswith(".v_scale")):
-        return None
-    attn_scale_name = name.replace(".k_proj.k_scale", ".attn.k_scale").replace(
-        ".v_proj.v_scale", ".attn.v_scale"
-    )
-    scale_param = params_dict.get(attn_scale_name)
-    if scale_param is None:
-        return None
-    scale_weight_loader = getattr(scale_param, "weight_loader", None)
-    if scale_weight_loader is not None:
-        scale_weight_loader(scale_param, loaded_weight)
-    else:
-        scale_param.data.copy_(loaded_weight.to(scale_param.dtype))
-    return attn_scale_name
-
-
 class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
     def __init__(
         self,
@@ -1608,6 +1588,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
         super().__init__(config=config, quant_config=quant_config, prefix=prefix)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -1697,13 +1678,6 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
                 and hasattr(self, "start_layer")
                 and (layer_id < self.start_layer or layer_id >= self.end_layer)
             ):
-                continue
-
-            remapped_kv_scale_name = remap_and_load_qwen3_5_kv_scale(
-                name, loaded_weight, params_dict
-            )
-            if remapped_kv_scale_name is not None:
-                loaded_params.add(remapped_kv_scale_name)
                 continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -1876,6 +1850,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
             torch.cuda.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -2035,6 +2010,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             torch.cuda.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -2170,13 +2146,6 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 and hasattr(self, "start_layer")
                 and (layer_id < self.start_layer or layer_id >= self.end_layer)
             ):
-                continue
-
-            remapped_kv_scale_name = remap_and_load_qwen3_5_kv_scale(
-                name, loaded_weight, params_dict
-            )
-            if remapped_kv_scale_name is not None:
-                loaded_params.add(remapped_kv_scale_name)
                 continue
 
             if self.enable_shared_expert_fusion:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1560,6 +1560,44 @@ class Qwen3_5ForCausalLM(nn.Module):
         )
 
 
+def remap_and_load_qwen3_5_kv_scale(
+    name: str, loaded_weight: torch.Tensor, params_dict: dict
+) -> Optional[str]:
+    """Remap a ModelOpt FP4 checkpoint's attention KV-scale name onto the
+    RadixAttention scale param and load it, if the target exists.
+
+    ModelOpt FP4 checkpoints that quantize attention bake per-layer k_scale/
+    v_scale under q/k_proj, e.g. "layers.N.self_attn.k_proj.k_scale". By the time
+    names reach this point in load_weights(), ".self_attn" has already been
+    stripped, so the stock maybe_remap_kv_scale_name() (which keys off
+    ".self_attn."/".mixer." still being present) cannot match. Remap directly to
+    the RadixAttention scale param instead and copy the value.
+
+    No-op (returns None, does not raise) for names that are not a k_scale/v_scale
+    suffix, or whose remapped target is not present in params_dict -- e.g.
+    NVIDIA's MoE-only NVFP4 checkpoints never emit these keys for attention at
+    all, so this function is never meaningfully invoked for them.
+
+    Returns:
+        The remapped, loaded param name (add this to loaded_params), or None if
+        nothing was loaded.
+    """
+    if not (name.endswith(".k_scale") or name.endswith(".v_scale")):
+        return None
+    attn_scale_name = name.replace(".k_proj.k_scale", ".attn.k_scale").replace(
+        ".v_proj.v_scale", ".attn.v_scale"
+    )
+    scale_param = params_dict.get(attn_scale_name)
+    if scale_param is None:
+        return None
+    scale_weight_loader = getattr(scale_param, "weight_loader", None)
+    if scale_weight_loader is not None:
+        scale_weight_loader(scale_param, loaded_weight)
+    else:
+        scale_param.data.copy_(loaded_weight.to(scale_param.dtype))
+    return attn_scale_name
+
+
 class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
     def __init__(
         self,
@@ -1661,31 +1699,12 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
             ):
                 continue
 
-            if name.endswith(".k_scale") or name.endswith(".v_scale"):
-                # ModelOpt FP4 checkpoints that quantize attention bake per-layer
-                # k_scale/v_scale under q/k_proj, e.g.
-                # "layers.N.self_attn.k_proj.k_scale". The stock
-                # maybe_remap_kv_scale_name() cannot handle this here: it keys off
-                # ".self_attn."/".mixer." still being present in the name, but we
-                # already stripped ".self_attn" a few lines up. Remap directly to
-                # the RadixAttention scale param instead and copy the value; the
-                # non-stacked fallback branch below only loads names that already
-                # match params_dict as-is, so without this the scale would be
-                # silently dropped via ignore_suffixes. This is a no-op for
-                # NVIDIA's MoE-only NVFP4 checkpoints, which do not emit
-                # k_scale/v_scale keys for attention.
-                attn_scale_name = name.replace(
-                    ".k_proj.k_scale", ".attn.k_scale"
-                ).replace(".v_proj.v_scale", ".attn.v_scale")
-                if attn_scale_name in params_dict:
-                    scale_param = params_dict[attn_scale_name]
-                    scale_weight_loader = getattr(scale_param, "weight_loader", None)
-                    if scale_weight_loader is not None:
-                        scale_weight_loader(scale_param, loaded_weight)
-                    else:
-                        scale_param.data.copy_(loaded_weight.to(scale_param.dtype))
-                    loaded_params.add(attn_scale_name)
-                    continue
+            remapped_kv_scale_name = remap_and_load_qwen3_5_kv_scale(
+                name, loaded_weight, params_dict
+            )
+            if remapped_kv_scale_name is not None:
+                loaded_params.add(remapped_kv_scale_name)
+                continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if "experts.gate_up_proj" in name or "experts.down_proj" in name:
@@ -2153,31 +2172,12 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             ):
                 continue
 
-            if name.endswith(".k_scale") or name.endswith(".v_scale"):
-                # ModelOpt FP4 checkpoints that quantize attention bake per-layer
-                # k_scale/v_scale under q/k_proj, e.g.
-                # "layers.N.self_attn.k_proj.k_scale". The stock
-                # maybe_remap_kv_scale_name() cannot handle this here: it keys off
-                # ".self_attn."/".mixer." still being present in the name, but we
-                # already stripped ".self_attn" a few lines up. Remap directly to
-                # the RadixAttention scale param instead and copy the value; the
-                # non-stacked fallback branch below only loads names that already
-                # match params_dict as-is, so without this the scale would be
-                # silently dropped via ignore_suffixes. This is a no-op for
-                # NVIDIA's MoE-only NVFP4 checkpoints, which do not emit
-                # k_scale/v_scale keys for attention.
-                attn_scale_name = name.replace(
-                    ".k_proj.k_scale", ".attn.k_scale"
-                ).replace(".v_proj.v_scale", ".attn.v_scale")
-                if attn_scale_name in params_dict:
-                    scale_param = params_dict[attn_scale_name]
-                    scale_weight_loader = getattr(scale_param, "weight_loader", None)
-                    if scale_weight_loader is not None:
-                        scale_weight_loader(scale_param, loaded_weight)
-                    else:
-                        scale_param.data.copy_(loaded_weight.to(scale_param.dtype))
-                    loaded_params.add(attn_scale_name)
-                    continue
+            remapped_kv_scale_name = remap_and_load_qwen3_5_kv_scale(
+                name, loaded_weight, params_dict
+            )
+            if remapped_kv_scale_name is not None:
+                loaded_params.add(remapped_kv_scale_name)
+                continue
 
             if self.enable_shared_expert_fusion:
                 if "mlp.shared_expert." in name:

--- a/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
+++ b/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
@@ -1,0 +1,287 @@
+"""Unit tests for sgl-project/sglang PR #31220 ("Qwen3.5: quantized attention on
+modelopt_fp4 checkpoints").
+
+Written to match the conventions of test/registered/quant/test_quant_config_parsing.py
+and test/registered/unit/layers/quantization/test_modelopt_nvfp4.py: unittest +
+CustomTestCase, register_cpu_ci (no GPU / no real checkpoint needed), and testing
+against the REAL sglang classes (ModelOptFp4Config, RadixAttention) rather than
+mocks wherever the real class is CPU-safe.
+
+Covers the three changes in commits d6ee507be7 and 718a48a433 on branch
+qwen35-modelopt-fp4-quantized-attention:
+
+  1. Per-prefix quantized/BF16 decision (ModelOptFp4Config.is_layer_excluded) is
+     honored for attention instead of being hard-overridden to "always BF16".
+  2. RadixAttention registers k_scale/v_scale parameters when constructed with a
+     quant_config carrying kv_cache_quant_algo="FP8" (Qwen3_5AttentionDecoderLayer
+     now passes quant_config through instead of always passing None).
+  3. The checkpoint's baked k_scale/v_scale tensors get remapped from their
+     "...k_proj.k_scale" / "...v_proj.v_scale" checkpoint names onto the
+     RadixAttention module's "...attn.k_scale" / "...attn.v_scale" parameter names
+     and loaded into them, in load_weights().
+
+Change 3 targets `remap_and_load_qwen3_5_kv_scale(name, loaded_weight, params_dict)`,
+a module-level helper in sglang.srt.models.qwen3_5 (mirroring the stock
+`maybe_remap_kv_scale_name(name, params_dict)` signature/style) that was extracted
+from two byte-identical ~26-line inline blocks previously copy-pasted between
+Qwen3_5MoeForCausalLM.load_weights and Qwen3_5MoeForConditionalGeneration.load_weights.
+Pure dedup + testability extraction; no behavior change.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.models.qwen3_5 import remap_and_load_qwen3_5_kv_scale
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+# ---------------------------------------------------------------------------
+# Change 1: is_layer_excluded() per-prefix decision (quant vs BF16 attention)
+# ---------------------------------------------------------------------------
+class TestModelOptFp4AttentionExclusion(CustomTestCase):
+    """Reproduces the two checkpoint shapes this PR must tell apart:
+
+    - NVIDIA's released Qwen3.5-397B-A17B-NVFP4 (MoE-only): attention modules are
+      listed in exclude_modules, so they must stay BF16 (UnquantizedLinearMethod).
+      This is the existing, must-not-regress behavior.
+    - A uniform-W4A4 checkpoint (e.g. the PR's Ornith-1.0-35B verification build):
+      attention is NOT excluded, so it must be quantized like everything else.
+      Before this PR, qwen3_5.py force-overrode this to BF16 regardless of
+      exclude_modules, which is the bug being fixed.
+    """
+
+    def test_moe_only_checkpoint_excludes_attention(self):
+        # Representative of NVIDIA's Qwen3.5 NVFP4 hf_quant_config.json shape:
+        # attention (self_attn) and lm_head are excluded, MoE experts are not.
+        cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo="FP8",
+            group_size=16,
+            exclude_modules=["*self_attn*", "lm_head"],
+        )
+
+        self.assertTrue(
+            cfg.is_layer_excluded("model.layers.0.self_attn.qkv_proj"),
+            "MoE-only checkpoint: attention must stay excluded (BF16) -- this is "
+            "the pre-existing, must-not-regress case.",
+        )
+        self.assertTrue(cfg.is_layer_excluded("lm_head"))
+        self.assertFalse(
+            cfg.is_layer_excluded("model.layers.0.mlp.experts.3.gate_up_proj"),
+            "MoE experts are not excluded and must be quantized.",
+        )
+
+    def test_uniform_w4a4_checkpoint_quantizes_attention(self):
+        # Representative of a uniform W4A4 checkpoint (e.g. Ornith-1.0-35B-NVFP4):
+        # only lm_head is excluded; attention is deliberately quantized too.
+        cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo="FP8",
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+
+        self.assertFalse(
+            cfg.is_layer_excluded("model.layers.0.self_attn.qkv_proj"),
+            "Uniform W4A4 checkpoint: attention is NOT excluded and must be "
+            "quantized -- this is the bug this PR fixes (previously "
+            "hard-overridden to BF16 for any modelopt_fp4 checkpoint).",
+        )
+        self.assertFalse(
+            cfg.is_layer_excluded("model.layers.0.linear_attn.in_proj_qkvz"),
+            "Same for the Gated-DeltaNet linear-attention path.",
+        )
+        self.assertTrue(cfg.is_layer_excluded("lm_head"))
+
+
+# ---------------------------------------------------------------------------
+# Change 2: RadixAttention registers k_scale/v_scale when given quant_config
+# ---------------------------------------------------------------------------
+class TestRadixAttentionKvScaleRegistration(CustomTestCase):
+    """RadixAttention only gets k_scale/v_scale parameters (a place for baked FP8
+    KV scales to load into) if it is constructed WITH a quant_config whose
+    kv_cache_quant_algo is set -- see ModelOptQuantConfig._get_quant_method's
+    `elif self.kv_cache_quant_algo and isinstance(layer, RadixAttention)` branch
+    and BaseKVCacheMethod.create_weights. Before this PR,
+    Qwen3_5AttentionDecoderLayer always constructed RadixAttention with
+    quant_config=None, so this branch never fired and baked KV scales had nowhere
+    to load into (silently defaulted to 1.0 at process_weights_after_loading).
+
+    Pure CPU test: RadixAttention.__init__ and create_weights() do no CUDA work.
+    """
+
+    def _make_attn(self, quant_config):
+        return RadixAttention(
+            num_heads=2,
+            head_dim=8,
+            scaling=1.0,
+            num_kv_heads=2,
+            layer_id=0,
+            quant_config=quant_config,
+            prefix="model.layers.0.attn",
+        )
+
+    def test_with_fp8_kv_quant_config_registers_scale_params(self):
+        cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo="FP8",
+            group_size=16,
+            exclude_modules=[],
+        )
+        attn = self._make_attn(cfg)
+
+        self.assertIsInstance(attn.k_scale, torch.nn.Parameter)
+        self.assertIsInstance(attn.v_scale, torch.nn.Parameter)
+        # BaseKVCacheMethod.create_weights seeds -1.0 (invalid sentinel) so a
+        # checkpoint that never emits k_scale/v_scale falls back to 1.0 later
+        # in process_weights_after_loading -- distinct from "never registered".
+        self.assertEqual(attn.k_scale.item(), -1.0)
+        self.assertEqual(attn.v_scale.item(), -1.0)
+
+    def test_without_quant_config_has_no_scale_params(self):
+        attn = self._make_attn(None)
+
+        self.assertIsNone(attn.k_scale)
+        self.assertIsNone(attn.v_scale)
+
+    def test_quant_config_without_kv_cache_algo_has_no_scale_params(self):
+        # A quant_config that quantizes attention linears but does NOT declare a
+        # KV-cache quant algo (kv_cache_quant_algo=None) must not register scale
+        # params either -- confirms the branch is gated on kv_cache_quant_algo,
+        # not merely on quant_config being non-None.
+        cfg = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            group_size=16,
+            exclude_modules=[],
+        )
+        attn = self._make_attn(cfg)
+
+        self.assertIsNone(attn.k_scale)
+        self.assertIsNone(attn.v_scale)
+
+
+# ---------------------------------------------------------------------------
+# Change 3: baked k_scale/v_scale checkpoint tensors remap onto RadixAttention
+# ---------------------------------------------------------------------------
+class TestQwen3_5KvScaleRemap(CustomTestCase):
+    """load_weights() strips ".self_attn" from parameter names BEFORE the stock
+    maybe_remap_kv_scale_name() would see them, so that helper can never match
+    (it keys off ".self_attn."/".mixer." still being present). This PR adds an
+    explicit remap step right after the strip. These tests target the extracted
+    `remap_and_load_qwen3_5_kv_scale` helper (see the report's proposed diff)
+    rather than re-deriving the two inline blocks that used to live in
+    Qwen3_5MoeForCausalLM.load_weights / Qwen3_5MoeForConditionalGeneration.load_weights.
+    """
+
+    def _make_param_dict_with_attn_scale(self, key: str, weight_loader=None):
+        scale = torch.nn.Parameter(torch.tensor(-1.0, dtype=torch.float32))
+        if weight_loader is not None:
+            scale.weight_loader = weight_loader
+        return {key: scale}, scale
+
+    def test_remaps_k_proj_scale_to_attn_and_loads_value(self):
+        # Name as it arrives in load_weights AFTER ".self_attn" has already been
+        # stripped a few lines above the remap block -- see qwen3_5.py L1523-24 /
+        # L2015-16 (`if ".self_attn." in name: name = name.replace(".self_attn", "")`).
+        name = "model.layers.3.k_proj.k_scale"
+        params_dict, scale_param = self._make_param_dict_with_attn_scale(
+            "model.layers.3.attn.k_scale"
+        )
+        loaded_weight = torch.tensor(0.0347, dtype=torch.float32)
+
+        remapped_name = remap_and_load_qwen3_5_kv_scale(
+            name, loaded_weight, params_dict
+        )
+
+        self.assertEqual(remapped_name, "model.layers.3.attn.k_scale")
+        torch.testing.assert_close(
+            scale_param.data, torch.tensor(0.0347, dtype=torch.float32)
+        )
+
+    def test_remaps_v_proj_scale_to_attn_and_loads_value(self):
+        name = "model.layers.3.v_proj.v_scale"
+        params_dict, scale_param = self._make_param_dict_with_attn_scale(
+            "model.layers.3.attn.v_scale"
+        )
+        loaded_weight = torch.tensor(0.0128, dtype=torch.float32)
+
+        remapped_name = remap_and_load_qwen3_5_kv_scale(
+            name, loaded_weight, params_dict
+        )
+
+        self.assertEqual(remapped_name, "model.layers.3.attn.v_scale")
+        torch.testing.assert_close(
+            scale_param.data, torch.tensor(0.0128, dtype=torch.float32)
+        )
+
+    def test_uses_weight_loader_when_target_param_has_one(self):
+        # RadixAttention's k_scale/v_scale are plain nn.Parameters with no
+        # weight_loader (BaseKVCacheMethod.create_weights sets none), so the
+        # .data.copy_ fallback is the common path today -- but other call sites
+        # (or a future refactor) may attach a weight_loader, so the loader path
+        # must be preferred when present, matching the non-stacked fallback
+        # convention used elsewhere in load_weights.
+        calls = []
+
+        def spy_loader(param, weight):
+            calls.append(weight.item())
+            param.data.copy_(weight)
+
+        name = "model.layers.7.k_proj.k_scale"
+        params_dict, scale_param = self._make_param_dict_with_attn_scale(
+            "model.layers.7.attn.k_scale", weight_loader=spy_loader
+        )
+        loaded_weight = torch.tensor(0.021, dtype=torch.float32)
+
+        remap_and_load_qwen3_5_kv_scale(name, loaded_weight, params_dict)
+
+        # exactly one call, value compared with float32-precision tolerance
+        # (torch.tensor(0.021, float32).item() == 0.020999999716...)
+        self.assertEqual(len(calls), 1)
+        self.assertAlmostEqual(calls[0], 0.021, places=6)
+
+    def test_no_op_when_target_attn_param_absent(self):
+        # NVIDIA's MoE-only NVFP4 checkpoint never emits k_scale/v_scale for
+        # attention at all (this code path never even runs for it in practice,
+        # since load_weights only enters the remap branch when
+        # name.endswith(".k_scale"/".v_scale")). This test instead covers the
+        # defensive case: a checkpoint DOES emit the scale key, but the running
+        # model has no matching RadixAttention param under that prefix (e.g. a
+        # pipeline-parallel rank that does not own this layer) -- must not raise,
+        # must signal "not consumed" so the caller's generic fallback / warning
+        # path can still see it.
+        name = "model.layers.99.k_proj.k_scale"
+        params_dict = {}  # no "model.layers.99.attn.k_scale" present
+        loaded_weight = torch.tensor(0.05, dtype=torch.float32)
+
+        remapped_name = remap_and_load_qwen3_5_kv_scale(
+            name, loaded_weight, params_dict
+        )
+
+        self.assertIsNone(remapped_name)
+
+    def test_non_kv_scale_name_is_left_untouched(self):
+        # Sanity: the helper is only ever invoked from inside the
+        # `name.endswith(".k_scale") or name.endswith(".v_scale")` guard in
+        # load_weights, but assert its own behavior is a safe no-op if that
+        # invariant is ever violated (e.g. future refactor calls it more broadly).
+        name = "model.layers.0.mlp.experts.5.down_proj.weight"
+        params_dict = {}
+        loaded_weight = torch.zeros(4)
+
+        remapped_name = remap_and_load_qwen3_5_kv_scale(
+            name, loaded_weight, params_dict
+        )
+
+        self.assertIsNone(remapped_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
+++ b/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
@@ -7,8 +7,7 @@ CustomTestCase, register_cpu_ci (no GPU / no real checkpoint needed), and testin
 against the REAL sglang classes (ModelOptFp4Config, RadixAttention) rather than
 mocks wherever the real class is CPU-safe.
 
-Covers the three changes in commits d6ee507be7 and 718a48a433 on branch
-qwen35-modelopt-fp4-quantized-attention:
+Covers the three changes on branch qwen35-modelopt-fp4-quantized-attention:
 
   1. Per-prefix quantized/BF16 decision (ModelOptFp4Config.is_layer_excluded) is
      honored for attention instead of being hard-overridden to "always BF16".
@@ -16,16 +15,14 @@ qwen35-modelopt-fp4-quantized-attention:
      quant_config carrying kv_cache_quant_algo="FP8" (Qwen3_5AttentionDecoderLayer
      now passes quant_config through instead of always passing None).
   3. The checkpoint's baked k_scale/v_scale tensors get remapped from their
-     "...k_proj.k_scale" / "...v_proj.v_scale" checkpoint names onto the
-     RadixAttention module's "...attn.k_scale" / "...attn.v_scale" parameter names
-     and loaded into them, in load_weights().
+     "...self_attn.k_proj.k_scale" / "...self_attn.v_proj.v_scale" checkpoint
+     names onto the RadixAttention module's "...attn.k_scale" / "...attn.v_scale"
+     parameter names, in load_weights().
 
-Change 3 targets `remap_and_load_qwen3_5_kv_scale(name, loaded_weight, params_dict)`,
-a module-level helper in sglang.srt.models.qwen3_5 (mirroring the stock
-`maybe_remap_kv_scale_name(name, params_dict)` signature/style) that was extracted
-from two byte-identical ~26-line inline blocks previously copy-pasted between
-Qwen3_5MoeForCausalLM.load_weights and Qwen3_5MoeForConditionalGeneration.load_weights.
-Pure dedup + testability extraction; no behavior change.
+Change 3 targets `QWEN3_5_KV_SCALE_MAPPER`, a module-level WeightsMapper in
+sglang.srt.models.qwen3_5 (the same type the loader-facing hf_to_sglang_mapper
+class attribute uses) that every Qwen3_5* load_weights() applies to the incoming
+weight stream before its name-munging loop.
 """
 
 import unittest
@@ -34,7 +31,8 @@ import torch
 
 from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.models.qwen3_5 import remap_and_load_qwen3_5_kv_scale
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen3_5 import QWEN3_5_KV_SCALE_MAPPER
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -168,119 +166,78 @@ class TestRadixAttentionKvScaleRegistration(CustomTestCase):
 
 
 # ---------------------------------------------------------------------------
-# Change 3: baked k_scale/v_scale checkpoint tensors remap onto RadixAttention
+# Change 3: baked k_scale/v_scale checkpoint names remap onto RadixAttention
 # ---------------------------------------------------------------------------
-class TestQwen3_5KvScaleRemap(CustomTestCase):
-    """load_weights() strips ".self_attn" from parameter names BEFORE the stock
-    maybe_remap_kv_scale_name() would see them, so that helper can never match
-    (it keys off ".self_attn."/".mixer." still being present). This PR adds an
-    explicit remap step right after the strip. These tests target the extracted
-    `remap_and_load_qwen3_5_kv_scale` helper (see the report's proposed diff)
-    rather than re-deriving the two inline blocks that used to live in
-    Qwen3_5MoeForCausalLM.load_weights / Qwen3_5MoeForConditionalGeneration.load_weights.
+class TestQwen3_5KvScaleMapper(CustomTestCase):
+    """Every Qwen3_5* load_weights() strips ".self_attn" out of checkpoint names
+    early, so the stock maybe_remap_kv_scale_name() can never match (its modelopt
+    branch keys off ".self_attn."/".mixer." still being present, and its
+    params_dict membership check fails either way because the sglang module tree
+    has no self_attn level). QWEN3_5_KV_SCALE_MAPPER is therefore applied to the
+    weight stream BEFORE the loop: the mapped name "...attn.k_scale" no longer
+    contains "k_proj", so the stacked-params qkv_proj matching (which used to
+    consume and silently drop the scale) never fires, and the name loads through
+    the loop's generic fallback branch.
     """
 
-    def _make_param_dict_with_attn_scale(self, key: str, weight_loader=None):
-        scale = torch.nn.Parameter(torch.tensor(-1.0, dtype=torch.float32))
-        if weight_loader is not None:
-            scale.weight_loader = weight_loader
-        return {key: scale}, scale
+    def test_maps_baked_kv_scale_names_onto_radix_attention(self):
+        # Checkpoint-name shape is dictated by ModelOpt's export format (scales
+        # baked under the HF attention projections); target-name shape by the
+        # RadixAttention attribute path in the sglang module tree. Both sides
+        # are external contracts -- a typo in either silently zeroes the scales.
+        weights = [
+            ("model.layers.3.self_attn.k_proj.k_scale", torch.tensor(0.0347)),
+            ("model.layers.3.self_attn.v_proj.v_scale", torch.tensor(0.0128)),
+        ]
 
-    def test_remaps_k_proj_scale_to_attn_and_loads_value(self):
-        # Name as it arrives in load_weights AFTER ".self_attn" has already been
-        # stripped a few lines above the remap block -- see qwen3_5.py L1523-24 /
-        # L2015-16 (`if ".self_attn." in name: name = name.replace(".self_attn", "")`).
-        name = "model.layers.3.k_proj.k_scale"
-        params_dict, scale_param = self._make_param_dict_with_attn_scale(
-            "model.layers.3.attn.k_scale"
+        mapped = list(QWEN3_5_KV_SCALE_MAPPER.apply(weights))
+
+        self.assertEqual(
+            [name for name, _ in mapped],
+            ["model.layers.3.attn.k_scale", "model.layers.3.attn.v_scale"],
         )
-        loaded_weight = torch.tensor(0.0347, dtype=torch.float32)
+        torch.testing.assert_close(mapped[0][1], torch.tensor(0.0347))
+        torch.testing.assert_close(mapped[1][1], torch.tensor(0.0128))
 
-        remapped_name = remap_and_load_qwen3_5_kv_scale(
-            name, loaded_weight, params_dict
+    def test_all_other_names_pass_through_unchanged(self):
+        # Negative-branch contract: the mapper must be a strict no-op for every
+        # non-KV-scale weight -- including the self_attn projections themselves
+        # (still needed by the qkv_proj stacked matching), the GDN linear-attn
+        # projections, and per-projection quant scales like input_scale /
+        # weight_scale that modelopt also emits under self_attn. A key that is
+        # too broad (or a None mapping, which WeightsMapper.apply DROPS from the
+        # stream) would corrupt regular weight loading.
+        names = [
+            "model.layers.3.self_attn.k_proj.weight",
+            "model.layers.3.self_attn.k_proj.input_scale",
+            "model.layers.3.self_attn.k_proj.weight_scale",
+            "model.layers.2.linear_attn.in_proj_qkvz.weight",
+            "model.layers.0.mlp.experts.5.down_proj.weight",
+            "lm_head.weight",
+        ]
+        weights = [(name, torch.zeros(1)) for name in names]
+
+        mapped = list(QWEN3_5_KV_SCALE_MAPPER.apply(weights))
+
+        self.assertEqual([name for name, _ in mapped], names)
+
+    def test_mapped_scale_loads_via_default_weight_loader(self):
+        # After mapping, load_weights' generic fallback branch does
+        # `getattr(param, "weight_loader", default_weight_loader)`; RadixAttention
+        # scale params carry no weight_loader (BaseKVCacheMethod.create_weights),
+        # so default_weight_loader must land the value. Its scalar path
+        # (numel()==1 -> fill_) is what tolerates the 0-dim param vs shape-[1]
+        # checkpoint tensor -- a future shape-strictness change there would
+        # silently break exactly this load.
+        scale_param = torch.nn.Parameter(
+            torch.tensor(-1.0, dtype=torch.float32), requires_grad=False
         )
+        loaded_weight = torch.tensor([0.0347], dtype=torch.float32)
 
-        self.assertEqual(remapped_name, "model.layers.3.attn.k_scale")
-        torch.testing.assert_close(
-            scale_param.data, torch.tensor(0.0347, dtype=torch.float32)
-        )
+        weight_loader = getattr(scale_param, "weight_loader", default_weight_loader)
+        weight_loader(scale_param, loaded_weight)
 
-    def test_remaps_v_proj_scale_to_attn_and_loads_value(self):
-        name = "model.layers.3.v_proj.v_scale"
-        params_dict, scale_param = self._make_param_dict_with_attn_scale(
-            "model.layers.3.attn.v_scale"
-        )
-        loaded_weight = torch.tensor(0.0128, dtype=torch.float32)
-
-        remapped_name = remap_and_load_qwen3_5_kv_scale(
-            name, loaded_weight, params_dict
-        )
-
-        self.assertEqual(remapped_name, "model.layers.3.attn.v_scale")
-        torch.testing.assert_close(
-            scale_param.data, torch.tensor(0.0128, dtype=torch.float32)
-        )
-
-    def test_uses_weight_loader_when_target_param_has_one(self):
-        # RadixAttention's k_scale/v_scale are plain nn.Parameters with no
-        # weight_loader (BaseKVCacheMethod.create_weights sets none), so the
-        # .data.copy_ fallback is the common path today -- but other call sites
-        # (or a future refactor) may attach a weight_loader, so the loader path
-        # must be preferred when present, matching the non-stacked fallback
-        # convention used elsewhere in load_weights.
-        calls = []
-
-        def spy_loader(param, weight):
-            calls.append(weight.item())
-            param.data.copy_(weight)
-
-        name = "model.layers.7.k_proj.k_scale"
-        params_dict, scale_param = self._make_param_dict_with_attn_scale(
-            "model.layers.7.attn.k_scale", weight_loader=spy_loader
-        )
-        loaded_weight = torch.tensor(0.021, dtype=torch.float32)
-
-        remap_and_load_qwen3_5_kv_scale(name, loaded_weight, params_dict)
-
-        # exactly one call, value compared with float32-precision tolerance
-        # (torch.tensor(0.021, float32).item() == 0.020999999716...)
-        self.assertEqual(len(calls), 1)
-        self.assertAlmostEqual(calls[0], 0.021, places=6)
-
-    def test_no_op_when_target_attn_param_absent(self):
-        # NVIDIA's MoE-only NVFP4 checkpoint never emits k_scale/v_scale for
-        # attention at all (this code path never even runs for it in practice,
-        # since load_weights only enters the remap branch when
-        # name.endswith(".k_scale"/".v_scale")). This test instead covers the
-        # defensive case: a checkpoint DOES emit the scale key, but the running
-        # model has no matching RadixAttention param under that prefix (e.g. a
-        # pipeline-parallel rank that does not own this layer) -- must not raise,
-        # must signal "not consumed" so the caller's generic fallback / warning
-        # path can still see it.
-        name = "model.layers.99.k_proj.k_scale"
-        params_dict = {}  # no "model.layers.99.attn.k_scale" present
-        loaded_weight = torch.tensor(0.05, dtype=torch.float32)
-
-        remapped_name = remap_and_load_qwen3_5_kv_scale(
-            name, loaded_weight, params_dict
-        )
-
-        self.assertIsNone(remapped_name)
-
-    def test_non_kv_scale_name_is_left_untouched(self):
-        # Sanity: the helper is only ever invoked from inside the
-        # `name.endswith(".k_scale") or name.endswith(".v_scale")` guard in
-        # load_weights, but assert its own behavior is a safe no-op if that
-        # invariant is ever violated (e.g. future refactor calls it more broadly).
-        name = "model.layers.0.mlp.experts.5.down_proj.weight"
-        params_dict = {}
-        loaded_weight = torch.zeros(4)
-
-        remapped_name = remap_and_load_qwen3_5_kv_scale(
-            name, loaded_weight, params_dict
-        )
-
-        self.assertIsNone(remapped_name)
+        self.assertAlmostEqual(scale_param.item(), 0.0347, places=6)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
+++ b/test/registered/unit/models/test_qwen3_5_modelopt_fp4.py
@@ -1,28 +1,13 @@
-"""Unit tests for sgl-project/sglang PR #31220 ("Qwen3.5: quantized attention on
-modelopt_fp4 checkpoints").
+"""Unit tests for modelopt_fp4 checkpoints that quantize Qwen3.5 attention.
 
-Written to match the conventions of test/registered/quant/test_quant_config_parsing.py
-and test/registered/unit/layers/quantization/test_modelopt_nvfp4.py: unittest +
-CustomTestCase, register_cpu_ci (no GPU / no real checkpoint needed), and testing
-against the REAL sglang classes (ModelOptFp4Config, RadixAttention) rather than
-mocks wherever the real class is CPU-safe.
-
-Covers the three changes on branch qwen35-modelopt-fp4-quantized-attention:
-
-  1. Per-prefix quantized/BF16 decision (ModelOptFp4Config.is_layer_excluded) is
-     honored for attention instead of being hard-overridden to "always BF16".
-  2. RadixAttention registers k_scale/v_scale parameters when constructed with a
-     quant_config carrying kv_cache_quant_algo="FP8" (Qwen3_5AttentionDecoderLayer
-     now passes quant_config through instead of always passing None).
-  3. The checkpoint's baked k_scale/v_scale tensors get remapped from their
-     "...self_attn.k_proj.k_scale" / "...self_attn.v_proj.v_scale" checkpoint
-     names onto the RadixAttention module's "...attn.k_scale" / "...attn.v_scale"
-     parameter names, in load_weights().
-
-Change 3 targets `QWEN3_5_KV_SCALE_MAPPER`, a module-level WeightsMapper in
-sglang.srt.models.qwen3_5 (the same type the loader-facing hf_to_sglang_mapper
-class attribute uses) that every Qwen3_5* load_weights() applies to the incoming
-weight stream before its name-munging loop.
+Covers three things:
+  1. ModelOptFp4Config.is_layer_excluded() decides per prefix whether attention is
+     quantized or kept in BF16.
+  2. RadixAttention registers k_scale/v_scale when built with a quant_config that
+     declares kv_cache_quant_algo; without them, baked KV scales have nowhere to
+     load into and silently fall back to 1.0.
+  3. QWEN3_5_KV_SCALE_MAPPER remaps the checkpoint's baked KV-scale names onto the
+     RadixAttention parameter names.
 """
 
 import unittest
@@ -39,24 +24,10 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
-# ---------------------------------------------------------------------------
-# Change 1: is_layer_excluded() per-prefix decision (quant vs BF16 attention)
-# ---------------------------------------------------------------------------
 class TestModelOptFp4AttentionExclusion(CustomTestCase):
-    """Reproduces the two checkpoint shapes this PR must tell apart:
-
-    - NVIDIA's released Qwen3.5-397B-A17B-NVFP4 (MoE-only): attention modules are
-      listed in exclude_modules, so they must stay BF16 (UnquantizedLinearMethod).
-      This is the existing, must-not-regress behavior.
-    - A uniform-W4A4 checkpoint (e.g. the PR's Ornith-1.0-35B verification build):
-      attention is NOT excluded, so it must be quantized like everything else.
-      Before this PR, qwen3_5.py force-overrode this to BF16 regardless of
-      exclude_modules, which is the bug being fixed.
-    """
-
     def test_moe_only_checkpoint_excludes_attention(self):
-        # Representative of NVIDIA's Qwen3.5 NVFP4 hf_quant_config.json shape:
-        # attention (self_attn) and lm_head are excluded, MoE experts are not.
+        # NVIDIA's Qwen3.5 NVFP4 checkpoints: attention and lm_head are excluded,
+        # MoE experts are not.
         cfg = ModelOptFp4Config(
             is_checkpoint_nvfp4_serialized=True,
             kv_cache_quant_algo="FP8",
@@ -64,20 +35,14 @@ class TestModelOptFp4AttentionExclusion(CustomTestCase):
             exclude_modules=["*self_attn*", "lm_head"],
         )
 
-        self.assertTrue(
-            cfg.is_layer_excluded("model.layers.0.self_attn.qkv_proj"),
-            "MoE-only checkpoint: attention must stay excluded (BF16) -- this is "
-            "the pre-existing, must-not-regress case.",
-        )
+        self.assertTrue(cfg.is_layer_excluded("model.layers.0.self_attn.qkv_proj"))
         self.assertTrue(cfg.is_layer_excluded("lm_head"))
         self.assertFalse(
-            cfg.is_layer_excluded("model.layers.0.mlp.experts.3.gate_up_proj"),
-            "MoE experts are not excluded and must be quantized.",
+            cfg.is_layer_excluded("model.layers.0.mlp.experts.3.gate_up_proj")
         )
 
     def test_uniform_w4a4_checkpoint_quantizes_attention(self):
-        # Representative of a uniform W4A4 checkpoint (e.g. Ornith-1.0-35B-NVFP4):
-        # only lm_head is excluded; attention is deliberately quantized too.
+        # Uniform W4A4 checkpoint: only lm_head is excluded, attention is quantized.
         cfg = ModelOptFp4Config(
             is_checkpoint_nvfp4_serialized=True,
             kv_cache_quant_algo="FP8",
@@ -85,35 +50,14 @@ class TestModelOptFp4AttentionExclusion(CustomTestCase):
             exclude_modules=["lm_head"],
         )
 
+        self.assertFalse(cfg.is_layer_excluded("model.layers.0.self_attn.qkv_proj"))
         self.assertFalse(
-            cfg.is_layer_excluded("model.layers.0.self_attn.qkv_proj"),
-            "Uniform W4A4 checkpoint: attention is NOT excluded and must be "
-            "quantized -- this is the bug this PR fixes (previously "
-            "hard-overridden to BF16 for any modelopt_fp4 checkpoint).",
-        )
-        self.assertFalse(
-            cfg.is_layer_excluded("model.layers.0.linear_attn.in_proj_qkvz"),
-            "Same for the Gated-DeltaNet linear-attention path.",
+            cfg.is_layer_excluded("model.layers.0.linear_attn.in_proj_qkvz")
         )
         self.assertTrue(cfg.is_layer_excluded("lm_head"))
 
 
-# ---------------------------------------------------------------------------
-# Change 2: RadixAttention registers k_scale/v_scale when given quant_config
-# ---------------------------------------------------------------------------
 class TestRadixAttentionKvScaleRegistration(CustomTestCase):
-    """RadixAttention only gets k_scale/v_scale parameters (a place for baked FP8
-    KV scales to load into) if it is constructed WITH a quant_config whose
-    kv_cache_quant_algo is set -- see ModelOptQuantConfig._get_quant_method's
-    `elif self.kv_cache_quant_algo and isinstance(layer, RadixAttention)` branch
-    and BaseKVCacheMethod.create_weights. Before this PR,
-    Qwen3_5AttentionDecoderLayer always constructed RadixAttention with
-    quant_config=None, so this branch never fired and baked KV scales had nowhere
-    to load into (silently defaulted to 1.0 at process_weights_after_loading).
-
-    Pure CPU test: RadixAttention.__init__ and create_weights() do no CUDA work.
-    """
-
     def _make_attn(self, quant_config):
         return RadixAttention(
             num_heads=2,
@@ -136,9 +80,7 @@ class TestRadixAttentionKvScaleRegistration(CustomTestCase):
 
         self.assertIsInstance(attn.k_scale, torch.nn.Parameter)
         self.assertIsInstance(attn.v_scale, torch.nn.Parameter)
-        # BaseKVCacheMethod.create_weights seeds -1.0 (invalid sentinel) so a
-        # checkpoint that never emits k_scale/v_scale falls back to 1.0 later
-        # in process_weights_after_loading -- distinct from "never registered".
+        # create_weights seeds -1.0, the sentinel for "checkpoint had no scale".
         self.assertEqual(attn.k_scale.item(), -1.0)
         self.assertEqual(attn.v_scale.item(), -1.0)
 
@@ -149,10 +91,7 @@ class TestRadixAttentionKvScaleRegistration(CustomTestCase):
         self.assertIsNone(attn.v_scale)
 
     def test_quant_config_without_kv_cache_algo_has_no_scale_params(self):
-        # A quant_config that quantizes attention linears but does NOT declare a
-        # KV-cache quant algo (kv_cache_quant_algo=None) must not register scale
-        # params either -- confirms the branch is gated on kv_cache_quant_algo,
-        # not merely on quant_config being non-None.
+        # Registration is gated on kv_cache_quant_algo, not on quant_config alone.
         cfg = ModelOptFp4Config(
             is_checkpoint_nvfp4_serialized=True,
             kv_cache_quant_algo=None,
@@ -165,26 +104,10 @@ class TestRadixAttentionKvScaleRegistration(CustomTestCase):
         self.assertIsNone(attn.v_scale)
 
 
-# ---------------------------------------------------------------------------
-# Change 3: baked k_scale/v_scale checkpoint names remap onto RadixAttention
-# ---------------------------------------------------------------------------
 class TestQwen3_5KvScaleMapper(CustomTestCase):
-    """Every Qwen3_5* load_weights() strips ".self_attn" out of checkpoint names
-    early, so the stock maybe_remap_kv_scale_name() can never match (its modelopt
-    branch keys off ".self_attn."/".mixer." still being present, and its
-    params_dict membership check fails either way because the sglang module tree
-    has no self_attn level). QWEN3_5_KV_SCALE_MAPPER is therefore applied to the
-    weight stream BEFORE the loop: the mapped name "...attn.k_scale" no longer
-    contains "k_proj", so the stacked-params qkv_proj matching (which used to
-    consume and silently drop the scale) never fires, and the name loads through
-    the loop's generic fallback branch.
-    """
-
     def test_maps_baked_kv_scale_names_onto_radix_attention(self):
-        # Checkpoint-name shape is dictated by ModelOpt's export format (scales
-        # baked under the HF attention projections); target-name shape by the
-        # RadixAttention attribute path in the sglang module tree. Both sides
-        # are external contracts -- a typo in either silently zeroes the scales.
+        # Source names come from ModelOpt's export format, target names from the
+        # sglang module tree; a typo on either side silently zeroes the scales.
         weights = [
             ("model.layers.3.self_attn.k_proj.k_scale", torch.tensor(0.0347)),
             ("model.layers.3.self_attn.v_proj.v_scale", torch.tensor(0.0128)),
@@ -200,13 +123,7 @@ class TestQwen3_5KvScaleMapper(CustomTestCase):
         torch.testing.assert_close(mapped[1][1], torch.tensor(0.0128))
 
     def test_all_other_names_pass_through_unchanged(self):
-        # Negative-branch contract: the mapper must be a strict no-op for every
-        # non-KV-scale weight -- including the self_attn projections themselves
-        # (still needed by the qkv_proj stacked matching), the GDN linear-attn
-        # projections, and per-projection quant scales like input_scale /
-        # weight_scale that modelopt also emits under self_attn. A key that is
-        # too broad (or a None mapping, which WeightsMapper.apply DROPS from the
-        # stream) would corrupt regular weight loading.
+        # A mapping key that is too broad would corrupt regular weight loading.
         names = [
             "model.layers.3.self_attn.k_proj.weight",
             "model.layers.3.self_attn.k_proj.input_scale",
@@ -222,13 +139,9 @@ class TestQwen3_5KvScaleMapper(CustomTestCase):
         self.assertEqual([name for name, _ in mapped], names)
 
     def test_mapped_scale_loads_via_default_weight_loader(self):
-        # After mapping, load_weights' generic fallback branch does
-        # `getattr(param, "weight_loader", default_weight_loader)`; RadixAttention
-        # scale params carry no weight_loader (BaseKVCacheMethod.create_weights),
-        # so default_weight_loader must land the value. Its scalar path
-        # (numel()==1 -> fill_) is what tolerates the 0-dim param vs shape-[1]
-        # checkpoint tensor -- a future shape-strictness change there would
-        # silently break exactly this load.
+        # The scale params carry no weight_loader, so load_weights' fallback uses
+        # default_weight_loader; its scalar path is what tolerates the 0-dim param
+        # vs the shape-[1] checkpoint tensor.
         scale_param = torch.nn.Parameter(
             torch.tensor(-1.0, dtype=torch.float32), requires_grad=False
         )


### PR DESCRIPTION
## Motivation

`#18937` ("[Qwen3.5] Enable nvfp4 checkpoint") added SGLang support for
NVIDIA's released `nvidia/Qwen3.5-397B-A17B-NVFP4` checkpoint. That
checkpoint quantizes only the MoE experts and excludes attention
(attention ships in BF16), so the PR hard-forced `quant_config` to
`None` for the linear-attention and full-attention modules whenever
`quant_config.get_name() == "modelopt_fp4"`, and never wired FP8 KV
scale loading for attention.

That override is unconditional on the quant method name rather than
being derived from the checkpoint's own `exclude_modules`, so it also
silently forces BF16 attention on any other `modelopt_fp4` checkpoint,
including ones that deliberately quantize attention (uniform W4A4).
This was flagged in review on #18937 itself
(https://github.com/sgl-project/sglang/pull/18937#issuecomment-3931578174):

> Why hardcode quant_config=None instead of deriving it from the model
> configuration? Bypassing quantization logic at the SGLang level is
> counterproductive since NVFP4 checkpoints do not contain native BF16
> weights. Consequently, this PR breaks compatibility with the
> majority of NVFP4 models available on Hugging Face.

The author acknowledged this and said they would look at a fix
(https://github.com/sgl-project/sglang/pull/18937#issuecomment-3937106915),
but it was not addressed there. This PR is that fix.

## Modifications

1. **Allow modelopt_fp4 to quantize attention.** In
   `Qwen3_5LinearDecoderLayer.__init__` and
   `Qwen3_5AttentionDecoderLayer.__init__`, remove the hardcoded
   `quant_config = None if ... modelopt_fp4 ... else quant_config` and
   pass `quant_config` straight through. `ModelOptFp4Config`'s
   `is_layer_excluded()` already makes the correct per-prefix
   quantized/BF16 decision from the checkpoint's own
   `exclude_modules`, so the override was both unnecessary and wrong
   for checkpoints that quantize attention. For NVIDIA's MoE-only
   NVFP4 checkpoint this is a no-op: attention stays listed in
   `exclude_modules`, so `is_layer_excluded()` still returns
   `UnquantizedLinearMethod` for it and behavior is unchanged.

2. **Pass `quant_config` to `RadixAttention`** in
   `Qwen3_5AttentionDecoderLayer` (mirrors the pattern already used in
   several other models, e.g. `deepseek.py`, `apertus.py`,
   `baichuan.py`) so a checkpoint's FP8-KV quant method registers
   `k_scale`/`v_scale` parameters on it. Without this there is nowhere
   for baked KV scales to load into, so they silently default to 1.0.

3. **Load the baked FP8 KV scales in `load_weights()`** via a
   declarative `WeightsMapper` (reworked per review -- the first
   revision used a bespoke remap-and-load helper). A module constant
   `QWEN3_5_KV_SCALE_MAPPER` maps the ModelOpt checkpoint names
   `...self_attn.k_proj.k_scale` / `...self_attn.v_proj.v_scale` onto
   the RadixAttention param names `...attn.k_scale` / `...attn.v_scale`,
   and every `load_weights()` in `qwen3_5.py` (all four model classes:
   `Qwen3_5ForCausalLM`, `Qwen3_5MoeForCausalLM`,
   `Qwen3_5ForConditionalGeneration`,
   `Qwen3_5MoeForConditionalGeneration`) applies it to the incoming
   weight stream before its name-munging loop. After the rename the
   scale names contain no `k_proj`/`v_proj`, so the stacked `qkv_proj`
   shard matching (which used to consume and silently drop them) never
   fires, and they load through the loop's existing generic
   `weight_loader` fallback branch -- no custom load path. The stock
   `maybe_remap_kv_scale_name()` cannot be used here: these
   `load_weights()` strip `.self_attn` early (the sglang module tree
   has no `self_attn` level), and the helper both keys off
   `.self_attn.`/`.mixer.` still being present and checks its remapped
   name against `params_dict`, so it returns `None` in either call
   position. The mapper only renames keys that exist, so it is a no-op
   for NVIDIA's MoE-only NVFP4 checkpoint (which never emits attention
   `k_scale`/`v_scale`). `qwen3_5_mtp.py` is deliberately not covered
   (no MTP checkpoint with baked attention KV scales to verify
   against).

## Backward compatibility

All three changes are inert for NVIDIA's MoE-only NVFP4 checkpoint:
change 1 is a no-op because `is_layer_excluded()` still excludes
attention via `exclude_modules`; change 3 is a no-op because that
checkpoint does not emit `k_scale`/`v_scale` keys for attention.
Change 2 only adds a registration point on `RadixAttention` that is
unused unless a quant method is actually attached.

## Verification

These changes are ports (to clean source form) of launch-time patches verified working end to end on a DGX Spark GB10/sm121, serving a uniform-W4A4 NVFP4 checkpoint (Ornith-1.0-35B, attention AND experts quantized) through SGLang with the `flashinfer` attention backend and `flashinfer_cutlass` MoE backend:

- The checkpoint loads and serves without the previous silent drop-to-BF16 / dropped-KV-scale behavior.
- It produces coherent, on-topic completions (e.g. correctly answering "Canberra" for the capital of Australia and computing 17x24=408).
- The baked per-layer FP8 KV scales load into the runtime: the `k_scale_float`/`v_scale_float` that `Attention.forward()` reads hold the calibrated per-layer values (roughly 0.01 to 0.045 across the full-attention layers 3, 7, ..., 39), not the 1.0 fallback. (Note: SGLang's "no scaling factors provided" startup log is gated only on the legacy `--quantization-param-path` flag and is unrelated to the per-layer modelopt scales, so it is not a signal either way.)

GSM8K (chat + reasoning, 4-shot, N=400) on this checkpoint: strict == flexible = **0.9675** (387/400; 0 errors). The public, reproducible checkpoint and the full result are in the comment below. Maintainers with the NVIDIA reference checkpoint can confirm this does not regress `nvidia/Qwen3.5-397B-A17B-NVFP4` on the MoE-only path.

**Re-verification of the `WeightsMapper` revision** (same GB10/sm121 setup, serving via launch-time application of exactly this PR's diff), now covering both an MoE and a dense model class with the two public uniform-W4A4 NVFP4 checkpoints:

- **MoE VL** ([vroomfondel/Ornith-1.0-35B-NVFP4-ModelOpt](https://huggingface.co/vroomfondel/Ornith-1.0-35B-NVFP4-ModelOpt), `Qwen3_5MoeForConditionalGeneration`): loads and serves coherently; all 10 full-attention layers hold calibrated per-layer KV scales at runtime (k_scale 0.028-0.045, v_scale 0.012-0.037; verified by logging `k_scale_float`/`v_scale_float` at `process_weights_after_loading`). GSM8K: 0.9575 strict == flexible (383/400, 0 errors) vs 0.97 for the helper revision -- within sampling noise for two temp-0.6 runs.
- **Dense VL** ([vroomfondel/Ornith-1.0-9B-NVFP4-ModelOpt](https://huggingface.co/vroomfondel/Ornith-1.0-9B-NVFP4-ModelOpt), `Qwen3_5ForConditionalGeneration` -- a class the first revision did not cover): loads and serves coherently; calibrated per-layer KV scales at runtime (k_scale 0.026-0.042, v_scale 0.041-0.276). GSM8K: 0.9375 strict (375/400, 0 errors) vs 0.94 for the helper-revision baseline of this checkpoint -- within noise.

## Known limitation (not addressed here)

This PR only changes the load path (module construction +
`load_weights()`). It does **not** address
https://github.com/sgl-project/sglang/issues/29577, which reports that
a text-only Qwen3.5 `modelopt_fp4` checkpoint reaches
`RadixLinearAttention.forward()` -> base `AttentionBackend.forward()`
with a `TypeError` on the `triton` attention backend, because
`model_runner.hybrid_gdn_config` does not recognize the text-only
`qwen3_5_text`/`qwen3_5_moe_text` config classes and so never installs
`HybridLinearAttnBackend`. Our own verification used the `flashinfer`
attention backend, not `triton`, so it does not exercise that path.
That is a separate, forward-path bug and needs its own fix.

Related: #29577

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) (ran `black`, `isort`, and `ruff --select=F401,F821,UP037` on the changed file; pinned tool versions matched by hand, no `pre-commit` binary on the box used).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Added `test/registered/unit/models/test_qwen3_5_modelopt_fp4.py`: CPU-only unit tests (no checkpoint, no GPU) covering all three changes -- the `ModelOptFp4Config.is_layer_excluded` attention decision, `RadixAttention` k_scale/v_scale registration, and the `QWEN3_5_KV_SCALE_MAPPER` name mapping + generic-branch load path (8 tests, passing against the installed sglang on CPU). A full end-to-end *load* test would still need a small public NVFP4 checkpoint that quantizes attention; the verification checkpoints are public ([vroomfondel/Ornith-1.0-35B-NVFP4-ModelOpt](https://huggingface.co/vroomfondel/Ornith-1.0-35B-NVFP4-ModelOpt), [vroomfondel/Ornith-1.0-9B-NVFP4-ModelOpt](https://huggingface.co/vroomfondel/Ornith-1.0-9B-NVFP4-ModelOpt)) but at ~21 GB / ~8 GB are large as CI fixtures, so that part is left to a manual / GPU-runner run.
- [ ] Update documentation (no user-facing behavior change for the checkpoints this repo currently documents).
- [x] Provide accuracy results (GSM8K, chat + reasoning, 4-shot, N=400, GB10/sm121: 0.9675 on the first revision, and 0.9575 / 0.9375 for the `WeightsMapper` revision on the 35B MoE / 9B dense checkpoints vs their 0.97 / 0.94 baselines -- see Verification). Speed was not benchmarked.
- [x] Follow the SGLang code style guidance (matched existing naming and comment density; black/isort/ruff as above).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30345051736](https://github.com/sgl-project/sglang/actions/runs/30345051736)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30417812943](https://github.com/sgl-project/sglang/actions/runs/30417812943)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->





