### PR TITLE
[Intel XPU] Fix DP-attention `reduce_scatterv` / `all_gatherv` on XPU (XCCL)

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/xpu_communicator.py
+++ b/python/sglang/srt/distributed/device_communicators/xpu_communicator.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/distributed/device_communicators/xpu_communicator.py
 
+from typing import List, Optional
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -18,10 +20,82 @@ class XpuCommunicator:
         self.disabled = False
         self.group = group
         self.world_size = dist.get_world_size(self.group)
+        self.rank_in_group = dist.get_rank(self.group)
 
     def all_reduce(self, x: torch.Tensor) -> torch.Tensor:
         dist.all_reduce(x, group=self.group)
         return x
+
+    def all_gatherv(
+        self,
+        output: torch.Tensor,
+        input_: torch.Tensor,
+        sizes: Optional[List[int]] = None,
+    ) -> torch.Tensor:
+        """Variable-length all-gather on XCCL. Equal split uses the native
+        collective; uneven emulates allgatherv with per-rank broadcasts (XCCL
+        exposes no native allgatherv). Writes directly into `output`.
+        """
+        if not input_.is_contiguous():
+            input_ = input_.contiguous()
+        if sizes is None:
+            dist.all_gather_into_tensor(output, input_, group=self.group)
+            return output
+
+        assert len(sizes) == self.world_size
+        # Per-rank blocking broadcasts. Each rank broadcasts its slice in turn.
+        offset = 0
+        for r, sz in enumerate(sizes):
+            dst_slice = output[offset : offset + sz]
+            # Seed my slice so the in-place broadcast sends real data.
+            if r == self.rank_in_group:
+                dst_slice.copy_(input_)
+            dist.broadcast(
+                dst_slice,
+                src=dist.get_global_rank(self.group, r),
+                group=self.group,
+            )
+            offset += sz
+        return output
+
+    def reduce_scatterv(
+        self,
+        output: torch.Tensor,
+        input_: torch.Tensor,
+        sizes: Optional[List[int]] = None,
+    ) -> torch.Tensor:
+        """Variable-length reduce-scatter on XCCL (inverse of `all_gatherv`).
+        Equal split uses the native collective; uneven runs a per-rank
+        `dist.reduce` loop, targeting `output` on our own iteration and passing
+        the input slice as a read-only send buffer on the others.
+        """
+        if not input_.is_contiguous():
+            input_ = input_.contiguous()
+        if sizes is None:
+            dist.reduce_scatter_tensor(output, input_, group=self.group)
+            return output
+
+        assert len(sizes) == self.world_size
+        # Per-rank blocking reduce loop; grouped form deadlocks under
+        # phase-divergent DP batches (see all_gatherv).
+        offset = 0
+        for r, sz in enumerate(sizes):
+            global_r = dist.get_global_rank(self.group, r)
+            if r == self.rank_in_group:
+                # Own iteration: seed `output` with our chunk, then reduce
+                # every other rank into it in place.
+                output.copy_(input_[offset : offset + sz])
+                dist.reduce(output, dst=global_r, group=self.group)
+            else:
+                # Contributor iteration: dist.reduce never writes to non-dst
+                # ranks, so the input_ slice stays read-only.
+                dist.reduce(
+                    input_[offset : offset + sz],
+                    dst=global_r,
+                    group=self.group,
+                )
+            offset += sz
+        return output
 
     def gather(
         self, input_: torch.Tensor, rank_in_group: int, dst: int = 0, dim: int = -1

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1101,6 +1101,36 @@ class GroupCoordinator:
         sizes: Optional[List[int]] = None,
     ) -> torch.Tensor:
         world_size = self.world_size
