### PR TITLE
Let CI server launches wait longer for ports held by a dying predecessor

### DIFF
--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -54,8 +54,17 @@ MAX_VALID_PORT = 65535
 
 
 def wait_port_available(
-    port: int, port_name: str, timeout_s: int = 30, raise_exception: bool = True
+    port: int,
+    port_name: str,
+    timeout_s: Optional[int] = None,
+    raise_exception: bool = True,
 ) -> bool:
+    if timeout_s is None:
+        # A killed server can hold its ports well past kill_process_tree()'s
+        # return while GPU teardown completes (>30s observed on GB300), so CI
+        # raises this via SGLANG_WAIT_PORT_TIMEOUT before relaunching a server
+        # on the same port plan.
+        timeout_s = int(os.environ.get("SGLANG_WAIT_PORT_TIMEOUT", "30"))
     if port < 0 or port > MAX_VALID_PORT:
         raise ValueError(
             f"{port_name} has invalid port number {port}. "

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -927,6 +927,11 @@ def popen_launch_server(
         merged.update(env)
         env = merged
 
+    # A dying predecessor can hold the derived port plan past
+    # kill_process_tree() while GPU teardown completes; give CI launches
+    # teardown-sized patience (see wait_port_available).
+    env.setdefault("SGLANG_WAIT_PORT_TIMEOUT", "120")
+
     # Store per-run marker path for potential invalidation
     per_run_marker_path = None
     try:


### PR DESCRIPTION
## Problem

Flaky GB300 CI failure ([example](https://github.com/sgl-project/sglang/actions/runs/29375742882/job/87244931206), recurred on 3 different PRs' jobs in 24h): a test's server launch dies with

```
ValueError: rpc_port at 11236 is not available in 30 seconds. rpc_port is used by a process already.
process.cmdline()=['...sglang', 'serve', ...] process.status()='running'
```

The port holder is the previous (crashed or killed) server launch: SIGKILL defers while a process sits in uninterruptible GPU teardown, so a killed server holds its derived port plan well past `kill_process_tree()`'s return — >30s observed on GB300 — and the next launch on the same `--port` dies at the port check.

## Fix (minimal, per review feedback)

- `wait_port_available`: timeout tunable via `SGLANG_WAIT_PORT_TIMEOUT` (default 30s unchanged)
- `popen_launch_server` sets it to 120s for CI launches

15 lines, no behavior change outside CI test launches.

## Validation on the affected runner

- Production log shows the wait extending to 120s where vanilla failed at 30s
- Green CI run of the two originally-failing tests (`test_deepseek_v3_cutedsl_4gpu`, `test_flashinfer_a2a`) on gb300-4-gpu-02

Note: leftovers that hang *indefinitely* (observed >1h) are not fixed by waiting; that cleanup is split into a follow-up PR as discussed, and is also mitigated at the runner level by a pre-job cleanup hook already deployed on gb300-4-gpu-02.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29630770387](https://github.com/sgl-project/sglang/actions/runs/29630770387)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29630770320](https://github.com/sgl-project/sglang/actions/runs/29630770320)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->