### PR TITLE
[Bugfix] Drain Mooncake transfers before releasing KV pages

### DIFF
--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -12,6 +12,7 @@ from sglang.srt.disaggregation.mooncake.conn import (
     MooncakeKVManager,
     MooncakeKVReceiver,
     MooncakeKVSender,
+    _submit_transfer_futures,
 )
 from sglang.srt.utils.network import get_local_ip_auto
 
@@ -156,21 +157,11 @@ class AscendKVManager(MooncakeKVManager):
             return self._transfer_data(mooncake_session_id, transfer_blocks)
 
         if self.enable_custom_mem_pool:
-            futures = [
-                executor.submit(
-                    process_layer,
-                    src_ptr,
-                    dst_ptr,
-                    item_len,
-                )
+            calls = [
+                (process_layer, (src_ptr, dst_ptr, item_len))
                 for (src_ptr, dst_ptr, item_len) in layers_params
             ]
-            for future in concurrent.futures.as_completed(futures):
-                status = future.result()
-                if status != 0:
-                    for f in futures:
-                        f.cancel()
-                    return status
+            return _submit_transfer_futures(executor, calls)
         else:
             # Combining all layers' params in one batch transfer is more efficient
             # compared to using multiple threads

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -170,6 +170,15 @@ class BaseKVSender(ABC):
         """
         pass
 
+    def begin_failure_quiescence(self):
+        pass
+
+    def is_transfer_quiesced(self) -> bool:
+        return True
+
+    def is_failure_quiescing(self) -> bool:
+        return False
+
 
 class BaseKVReceiver(ABC):
     @abstractmethod
@@ -228,6 +237,15 @@ class BaseKVReceiver(ABC):
         Abort the current transfer.
         """
         pass
+
+    def begin_failure_quiescence(self):
+        pass
+
+    def is_transfer_quiesced(self) -> bool:
+        return True
+
+    def is_failure_quiescing(self) -> bool:
+        return False
 
 
 class BaseKVBootstrapServer(ABC):

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -80,6 +80,7 @@ class PrefillServerInfo:
     # /generate to http://{bootstrap_host}:{prefill_http_port} to trigger a KV
     # recompute -- no router-injected pd_rebootstrap_prefill_url needed.
     prefill_http_port: Optional[int] = None
+    capabilities: Optional[List[str]] = None
 
     # Pre-computed rank mapping (set by try_ensure_parallel_info on decode side)
     target_tp_rank: Optional[int] = None
@@ -103,16 +104,19 @@ class PrefillServerInfo:
         self.prefill_http_port = (
             int(self.prefill_http_port) if self.prefill_http_port is not None else None
         )
+        self.capabilities = list(self.capabilities or [])
 
 
 @dataclasses.dataclass
 class PrefillRankInfo:
     rank_ip: str
     rank_port: int
+    capabilities: Optional[List[str]] = None
 
     def __post_init__(self):
         self.rank_ip = str(self.rank_ip)
         self.rank_port = int(self.rank_port)
+        self.capabilities = list(self.capabilities or [])
 
 
 class CommonKVManager(BaseKVManager):
@@ -636,6 +640,9 @@ class CommonKVManager(BaseKVManager):
             # router-injected pd_rebootstrap_prefill_url.
             "prefill_http_port": self.server_args.port,
         }
+        capabilities = self.get_bootstrap_capabilities()
+        if capabilities:
+            payload["capabilities"] = capabilities
 
         max_retries, initial_delay, max_delay = 5, 1.0, 30.0
         for attempt in range(max_retries):
@@ -664,6 +671,9 @@ class CommonKVManager(BaseKVManager):
         logger.error(
             f"Prefill instance failed to register to bootstrap server after {max_retries} retries"
         )
+
+    def get_bootstrap_capabilities(self) -> List[str]:
+        return []
 
     def _connect(self, endpoint: str, is_ipv6: bool = False):
         with self._socket_lock:
@@ -1453,6 +1463,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.follow_bootstrap_room: Optional[bool] = None
         self.enable_dsa_cache_layer_split: Optional[bool] = None
         self.prefill_http_port: Optional[int] = None
+        self.capabilities: List[str] = []
         self.prefill_port_table: Dict[
             int, Dict[int, Dict[int, Dict[int, PrefillRankInfo]]]
         ] = {}
@@ -1520,6 +1531,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         page_size = int(data["page_size"])
         kv_cache_dtype = data["kv_cache_dtype"]
         prefill_http_port = data.get("prefill_http_port")
+        capabilities = list(data.get("capabilities") or [])
 
         if self.attn_tp_size is None:
             self.attn_tp_size = attn_tp_size
@@ -1541,6 +1553,9 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
 
         if self.prefill_http_port is None and prefill_http_port is not None:
             self.prefill_http_port = int(prefill_http_port)
+
+        if capabilities:
+            self.capabilities = capabilities
 
         if self.follow_bootstrap_room is None:
             load_balance_method = data.get(
@@ -1567,6 +1582,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             tp_group_table[pp_rank] = PrefillRankInfo(
                 rank_ip=rank_ip,
                 rank_port=rank_port,
+                capabilities=capabilities,
             )
 
             self._registered_count += 1
@@ -1618,8 +1634,12 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 ),
                 enable_dsa_cache_layer_split=bool(self.enable_dsa_cache_layer_split),
                 prefill_http_port=self.prefill_http_port,
+                capabilities=self.capabilities,
             )
-            return web.json_response(dataclasses.asdict(info), status=200)
+            response = dataclasses.asdict(info)
+            if not response["capabilities"]:
+                response.pop("capabilities")
+            return web.json_response(response, status=200)
 
         if not self._is_ready():
             return web.Response(
@@ -1641,7 +1661,10 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 status=404,
             )
 
-        return web.json_response(dataclasses.asdict(bootstrap_info), status=200)
+        response = dataclasses.asdict(bootstrap_info)
+        if not response["capabilities"]:
+            response.pop("capabilities")
+        return web.json_response(response, status=200)
 
     async def _handle_register_dp_rank(self, request: web.Request):
         data = await request.json()

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -12,6 +12,7 @@ import dataclasses
 import logging
 import struct
 import threading
+from collections import defaultdict
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
@@ -80,14 +81,20 @@ class DecodeStagingHandler:
         self.scheduler = scheduler
         self._room_to_decode_req: dict = {}
         self._wm_subscribers: dict = {}
+        self._aborting_rooms: set = set()
+        self._abort_finalized_rooms: set = set()
+        self._abort_finalizing_rooms: set = set()
+        self._scatter_submitting: dict = defaultdict(int)
+        self._abort_lock = threading.RLock()
 
     def register_wm_subscriber(self, receiver, session_id: str) -> None:
         """Register a prefill's bootstrap connection for watermark broadcasts."""
         if receiver is None or not getattr(receiver, "bootstrap_infos", None):
             return
         key = tuple(str(bi) for bi in receiver.bootstrap_infos)
-        if key not in self._wm_subscribers:
-            self._wm_subscribers[key] = (receiver, session_id)
+        with self._abort_lock:
+            if key not in self._wm_subscribers:
+                self._wm_subscribers[key] = (receiver, session_id)
 
     def num_writers_for(self, decode_req) -> int:
         """Compute num_writers for a specific request based on its prefill TP."""
@@ -132,11 +139,175 @@ class DecodeStagingHandler:
     # Registration: called from main thread (DecodeTransferQueue)
     # ------------------------------------------------------------------
 
-    def register_decode_req(self, room: int, decode_req: DecodeRequest) -> None:
-        self._room_to_decode_req[room] = decode_req
+    def register_room_bootstrap(self, room, bootstrap_infos, receiver) -> bool:
+        with self._abort_lock:
+            if room in self._aborting_rooms:
+                return False
+            self.kv_manager._staging_ctx.room_bootstrap[room] = bootstrap_infos
+            self.kv_manager._staging_ctx.room_receivers[room] = receiver
+            return True
+
+    def register_decode_req(self, room: int, decode_req: DecodeRequest) -> bool:
+        with self._abort_lock:
+            self._room_to_decode_req[room] = decode_req
+            return room not in self._aborting_rooms
 
     def unregister_decode_req(self, room: int) -> None:
-        self._room_to_decode_req.pop(room, None)
+        with self._abort_lock:
+            self._room_to_decode_req.pop(room, None)
+            self.kv_manager._staging_ctx.room_bootstrap.pop(room, None)
+            self.kv_manager._staging_ctx.room_receivers.pop(room, None)
+            writer_counts = getattr(self.kv_manager, "_chunk_writer_counts", None)
+            if writer_counts is not None:
+                writer_counts.pop(room, None)
+            self._scatter_submitting.pop(room, None)
+
+    def begin_abort(self, room: int) -> None:
+        with self._abort_lock:
+            self._aborting_rooms.add(room)
+
+    def finalize_abort(self, room: int, decode_req: DecodeRequest) -> bool:
+        with self._abort_lock:
+            if room in self._abort_finalized_rooms:
+                return True
+            if room in self._abort_finalizing_rooms or self._scatter_submitting[room]:
+                return False
+
+        self.advance_scatter(decode_req)
+
+        with self._abort_lock:
+            if room in self._abort_finalized_rooms:
+                return True
+            if self._scatter_submitting[room]:
+                return False
+            if getattr(decode_req, "_chunk_events", None):
+                return False
+            if getattr(decode_req, "_scatter_event", None) is not None:
+                return False
+            if getattr(decode_req, "_freeing_staging_alloc_ids", None):
+                return False
+
+            receiver = decode_req.kv_receiver
+            alloc_ids = [
+                alloc_id
+                for alloc_id, _offset, _round, _end, _pages in (
+                    getattr(receiver, "chunk_staging_infos", None) or []
+                )
+                if alloc_id >= 0
+            ]
+            self._abort_finalizing_rooms.add(room)
+
+        try:
+            for alloc_id in alloc_ids:
+                self._free_and_send_watermark(alloc_id, decode_req)
+        except Exception:
+            with self._abort_lock:
+                self._abort_finalizing_rooms.discard(room)
+            raise
+
+        with self._abort_lock:
+            receiver.chunk_staging_infos = []
+            writer_counts = getattr(self.kv_manager, "_chunk_writer_counts", None)
+            if writer_counts is not None:
+                writer_counts.pop(room, None)
+            self.kv_manager._staging_ctx.room_bootstrap.pop(room, None)
+            self.kv_manager._staging_ctx.room_receivers.pop(room, None)
+            self._room_to_decode_req.pop(room, None)
+            self._scatter_submitting.pop(room, None)
+            self._abort_finalizing_rooms.discard(room)
+            self._abort_finalized_rooms.add(room)
+            return True
+
+    def finalize_room_abort(self, room: int) -> bool:
+        with self._abort_lock:
+            if room in self._abort_finalized_rooms:
+                return True
+            decode_req = self._room_to_decode_req.get(room)
+        return decode_req is not None and self.finalize_abort(room, decode_req)
+
+    def clear_abort(self, room: int) -> None:
+        with self._abort_lock:
+            self._abort_finalized_rooms.discard(room)
+
+    def is_abort_finalized(self, room: int) -> bool:
+        with self._abort_lock:
+            return room in self._abort_finalized_rooms
+
+    def handle_staging_req(
+        self,
+        msg,
+        kv_args,
+        attn_tp_size: int,
+        kv_buffer_tensors,
+    ) -> bool:
+        room = int(msg[1].decode("ascii"))
+        chunk_idx = int(msg[2].decode("ascii"))
+        session_id = msg[4].decode("ascii")
+
+        with self._abort_lock:
+            if room in self._aborting_rooms:
+                return False
+            receiver = self.kv_manager._staging_ctx.room_receivers.get(room)
+            decode_req = self._room_to_decode_req.get(room)
+            if decode_req is None or receiver is None:
+                return False
+            if decode_req.kv_receiver is not receiver:
+                return False
+            prefill_attn_tp_size = receiver.prefill_info.attn_tp_size
+            infos = getattr(receiver, "chunk_staging_infos", [])
+            existing = _get_staging_response(infos, chunk_idx)
+
+        candidate = None
+        if existing is None:
+            candidate = _allocate_staging_request(
+                msg,
+                self.staging_allocator,
+                kv_args,
+                attn_tp_size,
+                prefill_attn_tp_size,
+            )
+
+        raced_alloc_id = None
+        with self._abort_lock:
+            if (
+                room in self._aborting_rooms
+                or self.kv_manager._staging_ctx.room_receivers.get(room) is not receiver
+                or self._room_to_decode_req.get(room) is not decode_req
+                or decode_req.kv_receiver is not receiver
+            ):
+                if candidate is not None and candidate[0] >= 0:
+                    raced_alloc_id = candidate[0]
+                response = None
+            else:
+                existing = _get_staging_response(infos, chunk_idx)
+                if existing is not None:
+                    if candidate is not None and candidate[0] >= 0:
+                        raced_alloc_id = candidate[0]
+                    response = existing
+                else:
+                    _set_staging_response(infos, chunk_idx, candidate)
+                    response = candidate[1:4]
+                bootstrap_infos = list(
+                    self.kv_manager._staging_ctx.room_bootstrap.get(room, ())
+                )
+
+        if raced_alloc_id is not None:
+            self.staging_allocator.free(raced_alloc_id)
+        if response is None:
+            return False
+
+        with self._abort_lock:
+            if room in self._aborting_rooms:
+                return False
+        _send_staging_response(
+            receiver,
+            bootstrap_infos,
+            room,
+            chunk_idx,
+            session_id,
+            response,
+        )
+        return True
 
     # ------------------------------------------------------------------
     # Scatter submission: called from decode_thread (background)
