### PR TITLE
Fix gate stride for 4D decode layouts

### DIFF
--- a/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -281,7 +281,9 @@ def fused_sigmoid_gating_delta_rule_update(
     # Both paths (KDA/GDN) advance p_a once per token, so use the token-axis stride.
     # For 2D a ([T, ...]) this is stride(0); for 3D a ([B, T, ...]) this is stride(1).
     # Using stride()[-2] covers GDN [T, HV] and KDA layouts ([T, HV*K] / [B, T, HV*K]).
-    stride_a = a.stride()[-2]
+    # KDA decode also passes 4-D [B, T, H, K], where [-2] is the head stride, not the
+    # token stride; take dim 1 explicitly for that layout.
+    stride_a = a.stride()[1] if a.ndim == 4 else a.stride()[-2]
     HV = v.shape[2]
     N = B if cu_seqlens is None else len(cu_seqlens) - 1
     BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)


### PR DESCRIPTION
## Summary

- Use the token-axis stride for 4D gate tensors in the fused sigmoid gating recurrent update.
- Preserve the existing stride behavior for 2D and 3D layouts.

## Testing

- `python3 -m py_compile python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py`
- `git diff --check`
- `git ls-files --eol -- python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py`
- Not run locally: `uv run pre-commit run --files ...` and `uv run ruff check ...` because those commands were not installed in the local uv environment.

## Original commits

- `3b43dcb9b`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29373243349](https://github.com/sgl-project/sglang/actions/runs/29373243349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29373243071](https://github.com/sgl-project/sglang/actions/runs/29373243071)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->