### PR TITLE
Skip no-op EAGLE sampling renormalization

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -699,20 +699,22 @@ def eagle_sample(
             next_token_logits / expanded_temperature, dim=-1
         )  # (bs * num_draft_tokens, vocab_size)
         maybe_detect_nan(target_probs, "v2 verify: target_probs after softmax")
-        target_probs = top_k_renorm_prob(
-            target_probs,
-            torch.repeat_interleave(
-                sampling_info.top_ks, verify_input.draft_token_num, dim=0
-            ),
-        )  # (bs * num_draft_tokens, vocab_size)
-        maybe_detect_nan(target_probs, "v2 verify: target_probs after top_k_renorm")
-        target_probs = top_p_renorm_prob(
-            target_probs,
-            torch.repeat_interleave(
-                sampling_info.top_ps, verify_input.draft_token_num, dim=0
-            ),
-        )
-        maybe_detect_nan(target_probs, "v2 verify: target_probs after top_p_renorm")
+        if sampling_info.need_top_k_sampling:
+            target_probs = top_k_renorm_prob(
+                target_probs,
+                torch.repeat_interleave(
+                    sampling_info.top_ks, verify_input.draft_token_num, dim=0
+                ),
+            )  # (bs * num_draft_tokens, vocab_size)
+            maybe_detect_nan(target_probs, "v2 verify: target_probs after top_k_renorm")
+        if sampling_info.need_top_p_sampling:
+            target_probs = top_p_renorm_prob(
+                target_probs,
+                torch.repeat_interleave(
+                    sampling_info.top_ps, verify_input.draft_token_num, dim=0
+                ),
+            )
+            maybe_detect_nan(target_probs, "v2 verify: target_probs after top_p_renorm")
         target_probs = target_probs.reshape(bs, verify_input.draft_token_num, -1)
         draft_probs = (
             verify_input.draft_probs


### PR DESCRIPTION
## Summary

- Skip EAGLE target top-k renormalization when no request in the batch uses top-k filtering.
- Skip target top-p renormalization when no request in the batch uses top-p filtering.
- Preserve temperature-scaled softmax and all non-default filtering paths.

## Motivation

EAGLE verification currently executes both full-vocabulary renormalization operations for the default `top_k=all`, `top_p=1` configuration. Both operations are identity transforms in this case, but still add GPU work to every verification step.

The redundant work is larger than in the standard sampling path. Standard sampling operates on a probability tensor shaped `[batch_size, vocab_size]`, while EAGLE verification builds target probabilities shaped `[batch_size * draft_token_num, vocab_size]`. Each EAGLE renormalization therefore processes `draft_token_num` times as many vocabulary rows, and the current path performs separate top-k and top-p passes. The standard default-sampling path already skips these transforms entirely.

`SamplingBatchInfo` already tracks whether any request in the batch requires each filter. The verification path can therefore skip the corresponding operation when no request needs it, while mixed batches continue to use the filtered path.

## Performance

A 30-minute disaggregated serving AgentX benchmark at concurrency 10 showed lower inter-token latency across all reported percentiles (lower is better):

| ITL | Main | This PR | Improvement |
| --- | ---: | ---: | ---: |
| Average | 8.19 ms | 7.96 ms | 2.81% |
| P50 | 7.65 ms | 7.46 ms | 2.48% |
| P90 | 8.27 ms | 7.99 ms | 3.39% |
| P99 | 11.97 ms | 11.38 ms | 4.93% |

## Validation

- `pre-commit run --all-files --show-diff-on-failure`
- 30-minute disaggregated serving A/B benchmark at concurrency 10
