### PR TITLE
fix: balance automatic NUMA binding across affinity nodes

### DIFF
--- a/python/sglang/srt/utils/numa_utils.py
+++ b/python/sglang/srt/utils/numa_utils.py
@@ -134,11 +134,13 @@ def get_numa_node_if_available(server_args: ServerArgs, gpu_id: int) -> Optional
         if len(queried_numa_node) == 0:
             return None
         if len(queried_numa_node) > 1:
-            # get_numa_node_for_gpu could return multiple nodes, we use the first one for now.
-            # I don't think there any hardware configs that would have more than one.
+            selected_node = queried_numa_node[gpu_id % len(queried_numa_node)]
             logger.warning(
-                f"Multiple NUMA nodes found for GPU {gpu_id}: {queried_numa_node}. Using the first one."
+                f"Multiple NUMA nodes found for GPU {gpu_id}: "
+                f"{queried_numa_node}. Selecting node {selected_node} "
+                "with round-robin."
             )
+            return selected_node
         return queried_numa_node[0]
     return None
 

--- a/python/sglang/srt/utils/numa_utils.py
+++ b/python/sglang/srt/utils/numa_utils.py
@@ -134,11 +134,15 @@ def get_numa_node_if_available(server_args: ServerArgs, gpu_id: int) -> Optional
         if len(queried_numa_node) == 0:
             return None
         if len(queried_numa_node) > 1:
-            selected_node = queried_numa_node[gpu_id % len(queried_numa_node)]
+            local_worker_index = (
+                gpu_id - server_args.base_gpu_id
+            ) // server_args.gpu_id_step
+            selected_node = queried_numa_node[
+                local_worker_index % len(queried_numa_node)
+            ]
             logger.warning(
                 f"Multiple NUMA nodes found for GPU {gpu_id}: "
-                f"{queried_numa_node}. Selecting node {selected_node} "
-                "with round-robin."
+                f"{queried_numa_node}. Selecting node {selected_node}."
             )
             return selected_node
         return queried_numa_node[0]

--- a/test/registered/utils/test_numa_utils.py
+++ b/test/registered/utils/test_numa_utils.py
@@ -204,17 +204,24 @@ class TestGetNumaNodeIfAvailable(unittest.TestCase):
 
     @patch("sglang.srt.utils.numa_utils._query_numa_node_for_gpu", return_value=[0, 2])
     @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=True)
-    def test_returns_first_node_when_multiple_found(self, _mock_avail, _mock_gpu):
+    def test_round_robins_when_multiple_nodes_found(self, _mock_avail, _mock_gpu):
         args = self._make_server_args(numa_node=None)
-        self.assertEqual(get_numa_node_if_available(args, 0), 0)
+        with self.assertLogs("sglang.srt.utils.numa_utils", level="WARNING"):
+            selected_nodes = [
+                get_numa_node_if_available(args, gpu_id) for gpu_id in range(4)
+            ]
+        self.assertEqual(selected_nodes, [0, 2, 0, 2])
 
     @patch("sglang.srt.utils.numa_utils._query_numa_node_for_gpu", return_value=[0, 2])
     @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=True)
     def test_logs_warning_when_multiple_nodes(self, _mock_avail, _mock_gpu):
         args = self._make_server_args(numa_node=None)
         with self.assertLogs("sglang.srt.utils.numa_utils", level="WARNING") as cm:
-            get_numa_node_if_available(args, 0)
-        self.assertTrue(any("Multiple NUMA nodes" in msg for msg in cm.output))
+            selected_node = get_numa_node_if_available(args, 1)
+        self.assertEqual(selected_node, 2)
+        self.assertTrue(
+            any("Selecting node 2 with round-robin" in msg for msg in cm.output)
+        )
 
     @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=True)
     @patch("sglang.srt.utils.numa_utils._query_numa_node_for_gpu", return_value=[1])

--- a/test/registered/utils/test_numa_utils.py
+++ b/test/registered/utils/test_numa_utils.py
@@ -176,6 +176,8 @@ class TestGetNumaNodeIfAvailable(unittest.TestCase):
     def _make_server_args(self, numa_node=None):
         args = MagicMock()
         args.numa_node = numa_node
