### PR TITLE
[PD] Translate virtual KV indices to physical before disagg KV transfer (unified memory pool)

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1083,6 +1083,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 kv_indices = self.req_to_token_pool.req_to_token[
                     decode_req.req.req_pool_idx
                 ][total_prefix_len:origin_input_len]
+                # req_to_token holds VIRTUAL ids under the unified memory pool
+                # (MultiEndedAllocator), which relocates physical pages -> virtual
+                # != physical after churn. Resolve to current PHYSICAL so prefill's
+                # RDMA write lands in the right decode slots (mirrors prefill
+                # send_kv_chunk). getattr-guarded: no-op without translate_kv_loc.
+                translate_kv_loc = getattr(
+                    self.token_to_kv_pool_allocator, "translate_kv_loc", None
+                )
+                if translate_kv_loc is not None:
+                    kv_indices = translate_kv_loc(kv_indices.long())
 
             seq_len = origin_input_len
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1165,6 +1165,17 @@ class SchedulerDisaggregationPrefillMixin:
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, start_idx:end_idx
         ]
+        # Under the unified memory pool (MultiEndedAllocator), req_to_token stores
+        # VIRTUAL token ids and physical pages get relocated by compaction, so
+        # virtual != physical after churn. The KV buffer / PD transfer is indexed by
+        # PHYSICAL slot, so resolve virtual -> current physical here, mirroring the
+        # attention backend (translate_kv_loc). getattr-guarded: no-op for allocators
+        # without translate_kv_loc, leaving every other backend/config unchanged.
+        translate_kv_loc = getattr(
+            self.token_to_kv_pool_allocator, "translate_kv_loc", None
+        )
+        if translate_kv_loc is not None:
+            kv_indices = translate_kv_loc(kv_indices.long())
         page_indices = kv_to_page_indices(kv_indices, page_size)
         if not req.disagg_kv_sender.should_send_kv_chunk(len(page_indices), last_chunk):
             return


### PR DESCRIPTION
## Motivation

Under the unified memory pool (`unified_kv_triton` / `MultiEndedAllocator`), `req_to_token` stores **virtual** token ids and the allocator **relocates physical KV pages during compaction**, so `virtual != physical` once the pool churns. The attention backend already resolves virtual→physical via `translate_kv_loc` before touching the KV buffer (`layers/attention/triton_backend.py`), but the **PD KV-transfer path passed the raw virtual `req_to_token` indices** to the transfer layer, which uses them as **physical** KV-buffer offsets.

Initially `virtual == physical` (identity bind off the watermark), so it works; once compaction diverges the v2p mapping, the transfer reads/writes the **wrong physical KV pages** → KV corruption, and at KV saturation it can touch a reclaimed / being-overwritten page → GPU crash. We hit this reproducibly as `HSA_STATUS_ERROR_EXCEPTION 0x1016` on the decode server during long-running, high-concurrency DeepSeek-V4 PD runs (1P1D, `--disaggregation-transfer-backend mori`, `unified_kv_triton`) at ~99% KV saturation. It only manifests after enough churn, which is why short runs pass and long ones crash.

## Modifications

Translate virtual → current physical at the two PD transfer boundaries, mirroring what the attention backend already does:

- `disaggregation/prefill.py::send_kv_chunk` — source KV indices, before `kv_to_page_indices`.
- `disaggregation/decode.py::pop_preallocated` — destination KV indices, before `send_metadata`.

The call is `getattr`-guarded on `translate_kv_loc`, so allocators that don't define it (every non-unified backend/config) get an identity no-op — no behavior change outside the unified memory pool.

## Accuracy Tests

Not a change to model math — this corrects KV *addressing* on the PD transfer path. Validated end-to-end: without the fix the unified-pool PD run corrupts KV / crashes under churn; with it, long high-concurrency runs complete normally.

## Speed Tests and Profiling

DeepSeek-V4 PD, 1P1D (TP8/EP8), `mori` transfer backend, `unified_kv_triton`, concurrency 96, 3600s window:

- **Before**: decode crashes with `0x1016` at ~99% KV saturation within ~25–35 min.
- **After**: runs the full ~60 min profiling window crash-free (error rate ≈ 0.02%), with **no measurable throughput/latency regression** — the translation reuses the allocator's existing v2p gather (the same one the attention backend already performs), so it is effectively free. Prefill input ≈ 162k tok/s and decode ITL p50 ≈ 41 ms match the pre-crash numbers of the unfixed run.

## Checklist

- [x] Format your code according to pre-commit (black + isort clean).
- [x] Follow the SGLang code style guidance.
- [ ] Add unit tests (behavior is only observable under a full unified-pool PD + mori transfer run; happy to add coverage if maintainers can point to the right harness).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30081038529](https://github.com/sgl-project/sglang/actions/runs/30081038529)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30081038484](https://github.com/sgl-project/sglang/actions/runs/30081038484)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->