### PR TITLE
feat(tokenizer): segment encode_batch for long RAG (w_cap=len/1k*2, prefill cache-hit @ L20)

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -387,6 +387,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     trust_remote_code=server_args.trust_remote_code,
                     revision=server_args.revision,
                     tokenizer_backend=server_args.tokenizer_backend,
+                    enable_segment_batch_encode=server_args.enable_segment_batch_encode,
+                    segment_split_delimiter=server_args.segment_split_delimiter,
+                    segment_batch_min_chars=server_args.segment_batch_min_chars,
                 )
 
         # Initialize async dynamic batch tokenizer if enabled (common for both multimodal and non-multimodal)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2701,6 +2701,18 @@ class ServerArgs:
         bool,
         "Enable batch tokenization for improved performance when processing multiple text inputs. Do not use with image inputs, pre-tokenized input_ids, or input_embeds.",
     ] = False
+    enable_segment_batch_encode: A[
+        bool,
+        "Enable lossless segmented encode_batch for long single-string prompts (RAG/multi-passage).",
+    ] = False
+    segment_split_delimiter: A[
+        Optional[str],
+        "[Only if --enable-segment-batch-encode] Delimiter to split on. Default: auto ('### Passage ' or eos).",
+    ] = None
+    segment_batch_min_chars: A[
+        int,
+        "[Only if --enable-segment-batch-encode] Min prompt chars before segmenting.",
+    ] = 4096
     disable_tokenizer_batch_decode: A[
         bool,
         "Disable batch decoding when decoding multiple completions.",
@@ -6103,6 +6115,12 @@ class ServerArgs:
                     "skip_tokenizer_init=True ignores --enable-dynamic-batch-tokenizer; disabling it."
                 )
                 self.enable_dynamic_batch_tokenizer = False
