### PR TITLE
[Platform] Route OOT device-name queries through current_platform

### DIFF
--- a/docs_new/docs/hardware-platforms/plugin.mdx
+++ b/docs_new/docs/hardware-platforms/plugin.mdx
@@ -70,7 +70,7 @@ Key design points:
 - All methods are **instance methods** (not classmethods), called through the `current_platform` singleton
 - Device operations and factory methods raise `NotImplementedError` by default (fail-fast)
 - Capability flags use safe conservative defaults (`False`/`pass`)
-- Methods are annotated `[Active]` (called by SGLang core) or `[Planned]` (reserved for future migration)
+- Methods are annotated `[Active]` (at least one SGLang core path is routed through `current_platform`) or `[Planned]` (reserved for future migration)
 
 ### Platform Discovery (`current_platform`)
 
@@ -203,6 +203,7 @@ class MyDeviceMixin(DeviceMixin):
     device_type = "my_device"   # torch device type
 
     def set_device(self, device) -> None: ...
+    # Optional override; otherwise SRT keeps legacy runtime name detection.
     def get_device_name(self, device_id=0) -> str: ...
     def get_device_total_memory(self, device_id=0) -> int: ...
     def get_current_memory_usage(self, device=None) -> float: ...
@@ -292,7 +293,7 @@ python -c "from sglang.srt.platforms import current_platform; print(current_plat
 
 #### Device Operations (from DeviceMixin)
 
-> Methods annotated **[Active]** are called by SGLang core through `current_platform` — OOT implementations take effect immediately.
+> Methods annotated **[Active]** have at least one SGLang core path routed through `current_platform` — OOT implementations take effect on those routed paths.
 > Methods annotated **[Planned]** are reserved interfaces — SGLang core still uses hardcoded calls (e.g. `torch.cuda.empty_cache()`). OOT implementations will NOT take effect until the core is migrated in a future PR.
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
@@ -326,8 +327,8 @@ python -c "from sglang.srt.platforms import current_platform; print(current_plat
     <tr>
       <td><code>get_device_name(device_id)</code></td>
       <td><code>raise NotImplementedError</code></td>
-      <td>Planned</td>
-      <td>Get human-readable device name</td>
+      <td><strong>Active</strong></td>
+      <td>Optional OOT override for a human-readable device name. Without an override, SRT keeps its existing runtime detection.</td>
     </tr>
     <tr>
       <td><code>get_device_uuid(device_id)</code></td>

--- a/python/sglang/srt/platforms/device_mixin.py
+++ b/python/sglang/srt/platforms/device_mixin.py
@@ -18,8 +18,9 @@ Hierarchy example (OOT plugin)::
 
 Method status annotations:
 
-- ``[Active]``  — SGLang core calls this method through ``current_platform``.
-  OOT implementations take effect immediately.
+- ``[Active]``  — SGLang core has at least one path routed through
+  ``current_platform`` for this method. OOT implementations take effect on
+  those routed paths.
 - ``[Planned]`` — Reserved interface. SGLang core still uses hardcoded calls
   (e.g. ``torch.cuda.empty_cache()``). OOT implementations will NOT take
   effect until the core is migrated in a future PR.
@@ -145,8 +146,8 @@ class DeviceMixin:
         return self._enum == PlatformEnum.OOT
 
     # ------------------------------------------------------------------
-    # Active methods — core calls these through current_platform.
-    # OOT implementations take effect immediately.
+    # Active methods — core has at least one current_platform call path.
+    # OOT implementations take effect on the routed paths.
     # ------------------------------------------------------------------
 
     def get_device_total_memory(self, device_id: int = 0) -> int:
@@ -157,6 +158,10 @@ class DeviceMixin:
         self, device: Optional["torch.device"] = None
     ) -> float:
         """[Active] Get current peak memory usage in bytes."""
+        raise NotImplementedError
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        """[Active] Get human-readable device name on routed paths."""
         raise NotImplementedError
 
     def is_pin_memory_available(self, device=None) -> bool:
@@ -177,10 +182,6 @@ class DeviceMixin:
 
     def set_device(self, device: "torch.device") -> None:
         """[Planned] Set the current device."""
-        raise NotImplementedError
-
-    def get_device_name(self, device_id: int = 0) -> str:
-        """[Planned] Get human-readable device name."""
         raise NotImplementedError
 
     def get_device_uuid(self, device_id: int = 0) -> str:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -97,6 +97,7 @@ from typing_extensions import Literal
 from sglang.srt.environ import envs
 from sglang.srt.observability.func_timer import enable_func_timer
 from sglang.srt.platforms import current_platform
+from sglang.srt.platforms.device_mixin import DeviceMixin
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.video_decoder import _BACKEND, VideoDecoderWrapper
 
@@ -823,6 +824,12 @@ def get_device_memory_capacity(device: str = None):
 
 
 def get_device_name(device_id: int = 0) -> str:
+    if (
+        current_platform.is_out_of_tree()
+        and type(current_platform).get_device_name is not DeviceMixin.get_device_name
+    ):
+        return current_platform.get_device_name(device_id)
+
     if (hasattr(torch, "cuda") and torch.cuda.is_available()) or is_musa():
         return torch.cuda.get_device_name(device_id)
 

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -431,6 +431,106 @@ class TestPinMemoryAvailability(CustomTestCase):
         mock_cuda_available.assert_not_called()
 
 
