### PR TITLE
[Hicache]Fix non-blocking HiCache storage prefetch misses

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -28,6 +28,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageExtraInfo,
     PoolName,
     PoolTransfer,
+    PoolTransferResult,
 )
 
 if TYPE_CHECKING:
@@ -96,9 +97,7 @@ class LayerDoneCounter:
 
     def update_producer(self):
         self.producer_index = (self.producer_index + 1) % self.num_counters
-        assert self.events[
-            self.producer_index
-        ].finish_event.query(), (
+        assert self.events[self.producer_index].finish_event.query(), (
             "Producer finish event should be ready before being reused."
         )
         return self.producer_index
@@ -117,7 +116,6 @@ class LayerDoneCounter:
 
 
 class CacheOperation:
-
     counter = 0
 
     def __init__(
@@ -175,6 +173,7 @@ class StorageOperation:
         last_hash: Optional[str] = None,
         hash_value: Optional[List[str]] = None,
         prefix_keys: Optional[List[str]] = None,
+        pool_transfers: Optional[list[PoolTransfer]] = None,
     ):
         self.host_indices = host_indices
         self.token_ids = token_ids
@@ -182,6 +181,8 @@ class StorageOperation:
         self.completed_tokens = 0
         self.hash_value = hash_value if hash_value is not None else []
         self.prefix_keys = prefix_keys
+        self.pool_transfers = pool_transfers
+        self.pool_storage_result = PoolTransferResult.empty()
 
         self.id = StorageOperation.counter
         StorageOperation.counter += 1
@@ -197,6 +198,7 @@ class PrefetchOperation(StorageOperation):
         token_ids: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        pool_transfers: Optional[list[PoolTransfer]] = None,
     ):
         self.request_id = request_id
 
@@ -205,7 +207,14 @@ class PrefetchOperation(StorageOperation):
         self.storage_hit_count = 0
         self.start_time = time.monotonic()
 
-        super().__init__(None, token_ids, last_hash, prefix_keys=prefix_keys)
+        super().__init__(
+            None,
+            token_ids,
+            last_hash,
+            prefix_keys=prefix_keys,
+            pool_transfers=pool_transfers,
+        )
+        self.pool_transfers_done = not bool(pool_transfers)
 
     def increment(self, num_tokens: int):
         with self._lock:
@@ -223,7 +232,6 @@ class PrefetchOperation(StorageOperation):
 
 
 class HiCacheController:
