### PR TITLE
[AMD] Fix DeepSeek-V4 FP4 MoE expert memory bloat

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1319,10 +1319,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             gu_intv = envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
             fp4_weight_dtype = _require_fp4_dtype()
 
-            # CK FP4 MoE kernel requires K_packed divisible by 128
-            # (i.e., K_logical divisible by 256).
-            # Pad intermediate_size_per_partition if needed.
-            fp4_k_align = 256
+            # DeepSeek V4 MoE is implemented by the FlyDSL kernel, which supports
+            # tile_k=128, so we only need to pad dim to 128. This lets DeepSeek-V4-Pro
+            # at TP8 skip padding 384 -> 512, reducing routed-expert memory by ~25%.
+            # shuffle_scale also supports non-256 shapes since aiter PR#4130.
+            fp4_k_align = 128
             E, w13_N, w13_K_packed = layer.w13_weight.shape
             _, w2_N, w2_K_packed = layer.w2_weight.shape
             inter_per_part = w13_N // 2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Need aiter version bump before merge.
Needed aiter: PR#4130

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

On AMD M355 each layer's MoE weights take **2.105 GB**, while the same layer on NVIDIA B200 is **1.582 GB** (~25% gap).
The cause is that on AMD we pad the `w13` expert weight up to a multiple of **256**.
For DeepSeek-V4-Pro on 8 GPUs (TP8) the per-partition intermediate size is `3072 / 8 = 384`, which gets rounded up to **512**, inflating the routed-expert weights by ~1/3.

After this change, per-layer per-rank MoE drops to 1.592 GiB (close to NV's 1.582 GiB), reducing total model weights by ~40 GiB.

## Modifications

<!-- Detail the changes made in this pull request. -->

Change `fp4_k_align` from `256` to `128` in `process_weights_after_loading_block_quant()`.
DeepSeek-V4 MoE runs on the FlyDSL kernel, which supports `tile_k=128`, so K only needs to be padded to a multiple of 128. `384` stays `384` instead of `512`.

This cannot affect other models: the code path is guarded by
```python
# python/sglang/srt/layers/quantization/fp8.py
if _use_aiter and self.is_fp4_expert:
```

and `is_fp4_expert` is only set for DeepSeek-V4:
```python
# python/sglang/srt/configs/model_config.py
if is_deepseek_v4(self.hf_config):
    self.is_fp4_experts = envs.SGLANG_DSV4_FP4_EXPERTS.get()
```

This change also requires cherry-picking aiter PR#4130 (merged): the shuffle_scale in the currently pinned aiter only supports 256-padded shapes; non-256 shapes are supported starting from that PR.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

GSM8k:
- tp8:
  ```
  100%|██████████| 1319/1319 [00:52<00:00, 25.03it/s]
  Accuracy: 0.940
  Invalid: 0.000
  Latency: 52.696 s
  Output throughput: 2204.778 token/s
  ```
- tp8+dp8:
  ```
  100%|██████████| 1319/1319 [00:58<00:00, 22.64it/s]
  Accuracy: 0.942
  Invalid: 0.000
  Latency: 58.267 s
  Output throughput: 2021.708 token/s
  ```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

<details>
  <summary>Client Cmd</summary>
  
  ```
  python3 -m sglang.bench_serving \
    --backend sglang-oai --base-url http://localhost:8000 \
    --model DeepSeek-V4-Pro \
    --dataset-name random --random-input-len 8192 --random-output-len 1024 \
    --random-range-ratio 0.8 \
    --num-prompts 64 --max-concurrency 8 \
    --warmup-requests 16 --request-rate inf
  ```
</details>

8k1k, cc8, random=0.8 (no regression)
|            | config | mem after loading weight (GB) |  ITL | TTFT | TTT |
| ---------- | ------ | -------------- | --------- | --- | ---- | 
| before PR  | tp8    |         159.07      |      15.84      |   315.41   |    3860.72   |    
| after PR   |       |   112.36     |       15.81    |    319.31   |    3863.6   |   

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.












<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29491528112](https://github.com/sgl-project/sglang/actions/runs/29491528112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29491540358](https://github.com/sgl-project/sglang/actions/runs/29491540358)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->