### PR TITLE
[CI] Lower GLM-5.2 NVFP4 MTP speed threshold

### DIFF
--- a/test/registered/models_e2e/test_dsa_glm52_nvfp4_tp_mtp.py
+++ b/test/registered/models_e2e/test_dsa_glm52_nvfp4_tp_mtp.py
@@ -21,7 +21,7 @@ class TestGLM52NVFP4TPMTP(
     model = "nvidia/GLM-5.2-NVFP4"
     tp_size = 4
     mem_fraction_static = 0.8
-    bs_1_speed_thres = 300
+    bs_1_speed_thres = 250
     extra_server_args = [
         "--moe-runner-backend",
         "flashinfer_trtllm",


### PR DESCRIPTION
## Summary

Lower the GLM-5.2 NVFP4 MTP speed threshold to 250 tps after perf changed in #31001. CI now runs around 270 tps, with a low of 254.43.

I ran it the same way CI does on a bare-metal HGX B200 locally, not a VM or containerized environment. It passed but stayed close to 300 tps, so the CI container overhead seems quite high. Without the CI env vars, we can expect higher tps.

| Revision | CI env vars | Latency (s) | Tokens | Acc length | tps |
| --- | --- | ---: | ---: | ---: | ---: |
| Main | Yes | 1.108 | 347 | 4.284 | 313.23 |
| Main | No | 0.972 | 347 | 4.284 | 357.05 |
| Reverting #31001 | Yes | 3.362 | 1,182 | 4.599 | 351.53 |
| Reverting #31001 | No | 2.917 | 1,182 | 4.599 | 405.27 |

## Detailed results

### Main

#### With CI env vars

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_IS_IN_CI=true \
SGLANG_ENABLE_ASYNC_ASSERT=true \
SGLANG_CUDA_COREDUMP=1 \
SGLANG_JIT_DEEPGEMM_FAST_WARMUP=true \
python test/registered/models_e2e/test_dsa_glm52_nvfp4_tp_mtp.py -f
```

```text
attempt 1
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    1.108    |  347   |   4.284    |     313.23      |
+-------------+--------+------------+-----------------+
```

#### Without CI env vars

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
python test/registered/models_e2e/test_dsa_glm52_nvfp4_tp_mtp.py -f
```

```text
attempt 1
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    0.972    |  347   |   4.284    |     357.05      |
+-------------+--------+------------+-----------------+
```

### Reverting #31001

#### With CI env vars

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_IS_IN_CI=true \
SGLANG_ENABLE_ASYNC_ASSERT=true \
SGLANG_CUDA_COREDUMP=1 \
SGLANG_JIT_DEEPGEMM_FAST_WARMUP=true \
python test/registered/models_e2e/test_dsa_glm52_nvfp4_tp_mtp.py -f
```

```text
attempt 1
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    3.362    |  1182  |   4.599    |     351.53      |
+-------------+--------+------------+-----------------+
```

#### Without CI env vars

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
python test/registered/models_e2e/test_dsa_glm52_nvfp4_tp_mtp.py -f
```

```text
attempt 1
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    2.917    |  1182  |   4.599    |     405.27      |
+-------------+--------+------------+-----------------+
```