### PR TITLE
[AMD] Make the aiter imports on the startup path optional

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -11,15 +11,31 @@ from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import direct_register_custom_op, mxfp_supported
 
 _is_hip = is_hip()
+# aiter is optional -- absent from pyproject.toml, no published wheel -- so
+# is_hip() does not imply these kernels are importable, and neither does a
+# working `import aiter`: a version-skewed build can ship the module without
+# the symbol. This file is imported unconditionally at startup by the
+# quantization registry, so an unguarded import takes the server down before
+# any model is selected.
+_has_aiter_mxfp4 = False
 if _is_hip:
-    from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
-        fused_gemm_afp4wfp4_split_cat as _fused_gemm_afp4wfp4_split_cat_orig,
-    )
-    from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4 as _gemm_afp4wfp4_orig
-    from aiter.ops.triton.gemm_afp4wfp4_pre_quant_atomic import (
-        gemm_afp4wfp4_pre_quant as _gemm_afp4wfp4_pre_quant_orig,
-    )
-    from aiter.ops.triton.quant import dynamic_mxfp4_quant as _dynamic_mxfp4_quant_orig
+    try:
+        from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
+            fused_gemm_afp4wfp4_split_cat as _fused_gemm_afp4wfp4_split_cat_orig,
+        )
+        from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4 as _gemm_afp4wfp4_orig
+        from aiter.ops.triton.gemm_afp4wfp4_pre_quant_atomic import (
+            gemm_afp4wfp4_pre_quant as _gemm_afp4wfp4_pre_quant_orig,
+        )
+        from aiter.ops.triton.quant import (
+            dynamic_mxfp4_quant as _dynamic_mxfp4_quant_orig,
+        )
+
+        _has_aiter_mxfp4 = True
+    except ImportError:
+        pass
+
+if _has_aiter_mxfp4:
 
     def _aiter_gemm_afp4wfp4(
         x: torch.Tensor,
@@ -168,6 +184,12 @@ class QuarkW4A4MXFP4(QuarkLinearScheme):
         self.weight_quant_spec = weight_quant_spec
         self.input_quant_spec = input_quant_spec
         self.is_checkpoint_mxfp4_serialized = is_checkpoint_mxfp4_serialized
+
+        if not _has_aiter_mxfp4:
+            raise NotImplementedError(
+                "The MXFP4 scheme requires aiter. Please make sure a compatible "
+                "aiter is installed on your AMD device."
+            )
 
         if not self.is_checkpoint_mxfp4_serialized:
             if not mxfp_supported():

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -36,8 +36,14 @@ if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
     from aiter.utility.fp4_utils import e8m0_shuffle
 
+# aiter is optional, so is_hip() does not imply this kernel is importable, and
+# a version-skewed build can ship the module without the symbol. This file is
+# imported unconditionally at startup by the quantization registry.
 if _is_hip:
-    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    try:
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    except ImportError:
+        dynamic_mxfp4_quant = None
 else:
     dynamic_mxfp4_quant = None
 

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -27,7 +27,13 @@ _is_hip = is_hip()
 
 
 if _is_hip:
-    from aiter.ops.shuffle import shuffle_weight
+    # aiter is optional, so is_hip() does not imply this kernel is importable,
+    # and a version-skewed build can ship the module without the symbol. This
+    # file is imported unconditionally at startup by the quantization registry.
+    try:
+        from aiter.ops.shuffle import shuffle_weight
+    except ImportError:
+        shuffle_weight = None
 
     ON_GFX950 = "gfx950" in torch.cuda.get_device_properties("cuda").gcnArchName
 
@@ -143,6 +149,12 @@ class QuarkInt4Fp8MoEMethod(FusedMoEMethodBase):
         if not _is_hip:
             raise NotImplementedError(
                 "The quark_int4fp8_moe online quantization scheme is only supported on AMD GPUs."
+            )
+
+        if shuffle_weight is None:
+            raise NotImplementedError(
+                "The quark_int4fp8_moe online quantization scheme requires aiter. "
+                "Please make sure a compatible aiter is installed on your AMD device."
             )
 
     def get_weight_loader(self, layer, original_weight_loader):


### PR DESCRIPTION
## Motivation

aiter is an optional dependency. It is absent from `pyproject.toml`, has no published wheel — the repo's own [`3rdparty/amd/wheel/README.md`](https://github.com/sgl-project/sglang/blob/main/3rdparty/amd/wheel/README.md) notes *"Wheel-izing it is ongoing"* — and is only present when built from source per `docker/rocm.Dockerfile`.

But three modules guard their aiter imports with `if _is_hip:`, using it as a proxy for *"aiter is importable"*:

```python
_is_hip = is_hip()
if _is_hip:
    from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4   # unguarded
```

`is_hip()` is not that proxy. It is true on **any** AMD device, including one where aiter was never built. And a successful `import aiter` does not imply a given symbol exists either — a version-skewed build ships the module without it:

```
ImportError: cannot import name 'shuffle_scale' from 'aiter.ops.shuffle'
```

**These three modules are imported unconditionally at startup by the quantization registry**, so the import is not deferred to first use. With aiter unavailable the server cannot start **at all — for any model, including plain bf16** — failing during argument parsing before a model is even selected:

```
launch_server.py -> ServerArgs.__post_init__ -> get_model_config
  -> layers/quantization/__init__.py -> quark.py -> quark/schemes/__init__.py
  -> quark_w4a4_mxfp4.py -> ImportError: No module named 'aiter'
```

This is **not RDNA-specific**: `is_hip()` is true on MI300X too, so any AMD user without a matching aiter hits it. It is simply most visible on RDNA, where aiter is not used at all.

Reported independently on **gfx1100 (RDNA3 discrete)** by @AIwork4me in #30599, who hand-patched `quark_w4a4_mxfp4.py` to get a server up. Their aiter was **version-skewed** rather than absent — two different failure modes, same wall.

Companion to #31137 (sgl-kernel gfx1151 build enablement) and #31143 (jit_kernel HIP-compat, merged). Tracked under #30599. Together with #31137 this is what lets a source build run without aiter present: #31137 makes sgl-kernel build for the target, and this removes the import wall that would otherwise stop the server before any model is selected. #31403 fixes an unrelated RMSNorm bug on the same no-aiter path, and is what the end-to-end result below additionally requires.

## Modifications

Three modules — the ones the quantization registry imports at startup:

1. **`quark/schemes/quark_w4a4_mxfp4.py`** — wrap the four aiter imports in `try/except ImportError` behind a `_has_aiter_mxfp4` flag, and gate the aiter-backed op registrations on it.
2. **`quark/schemes/quark_w4a4_mxfp4_moe.py`** — wrap the import; the existing `else: dynamic_mxfp4_quant = None` binding and its `is None` check at the call site already handle the rest.
3. **`quark_int4fp8_moe.py`** — wrap the import, binding `shuffle_weight = None`. `ON_GFX950` stays outside the guard because it is read separately.

Where a name is consumed later, raise a clear `NotImplementedError` **at construction** rather than letting it surface as a `NameError` (or a `NoneType` call) from inside a weight loader.

**This introduces no new mechanism.** Both patterns already exist in the tree:

- the flag + `try/except ImportError: pass` shape is `models/qwen3.py`'s `_has_fused_qk_norm_mrope`;
- bind-to-`None` + check-and-raise is `quark_w4a4_mxfp4_moe.py`'s own `dynamic_mxfp4_quant`.

`try/except` is used rather than an `importlib.util.find_spec` probe deliberately: `find_spec` proves a *module* exists but says nothing about its *symbols*, so it does not catch the version-skew case above.

**Scope is deliberately narrow.** The remaining aiter imports in the tree live in modules that exist to *wrap* aiter (`rocm_linear_utils.py`, `rocm_mxfp4_utils.py`, and friends), whose importers are already guarded. There a hard import is **correct** — it fails immediately and clearly instead of degrading into a `NameError` later — so they are left alone.

## Accuracy Tests

No kernel or math changes. When aiter is available the aiter path is selected exactly as before.

Verified on **gfx1151 (Radeon 8060S / Strix Halo)** in all three states, serving `Qwen/Qwen2.5-7B-Instruct-AWQ`:

| aiter state | quantization registry | `QuarkW4A4MXFP4` | server |
|---|---|---|---|
| **present + working** | imports, 30 methods | constructs, aiter path selected | ✅ ready, 0 hipError, `17×4` → `68` |
| **absent** | imports, 30 methods | clear `NotImplementedError` | ✅ ready, 0 hipError, `17×4` → `68` |
| **present, symbols missing** | imports, 30 methods | clear `NotImplementedError` | — |

- **aiter present is the regression case** and is unchanged: `_has_aiter_mxfp4=True`, the real kernels bound, same output.
- With aiter absent: 0 `NameError`, 0 `NoneType object is not callable`.
- The aiter-absent run was confirmed to have aiter genuinely blocked (`No module named 'aiter'`, `_has_aiter_mxfp4=False`) rather than silently passing.
- The end-to-end serve additionally requires #31403 (an unrelated RMSNorm bug on the same no-aiter path); this PR alone removes the import wall.

## Speed Tests and Profiling

Not applicable. Import-time guards only — no kernel, scheduling, or dispatch change. With aiter present the selected code path is identical to before.

## Unit tests

None added. There is no precedent for unit-testing optional-dependency guards here — `is_triton_kernels_available()` has none — and a test asserting that `try/except ImportError` catches an `ImportError` would be a tautology under the repo's `unit-test-admission` rule. Import-time behaviour needs process isolation to test meaningfully, which `test/registered/unit/` has no precedent for either. The evidence is the three-state matrix above. Happy to add a subprocess-isolated test if reviewers would prefer coverage here.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — all hooks pass.
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) — see the section above; validated end to end instead.
- [ ] Update documentation — not needed; this removes a hidden requirement rather than adding one.
- [x] Provide accuracy and speed benchmark results — accuracy verified on gfx1151 above; speed N/A (import guards only).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29473957547](https://github.com/sgl-project/sglang/actions/runs/29473957547)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29473957420](https://github.com/sgl-project/sglang/actions/runs/29473957420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->