### PR TITLE
[Fix] Wire the detokenizer soft watchdog into the multi-http-worker event loop

### DIFF
--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -382,28 +382,28 @@ class MultiHttpWorkerDetokenizerMixin:
         """The event loop that handles requests, for multi multi-http-worker mode"""
         self.socket_mapping = SocketMapping()
         while True:
-            recv_obj = sock_recv(self.recv_from_scheduler)
+            with self.soft_watchdog.disable():
+                recv_obj = sock_recv(self.recv_from_scheduler)
             output = self._request_dispatcher(recv_obj)
-            if output is None:
-                continue
-
-            # Fan out the output back to the originating tokenizer worker(s).
-            # In multi-detokenizer mode the upstream MultiDetokenizerRouter may
-            # forward either batched or single requests, so handle both shapes.
-            if isinstance(recv_obj, BaseBatchReq):
-                for i, ipc_name in enumerate(recv_obj.http_worker_ipcs):
-                    new_output = _handle_output_by_index(output, i)
+            if output is not None:
+                # Fan out the output back to the originating tokenizer worker(s).
+                # In multi-detokenizer mode the upstream MultiDetokenizerRouter may
+                # forward either batched or single requests, so handle both shapes.
+                if isinstance(recv_obj, BaseBatchReq):
+                    for i, ipc_name in enumerate(recv_obj.http_worker_ipcs):
+                        new_output = _handle_output_by_index(output, i)
+                        self.socket_mapping.send_output(
+                            ipc_name, new_output, is_tokenizer=True
+                        )
+                elif isinstance(recv_obj, BaseReq):
                     self.socket_mapping.send_output(
-                        ipc_name, new_output, is_tokenizer=True
+                        recv_obj.http_worker_ipc, output, is_tokenizer=True
                     )
-            elif isinstance(recv_obj, BaseReq):
-                self.socket_mapping.send_output(
-                    recv_obj.http_worker_ipc, output, is_tokenizer=True
-                )
-            else:
-                raise ValueError(
-                    f"multi_http_worker_event_loop got unexpected req type {type(recv_obj)}"
-                )
+                else:
+                    raise ValueError(
+                        f"multi_http_worker_event_loop got unexpected req type {type(recv_obj)}"
+                    )
+            self.soft_watchdog.feed()
 
 
 class MultiTokenizerRouter:

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -381,6 +381,8 @@ class MultiHttpWorkerDetokenizerMixin:
     def multi_http_worker_event_loop(self: DetokenizerManager):
         """The event loop that handles requests, for multi multi-http-worker mode"""
         self.socket_mapping = SocketMapping()
+        # Watchdog wiring mirrors DetokenizerManager.event_loop: the watchdog is
+        # paused while waiting for input and fed once per processed message.
         while True:
             with self.soft_watchdog.disable():
                 recv_obj = sock_recv(self.recv_from_scheduler)


### PR DESCRIPTION
With `--tokenizer-worker-num > 1` and `--soft-watchdog-timeout` set, the detokenizer's `multi_http_worker_event_loop` never disables the watchdog while parked on `sock_recv` and never feeds it after processing, so the watchdog times out unconditionally every interval on a healthy pod — triggering a py-spy dump of all server processes every N seconds. Mirror the single-worker `event_loop` wiring: disable during recv, feed at the end of each iteration.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29466164026](https://github.com/sgl-project/sglang/actions/runs/29466164026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29466163983](https://github.com/sgl-project/sglang/actions/runs/29466163983)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->