### PR TITLE
[CI] Fall back for low-quality partition model fits

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -145,7 +145,9 @@ jobs:
           python3 scripts/ci/cuda/warmup_server.py ${{ inputs.warmup_server_models }}
 
       - name: Fetch live partition model
-        if: fromJson(inputs.check_changes).partition_model_sha != ''
+        if: >-
+          fromJson(inputs.check_changes).partition_model_sha != '' &&
+          fromJson(inputs.partitions)[inputs.self_name].use_live_est
         run: |
           # SHA resolved by check-changes -> require fetch (curl --retry)
           # so all shards stay on the same snapshot.
@@ -163,7 +165,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite ${{ inputs.self_name }} \
             --auto-partition-id ${{ matrix.partition }} \
             --auto-partition-size ${{ fromJson(inputs.partitions)[inputs.self_name].size }} \
-            --partition-model-file /tmp/partition-model.json \
+            ${{ fromJson(inputs.partitions)[inputs.self_name].use_live_est && '--partition-model-file /tmp/partition-model.json' || '' }} \
             ${{ inputs.timeout_per_file && format('--timeout-per-file {0}', inputs.timeout_per_file) || '' }} \
             $CONTINUE_ON_ERROR_FLAG
 

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -2,7 +2,7 @@
 keyed by suite name. Consumed by pr-test.yml stage jobs as
 `fromJson(needs.check-changes.outputs.partitions)['<suite>']`.
 
-    partitions={"base-b-test-1-gpu-small": {"size": 8, "arr": [0,...,7], "max_parallel": 2}, ...}
+    partitions={"base-b-test-1-gpu-small": {"size": 8, "arr": [0,...,7], "max_parallel": 2, "use_live_est": true}, ...}
 """
 
 import argparse
@@ -43,6 +43,7 @@ _BASE_A_OVERRIDES = {
 }
 
 _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
+_MIN_FIT_R_SQUARED = 0.5
 
 
 def load_run_timeouts(pr_test_yml_path: str) -> dict:
@@ -110,15 +111,29 @@ def compute_max_parallel(size: int) -> int:
     return max(size // 3, 1)
 
 
+def validated_fit(fit: dict) -> tuple[float, float] | None:
+    """Return a meaningful runtime fit, or None to use static estimates."""
+    coeff = fit.get("coeff", 1.0)
+    bias = fit.get("bias", 0.0)
+    r_squared = fit.get("r_squared")
+    if not all(type(value) in (int, float) for value in (coeff, bias, r_squared)):
+        return None
+    if not all(math.isfinite(value) for value in (coeff, bias, r_squared)):
+        return None
+    if coeff <= 0 or not _MIN_FIT_R_SQUARED <= r_squared <= 1.0:
+        return None
+    return coeff, bias
+
+
 def compute_partitions(
     tests, repo_root, run_timeouts, partition_model=None, full_parallel=False
 ):
     """Group per-commit tests by suite and emit partition metadata.
 
     `run_timeouts`: `suite -> minutes` from `load_run_timeouts`.
-    `partition_model`: optional sglang-ci-stats `model.json`; per-file
-    `est` and per-suite `(coeff, bias)` each fall back independently to
-    in-source `est_time` / `(1.0, 0.0)`.
+    `partition_model`: optional sglang-ci-stats `model.json`. A missing or
+    invalid suite fit makes both sizing and runtime LPT fall back to in-source
+    `est_time` with `(coeff=1.0, bias=0.0)`.
     `full_parallel=True` lifts the matrix-fanout throttle.
     """
     # Allowlist: stages pr-test.yml dispatches. Stress / weekly /
@@ -139,15 +154,18 @@ def compute_partitions(
 
     result = {}
     for suite, group in suite_tests.items():
-        live_est = est_table.get(suite, {})
+        fit = validated_fit(fit_table.get(suite) or {})
+        if fit is None:
+            coeff, bias = 1.0, 0.0
+            live_est = {}
+        else:
+            coeff, bias = fit
+            live_est = est_table.get(suite, {})
+
         total = 0.0
         for t in group:
             relpath = os.path.relpath(t.filename, repo_root)
             total += live_est.get(relpath, t.est_time)
-
-        fit = fit_table.get(suite) or {}
-        coeff = fit.get("coeff", 1.0)
-        bias = fit.get("bias", 0.0)
 
         # Each shard pays `bias` once, so size >= coeff*total / (target-bias).
         if suite in _BASE_A_OVERRIDES:
@@ -176,6 +194,7 @@ def compute_partitions(
             "size": size,
             "arr": list(range(size)),
             "max_parallel": max_parallel,
+            "use_live_est": fit is not None,
         }
     return result
 


### PR DESCRIPTION
## Summary

Validate live `sglang-ci-stats` fits before using them for CI partition sizing and runtime LPT assignment.

A suite uses live estimates only when:

- `coeff`, `bias`, and `r_squared` are numeric and finite
- `coeff` is positive
- `0.5 <= r_squared <= 1.0`

Missing or invalid fits fall back to in-source `est_time` with `coeff=1.0` and `bias=0.0`.

The partition metadata now includes `use_live_est`, ensuring shard sizing and runtime file assignment use the same estimate source. Static-fallback shards also skip downloading the unused live model.

## Motivation

A generated `sglang-ci-stats` model contained this fit for `base-c-test-deepep-4-gpu-b200`:

```text
coeff=-1.2093
bias=1462.2
r_squared=0.2399
```

The partitioning script accepted it and failed because its fitted bias exceeded the suite's 1350-second sizing target:

```text
RuntimeError: Suite 'base-c-test-deepep-4-gpu-b200':
fit bias=1462.2s >= target=1350.0s
```

This caused NVIDIA PR CI to fail during `check-changes`, before GPU tests were dispatched.

The producer documents `r_squared` as the diagnostic for whether a fit is meaningful and instructs consumers to fall back when it is too low. The consumer previously did not implement that validation.

## Behavior

High-quality fits remain enabled, including unconstrained OLS fits with negative intercepts:

```text
base-b-test-1-gpu-large:
  coeff=1.279
  bias=-168.2
  r_squared=0.9319
  size=8
  use_live_est=true
```

Low-quality or physically invalid fits use the static path consistently for both sizing and runtime assignment:

```text
base-c-test-4-gpu-b200:
  r_squared=0.3347
  size=4
  use_live_est=false

base-c-test-deepep-4-gpu-b200:
  coeff=-1.2093
  r_squared=0.2399
  size=1
  use_live_est=false
```

Malformed booleans, non-finite values, nonpositive coefficients, and out-of-range `r_squared` values are also rejected.

## Verification

- `python -m py_compile scripts/ci/utils/compute_partitions.py`
- `ruff check scripts/ci/utils/compute_partitions.py`
- `black --check scripts/ci/utils/compute_partitions.py`
- Parsed `_pr-test-stage.yml` with PyYAML
- Ran partition generation end to end against the current `sglang-ci-stats/model.json`
- Verified representative live and static metadata
- `git diff --check`
- `actionlint .github/workflows/_pr-test-stage.yml`





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29469037274](https://github.com/sgl-project/sglang/actions/runs/29469037274)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29469037206](https://github.com/sgl-project/sglang/actions/runs/29469037206)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->