@@ -150,32 +321,37 @@ class DecodeStagingHandler:
         Called from decode_thread.  Records a CUDA event on decode_req so
         the main thread can later check completion and free the allocation.
         """
-        decode_req = self._room_to_decode_req.get(room)
-        if decode_req is None:
-            logger.warning(
-                "[STAGING] submit_chunk_scatter: room=%s not registered, "
-                "chunk_idx=%s. This should not happen if register_decode_req "
-                "is called at kv_receiver.init() time.",
-                room,
-                chunk_idx,
-            )
-            return False
-        chunk_infos = getattr(decode_req.kv_receiver, "chunk_staging_infos", [])
-        if chunk_idx >= len(chunk_infos):
-            return False
-        alloc_id, staging_offset, _, _, _ = chunk_infos[chunk_idx]
-        if staging_offset < 0 or alloc_id < 0:
-            return False
+        with self._abort_lock:
+            if room in self._aborting_rooms:
+                return False
+            decode_req = self._room_to_decode_req.get(room)
+            if decode_req is None:
+                return False
+            chunk_infos = getattr(decode_req.kv_receiver, "chunk_staging_infos", [])
+            if chunk_idx >= len(chunk_infos):
+                return False
+            alloc_id, staging_offset, _, _, _ = chunk_infos[chunk_idx]
+            if staging_offset < 0 or alloc_id < 0:
+                return False
+            self._scatter_submitting[room] += 1
 
-        ok = self._scatter_region(staging_offset, page_start, num_pages, decode_req)
-        if ok:
-            event = torch.cuda.Event()
-            event.record(self.staging_allocator._scatter_stream)
-            if not hasattr(decode_req, "_chunk_events"):
-                decode_req._chunk_events = []
-            decode_req._chunk_events.append((event, alloc_id))
-            chunk_infos[chunk_idx] = (-1, -1, 0, -1, 0)
-        else:
+        ok = False
+        event = None
+        try:
+            ok = self._scatter_region(staging_offset, page_start, num_pages, decode_req)
+            if ok:
+                event = torch.cuda.Event()
+                event.record(self.staging_allocator._scatter_stream)
+        finally:
+            with self._abort_lock:
+                self._scatter_submitting[room] -= 1
+                if event is not None:
+                    if not hasattr(decode_req, "_chunk_events"):
+                        decode_req._chunk_events = []
+                    decode_req._chunk_events.append((event, alloc_id))
+                    chunk_infos[chunk_idx] = (-1, -1, 0, -1, 0)
+
+        if not ok:
             logger.warning(
                 "submit_chunk_scatter failed room=%s chunk_idx=%s tp_rank=%s",
                 room,
@@ -186,7 +362,8 @@ class DecodeStagingHandler:
 
     def is_staging_room(self, room: int) -> bool:
         """Check if a room is registered for staging scatter."""
-        return room in self._room_to_decode_req
+        with self._abort_lock:
+            return room in self._room_to_decode_req
 
     def handle_chunk_arrived(
         self,
@@ -203,21 +380,41 @@ class DecodeStagingHandler:
         once all writers for this chunk have reported in. Returns True if scatter
         was submitted.
         """
-        chunk_writer_counts[room][chunk_idx].append((page_start, num_pages, writer_id))
-        decode_req = self._room_to_decode_req.get(room)
-        if decode_req is None:
-            logger.warning(
-                "Staging chunk arrived for unregistered room=%s chunk=%d, skipping",
-                room,
-                chunk_idx,
-            )
-            return False
-        writers_arrived = len(chunk_writer_counts[room][chunk_idx])
-        num_writers = self.num_writers_for(decode_req)
-        if writers_arrived >= num_writers:
-            self.submit_chunk_scatter(room, chunk_idx, page_start, num_pages)
-            del chunk_writer_counts[room][chunk_idx]
-            return True
+        with self._abort_lock:
+            if room in self._aborting_rooms:
+                return False
+            decode_req = self._room_to_decode_req.get(room)
+            if decode_req is None:
+                return False
+            arrivals = chunk_writer_counts[room][chunk_idx]
+            for existing_start, existing_pages, existing_writer in arrivals:
+                if existing_writer == writer_id:
+                    if (existing_start, existing_pages) != (page_start, num_pages):
+                        logger.error(
+                            "Conflicting CHUNK_READY from writer=%s room=%s chunk=%s",
+                            writer_id,
+                            room,
+                            chunk_idx,
+                        )
+                    return False
+                if (existing_start, existing_pages) != (page_start, num_pages):
+                    logger.error(
+                        "Conflicting CHUNK_READY range room=%s chunk=%s: "
+                        "expected=(%s,%s) got=(%s,%s)",
+                        room,
+                        chunk_idx,
+                        existing_start,
+                        existing_pages,
+                        page_start,
+                        num_pages,
+                    )
+                    return False
+            arrivals.append((page_start, num_pages, writer_id))
+            ready = len(arrivals) >= self.num_writers_for(decode_req)
+            if ready:
+                chunk_writer_counts[room].pop(chunk_idx, None)
+        if ready:
+            return self.submit_chunk_scatter(room, chunk_idx, page_start, num_pages)
         return False
 
     def submit_last_scatter_async(self, room: int) -> bool:
@@ -227,24 +424,30 @@ class DecodeStagingHandler:
         ``_staging_last_scatter_submitted`` so the main thread sees the
         event when it checks the flag (CPython GIL guarantees ordering).
         """
-        decode_req = self._room_to_decode_req.get(room)
-        if decode_req is None:
-            logger.warning(
-                "[STAGING] submit_last_scatter_async: room=%s not registered. "
-                "This should not happen if register_decode_req is called at "
-                "kv_receiver.init() time.",
-                room,
-            )
-            return False
-        alloc_id = self._submit_last_scatter(decode_req)
-        if alloc_id >= 0:
-            event = torch.cuda.Event()
-            event.record(self.staging_allocator._scatter_stream)
-            decode_req._scatter_event = event
-            decode_req._scatter_alloc_id = alloc_id
-            decode_req._staging_last_scatter_submitted = True
-        else:
-            decode_req._staging_scatter_done = True
+        with self._abort_lock:
+            if room in self._aborting_rooms:
+                return False
+            decode_req = self._room_to_decode_req.get(room)
+            if decode_req is None:
+                return False
+            self._scatter_submitting[room] += 1
+
+        alloc_id = -1
+        event = None
+        try:
+            alloc_id = self._submit_last_scatter(decode_req)
+            if alloc_id >= 0:
+                event = torch.cuda.Event()
+                event.record(self.staging_allocator._scatter_stream)
+        finally:
+            with self._abort_lock:
+                self._scatter_submitting[room] -= 1
+                if event is not None:
+                    decode_req._scatter_event = event
+                    decode_req._scatter_alloc_id = alloc_id
+                    decode_req._staging_last_scatter_submitted = True
+                elif alloc_id < 0:
+                    decode_req._staging_scatter_done = True
         return True
 
     # ------------------------------------------------------------------
@@ -253,9 +456,10 @@ class DecodeStagingHandler:
 
     def is_done(self, decode_req: DecodeRequest) -> bool:
         """Return True if staging scatter is complete for this request."""
-        if not getattr(decode_req, "_staging_scatter_done", False):
-            return False
-        return not getattr(decode_req, "_chunk_events", None)
+        with self._abort_lock:
+            if not getattr(decode_req, "_staging_scatter_done", False):
+                return False
+            return not getattr(decode_req, "_chunk_events", None)
 
     def advance_scatter(self, decode_req: DecodeRequest) -> None:
         """Check CUDA events and free completed staging allocations.
@@ -264,24 +468,28 @@ class DecodeStagingHandler:
         (via submit_chunk_scatter / submit_last_scatter_async).  This
         method only polls the recorded events and releases staging memory.
         """
-        room = decode_req.req.bootstrap_room
-        chunk_events = getattr(decode_req, "_chunk_events", None)
-        if chunk_events:
-            for i in range(len(chunk_events) - 1, -1, -1):
-                event, alloc_id = chunk_events[i]
-                if event.query():
-                    chunk_events.pop(i)
-                    self._free_and_send_watermark(alloc_id, decode_req)
+        with self._abort_lock:
+            chunk_events = list(getattr(decode_req, "_chunk_events", None) or [])
+            last_event = getattr(decode_req, "_scatter_event", None)
+            last_alloc_id = getattr(decode_req, "_scatter_alloc_id", -1)
 
-        if not getattr(decode_req, "_staging_last_scatter_submitted", False):
-            return
+        completed_chunks = [item for item in chunk_events if item[0].query()]
+        last_complete = last_event is not None and last_event.query()
+        alloc_ids = []
+        with self._abort_lock:
+            current_events = getattr(decode_req, "_chunk_events", None) or []
+            for item in completed_chunks:
+                if item in current_events:
+                    current_events.remove(item)
+                    alloc_ids.append(item[1])
+            if last_complete and decode_req._scatter_event is last_event:
+                decode_req._scatter_event = None
+                decode_req._scatter_alloc_id = -1
+                decode_req._staging_scatter_done = True
+                alloc_ids.append(last_alloc_id)
 
-        event = getattr(decode_req, "_scatter_event", None)
-        if event is not None and event.query():
-            self._free_and_send_watermark(decode_req._scatter_alloc_id, decode_req)
-            decode_req._scatter_event = None
-            decode_req._scatter_alloc_id = -1
-            decode_req._staging_scatter_done = True
+        for alloc_id in alloc_ids:
+            self._free_and_send_watermark(alloc_id, decode_req)
 
     # ------------------------------------------------------------------
     # Internal methods
@@ -373,13 +581,34 @@ class DecodeStagingHandler:
         self, alloc_id: int, decode_req: DecodeRequest
     ) -> None:
         """Free a staging allocation and broadcast watermark to all prefills."""
-        self.staging_allocator.free(alloc_id)
-        post_wm = self.staging_allocator.get_watermark()
-        room = decode_req.req.bootstrap_room
+        with self._abort_lock:
+            freed = getattr(decode_req, "_freed_staging_alloc_ids", None)
+            if freed is None:
+                freed = decode_req._freed_staging_alloc_ids = set()
+            freeing = getattr(decode_req, "_freeing_staging_alloc_ids", None)
+            if freeing is None:
+                freeing = decode_req._freeing_staging_alloc_ids = set()
+            if alloc_id in freed or alloc_id in freeing:
+                return
+            freeing.add(alloc_id)
+
+        try:
+            self.staging_allocator.free(alloc_id)
+            post_wm = self.staging_allocator.get_watermark()
+        except Exception:
+            with self._abort_lock:
+                freeing.discard(alloc_id)
+            raise
+
+        with self._abort_lock:
+            freeing.discard(alloc_id)
+            freed.add(alloc_id)
+            subscribers = list(self._wm_subscribers.values())
+
         wm_round, wm_tail = post_wm
         wm_round_b = str(wm_round).encode("ascii")
         wm_tail_b = str(wm_tail).encode("ascii")
-        for _key, (receiver, session_id) in list(self._wm_subscribers.items()):
+        for receiver, session_id in subscribers:
             sid_b = session_id.encode("ascii")
             for bootstrap_info in receiver.bootstrap_infos:
                 try:
@@ -654,6 +883,98 @@ def init_staging_allocator(register_fn, kv_args):
     return allocator
 
 
+def _get_staging_response(infos, chunk_idx):
+    from sglang.srt.disaggregation.common.staging_buffer import StagingAllocator
+
+    if chunk_idx < len(infos) and infos[chunk_idx][0] >= 0:
+        _, offset, rnd, end, _ = infos[chunk_idx]
+        return offset, rnd, end
+    if (
+        chunk_idx < len(infos)
+        and infos[chunk_idx][1] == StagingAllocator.ALLOC_OVERSIZED
+    ):
+        return StagingAllocator.ALLOC_OVERSIZED, 0, -1
+    return None
+
+
+def _allocate_staging_request(
+    msg,
+    staging_allocator,
+    kv_args,
+    attn_tp_size: int,
+    prefill_attn_tp_size: int,
+):
+    from sglang.srt.disaggregation.common.staging_buffer import (
+        StagingAllocator,
+        compute_staging_layout,
+        resolve_total_kv_heads,
+    )
+
+    room = int(msg[1].decode("ascii"))
+    chunk_idx = int(msg[2].decode("ascii"))
+    chunk_num_pages = int(msg[3].decode("ascii"))
+    page_size = kv_args.page_size
+    kv_item_lens = kv_args.kv_item_lens
+    num_kv_layers = len(kv_item_lens) // 2
+    decode_bytes_per_token = kv_item_lens[0] // page_size
+    total_kv_heads = resolve_total_kv_heads(kv_args, attn_tp_size)
+    dst_heads_per_rank = max(1, total_kv_heads // max(1, attn_tp_size))
+    bytes_per_head_per_token = decode_bytes_per_token // dst_heads_per_rank
+    dst_tp_rank = kv_args.engine_rank % max(1, attn_tp_size)
+
+    _, _, required = compute_staging_layout(
+        prefill_attn_tp_size,
+        attn_tp_size,
+        dst_tp_rank,
+        total_kv_heads,
+        chunk_num_pages * page_size,
+        bytes_per_head_per_token,
+        num_kv_layers,
+    )
+    result = staging_allocator.assign(required)
+    if result is None:
+        logger.error(
+            "[STAGING_REQ] alloc failed room=%s chunk=%d (need %d bytes, "
+            "buffer total=%d bytes). Increase SGLANG_DISAGG_STAGING_POOL_SIZE_MB.",
+            room,
+            chunk_idx,
+            required,
+            staging_allocator.total_size,
+        )
+        return -1, StagingAllocator.ALLOC_OVERSIZED, 0, -1, chunk_num_pages
+    alloc_id, offset, rnd = result
+    return alloc_id, offset, rnd, offset + required, chunk_num_pages
+
+
+def _set_staging_response(infos, chunk_idx, allocation) -> None:
+    while len(infos) <= chunk_idx:
+        infos.append((-1, -1, 0, -1, 0))
+    infos[chunk_idx] = allocation
+
+
+def _send_staging_response(
+    receiver, bootstrap_infos, room, chunk_idx, session_id, response
+) -> None:
+    offset, rnd, end = response
+    for bootstrap_info in bootstrap_infos:
+        try:
+            sock, lock = receiver._connect_to_bootstrap_server(bootstrap_info)
+            with lock:
+                sock.send_multipart(
+                    [
+                        b"STAGING_RSP",
+                        str(room).encode("ascii"),
+                        str(chunk_idx).encode("ascii"),
+                        str(offset).encode("ascii"),
+                        str(rnd).encode("ascii"),
+                        str(end).encode("ascii"),
+                        session_id.encode("ascii"),
+                    ]
+                )
+        except Exception:
+            pass
+
+
 def handle_staging_req(
     msg,
     staging_allocator,
@@ -664,115 +985,32 @@ def handle_staging_req(
     room_receivers: dict,
     room_bootstrap: dict,
 ):
-    """Allocate staging for a chunk on-demand and send STAGING_RSP to prefill.
-
-    Deduplicates: multiple prefill TP ranks requesting the same (room, chunk_idx)
-    only allocate once.  Sends ALLOC_OVERSIZED on permanent failure.
-    """
-    from sglang.srt.disaggregation.common.staging_buffer import StagingAllocator
-
     room = int(msg[1].decode("ascii"))
     chunk_idx = int(msg[2].decode("ascii"))
-    chunk_num_pages = int(msg[3].decode("ascii"))
     session_id = msg[4].decode("ascii")
-
-    if staging_allocator is None:
-        logger.warning(
-            "STAGING_REQ ignored: allocator is None room=%s chunk=%s",
-            room,
-            chunk_idx,
-        )
-        return
-
     receiver = room_receivers.get(room)
-    if receiver is None:
-        logger.warning(
-            "STAGING_REQ dropped: no receiver for room=%s chunk=%s session=%s",
-            room,
-            chunk_idx,
-            session_id,
-        )
+    if staging_allocator is None or receiver is None:
         return
     infos = getattr(receiver, "chunk_staging_infos", [])
-
-    if chunk_idx < len(infos) and infos[chunk_idx][0] >= 0:
-        _, offset, rnd, end, _ = infos[chunk_idx]
-    elif (
-        chunk_idx < len(infos)
-        and infos[chunk_idx][1] == StagingAllocator.ALLOC_OVERSIZED
-    ):
-        offset, rnd, end = StagingAllocator.ALLOC_OVERSIZED, 0, -1
-    else:
-        from sglang.srt.disaggregation.common.staging_buffer import (
-            compute_staging_layout,
-            resolve_total_kv_heads,
-        )
-
-        page_size = kv_args.page_size
-        kv_item_lens = kv_args.kv_item_lens
-        num_kv_layers = len(kv_item_lens) // 2
-        decode_bytes_per_token = kv_item_lens[0] // page_size
-        total_kv_heads = resolve_total_kv_heads(kv_args, attn_tp_size)
-        dst_heads_per_rank = max(1, total_kv_heads // max(1, attn_tp_size))
-        bytes_per_head_per_token = decode_bytes_per_token // dst_heads_per_rank
-        dst_tp_rank = kv_args.engine_rank % max(1, attn_tp_size)
-
-        chunk_tokens = chunk_num_pages * page_size
-        _, _, required = compute_staging_layout(
-            prefill_attn_tp_size,
+    response = _get_staging_response(infos, chunk_idx)
+    if response is None:
+        allocation = _allocate_staging_request(
+            msg,
+            staging_allocator,
+            kv_args,
             attn_tp_size,
-            dst_tp_rank,
-            total_kv_heads,
-            chunk_tokens,
-            bytes_per_head_per_token,
-            num_kv_layers,
+            prefill_attn_tp_size,
         )
-        result = staging_allocator.assign(required)
-        if result is None:
-            logger.error(
-                "[STAGING_REQ] alloc failed room=%s chunk=%d (need %d bytes, "
-                "buffer total=%d bytes). Increase SGLANG_DISAGG_STAGING_POOL_SIZE_MB.",
-                room,
-                chunk_idx,
-                required,
-                staging_allocator.total_size,
-            )
-            offset, rnd, end = StagingAllocator.ALLOC_OVERSIZED, 0, -1
-            while len(infos) <= chunk_idx:
-                infos.append((-1, -1, 0, -1, 0))
-            infos[chunk_idx] = (
-                -1,
-                StagingAllocator.ALLOC_OVERSIZED,
-                0,
-                -1,
-                chunk_num_pages,
-            )
-        else:
-            alloc_id, offset, rnd = result
-            end = offset + required
-            while len(infos) <= chunk_idx:
-                infos.append((-1, -1, 0, -1, 0))
-            infos[chunk_idx] = (alloc_id, offset, rnd, end, chunk_num_pages)
-
-    bootstrap_infos = room_bootstrap.get(room)
-    if bootstrap_infos:
-        for bi in bootstrap_infos:
-            try:
-                sock, lock = receiver._connect_to_bootstrap_server(bi)
-                with lock:
-                    sock.send_multipart(
-                        [
-                            b"STAGING_RSP",
-                            str(room).encode("ascii"),
-                            str(chunk_idx).encode("ascii"),
-                            str(offset).encode("ascii"),
-                            str(rnd).encode("ascii"),
-                            str(end).encode("ascii"),
-                            session_id.encode("ascii"),
-                        ]
-                    )
-            except Exception:
-                pass
+        _set_staging_response(infos, chunk_idx, allocation)
+        response = allocation[1:4]
+    _send_staging_response(
+        receiver,
+        room_bootstrap.get(room, ()),
+        room,
+        chunk_idx,
+        session_id,
+        response,
+    )
 
 
 def prefetch_staging_reqs(
@@ -782,6 +1020,7 @@ def prefetch_staging_reqs(
     chunked_prefill_size: int,
     staging_requested: set,
     prefetch_sockets: dict,
+    send_message=None,
 ) -> None:
     """Send STAGING_REQ for all chunks before the prefill forward starts.
 