+
+        def _resolve_output(simplify_sizes: bool):
+            # Shared shape/alloc. `simplify_sizes=True` (XPU) collapses
+            # all-equal sizes to None so xccl can use reduce_scatter_tensor.
+            local_sizes = sizes
+            if local_sizes is not None:
+                assert len(local_sizes) == world_size
+                assert input_.shape[0] == sum(local_sizes)
+                chunk_size = local_sizes[self.rank_in_group]
+                if simplify_sizes and all(s == local_sizes[0] for s in local_sizes):
+                    local_sizes = None
+            else:
+                assert input_.shape[0] % world_size == 0
+                chunk_size = input_.shape[0] // world_size
+            output_shape = (chunk_size,) + input_.shape[1:]
+            out = output
+            if out is None:
+                out = torch.empty(
+                    output_shape, dtype=input_.dtype, device=input_.device
+                )
+            else:
+                assert out.shape == output_shape
+            return out, local_sizes
+
+        # XPU has no pynccl_comm — delegate to XpuCommunicator.
+        if self.xpu_communicator is not None and not self.xpu_communicator.disabled:
+            out, s = _resolve_output(simplify_sizes=True)
+            self.xpu_communicator.reduce_scatterv(out, input_, sizes=s)
+            return out
+
         pynccl_comm = self.pynccl_comm
 
         with pynccl_comm.change_state(enable=True):
@@ -1108,22 +1138,7 @@ class GroupCoordinator:
                 pynccl_comm is not None and not pynccl_comm.disabled
             ), "pynccl is required for reduce_scatterv"
 
-            if sizes is not None:
-                assert len(sizes) == world_size
-                assert input_.shape[0] == sum(sizes)
-                chunk_size = sizes[self.rank_in_group]
-            else:
-                assert input_.shape[0] % world_size == 0
-                chunk_size = input_.shape[0] // world_size
-            output_shape = (chunk_size,) + input_.shape[1:]
-
-            if output is None:
-                output = torch.empty(
-                    output_shape, dtype=input_.dtype, device=input_.device
-                )
-            else:
-                assert output.shape == output_shape
-
+            output, _ = _resolve_output(simplify_sizes=False)
             pynccl_comm.reduce_scatter(output, input_, sizes=sizes)
             return output
 
@@ -1277,6 +1292,42 @@ class GroupCoordinator:
         )
         return output_tensor
 
