### PR TITLE
chore: bump tokenspeed_mla to 0.1.8

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
   "tiktoken",
   "tilelang==0.1.11",
   "timm==1.0.16",
-  "tokenspeed_mla==0.1.9",
+  "tokenspeed_mla==0.1.8",
   "torch==2.11.0",
   "torch_memory_saver>=0.0.9.post1",
   "torchao==0.17.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
   "tiktoken",
   "tilelang==0.1.11",
   "timm==1.0.16",
-  "tokenspeed_mla==0.1.7",
+  "tokenspeed_mla==0.1.9",
   "torch==2.11.0",
   "torch_memory_saver>=0.0.9.post1",
   "torchao==0.17.0",


### PR DESCRIPTION
## Motivation

Bump `tokenspeed_mla` from 0.1.7 to 0.1.8 ([upstream release](https://github.com/lightseekorg/tokenspeed/pull/504)).

Note: 0.1.9 is not currently installable with sglang — it hard-pins `apache-tvm-ffi==0.1.12`, which conflicts with `sgl-deep-gemm==0.1.4` (pins `apache-tvm-ffi==0.1.11`, no newer release available). 0.1.8 keeps the same dependency envelope as 0.1.7 (`apache-tvm-ffi<=0.1.11,>=0.1.5`, same `tokenspeed-triton` floor), so it is a drop-in. We can move to 0.1.9 once sgl-deep-gemm ships a build against tvm-ffi 0.1.12.

## Modifications

- `python/pyproject.toml`: `tokenspeed_mla==0.1.7` → `tokenspeed_mla==0.1.8`

## Testing

Via `/rerun-test`:
- TokenSpeed MLA unittest: `test/registered/attention/unittests/mla/test_tokenspeed_mla.py`
- Kimi K2.5 NVFP4 eagle nightly: `test/registered/quant/test_kimi_k25_nvfp4_eagle.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)