### PR TITLE
[BugFix] Avoid redundant KV index cloning in Mamba radix cache

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -494,7 +494,9 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         value, last_node, best_value_len = self._match_prefix_helper(key)
         return self._match_post_processor(params, value, last_node, best_value_len)
 
-    def insert(self, params: InsertParams) -> InsertResult:
+    def insert(
+        self, params: InsertParams, *, take_value_ownership: bool = False
+    ) -> InsertResult:
         if self.disable:
             return InsertResult(prefix_len=0, mamba_exist=False)
 
@@ -506,7 +508,13 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         if value is None:
             value = torch.tensor([x for x in key.token_ids], dtype=torch.int64)
         prefix_len, mamba_exist = self._insert_helper(
-            self.root_node, key, value, mamba_value, params.chunked, prev_prefix_len
+            self.root_node,
+            key,
+            value,
+            mamba_value,
+            params.chunked,
+            prev_prefix_len,
+            take_value_ownership,
         )
         return InsertResult(prefix_len=prefix_len, mamba_exist=mamba_exist)
 
@@ -578,7 +586,8 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                     value=page_aligned_kv_indices,
                     mamba_value=mamba_value,
                     prev_prefix_len=req.cache_protected_len,
-                )
+                ),
+                take_value_ownership=True,
             )
             mamba_exist = result.mamba_exist
         else:
@@ -672,7 +681,8 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 mamba_value=mamba_value_forked,
                 prev_prefix_len=req.cache_protected_len,
                 chunked=chunked,
-            )
+            ),
+            take_value_ownership=True,
         )
         new_prefix_len, mamba_exist = result.prefix_len, result.mamba_exist
         # there is a mamba cache in radix cache, release it
@@ -1118,6 +1128,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         mamba_value,
         chunked: bool = False,
         prev_prefix_len: int = 0,
+        take_value_ownership: bool = False,
     ) -> Tuple[int, bool]:
         # Update the last access time from root to leaf, so that
         # mamba will tombstone the node closer to root first
@@ -1161,7 +1172,16 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             new_node = TreeNode()
             new_node.parent = node
             new_node.key = key
-            new_node.value = value.clone()
+            # cache_finished_req/cache_unfinished_req pass a dedicated int64
+            # tensor that is no longer used by the caller. Avoid cloning it
+            # when the whole tensor becomes a new leaf. If a prefix was
+            # consumed, keep cloning the suffix so the node does not retain
+            # the backing storage for the already-matched prefix.
+            new_node.value = (
+                value
+                if take_value_ownership and total_prefix_length == 0
+                else value.clone()
+            )
             new_node.mamba_value = mamba_value
             self.full_lru_list.insert_mru(new_node)
             self.mamba_lru_list.insert_mru(new_node)

--- a/test/registered/unit/mem_cache/test_mamba_unittest.py
+++ b/test/registered/unit/mem_cache/test_mamba_unittest.py
@@ -143,6 +143,49 @@ class TestMamba(unittest.TestCase):
         assert req_to_token_pool.available_size() == max_num_reqs - 1
         assert req_to_token_pool.mamba_pool.available_size() == mamba_cache_size - 1
 
+    def test_mamba_radix_cache_insert_value_ownership(self):
+        tree = object.__new__(MambaRadixCache)
+        tree.disable = False
+        tree.page_size = 1
+        tree.root_node = TreeNode()
+        tree.root_node.key = RadixKey([])
+        tree.full_lru_list = LRUList(mamba=False)
+        tree.mamba_lru_list = LRUList(mamba=True)
+        tree.full_evictable_size_ = 0
+        tree.mamba_evictable_size_ = 0
+        tree._record_store_event = lambda node: None
+
+        owned_key = RadixKey([101, 102, 103])
+        owned_value = torch.tensor([11, 12, 13], dtype=torch.int64)
+        owned_storage_ptr = owned_value.untyped_storage().data_ptr()
+        tree.insert(
+            InsertParams(
+                key=owned_key,
+                value=owned_value,
+                mamba_value=torch.tensor([1], dtype=torch.int64),
+            ),
+            take_value_ownership=True,
+        )
+        owned_node = tree.root_node.children[owned_key.child_key(tree.page_size)]
+        self.assertEqual(
+            owned_node.value.untyped_storage().data_ptr(), owned_storage_ptr
+        )
+
+        copied_key = RadixKey([201, 202, 203])
+        copied_value = torch.tensor([21, 22, 23], dtype=torch.int64)
+        copied_storage_ptr = copied_value.untyped_storage().data_ptr()
+        tree.insert(
+            InsertParams(
+                key=copied_key,
+                value=copied_value,
+                mamba_value=torch.tensor([2], dtype=torch.int64),
+            )
+        )
+        copied_node = tree.root_node.children[copied_key.child_key(tree.page_size)]
+        self.assertNotEqual(
+            copied_node.value.untyped_storage().data_ptr(), copied_storage_ptr
+        )
+
     def test_mamba_radix_cache_1(self):
         tree, allocator, req_to_token_pool, make_dummy_req = (
             self._setup_tree_and_allocator()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR avoids a redundant KV index tensor copy when inserting finished or unfinished requests into the Mamba radix cache.

The change reduces unnecessary device-memory allocations and helps prevent gradual HBM growth under sustained Mamba workloads.

## Modifications


## Accuracy Tests



## Speed Tests and Profiling



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->