### PR TITLE
[Spec] Inline DP-attention width scaling; drop the coefficient indirection

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -774,9 +774,16 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
             # process global_num_tokens and global_num_tokens_for_logprob
             if batch.spec_info is not None:
-                spec_info: SpecInput = batch.spec_info
+                from sglang.srt.speculative.spec_info import (
+                    spec_scale_global_num_tokens,
+                )
+
                 global_num_tokens, global_num_tokens_for_logprob = (
-                    spec_info.get_spec_adjusted_global_num_tokens(batch)
+                    spec_scale_global_num_tokens(
+                        batch.spec_info,
+                        batch.global_num_tokens,
+                        batch.global_num_tokens_for_logprob,
+                    )
                 )
             else:
                 global_num_tokens = batch.global_num_tokens
@@ -1247,11 +1254,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 if self.forward_mode.is_idle():
                     self._original_forward_mode = self.forward_mode
                     self.forward_mode = ForwardMode.TARGET_VERIFY
-                # Invert the get_spec_adjusted_global_num_tokens scaling: the
-                # divisor must equal its coefficient, not the raw width field.
-                bs = self.batch_size = (
-                    num_tokens // self.spec_info.get_spec_adjust_token_coefficient()[0]
-                )
+                # Invert the spec_scale_global_num_tokens scaling.
+                bs = self.batch_size = num_tokens // self.spec_info.num_tokens_per_req
             elif self.is_extend_in_batch and dp_padding_mode.is_max_len():
                 self._original_forward_mode = self.forward_mode
                 self.forward_mode = ForwardMode.EXTEND
@@ -1312,10 +1316,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     self.extend_logprob_start_lens_cpu = self.extend_prefix_lens_cpu
             else:
                 if self.spec_info is not None:
-                    # Invert the get_spec_adjusted_global_num_tokens scaling.
+                    # Invert the spec_scale_global_num_tokens scaling.
                     bs = self.batch_size = (
-                        num_tokens
-                        // self.spec_info.get_spec_adjust_token_coefficient()[0]
+                        num_tokens // self.spec_info.num_tokens_per_req
                     )
                 else:
                     bs = self.batch_size = num_tokens

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -21,7 +21,10 @@ from sglang.srt.speculative.dspark_components.dspark_planner import VerifyWindow
 from sglang.srt.speculative.dspark_components.kernels.dspark_draft_model import (
     SampleStepTokens,
 )
-from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_info import (
+    SpeculativeAlgorithm,
+    spec_scale_global_num_tokens,
+)
 from sglang.srt.speculative.spec_utils import draft_tp_context
 
 logger = logging.getLogger(__name__)
@@ -406,8 +409,10 @@ class DraftBlockProposer:
     ) -> None:
         if not self._dp_moe_sync or batch.global_num_tokens is None:
             return
-        gnt, gnt_logprob = (
-            self._draft_block_spec_info.get_spec_adjusted_global_num_tokens(batch)
+        gnt, gnt_logprob = spec_scale_global_num_tokens(
+            self._draft_block_spec_info,
+            batch.global_num_tokens,
+            batch.global_num_tokens_for_logprob,
         )
         device = self.draft_model_runner.device
         forward_batch.global_num_tokens_cpu = gnt

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -350,18 +350,22 @@ class SpecInput(ABC):
             SpecInputType.NGRAM_VERIFY,
         }
 
-    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
-        return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
-    def get_spec_adjusted_global_num_tokens(
-        self, batch: ScheduleBatch
-    ) -> Tuple[List[int], List[int]]:
-        c1, c2 = self.get_spec_adjust_token_coefficient()
-        global_num_tokens = [x * c1 for x in batch.global_num_tokens]
-        global_num_tokens_for_logprob = [
-            x * c2 for x in batch.global_num_tokens_for_logprob
-        ]
-        return global_num_tokens, global_num_tokens_for_logprob
+def spec_scale_global_num_tokens(
+    spec_info: SpecInput,
+    global_num_tokens: List[int],
+    global_num_tokens_for_logprob: List[int],
+) -> Tuple[List[int], List[int]]:
+    """Scale the raw per-rank sync values (request counts on decode-family
+    rounds) into this forward's token units using the spec input's uniform
+    per-request widths."""
+    return (
+        [x * spec_info.num_tokens_per_req for x in global_num_tokens],
+        [
+            x * spec_info.num_tokens_for_logprob_per_req
+            for x in global_num_tokens_for_logprob
+        ],
+    )
 
 
 def create_dummy_verify_input(


### PR DESCRIPTION
Stacks on #31245. `get_spec_adjust_token_coefficient` / `get_spec_adjusted_global_num_tokens` were a virtual-method pair whose only remaining implementation returned `(num_tokens_per_req, num_tokens_for_logprob_per_req)` verbatim, so the indirection carried no information. Replace both with one explicit module function `spec_scale_global_num_tokens` that scales the raw per-rank sync values (request counts on decode-family rounds) by the spec input's uniform widths:

- `ForwardBatch` build and the dspark draft-block MoE sync are the two scaling call sites.
- The two idle-padding inversions read `spec_info.num_tokens_per_req` directly — divisor and multiplier are now visibly the same field.

Value-equivalent everywhere: the base coefficient implementation had zero overrides left.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29446868852](https://github.com/sgl-project/sglang/actions/runs/29446868852)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29453603231](https://github.com/sgl-project/sglang/actions/runs/29453603231)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->