### PR TITLE
fix(metrics): guard FPM decode metrics against None seq_lens_cpu

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -274,8 +274,16 @@ class SchedulerMetricsReporter:
             for req in batch.decoding_reqs or []:
                 decode_kv.add(req.seqlen)
         elif batch.forward_mode.is_decode():
-            for sl in batch.seq_lens_cpu:
-                decode_kv.add(int(sl))
+            if batch.seq_lens_cpu is not None:
+                for sl in batch.seq_lens_cpu:
+                    decode_kv.add(int(sl))
+            else:
+                # seq_lens_cpu can legitimately be None for a decode batch
+                # produced by merge_batch() (e.g. DP attention + mixed chunk),
+                # so fall back to per-request seqlen the same way
+                # _decode_total_seq_lens() does.
+                for req in batch.reqs:
+                    decode_kv.add(req.seqlen)
 
         return ScheduledRequestMetrics(
             num_prefill_requests=num_prefill_requests,


### PR DESCRIPTION
## Problem

When Forward Pass Metrics (FPM) is enabled, `_build_scheduled_request_metrics()` assumes `ScheduleBatch.seq_lens_cpu` is always populated for decode batches:

```python
elif batch.forward_mode.is_decode():
    for sl in batch.seq_lens_cpu:
        decode_kv.add(int(sl))
```

But `ScheduleBatch.merge_batch()` explicitly allows `seq_lens_cpu` to become `None`:

```python
if self.seq_lens_cpu is None or other.seq_lens_cpu is None:
    self.seq_lens_cpu = None
```

So a legitimately-merged decode batch (reproducible with `--enable-dp-attention --enable-dp-lm-head --enable-mixed-chunk --enable-forward-pass-metrics`) makes the loop raise:

```
TypeError: 'NoneType' object is not iterable
```

This propagates out of `_emit_forward_pass_metrics()` and **terminates the scheduler process**. Because all DP ranks participate in collective communication, the remaining workers then fail with Gloo errors and the deployment becomes unavailable.

## Fix

Guard the decode branch: when `seq_lens_cpu` is `None`, fall back to per-request `req.seqlen`. This mirrors the defensive logic already present in this same file — both `_decode_total_seq_lens()` (which does exactly this fallback) and the `is_mixed()` branch immediately above, which already sums `req.seqlen` over `batch.decoding_reqs`. Metrics stay accurate rather than being skipped.

Fixes #31309

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29407872130](https://github.com/sgl-project/sglang/actions/runs/29407872130)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29407872042](https://github.com/sgl-project/sglang/actions/runs/29407872042)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->