### PR TITLE
VSA flex/flashv4

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 import functools
 import math
+import os
 from dataclasses import dataclass
 
 import torch
+from torch.nn.attention.flex_attention import BlockMask, flex_attention
 
 try:
     from vsa import video_sparse_attn
@@ -25,7 +27,11 @@ from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
-VSA_TILE_SIZE = (4, 4, 4)
+
+USE_FLEX_ATTENTION = os.environ.get("SGLANG_VSA_USE_FLEX", "0") == "1"
+VSA_TILE_SIZE = (16, 4, 4) if USE_FLEX_ATTENTION else (4, 4, 4)
+VSA_TILE_NUMEL = math.prod(VSA_TILE_SIZE)
+VSA_KV_BLOCK_SIZE = 128
 
 
 @functools.lru_cache(maxsize=10)
@@ -121,6 +127,115 @@ def get_non_pad_index(
         < variable_block_sizes[:, None]
     )
     return index_pad[index_mask]
+
+
+def pool_to_vsa_tiles(
+    x: torch.Tensor,
+    variable_block_sizes: torch.Tensor,
+) -> torch.Tensor:
+    """Mean-pool tile-major tokens with fp32 accumulation for stable coarse scores."""
+    tiled = x.unflatten(-2, (-1, VSA_TILE_NUMEL))
+    counts = variable_block_sizes.to(device=x.device, dtype=torch.float32).clamp_min(1)
+    return (tiled.float().sum(dim=-2) / counts[None, None, :, None]).to(x.dtype)
+
+
+def generate_vsa_padding_mask_mod(
+    variable_block_sizes: torch.Tensor,
+):
+    """Mask out padded KV tokens from partially-filled VSA tiles."""
+
+    def vsa_padding_mask_mod(b, h, q_idx, kv_idx):
+        kv_tile = kv_idx // VSA_TILE_NUMEL
+        return kv_idx % VSA_TILE_NUMEL < variable_block_sizes[kv_tile]
+
+    return vsa_padding_mask_mod
+
+
+def create_vsa_flash_block_mask(
+    topk_indices: torch.Tensor,
+    variable_block_sizes: torch.Tensor,
+) -> BlockMask:
+    """Build a VSA block mask for Flex FLASH, including padded edge tiles."""
+    selected_indices = topk_indices.sort(dim=-1).values.contiguous()
+    top_k = selected_indices.shape[-1]
+    kv_factor = VSA_TILE_NUMEL // VSA_KV_BLOCK_SIZE
+    selected_sizes = variable_block_sizes[selected_indices.long()]
+    subblock_offsets = torch.arange(
+        kv_factor, device=selected_indices.device, dtype=torch.int32
+    )
+    subblock_starts = subblock_offsets * VSA_KV_BLOCK_SIZE
+    subblock_ends = subblock_starts + VSA_KV_BLOCK_SIZE
+    expanded_indices = (
+        selected_indices[..., None] * kv_factor + subblock_offsets
+    ).flatten(-2)
+    valid_subblocks = (selected_sizes[..., None] > subblock_starts).flatten(-2)
+    full_subblocks = (selected_sizes[..., None] >= subblock_ends).flatten(-2)
+    partial_subblocks = valid_subblocks & ~full_subblocks
+
+    full_order = torch.argsort((~full_subblocks).to(torch.int32), dim=-1, stable=True)
+    partial_order = torch.argsort(
+        (~partial_subblocks).to(torch.int32), dim=-1, stable=True
+    )
+    kv_indices = torch.zeros(
+        *selected_indices.shape[:-1],
+        variable_block_sizes.shape[0] * kv_factor,
+        dtype=torch.int32,
+        device=selected_indices.device,
+    )
+    full_kv_indices = torch.zeros_like(kv_indices)
+    kv_indices[..., : top_k * kv_factor] = torch.gather(
+        expanded_indices, -1, partial_order
+    )
+    full_kv_indices[..., : top_k * kv_factor] = torch.gather(
+        expanded_indices, -1, full_order
+    )
+    return BlockMask.from_kv_blocks(
+        kv_num_blocks=partial_subblocks.sum(dim=-1).to(torch.int32),
+        kv_indices=kv_indices,
+        full_kv_num_blocks=full_subblocks.sum(dim=-1).to(torch.int32),
+        full_kv_indices=full_kv_indices,
+        BLOCK_SIZE=(VSA_TILE_NUMEL, VSA_KV_BLOCK_SIZE),
+        mask_mod=generate_vsa_padding_mask_mod(variable_block_sizes),
+        seq_lengths=(
+            selected_indices.shape[-2] * VSA_TILE_NUMEL,
+            variable_block_sizes.shape[0] * VSA_TILE_NUMEL,
+        ),
+    )
+
+
+def flex_vsa_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    gate_compress: torch.Tensor,
+    variable_block_sizes: torch.Tensor,
+    cur_topk: int,
+) -> torch.Tensor:
+    """Run the full VSA forward so torch.compile can capture mask construction."""
+    pooled_query = pool_to_vsa_tiles(query, variable_block_sizes)
+    pooled_key = pool_to_vsa_tiles(key, variable_block_sizes)
+    pooled_value = pool_to_vsa_tiles(value, variable_block_sizes)
+    scores = torch.matmul(pooled_query, pooled_key.transpose(-2, -1)) / math.sqrt(
+        query.shape[-1]
+    )
+    topk_indices = torch.topk(scores, k=cur_topk, dim=-1).indices.to(torch.int32)
+    probabilities = torch.softmax(scores, dim=-1)
+
+    block_mask = create_vsa_flash_block_mask(topk_indices, variable_block_sizes)
+    fine = flex_attention(
+        query,
+        key,
+        value,
+        block_mask=block_mask,
+        kernel_options={"BACKEND": "FLASH"},
+    )
+    coarse = torch.matmul(probabilities, pooled_value).repeat_interleave(
+        VSA_TILE_NUMEL, dim=-2
+    )
+    return fine + coarse[..., : fine.shape[-2], :] * gate_compress
+
+
+compiled_flex_vsa_forward = torch.compile(flex_vsa_forward, dynamic=False)
 
 
 class VideoSparseAttentionBackend(AttentionBackend):
