### PR TITLE
[AMD] Fix packed DSA FP8 KV write routing on HIP

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2876,32 +2876,25 @@ class MLATokenToKVPool(KVCache):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ) -> None:
-        if _is_hip and self.use_dsa and self.dtype == fp8_dtype:
-            # HIP FP8 path uses raw MLA KV layout (nope + rope) without per-block scales.
-            # Fuse BF16/FP16 -> FP8 cast with paged KV write.
+        if self.dsa_kv_cache_store_fp8:
+            # Packed DSA KV keeps group scales and BF16 rope bytes in the cache.
+            cache_k_nope_fp8, cache_k_rope_fp8 = quantize_k_cache_separate(
+                cache_k_nope, cache_k_rope
+            )
+            set_mla_kv_buffer_triton(
+                dst_buffer,
+                loc,
+                cache_k_nope_fp8,
+                cache_k_rope_fp8,
+            )
+        elif _is_hip and self.use_dsa and self.dtype == fp8_dtype:
+            # HIP raw FP8 layout is used only when no packed-cache dimension is set.
             set_mla_kv_buffer_triton_fp8_quant(
                 dst_buffer,
                 loc,
                 cache_k_nope,
                 cache_k_rope,
                 fp8_dtype,
-            )
-        elif self.dsa_kv_cache_store_fp8:
-            # OPTIMIZATION: Quantize k_nope and k_rope separately to avoid concat overhead
-            # This also enables reuse of set_mla_kv_buffer_triton two-tensor write path
-            # quantize_k_cache_separate returns (nope_part, rope_part) as uint8 bytes
-            cache_k_nope_fp8, cache_k_rope_fp8 = quantize_k_cache_separate(
-                cache_k_nope, cache_k_rope
-            )
-
-            # Reuse existing two-tensor write kernel (works with FP8 byte layout)
-            # cache_k_nope_fp8: (num_tokens, 1, 528) uint8 [nope_fp8(512) | scales(16)]
-            # cache_k_rope_fp8: (num_tokens, 1, 128) uint8 [rope_bf16_bytes(128)]
-            set_mla_kv_buffer_triton(
-                dst_buffer,
-                loc,
-                cache_k_nope_fp8,
-                cache_k_rope_fp8,
             )
         else:
             if cache_k_nope.dtype != self.dtype:

--- a/test/registered/unit/mem_cache/test_mla_fp8_write_routing.py
+++ b/test/registered/unit/mem_cache/test_mla_fp8_write_routing.py
@@ -1,0 +1,68 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.mem_cache import memory_pool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMLAFP8WriteRouting(unittest.TestCase):
+    def test_packed_dsa_writer_precedes_hip_raw_fp8_writer(self):
+        pool = SimpleNamespace(
+            dsa_kv_cache_store_fp8=True,
+            use_dsa=True,
+            dtype=memory_pool.fp8_dtype,
+        )
+        packed_nope = object()
+        packed_rope = object()
+
+        with (
+            mock.patch.object(
+                memory_pool,
+                "quantize_k_cache_separate",
+                return_value=(packed_nope, packed_rope),
+            ) as quantize,
+            mock.patch.object(memory_pool, "set_mla_kv_buffer_triton") as write_packed,
+            mock.patch.object(
+                memory_pool, "set_mla_kv_buffer_triton_fp8_quant"
+            ) as write_raw,
+            mock.patch.object(memory_pool, "_is_hip", True),
+        ):
+            memory_pool.MLATokenToKVPool._write_mla_kv_buffer(
+                pool, "dst", "loc", "nope", "rope"
+            )
+
+        quantize.assert_called_once_with("nope", "rope")
+        write_packed.assert_called_once_with("dst", "loc", packed_nope, packed_rope)
+        write_raw.assert_not_called()
+
+    def test_raw_hip_fp8_writer_remains_the_fallback(self):
+        pool = SimpleNamespace(
+            dsa_kv_cache_store_fp8=False,
+            use_dsa=True,
+            dtype=memory_pool.fp8_dtype,
+        )
+
+        with (
+            mock.patch.object(memory_pool, "quantize_k_cache_separate") as quantize,
+            mock.patch.object(memory_pool, "set_mla_kv_buffer_triton") as write_packed,
+            mock.patch.object(
+                memory_pool, "set_mla_kv_buffer_triton_fp8_quant"
+            ) as write_raw,
+            mock.patch.object(memory_pool, "_is_hip", True),
+        ):
+            memory_pool.MLATokenToKVPool._write_mla_kv_buffer(
+                pool, "dst", "loc", "nope", "rope"
+            )
+
+        quantize.assert_not_called()
+        write_packed.assert_not_called()
+        write_raw.assert_called_once_with(
+            "dst", "loc", "nope", "rope", memory_pool.fp8_dtype
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On HIP, a packed DSA FP8 KV pool also matches the generic raw-FP8 writer condition. The raw writer therefore runs first and stores a 576-byte all-FP8 record into a cache interpreted as the 656-byte `[nope | scales | rope]` layout, corrupting the FP32 scales and BF16 rope values.

## Modifications

- Prioritize the explicit `dsa_kv_cache_store_fp8` packed-layout path.
- Keep the generic HIP raw-FP8 writer as the fallback.
- Add a CPU unit test covering both routes.

## Tests

```bash
python -m pytest -q \
  test/registered/unit/mem_cache/test_mla_fp8_write_routing.py
```

Before: `1 failed, 1 passed`. After: `2 passed`.

Black, isort, ruff, test-registration, `py_compile`, and `git diff --check` pass.

---
*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29420848683](https://github.com/sgl-project/sglang/actions/runs/29420848683)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29420848328](https://github.com/sgl-project/sglang/actions/runs/29420848328)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->