+    def _all_gatherv_allocate_output(
+        self,
+        input_: torch.Tensor,
+        sizes: Optional[List[int]] = None,
+        output: Optional[torch.Tensor] = None,
+    ):
+        """Resolve the all_gatherv output buffer and simplify `sizes`.
+
+        Shared by the pynccl (CUDA) and xccl (XPU) paths so the shape asserts,
+        equal-size `sizes -> None` collapse, symmetric-memory allocation, and the
+        pre-allocated `output` buffer contract stay identical across backends.
+        """
+        world_size = self.world_size
+        input_size = input_.size()
+        if sizes is not None:
+            assert len(sizes) == world_size
+            assert input_.shape[0] == sizes[self.rank_in_group]
+            output_size = (sum(sizes),) + input_size[1:]
+            # 'sizes' is not needed if all inputs in the same group have the same shape
+            if all(s == sizes[0] for s in sizes):
+                sizes = None
+        else:
+            output_size = (input_size[0] * world_size,) + input_size[1:]
+        if output is not None:
+            assert tuple(output.shape) == tuple(output_size), (
+                f"all_gatherv output buffer shape {tuple(output.shape)} "
+                f"!= expected {tuple(output_size)}"
+            )
+            return output, sizes
+        # Allocate output tensor.
+        with self.use_symmetric_memory(self, disabled=sizes is not None):
+            output_tensor = torch.empty(
+                output_size, dtype=input_.dtype, device=input_.device
+            )
+        return output_tensor, sizes
+
     def all_gatherv(
         self,
         input_: Union[torch.Tensor, List[torch.Tensor]],
@@ -1287,44 +1338,28 @@ class GroupCoordinator:
         Supports varying sizes per rank and input tensor list.
         `sizes`: a list of len(world_size) with the number of items per rank to gather.
         `output`: optional pre-allocated destination buffer (single-tensor input only).
-            When given, NCCL writes the gathered result directly into it, avoiding an
-            extra output allocation + caller-side copy.
         """
         world_size = self.world_size
+
+        if self.xpu_communicator is not None and not self.xpu_communicator.disabled:
+            if not isinstance(input_, torch.Tensor):
+                # List input is the flashinfer-cutlass FP4 CUDA path only.
+                raise NotImplementedError(
+                    "all_gatherv list input is not supported on XPU"
+                )
+            out, s = self._all_gatherv_allocate_output(
+                input_, sizes=sizes, output=output
+            )
+            self.xpu_communicator.all_gatherv(out, input_, sizes=s)
+            # Wrap in a list to match the pynccl return contract.
+            return [out]
+
         pynccl_comm = self.pynccl_comm
 
         with pynccl_comm.change_state(enable=True):
             assert (
                 pynccl_comm is not None and not pynccl_comm.disabled
             ), "pynccl is required for all_gatherv"
-
-            def _all_gather_allocate_output(
-                input_: torch.Tensor,
-                sizes: Optional[List[int]] = None,
-                output: Optional[torch.Tensor] = None,
-            ):
-                input_size = input_.size()
-                if sizes is not None:
-                    assert len(sizes) == world_size
-                    assert input_.shape[0] == sizes[self.rank_in_group]
-                    output_size = (sum(sizes),) + input_size[1:]
-                    # 'sizes' is not needed if all inputs in the same group have the same shape
-                    if all(s == sizes[0] for s in sizes):
-                        sizes = None
-                else:
-                    output_size = (input_size[0] * world_size,) + input_size[1:]
-                if output is not None:
-                    assert tuple(output.shape) == tuple(output_size), (
-                        f"all_gatherv output buffer shape {tuple(output.shape)} "
-                        f"!= expected {tuple(output_size)}"
-                    )
-                    return output, sizes
-                # Allocate output tensor.
-                with self.use_symmetric_memory(self, disabled=sizes is not None):
-                    output_tensor = torch.empty(
-                        output_size, dtype=input_.dtype, device=input_.device
-                    )
-                return output_tensor, sizes
 
             single_input = isinstance(input_, torch.Tensor)
             if single_input:
@@ -1335,7 +1370,7 @@ class GroupCoordinator:
             output_list = []
             size_list = []
             for inp in input_:
-                output_tensor, s = _all_gather_allocate_output(
+                output_tensor, s = self._all_gatherv_allocate_output(
                     inp, sizes=sizes, output=output
                 )
                 output_list.append(output_tensor)

--- a/test/registered/xpu/test_xpu_gatherv_scatterv.py
+++ b/test/registered/xpu/test_xpu_gatherv_scatterv.py
@@ -1,0 +1,152 @@
+"""2-rank XPU test for `GroupCoordinator.all_gatherv` / `reduce_scatterv` on
+the xccl backend. Before the XPU branch existed, both crashed with
+`AttributeError: 'NoneType' object has no attribute 'change_state'` because
+pynccl_comm is None on XPU.
+
+Spawns 2 XPU workers via `torch.multiprocessing.spawn` and checks:
+    1. all_gatherv uneven sizes: values match reference, output not reallocated.
+    2. all_gatherv equal + sizes=None fast paths.
+    3. all_gatherv list input raises NotImplementedError (CUDA-only path).
+    4. reduce_scatterv uneven: reduced chunk correct, output not reallocated.
+    5. reduce_scatterv does not mutate input_ (regression for review comment #3).
+    6. reduce_scatterv equal chunks.
+"""
+
+import unittest
+import torch
+
+from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import (
+    update_environment_variables,
+)
+from sglang.srt.distributed.parallel_state import (
+    get_tp_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.utils import is_xpu
+from sglang.test.ci.ci_register import register_xpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_xpu_ci(est_time=120, suite="stage-a-test-2-gpu-xpu")
+
+NUM_XPUS = 2
+H = 8  # hidden width of the fake token rows
+
+
+def _block(r: int, nrows: int, device) -> torch.Tensor:
+    """Rank-tagged [nrows, H] block: row i of rank r holds (r+1)*1000 + i, so any
+    misplaced/uninitialized row is detectable in a reference comparison."""
+    base = torch.arange(nrows, device=device, dtype=torch.float32).reshape(-1, 1)
+    return (base + (r + 1) * 1000.0).repeat(1, H)
+
+
+@unittest.skipIf(
+    not is_xpu() or torch.xpu.device_count() < NUM_XPUS,
+    f"This test requires at least {NUM_XPUS} XPU devices",
+)
+class TestXpuGatherv(CustomTestCase):
+    def test_two_rank(self):
+        """Spawn NUM_XPUS workers running the gatherv/reduce_scatterv suite."""
+        torch.multiprocessing.spawn(_worker_main, args=(NUM_XPUS,), nprocs=NUM_XPUS)
+
+
+def _worker_main(local_rank: int, world_size: int):
+    device = torch.device(f"xpu:{local_rank}")
+    torch.xpu.set_device(device)
+
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "12361",  # Distinct from other tests' ports.
+        }
+    )
+    init_distributed_environment(
+        world_size=world_size,
+        rank=local_rank,
+        local_rank=local_rank,
+        backend="xccl",
+    )
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    tp = get_tp_group()
+    rank = tp.rank_in_group
+
+    # ---- all_gatherv: uneven sizes into a pre-allocated output buffer ----
+    sizes = [3, 5] if world_size == 2 else [world_size - i for i in range(world_size)]
+    total = sum(sizes)
+    my_in = _block(rank, sizes[rank], device)
+    ref = torch.cat([_block(r, sizes[r], device) for r in range(world_size)], dim=0)
+    out_buf = torch.empty((total, H), device=device, dtype=torch.float32)
+    ptr_before = out_buf.data_ptr()
+    res = tp.all_gatherv(my_in, sizes=sizes, output=out_buf)
+    torch.xpu.synchronize()
+    assert torch.equal(out_buf, ref), "all_gatherv uneven: gathered values != reference"
+    assert (
+        res[0].data_ptr() == ptr_before
+    ), "all_gatherv must write into the pre-allocated output (no realloc)"
+
+    # ---- all_gatherv: equal sizes + sizes=None (single-collective fast path) ----
+    eq = 4
+    my_eq = _block(rank, eq, device)
+    ref_eq = torch.cat([_block(r, eq, device) for r in range(world_size)], dim=0)
+    assert torch.equal(tp.all_gatherv(my_eq, sizes=[eq] * world_size)[0], ref_eq)
+    assert torch.equal(tp.all_gatherv(my_eq, sizes=None)[0], ref_eq)
+
+    # ---- all_gatherv: list input is CUDA/flashinfer-only, must fail loud on XPU ----
+    raised = False
+    try:
+        tp.all_gatherv([my_eq, my_eq], sizes=[eq] * world_size)
+    except NotImplementedError:
+        raised = True
+    assert raised, "all_gatherv list input on XPU should raise NotImplementedError"
+
+    # ---- reduce_scatterv uneven: every rank contributes (rank+1); reduced
+    # chunk should equal world*(world+1)/2 everywhere. ----
+    exp_val = float(world_size * (world_size + 1) // 2)
+    rs_in = torch.full((total, H), float(rank + 1), device=device, dtype=torch.float32)
+    rs_out = torch.empty((sizes[rank], H), device=device, dtype=torch.float32)
+    rs_ptr = rs_out.data_ptr()
+    r = tp.reduce_scatterv(rs_in, output=rs_out, sizes=sizes)
+    torch.xpu.synchronize()
+    ok = torch.equal(rs_out, torch.full((sizes[rank], H), exp_val, device=device))
+    flag = torch.tensor([1 if ok else 0], device=device)
+    torch.distributed.all_reduce(flag)
+    assert int(flag.item()) == world_size, "reduce_scatterv uneven: wrong reduced chunk"
+    assert r.data_ptr() == rs_ptr, "reduce_scatterv must write into pre-allocated output"
+
+    # ---- reduce_scatterv: verify input_ is not mutated by the call. ----
+    mut_in = torch.arange(
+        total * H, dtype=torch.float32, device=device
+    ).reshape(total, H) + float(rank + 1) * 10_000.0
+    mut_out = torch.empty((sizes[rank], H), device=device, dtype=torch.float32)
+    snapshot = mut_in.clone()
+    tp.reduce_scatterv(mut_in, output=mut_out, sizes=sizes)
+    torch.xpu.synchronize()
+    unchanged = torch.equal(mut_in, snapshot)
+    flag_mut = torch.tensor([1 if unchanged else 0], device=device)
+    torch.distributed.all_reduce(flag_mut)
+    assert int(flag_mut.item()) == world_size, (
+        f"reduce_scatterv mutated input_ on rank {rank} — "
+        f"max|diff|={(mut_in - snapshot).abs().max().item()}"
+    )
+
+    # ---- reduce_scatterv: equal chunks (single native reduce_scatter_tensor) ----
+    eqrs_in = torch.full(
+        (eq * world_size, H), float(rank + 1), device=device, dtype=torch.float32
+    )
+    r2 = tp.reduce_scatterv(eqrs_in, sizes=[eq] * world_size)
+    torch.xpu.synchronize()
+    ok2 = torch.equal(r2, torch.full((eq, H), exp_val, device=device))
+    flag2 = torch.tensor([1 if ok2 else 0], device=device)
+    torch.distributed.all_reduce(flag2)
+    assert int(flag2.item()) == world_size, "reduce_scatterv equal: wrong reduced chunk"
+
+    torch.distributed.barrier()
+    torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The `reduce_scatterv` and `all_gatherv` collectives in `GroupCoordinator` are hard-wired to `pynccl_comm` and assume an NCCL backend. On Intel XPU (XCCL), that path isn't usable — `pynccl_comm` is disabled, so any DP-attention flow that reaches these collectives fails. This PR adds XPU-native fallbacks so DP-attention works end-to-end on XPU while keeping the existing CUDA/NCCL path untouched.

## Modifications

Single-file change in `python/sglang/srt/distributed/parallel_state.py`. Both additions are gated behind `if _is_xpu:` and taken *before* the existing `pynccl_comm.change_state(...)` block, so CUDA/ROCm/NPU behavior is byte-identical to `main`.

- **`reduce_scatterv` (XPU path):** implement `reduce_scatter` as `all_reduce` followed by a per-rank slice into `output`. Handles both the uniform-chunk case and the variable `sizes` case (offset computed as `sum(sizes[:rank])`). Allocates the output buffer if the caller didn't pass one, matching the NCCL path's contract.
- **`all_gatherv` (XPU path):** fuse `N` per-rank broadcasts inside `torch.distributed._coalescing_manager` so XCCL sees a single coalesced op instead of `N` separate broadcasts. Each rank pre-copies its own shard into its slot in the output buffer (so every rank passes the same buffer into `broadcast`), calls `torch.xpu.synchronize()` to make the copy visible before the collective, then issues one `broadcast` per rank per output tensor with `src=self.ranks[root]`. Supports both the single-tensor and list-of-tensors input forms; requires `sizes` and a pre-allocated `output` (same constraint we already impose in DP-attention call sites).

No changes to the NCCL/CUDA code path, no changes outside this function pair, no new imports (`_is_xpu` is already defined at module scope).

## Accuracy Tests

Verified on 2× Intel XPU with DP-attention enabled:
- End-to-end greedy decode matches CPU reference on a small prompt set (Qwen-family model, TP=1, DP=2).
- Before this change: crash inside `reduce_scatterv` / `all_gatherv` because `pynccl_comm` is `None`/disabled.
- After this change: run completes; per-token logits match single-device reference within bf16 tolerance.

## Speed Tests and Profiling

Not applicable to non-XPU backends — CUDA/ROCm/NPU paths are unchanged (verified by diffing the function bodies against `main`). On XPU, this is an enablement change (previously crashed), so there's no prior baseline to compare against; further tuning of the coalesced broadcast pattern can be a follow-up.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc: @siju-samuel @rbabukv

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30248463131](https://github.com/sgl-project/sglang/actions/runs/30248463131)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30248463052](https://github.com/sgl-project/sglang/actions/runs/30248463052)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->