### PR TITLE
[Spec] Remove unused CUDA draft-extend top-k from graph

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -423,15 +423,9 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
                 forward_batch.positions,
                 forward_batch,
             )
-            # ROCm's argmax tie-breaks differently from CUDA's softmax+max
-            # path on FP8 logits, which corrupts MTP draft selection on AMD.
-            # Keep the fastpath CUDA-only.
-            if self.topk == 1 and not _is_hip:
-                ret.topk_index = torch.argmax(
-                    ret.next_token_logits, dim=-1, keepdim=True
-                )
-                ret.topk_p = torch.ones_like(ret.topk_index, dtype=torch.float32)
-            else:
+            # ROCm's argmax tie-breaks differently from softmax+max on FP8
+            # logits, which corrupts MTP draft selection on AMD.
+            if _is_hip:
                 probs = torch.softmax(ret.next_token_logits, dim=-1)
                 ret.topk_p, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
 

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
@@ -604,17 +604,9 @@ def _run_eagle_draft_extend_eager(
             batch.positions,
             batch,
         )
-    # Mirror the production fast path from
-    # EAGLEDraftExtendCudaGraphRunner.replay (#26397): when topk == 1
-    # production skips the full-vocab softmax and returns
-    # `topk_p = ones_like(topk_index)` (the value is unused downstream).
-    # The eager reference must match this for assert_outputs_close.
     from sglang.srt.utils import is_hip
 
-    if settings.topk == 1 and not is_hip():
-        ret.topk_index = torch.argmax(ret.next_token_logits, dim=-1, keepdim=True)
-        ret.topk_p = torch.ones_like(ret.topk_index, dtype=torch.float32)
-    else:
+    if is_hip():
         probs = torch.softmax(ret.next_token_logits, dim=-1)
         ret.topk_p, ret.topk_index = fast_topk(probs, settings.topk, dim=-1)
     return ret


### PR DESCRIPTION
## Motivation

DRAFT_EXTEND_V2 CUDA graphs compute full-row top-k results that are discarded after replay. The worker selects the correct logits row and recomputes the consumed top-k values, so the captured memset, argmax reduction, and fill add unnecessary work.

## Modifications

- Skip the unused graph-local top-k computation on CUDA while preserving the existing ROCm path.
- Align the eager graph-runner reference with the DRAFT_EXTEND_V2 output contract.

## Accuracy Tests

main:
```bash
== gsm8k ==
1319 examples (single-shot)  |  541.8s  |  2056 tok/s  |  1.1M tokens

* score           =  94.24%
  stop_rate       =  96.29%
  truncated_rate  =  3.71%  [warn: hitting max_tokens]
  error_rate      =  0.00%
```

PR:
```bash
== gsm8k ==
1319 examples (single-shot)  |  566.6s  |  1928 tok/s  |  1.1M tokens

* score           =  94.39%
  stop_rate       =  96.36%
  truncated_rate  =  3.64%  [warn: hitting max_tokens]
  error_rate      =  0.00%
```

## Speed Tests and Profiling

main:
<img width="2056" height="328" alt="image" src="https://github.com/user-attachments/assets/adec059b-70a5-459a-813f-39fdfb5ba457" />


PR:
<img width="1820" height="401" alt="image" src="https://github.com/user-attachments/assets/1a6b0892-6f43-4785-adc8-ece11cb3efa6" />

cc @kpham-sgl 













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29491452451](https://github.com/sgl-project/sglang/actions/runs/29491452451)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29491452286](https://github.com/sgl-project/sglang/actions/runs/29491452286)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->