### PR TITLE
Debug(DSpark): Bisect target-verify CUDA Graph replay synchronization

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -150,6 +150,52 @@ def _copy_or_replace(dst, src):
     return src
 
 
+def _debug_metadata_tensor_state(metadata, label: str) -> None:
+    if not envs.SGLANG_LOG_DECODE_GRAPH_KEY.get():
+        return
+
+    owners = {
+        "core": getattr(metadata, "core_attn_metadata", None),
+        "indexer": getattr(metadata, "indexer_metadata", None),
+        "c4_compress": getattr(metadata, "c4_compress_metadata", None),
+        "c128_compress": getattr(metadata, "c128_compress_metadata", None),
+    }
+    state = {
+        "metadata_id": id(metadata),
+        "owners": {},
+    }
+    for owner_name, owner in owners.items():
+        if owner is None:
+            continue
+        owner_state = {"object_id": id(owner), "tensors": {}}
+        for field_name in (
+            "raw_out_loc",
+            "seq_lens_casual",
+            "positions_casual",
+            "page_table",
+            "c4_seq_lens",
+            "c4_out_loc",
+            "c128_out_loc",
+            "c128_page_indices",
+            "deep_gemm_metadata",
+            "topk_metadata",
+            "workspace",
+        ):
+            value = getattr(owner, field_name, None)
+            if not isinstance(value, torch.Tensor):
+                continue
+            owner_state["tensors"][field_name] = {
+                "object_id": id(value),
+                "shape": tuple(value.shape),
+                "stride": tuple(value.stride()),
+                "numel": value.numel(),
+                "storage_nbytes": value.untyped_storage().nbytes(),
+                "data_ptr": value.data_ptr(),
+            }
+        state["owners"][owner_name] = owner_state
+    logger.info("DSV4 Graph metadata state: label=%s state=%s", label, state)
+
+
 @dataclass
 class DSV4AttnMetadata:
     page_size: int
@@ -394,6 +440,8 @@ class DSV4Metadata:
         return self.core_attn_metadata
 
     def copy_(self, other: DSV4Metadata):
+        _debug_metadata_tensor_state(other, "copy_source_before")
+        _debug_metadata_tensor_state(self, "copy_destination_before")
         self.core_attn_metadata.copy_(other.core_attn_metadata)
         maybe_copy_inplace(self.indexer_metadata, src=other.indexer_metadata)
         maybe_copy_inplace(self.c4_compress_metadata, src=other.c4_compress_metadata)
@@ -401,8 +449,11 @@ class DSV4Metadata:
             self.c128_compress_metadata, src=other.c128_compress_metadata
         )
         self.sparse_prefill_cache = None
+        _debug_metadata_tensor_state(self, "copy_destination_after")
 
     def refresh_for_breakable_cuda_graph_replay_(self, static_metadata: DSV4Metadata):
+        _debug_metadata_tensor_state(static_metadata, "refresh_source_before")
+        _debug_metadata_tensor_state(self, "refresh_destination_before")
         self.core_attn_metadata.refresh_for_breakable_cuda_graph_replay_(
             static_metadata.core_attn_metadata
         )
@@ -420,6 +471,7 @@ class DSV4Metadata:
                 src=static_metadata.c128_compress_metadata,
             )
         self.sparse_prefill_cache = None
+        _debug_metadata_tensor_state(self, "refresh_destination_after")
 
 
 @dataclass

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1234,24 +1234,15 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         verify_lens = layout.verify_lens
         qo_indptr = layout.qo_indptr_device