@@ -819,6 +1058,16 @@ def prefetch_staging_reqs(
             remaining = total_pages - chunk_idx * full_chunk_pages
             chunk_pages = min(full_chunk_pages, remaining)
             try:
+                parts = [
+                    b"STAGING_REQ",
+                    str(room).encode("ascii"),
+                    str(chunk_idx).encode("ascii"),
+                    str(chunk_pages).encode("ascii"),
+                    session_id.encode("ascii"),
+                ]
+                if send_message is not None:
+                    send_message(tinfo.endpoint, tinfo.dst_port, parts)
+                    continue
                 na = NetworkAddress(tinfo.endpoint, tinfo.dst_port)
                 ep = na.to_tcp()
                 if ep not in prefetch_sockets:
@@ -827,14 +1076,6 @@ def prefetch_staging_reqs(
                         sock.setsockopt(zmq.IPV6, 1)
                     sock.connect(ep)
                     prefetch_sockets[ep] = sock
-                prefetch_sockets[ep].send_multipart(
-                    [
-                        b"STAGING_REQ",
-                        str(room).encode("ascii"),
-                        str(chunk_idx).encode("ascii"),
-                        str(chunk_pages).encode("ascii"),
-                        session_id.encode("ascii"),
-                    ]
-                )
+                prefetch_sockets[ep].send_multipart(parts)
             except Exception:
                 staging_requested.discard(stg_key)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1172,6 +1172,14 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             page_indices = kv_to_page_indices(kv_indices, kv_transfer_page_size).astype(
                 np.int32
             )
+            if (
+                self.transfer_queue.enable_staging
+                and hasattr(decode_req.kv_receiver, "require_staging")
+                and decode_req.kv_receiver.require_staging
+            ):
+                self.transfer_queue.staging_handler.register_decode_req(
+                    decode_req.req.bootstrap_room, decode_req
+                )
             decode_req.kv_receiver.send_metadata(
                 page_indices,
                 decode_req.metadata_buffer_index,
@@ -1182,14 +1190,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 self.kv_manager.submit_prefill_recompute(
                     decode_req.kv_receiver,
                     decode_req.req.build_rebootstrap_payload(),
-                )
-            if (
-                self.transfer_queue.enable_staging
-                and hasattr(decode_req.kv_receiver, "require_staging")
-                and decode_req.kv_receiver.require_staging
-            ):
-                self.transfer_queue.staging_handler.register_decode_req(
-                    decode_req.req.bootstrap_room, decode_req
                 )
             preallocated_reqs.append(decode_req)
             indices_to_remove.add(i)

--- a/python/sglang/srt/disaggregation/decode_hicache_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_hicache_mixin.py
@@ -164,6 +164,15 @@ class HiCacheRestoreGatedKVReceiver:
             return KVPoll.Transferring
         return poll
 
+    def begin_failure_quiescence(self):
+        return self.decode_req.kv_receiver.begin_failure_quiescence()
+
+    def is_transfer_quiesced(self) -> bool:
+        return self.decode_req.kv_receiver.is_transfer_quiesced()
+
+    def is_failure_quiescing(self) -> bool:
+        return self.decode_req.kv_receiver.is_failure_quiescing()
+
 
 class DecodeHiCacheTransferMixin:
     """HiCache hooks for ``DecodeTransferQueue``: drive restore state machine."""

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -57,10 +57,92 @@ from sglang.srt.utils.network import NetworkAddress
 
 logger = logging.getLogger(__name__)
 
+QUIESCE_CAPABILITY = "QUIESCE_V1"
+QUIESCE_CAPABILITY_BYTES = QUIESCE_CAPABILITY.encode("ascii")
+ABORT_RETRY_INTERVAL_S = 0.5
+
 FAILED_SESSION_RECOVERIES = Counter(
     "sglang:failed_session_recoveries_total",
     "Number of mooncake_session_ids un-blacklisted via probe.",
 )
+
+
+class RoomTransferLifetime:
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._active = 0
+        self._accepting = True
+
+    def acquire(self) -> bool:
+        with self._condition:
+            if not self._accepting:
+                return False
+            self._active += 1
+            return True
+
+    def release(self) -> None:
+        with self._condition:
+            self._active -= 1
+            if self._active == 0:
+                self._condition.notify_all()
+
+    def abort(self) -> None:
+        with self._condition:
+            self._accepting = False
+            if self._active == 0:
+                self._condition.notify_all()
+
+    def is_quiesced(self) -> bool:
+        with self._condition:
+            return not self._accepting and self._active == 0
+
+    def wait(self) -> None:
+        with self._condition:
+            self._condition.wait_for(lambda: self._active == 0)
+
+
+def _wait_transfer_futures(futures) -> int:
+    first_status = 0
+    first_exception = None
+    for future in concurrent.futures.as_completed(futures):
+        try:
+            status = future.result()
+            if status != 0 and first_status == 0:
+                first_status = status
+                for sibling in futures:
+                    sibling.cancel()
+        except concurrent.futures.CancelledError:
+            continue
+        except BaseException as e:
+            if first_exception is None:
+                first_exception = e
+                for sibling in futures:
+                    sibling.cancel()
+    concurrent.futures.wait(futures)
+    if first_exception is not None:
+        raise first_exception
+    return first_status
+
+
+def _submit_transfer_futures(executor, calls) -> int:
+    futures = []
+    try:
+        for fn, args in calls:
+            futures.append(executor.submit(fn, *args))
+    except BaseException:
+        for future in futures:
+            future.cancel()
+        concurrent.futures.wait(futures)
+        raise
+    return _wait_transfer_futures(futures)
+
+
+def _has_kv_registration_capability(msg: List[bytes]) -> bool:
+    return len(msg) > 14 and msg[14] == QUIESCE_CAPABILITY_BYTES
+
+
+def _has_transfer_metadata_capability(msg: List[bytes]) -> bool:
+    return len(msg) > 9 and msg[9] == QUIESCE_CAPABILITY_BYTES
 
 
 # decode
@@ -76,6 +158,7 @@ class TransferInfo:
     required_dst_info_num: int
     is_dummy: bool
     decode_prefix_len: Optional[int] = None
+    abort_token: bytes = b""
     # Note: always put the optional staging field at the final (it will be set through 'STAGING_RSP' pkg when needed)
     staging: Optional[StagingTransferInfo] = None
 
@@ -104,6 +187,7 @@ class TransferInfo:
             decode_prefix_len=(
                 int(msg[8].decode("ascii")) if len(msg) > 8 and msg[8] != b"" else None
             ),
+            abort_token=msg[10] if len(msg) > 10 else b"",
         )
 
 
@@ -161,15 +245,22 @@ class MooncakeKVManager(CommonKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        self._endpoint_send_locks = {}
+        self._endpoint_send_locks_lock = threading.Lock()
         self.init_engine()
         self.register_buffer_to_engine()
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         self.enable_trace = server_args.enable_trace
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            self.start_prefill_thread()
+            self.room_lifetimes = {}
+            self.room_abort_tokens = defaultdict(set)
+            self.room_lifetimes_lock = threading.Lock()
+            self._abort_ack_inflight = set()
+            self._abort_ack_lock = threading.Lock()
             self.session_failures = defaultdict(int)
             self.failed_sessions = set()
             self.session_lock = threading.Lock()
+            self.start_prefill_thread()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
             transfer_thread_pool_size = (
@@ -228,6 +319,9 @@ class MooncakeKVManager(CommonKVManager):
                     daemon=True,
                 ).start()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
+            self.aborting_rooms = set()
+            self.abort_receivers = {}
+            self._abort_receivers_lock = threading.Lock()
             self._staging_ctx = DecodeStagingContext() if self.enable_staging else None
             if self.enable_staging:
                 self._init_staging_allocator()
@@ -235,8 +329,71 @@ class MooncakeKVManager(CommonKVManager):
                 self._chunk_writer_counts: dict = defaultdict(lambda: defaultdict(list))
             self.start_decode_thread()
 
+    def _get_room_lifetime(self, room: int) -> RoomTransferLifetime:
+        with self.room_lifetimes_lock:
+            return self.room_lifetimes.setdefault(room, RoomTransferLifetime())
+
+    def _find_room_lifetime(self, room: int) -> Optional[RoomTransferLifetime]:
+        with self.room_lifetimes_lock:
+            return self.room_lifetimes.get(room)
+
+    def _abort_room(self, room: int) -> Optional[RoomTransferLifetime]:
+        lifetime = self._find_room_lifetime(room)
+        if lifetime is not None:
+            lifetime.abort()
+        return lifetime
+
+    def _register_room_abort_token(self, room: int, token: bytes) -> None:
+        with self.room_lifetimes_lock:
+            self.room_abort_tokens[room].add(token)
+
+    def _abort_room_for_token(
+        self, room: int, token: bytes
+    ) -> Optional[RoomTransferLifetime]:
+        with self.room_lifetimes_lock:
+            if token not in self.room_abort_tokens.get(room, ()):
+                return None
+            lifetime = self.room_lifetimes.get(room)
+        if lifetime is not None:
+            lifetime.abort()
+        return lifetime
+
+    def _clear_room_lifetime(self, room: int) -> None:
+        with self.room_lifetimes_lock:
+            self.room_lifetimes.pop(room, None)
+            self.room_abort_tokens.pop(room, None)
+
+    def _get_endpoint_send_lock(self, endpoint: str) -> threading.Lock:
+        with self._endpoint_send_locks_lock:
+            return self._endpoint_send_locks.setdefault(endpoint, threading.Lock())
+
+    def _send_manager_message(
+        self, remote: str, dst_port: int, parts: List[bytes]
+    ) -> None:
+        na = NetworkAddress(remote, dst_port)
+        endpoint = na.to_tcp()
+        with self._get_endpoint_send_lock(endpoint):
+            self._connect(endpoint, is_ipv6=na.is_ipv6).send_multipart(parts)
+
     def init_engine(self):
         self.engine = get_mooncake_transfer_engine()
+
+    def get_bootstrap_capabilities(self) -> List[str]:
+        return [QUIESCE_CAPABILITY]
+
+    def try_ensure_parallel_info(self, bootstrap_addr: str) -> bool:
+        if not super().try_ensure_parallel_info(bootstrap_addr):
+            return False
+        info = self.prefill_info_table[bootstrap_addr]
+        if QUIESCE_CAPABILITY in info.capabilities:
+            return True
+        self.prefill_info_table.pop(bootstrap_addr, None)
+        logger.error(
+            "Mooncake prefill %s does not advertise %s; refusing KV transfer",
+            bootstrap_addr,
+            QUIESCE_CAPABILITY,
+        )
+        return False
 
     def register_buffer_to_engine(self):
         # Batch register KV data buffers
@@ -277,8 +434,12 @@ class MooncakeKVManager(CommonKVManager):
     # ------------------------------------------------------------------
 
     def register_staging_room_bootstrap(self, room, bootstrap_infos, receiver):
+        handler = getattr(self, "_staging_handler", None)
+        if handler is not None:
+            return handler.register_room_bootstrap(room, bootstrap_infos, receiver)
         self._staging_ctx.room_bootstrap[room] = bootstrap_infos
         self._staging_ctx.room_receivers[room] = receiver
+        return True
 
     def set_kv_buffer_tensors(self, k_buffers: list, v_buffers: list, page_size: int):
         self.kv_buffer_tensors = {
@@ -311,38 +472,45 @@ class MooncakeKVManager(CommonKVManager):
         self.kv_buffer_tensors = None
 
     def _handle_staging_req(self, msg):
-        from sglang.srt.disaggregation.common.staging_handler import (
-            handle_staging_req,
-        )
-
         room = int(msg[1].decode("ascii"))
         session_id = msg[4].decode("ascii")
         handler = self._staging_handler
         assert (
             handler is not None
         ), "STAGING_REQ received before staging handler initialized"
-        decode_req = handler._room_to_decode_req.get(room)
-        if decode_req is None:
-            logger.warning(
-                "STAGING_REQ received for unregistered room=%s, skipping",
-                room,
-            )
-            return
-        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
-        handle_staging_req(
+        accepted = handler.handle_staging_req(
             msg,
-            self._staging_ctx.allocator,
             self.kv_args,
             self.attn_tp_size,
-            prefill_tp,
             getattr(self, "kv_buffer_tensors", None),
-            self._staging_ctx.room_receivers,
-            self._staging_ctx.room_bootstrap,
         )
 
         receiver = self._staging_ctx.room_receivers.get(room)
-        if receiver is not None:
+        if accepted and receiver is not None:
             handler.register_wm_subscriber(receiver, session_id)
+
+    def _handle_chunk_ready(self, msg) -> bool:
+        room = int(msg[1].decode("ascii"))
+        if room in self.aborting_rooms:
+            return False
+        handler = self._staging_handler
+        assert handler is not None, "CHUNK_READY before staging handler initialized"
+        return handler.handle_chunk_arrived(
+            room,
+            int(msg[2].decode("ascii")),
+            int(msg[3].decode("ascii")),
+            int(msg[4].decode("ascii")),
+            msg[6].decode("ascii") if len(msg) > 6 else msg[5].decode("ascii"),
+            self._chunk_writer_counts,
+        )
+
+    def _handle_abort_ack(self, msg) -> None:
+        room = int(msg[1].decode("ascii"))
+        token = msg[2] if len(msg) > 2 else None
+        with self._abort_receivers_lock:
+            receiver = self.abort_receivers.get(room)
+        if receiver is not None:
+            receiver._record_abort_ack(token)
 
     def _is_watermark_ready(
         self, session_id: str, alloc_round: int, alloc_end: int
@@ -365,11 +533,9 @@ class MooncakeKVManager(CommonKVManager):
     def _send_chunk_ready(self, req, chunk_idx, kv_chunk, prefill_unique_rank):
         """Notify decode that a non-last staging chunk RDMA is complete."""
         try:
-            na = NetworkAddress(req.endpoint, req.dst_port)
-            self._connect(
-                na.to_tcp(),
-                is_ipv6=na.is_ipv6,
-            ).send_multipart(
+            self._send_manager_message(
+                req.endpoint,
+                req.dst_port,
                 [
                     b"CHUNK_READY",
                     str(req.room).encode("ascii"),
@@ -378,7 +544,7 @@ class MooncakeKVManager(CommonKVManager):
                     str(len(kv_chunk.prefill_kv_indices)).encode("ascii"),
                     req.mooncake_session_id.encode("ascii"),
                     str(prefill_unique_rank).encode("ascii"),
-                ]
+                ],
             )
         except Exception:
             pass
@@ -469,6 +635,7 @@ class MooncakeKVManager(CommonKVManager):
             self.server_args.chunked_prefill_size,
             self._staging_ctx.prefetch_requested,
             self._staging_ctx.prefetch_sockets,
+            send_message=self._send_manager_message,
         )
 
     def send_kvcache_staged(
@@ -670,22 +837,11 @@ class MooncakeKVManager(CommonKVManager):
             return self._transfer_data(mooncake_session_id, transfer_blocks)
 
         if self.enable_custom_mem_pool:
-            futures = [
-                executor.submit(
-                    process_layer,
-                    src_ptr,
-                    dst_ptr,
-                    item_len,
-                )
+            calls = [
+                (process_layer, (src_ptr, dst_ptr, item_len))
                 for (src_ptr, dst_ptr, item_len) in layers_params
             ]
-            for future in concurrent.futures.as_completed(futures):
-                status = future.result()
-                if status != 0:
-                    for f in futures:
-                        f.cancel()
-                    return status
-            return 0
+            return _submit_transfer_futures(executor, calls)
         else:
             # Combining all layers' params in one batch transfer is more efficient
             # compared to using multiple threads
@@ -813,24 +969,13 @@ class MooncakeKVManager(CommonKVManager):
                 mooncake_session_id, src_addr_list, dst_addr_list, length_list
             )
 
-        futures = []
+        calls = []
         for i in range(layers_current_pp_stage):
-            futures.append(
-                executor.submit(process_layer_tp_aware, src_k_ptrs[i], dst_k_ptrs[i])
-            )
+            calls.append((process_layer_tp_aware, (src_k_ptrs[i], dst_k_ptrs[i])))
         for i in range(layers_current_pp_stage):
-            futures.append(
-                executor.submit(process_layer_tp_aware, src_v_ptrs[i], dst_v_ptrs[i])
-            )
+            calls.append((process_layer_tp_aware, (src_v_ptrs[i], dst_v_ptrs[i])))
 
-        for future in concurrent.futures.as_completed(futures):
-            status = future.result()
-            if status != 0:
-                for f in futures:
-                    f.cancel()
-                return status
-
-        return 0
+        return _submit_transfer_futures(executor, calls)
 
     def send_aux(
         self,
@@ -890,10 +1035,9 @@ class MooncakeKVManager(CommonKVManager):
         aux_index: int,
         data: bytes,
     ):
-        na = NetworkAddress(remote, dst_port)
-        socket = self._connect(na.to_tcp(), is_ipv6=na.is_ipv6)
-
-        socket.send_multipart(
+        self._send_manager_message(
+            remote,
+            dst_port,
             [
                 MooncakeKVManager.AUX_DATA_HEADER,
                 str(room).encode("ascii"),
@@ -901,12 +1045,15 @@ class MooncakeKVManager(CommonKVManager):
                 str(aux_index).encode("ascii"),
                 struct.pack(">I", len(data)),
                 data,
-            ]
+            ],
         )
 
     def _handle_aux_data(self, msg: List[bytes]):
         """Handle AUX_DATA messages received by the decode thread."""
         room = int(msg[1].decode("ascii"))
+        if room in self.aborting_rooms:
+            logger.debug("Dropping AUX_DATA for aborting room %s", room)
+            return
         buffer_index = int(msg[2].decode("ascii"))
         aux_index = int(msg[3].decode("ascii"))
         data_length = struct.unpack(">I", msg[4])[0]
@@ -1225,13 +1372,14 @@ class MooncakeKVManager(CommonKVManager):
     def sync_status_to_decode_endpoint(
         self, remote: str, dst_port: int, room: int, status: int, prefill_rank: int
     ):
-        na = NetworkAddress(remote, dst_port)
-        self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
+        self._send_manager_message(
+            remote,
+            dst_port,
             [
                 str(room).encode("ascii"),
                 str(status).encode("ascii"),
                 str(prefill_rank).encode("ascii"),
-            ]
+            ],
         )
 
     def transfer_worker(
@@ -1250,6 +1398,8 @@ class MooncakeKVManager(CommonKVManager):
             )
 
         while True:
+            lifetime = None
+            lease_acquired = False
             try:
                 kv_chunk: TransferKVChunk = queue.get()
                 if self.enable_trace:
@@ -1258,6 +1408,12 @@ class MooncakeKVManager(CommonKVManager):
                         MooncakeRequestStage.MOONCAKE_WORKER_SEND.stage_name,
                         MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
                     )
+
+                lifetime = self._get_room_lifetime(kv_chunk.room)
+                lease_acquired = lifetime.acquire()
+                if not lease_acquired:
+                    logger.debug("Skipping chunk for aborted room %s", kv_chunk.room)
+                    continue
 
                 if (
                     kv_chunk.room not in self.request_status
@@ -1473,6 +1629,48 @@ class MooncakeKVManager(CommonKVManager):
                 raise RuntimeError(
                     f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
                 )
+            finally:
+                if lease_acquired:
+                    lifetime.release()
+
+    def _send_abort_ack_when_quiesced(
+        self,
+        lifetime: Optional[RoomTransferLifetime],
+        room: int,
+        decode_ip: str,
+        decode_port: int,
+        token: bytes,
+    ) -> None:
+        try:
+            if lifetime is not None:
+                lifetime.wait()
+            self._send_manager_message(
+                decode_ip, decode_port, [b"ABORT_ACK", str(room).encode("ascii"), token]
+            )
+        except Exception as e:
+            logger.debug("Failed to send ABORT_ACK for room %s: %s", room, e)
+        finally:
+            with self._abort_ack_lock:
+                self._abort_ack_inflight.discard((room, decode_ip, decode_port, token))
+
+    def _schedule_abort_ack(
+        self,
+        lifetime: Optional[RoomTransferLifetime],
+        room: int,
+        decode_ip: str,
+        decode_port: int,
+        token: bytes,
+    ) -> None:
+        key = (room, decode_ip, decode_port, token)
+        with self._abort_ack_lock:
+            if key in self._abort_ack_inflight:
+                return
+            self._abort_ack_inflight.add(key)
+        threading.Thread(
+            target=self._send_abort_ack_when_quiesced,
+            args=(lifetime, room, decode_ip, decode_port, token),
+            daemon=True,
+        ).start()
 
     def start_prefill_thread(self):
         def bootstrap_thread():
@@ -1502,9 +1700,12 @@ class MooncakeKVManager(CommonKVManager):
                     room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
                     decode_ip = waiting_req_bytes[2].decode("ascii")
                     decode_port = int(waiting_req_bytes[3].decode("ascii"))
+                    token = waiting_req_bytes[4] if len(waiting_req_bytes) > 4 else b""
+                    lifetime = self._abort_room_for_token(room_to_be_aborted, token)
                     # No need to abort the room if it has already succeeded
                     if (
-                        room_to_be_aborted in self.request_status
+                        lifetime is not None
+                        and room_to_be_aborted in self.request_status
                         and self.check_status(room_to_be_aborted) != KVPoll.Success
                     ):
                         self.update_status(room_to_be_aborted, KVPoll.Failed)
@@ -1517,26 +1718,23 @@ class MooncakeKVManager(CommonKVManager):
                             f"Received abort notification for room {room_to_be_aborted}, "
                             f"ignoring (already completed or unknown)"
                         )
-                    # Send ACK back to decode endpoint
-                    try:
-                        na = NetworkAddress(decode_ip, decode_port)
-                        self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
-                            [
-                                b"ABORT_ACK",
-                                str(room_to_be_aborted).encode("ascii"),
-                            ]
-                        )
-                        logger.debug(
-                            f"Sent ABORT_ACK for room {room_to_be_aborted} to "
-                            f"{decode_ip}:{decode_port}"
-                        )
-                    except Exception as e:
-                        logger.debug(
-                            f"Failed to send ABORT_ACK for room {room_to_be_aborted}: {e}"
-                        )
+                    self._schedule_abort_ack(
+                        lifetime,
+                        room_to_be_aborted,
+                        decode_ip,
+                        decode_port,
+                        token,
+                    )
                     continue
                 mooncake_session_id = waiting_req_bytes[3].decode("ascii")
                 if room == "None":
+                    if not _has_kv_registration_capability(waiting_req_bytes):
+                        logger.error(
+                            "Rejecting Mooncake KV registration without %s from %s",
+                            QUIESCE_CAPABILITY,
+                            mooncake_session_id,
+                        )
+                        continue
                     self.decode_kv_args_table[mooncake_session_id] = (
                         KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
                     )
@@ -1552,24 +1750,45 @@ class MooncakeKVManager(CommonKVManager):
                 else:
                     required_dst_info_num = int(waiting_req_bytes[7].decode("ascii"))
                     room = int(room)
-                    if room not in self.transfer_infos:
-                        self.transfer_infos[room] = {}
-
-                    self.transfer_infos[room][mooncake_session_id] = (
-                        TransferInfo.from_zmq(waiting_req_bytes)
-                    )
-                    # NOTE: after bootstrapping we can mark the req as waiting for input
-                    if len(self.transfer_infos[room]) == required_dst_info_num:
-                        self.resolve_kv_replica_factor(self.transfer_infos[room])
-                        self.req_to_decode_prefix_len[room] = next(
-                            (
-                                info.decode_prefix_len
-                                for info in self.transfer_infos[room].values()
-                                if info.decode_prefix_len is not None
-                            ),
-                            0,
+                    if not _has_transfer_metadata_capability(waiting_req_bytes):
+                        self.record_failure(
+                            room,
+                            f"Mooncake decode metadata is missing {QUIESCE_CAPABILITY}",
                         )
-                        self.update_status(room, KVPoll.WaitingForInput)
+                        self.update_status(room, KVPoll.Failed)
+                        continue
+                    if (
+                        room not in self.request_status
+                        or self.check_status(room) == KVPoll.Success
+                    ):
+                        logger.debug(
+                            "Dropping metadata for unknown/completed room %s", room
+                        )
+                        continue
+                    lifetime = self._get_room_lifetime(room)
+                    if not lifetime.acquire():
+                        logger.debug("Dropping bootstrap for aborted room %s", room)
+                        continue
+                    try:
+                        if room not in self.transfer_infos:
+                            self.transfer_infos[room] = {}
+
+                        transfer_info = TransferInfo.from_zmq(waiting_req_bytes)
+                        self._register_room_abort_token(room, transfer_info.abort_token)
+                        self.transfer_infos[room][mooncake_session_id] = transfer_info
+                        if len(self.transfer_infos[room]) == required_dst_info_num:
+                            self.resolve_kv_replica_factor(self.transfer_infos[room])
+                            self.req_to_decode_prefix_len[room] = next(
+                                (
+                                    info.decode_prefix_len
+                                    for info in self.transfer_infos[room].values()
+                                    if info.decode_prefix_len is not None
+                                ),
+                                0,
+                            )
+                            self.update_status(room, KVPoll.WaitingForInput)
+                    finally:
+                        lifetime.release()
 
         threading.Thread(target=bootstrap_thread).start()
 
@@ -1583,41 +1802,28 @@ class MooncakeKVManager(CommonKVManager):
 
                 # Staging: prefill notifies a chunk written to staging buffer
                 if msg[0] == b"CHUNK_READY":
-                    room = int(msg[1].decode("ascii"))
-                    chunk_idx = int(msg[2].decode("ascii"))
-                    page_start = int(msg[3].decode("ascii"))
-                    num_pages = int(msg[4].decode("ascii"))
-                    session_id = msg[5].decode("ascii")
-                    handler = self._staging_handler
-                    assert (
-                        handler is not None
-                    ), "CHUNK_READY received before staging handler initialized"
-                    handler.handle_chunk_arrived(
-                        room,
-                        chunk_idx,
-                        page_start,
-                        num_pages,
-                        session_id,
-                        self._chunk_writer_counts,
-                    )
+                    self._handle_chunk_ready(msg)
                     continue
 
                 # Staging: prefill pre-requests staging allocation before forward
                 if msg[0] == b"STAGING_REQ":
+                    room = int(msg[1].decode("ascii"))
+                    if room in self.aborting_rooms:
+                        continue
                     self._handle_staging_req(msg)
                     continue
 
                 # Prefill acknowledges abort notification
                 if msg[0] == b"ABORT_ACK":
-                    # TODO(shangming): use this info to implement the deferred release mechanism if needed
-                    ack_aborted_room = int(msg[1].decode("ascii"))
-                    logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
+                    self._handle_abort_ack(msg)
                     continue
 
                 bootstrap_room, status, prefill_rank = msg
                 status = int(status.decode("ascii"))
                 bootstrap_room = int(bootstrap_room.decode("ascii"))
                 prefill_rank = int(prefill_rank.decode("ascii"))
+                if bootstrap_room in self.aborting_rooms:
+                    continue
 
                 if status == KVPoll.Success:
                     if bootstrap_room in self.request_status:
@@ -1658,6 +1864,33 @@ class MooncakeKVManager(CommonKVManager):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
 
+        lifetime = self._get_room_lifetime(bootstrap_room)
+        if not lifetime.acquire():
+            logger.debug("Request with bootstrap_room=%s was aborted", bootstrap_room)
+            return
+        try:
+            self._add_transfer_request_with_lease(
+                bootstrap_room,
+                kv_indices,
+                index_slice,
+                is_last_chunk,
+                aux_index,
+                state_indices,
+                trace_ctx,
+            )
+        finally:
+            lifetime.release()
+
+    def _add_transfer_request_with_lease(
+        self,
+        bootstrap_room,
+        kv_indices,
+        index_slice,
+        is_last_chunk,
+        aux_index,
+        state_indices,
+        trace_ctx,
+    ):
         if (
             bootstrap_room not in self.request_status
             or self.check_status(bootstrap_room) == KVPoll.Failed
@@ -1763,6 +1996,7 @@ class MooncakeKVSender(CommonKVSender):
             req_has_disagg_prefill_dp_rank,
         )
         self.conclude_state = None
+        self._failure_quiescence_started = False
         self.init_time = time.time()
         self._init_trace_ctx()
 
@@ -1801,17 +2035,49 @@ class MooncakeKVSender(CommonKVSender):
     def poll(self) -> KVPoll:
         if self.conclude_state is None:
             status = self.kv_mgr.check_status(self.bootstrap_room)
-            if status in (KVPoll.Success, KVPoll.Failed):
+            if status == KVPoll.Failed:
+                self.begin_failure_quiescence()
+                if not self.is_transfer_quiesced():
+                    return KVPoll.Transferring
+                self.conclude_state = status
+                self.trace_ctx.trace_req_finish()
+            elif status == KVPoll.Success:
+                lifetime = self.kv_mgr._abort_room(self.bootstrap_room)
+                if lifetime is not None and not lifetime.is_quiesced():
+                    return KVPoll.Transferring
                 self.conclude_state = status
                 self.trace_ctx.trace_req_finish()
             elif status == KVPoll.Bootstrapping:
                 timeout_result = self._check_bootstrap_timeout()
                 if timeout_result is not None:
-                    return timeout_result
+                    self.begin_failure_quiescence()
+                    return (
+                        KVPoll.Failed
+                        if self.is_transfer_quiesced()
+                        else KVPoll.Transferring
+                    )
 
             return status
         else:
             return self.conclude_state
+
+    def begin_failure_quiescence(self):
+        if self._failure_quiescence_started:
+            return
+        self._failure_quiescence_started = True
+        self.kv_mgr._abort_room(self.bootstrap_room)
+        super().abort()
+
+    def is_transfer_quiesced(self) -> bool:
+        lifetime = self.kv_mgr._find_room_lifetime(self.bootstrap_room)
+        return lifetime is None or lifetime.is_quiesced()
+
+    def is_failure_quiescing(self) -> bool:
+        return self._failure_quiescence_started
+
+    def clear(self) -> None:
+        super().clear()
+        self.kv_mgr._clear_room_lifetime(self.bootstrap_room)
 
     def failure_exception(self):
         # Explicitly set the status to failure since this request has failed in another rank
@@ -1845,7 +2111,7 @@ class MooncakeKVSender(CommonKVSender):
         self.trace_ctx.trace_req_start()
 
     def abort(self):
-        super().abort()
+        self.begin_failure_quiescence()
         self.trace_ctx.abort(abort_info={"reason": "Aborted"})
         self.trace_ctx.trace_req_finish()
 
@@ -1857,9 +2123,49 @@ class MooncakeKVReceiver(CommonKVReceiver):
         bootstrap_addr: str,
         bootstrap_room: Optional[int] = None,
     ):
-        self.session_id = mgr.get_session_id()
-        self.init_time = None
-        super().__init__(mgr, bootstrap_addr, bootstrap_room)
+        with mgr._abort_receivers_lock:
+            if bootstrap_room is not None and bootstrap_room in mgr.abort_receivers:
+                raise RuntimeError(
+                    f"Mooncake bootstrap room {bootstrap_room} is already active"
+                )
+            self.session_id = mgr.get_session_id()
+            self.init_time = None
+            self._expected_abort_acks = set()
+            self._received_abort_acks = set()
+            self._abort_targets = []
+            self._abort_ack_lock = threading.Lock()
+            self._last_abort_send = float("-inf")
+            self._staging_registered = False
+            super().__init__(mgr, bootstrap_addr, bootstrap_room)
+            mgr.abort_receivers[bootstrap_room] = self
+            if bootstrap_room in mgr.aborting_rooms:
+                mgr.record_failure(
+                    bootstrap_room,
+                    "Mooncake bootstrap room cannot be reused after abort",
+                )
+                mgr.update_status(bootstrap_room, KVPoll.Failed)
+                self.conclude_state = KVPoll.Failed
+
+    def init(self, prefill_dp_rank: int):
+        if self.conclude_state == KVPoll.Failed:
+            return
+        super().init(prefill_dp_rank)
+
+    def _get_bootstrap_info_from_server(
+        self, prefill_dp_rank, prefill_cp_rank, target_tp_rank, target_pp_rank
+    ):
+        info = super()._get_bootstrap_info_from_server(
+            prefill_dp_rank, prefill_cp_rank, target_tp_rank, target_pp_rank
+        )
+        if info is None:
+            return None
+        if QUIESCE_CAPABILITY not in info.get("capabilities", []):
+            self.kv_mgr.record_failure(
+                self.bootstrap_room,
+                f"Mooncake prefill rank is missing {QUIESCE_CAPABILITY}",
+            )
+            return None
+        return info
 
     def _register_kv_args(self):
         for bootstrap_info in self.bootstrap_infos:
@@ -1913,6 +2219,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         packed_state_dim_per_tensor,
                         packed_staging_base_ptr,
                         staging_total_size_str,
+                        QUIESCE_CAPABILITY_BYTES,
                     ]
                 )
 
@@ -1936,11 +2243,12 @@ class MooncakeKVReceiver(CommonKVReceiver):
             and self.kv_mgr._staging_ctx.allocator is not None
         ):
             self.chunk_staging_infos = []
