### PR TITLE
[Fix] Correct DeepGEMM benchmark time units

### DIFF
--- a/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_gemm.py
+++ b/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_gemm.py
@@ -350,8 +350,8 @@ def get_benchmark(tp_size):
         tflops = flops / (ms * 1e-3) / 1e12
 
         # Print shape-specific results with TFLOPS
-        print(f"Time: {ms*1000:.2f} ms, TFLOPS: {tflops:.2f}")
-        return ms * 1000, max_ms * 1000, min_ms * 1000  # convert to ms
+        print(f"Time: {ms:.3f} ms, TFLOPS: {tflops:.2f}")
+        return ms, min_ms, max_ms
 
     return benchmark
 

--- a/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_group_gemm.py
+++ b/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_group_gemm.py
@@ -435,8 +435,8 @@ def get_benchmark(tp_size):
         flops = 2 * m * n * k  # multiply-adds
         tflops = flops / (ms * 1e-3) / 1e12
 
-        print(f"Time: {ms*1000:.2f} ms, TFLOPS: {tflops:.2f}")
-        return ms * 1000, max_ms * 1000, min_ms * 1000  # convert to ms
+        print(f"Time: {ms:.3f} ms, TFLOPS: {tflops:.2f}")
+        return ms, min_ms, max_ms
 
     return benchmark
 


### PR DESCRIPTION
## Motivation

`run_bench` returns latency in milliseconds, but the FP8 and grouped FP8 DeepGEMM benchmarks multiplied the returned values by 1000 while still labeling them as `ms`. This made reported and plotted latency values 1000x too large.

The benchmark return values also placed the maximum before the minimum, reversing the error-bar bounds for latency.

## Modifications

- Report the `run_bench` latency directly in milliseconds.
- Return benchmark quantiles as `(median, min, max)`.
- Keep the existing TFLOPS calculation unchanged because it already converts milliseconds to seconds correctly.
- Leave the Blackwell benchmarks unchanged because they intentionally report microseconds with `ylabel="us"`.

## Tests

- `python3 -m py_compile benchmark/kernels/deepseek/benchmark_deepgemm_fp8_gemm.py benchmark/kernels/deepseek/benchmark_deepgemm_fp8_group_gemm.py`
- `git diff --check`

GPU benchmark execution was not available in the current environment.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29466006650](https://github.com/sgl-project/sglang/actions/runs/29466006650)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29466006564](https://github.com/sgl-project/sglang/actions/runs/29466006564)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->