### PR TITLE
[DSA] Add an arch-independent torch paged-MQA-logits backend with a fused Triton fast path

### DIFF
--- a/python/sglang/srt/arg_groups/fields/exec_.py
+++ b/python/sglang/srt/arg_groups/fields/exec_.py
@@ -247,8 +247,8 @@ class ExecKernel(msgspec.Struct):
     dsa_paged_mqa_logits_backend: A[
         str,
         Arg(
-            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only).",
-            choices=["auto", "deepgemm", "cutedsl", "aiter"],
+            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only), 'torch' (pure-torch fallback, any CUDA arch, e.g. SM120/SM121 where neither DeepGEMM nor CuteDSL run; slower, opt-in only).",
+            choices=["auto", "deepgemm", "cutedsl", "aiter", "torch"],
         ),
     ] = "auto"
     dsa_topk_backend: A[

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -807,6 +807,13 @@ class Envs:
     # "cuda" = the hand-written SM90 WGMMA kernel (bitwise identical to the
     # Triton two_dot variant, 1.16-1.38x faster across GLM/DS shapes).
     SGLANG_OPT_Q8KV8_QPREP_VARIANT = EnvStr("auto")
+    # Fused Triton fast path for dsa_paged_mqa_logits_backend="torch" (on by
+    # default; the pure-torch kernel pays the full CUDA-graph-capture page
+    # table width every step, the Triton kernel early-exits per block on the
+    # true seq_len at replay time). Falls back to the pure-torch kernel when
+    # triton is unavailable or num_heads < 16 (tl.dot minimum). Has no effect
+    # unless dsa_paged_mqa_logits_backend="torch" is selected.
+    SGLANG_DSA_INDEXER_TRITON = EnvBool(True)
 
     # sgl-kernel
     SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1576,6 +1576,13 @@ class Envs:
     # "cuda" = the hand-written SM90 WGMMA kernel (bitwise identical to the
     # Triton two_dot variant, 1.16-1.38x faster across GLM/DS shapes).
     SGLANG_OPT_Q8KV8_QPREP_VARIANT = EnvStr("auto")
+    # Fused Triton fast path for dsa_paged_mqa_logits_backend="torch" (on by
+    # default; the pure-torch kernel pays the full CUDA-graph-capture page
+    # table width every step, the Triton kernel early-exits per block on the
+    # true seq_len at replay time). Falls back to the pure-torch kernel when
+    # triton is unavailable or num_heads < 16 (tl.dot minimum). Has no effect
+    # unless dsa_paged_mqa_logits_backend="torch" is selected.
+    SGLANG_DSA_INDEXER_TRITON = EnvBool(True)
 
     # ===================================================================
     # MiniMax M3

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -18,6 +18,9 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
     DSAPagedMQALogitsBackend,
 )
