### PR TITLE
[Fix] LPLB: derive shared-memory budget from the active device

### DIFF
--- a/python/sglang/kernels/ops/lplb/shmem_budget.py
+++ b/python/sglang/kernels/ops/lplb/shmem_budget.py
@@ -15,7 +15,7 @@ Dynamic shared-memory cap per block (with opt-in via
 ``cudaFuncAttributeMaxDynamicSharedMemorySize``):
 
     A100   SM_80   164 KB   practical 160 KB
-    H100   SM_90   227 KB   practical 223 KB  <- default target
+    H100   SM_90   227 KB   practical 223 KB
     H200   SM_90   227 KB
     H20    SM_90   227 KB
     B200   SM_100  228 KB   practical 224 KB
@@ -23,7 +23,13 @@ Dynamic shared-memory cap per block (with opt-in via
 
 from __future__ import annotations
 
+import functools
+import logging
 from dataclasses import dataclass
+
+import torch
+
+logger = logging.getLogger(__name__)
 
 # Per-block slack reserved for cuBLASDx workspace and CUDA runtime state.
 _RUNTIME_PAD_BYTES = 256
@@ -31,7 +37,7 @@ _RUNTIME_PAD_BYTES = 256
 # fp32
 _BYTES_PER_ELEM = 4
 
-# Practical per-block dynamic shmem caps (bytes)
+# Static fallback for torch builds without `shared_memory_per_block_optin`.
 GPU_BUDGETS_BYTES: dict[str, int] = {
     "a100": 160 * 1024,
     "h100": 223 * 1024,
@@ -39,6 +45,59 @@ GPU_BUDGETS_BYTES: dict[str, int] = {
     "h20": 223 * 1024,
     "b200": 224 * 1024,
 }
+
+# H100/H200/H20 share a budget, so SM major 9 covers all three.
+_SM_MAJOR_TO_GPU_KEY = {8: "a100", 9: "h100", 10: "b200"}
+
+# Reserve the same 4 KiB margin used by the static practical budgets.
+_PRACTICAL_MARGIN_BYTES = 4096
+
+
+def _fallback_gpu_key_for_device(index: int) -> str:
+    major, _ = torch.cuda.get_device_capability(index)
+    key = _SM_MAJOR_TO_GPU_KEY.get(major)
+    if key is None:
+        raise RuntimeError(
+            f"LPLB shmem budget: unrecognized SM major {major} for device "
+            f"{index}; this torch build does not expose "
+            "shared_memory_per_block_optin, so no safe shared-memory budget "
+            "can be derived. Upgrade torch or add an explicit architecture budget."
+        )
+    return key
+
+
+def _canonicalize_device_index(device: torch.device | int | str | None) -> int:
+    """Resolve index-less CUDA devices before using them as cache keys."""
+    if device is None:
+        return torch.cuda.current_device()
+    if not isinstance(device, torch.device):
+        device = torch.device(device)
+    return device.index if device.index is not None else torch.cuda.current_device()
+
+
+@functools.lru_cache(maxsize=None)
+def _budget_bytes_for_device(index: int) -> int:
+    """Return the safe dynamic shared-memory budget for a CUDA device.
+
+    Uses the live device property when available and a fail-closed static
+    fallback for older torch builds.
+    """
+    optin_bytes = getattr(
+        torch.cuda.get_device_properties(index), "shared_memory_per_block_optin", None
+    )
+    if optin_bytes is None:
+        logger.warning(
+            "LPLB shmem budget: torch build lacks "
+            f"shared_memory_per_block_optin (device {index}); falling back "
+            "to the static per-GPU table."
+        )
+        return GPU_BUDGETS_BYTES[_fallback_gpu_key_for_device(index)]
+    return optin_bytes - _PRACTICAL_MARGIN_BYTES
+
+
+def budget_bytes_for_device(device: torch.device | int | str | None = None) -> int:
+    """Return the safe shared-memory budget for `device`."""
+    return _budget_bytes_for_device(_canonicalize_device_index(device))
 
 
 @dataclass(frozen=True)
@@ -93,6 +152,7 @@ def breakdown(
 
 
 def gpu_budget_bytes(gpu: str) -> int:
+    """Look up a named static fallback budget."""
     key = gpu.lower()
     if key not in GPU_BUDGETS_BYTES:
         raise ValueError(
@@ -101,31 +161,29 @@ def gpu_budget_bytes(gpu: str) -> int:
     return GPU_BUDGETS_BYTES[key]
 
 
-def fits(nc: int, nv: int, gpu: str = "h100") -> bool:
-    return shmem_bytes(nc, nv) <= gpu_budget_bytes(gpu)
+def fits(nc: int, nv: int, budget_bytes: int) -> bool:
+    return shmem_bytes(nc, nv) <= budget_bytes
 
 
-def assert_fits(nc: int, nv: int, gpu: str = "h100") -> None:
-    """Raise if the fused kernel will not fit on the target GPU."""
+def assert_fits(nc: int, nv: int, budget_bytes: int) -> None:
+    """Raise if the fused kernel will not fit in `budget_bytes` of shared memory."""
     used = shmem_bytes(nc, nv)
-    cap = gpu_budget_bytes(gpu)
-    if used > cap:
+    if used > budget_bytes:
         raise ValueError(
-            f"fused IPM kernel needs {used/1024:.1f} KiB of shared memory for "
-            f"NC={nc}, NV={nv}, but {gpu} allows {cap/1024:.1f} KiB/block. "
-            f"Either reduce problem size or switch to a tiled design."
+            f"fused IPM kernel needs {used / 1024:.1f} KiB of shared memory for "
+            f"NC={nc}, NV={nv}, but the device budget is {budget_bytes / 1024:.1f} "
+            f"KiB/block. Either reduce problem size or switch to a tiled design."
         )
 
 
-def max_nc_for_nv(nv: int, gpu: str = "h100") -> int:
+def max_nc_for_nv(nv: int, budget_bytes: int) -> int:
     """Largest NC that fits for a given NV. Solves
-        4 * (NC^2 + (NV+1)*NC + 3*NV) + pad <= cap
+        4 * (NC^2 + (NV+1)*NC + 3*NV) + pad <= budget_bytes
     via the quadratic formula (monotone in NC). Returns 0 if even NC=1 overflows.
     """
-    cap = gpu_budget_bytes(gpu)
     b = _BYTES_PER_ELEM
-    # cap - pad >= b * (NC^2 + (NV+1)*NC + 3*NV)
-    rhs = (cap - _RUNTIME_PAD_BYTES) / b - 3 * nv
+    # budget_bytes - pad >= b * (NC^2 + (NV+1)*NC + 3*NV)
+    rhs = (budget_bytes - _RUNTIME_PAD_BYTES) / b - 3 * nv
     if rhs <= 0:
         return 0
     # NC^2 + (NV+1)*NC - rhs <= 0
@@ -133,20 +191,19 @@ def max_nc_for_nv(nv: int, gpu: str = "h100") -> int:
 
     disc = (nv + 1) ** 2 + 4 * rhs
     nc_max = int((-(nv + 1) + math.sqrt(disc)) / 2.0)
-    while nc_max > 0 and shmem_bytes(nc_max, nv) > cap:
+    while nc_max > 0 and shmem_bytes(nc_max, nv) > budget_bytes:
         nc_max -= 1
     return max(nc_max, 0)
 
 
-def report(nc: int, nv: int, gpu: str = "h100") -> str:
+def report(nc: int, nv: int, budget_bytes: int) -> str:
     """Human-readable summary — used by kernels on init for logging."""
     bd = breakdown(nc, nv)
-    cap = gpu_budget_bytes(gpu)
-    status = "FITS" if bd.total_bytes <= cap else "OVER BUDGET"
+    status = "FITS" if bd.total_bytes <= budget_bytes else "OVER BUDGET"
     return (
-        f"[shmem] NC={nc} NV={nv} gpu={gpu} | "
-        f"A={bd.a_bytes/1024:.1f}K "
-        f"ata={bd.ata_bytes/1024:.1f}K "
-        f"rest={(bd.c_bytes+bd.x_bytes+bd.rhs_bytes+bd.d_bytes)/1024:.1f}K | "
-        f"total={bd.total_bytes/1024:.1f}K / {cap/1024:.1f}K  {status}"
+        f"[shmem] NC={nc} NV={nv} | "
+        f"A={bd.a_bytes / 1024:.1f}K "
+        f"ata={bd.ata_bytes / 1024:.1f}K "
+        f"rest={(bd.c_bytes + bd.x_bytes + bd.rhs_bytes + bd.d_bytes) / 1024:.1f}K | "
+        f"total={bd.total_bytes / 1024:.1f}K / {budget_bytes / 1024:.1f}K  {status}"
     )

--- a/python/sglang/kernels/ops/lplb/torch_solver.py
+++ b/python/sglang/kernels/ops/lplb/torch_solver.py
@@ -26,12 +26,14 @@ _FUSED_AVAILABLE = False
 _FUSED_SOLVE_IPM = None  # type: ignore[assignment]
 _FUSED_WARMUP = None  # type: ignore[assignment]
 _FUSED_ASSERT_FITS = None  # type: ignore[assignment]
+_FUSED_BUDGET_BYTES_FOR_DEVICE = None  # type: ignore[assignment]
 
 
 def _init_fused_backend() -> None:
     """Resolve the fused backend once. Records WHY it's disabled when it is."""
     global _BACKEND_CHECKED, _FUSED_AVAILABLE
     global _FUSED_SOLVE_IPM, _FUSED_WARMUP, _FUSED_ASSERT_FITS
+    global _FUSED_BUDGET_BYTES_FOR_DEVICE
 
     if _BACKEND_CHECKED:
         return
@@ -52,7 +54,10 @@ def _init_fused_backend() -> None:
     try:
         from sglang.kernels.ops.lplb.cuda_solver import solve_ipm as fused_solve_ipm
         from sglang.kernels.ops.lplb.cuda_solver import warmup as fused_warmup
-        from sglang.kernels.ops.lplb.shmem_budget import assert_fits
+        from sglang.kernels.ops.lplb.shmem_budget import (
+            assert_fits,
+            budget_bytes_for_device,
+        )
     except ImportError as e:
         logger.info(
             f"LPLB fused solver disabled: {e}. "
@@ -64,6 +69,7 @@ def _init_fused_backend() -> None:
     _FUSED_SOLVE_IPM = fused_solve_ipm
     _FUSED_WARMUP = fused_warmup
     _FUSED_ASSERT_FITS = assert_fits
+    _FUSED_BUDGET_BYTES_FOR_DEVICE = budget_bytes_for_device
     _FUSED_AVAILABLE = True
     logger.info("LPLB fused solver enabled (CUDA C++ via load_jit, cuBLASDx)")
 
@@ -91,7 +97,7 @@ def warmup(nc: int, nv: int, num_iters: int = 5, device: str = "cuda") -> None:
     _init_fused_backend()
     if not _FUSED_AVAILABLE:
         raise RuntimeError(f"LPLB fused solver unavailable: {_unavailable_reason()}")
-    _FUSED_ASSERT_FITS(nc, nv, gpu="h100")
+    _FUSED_ASSERT_FITS(nc, nv, budget_bytes=_FUSED_BUDGET_BYTES_FOR_DEVICE(device))
     _FUSED_WARMUP(nc, nv, num_iters=num_iters, device=device)
 
 

--- a/test/registered/eplb/test_lplb_distributed.py
+++ b/test/registered/eplb/test_lplb_distributed.py
@@ -27,6 +27,8 @@ Pattern follows `test/registered/layers/mamba/test_mamba2_mixer.py` —
 plays poorly with arbitrary subprocess launchers.
 """
 
+import logging
+
 import pytest
 import torch
 
@@ -173,8 +175,8 @@ def test_solve_ipm_matches_torch_reference():
     max_diff = (cuda_x - torch_x).abs().max().item()
     print(
         f"\n[ipm-compare] converged={converged}  max|cuda-torch|={max_diff:.3e}  "
-        f"cuda={[round(v,4) for v in cuda_x.tolist()]}  "
-        f"torch={[round(v,4) for v in torch_x.tolist()]}"
+        f"cuda={[round(v, 4) for v in cuda_x.tolist()]}  "
+        f"torch={[round(v, 4) for v in torch_x.tolist()]}"
     )
     assert converged, (
         "IPM returned the 0.5 non-convergence sentinel — the comparison would "
@@ -183,6 +185,58 @@ def test_solve_ipm_matches_torch_reference():
     assert torch.allclose(
         cuda_x, torch_x, atol=1e-2, rtol=1e-2
     ), f"fused IPM diverges from torch reference: max abs diff {max_diff:.3e}"
+
+
+def test_budget_bytes_for_device(monkeypatch, caplog):
+    """Cover live device properties, index resolution, and legacy fallback."""
+    from sglang.kernels.ops.lplb import shmem_budget
+
+    class _Props:
+        def __init__(self, optin_bytes):
+            self.shared_memory_per_block_optin = optin_bytes
+
+    props = {0: _Props(227 * 1024), 1: _Props(99 * 1024)}
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda d: props[d])
+    shmem_budget._budget_bytes_for_device.cache_clear()
+
+    assert shmem_budget.budget_bytes_for_device(torch.device("cuda", 0)) == 223 * 1024
+    assert (
+        shmem_budget.budget_bytes_for_device("cuda:0")
+        == shmem_budget.GPU_BUDGETS_BYTES["h100"]
+    )
+    assert (
+        shmem_budget.budget_bytes_for_device("cuda:1") == 99 * 1024 - 4096 == 95 * 1024
+    )
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 1)
+    assert shmem_budget.budget_bytes_for_device("cuda") == 99 * 1024 - 4096
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    assert shmem_budget.budget_bytes_for_device("cuda") == 223 * 1024
+
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda d: object())
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda d: (9, 0))
+    shmem_budget._budget_bytes_for_device.cache_clear()
+    with caplog.at_level(
+        logging.WARNING, logger="sglang.kernels.ops.lplb.shmem_budget"
+    ):
+        assert (
+            shmem_budget.budget_bytes_for_device("cuda:0")
+            == shmem_budget.GPU_BUDGETS_BYTES["h100"]
+        )
+    assert any(
+        "shared_memory_per_block_optin" in m and "falling back" in m
+        for m in caplog.messages
+    )
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda d: (12, 0))
+    shmem_budget._budget_bytes_for_device.cache_clear()
+    with pytest.raises(
+        RuntimeError,
+        match=r"unrecognized SM major 12.*no safe shared-memory budget",
+    ):
+        shmem_budget.budget_bytes_for_device("cuda:2")
+
+    shmem_budget._budget_bytes_for_device.cache_clear()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Motivation

LPLB validates the fused IPM kernel's dynamic shared-memory requirement before
launch, but the warmup path hardcodes the H100 budget. The static fallback also
cannot safely represent newer architectures: an unknown SM major can inherit a
larger device's limit, pass preflight, and then fail at launch.

## Modifications

- Read `shared_memory_per_block_optin` from the active CUDA device and retain the
  existing 4096-byte practical margin.
- Canonicalize index-less CUDA devices before caching the resolved budget, so a
  later `torch.cuda.set_device()` cannot reuse another device's value.
- Use the static table only on older torch builds and fail closed for unknown SM
  majors.
- Require capacity helpers to receive an explicit byte budget, and pass the
  warmup device through to the preflight check.

## Accuracy Tests

- Full registered LPLB CUDA test on 2x B300.
- Fused IPM vs. PyTorch reference: `max|cuda-torch|=6.124e-06`.
- Runtime-property, device-index canonicalization, legacy fallback, and
  fail-closed budget tests.

## Speed Tests and Profiling

N/A — this changes startup preflight accounting, not the kernel execution path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30700618189](https://github.com/sgl-project/sglang/actions/runs/30700618189)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30700618143](https://github.com/sgl-project/sglang/actions/runs/30700618143)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
