### PR TITLE
[server] Allow max_running_requests to be tuned at runtime via /set_internal_state

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -873,6 +873,11 @@ class Scheduler(
             _,
             _,
         ) = self.tp_worker.get_worker_info()
+        # Init-time hard cap used to clamp the runtime-tunable soft cap exposed
+        # via `/set_internal_state`. The running-batch `buffer_size` and the
+        # `pp_max_micro_batch_size` default are sized against this value at
+        # init, so the runtime override may only reduce the effective cap.
+        self._max_running_requests_hard_cap = self.max_running_requests
         # DFlash auto-enables the legacy formula; other workloads opt in via
         # --min-free-slots-delay. Built independently of the prefill delayer.
         self.min_free_slots_delayer: Optional[MinFreeSlotsDelayer] = None
@@ -3839,6 +3844,7 @@ class Scheduler(
                 "speculative_accept_threshold_acc",
                 "dspark_force_budget_frac",
                 "dspark_clear_info_records",
+                "max_running_requests",
             ]
         )
 
@@ -3853,6 +3859,14 @@ class Scheduler(
             ):
                 logging.warning(
                     f"Updating {k} to {v} is rejected because it is out of the valid range [1, {self.max_running_requests // self.ps.pp_size}]."
+                )
+                if_success = False
+                break
+            elif k == "max_running_requests" and (
+                v is None or int(v) > self._max_running_requests_hard_cap or int(v) < 1
+            ):
+                logging.warning(
+                    f"Updating {k} to {v} is rejected because it is out of the valid range [1, {self._max_running_requests_hard_cap}]."
                 )
                 if_success = False
                 break
