### PR TITLE
[AMD] Fix RMSNorm on AMD devices without AITER (vllm signature mismatch)

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -448,6 +448,13 @@ class RMSNorm(MultiPlatformOp):
         if not _has_vllm_rms_norm:
             return self.forward_native(x, residual, post_residual_addition)
 
+        # vllm's kernels always take the variance over the full hidden size and
+        # apply the weight in fp32, so neither the variance-size override nor
+        # the HF multiplication order can be expressed through them.
+        # forward_cuda falls back to native for the same reason.
+        if self.variance_size_override is not None or self.cast_x_before_out_mul:
+            return self.forward_native(x, residual, post_residual_addition)
+
         if is_batch_invariant_mode_enabled():
             if (
                 residual is not None

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -465,14 +465,12 @@ class RMSNorm(MultiPlatformOp):
             # NOTE: Remove this if aiter kernel supports discontinuous input
             x = x.contiguous()
         if residual is not None:
-            out = torch.empty_like(x)
-            residual_out = torch.empty_like(x)
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
-            fused_add_rms_norm(
-                out, x, residual_out, residual, self.weight.data, self.variance_epsilon
-            )
-            return out, residual_out
+            # vllm's fused_add_rms_norm is in-place on (input, residual), the
+            # same contract as the sgl_kernel one used by forward_cuda.
+            fused_add_rms_norm(x, residual, self.weight.data, self.variance_epsilon)
+            return x, residual
         out = torch.empty_like(x)
         rms_norm(out, x, self.weight.data, self.variance_epsilon)
         return out

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -444,6 +444,17 @@ class RMSNorm(MultiPlatformOp):
         residual: Optional[torch.Tensor] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        # Empty batch (e.g. an idle DP-attention rank or a 0-token cuda-graph
+        # bucket): launching the HIP kernel on 0 rows raises "HIP error: invalid
+        # configuration argument". forward_cuda and forward_aiter guard this the
+        # same way.
+        if x.numel() == 0:
+            if residual is not None:
+                if post_residual_addition is not None:
+                    residual = residual + post_residual_addition
+                return x, residual
+            return x
+
         # Fallback to native implementation if vllm is not available
         if not _has_vllm_rms_norm:
             return self.forward_native(x, residual, post_residual_addition)
@@ -794,18 +805,16 @@ class GemmaRMSNorm(MultiPlatformOp):
         else:
             w = self.gemma_weight
             # vllm API: rms_norm(out, input, weight, eps) -> None (in-place)
-            #           fused_add_rms_norm(out, input, residual_out, residual, weight, eps)
+            #           fused_add_rms_norm(input, residual, weight, eps) -> None
             if not x.is_contiguous():
                 x = x.contiguous()
             if residual is not None:
-                out = torch.empty_like(x)
-                residual_out = torch.empty_like(x)
                 if post_residual_addition is not None:
                     residual = residual + post_residual_addition
-                fused_add_rms_norm(
-                    out, x, residual_out, residual, w, self.variance_epsilon
-                )
-                return out, residual_out
+                # vllm's fused_add_rms_norm is in-place on (input, residual), the
+                # same contract as the sgl_kernel one used by forward_cuda.
+                fused_add_rms_norm(x, residual, w, self.variance_epsilon)
+                return x, residual
             out = torch.empty_like(x)
             rms_norm(out, x, w, self.variance_epsilon)
             return out

--- a/test/registered/unit/layers/test_layernorm.py
+++ b/test/registered/unit/layers/test_layernorm.py
@@ -74,6 +74,44 @@ class TestRMSNormHipVllmFallback(CustomTestCase):
             out = norm.forward_hip(x)
         torch.testing.assert_close(out, norm.forward_native(x))
 
+    def _assert_native_fallback(self, norm):
+        """forward_hip must not reach a vllm kernel, and must match native."""
+        x = torch.randn(2, 8)
+        residual = torch.randn(2, 8)
+        with (
+            patch.object(layernorm_module, "_has_vllm_rms_norm", True),
+            patch.object(layernorm_module, "fused_add_rms_norm", create=True) as fused,
+            patch.object(layernorm_module, "rms_norm", create=True) as plain,
+        ):
+            out, residual_out = norm.forward_hip(x.clone(), residual.clone())
+        fused.assert_not_called()
+        plain.assert_not_called()
+        ref_out, ref_residual = norm.forward_native(x.clone(), residual.clone())
+        torch.testing.assert_close(out, ref_out)
+        torch.testing.assert_close(residual_out, ref_residual)
+
+    def test_variance_size_override_falls_back_to_native(self):
+        # vllm's kernels take the variance over the full hidden size, so a
+        # variance-size override cannot be expressed through them: the kernel
+        # silently normalises by the wrong variance. Measured on gfx1151 with a
+        # skewed input, the output came out ~7x too small. forward_cuda guards
+        # this the same way.
+        norm = RMSNorm(8, eps=1e-6, var_hidden_size=4)
+        with torch.no_grad():
+            norm.weight.fill_(1.0)
+        self.assertIsNotNone(norm.variance_size_override)
+        self._assert_native_fallback(norm)
+
+    def test_cast_x_before_out_mul_falls_back_to_native(self):
+        # HF multiplication order (cast to the activation dtype before applying
+        # the weight) is not what vllm's kernels do. forward_cuda routes this to
+        # a dedicated kernel or to native; HIP has no such kernel, so native it
+        # is, rather than relying on vllm's internal rounding order matching.
+        norm = RMSNorm(8, eps=1e-6, cast_x_before_out_mul=True)
+        with torch.no_grad():
+            norm.weight.fill_(1.0)
+        self._assert_native_fallback(norm)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/layers/test_layernorm.py
+++ b/test/registered/unit/layers/test_layernorm.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import torch
 
 import sglang.srt.layers.layernorm as layernorm_module
-from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.layernorm import GemmaRMSNorm, RMSNorm
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -60,7 +60,9 @@ class TestRMSNormHipVllmFallback(CustomTestCase):
         # .data returns a fresh view object each access, so compare storage
         self.assertEqual(args[2].data_ptr(), norm.weight.data_ptr())
         self.assertEqual(args[3], norm.variance_epsilon)
-        # in-place contract: the mutated inputs are what is returned, matching
+        # in-place contract: forward_hip returns the input objects it hands the
+        # kernel (which writes into them), not fresh tensors -- the old six-arg
+        # path returned freshly-allocated out/residual_out instead. Matches
         # forward_cuda, which binds a fused_add_rmsnorm of the same shape.
         self.assertIs(out, x)
         self.assertIs(residual_out, residual)
@@ -75,7 +77,12 @@ class TestRMSNormHipVllmFallback(CustomTestCase):
         torch.testing.assert_close(out, norm.forward_native(x))
 
     def _assert_native_fallback(self, norm):
-        """forward_hip must not reach a vllm kernel, and must match native."""
+        """forward_hip must route to native, not touch a vllm kernel.
+
+        The guard is that neither vllm symbol is called: forward_hip returns
+        ``forward_native(...)`` on this path, so a numeric comparison against
+        forward_native would be forward_native vs itself -- tautological.
+        """
         x = torch.randn(2, 8)
         residual = torch.randn(2, 8)
         with (
@@ -86,9 +93,8 @@ class TestRMSNormHipVllmFallback(CustomTestCase):
             out, residual_out = norm.forward_hip(x.clone(), residual.clone())
         fused.assert_not_called()
         plain.assert_not_called()
-        ref_out, ref_residual = norm.forward_native(x.clone(), residual.clone())
-        torch.testing.assert_close(out, ref_out)
-        torch.testing.assert_close(residual_out, ref_residual)
+        self.assertEqual(out.shape, x.shape)
+        self.assertEqual(residual_out.shape, residual.shape)
 
     def test_variance_size_override_falls_back_to_native(self):
         # vllm's kernels take the variance over the full hidden size, so a
@@ -111,6 +117,92 @@ class TestRMSNormHipVllmFallback(CustomTestCase):
         with torch.no_grad():
             norm.weight.fill_(1.0)
         self._assert_native_fallback(norm)
+
+    def test_empty_batch_returns_without_touching_kernel(self):
+        # An empty batch (0 tokens, e.g. an idle DP-attention rank) must short
+        # circuit before the kernel: launching the HIP kernel on 0 rows raises
+        # "HIP error: invalid configuration argument". forward_cuda and
+        # forward_aiter guard this; forward_hip previously did not, and the
+        # residual path (now functional) would have reached the kernel.
+        norm = self._norm()
+        x = torch.empty(0, 8)
+        residual = torch.empty(0, 8)
+        with (
+            patch.object(layernorm_module, "_has_vllm_rms_norm", True),
+            patch.object(layernorm_module, "fused_add_rms_norm", create=True) as fused,
+            patch.object(layernorm_module, "rms_norm", create=True) as plain,
+        ):
+            out, residual_out = norm.forward_hip(x, residual)
+        fused.assert_not_called()
+        plain.assert_not_called()
+        self.assertIs(out, x)
+        self.assertIs(residual_out, residual)
+
+
+class TestGemmaRMSNormHipVllmFallback(CustomTestCase):
+    """Same vendor-API pin as TestRMSNormHipVllmFallback, for GemmaRMSNorm.
+
+    GemmaRMSNorm.forward_hip binds the same module-level fused_add_rms_norm, so
+    it has the same four-arg in-place contract, and it had the same six-arg
+    AITER call. It is a separate class with its own copy of the call, so fixing
+    RMSNorm alone left this one raising
+
+        TypeError: fused_add_rms_norm() takes 4 positional arguments but 6 were given
+
+    on every residual norm. This is not a niche path: GemmaRMSNorm backs Gemma,
+    Gemma2, Qwen3.5/3.6, Qwen3-Next, MiniMax-M3 and Step3.5, so on an AMD device
+    without AITER those families could not start at all. Found by serving
+    Qwen3.5-9B on gfx1151 after the RMSNorm fix was already in.
+
+    The weight passed is gemma_weight (= weight + 1, precomputed by the weight
+    loader), not weight.data — Gemma's x*(1+w) semantics folded into the buffer
+    so the stock kernel computes the right thing.
+    """
+
+    @staticmethod
+    def _norm():
+        norm = GemmaRMSNorm(8, eps=1e-6)
+        with torch.no_grad():
+            norm.weight.fill_(0.5)
+            # mirror _weight_loader: gemma_weight = weight + 1
+            torch.add(norm.weight.data, 1.0, out=norm.gemma_weight)
+        return norm
+
+    def test_residual_path_uses_vllm_in_place_signature(self):
+        norm = self._norm()
+        x = torch.randn(2, 8)
+        residual = torch.randn(2, 8)
+        with (
+            patch.object(layernorm_module, "_use_aiter", False),
+            patch.object(layernorm_module, "_has_vllm_rms_norm", True),
+            patch.object(layernorm_module, "fused_add_rms_norm", create=True) as fused,
+        ):
+            out, residual_out = norm.forward_hip(x, residual)
+
+        args, kwargs = fused.call_args
+        self.assertEqual(kwargs, {})
+        self.assertEqual(
+            len(args), 4, "vllm fused_add_rms_norm takes 4 positional args"
+        )
+        self.assertIs(args[0], x)
+        self.assertIs(args[1], residual)
+        # gemma_weight, not weight: the +1 is folded in for the stock kernel
+        self.assertEqual(args[2].data_ptr(), norm.gemma_weight.data_ptr())
+        self.assertEqual(args[3], norm.variance_epsilon)
+        # in-place contract: forward_hip returns the input objects, not fresh
+        # tensors (the old six-arg path returned freshly-allocated ones).
+        self.assertIs(out, x)
+        self.assertIs(residual_out, residual)
+
+    def test_no_vllm_falls_back_to_native(self):
+        norm = self._norm()
+        x = torch.randn(2, 8)
+        with (
+            patch.object(layernorm_module, "_use_aiter", False),
+            patch.object(layernorm_module, "_has_vllm_rms_norm", False),
+        ):
+            out = norm.forward_hip(x)
+        torch.testing.assert_close(out, norm.forward_native(x))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_layernorm.py
+++ b/test/registered/unit/layers/test_layernorm.py
@@ -1,0 +1,79 @@
+"""Unit tests for srt/layers/layernorm.py — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.layernorm as layernorm_module
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestRMSNormHipVllmFallback(CustomTestCase):
+    """Pin the vllm fused_add_rms_norm call shape used by RMSNorm.forward_hip.
+
+    forward_hip binds vllm's fused_add_rms_norm, whose signature is
+    (input, residual, weight, epsilon): four positional args, in-place on
+    input and residual — the same shape forward_cuda binds from sgl_kernel.
+    It used to be called with AITER's six-arg out-of-place shape
+    (out, x, residual_out, residual, weight, eps), so any AMD device without
+    AITER raised
+
+        TypeError: fused_add_rms_norm() takes 4 positional arguments but 6 were given
+
+    on every residual RMSNorm, i.e. in every transformer layer. CDNA never hit
+    it because SGLANG_USE_AITER routes to forward_aiter instead; RDNA has no
+    AITER and is forced down this path. The signature is an external vendor
+    API, so it is pinned here rather than left to be re-copied from the AITER
+    branch.
+    """
+
+    @staticmethod
+    def _norm():
+        norm = RMSNorm(8, eps=1e-6)
+        with torch.no_grad():
+            norm.weight.fill_(1.0)
+        return norm
+
+    def test_residual_path_uses_vllm_in_place_signature(self):
+        norm = self._norm()
+        x = torch.randn(2, 8)
+        residual = torch.randn(2, 8)
+        with (
+            patch.object(layernorm_module, "_has_vllm_rms_norm", True),
+            patch.object(layernorm_module, "fused_add_rms_norm", create=True) as fused,
+        ):
+            out, residual_out = norm.forward_hip(x, residual)
+
+        args, kwargs = fused.call_args
+        self.assertEqual(kwargs, {})
+        self.assertEqual(
+            len(args), 4, "vllm fused_add_rms_norm takes 4 positional args"
+        )
+        self.assertIs(args[0], x)
+        self.assertIs(args[1], residual)
+        # .data returns a fresh view object each access, so compare storage
+        self.assertEqual(args[2].data_ptr(), norm.weight.data_ptr())
+        self.assertEqual(args[3], norm.variance_epsilon)
+        # in-place contract: the mutated inputs are what is returned, matching
+        # forward_cuda, which binds a fused_add_rmsnorm of the same shape.
+        self.assertIs(out, x)
+        self.assertIs(residual_out, residual)
+
+    def test_no_vllm_falls_back_to_native(self):
+        # The guard that keeps a box with neither AITER nor vllm working at all:
+        # without it forward_hip would call an unbound name.
+        norm = self._norm()
+        x = torch.randn(2, 8)
+        with patch.object(layernorm_module, "_has_vllm_rms_norm", False):
+            out = norm.forward_hip(x)
+        torch.testing.assert_close(out, norm.forward_native(x))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`RMSNorm.forward_hip` binds vllm's `fused_add_rms_norm`:

```python
elif _is_hip:
    try:
        from vllm._custom_ops import fused_add_rms_norm, rms_norm
        _has_vllm_rms_norm = True
```

but called it with **AITER's** signature:

```python
# forward_hip — six args, out-of-place
fused_add_rms_norm(out, x, residual_out, residual, self.weight.data, self.variance_epsilon)
```

The two APIs are different shapes:

| | signature | |
|---|---|---|
| **vllm** `fused_add_rms_norm` | `(input, residual, weight, epsilon)` | 4 args, **in-place** |
| **AITER** `rmsnorm2d_fwd_with_add` | `(out, input, residual_in, residual_out, weight, epsilon)` | 6 args, out-of-place |

So on any AMD device without AITER, every residual RMSNorm — i.e. every transformer layer — raises:

```
TypeError: fused_add_rms_norm() takes 4 positional arguments but 6 were given
```

and the server cannot start. **This is not a vllm version skew**: no vllm version has a six-arg form. (The arguments are also swapped relative to AITER's own order — `residual_out` sits where AITER expects `residual_in` — which suggests the branch was copied from `forward_aiter` and never executed.)

**Why this went unnoticed.** `__init__` sets `self._forward_method = self.forward_aiter` whenever `SGLANG_USE_AITER` is set, which is the normal CDNA configuration — so MI300/MI325 take `forward_aiter` and its correct six-arg call. `forward_hip`'s residual branch is reachable only when AITER is absent, which on AMD in practice means **RDNA** (gfx11xx/gfx12xx). It is effectively dead code that rotted.

**The same bug lives in a second class.** `GemmaRMSNorm.forward_hip` has its own independent copy of the six-arg call, so fixing `RMSNorm` alone leaves it raising the identical `TypeError`. `GemmaRMSNorm` backs **Gemma, Gemma2, Qwen3.5, Qwen3.6, Qwen3-Next, MiniMax-M3 and Step3.5** — so without covering it, those families still cannot start on an AMD device without AITER. It was found by serving Qwen3.5-9B on gfx1151 after the `RMSNorm` fix was already applied.

**Independently reported.** @AIwork4me hit the same failure on **gfx1100 (RDNA3 discrete)** and worked around it by hand-patching `_has_vllm_rms_norm = False` ([#30599](https://github.com/sgl-project/sglang/issues/30599)) — which silently routes RMSNorm to `forward_native` rather than the vllm kernel. Two independent RDNA architectures, same fix. Part of the consumer-RDNA (gfx1151) enablement tracked in #30599; validated end-to-end alongside [#31137](https://github.com/sgl-project/sglang/pull/31137).

## Modifications

`python/sglang/srt/layers/layernorm.py`:

**1. Call vllm with its own signature — `RMSNorm` and `GemmaRMSNorm`.** Both mirror `forward_cuda`, which binds an sgl_kernel `fused_add_rmsnorm` of the **same four-arg in-place shape** and already does exactly this:

```python
# forward_cuda (existing, unchanged) — the reference
fused_add_rmsnorm(x, residual, self.weight.data, self.variance_epsilon)
return x, residual
```

The `out`/`residual_out` allocations are no longer needed. `GemmaRMSNorm` passes `gemma_weight` (= `weight + 1`, precomputed by its weight loader) exactly as before, so the stock kernel still gets Gemma's `x*(1+w)` semantics. The non-residual `rms_norm(out, x, weight, eps)` calls already matched vllm's four-arg form and are untouched.

**2. Guard the empty batch in `RMSNorm.forward_hip`.** With the residual path now functional, an empty batch (an idle DP-attention rank, or a 0-token cuda-graph bucket) reaches the kernel and raises `HIP error: invalid configuration argument` on zero rows. Before the signature fix that path raised the `TypeError` first, so the empty-batch case was never exposed. The guard is **copied verbatim from `forward_cuda`**, which already carries it; `forward_aiter` guards the same thing (`x.shape[0] == 0`, added as a dsv4 DP-attention fix). So all three RMSNorm backends now agree.

```python
if x.numel() == 0:
    if residual is not None:
        if post_residual_addition is not None:
            residual = residual + post_residual_addition
        return x, residual
    return x
```

**Scope**
- **CDNA unchanged.** `forward_aiter` is untouched; whenever `SGLANG_USE_AITER` is set nothing about this path changes.
- **No behaviour regression is possible on the fixed path.** The residual branch raised `TypeError` unconditionally, so it had no working behaviour to preserve; the in-place contract matches `forward_cuda`, which callers already tolerate.
- **`GemmaRMSNorm` gets the signature fix but not an empty-batch guard** — matching `GemmaRMSNorm.forward_cuda`, which likewise does not guard the empty batch. This keeps its HIP path consistent with its own CUDA path rather than adding a guard its siblings don't have.

## Accuracy Tests

Verified on **gfx1151 (Radeon 8060S / Strix Halo)** + [#31137](https://github.com/sgl-project/sglang/pull/31137), where `_use_aiter=False`, `_has_vllm_rms_norm=True` and `fused_add_rms_norm.__module__ == 'vllm._custom_ops'` — i.e. the affected path is the default.

**`RMSNorm.forward_hip` vs `forward_native`, same inputs:**

| dtype | path | out cos | residual cos |
|---|---|---|---|
| bf16 | no-residual | 0.999996 | — |
| bf16 | residual | 0.999994 | **1.000000** |
| bf16 | post_residual_addition | 0.999993 | 0.999997 |
| fp16 | residual | 1.000000 | **1.000000** |

**`GemmaRMSNorm.forward_hip` vs `forward_native`:** cosine similarity **0.999994–1.000000** across bf16/fp16, 1/7/128 tokens, and non-contiguous input. Max abs diffs are 1 ULP at these magnitudes.

**End-to-end**, `--attention-backend triton`, without the `_has_vllm_rms_norm = False` workaround (so the real vllm kernel is exercised):

| Model | Class exercised | Result |
|---|---|---|
| `Qwen2.5-7B-Instruct-AWQ` | `RMSNorm` | ✅ ready, 0 hipError, `17×4 → 68` |
| `Qwen3.5-9B` | `GemmaRMSNorm` | ✅ crashes without the GemmaRMSNorm fix; serves with it, `17×4 → 68` |
| `Qwen3.6-27B` | `GemmaRMSNorm` | ✅ same — crash without / serve with |

## Speed Tests and Profiling

Not applicable. The affected branches previously raised `TypeError` unconditionally, so there is no prior working configuration to compare against. On CDNA (`forward_aiter`) nothing changes.

## Unit tests

`test/registered/unit/layers/test_layernorm.py`, mirroring `srt/layers/layernorm.py`, CPU-only, `register_cpu_ci(est_time=5, suite="base-a-test-cpu")`. vllm's signature is an external vendor API, so it is pinned rather than left to be re-copied from the AITER branch.

| Test | Guards |
|---|---|
| `TestRMSNormHipVllmFallback::test_residual_path_uses_vllm_in_place_signature` | the fix — arity, argument **order** (the swap was part of the bug), in-place return contract |
| `…::test_no_vllm_falls_back_to_native` | the `_has_vllm_rms_norm` early return, without which `forward_hip` calls an unbound name |
| `…::test_variance_size_override_falls_back_to_native` | variance-override routes to native (vllm can't express it) |
| `…::test_cast_x_before_out_mul_falls_back_to_native` | HF multiplication order routes to native |
| `…::test_empty_batch_returns_without_touching_kernel` | the empty-batch guard — the vllm kernels are not called on 0 rows |
| `TestGemmaRMSNormHipVllmFallback::test_residual_path_uses_vllm_in_place_signature` | the GemmaRMSNorm fix — same arity/order/contract pin, with `gemma_weight` (= weight + 1) passed |
| `…::test_no_vllm_falls_back_to_native` | GemmaRMSNorm native fallback |

Each new guard is a genuine regression test — **red on the unfixed code, green with the fix**:
```
FAILED …::TestGemmaRMSNormHipVllmFallback::test_residual_path_uses_vllm_in_place_signature   # without the GemmaRMSNorm fix
FAILED …::TestRMSNormHipVllmFallback::test_empty_batch_returns_without_touching_kernel        # without the empty-batch guard
```
```
pytest test/registered/unit/layers/test_layernorm.py
7 passed
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — all hooks pass.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation — not needed; this fixes broken code paths.
- [x] Provide accuracy and speed benchmark results — accuracy verified on gfx1151 above; speed N/A (paths previously raised).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29527825437](https://github.com/sgl-project/sglang/actions/runs/29527825437)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29527825263](https://github.com/sgl-project/sglang/actions/runs/29527825263)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->