### PR TITLE
Fix LongCat-2.0 real EP (deepep): double all-reduce + ScMoE RoPE crash

### DIFF
--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -123,6 +123,24 @@ else:
 logger = logging.getLogger(__name__)
 
 
+def _scmoe_align_rows(t, target):
+    """Align a [rows,H] tensor to `target` rows across the attn-tp group:
+    all_gather when target>rows (target==rows*attn_tp_size), or take this rank's
+    contiguous segment when target<rows."""
+    if t is None or t.shape[0] == target:
+        return t
+    from sglang.srt.layers.dp_attention import attn_tp_all_gather_into_tensor as _ag
+    from sglang.srt.runtime_context import get_parallel as _gp
+
+    cur = t.shape[0]
+    if target > cur:
+        out = t.new_empty((target, *t.shape[1:]))
+        _ag(out, t.contiguous())
+        return out
+    r = _gp().attn_tp_rank
+    return t[r * target : r * target + target].contiguous()
+
+
 class LongcatFlashMLP(nn.Module):
     def __init__(
         self,
@@ -284,7 +302,12 @@ class LongcatFlashMoE(nn.Module):
         if self.zero_expert_type is not None and hidden_states.shape[0] > 0:
             final_hidden_states += zero_expert_result.to(final_hidden_states.device)
 
-        if self.tp_size > 1:
+        # LONGCAT_MOE_A2A_SKIP_ALLREDUCE: skip the post-experts TP all-reduce when a
+        # real EP a2a backend is active -- self.experts (DeepEPMoE) already combined
+        # expert outputs across EP ranks, so an extra all-reduce double-counts.
+        from sglang.srt.layers.moe.utils import get_moe_a2a_backend as _lc_gab
+
+        if self.tp_size > 1 and _lc_gab().is_none():
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         return final_hidden_states.view(num_tokens, hidden_dim)
@@ -459,6 +482,11 @@ class LongcatFlashDecoderLayer(nn.Module):
             prev_topk_indices,
         )
 
+        # SCMOE_ATTN1_GATHER: reconcile mlp-branch (hidden/residual) with moe-branch
+        # (moe_hidden_states) row counts before the add, so residual tracks hidden.
+        _scmoe_tgt = moe_hidden_states.shape[0]
+        hidden_states = _scmoe_align_rows(hidden_states, _scmoe_tgt)
+        residual = _scmoe_align_rows(residual, _scmoe_tgt)
         hidden_states = moe_hidden_states + hidden_states
         return hidden_states, residual, prev_topk_indices
 
@@ -471,6 +499,21 @@ class LongcatFlashDecoderLayer(nn.Module):
         zero_allocator,
         prev_topk_indices,
     ):
+        # SCMOE_ATTN1_GATHER: gather the dense-branch hidden(+residual) to full
+        # tokens before mlps[0] so its all_reduce is valid; slice back at the merge.
+        from sglang.srt.layers.moe.utils import get_moe_a2a_backend as _scmoe_gab
+
+        _scmoe_ats = self.attn_tp_size
+        _scmoe_do = (
+            not _scmoe_gab().is_none()
+            and _scmoe_ats > 1
+            and hidden_states.shape[0] != 0
+            and hidden_states.shape[0] * _scmoe_ats == positions.shape[0]
+        )
+        if _scmoe_do:
+            hidden_states = _scmoe_align_rows(hidden_states, positions.shape[0])
+            residual = _scmoe_align_rows(residual, positions.shape[0])
+
         # first_mlp
         hidden_states = self.mlps[0](hidden_states)
         # TP all_reduce


### PR DESCRIPTION
## Motivation

LongCat-2.0 crashes or emits garbage under a real MoE all-to-all backend
(`--moe-a2a-backend deepep`, tp16/ep16). Two coupled bugs, both specific to the
real-EP path (no-ops when `a2a=none`):

1. **`LongcatFlashMoE.forward` double all-reduce.** `forward()` ends with an
   unconditional post-experts `tensor_model_parallel_all_reduce`. Correct for
   `a2a=none` (EP-over-TP: experts are TP-sharded partial sums), but under a real
   a2a backend `self.experts` is a `DeepEPMoE` whose forward already does
   `dispatch -> run_moe_core -> combine`, and the combine reduces expert outputs
   across EP ranks. The extra TP all-reduce sums the already-combined result a
   second time → the MoE branch output is inflated ~`tp_size`× → coherent-but-garbage
   output. DeepSeek-V2 already gates the identical all-reduce via
   `should_skip_post_experts_all_reduce()`; LongCat's single MoE path never gated it.

2. **ScMoE dense-branch RoPE crash / branch-merge mismatch.** The ScMoE dense branch
   (`forward_mlp`: `mlps[0] -> self_attn[1] -> mlps[1]`) is pure TP and must run on
   replicated-full tokens (each mlp does an all-reduce; `self_attn[1]`'s RoPE needs
   full `positions`). Under a real a2a backend the moe branch scatters hidden to
   1 token/rank, so `forward_mlp` receives scattered input →
   `shape '[16,-1,64]' invalid for input of size 256` at the RoPE view, and a later
   branch-merge shape mismatch at the final norm.

## Modifications

- `LongcatFlashMoE.forward`: gate the post-experts all-reduce on
  `get_moe_a2a_backend().is_none()` so it only runs in the EP-over-TP path.
- `LongcatFlashDecoderLayer.forward_mlp`: when a real a2a backend is active, all-gather
  the dense-branch `hidden`(+`residual`) to full tokens before `mlps[0]` (helper
  `_scmoe_align_rows`), and reconcile row counts against the moe branch at the merge.
- Both paths are gated so `a2a=none` behavior is unchanged.

## Accuracy Tests

`meituan-longcat/LongCat-2.0-FP8`, tp16/ep16 over EFA, `--moe-a2a-backend deepep`:
- Without the fixes: server crashes at the RoPE reshape, or (with the RoPE fix alone)
  emits garbage due to the double all-reduce.
- With both fixes: coherent output on EN/ZH/math prompts (e.g. "The capital of France
  is Paris"), in both deepep `normal` and `low_latency` modes; a norm probe confirms
  the MoE branch magnitude drops from ~4–5 (inflated) back to ~1.1 (matching the
  correct `a2a=none` baseline).

## Checklist

- [x] Format your code according to pre-commit (isort/black/ruff all pass).
- [ ] Add unit tests.
- [x] Provide accuracy results (above).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29404195293](https://github.com/sgl-project/sglang/actions/runs/29404195293)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29404194946](https://github.com/sgl-project/sglang/actions/runs/29404194946)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->