### PR TITLE
[Perf] Cache uniform ragged-verify layout for DSpark verify-all compact

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -124,6 +124,7 @@ class DSparkVerifyPlanner:
         self._dynamic_graph_tier = False
         self._dp_tier_gather_enabled = False
         self._is_verify_all = True
+        self._uniform_layout_cache: dict = {}
         if self._ragged_verify_mode is not RaggedVerifyMode.STATIC:
             if self._confidence_head is None:
                 raise ValueError(
@@ -417,6 +418,24 @@ class DSparkVerifyPlanner:
     ) -> Optional[RaggedVerifyLayout]:
         if self._ragged_verify_mode is RaggedVerifyMode.STATIC:
             return None
+        if self._is_verify_all and self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
+            # Verify-all admits every request at full width, so the layout is a
+            # constant per (bs, tier): skip the per-step budget/topk schedule
+            # and its host<->device transfers (a hidden per-step stream sync)
+            # and serve a cached uniform layout instead.
+            key = (int(req_pool_indices.shape[0]), global_num_reqs)
+            layout = self._uniform_layout_cache.get(key)
+            if layout is None:
+                layout = uniform_ragged_layout(
+                    bs=key[0],
+                    device=device,
+                    verify_num_draft_tokens=self.verify_num_draft_tokens,
+                    ragged_verify_mode=self._ragged_verify_mode,
+                    model_runner=self.model_runner,
+                    tier_num_reqs=global_num_reqs,
+                )
+                self._uniform_layout_cache[key] = layout
+            return layout
         verify_lens = self._schedule_verify_lens(
             req_pool_indices=req_pool_indices,
             prefix_lens=prefix_lens,
@@ -562,7 +581,18 @@ class DSparkVerifyPlanner:
             confidence=confidence,
             budget=budget,
             cfg=self._schedule_cfg,
-        ).to(device=device, dtype=torch.int32)
+        )
+        if verify_lens.device.type == "cpu":
+            # Pageable H2D would make cudaMemcpyAsync wait for the compute
+            # stream to drain (a per-step hidden sync); stage through pinned
+            # memory so the copy is truly async and the host runs ahead.
+            verify_lens = (
+                verify_lens.to(torch.int32)
+                .pin_memory()
+                .to(device=device, non_blocking=True)
+            )
+        else:
+            verify_lens = verify_lens.to(device=device, dtype=torch.int32)
 
         if envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
             verify_lens_64 = verify_lens.to(torch.int64)

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -422,11 +422,11 @@ class DSparkVerifyPlanner:
             # Verify-all admits every request at full width, so the layout is a
             # constant per (bs, tier): skip the per-step budget/topk schedule
             # and its host<->device transfers (a hidden per-step stream sync)
-            # and serve a cached uniform layout instead.
+            # and serve a cached uniform layout instead. None (layout exceeds
+            # the captured grid) is a per-key constant too, so cache it as well.
             key = (int(req_pool_indices.shape[0]), global_num_reqs)
-            layout = self._uniform_layout_cache.get(key)
-            if layout is None:
-                layout = uniform_ragged_layout(
+            if key not in self._uniform_layout_cache:
+                self._uniform_layout_cache[key] = uniform_ragged_layout(
                     bs=key[0],
                     device=device,
                     verify_num_draft_tokens=self.verify_num_draft_tokens,
@@ -434,8 +434,7 @@ class DSparkVerifyPlanner:
                     model_runner=self.model_runner,
                     tier_num_reqs=global_num_reqs,
                 )
-                self._uniform_layout_cache[key] = layout
-            return layout
+            return self._uniform_layout_cache[key]
         verify_lens = self._schedule_verify_lens(
             req_pool_indices=req_pool_indices,
             prefix_lens=prefix_lens,

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -581,18 +581,7 @@ class DSparkVerifyPlanner:
             confidence=confidence,
             budget=budget,
             cfg=self._schedule_cfg,
-        )
-        if verify_lens.device.type == "cpu":
-            # Pageable H2D would make cudaMemcpyAsync wait for the compute
-            # stream to drain (a per-step hidden sync); stage through pinned
-            # memory so the copy is truly async and the host runs ahead.
-            verify_lens = (
-                verify_lens.to(torch.int32)
-                .pin_memory()
-                .to(device=device, non_blocking=True)
-            )
-        else:
-            verify_lens = verify_lens.to(device=device, dtype=torch.int32)
+        ).to(device=device, dtype=torch.int32)
 
         if envs.SGLANG_ENABLE_ASYNC_ASSERT.get():
             verify_lens_64 = verify_lens.to(torch.int64)

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -419,11 +419,9 @@ class DSparkVerifyPlanner:
         if self._ragged_verify_mode is RaggedVerifyMode.STATIC:
             return None
         if self._is_verify_all and self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
-            # Verify-all admits every request at full width, so the layout is a
-            # constant per (bs, tier): skip the per-step budget/topk schedule
-            # and its host<->device transfers (a hidden per-step stream sync)
-            # and serve a cached uniform layout instead. None (layout exceeds
-            # the captured grid) is a per-key constant too, so cache it as well.
+            # Verify-all: the uniform layout (or None, past the captured grid)
+            # is constant per (bs, tier); serve it from cache instead of paying
+            # the per-step schedule and its host<->device round-trips.
             key = (int(req_pool_indices.shape[0]), global_num_reqs)
             if key not in self._uniform_layout_cache:
                 self._uniform_layout_cache[key] = uniform_ragged_layout(


### PR DESCRIPTION
Without an SPS table, DSpark compact mode degenerates to verify-all, but the planner still reruns the per-step budget/topk schedule and rebuilds a constant uniform layout every step, with host<->device round-trips that act as per-step stream syncs. Serve a cached uniform layout keyed by (bs, tier) instead.

Validation: bs=1 dense-draft deployment in verify-all compact, decode forward occupancy 0.72 -> 0.90 (kernel-union).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29483474432](https://github.com/sgl-project/sglang/actions/runs/29483474432)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29483474300](https://github.com/sgl-project/sglang/actions/runs/29483474300)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->