### PR TITLE
[HiSparse] Optimize small-batch perf with multi-CTA cache sharding

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
@@ -1,0 +1,370 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace {
+
+constexpr int kShardedWarpSize = 32;
+constexpr unsigned kShardedFullWarpMask = 0xffffffffu;
+constexpr uint16_t kShardedQueueHit = 0xffffu;
+
+__device__ __forceinline__ uint32_t sharded_mix32(uint32_t value) {
+  value ^= value >> 16;
+  value *= 0x7feb352du;
+  value ^= value >> 15;
+  value *= 0x846ca68bu;
+  value ^= value >> 16;
+  return value;
+}
+
+__device__ __forceinline__ void
+sharded_transfer_item_warp(int lane, const void* src_addr, void* dst_addr, int64_t item_size_bytes) {
+  const int total_pairs = item_size_bytes / 16;
+  const auto* src = static_cast<const uint64_t*>(src_addr);
+  auto* dst = static_cast<uint64_t*>(dst_addr);
+  for (int pair = lane; pair < total_pairs; pair += kShardedWarpSize) {
+    uint64_t lo;
+    uint64_t hi;
+    const uint64_t* src_pair = src + pair * 2;
+    asm volatile("ld.global.nc.v2.b64 {%0,%1},[%2];" : "=l"(lo), "=l"(hi) : "l"(src_pair) : "memory");
+    uint64_t* dst_pair = dst + pair * 2;
+    asm volatile("st.global.cg.v2.b64 [%0],{%1,%2};" : : "l"(dst_pair), "l"(lo), "l"(hi) : "memory");
+  }
+
+  const int tail_words = (item_size_bytes - total_pairs * 16) / 8;
+  if (lane < tail_words) {
+    const auto* src_tail = reinterpret_cast<const uint64_t*>(static_cast<const char*>(src_addr) + total_pairs * 16);
+    auto* dst_tail = reinterpret_cast<uint64_t*>(static_cast<char*>(dst_addr) + total_pairs * 16);
+    uint64_t value;
+    asm volatile("ld.global.nc.b64 %0,[%1];" : "=l"(value) : "l"(src_tail + lane) : "memory");
+    asm volatile("st.global.cg.b64 [%0],%1;" : : "l"(dst_tail + lane), "l"(value) : "memory");
+  }
+}
+
+template <int BLOCK_SIZE, int HOT_BUFFER_SIZE, int LOGICAL_SHARDS, int NUM_CTAS>
+struct ShardedSmemLayout {
+  static constexpr int kWays = HOT_BUFFER_SIZE / LOGICAL_SHARDS;
+  static constexpr int kLocalShards = LOGICAL_SHARDS / NUM_CTAS;
+  static constexpr int kWarps = BLOCK_SIZE / kShardedWarpSize;
+  static constexpr int kWorkers = kLocalShards < kWarps ? kLocalShards : kWarps;
+  static constexpr size_t kQueueBytes = kLocalShards * kWays * sizeof(uint16_t);
+  static constexpr size_t kCountsBytes = kLocalShards * sizeof(int32_t);
+  static constexpr size_t kWorkerU8Bytes = 2 * kWorkers * kWays * sizeof(uint8_t);
+  static constexpr size_t kWorkerU16Bytes = kWorkers * kWays * sizeof(uint16_t);
+  static constexpr size_t kBytes = kQueueBytes + 2 * kCountsBytes + kWorkerU8Bytes + kWorkerU16Bytes;
+};
+
+// Process one logical shard after the CTA has routed its top-k entries.
+//
+// Required invariants:
+// - request_lru[shard_base:shard_base + K_WAYS] is a permutation of [0, K_WAYS).
+// - Cache tags are unique within the shard.
+// - Queued top-k tokens are unique and non-negative.
+// - The first miss_count evictable ways become victims.
+// - The resulting LRU order is stale ways, newly loaded ways, then cache hits.
+template <int K_WAYS>
+__device__ __forceinline__ void process_shard(
+    int lane,
+    unsigned lanes_before,
+    int logical_shard,
+    int shard_base,
+    uint16_t* queue,
+    int queue_count,
+    const int32_t* request_top_k,
+    int32_t* request_output,
+    int32_t* request_tags,
+    const int32_t* request_locations,
+    const int64_t* request_host,
+    uint8_t* request_lru,
+    const void* host_cache,
+    void* device_buffer,
+    int32_t* request_counts,
+    int32_t* request_overflows,
+    int local_overflow,
+    uint8_t* worker_evictable,
+    uint8_t* worker_hits,
+    uint16_t* worker_misses,
+    int64_t item_size_bytes) {
+  constexpr int kWayGroups = K_WAYS / kShardedWarpSize;
+
+  if (lane == 0) {
+    for (int i = 1; i < queue_count; ++i) {
+      const uint16_t value = queue[i];
+      int j = i - 1;
+      while (j >= 0 && queue[j] > value) {
+        queue[j + 1] = queue[j];
+        --j;
+      }
+      queue[j + 1] = value;
+    }
+  }
+  __syncwarp(kShardedFullWarpMask);
+
+  int32_t tags[kWayGroups];
+  unsigned protected_masks[kWayGroups];
+#pragma unroll
+  for (int group = 0; group < kWayGroups; ++group) {
+    tags[group] = request_tags[shard_base + group * kShardedWarpSize + lane];
+    protected_masks[group] = 0;
+  }
+  for (int i = 0; i < queue_count; ++i) {
+    const int selected = queue[i];
+    const int32_t token = request_top_k[selected];
+    int hit_way = -1;
+#pragma unroll
+    for (int group = 0; group < kWayGroups; ++group) {
+      const unsigned matches = __ballot_sync(kShardedFullWarpMask, tags[group] == token);
+      protected_masks[group] |= matches;
+      if (hit_way < 0 && matches) {
+        hit_way = group * kShardedWarpSize + __ffs(matches) - 1;
+      }
+    }
+    if (hit_way >= 0 && lane == 0) {
+      request_output[selected] = request_locations[shard_base + hit_way];
+      queue[i] = kShardedQueueHit;
+    }
+    __syncwarp(kShardedFullWarpMask);
+  }
+
+  int evictable_count = 0;
+  int hit_count = 0;
+#pragma unroll
+  for (int group = 0; group < kWayGroups; ++group) {
+    const uint8_t old_way = request_lru[shard_base + group * kShardedWarpSize + lane];
+    const bool is_hit = (protected_masks[old_way / kShardedWarpSize] >> (old_way & (kShardedWarpSize - 1))) & 1u;
+    const unsigned evict_positions = __ballot_sync(kShardedFullWarpMask, !is_hit);
+    const unsigned hit_positions = __ballot_sync(kShardedFullWarpMask, is_hit);
+    if (!is_hit) {
+      worker_evictable[evictable_count + __popc(evict_positions & lanes_before)] = old_way;
+    } else {
+      worker_hits[hit_count + __popc(hit_positions & lanes_before)] = old_way;
+    }
+    evictable_count += __popc(evict_positions);
+    hit_count += __popc(hit_positions);
+  }
+  __syncwarp(kShardedFullWarpMask);
+
+  int miss_count = 0;
+#pragma unroll
+  for (int group = 0; group < kWayGroups; ++group) {
+    const int queue_position = group * kShardedWarpSize + lane;
+    const bool is_miss = queue_position < queue_count && queue[queue_position] != kShardedQueueHit;
+    const unsigned miss_positions = __ballot_sync(kShardedFullWarpMask, is_miss);
+    if (is_miss) {
+      worker_misses[miss_count + __popc(miss_positions & lanes_before)] = queue[queue_position];
+    }
+    miss_count += __popc(miss_positions);
+  }
+  __syncwarp(kShardedFullWarpMask);
+
+  for (int miss = lane; miss < miss_count; miss += kShardedWarpSize) {
+    const int selected = worker_misses[miss];
+    const int32_t token = request_top_k[selected];
+    const int victim = worker_evictable[miss];
+    const int32_t destination = request_locations[shard_base + victim];
+    request_tags[shard_base + victim] = token;
+    request_output[selected] = destination;
+  }
+  __syncwarp(kShardedFullWarpMask);
+
+  for (int miss = 0; miss < miss_count; ++miss) {
+    const int selected = worker_misses[miss];
+    const int32_t token = request_top_k[selected];
+    const int victim = worker_evictable[miss];
+    const int64_t src_loc = request_host[token];
+    const int32_t dst_loc = request_locations[shard_base + victim];
+    const auto* src = static_cast<const char*>(host_cache) + src_loc * item_size_bytes;
+    auto* dst = static_cast<char*>(device_buffer) + static_cast<int64_t>(dst_loc) * item_size_bytes;
+    sharded_transfer_item_warp(lane, src, dst, item_size_bytes);
+  }
+
+  for (int position = lane; position < K_WAYS; position += kShardedWarpSize) {
+    uint8_t value;
+    if (position < evictable_count - miss_count) {
+      value = worker_evictable[position + miss_count];
+    } else if (position < evictable_count) {
+      value = worker_evictable[position - (evictable_count - miss_count)];
+    } else {
+      value = worker_hits[position - evictable_count];
+    }
+    request_lru[shard_base + position] = value;
+  }
+  if (lane == 0) {
+    request_counts[logical_shard] = miss_count;
+    request_overflows[logical_shard] = local_overflow;
+  }
+}
+
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, int LOGICAL_SHARDS, int NUM_CTAS, int MIN_BLOCKS_PER_SM>
+__global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
+    const int32_t* __restrict__ top_k_tokens,
+    int32_t* __restrict__ device_buffer_tokens,
+    const int64_t* __restrict__ host_cache_locs,
+    const int32_t* __restrict__ device_buffer_locs,
+    int32_t* __restrict__ top_k_device_locs,
+    const int64_t* __restrict__ req_pool_indices,
+    const int32_t* __restrict__ seq_lens,
+    uint8_t* __restrict__ lru_slots,
+    const void* __restrict__ host_cache,
+    void* __restrict__ device_buffer,
+    int32_t* __restrict__ split_miss_counts,
+    int32_t* __restrict__ shard_overflows,
+    const int32_t* __restrict__ num_real_reqs,
+    int64_t host_stride,
+    int64_t item_size_bytes) {
+  static_assert(BLOCK_SIZE % kShardedWarpSize == 0, "whole warps required");
+  static_assert(BLOCK_SIZE >= kShardedWarpSize && BLOCK_SIZE <= 512, "unsupported CTA size");
+  static_assert(
+      LOGICAL_SHARDS == 64 || LOGICAL_SHARDS == 128 || LOGICAL_SHARDS == 256, "unsupported logical shard count");
+  static_assert((LOGICAL_SHARDS & (LOGICAL_SHARDS - 1)) == 0, "LOGICAL_SHARDS must be a power of two");
+  static_assert(NUM_CTAS > 0 && (NUM_CTAS & (NUM_CTAS - 1)) == 0, "NUM_CTAS must be a power of two");
+  static_assert(HOT_BUFFER_SIZE % LOGICAL_SHARDS == 0, "invalid geometry");
+  static_assert(LOGICAL_SHARDS % NUM_CTAS == 0, "NUM_CTAS must divide shards");
+  using Layout = ShardedSmemLayout<BLOCK_SIZE, HOT_BUFFER_SIZE, LOGICAL_SHARDS, NUM_CTAS>;
+  constexpr int kWays = Layout::kWays;
+  constexpr int kLocalShards = Layout::kLocalShards;
+  constexpr int kWorkers = Layout::kWorkers;
+  static_assert(kWays == 32 || kWays == 64 || kWays == 128, "unsupported ways");
+
+  const int request = blockIdx.x / NUM_CTAS;
+  if (request >= num_real_reqs[0]) return;
+  const int cta_rank = blockIdx.x & (NUM_CTAS - 1);
+  const int tid = threadIdx.x;
+  const int warp = tid / kShardedWarpSize;
+  const int lane = tid & (kShardedWarpSize - 1);
+  const unsigned lanes_before = (1u << lane) - 1u;
+  const int64_t pool_index = req_pool_indices[request];
+  const int32_t newest_token = seq_lens[request] - 1;
+
+  const int32_t* request_top_k = top_k_tokens + request * NUM_TOP_K;
+  int32_t* request_output = top_k_device_locs + request * NUM_TOP_K;
+  int32_t* request_tags = device_buffer_tokens + pool_index * (HOT_BUFFER_SIZE + 1);
+  const int32_t* request_locations = device_buffer_locs + pool_index * (HOT_BUFFER_SIZE + 1);
+  const int64_t* request_host = host_cache_locs + pool_index * host_stride;
+  uint8_t* request_lru = lru_slots + pool_index * HOT_BUFFER_SIZE;
+  int32_t* request_counts = split_miss_counts + request * LOGICAL_SHARDS;
+  int32_t* request_overflows = shard_overflows + request * LOGICAL_SHARDS;
+
+  extern __shared__ char shared_raw[];
+  uint16_t* queues = reinterpret_cast<uint16_t*>(shared_raw);
+  int32_t* queue_counts = reinterpret_cast<int32_t*>(shared_raw + Layout::kQueueBytes);
+  int32_t* local_overflows = reinterpret_cast<int32_t*>(shared_raw + Layout::kQueueBytes + Layout::kCountsBytes);
+  uint8_t* evictable = reinterpret_cast<uint8_t*>(shared_raw + Layout::kQueueBytes + 2 * Layout::kCountsBytes);
+  uint8_t* hit_order = evictable + kWorkers * kWays;
+  uint16_t* miss_indices = reinterpret_cast<uint16_t*>(hit_order + kWorkers * kWays);
+
+  // Phase 1: initialize the per-CTA shard queues.
+  for (int local = tid; local < kLocalShards; local += BLOCK_SIZE) {
+    queue_counts[local] = 0;
+    local_overflows[local] = 0;
+  }
+  __syncthreads();
+
+  // Phase 2: route top-k entries to this CTA's logical shards.
+  for (int selected = tid; selected < NUM_TOP_K; selected += BLOCK_SIZE) {
+    const int32_t token = request_top_k[selected];
+    const int logical_shard = sharded_mix32(static_cast<uint32_t>(token)) & (LOGICAL_SHARDS - 1);
+    if ((logical_shard & (NUM_CTAS - 1)) != cta_rank) continue;
+    if (token == newest_token) {
+      request_output[selected] = request_locations[HOT_BUFFER_SIZE];
+      continue;
+    }
+    const int local_shard = logical_shard / NUM_CTAS;
+    const int position = atomicAdd(&queue_counts[local_shard], 1);
+    if (position < kWays) {
+      queues[local_shard * kWays + position] = static_cast<uint16_t>(selected);
+    } else {
+      // TODO: Add a slower fallback path instead of dropping entries when a shard queue exceeds kWays.
+      atomicAdd(&local_overflows[local_shard], 1);
+    }
+  }
+  __syncthreads();
+
+  // Phase 3: process each queued shard and apply its fused metadata/copy transition.
+  for (int wave = 0; wave * kWorkers < kLocalShards; ++wave) {
+    const int local_shard = wave * kWorkers + warp;
+    const bool active = warp < kWorkers && local_shard < kLocalShards;
+    if (active) {
+      const int logical_shard = cta_rank + local_shard * NUM_CTAS;
+      const int shard_base = logical_shard * kWays;
+      uint16_t* queue = queues + local_shard * kWays;
+      const int queue_count = queue_counts[local_shard] < kWays ? queue_counts[local_shard] : kWays;
+      uint8_t* worker_evictable = evictable + warp * kWays;
+      uint8_t* worker_hits = hit_order + warp * kWays;
+      uint16_t* worker_misses = miss_indices + warp * kWays;
+      process_shard<kWays>(
+          lane,
+          lanes_before,
+          logical_shard,
+          shard_base,
+          queue,
+          queue_count,
+          request_top_k,
+          request_output,
+          request_tags,
+          request_locations,
+          request_host,
+          request_lru,
+          host_cache,
+          device_buffer,
+          request_counts,
+          request_overflows,
+          local_overflows[local_shard],
+          worker_evictable,
+          worker_hits,
+          worker_misses,
+          item_size_bytes);
+    }
+    __syncthreads();
+  }
+}
+
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, int LOGICAL_SHARDS, int NUM_CTAS, int MIN_BLOCKS_PER_SM>
+void load_cache_to_device_buffer_mla_sharded(
+    tvm::ffi::TensorView top_k_tokens,
+    tvm::ffi::TensorView device_buffer_tokens,
+    tvm::ffi::TensorView host_cache_locs,
+    tvm::ffi::TensorView device_buffer_locs,
+    tvm::ffi::TensorView host_cache,
+    tvm::ffi::TensorView device_buffer,
+    tvm::ffi::TensorView top_k_device_locs,
+    tvm::ffi::TensorView req_pool_indices,
+    tvm::ffi::TensorView seq_lens,
+    tvm::ffi::TensorView lru_slots,
+    tvm::ffi::TensorView split_miss_counts,
+    tvm::ffi::TensorView shard_overflows,
+    tvm::ffi::TensorView num_real_reqs,
+    int64_t item_size_bytes) {
+  using namespace host;
+  const int batch_size = static_cast<int>(top_k_tokens.shape()[0]);
+  const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
+  constexpr size_t shared_bytes = ShardedSmemLayout<BLOCK_SIZE, HOT_BUFFER_SIZE, LOGICAL_SHARDS, NUM_CTAS>::kBytes;
+  LaunchKernel(batch_size * NUM_CTAS, BLOCK_SIZE, device, shared_bytes)(
+      sharded_kernel<BLOCK_SIZE, NUM_TOP_K, HOT_BUFFER_SIZE, LOGICAL_SHARDS, NUM_CTAS, MIN_BLOCKS_PER_SM>,
+      static_cast<const int32_t*>(top_k_tokens.data_ptr()),
+      static_cast<int32_t*>(device_buffer_tokens.data_ptr()),
+      static_cast<const int64_t*>(host_cache_locs.data_ptr()),
+      static_cast<const int32_t*>(device_buffer_locs.data_ptr()),
+      static_cast<int32_t*>(top_k_device_locs.data_ptr()),
+      static_cast<const int64_t*>(req_pool_indices.data_ptr()),
+      static_cast<const int32_t*>(seq_lens.data_ptr()),
+      static_cast<uint8_t*>(lru_slots.data_ptr()),
+      host_cache.data_ptr(),
+      device_buffer.data_ptr(),
+      static_cast<int32_t*>(split_miss_counts.data_ptr()),
+      static_cast<int32_t*>(shard_overflows.data_ptr()),
+      static_cast<const int32_t*>(num_real_reqs.data_ptr()),
+      host_cache_locs.strides()[0],
+      item_size_bytes);
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
@@ -197,6 +197,8 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
     int32_t* __restrict__ split_miss_counts,
     int32_t* __restrict__ shard_overflows,
     const int32_t* __restrict__ num_real_reqs,
+    int64_t device_buffer_tokens_stride,
+    int64_t device_buffer_locs_stride,
     int64_t host_stride,
     int64_t item_size_bytes) {
   static_assert(BLOCK_SIZE % kShardedWarpSize == 0, "whole warps required");
@@ -219,12 +221,14 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   const int lane = tid & (kShardedWarpSize - 1);
   const unsigned lanes_before = (1u << lane) - 1u;
   const int64_t pool_index = req_pool_indices[request];
-  const int32_t newest_token = seq_lens[request] - 1;
+  const int32_t seq_len = seq_lens[request];
+  const int32_t newest_token = seq_len - 1;
+  const int32_t num_selected = seq_len < NUM_TOP_K ? seq_len : NUM_TOP_K;
 
   const int32_t* request_top_k = top_k_tokens + request * NUM_TOP_K;
   int32_t* request_output = top_k_device_locs + request * NUM_TOP_K;
-  int32_t* request_tags = device_buffer_tokens + pool_index * (HOT_BUFFER_SIZE + 1);
-  const int32_t* request_locations = device_buffer_locs + pool_index * (HOT_BUFFER_SIZE + 1);
+  int32_t* request_tags = device_buffer_tokens + pool_index * device_buffer_tokens_stride;
+  const int32_t* request_locations = device_buffer_locs + pool_index * device_buffer_locs_stride;
   const int64_t* request_host = host_cache_locs + pool_index * host_stride;
   uint8_t* request_lru = lru_slots + pool_index * HOT_BUFFER_SIZE;
   int32_t* request_counts = split_miss_counts + request * kLogicalShards;
@@ -246,8 +250,9 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   __syncthreads();
 
   // Phase 2: route top-k entries to this CTA's logical shards.
-  for (int selected = tid; selected < NUM_TOP_K; selected += BLOCK_SIZE) {
+  for (int selected = tid; selected < num_selected; selected += BLOCK_SIZE) {
     const int32_t token = request_top_k[selected];
+    if (token < 0) continue;
     const int logical_shard = sharded_mix32(static_cast<uint32_t>(token)) % kLogicalShards;
     if ((logical_shard & (NUM_CTAS - 1)) != cta_rank) continue;
     if (token == newest_token) {
@@ -266,7 +271,8 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   __syncthreads();
 
   // Phase 3: process each queued shard and apply its fused metadata/copy
-  // transition. Keep waves synchronized to pace copy-heavy sysmem traffic.
+  // transition. Warps only reuse their own scratch, so waves can progress
+  // independently after routing completes.
   constexpr int kNumWaves = (kLocalShards + kWorkers - 1) / kWorkers;
   for (int wave = 0; wave < kNumWaves; ++wave) {
     const int local_shard = wave * kWorkers + warp;
@@ -301,7 +307,6 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
           worker_misses,
           item_size_bytes);
     }
-    __syncthreads();
   }
 }
 
@@ -340,6 +345,8 @@ void load_cache_to_device_buffer_mla_sharded(
       static_cast<int32_t*>(split_miss_counts.data_ptr()),
       static_cast<int32_t*>(shard_overflows.data_ptr()),
       static_cast<const int32_t*>(num_real_reqs.data_ptr()),
+      device_buffer_tokens.strides()[0],
+      device_buffer_locs.strides()[0],
       host_cache_locs.strides()[0],
       item_size_bytes);
 }

