### PR TITLE
Skip AMD nightly local registry push

### DIFF
--- a/.github/workflows/release-docker-amd-nightly.yml
+++ b/.github/workflows/release-docker-amd-nightly.yml
@@ -125,7 +125,7 @@ jobs:
   # of publish failed; legs without an artifact will fail at download and be
   # the only ones marked red.
   push_local_registry:
-    if: ${{ !cancelled() && github.repository == 'sgl-project/sglang' }}
+    if: ${{ false }}
     runs-on: linux-mi300-1gpu-sglang
     environment: 'prod'
     needs: publish

--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -134,7 +134,7 @@ jobs:
   # of publish failed; legs without an artifact will fail at download and be
   # the only ones marked red.
   push_local_registry:
-    if: ${{ !cancelled() && github.repository == 'sgl-project/sglang' && (github.event_name != 'workflow_dispatch' || inputs.job_select == 'all' || inputs.job_select == 'publish') }}
+    if: ${{ false }}
     runs-on: linux-mi300-1gpu-sglang
     environment: 'prod'
     needs: publish


### PR DESCRIPTION
## Motivation

Temporarily skip the AMD release nightly local registry mirror job while keeping the normal nightly Docker image publication paths intact.

## Modifications

- Set `push_local_registry` to `if: ${{ false }}` in the ROCm 7.0 AMD release nightly workflow.
- Set `push_local_registry` to `if: ${{ false }}` in the ROCm 7.2 AMD release nightly workflow.
- Preserve the previous `if` conditions as comments so the local registry mirror can be restored directly.

## Accuracy Tests

N/A. This only changes GitHub Actions workflow job gating.

## Speed Tests and Profiling

N/A. This does not change runtime code.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Validation

- `git diff --check`
- Parsed both edited workflow files with PyYAML.
- Commit pre-commit hooks passed, including `check yaml` and duplicate workflow job name validation.

No release workflow was manually dispatched, because the affected workflows build and publish Docker images.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29478974037](https://github.com/sgl-project/sglang/actions/runs/29478974037)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29478973899](https://github.com/sgl-project/sglang/actions/runs/29478973899)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->