### PR TITLE
fix: prevent ReqTimeStats from being dropped during IPC serialization

### DIFF
--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -623,17 +623,19 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
     transfer_speed_gb_s: float = 0.0
     transfer_total_mb: float = 0.0
 
+    has_timing_data: bool = False
+
     def __getstate__(self) -> object:
         # send to detokenizer/tokenizer
-        if not self.enable_metrics:
+        if not (self.enable_metrics or self.has_timing_data):
             return {}
 
         state = {
+            "has_timing_data": True,
             "wait_queue_entry_time": self.wait_queue_entry_time,
             "forward_entry_time": self.forward_entry_time,
             "prefill_finished_time": self.prefill_finished_time,
             "diff_realtime_monotonic": global_diff_realtime_monotonic,
-            "enable_metrics": self.enable_metrics,
         }
         return state
 

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -633,6 +633,7 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
             "forward_entry_time": self.forward_entry_time,
             "prefill_finished_time": self.prefill_finished_time,
             "diff_realtime_monotonic": global_diff_realtime_monotonic,
+            "enable_metrics": self.enable_metrics,
         }
         return state
 


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
### Problem
`queue_time` is always 0.0 in `/generate` responses even when the server is launched with `--enable-metrics`

### Root Cause
`SchedulerReqTimeStats` is propagated across two IPC hops:

1. Scheduler → Detokenizer
2. Detokenizer → TokenizerManager

The object is serialized and deserialized through `zmq.send_pyobj()` and `zmq.recv_pyobj()` at each hop.

However, `SchedulerReqTimeStats.__getstate__()` does not include enable_metrics in the serialized state. After the first deserialization in the Detokenizer, `enable_metrics` falls back to its default value of `False`.

When the object is serialized again for the second IPC hop, the following guard causes all timing fields to be dropped:
```
if not self.enable_metrics:
    return {}
```
As a result, the request timing fields are dropped before reaching the `TokenizerManager`.
The `TokenizerManager` then calculates `queue_time` using zero-initialized timestamps, resulting in `0.0`.

## Modifications

<!-- Detail the changes made in this pull request. -->

Include `enable_metrics` in the serialized state returned by `SchedulerReqTimeStats.__getstate__()`.

This preserves the metrics-enabled state across both IPC hops and prevents request timing fields from being dropped before reaching the `TokenizerManager`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Launched the server with `--enable-metrics` and sent a request to the `/generate` endpoint.

### Before

The request timing fields were missing, and `queue_time` was always reported as 0.0.
```
{
  "meta_info": {
    "queue_time": 0.0
  }
}
```
### After

The request timing fields are preserved, and queue_time is correctly reported.
```
{
  "meta_info": {
    "forward_entry_time": 1784120656.9927032,
    "prefill_finished_time": 1784120657.1656446,
    "queue_time": 0.0002529621124267578
  }
}
```
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30143953996](https://github.com/sgl-project/sglang/actions/runs/30143953996)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30143953994](https://github.com/sgl-project/sglang/actions/runs/30143953994)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->