-
     def __init__(
         self,
         token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
@@ -374,13 +382,31 @@ class HiCacheController:
         self.prefetch_queue = Queue()
         self.backup_queue = Queue()
 
-        self.prefetch_hit_queue: Queue[StorageOperation] = Queue()
         self.prefetch_revoke_queue: Queue[str] = Queue()
+        self.ack_prefetch_queue: Queue[PrefetchOperation] = Queue()
         self.ack_backup_queue: Queue[StorageOperation] = Queue()
         self.host_mem_release_queue: Queue[torch.Tensor] = Queue()
+        self._init_extra_host_mem_release_queues()
 
         self.prefetch_thread.start()
         self.backup_thread.start()
+
+    def _init_extra_host_mem_release_queues(self) -> None:
+        self.extra_host_mem_release_queues = {}
+        entries = getattr(self.mem_pool_host, "entries", None) or []
+        anchor_entry = getattr(self.mem_pool_host, "anchor_entry", None)
+        for entry in entries:
+            if entry is anchor_entry or entry.is_primary_index_anchor:
+                continue
+            self.extra_host_mem_release_queues[entry.name] = Queue()
+
+    def _append_host_mem_release_pages(
+        self, release_queue: Queue, host_indices: torch.Tensor, page_size: int
+    ) -> None:
+        if host_indices.numel() == 0:
+            return
+        for page in host_indices.split(page_size):
+            release_queue.put(page)
 
     def _stop_storage_threads(self):
         """Stop storage prefetch/backup threads and drain internal queues.
@@ -612,9 +638,9 @@ class HiCacheController:
         should_split_heads = False
 
         if tp_lcm_size:
-            assert (
-                tp_lcm_size % self.tp_size == 0
-            ), "tp_lcm_size must be divisible by tp_size."
+            assert tp_lcm_size % self.tp_size == 0, (
+                "tp_lcm_size must be divisible by tp_size."
+            )
             should_split_heads = (
                 not is_rank_replicated
                 and self.mem_pool_host.layout == "page_head"
@@ -653,9 +679,13 @@ class HiCacheController:
             self.prefetch_queue.queue.clear()
             self.backup_queue.queue.clear()
             self.prefetch_revoke_queue.queue.clear()
-            self.prefetch_hit_queue.queue.clear()
+            self.ack_prefetch_queue.queue.clear()
             self.ack_backup_queue.queue.clear()
             self.host_mem_release_queue.queue.clear()
+            for release_queue in getattr(
+                self, "extra_host_mem_release_queues", {}
+            ).values():
+                release_queue.queue.clear()
             self.prefetch_tokens_occupied = 0
 
         self.storage_stop_event.clear()
@@ -903,12 +933,17 @@ class HiCacheController:
         new_input_tokens: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        extra_pools: Optional[list[PoolTransfer]] = None,
     ) -> PrefetchOperation:
         """
         Prefetch KV caches from storage backend to host memory.
         """
         operation = PrefetchOperation(
-            request_id, new_input_tokens, last_hash, prefix_keys
+            request_id,
+            new_input_tokens,
+            last_hash,
+            prefix_keys=prefix_keys,
+            pool_transfers=extra_pools,
         )
         self.prefetch_queue.put(operation)
         return operation
@@ -917,12 +952,33 @@ class HiCacheController:
         operation.mark_terminate()
         return operation.completed_tokens, operation.hash_value
 
-    def append_host_mem_release(self, host_indices: torch.Tensor):
-        if host_indices.numel() == 0:
-            return
-        pages = host_indices.split(self.mem_pool_host.page_size)
-        for page in pages:
-            self.host_mem_release_queue.put(page)
+    def append_host_mem_release(
+        self,
+        host_indices: Optional[torch.Tensor] = None,
+        extra_pools: Optional[list[PoolTransfer]] = None,
+    ):
+        if host_indices is not None:
+            self._append_host_mem_release_pages(
+                self.host_mem_release_queue,
+                host_indices,
+                self.mem_pool_host.page_size,
+            )
+        for transfer in extra_pools or []:
+            if transfer.host_indices is None or transfer.host_indices.numel() == 0:
+                continue
+            entry = self.mem_pool_host.entry_map.get(transfer.name)
+            if (
+                entry is None
+                or entry.is_primary_index_anchor
+                or transfer.indices_from_pool is not None
+            ):
+                continue
+            release_queue = self.extra_host_mem_release_queues.get(transfer.name)
+            if release_queue is None:
+                continue
+            self._append_host_mem_release_pages(
+                release_queue, transfer.host_indices, entry.host_pool.page_size
+            )
 
     def _page_get_zero_copy(
         self, operation, hash_values, host_indices, extra_info=None
@@ -993,6 +1049,14 @@ class HiCacheController:
             if prefix_keys and len(prefix_keys) > 0:
                 prefix_keys += batch_hashes
 
+        kv_completed_pages = operation.completed_tokens // self.page_size
+        if operation.pool_transfers and kv_completed_pages == len(operation.hash_value):
+            results = self.storage_backend.batch_get_v2(
+                operation.pool_transfers, HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
+            )
+            operation.pool_storage_result.update_extra_pool_hit_pages(results)
+        operation.pool_transfers_done = True
+
     def prefetch_io_aux_func(self):
         """
         Auxiliary function conducting IO operations for prefetching.
@@ -1004,9 +1068,10 @@ class HiCacheController:
                     continue
                 self._page_transfer(operation)
                 # operation terminated by controller, release pre-allocated memory
-                self.append_host_mem_release(
-                    operation.host_indices[operation.completed_tokens :]
-                )
+                if operation.host_indices is not None:
+                    self.append_host_mem_release(
+                        operation.host_indices[operation.completed_tokens :]
+                    )
             except Empty:
                 continue
 
@@ -1019,6 +1084,9 @@ class HiCacheController:
             return True
         # todo: more sophisticated rate limiting based on storage backend performance
         return False
+
+    def enqueue_prefetch_transfer(self, operation: PrefetchOperation):
+        self.prefetch_buffer.put(operation)
 
     def _storage_hit_query(self, operation) -> tuple[list[str], int]:
         last_hash = operation.last_hash
@@ -1034,7 +1102,18 @@ class HiCacheController:
         for start in range(0, len(page_hashes), STORAGE_BATCH_SIZE):
             batch_hashes = page_hashes[start : start + STORAGE_BATCH_SIZE]
             extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
-            hit_page_num = self.storage_backend.batch_exists(batch_hashes, extra_info)
+            if operation.pool_transfers:
+                hit_result = self.storage_backend.batch_exists_v2(
+                    batch_hashes, operation.pool_transfers, extra_info
+                )
+                hit_page_num = hit_result.kv_hit_pages
+            else:
+                hit_page_num = self.storage_backend.batch_exists(
+                    batch_hashes, extra_info
+                )
+            operation.pool_storage_result.update_kv_hit_pages(
+                start + hit_page_num
+            )
             hash_value.extend(batch_hashes[:hit_page_num])
             storage_query_count += hit_page_num * self.page_size
             if hit_page_num < len(batch_hashes):
@@ -1070,19 +1149,25 @@ class HiCacheController:
                 )
                 storage_hit_count = storage_hit_count_tensor.item()
 
