### PR TITLE
fix(parser): Apertus2509Detector.force_nonempty_content silently no-ops on truncated streams

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -844,7 +844,7 @@ class Apertus2509Detector(BaseReasoningFormatDetector):
 
         return out
 
-    def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
+    def _parse_streaming_increment_impl(self, new_text: str) -> StreamingParseResult:
         self._buffer += new_text
 
         out_reasoning = ""

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -396,7 +396,7 @@ class TestNemotron3Detector(CustomTestCase):
 
 
 class TestApertus2509DetectorForceNonempty(CustomTestCase):
-    """force_nonempty_content swap on Apertus2509 (non-streaming, via base helper)."""
+    """force_nonempty_content swap on Apertus2509 (non-streaming and streaming)."""
 
     def test_swap_when_only_reasoning(self):
         detector = Apertus2509Detector(force_nonempty_content=True)
@@ -417,6 +417,35 @@ class TestApertus2509DetectorForceNonempty(CustomTestCase):
         result = detector.detect_and_parse(text)
         self.assertEqual(result.reasoning_text, "reason")
         self.assertEqual(result.normal_text, "answer")
+
+    def test_streaming_truncated_reasoning_reclassified_on_finish(self):
+        """Regression: Apertus2509Detector defines its own
+        parse_streaming_increment (custom multi-token state machine), which
+        shadows BaseReasoningFormatDetector.parse_streaming_increment instead
+        of being called through it as _parse_streaming_increment_impl. The
+        base wrapper is what accumulates self._accumulated_reasoning, so
+        finish() previously always reclassified an empty string on truncated
+        streams and force_nonempty_content silently did nothing for Apertus."""
+        detector = Apertus2509Detector(force_nonempty_content=True)
+        detector.parse_streaming_increment(detector.think_start_token)
+        detector.parse_streaming_increment("reasoning part one")
+        detector.parse_streaming_increment(" more reasoning")
+        end = detector.finish()
+        self.assertEqual(end.reasoning_text, "")
+        self.assertEqual(end.normal_text, "reasoning part one more reasoning")
+
+    def test_streaming_completed_reasoning_not_reclassified_on_finish(self):
+        """finish() must no-op once think_end_token already closed reasoning
+        normally, mirroring the truncated-vs-completed distinction covered
+        for Nemotron3Detector above."""
+        detector = Apertus2509Detector(force_nonempty_content=True)
+        detector.parse_streaming_increment(detector.think_start_token)
+        detector.parse_streaming_increment("reasoning")
+        detector.parse_streaming_increment(detector.think_end_token)
+        detector.parse_streaming_increment("final answer")
+        end = detector.finish()
+        self.assertEqual(end.normal_text, "")
+        self.assertEqual(end.reasoning_text, "")
 
 
 class TestGemma4Detector(CustomTestCase):


### PR DESCRIPTION
## Motivation

`force_nonempty_content` exists so that when a model's generation gets truncated (e.g. hit `max_tokens`) while still inside a reasoning block — never producing a real answer — the accumulated reasoning gets reclassified as `content` instead of leaving `message.content` empty. This matters for coding agents / clients that only read `content`.

`Apertus2509Detector` defines its own `parse_streaming_increment` (a custom multi-token state machine for `<|inner_prefix|>`/`<|inner_suffix|>` plus embedded tool calls), which **shadows** `BaseReasoningFormatDetector.parse_streaming_increment` entirely instead of being invoked *through* it as `_parse_streaming_increment_impl`. The base class's public method is a thin wrapper:

```python
def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
    ret = self._parse_streaming_increment_impl(new_text)
    if self._force_nonempty_content:
        if self._in_reasoning:
            self._accumulated_reasoning += ret.reasoning_text
        else:
            self._accumulated_reasoning = ""
    return ret
```

`finish()` reads `self._accumulated_reasoning` to backfill `normal_text` when the stream ends truncated mid-reasoning. Since Apertus's override never populates `self._accumulated_reasoning` (it isn't called through the wrapper at all), `finish()` always reclassified an empty string for Apertus — `force_nonempty_content` silently did nothing on truncated streams.

## Modification

Apertus already maintains `self._in_reasoning` correctly throughout its own state machine (toggled `True` on `<|inner_prefix|>`, `False` on `<|inner_suffix|>`/end), so simply renaming its override from `parse_streaming_increment` to `_parse_streaming_increment_impl` lets it run through the base class's public wrapper unchanged — no other logic touched.

`CohereCommand4Detector` has the same class of gap, but its `parse_streaming_increment` docstring documents an intentional incompatibility with the base wrapper's `force_reasoning` semantics ("Cohere's 'reasoning=False' path... is fundamentally incompatible with the base detector's force_reasoning semantics"). Fixing it needs more care than a rename and is left for a follow-up rather than bundled into this minimal-risk PR.

## Repro

```python
detector = Apertus2509Detector(force_nonempty_content=True)
detector.parse_streaming_increment("<|inner_prefix|>")
detector.parse_streaming_increment("reasoning part one")
detector.parse_streaming_increment(" more reasoning")
end = detector.finish()
# before: end.normal_text == ''
# after:  end.normal_text == 'reasoning part one more reasoning'
```

## Testing

- Reproduced against a real `Apertus2509Detector` instance before touching source (see repro above).
- Added two cases to `TestApertus2509DetectorForceNonempty` in `test/registered/unit/parser/test_reasoning_parser.py`:
  - `test_streaming_truncated_reasoning_reclassified_on_finish` — the regression, verified red before the fix (stashed the source change and re-ran) and green after.
  - `test_streaming_completed_reasoning_not_reclassified_on_finish` — confirms `finish()` still no-ops once `think_end_token` closed reasoning normally (guards against a naive fix reintroducing double-emission).
- Manually executed all 4 methods in `TestApertus2509DetectorForceNonempty` (2 new + 2 pre-existing) directly against the real class — all pass. Could not run the full file through `pytest` locally since `CustomTestCase`'s import chain requires GPU-compiled `sgl_kernel`, unavailable in this CPU-only dev environment.
- `ruff check`: clean on the changed line ranges (2 pre-existing unrelated `F841` warnings elsewhere in the test file, well outside this diff's hunks).
- `black --check`: clean.

## Xref

Open PR #28415 touches the same two files but is a fully non-overlapping bugfix (guards against `force_nonempty_content` crashing detector classes whose `__init__` doesn't accept the kwarg; adds a disjoint test class at end-of-file, doesn't touch `Apertus2509Detector`'s streaming logic). Closed PR #30544 (a broader refactor attempt) explicitly flagged this exact Apertus gap as deferred/unaddressed.

## AI disclosure

Found via an AI-assisted (Claude) review pass over `sglang/srt/parser/`, independently reproduced, fixed, and verified before submitting.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29460732966](https://github.com/sgl-project/sglang/actions/runs/29460732966)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29460732667](https://github.com/sgl-project/sglang/actions/runs/29460732667)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->