-        # Prefer CPU-side metadata; only fall back to CUDA .item() (which forces a
-        # device-to-host sync) when the CPU fields are unavailable. This keeps the
-        # debug logger from perturbing the very timing it is meant to observe.
-        if layout.total_verify_tokens is not None:
-            verify_tokens = int(layout.total_verify_tokens)
-            qo_indptr_last = int(layout.total_verify_tokens)
-        else:
-            verify_tokens = int(verify_lens.sum().item())
-            qo_indptr_last = (
-                int(qo_indptr[-1].item()) if qo_indptr.numel() > 0 else 0
-            )
-
-        if layout.verify_lens_cpu:
-            verify_lens_last = int(layout.verify_lens_cpu[-1])
-        else:
-            verify_lens_last = (
-                int(verify_lens[-1].item()) if verify_lens.numel() > 0 else 0
-            )
+        # Prefer CPU-side metadata; NEVER fall back to CUDA .item() (which forces a
+        # device-to-host sync). A sync here perturbs the timing this logger observes
+        # and becomes the surfacing point for asynchronous CUDA errors. When the CPU
+        # scalars are unavailable (usual at replay), emit -1 instead of syncing.
+        cpu_total = layout.total_verify_tokens
+        cpu_lens = layout.verify_lens_cpu
+        verify_tokens = int(cpu_total) if cpu_total is not None else -1
+        qo_indptr_last = int(cpu_total) if cpu_total is not None else -1
+        verify_lens_last = int(cpu_lens[-1]) if cpu_lens else -1
         logger.info(
             "Ragged Graph replay state: key_size=%s raw_bs=%d slots=%d "
             "graph_tokens=%d verify_tokens=%d verify_lens_ptr=%d "

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1234,7 +1234,24 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         verify_lens = layout.verify_lens
         qo_indptr = layout.qo_indptr_device
-        verify_tokens = int(verify_lens.sum().item())
+        # Prefer CPU-side metadata; only fall back to CUDA .item() (which forces a
+        # device-to-host sync) when the CPU fields are unavailable. This keeps the
+        # debug logger from perturbing the very timing it is meant to observe.
+        if layout.total_verify_tokens is not None:
+            verify_tokens = int(layout.total_verify_tokens)
+            qo_indptr_last = int(layout.total_verify_tokens)
+        else:
+            verify_tokens = int(verify_lens.sum().item())
+            qo_indptr_last = (
+                int(qo_indptr[-1].item()) if qo_indptr.numel() > 0 else 0
+            )
+
+        if layout.verify_lens_cpu:
+            verify_lens_last = int(layout.verify_lens_cpu[-1])
+        else:
+            verify_lens_last = (
+                int(verify_lens[-1].item()) if verify_lens.numel() > 0 else 0
+            )
         logger.info(
             "Ragged Graph replay state: key_size=%s raw_bs=%d slots=%d "
             "graph_tokens=%d verify_tokens=%d verify_lens_ptr=%d "
@@ -1246,8 +1263,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             verify_tokens,
             verify_lens.data_ptr(),
             qo_indptr.data_ptr(),
-            int(verify_lens[-1].item()),
-            int(qo_indptr[-1].item()),
+            verify_lens_last,
+            qo_indptr_last,
             tensor_state,
         )
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1210,7 +1210,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if not envs.SGLANG_LOG_DECODE_GRAPH_KEY.get() or not self.ragged_verify_mode:
             return
 
-        layout = self._ragged_verify_layout(forward_batch)
+        layout = resolve_ragged_verify_layout(forward_batch)
         if layout is None:
             return
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -96,6 +96,7 @@ from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
+    get_bool_env_var,
     require_attn_tp_gather,
     require_mlp_tp_gather,
 )
@@ -1205,6 +1206,51 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         return round_up_grid(total_verify_tokens, self.capture_num_tokens)
 
+    def _log_ragged_replay_state(self, forward_batch: ForwardBatch) -> None:
+        if not envs.SGLANG_LOG_DECODE_GRAPH_KEY.get() or not self.ragged_verify_mode:
+            return
+
+        layout = self._ragged_verify_layout(forward_batch)
+        if layout is None:
+            return
+
+        tensors = {
+            "input_ids": self.buffers.input_ids,
+            "positions": self.buffers.positions,
+            "req_pool_indices": self.buffers.req_pool_indices,
+            "seq_lens": self.buffers.seq_lens,
+        }
+        tensor_state = {}
+        for name, tensor in tensors.items():
+            if tensor is None:
+                continue
+            tensor_state[name] = {
+                "shape": tuple(tensor.shape),
+                "stride": tuple(tensor.stride()),
+                "numel": tensor.numel(),
+                "storage_nbytes": tensor.untyped_storage().nbytes(),
+                "data_ptr": tensor.data_ptr(),
+            }
+
+        verify_lens = layout.verify_lens
+        qo_indptr = layout.qo_indptr_device
+        verify_tokens = int(verify_lens.sum().item())
+        logger.info(
+            "Ragged Graph replay state: key_size=%s raw_bs=%d slots=%d "
+            "graph_tokens=%d verify_tokens=%d verify_lens_ptr=%d "
+            "qo_indptr_ptr=%d verify_lens_last=%d qo_indptr_last=%d tensors=%s",
+            self._replay_graph_key.size,
+            forward_batch.batch_size,
+            self._ragged_capture_slots(self._replay_graph_key.size),
+            layout.graph_num_tokens,
+            verify_tokens,
+            verify_lens.data_ptr(),
+            qo_indptr.data_ptr(),
+            int(verify_lens[-1].item()),
+            int(qo_indptr[-1].item()),
+            tensor_state,
+        )
+
     def execute(
         self,
         forward_batch: ForwardBatch,
@@ -1233,7 +1279,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             and self.attn_backend.use_captured_forward_metadata_for_breakable_cuda_graph
         )
         with timer_ctx, self.backend.replay_session():
