### PR TITLE
[DSV4] Fix draft-extend CUDA graph padding and WAR ordering

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -128,10 +128,13 @@ class AttentionBackend(ABC):
     def shared_read_boundary(self, forward_mode: ForwardMode) -> SharedReadBoundary:
         """Declare where this backend's scheduler-shared reads end per mode.
 
-        Decode/verify default to IN_REPLAY: the out-graph/in-graph init
-        contract above makes it a safe upper bound for any backend honoring
-        the contract. Override for audited deviations.
+        Draft extend defaults to PRE_REPLAY after its out-of-graph metadata
+        initialization. Decode/verify default to IN_REPLAY: the
+        out-graph/in-graph init contract above makes it a safe upper bound for
+        any backend honoring the contract. Override for audited deviations.
         """
+        if forward_mode.is_draft_extend_v2():
+            return SharedReadBoundary.PRE_REPLAY
         if forward_mode.is_decode() or forward_mode.is_target_verify():
             return SharedReadBoundary.IN_REPLAY
         return SharedReadBoundary.UNKNOWN

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -129,6 +129,10 @@ class AttentionBackend(ABC):
         should override this hook for both capture and replay.
         """
 
+    # Defer the scheduler WAR read-done event when CUDA graph replay still reads
+    # scheduler-owned shared buffers after out-of-graph metadata preparation.
+    defer_war_read_done_until_after_replay: bool = False
+
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         """Init the global shared states for cuda graph."""
         raise NotImplementedError()

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -505,8 +505,9 @@ class DeepseekV4AttnBackend(
     needs_cpu_seq_lens: bool = False
 
     def shared_read_boundary(self, forward_mode: ForwardMode) -> SharedReadBoundary:
-        # Breakable-graph verify rereads shared state across segments.
-        if forward_mode.is_target_verify():
+        # Breakable-graph verify rereads shared state across segments. Draft
+        # extend also consumes scheduler-owned buffers during graph replay.
+        if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
             return SharedReadBoundary.POST_REPLAY
         return super().shared_read_boundary(forward_mode)
 
@@ -1969,6 +1970,9 @@ class DeepseekV4AttnBackend(
         seq_lens_casual = seq_lens[:, None] + torch.arange(
             -qo_len + 1, 1, **self.cuda_int32_kwargs
         )
+        # Graph-padded requests use seq_len=1 even when qo_len is wider. Keep
+        # their causal rows on reserved slot 0 instead of producing negatives.
+        seq_lens_casual.clamp_min_(1)
         seq_lens_casual = seq_lens_casual.flatten()
         idx_to_req_repeated = torch.arange(
             bs, **self.cuda_int32_kwargs

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -490,6 +490,7 @@ class DeepseekV4AttnBackend(
     use_captured_forward_metadata_for_breakable_cuda_graph: bool = True
     supports_ragged_verify_graph: bool = True
     needs_cpu_seq_lens: bool = False
+    defer_war_read_done_until_after_replay: bool = True
 
     def __init__(
         self,
@@ -1925,6 +1926,9 @@ class DeepseekV4AttnBackend(
         seq_lens_casual = seq_lens[:, None] + torch.arange(
             -qo_len + 1, 1, **self.cuda_int32_kwargs
         )
+        # Graph-padded requests use seq_len=1 even when qo_len is wider. Keep
+        # their causal rows on reserved slot 0 instead of producing negatives.
+        seq_lens_casual.clamp_min_(1)
         seq_lens_casual = seq_lens_casual.flatten()
         idx_to_req_repeated = torch.arange(
             bs, **self.cuda_int32_kwargs

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 import torch
 
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
+from sglang.srt.layers.attention.base_attn_backend import SharedReadBoundary
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
     set_dp_buffer_len,
@@ -589,21 +590,29 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
-        # Snapshot built -- the forward is done reading the shared pool. Publish
-        # a read-done event the scheduler's WAR barrier waits on (draft extend
-        # is the EAGLE-family war-publish phase; last write wins the mailbox).
-        read_done = self.device_module.Event()
-        read_done.record()
-        self.model_runner.war_fastpath_read_done_event = read_done
-
         self.raw_bs = raw_bs
         self.bs = bs
         shape_key = self._make_graph_key(bs)
         with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
-            out = self._replay_graph(shape_key, forward_batch)
+            out = self._replay_graph_with_war_read_done(shape_key, forward_batch)
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],
             hidden_states=out.hidden_states[:num_tokens],
         )
+        return out
+
+    def _replay_graph_with_war_read_done(self, shape_key, forward_batch):
+        read_boundary = self.draft_extend_attn_backend.shared_read_boundary(
+            self.forward_mode
+        )
+        # This runner does not plant an external event in its captured graph,
+        # so an in-replay declaration must conservatively publish pre-replay.
+        if read_boundary is SharedReadBoundary.IN_REPLAY:
+            read_boundary = SharedReadBoundary.PRE_REPLAY
+        if read_boundary is SharedReadBoundary.PRE_REPLAY:
+            self._publish_war_read_done(in_graph=False)
+        out = self._replay_graph(shape_key, forward_batch)
+        if read_boundary is SharedReadBoundary.POST_REPLAY:
+            self._publish_war_read_done(in_graph=False)
         return out

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -589,20 +589,30 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
-        # Snapshot built -- the forward is done reading the shared pool. Publish
-        # a read-done event the scheduler's WAR barrier waits on.
-        read_done = self.device_module.Event()
-        read_done.record()
-        self.model_runner.war_fastpath_read_done_event = read_done
-
         self.raw_bs = raw_bs
         self.bs = bs
         shape_key = self._make_graph_key(bs)
         with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
-            out = self._replay_graph(shape_key, forward_batch)
+            out = self._replay_graph_with_war_read_done(shape_key, forward_batch)
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],
             hidden_states=out.hidden_states[:num_tokens],
         )
         return out
+
+    def _replay_graph_with_war_read_done(self, shape_key, forward_batch):
+        defer_read_done = (
+            self.draft_extend_attn_backend.defer_war_read_done_until_after_replay
+        )
+        if not defer_read_done:
+            self._record_war_fastpath_read_done()
+        out = self._replay_graph(shape_key, forward_batch)
+        if defer_read_done:
+            self._record_war_fastpath_read_done()
+        return out
+
+    def _record_war_fastpath_read_done(self) -> None:
+        read_done = self.device_module.Event()
+        read_done.record()
+        self.model_runner.war_fastpath_read_done_event = read_done

--- a/test/registered/unit/spec/test_dsv4_draft_extend_cuda_graph.py
+++ b/test/registered/unit/spec/test_dsv4_draft_extend_cuda_graph.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.deepseek_v4_backend import DeepseekV4AttnBackend
+from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
+    EAGLEDraftExtendCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestDSV4DraftExtendCudaGraph(TestCase):
+    def test_padding_causal_lengths_stay_nonnegative(self):
+        backend = object.__new__(DeepseekV4AttnBackend)
+        backend.cuda_int32_kwargs = {"dtype": torch.int32, "device": "cpu"}
+
+        seq_lens_casual, req_pool_indices = (
+            backend.expand_extend_with_same_length(
+                bs=1,
+                qo_len=4,
+                seq_lens=torch.tensor([1], dtype=torch.int32),
+                req_pool_indices=torch.tensor([0], dtype=torch.int32),
+            )
+        )
+
+        self.assertEqual(seq_lens_casual.tolist(), [1, 1, 1, 1])
+        self.assertEqual((seq_lens_casual - 1).tolist(), [0, 0, 0, 0])
+        self.assertEqual(req_pool_indices.tolist(), [0, 0, 0, 0])
+
+    def test_read_done_order_follows_backend_capability(self):
+        cases = (
+            (AttentionBackend, ["event", "replay"]),
+            (DeepseekV4AttnBackend, ["replay", "event"]),
+        )
+        for backend, expected_order in cases:
+            with self.subTest(backend=backend.__name__):
+                runner = object.__new__(EAGLEDraftExtendCudaGraphRunner)
+                runner.draft_extend_attn_backend = backend
+                call_order = []
+                runner._record_war_fastpath_read_done = mock.Mock(
+                    side_effect=lambda: call_order.append("event")
+                )
+                runner._replay_graph = mock.Mock(
+                    side_effect=lambda *_args: call_order.append("replay") or "output"
+                )
+
+                output = runner._replay_graph_with_war_read_done(
+                    SimpleNamespace(), SimpleNamespace()
+                )
+
+                self.assertEqual(output, "output")
+                self.assertEqual(call_order, expected_order)

--- a/test/registered/unit/spec/test_dsv4_draft_extend_cuda_graph.py
+++ b/test/registered/unit/spec/test_dsv4_draft_extend_cuda_graph.py
@@ -1,3 +1,4 @@
+import unittest
 from types import SimpleNamespace
 from unittest import TestCase, mock
 
@@ -18,13 +19,11 @@ class TestDSV4DraftExtendCudaGraph(TestCase):
         backend = object.__new__(DeepseekV4AttnBackend)
         backend.cuda_int32_kwargs = {"dtype": torch.int32, "device": "cpu"}
 
-        seq_lens_casual, req_pool_indices = (
-            backend.expand_extend_with_same_length(
-                bs=1,
-                qo_len=4,
-                seq_lens=torch.tensor([1], dtype=torch.int32),
-                req_pool_indices=torch.tensor([0], dtype=torch.int32),
-            )
+        seq_lens_casual, req_pool_indices = backend.expand_extend_with_same_length(
+            bs=1,
+            qo_len=4,
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            req_pool_indices=torch.tensor([0], dtype=torch.int32),
         )
 
         self.assertEqual(seq_lens_casual.tolist(), [1, 1, 1, 1])
@@ -54,3 +53,7 @@ class TestDSV4DraftExtendCudaGraph(TestCase):
 
                 self.assertEqual(output, "output")
                 self.assertEqual(call_order, expected_order)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Follow-up to #30853. Enabling DSV4 draft-extend CUDA graphs exposes two correctness issues:

1. Graph-bucket padding uses seq_len=1. When the captured draft width is 4, uniform-width expansion produces causal lengths [-2, -1, 0, 1], and therefore negative positions and invalid attention metadata for padded rows.
2. DSV4 translates out_cache_loc through the live full-to-SWA mapping inside the captured graph. The runner currently publishes the scheduler WAR read-done event before replay, so the schedule stream may overwrite shared mapping state while replay is still reading it.

## Changes

- Clamp DSV4 uniform-width causal lengths to 1, keeping padding on reserved slot 0 while leaving valid requests unchanged.
- Add an explicit AttentionBackend capability for replay-time shared-buffer reads.
- Defer the draft-extend WAR read-done event until after replay only for DSV4; other backends retain the pre-replay fast path.
- Add focused CPU tests for padding metadata and both event-order modes.

This follows the same padded-row underflow diagnosis fixed for DSA in #30378. The WAR ordering follows the existing distinction between snapshot-complete reads (#29541) and replay-time captured-metadata reads (#30261).

## Validation

- Baseline CUDA reproduction: seq_len=1, draft width=4 produced [-2, -1, 0, 1], and source-order inspection confirmed read_done.record() ran before replay.
- PYTHONPATH=python python -m pytest -q test/registered/unit/spec/test_dsv4_draft_extend_cuda_graph.py: 2 passed, including 2 event-order subtests.
- pre-commit run --all-files --show-diff-on-failure: passed.
- Prior 30-minute end-to-end A/B of the post-replay event path completed with zero request errors; average ITL was 7.996 ms before and 7.930 ms after, with p99 11.257 ms before and 10.977 ms after (within expected run variance, no observed regression).

## Checklist

- [x] Format code with pre-commit
- [x] Add focused tests
- [x] Verify no existing open PR fixes these DSV4 draft-extend paths

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31584979461](https://github.com/sgl-project/sglang/actions/runs/31584979461)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31584979150](https://github.com/sgl-project/sglang/actions/runs/31584979150)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->