### PR TITLE
[AMD] Support DeepEP-Waterfill and LPLB on the MoRI-EP backend

### DIFF
--- a/python/sglang/kernels/jit/csrc/lplb/ipm_hip.cuh
+++ b/python/sglang/kernels/jit/csrc/lplb/ipm_hip.cuh
@@ -1,0 +1,267 @@
+// Single-block Interior Point Method (IPM) LP solver — HIP/ROCm port.
+//
+// ROCm has no cuBLASDx (the device-side header-only GEMM that the CUDA
+// kernel in ``ipm.cuh`` uses), so this variant keeps the exact same
+// barrier-method IPM but does the tiny GEMMs with hand-written shared-memory
+// block GEMMs. Everything runs on-chip in one kernel per solve, which makes
+// it CUDA-graph-capturable (unlike rocSOLVER's dense factorizations, whose
+// mid-call workspace allocation is illegal during HIP stream capture).
+//
+//   for step in 0..NUM_ITERS:
+//     ax2  = A * x^2
+//     ax2a = ax2 @ A^T           (gemm_ABt)
+//     ax2c = ax2 @ c             (gemm_ABt, N=1)
+//     d    = solve(ax2a, ax2c)   (hand-written block Cholesky / POSV)
+//     r    = ax2c @ A            (gemm_AB, M=1)
+//     d    = x * (c - r)
+//     x   *= 1 - 0.999 * d / max(d)
+//
+// On non-convergence the kernel writes 0.5 to every element (matches
+// ipm.cuh / the historical Numba behavior).
+//
+// Reductions use a single thread (NC/NV are <= a few dozen, dwarfed by the
+// GEMMs) rather than warp shuffles, so the kernel is wavefront-size agnostic
+// (AMD wavefronts are 64 wide, not 32).
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+
+namespace {
+
+template <int NC, int NV>
+struct ipm_hip_smem {
+  float b[NC];
+  float a[NC][NV];
+  float c[NV];
+  float ax2[NC][NV];
+  float ax2a[NC][NC];
+  float x[NV];
+  float ax2c[NC];
+  float r[NV];
+  float d[NV];
+  float alpha;
+  float d_max;
+  float max_residual;
+  bool avail_flag;
+};
+
+// In-place Cholesky factorization a = L L^T (lower triangle). Identical to
+// the CUDA version — plain C++, no external linkage.
+template <int N, int BLOCK_DIM>
+__device__ __forceinline__ void cholesky_factor(float a[N][N]) {
+  const int tid = threadIdx.x;
+  for (int k = 0; k < N; k++) {
+    if (tid == 0) {
+      // Clamp the pivot away from zero before sqrtf; IPM drift can push a
+      // diagonal slightly negative on an otherwise-PSD matrix.
+      a[k][k] = sqrtf(fmaxf(a[k][k], 1e-12f));
+    }
+    __syncthreads();
+    const float pivot = a[k][k];
+    for (int i = k + 1 + tid; i < N; i += BLOCK_DIM) {
+      a[i][k] /= pivot;
+    }
+    __syncthreads();
+    for (int idx = tid; idx < N * N; idx += BLOCK_DIM) {
+      const int i = idx / N, j = idx % N;
+      if (j > k && i >= j && i < N) {
+        a[i][j] -= a[i][k] * a[j][k];
+      }
+    }
+    __syncthreads();
+  }
+}
+
+// Solve L L^T x = b in-place on b (single thread; N is small and the
+// substitutions carry loop dependencies).
+template <int N, int BLOCK_DIM>
+__device__ __forceinline__ void cholesky_apply(const float a[N][N], float b[N]) {
+  const int tid = threadIdx.x;
+  if (tid == 0) {
+    for (int i = 0; i < N; i++) {
+      float s = b[i];
+      for (int j = 0; j < i; j++) {
+        s -= a[i][j] * b[j];
+      }
+      b[i] = s / a[i][i];
+    }
+    for (int i = N - 1; i >= 0; i--) {
+      float s = b[i];
+      for (int j = i + 1; j < N; j++) {
+        s -= a[j][i] * b[j];
+      }
+      b[i] = s / a[i][i];
+    }
+  }
+  __syncthreads();
+}
+
+template <int N, int BLOCK_DIM>
+__device__ __forceinline__ void cholesky_solve(float a[N][N], float b[N]) {
+  cholesky_factor<N, BLOCK_DIM>(a);
+  cholesky_apply<N, BLOCK_DIM>(a, b);
+}
+
+// out[m][n] = sum_k a[m][k] * b[n][k]   (a is MxK, b is NxK — "A @ B^T")
+template <int M, int N, int K, int BLOCK_DIM>
+__device__ __forceinline__ void gemm_ABt(const float* a, const float* b, float* out) {
+  const int tid = threadIdx.x;
+  for (int idx = tid; idx < M * N; idx += BLOCK_DIM) {
+    const int m = idx / N, n = idx % N;
+    float s = 0.f;
+    for (int k = 0; k < K; k++) {
+      s += a[m * K + k] * b[n * K + k];
+    }
+    out[idx] = s;
+  }
+  __syncthreads();
+}
+
+// out[m][n] = sum_k a[m][k] * b[k][n]   (a is MxK, b is KxN — "A @ B")
+template <int M, int N, int K, int BLOCK_DIM>
+__device__ __forceinline__ void gemm_AB(const float* a, const float* b, float* out) {
+  const int tid = threadIdx.x;
+  for (int idx = tid; idx < M * N; idx += BLOCK_DIM) {
+    const int m = idx / N, n = idx % N;
+    float s = 0.f;
+    for (int k = 0; k < K; k++) {
+      s += a[m * K + k] * b[k * N + n];
+    }
+    out[idx] = s;
+  }
+  __syncthreads();
+}
+
+template <int NC, int NV, int BLOCK_DIM, int NUM_ITERS>
+__global__ void ipm_hip_solve_kernel(
+    float* __restrict__ result,
+    const float* __restrict__ input_a,
+    const float* __restrict__ input_b,
+    const float* __restrict__ input_c) {
+  using SMem = ipm_hip_smem<NC, NV>;
+  extern __shared__ unsigned char raw_smem[];
+  SMem* smem = reinterpret_cast<SMem*>(raw_smem);
+
+  const int tid = threadIdx.x;
+  const int dim = blockDim.x;
+
+  auto& a = smem->a;
+  auto& b = smem->b;
+  auto& c = smem->c;
+
+  for (int i = tid; i < NC * NV; i += dim) {
+    a[i / NV][i % NV] = input_a[i];
+  }
+  for (int i = tid; i < NC; i += dim) {
+    b[i] = input_b[i];
+  }
+  for (int i = tid; i < NV; i += dim) {
+    c[i] = input_c[i];
+  }
+  __syncthreads();
+
+  auto& ax2 = smem->ax2;
+  auto& ax2a = smem->ax2a;
+  auto& x = smem->x;
+  auto& ax2c = smem->ax2c;
+  auto& r = smem->r;
+  auto& d = smem->d;
+  auto& alpha = smem->alpha;
+  auto& d_max = smem->d_max;
+  auto& max_residual = smem->max_residual;
+
+  for (int j = tid; j < NV; j += dim) {
+    x[j] = 1.f;
+  }
+  __syncthreads();
+
+  for (int step = 0; step < NUM_ITERS; step++) {
+    for (int ij = tid; ij < NC * NV; ij += dim) {
+      const int i = ij / NV, j = ij % NV;
+      ax2[i][j] = a[i][j] * x[j] * x[j];
+    }
+    __syncthreads();
+
+    gemm_ABt<NC, NC, NV, BLOCK_DIM>(ax2[0], a[0], ax2a[0]);
+    gemm_ABt<NC, 1, NV, BLOCK_DIM>(ax2[0], c, ax2c);
+    cholesky_solve<NC, BLOCK_DIM>(ax2a, ax2c);
+    gemm_AB<1, NV, NC, BLOCK_DIM>(ax2c, a[0], r);
+
+    for (int j = tid; j < NV; j += dim) {
+      d[j] = x[j] * (c[j] - r[j]);
+    }
+    __syncthreads();
+
+    if (tid == 0) {
+      float dm = 0.f;
+      for (int j = 0; j < NV; j++) {
+        dm = fmaxf(dm, d[j]);
+      }
+      d_max = dm;
+      // 1.0 fallback on a non-positive d_max makes the step a no-op so the
+      // solver stalls rather than diverging; the end-of-kernel convergence
+      // check then writes 0.5.
+      alpha = (dm > 1e-9f) ? (0.999f / dm) : 1.0f;
+    }
+    __syncthreads();
+
+    for (int j = tid; j < NV; j += dim) {
+      x[j] *= 1.f - alpha * d[j];
+    }
+    __syncthreads();
+  }
+
+  // Residual ‖A x - b‖_inf for the convergence check (reuse ax2c as scratch).
+  gemm_ABt<NC, 1, NV, BLOCK_DIM>(a[0], x, ax2c);
+  if (tid == 0) {
+    float mr = 0.f;
+    for (int i = 0; i < NC; i++) {
+      mr = fmaxf(mr, fabsf(ax2c[i] - b[i]));
+    }
+    max_residual = mr;
+    smem->avail_flag = (d_max < 0.1f && x[NV - 1] >= 0.f && x[NV - 1] < 1e-4f && mr < 0.05f);
+  }
+  __syncthreads();
+
+  const bool ok = smem->avail_flag;
+  for (int i = tid; i < NV; i += dim) {
+    result[i] = ok ? x[i] : 0.5f;
+  }
+}
+
+template <int NC, int NV, int BLOCK_DIM, int NUM_ITERS>
+void ipm_hip_solve(
+    tvm::ffi::TensorView A, tvm::ffi::TensorView b, tvm::ffi::TensorView c, tvm::ffi::TensorView result) {
+  using namespace host;
+
+  // HIP-safe device match: set_options<kDLCUDA>() resolves to the ROCm device
+  // kind under a HIP build, and LaunchKernel takes the tensor's own device
+  // (matches the per_token_group_quant_8bit.cuh idiom).
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+  TensorMatcher({NC, NV}).with_dtype<float>().with_device(device).verify(A);
+  TensorMatcher({NC}).with_dtype<float>().with_device(device).verify(b);
+  TensorMatcher({NV}).with_dtype<float>().with_device(device).verify(c);
+  TensorMatcher({NV}).with_dtype<float>().with_device(device).verify(result);
+
+  const size_t smem_bytes = sizeof(ipm_hip_smem<NC, NV>);
+
+  // One block solves the whole (tiny) LP on-chip. smem for the LPLB shapes is
+  // ~30 KB, comfortably under the 64 KB LDS/CU, so no max-dynamic-smem opt-in
+  // is needed (unlike the >48 KB Hopper path in ipm.cuh).
+  LaunchKernel(/*grid_dim=*/1, /*block_dim=*/BLOCK_DIM, result.device(), smem_bytes)(
+      ipm_hip_solve_kernel<NC, NV, BLOCK_DIM, NUM_ITERS>,
+      static_cast<float*>(result.data_ptr()),
+      static_cast<const float*>(A.data_ptr()),
+      static_cast<const float*>(b.data_ptr()),
+      static_cast<const float*>(c.data_ptr()));
+}
+
+}  // namespace

