### PR TITLE
Fix FPM decode metrics when seq_lens_cpu is missing

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -16,8 +16,6 @@ from typing import (
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.managers.schedule_batch import ScheduleBatch
-from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.observability.metrics_collector import (
     DPCooperationInfo,
     QueueCount,
@@ -30,10 +28,10 @@ from sglang.srt.utils.device_timer import DeviceTimer
 from sglang.srt.utils.scheduler_status_logger import SchedulerStatusLogger
 
 if TYPE_CHECKING:
-    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
     from sglang.srt.managers.schedule_policy import PrefillAdder
     from sglang.srt.managers.scheduler import Scheduler
-    from sglang.srt.managers.utils import EmbeddingBatchResult
+    from sglang.srt.managers.utils import EmbeddingBatchResult, GenerationBatchResult
 
 
 logger = logging.getLogger(__name__)
@@ -263,7 +261,12 @@ class SchedulerMetricsReporter:
             for req in batch.decoding_reqs or []:
                 decode_kv.add(req.seqlen)
         elif batch.forward_mode.is_decode():
-            for sl in batch.seq_lens_cpu:
+            decode_seq_lens = (
+                batch.seq_lens_cpu
+                if batch.seq_lens_cpu is not None
+                else (req.seqlen for req in batch.reqs)
+            )
+            for sl in decode_seq_lens:
                 decode_kv.add(int(sl))
 
         return ScheduledRequestMetrics(
@@ -806,6 +809,9 @@ class SchedulerMetricsReporter:
     ):
         if not self.enable_metrics:
             return
+
+        from sglang.srt.managers.utils import GenerationBatchResult
+
         if not isinstance(result, GenerationBatchResult):
             return
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -25,9 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.utils import exponential_buckets, generate_buckets
-from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_bool_env_var
 from sglang.srt.utils.gauge_histogram import GaugeHistogram
 
@@ -35,6 +33,7 @@ if TYPE_CHECKING:
     from prometheus_client import Gauge
 
     from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.server_args import ServerArgs
 
 SGLANG_TEST_REQUEST_TIME_STATS = get_bool_env_var("SGLANG_TEST_REQUEST_TIME_STATS")
 
@@ -171,6 +170,8 @@ class DPCooperationInfo:
 
     @staticmethod
     def create(forward_modes: List[int]):
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
         return DPCooperationInfo(
             # Count ranks that are doing any extend-like work.
             # With overlap scheduling, prefill can appear as MIXED rather than EXTEND.

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -12,6 +12,7 @@ from sglang.srt.managers.scheduler_components.metrics_reporter import (
     PrefillStats,
     SchedulerMetricsReporter,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_ps(**overrides) -> ParallelState:
@@ -125,7 +126,7 @@ def _make_reporter(scheduler) -> SchedulerMetricsReporter:
     )
 
 
-class TestForwardPassMetrics(unittest.TestCase):
+class TestForwardPassMetrics(CustomTestCase):
     def setUp(self):
         self.scheduler = types.SimpleNamespace()
         self.scheduler._fpm_worker_id = "worker-7"
@@ -149,6 +150,28 @@ class TestForwardPassMetrics(unittest.TestCase):
         )
         defaults.update(overrides)
         return types.SimpleNamespace(**defaults)
+
+    def test_build_decode_metrics_falls_back_to_request_lengths(self):
+        batch = self._make_batch(
+            reqs=[_FakeReq(11), _FakeReq(17), _FakeReq(23)],
+            seq_lens_cpu=None,
+        )
+
+        metrics = self.reporter._build_scheduled_request_metrics(batch)
+
+        self.assertEqual(metrics.num_decode_requests, 3)
+        self.assertEqual(metrics.sum_decode_kv_tokens, 51)
+
+    def test_build_decode_metrics_prefers_seq_lens_cpu(self):
+        batch = self._make_batch(
+            reqs=[_FakeReq(100), _FakeReq(200)],
+            seq_lens_cpu=[5, 7],
+        )
+
+        metrics = self.reporter._build_scheduled_request_metrics(batch)
+
+        self.assertEqual(metrics.num_decode_requests, 2)
+        self.assertEqual(metrics.sum_decode_kv_tokens, 12)
 
     def test_emit_mixed_batch_separates_prefill_and_decode(self):
         self.scheduler._fpm_dp_rank = 3


### PR DESCRIPTION
## Motivation
Fixes #31309. Forward Pass Metrics could crash on decode batches when `ScheduleBatch.merge_batch()` leaves `seq_lens_cpu=None`, which is valid for merged decode batches.

## Modifications
- Fall back to `req.seqlen` when decode scheduled-request metrics do not have `seq_lens_cpu`.
- Keep using `seq_lens_cpu` when it is available.
- Move a few type-only / narrow-use imports out of module import paths so FPM unit tests stay lightweight.

## Accuracy Tests
Not applicable. This only changes observability metric construction.

## Speed Tests and Profiling
Not applicable. No inference hot path behavior is changed.

## Checklist
- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Tests:
- `PYTHONPATH=python .venv/bin/python test/registered/unit/observability/test_forward_pass_metrics.py`
- `PYTHONPATH=python .venv/bin/python test/registered/unit/observability/test_metrics_utils.py`
- `git diff --check`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29476167223](https://github.com/sgl-project/sglang/actions/runs/29476167223)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29476167103](https://github.com/sgl-project/sglang/actions/runs/29476167103)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->