### PR TITLE
[Dashboard] Add token-weighted prefix cache hit rate panel

### DIFF
--- a/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
+++ b/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
@@ -908,7 +908,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by (instance) (rate(sglang_realtime_tokens_total{mode=\"prefill_cache\"}[$__rate_interval])) / sum by (instance) (rate(sglang_realtime_tokens_total{mode=~\"prefill_cache|prefill_compute\"}[$__rate_interval]))",
+          "expr": "sum by (instance) (rate(sglang:realtime_tokens_total{mode=\"prefill_cache\"}[$__rate_interval])) / sum by (instance) (rate(sglang:realtime_tokens_total{mode=~\"prefill_cache|prefill_compute\"}[$__rate_interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,

--- a/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
+++ b/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
@@ -823,6 +823,109 @@
         "default": true,
         "type": "prometheus"
       },
+      "description": "Shows the fraction of prefill tokens served from prefix cache, computed from token counters.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by (instance) (rate(sglang_realtime_tokens_total{mode=\"prefill_cache\"}[$__rate_interval])) / sum by (instance) (rate(sglang_realtime_tokens_total{mode=~\"prefill_cache|prefill_compute\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Token-weighted Prefix Cache Hit Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
Closes #31327

## Motivation

The existing `Cache Hit Rate` panel is based on `sglang:cache_hit_rate`
and is useful for observing recent or batch-level scheduler behavior.
However, averaging this gauge over a long time range does not directly
show what fraction of prefill tokens were actually served from prefix
cache.

This PR adds a separate token-weighted panel to answer the following
operational question:

> Over the selected time range, what fraction of prefill tokens were
> served from prefix cache?

The existing `Cache Hit Rate` panel is kept unchanged.

## Modifications

- Add a new `Token-weighted Prefix Cache Hit Rate` panel to the Grafana
  dashboard.
- Calculate the token-weighted prefix cache hit rate using the existing
  `sglang:realtime_tokens_total` counter:

  ```promql
  sum by (instance) (
    rate(sglang:realtime_tokens_total{mode="prefill_cache"}[$__rate_interval])
  )
  /
  sum by (instance) (
    rate(sglang:realtime_tokens_total{mode=~"prefill_cache|prefill_compute"}[$__rate_interval])
  )
  ```

- Aggregate the result by instance.
- Keep the existing `Cache Hit Rate` panel unchanged.
- Reuse existing metrics without changing backend metric semantics.
- No backend, inference, or scheduler code is changed.

## Accuracy Tests

Not applicable. This dashboard-only change does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This dashboard-only change does not affect inference
execution or performance.

## Testing

- Validated the dashboard JSON with:

  ```bash
  python3 -m json.tool examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
  ```

- Verified that the new panel uses a unique panel ID (`21`).
- Loaded the dashboard in the example Grafana monitoring stack and verified
  that the new panel was provisioned successfully.

## Checklist

- [x] Validated the dashboard JSON format.
- [x] Followed the existing Grafana dashboard structure.
- [x] Kept the existing `Cache Hit Rate` panel unchanged.
- [x] Verified the new panel in the example Grafana monitoring stack.
- [x] Confirmed that no backend, inference, or scheduler code is changed.
- [x] Unit tests, accuracy tests, and speed benchmarks are not applicable
  to this dashboard-only change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32947719802](https://github.com/sgl-project/sglang/actions/runs/32947719802)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32947719621](https://github.com/sgl-project/sglang/actions/runs/32947719621)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->