### PR TITLE
[jit_kernel] Default JIT builds to arch-specific target on Hopper+

### DIFF
--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -353,7 +353,12 @@ def _init_jit_cuda_arch_once():
     except Exception:
         logger.warning("Cannot detect CUDA architecture.")
         major, minor = 0, 0  # invalid value to trigger compile error if used
-    _CUDA_ARCH = ArchInfo(major, minor, "")
+    # JIT compiles only for the physically present device, so the
+    # arch-specific "a" target (strict superset of plain/"f") is always
+    # correct on Hopper+. HIP/MUSA capability numbers aren't CUDA SM
+    # versions and stay unsuffixed.
+    suffix = "a" if major >= 9 and not (is_hip_runtime() or is_musa_runtime()) else ""
+    _CUDA_ARCH = ArchInfo(major, minor, suffix)
 
 
 @contextmanager

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -24,6 +24,7 @@ from typing import (
 
 import torch
 
+from sglang.srt.utils.common import get_cuda_version
 from sglang.utils import is_in_ci
 
 if TYPE_CHECKING:
@@ -344,6 +345,26 @@ class ArchInfo:
         return f"-DSGL_CUDA_ARCH={self.major * 100 + self.minor * 10}"
 
 
+def _cuda_arch_suffix(major: int, minor: int) -> str:
+    """Mirror FlashInfer's `_normalize_cuda_arch`
+    (`flashinfer/compilation_context.py`): 9.x -> "a"; 12.x -> "0f" carved out
+    from "a" (needs CUDA >= 12.9, since SM120 and SM121 need separate cubins
+    to avoid `cudaErrorIllegalInstruction`); 10.x+ -> "a"; below 9.0 -> plain.
+    Only divergence: pre-12.9 CUDA falls back to plain here instead of
+    FlashInfer's RuntimeError, preserving this function's pre-existing
+    behavior for an undetected/old toolkit.
+    """
+    if major == 9:
+        return "a"
+    if major == 12:
+        if get_cuda_version() < (12, 9):
+            return ""
+        return "f" if minor == 0 else "a"
+    if major >= 10:
+        return "a"
+    return ""
+
+
 @cache_once
 def _init_jit_cuda_arch_once():
     global _CUDA_ARCH
@@ -354,10 +375,13 @@ def _init_jit_cuda_arch_once():
         logger.warning("Cannot detect CUDA architecture.")
         major, minor = 0, 0  # invalid value to trigger compile error if used
     # JIT compiles only for the physically present device, so the
-    # arch-specific "a" target (strict superset of plain/"f") is always
-    # correct on Hopper+. HIP/MUSA capability numbers aren't CUDA SM
-    # versions and stay unsuffixed.
-    suffix = "a" if major >= 9 and not (is_hip_runtime() or is_musa_runtime()) else ""
+    # arch-specific "a"/"f" targets are always correct on Hopper+. HIP/MUSA
+    # capability numbers aren't CUDA SM versions and stay unsuffixed.
+    suffix = (
+        ""
+        if (is_hip_runtime() or is_musa_runtime())
+        else _cuda_arch_suffix(major, minor)
+    )
     _CUDA_ARCH = ArchInfo(major, minor, suffix)
 
 

--- a/test/registered/jit/test_jit_arch_suffix.py
+++ b/test/registered/jit/test_jit_arch_suffix.py
@@ -2,10 +2,13 @@
 Unit tests for JIT CUDA arch-suffix defaulting (`_init_jit_cuda_arch_once`).
 
 Covers sgl-project/sglang#19963: JIT compiles only for the physically
-present device, so Hopper+ (CC >= 9.0) should default to the arch-specific
-"a" target (a strict superset of plain/"f"), matching FlashInfer's
-autodetection. HIP/MUSA capability numbers are not CUDA SM versions and
-must stay unsuffixed.
+present device, so Hopper+ (CC >= 9.0) should default to an arch-specific
+target, mirroring FlashInfer's own `_normalize_cuda_arch`
+(`flashinfer/compilation_context.py`) -- "a" for 9.x/10.x+, except SM 12.x
+carves out "f" for .0 (SM120) vs "a" for .1+ (CUDA >= 12.9 only), since
+SM120 and SM121 need separate cubins to avoid `cudaErrorIllegalInstruction`.
+HIP/MUSA capability numbers are not CUDA SM versions and must stay
+unsuffixed.
 
 Pure CPU logic (monkeypatched `torch.cuda`), no GPU required.
 """
@@ -33,13 +36,16 @@ def _assert_arch_not_leaked():
     assert after is before, "utils._CUDA_ARCH leaked past test teardown"
 
 
-def _init_arch(monkeypatch, capability, *, hip=False, musa=False):
+def _init_arch(monkeypatch, capability, *, hip=False, musa=False, cuda_version=(13, 0)):
     monkeypatch.setattr(
         utils.torch.cuda, "get_device_capability", lambda device=None: capability
     )
     monkeypatch.setattr(utils.torch.cuda, "current_device", lambda: 0)
     monkeypatch.setattr(utils, "is_hip_runtime", lambda: hip)
     monkeypatch.setattr(utils, "is_musa_runtime", lambda: musa)
+    # Only the major==12 branch reads this; default (13, 0) keeps every
+    # other capability's expectation independent of the toolkit version.
+    monkeypatch.setattr(utils, "get_cuda_version", lambda: cuda_version)
     # `_init_jit_cuda_arch_once` writes the module-level `utils._CUDA_ARCH`
     # global directly, so bypassing @cache_once via __wrapped__() leaves it
     # mutated for the rest of the process (see `_assert_arch_not_leaked`
@@ -62,13 +68,29 @@ def _init_arch(monkeypatch, capability, *, hip=False, musa=False):
     [
         ((9, 0), "9.0a"),  # Hopper
         ((10, 0), "10.0a"),  # Blackwell datacenter
-        ((12, 0), "12.0a"),  # Blackwell consumer
+        ((10, 3), "10.3a"),  # Blackwell datacenter family variant (SM103)
         ((8, 0), "8.0"),  # Ampere: below threshold, unsuffixed
         ((7, 5), "7.5"),  # Turing: below threshold, unsuffixed
     ],
 )
 def test_default_cuda_arch_suffix(monkeypatch, capability, expected):
+    # Default cuda_version=(13, 0): irrelevant here except as a control for
+    # the SM 12.x cases below, which vary it explicitly.
     assert _init_arch(monkeypatch, capability) == expected
+
+
+@pytest.mark.parametrize(
+    "capability,cuda_version,expected",
+    [
+        ((12, 0), (13, 0), "12.0f"),  # SM120: carved out of "a" to avoid
+        # cudaErrorIllegalInstruction on SM121 (DGX Spark) running SM120 cubin
+        ((12, 1), (13, 0), "12.1a"),  # SM121: not carved out, "a" like 10.x+
+        ((12, 0), (12, 4), "12.0"),  # pre-12.9 toolkit: no family/"f" cubin
+        # support -- fall back to plain instead of FlashInfer's RuntimeError
+    ],
+)
+def test_sm12x_cuda_arch_suffix(monkeypatch, capability, cuda_version, expected):
+    assert _init_arch(monkeypatch, capability, cuda_version=cuda_version) == expected
 
 
 def test_hip_runtime_stays_unsuffixed(monkeypatch):

--- a/test/registered/jit/test_jit_arch_suffix.py
+++ b/test/registered/jit/test_jit_arch_suffix.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for JIT CUDA arch-suffix defaulting (`_init_jit_cuda_arch_once`).
+
+Covers sgl-project/sglang#19963: JIT compiles only for the physically
+present device, so Hopper+ (CC >= 9.0) should default to the arch-specific
+"a" target (a strict superset of plain/"f"), matching FlashInfer's
+autodetection. HIP/MUSA capability numbers are not CUDA SM versions and
+must stay unsuffixed.
+
+Pure CPU logic (monkeypatched `torch.cuda`), no GPU required.
+"""
+
+import sys
+
+import pytest
+
+from sglang.jit_kernel import utils
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=3, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+_UNSET = object()
+
+
+@pytest.fixture(autouse=True)
+def _assert_arch_not_leaked():
+    # Teardown guard for the save/restore in `_init_arch` below: every test in
+    # this file must leave `utils._CUDA_ARCH` exactly as it found it, since
+    # it's process-wide state other @cache_once functions latch onto.
+    before = getattr(utils, "_CUDA_ARCH", _UNSET)
+    yield
+    after = getattr(utils, "_CUDA_ARCH", _UNSET)
+    assert after is before, "utils._CUDA_ARCH leaked past test teardown"
+
+
+def _init_arch(monkeypatch, capability, *, hip=False, musa=False):
+    monkeypatch.setattr(
+        utils.torch.cuda, "get_device_capability", lambda device=None: capability
+    )
+    monkeypatch.setattr(utils.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(utils, "is_hip_runtime", lambda: hip)
+    monkeypatch.setattr(utils, "is_musa_runtime", lambda: musa)
+    # `_init_jit_cuda_arch_once` writes the module-level `utils._CUDA_ARCH`
+    # global directly, so bypassing @cache_once via __wrapped__() leaves it
+    # mutated for the rest of the process (see `_assert_arch_not_leaked`
+    # above for why that matters). Save/restore explicitly, including the
+    # "never initialized" case.
+    previous = getattr(utils, "_CUDA_ARCH", _UNSET)
+    try:
+        utils._init_jit_cuda_arch_once.__wrapped__()
+        return utils._CUDA_ARCH.target_name
+    finally:
+        if previous is _UNSET:
+            if hasattr(utils, "_CUDA_ARCH"):
+                del utils._CUDA_ARCH
+        else:
+            utils._CUDA_ARCH = previous
+
+
+@pytest.mark.parametrize(
+    "capability,expected",
+    [
+        ((9, 0), "9.0a"),  # Hopper
+        ((10, 0), "10.0a"),  # Blackwell datacenter
+        ((12, 0), "12.0a"),  # Blackwell consumer
+        ((8, 0), "8.0"),  # Ampere: below threshold, unsuffixed
+        ((7, 5), "7.5"),  # Turing: below threshold, unsuffixed
+    ],
+)
+def test_default_cuda_arch_suffix(monkeypatch, capability, expected):
+    assert _init_arch(monkeypatch, capability) == expected
+
+
+def test_hip_runtime_stays_unsuffixed(monkeypatch):
+    # AMD MI300-class capability numbers alias into major >= 9 too, but HIP
+    # has no CUDA "a"/"f" target concept.
+    assert _init_arch(monkeypatch, (9, 4), hip=True) == "9.4"
+
+
+def test_musa_runtime_stays_unsuffixed(monkeypatch):
+    assert _init_arch(monkeypatch, (9, 0), musa=True) == "9.0"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

`_init_jit_cuda_arch_once()` hardcodes `ArchInfo(major, minor, suffix="")`, so JIT kernels
default to a plain `sm_XY0` target. Since JIT always compiles for the device physically
present, forward compatibility is moot and the arch-specific `a` target (a strict superset
of plain/`f`) is always correct — but today each kernel must remember to wrap itself in
`override_jit_cuda_arch(..., "a")` (`nvfp4.py`, `mxfp8.py`, `sparse_mla_q8kv8_prefill_sm90.py`
do; forgetting silently compiles a target lacking the needed instructions).

This revives #19963 (approved by @DarkSharpness, @b8zhong, @mmangkad; verified against
FlashInfer's identical autodetection rule), whose patch target was orphaned by the #21022
refactor.

## Modifications

- `utils.py`: `_cuda_arch_suffix(major, minor)` mirrors FlashInfer's `_normalize_cuda_arch`
  (`flashinfer/compilation_context.py`): `9.x`→`a`; `12.0`→`f` / `12.1+`→`a` (gated on
  CUDA≥12.9 — SM120 and SM121 need separate cubins to avoid `cudaErrorIllegalInstruction`);
  `10.x+`→`a`; below 9.0, HIP and MUSA stay plain. Only divergence from FlashInfer: below
  CUDA 12.9, 12.x falls back to plain instead of raising. (Follow-up commit: the initial
  `major >= 9 → "a"` blanket collapsed SM120 into the same target as 10.x, missing
  FlashInfer's 12.0-specific `f` carve-out.)
- `test/registered/jit/test_jit_arch_suffix.py`: CI-registered unit coverage
  (Hopper/Blackwell → `"a"`, pre-Hopper/HIP/MUSA → unsuffixed).

Impact audit: all 67 `load_jit()` sites checked. The only exact `__CUDA_ARCH__ ==` guards are
`== 750` (below threshold) and `== 900` (already pinned to `"a"` unconditionally); the suffix
does not change what `__CUDA_ARCH__` expands to. The three existing override sites assign
`ArchInfo` absolutely, so they become no-ops (their tests pass unchanged). Cache directories
key on `target_name`, so affected kernels recompile once on first use — expected.

## Accuracy Tests

On Blackwell (CC 10.0): default becomes `10.0a` (cuobjdump-confirmed `sm_100a.cubin`);
previously-plain LPLB kernels (`dispatch_probability`, bit-exact vs torch reference;
`prep_lp_inputs`) compile and pass; `test_per_token_group_quant_8bit` 1120/1120 non-flaky
pass (268 `column_major` failures pre-exist on unpatched main); `test_nvfp4_quant` 16/16
unchanged. New `test_jit_arch_suffix.py`: 7/7, runs in CI (`base-b-kernel-unit`).

SM103/B300: target changes `sm_103` → `sm_103a`. `sm_103/103a/103f` ship together in
CUDA 12.9, and FlashInfer's autodetection already emits `a` unconditionally on SM 9.x/10.x+,
so this matches what FlashInfer runs on B300 today. Untested on physical SM103 hardware.

## Speed Tests and Profiling

N/A — changes only the compile target, not kernel logic.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