@@ -3906,6 +3920,15 @@ class Scheduler(
                 self.draft_worker.clear_info_records()
             if remaining:
                 get_server_args().override(source="update_server_args", **remaining)
+            # `schedule_policy` reads `self.max_running_requests` fresh each
+            # iteration (via `SchedulePolicy(..., max_running_requests=...)`),
+            # so mirroring the override onto the instance attribute is what
+            # actually gates the next admission decision. Init-time-derived
+            # state (buffer_size, pp_max_micro_batch_size default,
+            # MinFreeSlotsDelayer) stays sized against the hard cap and is
+            # unaffected by lowering.
+            if "max_running_requests" in remaining:
+                self.max_running_requests = int(remaining["max_running_requests"])
             logger.info(f"Global server args updated! {get_server_args()=}")
 
         return SetInternalStateReqOutput(updated=if_success)

--- a/test/registered/unit/managers/test_scheduler_set_internal_state.py
+++ b/test/registered/unit/managers/test_scheduler_set_internal_state.py
@@ -1,0 +1,92 @@
+"""Scheduler.set_internal_state runtime-mutable allowlist tests.
+
+Focused on the `max_running_requests` runtime override path: it is the only
+allowlisted knob that mirrors onto a scheduler instance attribute (the schedule
+policy reads `self.max_running_requests` fresh each iteration, so the mirror is
+what actually gates the next admission decision).
+
+Fragility: bypasses `Scheduler.__init__` via `__new__` and injects only the
+attrs `set_internal_state` reads (`_max_running_requests_hard_cap`,
+`max_running_requests`, `spec_algorithm`, `metrics_reporter`). Update the
+fixture if `set_internal_state` starts reading another attr for the non-DSpark
+path.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import SetInternalStateReq
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_scheduler(hard_cap: int, current: int) -> Scheduler:
+    sch = Scheduler.__new__(Scheduler)
+    sch._max_running_requests_hard_cap = hard_cap
+    sch.max_running_requests = current
+    sch.spec_algorithm = SimpleNamespace(is_none=lambda: True)
+    sch.metrics_reporter = SimpleNamespace(
+        spec_total_num_forward_ct=0,
+        spec_total_num_accept_tokens=0,
+    )
+    return sch
+
+
+class TestSetInternalStateMaxRunningRequests(CustomTestCase):
+    def test_accepted_update_mirrors_onto_instance_attribute(self):
+        # Guards: without the mirror, `schedule_policy` keeps reading the init
+        # cap and the runtime override has no admission-side effect.
+        sch = _make_scheduler(hard_cap=128, current=128)
+        req = SetInternalStateReq(server_args={"max_running_requests": 32})
+        with patch(
+            "sglang.srt.managers.scheduler.get_server_args"
+        ) as mock_get_server_args:
+            mock_get_server_args.return_value.override = lambda source, **kw: None
+            resp = sch.set_internal_state(req)
+        self.assertTrue(resp.updated)
+        self.assertEqual(sch.max_running_requests, 32)
+
+    def test_value_above_hard_cap_is_rejected_and_leaves_state_unchanged(self):
+        # Guards the upper clamp: raising above the init cap would violate
+        # `buffer_size = max_running_requests * 2` (sized at init) and the
+        # pp_max_micro_batch_size default.
+        sch = _make_scheduler(hard_cap=128, current=64)
+        req = SetInternalStateReq(server_args={"max_running_requests": 256})
+        resp = sch.set_internal_state(req)
+        self.assertFalse(resp.updated)
+        self.assertEqual(sch.max_running_requests, 64)
+
+    def test_value_below_one_is_rejected(self):
+        # Guards the lower clamp: 0 would stall admission entirely and any
+        # negative value is nonsensical.
+        sch = _make_scheduler(hard_cap=128, current=64)
+        for bad in (0, -1):
+            with self.subTest(bad=bad):
+                req = SetInternalStateReq(server_args={"max_running_requests": bad})
+                resp = sch.set_internal_state(req)
+                self.assertFalse(resp.updated)
+                self.assertEqual(sch.max_running_requests, 64)
+
+    def test_max_running_requests_is_in_allowlist(self):
+        # Bookkeeping guard: an "unknown key" rejection would silently regress
+        # the runtime tunable. This case fails red if someone removes the
+        # allowlist entry without also removing the branch.
+        sch = _make_scheduler(hard_cap=128, current=128)
+        req = SetInternalStateReq(server_args={"max_running_requests": 64})
+        with patch(
+            "sglang.srt.managers.scheduler.get_server_args"
+        ) as mock_get_server_args:
+            mock_get_server_args.return_value.override = lambda source, **kw: None
+            resp = sch.set_internal_state(req)
+        self.assertTrue(resp.updated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`/set_internal_state` already exists as the runtime-mutation channel for scheduler knobs (used today for `pp_max_micro_batch_size` and speculative thresholds), but `max_running_requests` — the primary admission-side concurrency cap — is still fixed at engine start. Operators who want to lower the effective in-flight cap in response to load or SLO signals have to restart the engine.

## Modifications

Extend the existing allowlist in `Scheduler.set_internal_state` to include `max_running_requests` as a **soft cap**, clamped to `[1, init_cap]`:

- The init value is captured once as `_max_running_requests_hard_cap` and used as the upper bound. Buffer-side allocations (`buffer_size = max_running_requests * 2`) and the derived `pp_max_micro_batch_size` default are sized against the hard cap at init, so the runtime override may only reduce the effective cap.
- After validation, the new value is mirrored onto `self.max_running_requests`. `schedule_policy` reads that attribute fresh each iteration (via `SchedulePolicy(..., max_running_requests=...)`), so the change gates the next admission decision without touching in-flight requests.
- Values outside `[1, hard_cap]` or `None` are rejected with a warning and the state is left unchanged, matching the existing `pp_max_micro_batch_size` pattern.

## Example

```bash
curl -s -X POST http://localhost:30000/set_internal_state \
  -H "Content-Type: application/json" \
  -d '{"server_args": {"max_running_requests": 32}}'
```

Then verify via `/get_internal_state` — the existing `effective_max_running_requests_per_dp` field already reads `self.max_running_requests` live and reflects the new soft cap.

## Test plan

- [x] New unit test `test/registered/unit/managers/test_scheduler_set_internal_state.py` (4 cases): valid update mirrors onto `self.max_running_requests`, above-hard-cap rejected, below-1 (0 and -1) rejected, allowlist bookkeeping.
- [x] `pre-commit run` clean.

## Non-goals / future work

- **Raising above init cap.** Requires resizing the pre-allocated `buffer_size` and the `pp_max_micro_batch_size` default; parallel to the existing `ModelRunner.resize` path used by DFlash auto-resize (`model_runner.py:721-725`).
- **Cleaning up `max_running_requests_under_SLO`.** There's a related TODO at `scheduler_components/metrics_reporter.py:1053` — its setter is also missing (regressed #22713), leaving `sglang:utilization` stuck at 0. Not in scope for this PR but a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29499374678](https://github.com/sgl-project/sglang/actions/runs/29499374678)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29499374362](https://github.com/sgl-project/sglang/actions/runs/29499374362)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->