### PR TITLE
fix(dsa): reject prefill-only flashmla_auto for --dsa-decode-backend at argparse

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2203,7 +2203,7 @@ class DeepseekSparseAttnBackend(
             )
 
         else:
-            assert False, f"Unsupported {self.dsa_decode_impl = }"
+            raise ValueError(f"Unsupported {self.dsa_decode_impl = }")
 
     def _forward_fa3(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -333,6 +333,13 @@ DSA_CHOICES = [
 ]
 NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
+# flashmla_auto is a prefill-only value: only the prefill path resolves it via
+# enable_auto_select_prefill_impl (see dsa_backend.py). The decode dispatch has no
+# flashmla_auto branch and asserts on it, so exclude it from the decode choices to
+# fail fast at argparse instead of at the first decode step. For an auto-selected
+# decode backend, leave --dsa-decode-backend unset.
+DSA_DECODE_CHOICES = [c for c in DSA_CHOICES if c != "flashmla_auto"]
+
 DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
 
 DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
@@ -1461,7 +1468,7 @@ class ServerArgs:
         Optional[str],
         Arg(
             help="DSA (DeepSeek Sparse Attention) decode backend. If not specified, auto-detects based on hardware and kv_cache_dtype.",
-            choices=DSA_CHOICES,
+            choices=DSA_DECODE_CHOICES,
             resolvable=True,
         ),
     ] = None
@@ -6715,7 +6722,7 @@ class ServerArgs:
             new_flag="--dsa-decode-backend",
             default=argparse.SUPPRESS,
             type=str,
-            choices=DSA_CHOICES,
+            choices=DSA_DECODE_CHOICES,
             help="[Deprecated] Use --dsa-decode-backend instead.",
         )
         parser.add_argument(

--- a/test/registered/unit/test_dsa_decode_backend_validation.py
+++ b/test/registered/unit/test_dsa_decode_backend_validation.py
@@ -1,0 +1,67 @@
+"""Tests that the DSA decode backend argument rejects the prefill-only
+``flashmla_auto`` value at argparse time instead of deferring the failure to the
+first decode step.
+
+``flashmla_auto`` is only resolvable on the prefill path
+(``enable_auto_select_prefill_impl`` in ``dsa_backend.py``); the decode dispatch
+has no branch for it and would ``raise ValueError(f"Unsupported ...")``. It used
+to pass argparse because the decode arg (and its deprecated ``--nsa-decode-backend``
+alias) shared the full ``DSA_CHOICES`` list with the prefill arg, so the server
+booted and crashed only at the first decode forward. The decode arg now uses the
+narrowed ``DSA_DECODE_CHOICES`` list.
+"""
+
+import argparse
+import contextlib
+import io
+import unittest
+
+from sglang.srt.server_args import DSA_CHOICES, DSA_DECODE_CHOICES, ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestDsaDecodeBackendValidation(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(cls.parser)
+
+    def _parse(self, args_list):
+        # argparse writes usage to stderr on a bad choice; keep test output clean.
+        with contextlib.redirect_stderr(io.StringIO()):
+            return self.parser.parse_args(["--model", "dummy"] + args_list)
+
+    def test_decode_choices_exclude_only_flashmla_auto(self):
+        """The narrowed decode list drops flashmla_auto and nothing else."""
+        self.assertNotIn("flashmla_auto", DSA_DECODE_CHOICES)
+        self.assertEqual(set(DSA_DECODE_CHOICES), set(DSA_CHOICES) - {"flashmla_auto"})
+
+    def test_decode_backend_rejects_flashmla_auto(self):
+        """--dsa-decode-backend flashmla_auto fails fast at argparse."""
+        with self.assertRaises(SystemExit):
+            self._parse(["--dsa-decode-backend", "flashmla_auto"])
+
+    def test_nsa_decode_alias_rejects_flashmla_auto(self):
+        """The deprecated --nsa-decode-backend alias is narrowed too."""
+        with self.assertRaises(SystemExit):
+            self._parse(["--nsa-decode-backend", "flashmla_auto"])
+
+    def test_decode_backend_accepts_valid_values(self):
+        """Every non-auto DSA backend is still accepted for decode."""
+        for backend in DSA_DECODE_CHOICES:
+            with self.subTest(backend=backend):
+                args = self._parse(["--dsa-decode-backend", backend])
+                self.assertEqual(args.dsa_decode_backend, backend)
+
+    def test_prefill_backend_still_accepts_flashmla_auto(self):
+        """flashmla_auto remains valid on the prefill path (unchanged)."""
+        args = self._parse(["--dsa-prefill-backend", "flashmla_auto"])
+        self.assertEqual(args.dsa_prefill_backend, "flashmla_auto")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`flashmla_auto` is a **prefill-only** DSA (DeepSeek Sparse Attention) backend: only the prefill path resolves it, via `enable_auto_select_prefill_impl` in `dsa_backend.py`. The decode dispatch has no `flashmla_auto` branch. But the decode argument (`--dsa-decode-backend`) and its deprecated alias (`--nsa-decode-backend`) shared the full `DSA_CHOICES` list with the prefill argument, so `flashmla_auto` passed argparse validation for decode. The server then booted fully and crashed only at the **first decode step** with `Unsupported self.dsa_decode_impl = 'flashmla_auto'` — a deferred failure that is easy to mistake for a runtime/model bug rather than a bad CLI value. (A genuinely unknown value like `flashmla_xyz` is correctly rejected at parse time; `flashmla_auto` was the one list-valid-but-decode-invalid value that slipped through.)

## Modifications

- Add `DSA_DECODE_CHOICES` (= `DSA_CHOICES` minus `flashmla_auto`) in `server_args.py` and use it as `choices=` for the `dsa_decode_backend` field and for the deprecated `--nsa-decode-backend` alias. The prefill argument keeps the full `DSA_CHOICES`, so `flashmla_auto` remains valid for prefill. Invalid decode values now fail fast at argparse and `--help` self-documents the allowed set.
- Convert the decode-dispatch fallthrough in `dsa_backend.py` from `assert False, f"Unsupported {self.dsa_decode_impl = }"` to `raise ValueError(...)`, so the guard survives `python -O` (which strips `assert`).
- Add a CPU-only unit test (`test/registered/unit/test_dsa_decode_backend_validation.py`) covering: `--dsa-decode-backend flashmla_auto` and `--nsa-decode-backend flashmla_auto` are rejected (`SystemExit`); every remaining decode value is accepted; `flashmla_auto` is still accepted for prefill; and `DSA_DECODE_CHOICES` drops exactly `flashmla_auto`.

For an auto-selected decode backend, the correct usage is to leave `--dsa-decode-backend` unset (the resolution pass picks a valid decode impl); this is now reflected in a code comment next to `DSA_DECODE_CHOICES`.

## Accuracy Tests

Not applicable — CLI argument validation only, no change to model outputs or kernels.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) (black 26.1.0 + isort 7.0.0).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) (CPU-only, registered via `register_cpu_ci`).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29425478047](https://github.com/sgl-project/sglang/actions/runs/29425478047)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29425477599](https://github.com/sgl-project/sglang/actions/runs/29425477599)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->