### PR TITLE
fix(function_call): don't leak partial bot_token bytes in DeepSeek V3/V3.1 streaming detectors

### DIFF
--- a/python/sglang/srt/function_call/deepseekv31_detector.py
+++ b/python/sglang/srt/function_call/deepseekv31_detector.py
@@ -102,11 +102,24 @@ class DeepSeekV31Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
-            self._buffer = ""
+            # bot_token/tool_call_begin are multi-codepoint markers, not single
+            # vocab tokens, so they routinely arrive split across increments.
+            # Only flush text that cannot become the start of either marker;
+            # keep a possible partial prefix buffered for the next increment.
+            partial_len = max(
+                self._ends_with_partial_token(current_text, self.bot_token),
+                self._ends_with_partial_token(current_text, "<｜tool▁call▁begin｜>"),
+            )
+            if partial_len:
+                safe_text = current_text[:-partial_len]
+                self._buffer = current_text[-partial_len:]
+            else:
+                safe_text = current_text
+                self._buffer = ""
             for e_token in [self.eot_token, "<｜tool▁call▁end｜>"]:
-                if e_token in new_text:
-                    new_text = new_text.replace(e_token, "")
-            return StreamingParseResult(normal_text=new_text)
+                if e_token in safe_text:
+                    safe_text = safe_text.replace(e_token, "")
+            return StreamingParseResult(normal_text=safe_text)
 
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)

--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -100,11 +100,24 @@ class DeepSeekV3Detector(BaseFormatDetector):
         )
 
         if not has_tool_call:
-            self._buffer = ""
+            # bot_token/tool_call_begin are multi-codepoint markers, not single
+            # vocab tokens, so they routinely arrive split across increments.
+            # Only flush text that cannot become the start of either marker;
+            # keep a possible partial prefix buffered for the next increment.
+            partial_len = max(
+                self._ends_with_partial_token(current_text, self.bot_token),
+                self._ends_with_partial_token(current_text, "<｜tool▁call▁begin｜>"),
+            )
+            if partial_len:
+                safe_text = current_text[:-partial_len]
+                self._buffer = current_text[-partial_len:]
+            else:
+                safe_text = current_text
+                self._buffer = ""
             for e_token in [self.eot_token, "```", "<｜tool▁call▁end｜>"]:
-                if e_token in new_text:
-                    new_text = new_text.replace(e_token, "")
-            return StreamingParseResult(normal_text=new_text)
+                if e_token in safe_text:
+                    safe_text = safe_text.replace(e_token, "")
+            return StreamingParseResult(normal_text=safe_text)
 
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)