+            if get_bool_env_var("SGLANG_DEBUG_CUDA_GRAPH_SYNC_BEFORE_LOAD_BATCH"):
+                logger.warning("Debug CUDA Graph mode: synchronizing before load_batch")
+                self.device_module.synchronize()
             self.load_batch(forward_batch, pp_proxy_tensors)
+            if get_bool_env_var("SGLANG_DEBUG_CUDA_GRAPH_SYNC_AFTER_LOAD_BATCH"):
+                logger.warning("Debug CUDA Graph mode: synchronizing after load_batch")
+                self.device_module.synchronize()
             if envs.SGLANG_LOG_DECODE_GRAPH_KEY.get():
                 logger.info(
                     "Decode graph replay: worker=%s key_size=%s (%s) mode=%s raw_bs=%d%s",
@@ -1248,10 +1300,17 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                         else ""
                     ),
                 )
+                self._log_ragged_replay_state(forward_batch)
             if publish_read_done and not read_done_post_replay:
                 read_done = self.device_module.Event()
                 read_done.record()
                 self.model_runner.war_fastpath_read_done_event = read_done
+            if get_bool_env_var("SGLANG_DEBUG_CUDA_GRAPH_SYNC_BEFORE_REPLAY"):
+                logger.warning(
+                    "Debug CUDA Graph mode: synchronizing before replay key_size=%s",
+                    self._replay_graph_key.size,
+                )
+                self.device_module.synchronize()
             output = self.backend.replay(self._replay_graph_key, forward_batch)
             if read_done_post_replay:
                 read_done = self.device_module.Event()


### PR DESCRIPTION
## Motivation

Issue #31023 tracks a timing-sensitive CUDA illegal-memory-access failure in the DSpark compact ragged target-verify CUDA Graph path on TP8.

PR #31195 fixes the previously observed cross-TP verify-budget / Graph-tier mismatch. After that fix, TP0-TP7 agree on:

```text
verify_token_budget
sum(verify_lens)
graph_num_tokens
target Graph key
```

However, the residual failure remains present. A fresh-service c256 matrix on A1 `22cfd54c` positively reproduced Bug 2:

```text
compact-SPS + CUDA Graph ON + overlap OFF: 0/5 crashes
compact-SPS + CUDA Graph ON + overlap ON:  4/4 executed runs crashed
overlap-on r5: not run because the pipeline exited during r4
```

A later valid Stage C forced-fraction probe completed all three mechanism arms without a crash:

```text
C1 direct key_size=240, overlap ON:        VALID_PASS
C2 ordered key_size=168 -> 240, overlap ON: VALID_PASS
C3 ordered key_size=168 -> 240, overlap OFF: VALID_PASS
```

Stage C is finite negative mechanism-probe evidence only. It does not supersede the c256 4/4 positive reproduction. Current evidence favors a sustained-overlap lifetime/ownership/stream-ordering problem over a simple “one 168 -> 240 transition always fails” model.

Related to #31023.

## Scope

This is a diagnostic Draft PR, not the final production fix.

It adds opt-in synchronization and sync-free metadata tracing around the DSpark target-verify CUDA Graph execute/replay boundary. Default behavior remains unchanged.

