### PR TITLE
Interleave decode passes between mixed prefills

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -999,6 +999,10 @@ class Scheduler(
             self.chunked_prefill_size is not None
             and self.server_args.enable_mixed_chunk
         )
+        self.mixed_chunk_decode_interleave_steps = (
+            self.server_args.mixed_chunk_decode_interleave_steps
+        )
+        self.mixed_chunk_decode_steps_remaining = 0
 
         # Init the dynamic chunking predictor for PP
         self.enable_dynamic_chunking = (
@@ -2614,6 +2618,36 @@ class Scheduler(
         # todo hisparse, maybe other info to contain for the new batch
         return batch
 
+    def _update_mixed_chunk_decode_interleave_budget(
+        self, last_batch: Optional[ScheduleBatch]
+    ) -> None:
+        """Track decode-only steps owed after the most recent extend batch."""
+        if last_batch is None:
+            return
+
+        if last_batch.forward_mode.is_extend():
+            self.mixed_chunk_decode_steps_remaining = (
+                self.mixed_chunk_decode_interleave_steps
+            )
+        elif (
+            last_batch.forward_mode.is_decode()
+            and self.mixed_chunk_decode_steps_remaining > 0
+        ):
+            self.mixed_chunk_decode_steps_remaining -= 1
+
+    def _should_interleave_mixed_chunk_decode(
+        self, running_batch: ScheduleBatch
+    ) -> bool:
+        """Return whether decode should run before admitting another prefill."""
+        return (
+            self.mixed_chunk_decode_steps_remaining > 0
+            and self.is_mixed_chunk
+            # A partially processed request must continue its next chunk.
+            and self.chunked_req is None
+            and not running_batch.is_empty()
+            and not running_batch.is_prefill_only
+        )
+
     @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_batch_to_run(
         self, running_batch: ScheduleBatch, last_batch: Optional[ScheduleBatch]
@@ -2703,8 +2737,12 @@ class Scheduler(
             if running_batch.is_empty():
                 running_batch.batch_is_full = False
 
+        self._update_mixed_chunk_decode_interleave_budget(last_batch)
+
         if self.dllm_config is not None:
             new_batch = self.get_new_batch_dllm(running_batch)
+        elif self._should_interleave_mixed_chunk_decode(running_batch):
+            new_batch = None
         else:
             prefill_plan = self.get_new_batch_prefill(running_batch)
             new_batch = prefill_plan.batch_to_run

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -849,6 +849,13 @@ class ServerArgs:
         bool,
         "Enabling mixing prefill and decode in a batch when using chunked prefill.",
     ] = False
+    mixed_chunk_decode_interleave_steps: A[
+        int,
+        "Run this many decode-only steps after a mixed-chunk prefill before "
+        "scheduling another non-chunked prefill. This can reduce decode stalls "
+        "under concurrent prefill-heavy workloads. Requires "
+        "--enable-mixed-chunk; 0 disables the interleave.",
+    ] = 0
 
     # -------------------------------------------------------------------------
     # Distributed topology and parallelism (TP, PP, DP, CP)
@@ -7101,6 +7108,15 @@ class ServerArgs:
                 "(DeepSeek-V4 non-EP DP TBO path)."
             )
 
+    def _validate_mixed_chunk_decode_interleave(self) -> None:
+        assert (
+            self.mixed_chunk_decode_interleave_steps >= 0
+        ), "mixed_chunk_decode_interleave_steps must be non-negative"
+        if self.mixed_chunk_decode_interleave_steps > 0:
+            assert (
+                self.enable_mixed_chunk
+            ), "--mixed-chunk-decode-interleave-steps requires --enable-mixed-chunk"
+
     def check_server_args(self):
         # Check parallel size constraints
         assert (
@@ -7158,6 +7174,8 @@ class ServerArgs:
             ), "enable_mixed_chunk is required for speculative decoding"
 
         # Check chunked prefill
+        self._validate_mixed_chunk_decode_interleave()
+
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).
         # Skip validation if disaggregation mode is decode.
         if self.chunked_prefill_size > 0 and self.disaggregation_mode != "decode":

--- a/test/registered/unit/managers/test_scheduler_mixed_chunk_interleave.py
+++ b/test/registered/unit/managers/test_scheduler_mixed_chunk_interleave.py
@@ -1,0 +1,85 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _batch(*, extend=False, decode=False):
+    forward_mode = MagicMock()
+    forward_mode.is_extend.return_value = extend
+    forward_mode.is_decode.return_value = decode
+    return SimpleNamespace(forward_mode=forward_mode)
+
+
+def _running_batch(*, empty=False, prefill_only=False):
+    batch = MagicMock()
+    batch.is_empty.return_value = empty
+    batch.is_prefill_only = prefill_only
+    return batch
+
+
+class TestMixedChunkDecodeInterleave(CustomTestCase):
+    def setUp(self):
+        self.scheduler = Scheduler.__new__(Scheduler)
+        self.scheduler.mixed_chunk_decode_interleave_steps = 2
+        self.scheduler.mixed_chunk_decode_steps_remaining = 0
+        self.scheduler.is_mixed_chunk = True
+        self.scheduler.chunked_req = None
+
+    def test_runs_configured_decode_steps_after_extend(self):
+        self.scheduler._update_mixed_chunk_decode_interleave_budget(_batch(extend=True))
+        self.assertTrue(
+            self.scheduler._should_interleave_mixed_chunk_decode(_running_batch())
+        )
+
+        self.scheduler._update_mixed_chunk_decode_interleave_budget(_batch(decode=True))
+        self.assertTrue(
+            self.scheduler._should_interleave_mixed_chunk_decode(_running_batch())
+        )
+
+        self.scheduler._update_mixed_chunk_decode_interleave_budget(_batch(decode=True))
+        self.assertFalse(
+            self.scheduler._should_interleave_mixed_chunk_decode(_running_batch())
+        )
+
+    def test_zero_steps_disables_interleave(self):
+        self.scheduler.mixed_chunk_decode_interleave_steps = 0
+        self.scheduler._update_mixed_chunk_decode_interleave_budget(_batch(extend=True))
+
+        self.assertFalse(
+            self.scheduler._should_interleave_mixed_chunk_decode(_running_batch())
+        )
+
+    def test_active_chunked_request_continues_prefill(self):
+        self.scheduler.mixed_chunk_decode_steps_remaining = 2
+        self.scheduler.chunked_req = MagicMock()
+
+        self.assertFalse(
+            self.scheduler._should_interleave_mixed_chunk_decode(_running_batch())
+        )
+
+    def test_empty_or_prefill_only_batch_cannot_decode(self):
+        self.scheduler.mixed_chunk_decode_steps_remaining = 2
+
+        self.assertFalse(
+            self.scheduler._should_interleave_mixed_chunk_decode(
+                _running_batch(empty=True)
+            )
+        )
+        self.assertFalse(
+            self.scheduler._should_interleave_mixed_chunk_decode(
+                _running_batch(prefill_only=True)
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -59,6 +59,35 @@ class TestPrepareServerArgs(CustomTestCase):
             os.unlink(config_file)
 
 
+class TestMixedChunkDecodeInterleaveArgs(CustomTestCase):
+    def test_requires_mixed_chunk(self):
+        server_args = ServerArgs(
+            model_path="dummy", mixed_chunk_decode_interleave_steps=2
+        )
+
+        with self.assertRaisesRegex(AssertionError, "requires --enable-mixed-chunk"):
+            server_args._validate_mixed_chunk_decode_interleave()
+
+    def test_accepts_non_negative_steps_with_mixed_chunk(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_mixed_chunk=True,
+            mixed_chunk_decode_interleave_steps=2,
+        )
+
+        server_args._validate_mixed_chunk_decode_interleave()
+
+    def test_rejects_negative_steps(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_mixed_chunk=True,
+            mixed_chunk_decode_interleave_steps=-1,
+        )
+
+        with self.assertRaisesRegex(AssertionError, "must be non-negative"):
+            server_args._validate_mixed_chunk_decode_interleave()
+
+
 class TestMultimodalFeatureTransport(CustomTestCase):
     @patch("sglang.srt.server_args.is_cuda", return_value=True)
     def test_cuda_ipc_is_explicit_and_bounded(self, _mock_is_cuda):


### PR DESCRIPTION
## What changed

- Add `--mixed-chunk-decode-interleave-steps` (default `0`).
- After an extend/mixed-prefill batch, optionally run a bounded number of decode-only passes before admitting another non-chunked prefill.
- Never interleave decode while an active chunked request must continue, and never attempt decode for an empty or prefill-only running batch.
- Add argument validation and scheduler state-machine tests.

## Root cause

H200 TP8 traces showed that Kimi-K2.7 prefill itself was already fast: the first 2,458-token SGLang prefill took about 161 ms versus about 193 ms in vLLM. The regression came from scheduling fairness. SGLang admitted consecutive, fragmented multimodal prefills, producing 720 main Marlin calls versus 480 in vLLM and stalling decode for 200–320 ms at a time. Standalone decode graph steps were otherwise close (roughly 9 ms in both engines).

This change makes that fairness tradeoff explicit and bounded instead of relying on a fixed global scheduling policy. The default remains unchanged.

## Performance

Median of three repeats; cache flushed before every case. Single-node 8x NVIDIA H200, TP8, Kimi-K2.7-Code, 8 requests, 4 images/request, seeded random resolution `random:512x512-768x1024`, input length 32. SGLang uses `--mixed-chunk-decode-interleave-steps 2`; the “before” column is the same SGLang stack with the interleave disabled. vLLM is v0.25.1 with encoder DP and its default async/chunked scheduler.

| Workload | Metric | SGLang before | SGLang after | vLLM | after vs vLLM |
|---|---:|---:|---:|---:|---:|
| out=8, rate=1 | request throughput | 0.659 | 0.659 | 0.659 | +0.0% |
| | mean TTFT (ms) | 222.36 | 223.38 | 243.14 | -8.1% |
| | mean TPOT (ms) | 16.36 | 15.93 | 16.85 | -5.5% |
| out=8, rate=4 | request throughput | 4.735 | 4.819 | 4.383 | +10.0% |
| | mean TTFT (ms) | 531.73 | 484.40 | 581.29 | -16.7% |
| | mean TPOT (ms) | 167.55 | 65.02 | 96.49 | -32.6% |
| out=8, burst | request throughput | 5.340 | 5.296 | 4.521 | +17.2% |
| | mean TTFT (ms) | 1139.56 | 1119.66 | 1200.57 | -6.7% |
| | mean TPOT (ms) | 217.62 | 52.35 | 107.32 | -51.2% |
| out=1, burst | request throughput | 5.408 | 5.376 | 4.596 | +17.0% |
| | mean TTFT (ms) | 1198.53 | 1182.43 | 1225.47 | -3.5% |

Positive throughput and negative latency deltas are better. The burst throughput change versus SGLang-before is -0.8%, while mean TPOT improves by 75.9%; this is the intended fairness tradeoff. At rate 4, throughput also improves by 1.8% while mean TPOT improves by 61.2%.

SGLang launch additions:

```bash
--chunked-prefill-size 8192 \
--enable-mixed-chunk \
--mixed-chunk-decode-interleave-steps 2
```

## Tests

- `python3 test/registered/unit/managers/test_scheduler_mixed_chunk_interleave.py -f` — 4 passed
- `python3 test/registered/unit/server_args/test_server_args.py -f` — 113 passed
- pre-commit hooks — passed
- H200 TP8 seeded random-image serving — 3 repeats for rate 1, rate 4, burst, and out=1 burst







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29465014066](https://github.com/sgl-project/sglang/actions/runs/29465014066)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29465013945](https://github.com/sgl-project/sglang/actions/runs/29465013945)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->