### PR TITLE
Fix shared-expert TP1 double-count on skipped post-experts all-reduce

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -917,6 +917,34 @@ class DeepseekV2MoE(nn.Module):
                 hidden_states, forward_batch, input_ids_global=input_ids_global
             )
 
+    def _reduce_and_add_tp1_shared_output(
+        self,
+        final_hidden_states: torch.Tensor,
+        shared_output: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Post-experts reduction plus the deferred TP1 shared-expert add.
+
+        TP1 shared experts are replicated, so they are added after the
+        all-reduce to avoid summing the same shared output once per TP rank.
+        When the all-reduce is skipped because a downstream cross-rank SUM
+        (dp-attention reduce-scatterv / fused all-reduce) performs the
+        reduction instead, that SUM would still count the replicated shared
+        output once per rank — pre-scale by 1/moe_ep_size so it contributes
+        exactly once (mirrors fused_shared_experts_scaling_factor on the
+        fused shared-experts path).
+        """
+        skip_post_all_reduce = should_skip_post_experts_all_reduce(
+            is_tp_path=True,
+        )
+        if self.tp_size > 1 and not skip_post_all_reduce:
+            final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
+        if shared_output is not None and self._shared_expert_tp1:
+            if self.tp_size > 1 and skip_post_all_reduce:
+                final_hidden_states += shared_output / self.moe_ep_size
+            else:
+                final_hidden_states += shared_output
+        return final_hidden_states
+
     def forward_normal_dual_stream(
         self,
         hidden_states: torch.Tensor,
@@ -1008,15 +1036,9 @@ class DeepseekV2MoE(nn.Module):
                 self.routed_scaling_factor,
             )
 
-        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
-            is_tp_path=True,
-        ):
-            final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
-        # TP1 shared experts are replicated, so add them after all-reduce to
-        # avoid summing the same shared output once per TP rank.
-        if self._shared_expert_tp1:
-            final_hidden_states += shared_output
-        return final_hidden_states
+        return self._reduce_and_add_tp1_shared_output(
+            final_hidden_states, shared_output
+        )
 
     def forward_normal(
         self,
@@ -1130,15 +1152,9 @@ class DeepseekV2MoE(nn.Module):
             self.routed_scaling_factor,
         )
 
-        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
-            is_tp_path=True,
-        ):
-            final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
-        # TP1 shared experts are replicated, so add them after all-reduce to
-        # avoid summing the same shared output once per TP rank.
-        if shared_output is not None and self._shared_expert_tp1:
-            final_hidden_states += shared_output
-        return final_hidden_states
+        return self._reduce_and_add_tp1_shared_output(
+            final_hidden_states, shared_output
+        )
 
     def forward_cpu(
         self,

--- a/test/registered/ep/test_shared_expert_tp1_reduce.py
+++ b/test/registered/ep/test_shared_expert_tp1_reduce.py
@@ -1,0 +1,112 @@
+"""Unit tests for DeepseekV2MoE._reduce_and_add_tp1_shared_output.
+
+Covers the TP1 shared-expert add across the three post-experts reduction
+regimes, with compatibility (unchanged behavior) as the primary concern:
+
+1. flag OFF                        -> helper never touches shared_output
+2. flag ON, all-reduce runs (TP)   -> full S added (pre-fix behavior)
+3. flag ON, all-reduce skipped     -> S/moe_ep_size added (the fix): a
+   downstream cross-rank SUM (dp-attention reduce-scatterv / fused
+   all-reduce) sums the replicated S once per rank, so the pre-scaled add
+   yields exactly R + S after that SUM.
+4. tp_size == 1                    -> full S added, no reduction
+"""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.models import deepseek_v2 as dsv2_mod
+from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-a", runner_config="1-gpu-small")
+
+
+def _make_moe(tp_size: int, moe_ep_size: int, shared_expert_tp1: bool):
+    moe = DeepseekV2MoE.__new__(DeepseekV2MoE)
+    moe.tp_size = tp_size
+    moe.moe_ep_size = moe_ep_size
+    moe._shared_expert_tp1 = shared_expert_tp1
+    return moe
+
+
+class TestSharedExpertTp1Reduce(CustomTestCase):
+    def setUp(self):
+        self.routed = torch.randn(4, 8)
+        self.shared = torch.randn(4, 8)
+
+    def _run(self, moe, *, skip_all_reduce: bool, shared=...):
+        shared = self.shared if shared is ... else shared
+        with mock.patch.object(
+            dsv2_mod,
+            "should_skip_post_experts_all_reduce",
+            return_value=skip_all_reduce,
+        ), mock.patch.object(
+            dsv2_mod,
+            "tensor_model_parallel_all_reduce",
+            side_effect=lambda t: t,
+        ) as all_reduce:
+            out = moe._reduce_and_add_tp1_shared_output(self.routed.clone(), shared)
+        return out, all_reduce
+
+    # ── Compatibility: pre-fix behavior must be unchanged ──────────────
+
+    def test_flag_off_shared_untouched(self):
+        moe = _make_moe(tp_size=8, moe_ep_size=8, shared_expert_tp1=False)
+        for skip in (False, True):
+            out, _ = self._run(moe, skip_all_reduce=skip)
+            torch.testing.assert_close(out, self.routed)
+
+    def test_flag_on_all_reduce_runs_adds_full_shared(self):
+        moe = _make_moe(tp_size=8, moe_ep_size=8, shared_expert_tp1=True)
+        out, all_reduce = self._run(moe, skip_all_reduce=False)
+        all_reduce.assert_called_once()
+        torch.testing.assert_close(out, self.routed + self.shared)
+
+    def test_tp1_adds_full_shared_no_reduce(self):
+        moe = _make_moe(tp_size=1, moe_ep_size=1, shared_expert_tp1=True)
+        for skip in (False, True):
+            out, all_reduce = self._run(moe, skip_all_reduce=skip)
+            all_reduce.assert_not_called()
+            torch.testing.assert_close(out, self.routed + self.shared)
+
+    def test_shared_none_is_noop(self):
+        moe = _make_moe(tp_size=8, moe_ep_size=8, shared_expert_tp1=True)
+        for skip in (False, True):
+            out, _ = self._run(moe, skip_all_reduce=skip, shared=None)
+            torch.testing.assert_close(out, self.routed)
+
+    # ── The fix: skipped all-reduce pre-scales the replicated shared ───
+
+    def test_flag_on_all_reduce_skipped_prescales_shared(self):
+        moe = _make_moe(tp_size=8, moe_ep_size=8, shared_expert_tp1=True)
+        out, all_reduce = self._run(moe, skip_all_reduce=True)
+        all_reduce.assert_not_called()
+        torch.testing.assert_close(out, self.routed + self.shared / 8)
+
+    def test_downstream_sum_restores_r_plus_s(self):
+        # Per-rank routed partials sum to R across the EP group; the
+        # replicated shared output is identical on every rank. The
+        # downstream reduce-scatter SUMs the per-rank tensors, so with the
+        # pre-scale the total is exactly R + S (pre-fix: R + ep_size*S).
+        ep_size = 8
+        moe = _make_moe(tp_size=ep_size, moe_ep_size=ep_size, shared_expert_tp1=True)
+        rank_partials = [torch.randn(4, 8) for _ in range(ep_size)]
+        routed_total = torch.stack(rank_partials).sum(dim=0)
+
+        summed = torch.zeros_like(routed_total)
+        for partial in rank_partials:
+            self.routed = partial
+            out, _ = self._run(moe, skip_all_reduce=True)
+            summed += out
+
+        torch.testing.assert_close(
+            summed, routed_total + self.shared, rtol=1e-5, atol=1e-5
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`SGLANG_SHARED_EXPERT_TP1=1` (required to serve FP8 block-quantized checkpoints of DeepseekV2MoE-family models at EP≤64, e.g. GLM-5.2 — the shared expert cannot TP-shard: `output_partition_size not divisible by block_n = 128`) numerically corrupts output whenever the post-experts all-reduce is skipped in favor of a downstream cross-rank SUM (`should_use_dp_reduce_scatterv()` under dp-attention + EP, or `fuse_mlp_allreduce`).

The replicated shared output is added on every rank *before* the deferred reduce-scatterv, so the SUM counts it once per rank: each token's MoE output becomes `R + ep_size·S` instead of `R + S` — ~`ep_size`× shared-expert amplification at every MoE layer → random-token garbage from the first token.

Fixes #31475.

## Modifications

In `DeepseekV2MoE.forward_normal` and `forward_normal_dual_stream`: capture the `should_skip_post_experts_all_reduce(is_tp_path=True)` decision; when the all-reduce was skipped (a downstream SUM will reduce), pre-scale the replicated shared output by `1/self.moe_ep_size` so the SUM contributes exactly one `S`. The plain-TP path (all-reduce ran) is unchanged. This mirrors the existing `fused_shared_experts_scaling_factor = 1/moe_ep_size` compensation on the fused shared-experts path.

## Accuracy Tests

**3-arm A/B on this exact code (official `lmsysorg/sglang:latest` = 0.5.15.post1 image, bug sites identical to main), DeepSeek-V2-Lite-Chat, single node, greedy decode, identical prompts:**

| Arm | Config | Unpatched | Patched |
|---|---|---|---|
| Regression | flag OFF, TP=EP=DP=8 + dp-attention | baseline | **byte-identical to unpatched** |
| Regression | flag ON, plain TP=4 (all-reduce runs) | baseline | **byte-identical to unpatched** |
| Fix | flag ON, TP=EP=DP=8 + dp-attention | random-token garbage (`了训，这个是.了8上码...`) | coherent (`24 * 17 = 408`, `Paris.`) |

Reproduced on H100 (sm90). Runtime instrumentation confirms the fix path is hit exactly as analyzed: `tp1=True skip=True use_rs=True` on the failing config.

Original discovery at scale: GLM-5.2-744B FP8, EP=DP=64 and 4× EP=DP=32 + EAGLE — same garbage→coherent flip; BF16 flag-toggle A/B isolated the flag (not FP8) as the trigger.

Unit tests: `test/registered/ep/test_shared_expert_tp1_reduce.py` covers the helper across all four regimes (flag off / plain-TP / skipped-reduce / tp1).

## Checklist
- [x] Format your code
- [x] Add unit tests
- [ ] Update documentation as needed















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29520574219](https://github.com/sgl-project/sglang/actions/runs/29520574219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29520574766](https://github.com/sgl-project/sglang/actions/runs/29520574766)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->