### PR TITLE
[CI] Remove nightly registrations redundant with scheduled stage runs

### DIFF
--- a/test/registered/jit/deepseek_v4/test_c128_v2.py
+++ b/test/registered/jit/deepseek_v4/test_c128_v2.py
@@ -19,7 +19,6 @@ from sglang.jit_kernel.tests.deepseek_v4.common import (
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 Context = Union[LegacyContext, PagedContext]

--- a/test/registered/jit/deepseek_v4/test_c4_v2.py
+++ b/test/registered/jit/deepseek_v4/test_c4_v2.py
@@ -19,7 +19,6 @@ from sglang.jit_kernel.tests.deepseek_v4.common import (
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 Context = Union[LegacyContext, PagedContext]

--- a/test/registered/jit/deepseek_v4/test_fp4_indexer.py
+++ b/test/registered/jit/deepseek_v4/test_fp4_indexer.py
@@ -22,7 +22,6 @@ from sglang.kernels.ops.attention.dsv4.fp4_indexer import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 
 HEAD_DIM = 128
 FP4_DIM = HEAD_DIM // 2

--- a/test/registered/jit/diffusion/test_diffusion_modelopt_fp8_scaled_mm.py
+++ b/test/registered/jit/diffusion/test_diffusion_modelopt_fp8_scaled_mm.py
@@ -15,7 +15,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=80, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16

--- a/test/registered/jit/diffusion/test_fused_norm_scale_shift.py
+++ b/test/registered/jit/diffusion/test_fused_norm_scale_shift.py
@@ -14,7 +14,6 @@ from sglang.jit_kernel.diffusion.cutedsl.scale_residual_norm_scale_shift import 
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 SHAPE_MAP = {

--- a/test/registered/jit/diffusion/test_group_norm_silu.py
+++ b/test/registered/jit/diffusion/test_group_norm_silu.py
@@ -10,7 +10,6 @@ from sglang.jit_kernel.diffusion.triton.group_norm_silu import triton_group_norm
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"

--- a/test/registered/jit/diffusion/test_qknorm_rope.py
+++ b/test/registered/jit/diffusion/test_qknorm_rope.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=44, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=176, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16

--- a/test/registered/jit/diffusion/test_qknorm_rope.py
+++ b/test/registered/jit/diffusion/test_qknorm_rope.py
@@ -9,7 +9,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=44, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=176, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16

--- a/test/registered/jit/diffusion/test_qknorm_rope.py
+++ b/test/registered/jit/diffusion/test_qknorm_rope.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=44, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=176, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"

--- a/test/registered/jit/diffusion/test_qwen_image_modulation.py
+++ b/test/registered/jit/diffusion/test_qwen_image_modulation.py
@@ -13,6 +13,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"

--- a/test/registered/jit/diffusion/test_qwen_image_modulation.py
+++ b/test/registered/jit/diffusion/test_qwen_image_modulation.py
@@ -13,7 +13,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"

--- a/test/registered/jit/diffusion/test_qwen_image_modulation.py
+++ b/test/registered/jit/diffusion/test_qwen_image_modulation.py
@@ -13,6 +13,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, suite="nightly-amd-kernel-1-gpu", nightly=True)
 

--- a/test/registered/jit/diffusion/test_varlen_pack_pad.py
+++ b/test/registered/jit/diffusion/test_varlen_pack_pad.py
@@ -16,7 +16,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"

--- a/test/registered/jit/diffusion/test_varlen_pack_pad.py
+++ b/test/registered/jit/diffusion/test_varlen_pack_pad.py
@@ -16,6 +16,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 

--- a/test/registered/jit/diffusion/test_varlen_pack_pad.py
+++ b/test/registered/jit/diffusion/test_varlen_pack_pad.py
@@ -16,6 +16,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=15, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"

--- a/test/registered/jit/diffusion/test_varlen_uspattn_equivalence.py
+++ b/test/registered/jit/diffusion/test_varlen_uspattn_equivalence.py
@@ -30,7 +30,6 @@ from sglang.multimodal_gen.runtime.layers.attention.layer import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPES = get_ci_test_range([torch.bfloat16, torch.float16], [torch.bfloat16])

--- a/test/registered/jit/diffusion/test_varlen_uspattn_equivalence.py
+++ b/test/registered/jit/diffusion/test_varlen_uspattn_equivalence.py
@@ -30,6 +30,7 @@ from sglang.multimodal_gen.runtime.layers.attention.layer import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"

--- a/test/registered/jit/diffusion/test_varlen_uspattn_equivalence.py
+++ b/test/registered/jit/diffusion/test_varlen_uspattn_equivalence.py
@@ -30,6 +30,7 @@ from sglang.multimodal_gen.runtime.layers.attention.layer import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=60, suite="nightly-kernel-1-gpu", nightly=True)
 
 DEVICE = "cuda"
 DTYPES = get_ci_test_range([torch.bfloat16, torch.float16], [torch.bfloat16])

--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -13,6 +13,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=20, stage="jit-kernel-unit", runner_config="amd")
 

