### PR TITLE
[Fix] MoE: run torch.compile sum-reduce under no_grad to unblock CUDA graph capture

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -319,8 +319,12 @@ def fused_experts(
 
 @torch.compile
 def moe_sum_reduce_torch_compile(x, out, routed_scaling_factor):
-    torch.sum(x, dim=1, out=out)
-    out.mul_(routed_scaling_factor)
+    # NOTE: no_grad is required. During CUDA graph capture `out` can be
+    # grad-tracked, and out= / in-place ops on it are rejected under autograd,
+    # which aborts capture on the non-AITER Triton MoE path. Inference-only.
+    with torch.no_grad():
+        torch.sum(x, dim=1, out=out)
+        out.mul_(routed_scaling_factor)
 
 
 @torch.compile

--- a/test/registered/unit/layers/moe/test_moe_sum_reduce_torch_compile.py
+++ b/test/registered/unit/layers/moe/test_moe_sum_reduce_torch_compile.py
@@ -1,0 +1,54 @@
+"""Regression test for MoE CUDA graph capture with the torch.compile sum-reduce.
+
+Bug: serving an MoE model with CUDA graphs enabled aborted during capture with
+``Capture cuda graph failed: RuntimeError when making fake tensor call ...
+sum(): functions with out=... arguments don't support automatic
+differentiation, but one of the arguments requires grad``.
+
+Mechanism: ``moe_sum_reduce_torch_compile`` reduces the per-expert outputs into
+a pre-allocated ``out`` buffer via ``torch.sum(..., out=out)`` plus an in-place
+``mul_``, and is chosen for small batches -- exactly the batch sizes captured
+for CUDA graphs. Capture traces the helper with ``torch.compile`` while autograd
+is enabled, so a grad-tracked ``out`` makes the ``out=`` and in-place ops
+illegal and capture aborts. Only the non-AITER Triton MoE path reaches this
+helper (e.g. RDNA / gfx1151); CDNA and CUDA route through AITER ``moe_sum``.
+
+This case invokes the helper with a grad-tracked ``out`` while autograd is
+enabled: it raises on the pre-fix code and must pass, with the correct
+reduction, after.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import (
+    moe_sum_reduce_torch_compile,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestMoeSumReduceTorchCompile(CustomTestCase):
+    def test_grad_tracked_out_does_not_break_capture(self):
+        device = "cuda"
+        torch.manual_seed(0)
+        num_tokens, topk, hidden = 8, 4, 16
+        routed_scaling_factor = 1.5
+
+        x = torch.randn(num_tokens, topk, hidden, device=device)
+        # A capture buffer that carries autograd metadata, as it does during
+        # CUDA graph capture (which does not run under no_grad).
+        out = torch.zeros(num_tokens, hidden, device=device, requires_grad=True)
+
+        with torch.enable_grad():
+            moe_sum_reduce_torch_compile(x, out, routed_scaling_factor)
+
+        expected = x.sum(dim=1) * routed_scaling_factor
+        torch.testing.assert_close(out.detach(), expected, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Serving an MoE model with CUDA graphs enabled aborts during decode-graph capture on the non-AITER Triton MoE path:

```
Exception: Capture cuda graph failed: RuntimeError when making fake tensor call
  Dynamo failed to run FX node with fake tensors: call_function sum(
    FakeTensor(..., size=(8, 8, 2048), dtype=torch.bfloat16),
    dim=1, out=FakeTensor(..., grad_fn=<AsStridedBackward0>))
  got RuntimeError("sum(): functions with out=... arguments don't support
  automatic differentiation, but one of the arguments requires grad.")

from user code:
  .../layers/moe/moe_runner/triton_utils/fused_moe.py:322, in moe_sum_reduce_torch_compile
    torch.sum(x, dim=1, out=out)
```

`moe_sum_reduce_torch_compile` reduces the per-expert outputs into a pre-allocated `out` buffer via `torch.sum(..., out=out)` plus an in-place `mul_`. It is selected for small batches (`_use_moe_sum_reduce_torch_compile`: `num_tokens <= 32`) — **exactly the batch sizes captured for CUDA graphs**. Capture traces the helper with `torch.compile` while autograd is enabled, so the grad-tracked capture buffer makes the `out=` / in-place ops illegal and Dynamo aborts.

Only the **non-AITER Triton MoE path** reaches this helper — e.g. consumer RDNA / gfx1151 (Strix Halo), which has no AITER `moe_sum`; CDNA and CUDA route through AITER and never hit it. On affected setups every MoE model must currently run with `--disable-cuda-graph`.

The fix is generic and **not AMD-gated** — it corrects the shared Triton MoE path for any non-AITER setup. Found while enabling consumer RDNA / gfx1151, tracked in #30599, alongside #31137 (`sgl-kernel` build enablement) and #31143 (`jit_kernel` HIP-compat, merged).

## Modifications

- `python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py` — run the reduction in `moe_sum_reduce_torch_compile` under `torch.no_grad()`. The reduction is inference-only, so disabling autograd is safe and changes no numerics; it simply lets `torch.compile` trace the `out=` / in-place ops during capture.
- `test/registered/unit/layers/moe/test_moe_sum_reduce_torch_compile.py` — new regression test (unit, no server; `stage="base-b"`, `runner_config="1-gpu-small"`, `est_time=10` measured). Invokes the helper with a grad-tracked `out` under `enable_grad`.

## Accuracy Tests

GSM8K on gfx1151 with **CUDA graphs enabled** (not previously possible for MoE):

| Model | Type | GSM8K | Invalid |
|---|---|---|---|
| Qwen1.5-MoE-A2.7B-Chat | MoE | 0.40 | 0.00 |
| Qwen2.5-7B-Instruct | dense (regression) | 0.90 | 0.00 |

The dense path never reaches this helper, so its run is a collateral-breakage check: the same box measured 0.92 before the change (50 vs 40 questions — unchanged within sampling noise).

The change is a **no-op unless `out` is grad-tracked**, verified at the function level with identical inputs:

| `out` | pre-fix | post-fix |
|---|---|---|
| not grad-tracked (CUDA/CDNA today) | OK, correct reduction | OK, correct reduction |
| grad-tracked, leaf | raises `TorchRuntimeError` | OK, correct |
| grad-tracked, non-leaf (as in capture) | raises `TorchRuntimeError` | OK, correct |

## Speed Tests and Profiling

No numerics or kernel change. The fix re-enables CUDA graphs for MoE models on the Triton path (previously forced onto `--disable-cuda-graph`), restoring decode-time graph replay.

## Test plan

Real gfx1151 (RDNA3.5 / Strix Halo), current `main` + #31143 + the `sgl-kernel` from #31137, Triton attention backend, **CUDA graphs enabled**:

| Model | Type | Graph capture | hipError | Notes |
|---|---|---|---|---|
| OLMoE-1B-7B-Instruct | MoE | ✅ bs=[1,2,4,8], 3.12 s | 0 | correct output; **aborts capture without this fix** |
| Qwen1.5-MoE-A2.7B-Chat | MoE | ✅ 6.00 s | 0 | GSM8K 0.40 / 0.00 invalid |
| Qwen2.5-7B-Instruct | dense | ✅ 1.84 s | 0 | regression check: GSM8K 0.90 / 0.00 invalid |

```bash
python -m sglang.launch_server --model-path allenai/OLMoE-1B-7B-0924-Instruct \
  --attention-backend triton --mem-fraction-static 0.5 --cuda-graph-max-bs 8
# before this fix: "Capture cuda graph failed: RuntimeError when making fake tensor call"
```

New unit test, verified in both directions (per the repo's bug-regression admission criteria):

- pre-fix code → `FAILED (errors=1)`: `torch._dynamo.exc.TorchRuntimeError: RuntimeError when making fake tensor call`
- post-fix code → `Ran 1 test ... OK`

## Checklist

- [x] Format with pre-commit.
- [x] Add unit tests — `test_moe_sum_reduce_torch_compile.py`, verified red on pre-fix and green on the fix.
- [ ] Update documentation — N/A.
- [x] Accuracy/speed benchmarks — GSM8K matrix above; no perf-sensitive change.
- [x] Follow the SGLang code style guidance.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29381080430](https://github.com/sgl-project/sglang/actions/runs/29381080430)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29381080309](https://github.com/sgl-project/sglang/actions/runs/29381080309)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->