### PR TITLE
[AMD] Register 2 CPU/triton unit + kernel tests for AMD 1-GPU PR CI

### DIFF
--- a/test/registered/kernels/test_gemma4_fused_routing.py
+++ b/test/registered/kernels/test_gemma4_fused_routing.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 import pytest
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=60, stage="stage-b", runner_config="1-gpu-small-amd")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),

--- a/test/registered/kernels/test_gemma4_fused_routing.py
+++ b/test/registered/kernels/test_gemma4_fused_routing.py
@@ -14,10 +14,9 @@ from __future__ import annotations
 import pytest
 import torch
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=60, stage="stage-b", runner_config="1-gpu-small-amd")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),

--- a/test/registered/moe/test_zero_experts.py
+++ b/test/registered/moe/test_zero_experts.py
@@ -3,10 +3,11 @@ import unittest
 import torch
 
 from sglang.kernels.ops.moe.ep_moe_kernels import zero_experts_compute_triton
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")

--- a/test/registered/unit/distributed/test_cuda_wrapper.py
+++ b/test/registered/unit/distributed/test_cuda_wrapper.py
@@ -2,9 +2,10 @@ import io
 
 import pytest
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=2, stage="stage-b", runner_config="1-gpu-small-amd")
 
 from sglang.srt.distributed.device_communicators import cuda_wrapper
 


### PR DESCRIPTION
## Motivation

These tests already run on NVIDIA per-commit CI (`base-b`) and are hardware-agnostic (pure mock) or **pure Triton kernels** that work on ROCm. Registering them for AMD is a 2-line edit per file — `register_amd_ci(...)` next to the existing `register_cuda_ci(...)`, mirroring the CUDA call's `stage=`/`runner_config=` shape with `-amd` appended to `runner_config`.

## Modifications

Both map NVIDIA `base-b` `1-gpu-small` → AMD `stage-b-test-1-gpu-small-amd`:

| File | est_time | Why it's safe on AMD |
|---|---|---|
| `unit/distributed/test_cuda_wrapper.py` | 2 | Pure unit test — monkeypatches `builtins.open` to feed a fake `/proc/self/maps` and asserts `find_loaded_library` string parsing. No GPU / CUDA calls; `cuda_wrapper` imports cleanly on ROCm (only `ctypes`/dataclass at import, `is_musa()` guarded). |
| `moe/test_zero_experts.py` | 5 | Correctness test for the pure `@triton.jit` `zero_experts_compute_triton` kernel; plain torch reference, no fp8 / cutlass. |

Local AST collector (`test/registered/`): `stage-b-test-1-gpu-small-amd` **125 → 127**.

### Dropped from this batch

`kernels/test_gemma4_fused_routing.py` was initially included but **dropped** — rocm720 CI showed `test_scale_applied` fails on ROCm: the fused Triton routing kernel diverges from the torch reference by up to `0.156` abs (2/32 elements) under the strict tie-break equality check. That's a real kernel-level ROCm numerical/tie-break difference, so it stays CUDA-only (no register-and-skip).

## CI Verification

- **rocm720 `stage-b-test-1-gpu-small-amd-rocm720`: both files green ✅** — verified twice: on the initial run (https://github.com/sgl-project/sglang/actions/runs/29458540855) and again on the gemma4-drop SHA (https://github.com/sgl-project/sglang/actions/runs/29524548175), with `test_zero_experts.py` (partition 9) and `test_cuda_wrapper.py` (partition 11) passing in both.
- mi3xx `stage-b-test-1-gpu-small-amd`: red due to a **pre-existing, branch-independent infra break** — the mi3xx image `rocm/sgl-dev:v0.5.15.post1-rocm700-mi30x-20260715` is ROCm 7.0, but `mori` (`src/cco/cco_init.cpp:95`) references `hipMemAllocationTypeUncached`, a ROCm-7.2+-only HIP enum, so `mori` fails to compile at container setup and every partition dies before any test runs. This is why the rocm720 lane (newer ROCm, enum present) builds and passes the same files. A 2-line test-registration diff cannot affect a C++ `mori` compile. (Details in the PR comment below.)

## Checklist

- [x] rocm720: both files green (`test_zero_experts.py`, `test_cuda_wrapper.py`), confirmed on two runs.
- [ ] mi3xx: blocked by pre-existing `mori`/rocm700 build break at container setup (not caused by this PR).
- [ ] NVIDIA CI (`PR Test`) unaffected — `register_cuda_ci` lines are unchanged.
