### PR TITLE
[sgl-kernel][test] Skip dsv3_fused_a_gemm test on consumer Blackwell (sm120/sm121)

### DIFF
--- a/sgl-kernel/tests/test_dsv3_fused_a_gemm.py
+++ b/sgl-kernel/tests/test_dsv3_fused_a_gemm.py
@@ -6,6 +6,17 @@ import torch.nn.functional as F
 from sgl_kernel import dsv3_fused_a_gemm
 
 
+def is_sm90_or_sm100_supported(device=None) -> bool:
+    # Kernel needs ~192KB smem; consumer Blackwell (sm12x) caps at ~100KB (see #29317).
+    return (torch.cuda.get_device_capability(device)[0] in (9, 10)) and (
+        torch.version.cuda >= "12.3"
+    )
+
+
+@pytest.mark.skipif(
+    not is_sm90_or_sm100_supported(),
+    reason="dsv3_fused_a_gemm is only supported on SM90/SM100",
+)
 @pytest.mark.parametrize("num_tokens", [1, 8, 15, 16])
 def test_dsv3_fused_a_gemm(num_tokens):
     kHdIn = 7168


### PR DESCRIPTION
## Motivation

On consumer Blackwell (sm120/sm121, e.g. GB10), `test_dsv3_fused_a_gemm` fails instead of skipping. The kernel requests ~192KB of dynamic shared memory, but consumer Blackwell caps at ~100KB per block, so the launch returns `cudaErrorInvalidValue`. Its only device guard is `TORCH_CHECK(sm >= 90)`, which accepts sm12x. This is a hard architectural limit (not a missing dispatch), so the test should skip on these GPUs.

## Modifications

- `test_dsv3_fused_a_gemm.py`: gate the test on `is_sm90_or_sm100_supported` so it skips on consumer Blackwell.

This PR was originally broader; the other two hunks were dropped after review:

- `test_fp8_blockwise_moe.py` — sm12x there is unimplemented, not unsupportable; the dispatch is being added in #28125, so skipping would hide cases that PR turns green.
- `test_flashmla.py` — the flashmla prefill guard is handled by #29902.

## Accuracy Tests

N/A — test-only change; no kernel/model-forward code or output changes.

## Speed Tests and Profiling

N/A — same reason.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests — N/A: test-infrastructure only, no product code
- [x] Update documentation — N/A: no public API / user-facing behavior change
- [x] Provide accuracy and speed benchmark results — N/A
- [x] Follow the SGLang code style guidance

Part of #31365.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29870545071](https://github.com/sgl-project/sglang/actions/runs/29870545071)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29870544904](https://github.com/sgl-project/sglang/actions/runs/29870544904)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->