--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -13,6 +13,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=20, stage="jit-kernel-unit", runner_config="amd")
 
 

--- a/test/registered/jit/test_activation.py
+++ b/test/registered/jit/test_activation.py
@@ -13,7 +13,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=30, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=20, stage="jit-kernel-unit", runner_config="amd")
 
 

--- a/test/registered/jit/test_add_constant.py
+++ b/test/registered/jit/test_add_constant.py
@@ -7,7 +7,6 @@ from sglang.jit_kernel.add_constant import add_constant
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=180, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=8, stage="jit-kernel-unit", runner_config="amd")
 
 

--- a/test/registered/jit/test_awq_dequantize.py
+++ b/test/registered/jit/test_awq_dequantize.py
@@ -8,7 +8,6 @@ from sglang.jit_kernel.awq_dequantize import awq_dequantize as jit_awq_dequantiz
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=9, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 try:
     from sgl_kernel import awq_dequantize as aot_awq_dequantize

--- a/test/registered/jit/test_awq_marlin_moe_repack.py
+++ b/test/registered/jit/test_awq_marlin_moe_repack.py
@@ -12,7 +12,6 @@ from sglang.srt.layers.quantization.utils import pack_cols, quantize_weights
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def _has_aot_awq_marlin_moe_repack() -> bool:

--- a/test/registered/jit/test_awq_marlin_repack.py
+++ b/test/registered/jit/test_awq_marlin_repack.py
@@ -13,7 +13,6 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_marlin_utils import get_weight_perm, marlin_weights
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def _has_aot_awq_marlin_repack() -> bool:

--- a/test/registered/jit/test_clamp_position.py
+++ b/test/registered/jit/test_clamp_position.py
@@ -7,7 +7,6 @@ from sglang.jit_kernel.clamp_position import clamp_position_cuda
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=12, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=12, stage="jit-kernel-unit", runner_config="amd")
 
 

