### PR TITLE
[Bug] Bound deterministic FlashInfer CUDA-graph decode launches

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -14,7 +14,16 @@ import os
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import partial
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import torch
 
@@ -61,6 +70,97 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+
+_PlanInfoT = TypeVar("_PlanInfoT", bound=Sequence[int])
+
+# flashinfer-python==0.6.14 PrefillPlanInfo::ToVector() field positions.
+_FLASHINFER_PREFILL_PLAN_INFO_LENGTH = 15
+_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX = 0
+_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX = 1
+_FLASHINFER_PREFILL_CTA_TILE_Q_INDEX = 3
+_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX = 13
+_FLASHINFER_PREFILL_SPLIT_KV_INDEX = 14
+
+
+def _narrow_deterministic_cuda_graph_decode_plan(
+    plan_info: _PlanInfoT,
+    *,
+    batch_size: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+) -> _PlanInfoT:
+    """Narrow FlashInfer 0.6.14's deterministic FA2 decode plan to initialized q tiles.
+
+    Tensor-core decode reuses ``PrefillPlanInfo``. With split-KV disabled, its
+    CUDA-graph padding has no validity mask, so only the initialized q-tile
+    entries may be launched.
+    """
+    if len(plan_info) != _FLASHINFER_PREFILL_PLAN_INFO_LENGTH:
+        raise RuntimeError(
+            "Unexpected FlashInfer FA2 plan ABI for deterministic CUDA-graph "
+            f"decode: expected {_FLASHINFER_PREFILL_PLAN_INFO_LENGTH} fields from "
+            f"flashinfer_python==0.6.14, got {len(plan_info)}."
+        )
+    if batch_size <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode plan batch_size: expected a positive value, "
+            f"got {batch_size}."
+        )
+    if num_qo_heads <= 0 or num_kv_heads <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode head counts: num_qo_heads and num_kv_heads "
+            f"must be positive, got {num_qo_heads} and {num_kv_heads}."
+        )
+    if num_qo_heads % num_kv_heads != 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode head counts: "
+            f"num_qo_heads ({num_qo_heads}) must be divisible by "
+            f"num_kv_heads ({num_kv_heads})."
+        )
+    if plan_info[_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX] != 1:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: expected a CUDA graph plan, "
+            f"got enable_cuda_graph={plan_info[_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX]}."
+        )
+    if plan_info[_FLASHINFER_PREFILL_SPLIT_KV_INDEX] != 0:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: expected split-KV to be disabled, "
+            f"got split_kv={plan_info[_FLASHINFER_PREFILL_SPLIT_KV_INDEX]}."
+        )
+    if plan_info[_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX] != batch_size:
+        raise RuntimeError(
+            "Invalid FlashInfer deterministic decode plan: expected one query row "
+            f"per request, got total_num_rows="
+            f"{plan_info[_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX]} and "
+            f"batch_size={batch_size}."
+        )
+
+    cta_tile_q = plan_info[_FLASHINFER_PREFILL_CTA_TILE_Q_INDEX]
+    if cta_tile_q <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: CTA q tile size must be positive, "
+            f"got {cta_tile_q}."
+        )
+
+    group_size = num_qo_heads // num_kv_heads
+    tiles_per_request = (group_size + cta_tile_q - 1) // cta_tile_q
+    # With one q row per request, FA2 packs the GQA group into q rows and
+    # initializes exactly one scheduler entry per CTA q tile. Split-KV-disabled
+    # plans have no validity mask, so the captured grid must stop at that bound.
+    exact_grid_x = batch_size * tiles_per_request
+    padded_batch_size = plan_info[_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX]
+    if exact_grid_x > padded_batch_size:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: narrowing would enlarge "
+            f"padded_batch_size from {padded_batch_size} to {exact_grid_x}."
+        )
+    if exact_grid_x == padded_batch_size:
+        return plan_info
+
+    narrowed_plan = list(plan_info)
+    narrowed_plan[_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX] = exact_grid_x
+    return cast(_PlanInfoT, type(plan_info)(narrowed_plan))
 
 
 def _cuda_graph_capture_max_bs(server_args, max_bs: int) -> int:
@@ -1743,6 +1843,24 @@ class FlashInferIndicesUpdaterDecode:
 
         if locally_override:
             global_override_indptr_cpu = None
