### PR TITLE
fix(fastapi routes): skip path-less routes in _get_fastapi_request_path

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2399,6 +2399,13 @@ def _get_fastapi_request_path(request) -> Tuple[str, bool]:
     from starlette.routing import Match
 
     for route in request.app.routes:
+        # FastAPI >= 0.137 stores lazy `_IncludedRouter` objects (BaseRoute
+        # subclasses without a `.path` attribute) in `app.routes` for anything
+        # mounted via `include_router` (e.g. `/v1/loads`). Accessing
+        # `route.path` on those raises AttributeError and turns every request
+        # into a 500. Skip path-less routes.
+        if getattr(route, "path", None) is None:
+            continue
         match, child_scope = route.matches(request.scope)
         if match == Match.FULL:
             return route.path, True


### PR DESCRIPTION
## Motivation

FastAPI 0.137+ can place path-less `_IncludedRouter` entries in `app.routes` for `include_router()` mounts such as `/v1/loads`. The HTTP metrics middleware previously assumed every matched route had a `.path`, which could raise `AttributeError` and turn a normal request into a 500.

### Repro

Calling `GET /v1/loads?include=core` could fail with:

```text
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

Observed request example:

```text
GET /v1/loads?include=core HTTP/1.1" 500 Internal Server Error
```

## Modifications

Guard `_get_fastapi_request_path()` against path-less routes by skipping any route whose `.path` attribute is missing before using it for the metrics label. This keeps request routing unchanged and only affects observability labeling.

Similar fix in vllm: https://github.com/vllm-project/vllm/pull/45629

## Accuracy Tests

Not applicable.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x]  Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29394820349](https://github.com/sgl-project/sglang/actions/runs/29394820349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29394820270](https://github.com/sgl-project/sglang/actions/runs/29394820270)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->