### PR TITLE
fix(metrics): resolve router-included endpoint path for metrics

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2398,10 +2398,32 @@ def add_prometheus_track_response_middleware(app):
 def _get_fastapi_request_path(request) -> Tuple[str, bool]:
     from starlette.routing import Match
 
-    for route in request.app.routes:
-        match, child_scope = route.matches(request.scope)
-        if match == Match.FULL:
-            return route.path, True
+    try:
+        from fastapi.routing import iter_route_contexts
+    except ImportError:
+        # FastAPI < 0.137.2: app.routes is flat and every matching route is an
+        # APIRoute exposing .path.
+        for route in request.app.routes:
+            match, _child_scope = route.matches(request.scope)
+            if match == Match.FULL:
+                return route.path, True
+        return request.url.path, False
+
+    # FastAPI >= 0.137.2: include_router() keeps a route tree, so app.routes may
+    # contain _IncludedRouter nodes that have no .path (reading it raises
+    # AttributeError). iter_route_contexts() flattens the tree into leaf
+    # RouteContexts, each carrying the fully-qualified template path (prefix
+    # included), which keeps the Prometheus endpoint label low-cardinality.
+    req_path = request.scope.get("path", request.url.path)
+    method = request.scope.get("method")
+    for ctx in iter_route_contexts(request.app.routes):
+        path = ctx.path
+        if path is None:
+            continue
+        if ctx.path_regex.match(req_path) is not None:
+            methods = ctx.methods
+            if not methods or method in methods:
+                return path, True
 
     return request.url.path, False
 

--- a/test/registered/unit/utils/test_get_fastapi_request_path.py
+++ b/test/registered/unit/utils/test_get_fastapi_request_path.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for _get_fastapi_request_path (Prometheus middleware path resolver).
+
+Regression guard for the FastAPI >= 0.137.2 behaviour where include_router()
+keeps a route tree, so app.routes may contain _IncludedRouter nodes that have
+no .path. Reading route.path on those raised AttributeError and made every
+router-included endpoint (e.g. /v1/loads) return HTTP 500 when --enable-metrics
+was set.
+
+Usage:
+    python3 -m pytest test/registered/unit/utils/test_get_fastapi_request_path.py -v
+"""
+
+import unittest
+
+from fastapi import APIRouter, FastAPI
+
+from sglang.srt.utils.common import _get_fastapi_request_path
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeURL:
+    def __init__(self, path: str):
+        self.path = path
+
+
+class _FakeRequest:
+    """Minimal stand-in exposing only what _get_fastapi_request_path reads."""
+
+    def __init__(self, app: FastAPI, path: str, method: str = "GET"):
+        self.app = app
+        self.url = _FakeURL(path)
+        self.scope = {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "root_path": "",
+            "headers": [],
+            "path_params": {},
+        }
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    # Directly registered route -> a plain APIRoute (has .path).
+    @app.get("/get_load")
+    def _get_load():
+        return {}
+
+    # Router-included routes -> reach the app via an _IncludedRouter node on
+    # FastAPI >= 0.137.2. This is the case that used to crash.
+    router = APIRouter()
+
+    @router.get("/v1/loads")
+    def _v1_loads():
+        return {}
+
+    @router.get("/v1/items/{item_id}")
+    def _v1_items(item_id: str):
+        return {}
+
+    app.include_router(router)
+
+    # Prefixed include -> the leaf's own path lacks the prefix, so the fix must
+    # match against the fully-qualified template path.
+    prefixed = APIRouter()
+
+    @prefixed.get("/things/{tid}")
+    def _things(tid: str):
+        return {}
+
+    app.include_router(prefixed, prefix="/api")
+
+    return app
+
+
+class TestGetFastapiRequestPath(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = _build_app()
+
+    def _path(self, request_path: str, method: str = "GET") -> str:
+        resolved, _handled = _get_fastapi_request_path(
+            _FakeRequest(self.app, request_path, method)
+        )
+        return resolved
+
+    def test_directly_registered_route(self):
+        self.assertEqual(self._path("/get_load"), "/get_load")
+
+    def test_router_included_route_does_not_crash(self):
+        # Regression: this raised AttributeError on _IncludedRouter before the fix.
+        self.assertEqual(self._path("/v1/loads"), "/v1/loads")
+
+    def test_router_included_parameterized_route_keeps_template(self):
+        self.assertEqual(self._path("/v1/items/123"), "/v1/items/{item_id}")
+
+    def test_prefixed_included_route_keeps_full_template(self):
+        self.assertEqual(self._path("/api/things/9"), "/api/things/{tid}")
+
+    def test_unmatched_path_falls_back_to_request_url(self):
+        self.assertEqual(self._path("/no/such/route"), "/no/such/route")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
- With `--enable-metrics`, requests to router-included endpoints (e.g. `/v1/loads`) return HTTP 500: `AttributeError: '_IncludedRouter' object has no attribute 'path'`.
- Since **FastAPI 0.137.0**, `include_router()` keeps a route tree instead of flattening, so `app.routes` can contain `_IncludedRouter` nodes (no `.path`).
- The metrics middleware's `_get_fastapi_request_path()` reads `route.path` on the matched route and crashes on those nodes.
- Directly-registered routes (e.g. `/get_load`) are unaffected.
- Relates to #28887. 
- Alternative to #28890 (uses the public API instead of walking `_IncludedRouter` internals).

## Modifications

<!-- Detail the changes made in this pull request. -->
- `_get_fastapi_request_path()` in `python/sglang/srt/utils/common.py`:
  - FastAPI >= 0.137.2: use the public `iter_route_contexts()` to flatten the route tree into leaf `RouteContext`s and match via `ctx.path_regex`, preserving the full template path (e.g. `/v1/items/{item_id}`).
  - FastAPI < 0.137.2: unchanged flat-iteration fallback.
- Added `test/registered/unit/utils/test_get_fastapi_request_path.py`.
- Verified on `fastapi 0.138.1`: `/v1/loads` and other included/parameterized/prefixed routes resolve to their template; `/get_load` unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29413520548](https://github.com/sgl-project/sglang/actions/runs/29413520548)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29413520327](https://github.com/sgl-project/sglang/actions/runs/29413520327)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->