## Modifications

- Add debug-only environment switches, all defaulting to off:
  - `SGLANG_DEBUG_CUDA_GRAPH_SYNC_BEFORE_LOAD_BATCH=1`
  - `SGLANG_DEBUG_CUDA_GRAPH_SYNC_AFTER_LOAD_BATCH=1`
  - `SGLANG_DEBUG_CUDA_GRAPH_SYNC_BEFORE_REPLAY=1`
- Synchronize at the selected execute-prologue boundary only when explicitly enabled.
- Under `SGLANG_LOG_DECODE_GRAPH_KEY`, log compact target-verify replay state and selected Graph-stable / nested DSV4 metadata identities, shapes, strides, capacities, and data pointers.
- Avoid CUDA tensor `.item()` in the replay-state logger; when CPU-side scalars are unavailable, emit sentinel values rather than forcing a device-to-host synchronization.
- Do not add synchronization or extra logging to the default path.

## Current evidence

### Cross-TP planning fix (#31195)

```text
N1 no-overlap, same service:          30/30
N2 no-overlap, restart per workload:  30/30
O1 overlap, same service:             30/30
O2 overlap, restart per workload:     30/30
Total:                                120/120
```

No divergence was observed in `verify_token_budget`, `sum(verify_lens)`, or target Graph key.

Conclusion: #31195 fixes the control-plane Graph-tier inconsistency. The residual failure investigated here is a separate execution/lifetime/synchronization issue.

### Positive c256 reproduction — July 25-26, 2026

Experiment:

```text
tag: bug2-repro-a1-22cfd54c-20260725
A1 commit: 22cfd54c
mode: compact-SPS
CUDA Graph: enabled
concurrency: 256
requests: 2560
input / output: 60000 / 1000
formal seed: 0
warmup seed: 1
shuffle: False
unreproducible: False
fresh service per run: yes
SPS SHA256: 7722243832273728c3b77a3f15f574a3d95880e2f3fd7667db67ff5322b90f5b
```

| Group | Stage | Overlap | Success / Total | Classification | Server survived | Illegal-memory | Scheduler exception | NCCL watchdog |
|---|---|:---:|---:|---|---|---:|---:|---:|
| A | overlap-off-c256-r1 | OFF | 2540 / 2560 | completed_with_request_failures | yes | 0 | 0 | 0 |
| A | overlap-off-c256-r2 | OFF | 2546 / 2560 | completed_with_request_failures | yes | 0 | 0 | 0 |
| A | overlap-off-c256-r3 | OFF | 2547 / 2560 | completed_with_request_failures | yes | 0 | 0 | 0 |
| A | overlap-off-c256-r4 | OFF | 2543 / 2560 | completed_with_request_failures | yes | 0 | 0 | 0 |
| A | overlap-off-c256-r5 | OFF | 2542 / 2560 | completed_with_request_failures | yes | 0 | 0 | 0 |
| B | overlap-on-c256-r1 | ON | 360 / 2560 | bug2_crash | no | 2 | 1 | 0 |
| B | overlap-on-c256-r2 | ON | 217 / 2560 | bug2_crash | no | 2 | 1 | 0 |
| B | overlap-on-c256-r3 | ON | 3 / 2560 | bug2_crash | no | 1 | 1 | 0 |
| B | overlap-on-c256-r4 | ON | 0 / 2560 | bug2_crash, reconstructed status | false | 2 | 0 | 2 |
| B | overlap-on-c256-r5 | ON | not run | pipeline exited during r4 | — | — | — | — |

Summary:

```text
overlap OFF: 0/5 Bug 2 crashes
overlap ON:  4/4 executed runs crashed
overlap ON r5: not run
```

For overlap-on r1-r3, the asynchronous CUDA error surfaced through:

```text
Scheduler hit an exception
  -> process_batch_result_decode
  -> result.copy_done.synchronize()
  -> torch.AcceleratorError: CUDA error: an illegal memory access was encountered
  -> terminate called
  -> SIGQUIT
  -> Fatal Python error: Aborted
```

For overlap-on r4, preserved evidence instead shows CUDA illegal-memory-access evidence plus ProcessGroupNCCL watchdog termination on rank 3, without a recorded scheduler-exception line.

