### PR TITLE
[Docs] Playground: migrate CP knob to canonical prefill-CP flags, align gating with runtime semantics

### DIFF
--- a/.claude/skills/cookbook-add-model/references/authoring-reference.md
+++ b/.claude/skills/cookbook-add-model/references/authoring-reference.md
@@ -147,6 +147,37 @@ schemas (full reference in the `_playground.jsx` header):
 - Constraints are AND across keys, OR within each key's array.
 - Bare `disabled: true` / `disable: true` is a static always-disabled form
   (used for "Coming soon" chips).
+- `disable` may also be an ARRAY of `{when: constraint, reason}` items (OR
+  across items, first match wins and supplies its own tooltip) — for
+  conditions that need OR across keys or per-condition reasons, e.g. the
+  GLM-5.2 CP knob (grayed on non-Hopper hw OR multi-node, different reasons).
+- Constraint keys are the 5 cell dims (`hw`/`variant`/`quant`/`strategy`/
+  `nodes`) plus cross-axis live facts: `dpAttnOn` (effective DP-Attention on),
+  `cpOn` (effective prefill-CP on), `cpStrategy` (effective CP layout),
+  `cpSizeTarget` (the only enable-able CP size — see below), `effTp`
+  (effective TP degree — override else derived), and `pdMode` (live
+  PD-Disagg role).
+- On the `attention` axis, knob-level `hide`/`disable` (on the knob object,
+  not a value entry) hides/grays the whole select, and the engine enforces
+  CP ↔ DP-Attention mutual exclusion itself — only for the interleave layout
+  (interleave prefill-CP requires `dp_size == 1`; zigzag coexists with
+  DP-Attention); apply() skips knobs/values that are disabled under the
+  live facts, so stale picks never emit a blocked combination.
+- The CP knob emits `--attn-cp-size N --enable-prefill-cp --cp-strategy S`,
+  where S is: an optional `{ id: "cpStrategy", values: [null, "interleave",
+  "zigzag"] }` knob's pick > the strategy already baked in the base cell
+  (legacy mode flags map in: in-seq-split → zigzag, round-robin-split →
+  interleave) > "interleave". Declare the cpStrategy knob only on models
+  whose runtime accepts both layouts (DeepSeek-V4 rejects zigzag; DSA
+  zigzag forces deepep + ep=tp + batch_size=1 — label it experimental).
+- CP sizes auto-gate in the engine to the runtime derivation
+  `attn_cp_size = tp/dp` (both in the grayed options and in apply), so
+  configs list plain size values — no per-value `effTp` constraints needed.
+  A model whose runtime honors arbitrary `--attn-cp-size` opts out with
+  `freeSize: true` on the cp knob.
+- Only expose a CP knob on models with model-side CP integration in SGLang
+  (DeepSeek-family / Qwen-MoE / Mellum); on others the emitted flags do
+  nothing or crash (that's why Hy3 and MiniMax-M3 have no CP knob).
 
 ## 2.4 Create the MDX page
 

--- a/.claude/skills/cookbook-add-model/references/authoring-reference.md
+++ b/.claude/skills/cookbook-add-model/references/authoring-reference.md
@@ -158,11 +158,12 @@ schemas (full reference in the `_playground.jsx` header):
   (effective TP degree — override else derived), and `pdMode` (live
   PD-Disagg role).
 - On the `attention` axis, knob-level `hide`/`disable` (on the knob object,
-  not a value entry) hides/grays the whole select, and the engine enforces
-  CP ↔ DP-Attention mutual exclusion itself — only for the interleave layout
-  (interleave prefill-CP requires `dp_size == 1`; zigzag coexists with
-  DP-Attention); apply() skips knobs/values that are disabled under the
-  live facts, so stale picks never emit a blocked combination.
+  not a value entry) hides/grays the whole select; apply() skips
+  knobs/values that are disabled under the live facts, so stale picks never
+  emit a blocked combination. Interleave prefill-CP + DP-Attention is
+  deliberately NOT grayed (combined support is planned upstream even though
+  current releases assert `dp_size == 1` for interleave) — the engine shows
+  a warning hint below the command box instead.
 - The CP knob emits `--attn-cp-size N --enable-prefill-cp --cp-strategy S`,
   where S is: an optional `{ id: "cpStrategy", values: [null, "interleave",
   "zigzag"] }` knob's pick > the strategy already baked in the base cell

--- a/docs_new/cookbook/autoregressive/Tencent/Hy3.mdx
+++ b/docs_new/cookbook/autoregressive/Tencent/Hy3.mdx
@@ -79,7 +79,7 @@ The Playground lets you turn on additional knobs on top of whichever Deploy cell
 
 The knobs come in two flavors:
 
-- **Built-in SGLang features** — parallelism overrides (TP / CP / DP-Attention), MoE backend + EP, reasoning / tool-call parsers, speculative-decoding presets, prefill/decode disaggregation, and HiCache tiers.
+- **Built-in SGLang features** — parallelism overrides (TP / DP-Attention), MoE backend + EP, reasoning / tool-call parsers, speculative-decoding presets, prefill/decode disaggregation, and HiCache tiers.
 - **Hy3 specific** — `--tool-call-parser auto` / `--reasoning-parser auto` (auto-detect Hy3's suffix-aware `hunyuan` parsers from the chat template; resolve the real special tokens from the tokenizer vocab at runtime).
 
 Lines highlighted **green** are added by your overrides; lines with **red strikethrough** were in the verified base but stripped by an override. When no override differs from the base cell, the playground inherits the base's **Verified** badge; any actual change flips it to **Not Verified** until the new configuration is run end-to-end and submitted back.

--- a/docs_new/src/snippets/_playground.jsx
+++ b/docs_new/src/snippets/_playground.jsx
@@ -354,21 +354,19 @@ export const Playground = ({ config }) => {
           effTp: h.parseIntFlag(flags, "--tp"),
         });
         // The runtime derives the prefill-CP size as attn_cp_size = tp/dp
-        // (a mismatched --attn-cp-size is overridden), so only CP == tp/dp
-        // is real. Mirrors the render-side auto-gating; a config opts out
-        // with `freeSize: true` on the cp knob (for models whose runtime
-        // honors arbitrary sizes).
+        // (a mismatched --attn-cp-size is overridden), so with DP-Attention
+        // off only CP == TP is real. With DP-Attention on the sizes are NOT
+        // gated: CP + DP-Attention is an allowed experiment (warning hint
+        // below the command box). Mirrors the render-side auto-gating; a
+        // config opts out entirely with `freeSize: true` on the cp knob.
         const cpSizeTargetNow = () => {
           if (knobEntry("cp").freeSize) return null;
-          const tp = h.parseIntFlag(flags, "--tp");
-          if (tp === null) return null;
           const dpIntent = (value.dpAttn !== null && value.dpAttn !== undefined)
             ? value.dpAttn
             : (h.hasFlag(flags, "--enable-dp-attention")
                 ? (h.parseIntFlag(flags, "--dp") ?? 1) : false);
-          const dpDeg = (typeof dpIntent === "number" && dpIntent > 0)
-            ? dpIntent : 1;
-          return tp / dpDeg;
+          if (typeof dpIntent === "number" && dpIntent > 1) return null;
+          return h.parseIntFlag(flags, "--tp");
         };
         // Skip a knob whose entry or picked value is hidden/disabled under
         // the live facts — mirrors the grayed controls, so stale state never
