### PR TITLE
fix inkling effort rounding and responses API passthrough

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -478,6 +478,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 else True
             ),
             stop=request.stop,
+            reasoning_effort=(request.reasoning.effort if request.reasoning else None),
         )
 
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal

--- a/python/sglang/srt/parser/inkling_renderer.py
+++ b/python/sglang/srt/parser/inkling_renderer.py
@@ -238,7 +238,7 @@ def _format_reasoning_effort(reasoning_effort: float) -> str:
     value = float(reasoning_effort)
     if not math.isfinite(value) or not 0.0 <= value <= 0.99:
         raise ValueError("Inkling reasoning_effort must be finite and in [0.0, 0.99]")
-    return str(round(value, 2))
+    return f"{round(value, 2):g}"
 
 
 def _expect_string_content(content: Any) -> str:

--- a/python/sglang/srt/parser/inkling_renderer.py
+++ b/python/sglang/srt/parser/inkling_renderer.py
@@ -238,8 +238,7 @@ def _format_reasoning_effort(reasoning_effort: float) -> str:
     value = float(reasoning_effort)
     if not math.isfinite(value) or not 0.0 <= value <= 0.99:
         raise ValueError("Inkling reasoning_effort must be finite and in [0.0, 0.99]")
-    millieffort = round(value * 1000)
-    return str(millieffort / 1000)
+    return str(round(value, 2))
 
 
 def _expect_string_content(content: Any) -> str:

--- a/test/registered/unit/parser/test_inkling_renderer.py
+++ b/test/registered/unit/parser/test_inkling_renderer.py
@@ -198,7 +198,7 @@ class TestInklingRenderer(unittest.TestCase):
             )
 
     def test_reasoning_effort_is_two_decimal_quantized_and_validated(self):
-        for value, expected in ((0.8766, "0.88"), (0.0, "0.0"), (0.99, "0.99")):
+        for value, expected in ((0.8766, "0.88"), (0.0, "0"), (0.99, "0.99")):
             with self.subTest(value=value):
                 actual = render_inkling_messages(
                     [{"role": "user", "content": "q"}],

--- a/test/registered/unit/parser/test_inkling_renderer.py
+++ b/test/registered/unit/parser/test_inkling_renderer.py
@@ -198,7 +198,13 @@ class TestInklingRenderer(unittest.TestCase):
             )
 
     def test_reasoning_effort_is_two_decimal_quantized_and_validated(self):
-        for value, expected in ((0.8766, "0.88"), (0.0, "0"), (0.99, "0.99")):
+        for value, expected in (
+            (0.8766, "0.88"),
+            (0.0, "0"),
+            (0.99, "0.99"),
+            (0.125, "0.12"),
+            (0.875, "0.88"),
+        ):
             with self.subTest(value=value):
                 actual = render_inkling_messages(
                     [{"role": "user", "content": "q"}],

--- a/test/registered/unit/parser/test_inkling_renderer.py
+++ b/test/registered/unit/parser/test_inkling_renderer.py
@@ -97,7 +97,7 @@ class TestInklingRenderer(unittest.TestCase):
                 author="tool_declare",
             )
             + _block(MESSAGE_SYSTEM, CONTENT_TEXT, "original")
-            + _block(MESSAGE_SYSTEM, CONTENT_TEXT, "Thinking effort level: 0.876")
+            + _block(MESSAGE_SYSTEM, CONTENT_TEXT, "Thinking effort level: 0.88")
             + _block(MESSAGE_USER, CONTENT_TEXT, "question")
         )
         self.assertEqual(actual, expected)
@@ -197,8 +197,8 @@ class TestInklingRenderer(unittest.TestCase):
                 self.tokenizer,
             )
 
-    def test_reasoning_effort_is_millieffort_quantized_and_validated(self):
-        for value, expected in ((0.8766, "0.877"), (0.0, "0.0"), (0.99, "0.99")):
+    def test_reasoning_effort_is_two_decimal_quantized_and_validated(self):
+        for value, expected in ((0.8766, "0.88"), (0.0, "0.0"), (0.99, "0.99")):
             with self.subTest(value=value):
                 actual = render_inkling_messages(
                     [{"role": "user", "content": "q"}],


### PR DESCRIPTION
## Summary

- Round reasoning effort to 2 decimal places instead of 3 (millieffort) to match the model spec.
- Forward `reasoning.effort` from `ResponsesRequest` to `ChatCompletionRequest` in the non-Harmony `_make_request` path, which was silently dropping it.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29470554888](https://github.com/sgl-project/sglang/actions/runs/29470554888)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29470554806](https://github.com/sgl-project/sglang/actions/runs/29470554806)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->