### PR TITLE
docker: build HPC-Ops into the GPU image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -161,7 +161,8 @@ ENV LANG=en_US.UTF-8 \
 #   base
 #     |
 #     +-- torch_deps ------> deepep_builder (needs torch)
-#     |                  \-> flashinfer_cache (needs flashinfer)
+#     |                  |-> flashinfer_cache (needs flashinfer)
+#     |                  \-> hpc_ops_builder (cmake-only build)
 #     |
 #     +-- devtools_builder (independent)
 #     +-- gateway_builder  (independent, only needs gateway source)
@@ -329,7 +330,31 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         python3 setup.py bdist_wheel -d /wheels
 
 ########################################################
-# PARALLEL STAGE 3: FlashInfer Cache (needs torch_deps)
+# PARALLEL STAGE 3: HPC-Ops Builder (needs torch_deps)
+########################################################
+FROM torch_deps AS hpc_ops_builder
+
+# HPC-Ops (https://github.com/Tencent/hpc-ops, MIT): fused attention / MoE /
+# RoPE kernels from the Tencent Hunyuan AI Infra team, consumed by the opt-in
+# hpc_ops attention and MoE runner backends.
+ARG HPC_OPS_COMMIT=2404f09766269d9533b66709f705c8eeb01421fc
+
+WORKDIR /build
+
+# The kernels target Hopper (sm90a) only, so skip non-x86_64 images.
+# setup.py derives the version from `git rev-parse`, so keep the .git dir
+# (a source zip archive would not build).
+RUN --mount=type=cache,target=/root/.cache/pip \
+    mkdir -p /wheels && \
+    if [ "$(uname -m)" = "x86_64" ]; then \
+        git clone https://github.com/Tencent/hpc-ops.git && \
+        cd hpc-ops && \
+        git checkout ${HPC_OPS_COMMIT} && \
+        python3 setup.py bdist_wheel -d /wheels; \
+    fi
+
+########################################################
+# PARALLEL STAGE 4: FlashInfer Cache (needs torch_deps)
 ########################################################
 FROM torch_deps AS flashinfer_cache
 
@@ -466,6 +491,13 @@ COPY --from=deepep_builder /wheels /tmp/wheels/deepep
 COPY --from=deepep_builder /build/DeepEP /sgl-workspace/DeepEP
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install /tmp/wheels/deepep/*.whl && rm -rf /tmp/wheels/deepep
+
+# Copy HPC-Ops wheel and install (empty on non-x86_64; kernels are sm90a-only)
+COPY --from=hpc_ops_builder /wheels /tmp/wheels/hpc-ops
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if ls /tmp/wheels/hpc-ops/*.whl >/dev/null 2>&1; then \
+        pip install --no-deps /tmp/wheels/hpc-ops/*.whl; \
+    fi && rm -rf /tmp/wheels/hpc-ops
 
 # Copy flashinfer cubin (always) and jit-cache (if installed) packages
 COPY --from=flashinfer_cache /flashinfer_jit_output/ /usr/local/lib/python3.12/dist-packages/


### PR DESCRIPTION
## Motivation

Per the discussion with the Hunyuan HPC-Ops team: depend on the `hpc` library directly in our image so that (a) the opt-in `hpc_ops` attention (#30540) and MoE runner (#30541) backends work out of the box (`import hpc` today requires a manual source build), and (b) future kernel-side improvements land by bumping one pinned commit, with no re-porting — the Python API stays stable.

HPC-Ops is MIT-licensed, so bundling it in the image is fine.

## Modifications

- New parallel BuildKit stage `hpc_ops_builder` (runs alongside `deepep_builder` / `flashinfer_cache`, so it does not extend the critical path): `git clone` at a pinned commit + `setup.py bdist_wheel`.
  - Pinned to `2404f097` — the exact commit both backends were validated against on H200.
  - The build is cmake-only (no GPU / no torch needed at build time); kernels are compiled for `sm90a` only, so the stage is a no-op on non-x86_64 images (e.g. GB200 arm64) and the final install guards on the wheel existing.
  - `git clone` instead of a source archive because `setup.py` derives the version from `git rev-parse`.
- Final stage installs the wheel with `--no-deps` (its only requirement is torch, which the image already has).

Image cost: wheel is ~31 MB (the bundled `_C.abi3.so` is ~117 MB uncompressed).

## Test

Replicated the exact stage commands inside the H200 container (`lmsysorg/sglang:dev`, CUDA 13.0):

```
hpc_ops-0.0.1.dev0+g2404f09-cp39-abi3-linux_x86_64.whl   (31 MB)
version: 0.0.1.dev0+g2404f09
ops: attention_decode_fp8=True fuse_moe_blockwise=True rope_norm_store_kv_fp8=True assign_attention_decode_task=True
```

i.e. clone → wheel build → `pip install --no-deps` → `import hpc` + op registration all pass headlessly.

Also built the actual Dockerfile chain on an H200 host (PR-CI does not build the GPU image — its docker job is a placeholder):

```
DOCKER_BUILDKIT=1 docker build --target hpc_ops_builder -f docker/Dockerfile .
=> naming to docker.io/library/hpc-ops-stage-test:latest   done
$ docker run --rm hpc-ops-stage-test ls /wheels
hpc_ops-0.0.1.dev0+g2404f09-cp39-abi3-linux_x86_64.whl   (32 MB)
```

The `hpc_ops_builder` RUN itself takes ~5.3 min (CUDA 13.0.1 base, `cmake -j16`) and overlaps with the DeepEP / FlashInfer builders, so wall-clock image build time is unchanged. (Both backends' full H200 e2e validation against this same commit is in #30540 / #30541.)

Heads-up for reviewers: hpc-ops' CMake filters source paths matching `.*test.*`, so the build directory must not contain "test" in its path — `/build` in this Dockerfile is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29463943666](https://github.com/sgl-project/sglang/actions/runs/29463943666)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29463954742](https://github.com/sgl-project/sglang/actions/runs/29463954742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
