### PR TITLE
ci: add MLX to coverage report backend display order

### DIFF
--- a/scripts/ci/utils/ci_coverage_report.py
+++ b/scripts/ci/utils/ci_coverage_report.py
@@ -32,8 +32,8 @@ from ci_register import CIRegistry, HWBackend, ut_parse_one_file
 # the report -- if the assert below fires, add the new backend name here in
 # the right display slot. Order isn't alphabetical: CUDA/AMD/NPU/CPU lead
 # (highest test volume historically), then accelerators that have been
-# wired into the registry more recently (XPU, MUSA).
-BACKEND_DISPLAY_ORDER = ("CUDA", "AMD", "NPU", "CPU", "XPU", "MUSA")
+# wired into the registry more recently (XPU, MUSA, MLX).
+BACKEND_DISPLAY_ORDER = ("CUDA", "AMD", "NPU", "CPU", "XPU", "MUSA", "MLX")
 assert set(BACKEND_DISPLAY_ORDER) == {
     b.name for b in HWBackend
 }, "BACKEND_DISPLAY_ORDER is out of sync with HWBackend"


### PR DESCRIPTION
## Motivation

The nightly [CI Coverage Overview](https://github.com/sgl-project/sglang/actions/runs/29477726634/job/87554264139) fails since #30121 added `MLX` to `HWBackend`: the report's sync guard requires `BACKEND_DISPLAY_ORDER` to cover every enum member so new backends can't be silently dropped from the tables.

## Modifications

Add `MLX` to `BACKEND_DISPLAY_ORDER`. Verified locally: all three sections (`summary` / `by-folder` / `by-suite`) render, MLX shows its 12 registrations.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29483049639](https://github.com/sgl-project/sglang/actions/runs/29483049639)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29483048550](https://github.com/sgl-project/sglang/actions/runs/29483048550)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->