+        args.base_gpu_id = 0
+        args.gpu_id_step = 1
         return args
 
     def test_returns_explicit_numa_node_from_server_args(self):
@@ -204,11 +206,12 @@ class TestGetNumaNodeIfAvailable(unittest.TestCase):
 
     @patch("sglang.srt.utils.numa_utils._query_numa_node_for_gpu", return_value=[0, 2])
     @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=True)
-    def test_round_robins_when_multiple_nodes_found(self, _mock_avail, _mock_gpu):
+    def test_round_robins_non_consecutive_gpu_ids(self, _mock_avail, _mock_gpu):
         args = self._make_server_args(numa_node=None)
+        args.gpu_id_step = 2
         with self.assertLogs("sglang.srt.utils.numa_utils", level="WARNING"):
             selected_nodes = [
-                get_numa_node_if_available(args, gpu_id) for gpu_id in range(4)
+                get_numa_node_if_available(args, gpu_id) for gpu_id in [0, 2, 4, 6]
             ]
         self.assertEqual(selected_nodes, [0, 2, 0, 2])
 
@@ -219,9 +222,7 @@ class TestGetNumaNodeIfAvailable(unittest.TestCase):
         with self.assertLogs("sglang.srt.utils.numa_utils", level="WARNING") as cm:
             selected_node = get_numa_node_if_available(args, 1)
         self.assertEqual(selected_node, 2)
-        self.assertTrue(
-            any("Selecting node 2 with round-robin" in msg for msg in cm.output)
-        )
+        self.assertTrue(any("Selecting node 2" in msg for msg in cm.output))
 
     @patch("sglang.srt.utils.numa_utils._is_numa_available", return_value=True)
     @patch("sglang.srt.utils.numa_utils._query_numa_node_for_gpu", return_value=[1])


### PR DESCRIPTION
## Motivation

When NVML reports multiple NUMA affinity nodes for a GPU, automatic NUMA binding currently logs a warning and always selects the first node. On systems where every GPU reports the same affinity set (for example, `[0, 1]`), this binds every GPU subprocess to NUMA node 0 and leaves the other affinity node unused, 

```
        GPU0    GPU1    GPU2    GPU3    GPU4    GPU5    GPU6    GPU7    NIC0    NIC1    NIC2    NIC3    NIC4    NIC5    NIC6    NIC7    CPU Affinity    NUMA Affinity   GPU NUMA ID
GPU0     X      NV18    NV18    NV18    NV18    NV18    NV18    NV18    PIX     PHB     PHB     PHB     PHB     PHB     PHB     PHB     0-187   0-1             N/A
GPU1    NV18     X      NV18    NV18    NV18    NV18    NV18    NV18    PHB     PIX     PHB     PHB     PHB     PHB     PHB     PHB     0-187   0-1             N/A
GPU2    NV18    NV18     X      NV18    NV18    NV18    NV18    NV18    PHB     PHB     PIX     PHB     PHB     PHB     PHB     PHB     0-187   0-1             N/A
GPU3    NV18    NV18    NV18     X      NV18    NV18    NV18    NV18    PHB     PHB     PHB     PIX     PHB     PHB     PHB     PHB     0-187   0-1             N/A
GPU4    NV18    NV18    NV18    NV18     X      NV18    NV18    NV18    PHB     PHB     PHB     PHB     PIX     PHB     PHB     PHB     0-187   0-1             N/A
GPU5    NV18    NV18    NV18    NV18    NV18     X      NV18    NV18    PHB     PHB     PHB     PHB     PHB     PIX     PHB     PHB     0-187   0-1             N/A
GPU6    NV18    NV18    NV18    NV18    NV18    NV18     X      NV18    PHB     PHB     PHB     PHB     PHB     PHB     PIX     PHB     0-187   0-1             N/A
GPU7    NV18    NV18    NV18    NV18    NV18    NV18    NV18     X      PHB     PHB     PHB     PHB     PHB     PHB     PHB     PIX     0-187   0-1             N/A

```
## Modification

Use a local worker index to round-robin automatic NUMA binding across multiple affinity nodes, including non-consecutive GPU IDs.

## Tests














<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29413166697](https://github.com/sgl-project/sglang/actions/runs/29413166697)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29413166471](https://github.com/sgl-project/sglang/actions/runs/29413166471)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->