-            self.kv_mgr.register_staging_room_bootstrap(
+            self._staging_registered = self.kv_mgr.register_staging_room_bootstrap(
                 self.bootstrap_room, self.bootstrap_infos, self
             )
 
-        for bootstrap_info in self.bootstrap_infos:
+        abort_targets = self._ensure_abort_targets()
+        for bootstrap_info, abort_token in abort_targets:
             sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
             is_dummy = bootstrap_info["is_dummy"]
 
@@ -1960,23 +2268,118 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         ),
                         str(self.required_dst_info_num).encode("ascii"),
                         str(decode_prefix_len or 0).encode("ascii"),
+                        QUIESCE_CAPABILITY_BYTES,
+                        abort_token,
                     ]
                 )
         self.init_time = time.time()
 
     def poll(self) -> KVPoll:
+        if self.conclude_state == KVPoll.Failed:
+            self.begin_failure_quiescence()
+            if not self.is_transfer_quiesced():
+                return KVPoll.Transferring
+            return self.conclude_state
         if self.conclude_state is not None:
             return self.conclude_state
 
         status = self.kv_mgr.check_status(self.bootstrap_room)
-        if status in (KVPoll.Success, KVPoll.Failed):
+        if status == KVPoll.Failed:
+            self.begin_failure_quiescence()
+            if not self.is_transfer_quiesced():
+                return KVPoll.Transferring
+            self.conclude_state = status
+        elif status == KVPoll.Success:
             self.conclude_state = status
         elif status == KVPoll.WaitingForInput:
             timeout_result = self._check_waiting_timeout()
             if timeout_result is not None:
