### PR TITLE
[AMD] DeepSeek-V3.2: disable top-k v2 on rocm (unblock stage-c AMD PR Test)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4349,6 +4349,12 @@ class ServerArgs:
 
             run_post_process_pass(self, _deepseek_moe_quant_resolution)
             if is_hip():
+                # The DSA top-k v2 JIT kernel is CUDA-only (it includes
+                # <cooperative_groups.h>) and has no precompiled ROCm op, so on AMD
+                # it fails to compile during CUDA-graph capture. Fall back to the
+                # v1 / legacy precompiled top-k transforms (mirrors the DeepseekV4
+                # HIP arm below).
+                envs.SGLANG_OPT_USE_TOPK_V2.set(False)
                 if not self._resolved().enable_dp_attention and self.nnodes == 1:
                     # TODO (Hubert): Put this back later
                     # self.enable_aiter_allreduce_fusion = True


### PR DESCRIPTION
## Motivation

The AMD nightly job `stage-c-test-large-8-gpu-amd (linux-mi325-8gpu-sglang, 1)` fails in `test/registered/amd/test_deepseek_v32_basic.py`. The server crashes during decode CUDA-graph capture:
```
File ".../srt/layers/attention/dsa_backend.py", line 653, in _build_topk_v2_plan return plan_topk_v2(seqlens_expanded)
File ".../jit_kernel/dsv4/topk.py", line 79, in plan_topk_v2 module = _jit_topk_v2_module() .../jit_kernel/include/sgl_kernel/deepseek_v4/topk_impl.cuh:27:10: fatal error: 'cooperative_groups.h' file not found RuntimeError: ninja exited with status 1
```
`SGLANG_OPT_USE_TOPK_V2` defaults to `True`, but the top-k v2 JIT kernel is CUDA-only (it includes `<cooperative_groups.h>`) and has no precompiled ROCm op, only the v1 / legacy transforms (`deepseek_v4_topk_transform_512`,
`fast_topk_transform_fused`) are registered in `common_extension_rocm.cc`. 
The HIP disable already exists for `DeepseekV4ForCausalLM`, but DeepSeek-V3.x runs through the separate DSA-family arch block (`DeepseekV3ForCausalLM` / `DeepseekV32ForCausalLM` / ...), which never turned it off.

### Root cause / regression:
- The fused top-k v2 kernel is CUDA-only (includes `<cooperative_groups.h>`, no precompiled ROCm op); it was introduced in #26788.
- The decode path began building its plan (`_build_topk_v2_plan`) in #30274, which is the exact frame in the crash traceback.
- The AMD disable added in #28920 only covered `DeepseekV4ForCausalLM`, so the
  DSA-family `DeepseekV32ForCausalLM` kept `SGLANG_OPT_USE_TOPK_V2=True` on ROCm and failed `ninja`/`cooperative_groups.h` during decode CUDA-graph capture.
  
## Modifications
- `python/sglang/srt/server_args.py`: in the DSA-family `is_hip()` arm, set
  `SGLANG_OPT_USE_TOPK_V2 = False`, mirroring the existing `DeepseekV4ForCausalLM`
  HIP arm.
On AMD the top-k dispatch now falls back to the precompiled v1 / legacy
transforms. `dsa_drop_wide_page_table` is already HIP-gated
(`is_cuda() and not _is_hip`), so `page_table_1` remains present for the legacy
path — no other code path changes on AMD.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29395450201](https://github.com/sgl-project/sglang/actions/runs/29395450201)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29395449442](https://github.com/sgl-project/sglang/actions/runs/29395449442)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->