### PR TITLE
fix: return 404 for unknown models on OpenAI-compatible endpoints

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -11,7 +11,13 @@ from fastapi import HTTPException, Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
-from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingRequest
+from sglang.srt.entrypoints.openai.protocol import (
+    DEFAULT_MODEL_NAME,
+    ErrorResponse,
+    OpenAIServingRequest,
+    ResponsesRequest,
+    V1RerankReqInput,
+)
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.observability.req_time_stats import monotonic_time
 from sglang.srt.server_args import ServerArgs
@@ -70,6 +76,43 @@ class OpenAIServingBase(ABC):
         # Fall back to explicit lora_path
         return explicit_lora_path
 
+    def validate_served_model(
+        self, request: Union[OpenAIServingRequest, ResponsesRequest]
+    ) -> Optional[ORJSONResponse]:
+        """Return a 404 response if the requested model is not served, else None."""
+        # Rerank requests carry no model field.
+        if isinstance(request, V1RerankReqInput):
+            return None
+
+        # An empty or default model means "use the served model".
+        model = request.model
+        if not model or model == DEFAULT_MODEL_NAME:
+            return None
+
+        valid_names = {self.tokenizer_manager.served_model_name}
+        if self.tokenizer_manager.server_args.enable_lora:
+            adapters = self.tokenizer_manager.lora_registry.get_all_adapters()
+            for lora_ref in adapters.values():
+                if lora_ref.lora_name is not None:
+                    valid_names.add(lora_ref.lora_name)
+
+        # Also accept the LoRA "base-model:adapter" form.
+        base_model, _ = self._parse_model_parameter(model)
+        if model in valid_names or base_model in valid_names:
+            return None
+
+        return ORJSONResponse(
+            status_code=404,
+            content={
+                "error": {
+                    "message": f"The model '{model}' does not exist",
+                    "type": "invalid_request_error",
+                    "param": "model",
+                    "code": "model_not_found",
+                }
+            },
+        )
+
     async def handle_request(
         self, request: OpenAIServingRequest, raw_request: Request
     ) -> Union[Any, StreamingResponse, ErrorResponse]:
@@ -79,6 +122,11 @@ class OpenAIServingBase(ABC):
         received_time = monotonic_time()
 
         try:
+            # Reject unknown models with an OpenAI-compatible 404.
+            model_error = self.validate_served_model(request)
+            if model_error is not None:
+                return model_error
+
             # Validate request
             error_msg = self._validate_request(request)
             if error_msg:

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -12,7 +12,6 @@ from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
 from sglang.srt.entrypoints.openai.protocol import (
-    DEFAULT_MODEL_NAME,
     ErrorResponse,
     OpenAIServingRequest,
     ResponsesRequest,
@@ -84,9 +83,13 @@ class OpenAIServingBase(ABC):
         if isinstance(request, V1RerankReqInput):
             return None
 
-        # An empty or default model means "use the served model".
+        # Only validate a model the client explicitly sent; a default-filled
+        # value means "use the served model".
+        if "model" not in request.model_fields_set:
+            return None
+
         model = request.model
-        if not model or model == DEFAULT_MODEL_NAME:
+        if not model:
             return None
 
         valid_names = {self.tokenizer_manager.served_model_name}

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -182,9 +182,13 @@ class OpenAIServingResponses(OpenAIServingChat):
         request: ResponsesRequest,
         raw_request: Optional[Request] = None,
     ) -> Union[AsyncGenerator[str, None], ResponsesResponse, ORJSONResponse]:
-        # Validate model
         if not self.tokenizer_manager:
             return self.create_error_response("Model not loaded")
+
+        # /v1/responses bypasses handle_request, so validate the model here too.
+        model_error = self.validate_served_model(request)
+        if model_error is not None:
+            return model_error
 
         # FIXME: If the engine is dead, raise an error
         # This is required for the streaming case

--- a/test/registered/unit/entrypoints/openai/test_serving_model_validation.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_model_validation.py
@@ -22,6 +22,7 @@ from fastapi import Request
 from utils import MockTemplateManager
 
 from sglang.srt.entrypoints.openai.protocol import (
+    DEFAULT_MODEL_NAME,
     ChatCompletionRequest,
     CompletionRequest,
     ResponsesRequest,
@@ -111,9 +112,9 @@ class ValidateServedModelTestCase(unittest.TestCase):
         )
         self.assertIsNone(self.chat.validate_served_model(request))
 