-                return timeout_result
+                self.begin_failure_quiescence()
+                return (
+                    KVPoll.Failed
+                    if self.is_transfer_quiesced()
+                    else KVPoll.Transferring
+                )
 
         return status
+
+    def _record_abort_ack(self, token: Optional[bytes]) -> None:
+        with self._abort_ack_lock:
+            if token in self._expected_abort_acks:
+                self._received_abort_acks.add(token)
+
+    def _abort_acks_complete(self) -> bool:
+        with self._abort_ack_lock:
+            return self._expected_abort_acks.issubset(self._received_abort_acks)
+
+    def _ensure_abort_targets(self):
+        with self._abort_ack_lock:
+            if not self._abort_targets and self.bootstrap_infos:
+                self._abort_targets = [
+                    (bootstrap_info, os.urandom(16).hex().encode("ascii"))
+                    for bootstrap_info in self.bootstrap_infos
+                ]
+                self._expected_abort_acks.update(
+                    token for _bootstrap_info, token in self._abort_targets
+                )
+            return list(self._abort_targets)
+
+    def abort(self):
+        self.kv_mgr.aborting_rooms.add(self.bootstrap_room)
+        handler = getattr(self.kv_mgr, "_staging_handler", None)
+        if handler is not None:
+            handler.begin_abort(self.bootstrap_room)
+        super().abort()
+
+    def begin_failure_quiescence(self):
+        self.abort()
+        self._send_abort_notification()
+
+    def is_failure_quiescing(self) -> bool:
+        return self.abort_notified
+
+    def is_transfer_quiesced(self) -> bool:
+        if not self._abort_acks_complete():
+            return False
+        handler = getattr(self.kv_mgr, "_staging_handler", None)
+        if not self._staging_registered:
+            return True
+        if handler is None:
+            return False
+        return handler.finalize_room_abort(self.bootstrap_room)
+
+    def _send_abort_notification(self):
+        now = time.monotonic()
+        self._ensure_abort_targets()
+        with self._abort_ack_lock:
+            if now - self._last_abort_send < ABORT_RETRY_INTERVAL_S:
+                return
+            self._last_abort_send = now
+            targets = [
+                (bootstrap_info, token)
+                for bootstrap_info, token in self._abort_targets
+                if token not in self._received_abort_acks
+            ]
+
+        for bootstrap_info, token in targets:
+            try:
+                sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
+                with lock:
+                    sock.send_multipart(
+                        [
+                            b"ABORT",
+                            str(self.bootstrap_room).encode("ascii"),
+                            self.kv_mgr.local_ip.encode("ascii"),
+                            str(self.kv_mgr.rank_port).encode("ascii"),
+                            token,
+                        ]
+                    )
+            except Exception as e:
+                logger.debug(
+                    "Failed to send abort notification for room %s: %s",
+                    self.bootstrap_room,
+                    e,
+                )
 
     def failure_exception(self):
         if self.conclude_state is None:
