### PR TITLE
[DO NOT MERGE] Revert #31001 to test GLM-5.2-NVFP4 bs_1_speed regression

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -457,14 +457,6 @@ class MoEGate(nn.Module):
                     "quark",
                 ):
                     correction_bias_dtype = torch.bfloat16
-                # NOTE(kpham-sgl): flashinfer trtllm routing requires a bf16
-                # routing_bias; an fp32 bias yields NaN routing on exact ties.
-                # Mirror the fp8 path's cast.
-                if (
-                    quant_config.get_name() == "modelopt_fp4"
-                    and get_moe_runner_backend().is_flashinfer_trtllm()
-                ):
-                    correction_bias_dtype = torch.bfloat16
             self.e_score_correction_bias = nn.Parameter(
                 torch.empty((config.n_routed_experts), dtype=correction_bias_dtype)
             )


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — CI experiment only

This reverts #31001 ("Fix GLM/DeepSeek NVFP4 + flashinfer_trtllm long-context `!!!!` collapse (NaN routing)", commit `f49cbbd`) **solely to confirm on CI** that it is the source of the `test_dsa_glm52_nvfp4_tp_mtp.py` `test_bs_1_speed` failure in the scheduled full runs.

## Background
The `base-c-test-4-gpu-b200` scheduled runs started failing at `test_bs_1_speed` beginning with the run that tested `cfc3d05` (first red), while `eb31b531` (previous scheduled run) was green.

CI symptom: the `bs=1` greedy generation collapsed from **1182 tokens → 347 tokens** (accept length **4.599 → 4.284**). Since the metric is `speed = completion_tokens / e2e_latency`, the much shorter output is dominated by fixed prefill/warmup overhead and falls under the `300 tok/s` gate (~295 on the runner).

## Local A/B (revert-on-`cfc3d05`, exact fixture args)
| Config | Acc length | Speed (tok/s) | Latency (s) | Tokens |
|--------|-----------:|--------------:|------------:|-------:|
| `cfc3d05` as-is | 4.284 | 341 | 1.02 | 347 |
| `cfc3d05` − revert #29151 | 4.284 | 340 | 1.02 | 347 (no change) |
| `cfc3d05` − revert **#31001** | **4.599** | 392 | 3.02 | **1182** (restored) |

Reverting **#31001** restores the pre-regression generation exactly; reverting #29151 (ModelOpt NVFP4 merged-linear scales) does nothing.

## Why not just merge this
#31001 is a genuine fix — without it, `modelopt_fp4` + `flashinfer_trtllm` hits NaN routing on exact ties and produces `!!!!` collapse in long context. The bf16 routing-bias cast has the *side effect* of changing this short-prompt greedy generation length. The real follow-up is to decide whether that routing change is expected and/or make the `bs_1_speed` check robust to output length. This PR is only to validate the root cause on CI.

Made with [Cursor](https://cursor.com)









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29389687076](https://github.com/sgl-project/sglang/actions/runs/29389687076)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29389686960](https://github.com/sgl-project/sglang/actions/runs/29389686960)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->