### PR TITLE
fix: keep duplicate MCP namespace routing consistent

### DIFF
--- a/python/sglang/srt/entrypoints/openai/tool_server.py
+++ b/python/sglang/srt/entrypoints/openai/tool_server.py
@@ -72,7 +72,6 @@ def post_process_tools_description(
 
 
 class ToolServer(ABC):
-
     @abstractmethod
     def has_tool(self, tool_name: str):
         pass
@@ -86,7 +85,6 @@ class ToolServer(ABC):
 
 
 class MCPToolServer(ToolServer):
-
     def __init__(self):
         self.harmony_tool_descriptions = {}
 
@@ -112,15 +110,16 @@ class MCPToolServer(ToolServer):
                     for tool in list_tools_response.tools
                 ],
             )
-            self.harmony_tool_descriptions[tool_from_mcp.name] = tool_from_mcp
-            if tool_from_mcp.name not in self.urls:
-                self.urls[tool_from_mcp.name] = url
-            else:
+            if tool_from_mcp.name in self.urls:
                 logger.warning(
                     "Tool %s already exists. Ignoring duplicate tool server %s",
                     tool_from_mcp.name,
                     url,
                 )
+                continue
+
+            self.harmony_tool_descriptions[tool_from_mcp.name] = tool_from_mcp
+            self.urls[tool_from_mcp.name] = url
 
     def has_tool(self, tool_name: str):
         return tool_name in self.harmony_tool_descriptions
@@ -143,7 +142,6 @@ class MCPToolServer(ToolServer):
 
 
 class DemoToolServer(ToolServer):
-
     def __init__(self, *, enable_python: bool = True):
         from sglang.srt.entrypoints.tool import (
             HarmonyBrowserTool,

--- a/python/sglang/srt/entrypoints/openai/tool_server.py
+++ b/python/sglang/srt/entrypoints/openai/tool_server.py
@@ -87,6 +87,7 @@ class ToolServer(ABC):
 class MCPToolServer(ToolServer):
     def __init__(self):
         self.harmony_tool_descriptions = {}
+        self.urls: dict[str, str] = {}
 
     async def add_tool_server(self, server_url: str):
         tool_urls = server_url.split(",")

--- a/test/registered/unit/entrypoints/openai/test_tool_server_namespace.py
+++ b/test/registered/unit/entrypoints/openai/test_tool_server_namespace.py
@@ -1,0 +1,89 @@
+"""Regression tests for MCP tool-server namespace routing."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.entrypoints.openai.tool_server import MCPToolServer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _server_response(namespace: str, instructions: str, tool_name: str):
+    initialize_response = SimpleNamespace(
+        serverInfo=SimpleNamespace(name=namespace),
+        instructions=instructions,
+    )
+    list_tools_response = SimpleNamespace(
+        tools=[
+            SimpleNamespace(
+                name=tool_name,
+                description=f"{tool_name} description",
+                inputSchema={"type": "object", "properties": {}},
+                annotations=None,
+            )
+        ]
+    )
+    return initialize_response, list_tools_response
+
+
+class TestMCPToolServerNamespaceRouting(CustomTestCase):
+    def test_duplicate_namespace_keeps_description_and_url_from_same_server(self):
+        responses = {
+            "http://first:8001/sse": _server_response(
+                "browser", "first server", "search"
+            ),
+            "http://second:8002/sse": _server_response(
+                "browser", "second server", "open"
+            ),
+        }
+
+        async def fake_list_server_and_tools(url):
+            return responses[url]
+
+        def fake_namespace_config(*, name, description, tools):
+            return SimpleNamespace(name=name, description=description, tools=tools)
+
+        def fake_tool_description(*, name, description, parameters):
+            return SimpleNamespace(
+                name=name, description=description, parameters=parameters
+            )
+
+        server = MCPToolServer()
+        with (
+            patch(
+                "sglang.srt.entrypoints.openai.tool_server.list_server_and_tools",
+                side_effect=fake_list_server_and_tools,
+            ),
+            patch(
+                "sglang.srt.entrypoints.openai.tool_server.ToolNamespaceConfig",
+                side_effect=fake_namespace_config,
+            ),
+            patch(
+                "sglang.srt.entrypoints.openai.tool_server.ToolDescription.new",
+                side_effect=fake_tool_description,
+            ),
+            self.assertLogs(
+                "sglang.srt.entrypoints.openai.tool_server", level="WARNING"
+            ) as captured_logs,
+        ):
+            asyncio.run(server.add_tool_server("first:8001,second:8002"))
+
+        self.assertEqual(server.urls, {"browser": "http://first:8001/sse"})
+        namespace = server.get_tool_description("browser")
+        self.assertEqual(namespace.description, "first server")
+        self.assertEqual([tool.name for tool in namespace.tools], ["search"])
+        self.assertTrue(
+            any(
+                "Ignoring duplicate tool server" in line
+                for line in captured_logs.output
+            )
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_tool_server_namespace.py
+++ b/test/registered/unit/entrypoints/openai/test_tool_server_namespace.py
@@ -30,6 +30,12 @@ def _server_response(namespace: str, instructions: str, tool_name: str):
 
 
 class TestMCPToolServerNamespaceRouting(CustomTestCase):
+    def test_initializes_empty_namespace_registries(self):
+        server = MCPToolServer()
+
+        self.assertEqual(server.harmony_tool_descriptions, {})
+        self.assertEqual(server.urls, {})
+
     def test_duplicate_namespace_keeps_description_and_url_from_same_server(self):
         responses = {
             "http://first:8001/sse": _server_response(


### PR DESCRIPTION
## Summary

- keep the first MCP server's Harmony tool description and execution URL when multiple servers expose the same namespace
- add a focused CPU regression test for duplicate namespace registration

## Root cause

`MCPToolServer.add_tool_server()` wrote `harmony_tool_descriptions[name]` before checking whether `urls[name]` already existed. For a duplicate namespace, the second server therefore replaced the model-visible tool description while the first server's URL remained the execution target.

That could make the schema shown to the model disagree with the server that actually receives the tool call. The existing warning says the duplicate server is ignored, so this change makes the behavior consistently first-wins.

## Validation

- focused CPU regression: `1 passed`
- `black --check` on both changed files
- `isort --check-only` on both changed files
- `ruff check --select=F401,F821,UP037` on both changed files
- `git diff --check`

Part of #20865.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30719747658](https://github.com/sgl-project/sglang/actions/runs/30719747658)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30719747575](https://github.com/sgl-project/sglang/actions/runs/30719747575)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->