### PR TITLE
[AMD] Bump MoRI to f7e6ac6 to fix ROCm install_dependency build break

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -110,7 +110,7 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
-ARG MORI_COMMIT="6f072775a73518440b29be60e85dda70db63ca43"
+ARG MORI_COMMIT="e31d426a13e96e1cbff96a1c904d291aefe8c46a"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -110,7 +110,7 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
-ARG MORI_COMMIT="e31d426a13e96e1cbff96a1c904d291aefe8c46a"
+ARG MORI_COMMIT="f7e6ac6863c53821bc7afb91a578cc6ce38fcad0"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).


### PR DESCRIPTION
## Motivation
The AMD **PR Test (AMD)** `Install dependencies` step is broken on `main`. It started failing after MoRI was bumped in `docker/rocm.Dockerfile`.
- Failing run: https://github.com/sgl-project/sglang/actions/runs/29461421122 (sglang `b0b2dfb`) — `Install dependencies` fails
- Last good run: https://github.com/sgl-project/sglang/actions/runs/29415344552 (sglang `495ae9a`) — passes
Both runs use the **same** CI image `rocm/sgl-dev:v0.5.15.post1-rocm700-mi30x-20260715`, so the only variable is the MoRI commit that `scripts/ci/amd/amd_ci_install_dependency.sh` re-clones and rebuilds from the Dockerfile-pinned `MORI_COMMIT`.
#30706 bumped `MORI_COMMIT` `e31d426` → `6f07277`. The newer MoRI adds a `cco` module whose `src/cco/cco_init.cpp:95` uses `hipMemAllocationTypeUncached`:
```
/sgl-workspace/mori/src/cco/cco_init.cpp:95:48: error: use of undeclared identifier 'hipMemAllocationTypeUncached'; did you mean 'hipMemAllocationTypeInvalid'?
```

`hipMemAllocationTypeUncached` (0x40000000) was only added to HIP on 2025-09-11 (ROCm/hip@642cd90) and is not present in the HIP headers of the currently pinned `rocm700` CI image, so the MoRI build fails → `Install dependencies` exits 1.

MoRI has since landed a hotfix commit (`f7e6ac6`) that makes the `cco` module build against this ROCm version.
## Modifications
- Bump `MORI_COMMIT` in `docker/rocm.Dockerfile`: `6f07277` → `f7e6ac6863c53821bc7afb91a578cc6ce38fcad0` (ROCm/mori hotfix).
- Keeps the `SGLANG_MORI_COMBINE_DTYPE=fp4` feature from #30706 working, unlike a plain revert of the pin.


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29474624471](https://github.com/sgl-project/sglang/actions/runs/29474624471)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29474624401](https://github.com/sgl-project/sglang/actions/runs/29474624401)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->