### PR TITLE
[AMD] (superseded by #30942) Skip MORI UMBP gtest discovery in ROCm image build

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -500,6 +500,12 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   cd /sgl-workspace/mori; \
   git checkout "${MORI_COMMIT}"; \
   git submodule update --init --recursive; \
+  # UMBP always adds its gtest targets (src/umbp/tests) regardless of BUILD_TESTS.
+  # gtest_discover_tests runs those binaries at build time to enumerate tests, but
+  # the image build host has no GPU (hipErrorNoDevice), so discovery produces empty
+  # output and CMake JSON parsing aborts the build. Gate UMBP tests on BUILD_TESTS
+  # (OFF here) to match how the top-level tests/cpp subdir is handled.
+  sed -i "s|add_subdirectory(tests)|if(BUILD_TESTS)\n  add_subdirectory(tests)\nendif()|" src/umbp/CMakeLists.txt; \
   python3 setup.py develop; \
   python3 -c "import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))" > /etc/ld.so.conf.d/torch.conf; \
   ldconfig; \


### PR DESCRIPTION
> **Status: superseded by #30942 — closing.** This documents the investigation and an alternative hardening approach; the break on `main` is already fixed by pinning `cmake==4.3.4`.

## What actually broke (corrected root cause)

The **Release Docker Images (AMD)** builds started failing on 2026-07-11 in the MORI step of `docker/rocm.Dockerfile`:

```
CMake Error at .../cmake-4.4/Modules/GoogleTest/ParseTestList.cmake:96 (string):
  string sub-command JSON failed parsing json string
ninja: build stopped: subcommand failed.
```

The **trigger** is a cmake version drift, not the MORI pin:

- `docker/rocm.Dockerfile` installed cmake **unpinned**, so each daily `--no-cache` build pulled the latest. Between 07-10 and 07-11 cmake drifted **4.3.4 → 4.4**, and cmake 4.4's `gtest_discover_tests` fails to parse the JSON test list of MORI's `umbp` unit tests (parallel discovery), aborting the MORI cmake build.
- MORI itself was pinned the whole time (`MORI_COMMIT=e31d426...`), so cmake was the only changing input — matching the "green through 07-10, red from 07-11" timeline and the flaky per-leg behavior (parallel-discovery race under 4.4).

This is exactly the diagnosis and fix in **#30942** (`[AMD] Pin cmake==4.3.4 in ROCm Dockerfile`), merged to `main` on 2026-07-13. Verified: the 07-14 `main` build installs `cmake-4.3.4` and reaches `[MORI] Done.` with no `ParseTestList` error.

## Why this PR is being closed

#30942 already fixes the breakage on `main` by pinning cmake to the last known-good version. This PR took a different (complementary) approach — gating MORI's UMBP tests behind `BUILD_TESTS` so the fragile `gtest_discover_tests` step is not built/run at image-build time at all (which would also let cmake move forward again). Since the maintainers landed the cmake pin, this is redundant on `main` and is being closed. It can be revisited later if we want to un-pin cmake.

## Remaining gap (needs attention)

`#30942` (`80965db`) is on `main` but is **not** on `release/v0.5.15` or tag `v0.5.15.post1` (confirmed via `git merge-base`). The release Dockerfile still installs cmake unpinned, which is why the `v0.5.15.post1` release image build (run 29305409282) still failed on 07-14. **The cmake pin needs to be cherry-picked to `release/v0.5.15`** to unblock that release line.