`result.copy_done.synchronize()` is the point where the asynchronous error was observed in r1-r3. It does not prove that the line initiated the invalid access.

The latest matrix establishes that overlap is a strong trigger in the tested environment. It does not establish that overlap is strictly required, because a historical overlap-OFF c256 run (`diagnostic-v3 c256-r3`) also reproduced the failure.

### Stage C Pass-1 — valid forced-fraction probe

Experiment root:

```text
stage-c-a1-22cfd54c-20260726
```

Pass-1 used minimal Graph-key logging to reduce observer effects.

| Stage | Fraction sequence | Overlap | Actual steady keys | Result | Classification | CUDA / scheduler / NCCL |
|---|---|:---:|---|---|---|---|
| C1 direct240 | `0.4` | ON | `240` only (`168=0`, `240=7304`, `480=0`) | 3/3 rounds, `match_fraction=1.00` | VALID_PASS | 0 / 0 / 0 |
| C2 transition | `0.2 -> 0.4` | ON | ordered `168 -> 240` (`168=7840`, `240=7368`, `480=0`) | each tier 3/3, `match_fraction=1.00` | VALID_PASS | 0 / 0 / 0 |
| C3 transition control | `0.2 -> 0.4` | OFF | ordered `168 -> 240` (`168=6832`, `240=6504`, `480=0`) | each tier 3/3, `match_fraction=1.00` | VALID_PASS | 0 / 0 / 0 |

Validity gates:

- actual import was A1 `22cfd54c`;
- CUDA Graph and compact target verify were active;
- C1 steady target-verify contained only key 240;
- C2/C3 contained ordered same-service 168 -> 240 transitions;
- C3 confirmed `--disable-overlap-schedule`;
- no key-size 480 collapse occurred;
- profiler `run` was used; the official SPS table was not overwritten;
- all services survived and returned health 200.

Interpretation:

- Direct key 240 did not fail in this finite probe.
- One ordered 168 -> 240 transition did not fail with overlap ON or OFF.
- A simple “large tier always fails” or “one transition always fails” model is not supported.
- Stage C does not prove transitions are universally safe and does not weaken the c256 positive reproduction.

The mechanism probe is much lighter than the strong reproducer:

```text
Stage C:
  batch 80, input length 16, short profiler decode,
  forced fractions, 3 repetitions per tier

c256 reproducer:
  concurrency 256, input/output 60000/1000,
  2560 requests, sustained real compact-SPS overlap
```

Current implication: the failure is more likely to require sustained high-concurrency overlap and longer-lived metadata/workspace/buffer/request/KV state than a single lightweight tier transition.

### Evidence integrity

For the positive c256 runs:

- complete source server logs are preserved;
- copied logs match source SHA256 values;
- crash excerpts contain surrounding context;
- crash evidence checksums are valid;
- r4 status is explicitly marked reconstructed.

For Stage C:

- source/copied logs match;
- C1/C2/C3 stage checksum validation is 9/9 OK for each stage;
- official SPS SHA256 remained `7722243832273728c3b77a3f15f574a3d95880e2f3fd7667db67ff5322b90f5b`.

### Finite synchronization bisect

```text
default async on historical failing machine:
  requested 160 tier 5/5, requested 240 tier 4/5, then service exit

sync before load_batch: 10/10
sync after load_batch:  10/10
sync before replay:     10/10
```

Global synchronization suppresses the failure in this finite matrix, but does not localize the exact producer/consumer streams and is not a production fix.

## Source-audit findings

The latest read-only audit found:

1. The full backend replay path refreshes the selected Graph-static DSV4 metadata via in-place `DSV4Metadata.copy_` before replay.
2. The Graph shape key is primarily based on graph size, stream index, and variant label; it does not directly encode all dynamic ragged layout or workspace dimensions.
3. Correctness therefore depends on complete metadata refresh, sufficient capacity, valid workspace/buffer ownership, and correct stream ordering before replay.
4. Some indexer/compressor work is captured inside the graph and may use internal alternate streams; a host-only pre-replay event cannot by itself diagnose or fix every graph-internal race.

These are audit findings and hypotheses, not proof of the exact root cause.

## Hypotheses under test