--- a/test/registered/jit/test_concat_mla.py
+++ b/test/registered/jit/test_concat_mla.py
@@ -8,7 +8,6 @@ import triton
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=17, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def torch_concat_mla_k(

--- a/test/registered/jit/test_custom_all_reduce.py
+++ b/test/registered/jit/test_custom_all_reduce.py
@@ -48,6 +48,11 @@ register_cuda_ci(
     stage="base-b-kernel-unit",
     runner_config="8-gpu-h200",
 )
+register_cuda_ci(
+    est_time=300,
+    suite="nightly-kernel-8-gpu-h200",
+    nightly=True,
+)
 
 # ---------------------------------------------------------------------------
 # Test parameters

--- a/test/registered/jit/test_custom_all_reduce.py
+++ b/test/registered/jit/test_custom_all_reduce.py
@@ -48,11 +48,6 @@ register_cuda_ci(
     stage="base-b-kernel-unit",
     runner_config="8-gpu-h200",
 )
-register_cuda_ci(
-    est_time=300,
-    suite="nightly-kernel-8-gpu-h200",
-    nightly=True,
-)
 
 # ---------------------------------------------------------------------------
 # Test parameters

--- a/test/registered/jit/test_custom_all_reduce.py
+++ b/test/registered/jit/test_custom_all_reduce.py
@@ -48,6 +48,7 @@ register_cuda_ci(
     stage="base-b-kernel-unit",
     runner_config="8-gpu-h200",
 )
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(
     est_time=300,
     suite="nightly-kernel-8-gpu-h200",

--- a/test/registered/jit/test_cutedsl_gdn.py
+++ b/test/registered/jit/test_cutedsl_gdn.py
@@ -30,7 +30,6 @@ except ImportError:
     TRITON_AVAILABLE = False
 
 register_cuda_ci(est_time=5, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def run_triton_kernel(A_log, dt_bias, q, k, v, a, b, initial_state, indices, scale):

--- a/test/registered/jit/test_dsv32_indexer_fusion.py
+++ b/test/registered/jit/test_dsv32_indexer_fusion.py
@@ -32,7 +32,6 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 _is_hip = is_hip()
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=90, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 HEAD_DIM = 128

--- a/test/registered/jit/test_dsv3_router_gemm.py
+++ b/test/registered/jit/test_dsv3_router_gemm.py
@@ -11,7 +11,6 @@ from sglang.jit_kernel.utils import get_ci_test_range, get_jit_cuda_arch, is_hip
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 HIDDEN_DIMS = [1024, 4096, 5120, 6144, 7168]
 ROUTER_GEMM_CASES = get_ci_test_range(

--- a/test/registered/jit/test_dsv3_router_gemm.py
+++ b/test/registered/jit/test_dsv3_router_gemm.py
@@ -11,6 +11,7 @@ from sglang.jit_kernel.utils import get_ci_test_range, get_jit_cuda_arch, is_hip
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 HIDDEN_DIMS = [1024, 4096, 5120, 6144, 7168]
 ROUTER_GEMM_CASES = get_ci_test_range(

--- a/test/registered/jit/test_dsv3_router_gemm.py
+++ b/test/registered/jit/test_dsv3_router_gemm.py
@@ -11,6 +11,7 @@ from sglang.jit_kernel.utils import get_ci_test_range, get_jit_cuda_arch, is_hip
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 HIDDEN_DIMS = [1024, 4096, 5120, 6144, 7168]

--- a/test/registered/jit/test_flash_attention_4.py
+++ b/test/registered/jit/test_flash_attention_4.py
@@ -16,7 +16,6 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
 register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
-register_cuda_ci(est_time=900, suite="nightly-kernel-1-gpu", nightly=True)
 
 # Skip this test on Hopper machine
 skip_condition = torch.cuda.get_device_capability() < (10, 0)

--- a/test/registered/jit/test_fused_add_rmsnorm.py
+++ b/test/registered/jit/test_fused_add_rmsnorm.py
@@ -8,7 +8,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def sglang_jit_fused_add_rmsnorm(

--- a/test/registered/jit/test_fused_add_rmsnorm.py
+++ b/test/registered/jit/test_fused_add_rmsnorm.py
@@ -8,6 +8,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 

--- a/test/registered/jit/test_fused_add_rmsnorm.py
+++ b/test/registered/jit/test_fused_add_rmsnorm.py
@@ -8,6 +8,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def sglang_jit_fused_add_rmsnorm(

--- a/test/registered/jit/test_fused_eh_norm.py
+++ b/test/registered/jit/test_fused_eh_norm.py
@@ -7,7 +7,6 @@ from sglang.jit_kernel.fused_eh_norm import fused_eh_norm
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.version.cuda is None,

--- a/test/registered/jit/test_fused_metadata_copy.py
+++ b/test/registered/jit/test_fused_metadata_copy.py
@@ -17,7 +17,6 @@ import torch
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=100, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=400, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=100, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 # =============================================================================

--- a/test/registered/jit/test_fused_store_index_cache.py
+++ b/test/registered/jit/test_fused_store_index_cache.py
@@ -49,7 +49,6 @@ except ImportError:
     _is_fp8_fnuz = False
 
 register_cuda_ci(est_time=24, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=24, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 PAGE_SIZE = 64

--- a/test/registered/jit/test_fused_verify_triton_gdn.py
+++ b/test/registered/jit/test_fused_verify_triton_gdn.py
@@ -27,7 +27,6 @@ except ImportError:
     KERNELS_AVAILABLE = False
 
 register_cuda_ci(est_time=6, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=10, suite="nightly-amd-kernel-1-gpu", nightly=True)
 
 

--- a/test/registered/jit/test_gptq_marlin.py
+++ b/test/registered/jit/test_gptq_marlin.py
@@ -24,7 +24,6 @@ from sglang.test.test_marlin_utils import (
 )
 
 register_cuda_ci(est_time=13, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 MNK_FACTORS = [
     (1, 1, 1),

--- a/test/registered/jit/test_gptq_marlin_repack.py
+++ b/test/registered/jit/test_gptq_marlin_repack.py
@@ -14,7 +14,6 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_marlin_utils import get_weight_perm, marlin_weights
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 MARLIN_K_CHUNKS = [128]
 MARLIN_N_CHUNKS = [64, 256]

--- a/test/registered/jit/test_hadamard_jit.py
+++ b/test/registered/jit/test_hadamard_jit.py
@@ -17,7 +17,6 @@ from sglang.jit_kernel.hadamard import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=128, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=512, suite="nightly-kernel-1-gpu", nightly=True)
 
 # Exact M×N Hadamard matrices (±1 entries) copied from
 # python/sglang/jit_kernel/csrc/fast-hadamard-transform/code_gen.py.

--- a/test/registered/jit/test_hicache.py
+++ b/test/registered/jit/test_hicache.py
@@ -15,7 +15,6 @@ from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available()

--- a/test/registered/jit/test_hisparse.py
+++ b/test/registered/jit/test_hisparse.py
@@ -13,7 +13,6 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available()

--- a/test/registered/jit/test_moe_align_block_size.py
+++ b/test/registered/jit/test_moe_align_block_size.py
@@ -11,6 +11,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def ceil_div(a, b):

--- a/test/registered/jit/test_moe_align_block_size.py
+++ b/test/registered/jit/test_moe_align_block_size.py
@@ -11,7 +11,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def ceil_div(a, b):

--- a/test/registered/jit/test_moe_align_block_size.py
+++ b/test/registered/jit/test_moe_align_block_size.py
@@ -11,6 +11,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 

--- a/test/registered/jit/test_moe_lora_align_block_size.py
+++ b/test/registered/jit/test_moe_lora_align_block_size.py
@@ -12,7 +12,6 @@ from sglang.jit_kernel.moe_lora_align import moe_lora_align_block_size
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def round_up(x, base):

--- a/test/registered/jit/test_moe_wna16_marlin.py
+++ b/test/registered/jit/test_moe_wna16_marlin.py
@@ -21,7 +21,6 @@ from sglang.test.test_marlin_utils import (
 )
 
 register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def _has_aot_moe_wna16_marlin_gemm() -> bool:

--- a/test/registered/jit/test_mxfp8_moe.py
+++ b/test/registered/jit/test_mxfp8_moe.py
@@ -11,7 +11,6 @@ from sglang.jit_kernel.mxfp8 import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=5, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def align(val: int, alignment: int = 128) -> int:

--- a/test/registered/jit/test_per_tensor_quant_fp8.py
+++ b/test/registered/jit/test_per_tensor_quant_fp8.py
@@ -10,6 +10,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 try:
     from sglang.srt.utils import is_hip

--- a/test/registered/jit/test_per_tensor_quant_fp8.py
+++ b/test/registered/jit/test_per_tensor_quant_fp8.py
@@ -10,6 +10,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 try:

--- a/test/registered/jit/test_per_tensor_quant_fp8.py
+++ b/test/registered/jit/test_per_tensor_quant_fp8.py
@@ -10,7 +10,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 try:
     from sglang.srt.utils import is_hip

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -12,6 +12,7 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -12,6 +12,7 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 if not torch.cuda.is_available():

--- a/test/registered/jit/test_per_token_group_quant_8bit.py
+++ b/test/registered/jit/test_per_token_group_quant_8bit.py
@@ -12,7 +12,6 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)

--- a/test/registered/jit/test_pos_enc.py
+++ b/test/registered/jit/test_pos_enc.py
@@ -11,7 +11,6 @@ from sglang.jit_kernel.rope import rotary_embedding
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=18, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 @triton.jit

--- a/test/registered/jit/test_qknorm.py
+++ b/test/registered/jit/test_qknorm.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def sglang_aot_qknorm(

--- a/test/registered/jit/test_qknorm.py
+++ b/test/registered/jit/test_qknorm.py
@@ -9,7 +9,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def sglang_aot_qknorm(

--- a/test/registered/jit/test_qknorm.py
+++ b/test/registered/jit/test_qknorm.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=37, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=148, suite="nightly-kernel-1-gpu", nightly=True)
 
 

--- a/test/registered/jit/test_qknorm_across_heads.py
+++ b/test/registered/jit/test_qknorm_across_heads.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 

--- a/test/registered/jit/test_qknorm_across_heads.py
+++ b/test/registered/jit/test_qknorm_across_heads.py
@@ -9,7 +9,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def sglang_jit_qknorm_across_heads(

--- a/test/registered/jit/test_qknorm_across_heads.py
+++ b/test/registered/jit/test_qknorm_across_heads.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 def sglang_jit_qknorm_across_heads(

--- a/test/registered/jit/test_renorm.py
+++ b/test/registered/jit/test_renorm.py
@@ -10,7 +10,6 @@ import torch
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=6, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 @pytest.mark.parametrize("batch_size", [1, 99, 989])

--- a/test/registered/jit/test_resolve_future_token_ids.py
+++ b/test/registered/jit/test_resolve_future_token_ids.py
@@ -7,7 +7,6 @@ from sglang.jit_kernel.resolve_future_token_ids import resolve_future_token_ids_
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=9, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=9, stage="jit-kernel-unit", runner_config="amd")
 
 

--- a/test/registered/jit/test_rmsnorm.py
+++ b/test/registered/jit/test_rmsnorm.py
@@ -9,7 +9,6 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=240, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 

--- a/test/registered/jit/test_rmsnorm.py
+++ b/test/registered/jit/test_rmsnorm.py
@@ -9,6 +9,7 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=240, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 
 

--- a/test/registered/jit/test_rmsnorm.py
+++ b/test/registered/jit/test_rmsnorm.py
@@ -9,6 +9,7 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=45, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=240, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=45, suite="jit-kernel-unit-test-amd")
 

--- a/test/registered/jit/test_rmsnorm_hf.py
+++ b/test/registered/jit/test_rmsnorm_hf.py
@@ -14,6 +14,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
 

--- a/test/registered/jit/test_rmsnorm_hf.py
+++ b/test/registered/jit/test_rmsnorm_hf.py
@@ -14,6 +14,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
 
 EPS = 1e-5

--- a/test/registered/jit/test_rmsnorm_hf.py
+++ b/test/registered/jit/test_rmsnorm_hf.py
@@ -14,7 +14,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
 
 EPS = 1e-5

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -9,6 +9,7 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=64, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=256, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=64, suite="jit-kernel-unit-test-amd")
 

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -9,6 +9,7 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=64, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=256, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=64, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"

--- a/test/registered/jit/test_rope.py
+++ b/test/registered/jit/test_rope.py
@@ -9,7 +9,6 @@ from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=64, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=256, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=64, suite="jit-kernel-unit-test-amd")
 
 DEVICE = "cuda"

--- a/test/registered/jit/test_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/jit/test_sparse_mla_q8kv8_prefill_sm90.py
@@ -10,7 +10,6 @@ from sglang.srt.utils import is_sm90_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=300, suite="nightly-kernel-1-gpu", nightly=True)
 
 
 DTYPE_FP8 = torch.float8_e4m3fn

--- a/test/registered/jit/test_store_cache.py
+++ b/test/registered/jit/test_store_cache.py
@@ -9,7 +9,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=55, stage="jit-kernel-unit", runner_config="amd")
 
 BS_LIST = [2**n for n in range(0, 15)]

--- a/test/registered/jit/test_store_cache.py
+++ b/test/registered/jit/test_store_cache.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=55, stage="jit-kernel-unit", runner_config="amd")
 
 BS_LIST = [2**n for n in range(0, 15)]

--- a/test/registered/jit/test_store_cache.py
+++ b/test/registered/jit/test_store_cache.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 register_amd_ci(est_time=55, stage="jit-kernel-unit", runner_config="amd")
 

--- a/test/registered/jit/test_symm_mem_all_gather.py
+++ b/test/registered/jit/test_symm_mem_all_gather.py
@@ -35,6 +35,7 @@ from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=240, stage="base-b-kernel-unit", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=240, suite="nightly-kernel-8-gpu-h200", nightly=True)
 
 # ---------------------------------------------------------------------------
 # Test parameters

--- a/test/registered/jit/test_symm_mem_all_gather.py
+++ b/test/registered/jit/test_symm_mem_all_gather.py
@@ -35,6 +35,7 @@ from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=240, stage="base-b-kernel-unit", runner_config="8-gpu-h200")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=240, suite="nightly-kernel-8-gpu-h200", nightly=True)
 
 # ---------------------------------------------------------------------------

--- a/test/registered/jit/test_symm_mem_all_gather.py
+++ b/test/registered/jit/test_symm_mem_all_gather.py
@@ -35,7 +35,6 @@ from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=240, stage="base-b-kernel-unit", runner_config="8-gpu-h200")
-register_cuda_ci(est_time=240, suite="nightly-kernel-8-gpu-h200", nightly=True)
 
 # ---------------------------------------------------------------------------
 # Test parameters

