### PR TITLE
Add correctness-first Domino support to DFlash V2

### DIFF
--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -370,6 +370,31 @@ class DFlashDraftModel(nn.Module):
         self.hidden_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
 
         self.block_size = draft_config.resolve_block_size(default=16)
+        self.projector_type = draft_config.projector_type
+        self.shift_label = draft_config.shift_label
+        self.prefix_gru: Optional[nn.GRU] = None
+        self.embed_proj: Optional[nn.Sequential] = None
+        if draft_config.is_domino:
+            assert draft_config.gru_hidden_dim is not None
+            assert draft_config.emb_dim is not None
+            self.prefix_gru = nn.GRU(
+                input_size=hidden_size,
+                hidden_size=int(draft_config.gru_hidden_dim),
+                num_layers=1,
+                batch_first=True,
+                bias=False,
+            )
+            self.embed_proj = nn.Sequential(
+                nn.Linear(
+                    hidden_size + int(draft_config.gru_hidden_dim),
+                    int(draft_config.emb_dim),
+                    bias=False,
+                ),
+                nn.SiLU(),
+                nn.Linear(
+                    int(draft_config.emb_dim), int(config.vocab_size), bias=False
+                ),
+            )
 
     def get_attention_sliding_window_size(self) -> Optional[int]:
         return get_dflash_attention_sliding_window_size(self.config)
@@ -441,6 +466,7 @@ class DFlashDraftModel(nn.Module):
         ]
 
         params_dict = dict(self.named_parameters())
+        loaded_params = set()
 
         def resolve_param_name(name: str) -> Optional[str]:
             if name in params_dict:
@@ -456,6 +482,14 @@ class DFlashDraftModel(nn.Module):
             return None
 
         for name, loaded_weight in weights:
+            unprefixed_name = name.removeprefix("model.")
+            if self.projector_type != "domino" and unprefixed_name.startswith(
+                ("prefix_gru.", "embed_proj.")
+            ):
+                raise ValueError(
+                    "DFLASH checkpoint contains Domino projector weights but "
+                    f"projector_type={self.projector_type!r}."
+                )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if f".{weight_name}." not in name:
                     continue
@@ -466,6 +500,7 @@ class DFlashDraftModel(nn.Module):
                 param = params_dict[resolved_name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight, shard_id)
+                loaded_params.add(resolved_name)
                 break
             else:
                 resolved_name = resolve_param_name(name)
@@ -473,6 +508,14 @@ class DFlashDraftModel(nn.Module):
                     # Ignore unexpected weights (e.g., HF rotary caches).
                     continue
                 param = params_dict[resolved_name]
+                if resolved_name.startswith(("prefix_gru.", "embed_proj.")) and tuple(
+                    loaded_weight.shape
+                ) != tuple(param.shape):
+                    raise ValueError(
+                        "DFLASH Domino projector weight shape mismatch: "
+                        f"expected {resolved_name}{tuple(param.shape)}, got "
+                        f"{tuple(loaded_weight.shape)} from {name!r}."
+                    )
                 if resolved_name.endswith("fc.weight") and tuple(
                     loaded_weight.shape
                 ) != tuple(param.shape):
@@ -485,6 +528,21 @@ class DFlashDraftModel(nn.Module):
                     )
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+                loaded_params.add(resolved_name)
+
+        if self.projector_type == "domino":
+            required = {
+                "prefix_gru.weight_ih_l0",
+                "prefix_gru.weight_hh_l0",
+                "embed_proj.0.weight",
+                "embed_proj.2.weight",
+            }
+            missing = required - loaded_params
+            if missing:
+                raise ValueError(
+                    "DFLASH Domino checkpoint is missing required projector weights: "
+                    f"{sorted(missing)}."
+                )
 
 
 class DFlashLagunaAttention(DFlashAttention):

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -648,6 +648,31 @@ class DFlashDraftModel(nn.Module):
             for conv in (layer.attention_conv, layer.mlp_conv):
                 if conv is not None:
                     conv.block_size = self.block_size
+        self.projector_type = draft_config.projector_type
+        self.shift_label = draft_config.shift_label
+        self.prefix_gru: Optional[nn.GRU] = None
+        self.embed_proj: Optional[nn.Sequential] = None
+        if draft_config.is_domino:
+            assert draft_config.gru_hidden_dim is not None
+            assert draft_config.emb_dim is not None
+            self.prefix_gru = nn.GRU(
+                input_size=hidden_size,
+                hidden_size=int(draft_config.gru_hidden_dim),
+                num_layers=1,
+                batch_first=True,
+                bias=False,
+            )
+            self.embed_proj = nn.Sequential(
+                nn.Linear(
+                    hidden_size + int(draft_config.gru_hidden_dim),
+                    int(draft_config.emb_dim),
+                    bias=False,
+                ),
+                nn.SiLU(),
+                nn.Linear(
+                    int(draft_config.emb_dim), int(config.vocab_size), bias=False
+                ),
+            )
 
     def get_attention_sliding_window_size(self) -> Optional[int]:
         return get_dflash_attention_sliding_window_size(self.config)
@@ -729,6 +754,7 @@ class DFlashDraftModel(nn.Module):
         ]
 
         params_dict = dict(self.named_parameters())
+        loaded_params = set()
 
         # Alias the native export's "encoder." names.
         _VENDOR_ENCODER_ALIASES = {
@@ -753,6 +779,14 @@ class DFlashDraftModel(nn.Module):
             return None
 
         for name, loaded_weight in weights:
+            unprefixed_name = name.removeprefix("model.")
+            if self.projector_type != "domino" and unprefixed_name.startswith(
+                ("prefix_gru.", "embed_proj.")
+            ):
+                raise ValueError(
+                    "DFLASH checkpoint contains Domino projector weights but "
+                    f"projector_type={self.projector_type!r}."
+                )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if f".{weight_name}." not in name:
                     continue
@@ -763,6 +797,7 @@ class DFlashDraftModel(nn.Module):
                 param = params_dict[resolved_name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight, shard_id)
+                loaded_params.add(resolved_name)
                 break
             else:
                 resolved_name = resolve_param_name(name)
@@ -797,8 +832,31 @@ class DFlashDraftModel(nn.Module):
                             f"(num_context_features={self.num_context_features}, hidden_size={int(self.config.hidden_size)}), "
                             f"but got {loaded_shape} for weight '{name}'."
                         )
+                if resolved_name.startswith(("prefix_gru.", "embed_proj.")) and tuple(
+                    loaded_weight.shape
+                ) != tuple(param.shape):
+                    raise ValueError(
+                        "DFLASH Domino projector weight shape mismatch: "
+                        f"expected {resolved_name}{tuple(param.shape)}, got "
+                        f"{tuple(loaded_weight.shape)} from {name!r}."
+                    )
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+                loaded_params.add(resolved_name)
+
+        if self.projector_type == "domino":
+            required = {
+                "prefix_gru.weight_ih_l0",
+                "prefix_gru.weight_hh_l0",
+                "embed_proj.0.weight",
+                "embed_proj.2.weight",
+            }
+            missing = required - loaded_params
+            if missing:
+                raise ValueError(
+                    "DFLASH Domino checkpoint is missing required projector weights: "
+                    f"{sorted(missing)}."
+                )
 
 
 class DFlashLagunaAttention(DFlashAttention):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1742,6 +1742,10 @@ class ServerArgs:
         Optional[int],
         "DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
     ] = None
+    speculative_domino_candidate_pool_size: A[
+        int,
+        "Domino only. Size of the approximate block-shared base-logit candidate pool. Set to 0 to score the full vocabulary.",
+    ] = 2048
     speculative_dspark_block_size: A[
         Optional[int],
         "DSPARK only. Draft block size gamma (number of proposed draft tokens). The verify window is gamma + 1, so this sets --speculative-num-draft-tokens = gamma + 1. Omit to auto-infer gamma from the draft checkpoint block_size.",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2102,6 +2102,10 @@ class ServerArgs:
         "DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
         NS("spec"),
     ] = None
+    speculative_domino_candidate_pool_size: A[
+        int,
+        "Domino only. Size of the approximate block-shared base-logit candidate pool. Set to 0 to score the full vocabulary.",
+    ] = 2048
     speculative_dspark_block_size: A[
         Optional[int],
         "DSPARK only. Draft block size gamma (number of proposed draft tokens). The verify window is gamma + 1, so this sets --speculative-num-draft-tokens = gamma + 1. Omit to auto-infer gamma from the draft checkpoint block_size.",

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -392,6 +392,15 @@ class DFlashDraftConfig:
     target_layer_ids: Optional[List[int]]
     mask_token: str
     mask_token_id: Optional[int]
+    projector_type: Optional[str]
+    shift_label: Optional[bool]
+    pure_draft_prefix_len: Optional[int]
+    gru_hidden_dim: Optional[int]
+    emb_dim: Optional[int]
+
+    @property
+    def is_domino(self) -> bool:
+        return self.projector_type == "domino"
 
     def require_num_layers(self) -> int:
         if self.num_hidden_layers is None:
@@ -510,6 +519,72 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
                 f"got {mask_token_id}."
             )
 
+    projector_type = dflash_cfg.get(
+        "projector_type", _cfg_get(draft_hf_config, "projector_type", None)
+    )
+    shift_label = None
+    pure_draft_prefix_len = None
+    gru_hidden_dim = None
+    emb_dim = None
+    if projector_type == "domino":
+        shift_label = dflash_cfg.get(
+            "shift_label", _cfg_get(draft_hf_config, "shift_label", None)
+        )
+        pure_draft_prefix_len = _parse_optional_int(
+            dflash_cfg.get(
+                "pure_draft_prefix_len",
+                _cfg_get(draft_hf_config, "pure_draft_prefix_len", None),
+            ),
+            field_name="DFLASH Domino pure_draft_prefix_len",
+            min_value=0,
+        )
+        gru_hidden_dim = _parse_optional_int(
+            dflash_cfg.get(
+                "gru_hidden_dim", _cfg_get(draft_hf_config, "gru_hidden_dim", None)
+            ),
+            field_name="DFLASH Domino gru_hidden_dim",
+            min_value=1,
+        )
+        nested_emb_dim = _parse_optional_int(
+            dflash_cfg.get("emb_dim", None),
+            field_name="DFLASH Domino dflash_config.emb_dim",
+            min_value=1,
+        )
+        top_level_emb_dim = _parse_optional_int(
+            _cfg_get(draft_hf_config, "emb_dim", None),
+            field_name="DFLASH Domino top-level emb_dim",
+            min_value=1,
+        )
+        if (
+            nested_emb_dim is not None
+            and top_level_emb_dim is not None
+            and nested_emb_dim != top_level_emb_dim
+        ):
+            raise ValueError(
+                "DFLASH Domino emb_dim differs between dflash_config and the "
+                f"top-level config: {nested_emb_dim} != {top_level_emb_dim}."
+            )
+        emb_dim = nested_emb_dim if nested_emb_dim is not None else top_level_emb_dim
+
+        if not isinstance(shift_label, bool):
+            raise ValueError(
+                "DFLASH Domino requires dflash_config.shift_label to be a bool, "
+                f"got {shift_label!r}."
+            )
+        if pure_draft_prefix_len != 1:
+            raise ValueError(
+                "DFLASH Domino currently requires pure_draft_prefix_len=1, "
+                f"got {pure_draft_prefix_len!r}."
+            )
+        if gru_hidden_dim is None:
+            raise ValueError("DFLASH Domino requires dflash_config.gru_hidden_dim.")
+        if emb_dim is None:
+            raise ValueError("DFLASH Domino requires dflash_config.emb_dim.")
+        if block_size is not None and block_size <= 1:
+            raise ValueError(
+                f"DFLASH Domino requires block_size > 1, got {block_size}."
+            )
+
     return DFlashDraftConfig(
         num_hidden_layers=num_hidden_layers,
         num_target_layers=num_target_layers,
@@ -517,6 +592,11 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
         target_layer_ids=parsed_target_layer_ids,
         mask_token=mask_token,
         mask_token_id=mask_token_id,
+        projector_type=projector_type,
+        shift_label=shift_label,
+        pure_draft_prefix_len=pure_draft_prefix_len,
+        gru_hidden_dim=gru_hidden_dim,
+        emb_dim=emb_dim,
     )
 
 

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -537,6 +537,15 @@ class DFlashDraftConfig:
     target_layer_ids: Optional[List[int]]
     mask_token: str
     mask_token_id: Optional[int]
