### PR TITLE
[model-gateway] fix: preserve MCP tool_choice for initial Responses requests

### DIFF
--- a/sgl-model-gateway/src/routers/openai/responses/mcp.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/mcp.rs
@@ -232,7 +232,9 @@ pub(super) fn prepare_mcp_tools_as_functions(
         }
         if !tools_json.is_empty() {
             obj.insert("tools".to_string(), Value::Array(tools_json));
-            obj.insert("tool_choice".to_string(), Value::String("auto".to_string()));
+            // Preserve an explicit choice on the initial request; default to auto.
+            obj.entry("tool_choice".to_string())
+                .or_insert_with(|| Value::String("auto".to_string()));
         }
     }
 }
@@ -288,6 +290,10 @@ pub(super) fn build_resume_payload(
             obj.insert("tools".to_string(), tools_json.clone());
         }
     }
+
+    // After a tool has run, let the model either call another tool or finish.
+    // Keeping an initial "required" choice here would force repeated calls.
+    obj.insert("tool_choice".to_string(), Value::String("auto".to_string()));
 
     // Set streaming mode based on caller's context
     obj.insert("stream".to_string(), Value::Bool(is_streaming));

--- a/sgl-model-gateway/tests/api/responses_api_test.rs
+++ b/sgl-model-gateway/tests/api/responses_api_test.rs
@@ -15,8 +15,34 @@ use smg::{
 
 use crate::common::{
     mock_mcp_server::MockMCPServer,
-    mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType},
+    mock_worker::{
+        start_response_request_capture, take_response_requests, HealthStatus, MockWorker,
+        MockWorkerConfig, WorkerType,
+    },
 };
+
+fn assert_mcp_tool_choice_sequence(requests: &[serde_json::Value]) {
+    assert_eq!(requests.len(), 2, "expected initial and follow-up requests");
+    assert_eq!(
+        requests[0].get("tool_choice").and_then(|v| v.as_str()),
+        Some("required"),
+        "initial request should preserve the client's tool_choice"
+    );
+    assert_eq!(
+        requests[1].get("tool_choice").and_then(|v| v.as_str()),
+        Some("auto"),
+        "post-MCP follow-up should allow the model to finish"
+    );
+    assert!(
+        requests[1]
+            .get("input")
+            .and_then(|v| v.as_array())
+            .is_some_and(|items| items.iter().any(|item| {
+                item.get("type").and_then(|v| v.as_str()) == Some("function_call_output")
+            })),
+        "follow-up request should contain the MCP tool result"
+    );
+}
 
 #[tokio::test]
 async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
@@ -41,6 +67,8 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         fail_rate: 0.0,
     });
     let worker_url = worker.start().await.expect("start worker");
+    let worker_port = worker.port().await;
+    start_response_request_capture(worker_port);
 
     // Build router config (HTTP OpenAI mode)
     let router_cfg = RouterConfig::builder()
@@ -80,7 +108,7 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         store: Some(true),
         stream: Some(false),
         temperature: Some(0.2),
