### PR TITLE
[AMD] Default RDNA (gfx1151 / Strix Halo) to the Triton attention backend

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -50,6 +50,7 @@ from sglang.srt.utils.common import (
     is_hip,
     is_musa,
     is_npu,
+    is_rdna_supported,
     is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
@@ -588,7 +589,11 @@ def _gpt_oss_overrides(server_args: Any, hf_config: Any) -> dict:
         elif is_xpu():
             overrides["attention_backend"] = "intel_xpu"
         elif is_hip():
-            overrides["attention_backend"] = "aiter"
+            # AITER attention is CDNA/wave64-only; RDNA (e.g. gfx1151) has no
+            # AITER support, so Triton is the working default there.
+            overrides["attention_backend"] = (
+                "triton" if is_rdna_supported() else "aiter"
+            )
         else:
             overrides["attention_backend"] = "triton"
     if is_xpu():
@@ -684,7 +689,12 @@ def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
         elif is_sm90_supported():
             backend, platform = "fa3", "sm90"
         elif is_hip():
-            backend, platform = "aiter", "hip"
+            # AITER attention is CDNA/wave64-only; RDNA (e.g. gfx1151) has no
+            # AITER support, so Triton is the working default there.
+            backend, platform = (
+                "triton" if is_rdna_supported() else "aiter",
+                "hip",
+            )
         elif server_args.device == "xpu":
             backend, platform = "intel_xpu", "xpu"
         else:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -79,6 +79,7 @@ from sglang.srt.utils.common import (
     is_musa,
     is_no_spec_infer_or_topk_one,
     is_npu,
+    is_rdna_supported,
     is_remote_url,
     is_sm90_supported,
     is_sm100_supported,
@@ -4751,7 +4752,9 @@ class ServerArgs:
             ):
                 return "trtllm_mha"
             elif is_hip():
-                return "aiter"
+                # AITER attention is CDNA/wave64-only; RDNA (e.g. gfx1151) has no
+                # AITER support, so Triton is the working default there.
+                return "triton" if is_rdna_supported() else "aiter"
             elif is_mps():
                 return "torch_native"
             else:
@@ -4766,6 +4769,10 @@ class ServerArgs:
             elif is_sm100_supported():
                 return "flashinfer"
             elif is_hip():
+                # AITER attention is CDNA/wave64-only; RDNA (e.g. gfx1151) has no
+                # AITER support.
+                if is_rdna_supported():
+                    return "triton"
                 head_num = model_config.get_num_kv_heads(self.tp_size)
                 # TODO current aiter only support head number 16 or 128 head number
                 if head_num == 128 or head_num == 16:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1032,6 +1032,21 @@ def is_gfx942_supported():
         return False
 
 
+@lru_cache(maxsize=1)
+def is_rdna_supported():
+    """
+    Returns whether the current platform is AMD RDNA (gfx11xx / gfx12xx).
+
+    Covers consumer Radeon parts, including gfx1151 (Strix Halo). AITER kernels
+    are CDNA/wave64-only, so RDNA relies on the Triton backends.
+    """
+    if torch.version.hip:
+        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        return any(gfx in gcn_arch for gfx in ["gfx11", "gfx12"])
+    else:
+        return False
+
+
 def get_hip_version():
     if torch.version.hip:
         return tuple(map(int, torch.version.hip.split("-")[0].split(".")))

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1555,5 +1555,46 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestRocmDefaultAttentionBackend(CustomTestCase):
+    # AITER attention is CDNA/wave64-only, so RDNA (gfx11xx/gfx12xx, e.g. gfx1151
+    # Strix Halo) must default to triton -- otherwise the server picks aiter and
+    # every RDNA user has to pass --attention-backend triton by hand. The CDNA
+    # cases guard the other direction: an over-broad RDNA check would silently
+    # steal MI300/MI325 away from aiter.
+    @staticmethod
+    def _default_backend(use_mla_backend, is_rdna, num_kv_heads=128):
+        model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+            get_num_kv_heads=lambda _tp_size: num_kv_heads,
+        )
+        with (
+            patch(
+                "sglang.srt.server_args.current_platform.is_out_of_tree",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.server_args.is_hopper_with_cuda_12_3", return_value=False
+            ),
+            patch("sglang.srt.server_args.is_sm100_supported", return_value=False),
+            patch("sglang.srt.server_args.is_hip", return_value=True),
+            patch("sglang.srt.server_args.is_rdna_supported", return_value=is_rdna),
+        ):
+            return ServerArgs._get_default_attn_backend(
+                SimpleNamespace(tp_size=1), use_mla_backend, model_config
+            )
+
+    def test_mha_defaults_to_triton_on_rdna(self):
+        self.assertEqual(self._default_backend(False, is_rdna=True), "triton")
+
+    def test_mha_defaults_to_aiter_on_cdna(self):
+        self.assertEqual(self._default_backend(False, is_rdna=False), "aiter")
+
+    def test_mla_defaults_to_triton_on_rdna(self):
+        self.assertEqual(self._default_backend(True, is_rdna=True), "triton")
+
+    def test_mla_defaults_to_aiter_on_cdna(self):
+        self.assertEqual(self._default_backend(True, is_rdna=False), "aiter")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1763,6 +1763,60 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 },
             )
 