+    projector_type: Optional[str]
+    shift_label: Optional[bool]
+    pure_draft_prefix_len: Optional[int]
+    gru_hidden_dim: Optional[int]
+    emb_dim: Optional[int]
+
+    @property
+    def is_domino(self) -> bool:
+        return self.projector_type == "domino"
 
     def require_num_layers(self) -> int:
         if self.num_hidden_layers is None:
@@ -697,6 +706,72 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
                 f"got {mask_token_id}."
             )
 
+    projector_type = dflash_cfg.get(
+        "projector_type", _cfg_get(draft_hf_config, "projector_type", None)
+    )
+    shift_label = None
+    pure_draft_prefix_len = None
+    gru_hidden_dim = None
+    emb_dim = None
+    if projector_type == "domino":
+        shift_label = dflash_cfg.get(
+            "shift_label", _cfg_get(draft_hf_config, "shift_label", None)
+        )
+        pure_draft_prefix_len = _parse_optional_int(
+            dflash_cfg.get(
+                "pure_draft_prefix_len",
+                _cfg_get(draft_hf_config, "pure_draft_prefix_len", None),
+            ),
+            field_name="DFLASH Domino pure_draft_prefix_len",
+            min_value=0,
+        )
+        gru_hidden_dim = _parse_optional_int(
+            dflash_cfg.get(
+                "gru_hidden_dim", _cfg_get(draft_hf_config, "gru_hidden_dim", None)
+            ),
+            field_name="DFLASH Domino gru_hidden_dim",
+            min_value=1,
+        )
+        nested_emb_dim = _parse_optional_int(
+            dflash_cfg.get("emb_dim", None),
+            field_name="DFLASH Domino dflash_config.emb_dim",
+            min_value=1,
+        )
+        top_level_emb_dim = _parse_optional_int(
+            _cfg_get(draft_hf_config, "emb_dim", None),
+            field_name="DFLASH Domino top-level emb_dim",
+            min_value=1,
+        )
+        if (
+            nested_emb_dim is not None
+            and top_level_emb_dim is not None
+            and nested_emb_dim != top_level_emb_dim
+        ):
+            raise ValueError(
+                "DFLASH Domino emb_dim differs between dflash_config and the "
+                f"top-level config: {nested_emb_dim} != {top_level_emb_dim}."
+            )
+        emb_dim = nested_emb_dim if nested_emb_dim is not None else top_level_emb_dim
+
+        if not isinstance(shift_label, bool):
+            raise ValueError(
+                "DFLASH Domino requires dflash_config.shift_label to be a bool, "
+                f"got {shift_label!r}."
+            )
+        if pure_draft_prefix_len != 1:
+            raise ValueError(
+                "DFLASH Domino currently requires pure_draft_prefix_len=1, "
+                f"got {pure_draft_prefix_len!r}."
+            )
+        if gru_hidden_dim is None:
+            raise ValueError("DFLASH Domino requires dflash_config.gru_hidden_dim.")
+        if emb_dim is None:
+            raise ValueError("DFLASH Domino requires dflash_config.emb_dim.")
+        if block_size is not None and block_size <= 1:
+            raise ValueError(
+                f"DFLASH Domino requires block_size > 1, got {block_size}."
+            )
+
     return DFlashDraftConfig(
         num_hidden_layers=num_hidden_layers,
         num_target_layers=num_target_layers,
@@ -710,6 +785,11 @@ def parse_dflash_draft_config(*, draft_hf_config: Any) -> DFlashDraftConfig:
         target_layer_ids=parsed_target_layer_ids,
         mask_token=mask_token,
         mask_token_id=mask_token_id,
+        projector_type=projector_type,
+        shift_label=shift_label,
+        pure_draft_prefix_len=pure_draft_prefix_len,
+        gru_hidden_dim=gru_hidden_dim,
+        emb_dim=emb_dim,
     )
 
 

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -165,6 +165,7 @@ class _DominoDraftSampler:
         block_size,
         shift_label,
         max_bs,
+        candidate_pool_size=2048,
     ):
         self.target_embedding = target_embedding
         self.lm_head_weight = lm_head_weight
@@ -173,6 +174,7 @@ class _DominoDraftSampler:
         self.vocab_size = int(vocab_size)
         self.block_size = int(block_size)
         self.shift_label = bool(shift_label)
+        self.candidate_pool_size = int(candidate_pool_size)
         max_tokens = int(max_bs) * (self.block_size - 1)
         self.out = torch.empty(
             (max_tokens,), dtype=torch.int64, device=lm_head_weight.device
@@ -193,6 +195,7 @@ class _DominoDraftSampler:
             embed_proj=self.embed_proj,
             vocab_size=self.vocab_size,
             shift_label=self.shift_label,
+            candidate_pool_size=self.candidate_pool_size,
         )
         self.out[: bs * (self.block_size - 1)].copy_(proposals.reshape(-1))
 
@@ -246,7 +249,15 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_hf_config=self.draft_model_runner.model_config.hf_config
         )
         self._is_domino = draft_config.is_domino
+        self.domino_candidate_pool_size = int(
+            server_args.speculative_domino_candidate_pool_size
+        )
         if self._is_domino:
+            if self.domino_candidate_pool_size < 0:
+                raise ValueError(
+                    "--speculative-domino-candidate-pool-size must be non-negative, "
+                    f"got {self.domino_candidate_pool_size}."
+                )
             target_model = self.target_worker.model_runner.model
             target_embedding = target_model.get_input_embeddings()
             lm_head = getattr(target_model, "lm_head", None)
@@ -307,7 +318,8 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
             if self._is_domino:
                 logger.info(
-                    "DFLASH Domino rollout enabled (eager BF16, TP=1, full-vocabulary greedy)."
+                    "DFLASH Domino rollout enabled (eager BF16, TP=1, block-shared candidate pool size=%s).",
+                    self.domino_candidate_pool_size,
                 )
             logger.info(
                 "DFLASH draft runner ready. mask_token=%s, mask_token_id=%s, mask_token_id_override=%s",
@@ -470,6 +482,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 block_size=self.block_size,
                 shift_label=self.draft_model.shift_label,
                 max_bs=max(self.server_args.cuda_graph_config.decode.bs),
+                candidate_pool_size=self.domino_candidate_pool_size,
             )
         if not hasattr(lm_head, "shard_indices"):
             if tp_group.world_size != 1:
@@ -1741,6 +1754,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 embed_proj=embed_proj,
                 vocab_size=int(self.model_runner.model_config.vocab_size),
                 shift_label=bool(self.draft_model.shift_label),
