### PR TITLE
[WIP][Spec] DSpark compact-verify on DSA backends + sync-free verify-all

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa_metadata.py
+++ b/python/sglang/kernels/ops/attention/dsa_metadata.py
@@ -524,6 +524,16 @@ def _fused_dsa_draft_extend_metadata_kernel(
         mask=req_row < bs,
         other=0,
     ).to(tl.int32)
+    # Columns past the request's kv length are never read by any consumer
+    # (attention and the indexer both stay within cache_seqlens); skip whole
+    # column blocks instead of copying the full captured table width.
+    kv_len = tl.load(
+        seq_lens + req_row * seq_lens_stride,
+        mask=req_row < bs,
+        other=0,
+    ).to(tl.int32)
+    if col_block * BLOCK_N >= kv_len:
+        return
     if STATIC_EXTEND_LEN:
         prefix = req_row * qo_len
     else:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1545,8 +1545,46 @@ class DeepseekSparseAttnBackend(
         elif forward_mode.is_target_verify():
             max_seqlen_k = self._graph_page_table_width(metadata)
 
-            # The fused metadata kernel assumes a uniform per-request width
-            # (next_n); ragged layouts take the layout-driven build below.
+            if verify_layout is not None and is_cuda() and not _is_hip:
+                from sglang.kernels.ops.attention.dsa_metadata import (
+                    fused_dsa_draft_extend_metadata,
+                )
+
+                # The ragged draft-extend fused kernel is the exact geometry
+                # needed here: per-request extend lengths (verify_lens),
+                # row->request mapping, expanded/dsa seqlens + cumsums, and
+                # the page-table expansion in one launch. Base lengths are
+                # seq + verify_len.
+                total_rows = int(verify_layout.graph_num_tokens)
+                fused_dsa_draft_extend_metadata(
+                    seq_lens=seq_lens + verify_layout.verify_lens,
+                    extend_seq_lens=verify_layout.verify_lens,
+                    req_pool_indices=req_pool_indices,
+                    req_to_token=self.req_to_token,
+                    cache_seqlens=metadata.cache_seqlens_int32,
+                    cu_seqlens_k=metadata.cu_seqlens_k,
+                    page_table_1=metadata.page_table_1,
+                    seqlens_expanded=metadata.dsa_seqlens_expanded,
+                    dsa_cache_seqlens=metadata.dsa_cache_seqlens_int32,
+                    dsa_cu_seqlens_k=metadata.dsa_cu_seqlens_k,
+                    real_page_table=metadata.real_page_table,
+                    bs=bs,
+                    total_len=total_rows,
+                    max_seqlen_k=max_seqlen_k,
+                    dsa_index_topk=self.dsa_index_topk,
+                    real_page_size=self.real_page_size,
+                    max_extend_len=self.speculative_num_draft_tokens,
+                    max_total_len=total_rows,
+                    static_extend_len=False,
+                )
+                cache_seqlens = metadata.cache_seqlens_int32
+                seqlens_expanded = metadata.dsa_seqlens_expanded[:total_rows]
+                dsa_cache_seqlens = metadata.dsa_cache_seqlens_int32[:total_rows]
+                page_indices = None
+                used_fused_metadata_generation = True
+
+            # The uniform fused metadata kernel assumes a fixed per-request
+            # width (next_n); non-CUDA ragged falls to the torch build below.
             if verify_layout is None and is_cuda() and not _is_hip:
                 from sglang.kernels.ops.attention.dsa_metadata import (
                     fused_dsa_target_verify_metadata,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -58,6 +58,12 @@ from sglang.srt.layers.utils.cp_utils import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_buffer
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    RaggedVerifyMode,
+    compute_target_verify_graph_key,
+    read_ragged_verify_mode,
+)
 from sglang.srt.utils import (
     get_bool_env_var,
     is_cuda,
@@ -334,6 +340,12 @@ class DeepseekSparseAttnBackend(
     # (page-table width) and never reads seq_lens_cpu / seq_lens_sum; opt out of
     # the D2H sync. The eager fallback derives lengths from GPU seq_lens.
     needs_cpu_seq_lens: bool = False
+    # Target-verify metadata is built per expanded token row (cu_seqlens_q is a
+    # unit arange, seqlens are expanded per request), so a ragged layout only
+    # changes the expanded row count. The SM100 DG-native [bs, next_n] paged-MQA
+    # schedule is the one uniform-width construct; it is bypassed (per-token
+    # schedule) when a ragged layout is present.
+    supports_ragged_verify_graph: bool = True
 
     def __init__(
         self,
@@ -606,14 +618,18 @@ class DeepseekSparseAttnBackend(
         cache_seqlens_int32: torch.Tensor,
         seqlens_expanded: torch.Tensor,
         batch_size: int,
+        ragged: bool = False,
     ) -> torch.Tensor:
         # target_verify with next_n>=2 uses DG-native q=[B,next_n,H,D] which
         # needs a [B, next_n] schedule; everything else stays per-token.
+        # A ragged verify layout has no uniform per-request width, so it always
+        # takes the per-token schedule.
         # TODO: SM90 supports DG-native next_n in {1,2} too — enable once
         # validated; for now DG-native is SM100+ only.
         next_n = self.speculative_num_draft_tokens
         if (
             forward_mode.is_target_verify()
+            and not ragged
             and next_n
             and next_n >= 2
             and is_sm100_supported()
@@ -701,6 +717,46 @@ class DeepseekSparseAttnBackend(
         )
         return page_table[:, strided_indices] // page_size
 
+    def _resolve_verify_layout(
+        self,
+        spec_info,
+        bs: int,
+        pad_to_slots: bool = True,
+    ) -> Optional[RaggedVerifyLayout]:
+        layout = getattr(spec_info, "ragged_verify_layout", None)
+        if layout is None:
+            return None
+        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
+            return None
+        if get_parallel().attn_cp_size > 1:
+            raise NotImplementedError(
+                "DSA ragged verify does not support context parallel (CP); "
+                "set SGLANG_RAGGED_VERIFY_MODE off for CP runs."
+            )
+        if not pad_to_slots:
+            # Eager forward: the batch carries exactly the real verify tokens,
+            # so the raw layout is the geometry (padding would add rows beyond
+            # the batch's q tokens).
+            return layout
+        # Graph capture/replay: pad to the captured slot count. The padded
+        # layout absorbs the tier's slack tokens into the padding rows
+        # (total == graph_num_tokens), so the whole tier stays covered and
+        # every metadata build below is sync-free.
+        return layout.padded_to_bucket(padded_bs=bs)
+
+    def _target_verify_graph_key(
+        self,
+        bs: int,
+        ragged_layout: Optional[RaggedVerifyLayout],
+    ):
+        if ragged_layout is None:
+            return bs
+        return compute_target_verify_graph_key(
+            bs=bs,
+            num_draft_tokens=self.speculative_num_draft_tokens,
+            ragged_layout=ragged_layout,
+        )
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -727,10 +783,21 @@ class DeepseekSparseAttnBackend(
 
         if forward_batch.forward_mode.is_target_verify():
             draft_token_num = self.speculative_num_draft_tokens
+            verify_layout = self._resolve_verify_layout(
+                forward_batch.spec_info, batch_size, pad_to_slots=False
+            )
         else:
             draft_token_num = 0
+            verify_layout = None
 
-        cache_seqlens_int32 = (forward_batch.seq_lens + draft_token_num).to(torch.int32)
+        if verify_layout is not None:
+            cache_seqlens_int32 = (
+                forward_batch.seq_lens + verify_layout.verify_lens
+            ).to(torch.int32)
+        else:
+            cache_seqlens_int32 = (forward_batch.seq_lens + draft_token_num).to(
+                torch.int32
+            )
         cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
         if forward_batch.seq_lens_cpu is not None:
             max_seqlen_k = int(
@@ -780,25 +847,50 @@ class DeepseekSparseAttnBackend(
             seqlens_expanded = cache_seqlens_int32
         elif forward_batch.forward_mode.is_target_verify():
             max_seqlen_q = 1
-            cu_seqlens_q = torch.arange(
-                0,
-                batch_size * self.speculative_num_draft_tokens + 1,
-                1,
-                dtype=torch.int32,
-                device=device,
-            )
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
-            forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
+            if verify_layout is not None:
+                verify_lens_cpu = verify_layout.verify_lens_cpu
+                if verify_lens_cpu is None:
+                    # Eager target-verify only runs off the graph path (e.g.
+                    # over-capture-bs); a one-off host sync is acceptable here.
+                    verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
+                extend_seq_lens_cpu = [int(v) for v in verify_lens_cpu]
+                total_q = int(sum(extend_seq_lens_cpu))
+                cu_seqlens_q = torch.arange(
+                    0, total_q + 1, 1, dtype=torch.int32, device=device
+                )
+                forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
+                seqlens_expanded = seqlens_expand_triton(
+                    verify_layout.verify_lens,
+                    cache_seqlens_int32,
+                    total_q,
+                    max(extend_seq_lens_cpu),
+                )
+                page_table = torch.repeat_interleave(
+                    page_table,
+                    repeats=verify_layout.verify_lens,
+                    dim=0,
+                    output_size=total_q,
+                )
+            else:
+                cu_seqlens_q = torch.arange(
+                    0,
+                    batch_size * self.speculative_num_draft_tokens + 1,
+                    1,
+                    dtype=torch.int32,
+                    device=device,
+                )
+                extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
+                forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
 
-            seqlens_expanded = seqlens_expand_triton(
-                torch.tensor(extend_seq_lens_cpu, dtype=torch.int32, device=device),
-                cache_seqlens_int32,
-                self.speculative_num_draft_tokens * batch_size,
-                self.speculative_num_draft_tokens,
-            )
-            page_table = torch.repeat_interleave(
-                page_table, repeats=self.speculative_num_draft_tokens, dim=0
-            )
+                seqlens_expanded = seqlens_expand_triton(
+                    torch.tensor(extend_seq_lens_cpu, dtype=torch.int32, device=device),
+                    cache_seqlens_int32,
+                    self.speculative_num_draft_tokens * batch_size,
+                    self.speculative_num_draft_tokens,
+                )
+                page_table = torch.repeat_interleave(
+                    page_table, repeats=self.speculative_num_draft_tokens, dim=0
+                )
         elif forward_batch.forward_mode.is_draft_extend_v2():
             if forward_batch.extend_prefix_lens_cpu is None:
                 assert forward_batch.extend_prefix_lens is not None
@@ -1183,6 +1275,8 @@ class DeepseekSparseAttnBackend(
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
         actual_forward_mode: Optional[ForwardMode] = None,
+        verify_layout: Optional[RaggedVerifyLayout] = None,
+        graph_key=None,
     ):
         """Create and store DSAMetadata for a new batch size during CUDA graph capture."""
         self.set_dsa_prefill_impl(forward_batch=None)
@@ -1227,12 +1321,25 @@ class DeepseekSparseAttnBackend(
             else:
                 flashmla_metadata = None
         elif forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
-            cache_seqlens_int32 = (seq_lens + self.speculative_num_draft_tokens).to(
-                torch.int32
-            )
+            if verify_layout is not None:
+                verify_lens_cpu = verify_layout.verify_lens_cpu
+                if verify_lens_cpu is None:
+                    # padded_to_bucket drops host mirrors; capture is a
+                    # one-time host-driven build, a D2H sync is fine here.
+                    verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
+                capture_extend_lens = [int(v) for v in verify_lens_cpu]
+                cache_seqlens_int32 = (seq_lens + verify_layout.verify_lens).to(
+                    torch.int32
+                )
+                real_rows = int(verify_layout.graph_num_tokens)
+            else:
+                capture_extend_lens = [self.speculative_num_draft_tokens] * bs
+                cache_seqlens_int32 = (seq_lens + self.speculative_num_draft_tokens).to(
+                    torch.int32
+                )
+                real_rows = bs * self.speculative_num_draft_tokens
             cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
             max_seqlen_q = 1
-            real_rows = bs * self.speculative_num_draft_tokens
             if self.dsa_drop_wide_page_table:
                 page_table_1 = None
                 max_seqlen_k = self.req_to_token.shape[1]
@@ -1244,17 +1351,19 @@ class DeepseekSparseAttnBackend(
 
             cu_seqlens_q = torch.arange(
                 0,
-                bs * self.speculative_num_draft_tokens + 1,
+                real_rows + 1,
                 1,
                 dtype=torch.int32,
                 device=self.device,
             )
 
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
+            extend_seq_lens_cpu = capture_extend_lens
 
             seqlens_int32_cpu = [
-                self.speculative_num_draft_tokens + kv_len
-                for kv_len in seq_lens.tolist()
+                qo_len + kv_len
+                for qo_len, kv_len in zip(
+                    capture_extend_lens, seq_lens.tolist(), strict=True
+                )
             ]
             seqlens_expanded = torch.cat(
                 [
@@ -1274,12 +1383,12 @@ class DeepseekSparseAttnBackend(
             dsa_cache_seqlens_int32 = compute_dsa_seqlens(
                 seqlens_expanded, dsa_index_topk=self.dsa_index_topk
             )
-            dsa_extend_seq_lens_list = [1] * bs * self.speculative_num_draft_tokens
+            dsa_extend_seq_lens_list = [1] * real_rows
 
             if self.dsa_decode_impl == "flashmla_kv":
                 flashmla_metadata = self.decode_cuda_graph_metadata[
                     "flashmla_metadata"
-                ].slice(slice(0, bs * self.speculative_num_draft_tokens + 1))
+                ].slice(slice(0, real_rows + 1))
 
                 flashmla_metadata.copy_(
                     self._compute_flashmla_metadata(
@@ -1309,7 +1418,11 @@ class DeepseekSparseAttnBackend(
             or forward_mode.is_draft_extend_v2()
         ):
             paged_mqa_ctx_lens_2d = self._build_paged_mqa_schedule_2d_ctx_lens(
-                forward_mode, cache_seqlens_int32, seqlens_expanded, bs
+                forward_mode,
+                cache_seqlens_int32,
+                seqlens_expanded,
+                bs,
+                ragged=verify_layout is not None,
             )
             paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
                 paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
@@ -1334,7 +1447,9 @@ class DeepseekSparseAttnBackend(
             dsa_extend_seq_lens_list=dsa_extend_seq_lens_list,
             topk_v2_plan=self._build_topk_v2_plan(seqlens_expanded),
         )
-        self.decode_cuda_graph_metadata[bs] = metadata
+        self.decode_cuda_graph_metadata[graph_key if graph_key is not None else bs] = (
+            metadata
+        )
         self.forward_metadata = metadata
 
     def _apply_cuda_graph_metadata(
@@ -1354,7 +1469,12 @@ class DeepseekSparseAttnBackend(
         also call this directly via _apply_cuda_graph_metadata when they
         need to pass out_cache_loc / actual_forward_mode explicitly.
         """
-        if bs not in self.decode_cuda_graph_metadata:
+        verify_layout = None
+        if forward_mode.is_target_verify():
+            verify_layout = self._resolve_verify_layout(spec_info, bs)
+        graph_key = self._target_verify_graph_key(bs, verify_layout)
+
+        if graph_key not in self.decode_cuda_graph_metadata:
             self._build_forward_metadata_cuda_graph(
                 bs,
                 None,
@@ -1365,6 +1485,8 @@ class DeepseekSparseAttnBackend(
                 spec_info,
                 out_cache_loc,
                 actual_forward_mode,
+                verify_layout=verify_layout,
+                graph_key=graph_key,
             )
             return
 
@@ -1374,7 +1496,7 @@ class DeepseekSparseAttnBackend(
         req_pool_indices = req_pool_indices[:bs]
 
         # Normal Decode
-        metadata: DSAMetadata = self.decode_cuda_graph_metadata[bs]
+        metadata: DSAMetadata = self.decode_cuda_graph_metadata[graph_key]
         used_fused_metadata_generation = False
         target_verify_ctx_lens_written = False
         if forward_mode.is_decode_or_idle():
@@ -1423,7 +1545,9 @@ class DeepseekSparseAttnBackend(
         elif forward_mode.is_target_verify():
             max_seqlen_k = self._graph_page_table_width(metadata)
 
-            if is_cuda() and not _is_hip:
+            # The fused metadata kernel assumes a uniform per-request width
+            # (next_n); ragged layouts take the layout-driven build below.
+            if verify_layout is None and is_cuda() and not _is_hip:
                 from sglang.kernels.ops.attention.dsa_metadata import (
                     fused_dsa_target_verify_metadata,
                 )
@@ -1470,38 +1594,77 @@ class DeepseekSparseAttnBackend(
                 used_fused_metadata_generation = True
 
             if not used_fused_metadata_generation:
-                cache_seqlens = (seq_lens + self.speculative_num_draft_tokens).to(
-                    torch.int32
-                )
-                metadata.cache_seqlens_int32.copy_(cache_seqlens)
-                metadata.cu_seqlens_k[1:].copy_(
-                    torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
-                )
-                page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
-                page_indices = torch.repeat_interleave(
-                    page_indices, repeats=self.speculative_num_draft_tokens, dim=0
-                )
-                metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
+                if verify_layout is not None:
+                    total_rows = int(verify_layout.graph_num_tokens)
+                    cache_seqlens = (seq_lens + verify_layout.verify_lens).to(
+                        torch.int32
+                    )
+                    metadata.cache_seqlens_int32.copy_(cache_seqlens)
+                    metadata.cu_seqlens_k[1:].copy_(
+                        torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
+                    )
+                    # Sync-free ragged expansion: map each expanded row to its
+                    # request by searchsorted over the device qo_indptr. The
+                    # padded layout covers the full tier (padding rows absorb
+                    # the slack tokens), so every row maps to a real or padded
+                    # request; padded rows' outputs are discarded by the
+                    # runner's output slice.
+                    qo_indptr = verify_layout.qo_indptr_device
+                    row_ids = torch.arange(
+                        total_rows, dtype=qo_indptr.dtype, device=self.device
+                    )
+                    row_to_req = torch.searchsorted(
+                        qo_indptr[1:], row_ids, right=True
+                    ).clamp_(max=bs - 1)
+                    pos_in_req = row_ids - qo_indptr[row_to_req]
+                    seqlens_expanded = (seq_lens[row_to_req] + pos_in_req + 1).to(
+                        torch.int32
+                    )
+                    metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
+                    dsa_cache_seqlens = compute_dsa_seqlens(
+                        seqlens_expanded, self.dsa_index_topk
+                    )
+                    metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
+                    page_indices = self.req_to_token[
+                        req_pool_indices[row_to_req], :max_seqlen_k
+                    ]
+                    metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
+                else:
+                    cache_seqlens = (seq_lens + self.speculative_num_draft_tokens).to(
+                        torch.int32
+                    )
+                    metadata.cache_seqlens_int32.copy_(cache_seqlens)
+                    metadata.cu_seqlens_k[1:].copy_(
+                        torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
+                    )
+                    page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
+                    page_indices = torch.repeat_interleave(
+                        page_indices,
+                        repeats=self.speculative_num_draft_tokens,
+                        dim=0,
+                    )
+                    metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
 
-                # Fill the constant per-req qo lengths on-device; torch.tensor(list,
-                # device=cuda) does a pageable H2D copy that blocks the host.
-                extend_seq_lens = torch.full(
-                    (bs,),
-                    self.speculative_num_draft_tokens,
-                    dtype=torch.int32,
-                    device=self.device,
-                )
-                seqlens_expanded = seqlens_expand_triton(
-                    extend_seq_lens,
-                    cache_seqlens,
-                    self.speculative_num_draft_tokens * bs,
-                    self.speculative_num_draft_tokens,
-                )
-                metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
-                dsa_cache_seqlens = compute_dsa_seqlens(
-                    seqlens_expanded, self.dsa_index_topk
-                )
-                metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
+                    # Fill the constant per-req qo lengths on-device;
+                    # torch.tensor(list, device=cuda) does a pageable H2D copy
+                    # that blocks the host.
+                    extend_seq_lens = torch.full(
+                        (bs,),
+                        self.speculative_num_draft_tokens,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                    seqlens_expanded = seqlens_expand_triton(
+                        extend_seq_lens,
+                        cache_seqlens,
+                        self.speculative_num_draft_tokens * bs,
+                        self.speculative_num_draft_tokens,
+                    )
+                    metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
+                    dsa_cache_seqlens = compute_dsa_seqlens(
+                        seqlens_expanded, self.dsa_index_topk
+                    )
+                    metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
         elif forward_mode.is_draft_extend_v2():
             # V2 draft-extend processes the full padded tree width
             # (speculative_num_draft_tokens) per req -- a static shape, like
@@ -1598,6 +1761,7 @@ class DeepseekSparseAttnBackend(
                     metadata.cache_seqlens_int32,
                     schedule_seqlens_expanded,
                     bs,
+                    ragged=verify_layout is not None,
                 )
             self._refresh_paged_mqa_schedule_metadata(metadata, seqlens_32_2d)
             self._refresh_topk_v2_plan(metadata)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1215,6 +1215,11 @@ class DeepseekSparseAttnBackend(
             and self.dsa_index_topk <= 2048
         )
 
+        # Staged per-step verify lens for the graph-recorded ragged verify
+        # prep (init_forward_metadata_in_graph).
+        self._ragged_verify_lens_buf = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
+        )
         max_ctx_len = self.req_to_token.shape[1]
         self.decode_cuda_graph_metadata: Dict = {
             "cache_seqlens": torch.ones(
@@ -1328,6 +1333,12 @@ class DeepseekSparseAttnBackend(
                     # one-time host-driven build, a D2H sync is fine here.
                     verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
                 capture_extend_lens = [int(v) for v in verify_lens_cpu]
+                # Stage the capture lens so the warmup execution of the
+                # graph-recorded prep (init_forward_metadata_in_graph) sees
+                # non-zero lengths.
+                self._ragged_verify_lens_buf[: len(capture_extend_lens)].copy_(
+                    verify_layout.verify_lens
+                )
                 cache_seqlens_int32 = (seq_lens + verify_layout.verify_lens).to(
                     torch.int32
                 )
@@ -1499,6 +1510,7 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata = self.decode_cuda_graph_metadata[graph_key]
         used_fused_metadata_generation = False
         target_verify_ctx_lens_written = False
+        prep_recorded_in_graph = False
         if forward_mode.is_decode_or_idle():
             # Normal Decode
             max_len = self._graph_page_table_width(metadata)
@@ -1546,42 +1558,18 @@ class DeepseekSparseAttnBackend(
             max_seqlen_k = self._graph_page_table_width(metadata)
 
             if verify_layout is not None and is_cuda() and not _is_hip:
-                from sglang.kernels.ops.attention.dsa_metadata import (
-                    fused_dsa_draft_extend_metadata,
-                )
-
-                # The ragged draft-extend fused kernel is the exact geometry
-                # needed here: per-request extend lengths (verify_lens),
-                # row->request mapping, expanded/dsa seqlens + cumsums, and
-                # the page-table expansion in one launch. Base lengths are
-                # seq + verify_len.
+                # The whole ragged prep chain (fused metadata kernel,
+                # paged-MQA schedule, top-k plan) is recorded INSIDE the
+                # verify graph (init_forward_metadata_in_graph); replay only
+                # stages the per-step verify lens.
+                self._ragged_verify_lens_buf[:bs].copy_(verify_layout.verify_lens)
                 total_rows = int(verify_layout.graph_num_tokens)
-                fused_dsa_draft_extend_metadata(
-                    seq_lens=seq_lens + verify_layout.verify_lens,
-                    extend_seq_lens=verify_layout.verify_lens,
-                    req_pool_indices=req_pool_indices,
-                    req_to_token=self.req_to_token,
-                    cache_seqlens=metadata.cache_seqlens_int32,
-                    cu_seqlens_k=metadata.cu_seqlens_k,
-                    page_table_1=metadata.page_table_1,
-                    seqlens_expanded=metadata.dsa_seqlens_expanded,
-                    dsa_cache_seqlens=metadata.dsa_cache_seqlens_int32,
-                    dsa_cu_seqlens_k=metadata.dsa_cu_seqlens_k,
-                    real_page_table=metadata.real_page_table,
-                    bs=bs,
-                    total_len=total_rows,
-                    max_seqlen_k=max_seqlen_k,
-                    dsa_index_topk=self.dsa_index_topk,
-                    real_page_size=self.real_page_size,
-                    max_extend_len=self.speculative_num_draft_tokens,
-                    max_total_len=total_rows,
-                    static_extend_len=False,
-                )
                 cache_seqlens = metadata.cache_seqlens_int32
                 seqlens_expanded = metadata.dsa_seqlens_expanded[:total_rows]
                 dsa_cache_seqlens = metadata.dsa_cache_seqlens_int32[:total_rows]
                 page_indices = None
                 used_fused_metadata_generation = True
+                prep_recorded_in_graph = True
 
             # The uniform fused metadata kernel assumes a fixed per-request
             # width (next_n); non-CUDA ragged falls to the torch build below.
@@ -1781,11 +1769,17 @@ class DeepseekSparseAttnBackend(
                 )
                 metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
 
-        # Update DeepGEMM paged MQA schedule metadata outside the captured graph.
-        if is_cuda() and (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend_v2()
+        # Update DeepGEMM paged MQA schedule metadata outside the captured
+        # graph -- except for the ragged verify path, whose whole prep chain
+        # (schedule included) is recorded in-graph.
+        if (
+            not prep_recorded_in_graph
+            and is_cuda()
+            and (
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
+            )
         ):
             if forward_mode.is_draft_extend_v2():
                 schedule_seqlens_expanded = metadata.dsa_seqlens_expanded
@@ -1844,6 +1838,57 @@ class DeepseekSparseAttnBackend(
             )
 
         self.forward_metadata = metadata
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Graph-recorded ragged verify prep: re-derives all target-verify
+        metadata inside the captured graph from the staged verify lens and
+        the runner's static seq_lens/req_pool_indices buffers, so replay-side
+        prep reduces to one staging copy (_apply_cuda_graph_metadata)."""
+        if not forward_batch.forward_mode.is_target_verify():
+            return
+        if not is_cuda() or _is_hip:
+            return
+        layout = getattr(forward_batch.spec_info, "ragged_verify_layout", None)
+        if layout is None:
+            return
+        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
+            return
+        from sglang.kernels.ops.attention.dsa_metadata import (
+            fused_dsa_draft_extend_metadata,
+        )
+
+        metadata = self.forward_metadata
+        bs = int(forward_batch.batch_size)
+        total_rows = int(layout.graph_num_tokens)
+        verify_lens = self._ragged_verify_lens_buf[:bs]
+        max_seqlen_k = self._graph_page_table_width(metadata)
+        seq_lens = forward_batch.seq_lens[:bs]
+        fused_dsa_draft_extend_metadata(
+            seq_lens=seq_lens + verify_lens,
+            extend_seq_lens=verify_lens,
+            req_pool_indices=forward_batch.req_pool_indices[:bs],
+            req_to_token=self.req_to_token,
+            cache_seqlens=metadata.cache_seqlens_int32,
+            cu_seqlens_k=metadata.cu_seqlens_k,
+            page_table_1=metadata.page_table_1,
+            seqlens_expanded=metadata.dsa_seqlens_expanded,
+            dsa_cache_seqlens=metadata.dsa_cache_seqlens_int32,
+            dsa_cu_seqlens_k=metadata.dsa_cu_seqlens_k,
+            real_page_table=metadata.real_page_table,
+            bs=bs,
+            total_len=total_rows,
+            max_seqlen_k=max_seqlen_k,
+            dsa_index_topk=self.dsa_index_topk,
+            real_page_size=self.real_page_size,
+            max_extend_len=self.speculative_num_draft_tokens,
+            max_total_len=total_rows,
+            static_extend_len=False,
+        )
+        ctx_lens_2d = metadata.dsa_seqlens_expanded[:total_rows].view(-1, 1)
+        if metadata.paged_mqa_ctx_lens_2d is not None:
+            metadata.paged_mqa_ctx_lens_2d.copy_(ctx_lens_2d)
+        self._refresh_paged_mqa_schedule_metadata(metadata, ctx_lens_2d)
+        self._refresh_topk_v2_plan(metadata)
 
     def init_forward_metadata_replay_cuda_graph_from_precomputed(
         self,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -267,6 +267,7 @@ class ModelRunner:
             server_args.speculative_algorithm
         )
         self.capture_tail_hooks = []
+        self.capture_head_hooks = []
         self.page_size = server_args.page_size
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -296,8 +296,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         ):
             logger.warning(
                 "Attention backend %s does not support ragged-verify graphs; "
-                "capturing fixed-width verify graphs instead (ragged batches "
-                "fall back to eager at replay).",
+                "capturing fixed-width verify graphs instead (SPS-table "
+                "trimming is disabled; compact verify runs verify-all).",
                 type(self.attn_backend).__name__,
             )
             self.ragged_verify_mode = False

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -992,6 +992,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 ):
                     kwargs["input_embeds"] = self.buffers.input_embeds[:num_tokens]
 
+                for capture_hook in self.model_runner.capture_head_hooks:
+                    capture_hook(self, forward_batch, num_tokens)
                 out = forward(
                     forward_batch.input_ids,
                     forward_batch.positions,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -285,6 +285,22 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             and (self.capture_forward_mode == ForwardMode.TARGET_VERIFY)
             and not self.model_runner.is_draft_worker
         )
+        # Capture geometry must respect the backend capability the replay gate
+        # (_can_run_ragged_verify_graph) already checks: with ragged slot
+        # geometry, capture_one_shape builds batches whose per-request width is
+        # not speculative_num_draft_tokens, and backends without ragged-verify
+        # support (e.g. DSA) prepare fixed-width metadata and crash in capture.
+        if (
+            self.ragged_verify_mode
+            and not self.attn_backend.supports_ragged_verify_graph
+        ):
+            logger.warning(
+                "Attention backend %s does not support ragged-verify graphs; "
+                "capturing fixed-width verify graphs instead (ragged batches "
+                "fall back to eager at replay).",
+                type(self.attn_backend).__name__,
+            )
+            self.ragged_verify_mode = False
         self.capture_num_tokens: Optional[list[int]] = (
             self._build_ragged_verify_token_buckets()
             if self.ragged_verify_mode

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -404,9 +404,13 @@ class DFlashDraftModel(nn.Module):
         pp_proxy_tensors=None,
     ) -> LogitsProcessorOutput:
         if input_embeds is None:
-            raise ValueError(
-                "DFlashDraftModel requires `input_embeds` (use the target embedding)."
-            )
+            if hasattr(self, "forward_embed"):
+                input_embeds = self.forward_embed(input_ids)
+            else:
+                raise ValueError(
+                    "DFlashDraftModel requires `input_embeds` (use the target "
+                    "embedding)."
+                )
         hidden_states = input_embeds
         residual: Optional[torch.Tensor] = None
 

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -378,8 +378,14 @@ class DSparkDraftMixin:
     def attach_shared_modules(
         self, *, embed_tokens: nn.Module, lm_head: nn.Module
     ) -> None:
-        del embed_tokens
+        self.embed_tokens = embed_tokens
         self.lm_head = lm_head
+
+    def forward_embed(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # Embeds with the shared target embedding INSIDE the draft graph
+        # (the runner skips the eager input_embeds staging when the draft
+        # model exposes forward_embed).
+        return self.embed_tokens(input_ids)
 
     def compute_base_logits(
         self, hidden: torch.Tensor

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -4,11 +4,13 @@ import logging
 from typing import Callable, Iterable, Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from sglang.srt.distributed.communication_op import tensor_model_parallel_all_gather
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dflash import DFlashDraftModel
+from sglang.srt.speculative.dflash_utils import can_dflash_slice_qkv_weight
 from sglang.srt.speculative.dspark_components.dspark_config import (
     parse_dspark_draft_config,
 )
@@ -458,6 +460,44 @@ class DSparkDraftMixin:
                 f"or disable the confidence head (enable_confidence_head=False)."
             )
 
+    def _stacked_ctx_kv_params(self) -> Optional[dict]:
+        """Stack every layer's KV projection into one weight so the per-step
+        target-hidden KV write runs one GEMM instead of one per layer -- the
+        input hidden is identical for every layer, so concatenating the output
+        columns is exact. Cached after the first call; None (per-layer loop
+        fallback) when any layer's QKV weight cannot be sliced (quantized) or
+        the layers disagree on norm epsilon / bias presence.
+        """
+        cached = getattr(self, "_stacked_ctx_kv_cache", False)
+        if cached is not False:
+            return cached
+        weights, biases, k_norm_weights = [], [], []
+        eps = None
+        for layer in self.layers:
+            attn = layer.self_attn
+            can_slice, _ = can_dflash_slice_qkv_weight(attn.qkv_proj)
+            if not can_slice or eps not in (None, attn.k_norm.variance_epsilon):
+                self._stacked_ctx_kv_cache = None
+                return None
+            eps = attn.k_norm.variance_epsilon
+            kv_slice = slice(attn.q_size, attn.q_size + 2 * attn.kv_size)
+            weights.append(attn.qkv_proj.weight[kv_slice])
+            biases.append(
+                attn.qkv_proj.bias[kv_slice] if attn.qkv_proj.bias is not None else None
+            )
+            k_norm_weights.append(attn.k_norm.weight)
+        has_bias = [b is not None for b in biases]
+        if any(has_bias) and not all(has_bias):
+            self._stacked_ctx_kv_cache = None
+            return None
+        self._stacked_ctx_kv_cache = {
+            "weight": torch.cat(weights, dim=0),
+            "bias": torch.cat(biases, dim=0) if all(has_bias) else None,
+            "k_norm_weight": torch.stack(k_norm_weights, dim=0).float(),
+            "eps": eps,
+        }
+        return self._stacked_ctx_kv_cache
+
     def write_target_hidden_kv(
         self,
         *,
@@ -469,13 +509,22 @@ class DSparkDraftMixin:
         commit_lens: Optional[torch.Tensor] = None,
     ) -> None:
         ctx_hidden = self.project_target_hidden(target_hidden)
-        for layer in self.layers:
+        stacked = self._stacked_ctx_kv_params()
+        if stacked is not None:
+            k_all, v_all = self._project_ctx_kv_stacked(
+                ctx_hidden=ctx_hidden, positions=positions, stacked=stacked
+            )
+        for i, layer in enumerate(self.layers):
             attn = layer.self_attn
-            k, v = attn.kv_proj_only(ctx_hidden)
-            k = attn.apply_k_norm(k)
-            k = attn.apply_k_rope(positions, k)
-            k = k.view(-1, attn.num_kv_heads, attn.head_dim)
-            v = v.view(-1, attn.num_kv_heads, attn.head_dim)
+            if stacked is not None:
+                k = k_all[i]
+                v = v_all[i]
+            else:
+                k, v = attn.kv_proj_only(ctx_hidden)
+                k = attn.apply_k_norm(k)
+                k = attn.apply_k_rope(positions, k)
+                k = k.view(-1, attn.num_kv_heads, attn.head_dim)
+                v = v.view(-1, attn.num_kv_heads, attn.head_dim)
             if cache_loc_2d is not None and commit_lens is not None:
                 pool.set_kv_buffer_prefix_valid(
                     attn.attn,
@@ -495,6 +544,52 @@ class DSparkDraftMixin:
                     attn.attn.k_scale,
                     attn.attn.v_scale,
                 )
+
+    def _project_ctx_kv_stacked(
+        self,
+        *,
+        ctx_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        stacked: dict,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        attn0 = self.layers[0].self_attn
+        num_layers = len(self.layers)
+        kv_size = attn0.kv_size
+        head_dim = attn0.head_dim
+        num_kv_heads = attn0.num_kv_heads
+        tokens = ctx_hidden.shape[0]
+
+        kv_all = F.linear(ctx_hidden, stacked["weight"], stacked["bias"])
+        kv_all = kv_all.view(tokens, num_layers, 2, kv_size)
+        # Batched per-head k-norm across layers (mirrors RMSNorm.forward_native:
+        # fp32 variance, weight multiply in fp32, cast back).
+        k32 = (
+            kv_all[:, :, 0, :]
+            .reshape(tokens, num_layers, num_kv_heads, head_dim)
+            .to(torch.float32)
+        )
+        variance = k32.pow(2).mean(dim=-1, keepdim=True)
+        k32 = k32 * torch.rsqrt(variance + stacked["eps"])
+        k32 = k32 * stacked["k_norm_weight"].view(1, num_layers, 1, head_dim)
+        k_all = k32.to(ctx_hidden.dtype)
+        # One RoPE over all layers' heads: every layer shares the rotary params
+        # and positions, so the N*kv_heads heads rotate identically.
+        k_flat = k_all.reshape(tokens, num_layers * kv_size)
+        dummy_q = k_flat.new_empty(k_flat.shape)
+        _, k_flat = attn0.rotary_emb(positions, dummy_q, k_flat)
+        # [layers, tokens, heads, dim] so per-layer slices are contiguous views.
+        k_all = (
+            k_flat.view(tokens, num_layers, num_kv_heads, head_dim)
+            .permute(1, 0, 2, 3)
+            .contiguous()
+        )
+        v_all = (
+            kv_all[:, :, 1, :]
+            .view(tokens, num_layers, num_kv_heads, head_dim)
+            .permute(1, 0, 2, 3)
+            .contiguous()
+        )
+        return k_all, v_all
 
 
 class DSparkDraftModel(DSparkDraftMixin, DFlashDraftModel):

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -506,4 +506,4 @@ class Qwen3DSparkModel(DSparkDraftModel):
     pass
 
 
-EntryClass = [Qwen3DSparkModel]
+EntryClass = [DSparkDraftModel, Qwen3DSparkModel]

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -235,9 +235,17 @@ class DraftBlockProposer:
         self._draft_block_spec_info = draft_block_spec_info
         self._draft_sampler = None
         self._dp_moe_sync = dp_moe_sync
+        self._kv_injector = None
 
     def attach_draft_sampler(self, draft_sampler) -> None:
         self._draft_sampler = draft_sampler
+
+    def attach_kv_injector(self, kv_injector) -> None:
+        self._kv_injector = kv_injector
+
+    def _pre_draft_forward(self, forward_batch) -> None:
+        if self._kv_injector is not None:
+            self._kv_injector.pre_draft_forward(forward_batch)
 
     def _base_logits_context(self):
         if self._dp_moe_sync:
@@ -334,6 +342,7 @@ class DraftBlockProposer:
             capture_hidden_mode=CaptureHiddenMode.NULL,
         )
         self._fill_dp_moe_sync_metadata(idle_batch, batch)
+        self._pre_draft_forward(idle_batch)
         with torch.inference_mode():
             self.draft_model_runner.forward(idle_batch)
 
@@ -390,6 +399,7 @@ class DraftBlockProposer:
             capture_hidden_mode=CaptureHiddenMode.NULL,
         )
         self._fill_dp_moe_sync_metadata(draft_forward_batch, batch)
+        self._pre_draft_forward(draft_forward_batch)
         with torch.inference_mode():
             draft_out = self.draft_model_runner.forward(draft_forward_batch)
         logits_output = draft_out.logits_output

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -18,6 +18,9 @@ from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.draft_worker_common import make_draft_input_v2
 from sglang.srt.speculative.dspark_components.dspark_planner import VerifyWindow
+from sglang.srt.speculative.dspark_components.kernels.dspark_accept import (
+    SoftmaxTemp,
+)
 from sglang.srt.speculative.dspark_components.kernels.dspark_draft_model import (
     SampleStepTokens,
 )
@@ -60,7 +63,17 @@ def greedy_step_sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tenso
 
 class DsparkDraftSampler:
 
-    def __init__(self, *, model, gamma, max_bs, device, confidence_fn=None, out=None):
+    def __init__(
+        self,
+        *,
+        model,
+        gamma,
+        max_bs,
+        device,
+        confidence_fn=None,
+        out=None,
+        draft_probs_out=None,
+    ):
         self.model = model
         self.markov_head = model.markov_head
         self.gamma = int(gamma)
@@ -77,19 +90,60 @@ class DsparkDraftSampler:
             if confidence_fn is not None
             else None
         )
+        # Staged sampling state: temps default 1.0 / mask default greedy, so
+        # un-staged replays reduce to the original greedy sampler.
+        self.temps_buf = torch.ones((int(max_bs),), dtype=torch.float32, device=device)
+        self.greedy_mask_buf = torch.ones(
+            (int(max_bs),), dtype=torch.bool, device=device
+        )
+        # Getter for the verify epilogue's draft_probs buffer (resolved at
+        # warmup/capture time, after the target-side warmup allocated it).
+        self.draft_probs_out = draft_probs_out
+
+    def stage_sampling(self, *, bs, temperatures=None, greedy_mask=None) -> None:
+        if temperatures is None:
+            self.temps_buf[:bs].fill_(1.0)
+        else:
+            self.temps_buf[:bs].copy_(temperatures.view(-1))
+        if greedy_mask is None:
+            self.greedy_mask_buf[:bs].fill_(True)
+        else:
+            self.greedy_mask_buf[:bs].copy_(greedy_mask)
 
     def __call__(self, hidden_states, input_ids):
         bs = hidden_states.shape[0] // self.gamma
         base_logits, confidence_tap = self.model.compute_base_logits(hidden_states)
         base_logits = base_logits.view(bs, self.gamma, -1)
         anchor = input_ids.view(bs, self.gamma)[:, 0]
-        draft_tokens, _ = self.markov_head.sample_block(
+        temps = self.temps_buf[:bs]
+        gmask = self.greedy_mask_buf[:bs]
+
+        def step_sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tensor:
+            exp_noise = torch.empty(
+                step_logits.shape, dtype=torch.float32, device=step_logits.device
+            ).exponential_(1)
+            return SampleStepTokens.execute(
+                step_logits=step_logits,
+                temperatures=temps,
+                greedy_mask=gmask,
+                exp_noise=exp_noise,
+            )
+
+        draft_tokens, corrected_logits = self.markov_head.sample_block(
             base_logits,
             first_prev_tokens=anchor,
             hidden_states=hidden_states.view(bs, self.gamma, -1),
-            sampler=greedy_step_sampler,
+            sampler=step_sampler,
         )
         self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
+        if self.draft_probs_out is not None:
+            probs = SoftmaxTemp.execute(
+                logits=corrected_logits.reshape(bs * self.gamma, -1),
+                temperatures=temps.view(bs, 1),
+                rows_per_request=self.gamma,
+            )
+            probs_buf = self.draft_probs_out(probs.shape[-1])
+            probs_buf[: bs * self.gamma].copy_(probs.reshape(bs * self.gamma, -1))
         if self.confidence_out is not None:
             confidence = self.confidence_fn(
                 draft_hidden=hidden_states.view(bs, self.gamma, -1),
@@ -109,6 +163,7 @@ def maybe_build_draft_sampler(
     tp_rank: int,
     confidence_fn=None,
     out=None,
+    draft_probs_out=None,
 ) -> Optional[DsparkDraftSampler]:
     """Build the graph-folded greedy draft sampler, or return None (with the
     reason logged) when the draft model cannot support folding and the
@@ -134,6 +189,7 @@ def maybe_build_draft_sampler(
         device=device,
         confidence_fn=confidence_fn,
         out=out,
+        draft_probs_out=draft_probs_out,
     )
 
 
@@ -262,8 +318,28 @@ class DraftBlockProposer:
         device: str,
         target_model,
         sampling_info,
+        allow_sampling_fold: bool = False,
     ) -> DraftProposal:
         embed_module = target_model.get_input_embeddings()
+        if self._draft_sampler is not None:
+            stage_all_greedy = sampling_info is None or sampling_info.is_all_greedy
+            self._draft_sampler.stage_sampling(
+                bs=bs,
+                temperatures=(
+                    None
+                    if sampling_info is None
+                    else sampling_info.temperatures.view(-1)
+                    .to(torch.float32)
+                    .clamp_min(1e-5)
+                ),
+                greedy_mask=(
+                    None
+                    if stage_all_greedy
+                    else resolve_greedy_mask(
+                        bs=bs, sampling_info=sampling_info, device=device
+                    )
+                ),
+            )
         fwd = self._run_forward(
             batch=batch,
             draft_input=draft_input,
@@ -279,7 +355,11 @@ class DraftBlockProposer:
         folded_confidence = None
         confidence_tap = None
         folded = False
-        if draft_sampler is not None and fwd.can_run_graph and all_greedy:
+        if (
+            draft_sampler is not None
+            and fwd.can_run_graph
+            and (all_greedy or allow_sampling_fold)
+        ):
             folded = True
             if sampling_info is None:
                 temperatures = torch.ones(bs, dtype=torch.float32, device=device)

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -194,13 +194,27 @@ class TargetHiddenKvInjector:
             return False
         stride = self.verify_num_draft_tokens
         bufs = self._inject_bufs
-        bufs["seq_lens"][bs:].zero_()
-        bufs["req_pool_indices"][bs:].zero_()
-        bufs["commit_lens"][bs:].zero_()
-        bufs["seq_lens"][:bs].copy_(batch.seq_lens[:bs])
-        bufs["req_pool_indices"][:bs].copy_(batch.req_pool_indices[:bs])
-        bufs["hidden"][: bs * stride].copy_(hidden_strided.view(bs * stride, -1))
-        bufs["commit_lens"][:bs].copy_(commit_lens[:bs])
+        torch._foreach_zero_(
+            [
+                bufs["seq_lens"][bs:],
+                bufs["req_pool_indices"][bs:],
+                bufs["commit_lens"][bs:],
+            ]
+        )
+        torch._foreach_copy_(
+            [
+                bufs["seq_lens"][:bs],
+                bufs["req_pool_indices"][:bs],
+                bufs["hidden"][: bs * stride],
+                bufs["commit_lens"][:bs],
+            ],
+            [
+                batch.seq_lens[:bs],
+                batch.req_pool_indices[:bs],
+                hidden_strided.view(bs * stride, -1),
+                commit_lens[:bs].to(torch.int32),
+            ],
+        )
         self._inject_pending = True
         self._inject_staged_bs = bs
         return True

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -4,10 +4,15 @@ import torch
 
 from sglang.kernels.ops.speculative.cache_locs import assign_extend_cache_locs_func
 from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.speculative.dspark_components.kernels.dspark_verify_window import (
     BuildCommitInjectLayout,
 )
-from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    RaggedVerifyMode,
+    read_ragged_verify_mode,
+)
 
 
 class TargetHiddenKvInjector:
@@ -27,6 +32,12 @@ class TargetHiddenKvInjector:
         self.device = device
         self.verify_num_draft_tokens = verify_num_draft_tokens
         self._block_pos_offsets = block_pos_offsets
+        # Static staging buffers for the draft-graph inject prologue
+        # (allocated at first graph capture, sized to the max capture bs).
+        self._inject_bufs: Optional[dict] = None
+        self._inject_max_bs = 0
+        self._inject_pending = False
+        self._inject_staged_bs = 0
 
     def inject_target_hidden(
         self,
@@ -101,6 +112,113 @@ class TargetHiddenKvInjector:
                 positions=positions,
                 pool=pool,
             )
+
+    def _dense_pool(self):
+        pool = self.draft_model_runner.token_to_kv_pool
+        if hasattr(pool, "set_swa_key_buffer_radix_fused_norm_rope"):
+            return None
+        return pool
+
+    def capture_prologue_hook(self, runner, forward_batch, num_tokens) -> None:
+        """Recorded at the head of the draft TARGET_VERIFY graph: commit the
+        staged target-hidden KV before the block-draft layers read it.
+        Un-staged replays (idle participation / static verify) see zeroed
+        commit_lens rows, which make every KV write a no-op."""
+        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
+            return
+        if self._dense_pool() is None:
+            return
+        if runner.capture_forward_mode != ForwardMode.TARGET_VERIFY:
+            return
+        if self._inject_bufs is None:
+            max_bs = int(runner.capture_bs[-1])
+            # The staged hidden is the concatenated multi-layer context
+            # features, not a single hidden vector.
+            hidden_size = (
+                self.draft_model.num_context_features
+                * self.model_runner.model_config.hidden_size
+            )
+            dev = self.device
+            self._inject_max_bs = max_bs
+            self._inject_bufs = {
+                "seq_lens": torch.zeros(max_bs, dtype=torch.int64, device=dev),
+                "req_pool_indices": torch.zeros(max_bs, dtype=torch.int64, device=dev),
+                "hidden": torch.zeros(
+                    max_bs * self.verify_num_draft_tokens,
+                    hidden_size,
+                    dtype=self.model_runner.dtype,
+                    device=dev,
+                ),
+                "commit_lens": torch.zeros(max_bs, dtype=torch.int32, device=dev),
+            }
+        bs = min(int(forward_batch.batch_size), self._inject_max_bs)
+        self._inject_prologue_body(bs)
+
+    def _inject_prologue_body(self, bs: int) -> None:
+        stride = self.verify_num_draft_tokens
+        bufs = self._inject_bufs
+        prefix_lens = bufs["seq_lens"][:bs]
+        positions_2d = prefix_lens.unsqueeze(1) + self._block_pos_offsets
+        verify_cache_loc = assign_extend_cache_locs_func(
+            req_pool_indices=bufs["req_pool_indices"][:bs],
+            req_to_token=self.model_runner.req_to_token_pool.req_to_token,
+            start_offset=prefix_lens,
+            end_offset=prefix_lens + stride,
+            batch_size=bs,
+            draft_token_num=stride,
+            device=self.device,
+        )
+        self.inject_target_hidden(
+            target_hidden=bufs["hidden"][: bs * stride],
+            cache_loc=verify_cache_loc,
+            cache_loc_2d=verify_cache_loc.view(bs, stride),
+            positions=positions_2d.reshape(-1),
+            commit_lens=bufs["commit_lens"][:bs],
+        )
+
+    def stage_ragged(
+        self,
+        *,
+        batch: ScheduleBatch,
+        hidden_strided: Optional[torch.Tensor],
+        commit_lens: torch.Tensor,
+        bs: int,
+    ) -> bool:
+        """Stage the ragged inject inputs for the draft-graph prologue.
+        Returns False when the caller must run the eager inject instead."""
+        if self._inject_bufs is None or self._dense_pool() is None:
+            return False
+        if hidden_strided is None or hidden_strided.numel() == 0:
+            return True
+        if bs > self._inject_max_bs:
+            return False
+        stride = self.verify_num_draft_tokens
+        bufs = self._inject_bufs
+        bufs["seq_lens"][bs:].zero_()
+        bufs["req_pool_indices"][bs:].zero_()
+        bufs["commit_lens"][bs:].zero_()
+        bufs["seq_lens"][:bs].copy_(batch.seq_lens[:bs])
+        bufs["req_pool_indices"][:bs].copy_(batch.req_pool_indices[:bs])
+        bufs["hidden"][: bs * stride].copy_(hidden_strided.view(bs * stride, -1))
+        bufs["commit_lens"][:bs].copy_(commit_lens[:bs])
+        self._inject_pending = True
+        self._inject_staged_bs = bs
+        return True
+
+    def pre_draft_forward(self, forward_batch) -> None:
+        """Called right before the draft block forward. Flushes the staged
+        inject eagerly when the forward will not replay a graph, and clears
+        stale commit_lens before un-staged graph replays (idle batches)."""
+        if self._inject_bufs is None:
+            return
+        runner = getattr(self.draft_model_runner, "decode_cuda_graph_runner", None)
+        will_graph = runner is not None and runner.can_run_graph(forward_batch)
+        if self._inject_pending:
+            self._inject_pending = False
+            if not will_graph:
+                self._inject_prologue_body(self._inject_staged_bs)
+        elif will_graph:
+            self._inject_bufs["commit_lens"].zero_()
 
     def inject_ragged(
         self,

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -125,6 +125,7 @@ class DSparkVerifyPlanner:
         self._dp_tier_gather_enabled = False
         self._is_verify_all = True
         self._uniform_layout_cache: dict = {}
+        self._fixed_width_graphs: Optional[bool] = None
         if self._ragged_verify_mode is not RaggedVerifyMode.STATIC:
             if self._confidence_head is None:
                 raise ValueError(
@@ -405,6 +406,22 @@ class DSparkVerifyPlanner:
             )
         )
 
+    def _fixed_width_verify_graphs(self) -> bool:
+        # Resolved lazily on first schedule: the attention backend does not
+        # exist yet when the planner is constructed.
+        if self._fixed_width_graphs is None:
+            graphs_on = not (
+                self.server_args.disable_cuda_graph
+                or self.server_args.disable_decode_cuda_graph
+            )
+            backend = getattr(self.model_runner, "attn_backend", None)
+            self._fixed_width_graphs = (
+                graphs_on
+                and backend is not None
+                and not getattr(backend, "supports_ragged_verify_graph", False)
+            )
+        return self._fixed_width_graphs
+
     def schedule_layout(
         self,
         *,
@@ -418,6 +435,21 @@ class DSparkVerifyPlanner:
     ) -> Optional[RaggedVerifyLayout]:
         if self._ragged_verify_mode is RaggedVerifyMode.STATIC:
             return None
+        if (
+            self._ragged_verify_mode is RaggedVerifyMode.COMPACT
+            and not self._is_verify_all
+            and self._fixed_width_verify_graphs()
+        ):
+            # Fixed-width verify graphs cannot replay a trimmed (ragged)
+            # batch (load_batch copies it into full-width buffers and dies
+            # on the size mismatch), and with the graph width fixed a trim
+            # saves no compute anyway: ignore the SPS table.
+            logger.warning(
+                "DSpark compact verify: decode cuda graphs are fixed-width "
+                "(attention backend lacks ragged-verify graph support); "
+                "ignoring the SPS table and running verify-all."
+            )
+            self._is_verify_all = True
         if self._is_verify_all and self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
             # Verify-all: the uniform layout (or None, past the captured grid)
             # is constant per (bs, tier); serve it from cache instead of paying

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -602,13 +602,7 @@ class DsparkVerifyEpilogue:
     ) -> None:
         self.strided_logits = self._ensure_out(self.strided_logits, compact_logits)
         self.strided_hidden = self._ensure_out(self.strided_hidden, compact_hidden)
-        if self.draft_probs_buf is None:
-            assert not torch.cuda.is_current_stream_capturing()
-            self.draft_probs_buf = torch.zeros(
-                (self.max_bs * self.gamma, compact_logits.shape[1]),
-                dtype=torch.float32,
-                device=compact_logits.device,
-            )
+        self.ensure_draft_probs_buf(compact_logits.shape[1], compact_logits.device)
         verify_lens = self.verify_lens_buf[:bs]
         self._scatter(compact_logits, compact_hidden, verify_lens, bs)
         commit_lens = self._accept(input_ids, seq_lens, verify_lens, bs)
@@ -734,6 +728,19 @@ class DsparkVerifyEpilogue:
             accept_index=accept_index, predicts=predicts, correct_len=s_len
         )
         return s_len, s_bonus, s_trim
+
+    def ensure_draft_probs_buf(self, vocab_size: int, device=None) -> torch.Tensor:
+        if self.draft_probs_buf is None:
+            assert not torch.cuda.is_current_stream_capturing(), (
+                "draft_probs_buf must be allocated during warmup, not inside "
+                "graph capture"
+            )
+            self.draft_probs_buf = torch.zeros(
+                (self.max_bs * self.gamma, vocab_size),
+                dtype=torch.float32,
+                device=device if device is not None else self.temps_buf.device,
+            )
+        return self.draft_probs_buf
 
     def arm_sampling(
         self,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -10,7 +10,10 @@ from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
-from sglang.srt.speculative.dflash_utils import apply_dflash_verify_logits_adjustments
+from sglang.srt.speculative.dflash_utils import (
+    _get_or_create_chain_verify_buffers,
+    apply_dflash_verify_logits_adjustments,
+)
 from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockResult
 from sglang.srt.speculative.dspark_components.dspark_kv_inject import (
     TargetHiddenKvInjector,
@@ -22,11 +25,13 @@ from sglang.srt.speculative.dspark_components.dspark_planner import (
 from sglang.srt.speculative.dspark_components.kernels.dspark_accept import (
     AcceptGreedy,
     AcceptSampling,
+    CapCorrectLen,
     FinalizeAcceptLens,
     SelectMixedAccept,
     SoftmaxTemp,
     accept_greedy_triton,
     finalize_accept_lens_triton,
+    gather_two_level_bonus_triton,
 )
 from sglang.srt.speculative.dspark_components.kernels.dspark_verify_window import (
     BuildCommitInjectLayout,
@@ -37,6 +42,7 @@ from sglang.srt.speculative.dspark_components.kernels.dspark_verify_window impor
     scatter_compact_to_strided_into,
 )
 from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+from sglang.srt.speculative.reject_sampling import chain_speculative_sampling_triton
 
 
 def verify_logits_adjustments_are_noop(sampling_info) -> bool:
@@ -501,6 +507,16 @@ class DsparkVerifyEpilogue:
         )
         self.strided_logits: Optional[torch.Tensor] = None
         self.strided_hidden: Optional[torch.Tensor] = None
+        # Sampling-accept fold: staged per-step inputs. temps default to 1.0
+        # so an un-armed replay's in-graph softmax stays finite (its result is
+        # discarded by the all-greedy mask anyway).
+        self.temps_buf = torch.ones(
+            (self.max_bs, 1), dtype=torch.float32, device=device
+        )
+        self.greedy_mask_buf = torch.ones(
+            (self.max_bs,), dtype=torch.bool, device=device
+        )
+        self.draft_probs_buf: Optional[torch.Tensor] = None
 
     def capture_hook(self, runner, out, forward_batch, num_tokens) -> None:
         # Record the epilogue into every target-verify graph of the main
@@ -586,6 +602,13 @@ class DsparkVerifyEpilogue:
     ) -> None:
         self.strided_logits = self._ensure_out(self.strided_logits, compact_logits)
         self.strided_hidden = self._ensure_out(self.strided_hidden, compact_hidden)
+        if self.draft_probs_buf is None:
+            assert not torch.cuda.is_current_stream_capturing()
+            self.draft_probs_buf = torch.zeros(
+                (self.max_bs * self.gamma, compact_logits.shape[1]),
+                dtype=torch.float32,
+                device=compact_logits.device,
+            )
         verify_lens = self.verify_lens_buf[:bs]
         self._scatter(compact_logits, compact_hidden, verify_lens, bs)
         commit_lens = self._accept(input_ids, seq_lens, verify_lens, bs)
@@ -627,6 +650,24 @@ class DsparkVerifyEpilogue:
             verify_num_draft_tokens=self.stride,
             cutoff_verify_lens=verify_lens,
         )
+        # Sampling accept runs unconditionally in-graph; per-row selection by
+        # the staged greedy mask discards whichever side is inactive (all
+        # inputs are staged buffers, so un-armed replays are finite no-ops).
+        s_len, s_bonus, s_trim = self._accept_sampling_in_graph(
+            candidates.view(bs, self.stride), verify_lens, bs
+        )
+        selected = SelectMixedAccept.execute(
+            greedy_mask=self.greedy_mask_buf[:bs],
+            greedy_len=correct_len,
+            greedy_bonus=bonus,
+            greedy_trim=cap_trim_lens,
+            sampling_len=s_len,
+            sampling_bonus=s_bonus,
+            sampling_trim=s_trim,
+        )
+        correct_len = selected.correct_len
+        bonus = selected.bonus
+        cap_trim_lens = selected.cap_trim_lens
         finalized = finalize_accept_lens_triton(
             correct_len=correct_len,
             cap_trim_lens=cap_trim_lens,
@@ -646,6 +687,81 @@ class DsparkVerifyEpilogue:
         self.new_seq_lens_buf[:bs].copy_(finalized.new_seq_lens)
         self.out_tokens_buf[:bs].copy_(out_tokens.view(bs, self.stride))
         return finalized.commit_lens
+
+    def _accept_sampling_in_graph(self, candidates_2d, verify_lens, bs: int):
+        device = candidates_2d.device
+        target_probs = SoftmaxTemp.execute(
+            logits=self.strided_logits[: bs * self.stride],
+            temperatures=self.temps_buf[:bs],
+            rows_per_request=self.stride,
+        ).view(bs, self.stride, -1)
+        (
+            retrieve_index,
+            retrieve_next_token,
+            retrieve_next_sibling,
+            predicts,
+            accept_index,
+            accept_token_num,
+        ) = _get_or_create_chain_verify_buffers(
+            bs=bs, draft_token_num=self.stride, device=device
+        )
+        uniform_samples = torch.rand(
+            (bs, self.gamma), dtype=torch.float32, device=device
+        )
+        uniform_samples_final = torch.rand((bs,), dtype=torch.float32, device=device)
+        chain_speculative_sampling_triton(
+            predicts=predicts,
+            accept_index=accept_index,
+            accept_token_num=accept_token_num,
+            candidates=candidates_2d,
+            retrive_index=retrieve_index,
+            retrive_next_token=retrieve_next_token,
+            retrive_next_sibling=retrieve_next_sibling,
+            uniform_samples=uniform_samples,
+            uniform_samples_for_final_sampling=uniform_samples_final,
+            target_probs=target_probs,
+            draft_probs=self.draft_probs_buf[: bs * self.gamma].view(
+                bs, self.gamma, -1
+            ),
+            threshold_single=1.0,
+            threshold_acc=1.0,
+            deterministic=True,
+        )
+        s_len, s_trim = CapCorrectLen.execute(
+            correct_len=accept_token_num, verify_lens=verify_lens
+        )
+        s_bonus = gather_two_level_bonus_triton(
+            accept_index=accept_index, predicts=predicts, correct_len=s_len
+        )
+        return s_len, s_bonus, s_trim
+
+    def arm_sampling(
+        self,
+        *,
+        bs: int,
+        greedy_mask=None,
+        temperatures=None,
+        draft_probs=None,
+        draft_tokens=None,
+    ) -> bool:
+        """Stage the sampling-accept inputs for the next verify replay.
+        Returns False when the fold cannot serve this step (buffers not yet
+        allocated by warmup)."""
+        if self.draft_probs_buf is None:
+            return False
+        if greedy_mask is None:
+            self.greedy_mask_buf[:bs].fill_(True)
+        else:
+            self.greedy_mask_buf[:bs].copy_(greedy_mask)
+        if temperatures is not None:
+            self.temps_buf[:bs].copy_(temperatures.view(bs, 1))
+        if draft_probs is not None:
+            self.draft_probs_buf[: bs * self.gamma].copy_(
+                draft_probs.reshape(bs * self.gamma, -1)
+            )
+        if draft_tokens is not None:
+            self.draft_tokens_buf[: bs * self.gamma].copy_(draft_tokens.reshape(-1))
+        return True
 
     def _commit_inject(
         self, commit_lens, verify_lens, seq_lens, req_pool_indices, bs: int

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -292,6 +292,14 @@ class TargetVerifyExecutor:
         run_compact: bool,
     ) -> None:
         if run_compact:
+            if self.kv_injector.stage_ragged(
+                batch=batch,
+                hidden_strided=hidden_strided,
+                commit_lens=commit_lens,
+                bs=bs,
+            ):
+                # Written inside the draft graph's inject prologue.
+                return
             self.kv_injector.inject_ragged(
                 batch=batch,
                 layout=layout,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -382,12 +382,21 @@ class TargetVerifyExecutor:
         logits_output = target_verify.logits_output
 
         stride = self.verify_num_draft_tokens
-        if self.verify_epilogue is not None and target_verify.can_run_cuda_graph:
+        # strided_logits stays None for the process lifetime when no captured
+        # graph recorded the epilogue (capture_hook early-returns for runners
+        # whose attention backend lacks ragged-verify graph support and thus
+        # capture fixed-width geometry) -- fall through to the compact readout
+        # below instead of asserting.
+        if (
+            self.verify_epilogue is not None
+            and target_verify.can_run_cuda_graph
+            and self.verify_epilogue.strided_logits is not None
+        ):
             strided_logits = self.verify_epilogue.strided_logits
             hidden_strided = self.verify_epilogue.strided_hidden
-            assert strided_logits is not None and hidden_strided is not None, (
-                "verify epilogue buffers unwritten after a graph replay -- the "
-                "replayed graph was captured without the epilogue"
+            assert hidden_strided is not None, (
+                "verify epilogue hidden buffer unwritten while logits buffer "
+                "is written -- inconsistent epilogue capture"
             )
             strided_logits = strided_logits[: bs * stride]
             hidden_strided = hidden_strided[: bs * stride]
@@ -486,7 +495,14 @@ class DsparkVerifyEpilogue:
         self.strided_hidden: Optional[torch.Tensor] = None
 
     def capture_hook(self, runner, out, forward_batch, num_tokens) -> None:
-        if runner.model_runner.is_draft_worker or not runner.ragged_verify_mode:
+        # Record the epilogue into every target-verify graph of the main
+        # worker: ragged-geometry captures AND the fixed-width fallback used
+        # when the attention backend lacks ragged-verify graph support
+        # (fixed width is the all-full-widths special case; the in-graph
+        # scatter/accept reads verify_lens_buf, so replay stays correct).
+        if runner.model_runner.is_draft_worker:
+            return
+        if runner.capture_forward_mode != ForwardMode.TARGET_VERIFY:
             return
         if (
             not isinstance(out, LogitsProcessorOutput)

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -312,6 +312,10 @@ class DSparkWorkerV2(BaseSpecWorker):
                         make_draft_sampler_capture_hook(self._draft_sampler)
                     )
                 self._proposer.attach_draft_sampler(self._draft_sampler)
+                self.draft_model_runner.capture_head_hooks.append(
+                    self._kv_injector.capture_prologue_hook
+                )
+                self._proposer.attach_kv_injector(self._kv_injector)
             self._draft_worker.init_cuda_graphs(
                 capture_decode_cuda_graph=capture_decode_cuda_graph
             )

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -53,6 +53,9 @@ from sglang.srt.speculative.dspark_components.dspark_verify import (
     TargetVerifyExecutor,
     verify_logits_adjustments_are_noop,
 )
+from sglang.srt.speculative.dspark_components.kernels.dspark_accept import (
+    SoftmaxTemp,
+)
 from sglang.srt.speculative.spec_utils import draft_tp_context
 from sglang.srt.utils import get_available_gpu_memory, is_cuda
 
@@ -478,6 +481,41 @@ class DSparkWorkerV2(BaseSpecWorker):
             new_seq_lens=next_draft_input.new_seq_lens,
         )
 
+    def _arm_accept_fold(
+        self, *, proposal, draft_block, draft_tokens, sampling_info, bs: int
+    ) -> bool:
+        """Stage the in-graph accept inputs. Greedy folds as before; sampling
+        folds when the draft's corrected logits exist (un-folded proposal) and
+        the target-probs path is the fused softmax (no top-k/top-p)."""
+        epilogue = self._verify_executor.verify_epilogue
+        all_greedy = sampling_info is None or sampling_info.is_all_greedy
+        if all_greedy:
+            return epilogue.arm_sampling(
+                bs=bs,
+                draft_tokens=None if proposal.folded else draft_tokens,
+            )
+        if proposal.folded:
+            # Folded proposals are all-greedy today; anything else keeps the
+            # eager accept.
+            return False
+        if draft_block.corrected_logits is None:
+            return False
+        if sampling_info.need_top_k_sampling or sampling_info.need_top_p_sampling:
+            return False
+        bs_c, gamma_rows, vocab = draft_block.corrected_logits.shape
+        draft_probs = SoftmaxTemp.execute(
+            logits=draft_block.corrected_logits.reshape(bs_c * gamma_rows, vocab),
+            temperatures=draft_block.temperatures,
+            rows_per_request=gamma_rows,
+        )
+        return epilogue.arm_sampling(
+            bs=bs,
+            greedy_mask=draft_block.greedy_mask,
+            temperatures=sampling_info.temperatures,
+            draft_probs=draft_probs,
+            draft_tokens=draft_tokens,
+        )
+
     def _forward_decode(
         self, batch: ScheduleBatch, on_publish
     ) -> GenerationBatchResult:
@@ -574,10 +612,17 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         fold_eligible = (
             self._verify_executor.verify_epilogue is not None
-            and proposal.folded
             and verify_logits_adjustments_are_noop(sampling_info)
             and self._simulate_acc_len <= 0
         )
+        if fold_eligible:
+            fold_eligible = self._arm_accept_fold(
+                proposal=proposal,
+                draft_block=draft_block,
+                draft_tokens=draft_tokens,
+                sampling_info=sampling_info,
+                bs=bs,
+            )
         with self._observers.segment(InfoSegment.TARGET_VERIFY):
             if run_compact:
                 target_verify, hidden_strided = self._verify_executor.run_compact(

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -340,6 +340,11 @@ class DSparkWorkerV2(BaseSpecWorker):
                 if self._verify_epilogue is not None
                 else None
             ),
+            draft_probs_out=(
+                self._verify_epilogue.ensure_draft_probs_buf
+                if self._verify_epilogue is not None
+                else None
+            ),
         )
 
     def clear_cache_pool(self):
@@ -495,9 +500,16 @@ class DSparkWorkerV2(BaseSpecWorker):
                 draft_tokens=None if proposal.folded else draft_tokens,
             )
         if proposal.folded:
-            # Folded proposals are all-greedy today; anything else keeps the
-            # eager accept.
-            return False
+            # Non-greedy folded proposal: the draft graph already wrote the
+            # draft tokens and draft probs into the shared buffers; stage
+            # only the mask and temperatures.
+            if sampling_info.need_top_k_sampling or sampling_info.need_top_p_sampling:
+                return False
+            return epilogue.arm_sampling(
+                bs=bs,
+                greedy_mask=draft_block.greedy_mask,
+                temperatures=sampling_info.temperatures,
+            )
         if draft_block.corrected_logits is None:
             return False
         if sampling_info.need_top_k_sampling or sampling_info.need_top_p_sampling:
@@ -559,7 +571,16 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         sampling_info = batch.sampling_info
         with self._draft_context(), self._observers.segment(InfoSegment.DRAFT):
+            accept_fold_ok = (
+                self._verify_executor.verify_epilogue is not None
+                and verify_logits_adjustments_are_noop(sampling_info)
+                and self._simulate_acc_len <= 0
+                and sampling_info is not None
+                and not sampling_info.need_top_k_sampling
+                and not sampling_info.need_top_p_sampling
+            )
             proposal = self._proposer.propose(
+                allow_sampling_fold=accept_fold_ok,
                 batch=batch,
                 draft_input=draft_input,
                 verify_window=verify_window,

--- a/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
+++ b/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
@@ -25,6 +25,7 @@ class TestRaggedVerifyGraphCapability(CustomTestCase):
         from sglang.srt.layers.attention.deepseek_v4_backend import (
             DeepseekV4AttnBackend,
         )
+        from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
         from sglang.srt.layers.attention.flashattention_backend import (
             FlashAttentionBackend,
         )
@@ -34,6 +35,7 @@ class TestRaggedVerifyGraphCapability(CustomTestCase):
             TRTLLMHAAttnBackend,
             DeepseekV4AttnBackend,
             FlashAttentionBackend,
+            DeepseekSparseAttnBackend,
         ):
             with self.subTest(backend=backend.__name__):
                 self.assertTrue(backend.supports_ragged_verify_graph)


### PR DESCRIPTION
WIP. Enables DSpark compact ragged-verify on GLM-5.2 (DSA) and removes a per-step stream sync on the verify-all path.

- Capture side now respects `supports_ragged_verify_graph`: backends without ragged-verify graph support (e.g. DSA) capture fixed-width verify graphs instead of crashing in deepgemm; the epilogue is recorded into those graphs too.
- Verify-all compact caches the uniform layout and stages `verify_lens` H2D through pinned memory, dropping the per-step host<->device round-trip.
- Register `DSparkDraftModel` so SpecForge dense-draft checkpoints load.

Not final: the pinned-H2D path is only exercised under verify-all so far (measured-SPS-table trimming not yet validated).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29564493992](https://github.com/sgl-project/sglang/actions/runs/29564493992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29564493850](https://github.com/sgl-project/sglang/actions/runs/29564493850)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->