### PR TITLE
fix(parser): CohereCommand4Detector.force_nonempty_content emits a truncated fragment

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1081,12 +1081,15 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
             )
         )
 
-    def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
+    def _parse_streaming_increment_impl(self, new_text: str) -> StreamingParseResult:
         """Streaming parse. Custom state machine -- we don't reuse the base
-        class because Cohere's "reasoning=False" path (the model emits no
-        ``<|END_THINKING|>``, just goes straight to a text or action block)
-        is fundamentally incompatible with the base detector's
-        ``force_reasoning`` semantics."""
+        class's parsing because Cohere's "reasoning=False" path (the model
+        emits no ``<|END_THINKING|>``, just goes straight to a text or action
+        block) is fundamentally incompatible with the base detector's
+        ``force_reasoning`` semantics. The base ``parse_streaming_increment``
+        wrapper still runs, driving ``_accumulated_reasoning`` off
+        ``_in_reasoning``, which this method keeps in sync with
+        ``_reasoning_done``."""
         self._buffer += new_text
         buf = self._buffer
 
@@ -1127,6 +1130,10 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
                 # the buffer for the post-thinking branch below to consume.
                 self._buffer = buf[first_pos:]
             self._reasoning_done = True
+            # Keep the base class's flag in sync: its parse_streaming_increment
+            # wrapper and finish() both key off _in_reasoning to decide whether
+            # a truncated stream still owes normal_text.
+            self._in_reasoning = False
             if reasoning_chunk:
                 return StreamingParseResult(reasoning_text=reasoning_chunk)
             buf = self._buffer

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -5,6 +5,7 @@ import unittest
 from sglang.srt.parser.reasoning_parser import (
     Apertus2509Detector,
     BaseReasoningFormatDetector,
+    CohereCommand4Detector,
     DeepSeekR1Detector,
     Gemma4Detector,
     Glm45Detector,
@@ -1146,6 +1147,52 @@ class TestPoolsideV1Registered(CustomTestCase):
         rp = ReasoningParser("poolside_v1", stream_reasoning=True)
         self.assertEqual(rp.detector.reasoning_default, "explicit_enable_thinking")
         self.assertTrue(rp.detector.thinks_internally)
+
+
+class TestCohereCommand4DetectorForceNonempty(CustomTestCase):
+    """force_nonempty_content on CohereCommand4 (streaming)."""
+
+    def test_streaming_truncated_reasoning_reclassified_on_finish(self):
+        """Regression: CohereCommand4Detector defines its own
+        parse_streaming_increment, shadowing the base wrapper that accumulates
+        self._accumulated_reasoning. It also tracks reasoning state in its own
+        _reasoning_done flag without ever updating the base's _in_reasoning, so
+        finish() reclassified only whatever tail happened to remain buffered
+        rather than the reasoning streamed so far."""
+        detector = CohereCommand4Detector(force_nonempty_content=True)
+        detector.parse_streaming_increment("Let me think")
+        detector.parse_streaming_increment(" about this")
+        detector.parse_streaming_increment(" problem carefully")
+        end = detector.finish()
+        self.assertEqual(end.reasoning_text, "")
+        self.assertEqual(end.normal_text, "Let me think about this problem carefully")
+
+    def test_streaming_completed_text_not_reclassified_on_finish(self):
+        detector = CohereCommand4Detector(force_nonempty_content=True)
+        detector.parse_streaming_increment("reason<|END_THINKING|>")
+        result = detector.parse_streaming_increment("<|START_TEXT|>answer<|END_TEXT|>")
+        end = detector.finish()
+        self.assertEqual(result.normal_text, "answer")
+        self.assertEqual(end.normal_text, "")
+
+    def test_streaming_action_block_not_reclassified_on_finish(self):
+        """A tool call is a legitimate non-text ending: the action block must
+        reach the tool-call parser untouched rather than being swapped into
+        normal_text as reasoning."""
+        detector = CohereCommand4Detector(force_nonempty_content=True)
+        detector.parse_streaming_increment("reason<|END_THINKING|>")
+        result = detector.parse_streaming_increment(
+            "<|START_ACTION|>[{}]<|END_ACTION|>"
+        )
+        end = detector.finish()
+        self.assertEqual(result.normal_text, "<|START_ACTION|>[{}]<|END_ACTION|>")
+        self.assertEqual(end.normal_text, "")
+
+    def test_streaming_truncated_without_force_nonempty_stays_empty(self):
+        detector = CohereCommand4Detector(force_nonempty_content=False)
+        detector.parse_streaming_increment("Let me think about this")
+        end = detector.finish()
+        self.assertEqual(end.normal_text, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`force_nonempty_content` exists so that a stream truncated mid-reasoning (max_new_tokens exhausted before `<|END_THINKING|>`) still yields content instead of an empty answer. For `CohereCommand4Detector` it does not just no-op — it emits a **corrupted** fragment:

```python
d = CohereCommand4Detector(force_nonempty_content=True)
for c in ["Let me think", " about this", " problem carefully"]:
    d.parse_streaming_increment(c)
d.finish().normal_text
# actual:   'oblem carefully'
# expected: 'Let me think about this problem carefully'
```

Two independent causes, both stemming from the detector's custom state machine:

1. `CohereCommand4Detector` defines its own `parse_streaming_increment`, **shadowing** `BaseReasoningFormatDetector.parse_streaming_increment` instead of being called through it as `_parse_streaming_increment_impl`. That wrapper is what accumulates `self._accumulated_reasoning`, so it stays empty for Cohere.
2. The detector tracks reasoning state in its own `_reasoning_done` flag and never updates the base's `_in_reasoning`, which `finish()` keys off. `_in_reasoning` is initialised to `force_reasoning` (True) and stays True forever.

So `finish()` computes `self._accumulated_reasoning + buffer` = `"" + buffer`, and `buffer` only holds the tail deliberately retained for marker-splitting across chunk boundaries — the last `max_keep` (15) characters. Hence `'oblem carefully'`.

This mirrors #31383 (Apertus2509Detector), but Cohere could not be fixed by the rename alone: its docstring notes the `reasoning=False` path is fundamentally incompatible with the base's `force_reasoning` semantics, and the base wrapper/`finish()` would read a never-synced `_in_reasoning`.

## Modifications

- Rename `parse_streaming_increment` → `_parse_streaming_increment_impl` so the base wrapper drives accumulation. The custom parsing logic is unchanged; only the wrapper (accumulation) is reinstated.
- Set `_in_reasoning = False` at the single point where `_reasoning_done` becomes True, so `finish()` can distinguish a truncated stream from a completed one.

Both start-of-block markers (`<|START_TEXT|>` and `<|START_ACTION|>`) reach that assignment through the shared code path, so a completed text block and a tool-call action block are both left untouched.

Tests (4 new cases): the truncated-stream regression, plus three negative-branch guards — completed text is not reclassified, a tool-call action block is not swallowed, and `force_nonempty_content=False` remains a no-op. Verified the regression case fails on pre-fix code and passes on the fix; full `test_reasoning_parser.py` is 92/92.

## Accuracy Tests

N/A — pure parser logic fix, no model output or sampling path affected.

## Speed Tests

N/A — no inference-speed-relevant change.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation as listed in the [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation) — N/A, internal parser behavior.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and tests. I ran the repro and the full test file locally and reviewed the diff before opening.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29499758572](https://github.com/sgl-project/sglang/actions/runs/29499758572)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29499758242](https://github.com/sgl-project/sglang/actions/runs/29499758242)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->