### PR TITLE
ci: strip invisible Unicode format chars from slash-command input

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import time
+import unicodedata
 from datetime import datetime, timezone
 
 import requests
@@ -245,6 +246,18 @@ def get_env_var(name):
         print(f"Error: Environment variable {name} not set.")
         sys.exit(1)
     return val
+
+
+def _strip_format_chars(s):
+    """Remove Unicode format characters (category Cf: LRM/RLM U+200E/200F,
+    zero-width space/joiners U+200B-200D, word joiner U+2060, BOM U+FEFF).
+
+    GitHub's copy-path button and rich-text copy inject these invisibly;
+    a pasted `/rerun-test foo.py<U+200E>` then never matches any test file
+    (see PR #31059). They are display hints and never legitimate in a
+    command or path, so dropping them is always safe.
+    """
+    return "".join(c for c in s if unicodedata.category(c) != "Cf")
 
 
 def load_permissions(user_login):
@@ -1348,7 +1361,7 @@ def main():
     repo_name = get_env_var("REPO_FULL_NAME")
     pr_number = int(get_env_var("PR_NUMBER"))
     comment_id = int(get_env_var("COMMENT_ID"))
-    comment_body = get_env_var("COMMENT_BODY").strip()
+    comment_body = _strip_format_chars(get_env_var("COMMENT_BODY")).strip()
     user_login = get_env_var("USER_LOGIN")
 
     # 2. Load Permissions (local file check first to avoid unnecessary API calls)


### PR DESCRIPTION
## Motivation

On #31059, `/rerun-test test_mamba_unittest.py` failed twice with *No test file found matching* even though the file exists. Hexdumping the comments shows the pasted filename ends in `E2 80 8E` — **U+200E LEFT-TO-RIGHT MARK**, invisible in the GitHub UI and typically injected by GitHub's copy-path button or rich-text copy. `str.strip()` removes whitespace only (U+200E is category Cf, not whitespace), so the handler literally searched for `test_mamba_unittest.py‎` and correctly found nothing.

## Modifications

Add `_strip_format_chars()` (drops all Unicode category-Cf characters: LRM/RLM U+200E/200F, zero-width U+200B–200D, word joiner U+2060, BOM U+FEFF) and apply it to `COMMENT_BODY` once at ingestion in `main()`, so every slash command and every argument is covered. Format characters are display hints and never legitimate in a command or path, so dropping them is always safe; non-Cf content (CJK filenames, `::` selectors, flags) passes through unchanged.

Verified against the exact poisoned bytes from #31059, all seven listed format chars, and legitimate-input passthrough.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29374601123](https://github.com/sgl-project/sglang/actions/runs/29374601123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29374600998](https://github.com/sgl-project/sglang/actions/runs/29374600998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->