### PR TITLE
[Fix] Resolve object-storage URI for model_name in get_processor

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -153,6 +153,8 @@ def get_processor(
 
     revision = kwargs.pop("revision", tokenizer_revision)
     tokenizer_name = resolve_runai_obj_uri(tokenizer_name)
+    if model_name is not None:
+        model_name = resolve_runai_obj_uri(model_name)
 
     if is_mistral_model(tokenizer_name):
         config = load_mistral_config(

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -15,6 +15,7 @@ from transformers.image_processing_utils import BaseImageProcessor
 
 from sglang.srt.utils import hf_transformers_patches
 from sglang.srt.utils.hf_transformers.common import (
+    AutoConfig,
     _is_deepseek_ocr2_model,
     _is_deepseek_ocr_model,
     _override_v_head_dim_if_zero,
@@ -24,8 +25,10 @@ from sglang.srt.utils.hf_transformers.common import (
     get_hf_text_config,
     get_rope_config,
 )
+from sglang.srt.utils.hf_transformers.processor import get_processor
 from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
 from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
+from sglang.srt.utils.runai_utils import ObjectStorageModel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
@@ -562,6 +565,47 @@ class TestPatchNemotronHPattern(unittest.TestCase):
             self.assertEqual(result, ["mamba", "moe", "attention"])
         except ImportError:
             self.skipTest("NemotronHConfig not available in this transformers version")
+
+
+# ---------------------------------------------------------------------------
+# get_processor: object-storage URI resolution
+# ---------------------------------------------------------------------------
+
+
+class _StopAfterConfigLookup(Exception):
+    """Sentinel raised to short-circuit get_processor() after the config lookup."""
+
+
+class TestGetProcessorObjectStorageUri(unittest.TestCase):
+    """get_processor() must resolve object-storage URIs for model_name.
+
+    Bug regression (#31240): get_processor() resolved s3://gs://az:// URIs for
+    tokenizer_name only, while TokenizerManager always passes model_name as the
+    raw server model path. For multimodal models loaded via the RunAI streamer,
+    the unresolved URI reached AutoConfig.from_pretrained, which rejects it
+    ("Repo id must be in the form 'repo_name'"), crashing processor init.
+    """
+
+    URI = "s3://bucket/models/Qwen/Qwen3.5-0.8B"
+
+    def _config_name_seen_by_autoconfig(self, model_name):
+        captured = {}
+
+        def capture(name, *args, **kwargs):
+            captured["name"] = name
+            raise _StopAfterConfigLookup
+
+        with patch.object(AutoConfig, "from_pretrained", side_effect=capture):
+            with self.assertRaises(_StopAfterConfigLookup):
+                get_processor(self.URI, model_name=model_name)
+        return captured["name"]
+
+    def test_model_name_uri_resolved_to_local_cache_path(self):
+        name = self._config_name_seen_by_autoconfig(self.URI)
+        self.assertEqual(name, ObjectStorageModel.get_path(self.URI))
+
+    def test_hub_repo_model_name_passes_through(self):
+        self.assertEqual(self._config_name_seen_by_autoconfig("org/repo"), "org/repo")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Multimodal-shaped models loaded from object storage (`s3://`, `gs://`, `az://`) with `--load-format runai_streamer` crash at processor init:

```
OSError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': 's3://<bucket>/models/Qwen/Qwen3.5-0.8B'
```

#22715 added object-storage URI resolution in `get_processor()` for `tokenizer_name`, but `get_processor()` takes a separate `model_name` argument that `TokenizerManager._get_processor_wrapper` always passes as the raw `server_args.model_path`. A few lines below the fixed line, the unresolved URI goes straight into `AutoConfig.from_pretrained`. Text-only models from the same bucket are unaffected since they never take the processor path.

Fixes #31240

## Modifications

- `python/sglang/srt/utils/hf_transformers/processor.py`: resolve `model_name` with `resolve_runai_obj_uri()` right where `tokenizer_name` is already resolved. Resolution is a no-op for HF repo ids and local paths.
- `test/registered/unit/utils/test_hf_transformers.py`: regression test asserting `AutoConfig.from_pretrained` receives the resolved local cache path when `model_name` is an object-storage URI (verified to fail on the pre-fix code), plus a pass-through case for plain HF repo ids. The file is already registered for CPU CI.

## Accuracy Tests

Not applicable: no change to model outputs; path resolution only.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29394897810](https://github.com/sgl-project/sglang/actions/runs/29394897810)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29394897611](https://github.com/sgl-project/sglang/actions/runs/29394897611)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->