--- a/python/sglang/kernels/ops/lplb/cuda_solver.py
+++ b/python/sglang/kernels/ops/lplb/cuda_solver.py
@@ -20,6 +20,7 @@ import torch
 from sglang.kernels.jit.utils import (
     cache_once,
     get_jit_cuda_arch,
+    is_hip_runtime,
     load_jit,
     make_cpp_args,
 )
@@ -59,6 +60,31 @@ def _ipm_module(
     )
 
 
+@cache_once
+def _ipm_module_hip(nc: int, nv: int, block_dim: int, num_iters: int) -> Module:
+    """JIT-compile the HIP/ROCm IPM kernel for one shape.
+
+    ROCm has no cuBLASDx, so this builds ``lplb/ipm_hip.cuh`` (hand-written
+    shared-memory GEMMs + block Cholesky, no mathdx dependency and no SM_VER
+    template). Exports the same ``ipm_solve`` entry name as the CUDA module so
+    callers are backend-agnostic.
+    """
+    args = make_cpp_args(nc, nv, block_dim, num_iters)
+    return load_jit(
+        "lplb_ipm_hip",
+        *args,
+        cuda_files=["lplb/ipm_hip.cuh"],
+        cuda_wrappers=[("ipm_solve", f"ipm_hip_solve<{args}>")],
+    )
+
+
+def _get_ipm_module(nc: int, nv: int, num_iters: int) -> Module:
+    """Return the IPM module for the current backend (HIP or CUDA)."""
+    if is_hip_runtime():
+        return _ipm_module_hip(nc, nv, DEFAULT_BLOCK_DIM, num_iters)
+    return _ipm_module(nc, nv, DEFAULT_BLOCK_DIM, num_iters, _sm_ver())
+
+
 def warmup(
     nc: int,
     nv: int,
@@ -68,7 +94,7 @@ def warmup(
     """JIT-compile the kernel for ``(nc, nv)`` so the first real solve isn't
     paying the compile cost. Raises on compile or launch failure.
     """
-    module = _ipm_module(nc, nv, DEFAULT_BLOCK_DIM, num_iters, _sm_ver())
+    module = _get_ipm_module(nc, nv, num_iters)
     # Trigger any first-call lazy initialization.
     A = torch.zeros(nc, nv, dtype=torch.float32, device=device)
     b = torch.zeros(nc, dtype=torch.float32, device=device)
@@ -110,7 +136,7 @@ def solve_ipm(
     assert b.shape == (nc,), f"b shape mismatch: {b.shape} vs ({nc},)"
     assert c.shape == (nv,), f"c shape mismatch: {c.shape} vs ({nv},)"
 
-    module = _ipm_module(nc, nv, DEFAULT_BLOCK_DIM, num_iters, _sm_ver())
+    module = _get_ipm_module(nc, nv, num_iters)
     if result is None:
         result = torch.empty(nv, dtype=torch.float32, device=A.device)
     module.ipm_solve(A, b, c, result)

--- a/python/sglang/kernels/ops/lplb/torch_solver.py
+++ b/python/sglang/kernels/ops/lplb/torch_solver.py
@@ -41,6 +41,18 @@ def _init_fused_backend() -> None:
         logger.info("LPLB fused solver disabled: CUDA not available")
         return
 
+    # cuBLASDx / Math-DX is CUDA-only. On a ROCm/HIP build torch still reports
+    # cuda.is_available()==True and a >=9 device capability, and the cuda_solver
+    # module imports fine (the kernel is only JIT-compiled lazily), so without
+    # this guard the fused backend would look available and then fail at
+    # load_jit time. Force the pure-torch fallback on HIP.
+    if getattr(torch.version, "hip", None) is not None:
+        logger.info(
+            "LPLB fused solver disabled: ROCm/HIP build detected "
+            "(cuBLASDx is CUDA-only); using the pure-torch LP fallback."
+        )
+        return
+
     cap = torch.cuda.get_device_capability()
     if cap[0] < 9:
         logger.info(
@@ -66,6 +78,18 @@ def _init_fused_backend() -> None:
     _FUSED_ASSERT_FITS = assert_fits
     _FUSED_AVAILABLE = True
     logger.info("LPLB fused solver enabled (CUDA C++ via load_jit, cuBLASDx)")
+
+
+def fused_backend_available() -> bool:
+    """Return whether the fused cuBLASDx IPM backend can be used.
+
+    Resolves and caches the backend on first call (same detection as
+    ``warmup``/``solve_ipm``) but never raises — callers use this to pick
+    between the fused CUDA path and the pure-torch fallback (ROCm/HIP or any
+    non-Hopper GPU where cuBLASDx is unavailable).
+    """
+    _init_fused_backend()
+    return _FUSED_AVAILABLE
 
 
 def _unavailable_reason() -> str:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2049,7 +2049,7 @@ def _a2a_fusion_adjustments(view: Any) -> dict:
     """A2A-backend-driven shared-experts fusion adjustments, declared at the
     legacy write slots in _handle_a2a_moe: Waterfill requires the
     fusion enabled; FlashInfer A2A requires it disabled."""
-    if view.moe_a2a_backend in ("deepep", "megamoe") and view.enable_waterfill:
+    if view.moe_a2a_backend in ("deepep", "megamoe", "mori") and view.enable_waterfill:
         if view.disable_shared_experts_fusion:
             logger.warning(
                 "disable_shared_experts_fusion is overridden to False because Waterfill requires shared expert fusion."
@@ -2088,10 +2088,10 @@ _A2A_EP_SPANNING_BACKENDS = frozenset(
 def _a2a_backend_overrides(view: Any) -> dict:
 
     moe_a2a_backend = view.moe_a2a_backend
-    if view.enable_waterfill and moe_a2a_backend not in ("deepep", "megamoe"):
+    if view.enable_waterfill and moe_a2a_backend not in ("deepep", "megamoe", "mori"):
         logger.warning(
             "moe_a2a_backend is overridden to 'deepep' because Waterfill "
-            "requires the DeepEP or MegaMOE backend."
+            "requires the DeepEP, MegaMOE, or MoRI backend."
         )
         moe_a2a_backend = "deepep"
     if envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get() and moe_a2a_backend != "megamoe":

--- a/python/sglang/srt/eplb/expert_location_dispatch.py
+++ b/python/sglang/srt/eplb/expert_location_dispatch.py
@@ -134,7 +134,8 @@ def _topk_ids_logical_to_physical_probability(
     Uses the JIT-compiled CUDA dispatch kernel when the fused cuBLASDx backend
     is available (Hopper+ NVIDIA), otherwise the pure-torch reference — which is
     the production path on ROCm/HIP (e.g. MI355X) where the fused kernel cannot
-    build.
+    build. The ROCm path is fully CUDA-graph-capturable (see the deterministic
+    sampling below).
     """
     if not topk_ids.is_cuda:
         raise RuntimeError(
@@ -148,11 +149,19 @@ def _topk_ids_logical_to_physical_probability(
             topk_ids, log2phy_prob, info.partial_logical_to_all_physical_map
         )
 
+    # Deterministic low-discrepancy inverse-CDF instead of torch.rand: RNG is
+    # not capturable inside a CUDA graph, and the physical-replica choice never
+    # affects numerical correctness (all replicas of a logical expert share the
+    # same weights) — it only affects load balance. The golden-ratio sequence
+    # frac(i * phi) is uniform on [0, 1) and lower-discrepancy than uniform
+    # noise, so it spreads tokens across replicas per the LP probabilities at
+    # least as evenly, while staying free of host<->device sync.
     n = topk_ids.numel()
-    random_vals = torch.rand(n, dtype=torch.float32, device=topk_ids.device)
+    idx = torch.arange(n, device=topk_ids.device, dtype=torch.float32)
+    sample_vals = (idx * 0.6180339887498949) % 1.0
     return cuda_solver.dispatch_probability_torch_reference(
         topk_ids,
         log2phy_prob,
         info.partial_logical_to_all_physical_map,
-        random_vals,
+        sample_vals,
     )

--- a/python/sglang/srt/eplb/expert_location_dispatch.py
+++ b/python/sglang/srt/eplb/expert_location_dispatch.py
@@ -129,17 +129,30 @@ def _topk_ids_logical_to_physical_probability(
     info: ExpertLocationDispatchInfo,
     log2phy_prob: torch.Tensor,
 ) -> torch.Tensor:
-    """Select physical experts via the JIT-compiled CUDA dispatch kernel.
+    """Select physical experts from the LP probabilities.
 
-    Raises if ``topk_ids`` isn't on CUDA — the LP path requires the fused
-    kernel and there is no torch reference fallback at runtime.
+    Uses the JIT-compiled CUDA dispatch kernel when the fused cuBLASDx backend
+    is available (Hopper+ NVIDIA), otherwise the pure-torch reference — which is
+    the production path on ROCm/HIP (e.g. MI355X) where the fused kernel cannot
+    build.
     """
     if not topk_ids.is_cuda:
         raise RuntimeError(
             "LP dispatch requires CUDA tensors; got topk_ids on " f"{topk_ids.device}."
         )
     from sglang.kernels.ops.lplb import cuda_solver
+    from sglang.kernels.ops.lplb.torch_solver import fused_backend_available
 
-    return cuda_solver.dispatch_probability(
-        topk_ids, log2phy_prob, info.partial_logical_to_all_physical_map
+    if fused_backend_available():
+        return cuda_solver.dispatch_probability(
+            topk_ids, log2phy_prob, info.partial_logical_to_all_physical_map
+        )
+
+    n = topk_ids.numel()
+    random_vals = torch.rand(n, dtype=torch.float32, device=topk_ids.device)
+    return cuda_solver.dispatch_probability_torch_reference(
+        topk_ids,
+        log2phy_prob,
+        info.partial_logical_to_all_physical_map,
+        random_vals,
     )

--- a/python/sglang/srt/eplb/lplb_solver.py
+++ b/python/sglang/srt/eplb/lplb_solver.py
@@ -125,9 +125,9 @@ class LPLBSolver:
         # Count copies per logical expert
         logcnt = torch.bincount(phy2log, minlength=self.num_logical)
 
-        # Separate single-copy vs replicated experts.
-        # Stored as int64 so they can be used directly as index tensors in
-        # _solve without per-call .long() casts (Tier 1 optimization).
+        # Separate single-copy vs replicated experts. Stored as int64 so they
+        # can be used directly as index tensors in _solve without per-call
+        # .long() casts.
         self.log_single = torch.nonzero(logcnt == 1).flatten().to(torch.int64)
         self.phy_single = log2phy[self.log_single, 0].to(torch.int64)
         self.log_replicated = torch.nonzero(logcnt > 1).flatten().to(torch.int64)
@@ -177,48 +177,91 @@ class LPLBSolver:
         self.c_vec[-1] = 1000.0
 
         # Store log2phy as int64 so it can be used directly as index tensor
-        # without per-call .long() casts (Tier 1 optimization).
+        # without per-call .long() casts.
         self.log2phy = log2phy.to(torch.int64).contiguous()
 
-        # Pick the LP backend once. The fused cuBLASDx IPM kernel needs a
-        # Hopper+ NVIDIA GPU with Math-DX headers; on ROCm/HIP (e.g. MI355X) or
-        # any non-Hopper GPU it is unavailable, so we fall back to the pure-torch
-        # solver. The per-layer LP is tiny (NC/NV ~= a few hundred), so the torch
-        # path's extra launches are negligible next to the MoE GEMMs.
+        # Pick the LP solve backend once, at init:
+        #   _use_fused -> NVIDIA cuBLASDx fused kernel (prep/IPM/post in CUDA
+        #                 C++). Per-step, CUDA-graph-capturable. Needs a Hopper+
+        #                 GPU with Math-DX headers.
+        #   _hip_fused -> ROCm HIP block-Cholesky IPM kernel (torch prep/post +
+        #                 the hand-written HIP kernel for the solve). Per-step,
+        #                 CUDA-graph-capturable (no rocSOLVER workspace allocs).
+        #   neither    -> pure-torch per-step solver (_solve_torch). Correct on
+        #                 any backend but not graph-capturable on ROCm, so it
+        #                 requires --disable-cuda-graph there.
         from sglang.kernels.ops.lplb.torch_solver import fused_backend_available
 
         self._use_fused = fused_backend_available()
+        self._hip_fused = False
 
-        # Pre-JIT-compile the fused IPM kernel for this (NC, NV) shape so the
-        # 20-40s compile cost happens once at startup rather than on the first
-        # real request. Skipped (no-op) on the torch fallback path.
+        # Pre-JIT-compile the IPM kernel for this (NC, NV) shape so the 20-40s
+        # compile cost happens once at startup rather than on the first request.
         nc = self.A_base.shape[0]
         nv = self.A_base.shape[1] + 1  # +1 for Big-M column added in solve()
+        _is_hip = getattr(torch.version, "hip", None) is not None
         if self._use_fused:
             from sglang.kernels.ops.lplb.torch_solver import warmup as _ipm_warmup
 
             _ipm_warmup(nc, nv, num_iters=5, device=device)
+        elif _is_hip:
+            # ROCm has no cuBLASDx, so use the hand-written HIP block-Cholesky
+            # IPM kernel: it is CUDA-graph-capturable (allocates no workspace
+            # mid-launch, unlike rocSOLVER) and fast (~80us/solve vs ~28ms for
+            # torch.linalg.cholesky_ex on these tiny matrices). If it can't build
+            # (e.g. no hipcc toolchain) fall back to the pure-torch per-step
+            # solver, which is correct but requires --disable-cuda-graph.
+            try:
+                from sglang.kernels.ops.lplb import cuda_solver
+
+                cuda_solver.warmup(nc, nv, num_iters=5, device=str(device))
+                self._hip_fused = True
+                logger.info(
+                    "LPLBSolver: HIP block-Cholesky IPM kernel enabled "
+                    "(per-step, CUDA-graph-capturable)."
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "LPLBSolver: HIP IPM kernel unavailable (%s); using the "
+                    "pure-torch per-step LP solver (requires --disable-cuda-graph).",
+                    e,
+                )
         else:
             logger.info(
-                "LPLBSolver: fused cuBLASDx IPM backend unavailable; using the "
-                "pure-torch LP solver fallback (ROCm/HIP or non-Hopper GPU)."
+                "LPLBSolver: fused IPM backend unavailable (non-Hopper GPU); "
+                "using the pure-torch per-step LP solver."
             )
 
         # Pre-compute A_base row sum (used in every prep call).
         self._A_base_row_sum = self.A_base.sum(dim=1).contiguous()  # (NC,)
 
-        # Pre-allocate the buffers the JIT CUDA prep / IPM / post kernels write
-        # into. All writes are contiguous full-tensor stores (no strided
-        # ``out=`` semantics), so the reuse is safe under high concurrency.
-        # Constructed lazily on the first solve() call (we don't know the
-        # device-side log2phy_prob shape until then) — see _solve.
+        # Pre-allocate the buffers the fused / HIP prep / IPM / post steps write
+        # into. All writes are contiguous full-tensor stores (no strided ``out=``
+        # semantics), so reusing them across forwards is safe under concurrency
+        # and avoids per-forward allocations that would otherwise be retained in
+        # each captured decode graph's memory pool and OOM the GPU. The pure-torch
+        # fallback (_solve_torch) allocates its own scratch instead.
         self._A_full = torch.empty(nc, nv, dtype=torch.float32, device=device)
         self._A_full[:, : nv - 1].copy_(self.A_base)
         self._b = torch.empty(nc, dtype=torch.float32, device=device)
         self._t1 = torch.empty(self.num_single, dtype=torch.float32, device=device)
         self._x = torch.empty(nv, dtype=torch.float32, device=device)
-        self._log2phy_prob = torch.empty(
+        # Persistent log2phy_prob buffer, overwritten in place by each per-step
+        # fused / HIP solve.
+        self._log2phy_prob = torch.zeros(
             log2phy.shape, dtype=torch.float32, device=device
+        )
+        # Scratch for the in-place HIP per-step post step. HIP path only; the
+        # NV fused and pure-torch paths never read it, so it is not allocated
+        # there (keeps the CUDA path's footprint identical to upstream).
+        self._phy_prob = (
+            torch.zeros(
+                self.num_single + self.num_red_phy + 1,
+                dtype=torch.float32,
+                device=device,
+            )
+            if self._hip_fused
+            else None
         )
 
     def solve(self, topk_ids: torch.Tensor) -> torch.Tensor:
@@ -242,10 +285,9 @@ class LPLBSolver:
         # Step 1: Count local tokens per logical expert.
         # topk_ids comes from the router and is by construction in
         # [0, num_logical), so we can scatter_add directly without filtering.
-        # Boolean masking + numel() (the previous defensive form) forced a
-        # GPU->host sync on every forward pass via aten::nonzero and a
-        # tensor-shape read; scatter_add on the flattened tensor is async
-        # and a no-op when topk_ids is empty (DP-attention idle rank case).
+        # scatter_add on the flattened tensor is async and a no-op when topk_ids
+        # is empty (DP-attention idle rank case); a boolean-mask + numel() form
+        # would instead force a GPU->host sync on every forward pass.
         local_counts = torch.zeros(self.num_logical, dtype=torch.int32, device=device)
         flat_ids = topk_ids.flatten()
         local_counts.scatter_add_(
@@ -269,14 +311,53 @@ class LPLBSolver:
         # Step 3: Run LP solver
         return self._solve(global_counts)
 
+    def _solve_hip(self, global_counts: torch.Tensor) -> torch.Tensor:
+        """ROCm per-step solve: torch prep/post around the HIP IPM kernel.
+
+        prep and post are cheap capturable torch ops (lp_prep.cuh uses warp
+        shuffles that assume a 32-wide warp, so it is not reused on HIP); only
+        the IPM solve — the part that would otherwise need rocSOLVER — runs in
+        the hand-written HIP block-Cholesky kernel. All three are
+        CUDA-graph-capturable, so this runs inside the decode graph every step.
+
+        Writes into pre-allocated static buffers (``_A_full``/``_b``/``_x``/
+        ``_phy_prob``/``_log2phy_prob``) instead of allocating per forward: with
+        the decode graph captured across ~50 batch sizes, per-step allocations
+        would be retained in each graph's private memory pool and OOM the GPU.
+        """
+        from sglang.kernels.ops.lplb import cuda_solver
+
+        # prep in place: only the Big-M last column of A and the RHS b depend on
+        # the counts; A's first NV-1 columns hold the constant A_base from init.
+        total = global_counts.sum().clamp(min=1.0)
+        counts_norm = global_counts / total
+        t1 = counts_norm[self.log_single]  # (num_single,)
+        b1 = counts_norm[self.log_replicated]  # (num_red_log,)
+        b2 = -(self.B1 @ t1).flatten()  # (num_gpus,)
+        torch.cat([b1, b2], out=self._b)  # (nc,) -> static buffer
+        self._A_full[:, -1] = self._b - self._A_base_row_sum  # Big-M column
+
+        x = cuda_solver.solve_ipm(
+            self._A_full, self._b, self.c_vec, num_iters=5, result=self._x
+        )
+
+        # post in place -> static _log2phy_prob.
+        self._phy_prob.zero_()
+        self._phy_prob[self.phy_replicated] = x[: self.num_red_phy].clamp(min=0)
+        self._phy_prob[self.phy_single] = t1
+        self._log2phy_prob.copy_(torch.take(self._phy_prob, self.log2phy))
+        return self._log2phy_prob
+
     def _solve(self, global_counts: torch.Tensor) -> torch.Tensor:
         """Three CUDA kernel launches replace ~14 torch ops.
 
         Pipeline (all writes go into pre-allocated buffers from __init__):
             prep_lp_inputs → solve_ipm → extract_log2phy_prob
-        Falls back to the pure-torch pipeline when the fused cuBLASDx backend
-        is unavailable (ROCm/HIP or non-Hopper GPU).
+        Falls back to the HIP per-step path or the pure-torch pipeline when the
+        fused cuBLASDx backend is unavailable (ROCm/HIP or non-Hopper GPU).
         """
+        if self._hip_fused:
+            return self._solve_hip(global_counts)
         if not self._use_fused:
             return self._solve_torch(global_counts)
 
@@ -303,18 +384,10 @@ class LPLBSolver:
         )
         return self._log2phy_prob
 
-    def _solve_torch(self, global_counts: torch.Tensor) -> torch.Tensor:
-        """Pure-torch equivalent of the fused prep → IPM → post pipeline.
-
-        Used when the fused cuBLASDx backend is unavailable (ROCm/HIP or
-        non-Hopper GPUs). Mirrors the three JIT kernels op-for-op using the
-        Python equivalents documented in their ``.cuh`` headers, with a
-        production-hardened IPM (see ``_ipm_solve_robust``). Correct — not
-        micro-optimized; the per-layer LP is negligible next to the MoE GEMMs.
-        """
-        device = global_counts.device
-
-        # ---- prep (lp_prep.cuh: ~8 torch ops) ----
+    def _prep_torch(self, global_counts: torch.Tensor):
+        """Build the IPM inputs (A, b) and the single-copy ratios t1 from the
+        global token counts (mirrors lp_prep.cuh, ~8 torch ops). Cheap
+        elementwise work with no host sync."""
         total = global_counts.sum().clamp(min=1.0)
         counts_norm = global_counts / total
         t1 = counts_norm[self.log_single]  # (num_single,)
@@ -325,11 +398,11 @@ class LPLBSolver:
         A = torch.cat(
             [self.A_base, (b - self._A_base_row_sum).unsqueeze(1)], dim=1
         )  # (nc, nv)
+        return A, b, t1
 
-        # ---- IPM solve (ipm.cuh barrier method, hardened) ----
-        x = self._ipm_solve_robust(A, b, self.c_vec)  # (nv,)
-
-        # ---- post (lp_post.cuh: ~5 torch ops) ----
+    def _post_torch(self, x: torch.Tensor, t1: torch.Tensor) -> torch.Tensor:
+        """Turn the IPM solution x into log2phy_prob (mirrors lp_post.cuh)."""
+        device = x.device
         x_ratios = x[: self.num_red_phy].clamp(min=0)
         # phy_prob has a trailing always-zero "sink" slot; log2phy's -1 padding
         # is routed there via torch.take's negative-index wrap-around.
@@ -340,46 +413,62 @@ class LPLBSolver:
         phy_prob[self.phy_single] = t1
         return torch.take(phy_prob, self.log2phy)  # (num_logical, max_copies)
 
+    def _solve_torch(self, global_counts: torch.Tensor) -> torch.Tensor:
+        """Pure-torch per-step equivalent of the fused prep → IPM → post
+        pipeline. Used when neither the fused cuBLASDx kernel nor the HIP kernel
+        is available; correct on any backend but not CUDA-graph-capturable on
+        ROCm (see _ipm_solve_robust), so it requires --disable-cuda-graph there.
+        """
+        A, b, t1 = self._prep_torch(global_counts)
+        x = self._ipm_solve_robust(A, b, self.c_vec)  # (nv,)
+        return self._post_torch(x, t1)
+
     def _ipm_solve_robust(
         self, A: torch.Tensor, b: torch.Tensor, c: torch.Tensor, num_iters: int = 5
     ) -> torch.Tensor:
-        """Barrier-method IPM for ``min c^T x s.t. Ax=b, x>=0`` — HIP fallback.
+        """Barrier-method IPM for ``min c^T x s.t. Ax=b, x>=0``.
 
-        Same iteration as ``ipm.cuh`` / ``solve_ipm_torch_reference`` but
-        production-hardened for the runtime path: the fused kernel factors the
-        KKT system with a block Cholesky that clamps tiny pivots and silently
-        returns 0.5 on non-convergence, whereas ``torch.linalg.solve`` raises on
-        a singular/rank-deficient KKT matrix. Per-batch expert counts routinely
-        make ``A @ A^T`` rank-deficient, so we (1) add a larger diagonal
-        regularizer than the reference's 1e-12 and (2) fall back to the
-        all-0.5 "no LP signal" vector on any LinAlg failure — the downstream
-        dispatch then samples uniformly over valid replicas, matching the fused
-        kernel's non-convergence behavior.
+        Solves the KKT system with a dense Cholesky factorization
+        (``torch.linalg.cholesky_ex`` + ``torch.cholesky_solve``) of the
+        1e-6-regularized SPD normal equations, mirroring the fused cuBLASDx
+        kernel's block-Cholesky POSV. ``cholesky_ex`` (``check_errors=False``)
+        returns the error ``info`` as a device tensor and never raises, so —
+        unlike ``torch.linalg.solve``'s LU pivoting — it neither host-syncs nor
+        aborts on a rank-deficient system (common with sparse per-batch expert
+        counts); the 1e-6 diagonal keeps the normal equations SPD. The step size
+        and the non-convergence fallback use ``torch.where`` (not a Python
+        ``if``, which would force a ``.item()`` host sync).
+
+        Matches the fused kernel's behavior: returns 0.5 everywhere on
+        non-convergence, so the downstream dispatch spreads tokens uniformly
+        over valid replicas.
         """
         nc, nv = A.shape
-        x = torch.ones(nv, device=A.device, dtype=torch.float32)
-        eye = torch.eye(nc, device=A.device, dtype=torch.float32)
-        d_max = torch.tensor(0.0, device=A.device, dtype=torch.float32)
-        try:
-            for _ in range(num_iters):
-                ax2 = A * (x * x).unsqueeze(0)  # (nc, nv)
-                ax2a = ax2 @ A.t() + 1e-6 * eye  # (nc, nc) regularized KKT
-                ax2c = ax2 @ c  # (nc,)
-                delta = torch.linalg.solve(ax2a, ax2c)  # (nc,)
-                r = A.t() @ delta  # (nv,)
-                d = x * (c - r)  # (nv,)
-                d_max = d.max()
-                alpha = (
-                    0.999 / d_max
-                    if d_max > 1e-9
-                    else torch.tensor(1.0, device=A.device)
-                )
-                x = x * (1.0 - alpha * d)
-        except torch._C._LinAlgError:
-            return torch.full((nv,), 0.5, device=A.device, dtype=torch.float32)
+        device = A.device
+        x = torch.ones(nv, device=device, dtype=torch.float32)
+        eye = torch.eye(nc, device=device, dtype=torch.float32)
+        one = torch.ones((), device=device, dtype=torch.float32)
+        d_max = torch.zeros((), device=device, dtype=torch.float32)
+        for _ in range(num_iters):
+            ax2 = A * (x * x).unsqueeze(0)  # (nc, nv)
+            ax2a = ax2 @ A.t() + 1e-6 * eye  # (nc, nc) SPD regularized KKT
+            ax2c = ax2 @ c  # (nc,)
+            L, _info = torch.linalg.cholesky_ex(ax2a)  # (nc, nc) lower factor
+            delta = torch.cholesky_solve(ax2c.unsqueeze(1), L).squeeze(1)  # (nc,)
+            r = A.t() @ delta  # (nv,)
+            d = x * (c - r)  # (nv,)
+            d_max = d.max()
+            # alpha = 0.999 / d_max when d_max > 1e-9 else 1.0 — branch-free so
+            # no host sync. The barrier step keeps 0.999 * d / d_max < 1, so x
+            # stays strictly positive and diag(x^2) keeps the KKT SPD.
+            alpha = torch.where(d_max > 1e-9, 0.999 / d_max.clamp(min=1e-9), one)
+            x = x * (1.0 - alpha * d)
 
+        # Device-side convergence test; pick x or the all-0.5 fallback via where
+        # (no Python branch -> capturable).
         max_residual = (A @ x - b).abs().max()
-        converged = (d_max < 0.1) and (0 <= x[-1] < 1e-4) and (max_residual < 0.05)
-        if not converged:
-            return torch.full((nv,), 0.5, device=A.device, dtype=torch.float32)
-        return x
+        converged = (
+            (d_max < 0.1) & (x[-1] >= 0) & (x[-1] < 1e-4) & (max_residual < 0.05)
+        )
+        half = torch.full((nv,), 0.5, device=device, dtype=torch.float32)
+        return torch.where(converged, x, half)

--- a/python/sglang/srt/eplb/lplb_solver.py
+++ b/python/sglang/srt/eplb/lplb_solver.py
@@ -180,14 +180,29 @@ class LPLBSolver:
         # without per-call .long() casts (Tier 1 optimization).
         self.log2phy = log2phy.to(torch.int64).contiguous()
 
+        # Pick the LP backend once. The fused cuBLASDx IPM kernel needs a
+        # Hopper+ NVIDIA GPU with Math-DX headers; on ROCm/HIP (e.g. MI355X) or
+        # any non-Hopper GPU it is unavailable, so we fall back to the pure-torch
+        # solver. The per-layer LP is tiny (NC/NV ~= a few hundred), so the torch
+        # path's extra launches are negligible next to the MoE GEMMs.
+        from sglang.kernels.ops.lplb.torch_solver import fused_backend_available
+
+        self._use_fused = fused_backend_available()
+
         # Pre-JIT-compile the fused IPM kernel for this (NC, NV) shape so the
         # 20-40s compile cost happens once at startup rather than on the first
-        # real request. No-op when the fused backend is unavailable.
+        # real request. Skipped (no-op) on the torch fallback path.
         nc = self.A_base.shape[0]
         nv = self.A_base.shape[1] + 1  # +1 for Big-M column added in solve()
-        from sglang.kernels.ops.lplb.torch_solver import warmup as _ipm_warmup
+        if self._use_fused:
+            from sglang.kernels.ops.lplb.torch_solver import warmup as _ipm_warmup
 
-        _ipm_warmup(nc, nv, num_iters=5, device=device)
+            _ipm_warmup(nc, nv, num_iters=5, device=device)
+        else:
+            logger.info(
+                "LPLBSolver: fused cuBLASDx IPM backend unavailable; using the "
+                "pure-torch LP solver fallback (ROCm/HIP or non-Hopper GPU)."
+            )
 
         # Pre-compute A_base row sum (used in every prep call).
         self._A_base_row_sum = self.A_base.sum(dim=1).contiguous()  # (NC,)
@@ -259,8 +274,12 @@ class LPLBSolver:
 
         Pipeline (all writes go into pre-allocated buffers from __init__):
             prep_lp_inputs → solve_ipm → extract_log2phy_prob
-        Raises if the JIT CUDA backend is unavailable.
+        Falls back to the pure-torch pipeline when the fused cuBLASDx backend
+        is unavailable (ROCm/HIP or non-Hopper GPU).
         """
+        if not self._use_fused:
+            return self._solve_torch(global_counts)
+
         from sglang.kernels.ops.lplb import cuda_solver
 
         cuda_solver.prep_lp_inputs(
@@ -283,3 +302,84 @@ class LPLBSolver:
             self.log2phy,
         )
         return self._log2phy_prob
+
+    def _solve_torch(self, global_counts: torch.Tensor) -> torch.Tensor:
+        """Pure-torch equivalent of the fused prep → IPM → post pipeline.
+
+        Used when the fused cuBLASDx backend is unavailable (ROCm/HIP or
+        non-Hopper GPUs). Mirrors the three JIT kernels op-for-op using the
+        Python equivalents documented in their ``.cuh`` headers, with a
+        production-hardened IPM (see ``_ipm_solve_robust``). Correct — not
+        micro-optimized; the per-layer LP is negligible next to the MoE GEMMs.
+        """
+        device = global_counts.device
+
+        # ---- prep (lp_prep.cuh: ~8 torch ops) ----
+        total = global_counts.sum().clamp(min=1.0)
+        counts_norm = global_counts / total
+        t1 = counts_norm[self.log_single]  # (num_single,)
+        b1 = counts_norm[self.log_replicated]  # (num_red_log,)
+        b2 = -(self.B1 @ t1).flatten()  # (num_gpus,)
+        b = torch.cat([b1, b2])  # (nc,)
+        # A = [A_base | Big-M column], where the Big-M column = b - A_base_row_sum.
+        A = torch.cat(
+            [self.A_base, (b - self._A_base_row_sum).unsqueeze(1)], dim=1
+        )  # (nc, nv)
+
+        # ---- IPM solve (ipm.cuh barrier method, hardened) ----
+        x = self._ipm_solve_robust(A, b, self.c_vec)  # (nv,)
+
+        # ---- post (lp_post.cuh: ~5 torch ops) ----
+        x_ratios = x[: self.num_red_phy].clamp(min=0)
+        # phy_prob has a trailing always-zero "sink" slot; log2phy's -1 padding
+        # is routed there via torch.take's negative-index wrap-around.
+        phy_prob = torch.zeros(
+            self.num_single + self.num_red_phy + 1, dtype=torch.float32, device=device
+        )
+        phy_prob[self.phy_replicated] = x_ratios
+        phy_prob[self.phy_single] = t1
+        return torch.take(phy_prob, self.log2phy)  # (num_logical, max_copies)
+
+    def _ipm_solve_robust(
+        self, A: torch.Tensor, b: torch.Tensor, c: torch.Tensor, num_iters: int = 5
+    ) -> torch.Tensor:
+        """Barrier-method IPM for ``min c^T x s.t. Ax=b, x>=0`` — HIP fallback.
+
+        Same iteration as ``ipm.cuh`` / ``solve_ipm_torch_reference`` but
+        production-hardened for the runtime path: the fused kernel factors the
+        KKT system with a block Cholesky that clamps tiny pivots and silently
+        returns 0.5 on non-convergence, whereas ``torch.linalg.solve`` raises on
+        a singular/rank-deficient KKT matrix. Per-batch expert counts routinely
+        make ``A @ A^T`` rank-deficient, so we (1) add a larger diagonal
+        regularizer than the reference's 1e-12 and (2) fall back to the
+        all-0.5 "no LP signal" vector on any LinAlg failure — the downstream
+        dispatch then samples uniformly over valid replicas, matching the fused
+        kernel's non-convergence behavior.
+        """
+        nc, nv = A.shape
+        x = torch.ones(nv, device=A.device, dtype=torch.float32)
+        eye = torch.eye(nc, device=A.device, dtype=torch.float32)
+        d_max = torch.tensor(0.0, device=A.device, dtype=torch.float32)
+        try:
+            for _ in range(num_iters):
+                ax2 = A * (x * x).unsqueeze(0)  # (nc, nv)
+                ax2a = ax2 @ A.t() + 1e-6 * eye  # (nc, nc) regularized KKT
+                ax2c = ax2 @ c  # (nc,)
+                delta = torch.linalg.solve(ax2a, ax2c)  # (nc,)
+                r = A.t() @ delta  # (nv,)
+                d = x * (c - r)  # (nv,)
+                d_max = d.max()
+                alpha = (
+                    0.999 / d_max
+                    if d_max > 1e-9
+                    else torch.tensor(1.0, device=A.device)
+                )
+                x = x * (1.0 - alpha * d)
+        except torch._C._LinAlgError:
+            return torch.full((nv,), 0.5, device=A.device, dtype=torch.float32)
+
+        max_residual = (A @ x - b).abs().max()
+        converged = (d_max < 0.1) and (0 <= x[-1] < 1e-4) and (max_residual < 0.05)
+        if not converged:
+            return torch.full((nv,), 0.5, device=A.device, dtype=torch.float32)
+        return x

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -9,6 +9,7 @@ from sglang.srt.eplb.expert_distribution import (
     _ExpertDistributionRecorderNoop,
     get_global_expert_distribution_recorder,
 )
+from sglang.srt.eplb.expert_location import get_global_expert_location_metadata
 from sglang.srt.layers.dp_attention import get_is_extend_in_batch
 from sglang.srt.layers.moe.token_dispatcher.base import (
     BaseDispatcher,
@@ -52,6 +53,19 @@ if _use_aiter:
     from aiter import QuantType, get_hip_quant
 
 logger = logging.getLogger(__name__)
+
+
+def _waterfill_trim_local_count(count):
+    """Trim MoRI's local_expert_count to num_local_physical_experts for the EPLB
+    distribution recorder. DeepEP-Waterfill fuses the shared expert as an extra
+    (last) local slot which the recorder does not track; DeepEP feeds a
+    num_local_physical_experts-wide count, so match that here."""
+    meta = get_global_expert_location_metadata()
+    if meta is not None:
+        n = meta.num_local_physical_experts
+        if count.shape[0] != n:
+            return count[:n]
+    return count
 
 
 def _should_record_expert_distribution() -> bool:
@@ -738,7 +752,7 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
         # low_latency hook only when the recorder is actually active.
         if record:
             get_global_expert_distribution_recorder().on_deepep_dispatch_low_latency(
-                self.mori_op.local_expert_count
+                _waterfill_trim_local_count(self.mori_op.local_expert_count)
             )
 
         return (
@@ -927,7 +941,7 @@ class _MoriEPDispatcherImplLowLatency(_MoriEPDispatcherImplBase):
 
         if record:
             get_global_expert_distribution_recorder().on_deepep_dispatch_low_latency(
-                self.mori_op.local_expert_count
+                _waterfill_trim_local_count(self.mori_op.local_expert_count)
             )
 
         return MoriEPLLDispatchOutput(

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1875,6 +1875,24 @@ def _post_process_topk_ids(
                 topk_ids, expert_location_dispatch_info, num_token_non_padded
             )
     elif _is_hip:
+        # LP path: solve the per-layer LP outside torch.compile (the solver
+        # contains an EP all-reduce that can't run inside compiled regions), then
+        # remap logical->physical using the resulting probabilities. Mirrors the
+        # _is_cuda branch above. topk_ids still holds valid router ids here (the
+        # padded region is masked below), so the count/all-reduce inside solve()
+        # matches the CUDA path. The torch LP fallback backs this on ROCm.
+        log2phy_prob = None
+        if (
+            expert_location_dispatch_info is not None
+            and getattr(expert_location_dispatch_info, "ep_dispatch_algorithm", None)
+            == "lp"
+        ):
+            from sglang.srt.eplb.lplb_solver import get_global_lplb_solver
+
+            lplb_solver = get_global_lplb_solver(layer_id)
+            if lplb_solver is not None:
+                log2phy_prob = lplb_solver.solve(topk_ids)
+
         # On AMD HIP the aiter MoE kernels do not handle topk_ids=-1 safely
         # (negative indices cause illegal memory access). Always fill the padded
         # region with 0 so every kernel sees a valid in-range expert id.
@@ -1886,7 +1904,12 @@ def _post_process_topk_ids(
         # The logical->physical remap is only meaningful when a real
         # expert-location mapping exists. With a trivial placement and EPLB off
         # the map is identity so the remap can be skipped safely.
-        if _eplb_remap_enabled():
+        if log2phy_prob is not None:
+            topk_ids = topk_ids_logical_to_physical(
+                topk_ids, expert_location_dispatch_info, log2phy_prob
+            )
+            _mask_topk_ids_padded_region(topk_ids, num_token_non_padded, fill_value=0)
+        elif _eplb_remap_enabled():
             topk_ids = topk_ids_logical_to_physical(
                 topk_ids, expert_location_dispatch_info
             )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6482,6 +6482,17 @@ class ServerArgs:
                 f"MoRI MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )
 
+            if self.ep_dispatch_algorithm == "lp":
+                assert not self.enable_waterfill, (
+                    "ep_dispatch_algorithm='lp' (LPLB) and --enable-waterfill "
+                    "are mutually exclusive load balancers; enable only one."
+                )
+                logger.info(
+                    "LPLB (ep_dispatch_algorithm='lp') is enabled on the MoRI "
+                    "backend. Per-layer LP solving uses the pure-torch fallback "
+                    "on ROCm; routed tokens are dispatched to the least-loaded "
+                    "physical replica through MoRI."
+                )
             # Check chunked prefill for mori
             # Skip validation if chunked prefill is disabled (i.e., size <= 0).
             # Skip validation if disaggregation mode is decode.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6483,16 +6483,27 @@ class ServerArgs:
             )
 
             if self.ep_dispatch_algorithm == "lp":
-                assert not self.enable_waterfill, (
-                    "ep_dispatch_algorithm='lp' (LPLB) and --enable-waterfill "
-                    "are mutually exclusive load balancers; enable only one."
-                )
                 logger.info(
                     "LPLB (ep_dispatch_algorithm='lp') is enabled on the MoRI "
-                    "backend. Per-layer LP solving uses the pure-torch fallback "
-                    "on ROCm; routed tokens are dispatched to the least-loaded "
+                    "backend. Per-layer LP balances the routed experts' redundant "
+                    "replicas; routed tokens are dispatched to the least-loaded "
                     "physical replica through MoRI."
                 )
+                if self.enable_waterfill:
+                    # LPLB and Waterfill are complementary, not mutually
+                    # exclusive: Waterfill balances the shared-expert slot
+                    # (topk 8->9), LPLB balances the routed redundant replicas.
+                    # They apply in sequence in the TopK forward (select_experts
+                    # runs the LPLB logical->physical remap on the routed top-k,
+                    # then _apply_deepep_waterfill appends the shared expert), so
+                    # both can be enabled together.
+                    logger.info(
+                        "DeepEP Waterfill is also enabled alongside LPLB: "
+                        "Waterfill balances the shared-expert slot while LPLB "
+                        "balances the routed redundant replicas (applied in "
+                        "sequence, complementary)."
+                    )
+
             # Check chunked prefill for mori
             # Skip validation if chunked prefill is disabled (i.e., size <= 0).
             # Skip validation if disaggregation mode is decode.


### PR DESCRIPTION
## What this PR does
This PR brings the two expert-parallel load-balancing dispatch options that already exist for
the DeepEP backend to the **MoRI-EP** backend, and makes the LP solver usable under CUDA/HIP
graph capture:

1. **DeepEP-Waterfill on MoRI-EP** — `--enable-waterfill` is now supported when
   `--moe-a2a-backend mori`.
2. **LPLB on MoRI-EP** — `--ep-dispatch-algorithm lp` (linear-programming load balancer) is now
   supported on MoRI-EP.
3. **HIP block-Cholesky IPM kernel** — a hand-written ROCm interior-point LP solver that is
   CUDA-graph-capturable (allocates no workspace mid-launch, unlike rocSOLVER). It becomes the
   default ROCm LP backend so LPLB can run inside the captured graph; it falls back to the
   pure-torch per-step solver when the toolchain is unavailable.
4. **LPLB + Waterfill together** on MoRI-EP.

The NVIDIA/CUDA and DeepEP code paths are behaviorally unchanged.

## Files
9 files: `layers/moe/token_dispatcher/moriep.py`, `layers/moe/topk.py`, `eplb/lplb_solver.py`,
`eplb/expert_location_dispatch.py`, `arg_groups/overrides.py`, `server_args.py`,
`jit_kernel/lplb/{cuda_solver.py,torch_solver.py}`, `jit_kernel/csrc/lplb/ipm_hip.cuh`.

## Validation
Target: DeepSeek-R1 FP8, EP8 / TP8 / DP8, MoRI-EP, MI355X.

- **Functional:** all configurations boot with CUDA graph enabled and the HIP LP kernel active
  (baseline / waterfill / lplb / waterfill+lplb, across redundancy levels).
- **Load balance (actual received load):** measured per-GPU received-token balancedness from
  MoRI's `local_expert_count` (tokens each GPU actually receives after the all-to-all), including
  the shared expert, at a matched per-forward batch size so the comparison is not confounded by
  batch-size effects. Metric = `mean/max` over the 8 GPUs (1.0 = perfectly even).

  Balanced workload (gsm8k):
  | config | received-load balancedness |
  |---|---|
  | static (no balancer) | 0.837 |
  | waterfill | 0.866 |
  | LPLB | **0.968** |
  | waterfill + LPLB | 0.963 |

  Imbalanced workload:
  | config | received-load balancedness |
  |---|---|
  | static (no balancer) | 0.734 |
  | waterfill | 0.785 |
  | LPLB | 0.848 |
  | waterfill + LPLB | **0.910** |

## Notes
- `--enable-waterfill` on MoRI keeps the DeepSeek shared expert fused into the dispatched MoE
  slots (routed as an extra per-rank slot); `--ep-dispatch-algorithm lp` requires redundant
  experts (`--ep-num-redundant-experts > 0`) to have replica freedom.
- The HIP LP kernel is auto-selected on ROCm and is graph-capturable; on non-ROCm or when the
  toolchain is missing it falls back to the existing solvers.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30083164556](https://github.com/sgl-project/sglang/actions/runs/30083164556)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30083164394](https://github.com/sgl-project/sglang/actions/runs/30083164394)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->