+class TestDeviceNameDispatch(CustomTestCase):
+    """Tests for common device-name dispatch through OOT platforms."""
+
+    def test_oot_device_name_override_is_used_before_runtime_probe(self):
+        from sglang.srt.utils import common
+
+        class P(SRTPlatform):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+            def __init__(self):
+                self.calls = []
+
+            def get_device_name(self, device_id=0):
+                self.calls.append(device_id)
+                return "Custom Accelerator"
+
+        platform = P()
+        with (
+            patch.object(common, "current_platform", platform),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_name") as mock_cuda_name,
+        ):
+            self.assertEqual(common.get_device_name(2), "Custom Accelerator")
+
+        self.assertEqual(platform.calls, [2])
+        mock_cuda_name.assert_not_called()
+
+    def test_oot_device_name_uses_documented_device_mixin_override(self):
+        from sglang.srt.utils import common
+
+        class M(DeviceMixin):
+            def get_device_name(self, device_id=0):
+                return f"Mixin Accelerator {device_id}"
+
+        class P(SRTPlatform, M):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+        with patch.object(common, "current_platform", P()):
+            self.assertEqual(common.get_device_name(3), "Mixin Accelerator 3")
+
+    def test_oot_without_override_preserves_legacy_runtime_detection(self):
+        from sglang.srt.utils import common
+
+        class P(SRTPlatform):
+            _enum = PlatformEnum.OOT
+            device_name = "custom"
+            device_type = "custom"
+
+        with (
+            patch.object(common, "current_platform", P()),
+            patch("torch.cuda.is_available", return_value=True),
+            patch(
+                "torch.cuda.get_device_name", return_value="Legacy CUDA Device"
+            ) as mock_cuda_name,
+        ):
+            self.assertEqual(common.get_device_name(4), "Legacy CUDA Device")
+
+        mock_cuda_name.assert_called_once_with(4)
+
+    def test_oot_device_name_override_errors_propagate(self):
+        from sglang.srt.utils import common
+
+        for error_type in (RuntimeError, NotImplementedError):
+            with self.subTest(error_type=error_type):
+
+                class P(SRTPlatform):
+                    _enum = PlatformEnum.OOT
+                    device_name = "custom"
+                    device_type = "custom"
+
+                    def get_device_name(self, device_id=0):
+                        raise error_type("device name query failed")
+
+                with patch.object(common, "current_platform", P()):
+                    with self.assertRaisesRegex(error_type, "query failed"):
+                        common.get_device_name(0)
+
+    def test_in_tree_platform_keeps_legacy_runtime_detection(self):
+        from sglang.srt.utils import common
+
+        class P(CudaSRTPlatform):
+            def get_device_name(self, device_id=0):
+                raise AssertionError("in-tree platform hook should not run")
+
+        with (
+            patch.object(common, "current_platform", P()),
+            patch("torch.cuda.is_available", return_value=True),
+            patch(
+                "torch.cuda.get_device_name", return_value="Legacy CUDA Device"
+            ) as mock_cuda_name,
+        ):
+            self.assertEqual(common.get_device_name(5), "Legacy CUDA Device")
+
+        mock_cuda_name.assert_called_once_with(5)
+
+
 # ---------------------------------------------------------------------------
 # Platform Discovery: _resolve_platform
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

`sglang.srt.utils.get_device_name()` currently detects device names through hardcoded CUDA/MUSA, XPU, HPU, and NPU runtime probes. As a result, an out-of-tree platform's existing `DeviceMixin.get_device_name(device_id)` implementation is not used by the SRT tuning and configuration paths that call this helper.

## Modifications

- Route `get_device_name(device_id)` through `current_platform` only when the active platform is OOT and explicitly overrides the `DeviceMixin` base hook.
- Preserve the existing CUDA/MUSA, XPU, HPU, and NPU runtime-probe fallback for OOT platforms without an override.
- Leave all in-tree platform behavior, direct `torch.*.get_device_name()` calls, and the multimodal platform hierarchy unchanged.
- Mark the routed `DeviceMixin.get_device_name(device_id)` path as active in the platform interface documentation.
- Add fake-platform tests for a direct override, the documented device-mixin MRO, missing-override fallback, error propagation, and unchanged in-tree dispatch.

## Accuracy Tests

N/A. No model forward, kernel, or output logic changes.

## Speed Tests and Profiling

N/A. Platform helper dispatch only.

## Validation

- `git diff --check origin/main...HEAD`
- `python3 -m py_compile` on all changed Python files
- Changed-files pre-commit checks, including AST, isort, Ruff, codespell, merge-conflict, and registered-test checks
- Black check on all changed Python files
- Five focused no-hardware behavior tests: direct override, documented mixin/MRO override, legacy fallback, override error propagation, and unchanged in-tree dispatch
- The registered platform pytest file does not collect in the local environment because the optional model/quantization dependency `gguf` is not installed; full registered execution is delegated to CI.

## Checklist

- [x] Format/lint done.
- [x] Unit tests added.
- [x] Documentation updated for the routed OOT hook.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29477359164](https://github.com/sgl-project/sglang/actions/runs/29477359164)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29477358807](https://github.com/sgl-project/sglang/actions/runs/29477358807)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->