+                candidate_pool_size=self.domino_candidate_pool_size,
             )
         elif self._draft_sampler is not None and draft_out.can_run_graph:
             draft_next = self._draft_sampler.out[

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -151,6 +151,52 @@ class _DflashDraftSampler:
         self.out[:n].copy_(selected.view(-1))
 
 
+class _DominoDraftSampler:
+    """Capture-safe TP=1 Domino rollout over a fixed-size draft block."""
+
+    def __init__(
+        self,
+        *,
+        target_embedding,
+        lm_head_weight,
+        prefix_gru,
+        embed_proj,
+        vocab_size,
+        block_size,
+        shift_label,
+        max_bs,
+    ):
+        self.target_embedding = target_embedding
+        self.lm_head_weight = lm_head_weight
+        self.prefix_gru = prefix_gru
+        self.embed_proj = embed_proj
+        self.vocab_size = int(vocab_size)
+        self.block_size = int(block_size)
+        self.shift_label = bool(shift_label)
+        max_tokens = int(max_bs) * (self.block_size - 1)
+        self.out = torch.empty(
+            (max_tokens,), dtype=torch.int64, device=lm_head_weight.device
+        )
+
+    def __call__(self, hidden_states, input_ids=None):
+        if input_ids is None:
+            raise RuntimeError("Domino draft sampler requires block input_ids.")
+        bs = hidden_states.shape[0] // self.block_size
+        draft_hidden = hidden_states.view(bs, self.block_size, -1)
+        verified_ids = input_ids.view(bs, self.block_size)[:, 0]
+        proposals = domino_greedy_rollout(
+            draft_hidden=draft_hidden,
+            verified_ids=verified_ids,
+            target_embedding=self.target_embedding,
+            lm_head_weight=self.lm_head_weight,
+            prefix_gru=self.prefix_gru,
+            embed_proj=self.embed_proj,
+            vocab_size=self.vocab_size,
+            shift_label=self.shift_label,
+        )
+        self.out[: bs * (self.block_size - 1)].copy_(proposals.reshape(-1))
+
+
 class DFlashWorkerV2(BaseSpecWorker):
     """DFLASH speculative decoding worker (spec-v2).
 
@@ -394,8 +440,6 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         if envs.SGLANG_DFLASH_EAGER_DRAFT_SAMPLER.get():
             return _eager("SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1")
-        if self._is_domino:
-            return _eager("Domino uses sequential eager rollout")
         if self.block_size <= 1:
             return _eager("block_size<=1")
         target_model = self._target_worker.model_runner.model
@@ -406,6 +450,27 @@ class DFlashWorkerV2(BaseSpecWorker):
             # Quantized lm_head (FP8/INT) would break the static matmul.
             return _eager("quantized lm_head")
         tp_group = get_tp_group()
+        if self._is_domino:
+            if tp_group.world_size != 1:
+                return _eager("Domino cuda graph currently requires tp=1")
+            prefix_gru = self.draft_model.prefix_gru
+            embed_proj = self.draft_model.embed_proj
+            if prefix_gru is None or embed_proj is None:
+                return _eager("Domino projector modules are unavailable")
+            if self.ps.tp_rank == 0:
+                logger.info(
+                    "DFLASH Domino rollout folded into the draft cuda graph (tp=1)."
+                )
+            return _DominoDraftSampler(
+                target_embedding=target_model.get_input_embeddings(),
+                lm_head_weight=lm_head.weight,
+                prefix_gru=prefix_gru,
+                embed_proj=embed_proj,
+                vocab_size=int(self.model_runner.model_config.vocab_size),
+                block_size=self.block_size,
+                shift_label=self.draft_model.shift_label,
+                max_bs=max(self.server_args.cuda_graph_config.decode.bs),
+            )
         if not hasattr(lm_head, "shard_indices"):
             if tp_group.world_size != 1:
                 # No shard metadata to recover per-rank vocab offsets from.
@@ -1650,7 +1715,15 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_out = self.draft_model_runner.forward(forward_batch)
         draft_logits_output = draft_out.logits_output
 
-        if self._is_domino:
+        if (
+            self._is_domino
+            and self._draft_sampler is not None
+            and draft_out.can_run_graph
+        ):
+            draft_next = self._draft_sampler.out[
+                : bs * (int(self.block_size) - 1)
+            ].view(bs, int(self.block_size) - 1)
+        elif self._is_domino:
             draft_hidden = draft_logits_output.hidden_states
             if draft_hidden is None:
                 raise RuntimeError("DFLASH draft model returned no hidden states.")

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -39,6 +39,10 @@ from sglang.srt.speculative.dflash_utils import (
     is_dflash_sampling_verify_available,
     parse_dflash_draft_config,
 )
+from sglang.srt.speculative.domino_utils import (
+    domino_greedy_rollout,
+    validate_domino_runtime,
+)
 from sglang.srt.speculative.draft_worker_common import (
     build_block_pos_offsets,
     build_draft_tp_worker,
@@ -195,6 +199,28 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_config = parse_dflash_draft_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config
         )
+        self._is_domino = draft_config.is_domino
+        if self._is_domino:
+            target_model = self.target_worker.model_runner.model
+            target_embedding = target_model.get_input_embeddings()
+            lm_head = getattr(target_model, "lm_head", None)
+            prefix_gru = getattr(self.draft_model, "prefix_gru", None)
+            embed_proj = getattr(self.draft_model, "embed_proj", None)
+            if lm_head is None or prefix_gru is None or embed_proj is None:
+                raise ValueError(
+                    "DFLASH Domino requires target lm_head and loaded Domino projector modules."
+                )
+            validate_domino_runtime(
+                device=torch.device(self.device),
+                tp_size=int(get_tp_group().world_size),
+                target_vocab_size=int(self.model_runner.model_config.vocab_size),
+                draft_vocab_size=int(self.draft_model_runner.model_config.vocab_size),
+                hidden_size=int(self.draft_model.config.hidden_size),
+                target_embedding=target_embedding,
+                lm_head=lm_head,
+                prefix_gru=prefix_gru,
+                embed_proj=embed_proj,
+            )
         if server_args.speculative_num_draft_tokens is None:
             # Should not happen (ServerArgs should have inferred it), but keep a fallback.
             self.block_size = int(draft_config.resolve_block_size(default=16))
@@ -212,6 +238,11 @@ class DFlashWorkerV2(BaseSpecWorker):
                     model_block_size,
                 )
         self.speculative_num_draft_tokens = int(self.block_size)
+        if self._is_domino and self.block_size <= 1:
+            raise ValueError(
+                "DFLASH Domino requires speculative_num_draft_tokens > 1, "
+                f"got {self.block_size}."
+            )
 
         self._mask_token = draft_config.mask_token
         self._mask_token_id_override = draft_config.mask_token_id
@@ -228,6 +259,10 @@ class DFlashWorkerV2(BaseSpecWorker):
                 self.draft_window_size,
                 self.use_compact_draft_cache,
             )
+            if self._is_domino:
+                logger.info(
+                    "DFLASH Domino rollout enabled (eager BF16, TP=1, full-vocabulary greedy)."
+                )
             logger.info(
                 "DFLASH draft runner ready. mask_token=%s, mask_token_id=%s, mask_token_id_override=%s",
                 self._mask_token,
@@ -359,6 +394,8 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         if envs.SGLANG_DFLASH_EAGER_DRAFT_SAMPLER.get():
             return _eager("SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1")
+        if self._is_domino:
+            return _eager("Domino uses sequential eager rollout")
         if self.block_size <= 1:
             return _eager("block_size<=1")
         target_model = self._target_worker.model_runner.model
@@ -1613,7 +1650,26 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_out = self.draft_model_runner.forward(forward_batch)
         draft_logits_output = draft_out.logits_output
 
-        if self._draft_sampler is not None and draft_out.can_run_graph:
+        if self._is_domino:
+            draft_hidden = draft_logits_output.hidden_states
+            if draft_hidden is None:
+                raise RuntimeError("DFLASH draft model returned no hidden states.")
+            draft_hidden = draft_hidden.view(bs, int(self.block_size), -1)
+            prefix_gru = self.draft_model.prefix_gru
+            embed_proj = self.draft_model.embed_proj
+            if prefix_gru is None or embed_proj is None:
+                raise RuntimeError("DFLASH Domino projector modules are unavailable.")
+            draft_next = domino_greedy_rollout(
+                draft_hidden=draft_hidden,
+                verified_ids=block_ids[:, 0],
+                target_embedding=embed_module,
+                lm_head_weight=lm_head.weight,
+                prefix_gru=prefix_gru,
+                embed_proj=embed_proj,
+                vocab_size=int(self.model_runner.model_config.vocab_size),
+                shift_label=bool(self.draft_model.shift_label),
+            )
+        elif self._draft_sampler is not None and draft_out.can_run_graph:
             draft_next = self._draft_sampler.out[
                 : bs * (int(self.block_size) - 1)
             ].view(bs, int(self.block_size) - 1)

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -285,6 +285,7 @@ class _DominoDraftSampler:
         block_size,
         shift_label,
         max_bs,
+        candidate_pool_size=2048,
     ):
         self.target_embedding = target_embedding
         self.lm_head_weight = lm_head_weight
@@ -293,6 +294,7 @@ class _DominoDraftSampler:
         self.vocab_size = int(vocab_size)
         self.block_size = int(block_size)
         self.shift_label = bool(shift_label)
+        self.candidate_pool_size = int(candidate_pool_size)
         max_tokens = int(max_bs) * (self.block_size - 1)
         self.out = torch.empty(
             (max_tokens,), dtype=torch.int64, device=lm_head_weight.device
@@ -313,6 +315,7 @@ class _DominoDraftSampler:
             embed_proj=self.embed_proj,
             vocab_size=self.vocab_size,
             shift_label=self.shift_label,
+            candidate_pool_size=self.candidate_pool_size,
         )
         self.out[: bs * (self.block_size - 1)].copy_(proposals.reshape(-1))
 
@@ -368,7 +371,15 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_hf_config=self.draft_model_runner.model_config.hf_config
         )
         self._is_domino = draft_config.is_domino
+        self.domino_candidate_pool_size = int(
+            server_args.speculative_domino_candidate_pool_size
+        )
         if self._is_domino:
+            if self.domino_candidate_pool_size < 0:
+                raise ValueError(
+                    "--speculative-domino-candidate-pool-size must be non-negative, "
+                    f"got {self.domino_candidate_pool_size}."
+                )
             target_model = self.target_worker.model_runner.model
             target_embedding = target_model.get_input_embeddings()
             lm_head = getattr(target_model, "lm_head", None)
@@ -436,7 +447,8 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
             if self._is_domino:
                 logger.info(
-                    "DFLASH Domino rollout enabled (eager BF16, TP=1, full-vocabulary greedy)."
+                    "DFLASH Domino rollout enabled (eager BF16, TP=1, block-shared candidate pool size=%s).",
+                    self.domino_candidate_pool_size,
                 )
             logger.info(
                 "DFLASH draft runner ready. mask_token=%s, mask_token_id=%s, mask_token_id_override=%s, noise_embed_scale=%s",
@@ -626,6 +638,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 block_size=self.block_size,
                 shift_label=self.draft_model.shift_label,
                 max_bs=max(self.server_args.cuda_graph_config.decode.bs),
+                candidate_pool_size=self.domino_candidate_pool_size,
             )
         if not hasattr(lm_head, "shard_indices"):
             if tp_group.world_size != 1:
@@ -2046,6 +2059,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 embed_proj=embed_proj,
                 vocab_size=int(self.model_runner.model_config.vocab_size),
                 shift_label=bool(self.draft_model.shift_label),
+                candidate_pool_size=self.domino_candidate_pool_size,
             )
         elif self._draft_sampler is not None and draft_out.can_run_graph:
             draft_next = self._draft_sampler.out[

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -53,6 +53,10 @@ from sglang.srt.speculative.dflash_utils import (
     is_dflash_sampling_verify_available,
     parse_dflash_draft_config,
 )
+from sglang.srt.speculative.domino_utils import (
+    domino_greedy_rollout,
+    validate_domino_runtime,
+)
 from sglang.srt.speculative.draft_worker_common import (
     build_block_pos_offsets,
     build_draft_tp_worker,
@@ -319,6 +323,28 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_config = parse_dflash_draft_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config
         )
+        self._is_domino = draft_config.is_domino
+        if self._is_domino:
+            target_model = self.target_worker.model_runner.model
+            target_embedding = target_model.get_input_embeddings()
+            lm_head = getattr(target_model, "lm_head", None)
+            prefix_gru = getattr(self.draft_model, "prefix_gru", None)
+            embed_proj = getattr(self.draft_model, "embed_proj", None)
+            if lm_head is None or prefix_gru is None or embed_proj is None:
+                raise ValueError(
+                    "DFLASH Domino requires target lm_head and loaded Domino projector modules."
+                )
+            validate_domino_runtime(
+                device=torch.device(self.device),
+                tp_size=int(get_tp_group().world_size),
+                target_vocab_size=int(self.model_runner.model_config.vocab_size),
+                draft_vocab_size=int(self.draft_model_runner.model_config.vocab_size),
+                hidden_size=int(self.draft_model.config.hidden_size),
+                target_embedding=target_embedding,
+                lm_head=lm_head,
+                prefix_gru=prefix_gru,
+                embed_proj=embed_proj,
+            )
         if get_spec().speculative_num_draft_tokens is None:
             # Should not happen (ServerArgs should have inferred it), but keep a fallback.
             self.block_size = int(draft_config.resolve_block_size(default=16))
@@ -337,6 +363,11 @@ class DFlashWorkerV2(BaseSpecWorker):
                 )
         self.draft_model.set_block_size(self.block_size)
         self.speculative_num_draft_tokens = int(self.block_size)
+        if self._is_domino and self.block_size <= 1:
+            raise ValueError(
+                "DFLASH Domino requires speculative_num_draft_tokens > 1, "
+                f"got {self.block_size}."
+            )
 
         self._mask_token = draft_config.mask_token
         self._mask_token_id_override = draft_config.mask_token_id
@@ -359,6 +390,10 @@ class DFlashWorkerV2(BaseSpecWorker):
                 self.draft_window_size,
                 self.use_compact_draft_cache,
             )
+            if self._is_domino:
+                logger.info(
+                    "DFLASH Domino rollout enabled (eager BF16, TP=1, full-vocabulary greedy)."
+                )
             logger.info(
                 "DFLASH draft runner ready. mask_token=%s, mask_token_id=%s, mask_token_id_override=%s, noise_embed_scale=%s",
                 self._mask_token,
@@ -492,6 +527,8 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         if envs.SGLANG_DFLASH_EAGER_DRAFT_SAMPLER.get():
             return _eager("SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1")
+        if self._is_domino:
+            return _eager("Domino uses sequential eager rollout")
         if self.block_size <= 1:
             return _eager("block_size<=1")
         target_model = self._target_worker.model_runner.model
@@ -1920,8 +1957,26 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_out = self.draft_model_runner.forward(forward_batch)
         draft_logits_output = draft_out.logits_output
 
-        folded = self._draft_sampler is not None and draft_out.can_run_graph
-        if folded:
+        if self._is_domino:
+            draft_hidden = draft_logits_output.hidden_states
+            if draft_hidden is None:
+                raise RuntimeError("DFLASH draft model returned no hidden states.")
+            draft_hidden = draft_hidden.view(bs, int(self.block_size), -1)
+            prefix_gru = self.draft_model.prefix_gru
+            embed_proj = self.draft_model.embed_proj
+            if prefix_gru is None or embed_proj is None:
+                raise RuntimeError("DFLASH Domino projector modules are unavailable.")
+            draft_next = domino_greedy_rollout(
+                draft_hidden=draft_hidden,
+                verified_ids=block_ids[:, 0],
+                target_embedding=embed_module,
+                lm_head_weight=lm_head.weight,
+                prefix_gru=prefix_gru,
+                embed_proj=embed_proj,
+                vocab_size=int(self.model_runner.model_config.vocab_size),
+                shift_label=bool(self.draft_model.shift_label),
+            )
+        elif self._draft_sampler is not None and draft_out.can_run_graph:
             draft_next = self._draft_sampler.out[
                 : bs * (int(self.block_size) - 1)
             ].view(bs, int(self.block_size) - 1)

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -271,6 +271,50 @@ class _SelectorDraftSampler:
         self.out[: tokens.numel()].copy_(tokens.reshape(-1))
         self.candidate_out[:bs].copy_(candidate_ids)
         self.q_out[:bs].copy_(q_rows)
+class _DominoDraftSampler:
+    """Capture-safe TP=1 Domino rollout over a fixed-size draft block."""
+
+    def __init__(
+        self,
+        *,
+        target_embedding,
+        lm_head_weight,
+        prefix_gru,
+        embed_proj,
+        vocab_size,
+        block_size,
+        shift_label,
+        max_bs,
+    ):
+        self.target_embedding = target_embedding
+        self.lm_head_weight = lm_head_weight
+        self.prefix_gru = prefix_gru
+        self.embed_proj = embed_proj
+        self.vocab_size = int(vocab_size)
+        self.block_size = int(block_size)
+        self.shift_label = bool(shift_label)
+        max_tokens = int(max_bs) * (self.block_size - 1)
+        self.out = torch.empty(
+            (max_tokens,), dtype=torch.int64, device=lm_head_weight.device
+        )
+
+    def __call__(self, hidden_states, input_ids=None):
+        if input_ids is None:
+            raise RuntimeError("Domino draft sampler requires block input_ids.")
+        bs = hidden_states.shape[0] // self.block_size
+        draft_hidden = hidden_states.view(bs, self.block_size, -1)
+        verified_ids = input_ids.view(bs, self.block_size)[:, 0]
+        proposals = domino_greedy_rollout(
+            draft_hidden=draft_hidden,
+            verified_ids=verified_ids,
+            target_embedding=self.target_embedding,
+            lm_head_weight=self.lm_head_weight,
+            prefix_gru=self.prefix_gru,
+            embed_proj=self.embed_proj,
+            vocab_size=self.vocab_size,
+            shift_label=self.shift_label,
+        )
+        self.out[: bs * (self.block_size - 1)].copy_(proposals.reshape(-1))
 
 
 class DFlashWorkerV2(BaseSpecWorker):
@@ -527,8 +571,6 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         if envs.SGLANG_DFLASH_EAGER_DRAFT_SAMPLER.get():
             return _eager("SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1")
-        if self._is_domino:
-            return _eager("Domino uses sequential eager rollout")
         if self.block_size <= 1:
             return _eager("block_size<=1")
         target_model = self._target_worker.model_runner.model
@@ -564,6 +606,27 @@ class DFlashWorkerV2(BaseSpecWorker):
             # Quantized lm_head (FP8/INT) would break the static matmul.
             return _eager("quantized lm_head")
         tp_group = get_tp_group()
+        if self._is_domino:
+            if tp_group.world_size != 1:
+                return _eager("Domino cuda graph currently requires tp=1")
+            prefix_gru = self.draft_model.prefix_gru
+            embed_proj = self.draft_model.embed_proj
+            if prefix_gru is None or embed_proj is None:
+                return _eager("Domino projector modules are unavailable")
+            if self.ps.tp_rank == 0:
+                logger.info(
+                    "DFLASH Domino rollout folded into the draft cuda graph (tp=1)."
+                )
+            return _DominoDraftSampler(
+                target_embedding=target_model.get_input_embeddings(),
+                lm_head_weight=lm_head.weight,
+                prefix_gru=prefix_gru,
+                embed_proj=embed_proj,
+                vocab_size=int(self.model_runner.model_config.vocab_size),
+                block_size=self.block_size,
+                shift_label=self.draft_model.shift_label,
+                max_bs=max(self.server_args.cuda_graph_config.decode.bs),
+            )
         if not hasattr(lm_head, "shard_indices"):
             if tp_group.world_size != 1:
                 # No shard metadata to recover per-rank vocab offsets from.
@@ -1957,7 +2020,15 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_out = self.draft_model_runner.forward(forward_batch)
         draft_logits_output = draft_out.logits_output
 
-        if self._is_domino:
+        if (
+            self._is_domino
+            and self._draft_sampler is not None
+            and draft_out.can_run_graph
+        ):
+            draft_next = self._draft_sampler.out[
+                : bs * (int(self.block_size) - 1)
+            ].view(bs, int(self.block_size) - 1)
+        elif self._is_domino:
             draft_hidden = draft_logits_output.hidden_states
             if draft_hidden is None:
                 raise RuntimeError("DFLASH draft model returned no hidden states.")

--- a/python/sglang/srt/speculative/domino_utils.py
+++ b/python/sglang/srt/speculative/domino_utils.py
@@ -110,7 +110,7 @@ def domino_greedy_rollout(
         raise ValueError(
             f"draft_hidden must have shape [batch, block, hidden], got {tuple(draft_hidden.shape)}."
         )
-    batch_size, block_size, _ = draft_hidden.shape
+    batch_size, block_size, hidden_size = draft_hidden.shape
     if verified_ids.shape != (batch_size,):
         raise ValueError(
             f"verified_ids must have shape ({batch_size},), got {tuple(verified_ids.shape)}."
@@ -127,13 +127,15 @@ def domino_greedy_rollout(
         )
 
     weight = lm_head_weight[: int(vocab_size)]
+    z_for_logits = z.to(weight.dtype) if z.dtype != weight.dtype else z
+    logits_input = (
+        z_for_logits.transpose(0, 1)
+        .contiguous()
+        .view(num_proposals * batch_size, hidden_size)
+    )
+    base_logits = F.linear(logits_input, weight).view(num_proposals, batch_size, -1)
 
-    def base_logits(hidden: torch.Tensor) -> torch.Tensor:
-        if hidden.dtype != weight.dtype:
-            hidden = hidden.to(weight.dtype)
-        return F.linear(hidden, weight)
-
-    first_ids = torch.argmax(base_logits(z[:, 0, :]), dim=-1).to(torch.long)
+    first_ids = torch.argmax(base_logits[0], dim=-1).to(torch.long)
     proposals = [first_ids]
     if num_proposals == 1:
         return first_ids[:, None]
@@ -144,9 +146,7 @@ def domino_greedy_rollout(
     for index in range(1, num_proposals):
         step_hidden = z[:, index, :]
         correction = embed_proj(torch.cat((step_hidden, gru_hidden[0]), dim=-1))
-        next_ids = torch.argmax(base_logits(step_hidden) + correction, dim=-1).to(
-            torch.long
-        )
+        next_ids = torch.argmax(base_logits[index] + correction, dim=-1).to(torch.long)
         proposals.append(next_ids)
         if index + 1 < num_proposals:
             _, gru_hidden = prefix_gru(target_embedding(next_ids[:, None]), gru_hidden)

--- a/python/sglang/srt/speculative/domino_utils.py
+++ b/python/sglang/srt/speculative/domino_utils.py
@@ -5,6 +5,20 @@ import torch.nn.functional as F
 from torch import nn
 
 
+def _domino_gru_cell(
+    prefix_gru: nn.GRU, input: torch.Tensor, hidden: torch.Tensor
+) -> torch.Tensor:
+    """Run one feedback step without cuDNN's per-call RNN weight packing."""
+    return torch.ops.aten.gru_cell.default(
+        input,
+        hidden,
+        prefix_gru.weight_ih_l0,
+        prefix_gru.weight_hh_l0,
+        prefix_gru.bias_ih_l0 if prefix_gru.bias else None,
+        prefix_gru.bias_hh_l0 if prefix_gru.bias else None,
+    )
+
+
 def validate_domino_runtime(
     *,
     device: torch.device,
@@ -149,6 +163,8 @@ def domino_greedy_rollout(
         next_ids = torch.argmax(base_logits[index] + correction, dim=-1).to(torch.long)
         proposals.append(next_ids)
         if index + 1 < num_proposals:
-            _, gru_hidden = prefix_gru(target_embedding(next_ids[:, None]), gru_hidden)
+            gru_hidden = _domino_gru_cell(
+                prefix_gru, target_embedding(next_ids), gru_hidden[0]
+            )[None]
 
     return torch.stack(proposals, dim=1)

--- a/python/sglang/srt/speculative/domino_utils.py
+++ b/python/sglang/srt/speculative/domino_utils.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+def validate_domino_runtime(
+    *,
+    device: torch.device,
+    tp_size: int,
+    target_vocab_size: int,
+    draft_vocab_size: int,
+    hidden_size: int,
+    target_embedding: nn.Module,
+    lm_head: nn.Module,
+    prefix_gru: nn.GRU,
+    embed_proj: nn.Sequential,
+) -> None:
+    """Validate the deliberately narrow correctness-first Domino runtime."""
+    if device.type != "cuda":
+        raise ValueError(f"DFLASH Domino currently requires CUDA, got {device}.")
+    if int(tp_size) != 1:
+        raise ValueError(f"DFLASH Domino currently requires TP=1, got TP={tp_size}.")
+    if int(target_vocab_size) != int(draft_vocab_size):
+        raise ValueError(
+            "DFLASH Domino requires identical target and draft vocab sizes, "
+            f"got target={target_vocab_size}, draft={draft_vocab_size}."
+        )
+
+    embedding_weight = getattr(target_embedding, "weight", None)
+    lm_head_weight = getattr(lm_head, "weight", None)
+    if embedding_weight is None or lm_head_weight is None:
+        raise ValueError(
+            "DFLASH Domino requires target embedding and lm_head weight tensors."
+        )
+
+    shard = getattr(lm_head, "shard_indices", None)
+    if shard is not None:
+        if int(shard.num_added_elements) != 0:
+            raise ValueError(
+                "DFLASH Domino does not support added-vocab lm_head shards."
+            )
+        if int(shard.org_vocab_start_index) != 0 or int(shard.num_org_elements) != int(
+            target_vocab_size
+        ):
+            raise ValueError(
+                "DFLASH Domino requires the complete target vocabulary on TP=1."
+            )
+    elif int(lm_head_weight.shape[0]) != int(target_vocab_size):
+        raise ValueError(
+            "DFLASH Domino lm_head row count must equal the target vocab size, "
+            f"got rows={int(lm_head_weight.shape[0])}, vocab={target_vocab_size}."
+        )
+
+    if int(embedding_weight.shape[0]) < int(target_vocab_size):
+        raise ValueError(
+            "DFLASH Domino target embedding has fewer rows than the target vocab "
+            f"size: rows={int(embedding_weight.shape[0])}, vocab={target_vocab_size}."
+        )
+
+    if int(embedding_weight.shape[-1]) != int(hidden_size) or int(
+        lm_head_weight.shape[-1]
+    ) != int(hidden_size):
+        raise ValueError(
+            "DFLASH Domino target embedding/lm_head hidden size does not match "
+            f"the draft hidden size {hidden_size}."
+        )
+    if int(prefix_gru.input_size) != int(hidden_size):
+        raise ValueError(
+            "DFLASH Domino GRU input size does not match the draft hidden size."
+        )
+    if int(embed_proj[0].in_features) != int(hidden_size + prefix_gru.hidden_size):
+        raise ValueError("DFLASH Domino projector input shape is inconsistent.")
+    if int(embed_proj[2].out_features) != int(target_vocab_size):
+        raise ValueError("DFLASH Domino projector output vocab size is inconsistent.")
+
+    weights = (
+        embedding_weight,
+        lm_head_weight,
+        prefix_gru.weight_ih_l0,
+        prefix_gru.weight_hh_l0,
+        embed_proj[0].weight,
+        embed_proj[2].weight,
+    )
+    non_bf16 = [
+        str(weight.dtype) for weight in weights if weight.dtype != torch.bfloat16
+    ]
+    if non_bf16:
+        raise ValueError(
+            "DFLASH Domino currently requires BF16 target and projector weights; "
+            f"found {non_bf16}."
+        )
+
+
+@torch.no_grad()
+def domino_greedy_rollout(
+    *,
+    draft_hidden: torch.Tensor,
+    verified_ids: torch.Tensor,
+    target_embedding: nn.Module,
+    lm_head_weight: torch.Tensor,
+    prefix_gru: nn.GRU,
+    embed_proj: nn.Sequential,
+    vocab_size: int,
+    shift_label: bool,
+) -> torch.Tensor:
+    """Generate a Domino chain with native GRU and full-vocabulary greedy logits."""
+    if draft_hidden.ndim != 3:
+        raise ValueError(
+            f"draft_hidden must have shape [batch, block, hidden], got {tuple(draft_hidden.shape)}."
+        )
+    batch_size, block_size, _ = draft_hidden.shape
+    if verified_ids.shape != (batch_size,):
+        raise ValueError(
+            f"verified_ids must have shape ({batch_size},), got {tuple(verified_ids.shape)}."
+        )
+
+    num_proposals = int(block_size) - 1
+    if num_proposals < 1:
+        raise ValueError(f"Domino requires block_size > 1, got {block_size}.")
+    start = 0 if shift_label else 1
+    z = draft_hidden[:, start : start + num_proposals, :]
+    if int(z.shape[1]) != num_proposals:
+        raise ValueError(
+            "Domino draft hidden states do not contain enough proposal positions."
+        )
+
+    weight = lm_head_weight[: int(vocab_size)]
+
+    def base_logits(hidden: torch.Tensor) -> torch.Tensor:
+        if hidden.dtype != weight.dtype:
+            hidden = hidden.to(weight.dtype)
+        return F.linear(hidden, weight)
+
+    first_ids = torch.argmax(base_logits(z[:, 0, :]), dim=-1).to(torch.long)
+    proposals = [first_ids]
+    if num_proposals == 1:
+        return first_ids[:, None]
+
+    prefix_ids = torch.stack((verified_ids, first_ids), dim=1)
+    _, gru_hidden = prefix_gru(target_embedding(prefix_ids))
+
+    for index in range(1, num_proposals):
+        step_hidden = z[:, index, :]
+        correction = embed_proj(torch.cat((step_hidden, gru_hidden[0]), dim=-1))
+        next_ids = torch.argmax(base_logits(step_hidden) + correction, dim=-1).to(
+            torch.long
+        )
+        proposals.append(next_ids)
+        if index + 1 < num_proposals:
+            _, gru_hidden = prefix_gru(target_embedding(next_ids[:, None]), gru_hidden)
+
+    return torch.stack(proposals, dim=1)

--- a/python/sglang/srt/speculative/domino_utils.py
+++ b/python/sglang/srt/speculative/domino_utils.py
@@ -4,6 +4,8 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+_DOMINO_CANDIDATE_POOL_SIZE = 2048
+
 
 def _domino_gru_cell(
     prefix_gru: nn.GRU, input: torch.Tensor, hidden: torch.Tensor
@@ -118,8 +120,9 @@ def domino_greedy_rollout(
     embed_proj: nn.Sequential,
     vocab_size: int,
     shift_label: bool,
+    candidate_pool_size: int = _DOMINO_CANDIDATE_POOL_SIZE,
 ) -> torch.Tensor:
-    """Generate a Domino chain with native GRU and full-vocabulary greedy logits."""
+    """Generate a Domino chain using one block-shared base-logit candidate pool."""
     if draft_hidden.ndim != 3:
         raise ValueError(
             f"draft_hidden must have shape [batch, block, hidden], got {tuple(draft_hidden.shape)}."
@@ -133,6 +136,13 @@ def domino_greedy_rollout(
     num_proposals = int(block_size) - 1
     if num_proposals < 1:
         raise ValueError(f"Domino requires block_size > 1, got {block_size}.")
+    candidate_pool_size = int(candidate_pool_size)
+    if candidate_pool_size < 0:
+        raise ValueError(
+            "Domino candidate_pool_size must be non-negative, "
+            f"got {candidate_pool_size}."
+        )
+    candidate_pool_size = min(candidate_pool_size, int(vocab_size))
     start = 0 if shift_label else 1
     z = draft_hidden[:, start : start + num_proposals, :]
     if int(z.shape[1]) != num_proposals:
@@ -154,13 +164,47 @@ def domino_greedy_rollout(
     if num_proposals == 1:
         return first_ids[:, None]
 
+    candidate_ids = None
+    candidate_base = None
+    candidate_weight = None
+    if 0 < candidate_pool_size < int(vocab_size):
+        feedback_logits = base_logits[1:]
+        candidate_ids = torch.topk(
+            feedback_logits.amax(dim=0),
+            k=candidate_pool_size,
+            dim=-1,
+            sorted=False,
+        ).indices.contiguous()
+        candidate_base = torch.gather(
+            feedback_logits.transpose(0, 1),
+            2,
+            candidate_ids[:, None, :].expand(-1, num_proposals - 1, -1),
+        ).transpose(0, 1)
+        candidate_weight = F.embedding(candidate_ids, embed_proj[2].weight)
+
     prefix_ids = torch.stack((verified_ids, first_ids), dim=1)
     _, gru_hidden = prefix_gru(target_embedding(prefix_ids))
 
     for index in range(1, num_proposals):
         step_hidden = z[:, index, :]
-        correction = embed_proj(torch.cat((step_hidden, gru_hidden[0]), dim=-1))
-        next_ids = torch.argmax(base_logits[index] + correction, dim=-1).to(torch.long)
+        correction_hidden = embed_proj[1](
+            embed_proj[0](torch.cat((step_hidden, gru_hidden[0]), dim=-1))
+        )
+        if candidate_ids is None:
+            correction = embed_proj[2](correction_hidden)
+            next_ids = torch.argmax(base_logits[index] + correction, dim=-1).to(
+                torch.long
+            )
+        else:
+            correction = torch.bmm(
+                candidate_weight, correction_hidden.unsqueeze(-1)
+            ).squeeze(-1)
+            candidate_position = torch.argmax(
+                candidate_base[index - 1] + correction, dim=-1
+            )
+            next_ids = torch.gather(
+                candidate_ids, 1, candidate_position[:, None]
+            ).squeeze(1)
         proposals.append(next_ids)
         if index + 1 < num_proposals:
             gru_hidden = _domino_gru_cell(

--- a/python/sglang/srt/speculative/domino_utils.py
+++ b/python/sglang/srt/speculative/domino_utils.py
@@ -4,6 +4,8 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+_DOMINO_CANDIDATE_POOL_SIZE = 2048
+
 
 def validate_domino_runtime(
     *,
@@ -104,8 +106,9 @@ def domino_greedy_rollout(
     embed_proj: nn.Sequential,
     vocab_size: int,
     shift_label: bool,
+    candidate_pool_size: int = _DOMINO_CANDIDATE_POOL_SIZE,
 ) -> torch.Tensor:
-    """Generate a Domino chain with native GRU and full-vocabulary greedy logits."""
+    """Generate a Domino chain using one block-shared base-logit candidate pool."""
     if draft_hidden.ndim != 3:
         raise ValueError(
             f"draft_hidden must have shape [batch, block, hidden], got {tuple(draft_hidden.shape)}."
@@ -119,6 +122,13 @@ def domino_greedy_rollout(
     num_proposals = int(block_size) - 1
     if num_proposals < 1:
         raise ValueError(f"Domino requires block_size > 1, got {block_size}.")
+    candidate_pool_size = int(candidate_pool_size)
+    if candidate_pool_size < 0:
+        raise ValueError(
+            "Domino candidate_pool_size must be non-negative, "
+            f"got {candidate_pool_size}."
+        )
+    candidate_pool_size = min(candidate_pool_size, int(vocab_size))
     start = 0 if shift_label else 1
     z = draft_hidden[:, start : start + num_proposals, :]
     if int(z.shape[1]) != num_proposals:
@@ -140,13 +150,47 @@ def domino_greedy_rollout(
     if num_proposals == 1:
         return first_ids[:, None]
 
+    candidate_ids = None
+    candidate_base = None
+    candidate_weight = None
+    if 0 < candidate_pool_size < int(vocab_size):
+        feedback_logits = base_logits[1:]
+        candidate_ids = torch.topk(
+            feedback_logits.amax(dim=0),
+            k=candidate_pool_size,
+            dim=-1,
+            sorted=False,
+        ).indices.contiguous()
+        candidate_base = torch.gather(
+            feedback_logits.transpose(0, 1),
+            2,
+            candidate_ids[:, None, :].expand(-1, num_proposals - 1, -1),
+        ).transpose(0, 1)
+        candidate_weight = F.embedding(candidate_ids, embed_proj[2].weight)
+
     prefix_ids = torch.stack((verified_ids, first_ids), dim=1)
     _, gru_hidden = prefix_gru(target_embedding(prefix_ids))
 
     for index in range(1, num_proposals):
         step_hidden = z[:, index, :]
-        correction = embed_proj(torch.cat((step_hidden, gru_hidden[0]), dim=-1))
-        next_ids = torch.argmax(base_logits[index] + correction, dim=-1).to(torch.long)
+        correction_hidden = embed_proj[1](
+            embed_proj[0](torch.cat((step_hidden, gru_hidden[0]), dim=-1))
+        )
+        if candidate_ids is None:
+            correction = embed_proj[2](correction_hidden)
+            next_ids = torch.argmax(base_logits[index] + correction, dim=-1).to(
+                torch.long
+            )
+        else:
+            correction = torch.bmm(
+                candidate_weight, correction_hidden.unsqueeze(-1)
+            ).squeeze(-1)
+            candidate_position = torch.argmax(
+                candidate_base[index - 1] + correction, dim=-1
+            )
+            next_ids = torch.gather(
+                candidate_ids, 1, candidate_position[:, None]
+            ).squeeze(1)
         proposals.append(next_ids)
         if index + 1 < num_proposals:
             _, gru_hidden = prefix_gru(target_embedding(next_ids[:, None]), gru_hidden)

--- a/test/registered/spec/dflash/test_dflash_domino.py
+++ b/test/registered/spec/dflash/test_dflash_domino.py
@@ -1,0 +1,65 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    kill_process_tree,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=360, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestDFlashDomino(CustomTestCase, GSM8KMixin):
+    model = "Qwen/Qwen3-8B"
+    draft_model = "Huang2020/Qwen3-8B-Domino-b16"
+    gsm8k_score_threshold = 0.90
+    gsm8k_num_examples = 200
+    gsm8k_accept_length_thres = 4.0
+    gsm8k_num_threads = 128
+    gsm8k_num_shots = 5
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--dtype",
+                "bfloat16",
+                "--tp-size",
+                "1",
+                "--attention-backend",
+                "triton",
+                "--speculative-algorithm",
+                "DFLASH",
+                "--speculative-draft-model-path",
+                cls.draft_model,
+                "--speculative-draft-attention-backend",
+                "triton",
+                "--cuda-graph-backend-decode",
+                "disabled",
+                "--cuda-graph-backend-prefill",
+                "disabled",
+                "--disable-overlap-schedule",
+                "--max-running-requests",
+                "64",
+                "--mem-fraction-static",
+                "0.7",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_domino.py
+++ b/test/registered/unit/spec/test_dflash_domino.py
@@ -203,7 +203,9 @@ class TestDFlashDominoRollout(CustomTestCase):
             dtype=self.dtype,
         )
 
-    def _oracle(self, draft_hidden, verified_ids, shift_label):
+    def _oracle(
+        self, draft_hidden, verified_ids, shift_label, candidate_pool_size=None
+    ):
         num_proposals = draft_hidden.shape[1] - 1
         start = 0 if shift_label else 1
         z = draft_hidden[:, start : start + num_proposals]
@@ -213,11 +215,45 @@ class TestDFlashDominoRollout(CustomTestCase):
         if num_proposals == 1:
             return first_ids[:, None]
 
+        candidate_ids = None
+        candidate_base = None
+        candidate_weight = None
+        if candidate_pool_size is not None:
+            candidate_pool_size = min(candidate_pool_size, self.vocab_size)
+            if 0 < candidate_pool_size < self.vocab_size:
+                feedback_logits = base_logits[:, 1:]
+                candidate_ids = torch.topk(
+                    feedback_logits.amax(dim=1),
+                    k=candidate_pool_size,
+                    dim=-1,
+                    sorted=False,
+                ).indices
+                candidate_base = torch.gather(
+                    feedback_logits,
+                    2,
+                    candidate_ids[:, None, :].expand(-1, num_proposals - 1, -1),
+                )
+                candidate_weight = F.embedding(candidate_ids, self.embed_proj[2].weight)
+
         prefix_ids = torch.cat((verified_ids[:, None], first_ids[:, None]), dim=1)
         _, state = self.prefix_gru(self.embedding(prefix_ids))
         for index in range(1, num_proposals):
-            bias = self.embed_proj(torch.cat((z[:, index], state[0]), dim=-1))
-            next_ids = torch.argmax(base_logits[:, index] + bias, dim=-1)
+            correction_hidden = self.embed_proj[1](
+                self.embed_proj[0](torch.cat((z[:, index], state[0]), dim=-1))
+            )
+            if candidate_ids is None:
+                bias = self.embed_proj[2](correction_hidden)
+                next_ids = torch.argmax(base_logits[:, index] + bias, dim=-1)
+            else:
+                bias = torch.bmm(
+                    candidate_weight, correction_hidden.unsqueeze(-1)
+                ).squeeze(-1)
+                candidate_position = torch.argmax(
+                    candidate_base[:, index - 1] + bias, dim=-1
+                )
+                next_ids = torch.gather(
+                    candidate_ids, 1, candidate_position[:, None]
+                ).squeeze(1)
             output.append(next_ids)
             if index + 1 < num_proposals:
                 _, state = self.prefix_gru(self.embedding(next_ids[:, None]), state)
@@ -259,38 +295,112 @@ class TestDFlashDominoRollout(CustomTestCase):
                         actual[:, 0], first_expected, rtol=0, atol=0
                     )
 
-    def test_batch_rollout_matches_each_individual_row(self):
+    def test_block_candidate_pool_matches_oracle(self):
+        block_size = 7
         draft_hidden = torch.randn(
-            3, 7, self.hidden_size, device=self.device, dtype=self.dtype
+            3,
+            block_size,
+            self.hidden_size,
+            device=self.device,
+            dtype=self.dtype,
         )
         verified_ids = torch.tensor([1, 4, 9], device=self.device)
-        batched = domino_greedy_rollout(
-            draft_hidden=draft_hidden,
-            verified_ids=verified_ids,
-            target_embedding=self.embedding,
-            lm_head_weight=self.lm_head_weight,
-            prefix_gru=self.prefix_gru,
-            embed_proj=self.embed_proj,
-            vocab_size=self.vocab_size,
-            shift_label=True,
+        for shift_label in (True, False):
+            with self.subTest(shift_label=shift_label):
+                actual = domino_greedy_rollout(
+                    draft_hidden=draft_hidden,
+                    verified_ids=verified_ids,
+                    target_embedding=self.embedding,
+                    lm_head_weight=self.lm_head_weight,
+                    prefix_gru=self.prefix_gru,
+                    embed_proj=self.embed_proj,
+                    vocab_size=self.vocab_size,
+                    shift_label=shift_label,
+                    candidate_pool_size=5,
+                )
+                expected = self._oracle(
+                    draft_hidden,
+                    verified_ids,
+                    shift_label=shift_label,
+                    candidate_pool_size=5,
+                )
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                first_hidden = draft_hidden[:, 0 if shift_label else 1]
+                first_expected = torch.argmax(
+                    F.linear(first_hidden, self.lm_head_weight), dim=-1
+                )
+                torch.testing.assert_close(actual[:, 0], first_expected, rtol=0, atol=0)
+
+    def test_candidate_pool_boundaries(self):
+        draft_hidden = torch.randn(
+            2, 7, self.hidden_size, device=self.device, dtype=self.dtype
         )
-        individual = torch.cat(
-            [
-                domino_greedy_rollout(
-                    draft_hidden=draft_hidden[index : index + 1],
-                    verified_ids=verified_ids[index : index + 1],
+        verified_ids = torch.tensor([2, 7], device=self.device)
+        expected = self._oracle(draft_hidden, verified_ids, shift_label=True)
+        for candidate_pool_size in (0, self.vocab_size, self.vocab_size + 1):
+            with self.subTest(candidate_pool_size=candidate_pool_size):
+                actual = domino_greedy_rollout(
+                    draft_hidden=draft_hidden,
+                    verified_ids=verified_ids,
                     target_embedding=self.embedding,
                     lm_head_weight=self.lm_head_weight,
                     prefix_gru=self.prefix_gru,
                     embed_proj=self.embed_proj,
                     vocab_size=self.vocab_size,
                     shift_label=True,
+                    candidate_pool_size=candidate_pool_size,
                 )
-                for index in range(3)
-            ],
-            dim=0,
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            domino_greedy_rollout(
+                draft_hidden=draft_hidden,
+                verified_ids=verified_ids,
+                target_embedding=self.embedding,
+                lm_head_weight=self.lm_head_weight,
+                prefix_gru=self.prefix_gru,
+                embed_proj=self.embed_proj,
+                vocab_size=self.vocab_size,
+                shift_label=True,
+                candidate_pool_size=-1,
+            )
+
+    def test_batch_rollout_matches_each_individual_row(self):
+        draft_hidden = torch.randn(
+            3, 7, self.hidden_size, device=self.device, dtype=self.dtype
         )
-        torch.testing.assert_close(batched, individual, rtol=0, atol=0)
+        verified_ids = torch.tensor([1, 4, 9], device=self.device)
+        for candidate_pool_size in (0, 5):
+            with self.subTest(candidate_pool_size=candidate_pool_size):
+                batched = domino_greedy_rollout(
+                    draft_hidden=draft_hidden,
+                    verified_ids=verified_ids,
+                    target_embedding=self.embedding,
+                    lm_head_weight=self.lm_head_weight,
+                    prefix_gru=self.prefix_gru,
+                    embed_proj=self.embed_proj,
+                    vocab_size=self.vocab_size,
+                    shift_label=True,
+                    candidate_pool_size=candidate_pool_size,
+                )
+                individual = torch.cat(
+                    [
+                        domino_greedy_rollout(
+                            draft_hidden=draft_hidden[index : index + 1],
+                            verified_ids=verified_ids[index : index + 1],
+                            target_embedding=self.embedding,
+                            lm_head_weight=self.lm_head_weight,
+                            prefix_gru=self.prefix_gru,
+                            embed_proj=self.embed_proj,
+                            vocab_size=self.vocab_size,
+                            shift_label=True,
+                            candidate_pool_size=candidate_pool_size,
+                        )
+                        for index in range(3)
+                    ],
+                    dim=0,
+                )
+                torch.testing.assert_close(batched, individual, rtol=0, atol=0)
 
     def test_capture_sampler_matches_eager_rollout(self):
         from sglang.srt.speculative.dflash_worker_v2 import _DominoDraftSampler
@@ -323,6 +433,7 @@ class TestDFlashDominoRollout(CustomTestCase):
                     block_size=block_size,
                     shift_label=shift_label,
                     max_bs=batch_size,
+                    candidate_pool_size=5,
                 )
                 sampler(draft_hidden.reshape(-1, self.hidden_size), block_ids.flatten())
                 expected = domino_greedy_rollout(
@@ -334,11 +445,55 @@ class TestDFlashDominoRollout(CustomTestCase):
                     embed_proj=self.embed_proj,
                     vocab_size=self.vocab_size,
                     shift_label=shift_label,
+                    candidate_pool_size=5,
                 )
                 actual = sampler.out[: batch_size * (block_size - 1)].view(
                     batch_size, block_size - 1
                 )
                 torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_candidate_pool_cuda_graph_replay(self):
+        block_size = 7
+        batch_size = 3
+        static_hidden = torch.randn(
+            batch_size,
+            block_size,
+            self.hidden_size,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        static_ids = torch.tensor([1, 4, 9], device=self.device)
+
+        def rollout():
+            return domino_greedy_rollout(
+                draft_hidden=static_hidden,
+                verified_ids=static_ids,
+                target_embedding=self.embedding,
+                lm_head_weight=self.lm_head_weight,
+                prefix_gru=self.prefix_gru,
+                embed_proj=self.embed_proj,
+                vocab_size=self.vocab_size,
+                shift_label=True,
+                candidate_pool_size=5,
+            )
+
+        rollout()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = rollout()
+
+        static_hidden.copy_(torch.randn_like(static_hidden))
+        static_ids.copy_(torch.tensor([2, 7, 11], device=self.device))
+        expected = self._oracle(
+            static_hidden,
+            static_ids,
+            shift_label=True,
+            candidate_pool_size=5,
+        )
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
     def test_capture_sampler_replays_with_new_inputs(self):
@@ -355,6 +510,7 @@ class TestDFlashDominoRollout(CustomTestCase):
             block_size=block_size,
             shift_label=True,
             max_bs=batch_size,
+            candidate_pool_size=5,
         )
         static_hidden = torch.randn(
             batch_size * block_size,
@@ -395,6 +551,7 @@ class TestDFlashDominoRollout(CustomTestCase):
             embed_proj=self.embed_proj,
             vocab_size=self.vocab_size,
             shift_label=True,
+            candidate_pool_size=5,
         )
         graph.replay()
         torch.cuda.synchronize()

--- a/test/registered/unit/spec/test_dflash_domino.py
+++ b/test/registered/unit/spec/test_dflash_domino.py
@@ -292,6 +292,118 @@ class TestDFlashDominoRollout(CustomTestCase):
         )
         torch.testing.assert_close(batched, individual, rtol=0, atol=0)
 
+    def test_capture_sampler_matches_eager_rollout(self):
+        from sglang.srt.speculative.dflash_worker_v2 import _DominoDraftSampler
+
+        block_size = 7
+        batch_size = 3
+        for shift_label in (True, False):
+            with self.subTest(shift_label=shift_label):
+                draft_hidden = torch.randn(
+                    batch_size,
+                    block_size,
+                    self.hidden_size,
+                    device=self.device,
+                    dtype=self.dtype,
+                )
+                verified_ids = torch.tensor([1, 4, 9], device=self.device)
+                block_ids = torch.zeros(
+                    batch_size,
+                    block_size,
+                    device=self.device,
+                    dtype=torch.long,
+                )
+                block_ids[:, 0].copy_(verified_ids)
+                sampler = _DominoDraftSampler(
+                    target_embedding=self.embedding,
+                    lm_head_weight=self.lm_head_weight,
+                    prefix_gru=self.prefix_gru,
+                    embed_proj=self.embed_proj,
+                    vocab_size=self.vocab_size,
+                    block_size=block_size,
+                    shift_label=shift_label,
+                    max_bs=batch_size,
+                )
+                sampler(draft_hidden.reshape(-1, self.hidden_size), block_ids.flatten())
+                expected = domino_greedy_rollout(
+                    draft_hidden=draft_hidden,
+                    verified_ids=verified_ids,
+                    target_embedding=self.embedding,
+                    lm_head_weight=self.lm_head_weight,
+                    prefix_gru=self.prefix_gru,
+                    embed_proj=self.embed_proj,
+                    vocab_size=self.vocab_size,
+                    shift_label=shift_label,
+                )
+                actual = sampler.out[: batch_size * (block_size - 1)].view(
+                    batch_size, block_size - 1
+                )
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_capture_sampler_replays_with_new_inputs(self):
+        from sglang.srt.speculative.dflash_worker_v2 import _DominoDraftSampler
+
+        block_size = 4
+        batch_size = 2
+        sampler = _DominoDraftSampler(
+            target_embedding=self.embedding,
+            lm_head_weight=self.lm_head_weight,
+            prefix_gru=self.prefix_gru,
+            embed_proj=self.embed_proj,
+            vocab_size=self.vocab_size,
+            block_size=block_size,
+            shift_label=True,
+            max_bs=batch_size,
+        )
+        static_hidden = torch.randn(
+            batch_size * block_size,
+            self.hidden_size,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        static_ids = torch.zeros(
+            batch_size * block_size, device=self.device, dtype=torch.long
+        )
+        static_ids.view(batch_size, block_size)[:, 0].copy_(
+            torch.tensor([2, 7], device=self.device)
+        )
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            sampler(static_hidden, static_ids)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            sampler(static_hidden, static_ids)
+
+        new_hidden = torch.randn_like(static_hidden)
+        new_ids = torch.zeros_like(static_ids)
+        new_ids.view(batch_size, block_size)[:, 0].copy_(
+            torch.tensor([3, 11], device=self.device)
+        )
+        static_hidden.copy_(new_hidden)
+        static_ids.copy_(new_ids)
+        expected = domino_greedy_rollout(
+            draft_hidden=new_hidden.view(batch_size, block_size, self.hidden_size),
+            verified_ids=new_ids.view(batch_size, block_size)[:, 0],
+            target_embedding=self.embedding,
+            lm_head_weight=self.lm_head_weight,
+            prefix_gru=self.prefix_gru,
+            embed_proj=self.embed_proj,
+            vocab_size=self.vocab_size,
+            shift_label=True,
+        )
+        graph.replay()
+        torch.cuda.synchronize()
+
+        actual = sampler.out[: batch_size * (block_size - 1)].view(
+            batch_size, block_size - 1
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
 
 class TestDFlashDominoRuntimeValidation(CustomTestCase):
     def _modules(self, dtype=torch.bfloat16):

--- a/test/registered/unit/spec/test_dflash_domino.py
+++ b/test/registered/unit/spec/test_dflash_domino.py
@@ -1,0 +1,357 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang.srt.models.dflash import DFlashDraftModel
+from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
+from sglang.srt.speculative.domino_utils import (
+    domino_greedy_rollout,
+    validate_domino_runtime,
+)
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+def _domino_config(**overrides):
+    dflash_config = {
+        "projector_type": "domino",
+        "mask_token_id": 29,
+        "shift_label": True,
+        "target_layer_ids": [1, 3],
+        "pure_draft_prefix_len": 1,
+        "gru_hidden_dim": 4,
+        "emb_dim": 5,
+    }
+    dflash_config.update(overrides.pop("dflash_config", {}))
+    fields = {
+        "num_hidden_layers": 2,
+        "num_target_layers": 4,
+        "block_size": 16,
+        "hidden_size": 8,
+        "vocab_size": 31,
+        "emb_dim": 5,
+        "dflash_config": dflash_config,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _projector_model(projector_type="domino"):
+    model = DFlashDraftModel.__new__(DFlashDraftModel)
+    nn.Module.__init__(model)
+    model.projector_type = projector_type
+    model.config = SimpleNamespace(hidden_size=8)
+    if projector_type == "domino":
+        model.prefix_gru = nn.GRU(8, 4, batch_first=True, bias=False)
+        model.embed_proj = nn.Sequential(
+            nn.Linear(12, 5, bias=False),
+            nn.SiLU(),
+            nn.Linear(5, 31, bias=False),
+        )
+    else:
+        model.prefix_gru = None
+        model.embed_proj = None
+    return model
+
+
+def _projector_weights(model):
+    return {
+        "prefix_gru.weight_ih_l0": torch.randn_like(model.prefix_gru.weight_ih_l0),
+        "prefix_gru.weight_hh_l0": torch.randn_like(model.prefix_gru.weight_hh_l0),
+        "embed_proj.0.weight": torch.randn_like(model.embed_proj[0].weight),
+        "embed_proj.2.weight": torch.randn_like(model.embed_proj[2].weight),
+    }
+
+
+class TestDFlashDominoConfig(CustomTestCase):
+    def test_public_config_fields(self):
+        parsed = parse_dflash_draft_config(draft_hf_config=_domino_config())
+        self.assertTrue(parsed.is_domino)
+        self.assertTrue(parsed.shift_label)
+        self.assertEqual(parsed.pure_draft_prefix_len, 1)
+        self.assertEqual(parsed.gru_hidden_dim, 4)
+        self.assertEqual(parsed.emb_dim, 5)
+        self.assertEqual(parsed.block_size, 16)
+
+    def test_top_level_emb_dim_fallback(self):
+        config = _domino_config()
+        del config.dflash_config["emb_dim"]
+        self.assertEqual(parse_dflash_draft_config(draft_hf_config=config).emb_dim, 5)
+
+    def test_plain_dflash_and_other_projectors_are_unchanged(self):
+        for projector_type in (None, "linear", "dspark"):
+            with self.subTest(projector_type=projector_type):
+                config = _domino_config(
+                    dflash_config={
+                        "projector_type": projector_type,
+                        "shift_label": None,
+                        "pure_draft_prefix_len": None,
+                        "gru_hidden_dim": None,
+                        "emb_dim": None,
+                    },
+                    emb_dim=None,
+                )
+                parsed = parse_dflash_draft_config(draft_hf_config=config)
+                self.assertFalse(parsed.is_domino)
+
+    def test_invalid_domino_config_fails_fast(self):
+        cases = {
+            "shift_label": {"shift_label": 1},
+            "pure_draft_prefix_len": {"pure_draft_prefix_len": 2},
+            "gru_hidden_dim": {"gru_hidden_dim": None},
+        }
+        for expected, updates in cases.items():
+            with self.subTest(expected=expected):
+                with self.assertRaisesRegex(ValueError, expected):
+                    parse_dflash_draft_config(
+                        draft_hf_config=_domino_config(dflash_config=updates)
+                    )
+
+        config = _domino_config(dflash_config={"emb_dim": None}, emb_dim=None)
+        with self.assertRaisesRegex(ValueError, "emb_dim"):
+            parse_dflash_draft_config(draft_hf_config=config)
+
+        with self.assertRaisesRegex(ValueError, "block_size > 1"):
+            parse_dflash_draft_config(draft_hf_config=_domino_config(block_size=1))
+
+    def test_conflicting_emb_dim_fails(self):
+        with self.assertRaisesRegex(ValueError, "emb_dim differs"):
+            parse_dflash_draft_config(draft_hf_config=_domino_config(emb_dim=6))
+
+
+class TestDFlashDominoWeights(CustomTestCase):
+    def test_projector_weights_load_exactly(self):
+        model = _projector_model()
+        weights = _projector_weights(model)
+        model.load_weights(weights.items())
+        for name, expected in weights.items():
+            torch.testing.assert_close(
+                dict(model.named_parameters())[name], expected, rtol=0, atol=0
+            )
+
+    def test_each_required_projector_weight_is_checked(self):
+        for missing_name in _projector_weights(_projector_model()):
+            with self.subTest(missing_name=missing_name):
+                model = _projector_model()
+                weights = _projector_weights(model)
+                del weights[missing_name]
+                with self.assertRaisesRegex(ValueError, missing_name):
+                    model.load_weights(weights.items())
+
+    def test_projector_shape_mismatch_fails(self):
+        model = _projector_model()
+        weights = _projector_weights(model)
+        weights["embed_proj.2.weight"] = torch.empty(30, 5)
+        with self.assertRaisesRegex(ValueError, "shape mismatch"):
+            model.load_weights(weights.items())
+
+    def test_plain_dflash_does_not_require_projector_weights(self):
+        _projector_model(projector_type=None).load_weights([])
+
+    def test_projector_weights_require_domino_config(self):
+        model = _projector_model(projector_type="domnio")
+        with self.assertRaisesRegex(ValueError, "projector_type"):
+            model.load_weights([("prefix_gru.weight_ih_l0", torch.empty(12, 8))])
+
+
+class TestDFlashDominoRollout(CustomTestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.dtype = torch.bfloat16 if self.device.type == "cuda" else torch.float32
+        self.hidden_size = 8
+        self.gru_hidden_size = 4
+        self.vocab_size = 31
+        self.embedding = nn.Embedding(
+            self.vocab_size, self.hidden_size, device=self.device, dtype=self.dtype
+        )
+        self.prefix_gru = nn.GRU(
+            self.hidden_size,
+            self.gru_hidden_size,
+            batch_first=True,
+            bias=False,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        self.embed_proj = nn.Sequential(
+            nn.Linear(
+                self.hidden_size + self.gru_hidden_size,
+                5,
+                bias=False,
+                device=self.device,
+                dtype=self.dtype,
+            ),
+            nn.SiLU(),
+            nn.Linear(
+                5,
+                self.vocab_size,
+                bias=False,
+                device=self.device,
+                dtype=self.dtype,
+            ),
+        )
+        self.lm_head_weight = torch.randn(
+            self.vocab_size,
+            self.hidden_size,
+            device=self.device,
+            dtype=self.dtype,
+        )
+
+    def _oracle(self, draft_hidden, verified_ids, shift_label):
+        num_proposals = draft_hidden.shape[1] - 1
+        start = 0 if shift_label else 1
+        z = draft_hidden[:, start : start + num_proposals]
+        base_logits = F.linear(z, self.lm_head_weight)
+        first_ids = torch.argmax(base_logits[:, 0], dim=-1)
+        output = [first_ids]
+        if num_proposals == 1:
+            return first_ids[:, None]
+
+        prefix_ids = torch.cat((verified_ids[:, None], first_ids[:, None]), dim=1)
+        _, state = self.prefix_gru(self.embedding(prefix_ids))
+        for index in range(1, num_proposals):
+            bias = self.embed_proj(torch.cat((z[:, index], state[0]), dim=-1))
+            next_ids = torch.argmax(base_logits[:, index] + bias, dim=-1)
+            output.append(next_ids)
+            if index + 1 < num_proposals:
+                _, state = self.prefix_gru(self.embedding(next_ids[:, None]), state)
+        return torch.stack(output, dim=1)
+
+    def test_full_chain_matches_native_oracle(self):
+        for block_size in (2, 16):
+            for shift_label in (True, False):
+                with self.subTest(block_size=block_size, shift_label=shift_label):
+                    draft_hidden = torch.randn(
+                        2,
+                        block_size,
+                        self.hidden_size,
+                        device=self.device,
+                        dtype=self.dtype,
+                    )
+                    verified_ids = torch.tensor([2, 7], device=self.device)
+                    actual = domino_greedy_rollout(
+                        draft_hidden=draft_hidden,
+                        verified_ids=verified_ids,
+                        target_embedding=self.embedding,
+                        lm_head_weight=self.lm_head_weight,
+                        prefix_gru=self.prefix_gru,
+                        embed_proj=self.embed_proj,
+                        vocab_size=self.vocab_size,
+                        shift_label=shift_label,
+                    )
+                    expected = self._oracle(
+                        draft_hidden, verified_ids, shift_label=shift_label
+                    )
+                    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                    self.assertEqual(actual.shape, (2, block_size - 1))
+
+                    first_hidden = draft_hidden[:, 0 if shift_label else 1]
+                    first_expected = torch.argmax(
+                        F.linear(first_hidden, self.lm_head_weight), dim=-1
+                    )
+                    torch.testing.assert_close(
+                        actual[:, 0], first_expected, rtol=0, atol=0
+                    )
+
+    def test_batch_rollout_matches_each_individual_row(self):
+        draft_hidden = torch.randn(
+            3, 7, self.hidden_size, device=self.device, dtype=self.dtype
+        )
+        verified_ids = torch.tensor([1, 4, 9], device=self.device)
+        batched = domino_greedy_rollout(
+            draft_hidden=draft_hidden,
+            verified_ids=verified_ids,
+            target_embedding=self.embedding,
+            lm_head_weight=self.lm_head_weight,
+            prefix_gru=self.prefix_gru,
+            embed_proj=self.embed_proj,
+            vocab_size=self.vocab_size,
+            shift_label=True,
+        )
+        individual = torch.cat(
+            [
+                domino_greedy_rollout(
+                    draft_hidden=draft_hidden[index : index + 1],
+                    verified_ids=verified_ids[index : index + 1],
+                    target_embedding=self.embedding,
+                    lm_head_weight=self.lm_head_weight,
+                    prefix_gru=self.prefix_gru,
+                    embed_proj=self.embed_proj,
+                    vocab_size=self.vocab_size,
+                    shift_label=True,
+                )
+                for index in range(3)
+            ],
+            dim=0,
+        )
+        torch.testing.assert_close(batched, individual, rtol=0, atol=0)
+
+
+class TestDFlashDominoRuntimeValidation(CustomTestCase):
+    def _modules(self, dtype=torch.bfloat16):
+        embedding = nn.Embedding(31, 8, dtype=dtype)
+        lm_head = nn.Linear(8, 31, bias=False, dtype=dtype)
+        prefix_gru = nn.GRU(8, 4, batch_first=True, bias=False, dtype=dtype)
+        embed_proj = nn.Sequential(
+            nn.Linear(12, 5, bias=False, dtype=dtype),
+            nn.SiLU(),
+            nn.Linear(5, 31, bias=False, dtype=dtype),
+        )
+        return embedding, lm_head, prefix_gru, embed_proj
+
+    def _validate(self, **overrides):
+        embedding, lm_head, prefix_gru, embed_proj = overrides.pop(
+            "modules", self._modules()
+        )
+        args = {
+            "device": torch.device("cuda"),
+            "tp_size": 1,
+            "target_vocab_size": 31,
+            "draft_vocab_size": 31,
+            "hidden_size": 8,
+            "target_embedding": embedding,
+            "lm_head": lm_head,
+            "prefix_gru": prefix_gru,
+            "embed_proj": embed_proj,
+        }
+        args.update(overrides)
+        validate_domino_runtime(**args)
+
+    def test_supported_runtime(self):
+        self._validate()
+
+    def test_tp_and_vocab_mismatches_fail(self):
+        with self.assertRaisesRegex(ValueError, "TP=1"):
+            self._validate(tp_size=2)
+        with self.assertRaisesRegex(ValueError, "identical target and draft"):
+            self._validate(draft_vocab_size=30)
+
+    def test_added_vocab_fails(self):
+        modules = self._modules()
+        modules[1].shard_indices = SimpleNamespace(
+            num_added_elements=1,
+            org_vocab_start_index=0,
+            num_org_elements=31,
+        )
+        with self.assertRaisesRegex(ValueError, "added-vocab"):
+            self._validate(modules=modules)
+
+    def test_embedding_vocab_mismatch_fails(self):
+        _, lm_head, prefix_gru, embed_proj = self._modules()
+        embedding = nn.Embedding(30, 8, dtype=torch.bfloat16)
+        with self.assertRaisesRegex(ValueError, "fewer rows"):
+            self._validate(modules=(embedding, lm_head, prefix_gru, embed_proj))
+
+    def test_non_bf16_fails(self):
+        with self.assertRaisesRegex(ValueError, "BF16"):
+            self._validate(modules=self._modules(dtype=torch.float32))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds Domino projector support to the current DFlash V2 worker for the
public `Huang2020/Qwen3-8B-Domino-b16` checkpoint. It reuses SGLang's existing
target
verification, continuous-prefix acceptance, bonus-token handling, and KV-cache
commit paths unchanged.

The implementation is independent of the earlier integration in #28998 and is
based on the public Domino reference and the current DFlash V2 interfaces.
Addresses #28977 and #29511.

## Design

- Parse, validate, instantiate, and strictly load the checkpoint-native
  bias-free prefix GRU and two-layer SiLU correction projector.
- Generate 15 proposals for the public block-size-16 checkpoint. The first is
  the full-vocabulary DFlash argmax; the GRU is initialized with
  `[verified_token, first_proposal]`, and every realized proposal is fed back
  before the next correction step.
- Keep the base LM-head projection full-vocabulary. Correction scoring uses one
  per-request, block-shared candidate pool with `K=2048` by default; set
  `--speculative-domino-candidate-pool-size 0` for full-vocabulary correction.
- Use native `nn.GRU` for the two-token prefix and ATen `GRUCell` for the 13
  one-token feedback updates.
- Capture the complete rollout in the existing DFlash draft CUDA Graph, with an
  eager fallback when the graph is disabled or unavailable.

The four performance changes are documented separately:

1. [Perf 1: step-major base-logit precompute](https://github.com/sgl-project/sglang/pull/31328#issuecomment-5031396465)
2. [Perf 2: full rollout CUDA Graph](https://github.com/sgl-project/sglang/pull/31328#issuecomment-5035209078)
3. [Perf 3: GRUCell feedback](https://github.com/sgl-project/sglang/pull/31328#issuecomment-5035756608)
4. [Perf 4: block-shared K2048 candidate pool](https://github.com/sgl-project/sglang/pull/31328#issuecomment-5035759488)

## Supported and numerical scope

- Tested scope: A100 80GB, CUDA, BF16, TP=1 for Qwen3-8B,
  `pure_draft_prefix_len=1`, and block size 16.
- Graph results cover exact capture batch shapes with
  `--disable-cuda-graph-padding`. Padded replay is not claimed.
- ATen GRUCell and cuDNN GRU use different BF16 operation orderings, so their
  proposal tokens are not generally bit-exact.
- `K=2048` is an approximate search for the correction argmax. Target
  verification is unchanged, but the observed K2048-versus-K0 output parity is
  limited to the fixed workloads reported below; it is not a general
  equivalence guarantee.

## Validation

- Registered eager GSM8K-200 gate with public models/data: score `0.950`, average
  speculative acceptance length `4.5544` (gates: `>=0.90` and `>4.0`).
- Exact-shape Perf 1 versus Perf 2 graph A/B: GSM8K-200 score `0.950` in both
  arms and `0/208` fixed-512 ShareGPT text mismatches.
- Perf 3 eager versus exact-shape graph replay: `0/21,900` proposal mismatches
  over 20 random trials per batch. GSM8K-200 remained `0.950`.
- Perf 4 K2048 versus full-vocabulary K0: GSM8K-32 matched `32/32` output-ID
  sequences with acceptance length `4.7975`; ShareGPT C32 matched `128/128`
  texts with acceptance length `3.7980`.
- Focused config, weight-loading, runtime validation, full-chain, batch
  independence, candidate-pool, sampler, and CUDA Graph replay tests:
  `22 passed`, `23 subtests passed`.

```bash
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=python \
python3 -m pytest -q -s \
  test/registered/spec/dflash/test_dflash_domino.py

PYTHONPATH=python python3 -m pytest -q \
  test/registered/unit/spec/test_dflash_domino.py
```

## Performance summary

The first table is a standalone Domino-rollout benchmark on one A100 80GB,
BF16/TP=1, 15 proposals, exact batch shapes, and full-vocabulary correction
(`K=0`). Target verification and the DFlash backbone are excluded. Values are
the median of six balanced measurements with 30 CUDA-event iterations each.

| Batch | No optimization | Perf 1 | Perf 2 | Perf 3 | No-opt to Perf 3 |
|---:|---:|---:|---:|---:|---:|
| 1 | 13.416 ms | 5.888 ms | 3.372 ms | 2.363 ms *(base: 0.674 ms)* | 5.68x |
| 8 | 14.104 ms | 6.023 ms | 3.875 ms | 2.881 ms *(base: 0.775 ms)* | 4.90x |
| 64 | 15.851 ms | 8.821 ms | 8.571 ms | 7.808 ms *(base: 4.555 ms)* | 2.03x |

Parenthesized base-logit time is included in the total but belongs to DFlash; it
is not Domino-specific overhead.

Perf 4 uses a separate candidate-pool harness and aggregation, so it is reported
as its own K0 A/B rather than appended to the table above.

| Batch | Full correction, K0 | Candidate pool, K2048 | Reduction |
|---:|---:|---:|---:|
| 1 | 2.441 ms *(base: 0.724 ms)* | 1.618 ms *(base: 0.724 ms)* | 33.7% |
| 8 | 2.879 ms *(base: 0.817 ms)* | 2.122 ms *(base: 0.817 ms)* | 26.3% |
| 64 | 7.700 ms *(base: 5.104 ms)* | 7.188 ms *(base: 5.104 ms)* | 6.7% |

The same parenthesized DFlash base-logit time is included in both Perf 4 arms.

Using SGLang's official serving benchmark runner:

- Perf 2 versus Perf 1 improved output throughput by `11.2%`, `3.4%`, and
  `1.5%` at concurrency 1/8/32.
- Perf 3 versus Perf 2 improved output throughput by `5.8%`, `3.5%`, and
  `1.9%`; C32 acceptance length changed by `-0.16%`.
- Perf 4 K2048 versus K0 measured `1450.31` versus `1431.25` output tok/s at
  C32 (`+1.3%`). This was one run per K and is treated as exploratory/noise-level,
  not a serving-speedup claim.

### Final end-to-end serving benchmark

A final 135-cell TP1 serving sweep compared target-only decoding, the official
Qwen3-8B DFlash b16 draft, and Domino b16 K2048 on one A100 80GB.

[![Qwen3-8B end-to-end serving throughput](https://raw.githubusercontent.com/jianuo-huang/sglang/f3ee42f1406d867482f90568126f6c2eeea4f2cc/.github/benchmark-assets/domino-pr-31328-final.svg)](https://github.com/sgl-project/sglang/pull/31328#issuecomment-5041901375)

Full settings and all numerical results: [benchmark comment](https://github.com/sgl-project/sglang/pull/31328#issuecomment-5041901375).

Rollout microbenchmark speedups are not end-to-end serving claims. Exact setup,
correctness data, caveats, figures, and benchmark commands are in the four
linked performance comments.

## Checklist

- [x] Format changed files with the repository pre-commit hooks.
- [x] Add focused CPU/CUDA unit tests and a registered CUDA E2E gate.
- [x] Provide accuracy, acceptance-length, rollout, and official serving results.
- [ ] Add user documentation after the supported runtime contract is agreed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33199855245](https://github.com/sgl-project/sglang/actions/runs/33199855245)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33199855055](https://github.com/sgl-project/sglang/actions/runs/33199855055)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33199855228](https://github.com/sgl-project/sglang/actions/runs/33199855228)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