+
+        if (
+            disable_split_kv is True
+            and wrapper.is_cuda_graph_enabled
+            and wrapper.use_tensor_cores
+            and getattr(wrapper, "_backend", None) == "fa2"
+        ):
+            plan_info = getattr(wrapper, "_plan_info", None)
+            if plan_info is None:
+                raise RuntimeError(
+                    "FlashInfer split-KV-disabled CUDA graph decode did not produce a plan."
+                )
+            wrapper._plan_info = _narrow_deterministic_cuda_graph_decode_plan(
+                plan_info,
+                batch_size=bs,
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads,
+            )
 
 
 class FlashInferIndicesUpdaterPrefill:

--- a/test/registered/unit/layers/attention/test_flashinfer_decode_plan.py
+++ b/test/registered/unit/layers/attention/test_flashinfer_decode_plan.py
@@ -1,0 +1,223 @@
+"""Unit tests for deterministic FlashInfer CUDA-graph decode launch bounds."""
+
+import unittest
+
+from tvm_ffi import Array
+
+from sglang.srt.layers.attention.flashinfer_backend import (
+    _narrow_deterministic_cuda_graph_decode_plan,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _plan_info(
+    *,
+    padded_batch_size=132,
+    total_num_rows=2,
+    cta_tile_q=16,
+    enable_cuda_graph=1,
+    split_kv=0,
+    offset_seed=100,
+):
+    """Build FlashInfer 0.6.14's 15-field PrefillPlanInfo vector."""
+    return [
+        padded_batch_size,
+        total_num_rows,
+        offset_seed + 2,
+        cta_tile_q,
+        offset_seed + 4,
+        offset_seed + 5,
+        offset_seed + 6,
+        offset_seed + 7,
+        offset_seed + 8,
+        offset_seed + 9,
+        offset_seed + 10,
+        offset_seed + 11,
+        offset_seed + 12,
+        enable_cuda_graph,
+        split_kv,
+    ]
+
+
+class TestFlashInferDecodePlanLaunchBound(CustomTestCase):
+    def test_narrows_mha_and_gqa_to_one_tile_per_request(self):
+        for name, num_qo_heads, num_kv_heads in (
+            ("mha", 16, 16),
+            ("gqa", 16, 2),
+        ):
+            with self.subTest(name=name):
+                plan_info = _plan_info(total_num_rows=4)
+                narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+                    plan_info,
+                    batch_size=4,
+                    num_qo_heads=num_qo_heads,
+                    num_kv_heads=num_kv_heads,
+                )
+                self.assertEqual(narrowed[0], 4)
+
+    def test_group_larger_than_cta_tile_keeps_all_query_tiles(self):
+        plan_info = _plan_info(total_num_rows=3)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=3,
+            num_qo_heads=32,
+            num_kv_heads=1,
+        )
+
+        # GQA group size 32 needs two CTA-q tiles per request when CTA_TILE_Q=16.
+        self.assertEqual(narrowed[0], 6)
+
+    def test_preserves_native_ffi_array_without_mutating_input(self):
+        plan_info = Array(_plan_info())
+        original = tuple(plan_info)
+
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertIs(type(narrowed), type(plan_info))
+        self.assertIsNot(narrowed, plan_info)
+        self.assertEqual(tuple(plan_info), original)
+
+    def test_changes_only_padded_batch_size(self):
+        plan_info = _plan_info(offset_seed=700)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertEqual(narrowed[0], 2)
+        self.assertEqual(narrowed[1:], plan_info[1:])
+
+    def test_equal_bound_returns_the_same_object(self):
+        plan_info = _plan_info(padded_batch_size=2)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertIs(narrowed, plan_info)
+
+    def test_representative_normal_and_fast_plan_vectors(self):
+        # The normal capture planner and fast replay planner can produce
+        # different workspace offsets, but share the same scheduling ABI.
+        for planner, offset_seed in (("normal", 100), ("fast", 1000)):
+            with self.subTest(planner=planner):
+                plan_info = _plan_info(offset_seed=offset_seed)
+                narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+                    plan_info,
+                    batch_size=2,
+                    num_qo_heads=16,
+                    num_kv_heads=2,
+                )
+                self.assertEqual(narrowed[0], 2)
+                self.assertEqual(narrowed[1:], plan_info[1:])
+
+    def test_rejects_malformed_plan_abi(self):
+        for length in (14, 16):
+            with self.subTest(length=length):
+                plan_info = _plan_info()
+                plan_info = plan_info[:length] if length < 15 else plan_info + [0]
+                with self.assertRaisesRegex(RuntimeError, "expected 15 fields"):
+                    _narrow_deterministic_cuda_graph_decode_plan(
+                        plan_info,
+                        batch_size=2,
+                        num_qo_heads=16,
+                        num_kv_heads=2,
+                    )
+
+    def test_rejects_non_target_plan_flags_and_row_count(self):
+        cases = (
+            (
+                "not_cuda_graph",
+                _plan_info(enable_cuda_graph=0),
+                "expected a CUDA graph plan",
+            ),
+            (
+                "split_kv",
+                _plan_info(split_kv=1),
+                "expected split-KV to be disabled",
+            ),
+            (
+                "multiple_query_rows",
+                _plan_info(total_num_rows=3),
+                "expected one query row per request",
+            ),
+        )
+        for name, plan_info, message in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    _narrow_deterministic_cuda_graph_decode_plan(
+                        plan_info,
+                        batch_size=2,
+                        num_qo_heads=16,
+                        num_kv_heads=2,
+                    )
+
+    def test_rejects_invalid_dimensions(self):
+        cases = (
+            (
+                "batch_size",
+                _plan_info(),
+                dict(batch_size=0, num_qo_heads=16, num_kv_heads=2),
+                "expected a positive value",
+            ),
+            (
+                "qo_heads",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=0, num_kv_heads=2),
+                "num_qo_heads and num_kv_heads must be positive",
+            ),
+            (
+                "kv_heads",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=0),
+                "num_qo_heads and num_kv_heads must be positive",
+            ),
+            (
+                "head_divisibility",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=10, num_kv_heads=3),
+                r"num_qo_heads \(10\) must be divisible by num_kv_heads \(3\)",
+            ),
+            (
+                "zero_cta_tile",
+                _plan_info(cta_tile_q=0),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=2),
+                "CTA q tile size must be positive",
+            ),
+            (
+                "negative_cta_tile",
+                _plan_info(cta_tile_q=-16),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=2),
+                "CTA q tile size must be positive",
+            ),
+        )
+        for name, plan_info, kwargs, message in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    _narrow_deterministic_cuda_graph_decode_plan(plan_info, **kwargs)
+
+    def test_rejects_attempted_enlargement(self):
+        plan_info = _plan_info(padded_batch_size=1)
+        with self.assertRaisesRegex(RuntimeError, "narrowing would enlarge"):
+            _narrow_deterministic_cuda_graph_decode_plan(
+                plan_info,
+                batch_size=2,
+                num_qo_heads=16,
+                num_kv_heads=2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Reviewer TL;DR

- Fixes FlashInfer 0.6.14 FA2 deterministic CUDA-graph decode launching padded CTAs beyond initialized scheduler entries when split-KV is disabled.
- The guard applies only to FA2 tensor-core, one-token CUDA-graph decode with `disable_split_kv=True`; eager, split-KV, CUDA-core, prefill/extend/verify, and non-deterministic paths are unchanged.
- Only `plan_info[0]` is reduced; the private 15-field ABI is validated, fields 1–14 stay identical, and the native immutable `tvm_ffi.Array` type is preserved.
- On H100 at B=2/Q=16/KV=2, grid-x changes 132→2 (264→4 CTAs); isolated graph-replay p50 improves 9.0058→6.1245 µs (-31.99%).
- CPU tests, normal/fast native plans, real capture→replan→replay, deterministic decode, and split-KV/eager/non-deterministic controls were validated.

## Motivation

SGLang pins [`flashinfer_python[cu13]==0.6.14`](https://github.com/sgl-project/sglang/blob/45824c69ca7e2248da17f660960ace65249907f5/python/pyproject.toml#L34). Deterministic CUDA-graph decode selects FlashInfer's FA2 tensor-core path with split-KV disabled.

FlashInfer's FA2 scheduler initializes entries only for real `(request, q-tile, KV-tile)` work, but CUDA-graph planning pads grid-x using a split-work occupancy bound ([scheduler construction and padding](https://github.com/flashinfer-ai/flashinfer/blob/19f1a41e6b21f0c422d775e377b6fdf9a1fc9d23/include/flashinfer/attention/scheduler.cuh#L576-L612), [work bound](https://github.com/flashinfer-ai/flashinfer/blob/19f1a41e6b21f0c422d775e377b6fdf9a1fc9d23/include/flashinfer/attention/scheduler.cuh#L712-L727)). The scheduler creates a validity mask only for split-KV plans ([workspace population](https://github.com/flashinfer-ai/flashinfer/blob/19f1a41e6b21f0c422d775e377b6fdf9a1fc9d23/include/flashinfer/attention/scheduler.cuh#L729-L789)), while the kernel uses `plan_info[0]` directly as grid-x ([launch](https://github.com/flashinfer-ai/flashinfer/blob/19f1a41e6b21f0c422d775e377b6fdf9a1fc9d23/include/flashinfer/attention/prefill.cuh#L3605-L3629)).

For B=2, 16 Q heads, and 2 KV heads on a 132-SM H100, FlashInfer plans grid-x 132 although only scheduler entries 0 and 1 are initialized. A host-workspace probe filled with `0xA5` confirmed that the first request/q-tile/KV-tile tail entries remained `0xA5A5A5A5`. The poisoned plan was inspected but intentionally not launched.

A controlled zero tail aliases request 0 and causes observed redundant work. Reused nonzero workspace contents create a conditional stale-index correctness risk; this PR does not claim unconditional output corruption.

For one-token decode, the exact initialized grid-x is:

`batch_size * ceil((num_qo_heads / num_kv_heads) / cta_tile_q)`

Upstream tracking: [issue #4002](https://github.com/flashinfer-ai/flashinfer/issues/4002), with the root planner fix in [flashinfer-ai/flashinfer#4016](https://github.com/flashinfer-ai/flashinfer/pull/4016). This version-bounded integration workaround can be removed once SGLang upgrades to a FlashInfer release containing that upstream fix.

## Modifications

- Add a private pure helper pinned to FlashInfer 0.6.14's [15-field FA2 `PrefillPlanInfo` ABI](https://github.com/flashinfer-ai/flashinfer/blob/19f1a41e6b21f0c422d775e377b6fdf9a1fc9d23/include/flashinfer/attention/scheduler.cuh#L615-L690).
- Validate ABI length, CUDA-graph/no-split flags, one row per request, head geometry, CTA tile size, and the no-enlargement invariant; raise a descriptive `RuntimeError` on an active-path mismatch.
- Reduce only `plan_info[0]`, leaving all offsets and other fields unchanged.
- Reconstruct `type(plan_info)(values)` to preserve FlashInfer's immutable FFI container.
- Apply the helper once at the common post-planning point for both regular `begin_forward()` and `fast_decode_plan()`.
- Add a registered CPU unit test covering MHA/GQA, multi-tile groups, container and field preservation, equal-bound identity, normal/fast vectors, malformed ABI, invalid dimensions/flags, and attempted enlargement.

No public API, configuration, dependency, or documentation changes.

## Accuracy Tests

| Validation | Result |
|---|---|
| `compileall`, registered-test validation, `git diff --check`, changed-file pre-commit | Pass |
| New CPU helper test, including native `tvm_ffi.Array` | 10/10 pass |
| Native regular/fast plans, B=1/2/8 and KV=2/1024/8192 | 18/18 retained the FFI type; fields 1–14 unchanged |
| Nsight regular/fast captures, B=1/2/8 and KV=2/8192 | 12/12 runtime grids matched the bounded plans |
| Existing FlashInfer dense-attention coverage | 8/8 pass |
| `TestFlashinferDeterministic` with `Qwen/Qwen3-8B` | 2/2 pass |

For B=2/KV=2, both planners changed exactly:

`[132, 2, 1600, 16, 0, 528, 1056, 0, 1584, 1596, 0, 0, 0, 1, 0]`

to:

`[2, 2, 1600, 16, 0, 528, 1056, 0, 1584, 1596, 0, 0, 0, 1, 0]`

A real `torch.cuda.CUDAGraph` test captured the regular plan at KV=2, performed a fast replan at KV=8192, and replayed B=1/2/8:

- Short captured outputs were bitwise equal to one-shot FlashInfer.
- Long replay maximum absolute difference from one-shot FlashInfer was `4.8828125e-4`.
- Maximum absolute difference from FP32 across all outputs was `1.5625e-2`; worst mean difference was `2.7877e-4`.
- All non-grid plan fields remained identical across capture and replan.

Controls remained unchanged: split-KV graphs retained `split_kv=1` and grid-x 132; eager deterministic decode and non-deterministic dense decode remained outside the guard.

<details>
<summary>Environment and attempted full-suite evidence</summary>

| Component | Version |
|---|---|
| GPU | NVIDIA H100 80GB HBM3, 132 SMs, compute capability 9.0 |
| Driver | 570.148.08 |
| OS / Python | Ubuntu 24.04.2 LTS x86_64 / Python 3.12.3 |
| Container | `lmsysorg/sglang:dev-cu12@sha256:3c783bf6033361487749c92399cc1eb4a22c6e038b9f8f96e1fd8e2ea0719052` |
| PyTorch / CUDA | `2.11.0+cu129` / 12.9 |
| FlashInfer | `flashinfer-python==0.6.14`, `flashinfer-cubin==0.6.14`, `flashinfer-jit-cache==0.6.14+cu129` |
| FFI | `apache-tvm-ffi==0.1.11` |
| Nsight Systems | 2026.3.1.157 |

- `base-a-test-cpu`: 249/251 files passed in 2,445.93 s. The new test passed. Both failures reproduced without this patch and are specific to running the CPU suite in a CUDA-visible development image: installed `sglang-kernel` namespace detection and eager CUDA allocation by upstream FP4 module constants.
- `base-b-test-1-gpu-large`: 71/99 files passed in 6,431.30 s. Of 28 failed files, 26 were Hugging Face 401s for gated models. One AWQ/FA3 cold-start Marlin compilation exceeded 600 s and passed its warm-cache rerun; one FA3/DSPARK output hit the suite token limit and passed at 256 tokens. No failure executed or implicated the guarded path.
- The full deterministic registered file passed 6 tests in 253.098 s (1 skipped). The full FlashInfer dense-attention file passed 8 tests in 11.010 s.

</details>

## Speed Tests and Profiling

The representative H100 case used B=2, 16 Q heads, 2 KV heads, head dimension 128, BF16, page size 1, and KV length 2. The before case zero-initialized planner-tail storage to make the padded launch safe and deterministic while retaining its redundant work. Inputs, kernel specialization, block shape, and graph topology were otherwise identical.

CUDA-event protocol: 20 warmups, then 25 samples of 200 isolated attention-graph replays.

| Captured graph | p10 | p50 | p90 | Minimum |
|---|---:|---:|---:|---:|
| Padded zero-tail baseline | 8.9968 µs | 9.0058 µs | 9.0160 µs | 8.9957 µs |
| Bounded | 6.1213 µs | 6.1245 µs | 6.1280 µs | 6.1194 µs |

Median isolated replay latency decreased by 31.99% (1.470×). Both variants were bitwise equal to the one-shot BF16 output and had identical FP32-reference error (`max=0.0078125`, `mean=0.00028756`).

Nsight captured the same FA2 kernel specialization and block `(32, 1, 4)`:

| Plan | Grid | CTAs | Kernel duration |
|---|---|---:|---:|
| Padded zero-tail baseline | `(132, 1, 2)` | 264 | 8.543 µs |
| Bounded | `(2, 1, 2)` | 4 | 5.600 µs |

This is a targeted attention-kernel replay improvement; end-to-end throughput depends on workload. No timing assertion is added to CI.

## Checklist

- [x] Format code with [pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add registered unit tests following the [testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation reviewed: no public API, configuration, dependency, or user-facing behavior requires documentation.
- [x] Provide [accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) evidence.
- [x] Follow the SGLang [code-style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29884749350](https://github.com/sgl-project/sglang/actions/runs/29884749350)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29884749190](https://github.com/sgl-project/sglang/actions/runs/29884749190)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
