### PR TITLE
Fix multimodal input path crashes on non-CUDA machines

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -144,6 +144,7 @@ srt_mps = [
     "sglang[runtime_common]",
     "torch==2.11.0",
     "torchao==0.9.0",
+    "torchcodec",
     "torchaudio==2.11.0",
     "torchvision",
 ]

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -4,6 +4,7 @@ Multi-modality utils
 
 import copy
 import hashlib
+import math
 import os
 import pickle
 import sys
@@ -1700,7 +1701,11 @@ class ShmPointerMMData:
                 # the process is killed with SIGBUS. Reserving the pages up
                 # front turns exhaustion into a catchable OSError (ENOSPC).
                 os.posix_fallocate(shm._fd, 0, nbytes)
-            dst = torch.frombuffer(shm.buf, dtype=torch.uint8)
+            # POSIX shared-memory implementations may expose a page-rounded
+            # buffer even when ``size`` is not page aligned (notably on
+            # macOS).  Copy only the logical tensor payload rather than the
+            # complete backing buffer.
+            dst = torch.frombuffer(shm.buf, dtype=torch.uint8, count=nbytes)
             dst.copy_(tensor.view(torch.uint8).reshape(-1))
         except BaseException:
             shm.close()
@@ -1725,9 +1730,11 @@ class ShmPointerMMData:
         self.precomputed_hash = state.get("precomputed_hash")
         self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
         # Zero-copy view into shared memory (no clone, no unlink)
-        self.tensor = torch.frombuffer(self._shm_handle.buf, dtype=self.dtype).reshape(
-            self.shape
-        )
+        self.tensor = torch.frombuffer(
+            self._shm_handle.buf,
+            dtype=self.dtype,
+            count=math.prod(self.shape),
+        ).reshape(self.shape)
 
     def materialize(self) -> torch.Tensor:
         """Clone tensor from shm to owned memory, then release shm handle."""

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -36,6 +36,7 @@ from sglang.srt.utils.cuda_ipc_transport_utils import (
     CudaIpcTensorTransportProxy,
     MmItemMemoryPool,
 )
+from sglang.srt.utils.tensor_bridge import use_mlx
 
 _is_cpu = is_cpu()
 _is_npu = is_npu()
@@ -438,7 +439,11 @@ class BaseMultimodalProcessor(ABC):
             and isinstance(processor.image_processor, BaseImageProcessor)
             and not self.server_args.disable_fast_image_processor
         ):
-            if _is_cpu or get_server_args().rl_on_policy_target is not None:
+            if (
+                _is_cpu
+                or use_mlx()
+                or get_server_args().rl_on_policy_target is not None
+            ):
                 kwargs["device"] = "cpu"
             elif _is_xpu:
                 kwargs["device"] = "xpu"

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -35,7 +35,10 @@ from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
 from sglang.srt.utils import cpu_has_amx_support, is_cpu
-from sglang.srt.utils.video_decoder import VideoDecoderWrapper
+from sglang.srt.utils.video_decoder import (
+    VideoDecoderWrapper,
+    _pin_memory_if_available,
+)
 from sglang.utils import logger
 
 IMAGE_FACTOR = 28
@@ -237,7 +240,7 @@ async def preprocess_video(
         [resized_height, resized_width],
         interpolation=InterpolationMode.BILINEAR,
     )
-    video = video.pin_memory()
+    video = _pin_memory_if_available(video)
     video_metadata = {
         "fps": video_fps,
         "duration": total_frames / video_fps,

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -7,6 +7,14 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+
+def _pin_memory_if_available(tensor):
+    """Keep decoded frames pageable on non-CUDA platforms such as MLX/MPS."""
+    import torch
+
+    return tensor.pin_memory() if torch.cuda.is_available() else tensor
+
+
 try:
     from torchcodec.decoders import VideoDecoder
 
@@ -127,10 +135,10 @@ class VideoDecoderWrapper:
 
         if _BACKEND == "torchcodec":
             batch = self._decoder.get_frames_at(indices)
-            return batch.data.pin_memory()
+            return _pin_memory_if_available(batch.data)
         else:
             arr = self._decoder.get_batch(indices).asnumpy()
-            return torch.from_numpy(arr).pin_memory()
+            return _pin_memory_if_available(torch.from_numpy(arr))
 
     def _parallel_decode(self, indices, num_threads):
         """Decode frames using multiple VideoDecoder instances in parallel threads."""
@@ -156,7 +164,7 @@ class VideoDecoderWrapper:
                 idx = future_to_idx[future]
                 results[idx] = future.result()
 
-        return torch.cat(results, dim=0).pin_memory()
+        return _pin_memory_if_available(torch.cat(results, dim=0))
 
     @property
     def source_bytes(self) -> bytes | None:

--- a/test/registered/unit/managers/test_mm_utils_shm.py
+++ b/test/registered/unit/managers/test_mm_utils_shm.py
@@ -1,0 +1,17 @@
+import pickle
+
+import torch
+
+from sglang.srt.managers.mm_utils import ShmPointerMMData
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_shm_pointer_round_trips_non_page_aligned_tensor():
+    tensor = torch.arange(1025, dtype=torch.float32).reshape(5, 205)
+    pointer = ShmPointerMMData(tensor)
+    restored_pointer = pickle.loads(pickle.dumps(pointer))
+
+    restored = restored_pointer.materialize()
+    torch.testing.assert_close(restored, tensor)

--- a/test/registered/unit/utils/test_video_decoder.py
+++ b/test/registered/unit/utils/test_video_decoder.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.utils.video_decoder import _pin_memory_if_available
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_decoded_frames_remain_pageable_without_cuda():
+    frames = torch.zeros((2, 4, 4, 3), dtype=torch.uint8)
+
+    with patch("torch.cuda.is_available", return_value=False), patch.object(
+        torch.Tensor, "pin_memory", side_effect=AssertionError("must not pin")
+    ):
+        result = _pin_memory_if_available(frames)
+
+    assert result is frames


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Ran into a few unrelated breakages in the multimodal input path while working on Apple/MLX support (#19137 ), all on machines without CUDA:
- `ShmPointerMMData` assumes the shm buffer length equals the tensor payload. macOS page-rounds the mapping, so multimodal feature transport breaks there. The new unit test segfaults on current main.
- video preprocessing pins decoded frames unconditionally, and `.pin_memory()` throws anywhere CUDA isn't available, including CPU only serving.
- the fast image processor falls through to `cuda:{base_gpu_id}` under the MLX backend.


## Modifications

<!-- Detail the changes made in this pull request. -->

- `mm_utils.py` reads only the tensor payload from the shm buffer on both ends.
- `video_decoder.py` and `qwen_vl.py` pin frames only when CUDA is available. Alse added `torchcodec` to the `srt_mps` extra so a decoder backend is installable  on Macs.
- `base_processor.py` keeps the fast image processor on CPU under the MLX backend. Plain `mps` probably wants the same thing, but I haven't tested that setup so I left it alone.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

No model-output change. Two unit tests added; on an Apple Silicon mac: 
Run 1, current main: the shm test kills thepytest process with a segfault.

`PYTHONPATH=python python -m pytest test/registered/unit/managers/test_mm_utils_shm.py -q`

Run 2, with this patch: both tests pass.
`PYTHONPATH=python python -m pytest test/registered/unit/managers/test_mm_utils_shm.py test/registered/unit/utils/test_video_decoder.py -q`




## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29437655139](https://github.com/sgl-project/sglang/actions/runs/29437655139)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29437655404](https://github.com/sgl-project/sglang/actions/runs/29437655404)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->