+
+            if self.enable_segment_batch_encode:
+                logger.warning(
+                    "skip_tokenizer_init=True ignores --enable-segment-batch-encode; disabling it."
+                )
+                self.enable_segment_batch_encode = False
 
             logger.info(
                 "skip_tokenizer_init=True: string-based stop conditions (stop, stop_regex) "

--- a/python/sglang/srt/utils/hf_transformers/segment_batch_encode.py
+++ b/python/sglang/srt/utils/hf_transformers/segment_batch_encode.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Contributors to the SGLang segment-batch-encode proposal.
+# Licensed under the Apache License, Version 2.0.
+"""Lossless segmented parallel encoding for long single-string prompts.
+
+Split text on a delimiter (default: ``### Passage `` for RAG, else eos),
+encode segments via Rust ``encode_batch``, concat token ids. Lossless when the
+delimiter is a hard BPE boundary.
+"""
+
+from __future__ import annotations
+
+import array
+import hashlib
+import logging
+import threading
+from collections import OrderedDict
+from typing import Any, Optional
+
+from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PASSAGE_DELIMITER = "### Passage "
+_DEFAULT_CACHE_MAX_ENTRIES = 100_000
+_DEFAULT_CACHE_MAX_TOKENS = 8_000_000
+_DEFAULT_MIN_CHARS = 4096
+
+
+def _segment_digest(text: str) -> bytes:
+    return hashlib.blake2b(text.encode("utf-8"), digest_size=16).digest()
+
+
+class _SegmentIdsCache:
+    def __init__(self, max_entries: int, max_total_tokens: int) -> None:
+        self._max_entries = max_entries
+        self._max_total_tokens = max_total_tokens
+        self._data: OrderedDict[bytes, array.array] = OrderedDict()
+        self._total_tokens = 0
+        self._lock = threading.Lock()
+
+    def get(self, key: bytes) -> array.array | None:
+        with self._lock:
+            ids = self._data.get(key)
+            if ids is not None:
+                self._data.move_to_end(key)
+            return ids
+
+    def put(self, key: bytes, ids: array.array) -> None:
+        with self._lock:
+            old = self._data.pop(key, None)
+            if old is not None:
+                self._total_tokens -= len(old)
+            if len(ids) > self._max_total_tokens:
+                return
+            self._data[key] = ids
+            self._total_tokens += len(ids)
+            while (
+                len(self._data) > self._max_entries
+                or self._total_tokens > self._max_total_tokens
+            ):
+                _, evicted = self._data.popitem(last=False)
+                self._total_tokens -= len(evicted)
+
+
+def resolve_split_delimiter(
+    tokenizer: PreTrainedTokenizer,
+    configured: Optional[str],
+    sample_text: Optional[str] = None,
+) -> Optional[str]:
+    if configured:
+        return configured
+    if sample_text and DEFAULT_PASSAGE_DELIMITER in sample_text:
+        return DEFAULT_PASSAGE_DELIMITER
+    return tokenizer.eos_token or None
+
+
+def _concat_items(items: list[str], delimiter: str) -> str:
+    if not items:
+        return ""
+    out = items[0]
+    for item in items[1:]:
+        out += delimiter + item
+    return out
+
+
+def _estimate_tokens(text: str) -> int:
+    # chars/4 is enough for segment planning; avoids a full encode.
+    return max(1, len(text) // 4)
+
+
+def compute_max_workers(est_tokens: int) -> int:
+    """Fan-out cap scales with length: 2 workers per 1k estimated tokens."""
+    return max(1, (est_tokens * 2) // 1000)
+
+
+def _plan_segment_items(
+    items: list[str],
+    delimiter: str,
+    *,
+    est_tokens: int,
+    max_workers: int | None = None,
+) -> list[str]:
+    """Merge passages into at most ``max_workers`` segments (default: len/1k*2)."""
+    if len(items) <= 1:
+        return items
+    n = max_workers if max_workers is not None else compute_max_workers(est_tokens)
+    n = min(len(items), max(1, n))
+    if n >= len(items):
+        return items
+    group = (len(items) + n - 1) // n
+    return [_concat_items(items[i : i + group], delimiter) for i in range(0, len(items), group)]
+
+
+def _encode_segments(
+    tokenizer: PreTrainedTokenizerFast,
+    items: list[str],
+    cache: _SegmentIdsCache | None,
+    add_special_tokens: bool,
+) -> list[list[int]]:
+    backend = tokenizer.backend_tokenizer
+    if cache is None:
+        encs = backend.encode_batch(items, add_special_tokens=add_special_tokens)
+        return [enc.ids for enc in encs]
+
+    digests = [_segment_digest(s) for s in items]
+    seg_ids: list[list[int] | None] = [None] * len(items)
+    cached: list[array.array | None] = [cache.get(d) for d in digests]
+    miss = [i for i, c in enumerate(cached) if c is None]
+    for i, c in enumerate(cached):
+        if c is not None:
+            seg_ids[i] = list(c)
+    if miss:
+        encs = backend.encode_batch(
+            [items[i] for i in miss], add_special_tokens=add_special_tokens
+        )
+        for j, enc in zip(miss, encs):
+            ids = array.array("i", enc.ids)
+            seg_ids[j] = list(ids)
+            cache.put(digests[j], ids)
+    return [ids or [] for ids in seg_ids]
+
+
+def segment_batch_encode_ids(
+    tokenizer: PreTrainedTokenizer,
+    text: str,
+    *,
+    split_delimiter: str,
+    add_special_tokens: bool = False,
+    segment_cache: _SegmentIdsCache | None = None,
+    interleave_delimiter: bool = True,
+) -> list[int]:
+    """Encode ``text`` via segmented ``encode_batch`` when beneficial."""
+    if not isinstance(text, str) or not text:
+        return tokenizer.encode(text, add_special_tokens=add_special_tokens)
+
+    if not isinstance(tokenizer, PreTrainedTokenizerFast):
+        return tokenizer.encode(text, add_special_tokens=add_special_tokens)
+
+    if add_special_tokens and tokenizer.num_special_tokens_to_add() > 0:
+        return tokenizer.encode(text, add_special_tokens=True)
+
+    raw_items = text.split(split_delimiter)
+    ends_with_delim = text.endswith(split_delimiter)
+    if raw_items and raw_items[-1] == "":
+        raw_items.pop()
+    if len(raw_items) <= 1:
+        return tokenizer.encode(text, add_special_tokens=add_special_tokens)
+
+    est = _estimate_tokens(text)
+    items = _plan_segment_items(raw_items, split_delimiter, est_tokens=est)
+    if len(items) <= 1:
+        return tokenizer.encode(text, add_special_tokens=add_special_tokens)
+
+    delim_ids = list(tokenizer.encode(split_delimiter, add_special_tokens=False))
+    seg_ids = _encode_segments(tokenizer, items, segment_cache, add_special_tokens)
+
+    result: list[int] = []
+    for i, ids in enumerate(seg_ids):
+        if i > 0:
+            result.extend(delim_ids)
+        result.extend(ids)
+    if ends_with_delim:
+        result.extend(delim_ids)
+    return result
+
+
+def make_segment_batch_encode_tokenizer(
+    tokenizer: PreTrainedTokenizer,
+    *,
+    split_delimiter: Optional[str] = None,
+    segment_cache: bool = False,
+    cache_max_entries: int = _DEFAULT_CACHE_MAX_ENTRIES,
+    cache_max_tokens: int = _DEFAULT_CACHE_MAX_TOKENS,
+    min_chars: int = _DEFAULT_MIN_CHARS,
+) -> PreTrainedTokenizer:
+    if not isinstance(tokenizer, PreTrainedTokenizerFast):
+        logger.warning(
+            "enable_segment_batch_encode requires a fast tokenizer; got %s",
+            type(tokenizer).__name__,
+        )
+        return tokenizer
+
+    delim = resolve_split_delimiter(tokenizer, split_delimiter)
+    if not delim:
+        logger.warning(
+            "enable_segment_batch_encode: no delimiter; feature disabled for this tokenizer"
+        )
+        return tokenizer
+
+    cache = (
+        _SegmentIdsCache(cache_max_entries, cache_max_tokens) if segment_cache else None
+    )
+    base_cls = tokenizer.__class__
+
+    class SegmentBatchEncodeTokenizerImpl(base_cls):  # type: ignore[misc,valid-type]
+        def encode(  # type: ignore[override]
+            self,
+            text,
+            *args,
+            add_special_tokens: bool = True,
+            **kwargs,
+        ):
+            if (
+                isinstance(text, str)
+                and len(text) >= min_chars
+                and text.count(delim) >= 1
+            ):
+                return segment_batch_encode_ids(
+                    self,
+                    text,
+                    split_delimiter=delim,
+                    add_special_tokens=add_special_tokens,
+                    segment_cache=cache,
+                )
+            return super().encode(
+                text, *args, add_special_tokens=add_special_tokens, **kwargs
+            )
+
+        def __call__(self, text=None, text_pair=None, *args, **kwargs):  # type: ignore[override]
+            # Single-string batch path used by TokenizerManager._tokenize_texts.
+            if (
+                text is not None
+                and text_pair is None
+                and isinstance(text, list)
+                and len(text) == 1
+                and isinstance(text[0], str)
+                and len(text[0]) >= min_chars
+                and text[0].count(delim) >= 1
+                and not kwargs.get("return_token_type_ids")
+            ):
+                add_special = kwargs.get("add_special_tokens", True)
+                return {
+                    "input_ids": [
+                        segment_batch_encode_ids(
+                            self,
+                            text[0],
+                            split_delimiter=delim,
+                            add_special_tokens=add_special,
+                            segment_cache=cache,
+                        )
+                    ]
+                }
+            return super().__call__(text, text_pair, *args, **kwargs)
+
+    SegmentBatchEncodeTokenizerImpl.__name__ = f"SegmentBatchEncode{base_cls.__name__}"
+    tokenizer.__class__ = SegmentBatchEncodeTokenizerImpl
+    logger.info(
+        "segment_batch_encode enabled: delimiter=%r segment_cache=%s min_chars=%d",
+        delim,
+        segment_cache,
+        min_chars,
+    )
+    return tokenizer

--- a/python/sglang/srt/utils/hf_transformers/tokenizer.py
+++ b/python/sglang/srt/utils/hf_transformers/tokenizer.py
@@ -464,6 +464,9 @@ def get_tokenizer(
     trust_remote_code: bool = False,
     tokenizer_revision: Optional[str] = None,
     tokenizer_backend: str = "huggingface",
+    enable_segment_batch_encode: bool = False,
+    segment_split_delimiter: Optional[str] = None,
+    segment_batch_min_chars: int = 4096,
     **kwargs,
 ) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
     """Gets a tokenizer for the given model name via Huggingface."""
@@ -529,7 +532,16 @@ def get_tokenizer(
                     tokenizer_name, *args, **common_kwargs
                 )
 
-        return _apply_post_load_fixes(tokenizer, tokenizer_name, tokenizer_revision)
+        tokenizer = _apply_post_load_fixes(tokenizer, tokenizer_name, tokenizer_revision)
+        if enable_segment_batch_encode:
+            from .segment_batch_encode import make_segment_batch_encode_tokenizer
+
+            tokenizer = make_segment_batch_encode_tokenizer(
+                tokenizer,
+                split_delimiter=segment_split_delimiter,
+                min_chars=segment_batch_min_chars,
+            )
+        return tokenizer
     except Exception as e:
         if tokenizer_backend == "fastokens":
             raise RuntimeError(

--- a/test/manual/benchmark_segment_batch_encode.py
+++ b/test/manual/benchmark_segment_batch_encode.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Manual benchmark for segment_batch_encode (SGLang PR data)."""
+
+import argparse
+import json
+import os
+import statistics
+import time
+
+from transformers import AutoTokenizer
+
+from sglang.srt.utils.hf_transformers.segment_batch_encode import (
+    DEFAULT_PASSAGE_DELIMITER,
+    make_segment_batch_encode_tokenizer,
+    segment_batch_encode_ids,
+)
+
+
+def bench(fn, warmup=5, iters=30):
+    for _ in range(warmup):
+        fn()
+    xs = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        xs.append((time.perf_counter() - t0) * 1000)
+    return statistics.median(xs)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-path", required=True)
+    ap.add_argument("--prompt-json")
+    ap.add_argument("--trust-remote-code", action="store_true")
+    args = ap.parse_args()
+
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "true")
+    tok = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=args.trust_remote_code)
+    if args.prompt_json:
+        msgs = json.load(open(args.prompt_json, encoding="utf-8"))
+        text = tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
+    else:
+        text = (DEFAULT_PASSAGE_DELIMITER + "demo\n") * 20
+
+    plain_ms = bench(lambda: tok.encode(text, add_special_tokens=False))
+    seg_ms = bench(
+        lambda: segment_batch_encode_ids(
+            tok, text, split_delimiter=DEFAULT_PASSAGE_DELIMITER, add_special_tokens=False,
+            interleave_delimiter=False,
+        )
+    )
+    wrapped = make_segment_batch_encode_tokenizer(tok, min_chars=1)
+    wrap_ms = bench(lambda: wrapped.encode(text, add_special_tokens=False))
+
+    print(f"tokens={len(tok.encode(text, add_special_tokens=False))} passages={text.count(DEFAULT_PASSAGE_DELIMITER)}")
+    print(f"plain_encode_ms={plain_ms:.1f}")
+    print(f"segment_batch_ms={seg_ms:.1f} speedup={plain_ms/seg_ms:.2f}x")
+    print(f"wrapped_encode_ms={wrap_ms:.1f} speedup={plain_ms/wrap_ms:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/utils/test_segment_batch_encode.py
+++ b/test/registered/unit/utils/test_segment_batch_encode.py
@@ -1,0 +1,108 @@
+"""Unit tests for segment_batch_encode."""
+
+import unittest
+
+from transformers import AutoTokenizer
+
+from sglang.srt.utils.hf_transformers.segment_batch_encode import (
+    DEFAULT_PASSAGE_DELIMITER,
+    make_segment_batch_encode_tokenizer,
+    resolve_split_delimiter,
+    segment_batch_encode_ids,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="stage-a-test-cpu", nightly=True)
+
+
+class TestSegmentBatchEncode(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "Qwen/Qwen2.5-0.5B-Instruct"
+        cls.tok = AutoTokenizer.from_pretrained(cls.model, trust_remote_code=True)
+
+    def _rag_text(self, n_passages: int = 5) -> str:
+        parts = [f"{DEFAULT_PASSAGE_DELIMITER}{i}\nContent block {i}.\n" for i in range(n_passages)]
+        return "".join(parts)
+
+    def test_resolve_delimiter_passage(self):
+        text = self._rag_text(3)
+        self.assertEqual(
+            resolve_split_delimiter(self.tok, None, sample_text=text),
+            DEFAULT_PASSAGE_DELIMITER,
+        )
+
+    def test_lossless_passage_split(self):
+        if not getattr(self.tok, "is_fast", False):
+            self.skipTest("fast tokenizer required")
+        text = self._rag_text(8)
+        plain = self.tok.encode(text, add_special_tokens=False)
+        seg = segment_batch_encode_ids(
+            self.tok,
+            text,
+            split_delimiter=DEFAULT_PASSAGE_DELIMITER,
+            add_special_tokens=False,
+            interleave_delimiter=False,
+        )
+        self.assertEqual(plain, seg)
+
+    def test_plan_workers_scale_with_length(self):
+        if not getattr(self.tok, "is_fast", False):
+            self.skipTest("fast tokenizer required")
+        from sglang.srt.utils.hf_transformers.segment_batch_encode import (
+            compute_max_workers,
+            _plan_segment_items,
+            _estimate_tokens,
+        )
+
+        text = self._rag_text(40)
+        est = _estimate_tokens(text)
+        self.assertEqual(compute_max_workers(est), max(1, (est * 2) // 1000))
+        raw = text.split(DEFAULT_PASSAGE_DELIMITER)
+        if raw and raw[-1] == "":
+            raw.pop()
+        planned = _plan_segment_items(raw, DEFAULT_PASSAGE_DELIMITER, est_tokens=est)
+        self.assertLessEqual(len(planned), compute_max_workers(est))
+
+    def test_lossless_adaptive_merge(self):
+        if not getattr(self.tok, "is_fast", False):
+            self.skipTest("fast tokenizer required")
+        text = self._rag_text(40)
+        plain = self.tok.encode(text, add_special_tokens=False)
+        seg = segment_batch_encode_ids(
+            self.tok,
+            text,
+            split_delimiter=DEFAULT_PASSAGE_DELIMITER,
+            add_special_tokens=False,
+        )
+        self.assertEqual(plain, seg)
+
+    def test_wrapper_short_text_unchanged(self):
+        if not getattr(self.tok, "is_fast", False):
+            self.skipTest("fast tokenizer required")
+        wrapped = make_segment_batch_encode_tokenizer(
+            AutoTokenizer.from_pretrained(self.model, trust_remote_code=True),
+            split_delimiter=DEFAULT_PASSAGE_DELIMITER,
+            min_chars=10_000,
+        )
+        short = "hello world"
+        self.assertEqual(
+            wrapped.encode(short, add_special_tokens=False),
+            self.tok.encode(short, add_special_tokens=False),
+        )
+
+    def test_wrapper_call_single_batch(self):
+        if not getattr(self.tok, "is_fast", False):
+            self.skipTest("fast tokenizer required")
+        text = self._rag_text(6)
+        wrapped = make_segment_batch_encode_tokenizer(
+            AutoTokenizer.from_pretrained(self.model, trust_remote_code=True),
+            split_delimiter=DEFAULT_PASSAGE_DELIMITER,
+            min_chars=1,
+        )
+        out = wrapped([text], add_special_tokens=False)
+        self.assertEqual(out["input_ids"][0], self.tok.encode(text, add_special_tokens=False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add opt-in `--enable-segment-batch-encode` for long single-string prompts (RAG / multi-passage). Split on `### Passage ` (or eos), encode segments via Rust `encode_batch`, concat token ids losslessly.

**Adaptive fan-out:** `max_workers = est_tokens // 1000 * 2` (2 per 1k tokens); merge passages into at most `min(passage_count, max_workers)` segments. Parallelism uses in-process Rayon **threads**, not OS processes.

## When this helps (business scenario)

Typical win is **prefill cache-hit + short decode** — repeat RAG queries where the document prefix is already in KV cache and the user only needs a brief answer (`max_tokens` small). In that path, server-side tokenization remains on the critical TTFT path; cold prefill is **not** accelerated.

- **Short prompts (~20k tokens):** tokenize is a small slice of TTFT → limited end-to-end gain.
- **Long prompts (70k–250k tokens):** tokenize grows to 100–320ms; segment batch cuts it to ~20–65ms (**~5–6x**). On L20 this removes a **material share** of cache-hit TTFT (~600–800ms with short decode) — the main production case for multi-passage RAG.

## Benchmark (Qwen3.5-122B-A10B-FP8, L20 ×256 CPU, unified real RAG, prefill cache-hit + short decode)

Measured after `max_tokens=1` warmup (prefix in KV cache), then cache-hit request with short decode. All rows lossless.

| tokens | segs | w_cap | thr† | plain tok | segment tok | tok_x |
|--------|------|-------|------|-----------|-------------|-------|
| 22364 | 15 | 44 | 15 | 27.4ms | 12.1ms | 2.27x |
| 34808 | 24 | 70 | 24 | 44.8ms | 12.9ms | 3.48x |
| 68877 | 57 | 138 | 57 | 108.1ms | 18.7ms | 5.77x |
| 99587 | 74 | 199 | 74 | 143.0ms | 26.7ms | 5.36x |
| 131711 | 106 | 264 | 106 | 226.2ms | 36.5ms | 6.20x |
| 198077 | 153 | 398 | 153 | 336.2ms | 53.7ms | 6.26x |
| 256648 | 199 | 515 | 199 | 384.5ms | 64.0ms | 6.01x |

† `w_cap = est_tokens//1000*2`; `segs = min(passage_count, w_cap)`; `thr = min(segs, 256)` Rayon threads.

At **131k+ tokens**, cache-hit TTFT (~600–800ms on this setup) benefits noticeably from the ~190–320ms tokenize reduction above — the scenario this flag is aimed at.

## Usage

```bash
python3 -m sglang.launch_server \
  --model-path /path/to/model \
  --enable-segment-batch-encode
```

Optional: `--segment-split-delimiter`, `--segment-batch-min-chars` (default 4096).

## Test plan

- [x] `pytest test/registered/unit/utils/test_segment_batch_encode.py` — lossless split, adaptive merge, wrapper paths
- [x] Manual: `python3 test/manual/benchmark_segment_batch_encode.py --model-path ... --prompt-json ...`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29426302831](https://github.com/sgl-project/sglang/actions/runs/29426302831)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29426298179](https://github.com/sgl-project/sglang/actions/runs/29426298179)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->