### PR TITLE
cookbook(qwen3.5): bump AMD ROCm docker images to v0.5.15.post1

### DIFF
--- a/docs_new/cookbook/autoregressive/Qwen/Qwen3.5.mdx
+++ b/docs_new/cookbook/autoregressive/Qwen/Qwen3.5.mdx
@@ -103,10 +103,10 @@ uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=pytho
 docker pull lmsysorg/sglang:latest
 
 # Or use Docker (AMD MI300X/MI325X)
-docker pull lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi30x-20260604
+docker pull lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi30x-20260715
 
 # Or use Docker (AMD MI355X)
-docker pull lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260604
+docker pull lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260715
 ```
 
 For the full Docker setup and other installation methods, please refer to the [official SGLang installation guide](../../../docs/get-started/install).


### PR DESCRIPTION
## Motivation

Bump the AMD ROCm docker image references in the Qwen3.5 cookbook page from the outdated `v0.5.12.post1-rocm720` (June 2026) to the latest `v0.5.15.post1-rocm720` (July 15 2026).

This aligns with InferenceX PR https://github.com/SemiAnalysisAI/InferenceX/pull/2094 which bumped the Qwen3.5-FP8 MI355X disagg benchmark image from ROCm 7.0 / sglang v0.5.11 to ROCm 7.2 / sglang v0.5.14. We go to v0.5.15.post1 as it is the latest pinned release on Docker Hub.

## Changes

- `docs_new/cookbook/autoregressive/Qwen/Qwen3.5.mdx`:
  - MI300X/MI325X: `v0.5.12.post1-rocm720-mi30x-20260604` → `v0.5.15.post1-rocm720-mi30x-20260715`
  - MI355X: `v0.5.12.post1-rocm720-mi35x-20260604` → `v0.5.15.post1-rocm720-mi35x-20260715`

## Notes

- The Qwen3.5 Deployment generator (`qwen35-deployment.jsx`) does not hardcode docker image tags, so no JSX changes needed.
- MORI PD-disaggregation support (like PR #30651 added for DeepSeek-V4) cannot be added here because Qwen3.5 is still in the legacy deployment format without Playground support. The config-driven migration PR #27848 is in progress.

cc @zijiexia @yichiche







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29493159620](https://github.com/sgl-project/sglang/actions/runs/29493159620)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29493159648](https://github.com/sgl-project/sglang/actions/runs/29493159648)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->