+    def test_rdna_attention_families_at_callable_level(self):
+        """GPT-OSS and Llama4 select their attention backend here, bypassing
+        _get_default_attn_backend. Both used to map every HIP device to aiter,
+        but aiter is CDNA/wave64-only and hard-asserts on RDNA (gfx11xx/gfx12xx,
+        e.g. gfx1151), so those two models could not start there. The CDNA half
+        guards the other direction: an over-broad RDNA check would steal
+        MI300/MI325 away from aiter.
+        """
+        from sglang.srt.arg_groups.overrides import (
+            _gpt_oss_overrides,
+            _llama4_overrides,
+        )
+
+        def _args(**kw):
+            defaults = dict(
+                device="cuda",
+                attention_backend=None,
+                is_attention_backend_not_set=lambda: True,
+                # keep the quant/moe blocks inert so these assertions stay
+                # attention-only
+                moe_runner_backend="triton",
+                quantization=None,
+            )
+            defaults.update(kw)
+            return SimpleNamespace(**defaults)
+
+        with (
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm90_supported", return_value=False),
+            patch.object(overrides_module, "is_cpu", return_value=False),
+            patch.object(overrides_module, "is_xpu", return_value=False),
+            patch.object(overrides_module, "is_hip", return_value=True),
+        ):
+            with patch.object(overrides_module, "is_rdna_supported", return_value=True):
+                self.assertEqual(
+                    _gpt_oss_overrides(_args(), None),
+                    {"attention_backend": "triton"},
+                )
+                self.assertEqual(
+                    _llama4_overrides(_args(), None),
+                    {"attention_backend": "triton"},
+                )
+            with patch.object(
+                overrides_module, "is_rdna_supported", return_value=False
+            ):
+                self.assertEqual(
+                    _gpt_oss_overrides(_args(), None),
+                    {"attention_backend": "aiter"},
+                )
+                self.assertEqual(
+                    _llama4_overrides(_args(), None),
+                    {"attention_backend": "aiter"},
+                )
+
     def test_deepseek_moe_quant_slot_pass(self):
         from sglang.srt.arg_groups.overrides import (
             ResolvedView,


### PR DESCRIPTION
## Motivation

`ServerArgs._get_default_attn_backend()` maps **every** HIP device to the **AITER** attention backend:

```python
elif is_hip():
    return "aiter"
```

AITER is CDNA/wave64-only and has no RDNA support. So on RDNA (gfx11xx/gfx12xx — consumer Radeon, including **gfx1151 / Strix Halo**) the default does not work, and every launch needs an explicit `--attention-backend triton`. This PR makes RDNA default to the backend those users already select by hand.

The same `is_hip()` → `aiter` default also appears in **two model-specific overrides** that bypass `_get_default_attn_backend()` entirely, so **GPT-OSS** and **Llama4** landed on AITER on RDNA even with the generic default fixed. On real gfx1151 that backend hard-asserts:

```
AssertionError: One of GPU archs of ['gfx1151'] is invalid or not supported
```

Companion to #31137 (sgl-kernel gfx1151 build enablement) and #31143 (jit_kernel HIP-compat, merged). Tracked under #30599.

## Modifications

1. **`python/sglang/srt/utils/common.py`** — add `is_rdna_supported()`, mirroring the existing `is_gfx942_supported()` / `is_gfx95_supported()` helpers exactly (`@lru_cache(maxsize=1)`, `torch.version.hip` guard, `gcnArchName` substring match). Matches `gfx11` (RDNA3/3.5) and `gfx12` (RDNA4).

2. **`python/sglang/srt/server_args.py`** — consult it in both HIP branches of `_get_default_attn_backend()`:
   - MHA: `return "triton" if is_rdna_supported() else "aiter"`
   - MLA: return `"triton"` on RDNA, ahead of the existing AITER head-count logic.

3. **`python/sglang/srt/arg_groups/overrides.py`** — the two overrides that bypass the generic default:
   - `_gpt_oss_overrides` (`GptOssForCausalLM`)
   - `_llama4_overrides` (`Llama4ForConditionalGeneration`, `Llama4ForCausalLM`)

4. **Unit tests** — `test/registered/unit/server_args/test_server_args.py` (generic default) and `test/registered/unit/test_model_overrides.py` (the two overrides).

**Scope / safety**
- **Default-only.** Every branch is gated on the user not having passed `--attention-backend`, so an explicit choice still wins.
- **CDNA unchanged.** MI300/MI325 keep `aiter`, including the MLA head-count logic — covered by negative tests on all three sites.
- **Consistent with existing AMD code.** `arg_groups/overrides.py:480` (`_minimax_m3_overrides`) already does `if is_hip(): attention_backend = "triton"`, and `:1933` already does `is_gfx95_mxfp8 = is_hip() and is_gfx95_supported()` → arch-based default in this same pipeline.

## Accuracy Tests

No kernel or forward math changes — this only selects the **default** backend on RDNA. CDNA and explicit-flag paths are untouched; on RDNA it resolves to the same Triton path users already select manually.

Verified on real **gfx1151 (Radeon 8060S / Strix Halo)**, with **no `--attention-backend` flag**.

**1. Generic default** — `Qwen/Qwen2.5-7B-Instruct`, end-to-end:
```
attention_backend='triton'        # auto-selected (previously: aiter)
The server is fired up and ready to roll!
```
- 0 `hipError`, 0 scheduler exceptions
- Generation correct: `"What is 17 multiplied by 4?"` → `68`
- Helper on the real device: `gcnArchName=gfx1151` → `is_rdna_supported()=True`, `is_gfx942_supported()=False`, `is_gfx95_supported()=False`

**2. Llama4 override** — `RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16`, end-to-end:
```
attention_backend='triton'
Use triton as attention backend on hip for Llama4 model
```
- 0 `hipError`. Previously this logged `Use aiter as attention backend on hip`, and AITER then hard-asserted on gfx1151.

**3. GPT-OSS override** — verified at the callable level on the same gfx1151 device (`arch=gfx1151`, `is_rdna_supported()=True`):

| | before | after |
|---|---|---|
| `_gpt_oss_overrides` | `'aiter'` | `'triton'` |
| `_llama4_overrides` | `'aiter'` | `'triton'` |

GPT-OSS is **not** verified end-to-end here, and deliberately so: on RDNA it currently fails earlier than attention-backend selection, because `mxfp4` is only registered on HIP when `mxfp_supported()` is true (gfx950 only), so the launch stops at `ValueError: Unknown quantization method: mxfp4` before a backend is ever resolved. That gate is a separate concern and out of scope here.

The `_gpt_oss_overrides` change is still required rather than deferred: the branch carries the identical `is_hip()` → `aiter` bug as `_llama4_overrides` (proven above to produce a dead server on RDNA), so leaving it in place would simply move the failure one step later for the next person to hit.

## Speed Tests and Profiling

Not applicable — backend *selection* only, no kernel or scheduling change. On CDNA and explicit-flag runs the resolved backend is identical to before; on RDNA it resolves to the Triton backend previously chosen manually, so there is no perf delta versus the working configuration.

## Unit tests

CPU-only (no GPU, no model), added to the existing already-CI-registered files, following each file's own conventions.

`test/registered/unit/server_args/test_server_args.py` → `TestRocmDefaultAttentionBackend`:

| Test | Guards |
|---|---|
| `test_mha_defaults_to_triton_on_rdna` | the fix (MHA) |
| `test_mha_defaults_to_aiter_on_cdna` | CDNA not stolen from AITER (MHA) |
| `test_mla_defaults_to_triton_on_rdna` | the fix (MLA path) |
| `test_mla_defaults_to_aiter_on_cdna` | CDNA not stolen from AITER (MLA) |

`test/registered/unit/test_model_overrides.py` → `test_rdna_attention_families_at_callable_level`, added to `TestGoldenModelOverrides` alongside the existing `test_monolith_attention_families_at_callable_level`, using that file's `patch.object(overrides_module, ...)` + local `_args(**kw)` conventions. Asserts RDNA→triton and CDNA→aiter for both `_gpt_oss_overrides` and `_llama4_overrides`.

The CDNA cases are deliberate negative branches: an over-broad RDNA match would silently move MI300/MI325 off AITER, and only these would catch it.

```
pytest test/registered/unit/server_args/test_server_args.py -k TestRocmDefaultAttentionBackend   # 4 passed
pytest test/registered/unit/test_model_overrides.py -k rdna_attention                            # 1 passed
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — all hooks pass, including `validate registered test CI registries`.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation — not needed; this removes a required flag rather than adding one.
- [x] Provide accuracy and speed benchmark results — accuracy verified on gfx1151 above; speed N/A (selection only).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29384550097](https://github.com/sgl-project/sglang/actions/runs/29384550097)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29384549974](https://github.com/sgl-project/sglang/actions/runs/29384549974)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->