Current priority after Stage C:

1. Workspace or Graph-stable buffer reuse before a previous consumer completes.
2. Missing producer/consumer ordering under sustained overlap.
3. Request-pool / KV-location / ragged metadata lifetime conflicts at high concurrency.
4. Incomplete recursive refresh of nested DSV4 metadata during repeated replay.
5. A Graph or metadata cache key omitting a required layout/workspace dimension.
6. A stale captured tensor view/data pointer or insufficient capacity.
7. Graph-internal indexer/compressor alternate-stream work.

A simple one-time 168 -> 240 transition is now a lower-priority trigger hypothesis.

## Next phase: R2 / D0-D3

Because the stable 4/4 reproducer is on A1 `22cfd54c` while this PR branch is based on a newer `main`, the planned R2 workflow is:

1. Transplant this PR's debug commits onto an independent throwaway branch/worktree based exactly on `22cfd54c`.
2. D0-A: rerun the original A1 c256 overlap-ON minimal-log baseline.
3. D0-B: run the R2 transplanted branch with all debug switches disabled to verify default-path reproduction equivalence.
4. D1: enable sync-free core/indexer/c4/c128 metadata identity/capacity tracing on the stable c256 reproducer.
5. D2: add debug workspace identity/generation/owner tracing.
6. D3: perform component-level event bisect one boundary at a time.

D0-A and D0-B must both retain reproduction capability before an instrumented non-reproduction can be interpreted.

## Non-goals

This PR does not claim that global synchronization is the production fix and does not propose merging an unconditional hot-path `torch.cuda.synchronize()`.

If a missing dependency is proven, the intended follow-up is the smallest correct ordering mechanism at the proven boundary, for example:

```python
metadata_ready_event.record(producer_stream)
replay_stream.wait_event(metadata_ready_event)
```

If synchronization only masks stale state, the follow-up should instead fix metadata copying, workspace ownership, tensor views, capacities, cache keys, or graph-internal stream ordering.

## Validation

- [x] Branch rebuilt from current upstream `main`.
- [x] Diff contains only:
  - `python/sglang/srt/layers/attention/deepseek_v4_backend.py`
  - `python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py`
- [x] `git diff --check` passes.
- [x] `py_compile` passes for both modified files.
- [x] Default behavior is unchanged when all debug switches are unset.
- [x] Replay-state logger avoids CUDA tensor `.item()` fallback and therefore avoids injecting an accidental synchronization point.
- [x] Before-load, after-load, and before-replay synchronization trials each completed 10/10 in the finite matrix.
- [x] Latest overlap-OFF fresh-service c256 arm completed 5/5 without Bug 2.
- [x] Latest overlap-ON fresh-service c256 arm positively reproduced Bug 2 in 4/4 executed runs.
- [x] Preserved and checksummed complete crash evidence for overlap-on r1-r4.
- [x] Stage C C1 direct key 240 completed with a valid Graph-key gate.
- [x] Stage C C2 ordered 168 -> 240 with overlap ON completed with a valid Graph-key gate.
- [x] Stage C C3 ordered 168 -> 240 with overlap OFF completed with a valid Graph-key gate.
- [x] Confirmed Stage C is finite negative mechanism-probe evidence only.
- [ ] Build the R2 throwaway worktree on A1 `22cfd54c`.
- [ ] Revalidate D0-A original A1 reproduction.
- [ ] Revalidate D0-B R2 default-path reproduction equivalence.
- [ ] Run D1 metadata identity/capacity tracing on the stable c256 reproducer.
- [ ] Add D2 workspace generation/owner tracing.
- [ ] Perform D3 component-level event bisect at proven boundaries.
- [ ] Identify the exact producer/consumer stream or stale ownership boundary.
- [ ] Replace diagnostic synchronization with a production-safe fix before marking ready for review.

## Expected outcome

This Draft PR provides controlled synchronization and metadata/buffer tracing for determining whether the residual failure is caused by a missing replay dependency or stale/incomplete Graph-associated state.

It should remain in Draft until the production-safe fix is identified.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29908517098](https://github.com/sgl-project/sglang/actions/runs/29908517098)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29908516844](https://github.com/sgl-project/sglang/actions/runs/29908516844)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->