--- a/test/registered/unit/function_call/test_deepseekv3_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv3_detector.py
@@ -1,0 +1,108 @@
+"""Unit tests for DeepSeekV3Detector / DeepSeekV31Detector — no server, no model loading."""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.srt.function_call.deepseekv31_detector import DeepSeekV31Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+def _tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="get_weather",
+                description="Get weather information",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"},
+                    },
+                    "required": ["city"],
+                },
+            ),
+        ),
+    ]
+
+
+class TestDeepSeekV31StreamingPartialBotToken(unittest.TestCase):
+    """bot_token/tool_call_begin are multi-codepoint markers, not single vocab
+    tokens, so they routinely arrive split across streaming increments. The
+    detector must buffer a possible partial prefix instead of flushing it as
+    normal_text and wiping the buffer.
+    """
+
+    def setUp(self):
+        self.tools = _tools()
+
+    def test_bot_token_split_across_increments_is_not_leaked(self):
+        detector = DeepSeekV31Detector()
+        bot = "<｜tool▁calls▁begin｜>"
+        rest = (
+            '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"city": "Tokyo"}'
+            "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+        )
+        # Split the bot_token itself across three increments, matching how a
+        # real tokenizer emits this marker piecewise.
+        chunks = [bot[0:4], bot[4:9], bot[9:], rest]
+
+        all_normal = ""
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            all_normal += result.normal_text
+            all_calls.extend(result.calls)
+
+        self.assertEqual(all_normal, "")
+        self.assertEqual(len(all_calls), 1)
+        self.assertEqual(all_calls[0].name, "get_weather")
+
+    def test_plain_text_without_any_tool_call_still_flushes(self):
+        detector = DeepSeekV31Detector()
+        result = detector.parse_streaming_increment(
+            "Hello, how can I help you today?", self.tools
+        )
+        self.assertEqual(result.normal_text, "Hello, how can I help you today?")
+        self.assertEqual(result.calls, [])
+
+
+class TestDeepSeekV3StreamingPartialBotToken(unittest.TestCase):
+    def setUp(self):
+        self.tools = _tools()
+
+    def test_bot_token_split_across_increments_is_not_leaked(self):
+        detector = DeepSeekV3Detector()
+        bot = "<｜tool▁calls▁begin｜>"
+        rest = (
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+            '```json\n{"city": "Tokyo"}\n```'
+            "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+        )
+        chunks = [bot[0:4], bot[4:9], bot[9:], rest]
+
+        all_normal = ""
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            all_normal += result.normal_text
+            all_calls.extend(result.calls)
+
+        self.assertEqual(all_normal, "")
+        self.assertEqual(len(all_calls), 1)
+        self.assertEqual(all_calls[0].name, "get_weather")
+
+    def test_plain_text_without_any_tool_call_still_flushes(self):
+        detector = DeepSeekV3Detector()
+        result = detector.parse_streaming_increment(
+            "Hello, how can I help you today?", self.tools
+        )
+        self.assertEqual(result.normal_text, "Hello, how can I help you today?")
+        self.assertEqual(result.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DeepSeekV3Detector`/`DeepSeekV31Detector.parse_streaming_increment` decides whether a tool call is starting by checking `self.bot_token in current_text`. `bot_token` (`<｜tool▁calls▁begin｜>`) is a multi-codepoint marker built from ordinary BPE sub-word pieces, not a single vocab token — under normal token-by-token streaming it routinely arrives split across multiple increments.

Whenever a chunk doesn't yet contain the *complete* marker, the old code wiped `self._buffer` back to `""` and flushed the partial bytes straight into `normal_text`:

```python
if not has_tool_call:
    self._buffer = ""
    for e_token in [self.eot_token, "<｜tool▁call▁end｜>"]:
        if e_token in new_text:
            new_text = new_text.replace(e_token, "")
    return StreamingParseResult(normal_text=new_text)
```

So `<｜tool▁calls▁begin｜>` (or a truncated prefix of it) leaks into the user-visible response, and the tool call that follows is missed, delayed, or corrupted depending on exactly where the marker got split.

Minimal repro (no server needed):
```python
bot = "<｜tool▁calls▁begin｜>"
rest = '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"city": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
chunks = [bot[0:4], bot[4:9], bot[9:], rest]  # marker split into 3 realistic sub-token pieces

det = DeepSeekV31Detector()
normal_text = "".join(det.parse_streaming_increment(c, tools).normal_text for c in chunks)
# before fix: normal_text == '<｜tool▁calls▁begin｜>'  (leaked into the visible reply)
# after fix:  normal_text == ''
```

## Modifications

Mirror the `_ends_with_partial_token` pattern already used by the base class (`BaseFormatDetector.parse_streaming_increment`) and other detectors (e.g. `HermesDetector`) for exactly this class of problem: only flush text that provably cannot become the start of `bot_token` or `<｜tool▁call▁begin｜>`; keep a possible partial prefix buffered for the next increment instead of discarding it.

Applied identically to both `DeepSeekV3Detector` and `DeepSeekV31Detector` (same bug, same fix shape, each has its own independent buffer/regex). `DeepSeekV32Detector` was checked and already handles this correctly via its own `dsml_prefixes`/`ends_with_prefix` logic — not touched.

## Testing

- Reproduced the leak against a bare, unmodified detector instance before making any source change (see repro above).
- Added `test/registered/unit/function_call/test_deepseekv3_detector.py` — no existing unit test file covered either detector. Covers: bot_token split across streaming increments for both `DeepSeekV3Detector` and `DeepSeekV31Detector` (red before the fix, green after), plus a plain-text-with-no-tool-call sanity check for each.
- Ran the broader `test/registered/unit/function_call/` suite that's runnable without GPU/`xgrammar` packages: 196 passed. The 10 pre-existing failures in that suite (`test_get_model_structural_tag`/kimi structural-tag tests) reproduce identically on unmodified `main` — they need the optional `xgrammar` package and are unrelated to this change.
- `ruff check --select=F401,F821,UP037` and `black --check`: clean on all changed files.

## AI disclosure

This fix was found and implemented with Claude (Anthropic) assistance — the repro, root-cause analysis, fix, and regression tests were written by Claude and verified locally (bare repro red→green, full runnable test suite, ruff, black) before opening this PR. Happy to answer any questions or make adjustments during review.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (not applicable — internal parsing fix, no public API/doc change)
- [ ] Provide accuracy and speed benchmark results. (not applicable — pure string-parsing bugfix, no model/kernel/inference-speed impact)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29433049618](https://github.com/sgl-project/sglang/actions/runs/29433049618)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29433049323](https://github.com/sgl-project/sglang/actions/runs/29433049323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->