+from sglang.srt.layers.attention.dsa.torch_paged_mqa_logits import (
+    fp8_paged_mqa_logits_torch_dsa,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     aiter_can_use_preshuffle_paged_mqa,
     is_dsa_enable_prefill_cp,
@@ -963,6 +966,7 @@ class Indexer(MultiPlatformOp):
         ctx_2d = getattr(metadata, "paged_mqa_ctx_lens_2d", None)
         use_dg_native = (
             not use_cute_dsl
+            and not self.paged_mqa_logits_backend.is_torch()
             and _is_cuda
             and forward_batch.forward_mode.is_target_verify()
             and next_n >= 2
@@ -976,7 +980,7 @@ class Indexer(MultiPlatformOp):
             seqlens_32_2d = seqlens_32
         else:
             seqlens_32_2d = seqlens_32.unsqueeze(-1)
-        if _is_cuda:
+        if _is_cuda and not self.paged_mqa_logits_backend.is_torch():
             if schedule_metadata is None:
                 schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
                     seqlens_32_2d, blocksize, self.sm_count
@@ -1035,6 +1039,39 @@ class Indexer(MultiPlatformOp):
                 q_offset=q_offset,
                 B=B,
                 next_n=next_n,
+            )
+        elif self.paged_mqa_logits_backend.is_torch():
+            # Pass-through, no reshaping needed. `_get_topk_paged` (this
+            # method) is only ever invoked for decode_or_idle, target_verify
+            # and draft_extend_v2 -- see the three-way `forward_mode` gate
+            # around the `self._get_topk_paged(...)` call in this class's
+            # forward path; plain prefill/extend routes to `_get_topk_ragged`
+            # instead and never reaches here, so this dispatch does not need
+            # to (and must not silently try to) handle it. Across those three
+            # modes: q_fp8/weights are already sliced per token ([:q_offset]);
+            # seqlens_32_2d is per-token for verify/draft-extend-v2
+            # (metadata.get_seqlens_expanded(), see above) and per-request for
+            # decode (where per-token == per-request, next_n == 1); and
+            # block_tables (= metadata.get_page_table_64() =
+            # DSAMetadata.real_page_table) is ALREADY repeat_interleaved to
+            # per-token rows for target_verify/draft_extend_v2 by
+            # dsa_backend.py's init_forward_metadata /
+            # _build_forward_metadata_cuda_graph (`page_table =
+            # torch.repeat_interleave(page_table, repeats=...)` before the
+            # metadata is built) -- decode needs no repeat since it is already
+            # one row per request == one row per token there. So next_n >= 2
+            # needs no extra reshaping here: repeating again would
+            # double-expand block_tables against an already-per-token
+            # q/weights and trip the kernel's batch-size shape assert.
+            logits = fp8_paged_mqa_logits_torch_dsa(
+                q_fp8.unsqueeze(1)[:q_offset],
+                kv_cache_fp8,
+                weights[:q_offset],
+                seqlens_32_2d,
+                block_tables,
+                None,  # schedule_metadata unused by the torch/triton path
+                max_seq_len,
+                clean_logits=False,
             )
         else:
             logits = deepgemm_paged_mqa_logits_split(

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -26,6 +26,9 @@ from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
 from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
     DSAPagedMQALogitsBackend,
 )
+from sglang.srt.layers.attention.dsa.torch_paged_mqa_logits import (
+    fp8_paged_mqa_logits_torch_dsa,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     aiter_can_use_preshuffle_paged_mqa,
     is_dsa_enable_prefill_cp,
@@ -854,6 +857,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         ctx_2d = getattr(metadata, "paged_mqa_ctx_lens_2d", None)
         use_dg_native = (
             not use_cute_dsl
+            and not self.paged_mqa_logits_backend.is_torch()
             and _is_cuda
             and forward_batch.forward_mode.is_target_verify()
             and next_n >= 2
@@ -875,7 +879,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 seqlens_32_2d = seqlens_32.reshape(-1).contiguous().view(-1, 1)
         else:
             seqlens_32_2d = seqlens_32.contiguous().view(-1, 1)
-        if _is_cuda:
+        if _is_cuda and not self.paged_mqa_logits_backend.is_torch():
             if schedule_metadata is None:
                 schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
                     seqlens_32_2d, blocksize, self.sm_count
@@ -991,6 +995,39 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 q_offset=q_offset,
                 B=B,
                 next_n=next_n,
+            )
+        elif self.paged_mqa_logits_backend.is_torch():
+            # Pass-through, no reshaping needed. `_get_topk_paged` (this
+            # method) is only ever invoked for decode_or_idle, target_verify
+            # and draft_extend_v2 -- see the three-way `forward_mode` gate
+            # around the `self._get_topk_paged(...)` call in this class's
+            # forward path; plain prefill/extend routes to `_get_topk_ragged`
+            # instead and never reaches here, so this dispatch does not need
+            # to (and must not silently try to) handle it. Across those three
+            # modes: q_fp8/weights are already sliced per token ([:q_offset]);
+            # seqlens_32_2d is per-token for verify/draft-extend-v2
+            # (metadata.get_seqlens_expanded(), see above) and per-request for
+            # decode (where per-token == per-request, next_n == 1); and
+            # block_tables (= metadata.get_page_table_64() =
+            # DSAMetadata.real_page_table) is ALREADY repeat_interleaved to
+            # per-token rows for target_verify/draft_extend_v2 by
+            # dsa_backend.py's init_forward_metadata /
+            # _build_forward_metadata_cuda_graph (`page_table =
+            # torch.repeat_interleave(page_table, repeats=...)` before the
+            # metadata is built) -- decode needs no repeat since it is already
+            # one row per request == one row per token there. So next_n >= 2
+            # needs no extra reshaping here: repeating again would
+            # double-expand block_tables against an already-per-token
+            # q/weights and trip the kernel's batch-size shape assert.
+            logits = fp8_paged_mqa_logits_torch_dsa(
+                q_fp8.unsqueeze(1)[:q_offset],
+                kv_cache_fp8,
+                weights[:q_offset],
+                seqlens_32_2d,
+                block_tables,
+                None,  # schedule_metadata unused by the torch/triton path
+                max_seq_len,
+                clean_logits=False,
             )
         else:
             logits = deepgemm_paged_mqa_logits_split(

--- a/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
@@ -9,6 +9,10 @@ class DSAPagedMQALogitsBackend(Enum):
     DEEPGEMM = "deepgemm"
     CUTEDSL = "cutedsl"
     AITER = "aiter"
+    # Pure-torch fallback for CUDA archs that neither DeepGEMM nor CuTe DSL
+    # cover (e.g. SM120/SM121 consumer Blackwell). No arch gate by design;
+    # opt-in only (never selected by "auto"), see resolve() below.
+    TORCH = "torch"
 
     def is_deepgemm(self) -> bool:
         return self == DSAPagedMQALogitsBackend.DEEPGEMM
@@ -18,6 +22,9 @@ class DSAPagedMQALogitsBackend(Enum):
 
     def is_aiter(self) -> bool:
         return self == DSAPagedMQALogitsBackend.AITER
+
+    def is_torch(self) -> bool:
+        return self == DSAPagedMQALogitsBackend.TORCH
 
     @staticmethod
     def resolve(value: str) -> DSAPagedMQALogitsBackend:
@@ -39,4 +46,9 @@ class DSAPagedMQALogitsBackend(Enum):
                     "dsa_paged_mqa_logits_backend='cutedsl' requires SM100 (Blackwell)."
                 )
             return DSAPagedMQALogitsBackend.CUTEDSL
+        if value == "torch":
+            # No arch gate: that is the whole point of this backend. Not
+            # selected by "auto" (opt-in only) so archs where DeepGEMM/CuteDSL
+            # already work keep their existing (faster) default.
+            return DSAPagedMQALogitsBackend.TORCH
         raise ValueError(f"Unknown dsa_paged_mqa_logits_backend: {value!r}")

--- a/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/paged_mqa_logits_backend.py
@@ -10,6 +10,10 @@ class DSAPagedMQALogitsBackend(Enum):
     DEEPGEMM = "deepgemm"
     CUTEDSL = "cutedsl"
     AITER = "aiter"
+    # Pure-torch fallback for CUDA archs that neither DeepGEMM nor CuTe DSL
+    # cover (e.g. SM120/SM121 consumer Blackwell). No arch gate by design;
+    # opt-in only (never selected by "auto"), see resolve() below.
+    TORCH = "torch"
 
     def is_deepgemm(self) -> bool:
         return self == DSAPagedMQALogitsBackend.DEEPGEMM
@@ -19,6 +23,9 @@ class DSAPagedMQALogitsBackend(Enum):
 
     def is_aiter(self) -> bool:
         return self == DSAPagedMQALogitsBackend.AITER
+
+    def is_torch(self) -> bool:
+        return self == DSAPagedMQALogitsBackend.TORCH
 
     @staticmethod
     def resolve(value: str) -> DSAPagedMQALogitsBackend:
@@ -40,4 +47,9 @@ class DSAPagedMQALogitsBackend(Enum):
                     "dsa_paged_mqa_logits_backend='cutedsl' requires SM100 (Blackwell)."
                 )
             return DSAPagedMQALogitsBackend.CUTEDSL
+        if value == "torch":
+            # No arch gate: that is the whole point of this backend. Not
+            # selected by "auto" (opt-in only) so archs where DeepGEMM/CuteDSL
+            # already work keep their existing (faster) default.
+            return DSAPagedMQALogitsBackend.TORCH
         raise ValueError(f"Unknown dsa_paged_mqa_logits_backend: {value!r}")

--- a/python/sglang/srt/layers/attention/dsa/torch_paged_mqa_logits.py
+++ b/python/sglang/srt/layers/attention/dsa/torch_paged_mqa_logits.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-torch fallback for the DSA indexer's paged-MQA-logits kernel.
+
+`sglang.srt.layers.attention.dsa.dsa_indexer.Indexer._get_topk_paged` scores
+paged KV against the query via a paged-MQA-logits kernel before top-k
+selection. The existing backends (DeepGEMM, CuTe DSL, aiter) each have a hard
+arch/platform requirement: DeepGEMM's compiled kernel does not cover SM120/121
+(consumer Blackwell; upstream DeepGEMM declined support, see
+https://github.com/deepseek-ai/DeepGEMM/pull/318), CuTe DSL is gated to SM100
+and its `_setup_mma` uses `tcgen05.MmaF8F6F4Op`, a datacenter-Blackwell-only
+tensor-core op that does not exist on SM120/121, and aiter is ROCm-only. That
+leaves every CUDA arch outside SM90/SM100/ROCm with no working backend at all.
+
+This module is a vectorized (no `.item()`, no data-dependent control flow, so
+CUDA-graph-capture-safe) torch implementation with no arch requirement,
+selected via `--dsa-paged-mqa-logits-backend torch` (opt-in only; not chosen
+by "auto", so archs where DeepGEMM/CuTe DSL already work are unaffected).
+
+It follows the same layout and math as the sibling SM120 fallback added for
+the DeepSeek-V4 indexer in `sglang.srt.layers.attention.dsv4.indexer` (see
+`fp8_paged_mqa_logits_torch_sm120`, PR #24692) and discards the DeepGEMM
+schedule metadata the same way (`deep_gemm_metadata` is accepted for call-site
+signature compatibility only) -- the torch path does no SM-tiled scheduling,
+so callers may pass `None`. It accumulates the KV x Q dot product in float32
+rather than bfloat16; this is a deliberate accuracy/robustness choice for a
+fallback path that has no faster alternative to cross-check against on its
+target hardware, not a numerical-equivalence claim against the sibling
+kernel.
+
+Includes an optional fused Triton fast path (`triton_paged_mqa_logits.py`),
+dispatched below after the shape asserts. Under CUDA graph capture, the
+scan width is fixed at the full page-table capacity regardless of the
+request's true sequence length; this pure-torch kernel pays that full width
+on every step (gather + dequant + matmul over the whole capture width), while
+the Triton kernel early-exits per (request, KV-page) block on the true
+`seq_lens` value read at replay time. See `SGLANG_DSA_INDEXER_TRITON`
+(`sglang.srt.environ`) to control it; it is bit-exact with this module's pure
+implementation and is on by default.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+FP8_DTYPE = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+
+try:
+    from sglang.srt.layers.attention.dsa.triton_paged_mqa_logits import (
+        fp8_paged_mqa_logits_triton_dsa,
+    )
+
+    _TRITON_LOGITS_AVAILABLE = True
+except ImportError:  # pragma: no cover - triton is a standard SGLang CUDA dep
+    fp8_paged_mqa_logits_triton_dsa = None
+    _TRITON_LOGITS_AVAILABLE = False
+    logger.warning(
+        "DSA indexer: failed to import the Triton paged-MQA-logits fast path; "
+        "falling back to the pure-torch kernel (dsa_paged_mqa_logits_backend="
+        "'torch' still works, just slower under CUDA graph capture)."
+    )
+
+
+def fp8_paged_mqa_logits_torch_dsa(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata: Any,
+    max_seq_len: int,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    """CUDA-graph-compatible FP8 paged MQA logits, pure torch (no DeepGEMM/CuTe DSL).
+
+    `deep_gemm_metadata` is accepted for call-site signature compatibility
+    with the DeepGEMM/CuTe DSL backends but unused: this path does no SM-tiled
+    scheduling, so it has no notion of a schedule to consume. Callers may pass
+    `None`.
+
+    Dispatches to the fused Triton kernel (`SGLANG_DSA_INDEXER_TRITON`,
+    default on) right after the shape asserts below, so every layout
+    guarantee this function checks also holds for the Triton path.
+    """
+    _ = deep_gemm_metadata
+    batch_size, _, num_heads, head_dim = q_fp8.shape
+    block_size = kvcache_fp8.shape[1]
+    device = q_fp8.device
+
+    assert (
+        head_dim == 128
+    ), f"torch paged-MQA-logits fallback hardcodes DSA indexer head_dim=128, got {head_dim}"
+    assert block_size == 64, (
+        "torch paged-MQA-logits fallback hardcodes the DSA cache page layout "
+        f"(block_size=64), got {block_size}"
+    )
+    assert q_fp8.shape == (
+        batch_size,
+        1,
+        num_heads,
+        head_dim,
+    ), f"expected q_fp8 shape {(batch_size, 1, num_heads, head_dim)}, got {q_fp8.shape}"
+    assert kvcache_fp8.shape[1:] == (block_size, 1, head_dim + 4), (
+        f"expected kvcache_fp8 trailing shape {(block_size, 1, head_dim + 4)}, "
+        f"got {kvcache_fp8.shape[1:]}"
+    )
+    assert weight.shape == (
+        batch_size,
+        num_heads,
+    ), f"expected weight shape {(batch_size, num_heads)}, got {weight.shape}"
+    if seq_lens.dim() > 1:
+        seq_lens = seq_lens.squeeze(-1)
+    assert seq_lens.shape == (
+        batch_size,
+    ), f"expected seq_lens shape {(batch_size,)} after squeeze, got {seq_lens.shape}"
+    assert (
+        page_table.shape[0] == batch_size
+    ), f"expected page_table batch dim {batch_size}, got {page_table.shape[0]}"
+    assert (
+        clean_logits is False
+    ), "clean_logits=True is not supported; cleaning happens in topk_transform"
+
+    if (
+        _TRITON_LOGITS_AVAILABLE
+        and envs.SGLANG_DSA_INDEXER_TRITON.get()
+        and num_heads >= 16  # tl.dot's minimum inner dimension
+    ):
+        return fp8_paged_mqa_logits_triton_dsa(
+            q_fp8, kvcache_fp8, weight, seq_lens, page_table, None, max_seq_len
+        )
+
+    max_pages = (max_seq_len + block_size - 1) // block_size
+    max_padded_seq = max_pages * block_size
+
+    kvcache_flat = kvcache_fp8.view(-1, block_size * (head_dim + 4))
+    SCALE_OFFSET = block_size * head_dim
+
+    # page_table entries beyond a request's allocated page count are, in
+    # SGLang's current DSA req_to_token pool, always zero-initialized (never
+    # negative). This kernel nonetheless clamps defensively to a valid
+    # non-negative page id before gathering: the codebase's established
+    # convention for paged-gather kernels elsewhere (e.g. the sibling SM120
+    # FlashMLA decode kernel added by the same precedent PR) IS to represent
+    # "no page here" as -1 and clamp before use. A negative page id here would
+    # otherwise silently wrap around to a valid-looking but wrong row via
+    # Python/torch negative indexing rather than raising -- clamping makes
+    # that failure mode inert. Whatever garbage is gathered for a clamped
+    # (originally invalid) page is masked out below via `invalid_mask`, so
+    # the clamp never affects correctness of valid output positions.
+    page_ids = page_table[:, :max_pages].clamp(min=0)
+    kvcache_gathered = kvcache_flat[page_ids]
+
+    kv_value_raw = kvcache_gathered[..., :SCALE_OFFSET]
+    kv_scale_raw = kvcache_gathered[..., SCALE_OFFSET:]
+
+    kv_value = kv_value_raw.contiguous().view(dtype=FP8_DTYPE).to(torch.float32)
+    kv_value = kv_value.view(batch_size, max_padded_seq, head_dim)
+
+    kv_scale = kv_scale_raw.contiguous().view(dtype=torch.float32)
+    kv_scale = kv_scale.view(batch_size, max_padded_seq)
+
+    q = q_fp8[:, 0].to(torch.float32)
+
+    score = torch.bmm(kv_value, q.transpose(1, 2))
+
+    score = F.relu(score)
+    score = score * weight.unsqueeze(1)
+    score = score.sum(dim=2)
+
+    score = score * kv_scale
+
+    out_width = min(max_padded_seq, max_seq_len)
+    logits = score.new_full((batch_size, max_seq_len), float("-inf"))
+    logits[:, :out_width] = score[:, :out_width]
+
+    positions = torch.arange(max_seq_len, device=device)
+    invalid_mask = positions.unsqueeze(0) >= seq_lens.unsqueeze(1)
+    logits.masked_fill_(invalid_mask, float("-inf"))
+
+    return logits

--- a/python/sglang/srt/layers/attention/dsa/triton_paged_mqa_logits.py
+++ b/python/sglang/srt/layers/attention/dsa/triton_paged_mqa_logits.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Triton-fused paged-MQA-logits kernel: a fast path for the DSA indexer's
+`dsa_paged_mqa_logits_backend="torch"` fallback (see `torch_paged_mqa_logits.py`).
+
+Under CUDA graph capture, the page-table scan width used by the paged-MQA
+logits computation is fixed at the full page-table capacity (the CUDA-graph
+capture width), not the request's true (much shorter) sequence length --
+shapes must be static for a captured graph. `fp8_paged_mqa_logits_torch_dsa`
+pays that full width unconditionally on every step (gather + fp8-dequant +
+matmul over the whole capture width). This kernel keeps the same static
+launch grid (so it stays CUDA-graph-safe) but gives each program an early
+exit, read from `seq_lens` at REPLAY time, once its 64-token KV block lies
+entirely past the request's true sequence length -- so cost tracks the true
+context length instead of the capture width.
+
+Numerically bit-exact with `fp8_paged_mqa_logits_torch_dsa` for a given input
+(same fp8-load + inline-scale-dequant + q.k dot + relu + weighted head-sum;
+no fp32 HBM intermediates). Requires `num_heads >= 16` (`tl.dot`'s minimum
+inner dimension) -- the caller falls back to the torch kernel below that.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _dsa_indexer_logits_kernel(
+    q_ptr,  # fp8 [B, H, D], contiguous
+    kv_ptr,  # fp8 flat: per 64-token block, 64*D values then 64 fp32 scales
+    scale_ptr,  # same storage viewed as fp32, element-indexed
+    w_ptr,  # fp32 [B, H]
+    seq_ptr,  # int32 [B]
+    pt_ptr,  # int32 [B, W], page ids (page size 64)
+    out_ptr,  # fp32 [B, MAX_SEQ]
+    W: tl.constexpr,
+    MAX_SEQ: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    b = tl.program_id(0)
+    pblk = tl.program_id(1)
+    base = pblk * BLOCK
+    rows = base + tl.arange(0, BLOCK)
+    out_off = b * MAX_SEQ + rows
+    out_mask = rows < MAX_SEQ
+
+    seq = tl.load(seq_ptr + b)
+    if base >= seq:
+        # Entire block lies past this request's true sequence length: the
+        # static launch grid still schedules this program (grid width is
+        # capture-time constant), but there is nothing valid to score here.
+        # -inf matches the "invalid" fill the pure-torch path (and the
+        # downstream topk_transform's masking convention) expects.
+        tl.store(
+            out_ptr + out_off,
+            tl.full((BLOCK,), float("-inf"), tl.float32),
+            mask=out_mask,
+        )
+        return
+
+    page = tl.load(pt_ptr + b * W + pblk).to(tl.int64)
+    blk_base = page * (BLOCK * (D + 4))
+    offs = blk_base + tl.arange(0, BLOCK)[:, None] * D + tl.arange(0, D)[None, :]
+    kv = tl.load(kv_ptr + offs).to(tl.float32)  # [BLOCK, D]
+    s_base = page * (BLOCK * (D + 4) // 4) + (BLOCK * D // 4)
+    scale = tl.load(scale_ptr + s_base + tl.arange(0, BLOCK))  # [BLOCK]
+
+    q = tl.load(
+        q_ptr + b * H * D + tl.arange(0, H)[:, None] * D + tl.arange(0, D)[None, :]
+    ).to(
+        tl.float32
+    )  # [H, D]
+    w = tl.load(w_ptr + b * H + tl.arange(0, H))  # [H]
+
+    score = tl.dot(kv, tl.trans(q))  # [BLOCK, H]
+    score = tl.maximum(score, 0.0)
+    score = tl.sum(score * w[None, :], axis=1)  # [BLOCK]
+    score = score * scale
+
+    # Sub-block masking: a block can straddle the true seq_len boundary even
+    # though it passed the whole-block early-exit check above (base < seq but
+    # base + BLOCK > seq); rows past `seq` within this block must still be
+    # -inf.
+    valid = rows < seq
+    score = tl.where(valid, score, float("-inf"))
+    tl.store(out_ptr + out_off, score, mask=out_mask)
+
+
+def fp8_paged_mqa_logits_triton_dsa(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata: Any,
+    max_seq_len: int,
+    clean_logits: bool = False,
+) -> torch.Tensor:
+    """Same signature/semantics as `fp8_paged_mqa_logits_torch_dsa` (bit-exact).
+
+    Callers are expected to have already validated shapes (this is dispatched
+    from inside `fp8_paged_mqa_logits_torch_dsa`, after its asserts).
+    """
+    _ = deep_gemm_metadata
+    _ = clean_logits
+    batch_size, _one, num_heads, head_dim = q_fp8.shape
+    block_size = kvcache_fp8.shape[1]
+    assert head_dim == 128 and block_size == 64
+    assert num_heads >= 16, "Triton kernel requires num_heads >= 16 (tl.dot minimum)"
+    if seq_lens.dim() > 1:
+        seq_lens = seq_lens.squeeze(-1)
+    table_width = page_table.shape[1]
+    max_pages = (max_seq_len + block_size - 1) // block_size
+    grid_w = min(table_width, max_pages)
+
+    # page_table entries beyond a request's allocated page count are, in
+    # SGLang's current DSA req_to_token pool, always zero-initialized (never
+    # negative) -- but page ids are read directly (no clamp) inside the
+    # kernel above. This is safe here specifically because every program
+    # whose block lies past `seq_lens[b]` takes the early-exit branch BEFORE
+    # loading a page id at all (see the `base >= seq` check), so an
+    # out-of-range or otherwise garbage page id in a padding column is never
+    # dereferenced.
+    kv_flat = kvcache_fp8.reshape(-1)
+    scale_view = kvcache_fp8.view(torch.uint8).view(torch.float32).reshape(-1)
+    q = q_fp8.reshape(batch_size, num_heads, head_dim).contiguous()
+    out = torch.empty(batch_size, max_seq_len, dtype=torch.float32, device=q_fp8.device)
+    if grid_w * block_size < max_seq_len:
+        out.fill_(float("-inf"))
+
+    _dsa_indexer_logits_kernel[(batch_size, grid_w)](
+        q,
+        kv_flat,
+        scale_view,
+        weight.to(torch.float32).contiguous(),
+        seq_lens.to(torch.int32).contiguous(),
+        page_table.contiguous(),
+        out,
+        W=table_width,
+        MAX_SEQ=max_seq_len,
+        H=num_heads,
+        D=head_dim,
+        BLOCK=block_size,
+        num_warps=4,
+    )
+    return out

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -47,6 +47,9 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
 )
+from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
+    DSAPagedMQALogitsBackend,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -418,6 +421,13 @@ class DeepseekSparseAttnBackend(
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend(
             model_runner.server_args.dsa_topk_backend
         )
+        # Independent resolve mirroring dsa.dsa_indexer.Indexer.__init__'s own
+        # resolve() call: both must agree on the backend so the eager
+        # metadata precompute here and the indexer's kernel dispatch don't
+        # disagree about whether a DeepGEMM schedule is needed.
+        self.paged_mqa_logits_backend = DSAPagedMQALogitsBackend.resolve(
+            model_runner.server_args.dsa_paged_mqa_logits_backend
+        )
         if self.num_q_heads <= 64:
             self.flashmla_kv_num_q_heads = 64
         elif self.num_q_heads <= 128:
@@ -761,6 +771,14 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata,
         seqlens_32_2d: torch.Tensor,
     ) -> None:
+        # Torch backend: schedule metadata is unused (discarded by the torch
+        # kernel) and was never allocated (init_forward_metadata /
+        # _build_forward_metadata_cuda_graph both skip it too, see above) ->
+        # nothing to refresh. This single helper covers both cuda-graph-replay
+        # refresh call sites, so gating it here is sufficient without
+        # touching each call site separately.
+        if self.paged_mqa_logits_backend.is_torch():
+            return
         new_schedule = deep_gemm.get_paged_mqa_logits_metadata(
             seqlens_32_2d, 64, deep_gemm.get_num_sms()
         )
@@ -1110,12 +1128,18 @@ class DeepseekSparseAttnBackend(
                 seqlens_expanded,
                 forward_batch.batch_size,
             )
-            # NOTE: block_kv arg must be 64 here — DG computes SPLIT_KV =
-            # block_kv * 4 and both DG's and the indexer's compute kernels
-            # require SPLIT_KV = 256; this is independent of the cache page size.
-            paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
-                paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
-            )
+            # ctx_lens_2d is still needed unconditionally (consumed downstream
+            # as seqlens_32_2d regardless of logits backend); only the
+            # DeepGEMM schedule metadata call is skipped for the torch
+            # backend, which discards it anyway (accepted for call-site
+            # signature compatibility only, see torch_paged_mqa_logits.py).
+            if not self.paged_mqa_logits_backend.is_torch():
+                # NOTE: block_kv arg must be 64 here — DG computes SPLIT_KV =
+                # block_kv * 4 and both DG's and the indexer's compute kernels
+                # require SPLIT_KV = 256; this is independent of the cache page size.
+                paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
+                    paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
+                )
 
         metadata = DSAMetadata(
             page_size=self.real_page_size,
@@ -1456,9 +1480,10 @@ class DeepseekSparseAttnBackend(
             paged_mqa_ctx_lens_2d = self._build_paged_mqa_schedule_2d_ctx_lens(
                 forward_mode, cache_seqlens_int32, seqlens_expanded, bs
             )
-            paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
-                paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
-            )
+            if not self.paged_mqa_logits_backend.is_torch():
+                paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
+                    paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
+                )
 
         metadata = DSAMetadata(
             page_size=self.real_page_size,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -73,6 +73,9 @@ from sglang.srt.layers.attention.dsa.kpool_plan import (
     KPoolExtendPlan,
     KPoolWritePlan,
 )
+from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
+    DSAPagedMQALogitsBackend,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_interleave,
     compute_dsa_seqlens,
@@ -359,6 +362,13 @@ class DeepseekSparseAttnBackend(
         self.dsa_prefill_impl: _DSA_IMPL_T = get_exec().kernel.dsa_prefill_backend
         self.dsa_decode_impl: _DSA_IMPL_T = get_exec().kernel.dsa_decode_backend
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.resolve(model_runner)
+        # Independent resolve mirroring dsa.dsa_indexer.Indexer.__init__'s own
+        # resolve() call: both must agree on the backend so the eager
+        # metadata precompute here and the indexer's kernel dispatch don't
+        # disagree about whether a DeepGEMM schedule is needed.
+        self.paged_mqa_logits_backend = DSAPagedMQALogitsBackend.resolve(
+            get_exec().kernel.dsa_paged_mqa_logits_backend
+        )
         if self.num_q_heads <= 64:
             self.flashmla_kv_num_q_heads = 64
         elif self.num_q_heads <= 128:
@@ -736,6 +746,14 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata,
         seqlens_32_2d: torch.Tensor,
     ) -> None:
+        # Torch backend: schedule metadata is unused (discarded by the torch
+        # kernel) and was never allocated (init_forward_metadata /
+        # _build_forward_metadata_cuda_graph both skip it too, see above) ->
+        # nothing to refresh. This single helper covers both cuda-graph-replay
+        # refresh call sites, so gating it here is sufficient without
+        # touching each call site separately.
+        if self.paged_mqa_logits_backend.is_torch():
+            return
         new_schedule = deep_gemm.get_paged_mqa_logits_metadata(
             seqlens_32_2d, 64, deep_gemm.get_num_sms()
         )
@@ -1096,12 +1114,18 @@ class DeepseekSparseAttnBackend(
                 seqlens_expanded,
                 forward_batch.batch_size,
             )
-            # NOTE: block_kv arg must be 64 here — DG computes SPLIT_KV =
-            # block_kv * 4 and both DG's and the indexer's compute kernels
-            # require SPLIT_KV = 256; this is independent of the cache page size.
-            paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
-                paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
-            )
+            # ctx_lens_2d is still needed unconditionally (consumed downstream
+            # as seqlens_32_2d regardless of logits backend); only the
+            # DeepGEMM schedule metadata call is skipped for the torch
+            # backend, which discards it anyway (accepted for call-site
+            # signature compatibility only, see torch_paged_mqa_logits.py).
+            if not self.paged_mqa_logits_backend.is_torch():
+                # NOTE: block_kv arg must be 64 here — DG computes SPLIT_KV =
+                # block_kv * 4 and both DG's and the indexer's compute kernels
+                # require SPLIT_KV = 256; this is independent of the cache page size.
+                paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
+                    paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
+                )
 
         metadata = DSAMetadata(
             page_size=self.real_page_size,
@@ -1450,9 +1474,10 @@ class DeepseekSparseAttnBackend(
             paged_mqa_ctx_lens_2d = self._build_paged_mqa_schedule_2d_ctx_lens(
                 forward_mode, cache_seqlens_int32, seqlens_expanded, bs
             )
-            paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
-                paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
-            )
+            if not self.paged_mqa_logits_backend.is_torch():
+                paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
+                    paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
+                )
 
         metadata = DSAMetadata(
             page_size=self.real_page_size,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -337,7 +337,7 @@ NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
 DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
 
-DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
+DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter", "torch"]
 
 MAMBA_RADIX_CACHE_STRATEGY_CHOICES = [
     "auto",
@@ -1733,7 +1733,7 @@ class ServerArgs:
     dsa_paged_mqa_logits_backend: A[
         str,
         Arg(
-            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only).",
+            help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only), 'torch' (pure-torch fallback, any CUDA arch, e.g. SM120/SM121 where neither DeepGEMM nor CuteDSL run; slower, opt-in only).",
             choices=DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES,
         ),
         NS("exec.kernel"),

--- a/test/registered/kernels/test_dsa_paged_mqa_logits.py
+++ b/test/registered/kernels/test_dsa_paged_mqa_logits.py
@@ -1,0 +1,589 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `dsa_paged_mqa_logits_backend="torch"` (+ its Triton fast path).
+
+`fp8_paged_mqa_logits_torch_dsa` (`sglang.srt.layers.attention.dsa.
+torch_paged_mqa_logits`) is a pure-torch, CUDA-graph-safe fallback for the DSA
+indexer's paged-MQA-logits kernel, for CUDA archs that DeepGEMM/CuTe DSL don't
+cover. It optionally dispatches to a fused Triton kernel
+(`fp8_paged_mqa_logits_triton_dsa`, `dsa/triton_paged_mqa_logits.py`) that is
+bit-exact with it but far cheaper under CUDA graph capture (see that module's
+docstring). Modelled on the DSv4 SM120 precedent test,
+`test/registered/kernels/test_sm120_paged_mqa_logits.py` (added by PR #24692,
+"no SM120 hardware required" -- any CUDA GPU exercises this) -- same DSA cache
+layout constants, same style of numeric-equivalence and CUDA-graph tests.
+
+Coverage:
+- torch fn vs. an independent, deliberately un-vectorized ("loopy") Python
+  reference: no vectorized code is shared with either implementation under
+  test, so a bug shared between the torch and Triton kernels (both written
+  against the same design) would not also be present here.
+- Triton vs. torch fn: bit-exact-tolerance equivalence, including identical
+  -inf masks, across several (batch, seq_len, page-table-width) shapes.
+- Both KV-cache dtype views (raw uint8 / float8_e4m3fn): guards the historic
+  class of bug where a kernel treats raw uint8 bytes as integers instead of
+  reinterpreting them as FP8 (see the SM120 precedent's docstring).
+- Variable per-batch seq_lens, including a page_table with -1 ("no page here")
+  entries in a request's invalid trailing pages -- exercises the defensive
+  clamp in the torch fn and the Triton kernel's per-block early exit; neither
+  must dereference the sentinel or let it affect a valid position.
+- Per-token (flattened-batch) shapes matching the target-verify /
+  draft-extend-v2 calling convention: seqlens already expanded to one row per
+  token, page_table already repeat_interleaved to one row per token. A
+  regression test also asserts that repeating the page_table a SECOND time
+  (the double-expansion bug the live dgxarley bring-up hit at the MTP warmup)
+  is caught by the batch-size shape assert rather than silently miscomputing.
+- CUDA graph capture + replay, including a seq_lens change to the captured
+  static buffer between capture and replay, for both the torch-only and the
+  Triton dispatch path.
+- The `num_heads < 16` fallback guard (Triton's `tl.dot` minimum): verifies
+  the Triton kernel is not invoked below that threshold and the torch path
+  alone still produces the correct result.
+- Shape-assertion guards (wrong head_dim, unsupported clean_logits=True).
+
+Pure-PyTorch + Triton on any CUDA GPU -- no specific SM arch required.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.torch_paged_mqa_logits import (
+    FP8_DTYPE,
+    fp8_paged_mqa_logits_torch_dsa,
+)
+from sglang.srt.layers.attention.dsa.triton_paged_mqa_logits import (
+    fp8_paged_mqa_logits_triton_dsa,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=25, stage="base-b", runner_config="1-gpu-small")
+
+
+# DSA indexer paged-KV cache layout (fixed by the DSA token-to-KV pool):
+#   page_size = 64 tokens; head_dim = 128 FP8 values/token; 1 fp32 scale/token
+#   per-page memory: [page_size*head_dim FP8 bytes][page_size*4 scale bytes]
+#                   = [8192][256] = 8448 bytes
+# The (block_size, 1, head_dim+4) shape callers pass this tensor around in is
+# a fiction for shape-compatibility only: the real per-page layout is ALL
+# value bytes for the whole page, THEN all scale bytes -- NOT interleaved
+# per-token. `fp8_paged_mqa_logits_torch_dsa` and `..._triton_dsa` both
+# reinterpret it that way (flatten -> split at the value/scale boundary ->
+# reshape); the loopy reference below does the same independently.
+PAGE_SIZE = 64
+HEAD_DIM = 128
+SCALE_BYTES_PER_TOKEN = 4
+HEAD_DIM_WITH_SF = HEAD_DIM + SCALE_BYTES_PER_TOKEN  # 132
+PAGE_BYTES = PAGE_SIZE * HEAD_DIM + PAGE_SIZE * SCALE_BYTES_PER_TOKEN  # 8448
+
+
+def _build_kvcache(
+    num_pages: int,
+    *,
+    dtype_view: torch.dtype,
+    device: torch.device,
+    seed: int = 0,
+) -> torch.Tensor:
+    """Construct a paged KV cache matching the production layout.
+
+    Returns a tensor shaped (num_pages, PAGE_SIZE, 1, HEAD_DIM_WITH_SF) whose
+    underlying memory is the same regardless of `dtype_view`:
+      - [0 : PAGE_SIZE*HEAD_DIM)          : random FP8 bit patterns (values)
+      - [PAGE_SIZE*HEAD_DIM : PAGE_BYTES) : random positive fp32 scales (bytes)
+    """
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    raw = torch.empty(num_pages, PAGE_BYTES, dtype=torch.uint8, device=device)
+
+    # Bias away from bit patterns that map to NaN/Inf in float8_e4m3fn
+    # (sign|exp4|mantissa3; exp=0xF mantissa!=0 -> NaN). [0, 0x6F] keeps |x| < 256.
+    val_bytes = torch.randint(
+        0, 0x70, (num_pages, PAGE_SIZE * HEAD_DIM), generator=g, dtype=torch.uint8
+    ).to(device)
+    raw[:, : PAGE_SIZE * HEAD_DIM] = val_bytes
+
+    scales = (
+        torch.rand((num_pages, PAGE_SIZE), generator=g, dtype=torch.float32).to(device)
+        * 0.5
+        + 0.05
+    )
+    raw[:, PAGE_SIZE * HEAD_DIM :] = scales.contiguous().view(torch.uint8)
+
+    kv = raw.view(num_pages, PAGE_SIZE, 1, HEAD_DIM_WITH_SF)
+    return kv if dtype_view == torch.uint8 else kv.view(dtype=dtype_view)
+
+
+def _build_inputs(
+    batch_size: int,
+    seq_lens: list[int],
+    *,
+    kv_dtype_view: torch.dtype,
+    num_heads: int = 32,
+    device: torch.device = torch.device("cuda"),
+    seed: int = 0,
+    invalid_page_id: int | None = None,
+):
+    """Build (q_fp8, kvcache, weight, seq_lens, page_table, max_seq_len).
+
+    When `invalid_page_id` is given (e.g. -1), every page slot beyond a
+    request's own page count (but within the batch-wide `max_pages`) is set
+    to that id, instead of a real page -- exercising the sentinel-handling
+    path for batches with heterogeneous seq_lens.
+    """
+    assert len(seq_lens) == batch_size
+    max_seq_len = max(seq_lens)
+    max_pages = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+    num_pages_total = batch_size * max_pages + 1
+
+    kvcache = _build_kvcache(
+        num_pages_total, dtype_view=kv_dtype_view, device=device, seed=seed
+    )
+
+    g = torch.Generator(device="cpu").manual_seed(seed + 1)
+    q_bf16 = torch.randn(
+        (batch_size, 1, num_heads, HEAD_DIM), generator=g, dtype=torch.float32
+    ).to(device)
+    q_bf16 = q_bf16.clamp_(-2.0, 2.0)
+    q_fp8 = q_bf16.to(FP8_DTYPE)
+
+    weight = (
+        torch.rand((batch_size, num_heads), generator=g, dtype=torch.float32).to(device)
+        * 0.5
+    )
+
+    seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32, device=device)
+
+    page_table = torch.full(
+        (batch_size, max_pages),
+        invalid_page_id if invalid_page_id is not None else 0,
+        dtype=torch.int32,
+        device=device,
+    )
+    for i in range(batch_size):
+        own_pages = (seq_lens[i] + PAGE_SIZE - 1) // PAGE_SIZE
+        page_table[i, :own_pages] = torch.arange(
+            1 + i * max_pages,
+            1 + i * max_pages + own_pages,
+            dtype=torch.int32,
+            device=device,
+        )
+        if invalid_page_id is None:
+            # No sentinel requested: fill the remaining (unused) columns with
+            # real (if unused) page ids too, matching the original precedent
+            # test's behaviour of never emitting a sentinel.
+            remaining = max_pages - own_pages
+            if remaining > 0:
+                page_table[i, own_pages:] = torch.arange(
+                    1 + i * max_pages + own_pages,
+                    1 + i * max_pages + own_pages + remaining,
+                    dtype=torch.int32,
+                    device=device,
+                )
+
+    return q_fp8, kvcache, weight, seq_lens_t, page_table, max_seq_len
+
+
+def _loopy_reference(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    max_seq_len: int,
+) -> torch.Tensor:
+    """Independent, deliberately un-vectorized per-(request, position, head)
+    reference. Shares no computation path with the vectorized torch kernel
+    (batched gather + bmm) or the Triton kernel (one program per KV block) --
+    only the documented byte layout, which both must also honor.
+
+    Runs entirely on CPU in float64 for numerical clarity; only meant for
+    small test shapes.
+    """
+    batch_size, _, num_heads, head_dim = q_fp8.shape
+    block_size = kvcache_fp8.shape[1]
+    assert head_dim == HEAD_DIM and block_size == PAGE_SIZE
+
+    kv_cpu = kvcache_fp8.reshape(kvcache_fp8.shape[0], -1).cpu()
+    if kv_cpu.dtype == torch.uint8:
+        value_bytes = kv_cpu[:, : block_size * head_dim].view(FP8_DTYPE)
+    else:
+        value_bytes = kv_cpu[:, : block_size * head_dim]
+    scale_bytes = kv_cpu[:, block_size * head_dim :].contiguous().view(torch.float32)
+
+    values = value_bytes.to(torch.float64).reshape(
+        -1, block_size, head_dim
+    )  # (pages, 64, 128)
+    scales = scale_bytes.to(torch.float64).reshape(-1, block_size)  # (pages, 64)
+
+    q = q_fp8[:, 0].to(torch.float64).cpu()  # (B, H, D)
+    w = weight.to(torch.float64).cpu()  # (B, H)
+    sl = (seq_lens.squeeze(-1) if seq_lens.dim() > 1 else seq_lens).cpu()
+    pt = page_table.cpu()
+
+    out = torch.full((batch_size, max_seq_len), float("-inf"), dtype=torch.float64)
+    for b in range(batch_size):
+        seq_len_b = min(int(sl[b].item()), max_seq_len)
+        for pos in range(seq_len_b):
+            page_idx = pos // block_size
+            offset = pos % block_size
+            page_id = int(pt[b, page_idx].item())
+            kv_vec = values[page_id, offset]  # (D,)
+            scale = scales[page_id, offset].item()
+            acc = 0.0
+            for h in range(num_heads):
+                dot = torch.dot(kv_vec, q[b, h]).item()
+                dot = max(dot, 0.0)
+                acc += dot * w[b, h].item()
+            out[b, pos] = acc * scale
+    return out.to(q_fp8.device)
+
+
+def _compare(
+    ref: torch.Tensor,
+    out: torch.Tensor,
+    seq_lens: torch.Tensor,
+    *,
+    atol: float = 2e-2,
+    rtol: float = 2e-2,
+):
+    """Valid positions ([:seq_len)) must match; invalid positions must be -inf."""
+    batch_size, max_seq_len = ref.shape
+    seq_lens = seq_lens.squeeze(-1) if seq_lens.dim() > 1 else seq_lens
+    for i in range(batch_size):
+        sl = int(seq_lens[i].item())
+        torch.testing.assert_close(
+            ref[i, :sl].to(torch.float32),
+            out[i, :sl].to(torch.float32),
+            atol=atol,
+            rtol=rtol,
+            equal_nan=False,
+        )
+    positions = torch.arange(max_seq_len, device=out.device)
+    invalid = positions.unsqueeze(0) >= seq_lens.unsqueeze(1)
+    assert torch.all(
+        torch.isinf(out[invalid]) & (out[invalid] < 0)
+    ), "output must fill invalid positions with -inf"
+
+
+class TestDSAPagedMqaLogitsTorch(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA required")
+        cls.device = torch.device("cuda")
+
+    def _torch_only(self, *args, **kwargs):
+        with envs.SGLANG_DSA_INDEXER_TRITON.override(False):
+            return fp8_paged_mqa_logits_torch_dsa(*args, **kwargs)
+
+    def _triton_dispatch(self, *args, **kwargs):
+        with envs.SGLANG_DSA_INDEXER_TRITON.override(True):
+            return fp8_paged_mqa_logits_torch_dsa(*args, **kwargs)
+
+    # -- torch fn vs. independent loopy reference --------------------------
+
+    def test_torch_vs_loopy_bs1(self):
+        q, kv, w, sl, pt, msl = _build_inputs(
+            1, [96], kv_dtype_view=FP8_DTYPE, num_heads=8, device=self.device
+        )
+        ref = _loopy_reference(q, kv, w, sl, pt, msl)
+        out = self._torch_only(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        _compare(ref, out, sl)
+
+    def test_torch_vs_loopy_bs4_variable(self):
+        q, kv, w, sl, pt, msl = _build_inputs(
+            4,
+            [40, 96, 130, 192],
+            kv_dtype_view=FP8_DTYPE,
+            num_heads=8,
+            device=self.device,
+        )
+        ref = _loopy_reference(q, kv, w, sl, pt, msl)
+        out = self._torch_only(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        _compare(ref, out, sl)
+
+    def test_torch_vs_loopy_partial_last_page(self):
+        # 65 = 1 full page + 1 token -- exercises the partial trailing page.
+        q, kv, w, sl, pt, msl = _build_inputs(
+            2, [65, 129], kv_dtype_view=FP8_DTYPE, num_heads=8, device=self.device
+        )
+        ref = _loopy_reference(q, kv, w, sl, pt, msl)
+        out = self._torch_only(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        _compare(ref, out, sl)
+
+    def test_uint8_view_matches_fp8_view(self):
+        """Regression guard: identical raw bytes, different dtype VIEW of the
+        KV cache, must produce identical logits (historic garbled-output bug
+        class: treating raw uint8 bytes as integers instead of FP8)."""
+        q, kv_fp8, w, sl, pt, msl = _build_inputs(
+            2,
+            [40, 96],
+            kv_dtype_view=FP8_DTYPE,
+            num_heads=8,
+            device=self.device,
+            seed=7,
+        )
+        _, kv_u8, _, _, _, _ = _build_inputs(
+            2,
+            [40, 96],
+            kv_dtype_view=torch.uint8,
+            num_heads=8,
+            device=self.device,
+            seed=7,
+        )
+        out_fp8 = self._torch_only(q, kv_fp8, w, sl, pt, None, msl, clean_logits=False)
+        out_u8 = self._torch_only(q, kv_u8, w, sl, pt, None, msl, clean_logits=False)
+        torch.testing.assert_close(out_fp8, out_u8, atol=0, rtol=0, equal_nan=True)
+
+    # -- -1 sentinel: heterogeneous seq_lens with invalid trailing pages ---
+
+    def test_negative_sentinel_page_table_masked_and_no_crash(self):
+        """A page_table with -1 ("no page here") entries in a shorter
+        request's unused trailing columns must not crash the gather (the
+        torch fn clamps defensively) and those columns' output must still be
+        -inf regardless of what garbage got gathered at the clamped id."""
+        q, kv, w, sl, pt, msl = _build_inputs(
+            2,
+            [64, 192],
+            kv_dtype_view=FP8_DTYPE,
+            num_heads=8,
+            device=self.device,
+            invalid_page_id=-1,
+        )
+        # Request 0 (seq_len=64, 1 page) has 2 unused page slots (max_pages=3)
+        # filled with -1 by invalid_page_id; confirm the fixture did that.
+        assert int(pt[0, 1].item()) == -1 and int(pt[0, 2].item()) == -1
+        out = self._torch_only(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        ref = _loopy_reference(q, kv, w, sl, pt.clamp(min=0), msl)
+        _compare(ref, out, sl)
+
+    def test_negative_sentinel_triton_no_crash(self):
+        """Same fixture through the Triton path: the -1 page id is only ever
+        stored (not the version tested here -- see kernel docstring) when the
+        WHOLE block is past seq_len, so the early exit means it is never
+        dereferenced at all."""
+        q, kv, w, sl, pt, msl = _build_inputs(
+            2,
+            [64, 192],
+            kv_dtype_view=FP8_DTYPE,
+            num_heads=16,
+            device=self.device,
+            invalid_page_id=-1,
+        )
+        out_triton = fp8_paged_mqa_logits_triton_dsa(q, kv, w, sl, pt, None, msl)
+        out_torch = self._torch_only(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        _compare(out_torch, out_triton, sl, atol=1e-3, rtol=1e-3)
+
+    # -- Triton vs. torch: bit-exact-tolerance equivalence ------------------
+
+    def _assert_triton_matches_torch(self, batch_size, seq_lens, num_heads=32, seed=0):
+        q, kv, w, sl, pt, msl = _build_inputs(
+            batch_size,
+            seq_lens,
+            kv_dtype_view=FP8_DTYPE,
+            num_heads=num_heads,
+            device=self.device,
+            seed=seed,
+        )
+        out_torch = self._torch_only(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        out_triton = self._triton_dispatch(
+            q, kv, w, sl, pt, None, msl, clean_logits=False
+        )
+        # -inf masks must match exactly (this is a comparison, not floating
+        # math, so there is no tolerance to allow here).
+        torch.testing.assert_close(
+            torch.isinf(out_torch) & (out_torch < 0),
+            torch.isinf(out_triton) & (out_triton < 0),
+            atol=0,
+            rtol=0,
+        )
+        finite = ~(torch.isinf(out_torch) & (out_torch < 0))
+        torch.testing.assert_close(
+            out_torch[finite], out_triton[finite], atol=1e-3, rtol=1e-3, equal_nan=False
+        )
+
+    def test_triton_bitexact_vs_torch_bs1_short(self):
+        self._assert_triton_matches_torch(1, [300], num_heads=32)
+
+    def test_triton_bitexact_vs_torch_bs4_variable(self):
+        self._assert_triton_matches_torch(4, [128, 512, 900, 2048], num_heads=32)
+
+    def test_triton_bitexact_vs_torch_bs32_uniform(self):
+        self._assert_triton_matches_torch(32, [300] * 32, num_heads=32)
+
+    def test_triton_bitexact_vs_torch_dsv32_headcount(self):
+        # DSv3.2-family head count (64) -- distinct code path in
+        # _dsa_indexer_logits_kernel's per-head accumulation width.
+        self._assert_triton_matches_torch(2, [300, 900], num_heads=64)
+
+    # -- Per-token (flattened) shapes: target-verify / draft-extend-v2 -----
+
+    def test_per_token_expanded_shapes_next_n(self):
+        """Mirrors the dsa_indexer.py torch-backend dispatch calling
+        convention for target_verify/draft_extend_v2 (next_n >= 2): q/weights
+        already sliced to q_offset tokens, seqlens already expanded to one
+        row PER TOKEN, page_table already repeat_interleaved to one row per
+        token by dsa_backend.py's init_forward_metadata (`page_table =
+        torch.repeat_interleave(page_table, repeats=next_n, dim=0)` before
+        the metadata is built). The kernel itself must need no next_n
+        awareness -- batch dim = flattened tokens."""
+        num_requests = 3
+        next_n = 4
+        # >= 16 so the direct Triton call below is legal (tl.dot minimum);
+        # realistic values are 32 (GLM DSA) / 64 (DeepSeek-V3.2). The < 16
+        # fallback path has its own dedicated test.
+        num_heads = 32
+        ctx_lens = [64, 130, 300]  # per-request context length before verify
+        device = self.device
+
+        q_req, kv, w_req, _, pt_req, _ = _build_inputs(
+            num_requests,
+            [c + next_n for c in ctx_lens],
+            kv_dtype_view=FP8_DTYPE,
+            num_heads=num_heads,
+            device=device,
+        )
+        # Expand to per-token rows (B*next_n), exactly like
+        # seqlens_expand_triton + repeat_interleave(page_table, next_n).
+        q_tok = q_req.repeat_interleave(next_n, dim=0)  # (B*next_n, 1, H, D)
+        w_tok = w_req.repeat_interleave(next_n, dim=0)  # (B*next_n, H)
+        pt_tok = pt_req.repeat_interleave(next_n, dim=0)  # (B*next_n, max_pages)
+        # kv_len = c + next_n (full post-verify context); qo_len = next_n;
+        # dsa_backend.py builds this as arange(kv_len - qo_len + 1, kv_len + 1)
+        # = arange(c + 1, c + next_n + 1) -- context grows by one per draft
+        # position within a request's verify window.
+        seqlens_tok = torch.cat(
+            [
+                torch.arange(c + 1, c + next_n + 1, dtype=torch.int32, device=device)
+                for c in ctx_lens
+            ]
+        )
+        max_seq_len = max(c + next_n for c in ctx_lens)
+
+        out = self._torch_only(
+            q_tok, kv, w_tok, seqlens_tok, pt_tok, None, max_seq_len, clean_logits=False
+        )
+        ref = _loopy_reference(q_tok, kv, w_tok, seqlens_tok, pt_tok, max_seq_len)
+        _compare(ref, out, seqlens_tok)
+
+        out_triton = fp8_paged_mqa_logits_triton_dsa(
+            q_tok, kv, w_tok, seqlens_tok, pt_tok, None, max_seq_len
+        )
+        _compare(ref, out_triton, seqlens_tok)
+
+    def test_double_expansion_is_caught_by_shape_assert(self):
+        """Regression test for the double-expansion bug hit live at the MTP
+        warmup: repeating an already per-token page_table a second time must
+        NOT silently miscompute -- it must trip the batch-size shape assert,
+        because q_fp8's row count (still B*next_n) no longer matches the
+        (B*next_n*next_n)-row page_table."""
+        next_n = 4
+        q, kv, w, sl, pt, msl = _build_inputs(
+            2, [64, 130], kv_dtype_view=FP8_DTYPE, num_heads=8, device=self.device
+        )
+        q_tok = q.repeat_interleave(next_n, dim=0)
+        w_tok = w.repeat_interleave(next_n, dim=0)
+        sl_tok = sl.repeat_interleave(next_n, dim=0)
+        pt_correct = pt.repeat_interleave(next_n, dim=0)  # correct: matches q_tok rows
+        pt_double = pt_correct.repeat_interleave(next_n, dim=0)  # bug: double-expanded
+
+        # Sanity: the correctly-expanded call must NOT raise.
+        self._torch_only(
+            q_tok, kv, w_tok, sl_tok, pt_correct, None, msl, clean_logits=False
+        )
+
+        with self.assertRaises(AssertionError):
+            self._torch_only(
+                q_tok, kv, w_tok, sl_tok, pt_double, None, msl, clean_logits=False
+            )
+
+    # -- num_heads < 16: Triton fallback guard ------------------------------
+
+    def test_num_heads_below_16_skips_triton(self):
+        q, kv, w, sl, pt, msl = _build_inputs(
+            2, [64, 128], kv_dtype_view=FP8_DTYPE, num_heads=8, device=self.device
+        )
+        with mock.patch(
+            "sglang.srt.layers.attention.dsa.torch_paged_mqa_logits."
+            "fp8_paged_mqa_logits_triton_dsa",
+            side_effect=AssertionError("triton must not be called for num_heads < 16"),
+        ):
+            out = self._triton_dispatch(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        ref = _loopy_reference(q, kv, w, sl, pt, msl)
+        _compare(ref, out, sl)
+
+    def test_num_heads_above_16_uses_triton(self):
+        q, kv, w, sl, pt, msl = _build_inputs(
+            2, [64, 128], kv_dtype_view=FP8_DTYPE, num_heads=16, device=self.device
+        )
+        with mock.patch(
+            "sglang.srt.layers.attention.dsa.torch_paged_mqa_logits."
+            "fp8_paged_mqa_logits_triton_dsa",
+            wraps=fp8_paged_mqa_logits_triton_dsa,
+        ) as spy:
+            self._triton_dispatch(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        spy.assert_called_once()
+
+    # -- CUDA graph capture + replay ----------------------------------------
+
+    def _run_cuda_graph_case(self, use_triton: bool):
+        batch_size = 2
+        seq_lens = [128, 192]
+        q, kv, w, sl, pt, msl = _build_inputs(
+            batch_size,
+            seq_lens,
+            kv_dtype_view=FP8_DTYPE,
+            num_heads=16,
+            device=self.device,
+        )
+        call = self._triton_dispatch if use_triton else self._torch_only
+
+        for _ in range(2):
+            _ = call(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        torch.cuda.synchronize()
+
+        static_holder = {}
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            out = call(q, kv, w, sl, pt, None, msl, clean_logits=False)
+            static_holder["out"] = out
+
+        ref = call(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(static_holder["out"], ref, atol=1e-5, rtol=1e-5)
+
+        # Replay with a DIFFERENT seq_lens, in-place edit of the captured buffer.
+        sl_new = torch.tensor([64, 256], dtype=torch.int32, device=self.device)
+        sl.copy_(sl_new)
+        graph.replay()
+        torch.cuda.synchronize()
+        ref_new = call(q, kv, w, sl, pt, None, msl, clean_logits=False)
+        torch.testing.assert_close(static_holder["out"], ref_new, atol=1e-5, rtol=1e-5)
+
+    def test_cuda_graph_capture_and_replay_torch(self):
+        self._run_cuda_graph_case(use_triton=False)
+
+    def test_cuda_graph_capture_and_replay_triton(self):
+        self._run_cuda_graph_case(use_triton=True)
+
+    # -- Shape-assertion guards -----------------------------------------
+
+    def test_shape_assertions(self):
+        q, kv, w, sl, pt, msl = _build_inputs(
+            1, [64], kv_dtype_view=FP8_DTYPE, num_heads=8, device=self.device
+        )
+        bad_q = q[..., :64]  # head_dim != 128
+        with self.assertRaises(AssertionError):
+            self._torch_only(bad_q, kv, w, sl, pt, None, msl, clean_logits=False)
+        with self.assertRaises(AssertionError):
+            self._torch_only(q, kv, w, sl, pt, None, msl, clean_logits=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(unittest.main())


### PR DESCRIPTION
### Problem

The DSA indexer's paged-MQA-logits kernel has no backend that runs outside the current three:

- **DEEPGEMM** (the `auto` default): compiled C++ `Unsupported architecture` assert on SM120/SM121; DeepGEMM upstream declined SM12x support (deepgemm PR #318).
- **CUTEDSL**: gated behind `is_sm100_supported()`, and structurally SM100-only — `_setup_mma` uses `tcgen05.MmaF8F6F4Op`, a datacenter-Blackwell ISA op that does not exist on consumer Blackwell.
- **AITER**: ROCm.

So every DSA model (DeepSeek-V3.2 family, GLM `GlmMoeDsaForCausalLM`) crashes on its first decode step on SM120/SM121 (DGX Spark GB10, RTX PRO Blackwell). The dsv4 path already solved this exact problem for DeepSeek-V4 (`fp8_paged_mqa_logits_torch_sm120`, #24692), but the generic `dsa/dsa_indexer.py` path has no equivalent.

### Changes

1. **New backend value `torch`** in `DSAPagedMQALogitsBackend` + `--dsa-paged-mqa-logits-backend torch`. Opt-in only, NOT selected by `auto` — archs where DeepGEMM/CuteDSL work are unaffected.
2. **New module `dsa/torch_paged_mqa_logits.py`**: a vectorized, cuda-graph-safe (no `.item()`, no data-dependent control flow) pure-torch implementation for the generic DSA path. It discards the DeepGEMM schedule metadata (the torch path does no SM-tiled scheduling), so the eager `get_paged_mqa_logits_metadata()` call sites in `dsa_backend.py::init_forward_metadata` and the graph-replay refresh helper are skipped for this backend.
3. **Dispatch in `dsa_indexer.py::_get_topk_paged`**: pure pass-through for all modes this function serves (decode / target_verify / draft_extend_v2). No reshaping is needed: q/weights are already sliced per token, verify seqlens come from `get_seqlens_expanded()` (per-token), and `init_forward_metadata` already `repeat_interleave`s the page table to per-token rows for the multi-token modes.
4. **Fused Triton fast path `dsa/triton_paged_mqa_logits.py`** (env `SGLANG_DSA_INDEXER_TRITON`, registered in `environ.py`, default on; falls back to torch when triton is unavailable or `num_heads < 16`): one program per (token, 64-token KV page), static launch grid over the full page-table width (cuda-graph-safe) with per-block early exit on the true `seq_lens[b]` read at replay time; fused fp8 load + inline-scale dequant + q·k dot + relu + weighted head-sum, no fp32 HBM intermediates. Motivation: under cuda-graph the page-table width is a capture-time constant and the pure-torch kernel pays the full width every step — measured 1.476 ms/layer-call at width 131072 regardless of the true seq len; the Triton kernel is numerically equivalent and 0.024 ms at the same shape (61x).

### Evidence

Live-validated on a 4× DGX Spark (GB10, SM121) cluster serving `GlmMoeDsaForCausalLM` (504B REAP cut, NVFP4, TP4): decode/prefill/target-verify/draft-extend all healthy, MTP/NEXTN accept length ~2.1, GSM8K 2-shot n=20 conc 8 = 85% with 0 errors/restarts.

### Tests

`test/registered/kernels/test_dsa_paged_mqa_logits.py` (modeled on `test_sm120_paged_mqa_logits.py` from #24692; `register_cuda_ci`, runs on any CUDA GPU — no SM12x hardware required): torch vs loopy reference, Triton vs torch equivalence incl. identical `-inf` masks, both KV dtype views (uint8 / float8_e4m3fn), variable per-batch seq_lens, per-token expanded verify shapes (next_n >= 2) incl. a regression test that double-expanding the page table is caught by the shape assert, cuda-graph capture + replay incl. a seq-len change between capture and replay, and the `num_heads < 16` fallback guard. **17/17 pass on GB10 (SM121).**

### Notes

- Companion PR (the attention side for SM12x): the sparse-MLA routing PR — neither alone boots DSA on consumer Blackwell; they are independent to review/merge.
- The kernel hardcodes the DSA index-cache layout (head_dim 128, 64-token pages, per-page `[64*128 fp8][64*4 fp32 scales]`) and asserts it with descriptive messages.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34480941035](https://github.com/sgl-project/sglang/actions/runs/34480941035)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34480940779](https://github.com/sgl-project/sglang/actions/runs/34480940779)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34480941022](https://github.com/sgl-project/sglang/actions/runs/34480941022)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->