### PR TITLE
[HiCache] Support configurable prefetch IO workers

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -475,6 +475,7 @@ class Envs:
     # Mooncake Store
     SGLANG_HICACHE_MOONCAKE_CONFIG_PATH = EnvStr(None)
     SGLANG_HICACHE_MOONCAKE_REUSE_TE = EnvBool(True)
+    SGLANG_HICACHE_PREFETCH_IO_WORKERS = EnvInt(1)
     MOONCAKE_MASTER = EnvStr(None)
     MOONCAKE_CLIENT = EnvStr(None)
     MOONCAKE_LOCAL_HOSTNAME = EnvStr("localhost")

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.hicache_storage import (
     STORAGE_BATCH_SIZE,
     HiCacheStorageConfig,
@@ -377,7 +378,11 @@ class HiCacheController:
             if hasattr(self, "backup_queue"):
                 self.backup_queue.put_nowait(None)
             if hasattr(self, "prefetch_buffer"):
-                self.prefetch_buffer.put_nowait(None)
+                worker_count = len(getattr(self, "prefetch_io_aux_threads", []))
+                if worker_count == 0 and hasattr(self, "prefetch_io_aux_thread"):
+                    worker_count = 1
+                for _ in range(max(1, worker_count)):
+                    self.prefetch_buffer.put_nowait(None)
         except Exception:
             pass
 
@@ -387,8 +392,12 @@ class HiCacheController:
             threads.append(self.prefetch_thread)
         if hasattr(self, "backup_thread"):
             threads.append(self.backup_thread)
+        if hasattr(self, "prefetch_io_aux_threads"):
+            threads.extend(self.prefetch_io_aux_threads)
         if hasattr(self, "prefetch_io_aux_thread"):
-            threads.append(self.prefetch_io_aux_thread)
+            # Backward compatibility for controllers created before the worker list.
+            if self.prefetch_io_aux_thread not in threads:
+                threads.append(self.prefetch_io_aux_thread)
 
         for t in threads:
             try:
@@ -617,33 +626,21 @@ class HiCacheController:
         )
 
     def reset(self):
-        self.storage_stop_event.set()
-
         self.write_queue.clear()
         self.load_queue.clear()
         self.ack_write_queue.clear()
         self.ack_load_queue.clear()
+
         if self.enable_storage:
-            self.prefetch_thread.join()
-            self.backup_thread.join()
+            self._stop_storage_threads()
             self.prefetch_queue.queue.clear()
             self.backup_queue.queue.clear()
             self.prefetch_revoke_queue.queue.clear()
             self.ack_backup_queue.queue.clear()
             self.host_mem_release_queue.queue.clear()
             self.prefetch_tokens_occupied = 0
-
-        self.storage_stop_event.clear()
-
-        if self.enable_storage:
-            self.prefetch_thread = threading.Thread(
-                target=self.prefetch_thread_func, daemon=True
-            )
-            self.backup_thread = threading.Thread(
-                target=self.backup_thread_func, daemon=True
-            )
-            self.prefetch_thread.start()
-            self.backup_thread.start()
+            self.storage_stop_event.clear()
+            self._start_storage_threads()
 
     def write(
         self,
@@ -1019,10 +1016,17 @@ class HiCacheController:
         Manage prefetching operations from storage backend to host memory.
         """
         self.prefetch_buffer = Queue()
-        self.prefetch_io_aux_thread = threading.Thread(
-            target=self.prefetch_io_aux_func, daemon=True
-        )
-        self.prefetch_io_aux_thread.start()
+        prefetch_io_worker_count = max(1, envs.SGLANG_HICACHE_PREFETCH_IO_WORKERS.get())
+        self.prefetch_io_aux_threads = [
+            threading.Thread(
+                target=self.prefetch_io_aux_func,
+                name=f"hicache-prefetch-io-{idx}",
+                daemon=True,
+            )
+            for idx in range(prefetch_io_worker_count)
+        ]
+        for thread in self.prefetch_io_aux_threads:
+            thread.start()
         while (not self.storage_stop_event.is_set()) or not self.prefetch_queue.empty():
             try:
                 operation = self.prefetch_queue.get(block=True, timeout=1)


### PR DESCRIPTION
## Motivation

HiCache storage prefetch currently uses a single IO auxiliary worker to move prefetched KV pages from the storage backend into host memory. For storage backends such as Mooncake, batch-load workloads can become bottlenecked by this single worker even when there are multiple independent prefetch operations ready to run.

This PR makes the number of HiCache prefetch IO workers configurable while preserving the existing default behavior.

## Modifications

- Add `SGLANG_HICACHE_PREFETCH_IO_WORKERS`, defaulting to `1`.
- Start multiple `prefetch_io_aux_func` daemon workers when the env var is greater than `1`.
- Update shutdown handling to send one sentinel per prefetch IO worker and join all worker threads.
- Keep backward compatibility for controllers that still have the old single `prefetch_io_aux_thread` attribute.

## Accuracy Tests

This PR only changes HiCache storage prefetch scheduling parallelism. It does not change model forward logic or KV contents.

## Speed Tests and Profiling

Benchmark setup:

- Model: `/root/models/Qwen3-0.6B`
- Backend: Mooncake community main, built from `4234180a`
- HiCache storage backend: `mooncake`
- Workload: 32 prompts, 1024 input tokens, 896-token shared prefix, 8 output tokens
- Max concurrency: 16
- Flow: warm shared prefix, flush L1/L2 cache, replay requests to exercise L3 batch load

Results:

| Setting | Completed | Throughput | Mean TTFT | P90 TTFT | P99 TTFT | Mean Latency | P99 Latency |
|---|---:|---:|---:|---:|---:|---:|---:|
| `SGLANG_HICACHE_PREFETCH_IO_WORKERS=1` | 32/32 | 49.13 rps | 128.39 ms | 158.50 ms | 262.43 ms | 300.70 ms | 485.05 ms |
| `SGLANG_HICACHE_PREFETCH_IO_WORKERS=4` | 32/32 | 52.14 rps | 126.52 ms | 162.54 ms | 248.52 ms | 277.66 ms | 447.64 ms |
| `SGLANG_HICACHE_PREFETCH_IO_WORKERS=8` | 32/32 | 54.38 rps | 108.83 ms | 163.44 ms | 252.23 ms | 264.35 ms | 419.20 ms |

Compared with the default single-worker setting, `8` workers improved throughput by 10.7%, mean TTFT by 15.2%, mean latency by 12.1%, and P99 latency by 13.6% in this Mooncake batch-load benchmark.

Validation:

- `git diff --check`
- `python -m compileall -q python/sglang/srt/environ.py python/sglang/srt/managers/cache_controller.py`

## Checklist

- [x] Format/lint sanity checked with `git diff --check`.
- [x] Added a backward-compatible default: existing behavior remains `1` worker unless the env var is set.
- [x] Provided speed benchmark results.
- [ ] Full CI should be run by maintainers.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29483566643](https://github.com/sgl-project/sglang/actions/runs/29483566643)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29483566188](https://github.com/sgl-project/sglang/actions/runs/29483566188)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->