--- a/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
@@ -15,7 +15,6 @@ namespace {
 
 constexpr int kShardedWarpSize = 32;
 constexpr unsigned kShardedFullWarpMask = 0xffffffffu;
-constexpr uint16_t kShardedQueueHit = 0xffffu;
 
 __device__ __forceinline__ uint32_t sharded_mix32(uint32_t value) {
   value ^= value >> 16;
@@ -61,9 +60,8 @@ struct ShardedSmemLayout {
   static constexpr int kWorkers = kLocalShards < kWarps ? kLocalShards : kWarps;
   static constexpr size_t kQueueBytes = kLocalShards * kWays * sizeof(uint16_t);
   static constexpr size_t kCountsBytes = kLocalShards * sizeof(int32_t);
-  static constexpr size_t kWorkerU8Bytes = 2 * kWorkers * kWays * sizeof(uint8_t);
   static constexpr size_t kWorkerU16Bytes = kWorkers * kWays * sizeof(uint16_t);
-  static constexpr size_t kBytes = kQueueBytes + 2 * kCountsBytes + kWorkerU8Bytes + kWorkerU16Bytes;
+  static constexpr size_t kBytes = kQueueBytes + 2 * kCountsBytes + kWorkerU16Bytes;
 };
 
 // Process one logical shard after the CTA has routed its top-k entries.
@@ -92,90 +90,83 @@ __device__ __forceinline__ void process_shard(
     int32_t* request_counts,
     int32_t* request_overflows,
     int local_overflow,
-    uint8_t* worker_evictable,
-    uint8_t* worker_hits,
     uint16_t* worker_misses,
     int64_t item_size_bytes) {
   const int32_t tag = request_tags[shard_base + lane];
-  bool lane_hit = false;
+  bool way_hit = false;
+  bool my_entry_hit = false;
   for (int i = 0; i < queue_count; ++i) {
     const int selected = queue[i];
     const int32_t token = request_top_k[selected];
-    if (tag == token) {
-      lane_hit = true;
+    const bool match = tag == token;
+    const unsigned matches = __ballot_sync(kShardedFullWarpMask, match);
+    if (match) {
+      way_hit = true;
       request_output[selected] = request_locations[shard_base + lane];
-      queue[i] = kShardedQueueHit;
     }
-    __syncwarp(kShardedFullWarpMask);
+    if (lane == i) my_entry_hit = matches != 0;
   }
-  const unsigned protected_mask = __ballot_sync(kShardedFullWarpMask, lane_hit);
+  const unsigned protected_mask = __ballot_sync(kShardedFullWarpMask, way_hit);
 
   const uint8_t old_way = request_lru[shard_base + lane];
   const bool is_hit = (protected_mask >> old_way) & 1u;
   const unsigned evict_positions = __ballot_sync(kShardedFullWarpMask, !is_hit);
   const unsigned hit_positions = __ballot_sync(kShardedFullWarpMask, is_hit);
   const int evictable_count = __popc(evict_positions);
-  const int hit_count = __popc(hit_positions);
-  if (!is_hit) {
-    worker_evictable[__popc(evict_positions & lanes_before)] = old_way;
-  } else {
-    worker_hits[__popc(hit_positions & lanes_before)] = old_way;
-  }
-  __syncwarp(kShardedFullWarpMask);
+  const int evict_rank = __popc(evict_positions & lanes_before);
+  const int hit_rank = __popc(hit_positions & lanes_before);
 
-  const bool is_miss = lane < queue_count && queue[lane] != kShardedQueueHit;
+  const bool is_miss = lane < queue_count && !my_entry_hit;
   const unsigned miss_positions = __ballot_sync(kShardedFullWarpMask, is_miss);
   const int miss_count = __popc(miss_positions);
-  if (is_miss) {
-    worker_misses[__popc(miss_positions & lanes_before)] = queue[lane];
-  }
-  __syncwarp(kShardedFullWarpMask);
+  if (miss_count != 0) {
+    if (is_miss) {
+      worker_misses[__popc(miss_positions & lanes_before)] = queue[lane];
+    }
+    __syncwarp(kShardedFullWarpMask);
 
-  // Shared atomics do not preserve top-k order. Only misses need a stable
-  // order because that order determines their exact-LRU victims; hits only
-  // contribute to the protected-way set above.
-  if (lane == 0) {
-    for (int i = 1; i < miss_count; ++i) {
-      const uint16_t value = worker_misses[i];
-      int j = i - 1;
-      while (j >= 0 && worker_misses[j] > value) {
-        worker_misses[j + 1] = worker_misses[j];
-        --j;
+    // Shared atomics do not preserve top-k order. Only misses need a stable
+    // order because that order determines their exact-LRU victims.
+    if (lane == 0) {
+      for (int i = 1; i < miss_count; ++i) {
+        const uint16_t value = worker_misses[i];
+        int j = i - 1;
+        while (j >= 0 && worker_misses[j] > value) {
+          worker_misses[j + 1] = worker_misses[j];
+          --j;
+        }
+        worker_misses[j + 1] = value;
       }
-      worker_misses[j + 1] = value;
+    }
+    __syncwarp(kShardedFullWarpMask);
+
+    if (!is_hit && evict_rank < miss_count) {
+      const int selected = worker_misses[evict_rank];
+      const int32_t token = request_top_k[selected];
+      const int32_t destination = request_locations[shard_base + old_way];
+      request_tags[shard_base + old_way] = token;
+      request_output[selected] = destination;
+    }
+    __syncwarp(kShardedFullWarpMask);
+
+    for (int miss = 0; miss < miss_count; ++miss) {
+      const int selected = worker_misses[miss];
+      const int32_t token = request_top_k[selected];
+      const int64_t src_loc = request_host[token];
+      const int32_t dst_loc = request_output[selected];
+      const auto* src = static_cast<const char*>(host_cache) + src_loc * item_size_bytes;
+      auto* dst = static_cast<char*>(device_buffer) + static_cast<int64_t>(dst_loc) * item_size_bytes;
+      sharded_transfer_item_warp(lane, src, dst, item_size_bytes);
     }
   }
-  __syncwarp(kShardedFullWarpMask);
 
-  for (int miss = lane; miss < miss_count; miss += kShardedWarpSize) {
-    const int selected = worker_misses[miss];
-    const int32_t token = request_top_k[selected];
-    const int victim = worker_evictable[miss];
-    const int32_t destination = request_locations[shard_base + victim];
-    request_tags[shard_base + victim] = token;
-    request_output[selected] = destination;
-  }
-  __syncwarp(kShardedFullWarpMask);
-
-  for (int miss = 0; miss < miss_count; ++miss) {
-    const int selected = worker_misses[miss];
-    const int32_t token = request_top_k[selected];
-    const int64_t src_loc = request_host[token];
-    const int32_t dst_loc = request_output[selected];
-    const auto* src = static_cast<const char*>(host_cache) + src_loc * item_size_bytes;
-    auto* dst = static_cast<char*>(device_buffer) + static_cast<int64_t>(dst_loc) * item_size_bytes;
-    sharded_transfer_item_warp(lane, src, dst, item_size_bytes);
-  }
-
-  uint8_t lru_value;
-  if (lane < evictable_count - miss_count) {
-    lru_value = worker_evictable[lane + miss_count];
-  } else if (lane < evictable_count) {
-    lru_value = worker_evictable[lane - (evictable_count - miss_count)];
+  int new_pos;
+  if (!is_hit) {
+    new_pos = evict_rank < miss_count ? evictable_count - miss_count + evict_rank : evict_rank - miss_count;
   } else {
-    lru_value = worker_hits[lane - evictable_count];
+    new_pos = evictable_count + hit_rank;
   }
-  request_lru[shard_base + lane] = lru_value;
+  request_lru[shard_base + new_pos] = old_way;
   if (lane == 0) {
     request_counts[logical_shard] = miss_count;
     request_overflows[logical_shard] = local_overflow;
@@ -238,9 +229,7 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   uint16_t* queues = reinterpret_cast<uint16_t*>(shared_raw);
   int32_t* queue_counts = reinterpret_cast<int32_t*>(shared_raw + Layout::kQueueBytes);
   int32_t* local_overflows = reinterpret_cast<int32_t*>(shared_raw + Layout::kQueueBytes + Layout::kCountsBytes);
-  uint8_t* evictable = reinterpret_cast<uint8_t*>(shared_raw + Layout::kQueueBytes + 2 * Layout::kCountsBytes);
-  uint8_t* hit_order = evictable + kWorkers * kWays;
-  uint16_t* miss_indices = reinterpret_cast<uint16_t*>(hit_order + kWorkers * kWays);
+  uint16_t* miss_indices = reinterpret_cast<uint16_t*>(shared_raw + Layout::kQueueBytes + 2 * Layout::kCountsBytes);
 
   // Phase 1: initialize the per-CTA shard queues.
   for (int local = tid; local < kLocalShards; local += BLOCK_SIZE) {
@@ -281,8 +270,6 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
       const int shard_base = logical_shard * kWays;
       uint16_t* queue = queues + local_shard * kWays;
       const int queue_count = queue_counts[local_shard] < kWays ? queue_counts[local_shard] : kWays;
-      uint8_t* worker_evictable = evictable + warp * kWays;
-      uint8_t* worker_hits = hit_order + warp * kWays;
       uint16_t* worker_misses = miss_indices + warp * kWays;
       process_shard(
           lane,
@@ -302,8 +289,6 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
           request_counts,
           request_overflows,
           local_overflows[local_shard],
-          worker_evictable,
-          worker_hits,
           worker_misses,
           item_size_bytes);
     }

--- a/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
@@ -61,7 +61,7 @@ struct ShardedSmemLayout {
   static constexpr size_t kQueueBytes = kLocalShards * kWays * sizeof(uint16_t);
   static constexpr size_t kCountsBytes = kLocalShards * sizeof(int32_t);
   static constexpr size_t kWorkerU16Bytes = kWorkers * kWays * sizeof(uint16_t);
-  static constexpr size_t kBytes = kQueueBytes + 2 * kCountsBytes + kWorkerU16Bytes;
+  static constexpr size_t kBytes = kQueueBytes + kCountsBytes + kWorkerU16Bytes;
 };
 
 // Process one logical shard after the CTA has routed its top-k entries.
@@ -75,7 +75,6 @@ struct ShardedSmemLayout {
 __device__ __forceinline__ void process_shard(
     int lane,
     unsigned lanes_before,
-    int logical_shard,
     int shard_base,
     uint16_t* queue,
     int queue_count,
@@ -87,9 +86,6 @@ __device__ __forceinline__ void process_shard(
     uint8_t* request_lru,
     const void* host_cache,
     void* device_buffer,
-    int32_t* request_counts,
-    int32_t* request_overflows,
-    int local_overflow,
     uint16_t* worker_misses,
     int64_t item_size_bytes) {
   const int32_t tag = request_tags[shard_base + lane];
@@ -167,10 +163,6 @@ __device__ __forceinline__ void process_shard(
     new_pos = evictable_count + hit_rank;
   }
   request_lru[shard_base + new_pos] = old_way;
-  if (lane == 0) {
-    request_counts[logical_shard] = miss_count;
-    request_overflows[logical_shard] = local_overflow;
-  }
 }
 
 template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, int NUM_CTAS, int MIN_BLOCKS_PER_SM>
@@ -185,8 +177,6 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
     uint8_t* __restrict__ lru_slots,
     const void* __restrict__ host_cache,
     void* __restrict__ device_buffer,
-    int32_t* __restrict__ split_miss_counts,
-    int32_t* __restrict__ shard_overflows,
     const int32_t* __restrict__ num_real_reqs,
     int64_t device_buffer_tokens_stride,
     int64_t device_buffer_locs_stride,
@@ -222,19 +212,15 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   const int32_t* request_locations = device_buffer_locs + pool_index * device_buffer_locs_stride;
   const int64_t* request_host = host_cache_locs + pool_index * host_stride;
   uint8_t* request_lru = lru_slots + pool_index * HOT_BUFFER_SIZE;
-  int32_t* request_counts = split_miss_counts + request * kLogicalShards;
-  int32_t* request_overflows = shard_overflows + request * kLogicalShards;
 
   extern __shared__ char shared_raw[];
   uint16_t* queues = reinterpret_cast<uint16_t*>(shared_raw);
   int32_t* queue_counts = reinterpret_cast<int32_t*>(shared_raw + Layout::kQueueBytes);
-  int32_t* local_overflows = reinterpret_cast<int32_t*>(shared_raw + Layout::kQueueBytes + Layout::kCountsBytes);
-  uint16_t* miss_indices = reinterpret_cast<uint16_t*>(shared_raw + Layout::kQueueBytes + 2 * Layout::kCountsBytes);
+  uint16_t* miss_indices = reinterpret_cast<uint16_t*>(shared_raw + Layout::kQueueBytes + Layout::kCountsBytes);
 
   // Phase 1: initialize the per-CTA shard queues.
   for (int local = tid; local < kLocalShards; local += BLOCK_SIZE) {
     queue_counts[local] = 0;
-    local_overflows[local] = 0;
   }
   __syncthreads();
 
@@ -253,8 +239,8 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
     if (position < kWays) {
       queues[local_shard * kWays + position] = static_cast<uint16_t>(selected);
     } else {
-      // TODO: Add a slower fallback path instead of dropping entries when a shard queue exceeds kWays.
-      atomicAdd(&local_overflows[local_shard], 1);
+      // TODO: Add a slower fallback path instead of dropping entries when a
+      // shard queue exceeds kWays.
     }
   }
   __syncthreads();
@@ -274,7 +260,6 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
       process_shard(
           lane,
           lanes_before,
-          logical_shard,
           shard_base,
           queue,
           queue_count,
@@ -286,9 +271,6 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
           request_lru,
           host_cache,
           device_buffer,
-          request_counts,
-          request_overflows,
-          local_overflows[local_shard],
           worker_misses,
           item_size_bytes);
     }
@@ -307,8 +289,6 @@ void load_cache_to_device_buffer_mla_sharded(
     tvm::ffi::TensorView req_pool_indices,
     tvm::ffi::TensorView seq_lens,
     tvm::ffi::TensorView lru_slots,
-    tvm::ffi::TensorView split_miss_counts,
-    tvm::ffi::TensorView shard_overflows,
     tvm::ffi::TensorView num_real_reqs,
     int64_t item_size_bytes) {
   using namespace host;
@@ -327,8 +307,6 @@ void load_cache_to_device_buffer_mla_sharded(
       static_cast<uint8_t*>(lru_slots.data_ptr()),
       host_cache.data_ptr(),
       device_buffer.data_ptr(),
-      static_cast<int32_t*>(split_miss_counts.data_ptr()),
-      static_cast<int32_t*>(shard_overflows.data_ptr()),
       static_cast<const int32_t*>(num_real_reqs.data_ptr()),
       device_buffer_tokens.strides()[0],
       device_buffer_locs.strides()[0],

--- a/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
@@ -107,10 +107,9 @@ __device__ __forceinline__ void process_shard(
   const uint8_t old_way = request_lru[shard_base + lane];
   const bool is_hit = (protected_mask >> old_way) & 1u;
   const unsigned evict_positions = __ballot_sync(kShardedFullWarpMask, !is_hit);
-  const unsigned hit_positions = __ballot_sync(kShardedFullWarpMask, is_hit);
   const int evictable_count = __popc(evict_positions);
   const int evict_rank = __popc(evict_positions & lanes_before);
-  const int hit_rank = __popc(hit_positions & lanes_before);
+  const int hit_rank = lane - evict_rank;
 
   const bool is_miss = lane < queue_count && !my_entry_hit;
   const unsigned miss_positions = __ballot_sync(kShardedFullWarpMask, is_miss);
@@ -256,23 +255,25 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
       const int shard_base = logical_shard * kWays;
       uint16_t* queue = queues + local_shard * kWays;
       const int queue_count = queue_counts[local_shard] < kWays ? queue_counts[local_shard] : kWays;
-      uint16_t* worker_misses = miss_indices + warp * kWays;
-      process_shard(
-          lane,
-          lanes_before,
-          shard_base,
-          queue,
-          queue_count,
-          request_top_k,
-          request_output,
-          request_tags,
-          request_locations,
-          request_host,
-          request_lru,
-          host_cache,
-          device_buffer,
-          worker_misses,
-          item_size_bytes);
+      if (queue_count != 0) {
+        uint16_t* worker_misses = miss_indices + warp * kWays;
+        process_shard(
+            lane,
+            lanes_before,
+            shard_base,
+            queue,
+            queue_count,
+            request_top_k,
+            request_output,
+            request_tags,
+            request_locations,
+            request_host,
+            request_lru,
+            host_cache,
+            device_buffer,
+            worker_misses,
+            item_size_bytes);
+      }
     }
   }
 }

--- a/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse_sharded.cuh
@@ -50,10 +50,13 @@ sharded_transfer_item_warp(int lane, const void* src_addr, void* dst_addr, int64
   }
 }
 
-template <int BLOCK_SIZE, int HOT_BUFFER_SIZE, int LOGICAL_SHARDS, int NUM_CTAS>
+template <int BLOCK_SIZE, int HOT_BUFFER_SIZE, int NUM_CTAS>
 struct ShardedSmemLayout {
-  static constexpr int kWays = HOT_BUFFER_SIZE / LOGICAL_SHARDS;
-  static constexpr int kLocalShards = LOGICAL_SHARDS / NUM_CTAS;
+  static_assert(HOT_BUFFER_SIZE % kShardedWarpSize == 0, "HOT_BUFFER_SIZE must be divisible by warp size");
+  static constexpr int kLogicalShards = HOT_BUFFER_SIZE / kShardedWarpSize;
+  static_assert(kLogicalShards % NUM_CTAS == 0, "NUM_CTAS must divide logical shards");
+  static constexpr int kWays = kShardedWarpSize;
+  static constexpr int kLocalShards = kLogicalShards / NUM_CTAS;
   static constexpr int kWarps = BLOCK_SIZE / kShardedWarpSize;
   static constexpr int kWorkers = kLocalShards < kWarps ? kLocalShards : kWarps;
   static constexpr size_t kQueueBytes = kLocalShards * kWays * sizeof(uint16_t);
@@ -66,12 +69,11 @@ struct ShardedSmemLayout {
 // Process one logical shard after the CTA has routed its top-k entries.
 //
 // Required invariants:
-// - request_lru[shard_base:shard_base + K_WAYS] is a permutation of [0, K_WAYS).
+// - request_lru[shard_base:shard_base + warp_size] is a permutation of [0, warp_size).
 // - Cache tags are unique within the shard.
 // - Queued top-k tokens are unique and non-negative.
 // - The first miss_count evictable ways become victims.
 // - The resulting LRU order is stale ways, newly loaded ways, then cache hits.
-template <int K_WAYS>
 __device__ __forceinline__ void process_shard(
     int lane,
     unsigned lanes_before,
@@ -94,75 +96,54 @@ __device__ __forceinline__ void process_shard(
     uint8_t* worker_hits,
     uint16_t* worker_misses,
     int64_t item_size_bytes) {
-  constexpr int kWayGroups = K_WAYS / kShardedWarpSize;
-
-  if (lane == 0) {
-    for (int i = 1; i < queue_count; ++i) {
-      const uint16_t value = queue[i];
-      int j = i - 1;
-      while (j >= 0 && queue[j] > value) {
-        queue[j + 1] = queue[j];
-        --j;
-      }
-      queue[j + 1] = value;
-    }
-  }
-  __syncwarp(kShardedFullWarpMask);
-
-  int32_t tags[kWayGroups];
-  unsigned protected_masks[kWayGroups];
-#pragma unroll
-  for (int group = 0; group < kWayGroups; ++group) {
-    tags[group] = request_tags[shard_base + group * kShardedWarpSize + lane];
-    protected_masks[group] = 0;
-  }
+  const int32_t tag = request_tags[shard_base + lane];
+  bool lane_hit = false;
   for (int i = 0; i < queue_count; ++i) {
     const int selected = queue[i];
     const int32_t token = request_top_k[selected];
-    int hit_way = -1;
-#pragma unroll
-    for (int group = 0; group < kWayGroups; ++group) {
-      const unsigned matches = __ballot_sync(kShardedFullWarpMask, tags[group] == token);
-      protected_masks[group] |= matches;
-      if (hit_way < 0 && matches) {
-        hit_way = group * kShardedWarpSize + __ffs(matches) - 1;
-      }
-    }
-    if (hit_way >= 0 && lane == 0) {
-      request_output[selected] = request_locations[shard_base + hit_way];
+    if (tag == token) {
+      lane_hit = true;
+      request_output[selected] = request_locations[shard_base + lane];
       queue[i] = kShardedQueueHit;
     }
     __syncwarp(kShardedFullWarpMask);
   }
+  const unsigned protected_mask = __ballot_sync(kShardedFullWarpMask, lane_hit);
 
-  int evictable_count = 0;
-  int hit_count = 0;
-#pragma unroll
-  for (int group = 0; group < kWayGroups; ++group) {
-    const uint8_t old_way = request_lru[shard_base + group * kShardedWarpSize + lane];
-    const bool is_hit = (protected_masks[old_way / kShardedWarpSize] >> (old_way & (kShardedWarpSize - 1))) & 1u;
-    const unsigned evict_positions = __ballot_sync(kShardedFullWarpMask, !is_hit);
-    const unsigned hit_positions = __ballot_sync(kShardedFullWarpMask, is_hit);
-    if (!is_hit) {
-      worker_evictable[evictable_count + __popc(evict_positions & lanes_before)] = old_way;
-    } else {
-      worker_hits[hit_count + __popc(hit_positions & lanes_before)] = old_way;
-    }
-    evictable_count += __popc(evict_positions);
-    hit_count += __popc(hit_positions);
+  const uint8_t old_way = request_lru[shard_base + lane];
+  const bool is_hit = (protected_mask >> old_way) & 1u;
+  const unsigned evict_positions = __ballot_sync(kShardedFullWarpMask, !is_hit);
+  const unsigned hit_positions = __ballot_sync(kShardedFullWarpMask, is_hit);
+  const int evictable_count = __popc(evict_positions);
+  const int hit_count = __popc(hit_positions);
+  if (!is_hit) {
+    worker_evictable[__popc(evict_positions & lanes_before)] = old_way;
+  } else {
+    worker_hits[__popc(hit_positions & lanes_before)] = old_way;
   }
   __syncwarp(kShardedFullWarpMask);
 
-  int miss_count = 0;
-#pragma unroll
-  for (int group = 0; group < kWayGroups; ++group) {
-    const int queue_position = group * kShardedWarpSize + lane;
-    const bool is_miss = queue_position < queue_count && queue[queue_position] != kShardedQueueHit;
-    const unsigned miss_positions = __ballot_sync(kShardedFullWarpMask, is_miss);
-    if (is_miss) {
-      worker_misses[miss_count + __popc(miss_positions & lanes_before)] = queue[queue_position];
+  const bool is_miss = lane < queue_count && queue[lane] != kShardedQueueHit;
+  const unsigned miss_positions = __ballot_sync(kShardedFullWarpMask, is_miss);
+  const int miss_count = __popc(miss_positions);
+  if (is_miss) {
+    worker_misses[__popc(miss_positions & lanes_before)] = queue[lane];
+  }
+  __syncwarp(kShardedFullWarpMask);
+
+  // Shared atomics do not preserve top-k order. Only misses need a stable
+  // order because that order determines their exact-LRU victims; hits only
+  // contribute to the protected-way set above.
+  if (lane == 0) {
+    for (int i = 1; i < miss_count; ++i) {
+      const uint16_t value = worker_misses[i];
+      int j = i - 1;
+      while (j >= 0 && worker_misses[j] > value) {
+        worker_misses[j + 1] = worker_misses[j];
+        --j;
+      }
+      worker_misses[j + 1] = value;
     }
-    miss_count += __popc(miss_positions);
   }
   __syncwarp(kShardedFullWarpMask);
 
@@ -179,32 +160,29 @@ __device__ __forceinline__ void process_shard(
   for (int miss = 0; miss < miss_count; ++miss) {
     const int selected = worker_misses[miss];
     const int32_t token = request_top_k[selected];
-    const int victim = worker_evictable[miss];
     const int64_t src_loc = request_host[token];
-    const int32_t dst_loc = request_locations[shard_base + victim];
+    const int32_t dst_loc = request_output[selected];
     const auto* src = static_cast<const char*>(host_cache) + src_loc * item_size_bytes;
     auto* dst = static_cast<char*>(device_buffer) + static_cast<int64_t>(dst_loc) * item_size_bytes;
     sharded_transfer_item_warp(lane, src, dst, item_size_bytes);
   }
 
-  for (int position = lane; position < K_WAYS; position += kShardedWarpSize) {
-    uint8_t value;
-    if (position < evictable_count - miss_count) {
-      value = worker_evictable[position + miss_count];
-    } else if (position < evictable_count) {
-      value = worker_evictable[position - (evictable_count - miss_count)];
-    } else {
-      value = worker_hits[position - evictable_count];
-    }
-    request_lru[shard_base + position] = value;
+  uint8_t lru_value;
+  if (lane < evictable_count - miss_count) {
+    lru_value = worker_evictable[lane + miss_count];
+  } else if (lane < evictable_count) {
+    lru_value = worker_evictable[lane - (evictable_count - miss_count)];
+  } else {
+    lru_value = worker_hits[lane - evictable_count];
   }
+  request_lru[shard_base + lane] = lru_value;
   if (lane == 0) {
     request_counts[logical_shard] = miss_count;
     request_overflows[logical_shard] = local_overflow;
   }
 }
 
-template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, int LOGICAL_SHARDS, int NUM_CTAS, int MIN_BLOCKS_PER_SM>
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, int NUM_CTAS, int MIN_BLOCKS_PER_SM>
 __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
     const int32_t* __restrict__ top_k_tokens,
     int32_t* __restrict__ device_buffer_tokens,
@@ -222,18 +200,16 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
     int64_t host_stride,
     int64_t item_size_bytes) {
   static_assert(BLOCK_SIZE % kShardedWarpSize == 0, "whole warps required");
-  static_assert(BLOCK_SIZE >= kShardedWarpSize && BLOCK_SIZE <= 512, "unsupported CTA size");
-  static_assert(
-      LOGICAL_SHARDS == 64 || LOGICAL_SHARDS == 128 || LOGICAL_SHARDS == 256, "unsupported logical shard count");
-  static_assert((LOGICAL_SHARDS & (LOGICAL_SHARDS - 1)) == 0, "LOGICAL_SHARDS must be a power of two");
+  static_assert(BLOCK_SIZE >= kShardedWarpSize && BLOCK_SIZE <= 1024, "unsupported CTA size");
+  static_assert(HOT_BUFFER_SIZE % kShardedWarpSize == 0, "HOT_BUFFER_SIZE must be divisible by warp size");
+  constexpr int kLogicalShards = HOT_BUFFER_SIZE / kShardedWarpSize;
   static_assert(NUM_CTAS > 0 && (NUM_CTAS & (NUM_CTAS - 1)) == 0, "NUM_CTAS must be a power of two");
-  static_assert(HOT_BUFFER_SIZE % LOGICAL_SHARDS == 0, "invalid geometry");
-  static_assert(LOGICAL_SHARDS % NUM_CTAS == 0, "NUM_CTAS must divide shards");
-  using Layout = ShardedSmemLayout<BLOCK_SIZE, HOT_BUFFER_SIZE, LOGICAL_SHARDS, NUM_CTAS>;
+  static_assert(kLogicalShards % NUM_CTAS == 0, "NUM_CTAS must divide shards");
+  using Layout = ShardedSmemLayout<BLOCK_SIZE, HOT_BUFFER_SIZE, NUM_CTAS>;
   constexpr int kWays = Layout::kWays;
   constexpr int kLocalShards = Layout::kLocalShards;
   constexpr int kWorkers = Layout::kWorkers;
-  static_assert(kWays == 32 || kWays == 64 || kWays == 128, "unsupported ways");
+  static_assert(kWays == kShardedWarpSize, "one warp must own exactly one shard");
 
   const int request = blockIdx.x / NUM_CTAS;
   if (request >= num_real_reqs[0]) return;
@@ -251,8 +227,8 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   const int32_t* request_locations = device_buffer_locs + pool_index * (HOT_BUFFER_SIZE + 1);
   const int64_t* request_host = host_cache_locs + pool_index * host_stride;
   uint8_t* request_lru = lru_slots + pool_index * HOT_BUFFER_SIZE;
-  int32_t* request_counts = split_miss_counts + request * LOGICAL_SHARDS;
-  int32_t* request_overflows = shard_overflows + request * LOGICAL_SHARDS;
+  int32_t* request_counts = split_miss_counts + request * kLogicalShards;
+  int32_t* request_overflows = shard_overflows + request * kLogicalShards;
 
   extern __shared__ char shared_raw[];
   uint16_t* queues = reinterpret_cast<uint16_t*>(shared_raw);
@@ -272,7 +248,7 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   // Phase 2: route top-k entries to this CTA's logical shards.
   for (int selected = tid; selected < NUM_TOP_K; selected += BLOCK_SIZE) {
     const int32_t token = request_top_k[selected];
-    const int logical_shard = sharded_mix32(static_cast<uint32_t>(token)) & (LOGICAL_SHARDS - 1);
+    const int logical_shard = sharded_mix32(static_cast<uint32_t>(token)) % kLogicalShards;
     if ((logical_shard & (NUM_CTAS - 1)) != cta_rank) continue;
     if (token == newest_token) {
       request_output[selected] = request_locations[HOT_BUFFER_SIZE];
@@ -289,11 +265,12 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   }
   __syncthreads();
 
-  // Phase 3: process each queued shard and apply its fused metadata/copy transition.
-  for (int wave = 0; wave * kWorkers < kLocalShards; ++wave) {
+  // Phase 3: process each queued shard and apply its fused metadata/copy
+  // transition. Keep waves synchronized to pace copy-heavy sysmem traffic.
+  constexpr int kNumWaves = (kLocalShards + kWorkers - 1) / kWorkers;
+  for (int wave = 0; wave < kNumWaves; ++wave) {
     const int local_shard = wave * kWorkers + warp;
-    const bool active = warp < kWorkers && local_shard < kLocalShards;
-    if (active) {
+    if (warp < kWorkers && local_shard < kLocalShards) {
       const int logical_shard = cta_rank + local_shard * NUM_CTAS;
       const int shard_base = logical_shard * kWays;
       uint16_t* queue = queues + local_shard * kWays;
@@ -301,7 +278,7 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
       uint8_t* worker_evictable = evictable + warp * kWays;
       uint8_t* worker_hits = hit_order + warp * kWays;
       uint16_t* worker_misses = miss_indices + warp * kWays;
-      process_shard<kWays>(
+      process_shard(
           lane,
           lanes_before,
           logical_shard,
@@ -328,7 +305,7 @@ __global__ __launch_bounds__(BLOCK_SIZE, MIN_BLOCKS_PER_SM) void sharded_kernel(
   }
 }
 
-template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, int LOGICAL_SHARDS, int NUM_CTAS, int MIN_BLOCKS_PER_SM>
+template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, int NUM_CTAS, int MIN_BLOCKS_PER_SM>
 void load_cache_to_device_buffer_mla_sharded(
     tvm::ffi::TensorView top_k_tokens,
     tvm::ffi::TensorView device_buffer_tokens,
@@ -347,9 +324,9 @@ void load_cache_to_device_buffer_mla_sharded(
   using namespace host;
   const int batch_size = static_cast<int>(top_k_tokens.shape()[0]);
   const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
-  constexpr size_t shared_bytes = ShardedSmemLayout<BLOCK_SIZE, HOT_BUFFER_SIZE, LOGICAL_SHARDS, NUM_CTAS>::kBytes;
+  constexpr size_t shared_bytes = ShardedSmemLayout<BLOCK_SIZE, HOT_BUFFER_SIZE, NUM_CTAS>::kBytes;
   LaunchKernel(batch_size * NUM_CTAS, BLOCK_SIZE, device, shared_bytes)(
-      sharded_kernel<BLOCK_SIZE, NUM_TOP_K, HOT_BUFFER_SIZE, LOGICAL_SHARDS, NUM_CTAS, MIN_BLOCKS_PER_SM>,
+      sharded_kernel<BLOCK_SIZE, NUM_TOP_K, HOT_BUFFER_SIZE, NUM_CTAS, MIN_BLOCKS_PER_SM>,
       static_cast<const int32_t*>(top_k_tokens.data_ptr()),
       static_cast<int32_t*>(device_buffer_tokens.data_ptr()),
       static_cast<const int64_t*>(host_cache_locs.data_ptr()),

--- a/python/sglang/jit_kernel/hisparse_sharded.py
+++ b/python/sglang/jit_kernel/hisparse_sharded.py
@@ -1,0 +1,142 @@
+"""Exact-LRU kernel for independent logical shards."""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@functools.cache
+def _jit_sharded_module(
+    block_size: int,
+    num_top_k: int,
+    hot_buffer_size: int,
+    logical_shards: int,
+    num_ctas: int,
+    min_blocks_per_sm: int,
+) -> Module:
+    metadata_template_args = make_cpp_args(
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        logical_shards,
+        num_ctas,
+        min_blocks_per_sm,
+    )
+    return load_jit(
+        "hisparse_sharded",
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        logical_shards,
+        num_ctas,
+        min_blocks_per_sm,
+        cuda_files=["hisparse_sharded.cuh"],
+        cuda_wrappers=[
+            (
+                "load_cache_to_device_buffer_mla_sharded",
+                f"load_cache_to_device_buffer_mla_sharded<{metadata_template_args}>",
+            ),
+        ],
+    )
+
+
+def load_cache_to_device_buffer_mla_sharded(
+    *,
+    top_k_tokens: torch.Tensor,
+    device_buffer_tokens: torch.Tensor,
+    host_cache_locs: torch.Tensor,
+    device_buffer_locs: torch.Tensor,
+    host_cache: torch.Tensor,
+    device_buffer: torch.Tensor,
+    top_k_device_locs: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    lru_slots: torch.Tensor,
+    split_miss_counts: torch.Tensor,
+    shard_overflows: torch.Tensor,
+    num_real_reqs: torch.Tensor,
+    item_size_bytes: int,
+    num_top_k: int,
+    hot_buffer_size: int,
+    logical_shards: int,
+    num_ctas: int,
+    block_size: int,
+    min_blocks_per_sm: int = 1,
+) -> None:
+    batch_size = top_k_tokens.shape[0]
+    if logical_shards not in (64, 128, 256):
+        raise ValueError("logical_shards must be 64, 128, or 256")
+    if hot_buffer_size % logical_shards:
+        raise ValueError("hot_buffer_size must be divisible by logical_shards")
+    ways = hot_buffer_size // logical_shards
+    if ways not in (32, 64, 128):
+        raise ValueError("this experiment supports 32, 64, or 128 ways")
+    if num_ctas <= 0 or num_ctas > logical_shards:
+        raise ValueError("num_ctas must not exceed logical_shards")
+    if num_ctas & (num_ctas - 1) or logical_shards % num_ctas:
+        raise ValueError("num_ctas must be a power-of-two divisor of shards")
+    if block_size not in (32, 64, 128, 256, 512):
+        raise ValueError("block_size must be one of 32, 64, 128, 256, 512")
+    if min_blocks_per_sm not in (1, 2, 3, 4, 5, 6, 8):
+        raise ValueError("unsupported launch-bounds min_blocks_per_sm")
+    if req_pool_indices.dtype != torch.int64 or seq_lens.dtype != torch.int32:
+        raise ValueError("req_pool_indices must be int64 and seq_lens int32")
+    if num_real_reqs.dtype != torch.int32 or num_real_reqs.numel() != 1:
+        raise ValueError("num_real_reqs must be a single-element int32 tensor")
+    if lru_slots.dtype != torch.uint8:
+        raise ValueError("sharded exact LRU uses uint8 local way indices")
+    count_shape = (batch_size, logical_shards)
+    if split_miss_counts.shape != count_shape:
+        raise ValueError(f"split_miss_counts must have shape {count_shape}")
+    if shard_overflows.shape != count_shape:
+        raise ValueError(f"shard_overflows must have shape {count_shape}")
+    contiguous = (
+        top_k_tokens,
+        device_buffer_tokens,
+        host_cache_locs,
+        device_buffer_locs,
+        host_cache,
+        device_buffer,
+        top_k_device_locs,
+        req_pool_indices,
+        seq_lens,
+        lru_slots,
+        split_miss_counts,
+        shard_overflows,
+        num_real_reqs,
+    )
+    if not all(tensor.is_contiguous() for tensor in contiguous):
+        raise ValueError("sharded kernel requires contiguous tensors")
+
+    module = _jit_sharded_module(
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        logical_shards,
+        num_ctas,
+        min_blocks_per_sm,
+    )
+    module.load_cache_to_device_buffer_mla_sharded(
+        top_k_tokens,
+        device_buffer_tokens,
+        host_cache_locs,
+        device_buffer_locs,
+        host_cache,
+        device_buffer,
+        top_k_device_locs,
+        req_pool_indices,
+        seq_lens,
+        lru_slots,
+        split_miss_counts,
+        shard_overflows,
+        num_real_reqs,
+        item_size_bytes,
+    )

--- a/python/sglang/jit_kernel/hisparse_sharded.py
+++ b/python/sglang/jit_kernel/hisparse_sharded.py
@@ -66,8 +66,6 @@ def load_cache_to_device_buffer_mla_sharded(
     req_pool_indices: torch.Tensor,
     seq_lens: torch.Tensor,
     lru_slots: torch.Tensor,
-    split_miss_counts: torch.Tensor,
-    shard_overflows: torch.Tensor,
     num_real_reqs: torch.Tensor,
     item_size_bytes: int,
     num_top_k: int,
@@ -76,7 +74,6 @@ def load_cache_to_device_buffer_mla_sharded(
     block_size: int,
     min_blocks_per_sm: int = 1,
 ) -> None:
-    batch_size = top_k_tokens.shape[0]
     logical_shards = logical_shards_for_hot_buffer(hot_buffer_size, top_k_tokens.device)
     if num_ctas <= 0 or num_ctas > logical_shards:
         raise ValueError("num_ctas must not exceed logical_shards")
@@ -92,11 +89,6 @@ def load_cache_to_device_buffer_mla_sharded(
         raise ValueError("num_real_reqs must be a single-element int32 tensor")
     if lru_slots.dtype != torch.uint8:
         raise ValueError("sharded exact LRU uses uint8 local way indices")
-    count_shape = (batch_size, logical_shards)
-    if split_miss_counts.shape != count_shape:
-        raise ValueError(f"split_miss_counts must have shape {count_shape}")
-    if shard_overflows.shape != count_shape:
-        raise ValueError(f"shard_overflows must have shape {count_shape}")
     contiguous = (
         top_k_tokens,
         device_buffer_tokens,
@@ -108,8 +100,6 @@ def load_cache_to_device_buffer_mla_sharded(
         req_pool_indices,
         seq_lens,
         lru_slots,
-        split_miss_counts,
-        shard_overflows,
         num_real_reqs,
     )
     if not all(tensor.is_contiguous() for tensor in contiguous):
@@ -133,8 +123,6 @@ def load_cache_to_device_buffer_mla_sharded(
         req_pool_indices,
         seq_lens,
         lru_slots,
-        split_miss_counts,
-        shard_overflows,
         num_real_reqs,
         item_size_bytes,
     )

--- a/python/sglang/jit_kernel/hisparse_sharded.py
+++ b/python/sglang/jit_kernel/hisparse_sharded.py
@@ -79,8 +79,10 @@ def load_cache_to_device_buffer_mla_sharded(
         raise ValueError("num_ctas must not exceed logical_shards")
     if num_ctas & (num_ctas - 1) or logical_shards % num_ctas:
         raise ValueError("num_ctas must be a power-of-two divisor of shards")
-    if block_size not in (32, 64, 128, 256, 512, 768, 1024):
-        raise ValueError("block_size must be one of 32, 64, 128, 256, 512, 768, 1024")
+    if block_size not in (32, 64, 128, 256, 512, 640, 768, 1024):
+        raise ValueError(
+            "block_size must be one of 32, 64, 128, 256, 512, 640, 768, 1024"
+        )
     if min_blocks_per_sm not in (1, 2, 3, 4, 5, 6, 8):
         raise ValueError("unsupported launch-bounds min_blocks_per_sm")
     if req_pool_indices.dtype != torch.int64 or seq_lens.dtype != torch.int32:

--- a/python/sglang/jit_kernel/hisparse_sharded.py
+++ b/python/sglang/jit_kernel/hisparse_sharded.py
@@ -18,7 +18,6 @@ def _jit_sharded_module(
     block_size: int,
     num_top_k: int,
     hot_buffer_size: int,
-    logical_shards: int,
     num_ctas: int,
     min_blocks_per_sm: int,
 ) -> Module:
@@ -26,7 +25,6 @@ def _jit_sharded_module(
         block_size,
         num_top_k,
         hot_buffer_size,
-        logical_shards,
         num_ctas,
         min_blocks_per_sm,
     )
@@ -35,7 +33,6 @@ def _jit_sharded_module(
         block_size,
         num_top_k,
         hot_buffer_size,
-        logical_shards,
         num_ctas,
         min_blocks_per_sm,
         cuda_files=["hisparse_sharded.cuh"],
@@ -46,6 +43,15 @@ def _jit_sharded_module(
             ),
         ],
     )
+
+
+def logical_shards_for_hot_buffer(
+    hot_buffer_size: int, device: torch.device | str | int
+) -> int:
+    warp_size = torch.cuda.get_device_properties(device).warp_size
+    if hot_buffer_size % warp_size:
+        raise ValueError("hot_buffer_size must be divisible by the device warp size")
+    return hot_buffer_size // warp_size
 
 
 def load_cache_to_device_buffer_mla_sharded(
@@ -66,25 +72,18 @@ def load_cache_to_device_buffer_mla_sharded(
     item_size_bytes: int,
     num_top_k: int,
     hot_buffer_size: int,
-    logical_shards: int,
     num_ctas: int,
     block_size: int,
     min_blocks_per_sm: int = 1,
 ) -> None:
     batch_size = top_k_tokens.shape[0]
-    if logical_shards not in (64, 128, 256):
-        raise ValueError("logical_shards must be 64, 128, or 256")
-    if hot_buffer_size % logical_shards:
-        raise ValueError("hot_buffer_size must be divisible by logical_shards")
-    ways = hot_buffer_size // logical_shards
-    if ways not in (32, 64, 128):
-        raise ValueError("this experiment supports 32, 64, or 128 ways")
+    logical_shards = logical_shards_for_hot_buffer(hot_buffer_size, top_k_tokens.device)
     if num_ctas <= 0 or num_ctas > logical_shards:
         raise ValueError("num_ctas must not exceed logical_shards")
     if num_ctas & (num_ctas - 1) or logical_shards % num_ctas:
         raise ValueError("num_ctas must be a power-of-two divisor of shards")
-    if block_size not in (32, 64, 128, 256, 512):
-        raise ValueError("block_size must be one of 32, 64, 128, 256, 512")
+    if block_size not in (32, 64, 128, 256, 512, 768, 1024):
+        raise ValueError("block_size must be one of 32, 64, 128, 256, 512, 768, 1024")
     if min_blocks_per_sm not in (1, 2, 3, 4, 5, 6, 8):
         raise ValueError("unsupported launch-bounds min_blocks_per_sm")
     if req_pool_indices.dtype != torch.int64 or seq_lens.dtype != torch.int32:
@@ -120,7 +119,6 @@ def load_cache_to_device_buffer_mla_sharded(
         block_size,
         num_top_k,
         hot_buffer_size,
-        logical_shards,
         num_ctas,
         min_blocks_per_sm,
     )

--- a/test/registered/jit/benchmark/bench_hisparse.py
+++ b/test/registered/jit/benchmark/bench_hisparse.py
@@ -231,18 +231,6 @@ def _build_inputs(
         "initial_lru_slots": lru_slots.clone(),
         "num_real_reqs": torch.tensor([batch_size], dtype=torch.int32, device=DEVICE),
     }
-    if provider == "sharded":
-        logical_shards = logical_shards_for_hot_buffer(hot_buffer_size, DEVICE)
-        state["split_miss_counts"] = torch.empty(
-            (batch_size, logical_shards),
-            dtype=torch.int32,
-            device=DEVICE,
-        )
-        state["shard_overflows"] = torch.empty(
-            (batch_size, logical_shards),
-            dtype=torch.int32,
-            device=DEVICE,
-        )
     torch.cuda.synchronize()
     return state
 
@@ -281,8 +269,6 @@ def _launch_kernel(
             req_pool_indices=state["req_pool_indices"],
             seq_lens=state["seq_lens"],
             lru_slots=state["lru_slots"],
-            split_miss_counts=state["split_miss_counts"],
-            shard_overflows=state["shard_overflows"],
             num_real_reqs=state["num_real_reqs"],
             item_size_bytes=ITEM_SIZE_BYTES,
             num_top_k=TOP_K,
@@ -313,8 +299,6 @@ def _launch_kernel(
 
 def _check_result(state: Dict[str, torch.Tensor | int], provider: str) -> None:
     torch.cuda.synchronize()
-    if provider == "sharded" and state["shard_overflows"].any():
-        raise AssertionError("sharded queue overflow")
     expected_host_locs = state["host_cache_locs"].gather(
         1, state["top_k_tokens"].to(torch.int64)
     )

--- a/test/registered/jit/benchmark/bench_hisparse.py
+++ b/test/registered/jit/benchmark/bench_hisparse.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 from typing import Dict, Tuple
 
 import torch
@@ -7,37 +8,85 @@ import triton.testing
 
 from sglang.jit_kernel.benchmark.utils import DEFAULT_DEVICE, DEFAULT_DTYPE
 from sglang.jit_kernel.hisparse import load_cache_to_device_buffer_mla
+from sglang.jit_kernel.hisparse_sharded import (
+    load_cache_to_device_buffer_mla_sharded,
+)
+from sglang.jit_kernel.utils import is_hip_runtime
+from sglang.srt.utils.bench_utils import bench_kineto
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
-    est_time=12, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+    est_time=180, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
 )
-register_amd_ci(est_time=12, stage="jit-kernel-benchmark", runner_config="amd")
+register_amd_ci(est_time=90, stage="jit-kernel-benchmark", runner_config="amd")
 
 DEVICE = DEFAULT_DEVICE
 DTYPE = DEFAULT_DTYPE
 TOP_K = 2048
 ITEM_SIZE_BYTES = 512
-MISS_RATES = [0.2, 0.001]
-ROUNDS = 5
-WARMUP_ROUNDS = 5
-BATCH_SIZES = [1, 10, 100]
-HOT_BUFFER_SIZES = [4096, 8192]
-CONFIGS = [
+SHARDED_LOGICAL_SHARDS = 256
+SHARDED_BATCH_SIZES = [1, 2, 4, 16, 32, 64, 128, 256]
+SHARDED_MISSES_PER_REQ = [2, 410]
+SHARDED_CONFIGS = [
     (
         batch_size,
-        hot_buffer_size,
-        miss_rate,
-        batch_size * round(TOP_K * miss_rate),
+        8192,
+        misses_per_req / TOP_K,
+        batch_size * misses_per_req,
     )
-    for batch_size, hot_buffer_size, miss_rate in itertools.product(
-        BATCH_SIZES, HOT_BUFFER_SIZES, MISS_RATES
+    for batch_size, misses_per_req in itertools.product(
+        SHARDED_BATCH_SIZES, SHARDED_MISSES_PER_REQ
     )
 ]
+SHARDED_BLOCK_SIZE = 512
+SHARDED_MIN_BLOCKS_PER_SM = 3
+SHARDED_MAX_CTAS_PER_REQUEST = 64
+KINETO_TESTS = 30
 
-LINE_VALS = ["jit"]
-LINE_NAMES = ["SGL JIT Kernel"]
-STYLES = [("blue", "--")]
+if is_hip_runtime():
+    SHARDED_LINE_VALS = ["original"]
+    SHARDED_LINE_NAMES = ["Original"]
+    SHARDED_STYLES = [("blue", "--")]
+else:
+    SHARDED_LINE_VALS = ["original", "sharded"]
+    SHARDED_LINE_NAMES = ["Original", "Sharded"]
+    SHARDED_STYLES = [("blue", "--"), ("green", "-")]
+
+
+def _mix32(value: int) -> int:
+    value = (value ^ (value >> 16)) & 0xFFFFFFFF
+    value = (value * 0x7FEB352D) & 0xFFFFFFFF
+    value = (value ^ (value >> 15)) & 0xFFFFFFFF
+    value = (value * 0x846CA68B) & 0xFFFFFFFF
+    return (value ^ (value >> 16)) & 0xFFFFFFFF
+
+
+def _make_sharded_cache_tokens(
+    num_hits: int,
+    hot_buffer_size: int,
+    seq_len: int,
+) -> torch.Tensor:
+    ways = hot_buffer_size // SHARDED_LOGICAL_SHARDS
+    tokens_by_shard: list[list[int]] = [[] for _ in range(SHARDED_LOGICAL_SHARDS)]
+
+    for token in range(num_hits):
+        shard = _mix32(token) & (SHARDED_LOGICAL_SHARDS - 1)
+        tokens_by_shard[shard].append(token)
+    if any(len(tokens) > ways for tokens in tokens_by_shard):
+        raise RuntimeError("top-k hits exceed shard capacity")
+
+    remaining = hot_buffer_size - num_hits
+    filler = seq_len
+    while remaining:
+        shard = _mix32(filler) & (SHARDED_LOGICAL_SHARDS - 1)
+        if len(tokens_by_shard[shard]) < ways:
+            tokens_by_shard[shard].append(filler)
+            remaining -= 1
+        filler += 1
+
+    return torch.tensor(
+        [token for shard in tokens_by_shard for token in shard], dtype=torch.int32
+    )
 
 
 def _make_top_k_tokens(
@@ -54,8 +103,18 @@ def _miss_tokens_per_req(miss_rate: float) -> int:
     return round(TOP_K * miss_rate)
 
 
+def _sharded_num_ctas(batch_size: int) -> int:
+    sm_count = torch.cuda.get_device_properties(DEVICE).multi_processor_count
+    target_ctas_per_request = max(1.0, sm_count / batch_size)
+    nearest_power_of_two = 1 << round(math.log2(target_ctas_per_request))
+    return min(SHARDED_MAX_CTAS_PER_REQUEST, nearest_power_of_two)
+
+
 def _build_inputs(
-    batch_size: int, hot_buffer_size: int, miss_rate: float
+    batch_size: int,
+    hot_buffer_size: int,
+    miss_rate: float,
+    provider: str,
 ) -> Dict[str, torch.Tensor | int]:
     dtype_bytes = torch.empty((), dtype=DTYPE).element_size()
     kv_dim = ITEM_SIZE_BYTES // dtype_bytes
@@ -86,17 +145,40 @@ def _build_inputs(
     device_buffer_tokens = torch.full(
         (batch_size, padded_buffer_size), -1, dtype=torch.int32, device=DEVICE
     )
-    device_buffer_tokens[:, :hot_buffer_size] = torch.arange(
-        hot_buffer_size, dtype=torch.int32, device=DEVICE
+    cache_tokens = _make_sharded_cache_tokens(num_hits, hot_buffer_size, seq_len)
+    device_buffer_tokens[:, :hot_buffer_size] = cache_tokens.to(DEVICE)
+
+    if provider == "sharded":
+        ways = hot_buffer_size // SHARDED_LOGICAL_SHARDS
+        lru_slots = (
+            torch.arange(ways, dtype=torch.uint8, device=DEVICE)
+            .view(1, 1, ways)
+            .repeat(batch_size, SHARDED_LOGICAL_SHARDS, 1)
+            .reshape(batch_size, hot_buffer_size)
+            .contiguous()
+        )
+    else:
+        lru_slots = (
+            torch.arange(hot_buffer_size, dtype=torch.int16, device=DEVICE)
+            .view(1, -1)
+            .repeat(batch_size, 1)
+        )
+
+    resident_mask = cache_tokens < seq_len
+    resident_slots = torch.nonzero(resident_mask, as_tuple=False).flatten()
+    resident_tokens = cache_tokens[resident_mask].to(torch.int64)
+    request_offsets = torch.arange(batch_size, dtype=torch.int64).unsqueeze(1)
+    resident_host_locs = request_offsets * seq_len + resident_tokens.unsqueeze(0)
+    resident_device_locs = (
+        request_offsets * padded_buffer_size + resident_slots.unsqueeze(0)
+    )
+    device_buffer.index_copy_(
+        0,
+        resident_device_locs.flatten().to(DEVICE),
+        host_cache[resident_host_locs.flatten()].to(DEVICE, non_blocking=True),
     )
 
-    lru_slots = (
-        torch.arange(hot_buffer_size, dtype=torch.int16, device=DEVICE)
-        .view(1, -1)
-        .repeat(batch_size, 1)
-    )
-
-    return {
+    state = {
         "top_k_tokens": top_k_tokens,
         "device_buffer_tokens": device_buffer_tokens,
         "initial_device_buffer_tokens": device_buffer_tokens.clone(),
@@ -117,15 +199,58 @@ def _build_inputs(
         "initial_lru_slots": lru_slots.clone(),
         "num_real_reqs": torch.tensor([batch_size], dtype=torch.int32, device=DEVICE),
     }
+    if provider == "sharded":
+        state["split_miss_counts"] = torch.empty(
+            (batch_size, SHARDED_LOGICAL_SHARDS),
+            dtype=torch.int32,
+            device=DEVICE,
+        )
+        state["shard_overflows"] = torch.empty(
+            (batch_size, SHARDED_LOGICAL_SHARDS),
+            dtype=torch.int32,
+            device=DEVICE,
+        )
+    torch.cuda.synchronize()
+    return state
 
 
-def _time_kernel(batch_size: int, hot_buffer_size: int, miss_rate: float) -> float:
-    state = _build_inputs(batch_size, hot_buffer_size, miss_rate)
+def _reset_state(state: Dict[str, torch.Tensor | int]) -> None:
+    state["device_buffer_tokens"].copy_(state["initial_device_buffer_tokens"])
+    state["lru_slots"].copy_(state["initial_lru_slots"])
+    state["top_k_device_locs"].fill_(-1)
 
-    def run_once():
-        state["device_buffer_tokens"].copy_(state["initial_device_buffer_tokens"])
-        state["lru_slots"].copy_(state["initial_lru_slots"])
-        state["top_k_device_locs"].fill_(-1)
+
+def _launch_kernel(
+    state: Dict[str, torch.Tensor | int],
+    batch_size: int,
+    hot_buffer_size: int,
+    provider: str,
+) -> None:
+    if provider == "sharded":
+        num_ctas = _sharded_num_ctas(batch_size)
+        load_cache_to_device_buffer_mla_sharded(
+            top_k_tokens=state["top_k_tokens"],
+            device_buffer_tokens=state["device_buffer_tokens"],
+            host_cache_locs=state["host_cache_locs"],
+            device_buffer_locs=state["device_buffer_locs"],
+            host_cache=state["host_cache"],
+            device_buffer=state["device_buffer"],
+            top_k_device_locs=state["top_k_device_locs"],
+            req_pool_indices=state["req_pool_indices"],
+            seq_lens=state["seq_lens"],
+            lru_slots=state["lru_slots"],
+            split_miss_counts=state["split_miss_counts"],
+            shard_overflows=state["shard_overflows"],
+            num_real_reqs=state["num_real_reqs"],
+            item_size_bytes=ITEM_SIZE_BYTES,
+            num_top_k=TOP_K,
+            hot_buffer_size=hot_buffer_size,
+            logical_shards=SHARDED_LOGICAL_SHARDS,
+            num_ctas=num_ctas,
+            block_size=SHARDED_BLOCK_SIZE,
+            min_blocks_per_sm=SHARDED_MIN_BLOCKS_PER_SM,
+        )
+    else:
         load_cache_to_device_buffer_mla(
             top_k_tokens=state["top_k_tokens"],
             device_buffer_tokens=state["device_buffer_tokens"],
@@ -144,50 +269,86 @@ def _time_kernel(batch_size: int, hot_buffer_size: int, miss_rate: float) -> flo
             num_real_reqs=state["num_real_reqs"],
         )
 
-    run_once()
-    torch.cuda.synchronize()
-    for _ in range(WARMUP_ROUNDS):
-        run_once()
-    torch.cuda.synchronize()
 
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for _ in range(ROUNDS):
-        run_once()
-    end.record()
+def _check_result(state: Dict[str, torch.Tensor | int], provider: str) -> None:
     torch.cuda.synchronize()
-    return start.elapsed_time(end) * 1000.0 / ROUNDS
+    if provider == "sharded" and state["shard_overflows"].any():
+        raise AssertionError("sharded queue overflow")
+    expected_host_locs = state["host_cache_locs"].gather(
+        1, state["top_k_tokens"].to(torch.int64)
+    )
+    expected = state["host_cache"][expected_host_locs.cpu()].to(DEVICE)
+    actual = state["device_buffer"][state["top_k_device_locs"].to(torch.int64)]
+    if not torch.equal(actual, expected):
+        raise AssertionError(f"{provider} returned incorrect KV data")
+
+
+def _time_sharded_kernel_gpu(
+    batch_size: int,
+    hot_buffer_size: int,
+    miss_rate: float,
+    provider: str,
+) -> float:
+    state = _build_inputs(
+        batch_size,
+        hot_buffer_size,
+        miss_rate,
+        provider=provider,
+    )
+
+    def reset_and_launch() -> None:
+        _reset_state(state)
+        _launch_kernel(state, batch_size, hot_buffer_size, provider)
+
+    reset_and_launch()
+    _check_result(state, provider)
+    kernel_name = (
+        "sharded_kernel"
+        if provider == "sharded"
+        else "load_cache_to_device_buffer_kernel"
+    )
+    return (
+        bench_kineto(
+            reset_and_launch,
+            kernel_names=kernel_name,
+            num_tests=KINETO_TESTS,
+        )
+        * 1e6
+    )
 
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
         x_names=["batch_size", "hot_buffer_size", "miss_rate", "miss_tokens_cnt"],
-        x_vals=CONFIGS,
+        x_vals=SHARDED_CONFIGS,
         line_arg="provider",
-        line_vals=LINE_VALS,
-        line_names=LINE_NAMES,
-        styles=STYLES,
+        line_vals=SHARDED_LINE_VALS,
+        line_names=SHARDED_LINE_NAMES,
+        styles=SHARDED_STYLES,
         ylabel="us",
-        plot_name="hisparse-latency",
+        plot_name="hisparse-sharded-kineto-latency",
         args={},
     )
 )
-def benchmark_latency(
+def benchmark_sharded_kernel_gpu(
     batch_size: int,
     hot_buffer_size: int,
     miss_rate: float,
     miss_tokens_cnt: int,
     provider: str,
 ) -> Tuple[float, float, float]:
-    assert provider == "jit"
     batch_size = int(batch_size)
     hot_buffer_size = int(hot_buffer_size)
     miss_rate = float(miss_rate)
     assert miss_tokens_cnt == batch_size * _miss_tokens_per_req(miss_rate)
-    avg_us = _time_kernel(batch_size, hot_buffer_size, miss_rate)
+    avg_us = _time_sharded_kernel_gpu(
+        batch_size,
+        hot_buffer_size,
+        miss_rate,
+        provider=provider,
+    )
     return avg_us, avg_us, avg_us
 
 
 if __name__ == "__main__":
-    benchmark_latency.run(print_data=True)
+    benchmark_sharded_kernel_gpu.run(print_data=True)

--- a/test/registered/jit/benchmark/bench_hisparse.py
+++ b/test/registered/jit/benchmark/bench_hisparse.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+from functools import cache
 from typing import Dict, Tuple
 
 import torch
@@ -14,6 +15,10 @@ from sglang.jit_kernel.hisparse_sharded import (
 )
 from sglang.jit_kernel.utils import is_hip_runtime
 from sglang.srt.utils.bench_utils import bench_kineto
+from sglang.srt.utils.numa_utils import (
+    _query_numa_node_for_gpu,
+    numa_bind_to_node,
+)
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
@@ -47,6 +52,25 @@ SHARDED_N1_BLOCK_SIZE = 1024
 SHARDED_N1_MIN_BLOCKS_PER_SM = 1
 SHARDED_MAX_CTAS_PER_REQUEST = 64
 KINETO_TESTS = 100
+
+
+@cache
+def bind_to_cuda_device_numa_node(device: torch.device | str | int) -> int | None:
+    """Keep pinned-host first-touch local to the selected GPU's NUMA node."""
+    if isinstance(device, int):
+        gpu_id = device
+    else:
+        gpu_id = torch.device(device).index
+        if gpu_id is None:
+            gpu_id = torch.cuda.current_device()
+
+    numa_nodes = _query_numa_node_for_gpu(gpu_id)
+    if not numa_nodes:
+        return None
+    numa_node = numa_nodes[0]
+    numa_bind_to_node(numa_node)
+    return numa_node
+
 
 if is_hip_runtime():
     SHARDED_LINE_VALS = ["original"]
@@ -122,6 +146,7 @@ def _build_inputs(
     miss_rate: float,
     provider: str,
 ) -> Dict[str, torch.Tensor | int]:
+    bind_to_cuda_device_numa_node(DEVICE)
     dtype_bytes = torch.empty((), dtype=DTYPE).element_size()
     kv_dim = ITEM_SIZE_BYTES // dtype_bytes
     padded_buffer_size = hot_buffer_size + 1

--- a/test/registered/jit/benchmark/bench_hisparse.py
+++ b/test/registered/jit/benchmark/bench_hisparse.py
@@ -25,7 +25,7 @@ DEVICE = DEFAULT_DEVICE
 DTYPE = DEFAULT_DTYPE
 TOP_K = 2048
 ITEM_SIZE_BYTES = 512
-SHARDED_BATCH_SIZES = [1, 2, 4, 16, 32, 64, 128, 256]
+SHARDED_BATCH_SIZES = [1, 2, 4, 8, 16, 32, 64, 128, 256]
 SHARDED_HOT_BUFFER_SIZES = [8192, 6144]
 SHARDED_MISSES_PER_REQ = [2, 410]
 SHARDED_CONFIGS = [
@@ -46,7 +46,7 @@ SHARDED_MIN_BLOCKS_PER_SM = 3
 SHARDED_N1_BLOCK_SIZE = 1024
 SHARDED_N1_MIN_BLOCKS_PER_SM = 1
 SHARDED_MAX_CTAS_PER_REQUEST = 64
-KINETO_TESTS = 30
+KINETO_TESTS = 100
 
 if is_hip_runtime():
     SHARDED_LINE_VALS = ["original"]
@@ -236,7 +236,12 @@ def _launch_kernel(
 ) -> None:
     if provider == "sharded":
         num_ctas = _sharded_num_ctas(batch_size)
-        block_size = SHARDED_N1_BLOCK_SIZE if num_ctas == 1 else SHARDED_BLOCK_SIZE
+        sm_count = torch.cuda.get_device_properties(DEVICE).multi_processor_count
+        block_size = (
+            SHARDED_BLOCK_SIZE
+            if num_ctas > 1 or batch_size > sm_count
+            else SHARDED_N1_BLOCK_SIZE
+        )
         min_blocks_per_sm = (
             SHARDED_N1_MIN_BLOCKS_PER_SM if num_ctas == 1 else SHARDED_MIN_BLOCKS_PER_SM
         )

--- a/test/registered/jit/benchmark/bench_hisparse.py
+++ b/test/registered/jit/benchmark/bench_hisparse.py
@@ -50,6 +50,8 @@ SHARDED_BLOCK_SIZE = 512
 SHARDED_MIN_BLOCKS_PER_SM = 3
 SHARDED_N1_BLOCK_SIZE = 1024
 SHARDED_N1_MIN_BLOCKS_PER_SM = 1
+SHARDED_N1_LARGE_BATCH_BLOCK_SIZE = 640
+SHARDED_N1_LARGE_BATCH_MIN_BLOCKS_PER_SM = 2
 SHARDED_MAX_CTAS_PER_REQUEST = 64
 KINETO_TESTS = 100
 
@@ -250,14 +252,15 @@ def _launch_kernel(
     if provider == "sharded":
         num_ctas = _sharded_num_ctas(batch_size)
         sm_count = torch.cuda.get_device_properties(DEVICE).multi_processor_count
-        block_size = (
-            SHARDED_BLOCK_SIZE
-            if num_ctas > 1 or batch_size > sm_count
-            else SHARDED_N1_BLOCK_SIZE
-        )
-        min_blocks_per_sm = (
-            SHARDED_N1_MIN_BLOCKS_PER_SM if num_ctas == 1 else SHARDED_MIN_BLOCKS_PER_SM
-        )
+        if num_ctas > 1:
+            block_size = SHARDED_BLOCK_SIZE
+            min_blocks_per_sm = SHARDED_MIN_BLOCKS_PER_SM
+        elif batch_size > sm_count:
+            block_size = SHARDED_N1_LARGE_BATCH_BLOCK_SIZE
+            min_blocks_per_sm = SHARDED_N1_LARGE_BATCH_MIN_BLOCKS_PER_SM
+        else:
+            block_size = SHARDED_N1_BLOCK_SIZE
+            min_blocks_per_sm = SHARDED_N1_MIN_BLOCKS_PER_SM
         load_cache_to_device_buffer_mla_sharded(
             top_k_tokens=state["top_k_tokens"],
             device_buffer_tokens=state["device_buffer_tokens"],

--- a/test/registered/jit/benchmark/bench_hisparse.py
+++ b/test/registered/jit/benchmark/bench_hisparse.py
@@ -10,6 +10,7 @@ from sglang.jit_kernel.benchmark.utils import DEFAULT_DEVICE, DEFAULT_DTYPE
 from sglang.jit_kernel.hisparse import load_cache_to_device_buffer_mla
 from sglang.jit_kernel.hisparse_sharded import (
     load_cache_to_device_buffer_mla_sharded,
+    logical_shards_for_hot_buffer,
 )
 from sglang.jit_kernel.utils import is_hip_runtime
 from sglang.srt.utils.bench_utils import bench_kineto
@@ -24,22 +25,26 @@ DEVICE = DEFAULT_DEVICE
 DTYPE = DEFAULT_DTYPE
 TOP_K = 2048
 ITEM_SIZE_BYTES = 512
-SHARDED_LOGICAL_SHARDS = 256
 SHARDED_BATCH_SIZES = [1, 2, 4, 16, 32, 64, 128, 256]
+SHARDED_HOT_BUFFER_SIZES = [8192, 6144]
 SHARDED_MISSES_PER_REQ = [2, 410]
 SHARDED_CONFIGS = [
     (
         batch_size,
-        8192,
+        hot_buffer_size,
         misses_per_req / TOP_K,
         batch_size * misses_per_req,
     )
-    for batch_size, misses_per_req in itertools.product(
-        SHARDED_BATCH_SIZES, SHARDED_MISSES_PER_REQ
+    for hot_buffer_size, batch_size, misses_per_req in itertools.product(
+        SHARDED_HOT_BUFFER_SIZES,
+        SHARDED_BATCH_SIZES,
+        SHARDED_MISSES_PER_REQ,
     )
 ]
 SHARDED_BLOCK_SIZE = 512
 SHARDED_MIN_BLOCKS_PER_SM = 3
+SHARDED_N1_BLOCK_SIZE = 1024
+SHARDED_N1_MIN_BLOCKS_PER_SM = 1
 SHARDED_MAX_CTAS_PER_REQUEST = 64
 KINETO_TESTS = 30
 
@@ -66,11 +71,12 @@ def _make_sharded_cache_tokens(
     hot_buffer_size: int,
     seq_len: int,
 ) -> torch.Tensor:
-    ways = hot_buffer_size // SHARDED_LOGICAL_SHARDS
-    tokens_by_shard: list[list[int]] = [[] for _ in range(SHARDED_LOGICAL_SHARDS)]
+    logical_shards = logical_shards_for_hot_buffer(hot_buffer_size, DEVICE)
+    ways = torch.cuda.get_device_properties(DEVICE).warp_size
+    tokens_by_shard: list[list[int]] = [[] for _ in range(logical_shards)]
 
     for token in range(num_hits):
-        shard = _mix32(token) & (SHARDED_LOGICAL_SHARDS - 1)
+        shard = _mix32(token) % logical_shards
         tokens_by_shard[shard].append(token)
     if any(len(tokens) > ways for tokens in tokens_by_shard):
         raise RuntimeError("top-k hits exceed shard capacity")
@@ -78,7 +84,7 @@ def _make_sharded_cache_tokens(
     remaining = hot_buffer_size - num_hits
     filler = seq_len
     while remaining:
-        shard = _mix32(filler) & (SHARDED_LOGICAL_SHARDS - 1)
+        shard = _mix32(filler) % logical_shards
         if len(tokens_by_shard[shard]) < ways:
             tokens_by_shard[shard].append(filler)
             remaining -= 1
@@ -149,11 +155,12 @@ def _build_inputs(
     device_buffer_tokens[:, :hot_buffer_size] = cache_tokens.to(DEVICE)
 
     if provider == "sharded":
-        ways = hot_buffer_size // SHARDED_LOGICAL_SHARDS
+        logical_shards = logical_shards_for_hot_buffer(hot_buffer_size, DEVICE)
+        ways = torch.cuda.get_device_properties(DEVICE).warp_size
         lru_slots = (
             torch.arange(ways, dtype=torch.uint8, device=DEVICE)
             .view(1, 1, ways)
-            .repeat(batch_size, SHARDED_LOGICAL_SHARDS, 1)
+            .repeat(batch_size, logical_shards, 1)
             .reshape(batch_size, hot_buffer_size)
             .contiguous()
         )
@@ -200,13 +207,14 @@ def _build_inputs(
         "num_real_reqs": torch.tensor([batch_size], dtype=torch.int32, device=DEVICE),
     }
     if provider == "sharded":
+        logical_shards = logical_shards_for_hot_buffer(hot_buffer_size, DEVICE)
         state["split_miss_counts"] = torch.empty(
-            (batch_size, SHARDED_LOGICAL_SHARDS),
+            (batch_size, logical_shards),
             dtype=torch.int32,
             device=DEVICE,
         )
         state["shard_overflows"] = torch.empty(
-            (batch_size, SHARDED_LOGICAL_SHARDS),
+            (batch_size, logical_shards),
             dtype=torch.int32,
             device=DEVICE,
         )
@@ -228,6 +236,10 @@ def _launch_kernel(
 ) -> None:
     if provider == "sharded":
         num_ctas = _sharded_num_ctas(batch_size)
+        block_size = SHARDED_N1_BLOCK_SIZE if num_ctas == 1 else SHARDED_BLOCK_SIZE
+        min_blocks_per_sm = (
+            SHARDED_N1_MIN_BLOCKS_PER_SM if num_ctas == 1 else SHARDED_MIN_BLOCKS_PER_SM
+        )
         load_cache_to_device_buffer_mla_sharded(
             top_k_tokens=state["top_k_tokens"],
             device_buffer_tokens=state["device_buffer_tokens"],
@@ -245,10 +257,9 @@ def _launch_kernel(
             item_size_bytes=ITEM_SIZE_BYTES,
             num_top_k=TOP_K,
             hot_buffer_size=hot_buffer_size,
-            logical_shards=SHARDED_LOGICAL_SHARDS,
             num_ctas=num_ctas,
-            block_size=SHARDED_BLOCK_SIZE,
-            min_blocks_per_sm=SHARDED_MIN_BLOCKS_PER_SM,
+            block_size=block_size,
+            min_blocks_per_sm=min_blocks_per_sm,
         )
     else:
         load_cache_to_device_buffer_mla(


### PR DESCRIPTION
## Motivation

The current HiSparse kernel uses a strict  1 CTA per request mapping. This provides enough parallel work for large batches, but underutilizes the GPU at small batch sizes.

This PR explores a multi-CTA mapping for HiSparse. A single request can be split across several CTAs, allowing small batches to expose enough parallelism to the GPU while reducing the number of CTAs per request as the batch size grows.

Relates to https://github.com/sgl-project/sglang/issues/28874 (kernel task was marked with call for contribution)

## Modifications

The changes only affect the metadata preparation path, the copy path has not changed.

The kernel partitions each request's hot buffer into independent LRU logical shards and hashes every selected top-k token to one shard. Each CTA owns a subset of the logical shards, builds their top-k queues in shared memory, and assigns one warp at a time to each shard.

Benchmark updates:
* prepare bench data for sharded layout too
* uses `bench_kineto` to measure only the target GPU kernel, excluding Python/JIT wrapper and state-reset overhead

## Accuracy Tests

* benchmark tests correctness
TODO: full e2e accuracy test on top of GLM

## Speed Tests and Profiling

H200, top_k=2048, 256 logical shards x 32 ways, 512-byte KV items
Each value is avg@100

Hot buffer size = 8192

| Batch | Original, misses=2 | Sharded, misses=2 | Change | Original, misses=410 | Sharded, misses=410 | Change | Achieved PCIe read BW, misses=410 |
|------:|-------------------:|------------------:|-------:|---------------------:|--------------------:|-------:|-------------------------:|
|     1 |             24.1 µs |             7.3 µs | −69.8% |               47.4 µs |              17.0 µs | −64.2% |                13.7 GB/s |
|     2 |             24.2 µs |             7.4 µs | −69.6% |               48.0 µs |              22.1 µs | −53.9% |                20.9 GB/s |
|     4 |             24.5 µs |             7.4 µs | −69.7% |               49.9 µs |              31.8 µs | −36.3% |                29.0 GB/s |
|     8 |             24.6 µs |             8.3 µs | −66.4% |               75.8 µs |              59.4 µs | −21.6% |                31.0 GB/s |
|    16 |             24.9 µs |            10.3 µs | −58.6% |              127.0 µs |             115.3 µs |  −9.2% |                31.9 GB/s |
|    32 |             25.2 µs |            14.3 µs | −43.3% |              231.8 µs |             228.3 µs |  −1.5% |                32.2 GB/s |
|    64 |             25.7 µs |            22.6 µs | −11.9% |              411.7 µs |             437.8 µs |  +6.3% |                33.6 GB/s |
|   128 |             27.9 µs |            21.6 µs | −22.6% |              816.3 µs |             868.4 µs |  +6.4% |                33.8 GB/s |
|   256 |             35.8 µs |            35.4 µs |  -0.9% |             1641.0 µs |            1695.0 µs |  +3.3% |                34.8 GB/s |


Hot buffer size = 6144

| Batch | Original, misses=2 | Sharded, misses=2 | Change | Original, misses=410 | Sharded, misses=410 | Change | Achieved PCIe read BW, misses=410 |
|------:|-------------------:|------------------:|-------:|---------------------:|--------------------:|-------:|-------------------------:|
|     1 |             19.8 µs |             7.3 µs | −62.9% |               42.7 µs |              18.3 µs | −57.1% |                12.6 GB/s |
|     2 |             19.8 µs |             7.4 µs | −62.8% |               40.7 µs |              21.7 µs | −46.6% |                21.2 GB/s |
|     4 |             20.0 µs |             7.4 µs | −62.9% |               44.7 µs |              34.2 µs | −23.5% |                26.9 GB/s |
|     8 |             20.4 µs |             8.3 µs | −59.4% |               70.8 µs |              60.5 µs | −14.6% |                30.3 GB/s |
|    16 |             20.7 µs |            10.5 µs | −49.0% |              122.3 µs |             118.6 µs |  −3.0% |                31.0 GB/s |
|    32 |             21.1 µs |            14.1 µs | −33.5% |              225.9 µs |             229.1 µs |  +1.4% |                32.1 GB/s |
|    64 |             21.3 µs |            20.8 µs |  −2.7% |              404.1 µs |             433.6 µs |  +7.3% |                33.9 GB/s |
|   128 |             23.6 µs |            19.7 µs | −16.2% |              813.8 µs |             859.5 µs |  +5.6% |                34.2 GB/s |
|   256 |             29.8 µs |            32.6 µs | +9.2% |             1640.0 µs |            1699.0 µs |  +3.6% |                34.3 GB/s |

## TODOs

* Fallback to slow path if top-k tokens don't have enough ways cache (probability of this ~ 7 * 10^-9)


























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29737246872](https://github.com/sgl-project/sglang/actions/runs/29737246872)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29737246889](https://github.com/sgl-project/sglang/actions/runs/29737246889)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->