### PR TITLE
[CI] Guard partition consumers against failed check-changes and degenerate fits

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -99,6 +99,7 @@ jobs:
     if: |
       always() &&
       !cancelled() &&
+      needs.check-changes.result == 'success' &&
       github.event_name == 'pull_request' &&
       inputs.test_parallel_dispatch != true &&
       (needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true') &&
@@ -127,6 +128,7 @@ jobs:
     if: |
       always() &&
       !cancelled() &&
+      needs.check-changes.result == 'success' &&
       github.event_name == 'pull_request' &&
       inputs.test_parallel_dispatch != true &&
       (needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true') &&
@@ -266,6 +268,7 @@ jobs:
     needs: [check-changes, call-gate]
     if: |
       always() &&
+      needs.check-changes.result == 'success' &&
       ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == true) || (!failure() && !cancelled())) &&
       (needs.check-changes.outputs.main_package == 'true')
     runs-on: ubuntu-latest

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -148,6 +148,11 @@ def compute_partitions(
         fit = fit_table.get(suite) or {}
         coeff = fit.get("coeff", 1.0)
         bias = fit.get("bias", 0.0)
+        # Defense in depth: a non-positive slope is regression noise (more
+        # work cannot reduce wall time), and its runaway intercept can push
+        # every shard budget negative. Fall back to the static estimate.
+        if coeff <= 0:
+            coeff, bias = 1.0, 0.0
 
         # Each shard pays `bias` once, so size >= coeff*total / (target-bias).
         if suite in _BASE_A_OVERRIDES:


### PR DESCRIPTION
Two hardenings from today's CI outage (a degenerate partition-model fit failed `check-changes` repo-wide ([example](https://github.com/sgl-project/sglang/actions/runs/29466164026/job/87522759392): `Suite 'base-c-test-deepep-4-gpu-b200': fit bias=1462.2s >= target=1350.0s`), and every `wait-for-*` job then exploded with misleading `fromJson('')` template errors that buried the root cause ([example](https://github.com/sgl-project/sglang/actions/runs/29466164026/job/87522590733): `Error reading JToken from JsonReader`)):

- `pr-test.yml`: the three jobs that evaluate `fromJson(needs.check-changes.outputs.partitions)` (`wait-for-base-a`, `wait-for-base-b`, `base-a-test-cpu`) now require `needs.check-changes.result == 'success'`, so a check-changes failure yields one clear red job instead of a cascade of template errors.
- `compute_partitions.py`: fall back to the static estimate when a fit has a non-positive slope — physically impossible, and its runaway intercept is what pushed `bias >= target`. The model source now gates this too (sgl-project/sglang-ci-stats#7); this is the consumer-side backstop.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29472680879](https://github.com/sgl-project/sglang/actions/runs/29472680879)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29472680766](https://github.com/sgl-project/sglang/actions/runs/29472680766)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
