### PR TITLE
[diffusion] test: fix GLM-Image AR model-path to resolve local snapshot subfolder

### DIFF
--- a/python/sglang/multimodal_gen/test/single_test_file/test_ar_models.py
+++ b/python/sglang/multimodal_gen/test/single_test_file/test_ar_models.py
@@ -16,6 +16,7 @@ import os
 import unittest
 from pathlib import Path
 
+from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
 from sglang.multimodal_gen.test.test_utils import (
     DEFAULT_AR_MODEL_NAME_FOR_TEST,
     find_free_port,
@@ -53,13 +54,22 @@ class ARCluster(DisaggCluster):
         log = _LOG_DIR / "ar.log"
         self._logs["ar"] = log
 
+        # The AR sub-encoder and processor live in subfolders of the model repo
+        # (``vision_language_encoder/`` and ``processor/``).  A HuggingFace repo
+        # id cannot carry a subfolder, so passing e.g.
+        # ``zai-org/GLM-Image/vision_language_encoder/`` as --model-path fails
+        # with "Repo id must be in the form 'repo_name' or 'namespace/repo_name'".
+        # Resolve the repo to a local snapshot first and pass the local
+        # subfolder directories, which are valid filesystem paths.
+        local_model = maybe_download_model(self.model)
+
         cmd = [
             "sglang",
             "serve",
             "--model-path",
-            f"{self.model}/vision_language_encoder/",
+            os.path.join(local_model, "vision_language_encoder"),
             "--tokenizer-path",
-            f"{self.model}/processor/",
+            os.path.join(local_model, "processor"),
             "--enable-multimodal",
             "--cuda-graph-bs",
             "1",


### PR DESCRIPTION
## Motivation

`multimodal-gen-test-2-gpu-amd` shard running `test_ar_models.py::TestGLMImage` fails every nightly, and the job runs to the 150-minute workflow timeout. The GLM-Image autoregressive sub-encoder is launched as a separate `sglang serve`, and it crashes at startup:

```
OSError: Repo id must be in the form 'repo_name' or 'namespace/repo_name':
        'zai-org/GLM-Image/vision_language_encoder/'. Use `repo_type` argument if needed.
```

### Root cause

`zai-org/GLM-Image` is an HF repo whose weights live in subfolders (`vision_language_encoder/`, `processor/`, `transformer/`, …). `ARCluster._launch_roles` builds the AR server's model path by concatenating the subfolder onto the repo id:

```python
"--model-path",   f"{self.model}/vision_language_encoder/",   # zai-org/GLM-Image/vision_language_encoder/
"--tokenizer-path", f"{self.model}/processor/",
```

A HuggingFace repo id can only be `namespace/name` — a subfolder cannot be appended (HF expects a separate `subfolder=` argument), and sglang's model-path resolution has no HF-subfolder support. So the value fails `HFValidationError`, the AR server never starts, `wait_for_server_health` times out, and `TestGLMImage` errors at setup. No GPU/HIP involved — pure HF repo-id validation.

## Modifications

Resolve the repo to a local snapshot first via `maybe_download_model(self.model)` (the same helper `test_update_weights_from_disk.py` uses), then pass the local `vision_language_encoder` / `processor` **directories** as `--model-path` / `--tokenizer-path`. A local directory path that ends in a subfolder is a valid filesystem path and bypasses repo-id validation. 1 file, +11/-2.

## Test

Verified offline on MI300X (gfx942, ROCm image v0.5.15-rocm700, GLM-Image vision_language_encoder + processor subfolders downloaded):
- **Stock** `--model-path zai-org/GLM-Image/vision_language_encoder/` → `HFValidationError: Repo id must be in the form ...` (reproduces the CI failure).
- **Patched** (local snapshot subfolder path) → no repo-id error; the AR server proceeds through config parse into weight loading: `Load weight end. type=GlmImageForConditionalGeneration, mem usage=18.99 GB` and CUDA-graph capture. The exact failure point is cleared.

cc @Makcum888e

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29404472864](https://github.com/sgl-project/sglang/actions/runs/29404472864)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29404472658](https://github.com/sgl-project/sglang/actions/runs/29404472658)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->