@@ -331,6 +446,16 @@ class VideoSparseAttentionImpl(AttentionImpl):
             (1 - VSA_sparsity)
             * (attn_metadata.total_seq_length / math.prod(VSA_TILE_SIZE))
         )
+
+        if USE_FLEX_ATTENTION:
+            return compiled_flex_vsa_forward(
+                query,
+                key,
+                value,
+                gate_compress,
+                attn_metadata.variable_block_sizes.to(query.device),
+                cur_topk,
+            ).transpose(1, 2)
 
         if video_sparse_attn is None:
             raise NotImplementedError("video_sparse_attn is not installed")

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
@@ -247,31 +247,37 @@ class VideoSparseAttentionImpl(AttentionImpl):
 
     def tile(
         self,
-        x: torch.Tensor,
+        tensors: tuple[torch.Tensor, ...],
         attn_metadata: VideoSparseAttentionMetadata,
     ) -> torch.Tensor:
-        num_tiles = attn_metadata.num_tiles
-        t_padded_size = num_tiles[0] * VSA_TILE_SIZE[0]
-        h_padded_size = num_tiles[1] * VSA_TILE_SIZE[1]
-        w_padded_size = num_tiles[2] * VSA_TILE_SIZE[2]
+        """Tile inputs into one reusable buffer without concatenating them first."""
+        reference = tensors[0]
         target_shape = (
-            x.shape[0],
-            t_padded_size * h_padded_size * w_padded_size,
-            x.shape[-2],
-            x.shape[-1],
+            sum(tensor.shape[0] for tensor in tensors),
+            math.prod(attn_metadata.num_tiles) * math.prod(VSA_TILE_SIZE),
+            reference.shape[-2],
+            reference.shape[-1],
         )
 
         buf = attn_metadata.tile_buf
         if (
             buf is None
             or buf.shape != target_shape
-            or buf.dtype != x.dtype
-            or buf.device != x.device
+            or buf.dtype != reference.dtype
+            or buf.device != reference.device
         ):
-            buf = torch.zeros(target_shape, device=x.device, dtype=x.dtype)
+            buf = torch.zeros(
+                target_shape, device=reference.device, dtype=reference.dtype
+            )
             attn_metadata.tile_buf = buf
 
-        buf[:, attn_metadata.non_pad_index] = x[:, attn_metadata.tile_partition_indices]
+        start = 0
+        for tensor in tensors:
+            stop = start + tensor.shape[0]
+            buf[start:stop, attn_metadata.non_pad_index] = tensor[
+                :, attn_metadata.tile_partition_indices
+            ]
+            start = stop
         return buf
 
     def untile(
@@ -286,7 +292,18 @@ class VideoSparseAttentionImpl(AttentionImpl):
         qkv: torch.Tensor,
         attn_metadata: VideoSparseAttentionMetadata,
     ) -> torch.Tensor:
-        return self.tile(qkv, attn_metadata)
+        return self.tile((qkv,), attn_metadata)
+
+    def preprocess_qkvg(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        gate_compress: torch.Tensor,
+        attn_metadata: VideoSparseAttentionMetadata,
+    ) -> torch.Tensor:
+        """Preprocess separate VSA inputs without materializing concatenated Q/K/V/gate."""
+        return self.tile((query, key, value, gate_compress), attn_metadata)
 
     def postprocess_output(
         self,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -5,7 +5,7 @@ import functools
 import os
 from collections.abc import Sequence
 from contextlib import nullcontext
-from typing import Type
+from typing import TYPE_CHECKING, Type, cast
 
 import torch
 import torch.nn as nn
@@ -60,6 +60,11 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import 
     eager_on_graph,
     is_in_breakable_cuda_graph,
 )
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn import (
+        VideoSparseAttentionImpl,
+    )
 
 _PYTORCH_DEFAULT_CUDA_SDP_BACKENDS = [
     SDPBackend.CUDNN_ATTENTION,
@@ -358,49 +363,35 @@ class UlyssesAttention_VSA(UlyssesAttention):
         replicated_v: torch.Tensor | None = None,
         gate_compress: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Forward pass for distributed attention.
-
-        Args:
-            q (torch.Tensor): Query tensor [batch_size, seq_len, num_heads, head_dim]
-            k (torch.Tensor): Key tensor [batch_size, seq_len, num_heads, head_dim]
-            v (torch.Tensor): Value tensor [batch_size, seq_len, num_heads, head_dim]
-            gate_compress (torch.Tensor): Gate compress tensor [batch_size, seq_len, num_heads, head_dim]
-            replicated_q (Optional[torch.Tensor]): Replicated query tensor, typically for text tokens
-            replicated_k (Optional[torch.Tensor]): Replicated key tensor
-            replicated_v (Optional[torch.Tensor]): Replicated value tensor
-
-        Returns:
-            Tuple[torch.Tensor, Optional[torch.Tensor]]: A tuple containing:
-                - o (torch.Tensor): Output tensor after attention for the main sequence
-                - replicated_o (Optional[torch.Tensor]): Output tensor for replicated tokens, if provided
-        """
+        """Run distributed VSA without replicated text tokens."""
         # Check text tokens are not supported for VSA now
         assert (
             replicated_q is None and replicated_k is None and replicated_v is None
         ), "Replicated QKV is not supported for VSA now"
         # Check input shapes
         assert q.dim() == 4 and k.dim() == 4 and v.dim() == 4, "Expected 4D tensors"
+        assert gate_compress is not None, "VSA requires gate_compress"
 
         forward_context: ForwardContext = get_forward_context()
         ctx_attn_metadata = forward_context.attn_metadata
+        attn_impl = cast("VideoSparseAttentionImpl", self.attn_impl)
 
-        # Stack QKV
-        qkvg = torch.cat(
-            [q, k, v, gate_compress], dim=0
-        )  # [3, seq_len, num_heads, head_dim]
-
-        # Redistribute heads across sequence dimension
-        qkvg = sequence_model_parallel_all_to_all_4D(qkvg, scatter_dim=2, gather_dim=1)
-
-        qkvg = self.attn_impl.preprocess_qkv(qkvg, ctx_attn_metadata)
+        if get_sp_world_size() == 1:
+            qkvg = attn_impl.preprocess_qkvg(q, k, v, gate_compress, ctx_attn_metadata)
+        else:
+            qkvg = torch.cat([q, k, v, gate_compress], dim=0)
+            qkvg = sequence_model_parallel_all_to_all_4D(
+                qkvg, scatter_dim=2, gather_dim=1
+            )
+            qkvg = attn_impl.preprocess_qkv(qkvg, ctx_attn_metadata)
 
         q, k, v, gate_compress = qkvg.chunk(4, dim=0)
-        output = self.attn_impl.forward(
+        output = attn_impl.forward(
             q, k, v, gate_compress=gate_compress, attn_metadata=ctx_attn_metadata
-        )  # type: ignore[call-arg]
+        )
 
         # Apply backend-specific postprocess_output
-        output = self.attn_impl.postprocess_output(output, ctx_attn_metadata)
+        output = attn_impl.postprocess_output(output, ctx_attn_metadata)
 
         output = sequence_model_parallel_all_to_all_4D(
             output, scatter_dim=1, gather_dim=2

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -176,11 +176,13 @@ class _VideoSparseAttentionBackendResolver(_CudaAttentionBackendResolver):
     @classmethod
     def resolve(cls, platform) -> str:
         try:
-            from vsa import block_sparse_attn  # noqa: F401
-
             from sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn import (  # noqa: F401
+                USE_FLEX_ATTENTION,
                 VideoSparseAttentionBackend,
             )
+
+            if not USE_FLEX_ATTENTION:
+                from vsa import block_sparse_attn  # noqa: F401
 
             return "sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn.VideoSparseAttentionBackend"
         except ImportError as e:

--- a/python/sglang/multimodal_gen/test/unit/test_video_sparse_attention.py
+++ b/python/sglang/multimodal_gen/test/unit/test_video_sparse_attention.py
@@ -37,3 +37,27 @@ def test_video_sparse_attention_tile_buffer_reuse_and_untile():
     pad_mask = torch.ones(next_tiled.shape[1], dtype=torch.bool)
     pad_mask[metadata.non_pad_index.cpu()] = False
     assert torch.all(next_tiled[:, pad_mask] == 0)
+
+
+def test_video_sparse_attention_direct_qkvg_tiling_matches_concatenated_path():
+    metadata = VideoSparseAttentionMetadataBuilder().build(
+        current_timestep=0,
+        raw_latent_shape=(5, 7, 9),
+        patch_size=(1, 1, 1),
+        VSA_sparsity=0.5,
+        device=torch.device("cpu"),
+    )
+    impl = object.__new__(VideoSparseAttentionImpl)
+    query = torch.arange(
+        2 * metadata.total_seq_length * 3 * 4, dtype=torch.float32
+    ).reshape(2, metadata.total_seq_length, 3, 4)
+    tensors = (query, query + 1, query + 2, query + 3)
+
+    expected = impl.preprocess_qkv(torch.cat(tensors, dim=0), metadata).clone()
+    tile_buf = metadata.tile_buf
+    actual = impl.preprocess_qkvg(*tensors, metadata)
+
+    assert actual is tile_buf
+    assert torch.equal(actual, expected)
+    for tiled, original in zip(actual.chunk(4, dim=0), tensors):
+        assert torch.equal(impl.postprocess_output(tiled, metadata), original)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
I recently enabled VSA support in attention-gym using our new FA4 support in
FlexAttention. I got pretty good performance and wanted to put up a PR to show the end-to-end
gains we can get on Blackwell. This does require a newer version of PyTorch, which I imagine is
currently a blocker, since the older Inductor version fails with some rando error. We may need to wait until SGLang
can use the newer version of pt at least 2.13.


## Summary

Below is is the summary I had codex generate

  This adds an opt-in FlexAttention/FlashAttention-4 implementation of Video Sparse Attention
  (VSA) to SGLang. It builds on the VSA support recently added to attention-gym and measures how
  much of the isolated kernel improvement carries through to end-to-end Blackwell inference.

  The existing external `vsa` implementation remains the default. Set `SGLANG_VSA_USE_FLEX=1` to
  enable this path.

  ### What It Does

  - Uses `(16, 4, 4)` VSA tiles and maps each selected tile to 128-token FA4 KV blocks.
  - Handles partially padded edge tiles through FlexAttention block masks.
  - Compiles pooling, score calculation, top-k selection, block-mask construction, FA4, and
  coarse-output combination as one region.
  - Selects top-k blocks from pre-softmax scores to avoid bf16 softmax ties.
  - Avoids the intermediate Q/K/V/gate concatenation on single-GPU inference by gathering
  directly into the reusable tiled buffer.
  - Preserves the existing concatenate and all-to-all path for sequence-parallel execution.
  - Allows the Flex path to resolve without requiring the external `vsa` package.

  ### Performance

  Measured on an NVIDIA GB300 with bf16, `B=1`, `H=8`, `D=128`, and VSA sparsity `0.8`. Steady-
  state CUDA graph timings exclude compilation and warmup.

  Microbenchmarks across representative video grids:

  - Compiled tiled VSA region: **2.41x-3.43x faster**
  - Complete backend including tile/untile: **1.90x-2.30x faster**

  Supported FastWan workload: 61 frames, `480x832`, three DMD steps:

  - Mean pipeline latency: **1701 ms -> 1534 ms** (**1.109x**)
  - Median pipeline latency: **1700 ms -> 1531 ms** (**1.110x**)
  - Median denoising time: **642 ms -> 473 ms** (**1.36x**)

  The smaller end-to-end gain is expected because VSA is only part of denoising, while text
  encoding, MLPs, decoding, scheduling, and output materialization are unchanged.

  ### Validation

  - Direct tiling matches the concatenated path exactly and reuses the same buffer.
  - Whole VSA path captures as one Dynamo graph with zero graph breaks.
  - Score-based top-k has zero selection drift under compilation.
  - Whole-compiled output matches the fixed-mask compiled FA4 path within `9.77e-4` max error.
  - Targeted unit tests pass.
  - Ruff, Black, isort, and `git diff --check` pass.

  ### Current Blocker

  This currently requires a newer PyTorch nightly. SGLang pins PyTorch 2.11, where representative
  VSA shapes hit an Inductor generated-code failure. The same path works correctly on the tested
  nightly build, so this PR is a draft until the supported PyTorch/Inductor version is resolved.



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29473451209](https://github.com/sgl-project/sglang/actions/runs/29473451209)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29473451072](https://github.com/sgl-project/sglang/actions/runs/29473451072)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->