### PR TITLE
fa3: sync-free eagle spec via fixed-window draft-extend metadata

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -824,10 +824,16 @@ class FlashAttentionBackend(AttentionBackend):
                 forward_batch.req_pool_indices, : metadata.max_seq_len_k
             ]
 
-            if (
-                any(forward_batch.extend_prefix_lens_cpu)
-                or forward_batch.forward_mode.is_draft_extend_v2()
-            ):
+            if forward_batch.forward_mode.is_draft_extend_v2():
+                # Fixed-q window: extend lens are uniformly num_draft_tokens,
+                # so the host max is a config constant. Keeps this branch off
+                # extend_seq_lens_cpu, which the GPU-only spec path leaves None.
+                extend_seq_lens = forward_batch.extend_seq_lens
+                metadata.max_seq_len_q = self.speculative_num_draft_tokens
+                metadata.cu_seqlens_q = torch.nn.functional.pad(
+                    torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
+                )
+            elif any(forward_batch.extend_prefix_lens_cpu):
                 extend_seq_lens = forward_batch.extend_seq_lens
                 metadata.max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
                 metadata.cu_seqlens_q = torch.nn.functional.pad(
@@ -3022,6 +3028,11 @@ class FlashAttentionBackend(AttentionBackend):
 
 
 class FlashAttentionMultiStepBackend:
+    # Read by decide_needs_cpu_seq_lens (getattr defaults missing flags to
+    # True). The inner FlashAttentionBackend steps and the draft-extend path
+    # are device-side, so the spec CPU mirror is not needed.
+    needs_cpu_seq_lens: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -825,9 +825,8 @@ class FlashAttentionBackend(AttentionBackend):
             ]
 
             if forward_batch.forward_mode.is_draft_extend_v2():
-                # Fixed-q window: extend lens are uniformly num_draft_tokens,
-                # so the host max is a config constant. Keeps this branch off
-                # extend_seq_lens_cpu, which the GPU-only spec path leaves None.
+                # Fixed-q window: the host max is a config constant, and
+                # extend_seq_lens_cpu may be None on the GPU-only spec path.
                 extend_seq_lens = forward_batch.extend_seq_lens
                 metadata.max_seq_len_q = self.speculative_num_draft_tokens
                 metadata.cu_seqlens_q = torch.nn.functional.pad(
@@ -3028,9 +3027,8 @@ class FlashAttentionBackend(AttentionBackend):
 
 
 class FlashAttentionMultiStepBackend:
-    # Read by decide_needs_cpu_seq_lens (getattr defaults missing flags to
-    # True). The inner FlashAttentionBackend steps and the draft-extend path
-    # are device-side, so the spec CPU mirror is not needed.
+    # Read by decide_needs_cpu_seq_lens (a missing flag defaults to True);
+    # the multi-step draft and draft-extend paths are device-side.
     needs_cpu_seq_lens: bool = False
 
     def __init__(

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -162,7 +162,12 @@ def build_replay_fb_view(
             if forward_batch.seq_lens_sum is None
             else forward_batch.seq_lens_sum + (bs - raw_bs) * seq_len_fill_value
         ),
-        seq_lens_cpu=buffers.seq_lens_cpu[:bs],
+        # Propagate mirror absence: the pinned buffer is not refreshed when the
+        # batch carries no CPU mirror, and a stale non-None tensor defeats every
+        # backend's `seq_lens_cpu is not None` guard with garbage lens.
+        seq_lens_cpu=(
+            None if forward_batch.seq_lens_cpu is None else buffers.seq_lens_cpu[:bs]
+        ),
         num_padding=bs - raw_bs,
         encoder_lens=buffers.encoder_lens[:bs] if is_encoder_decoder else None,
         out_cache_loc=getattr(forward_batch, "out_cache_loc", None),

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -163,8 +163,7 @@ def build_replay_fb_view(
             else forward_batch.seq_lens_sum + (bs - raw_bs) * seq_len_fill_value
         ),
         # Propagate mirror absence: the pinned buffer is not refreshed when the
-        # batch carries no CPU mirror, and a stale non-None tensor defeats every
-        # backend's `seq_lens_cpu is not None` guard with garbage lens.
+        # batch has no CPU mirror; a stale non-None tensor defeats None-guards.
         seq_lens_cpu=(
             None if forward_batch.seq_lens_cpu is None else buffers.seq_lens_cpu[:bs]
         ),

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -588,7 +588,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             req_pool_indices=buffers.req_pool_indices,
             seq_lens=buffers.seq_lens,
             seq_lens_sum=seq_lens_sum,
-            seq_lens_cpu=buffers.seq_lens_cpu,
+            # Mirror absence must survive replay (stale buffer defeats None-guards).
+            seq_lens_cpu=(
+                None if forward_batch.seq_lens_cpu is None else buffers.seq_lens_cpu
+            ),
             encoder_lens=None,
             out_cache_loc=buffers.out_cache_loc[:num_tokens],
             out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),


### PR DESCRIPTION
Extend the sync-free treatment to fa3/fa4 EAGLE: declare `needs_cpu_seq_lens = False` on `FlashAttentionMultiStepBackend`. Previously the wrapper's missing flag defaulted to True, which kept `decide_needs_cpu_seq_lens` publishing the spec CPU mirror -- a per-step pinned D2H plus a `cudaStreamSynchronize` that blocks the scheduler behind target-verify -- for every fa3 EAGLE run. Follows #29589.

Two paths had to become mirror-independent first:

- **Eager draft-extend q metadata** (`flashattention_backend.py`): under `DRAFT_EXTEND_V2` the q window is uniformly `num_draft_tokens`, so `max_seq_len_q` is a config constant and the branch no longer reads `extend_prefix_lens_cpu` / `extend_seq_lens_cpu` (both None on the GPU-only spec path).
- **Graph replay None propagation** (`decode_cuda_graph_runner.py`, `eagle_draft_extend_cuda_graph_runner.py`): the replay ForwardBatch attached the pinned `seq_lens_cpu` buffer unconditionally, but the buffer registry silently skips the refresh when the source batch carries no mirror. Backends then saw a stale non-None tensor, so every `seq_lens_cpu is not None` guard took the mirror-present branch with garbage lens -- the fa3 topk>1 verify replay truncated its page table and read uninitialized KV, producing NaN logits. Propagate None the same way `seq_lens_sum` already does.

## Verification

- `test_constrained_decoding_spec_reasoning.py` (crashed with a CUDA coredump before the replay fix), `test_mla_int8_deepseek_v3.py`, and `test_hicache_variants.py` all pass.
- Profile (gpt-oss-120b, tp2, EAGLE3 topk=4 / steps=5 / draft=8, bs=8, CPU+GPU torch trace): the per-step `cudaStreamSynchronize` (~3.8 ms/iter host block) and the 392-byte pinned D2H are gone; decode iter 18.6 ms -> 14.4 ms (-22.5%), GPU idle 27-30% -> 8-9%; GPU busy time and accept length (1.84) unchanged.

Known follow-up: with the mirror absent, the fa3 topk>1 verify replay sizes its page-table copy by `max_context_len` instead of the batch max -- harmless at short context, a per-step copy-width overhead at long context. The topk<=1 branch already builds its page table on-device; porting that approach is left as a follow-up.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29453971558](https://github.com/sgl-project/sglang/actions/runs/29453971558)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29453971381](https://github.com/sgl-project/sglang/actions/runs/29453971381)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->