@@ -1992,6 +2395,15 @@ class MooncakeKVReceiver(CommonKVReceiver):
         raise KVTransferError(
             self.bootstrap_room, failure_reason, is_from_another_rank=is_propagated
         )
+
+    def clear(self) -> None:
+        super().clear()
+        handler = getattr(self.kv_mgr, "_staging_handler", None)
+        if handler is not None:
+            handler.clear_abort(self.bootstrap_room)
+        with self.kv_mgr._abort_receivers_lock:
+            if self.kv_mgr.abort_receivers.get(self.bootstrap_room) is self:
+                self.kv_mgr.abort_receivers.pop(self.bootstrap_room, None)
 
 
 class MooncakeKVBootstrapServer(CommonKVBootstrapServer):

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -526,8 +526,12 @@ class NixlKVManager(CommonKVManager):
         }
 
     def register_staging_room_bootstrap(self, room, bootstrap_infos, receiver):
+        handler = getattr(self, "_staging_handler", None)
+        if handler is not None:
+            return handler.register_room_bootstrap(room, bootstrap_infos, receiver)
         self._staging_ctx.room_bootstrap[room] = bootstrap_infos
         self._staging_ctx.room_receivers[room] = receiver
+        return True
 
     def _is_watermark_ready(
         self, agent_name: str, alloc_round: int, alloc_end: int
@@ -555,37 +559,21 @@ class NixlKVManager(CommonKVManager):
         threading.Thread(target=decode_staging_thread, daemon=True).start()
 
     def _handle_staging_req(self, msg):
-        from sglang.srt.disaggregation.common.staging_handler import (
-            handle_staging_req,
-        )
-
         room = int(msg[1].decode("ascii"))
         session_id = msg[4].decode("ascii")
         handler = self._staging_handler
         assert (
             handler is not None
         ), "STAGING_REQ received before staging handler initialized"
-        decode_req = handler._room_to_decode_req.get(room)
-        if decode_req is None:
-            logger.warning(
-                "STAGING_REQ received for unregistered room=%s, skipping",
-                room,
-            )
-            return
-        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
-        handle_staging_req(
+        accepted = handler.handle_staging_req(
             msg,
-            self._staging_ctx.allocator,
             self.kv_args,
             self.attn_tp_size,
-            prefill_tp,
             getattr(self, "kv_buffer_tensors", None),
-            self._staging_ctx.room_receivers,
-            self._staging_ctx.room_bootstrap,
         )
 
         receiver = self._staging_ctx.room_receivers.get(room)
-        if receiver is not None:
+        if accepted and receiver is not None:
             handler.register_wm_subscriber(receiver, session_id)
 
     def _prefetch_staging_reqs(self, room: int):

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -94,11 +94,20 @@ def _get_failure_prob() -> float:
 
 def _poll_with_failure_injection(pollers) -> List[int]:
     if (failure_prob := _get_failure_prob()) > 0:
-        return [
+        polls = [
             int(KVPoll.Failed) if random.random() < failure_prob else int(poller.poll())
             for poller in pollers
         ]
-    return [int(poller.poll()) for poller in pollers]
+    else:
+        polls = [int(poller.poll()) for poller in pollers]
+    return [
+        (
+            int(KVPoll.Failed)
+            if getattr(poller, "is_failure_quiescing", lambda: False)()
+            else poll
+        )
+        for poller, poll in zip(pollers, polls)
+    ]
 
 
 def _is_fake_transfer(req: Req, server_args: ServerArgs) -> bool:
@@ -126,6 +135,34 @@ def _apply_metadata_gate(polls, decode_reqs, metadata_buffers, server_args) -> N
                 polls[i] = int(KVPoll.Transferring)
 
 
+def _reduce_polls_with_quiescence(pollers, polls, groups):
+    poll_tensor = torch.tensor(polls, dtype=torch.uint8, device="cpu")
+    for group in groups:
+        dist.all_reduce(poll_tensor, op=dist.ReduceOp.MIN, group=group)
+
+    reduced_polls = poll_tensor.tolist()
+    failed = [poll == int(KVPoll.Failed) for poll in reduced_polls]
+    if not any(failed):
+        return reduced_polls
+
+    for poller, is_failed in zip(pollers, failed):
+        if is_failed:
+            poller.begin_failure_quiescence()
+
+    quiesced = [
+        int(not is_failed or poller.is_transfer_quiesced())
+        for poller, is_failed in zip(pollers, failed)
+    ]
+    quiesced_tensor = torch.tensor(quiesced, dtype=torch.uint8, device="cpu")
+    for group in groups:
+        dist.all_reduce(quiesced_tensor, op=dist.ReduceOp.MIN, group=group)
+
+    for i, is_failed in enumerate(failed):
+        if is_failed and not quiesced_tensor[i].item():
+            reduced_polls[i] = int(KVPoll.Transferring)
+    return reduced_polls
+
+
 def poll_and_all_reduce(
     pollers,
     gloo_group: dist.ProcessGroup,
@@ -143,9 +180,7 @@ def poll_and_all_reduce(
         and server_args is not None
     ):
         _apply_metadata_gate(polls, decode_reqs, metadata_buffers, server_args)
-    tensor_to_reduce = torch.tensor(polls, dtype=torch.uint8, device="cpu")
-    dist.all_reduce(tensor_to_reduce, op=dist.ReduceOp.MIN, group=gloo_group)
-    return tensor_to_reduce.tolist()
+    return _reduce_polls_with_quiescence(pollers, polls, [gloo_group])
 
 
 def poll_and_all_reduce_attn_cp_tp_group(
@@ -153,19 +188,12 @@ def poll_and_all_reduce_attn_cp_tp_group(
     attn_cp_cpu_group: dist.ProcessGroup,
     attn_tp_cpu_group: dist.ProcessGroup,
 ):
-    # First sync across attn-tp ranks so all TP participants for a given (dp, cp)
-    # shard observe the same status transitions.
-    polls = poll_and_all_reduce(pollers, attn_tp_cpu_group)
-
-    # Then sync across attn-cp ranks, so all TPxCP participants in one DP shard
-    # converge to the same global status.
-    tensor_to_reduce = torch.tensor(polls, dtype=torch.uint8, device="cpu")
-    dist.all_reduce(
-        tensor_to_reduce,
-        op=dist.ReduceOp.MIN,
-        group=attn_cp_cpu_group,
+    polls = _poll_with_failure_injection(pollers)
+    return _reduce_polls_with_quiescence(
+        pollers,
+        polls,
+        [attn_tp_cpu_group, attn_cp_cpu_group],
     )
-    return tensor_to_reduce.tolist()
 
 
 def poll_and_all_reduce_with_staging(
@@ -194,9 +222,13 @@ def poll_and_all_reduce_with_staging(
     # Apply metadata gate on the decode requests to downgrade Success → Transferring for requests whose metadata hasn't landed.
     if metadata_buffers is not None and server_args is not None:
         _apply_metadata_gate(raw_polls, decode_reqs, metadata_buffers, server_args)
-    poll_tensor = torch.tensor(raw_polls, dtype=torch.uint8, device="cpu")
-    dist.all_reduce(poll_tensor, op=dist.ReduceOp.MIN, group=gloo_group)
-    return poll_tensor.tolist()
+    return _reduce_polls_with_quiescence(receivers, raw_polls, [gloo_group])
+
+
+def defer_chunked_prefill_abort(req, inflight_queue) -> None:
+    req.disagg_kv_sender.abort()
+    if req not in inflight_queue:
+        inflight_queue.append(req)
 
 
 #########################

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -63,6 +63,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    defer_chunked_prefill_abort,
     get_dsa_seed_metadata_dim,
     prepare_abort,
 )
@@ -2557,18 +2558,15 @@ class Scheduler(
         req.time_stats.trace_ctx.abort(abort_info={"reason": "Aborted"})
         req.to_finish = None
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            req.disagg_kv_sender.abort()
-            maybe_release_metadata_buffer(
-                req, self.req_to_metadata_buffer_idx_allocator
-            )
-            req.pending_bootstrap = False
-        if self.enable_hicache_storage:
-            self.tree_cache.release_aborted_request(req.rid)
-        release_kv_cache(req, self.tree_cache, is_insert=False)
+            defer_chunked_prefill_abort(req, self.disagg_prefill_inflight_queue)
+        else:
+            if self.enable_hicache_storage:
+                self.tree_cache.release_aborted_request(req.rid)
+            release_kv_cache(req, self.tree_cache, is_insert=False)
+            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
 
         self.chunked_req = None
         self._pending_chunked_abort_req = None
-        self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
         logger.debug(f"Abort chunked prefill request. {req.rid=}")
 
     def _build_hisparse_decode_batch(self, reqs):

--- a/test/registered/unit/disaggregation/test_mooncake_abort_quiescence.py
+++ b/test/registered/unit/disaggregation/test_mooncake_abort_quiescence.py
@@ -1,0 +1,868 @@
+import concurrent.futures
+import threading
+import unittest
+from collections import defaultdict
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+
+from sglang.srt.disaggregation.ascend.conn import AscendKVManager
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import CommonKVManager, PrefillServerInfo
+from sglang.srt.disaggregation.common.staging_handler import DecodeStagingHandler
+from sglang.srt.disaggregation.common.utils import FastQueue, TransferKVChunk
+from sglang.srt.disaggregation.decode_hicache_mixin import (
+    HiCacheRestoreGatedKVReceiver,
+    HiCacheRestoreResult,
+)
+from sglang.srt.disaggregation.mooncake.conn import (
+    ABORT_RETRY_INTERVAL_S,
+    QUIESCE_CAPABILITY_BYTES,
+    KVArgsRegisterInfo,
+    MooncakeKVManager,
+    MooncakeKVReceiver,
+    RoomTransferLifetime,
+    TransferInfo,
+    _has_kv_registration_capability,
+    _has_transfer_metadata_capability,
+    _submit_transfer_futures,
+    _wait_transfer_futures,
+)
+from sglang.srt.disaggregation.utils import (
+    defer_chunked_prefill_abort,
+    poll_and_all_reduce,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestRoomTransferLifetime(unittest.TestCase):
+    def test_abort_waits_for_native_worker_before_ack(self):
+        lifetime = RoomTransferLifetime()
+        self.assertTrue(lifetime.acquire())
+        lifetime.abort()
+        ack_sent = threading.Event()
+
+        waiter = threading.Thread(target=lambda: (lifetime.wait(), ack_sent.set()))
+        waiter.start()
+        self.assertFalse(ack_sent.wait(0.05))
+        self.assertFalse(lifetime.acquire())
+
+        lifetime.release()
+        self.assertTrue(ack_sent.wait(1))
+        waiter.join()
+
+
+class TestExecutorDrain(unittest.TestCase):
+    def test_failure_waits_for_running_sibling(self):
+        sibling_started = threading.Event()
+        release_sibling = threading.Event()
+        returned = threading.Event()
+
+        def sibling():
+            sibling_started.set()
+            release_sibling.wait()
+            return 0
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(lambda: -1),
+                executor.submit(sibling),
+            ]
+            self.assertTrue(sibling_started.wait(1))
+            result = []
+            waiter = threading.Thread(
+                target=lambda: (
+                    result.append(_wait_transfer_futures(futures)),
+                    returned.set(),
+                )
+            )
+            waiter.start()
+            self.assertFalse(returned.wait(0.05))
+            release_sibling.set()
+            self.assertTrue(returned.wait(1))
+            waiter.join()
+        self.assertEqual(result, [-1])
+
+    def test_submit_failure_waits_for_already_running_future(self):
+        started = threading.Event()
+        release = threading.Event()
+        returned = threading.Event()
+        errors = []
+
+        def blocked():
+            started.set()
+            release.wait()
+            return 0
+
+        class RaiseOnSecondSubmit:
+            def __init__(self):
+                self.pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                self.calls = 0
+
+            def submit(self, fn, *args):
+                self.calls += 1
+                if self.calls == 2:
+                    raise RuntimeError("submit failed")
+                return self.pool.submit(fn, *args)
+
+        executor = RaiseOnSecondSubmit()
+
+        def submit_all():
+            try:
+                _submit_transfer_futures(
+                    executor,
+                    [(blocked, ()), (lambda: 0, ())],
+                )
+            except Exception as error:
+                errors.append(error)
+            finally:
+                returned.set()
+
+        waiter = threading.Thread(target=submit_all)
+        waiter.start()
+        self.assertTrue(started.wait(1))
+        self.assertFalse(returned.wait(0.05))
+        release.set()
+        self.assertTrue(returned.wait(1))
+        waiter.join()
+        executor.pool.shutdown()
+        self.assertEqual(str(errors[0]), "submit failed")
+
+    def test_ascend_custom_pool_submit_failure_drains_running_future(self):
+        started = threading.Event()
+        release = threading.Event()
+        returned = threading.Event()
+        errors = []
+
+        manager = AscendKVManager.__new__(AscendKVManager)
+        manager.pp_size = 1
+        manager.enable_custom_mem_pool = True
+        manager.kv_args = SimpleNamespace(
+            kv_data_ptrs=[100, 200],
+            kv_item_lens=[8, 8],
+        )
+
+        def transfer(*_args):
+            started.set()
+            release.wait()
+            return 0
+
+        manager._transfer_data = transfer
+
+        class RaiseOnSecondSubmit:
+            def __init__(self):
+                self.pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                self.calls = 0
+
+            def submit(self, fn, *args):
+                self.calls += 1
+                if self.calls == 2:
+                    raise RuntimeError("ascend submit failed")
+                return self.pool.submit(fn, *args)
+
+        executor = RaiseOnSecondSubmit()
+
+        def send():
+            try:
+                manager.send_kvcache(
+                    "session",
+                    np.array([0], dtype=np.int32),
+                    [300, 400],
+                    np.array([0], dtype=np.int32),
+                    executor,
+                )
+            except Exception as error:
+                errors.append(error)
+            finally:
+                returned.set()
+
+        waiter = threading.Thread(target=send)
+        waiter.start()
+        self.assertTrue(started.wait(1))
+        self.assertFalse(returned.wait(0.05))
+        release.set()
+        self.assertTrue(returned.wait(1))
+        waiter.join()
+        executor.pool.shutdown()
+        self.assertEqual(str(errors[0]), "ascend submit failed")
+
+
+class TestCollectiveFailureQuiescence(unittest.TestCase):
+    def test_failed_is_delayed_until_every_rank_is_quiesced(self):
+        poller = SimpleNamespace(
+            poll=Mock(return_value=KVPoll.Transferring),
+            begin_failure_quiescence=Mock(),
+            is_transfer_quiesced=Mock(return_value=True),
+        )
+        collective_call = 0
+
+        def all_reduce(tensor, **_kwargs):
+            nonlocal collective_call
+            if collective_call % 2 == 0:
+                tensor[0] = KVPoll.Failed
+            elif collective_call == 1:
+                tensor[0] = 0
+            collective_call += 1
+
+        with patch(
+            "sglang.srt.disaggregation.utils.dist.all_reduce", side_effect=all_reduce
+        ):
+            self.assertEqual(
+                poll_and_all_reduce([poller], object()), [KVPoll.Transferring]
+            )
+            self.assertEqual(poll_and_all_reduce([poller], object()), [KVPoll.Failed])
+
+        self.assertEqual(poller.begin_failure_quiescence.call_count, 2)
+
+    def test_hicache_receiver_delegates_failure_quiescence(self):
+        receiver = SimpleNamespace(
+            poll=Mock(return_value=KVPoll.Failed),
+            begin_failure_quiescence=Mock(return_value="begun"),
+            is_transfer_quiesced=Mock(return_value=False),
+            is_failure_quiescing=Mock(return_value=True),
+        )
+        gated = HiCacheRestoreGatedKVReceiver(
+            SimpleNamespace(
+                kv_receiver=receiver,
+                hicache_restore_status=HiCacheRestoreResult.PENDING,
+            )
+        )
+
+        self.assertEqual(gated.poll(), KVPoll.Failed)
+        self.assertEqual(gated.begin_failure_quiescence(), "begun")
+        self.assertFalse(gated.is_transfer_quiesced())
+        self.assertTrue(gated.is_failure_quiescing())
+        receiver.begin_failure_quiescence.assert_called_once_with()
+        receiver.is_transfer_quiesced.assert_called_once_with()
+        receiver.is_failure_quiescing.assert_called_once_with()
+
+
+class TestAbortAckTokens(unittest.TestCase):
+    @staticmethod
+    def _make_receiver(bootstrap_infos):
+        receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
+        receiver.bootstrap_room = 9
+        receiver.bootstrap_infos = bootstrap_infos
+        receiver.kv_mgr = SimpleNamespace(local_ip="127.0.0.1", rank_port=1234)
+        receiver._expected_abort_acks = set()
+        receiver._received_abort_acks = set()
+        receiver._abort_targets = []
+        receiver._abort_ack_lock = threading.Lock()
+        receiver._last_abort_send = float("-inf")
+        return receiver
+
+    def test_abort_sends_a_unique_token_to_every_participant(self):
+        receiver = self._make_receiver([{"rank": 0}, {"rank": 1}])
+        sockets = [Mock(), Mock()]
+        receiver._connect_to_bootstrap_server = Mock(
+            side_effect=[(socket, threading.Lock()) for socket in sockets]
+        )
+
+        receiver._send_abort_notification()
+
+        tokens = [socket.send_multipart.call_args.args[0][4] for socket in sockets]
+        self.assertEqual(len(set(tokens)), 2)
+        self.assertEqual(receiver._expected_abort_acks, set(tokens))
+
+    def test_abort_retries_missing_ack_with_stable_token(self):
+        infos = [{"rank": 0}, {"rank": 1}]
+        receiver = self._make_receiver(infos)
+        sockets = {0: Mock(), 1: Mock()}
+        receiver._connect_to_bootstrap_server = lambda info: (
+            sockets[info["rank"]],
+            threading.Lock(),
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.mooncake.conn.time.monotonic",
+            side_effect=[0, ABORT_RETRY_INTERVAL_S / 2, ABORT_RETRY_INTERVAL_S],
+        ):
+            receiver._send_abort_notification()
+            tokens = {
+                rank: sockets[rank].send_multipart.call_args.args[0][4]
+                for rank in sockets
+            }
+            receiver._send_abort_notification()
+            receiver._record_abort_ack(tokens[0])
+            receiver._send_abort_notification()
+
+        self.assertEqual(sockets[0].send_multipart.call_count, 1)
+        self.assertEqual(sockets[1].send_multipart.call_count, 2)
+        retried = sockets[1].send_multipart.call_args_list[1].args[0][4]
+        self.assertEqual(retried, tokens[1])
+
+    def test_every_token_is_required_and_legacy_ack_is_ignored(self):
+        receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
+        receiver._expected_abort_acks = {b"rank-0", b"rank-1"}
+        receiver._received_abort_acks = set()
+        receiver._abort_ack_lock = threading.Lock()
+
+        receiver._record_abort_ack(None)
+        receiver._record_abort_ack(b"rank-0")
+        self.assertFalse(receiver._abort_acks_complete())
+        receiver._record_abort_ack(b"rank-1")
+        self.assertTrue(receiver._abort_acks_complete())
+
+    def test_missing_bootstrap_info_is_safe_before_transfer(self):
+        receiver = self._make_receiver(None)
+        receiver.abort_notified = False
+        receiver.conclude_state = None
+        receiver.require_staging = False
+        receiver._staging_registered = False
+        receiver.kv_mgr = SimpleNamespace(
+            aborting_rooms=set(),
+            record_failure=Mock(),
+            update_status=Mock(),
+            _staging_handler=None,
+            local_ip="127.0.0.1",
+            rank_port=1234,
+        )
+
+        receiver.begin_failure_quiescence()
+
+        self.assertTrue(receiver.is_transfer_quiesced())
+        self.assertEqual(receiver._expected_abort_acks, set())
+
+
+class TestDecodeStagingAbort(unittest.TestCase):
+    def _make_handler(self, decode_req):
+        allocator = SimpleNamespace(
+            free=Mock(), get_watermark=Mock(return_value=(0, 0))
+        )
+        manager = SimpleNamespace(
+            _chunk_writer_counts={7: {0: ["writer"]}},
+            _staging_ctx=SimpleNamespace(
+                room_bootstrap={7: ["bootstrap"]},
+                room_receivers={7: decode_req.kv_receiver},
+            ),
+        )
+        handler = DecodeStagingHandler.__new__(DecodeStagingHandler)
+        handler._abort_lock = threading.RLock()
+        handler._aborting_rooms = set()
+        handler._abort_finalized_rooms = set()
+        handler._abort_finalizing_rooms = set()
+        handler._scatter_submitting = defaultdict(int)
+        handler._room_to_decode_req = {7: decode_req}
+        handler._wm_subscribers = {}
+        handler.kv_manager = manager
+        handler.staging_allocator = allocator
+        handler.decode_tp = 1
+        return handler, manager, allocator
+
+    def test_abort_finalization_waits_and_frees_every_allocation_once(self):
+        event = Mock()
+        event.query.return_value = False
+        receiver = SimpleNamespace(
+            chunk_staging_infos=[
+                (2, 100, 0, 0, 1),
+                (3, 200, 0, 0, 1),
+            ]
+        )
+        decode_req = SimpleNamespace(
+            req=SimpleNamespace(bootstrap_room=7),
+            kv_receiver=receiver,
+            _chunk_events=[(event, 1)],
+            _staging_last_scatter_submitted=False,
+        )
+        handler, manager, allocator = self._make_handler(decode_req)
+        event.query.side_effect = lambda: (
+            self.assertFalse(handler._abort_lock._is_owned()) or False
+        )
+        allocator.free.side_effect = lambda _alloc_id: self.assertFalse(
+            handler._abort_lock._is_owned()
+        )
+
+        handler.begin_abort(7)
+        self.assertFalse(handler.finalize_abort(7, decode_req))
+        allocator.free.assert_not_called()
+        counts = defaultdict(lambda: defaultdict(list))
+        self.assertFalse(handler.handle_chunk_arrived(7, 0, 0, 1, "rank", counts))
+        self.assertEqual(counts, {})
+
+        event.query.side_effect = lambda: (
+            self.assertFalse(handler._abort_lock._is_owned()) or True
+        )
+        self.assertTrue(handler.finalize_abort(7, decode_req))
+        self.assertTrue(handler.finalize_abort(7, decode_req))
+        self.assertEqual(
+            [call.args[0] for call in allocator.free.call_args_list], [1, 2, 3]
+        )
+        self.assertEqual(receiver.chunk_staging_infos, [])
+        self.assertNotIn(7, manager._chunk_writer_counts)
+        self.assertNotIn(7, manager._staging_ctx.room_bootstrap)
+        self.assertNotIn(7, manager._staging_ctx.room_receivers)
+        self.assertNotIn(7, handler._room_to_decode_req)
+
+    def test_staging_allocation_losing_abort_race_is_freed_without_response(self):
+        assign_started = threading.Event()
+        release_assign = threading.Event()
+        socket = Mock()
+
+        class BlockingAllocator:
+            total_size = 1024
+
+            def __init__(self):
+                self.free = Mock()
+
+            def assign(self, _required):
+                assign_started.set()
+                release_assign.wait()
+                return 11, 64, 0
+
+        receiver = SimpleNamespace(
+            chunk_staging_infos=[],
+            prefill_info=SimpleNamespace(attn_tp_size=2),
+            _connect_to_bootstrap_server=Mock(return_value=(socket, threading.Lock())),
+        )
+        decode_req = SimpleNamespace(kv_receiver=receiver)
+        manager = SimpleNamespace(
+            _staging_ctx=SimpleNamespace(
+                room_receivers={7: receiver},
+                room_bootstrap={7: [{"rank": 0}]},
+            )
+        )
+        handler = DecodeStagingHandler.__new__(DecodeStagingHandler)
+        handler._abort_lock = threading.RLock()
+        handler._aborting_rooms = set()
+        handler._abort_finalized_rooms = set()
+        handler._abort_finalizing_rooms = set()
+        handler._scatter_submitting = defaultdict(int)
+        handler._room_to_decode_req = {7: decode_req}
+        handler.kv_manager = manager
+        handler.staging_allocator = BlockingAllocator()
+        kv_args = SimpleNamespace(
+            page_size=1,
+            kv_item_lens=[8, 8],
+            total_kv_head_num=1,
+            kv_head_num=1,
+            engine_rank=0,
+        )
+        msg = [b"STAGING_REQ", b"7", b"0", b"1", b"session"]
+        result = []
+        worker = threading.Thread(
+            target=lambda: result.append(
+                handler.handle_staging_req(msg, kv_args, 1, None)
+            )
+        )
+        worker.start()
+        self.assertTrue(assign_started.wait(1))
+        handler.begin_abort(7)
+        release_assign.set()
+        worker.join()
+
+        self.assertEqual(result, [False])
+        handler.staging_allocator.free.assert_called_once_with(11)
+        self.assertEqual(receiver.chunk_staging_infos, [])
+        socket.send_multipart.assert_not_called()
+
+    def test_success_unregister_clears_state_and_late_request_cannot_allocate(self):
+        receiver = SimpleNamespace(
+            chunk_staging_infos=[],
+            prefill_info=SimpleNamespace(attn_tp_size=2),
+        )
+        decode_req = SimpleNamespace(kv_receiver=receiver)
+        handler, manager, allocator = self._make_handler(decode_req)
+        allocator.assign = Mock(return_value=(12, 64, 0))
+
+        handler.unregister_decode_req(7)
+
+        self.assertNotIn(7, handler._room_to_decode_req)
+        self.assertNotIn(7, manager._staging_ctx.room_receivers)
+        self.assertNotIn(7, manager._staging_ctx.room_bootstrap)
+        self.assertNotIn(7, manager._chunk_writer_counts)
+        msg = [b"STAGING_REQ", b"7", b"0", b"1", b"session"]
+        kv_args = SimpleNamespace(
+            page_size=1,
+            kv_item_lens=[8, 8],
+            total_kv_head_num=1,
+            kv_head_num=1,
+            engine_rank=0,
+        )
+        self.assertFalse(handler.handle_staging_req(msg, kv_args, 1, None))
+        allocator.assign.assert_not_called()
+
+    def test_chunk_ready_deduplicates_writers_and_rejects_conflicts(self):
+        receiver = SimpleNamespace(
+            chunk_staging_infos=[(1, 64, 0, 72, 1)],
+            prefill_info=SimpleNamespace(attn_tp_size=2),
+        )
+        decode_req = SimpleNamespace(kv_receiver=receiver)
+        handler, manager, _allocator = self._make_handler(decode_req)
+        handler.submit_chunk_scatter = Mock(return_value=True)
+        counts = defaultdict(lambda: defaultdict(list))
+
+        self.assertFalse(handler.handle_chunk_arrived(7, 0, 4, 1, "rank-0", counts))
+        self.assertFalse(handler.handle_chunk_arrived(7, 0, 4, 1, "rank-0", counts))
+        self.assertFalse(handler.handle_chunk_arrived(7, 0, 5, 1, "rank-1", counts))
+        self.assertEqual(len(counts[7][0]), 1)
+        handler.submit_chunk_scatter.assert_not_called()
+
+        self.assertTrue(handler.handle_chunk_arrived(7, 0, 4, 1, "rank-1", counts))
+        handler.submit_chunk_scatter.assert_called_once_with(7, 0, 4, 1)
+
+
+class TestMooncakeCapabilities(unittest.TestCase):
+    @staticmethod
+    def _prefill_info(capabilities):
+        return PrefillServerInfo(
+            attn_tp_size=1,
+            attn_cp_size=1,
+            dp_size=1,
+            pp_size=1,
+            page_size=1,
+            kv_cache_dtype="auto",
+            follow_bootstrap_room=True,
+            capabilities=capabilities,
+        )
+
+    def test_new_decode_rejects_prefill_without_capability(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.prefill_info_table = {"old-prefill": self._prefill_info([])}
+        with patch.object(
+            CommonKVManager, "try_ensure_parallel_info", return_value=True
+        ):
+            self.assertFalse(manager.try_ensure_parallel_info("old-prefill"))
+        self.assertNotIn("old-prefill", manager.prefill_info_table)
+
+    def test_new_prefill_rejects_decode_messages_without_capability(self):
+        self.assertFalse(_has_kv_registration_capability([b""] * 14))
+        self.assertFalse(_has_transfer_metadata_capability([b""] * 9))
+        self.assertTrue(
+            _has_kv_registration_capability([b""] * 14 + [QUIESCE_CAPABILITY_BYTES])
+        )
+        self.assertTrue(
+            _has_transfer_metadata_capability([b""] * 9 + [QUIESCE_CAPABILITY_BYTES])
+        )
+
+    def test_old_wire_parsers_ignore_appended_capability(self):
+        registration = [
+            b"None",
+            b"127.0.0.1",
+            b"1",
+            b"session",
+            b"",
+            b"",
+            b"",
+            b"0",
+            b"1",
+            b"1",
+            b"",
+            b"",
+            b"",
+            b"",
+            QUIESCE_CAPABILITY_BYTES,
+        ]
+        self.assertEqual(
+            KVArgsRegisterInfo.from_zmq(registration).mooncake_session_id, "session"
+        )
+
+        metadata = [
+            b"7",
+            b"127.0.0.1",
+            b"1",
+            b"session",
+            b"",
+            b"",
+            b"",
+            b"1",
+            b"0",
+            QUIESCE_CAPABILITY_BYTES,
+        ]
+        self.assertEqual(TransferInfo.from_zmq(metadata).room, 7)
+
+
+class TestTransferWorkerQuiescence(unittest.TestCase):
+    def test_native_transfer_delays_abort_ack(self):
+        entered = threading.Event()
+        release = threading.Event()
+
+        class BlockingEngine:
+            def batch_transfer_sync(self, *_args):
+                entered.set()
+                release.wait()
+                return 0
+
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.enable_trace = False
+        manager.enable_staging = False
+        manager.room_lifetimes = {}
+        manager.room_lifetimes_lock = threading.Lock()
+        manager._abort_ack_inflight = set()
+        manager._abort_ack_lock = threading.Lock()
+        manager._endpoint_send_locks = {}
+        manager._endpoint_send_locks_lock = threading.Lock()
+        manager.request_status = {7: KVPoll.Transferring}
+        manager.check_status = lambda room: manager.request_status[room]
+        manager.transfer_infos = {
+            7: {
+                "session:1": SimpleNamespace(
+                    room=7,
+                    endpoint="127.0.0.1",
+                    dst_port=1,
+                    mooncake_session_id="session:1",
+                    dst_kv_indices=np.array([0], dtype=np.int32),
+                    is_dummy=False,
+                )
+            }
+        }
+        manager.decode_kv_args_table = {
+            "session:1": SimpleNamespace(
+                dst_attn_tp_size=1,
+                dst_kv_ptrs=[1],
+            )
+        }
+        manager.session_lock = threading.Lock()
+        manager.failed_sessions = set()
+        manager.is_mla_backend = True
+        manager.is_hybrid_mla_backend = False
+        manager.attn_tp_size = 1
+        manager.attn_tp_rank = 0
+        manager.attn_cp_size = 1
+        manager.attn_cp_rank = 0
+        manager.pp_size = 1
+        manager.pp_rank = 0
+        manager.engine = BlockingEngine()
+        manager.req_to_decode_prefix_len = {}
+        manager.send_kvcache = MethodType(
+            lambda self, *_args: self.engine.batch_transfer_sync(), manager
+        )
+
+        queue = FastQueue()
+        worker = threading.Thread(
+            target=manager.transfer_worker,
+            args=(queue, Mock()),
+            daemon=True,
+        )
+        worker.start()
+        queue.put(
+            TransferKVChunk(
+                room=7,
+                prefill_kv_indices=np.array([0], dtype=np.int32),
+                index_slice=slice(0, 1),
+                is_last_chunk=False,
+                prefill_aux_index=None,
+                state_indices=None,
+                trace_ctx=Mock(),
+            )
+        )
+        self.assertTrue(entered.wait(1))
+
+        socket = Mock()
+        manager._connect = Mock(return_value=socket)
+        lifetime = manager._abort_room(7)
+        manager._schedule_abort_ack(lifetime, 7, "127.0.0.1", 1, b"token")
+        manager._schedule_abort_ack(lifetime, 7, "127.0.0.1", 1, b"token")
+        self.assertFalse(socket.send_multipart.called)
+        release.set()
+        for _ in range(100):
+            if socket.send_multipart.called:
+                break
+            threading.Event().wait(0.01)
+        self.assertTrue(socket.send_multipart.called)
+        self.assertEqual(socket.send_multipart.call_args.args[0][2], b"token")
+        for _ in range(100):
+            with manager._abort_ack_lock:
+                if not manager._abort_ack_inflight:
+                    break
+            threading.Event().wait(0.01)
+        manager._schedule_abort_ack(lifetime, 7, "127.0.0.1", 1, b"token")
+        for _ in range(100):
+            if socket.send_multipart.call_count == 2:
+                break
+            threading.Event().wait(0.01)
+        self.assertEqual(socket.send_multipart.call_count, 2)
+        self.assertEqual(socket.send_multipart.call_args.args[0][2], b"token")
+
+
+class TestManagerMessageOrdering(unittest.TestCase):
+    def test_abort_ack_cannot_overtake_status_on_same_endpoint(self):
+        first_send_entered = threading.Event()
+        release_first_send = threading.Event()
+        sent = []
+
+        class BlockingSocket:
+            def send_multipart(self, parts):
+                sent.append(parts[0])
+                if len(sent) == 1:
+                    first_send_entered.set()
+                    release_first_send.wait()
+
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager._endpoint_send_locks = {}
+        manager._endpoint_send_locks_lock = threading.Lock()
+        manager._abort_ack_inflight = set()
+        manager._abort_ack_lock = threading.Lock()
+        manager._connect = Mock(return_value=BlockingSocket())
+
+        status_thread = threading.Thread(
+            target=manager.sync_status_to_decode_endpoint,
+            args=("127.0.0.1", 1, 7, KVPoll.Failed, 0),
+        )
+        ack_thread = threading.Thread(
+            target=manager._send_abort_ack_when_quiesced,
+            args=(None, 7, "127.0.0.1", 1, b"token"),
+        )
+        status_thread.start()
+        self.assertTrue(first_send_entered.wait(1))
+        ack_thread.start()
+        self.assertEqual(sent, [b"7"])
+        release_first_send.set()
+        status_thread.join()
+        ack_thread.join()
+        self.assertEqual(sent, [b"7", b"ABORT_ACK"])
+
+
+class TestLateMessageRejection(unittest.TestCase):
+    def test_chunk_ready_uses_prefill_rank_as_writer_id(self):
+        staging_handler = SimpleNamespace(handle_chunk_arrived=Mock(return_value=True))
+        manager = SimpleNamespace(
+            aborting_rooms=set(),
+            _staging_handler=staging_handler,
+            _chunk_writer_counts=defaultdict(lambda: defaultdict(list)),
+        )
+
+        self.assertTrue(
+            MooncakeKVManager._handle_chunk_ready(
+                manager,
+                [b"CHUNK_READY", b"7", b"0", b"0", b"1", b"session", b"17"],
+            )
+        )
+
+        staging_handler.handle_chunk_arrived.assert_called_once_with(
+            7, 0, 0, 1, "17", manager._chunk_writer_counts
+        )
+
+    def test_clear_preserves_decode_abort_tombstones(self):
+        receiver = MooncakeKVReceiver.__new__(MooncakeKVReceiver)
+        receiver.bootstrap_room = 7
+        staging_handler = SimpleNamespace(
+            clear_abort=Mock(),
+            handle_chunk_arrived=Mock(),
+        )
+        manager = SimpleNamespace(
+            request_status={7: KVPoll.Failed},
+            required_prefill_response_num_table={7: 1},
+            prefill_response_tracker={7: set()},
+            abort_receivers={7: receiver},
+            _abort_receivers_lock=threading.Lock(),
+            aborting_rooms={7},
+            _staging_handler=staging_handler,
+            _chunk_writer_counts=defaultdict(lambda: defaultdict(list)),
+        )
+        receiver.kv_mgr = manager
+
+        receiver.clear()
+
+        self.assertIn(7, manager.aborting_rooms)
+        with patch(
+            "sglang.srt.disaggregation.mooncake.conn.AuxDataCodec.deserialize_data_to_buffer"
+        ) as deserialize:
+            manager.kv_args = Mock()
+            MooncakeKVManager._handle_aux_data(
+                manager,
+                [b"AUX_DATA", b"7", b"0", b"0", b"\x00\x00\x00\x00", b""],
+            )
+        deserialize.assert_not_called()
+        self.assertFalse(
+            MooncakeKVManager._handle_chunk_ready(
+                manager,
+                [b"CHUNK_READY", b"7", b"0", b"0", b"1", b"session"],
+            )
+        )
+        staging_handler.handle_chunk_arrived.assert_not_called()
+
+    def test_decode_room_reuse_fails_before_bootstrap(self):
+        manager = SimpleNamespace(
+            get_session_id=Mock(return_value="session"),
+            addr_to_rooms_tracker=defaultdict(set),
+            update_status=Mock(),
+            record_failure=Mock(),
+            aborting_rooms={7},
+            abort_receivers={},
+            _abort_receivers_lock=threading.Lock(),
+        )
+        receiver = MooncakeKVReceiver(manager, "bootstrap", 7)
+
+        with patch(
+            "sglang.srt.disaggregation.mooncake.conn.CommonKVReceiver.init"
+        ) as common_init:
+            receiver.init(0)
+
+        common_init.assert_not_called()
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+
+    def test_duplicate_active_room_does_not_replace_ack_receiver(self):
+        existing = SimpleNamespace(_record_abort_ack=Mock())
+        manager = SimpleNamespace(
+            abort_receivers={7: existing},
+            _abort_receivers_lock=threading.Lock(),
+            aborting_rooms=set(),
+            request_status={7: KVPoll.Transferring},
+            get_session_id=Mock(return_value="new-session"),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "already active"):
+            MooncakeKVReceiver(manager, "bootstrap", 7)
+
+        self.assertIs(manager.abort_receivers[7], existing)
+        self.assertEqual(manager.request_status[7], KVPoll.Transferring)
+        MooncakeKVManager._handle_abort_ack(
+            manager, [b"ABORT_ACK", b"7", b"stable-token"]
+        )
+        existing._record_abort_ack.assert_called_once_with(b"stable-token")
+        manager.get_session_id.assert_not_called()
+
+
+class TestRoomLifetimeTokens(unittest.TestCase):
+    def _manager(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.room_lifetimes = {}
+        manager.room_abort_tokens = defaultdict(set)
+        manager.room_lifetimes_lock = threading.Lock()
+        return manager
+
+    def test_unknown_and_completed_abort_do_not_create_lifetime(self):
+        manager = self._manager()
+
+        self.assertIsNone(manager._abort_room_for_token(7, b"unknown"))
+        self.assertEqual(manager.room_lifetimes, {})
+
+        manager._get_room_lifetime(7)
+        manager._register_room_abort_token(7, b"old")
+        manager._clear_room_lifetime(7)
+        self.assertIsNone(manager._abort_room_for_token(7, b"old"))
+        self.assertEqual(manager.room_lifetimes, {})
+
+    def test_late_old_token_cannot_abort_reused_room(self):
+        manager = self._manager()
+        lifetime = manager._get_room_lifetime(7)
+        manager._register_room_abort_token(7, b"new")
+
+        self.assertIsNone(manager._abort_room_for_token(7, b"old"))
+        self.assertTrue(lifetime.acquire())
+        lifetime.release()
+
+        self.assertIs(manager._abort_room_for_token(7, b"new"), lifetime)
+        self.assertFalse(lifetime.acquire())
+
+
+class TestChunkedAbortCleanup(unittest.TestCase):
+    def test_source_kv_moves_to_inflight_without_early_release_or_output(self):
+        req = SimpleNamespace(
+            rid="chunked",
+            disagg_kv_sender=Mock(),
+        )
+        inflight_queue = []
+
+        defer_chunked_prefill_abort(req, inflight_queue)
+        defer_chunked_prefill_abort(req, inflight_queue)
+
+        self.assertEqual(inflight_queue, [req])
+        self.assertEqual(req.disagg_kv_sender.abort.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Mooncake aborts and transfer timeouts currently make requests terminal before in-flight native transfers have quiesced. The scheduler can therefore return source or destination KV pages to the allocator while an existing RDMA, executor, or CUDA staging operation still reads or writes those addresses. If a page is reassigned, the old transfer can corrupt another request or read its KV state.

The existing `ABORT_ACK` only confirms that the abort notification was received. It does not prove that synchronous native transfer work has returned.

## Modifications

- Add a per-room transfer lifetime that closes admission on abort and tracks active Mooncake transfer workers.
- Drain all submitted executor futures, including running siblings after an error or partial submission failure, before releasing the room lifetime.
- Add tokenized, retryable abort notifications and defer `ABORT_ACK` until prefill transfer work is quiescent.
- Advertise and require the `QUIESCE_V1` capability on both peers so mixed versions fail before transferring KV rather than silently weakening the ownership barrier.
- Propagate logical failure across TP and CP ranks first, then report terminal failure only after every participant confirms local transfer quiescence.
- Retain decode staging allocations and chunked-prefill KV ownership until RDMA and CUDA staging work is complete, while rejecting late staging and auxiliary messages for aborted rooms.
- Serialize messages sent through shared Mooncake ZMQ endpoints so status, auxiliary data, and abort acknowledgements preserve ordering.
- Add deterministic unit coverage for blocked native transfers, sibling executor drain, capability negotiation, token retries, collective failure barriers, staging cleanup races, message ordering, and chunked-prefill retention.

This protocol requires coordinated rollout of prefill and decode peers. A peer that does not advertise `QUIESCE_V1` is rejected before KV transfer begins.

## Accuracy Tests

This change does not modify model forward computation or model outputs. It prevents stale transfers from reading or overwriting KV pages after request failure.

Focused and adjacent CPU unit tests passed:

```text
26 focused tests passed
104 focused-plus-adjacent tests passed
```

## Speed Tests and Profiling

No performance benchmarks were run. The normal data-transfer path is unchanged apart from lifecycle accounting and per-endpoint send serialization. The additional waiting occurs only when a transfer is aborted, fails, or must drain before ownership release.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29438714597](https://github.com/sgl-project/sglang/actions/runs/29438714597)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29438714032](https://github.com/sgl-project/sglang/actions/runs/29438714032)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->