-    # (c) an omitted model (default sentinel / None) is accepted
+    # (c) an omitted model (not in model_fields_set) is accepted
     def test_default_sentinel_model_is_valid(self):
-        # CompletionRequest omits ``model`` -> defaults to the sentinel value.
+        # Client omits ``model``, so it is not in model_fields_set -> skip.
         completion_request = CompletionRequest(prompt="hi")
         self.assertIsNone(self.completion.validate_served_model(completion_request))
         # ResponsesRequest leaves ``model`` as None when omitted.
@@ -149,6 +150,15 @@ class ValidateServedModelTestCase(unittest.TestCase):
     def test_rerank_request_is_unaffected(self):
         request = V1RerankReqInput(query="q", documents=["d1", "d2"])
         self.assertIsNone(self.chat.validate_served_model(request))
+
+    # (f) an explicit model equal to the default, against a different served
+    # name, is still caught (model_fields_set marks it as client-provided)
+    def test_explicit_default_model_returns_404(self):
+        request = CompletionRequest(model=DEFAULT_MODEL_NAME, prompt="hi")
+        result = self.completion.validate_served_model(request)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.status_code, 404)
+        self.assertEqual(self._error_body(result)["code"], "model_not_found")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_serving_model_validation.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_model_validation.py
@@ -1,0 +1,155 @@
+"""Unit tests for served-model validation on the OpenAI serving layer.
+
+These exercise ``OpenAIServingBase.validate_served_model`` and its wiring into
+``handle_request`` (chat / completions) and ``create_responses`` (responses).
+
+Note: the "valid" cases assert that ``validate_served_model`` returns ``None``
+(i.e. the request is allowed to proceed and is not rejected with a 404).
+Asserting a full HTTP 200 generation would require running the model pipeline,
+which needs a GPU / engine and is out of scope for a CPU unit test.
+"""
+
+import asyncio
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from fastapi import Request
+
+# Importing utils first installs the CPU stubs (sgl_kernel + torch.compile)
+# needed before the serving modules are imported.
+from utils import MockTemplateManager
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    ResponsesRequest,
+    V1RerankReqInput,
+)
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
+from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+SERVED_MODEL = "served-model"
+LORA_ADAPTER = "my-lora"
+
+
+def _make_tokenizer_manager(*, enable_lora=False, adapters=()):
+    tm = Mock()
+    tm.model_config = Mock(is_multimodal=False, context_len=4096)
+    tm.model_config.get_default_sampling_params.return_value = {}
+    tm.model_config.hf_config = Mock(
+        model_type="llama", architectures=["LlamaForCausalLM"]
+    )
+    tm.server_args = Mock(
+        enable_cache_report=False,
+        reasoning_parser=None,
+        tool_call_parser=None,
+        default_chat_template_kwargs=None,
+        stream_response_default_include_usage=False,
+        tokenizer_metrics_allowed_custom_labels=None,
+        incremental_streaming_output=False,
+        enable_lora=enable_lora,
+    )
+    tm.served_model_name = SERVED_MODEL
+    tm.tokenizer = Mock()
+
+    lora_registry = Mock()
+    lora_registry.get_all_adapters.return_value = {
+        name: SimpleNamespace(lora_name=name, lora_path=f"/loras/{name}")
+        for name in adapters
+    }
+    tm.lora_registry = lora_registry
+    return tm
+
+
+class ValidateServedModelTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tm = _make_tokenizer_manager()
+        self.template_manager = MockTemplateManager()
+        self.chat = OpenAIServingChat(self.tm, self.template_manager)
+        self.completion = OpenAIServingCompletion(self.tm, self.template_manager)
+        self.responses = OpenAIServingResponses(self.tm, self.template_manager)
+        self.raw_request = Mock(spec=Request)
+        self.raw_request.headers = {}
+
+    @staticmethod
+    def _error_body(response):
+        return json.loads(response.body)["error"]
+
+    # (a) unknown model -> 404 model_not_found for chat / completions / responses
+    def test_unknown_model_chat_returns_404(self):
+        request = ChatCompletionRequest(
+            model="ghost-model",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        result = asyncio.run(self.chat.handle_request(request, self.raw_request))
+        self.assertEqual(result.status_code, 404)
+        self.assertEqual(self._error_body(result)["code"], "model_not_found")
+
+    def test_unknown_model_completion_returns_404(self):
+        request = CompletionRequest(model="ghost-model", prompt="hi")
+        result = asyncio.run(self.completion.handle_request(request, self.raw_request))
+        self.assertEqual(result.status_code, 404)
+        self.assertEqual(self._error_body(result)["code"], "model_not_found")
+
+    def test_unknown_model_responses_returns_404(self):
+        request = ResponsesRequest(model="ghost-model", input="hi", store=False)
+        result = asyncio.run(self.responses.create_responses(request, raw_request=None))
+        self.assertEqual(result.status_code, 404)
+        self.assertEqual(self._error_body(result)["code"], "model_not_found")
+
+    # (b) the real served model name is accepted
+    def test_served_model_name_is_valid(self):
+        request = ChatCompletionRequest(
+            model=SERVED_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        self.assertIsNone(self.chat.validate_served_model(request))
+
+    # (c) an omitted model (default sentinel / None) is accepted
+    def test_default_sentinel_model_is_valid(self):
+        # CompletionRequest omits ``model`` -> defaults to the sentinel value.
+        completion_request = CompletionRequest(prompt="hi")
+        self.assertIsNone(self.completion.validate_served_model(completion_request))
+        # ResponsesRequest leaves ``model`` as None when omitted.
+        responses_request = ResponsesRequest(input="hi", store=False)
+        self.assertIsNone(self.responses.validate_served_model(responses_request))
+
+    # (d) a loaded LoRA adapter name is accepted
+    def test_loaded_lora_adapter_is_accepted(self):
+        tm = _make_tokenizer_manager(enable_lora=True, adapters=(LORA_ADAPTER,))
+        chat = OpenAIServingChat(tm, self.template_manager)
+
+        bare_adapter = ChatCompletionRequest(
+            model=LORA_ADAPTER,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        self.assertIsNone(chat.validate_served_model(bare_adapter))
+
+        # "base-model:adapter" colon syntax is accepted via the base model.
+        colon_syntax = ChatCompletionRequest(
+            model=f"{SERVED_MODEL}:{LORA_ADAPTER}",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        self.assertIsNone(chat.validate_served_model(colon_syntax))
+
+        # An adapter that is not loaded is still rejected.
+        not_loaded = ChatCompletionRequest(
+            model="not-loaded",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        self.assertIsNotNone(chat.validate_served_model(not_loaded))
+
+    # (e) a rerank request has no ``model`` field and is unaffected
+    def test_rerank_request_is_unaffected(self):
+        request = V1RerankReqInput(query="q", documents=["d1", "d2"])
+        self.assertIsNone(self.chat.validate_served_model(request))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/utils.py
+++ b/test/registered/unit/entrypoints/openai/utils.py
@@ -51,7 +51,9 @@ class MockTokenizerManager:
             tokenizer_metrics_allowed_custom_labels=None,
             tool_call_parser=None,
             incremental_streaming_output=False,
+            enable_lora=False,
         )
+        self.served_model_name = "x"
         self.tokenizer = Mock()
         self.tokenizer.encode.return_value = [1, 2, 3]
         self.tokenizer.chat_template = None


### PR DESCRIPTION
## Motivation

The OpenAI-compatible endpoints accepted any value for the `model` field and returned 200 even when the requested model was not the one being served. This diverges from the OpenAI spec, which returns a 404 `model_not_found` for an unknown model, and from SGLang's  `/v1/models/{model}` , which already returns 404. Fixes #31404.

## Modifications

Added a shared `validate_served_model` helper on `OpenAIServingBase` that returns a 404 `model_not_found` response for an unknown model and `None` otherwise. It accepts the served model name and any loaded LoRA adapters, including the `base-model:adapter` syntax, and skips requests that omit the model or use the default sentinel. The helper is called from `handle_request`, which every OpenAI endpoint inherits, and from `create_responses`, since `/v1/responses` does not go through `handle_request`. Rerank requests do not carry the `model` field. The 404 body matches the existing retrieve_model handler so clients get a consistent error.

## Accuracy Tests

Not applicable. 

## Speed Tests and Profiling

Not applicable. The check runs once per request before any engine work and short-circuits invalid requests earlier than before.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests for the new behavior.
- [ ] Update documentation (not applicable).
- [ ] Provide accuracy and speed benchmarks (not applicable; no model-output or speed impact).
- [x] Follow the SGLang code style guidance.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29524996953](https://github.com/sgl-project/sglang/actions/runs/29524996953)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29524996538](https://github.com/sgl-project/sglang/actions/runs/29524996538)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->