-                if storage_hit_count < self.prefetch_threshold:
+                if (
+                    operation.is_terminated()
+                    or storage_hit_count < self.prefetch_threshold
+                ):
                     # not to prefetch if not enough benefits
                     self.prefetch_revoke_queue.put(operation.request_id)
                     logger.debug(
                         f"Revoking prefetch for request {operation.request_id} due to insufficient hits ({storage_hit_count})."
                     )
                 else:
-                    # Record hit count, so the scheduler thread will know the exact memory to allocate
+                    # Record hit count, so the scheduler thread will know the exact memory to allocate.
                     operation.hash_value = hash_value[
                         : (storage_hit_count // self.page_size)
                     ]
                     operation.storage_hit_count = storage_hit_count
-                    self.prefetch_hit_queue.put(operation)
+                    logger.debug(
+                        f"Prefetching {len(operation.hash_value)} pages for request {operation.request_id}."
+                    )
+                    self.ack_prefetch_queue.put(operation)
 
             except Empty:
                 continue

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -1526,7 +1526,7 @@ class HiMambaRadixCache(MambaRadixCache):
             # mutations only happen on the scheduler thread at lockstep points
             # (releases are page-granular and drained by the TP-min count), so
             # every rank reaches the same success / fallback / revoke decision.
-            for operation in _drain_queue(cc.prefetch_hit_queue, n_storage_hit):
+            for operation in _drain_queue(cc.ack_prefetch_queue, n_storage_hit):
                 req_id = operation.request_id
                 info = self.ongoing_prefetch.get(req_id)
                 if info is None:
@@ -1701,7 +1701,7 @@ class HiMambaRadixCache(MambaRadixCache):
         qsizes = torch.tensor(
             [
                 cc.prefetch_revoke_queue.qsize(),
-                cc.prefetch_hit_queue.qsize(),
+                cc.ack_prefetch_queue.qsize(),
                 cc.ack_backup_queue.qsize(),
                 cc.host_mem_release_queue.qsize(),
             ],

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -611,7 +611,7 @@ class HiRadixCache(RadixCache):
             # happen on the scheduler thread at lockstep points (releases are
             # page-granular and drained by the TP-min count), so every rank
             # reaches the same success / fallback / revoke decision.
-            for operation in _drain_queue(cc.prefetch_hit_queue, n_storage_hit):
+            for operation in _drain_queue(cc.ack_prefetch_queue, n_storage_hit):
                 req_id = operation.request_id
                 info = self.ongoing_prefetch.get(req_id)
                 if info is None:
@@ -1462,7 +1462,7 @@ class HiRadixCache(RadixCache):
         qsizes = torch.tensor(
             [
                 cc.prefetch_revoke_queue.qsize(),
-                cc.prefetch_hit_queue.qsize(),
+                cc.ack_prefetch_queue.qsize(),
                 cc.ack_backup_queue.qsize(),
                 cc.host_mem_release_queue.qsize(),
             ],

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -305,6 +305,16 @@ class _OngoingPrefetch(NamedTuple):
     comp_xfers: dict[ComponentType, list[PoolTransfer]]
 
 
+class _PendingPrefetch(NamedTuple):
+    """Tracks a non-blocking storage-hit query before any host buffers exist."""
+
+    anchor_node: UnifiedTreeNode
+    prefetch_key: RadixKey
+    operation: PrefetchOperation
+    anchor_lock_params: DecLockRefParams
+    last_hash: Optional[str]
+
+
 class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
     def __init__(
         self,
@@ -479,6 +489,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self.ongoing_load_back: dict[int, _OngoingLoadBack] = {}
         self.enable_storage = False
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
+        self.pending_prefetch: dict[str, _PendingPrefetch] = {}
         self.ongoing_prefetch: dict[str, _OngoingPrefetch] = {}
         self.ongoing_backup: dict[int, tuple[UnifiedTreeNode, DecLockRefParams]] = {}
 
@@ -859,12 +870,12 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         new_indices = match_result.device_indices
         new_last_node = match_result.last_device_node
         new_prefix_len = result.prefix_len
-        assert (
-            req.cache_protected_len <= len(new_indices) + self.page_size - 1
-        ), f"{req.cache_protected_len=}, {len(new_indices)=}, {page_aligned_len=}"
-        assert new_prefix_len <= len(
-            new_indices
-        ), f"{new_prefix_len=}, {len(new_indices)=}"
+        assert req.cache_protected_len <= len(new_indices) + self.page_size - 1, (
+            f"{req.cache_protected_len=}, {len(new_indices)=}, {page_aligned_len=}"
+        )
+        assert new_prefix_len <= len(new_indices), (
+            f"{new_prefix_len=}, {len(new_indices)=}"
+        )
         self.req_to_token_pool.write(
             (req.req_pool_idx, slice(req.cache_protected_len, len(new_indices))),
             new_indices[req.cache_protected_len :],
@@ -1932,51 +1943,31 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         ):
             return
 
-        anchor_lock_params = self.inc_host_lock_ref(last_host_node).to_dec_params()
-        comp_xfers: dict[ComponentType, list[PoolTransfer]] = {}
-        alloc_failed = False
+        query_xfers: list[PoolTransfer] = []
         for comp in self._components_tuple:
-            if comp.component_type == BASE_COMPONENT_TYPE:
-                continue
-            transfers = comp.build_hicache_transfers(
-                last_host_node,
-                CacheTransferPhase.PREFETCH,
-                token_ids=prefetch_key.token_ids,
-                prefetch_tokens=len(prefetch_key),
-                last_hash=last_hash,
-            )
-            if transfers == []:
-                alloc_failed = True
-                break
-            if transfers:
-                comp_xfers[comp.component_type] = transfers
-        kv_xfer = PoolTransfer(name=PoolName.KV, host_indices=None)
-        sidecar_xfers = self._build_sidecar_transfers(
-            CacheTransferPhase.PREFETCH, kv_xfer, comp_xfers
-        )
-        if alloc_failed:
-            self.cache_controller.append_host_mem_release(
-                extra_pools=[x for xfers in comp_xfers.values() for x in xfers],
-            )
-            self.dec_host_lock_ref(last_host_node, anchor_lock_params)
-            return
+            if comp.component_type == ComponentType.MAMBA:
+                query_xfers.append(
+                    PoolTransfer(
+                        name=PoolName.MAMBA,
+                        keys=["__placeholder__"],
+                        hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                    )
+                )
 
-        aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
-        aux_xfers.extend(sidecar_xfers)
+        anchor_lock_params = self.inc_host_lock_ref(last_host_node).to_dec_params()
         operation = self.cache_controller.prefetch(
             req_id,
             prefetch_key,
             last_hash,
             prefix_keys,
-            extra_pools=aux_xfers or None,
+            extra_pools=query_xfers or None,
         )
-        self.ongoing_prefetch[req_id] = _OngoingPrefetch(
+        self.pending_prefetch[req_id] = _PendingPrefetch(
             last_host_node,
             prefetch_key,
-            None,
             operation,
             anchor_lock_params,
-            comp_xfers,
+            last_hash,
         )
         self.cache_controller.prefetch_tokens_occupied += len(prefetch_key)
 
@@ -2024,6 +2015,11 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         return can_terminate or operation_terminated
 
     def check_prefetch_progress(self, req_id: str) -> bool:
+        pending = self.pending_prefetch.get(req_id)
+        if pending is not None:
+            pending.operation.mark_terminate()
+            return True
+
         if req_id not in self.ongoing_prefetch:
             return True
 
@@ -2185,6 +2181,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         return min_completed_tokens
 
     def terminate_prefetch(self, req_id: str) -> None:
+        if req_id in self.pending_prefetch:
+            self.pending_prefetch[req_id].operation.mark_terminate()
+            return
         if req_id not in self.ongoing_prefetch:
             return
         operation = self.ongoing_prefetch[req_id].operation
@@ -2195,6 +2194,11 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
     def release_aborted_request(self, rid: str) -> None:
         self.prefetch_loaded_tokens_by_reqid.pop(rid, None)
+        pending = self.pending_prefetch.get(rid)
+        if pending is not None:
+            pending.operation.mark_terminate()
+            return
+
         if rid not in self.ongoing_prefetch:
             return
 
@@ -2245,7 +2249,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
     def _drain_storage_control_queues_impl(
         self,
         n_revoke: Optional[int],
-        n_storage_hit: Optional[int],
+        n_prefetch_ready: Optional[int],
         n_backup: Optional[int],
         n_release: Optional[int],
         extra_release_counts: Optional[dict[PoolName, int]],
@@ -2264,46 +2268,123 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 yield item
 
         def _drain_revoke():
+            drained = 0
             for req_id in _drain_queue(cc.prefetch_revoke_queue, n_revoke):
-                self._revoke_pending_prefetch(req_id)
+                pending = self.pending_prefetch.pop(req_id, None)
+                if pending is not None:
+                    drained += 1
+                    self.dec_host_lock_ref(
+                        pending.anchor_node, pending.anchor_lock_params
+                    )
+                    cc.prefetch_tokens_occupied -= len(pending.prefetch_key)
+                else:
+                    info = self.ongoing_prefetch.pop(req_id, None)
+                    if info is None:
+                        continue
+                    drained += 1
+                    (
+                        last_host_node,
+                        prefetch_key,
+                        _host_indices,
+                        _operation,
+                        anchor_lock_params,
+                        comp_xfers,
+                    ) = info
+                    cc.append_host_mem_release(
+                        extra_pools=[x for xfers in comp_xfers.values() for x in xfers]
+                    )
+                    self.dec_host_lock_ref(last_host_node, anchor_lock_params)
+                    cc.prefetch_tokens_occupied -= len(prefetch_key)
+                if cc.prefetch_tokens_occupied < 0:
+                    cc.prefetch_tokens_occupied = 0
+            return drained
 
-        def _drain_and_alloc_storage_hit():
-            for operation in _drain_queue(cc.prefetch_hit_queue, n_storage_hit):
-                req_id = operation.request_id
-                info = self.ongoing_prefetch.get(req_id)
+        def _drain_prefetch_ready():
+            drained = 0
+            for operation in _drain_queue(cc.ack_prefetch_queue, n_prefetch_ready):
+                info = self.pending_prefetch.pop(operation.request_id, None)
                 if info is None:
                     # request already aborted/cleaned up, skip
                     continue
+                drained += 1
                 if operation.is_terminated():
-                    # request was aborted while the storage query was in flight
-                    self._revoke_pending_prefetch(req_id)
+                    self.dec_host_lock_ref(info.anchor_node, info.anchor_lock_params)
+                    cc.prefetch_tokens_occupied -= len(info.prefetch_key)
+                    if cc.prefetch_tokens_occupied < 0:
+                        cc.prefetch_tokens_occupied = 0
                     continue
 
-                alloc_len = operation.storage_hit_count
-                host_indices = cc.mem_pool_host.alloc(alloc_len)
+                hit_tokens = len(operation.hash_value) * self.page_size
+                if hit_tokens <= 0:
+                    self.dec_host_lock_ref(info.anchor_node, info.anchor_lock_params)
+                    cc.prefetch_tokens_occupied -= len(info.prefetch_key)
+                    if cc.prefetch_tokens_occupied < 0:
+                        cc.prefetch_tokens_occupied = 0
+                    continue
+
+                host_indices = cc.mem_pool_host.alloc(hit_tokens)
                 if host_indices is None:
-                    self.evict_host(alloc_len)
-                    host_indices = cc.mem_pool_host.alloc(alloc_len)
+                    self.evict_host(hit_tokens)
+                    host_indices = cc.mem_pool_host.alloc(hit_tokens)
                 if host_indices is None:
-                    # Memory-pressure fallback: a shorter page-aligned prefix.
-                    available_size = cc.mem_pool_host.available_size()
-                    alloc_len = min(
-                        operation.storage_hit_count,
-                        available_size - (available_size % self.page_size),
+                    self.dec_host_lock_ref(info.anchor_node, info.anchor_lock_params)
+                    cc.prefetch_tokens_occupied -= len(info.prefetch_key)
+                    if cc.prefetch_tokens_occupied < 0:
+                        cc.prefetch_tokens_occupied = 0
+                    continue
+
+                hit_key = info.prefetch_key[:hit_tokens]
+                comp_xfers: dict[ComponentType, list[PoolTransfer]] = {}
+                alloc_failed = False
+                for comp in self._components_tuple:
+                    if comp.component_type == BASE_COMPONENT_TYPE:
+                        continue
+                    transfers = comp.build_hicache_transfers(
+                        info.anchor_node,
+                        CacheTransferPhase.PREFETCH,
+                        token_ids=hit_key.token_ids,
+                        prefetch_tokens=len(hit_key),
+                        last_hash=info.last_hash,
                     )
-                    if alloc_len >= self.prefetch_threshold:
-                        host_indices = cc.mem_pool_host.alloc(alloc_len)
-                if host_indices is None:
-                    self._revoke_pending_prefetch(req_id)
+                    if transfers == []:
+                        alloc_failed = True
+                        break
+                    if transfers:
+                        comp_xfers[comp.component_type] = transfers
+
+                kv_xfer = PoolTransfer(name=PoolName.KV, host_indices=host_indices)
+                sidecar_xfers = self._build_sidecar_transfers(
+                    CacheTransferPhase.PREFETCH, kv_xfer, comp_xfers
+                )
+                aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
+                aux_xfers.extend(sidecar_xfers)
+                if alloc_failed:
+                    cc.append_host_mem_release(
+                        host_indices=host_indices,
+                        extra_pools=aux_xfers or None,
+                    )
+                    self.dec_host_lock_ref(info.anchor_node, info.anchor_lock_params)
+                    cc.prefetch_tokens_occupied -= len(info.prefetch_key)
+                    if cc.prefetch_tokens_occupied < 0:
+                        cc.prefetch_tokens_occupied = 0
                     continue
 
-                operation.storage_hit_count = alloc_len
-                operation.hash_value = operation.hash_value[
-                    : alloc_len // self.page_size
-                ]
                 operation.host_indices = host_indices
-                self.ongoing_prefetch[req_id] = info._replace(host_indices=host_indices)
-                cc.prefetch_buffer.put(operation)
+                operation.pool_transfers = aux_xfers or None
+                operation.pool_transfers_done = not bool(aux_xfers)
+                self.ongoing_prefetch[operation.request_id] = _OngoingPrefetch(
+                    info.anchor_node,
+                    hit_key,
+                    host_indices,
+                    operation,
+                    info.anchor_lock_params,
+                    comp_xfers,
+                )
+                cc.prefetch_tokens_occupied -= len(info.prefetch_key) - len(hit_key)
+                if cc.prefetch_tokens_occupied < 0:
+                    cc.prefetch_tokens_occupied = 0
+                cc.enqueue_prefetch_transfer(operation)
+            return drained
 
         def _drain_backup():
             drained = 0
@@ -2354,7 +2435,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             return drained
 
         _drain_revoke()
-        _drain_and_alloc_storage_hit()
+        _drain_prefetch_ready()
         _drain_backup()
         _drain_release()
         _drain_extra_release()
@@ -2365,7 +2446,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         extra_pool_names = list(extra_release_queues)
         local_qsize_list = [
             cc.prefetch_revoke_queue.qsize(),
-            cc.prefetch_hit_queue.qsize(),
+            cc.ack_prefetch_queue.qsize(),
             cc.ack_backup_queue.qsize(),
             cc.host_mem_release_queue.qsize(),
             *[
@@ -2379,14 +2460,14 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         )
         self._all_reduce_attn_groups(qsizes, torch.distributed.ReduceOp.MIN)
         qsize_list = list(map(int, qsizes.tolist()))
-        n_revoke, n_storage_hit, n_backup, n_release = qsize_list[:4]
+        n_revoke, n_prefetch_ready, n_backup, n_release = qsize_list[:4]
         extra_release_counts = {
             pool_name: count
             for pool_name, count in zip(extra_pool_names, qsize_list[4:])
         }
         self._drain_storage_control_queues_impl(
             n_revoke=n_revoke,
-            n_storage_hit=n_storage_hit,
+            n_prefetch_ready=n_prefetch_ready,
             n_backup=n_backup,
             n_release=n_release,
             extra_release_counts=extra_release_counts,

--- a/test/registered/unit/mem_cache/test_unified_radix_hicache_dispatch.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_hicache_dispatch.py
@@ -1,7 +1,14 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from sglang.srt.mem_cache.hicache_storage import PoolName, SidecarPoolSpec
+from sglang.srt.managers.cache_controller import HiCacheController, PrefetchOperation
+from sglang.srt.mem_cache.hicache_storage import (
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+    PoolTransferResult,
+    SidecarPoolSpec,
+)
 from sglang.srt.mem_cache.hybrid_cache import hybrid_pool_assembler
 from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
     _STRATEGIES,
@@ -30,6 +37,36 @@ def _mock_kvcache(cls):
 FULL = ComponentType.FULL
 SWA = ComponentType.SWA
 MAMBA = ComponentType.MAMBA
+
+
+class TestStorageHitQuery(unittest.TestCase):
+    def test_exists_result_does_not_mark_extra_pool_as_loaded(self):
+        controller = HiCacheController.__new__(HiCacheController)
+        controller.page_size = 2
+        controller.get_hash_str = MagicMock(return_value=["hash-0", "hash-1"])
+        controller.storage_backend = MagicMock()
+        controller.storage_backend.batch_exists_v2.return_value = PoolTransferResult(
+            kv_hit_pages=2,
+            extra_pool_hit_pages={PoolName.MAMBA: 1},
+        )
+        operation = PrefetchOperation(
+            "request-id",
+            [1, 2, 3, 4],
+            pool_transfers=[
+                PoolTransfer(
+                    name=PoolName.MAMBA,
+                    keys=["mamba-state"],
+                    hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                )
+            ],
+        )
+
+        hashes, hit_tokens = controller._storage_hit_query(operation)
+
+        self.assertEqual(hashes, ["hash-0", "hash-1"])
+        self.assertEqual(hit_tokens, 4)
+        self.assertEqual(operation.pool_storage_result.kv_hit_pages, 2)
+        self.assertEqual(operation.pool_storage_result.extra_pool_hit_pages, {})
 
 
 class TestUnifiedRadixHiCacheDispatch(unittest.TestCase):


### PR DESCRIPTION
## Motivation

HiCache storage prefetch currently registers a request as an ongoing prefetch before the storage hit query finishes. In L3-miss-dominated workloads, this can make the scheduler wait on storage prefetch progress even when there is no data to load from storage.

This is especially visible on Qwen3.5 workloads with Mamba sidecar pools, because the old path may allocate host KV/Mamba buffers before knowing whether storage has matching pages. When the storage query misses, those buffers are immediately released, adding unnecessary resource churn and TTFT tail latency.

## Modifications

- Add `ack_prefetch_queue` to separate storage hit query completion from actual prefetch transfer enqueueing.
- Track storage-hit queries in `pending_prefetch` instead of `ongoing_prefetch`.
- Do not allocate host KV or Mamba buffers during the storage query phase.
- Promote a pending query to `ongoing_prefetch` only after storage reports enough hit pages.
- Let the scheduler continue immediately for pending storage queries. If the request no longer needs prefetch, mark the query terminated and revoke it.
- Keep the actual storage prefetch transfer path unchanged for real storage hits.

## Accuracy Tests

N/A. This PR only changes HiCache storage prefetch scheduling and resource allocation behavior. It does not modify model forward computation or output semantics.

## Speed Tests and Profiling

Tested on a Qwen3.5 workload where L1/L2 cache covers most hits and L3 storage queries are miss-dominated.

Workload summary:

- Model: `Qwen/Qwen3.5-397B-A17B-FP8`
- Requests: `672`
- Request rate: `4.0 req/s`
- Average prompt length: `1624`
- Average output length: `7.98`

Performance comparison:

| Variant | Storage Backend | Cache Hit Rate | Avg TTFT | P90 TTFT | P99 TTFT | Avg Latency | Pending Tokens |
|---|---|---:|---:|---:|---:|---:|---:|
| L1/L2 baseline | No L3 storage | 0.720619 | 0.35s | 0.50s | 1.14s | 0.57s | 0 |
| L1/L2 + L3 before fix | Mooncake storage | 0.720619 | 0.44s | 0.67s | 1.41s | 0.89s | 164048 |
| L1/L2 + L3 after fix | Mooncake storage | 0.720619 | 0.36s | 0.52s | 1.16s | 0.63s | 0 |

Detailed scheduler pending-token stats after this fix:

```text
pending_count: 573
pending_nonzero: 0
pending_sum: 0
pending_max: 0
prefetch_success_lines: 0
```

This confirms that miss-dominated L3 storage queries no longer block the scheduler as pending prefetches, while TTFT returns close to the L1/L2-only baseline.

Local checks:

```bash
python3 -m py_compile \
  python/sglang/srt/managers/cache_controller.py \
  python/sglang/srt/mem_cache/unified_radix_cache.py

/snap/bin/ruff format --check \
  python/sglang/srt/managers/cache_controller.py \
  python/sglang/srt/mem_cache/unified_radix_cache.py

/snap/bin/ruff check --ignore E402,F541 \
  python/sglang/srt/managers/cache_controller.py \
  python/sglang/srt/mem_cache/unified_radix_cache.py
```

## Checklist

- [x] Format touched files with `ruff format`.
- [x] Run syntax check with `py_compile`.
- [x] Provide speed benchmark/profiling results.
- [ ] Add unit tests if maintainers request a narrower synthetic HiCache test.
- [ ] Update documentation if maintainers think this behavior should be documented.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30072027419](https://github.com/sgl-project/sglang/actions/runs/30072027419)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30072027285](https://github.com/sgl-project/sglang/actions/runs/30072027285)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->