### PR TITLE
[AMD] Gate Qwen3-30B-A3B TP2 qkv/o_proj CK block-FP8 GEMM shapes to Triton (ROCm 7.0)

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -78,6 +78,8 @@ _use_aiter_bpreshuffle_gfx95 = _use_aiter_gfx95 and get_hip_version() >= (7, 2, 
 _AITER_GFX95_CK_W8A8_MAX_SAFE_M = {
     (2560, 4096): 2048,
     (4096, 1024): 4096,
+    (2560, 2048): 2048,
+    (2048, 2048): 4096,
 }
 
 


### PR DESCRIPTION
Co-authored-with: @XinyuJiangCMU 

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

On AMD gfx95 (MI35x) with **ROCm 7.0**, blockwise fp8 serving/RL-rollout of **Qwen3-30B-A3B-FP8** produces corrupted output: the dense block-FP8 GEMM (`ck_gemm_a8w8_blockscale`) returns NaN for the model's qkv/o_proj shapes above a per-shape prefill-M threshold, which poisons attention and tanks accuracy. The same run is correct on ROCm 7.2.

This is the same class of issue already handled for other shapes in [#29918](https://github.com/sgl-project/sglang/pull/29918) (Qwen3.5 TP8) and [#30940](https://github.com/sgl-project/sglang/pull/30940) (Qwen3.5 TP4). This PR extends the existing gate to the **Qwen3-30B-A3B TP2** per-shard shapes.

## Modifications

<!-- Detail the changes made in this pull request. -->

Add the two Qwen3-30B-A3B TP2 shapes to `_AITER_GFX95_CK_W8A8_MAX_SAFE_M` in `python/sglang/srt/layers/quantization/fp8_utils.py`. On gfx95 + ROCm < 7.2, when the runtime M exceeds a shape's safe bound the GEMM is routed to aiter-triton (numerically correct); at/below the bound the faster CK path is kept. ROCm ≥ 7.2 is unaffected (uses the bpreshuffle CK path).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Qwen3-30B-A3B-FP8, TP=2, `SGLANG_USE_AITER=1`, GSM8K (1319, 5-shot), MI35x:

| Config | ROCm | Accuracy | Invalid |
| ------ | ---- | -------- | ------- |
| Before (CK) | 7.0 | `0.6399` | `0.0205` |
| **After (this PR)** | 7.0 | `0.8696` | `0.0000` |
| Reference | 7.2 | `0.9007` | `0.0008` |

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29468295352](https://github.com/sgl-project/sglang/actions/runs/29468295352)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29468295217](https://github.com/sgl-project/sglang/actions/runs/29468295217)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->