@@ -385,16 +383,10 @@ export const Playground = ({ config }) => {
           return !!(e !== null && e !== undefined
             && h.evaluateChip(e, facts).disabled);
         };
-        // Interleave prefill-CP requires dp_size == 1, so CP and DP-Attention
-        // are mutually exclusive. Ties between two explicit picks break in
-        // DP-Attention's favor (CP application is skipped), matching the
-        // render-side graying. Order: tp → cp → dpAttn, so an explicit
-        // "CP off" strips baked CP before the dpAttn guard reads the flags.
-        const dpAttnIntentOn = () =>
-          (value.dpAttn !== null && value.dpAttn !== undefined
-           && !blocked("dpAttn", value.dpAttn))
-            ? (typeof value.dpAttn === "number" && value.dpAttn > 0)
-            : factsNow().dpAttnOn;
+        // NOTE: interleave prefill-CP + DP-Attention currently fails the
+        // runtime's dp_size == 1 assert, but combined support is planned
+        // upstream — the combination is allowed here (with a warning hint
+        // below the command box) rather than banned.
 
         if (value.tp !== null && !blocked("tp", value.tp)) {
           flags = h.stripFlagsByFirstToken(flags, ["--tp"]);
@@ -413,12 +405,7 @@ export const Playground = ({ config }) => {
               : null);
         const cpStrategyPick =
           cpStrategyOverride || bakedCpStrategy(flags) || "interleave";
-        if (cpPick !== null
-            && !blocked("cp", cpPick)
-            // Only the interleave layout requires dp_size == 1; zigzag
-            // coexists with DP-Attention.
-            && !(cpPick > 1 && cpStrategyPick === "interleave"
-                 && dpAttnIntentOn())) {
+        if (cpPick !== null && !blocked("cp", cpPick)) {
           // Own the whole CP flag family (canonical + every legacy spelling)
           // so an override fully replaces (or removes) whatever the base
           // recipe baked in.
@@ -432,13 +419,7 @@ export const Playground = ({ config }) => {
           }
         }
         if (value.dpAttn !== null && value.dpAttn !== undefined
-            && !blocked("dpAttn", value.dpAttn)
-            // Enabling DP-Attention is skipped only while the flags still
-            // carry interleave CP (baked in base and not overridden away
-            // above); zigzag CP coexists with DP-Attention.
-            && !(typeof value.dpAttn === "number" && value.dpAttn > 0
-                 && factsNow().cpOn
-                 && factsNow().cpStrategy === "interleave")) {
+            && !blocked("dpAttn", value.dpAttn)) {
           flags = h.stripFlagsByFirstToken(flags, ["--dp", "--enable-dp-attention"]);
           if (typeof value.dpAttn === "number" && value.dpAttn > 0) {
             flags = h.insertAfter(flags, h.ANCHOR_NEAR_TP, [
@@ -454,22 +435,10 @@ export const Playground = ({ config }) => {
         const knobs = fc.knobs || [];
         if (!knobs.length) return null;
         const setKnob = (k, v) => setValue({ ...value, [k]: v });
-        // Engine-level mutual exclusion, only for the interleave layout
-        // (zigzag prefill-CP coexists with DP-Attention): CP grays out while
-        // DP-Attention is effectively on, and vice versa. When BOTH carry an
-        // explicit pick, DP-Attention wins (mirrors apply), so its select
-        // stays live and only CP grays — no deadlocked pair of selects.
-        const interleaveCp = base.cpStrategy === "interleave";
-        const conflictReason = (knob) => {
-          if (knob.id === "cp" && base.dpAttnOn && interleaveCp) {
-            return "Prefill context parallel (interleave) requires dp_size == 1 — turn DP-Attention off first.";
-          }
-          if (knob.id === "dpAttn" && base.cpOn && interleaveCp
-              && !base.dpAttnOn) {
-            return "DP-Attention requires dp_size > 1, which interleave prefill context parallel forbids — turn CP off first.";
-          }
-          return null;
-        };
+        // Interleave prefill-CP + DP-Attention is deliberately NOT grayed:
+        // current releases assert dp_size == 1 for interleave, but combined
+        // support is planned upstream — a warning hint below the command box
+        // covers it instead.
         const labelFor = (knob) => (c) => {
           if (c.label !== undefined) return c.label;
           if (knob.id === "dpAttn") {
@@ -517,15 +486,14 @@ export const Playground = ({ config }) => {
               {knobs.map((knob) => {
                 const kc = h.evaluateChip(knob, base);
                 if (kc.hidden) return null;
-                const conflict = conflictReason(knob);
                 return (
                   <span key={knob.id} style={s.field}>
                     <span style={s.fieldLabel}>{knob.label || knob.id.toUpperCase()}</span>
                     {renderSelect(knobDisplay(knob), entriesFor(knob),
                       (nv) => setKnob(knob.id, nv), base, labelFor(knob),
                       { hideValues: hideNullFor(knob),
-                        disabled: kc.disabled || !!conflict,
-                        disabledReason: conflict || kc.disableReason })}
+                        disabled: kc.disabled,
+                        disabledReason: kc.disableReason })}
                   </span>
                 );
               })}
@@ -1817,8 +1785,7 @@ export const Playground = ({ config }) => {
   //   cpOn     — effective prefill-CP resolves to "on" (degree > 1),
   //              explicit override else derived-from-base.
   //   cpStrategy — effective CP layout ("zigzag" / "interleave"; explicit
-  //              override else baked-in-base else "interleave"). The CP ↔
-  //              DP-Attention mutual exclusion applies only to interleave.
+  //              override else baked-in-base else "interleave").
   //   cpSizeTarget — the only enable-able CP size (runtime derives
   //              attn_cp_size = tp/dp); null when TP is unknown or the cp
   //              knob opts out via `freeSize: true`.
@@ -1845,13 +1812,17 @@ export const Playground = ({ config }) => {
     : (attnDerived.dpAttn !== undefined ? attnDerived.dpAttn : null);
   const dpAttnOn = (effDpAttn === true)
     || (typeof effDpAttn === "number" && effDpAttn > 0);
-  // Runtime derivation attn_cp_size = tp/dp: the only enable-able CP size
-  // (null when TP is unknown or the cp knob opts out via `freeSize`).
+  // Runtime derivation attn_cp_size = tp/dp: with DP-Attention off, the only
+  // enable-able CP size is TP. With DP-Attention on, sizes are NOT gated —
+  // CP + DP-Attention is an allowed experiment covered by a warning hint
+  // (null also when TP is unknown or the cp knob opts out via `freeSize`).
   const dpDegEff = (typeof effDpAttn === "number" && effDpAttn > 0)
     ? effDpAttn : 1;
   const cpKnobFreeSize = !!(attnKnobs.find((k) => k.id === "cp") || {}).freeSize;
-  const cpSizeTarget = (!cpKnobFreeSize && typeof effTp === "number" && effTp > 0)
-    ? effTp / dpDegEff : null;
+  const cpSizeTarget =
+    (!cpKnobFreeSize && dpDegEff === 1
+     && typeof effTp === "number" && effTp > 0)
+      ? effTp : null;
   const cpSizeStale = (v) => typeof v === "number" && v > 1
     && cpSizeTarget !== null && v !== cpSizeTarget;
   const effCp = (attnDelta.cp !== null && attnDelta.cp !== undefined)
@@ -1897,6 +1868,14 @@ export const Playground = ({ config }) => {
   const pgMtpHint =
     pgFlagsLatest.some((f) => f.split(/[\s=]/)[0] === "--speculative-algorithm") &&
     !pgFlagsLatest.some((f) => f.split(/[\s=]/)[0] === "--max-running-requests");
+
+  // Interleave prefill-CP + DP-Attention hint on the EFFECTIVE command:
+  // deliberately allowed (combined support is planned upstream), but current
+  // releases assert dp_size == 1 for the interleave layout at startup.
+  const pgCpDpHint =
+    cpEnabledIn(pgFlagsLatest)
+    && (bakedCpStrategy(pgFlagsLatest) || "interleave") === "interleave"
+    && pgFlagsLatest.some((f) => f.split(/[\s=]/)[0] === "--enable-dp-attention");
 
   // Submission snippets: proposed cell + existing cell at the same match.
   const proposedCellSnippet = baseCell
@@ -2153,6 +2132,11 @@ export const Playground = ({ config }) => {
           {pgMtpHint && (
             <div style={s.mtpWarn}>
               ⚠️ Speculative decoding (MTP) is on — SGLang resets <code>--max-running-requests</code> to <strong>48</strong> when it isn't set. Add <code>--max-running-requests &lt;N&gt;</code> sized for your target concurrency.
+            </div>
+          )}
+          {pgCpDpHint && (
+            <div style={s.mtpWarn}>
+              ⚠️ Interleave prefill-CP together with DP-Attention: current SGLang releases assert <code>dp_size == 1</code> for the interleave layout, so this command fails at startup. Combined CP + DP-Attention support is planned upstream — keep one of the two off until it lands.
             </div>
           )}
         </div>

--- a/docs_new/src/snippets/_playground.jsx
+++ b/docs_new/src/snippets/_playground.jsx
@@ -110,6 +110,9 @@ export const Playground = ({ config }) => {
   // mapping base-cell dims to allowed-value arrays; matches when every key
   // matches (AND across keys, OR within a key). Empty/malformed never match.
   // `disabled: true` / `disable: true` are static always-disabled forms.
+  // `disable` may also be an ARRAY of `{when: constraint, reason?}` items
+  // (OR across items, first match wins and supplies its own reason) for
+  // conditions that need OR across keys or per-condition tooltips.
   const matchConstraint = (base, constraint) => {
     if (!constraint || typeof constraint !== "object") return false;
     const entries = Object.entries(constraint);
@@ -130,8 +133,20 @@ export const Playground = ({ config }) => {
     }
     const hidden = entry.hide ? matchConstraint(base, entry.hide) : false;
     let disabled = entry.disabled === true || entry.disable === true;
+    let disableReason = entry.disableReason || "";
     if (!disabled && entry.disable && typeof entry.disable === "object") {
-      disabled = matchConstraint(base, entry.disable);
+      if (Array.isArray(entry.disable)) {
+        for (const item of entry.disable) {
+          const cond = (item && item.when) || item;
+          if (matchConstraint(base, cond)) {
+            disabled = true;
+            if (item && item.reason) disableReason = item.reason;
+            break;
+          }
+        }
+      } else {
+        disabled = matchConstraint(base, entry.disable);
+      }
     }
     return {
       ...entry,
@@ -139,7 +154,7 @@ export const Playground = ({ config }) => {
       label: entry.label,
       hidden,
       disabled,
-      disableReason: entry.disableReason || "",
+      disableReason,
     };
   };
 
@@ -239,6 +254,37 @@ export const Playground = ({ config }) => {
     ANCHOR_NEAR_DPATTN, ANCHOR_NEAR_MOE,
   };
 
+  // -------- Prefill-CP flag family (shared by the attention axis) --------
+  // Every flag head that toggles/parameterizes prefill context parallelism:
+  // the canonical pair plus all per-family legacy spellings.
+  const CP_ENABLE_HEADS = [
+    "--enable-prefill-cp",
+    "--enable-nsa-prefill-context-parallel",
+    "--enable-dsa-prefill-context-parallel",
+    "--enable-prefill-context-parallel",
+  ];
+  const CP_MODE_HEADS = [
+    "--nsa-prefill-cp-mode", "--dsa-prefill-cp-mode", "--prefill-cp-mode",
+  ];
+  const CP_OWNED_HEADS = [
+    ...CP_ENABLE_HEADS, ...CP_MODE_HEADS, "--cp-strategy", "--attn-cp-size",
+  ];
+  // Legacy mode spellings → new-style --cp-strategy values.
+  const CP_MODE_TO_STRATEGY = {
+    "in-seq-split": "zigzag",
+    "round-robin-split": "interleave",
+  };
+  const cpEnabledIn = (flags) =>
+    CP_ENABLE_HEADS.some((head) => hasFlag(flags, head));
+  // Strategy a cell's flags carry: --cp-strategy first, else a mapped legacy
+  // mode flag, else null (no strategy baked).
+  const bakedCpStrategy = (flags) =>
+    findFlagArg(flags, "--cp-strategy")
+    || CP_MODE_TO_STRATEGY[findFlagArg(flags, "--nsa-prefill-cp-mode")]
+    || CP_MODE_TO_STRATEGY[findFlagArg(flags, "--dsa-prefill-cp-mode")]
+    || CP_MODE_TO_STRATEGY[findFlagArg(flags, "--prefill-cp-mode")]
+    || null;
+
   // ==========================================================================
   // 5. AXIS_HANDLERS — the built-in playground axis registry
   // ==========================================================================
@@ -255,12 +301,17 @@ export const Playground = ({ config }) => {
     // ---- Axis: Attention Parallelism ----------------------------------------
     // TP / CP / DP-Attention sub-knobs; `null` = inherit. DP-Attention is
     // combined: a numeric value emits `--dp N --enable-dp-attention`, `false`
-    // strips both.
+    // strips both. An optional `cpStrategy` knob (values from --cp-strategy:
+    // "zigzag" / "interleave") picks the CP layout; without it the strategy
+    // baked in the base is preserved, defaulting to "interleave" (the legacy
+    // knob's round-robin-split).
     attention: {
-      initState: () => ({ tp: null, cp: null, dpAttn: null }),
+      initState: () => ({ tp: null, cp: null, cpStrategy: null, dpAttn: null }),
 
       // DP-Attention: `--dp N --enable-dp-attention` → N; neither → false;
-      // bare `--enable-dp-attention` → 1. CP only resolves on/off (→ 2).
+      // bare `--enable-dp-attention` → 1. CP: any enable spelling →
+      // `--attn-cp-size N` (bare enable → 2, the legacy convention), plus the
+      // baked strategy (legacy mode flags mapped to zigzag/interleave).
       deriveFromBase: (cell, fc, h) => {
         const flags = (cell && cell.flags) || [];
         const dpVal = h.parseIntFlag(flags, "--dp");
@@ -269,9 +320,11 @@ export const Playground = ({ config }) => {
         if (dpVal !== null) dpAttn = dpVal;
         else if (hasDpAttn) dpAttn = 1;
         else dpAttn = false;
+        const cpSize = h.parseIntFlag(flags, "--attn-cp-size");
         return {
           tp: h.parseIntFlag(flags, "--tp"),
-          cp: h.hasFlag(flags, "--enable-nsa-prefill-context-parallel") ? 2 : null,
+          cp: cpEnabledIn(flags) ? (cpSize !== null ? cpSize : 2) : null,
+          cpStrategy: bakedCpStrategy(flags),
           dpAttn,
         };
       },
@@ -289,12 +342,103 @@ export const Playground = ({ config }) => {
         return changed ? next : value;
       },
 
-      apply: ({ flags, env, value, h }) => {
-        if (value.tp !== null) {
+      apply: ({ flags, env, value, fc, sel, h }) => {
+        // Live facts for constraint checks (same keys the render-side
+        // constraintBase exposes), recomputed after each mutation.
+        const knobEntry = (id) => (fc.knobs || []).find((k) => k.id === id) || {};
+        const factsNow = () => ({
+          ...(sel || {}),
+          dpAttnOn: h.hasFlag(flags, "--enable-dp-attention"),
+          cpOn: cpEnabledIn(flags),
+          cpStrategy: bakedCpStrategy(flags) || "interleave",
+          effTp: h.parseIntFlag(flags, "--tp"),
+        });
+        // The runtime derives the prefill-CP size as attn_cp_size = tp/dp
+        // (a mismatched --attn-cp-size is overridden), so only CP == tp/dp
+        // is real. Mirrors the render-side auto-gating; a config opts out
+        // with `freeSize: true` on the cp knob (for models whose runtime
+        // honors arbitrary sizes).
+        const cpSizeTargetNow = () => {
+          if (knobEntry("cp").freeSize) return null;
+          const tp = h.parseIntFlag(flags, "--tp");
+          if (tp === null) return null;
+          const dpIntent = (value.dpAttn !== null && value.dpAttn !== undefined)
+            ? value.dpAttn
+            : (h.hasFlag(flags, "--enable-dp-attention")
+                ? (h.parseIntFlag(flags, "--dp") ?? 1) : false);
+          const dpDeg = (typeof dpIntent === "number" && dpIntent > 0)
+            ? dpIntent : 1;
+          return tp / dpDeg;
+        };
+        // Skip a knob whose entry or picked value is hidden/disabled under
+        // the live facts — mirrors the grayed controls, so stale state never
+        // emits a blocked combination.
+        const blocked = (id, v) => {
+          const facts = factsNow();
+          const kc = h.evaluateChip(knobEntry(id), facts);
+          if (kc.hidden || kc.disabled) return true;
+          if (id === "cp" && typeof v === "number" && v > 1) {
+            const target = cpSizeTargetNow();
+            if (target !== null && v !== target) return true;
+          }
+          const e = h.findEntry(knobEntry(id).values || [], v);
+          return !!(e !== null && e !== undefined
+            && h.evaluateChip(e, facts).disabled);
+        };
+        // Interleave prefill-CP requires dp_size == 1, so CP and DP-Attention
+        // are mutually exclusive. Ties between two explicit picks break in
+        // DP-Attention's favor (CP application is skipped), matching the
+        // render-side graying. Order: tp → cp → dpAttn, so an explicit
+        // "CP off" strips baked CP before the dpAttn guard reads the flags.
+        const dpAttnIntentOn = () =>
+          (value.dpAttn !== null && value.dpAttn !== undefined
+           && !blocked("dpAttn", value.dpAttn))
+            ? (typeof value.dpAttn === "number" && value.dpAttn > 0)
+            : factsNow().dpAttnOn;
+
+        if (value.tp !== null && !blocked("tp", value.tp)) {
           flags = h.stripFlagsByFirstToken(flags, ["--tp"]);
           flags = h.insertAfter(flags, h.ANCHOR_NEAR_MODEL_PATH, [`--tp ${value.tp}`]);
         }
-        if (value.dpAttn !== null && value.dpAttn !== undefined) {
+        // CP override: an explicit size pick, or a strategy-only pick on a
+        // base that already carries CP. Strategy precedence: explicit knob >
+        // baked-in-base > "interleave" (the legacy knob's round-robin-split).
+        const cpStrategyOverride =
+          (value.cpStrategy && !blocked("cpStrategy", value.cpStrategy))
+            ? value.cpStrategy : null;
+        const cpPick = (value.cp !== null)
+          ? value.cp
+          : ((cpStrategyOverride && cpEnabledIn(flags))
+              ? (h.parseIntFlag(flags, "--attn-cp-size") ?? 2)
+              : null);
+        const cpStrategyPick =
+          cpStrategyOverride || bakedCpStrategy(flags) || "interleave";
+        if (cpPick !== null
+            && !blocked("cp", cpPick)
+            // Only the interleave layout requires dp_size == 1; zigzag
+            // coexists with DP-Attention.
+            && !(cpPick > 1 && cpStrategyPick === "interleave"
+                 && dpAttnIntentOn())) {
+          // Own the whole CP flag family (canonical + every legacy spelling)
+          // so an override fully replaces (or removes) whatever the base
+          // recipe baked in.
+          flags = h.stripFlagsByFirstToken(flags, CP_OWNED_HEADS);
+          if (cpPick > 1) {
+            flags = h.insertAfter(flags, h.ANCHOR_NEAR_DPATTN, [
+              `--attn-cp-size ${cpPick}`,
+              "--enable-prefill-cp",
+              `--cp-strategy ${cpStrategyPick}`,
+            ]);
+          }
+        }
+        if (value.dpAttn !== null && value.dpAttn !== undefined
+            && !blocked("dpAttn", value.dpAttn)
+            // Enabling DP-Attention is skipped only while the flags still
+            // carry interleave CP (baked in base and not overridden away
+            // above); zigzag CP coexists with DP-Attention.
+            && !(typeof value.dpAttn === "number" && value.dpAttn > 0
+                 && factsNow().cpOn
+                 && factsNow().cpStrategy === "interleave")) {
           flags = h.stripFlagsByFirstToken(flags, ["--dp", "--enable-dp-attention"]);
           if (typeof value.dpAttn === "number" && value.dpAttn > 0) {
             flags = h.insertAfter(flags, h.ANCHOR_NEAR_TP, [
@@ -303,24 +447,29 @@ export const Playground = ({ config }) => {
             ]);
           }
         }
-        if (value.cp !== null) {
-          flags = h.stripFlagsByFirstToken(flags, [
-            "--enable-nsa-prefill-context-parallel", "--nsa-prefill-cp-mode",
-          ]);
-          if (value.cp > 1) {
-            flags = h.insertAfter(flags, h.ANCHOR_NEAR_DPATTN, [
-              "--enable-nsa-prefill-context-parallel",
-              "--nsa-prefill-cp-mode round-robin-split",
-            ]);
-          }
-        }
         return { flags, env };
       },
 
-      render: ({ axisId, value, setValue, fc, base, s, renderSelect, derived }) => {
+      render: ({ axisId, value, setValue, fc, base, s, h, renderSelect, derived }) => {
         const knobs = fc.knobs || [];
         if (!knobs.length) return null;
         const setKnob = (k, v) => setValue({ ...value, [k]: v });
+        // Engine-level mutual exclusion, only for the interleave layout
+        // (zigzag prefill-CP coexists with DP-Attention): CP grays out while
+        // DP-Attention is effectively on, and vice versa. When BOTH carry an
+        // explicit pick, DP-Attention wins (mirrors apply), so its select
+        // stays live and only CP grays — no deadlocked pair of selects.
+        const interleaveCp = base.cpStrategy === "interleave";
+        const conflictReason = (knob) => {
+          if (knob.id === "cp" && base.dpAttnOn && interleaveCp) {
+            return "Prefill context parallel (interleave) requires dp_size == 1 — turn DP-Attention off first.";
+          }
+          if (knob.id === "dpAttn" && base.cpOn && interleaveCp
+              && !base.dpAttnOn) {
+            return "DP-Attention requires dp_size > 1, which interleave prefill context parallel forbids — turn CP off first.";
+          }
+          return null;
+        };
         const labelFor = (knob) => (c) => {
           if (c.label !== undefined) return c.label;
           if (knob.id === "dpAttn") {
@@ -341,18 +490,45 @@ export const Playground = ({ config }) => {
           const d = derived ? derived[knob.id] : null;
           return (d !== null && d !== undefined) ? [null] : [];
         };
+        // Auto-gate CP sizes to the runtime derivation attn_cp_size = tp/dp
+        // (mirrors apply's cpSizeTargetNow; `freeSize: true` opts out).
+        const entriesFor = (knob) => {
+          const vals = knob.values || [null];
+          if (knob.id !== "cp" || knob.freeSize) return vals;
+          const target = base.cpSizeTarget;
+          if (target === null || target === undefined) return vals;
+          return vals.map((entry) => {
+            const v = (entry === null || typeof entry !== "object")
+              ? entry : (entry.id !== undefined ? entry.id : entry.value);
+            if (typeof v !== "number" || v <= 1 || v === target) return entry;
+            const wrapped = (entry === null || typeof entry !== "object")
+              ? { value: entry } : { ...entry };
+            return {
+              ...wrapped,
+              disabled: true,
+              disableReason: `SGLang derives the prefill-CP size as attn_cp_size = TP / DP-Attention (= ${target} here), so only that size can be enabled.`,
+            };
+          });
+        };
         return (
           <div key={axisId} style={s.card}>
             <div style={s.compactRow}>
               <span style={s.axisTitle}>Attention</span>
-              {knobs.map((knob) => (
-                <span key={knob.id} style={s.field}>
-                  <span style={s.fieldLabel}>{knob.label || knob.id.toUpperCase()}</span>
-                  {renderSelect(knobDisplay(knob), knob.values || [null],
-                    (nv) => setKnob(knob.id, nv), base, labelFor(knob),
-                    { hideValues: hideNullFor(knob) })}
-                </span>
-              ))}
+              {knobs.map((knob) => {
+                const kc = h.evaluateChip(knob, base);
+                if (kc.hidden) return null;
+                const conflict = conflictReason(knob);
+                return (
+                  <span key={knob.id} style={s.field}>
+                    <span style={s.fieldLabel}>{knob.label || knob.id.toUpperCase()}</span>
+                    {renderSelect(knobDisplay(knob), entriesFor(knob),
+                      (nv) => setKnob(knob.id, nv), base, labelFor(knob),
+                      { hideValues: hideNullFor(knob),
+                        disabled: kc.disabled || !!conflict,
+                        disabledReason: conflict || kc.disableReason })}
+                  </span>
+                );
+              })}
             </div>
           </div>
         );
@@ -1638,16 +1814,60 @@ export const Playground = ({ config }) => {
   // (render path only; revertHidden keeps the clean 5-dim base).
   //   dpAttnOn — effective DP-Attention resolves to "on" (positive degree
   //              or true), explicit override else derived-from-base.
+  //   cpOn     — effective prefill-CP resolves to "on" (degree > 1),
+  //              explicit override else derived-from-base.
+  //   cpStrategy — effective CP layout ("zigzag" / "interleave"; explicit
+  //              override else baked-in-base else "interleave"). The CP ↔
+  //              DP-Attention mutual exclusion applies only to interleave.
+  //   cpSizeTarget — the only enable-able CP size (runtime derives
+  //              attn_cp_size = tp/dp); null when TP is unknown or the cp
+  //              knob opts out via `freeSize: true`.
+  //   effTp    — effective TP degree (override else derived).
   //   pdMode   — live PD-Disagg role; gates the decode-only HiSparse card.
   const attnDelta   = deltas.attention || {};
   const attnDerived = derivedMap.attention || {};
+  const attnKnobs   = ((pgFeatures.attention || {}).knobs) || [];
+  const effTp = (attnDelta.tp !== null && attnDelta.tp !== undefined)
+    ? attnDelta.tp
+    : (attnDerived.tp !== undefined ? attnDerived.tp : null);
+  // A picked value whose entry is disabled under the live facts is skipped
+  // by apply() and must not count as "on" (stale-state corner: e.g. CP=8
+  // picked, then TP switched to 4). Only explicit picks can go stale;
+  // derived-from-base values are always real.
+  const staleExplicit = (knobId, picked) => {
+    const knob = attnKnobs.find((k) => k.id === knobId);
+    const e = knob ? findEntry(knob.values || [], picked) : null;
+    return !!(e !== null && e !== undefined
+      && evaluateChip(e, { ...base, effTp }).disabled);
+  };
   const effDpAttn = (attnDelta.dpAttn !== null && attnDelta.dpAttn !== undefined)
-    ? attnDelta.dpAttn
+    ? (staleExplicit("dpAttn", attnDelta.dpAttn) ? null : attnDelta.dpAttn)
     : (attnDerived.dpAttn !== undefined ? attnDerived.dpAttn : null);
   const dpAttnOn = (effDpAttn === true)
     || (typeof effDpAttn === "number" && effDpAttn > 0);
+  // Runtime derivation attn_cp_size = tp/dp: the only enable-able CP size
+  // (null when TP is unknown or the cp knob opts out via `freeSize`).
+  const dpDegEff = (typeof effDpAttn === "number" && effDpAttn > 0)
+    ? effDpAttn : 1;
+  const cpKnobFreeSize = !!(attnKnobs.find((k) => k.id === "cp") || {}).freeSize;
+  const cpSizeTarget = (!cpKnobFreeSize && typeof effTp === "number" && effTp > 0)
+    ? effTp / dpDegEff : null;
+  const cpSizeStale = (v) => typeof v === "number" && v > 1
+    && cpSizeTarget !== null && v !== cpSizeTarget;
+  const effCp = (attnDelta.cp !== null && attnDelta.cp !== undefined)
+    ? ((staleExplicit("cp", attnDelta.cp) || cpSizeStale(attnDelta.cp))
+        ? null : attnDelta.cp)
+    : (attnDerived.cp !== undefined ? attnDerived.cp : null);
+  const cpOn = typeof effCp === "number" && effCp > 1;
+  const cpStrategy = ((attnDelta.cpStrategy
+      && !staleExplicit("cpStrategy", attnDelta.cpStrategy))
+    ? attnDelta.cpStrategy
+    : (attnDerived.cpStrategy !== undefined ? attnDerived.cpStrategy : null))
+    || "interleave";
   const pdMode = (deltas.pdDisagg && deltas.pdDisagg.mode) || "off";
-  const constraintBase = { ...base, dpAttnOn, pdMode };
+  const constraintBase = {
+    ...base, dpAttnOn, cpOn, cpStrategy, cpSizeTarget, effTp, pdMode,
+  };
 
   let baseCommand = "";
   let playgroundCommand = "";
@@ -1766,6 +1986,8 @@ export const Playground = ({ config }) => {
   // value to dodge form-value serialization; `onPick` gets the original
   // value. `labelFor` is an optional label resolver; `opts.hideValues`
   // suppresses values (e.g. the inherit sentinel when a base default exists).
+  // `opts.disabled` grays the whole select (knob-level gating), with
+  // `opts.disabledReason` as the hover tooltip.
   const renderSelect = (current, entries, onPick, base, labelFor, opts = {}) => {
     const hideSet = new Set(opts.hideValues || []);
     const items = [];
@@ -1783,7 +2005,9 @@ export const Playground = ({ config }) => {
     if (idx === -1) idx = 0;
     return (
       <select
-        style={s.select}
+        style={{ ...s.select, ...(opts.disabled ? s.chipDisabled : {}) }}
+        disabled={!!opts.disabled}
+        title={opts.disabled ? (opts.disabledReason || "Not available") : ""}
         value={idx}
         onChange={(e) => {
           const next = items[parseInt(e.target.value, 10)];

--- a/docs_new/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs_new/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -114,10 +114,13 @@ sgl-eval run mmmu_pro \\
   playgroundFeatures: {
 
     // ----- Attention Parallelism -----
+    // No CP knob: prefill Context Parallel needs model-side integration in
+    // SGLang (DeepSeek-family / Qwen-MoE / Mellum have it) and
+    // MiniMaxM3SparseForCausalLM has none — the engine's CP knob would emit
+    // --enable-prefill-cp flags that don't work on this model.
     attention: {
       knobs: [
         { id: "tp",     label: "TP", values: [null, 1, 2, 4, 8] },
-        { id: "cp",     label: "CP", values: [null, 1, 2, 4] },
         { id: "dpAttn", label: "DP-Attention",
           values: [null, false, 1, 2, 4, 8],
           labels: { "auto": "Auto", "false": "Off" } },

--- a/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -175,10 +175,10 @@ sgl-eval run aime25 \\
     // DP-Attention is a combined knob: value is the DP degree AND toggles `--enable-dp-attention`.
     // CP sizes auto-gate in the engine to the runtime derivation
     // attn_cp_size = tp/dp (a user-passed --attn-cp-size is overridden).
-    // CP is single-machine only (tp_size <= 8), and interleave CP requires
-    // dp_size == 1 (the engine grays CP while DP-Attention is on, and vice
-    // versa). No `cpStrategy` knob: DeepSeek-V4 supports only interleave
-    // (the runtime rejects zigzag).
+    // CP is single-machine only (tp_size <= 8). Interleave CP + DP-Attention
+    // currently fails the runtime's dp_size == 1 assert but is allowed here
+    // with a warning (combined support is planned upstream). No `cpStrategy`
+    // knob: DeepSeek-V4 supports only interleave (the runtime rejects zigzag).
     attention: {
       knobs: [
         { id: "tp", label: "TP", values: [

--- a/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -173,6 +173,12 @@ sgl-eval run aime25 \\
 
     // ----- Card 1: "Attention Parallelism" -----
     // DP-Attention is a combined knob: value is the DP degree AND toggles `--enable-dp-attention`.
+    // CP sizes auto-gate in the engine to the runtime derivation
+    // attn_cp_size = tp/dp (a user-passed --attn-cp-size is overridden).
+    // CP is single-machine only (tp_size <= 8), and interleave CP requires
+    // dp_size == 1 (the engine grays CP while DP-Attention is on, and vice
+    // versa). No `cpStrategy` knob: DeepSeek-V4 supports only interleave
+    // (the runtime rejects zigzag).
     attention: {
       knobs: [
         { id: "tp", label: "TP", values: [
@@ -184,7 +190,12 @@ sgl-eval run aime25 \\
           { value: 16, disable: { nodes: ["single"] },
             disableReason: "TP=16 requires 16 ranks — switch the Deploy panel's Nodes to Multi-Nodes first." },
         ]},
-        { id: "cp",     label: "CP", values: [null, 1, 2, 4] },
+        { id: "cp", label: "CP",
+          values: [null, { value: 1, label: "Off" }, 2, 4, 8],
+          disable: [
+            { when: { nodes: ["multi-2"] },
+              reason: "Prefill Context Parallel is single-machine only (SGLang asserts tp_size <= 8; cross-machine CP has precision issues)." },
+          ] },
         { id: "dpAttn", label: "DP-Attention",
           values: [
             null,

--- a/docs_new/src/snippets/configs/poolside/laguna-m1.jsx
+++ b/docs_new/src/snippets/configs/poolside/laguna-m1.jsx
@@ -120,8 +120,9 @@ sgl-eval run gsm8k \\
 
     // M.1 is global-attention (no SWA); expose TP + DP-Attention here. No CP: the default
     // trtllm_mha backend has no CP-aware KV-store (crashes), and the engine's built-in attention CP
-    // knob emits NSA flags (--enable-nsa-prefill-context-parallel) that apply to DeepSeek-family
-    // models, not M.1. (CP works only via the fa3 backend, which is Hopper SM90 — left out here.)
+    // knob emits prefill-CP flags (--enable-prefill-cp / --cp-strategy / --attn-cp-size) that apply
+    // to DeepSeek-family models, not M.1. (CP works only via the fa3 backend, which is Hopper
+    // SM90 — left out here.)
     // DP-Attention: VERIFIED functionally correct on 8×B200 BF16 (GSM8K 0.94, identical to the TP
     // baseline) but ~15–28% slower on this GQA model (8 KV heads). Playground experiment only —
     // deliberately NOT in the shipped Balanced recipe.

--- a/docs_new/src/snippets/configs/tencent/hy3.jsx
+++ b/docs_new/src/snippets/configs/tencent/hy3.jsx
@@ -109,6 +109,10 @@ sgl-eval run aime26 \\
   playgroundFeatures: {
 
     // ----- Card 1: "Attention Parallelism" -----
+    // No CP knob: prefill Context Parallel needs model-side integration in
+    // SGLang (DeepSeek-family / Qwen-MoE / Mellum have it) and HYV3ForCausalLM
+    // has none — the engine's CP knob would emit --enable-prefill-cp flags
+    // that don't work on this model.
     attention: {
       knobs: [
         { id: "tp", label: "TP", values: [
@@ -120,7 +124,6 @@ sgl-eval run aime26 \\
           { value: 16, disable: { nodes: ["single"] },
             disableReason: "TP=16 requires 16 ranks — switch the Deploy panel's Nodes to Multi-Nodes first." },
         ]},
-        { id: "cp",     label: "CP", values: [null, 1, 2, 4] },
         { id: "dpAttn", label: "DP-Attention",
           values: [
             null,

--- a/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
@@ -107,13 +107,12 @@ sgl-eval run aime25 \\
 
     // ----- Card 1: "Attention Parallelism" -----
     // DSA prefill Context Parallelism (CP) splits the long-prefill attention across
-    // `cp` ranks — verified on Hopper (H200). On Blackwell the DSA-CP FP8 rope kernel
-    // is not yet adapted, so keep CP off there for now.
+    // `cp` ranks — runs on Hopper (H200) and Blackwell (B200/GB300/B300).
     // CP sizes auto-gate in the engine to the runtime derivation
     // attn_cp_size = tp/dp (a user-passed --attn-cp-size is overridden).
-    // CP is single-machine only (tp_size <= 8), and interleave CP requires
-    // dp_size == 1 (the engine grays CP while DP-Attention is on, and vice
-    // versa — zigzag lifts that exclusion).
+    // CP is single-machine only (tp_size <= 8). Interleave CP + DP-Attention
+    // currently fails the runtime's dp_size == 1 assert but is allowed here
+    // with a warning (combined support is planned upstream).
     // Strategy knob: interleave (ex round-robin-split) is the layout verified
     // here and the default; zigzag (ex in-seq-split) is exposed as an
     // experiment — the runtime auto-configures deepep + ep=tp for it and
@@ -124,8 +123,8 @@ sgl-eval run aime25 \\
         { id: "cp", label: "CP (DSA prefill)",
           values: [null, { value: 1, label: "Off" }, 4, 8],
           disable: [
-            { when: { hw: ["b200", "gb300", "b300", "mi355x", "mi325x", "mi300x"] },
-              reason: "DSA prefill Context Parallel is verified on Hopper (H200); the Blackwell sm100 DSA-CP FP8 rope kernel is not yet adapted, and the ROCm DSA-CP path is not yet validated on AMD (MI300X/MI325X/MI355X)." },
+            { when: { hw: ["mi355x", "mi325x", "mi300x"] },
+              reason: "The ROCm DSA-CP path is not yet validated on AMD (MI300X/MI325X/MI355X) — keep CP off there for now." },
             { when: { nodes: ["multi-2"] },
               reason: "Prefill Context Parallel is single-machine only (SGLang asserts tp_size <= 8; cross-machine CP has precision issues)." },
           ] },
@@ -136,8 +135,8 @@ sgl-eval run aime25 \\
             { value: "zigzag", label: "zigzag (experimental)" },
           ],
           disable: [
-            { when: { hw: ["b200", "gb300", "b300", "mi355x", "mi325x", "mi300x"] },
-              reason: "DSA prefill Context Parallel is verified on Hopper (H200); the Blackwell sm100 DSA-CP FP8 rope kernel is not yet adapted, and the ROCm DSA-CP path is not yet validated on AMD (MI300X/MI325X/MI355X)." },
+            { when: { hw: ["mi355x", "mi325x", "mi300x"] },
+              reason: "The ROCm DSA-CP path is not yet validated on AMD (MI300X/MI325X/MI355X) — keep CP off there for now." },
             { when: { nodes: ["multi-2"] },
               reason: "Prefill Context Parallel is single-machine only (SGLang asserts tp_size <= 8; cross-machine CP has precision issues)." },
           ] },

--- a/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
+++ b/docs_new/src/snippets/configs/zai-org/glm-5.2.jsx
@@ -109,12 +109,38 @@ sgl-eval run aime25 \\
     // DSA prefill Context Parallelism (CP) splits the long-prefill attention across
     // `cp` ranks — verified on Hopper (H200). On Blackwell the DSA-CP FP8 rope kernel
     // is not yet adapted, so keep CP off there for now.
+    // CP sizes auto-gate in the engine to the runtime derivation
+    // attn_cp_size = tp/dp (a user-passed --attn-cp-size is overridden).
+    // CP is single-machine only (tp_size <= 8), and interleave CP requires
+    // dp_size == 1 (the engine grays CP while DP-Attention is on, and vice
+    // versa — zigzag lifts that exclusion).
+    // Strategy knob: interleave (ex round-robin-split) is the layout verified
+    // here and the default; zigzag (ex in-seq-split) is exposed as an
+    // experiment — the runtime auto-configures deepep + ep=tp for it and
+    // restricts it to batch_size=1 (long-context single-request runs).
     attention: {
       knobs: [
         { id: "tp", label: "TP", values: [null, 4, 8] },
-        { id: "cp", label: "CP (DSA prefill)", values: [null, 1, 2, 4, 8],
-          disable: { hw: ["b200", "gb300", "b300", "mi355x", "mi325x", "mi300x"] },
-          disableReason: "DSA prefill Context Parallel is verified on Hopper (H200); the Blackwell sm100 DSA-CP FP8 rope kernel is not yet adapted, and the ROCm DSA-CP path is not yet validated on AMD (MI300X/MI325X/MI355X)." },
+        { id: "cp", label: "CP (DSA prefill)",
+          values: [null, { value: 1, label: "Off" }, 4, 8],
+          disable: [
+            { when: { hw: ["b200", "gb300", "b300", "mi355x", "mi325x", "mi300x"] },
+              reason: "DSA prefill Context Parallel is verified on Hopper (H200); the Blackwell sm100 DSA-CP FP8 rope kernel is not yet adapted, and the ROCm DSA-CP path is not yet validated on AMD (MI300X/MI325X/MI355X)." },
+            { when: { nodes: ["multi-2"] },
+              reason: "Prefill Context Parallel is single-machine only (SGLang asserts tp_size <= 8; cross-machine CP has precision issues)." },
+          ] },
+        { id: "cpStrategy", label: "CP Strategy",
+          values: [
+            null,
+            "interleave",
+            { value: "zigzag", label: "zigzag (experimental)" },
+          ],
+          disable: [
+            { when: { hw: ["b200", "gb300", "b300", "mi355x", "mi325x", "mi300x"] },
+              reason: "DSA prefill Context Parallel is verified on Hopper (H200); the Blackwell sm100 DSA-CP FP8 rope kernel is not yet adapted, and the ROCm DSA-CP path is not yet validated on AMD (MI300X/MI325X/MI355X)." },
+            { when: { nodes: ["multi-2"] },
+              reason: "Prefill Context Parallel is single-machine only (SGLang asserts tp_size <= 8; cross-machine CP has precision issues)." },
+          ] },
         { id: "dpAttn", label: "DP-Attention",
           values: [null, false, 4, 8],
           labels: { "auto": "Auto", "false": "Off" } },


### PR DESCRIPTION
## Motivation

The playground's attention-axis CP knob still emitted the **deprecated** DSA/NSA flag pair (`--enable-nsa-prefill-context-parallel --nsa-prefill-cp-mode round-robin-split`, deprecated by #27312 in favor of `--enable-prefill-cp --cp-strategy`), and its `apply()` only stripped the legacy flag heads. This breaks against new-style recipes: the GLM-5.2 H20 W4AFP8 cell in #31006 bakes `--attn-cp-size 8 --enable-prefill-cp --cp-strategy interleave`, and the knob could **neither turn that CP off nor change its size** — UI state and the generated command disagreed.

Auditing the runtime semantics surfaced more UI-vs-command mismatches, all fixed here under the same principle (a control's UI state must match the emitted command, and the emitted command must be a shape the runtime actually accepts).

## Changes

**Engine (`_playground.jsx`)**
- The CP knob now emits the canonical set `--attn-cp-size N --enable-prefill-cp --cp-strategy S`, and owns the *whole* CP flag family (canonical + every legacy spelling) when overriding — so it can turn off / resize CP baked into any recipe, old- or new-style.
- Strategy is no longer hardcoded to interleave: precedence is optional `cpStrategy` knob pick > strategy already baked in the base cell (legacy modes map in: `in-seq-split`→`zigzag`, `round-robin-split`→`interleave`) > `interleave` default. A zigzag base is no longer silently rewritten on resize.
- CP sizes auto-gate to the runtime derivation `attn_cp_size = tp/dp` (the DeepSeek-family overrides / `deepseek_v4_hook` silently override a mismatched `--attn-cp-size`), in both the grayed options and `apply()`; `freeSize: true` opts a model out.
- CP ↔ DP-Attention mutual exclusion enforced for **interleave only** (`dp_size == 1` assert); zigzag coexists with DP-Attention. Ties between two explicit picks break in DP-Attention's favor, so the selects never deadlock.
- Knob-level `hide`/`disable` on attention knobs is now honored (the per-hw CP disable already present in the GLM-5.2 config was previously dead — CP was clickable on Blackwell/AMD), and `disable` accepts an array of `{when, reason}` conditions.
- `apply()` skips knobs/values disabled under live facts, so stale picks (e.g. CP=8 then TP→4) drop out of the command instead of emitting a blocked combination.

**Configs**
- **GLM-5.2**: plain CP size values (engine auto-gates); knob grayed on non-Hopper hw and multi-node; new **CP Strategy** knob (`interleave` / `zigzag (experimental)` — the runtime auto-configures deepep + `ep=tp` for zigzag and restricts it to batch_size=1).
- **DeepSeek-V4**: same auto-gating; deliberately no strategy knob (`validate_deepseek_v4_cp` rejects zigzag).
- **Hy3, MiniMax-M3**: CP knob removed — `HYV3ForCausalLM` / `MiniMaxM3SparseForCausalLM` have no model-side CP integration in SGLang (no `cp_split/gather` calls, no CP hooks in the override registry), so the emitted flags do nothing or crash. Comments document why, mirroring the existing laguna-m1 precedent.
- **laguna-m1**: comment updated to name the canonical flags.

The `cookbook-add-model` authoring reference is updated to document the new constraint facts (`cpStrategy`, `cpSizeTarget`), the disable-array form, size auto-gating / `freeSize`, and when to expose a CP / cpStrategy knob.

## Verification

`mint validate` passes; exercised end-to-end in a live docs preview:
- derive from a baked new-style CP cell (shows real size + strategy), turn-off and resize overrides;
- strategy switching (interleave ⇄ zigzag) updates the command and lifts/applies the DP-Attention exclusion accordingly;
- size options re-gate live on TP / DP-Attention changes, stale picks drop from the command;
- hw / multi-node / DP-conflict graying with correct tooltips on GLM-5.2 and DeepSeek-V4;
- Hy3 / MiniMax-M3 pages render with TP + DP-Attention only; other playground pages unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29480041598](https://github.com/sgl-project/sglang/actions/runs/29480041598)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29480041430](https://github.com/sgl-project/sglang/actions/runs/29480041430)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->