### PR TITLE
Skip dist_init/nccl port prechecks when the dist init method is overridden

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8846,13 +8846,21 @@ class PortArgs:
                 scheduler_input_port = worker_ports[dp_rank]
 
             is_joiner = server_args.is_ep_scale_joiner
+            # Under SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE, SGLang never binds
+            # dist_init_port / nccl_port (rendezvous uses the externally-managed
+            # store; see distributed/bootstrap.py:_resolve_dist_init_method), so
+            # their prechecks could only false-positive and are skipped.
+            dist_init_overridden = bool(
+                envs.SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE.get()
+            )
             try:
                 if dp_rank is None:
-                    if not is_joiner:
+                    if not (is_joiner or dist_init_overridden):
                         wait_port_available(dist_init_port, "dist_init_port")
                     wait_port_available(port_base, "port_base")
                     wait_port_available(detokenizer_port, "detokenizer_port")
-                    wait_port_available(nccl_port, "nccl_port")
+                    if not dist_init_overridden:
+                        wait_port_available(nccl_port, "nccl_port")
                     wait_port_available(rpc_port, "rpc_port")
                     wait_port_available(metrics_port, "metrics_port")
                     if server_args.nnodes > 1:


### PR DESCRIPTION
When `SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE` is set (typically to `env://` by an external orchestrator), distributed rendezvous goes through an externally-managed `TCPStore` at `MASTER_ADDR`/`MASTER_PORT` and SGLang never binds `dist_init_port` / `nccl_port` itself — see `_resolve_dist_init_method` in `distributed/bootstrap.py`, which consumes the override and returns it verbatim as the init method.

In that configuration the `wait_port_available(dist_init_port)` / `wait_port_available(nccl_port)` prechecks in `PortArgs.init_new` guard a bind that never happens. They can still raise `ValueError` if anything else on the host holds that port number — a co-tenant, a stale socket from a prior retry, or the externally-created store itself — turning a harmless port collision into a hard startup failure.

Skip those two checks when the override is set. All other ports (`port_base`, `detokenizer_port`, `rpc_port`, `metrics_port`, `scheduler_input_port`) are still bound as ZMQ sockets and remain checked, so the no-override path is unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30022800594](https://github.com/sgl-project/sglang/actions/runs/30022800594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30022800124](https://github.com/sgl-project/sglang/actions/runs/30022800124)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->