-        tool_choice: Some(ToolChoice::default()),
+        tool_choice: Some(ToolChoice::Value(ToolChoiceValue::Required)),
         tools: Some(vec![ResponseTool {
             r#type: ResponseToolType::Mcp,
             function: None,
@@ -186,21 +214,11 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         .filter_map(|v| v.as_str())
         .next();
 
-    if let Some(text) = final_text {
-        assert_eq!(text, "Tool result consumed; here is the final answer.");
-    } else {
-        let call_entry = output.iter().find(|entry| {
-            entry.get("type") == Some(&serde_json::Value::String("function_tool_call".into()))
-        });
-        assert!(call_entry.is_some(), "missing function tool call entry");
-        if let Some(entry) = call_entry {
-            assert_eq!(
-                entry.get("status").and_then(|v| v.as_str()),
-                Some("in_progress"),
-                "function call should be in progress when no content is returned"
-            );
-        }
-    }
+    assert_eq!(
+        final_text,
+        Some("Tool result consumed; here is the final answer."),
+        "missing final assistant message"
+    );
 
     let tools = body_json
         .get("tools")
@@ -213,6 +231,9 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         tool.get("server_label").and_then(|v| v.as_str()),
         Some("mock")
     );
+
+    let upstream_requests = take_response_requests(worker_port);
+    assert_mcp_tool_choice_sequence(&upstream_requests);
 
     // Cleanup
     worker.stop().await;
@@ -874,6 +895,8 @@ async fn test_streaming_with_mcp_tool_calls() {
     // 6. Verify SSE events are properly formatted
 
     let (mut mcp, mut worker, router, _dir) = setup_streaming_mcp_test().await;
+    let worker_port = worker.port().await;
+    start_response_request_capture(worker_port);
 
     // Build streaming request with MCP tools
     let req = ResponsesRequest {
@@ -892,7 +915,7 @@ async fn test_streaming_with_mcp_tool_calls() {
         store: Some(true),
         stream: Some(true), // KEY: Enable streaming
         temperature: Some(0.7),
-        tool_choice: Some(ToolChoice::Value(ToolChoiceValue::Auto)),
+        tool_choice: Some(ToolChoice::Value(ToolChoiceValue::Required)),
         tools: Some(vec![ResponseTool {
             r#type: ResponseToolType::Mcp,
             server_url: Some(mcp.url()),
@@ -1148,6 +1171,13 @@ async fn test_streaming_with_mcp_tool_calls() {
     // Verify no error events
     let has_error = body_text.contains("event: error");
     assert!(!has_error, "Should not have error events");
+    assert!(
+        body_text.contains("Tool result consumed; here is the final answer."),
+        "stream should contain the final assistant message"
+    );
+
+    let upstream_requests = take_response_requests(worker_port);
+    assert_mcp_tool_choice_sequence(&upstream_requests);
 
     worker.stop().await;
     mcp.stop().await;

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -129,6 +129,10 @@ impl MockWorker {
         Ok(url)
     }
 
+    pub async fn port(&self) -> u16 {
+        self.config.read().await.port
+    }
+
     /// Stop the mock worker server
     pub async fn stop(&mut self) {
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
@@ -718,6 +722,7 @@ async fn responses_handler(
     Json(payload): Json<serde_json::Value>,
 ) -> Response {
     let config = config.read().await;
+    record_response_request(config.port, &payload);
 
     if should_fail(&config).await {
         return (
@@ -1340,6 +1345,32 @@ async fn responses_handler(
             }))
             .into_response()
         }
+    }
+}
+
+// --- Responses request capture (for payload forwarding tests) ---
+static RESPONSE_REQUESTS: OnceLock<Mutex<HashMap<u16, Vec<serde_json::Value>>>> = OnceLock::new();
+
+fn get_response_requests() -> &'static Mutex<HashMap<u16, Vec<serde_json::Value>>> {
+    RESPONSE_REQUESTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Start capturing `/v1/responses` request payloads for a worker port.
+pub fn start_response_request_capture(port: u16) {
+    let mut requests = get_response_requests().lock().unwrap();
+    requests.insert(port, Vec::new());
+}
+
+/// Take all captured `/v1/responses` request payloads for a worker port.
+pub fn take_response_requests(port: u16) -> Vec<serde_json::Value> {
+    let mut requests = get_response_requests().lock().unwrap();
+    requests.remove(&port).unwrap_or_default()
+}
+
+fn record_response_request(port: u16, payload: &serde_json::Value) {
+    let mut requests = get_response_requests().lock().unwrap();
+    if let Some(captured) = requests.get_mut(&port) {
+        captured.push(payload.clone());
     }
 }
 


### PR DESCRIPTION
## Motivation

Fixes #31459.

The OpenAI Responses MCP path replaced an explicit client `tool_choice` with `"auto"` before the initial upstream request. Models that require `tool_choice: "required"` to invoke tools could therefore skip the MCP call.

## Modifications

- Preserve an explicit client `tool_choice` on the initial upstream request while retaining the existing `"auto"` default when it is omitted.
- Set `tool_choice` to `"auto"` only for internal post-MCP follow-up requests, allowing the model to call another tool or produce the final answer.
- Add streaming and non-streaming regression coverage that verifies the upstream `required` to `auto` sequence, the MCP tool result in the follow-up, the completed MCP call, and the final assistant message.

## Accuracy Tests

N/A — this changes request-routing semantics only and does not modify model computation or output accuracy.

The affected regression tests passed locally:

```text
cargo test --test api_tests api::responses_api_test::test_non_streaming_mcp_minimal_e2e_with_persistence -- --exact --nocapture
cargo test --test api_tests api::responses_api_test::test_streaming_with_mcp_tool_calls -- --exact --nocapture
```

Additional checks passed:

```text
cargo +nightly fmt -- --check
cargo clippy --all-targets --all-features -- -D warnings
```

The complete `cargo test` suite is covered by the PR Test (SMG) workflow.

## Speed Tests and Profiling

N/A — the change only moves a JSON field assignment between existing request preparation steps and has no meaningful performance impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: no user-facing API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A: routing-only bug fix.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29507469072](https://github.com/sgl-project/sglang/actions/runs/29507469072)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29507468583](https://github.com/sgl-project/sglang/actions/runs/29507468583)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->