### PR TITLE
[CI] Fix TRTLLM MHA graph metadata test fixture

### DIFF
--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -102,7 +102,7 @@ def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
         seq_lens=torch.ones(2, dtype=torch.int32),
         forward_mode=ForwardMode.DRAFT_EXTEND_V2,
         spec_info=SimpleNamespace(
-            num_tokens_per_req=0,
+            num_tokens_per_req=4,
             num_accept_tokens=ExplodingAcceptTokens(),
         ),
         positions=torch.arange(8, dtype=torch.int64),
@@ -110,6 +110,8 @@ def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
     )
 
     backend.init_forward_metadata_out_graph(fb, in_capture=True)
+    # The in-graph body must use the captured static stride, not replay-time state.
+    fb.spec_info.num_tokens_per_req = 0
     backend.init_forward_metadata_in_graph(fb)
 
     assert len(calls) == 1


### PR DESCRIPTION
## Summary

Fix the test broken by #31013











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29415233988](https://github.com/sgl-project/sglang/actions/runs/29415233988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29415233885](https://github.com/sgl-project/sglang/actions/runs/29415233885)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->