### PR TITLE
ci: bound nvidia-smi in detect_host so a wedged driver fails fast

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -85,13 +85,23 @@ detect_host() {
     else
         IS_BLACKWELL=0
         if command -v nvidia-smi >/dev/null 2>&1; then
+            # A wedged NVIDIA driver (dmesg: NVRM fullchip-reset asserts) makes
+            # nvidia-smi hang forever, silently eating the whole step timeout.
+            # Bound it and fail fast with a diagnosable error instead.
+            COMPUTE_CAPS=$(timeout -k 10 60 nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null) || {
+                if [ $? -ge 124 ]; then
+                    echo "FATAL: nvidia-smi hung for 60s -- GPU/driver likely wedged on this host (check dmesg for NVRM asserts; a reboot usually recovers it)" >&2
+                    exit 1
+                fi
+                COMPUTE_CAPS=""
+            }
             while IFS= read -r cap; do
                 major="${cap%%.*}"
                 if [ "${major:-0}" -ge 10 ] 2>/dev/null; then
                     IS_BLACKWELL=1
                     break
                 fi
-            done <<< "$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null || true)"
+            done <<< "$COMPUTE_CAPS"
         fi
         echo "IS_BLACKWELL=${IS_BLACKWELL} (auto-detected via nvidia-smi)"
     fi


### PR DESCRIPTION
## Motivation

When a host's NVIDIA driver wedges (dmesg: `NVRM: Assertion failed: ... NV_ERR_GPU_IN_FULLCHIP_RESET`), every nvidia-smi/CUDA call hangs forever. `detect_host` in `ci_install_dependency.sh` runs `nvidia-smi --query-gpu=compute_cap` with no bound, so the job silently eats the whole 20-minute Install dependencies step with zero diagnostics — see [job 87194296837](https://github.com/sgl-project/sglang/actions/runs/29363627492/job/87194296837), where the last log line before the step timeout is the nvidia-smi invocation. This is the CUDA-side analog of #31068 (AMD) / #30172 (XPU).

## Modifications

Wrap the query in `timeout -k 10 60`. On timeout, fail immediately with an explicit message pointing at the wedged driver (a reboot recovers the host). Plain nvidia-smi failures keep the existing silent `IS_BLACKWELL=0` fallback.

All four paths (Blackwell cap, non-Blackwell cap, nvidia-smi error, nvidia-smi hang) verified inside a live 5090 runner container.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828418609](https://github.com/sgl-project/sglang/actions/runs/34828418609)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828418090](https://github.com/sgl-project/sglang/actions/runs/34828418090)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34828418280](https://github.com/sgl-project/sglang/actions/runs/34828418280)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->