--- a/test/registered/jit/test_timestep_embedding.py
+++ b/test/registered/jit/test_timestep_embedding.py
@@ -17,6 +17,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+# Nightly is not redundant here: it sets SGLANG_JIT_KERNEL_RUN_FULL_TESTS=1 to expand get_ci_test_range sweeps.
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 CORRECTNESS_BATCH_SIZES = get_ci_test_range(

--- a/test/registered/jit/test_timestep_embedding.py
+++ b/test/registered/jit/test_timestep_embedding.py
@@ -17,6 +17,7 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 CORRECTNESS_BATCH_SIZES = get_ci_test_range(
     [1, 2, 8, 128, 256, 512, 1536, 2048, 4096, 11008, 16384],

--- a/test/registered/jit/test_timestep_embedding.py
+++ b/test/registered/jit/test_timestep_embedding.py
@@ -17,7 +17,6 @@ from sglang.jit_kernel.utils import get_ci_test_range
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=16, stage="base-b-kernel-unit", runner_config="1-gpu-large")
-register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
 
 CORRECTNESS_BATCH_SIZES = get_ci_test_range(
     [1, 2, 8, 128, 256, 512, 1536, 2048, 4096, 11008, 16384],

--- a/test/registered/jit/test_tp_qknorm.py
+++ b/test/registered/jit/test_tp_qknorm.py
@@ -32,11 +32,6 @@ register_cuda_ci(
     stage="base-b-kernel-unit",
     runner_config="8-gpu-h200",
 )
-register_cuda_ci(
-    est_time=300,
-    suite="nightly-kernel-8-gpu-h200",
-    nightly=True,
-)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Tests registered in a PR stage already run in the 2x-daily scheduled full runs (`run_all_tests=true` dispatches every base/extra/jit stage, and `call-pr-test-extra` fires on schedule), so a `nightly=True` registration in the same file runs the same test on the same runner class a third time.

This removes the 32 registrations where the nightly run is an exact duplicate. Kept: nightly registrations in the 19 files using `get_ci_test_range` / `SGLANG_JIT_KERNEL_RUN_FULL_TESTS` (the nightly-kernel jobs set that env to expand parameter sweeps, so their nightly pass is the only full-range coverage), nightly-only tests, and AMD/NPU registrations.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29450917664](https://github.com/sgl-project/sglang/actions/runs/29450917664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29450917311](https://github.com/sgl-project/sglang/actions/runs/29450917311)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->