### PR TITLE
[DSA] Enable sparse MLA decode+prefill on SM120/SM121 (consumer Blackwell) via flashinfer's packed sparse backend

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -76,6 +76,7 @@ from sglang.srt.utils import (
     is_gfx95_supported,
     is_hip,
     is_sm100_supported,
+    is_sm120_supported,
     print_warning_once,
 )
 
@@ -85,6 +86,10 @@ from sglang.srt.utils import (
 # concat). Enable with SGLANG_DSA_TRITON_PREFILL=1. Decode stays on TileLang.
 _DSA_TRITON_PREFILL = get_bool_env_var("SGLANG_DSA_TRITON_PREFILL")
 _IS_GFX95 = is_gfx95_supported()
+# SM120/SM121 (consumer Blackwell: DGX Spark GB10, RTX PRO/50-series) has no
+# trtllm-gen kernel; the "trtllm" dsa backend is routed to flashinfer's native
+# sparse-MLA kernel instead (see _forward_trtllm below).
+_IS_SM120 = is_sm120_supported()
 
 if is_cuda():
     import deep_gemm
@@ -3206,8 +3211,33 @@ class DeepseekSparseAttnBackend(
 
         metadata = self.forward_metadata
 
+        # Native SM120/SM121 sparse-MLA route: flashinfer's dispatcher picks
+        # its packed-KV "sparse" kernel (decode: warp-specialized kernels for
+        # <=64 tokens; more tokens: its prefill orchestrator) whenever
+        # backend="auto" is passed on cc==12 with sparse_mla_top_k>0.
+        # `dsa_kv_cache_store_fp8` is the precise gate: it is True exactly
+        # when the kv pool holds the 656-byte packed inline-scale layout that
+        # kernel consumes (see calculate_mla_kv_cache_dim's SM12x carve-out).
+        # A bf16 kv cache or a non-trtllm dsa backend keeps this False and
+        # the call below is byte-identical to upstream.
+        _sparse_sm120 = _IS_SM120 and self.dsa_kv_cache_store_fp8
+        if _sparse_sm120 and dsa_use_prefill_cp(forward_batch):
+            # DSA prefill context-parallelism (round-robin/in-seq split,
+            # cp_split_and_rebuild_position, the all-gather below) has only
+            # been exercised against the trtllm-gen fp8-quantize-fused-rope
+            # path, which _sparse_sm120 skips entirely (see the BF16 query
+            # note below). Rather than silently mis-route CP requests through
+            # an untested combination, fail loudly until CP support for the
+            # SM120 sparse kernel is implemented and validated.
+            raise NotImplementedError(
+                "DSA prefill context parallelism (enable_dsa_prefill_context_parallel) "
+                "is not supported together with the SM120/SM121 native sparse-MLA "
+                "route (dsa_prefill_backend/dsa_decode_backend='trtllm' on cc==12 "
+                "with an fp8 KV cache). Disable CP or use a non-trtllm dsa backend."
+            )
+
         merge_query = q_rope is not None
-        if self.kv_cache_dtype == torch.float8_e4m3fn:
+        if self.kv_cache_dtype == torch.float8_e4m3fn and not _sparse_sm120:
             # For FP8 path, we quantize the query and rope parts and merge them into a single tensor
             # Note: rope application in deepseek_v2.py:forward_absorb_prepare is skipped for FP8 decode path of this trtllm_mla backend
             assert q_rope is not None, "For FP8 path q_rope should not be None."
@@ -3333,7 +3363,10 @@ class DeepseekSparseAttnBackend(
 
         out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
             query=q,
-            kv_cache=kv,
+            # The SM120 sparse kernel's checker requires a torch.uint8 KV
+            # buffer; the pool's storage dtype is an fp8 view of the same
+            # packed bytes, so this is a reinterpret, not a copy.
+            kv_cache=kv.view(torch.uint8) if _sparse_sm120 else kv,
             workspace_buffer=self.workspace_buffer,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
@@ -3343,9 +3376,29 @@ class DeepseekSparseAttnBackend(
             max_seq_len=metadata.max_seq_len_k,
             sparse_mla_top_k=self.dsa_index_topk,
             bmm1_scale=bmm1_scale,
-            backend="trtllm-gen",
-            skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
-            multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
+            # backend="auto" lets flashinfer's dispatcher route cc==12 +
+            # sparse_mla_top_k>0 to its native SM120/121 sparse-MLA kernel
+            # instead of "trtllm-gen" (datacenter Blackwell only, absent on
+            # cc==12: "TllmGenFmhaRunner ... Unsupported architecture").
+            backend="auto" if _sparse_sm120 else "trtllm-gen",
+            # sglang's quantize_k_cache writes amax/448 ARBITRARY fp32 tile
+            # scales into the packed layout (not power-of-two / ue8m0
+            # scales). "arbitrary_fp32" is exactly flashinfer's GLM_NSA scale
+            # semantics for this layout; the default "auto" would assume
+            # pow2/ue8m0 scales (DSv3.2 semantics) and misread them.
+            kv_scale_format="arbitrary_fp32" if _sparse_sm120 else "auto",
+            # The sparse backend does not support the skip-softmax threshold
+            # optimization; passing a non-None value raises.
+            skip_softmax_threshold_scale_factor=(
+                None
+                if _sparse_sm120
+                else envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get()
+            ),
+            # The counter buffer is trtllm-gen-only; the sparse backend
+            # raises on a non-None value.
+            multi_ctas_kv_counter_buffer=(
+                None if _sparse_sm120 else self._multi_ctas_kv_counter_buffer
+            ),
         )
 
         return out

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -98,6 +98,12 @@ from sglang.srt.utils import (
 )
 
 _IS_GFX95 = is_gfx95_supported()
+# SM120/SM121 (consumer Blackwell: DGX Spark GB10, RTX PRO/50-series) has no
+# trtllm-gen kernel; the "trtllm" dsa backend is routed to flashinfer's native
+# sparse-MLA kernel instead (see _forward_trtllm below). Checked live via
+# get_platform().is_sm120 (not cached at module import time) to match the
+# platform-facts convention the rest of this file now uses for is_sm100, and
+# to keep the check honoring a test-time override_platform() scope.
 
 if is_cuda():
     import deep_gemm
@@ -3434,9 +3440,34 @@ class DeepseekSparseAttnBackend(
 
         metadata = self.forward_metadata
 
+        # Native SM120/SM121 sparse-MLA route: flashinfer's dispatcher picks
+        # its packed-KV "sparse" kernel (decode: warp-specialized kernels for
+        # <=64 tokens; more tokens: its prefill orchestrator) whenever
+        # backend="auto" is passed on cc==12 with sparse_mla_top_k>0.
+        # `dsa_kv_cache_store_fp8` is the precise gate: it is True exactly
+        # when the kv pool holds the 656-byte packed inline-scale layout that
+        # kernel consumes (see calculate_mla_kv_cache_dim's SM12x carve-out).
+        # A bf16 kv cache or a non-trtllm dsa backend keeps this False and
+        # the call below is byte-identical to upstream.
+        _sparse_sm120 = get_platform().is_sm120 and self.dsa_kv_cache_store_fp8
+        if _sparse_sm120 and dsa_use_prefill_cp(forward_batch):
+            # DSA prefill context-parallelism (round-robin/in-seq split,
+            # cp_split_and_rebuild_position, the all-gather below) has only
+            # been exercised against the trtllm-gen fp8-quantize-fused-rope
+            # path, which _sparse_sm120 skips entirely (see the BF16 query
+            # note below). Rather than silently mis-route CP requests through
+            # an untested combination, fail loudly until CP support for the
+            # SM120 sparse kernel is implemented and validated.
+            raise NotImplementedError(
+                "DSA prefill context parallelism (enable_dsa_prefill_context_parallel) "
+                "is not supported together with the SM120/SM121 native sparse-MLA "
+                "route (dsa_prefill_backend/dsa_decode_backend='trtllm' on cc==12 "
+                "with an fp8 KV cache). Disable CP or use a non-trtllm dsa backend."
+            )
+
         # The BF16 no-RoPE path passes a zero-width q_rope tensor.
         merge_query = q_rope is not None and self.qk_rope_head_dim > 0
-        if self.kv_cache_dtype == torch.float8_e4m3fn:
+        if self.kv_cache_dtype == torch.float8_e4m3fn and not _sparse_sm120:
             # For FP8 path, we quantize the query and rope parts and merge them into a single tensor
             # Note: rope application in deepseek_v2.py:forward_absorb_prepare is skipped for FP8 decode path of this trtllm_mla backend
             assert q_rope is not None, "For FP8 path q_rope should not be None."
@@ -3557,7 +3588,10 @@ class DeepseekSparseAttnBackend(
 
         out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
             query=q,
-            kv_cache=kv,
+            # The SM120 sparse kernel's checker requires a torch.uint8 KV
+            # buffer; the pool's storage dtype is an fp8 view of the same
+            # packed bytes, so this is a reinterpret, not a copy.
+            kv_cache=kv.view(torch.uint8) if _sparse_sm120 else kv,
             workspace_buffer=self.workspace_buffer,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
@@ -3567,10 +3601,32 @@ class DeepseekSparseAttnBackend(
             max_seq_len=metadata.max_seq_len_k,
             sparse_mla_top_k=sparse_mla_top_k,
             bmm1_scale=bmm1_scale,
-            backend="trtllm-gen",
-            skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+            # backend="auto" lets flashinfer's dispatcher route cc==12 +
+            # sparse_mla_top_k>0 to its native SM120/121 sparse-MLA kernel
+            # instead of "trtllm-gen" (datacenter Blackwell only, absent on
+            # cc==12: "TllmGenFmhaRunner ... Unsupported architecture").
+            backend="auto" if _sparse_sm120 else "trtllm-gen",
+            # sglang's quantize_k_cache writes amax/448 ARBITRARY fp32 tile
+            # scales into the packed layout (not power-of-two / ue8m0
+            # scales). "arbitrary_fp32" is exactly flashinfer's GLM_NSA scale
+            # semantics for this layout; the default "auto" would assume
+            # pow2/ue8m0 scales (DSv3.2 semantics) and misread them.
+            kv_scale_format="arbitrary_fp32" if _sparse_sm120 else "auto",
+            # The sparse backend does not support the skip-softmax threshold
+            # optimization; passing a non-None value raises.
+            skip_softmax_threshold_scale_factor=(
+                None
+                if _sparse_sm120
+                else envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get()
+            ),
+            # NoPE-only metadata (None otherwise, see above); orthogonal to
+            # the trtllm-gen/sparse backend choice, passed through unchanged.
             sparse_mla_top_k_lens=sparse_mla_top_k_lens,
-            multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
+            # The counter buffer is trtllm-gen-only; the sparse backend
+            # raises on a non-None value.
+            multi_ctas_kv_counter_buffer=(
+                None if _sparse_sm120 else self._multi_ctas_kv_counter_buffer
+            ),
         )
 
         return out

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -75,11 +75,13 @@ from sglang.srt.utils.common import (
     is_float4_e2m1fn_x2,
     is_hip,
     is_npu,
+    is_sm120_supported,
 )
 
 logger = logging.getLogger(__name__)
 
 _is_hip = is_hip()
+_is_sm120 = is_sm120_supported()
 
 
 def _get_dsv4_compress_state_dtypes() -> tuple[torch.dtype, torch.dtype]:
@@ -1913,7 +1915,19 @@ def calculate_mla_kv_cache_dim(
         server_args.dsa_prefill_backend == "trtllm"
         or server_args.dsa_decode_backend == "trtllm"
     ):
-        return kv_cache_dim
+        # On SM120/SM121 (consumer Blackwell) the "trtllm" dsa backend does
+        # NOT dispatch to the datacenter trtllm-gen kernel; DeepseekSparseAttn
+        # Backend._forward_trtllm instead routes it to flashinfer's native
+        # sparse-MLA kernel (backend="auto"), which consumes the 656-byte
+        # packed inline-scale layout (512 fp8 nope + 4x fp32 tile scales + 64
+        # bf16 rope) computed below -- the same layout quantize_k_cache
+        # already writes for the non-trtllm dsa backends. So do not early-
+        # return the plain layout on SM12x. Datacenter Blackwell (SM100/103)
+        # keeps the early return: trtllm-gen dequants via a scalar bmm1
+        # k_scale and expects the plain kv_lora_rank + qk_rope_head_dim
+        # layout.
+        if not _is_sm120:
+            return kv_cache_dim
 
     # On HIP, TileLang and AITER DSA kernels consume the raw MLA KV layout:
     # nope(512 fp8) + rope(64 fp8), without extra per-block scales.

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -83,6 +83,7 @@ from sglang.srt.runtime_context import (
     get_memory,
     get_mm,
     get_parallel,
+    get_platform,
     get_schedule,
     get_spec,
     max_speculative_num_draft_tokens,
@@ -2578,7 +2579,22 @@ def calculate_mla_kv_cache_dim(
         )
 
     if uses_trtllm_kv_layout:
-        return kv_cache_dim
+        # On SM120/SM121 (consumer Blackwell) the "trtllm" dsa backend does
+        # NOT dispatch to the datacenter trtllm-gen kernel; DeepseekSparseAttn
+        # Backend._forward_trtllm instead routes it to flashinfer's native
+        # sparse-MLA kernel (backend="auto"), which consumes the 656-byte
+        # packed inline-scale layout (512 fp8 nope + 4x fp32 tile scales + 64
+        # bf16 rope) computed below -- the same layout quantize_k_cache
+        # already writes for the non-trtllm dsa backends. So do not early-
+        # return the plain layout on SM12x. Datacenter Blackwell (SM100/103)
+        # keeps the early return: trtllm-gen dequants via a scalar bmm1
+        # k_scale and expects the plain kv_lora_rank + qk_rope_head_dim
+        # layout. Checked live via get_platform().is_sm120 (not cached at
+        # module import time), matching the platform-facts convention
+        # dsa_backend.py uses for is_sm100 (get_platform() replaced the old
+        # is_sm100_supported()/is_sm120_supported() utils helpers upstream).
+        if not get_platform().is_sm120:
+            return kv_cache_dim
 
     # On HIP, TileLang and AITER DSA kernels consume the raw MLA KV layout:
     # nope(512 fp8) + rope(64 fp8), without extra per-block scales.

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -72,13 +72,17 @@ from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args, 
 from sglang.srt.state_capturer.indexer_topk import (
     maybe_capture_indexer_topk,
 )
-from sglang.srt.utils import BumpAllocator
+from sglang.srt.utils import BumpAllocator, is_sm120_supported
 from sglang.srt.utils.custom_op import register_custom_op
 
 logger = logging.getLogger(__name__)
 _SGLANG_EXPERIMENTAL_LORA_OPTI = envs.SGLANG_EXPERIMENTAL_LORA_OPTI.get()
 _ENABLE_DSA_Q8KV8_BORN_FP8_Q = envs.SGLANG_ENABLE_DSA_Q8KV8_BORN_FP8_Q.get()
 _ENABLE_DSA_Q8KV8_QPREP_OVERLAP = envs.SGLANG_ENABLE_DSA_Q8KV8_QPREP_OVERLAP.get()
+# SM120/SM121 (consumer Blackwell) has no trtllm-gen kernel; the dsa "trtllm"
+# backend is routed to flashinfer's native sparse-MLA kernel instead, which
+# requires a BF16 query (see _fuse_rope_for_trtllm_mla below).
+_IS_SM120 = is_sm120_supported()
 
 if TYPE_CHECKING:
     from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
@@ -1238,6 +1242,15 @@ class DeepseekMLAForwardMixin:
         Check if we should skip rope and do fused rope+quantize for TRTLLM MLA decode in fp8_e4m3 path.
         """
         if self.current_attention_backend in ("dsa", "nsa"):
+            if _IS_SM120:
+                # On SM120/SM121 the dsa "trtllm" backend routes to
+                # flashinfer's native sparse-MLA kernel, which requires a
+                # BF16 query and dequantizes the KV cache itself via its
+                # inline per-block scales (rather than a fused rope+fp8-
+                # quantize of the query, which the datacenter trtllm-gen
+                # kernel expects). Keep rope in forward_absorb_prepare here
+                # so the query reaches _forward_trtllm in bf16.
+                return False
             return (
                 get_exec().kernel.dsa_decode_backend == "trtllm"
                 or get_exec().kernel.dsa_prefill_backend == "trtllm"

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -57,7 +57,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_musa,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel, get_platform
 from sglang.srt.state_capturer.indexer_topk import (
     maybe_capture_indexer_topk,
 )
@@ -68,6 +68,13 @@ logger = logging.getLogger(__name__)
 _SGLANG_EXPERIMENTAL_LORA_OPTI = envs.SGLANG_EXPERIMENTAL_LORA_OPTI.get()
 _ENABLE_DSA_Q8KV8_BORN_FP8_Q = envs.SGLANG_ENABLE_DSA_Q8KV8_BORN_FP8_Q.get()
 _ENABLE_DSA_Q8KV8_QPREP_OVERLAP = envs.SGLANG_ENABLE_DSA_Q8KV8_QPREP_OVERLAP.get()
+# SM120/SM121 (consumer Blackwell) has no trtllm-gen kernel; the dsa "trtllm"
+# backend is routed to flashinfer's native sparse-MLA kernel instead, which
+# requires a BF16 query (see _fuse_rope_for_trtllm_mla below). Checked live
+# via get_platform().is_sm120 (not cached at module import time), matching
+# the platform-facts convention dsa_backend.py uses for is_sm100
+# (get_platform() replaced the old is_sm100_supported()/is_sm120_supported()
+# utils helpers upstream).
 
 if TYPE_CHECKING:
     from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
@@ -938,6 +945,15 @@ class DeepseekMLAForwardMixin:
         if self.rotary_emb is None:
             return False
         if self.current_attention_backend in ("dsa", "nsa"):
+            if get_platform().is_sm120:
+                # On SM120/SM121 the dsa "trtllm" backend routes to
+                # flashinfer's native sparse-MLA kernel, which requires a
+                # BF16 query and dequantizes the KV cache itself via its
+                # inline per-block scales (rather than a fused rope+fp8-
+                # quantize of the query, which the datacenter trtllm-gen
+                # kernel expects). Keep rope in forward_absorb_prepare here
+                # so the query reaches _forward_trtllm in bf16.
+                return False
             return (
                 get_exec().kernel.dsa_decode_backend == "trtllm"
                 or get_exec().kernel.dsa_prefill_backend == "trtllm"

--- a/test/registered/kernels/test_dsa_sparse_mla_sm12x.py
+++ b/test/registered/kernels/test_dsa_sparse_mla_sm12x.py
@@ -1,0 +1,333 @@
+"""SM120/SM121 (consumer Blackwell) native sparse-MLA kernel validation.
+
+`DeepseekSparseAttnBackend._forward_trtllm` routes the dsa "trtllm" backend to
+flashinfer's native sparse-MLA kernel on SM12x (`backend="auto"`, packed
+uint8 KV view, `kv_scale_format="arbitrary_fp32"`) instead of the
+datacenter-only "trtllm-gen" kernel. This test builds a KV pool with
+sglang's REAL production `quantize_k_cache` (the exact 656-byte packed
+inline-scale layout the runtime writes: 512 fp8 nope + 4x fp32 tile scales +
+64 bf16 rope) and calls flashinfer's dispatcher exactly as `_forward_trtllm`
+does, comparing against a torch dequant (sglang's real `dequantize_k_cache_
+paged`) + masked-softmax reference.
+
+Requires SM120/SM121 hardware and flashinfer >= 0.6.x (ships
+`flashinfer/mla/_sparse_mla_sm120.py`); skipped everywhere else. Not
+exercised by CI (no SM120/121 runner today) -- validate manually:
+
+    pytest test/registered/kernels/test_dsa_sparse_mla_sm12x.py -v
+
+See UPSTREAM_SGLANG_DSA_SM12X_NATIVE_SPARSE_MLA.md for the live-deploy
+numbers this test's tolerances are based on (decode max|diff| 0.008 @
+topk=2048, prefill max|diff| 0.016 @ 2400 extend tokens).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.dsa.dequant_k_cache import dequantize_k_cache_paged
+from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache
+from sglang.kernels.ops.attention.dsa.transform_index import (
+    transform_index_page_table_decode,
+    transform_index_page_table_prefill,
+)
+from sglang.srt.utils import is_sm120_supported
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+DIM_NOPE = 512  # == kv_lora_rank
+DIM_ROPE = 64  # == qk_rope_head_dim
+DIM_TOTAL = DIM_NOPE + DIM_ROPE  # 576, per-token bf16 k layout before packing
+TOPK = 2048  # transform_index_page_table_*'s kernels hardcode TOPK=2048
+NUM_HEADS = 16  # matches the TP4/GB10 live-deploy head count
+
+
+def _build_kv_pool(
+    num_kv: int, *, device, seed: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Random bf16 K (nope+rope) -> sglang's real packed pool, plus the
+    exact reference dequant (also sglang's real production kernel) split
+    back into nope/rope for the torch attention reference."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    k_bf16 = (
+        torch.randn((num_kv, 1, 1, DIM_TOTAL), generator=g, dtype=torch.float32)
+        .to(device)
+        .to(torch.bfloat16)
+    )
+    packed_pool = quantize_k_cache(k_bf16)  # (num_kv, 1, 1, 656) fp8 view
+
+    page_table_1_flat = torch.arange(num_kv, dtype=torch.int32, device=device)
+    dequant = dequantize_k_cache_paged(
+        packed_pool, page_table_1_flat
+    )  # (num_kv, 1, 576) bf16
+    k_nope_ref = dequant[:, 0, :DIM_NOPE].float()
+    k_rope_ref = dequant[:, 0, DIM_NOPE:].float()
+    return packed_pool, k_nope_ref, k_rope_ref
+
+
+def _build_topk_indices(
+    qo_len: int, seq_lens: list[int], *, topk: int, device, seed: int
+) -> torch.Tensor:
+    """Per-query selected KV positions, -1 padded. Mirrors the shape the DSA
+    indexer produces: at most `min(seq_len, topk)` valid entries per row."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    result = torch.full((qo_len, topk), -1, dtype=torch.int32)
+    for i in range(qo_len):
+        n_valid = min(seq_lens[i], topk)
+        chosen = torch.randperm(seq_lens[i], generator=g)[:n_valid]
+        result[i, :n_valid] = chosen.to(torch.int32)
+    return result.to(device)
+
+
+def _torch_reference(
+    q_nope: torch.Tensor,  # (qo_len, num_heads, DIM_NOPE)
+    q_rope: torch.Tensor,  # (qo_len, num_heads, DIM_ROPE)
+    k_nope_ref: torch.Tensor,  # (num_kv, DIM_NOPE)
+    k_rope_ref: torch.Tensor,  # (num_kv, DIM_ROPE)
+    topk_indices: torch.Tensor,  # (qo_len, topk), -1 padded
+    bmm1_scale: float,
+) -> torch.Tensor:
+    """Masked-softmax MLA attention over the topk-selected KV positions only
+    (V = the nope/kv_lora_rank portion, matching MLA's absorbed-V design).
+    -1 entries are excluded from softmax entirely (native padding skip)."""
+    qo_len, topk = topk_indices.shape
+    valid = topk_indices >= 0  # (qo_len, topk)
+    gather_idx = topk_indices.clamp(min=0).long()  # (qo_len, topk)
+
+    gathered_nope = k_nope_ref[gather_idx]  # (qo_len, topk, DIM_NOPE)
+    gathered_rope = k_rope_ref[gather_idx]  # (qo_len, topk, DIM_ROPE)
+
+    # (qo_len, num_heads, topk)
+    scores = torch.einsum("qhd,qkd->qhk", q_nope.float(), gathered_nope)
+    scores = scores + torch.einsum("qhd,qkd->qhk", q_rope.float(), gathered_rope)
+    scores = scores * bmm1_scale
+    scores = scores.masked_fill(~valid.unsqueeze(1), float("-inf"))
+
+    weights = torch.softmax(scores, dim=-1)  # (qo_len, num_heads, topk)
+    out = torch.einsum(
+        "qhk,qkd->qhd", weights, gathered_nope
+    )  # (qo_len, num_heads, DIM_NOPE)
+    return out
+
+
+@unittest.skipUnless(
+    is_sm120_supported(), "Test requires SM120/SM121 (consumer Blackwell)"
+)
+class TestDsaSparseMlaSM12x(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.device("cuda")
+        import flashinfer.decode
+
+        cls.flashinfer_decode = flashinfer.decode
+        cls.workspace_buffer = torch.empty(
+            128 * 1024 * 1024, dtype=torch.uint8, device=cls.device
+        )
+
+    def _run_case(
+        self,
+        *,
+        seq_lens: list[int],
+        num_kv: int,
+        is_prefill: bool,
+        extend_lens: list[int] | None = None,
+        seed: int = 0,
+    ):
+        qo_len = len(seq_lens)
+        packed_pool, k_nope_ref, k_rope_ref = _build_kv_pool(
+            num_kv, device=self.device, seed=seed
+        )
+
+        g = torch.Generator(device="cpu").manual_seed(seed + 1)
+        q_nope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_NOPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+        q_rope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_ROPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+
+        topk_indices = _build_topk_indices(
+            qo_len, seq_lens, topk=TOPK, device=self.device, seed=seed + 2
+        )
+
+        # page_table: identity mapping, logical position i == physical kv slot i.
+        page_table = torch.arange(num_kv, dtype=torch.int32, device=self.device)
+        if is_prefill:
+            assert extend_lens is not None
+            page_table_2d = page_table.unsqueeze(0).expand(len(extend_lens), -1)
+            block_tables_1 = transform_index_page_table_prefill(
+                page_table=page_table_2d,
+                topk_indices=topk_indices,
+                extend_lens_cpu=extend_lens,
+                page_size=1,
+                output_num_tokens=qo_len,
+                page_table_is_expanded=False,
+            )
+        else:
+            page_table_2d = page_table.unsqueeze(0).expand(qo_len, -1)
+            block_tables_1 = transform_index_page_table_decode(
+                page_table=page_table_2d, topk_indices=topk_indices, page_size=1
+            )
+        block_tables = block_tables_1.unsqueeze(1)  # (qo_len, 1, topk)
+
+        bmm1_scale = 1.0 / (DIM_TOTAL**0.5)
+        q = torch.cat([q_nope, q_rope], dim=-1).view(qo_len, 1, NUM_HEADS, DIM_TOTAL)
+        # Real page geometry (num_pages, 1, 64, 656) like sglang's
+        # _forward_trtllm: page_block_size==64 is REQUIRED for the dedicated
+        # decode kernels to be dispatchable; a page-size-1 view mis-routes
+        # decode batches into the prefill orchestrator (num_tokens>64 check).
+        # Token-slot indices in block_tables stay valid: the binding derives
+        # (page, offset) from the tensor geometry.
+        kv = packed_pool.view(torch.uint8).reshape(-1, 64, 656).unsqueeze(1)
+        seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32, device=self.device)
+
+        out = self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+            query=q,
+            kv_cache=kv,
+            workspace_buffer=self.workspace_buffer,
+            qk_nope_head_dim=DIM_NOPE,
+            kv_lora_rank=DIM_NOPE,
+            qk_rope_head_dim=DIM_ROPE,
+            block_tables=block_tables,
+            seq_lens=seq_lens_t,
+            max_seq_len=num_kv,
+            sparse_mla_top_k=TOPK,
+            bmm1_scale=bmm1_scale,
+            backend="auto",
+            kv_scale_format="arbitrary_fp32",
+            skip_softmax_threshold_scale_factor=None,
+        )
+        out = out.view(qo_len, NUM_HEADS, DIM_NOPE)
+
+        ref = _torch_reference(
+            q_nope, q_rope, k_nope_ref, k_rope_ref, topk_indices, bmm1_scale
+        )
+        torch.testing.assert_close(
+            out.float(), ref.float(), atol=0.05, rtol=0.05, equal_nan=False
+        )
+
+    def test_decode_small_batch(self):
+        # bs=4, seq_len well under topk -- exercises the -1-padding skip.
+        # num_kv must be a multiple of 64 (real page geometry, see _run_case).
+        self._run_case(seq_lens=[100, 100, 100, 100], num_kv=128, is_prefill=False)
+
+    def test_decode_seq_len_exceeds_topk(self):
+        # seq_len (4096) > topk (2048): sglang passes the UNCLAMPED
+        # cache_seqlens for decode -- the kernel must clamp internally.
+        self._run_case(seq_lens=[4096, 4096], num_kv=4096, is_prefill=False)
+
+    def test_decode_variable_seq_lens(self):
+        self._run_case(seq_lens=[50, 500, 2500, 4096], num_kv=4096, is_prefill=False)
+
+    def test_prefill_large_extend(self):
+        # >64 extend tokens: routes into flashinfer's prefill orchestrator
+        # rather than the <=64-token warp-specialized decode kernels.
+        extend_lens = [96]
+        qo_len = sum(extend_lens)
+        self._run_case(
+            seq_lens=[3000] * qo_len,
+            num_kv=4096,
+            is_prefill=True,
+            extend_lens=extend_lens,
+        )
+
+    def test_graph_capture_and_replay(self):
+        seq_lens = [128, 128]
+        num_kv = 4096
+        qo_len = len(seq_lens)
+        packed_pool, k_nope_ref, k_rope_ref = _build_kv_pool(
+            num_kv, device=self.device, seed=42
+        )
+        g = torch.Generator(device="cpu").manual_seed(43)
+        q_nope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_NOPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+        q_rope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_ROPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+        topk_indices = _build_topk_indices(
+            qo_len, seq_lens, topk=TOPK, device=self.device, seed=44
+        )
+        page_table = torch.arange(num_kv, dtype=torch.int32, device=self.device)
+        page_table_2d = page_table.unsqueeze(0).expand(qo_len, -1)
+        block_tables = transform_index_page_table_decode(
+            page_table=page_table_2d, topk_indices=topk_indices, page_size=1
+        ).unsqueeze(1)
+
+        bmm1_scale = 1.0 / (DIM_TOTAL**0.5)
+        q = torch.cat([q_nope, q_rope], dim=-1).view(qo_len, 1, NUM_HEADS, DIM_TOTAL)
+        # Real page geometry (num_pages, 1, 64, 656) like sglang's
+        # _forward_trtllm: page_block_size==64 is REQUIRED for the dedicated
+        # decode kernels to be dispatchable; a page-size-1 view mis-routes
+        # decode batches into the prefill orchestrator (num_tokens>64 check).
+        # Token-slot indices in block_tables stay valid: the binding derives
+        # (page, offset) from the tensor geometry.
+        kv = packed_pool.view(torch.uint8).reshape(-1, 64, 656).unsqueeze(1)
+        seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32, device=self.device)
+
+        call_kwargs = dict(
+            query=q,
+            kv_cache=kv,
+            workspace_buffer=self.workspace_buffer,
+            qk_nope_head_dim=DIM_NOPE,
+            kv_lora_rank=DIM_NOPE,
+            qk_rope_head_dim=DIM_ROPE,
+            block_tables=block_tables,
+            seq_lens=seq_lens_t,
+            max_seq_len=num_kv,
+            sparse_mla_top_k=TOPK,
+            bmm1_scale=bmm1_scale,
+            backend="auto",
+            kv_scale_format="arbitrary_fp32",
+            skip_softmax_threshold_scale_factor=None,
+        )
+
+        # Warmup outside the graph (required before capture on most kernels).
+        for _ in range(2):
+            _ = self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+                **call_kwargs
+            )
+        torch.cuda.synchronize()
+
+        eager_out = self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+            **call_kwargs
+        )
+
+        graph = torch.cuda.CUDAGraph()
+        holder = {}
+        with torch.cuda.graph(graph):
+            holder["out"] = (
+                self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+                    **call_kwargs
+                )
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.isfinite(holder["out"]).all())
+        torch.testing.assert_close(
+            holder["out"].float(), eager_out.float(), atol=0.05, rtol=0.05
+        )
+
+        # Replay again unchanged (static inputs) -- must be deterministic.
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            holder["out"].float(), eager_out.float(), atol=0.05, rtol=0.05
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/test_dsa_sparse_mla_sm12x.py
+++ b/test/registered/kernels/test_dsa_sparse_mla_sm12x.py
@@ -1,0 +1,333 @@
+"""SM120/SM121 (consumer Blackwell) native sparse-MLA kernel validation.
+
+`DeepseekSparseAttnBackend._forward_trtllm` routes the dsa "trtllm" backend to
+flashinfer's native sparse-MLA kernel on SM12x (`backend="auto"`, packed
+uint8 KV view, `kv_scale_format="arbitrary_fp32"`) instead of the
+datacenter-only "trtllm-gen" kernel. This test builds a KV pool with
+sglang's REAL production `quantize_k_cache` (the exact 656-byte packed
+inline-scale layout the runtime writes: 512 fp8 nope + 4x fp32 tile scales +
+64 bf16 rope) and calls flashinfer's dispatcher exactly as `_forward_trtllm`
+does, comparing against a torch dequant (sglang's real `dequantize_k_cache_
+paged`) + masked-softmax reference.
+
+Requires SM120/SM121 hardware and flashinfer >= 0.6.x (ships
+`flashinfer/mla/_sparse_mla_sm120.py`); skipped everywhere else. Not
+exercised by CI (no SM120/121 runner today) -- validate manually:
+
+    pytest test/registered/kernels/test_dsa_sparse_mla_sm12x.py -v
+
+See UPSTREAM_SGLANG_DSA_SM12X_NATIVE_SPARSE_MLA.md for the live-deploy
+numbers this test's tolerances are based on (decode max|diff| 0.008 @
+topk=2048, prefill max|diff| 0.016 @ 2400 extend tokens).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.dsa.dequant_k_cache import dequantize_k_cache_paged
+from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache
+from sglang.kernels.ops.attention.dsa.transform_index import (
+    transform_index_page_table_decode,
+    transform_index_page_table_prefill,
+)
+from sglang.srt.runtime_context import get_platform
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+DIM_NOPE = 512  # == kv_lora_rank
+DIM_ROPE = 64  # == qk_rope_head_dim
+DIM_TOTAL = DIM_NOPE + DIM_ROPE  # 576, per-token bf16 k layout before packing
+TOPK = 2048  # transform_index_page_table_*'s kernels hardcode TOPK=2048
+NUM_HEADS = 16  # matches the TP4/GB10 live-deploy head count
+
+
+def _build_kv_pool(
+    num_kv: int, *, device, seed: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Random bf16 K (nope+rope) -> sglang's real packed pool, plus the
+    exact reference dequant (also sglang's real production kernel) split
+    back into nope/rope for the torch attention reference."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    k_bf16 = (
+        torch.randn((num_kv, 1, 1, DIM_TOTAL), generator=g, dtype=torch.float32)
+        .to(device)
+        .to(torch.bfloat16)
+    )
+    packed_pool = quantize_k_cache(k_bf16)  # (num_kv, 1, 1, 656) fp8 view
+
+    page_table_1_flat = torch.arange(num_kv, dtype=torch.int32, device=device)
+    dequant = dequantize_k_cache_paged(
+        packed_pool, page_table_1_flat
+    )  # (num_kv, 1, 576) bf16
+    k_nope_ref = dequant[:, 0, :DIM_NOPE].float()
+    k_rope_ref = dequant[:, 0, DIM_NOPE:].float()
+    return packed_pool, k_nope_ref, k_rope_ref
+
+
+def _build_topk_indices(
+    qo_len: int, seq_lens: list[int], *, topk: int, device, seed: int
+) -> torch.Tensor:
+    """Per-query selected KV positions, -1 padded. Mirrors the shape the DSA
+    indexer produces: at most `min(seq_len, topk)` valid entries per row."""
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    result = torch.full((qo_len, topk), -1, dtype=torch.int32)
+    for i in range(qo_len):
+        n_valid = min(seq_lens[i], topk)
+        chosen = torch.randperm(seq_lens[i], generator=g)[:n_valid]
+        result[i, :n_valid] = chosen.to(torch.int32)
+    return result.to(device)
+
+
+def _torch_reference(
+    q_nope: torch.Tensor,  # (qo_len, num_heads, DIM_NOPE)
+    q_rope: torch.Tensor,  # (qo_len, num_heads, DIM_ROPE)
+    k_nope_ref: torch.Tensor,  # (num_kv, DIM_NOPE)
+    k_rope_ref: torch.Tensor,  # (num_kv, DIM_ROPE)
+    topk_indices: torch.Tensor,  # (qo_len, topk), -1 padded
+    bmm1_scale: float,
+) -> torch.Tensor:
+    """Masked-softmax MLA attention over the topk-selected KV positions only
+    (V = the nope/kv_lora_rank portion, matching MLA's absorbed-V design).
+    -1 entries are excluded from softmax entirely (native padding skip)."""
+    qo_len, topk = topk_indices.shape
+    valid = topk_indices >= 0  # (qo_len, topk)
+    gather_idx = topk_indices.clamp(min=0).long()  # (qo_len, topk)
+
+    gathered_nope = k_nope_ref[gather_idx]  # (qo_len, topk, DIM_NOPE)
+    gathered_rope = k_rope_ref[gather_idx]  # (qo_len, topk, DIM_ROPE)
+
+    # (qo_len, num_heads, topk)
+    scores = torch.einsum("qhd,qkd->qhk", q_nope.float(), gathered_nope)
+    scores = scores + torch.einsum("qhd,qkd->qhk", q_rope.float(), gathered_rope)
+    scores = scores * bmm1_scale
+    scores = scores.masked_fill(~valid.unsqueeze(1), float("-inf"))
+
+    weights = torch.softmax(scores, dim=-1)  # (qo_len, num_heads, topk)
+    out = torch.einsum(
+        "qhk,qkd->qhd", weights, gathered_nope
+    )  # (qo_len, num_heads, DIM_NOPE)
+    return out
+
+
+@unittest.skipUnless(
+    get_platform().is_sm120, "Test requires SM120/SM121 (consumer Blackwell)"
+)
+class TestDsaSparseMlaSM12x(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = torch.device("cuda")
+        import flashinfer.decode
+
+        cls.flashinfer_decode = flashinfer.decode
+        cls.workspace_buffer = torch.empty(
+            128 * 1024 * 1024, dtype=torch.uint8, device=cls.device
+        )
+
+    def _run_case(
+        self,
+        *,
+        seq_lens: list[int],
+        num_kv: int,
+        is_prefill: bool,
+        extend_lens: list[int] | None = None,
+        seed: int = 0,
+    ):
+        qo_len = len(seq_lens)
+        packed_pool, k_nope_ref, k_rope_ref = _build_kv_pool(
+            num_kv, device=self.device, seed=seed
+        )
+
+        g = torch.Generator(device="cpu").manual_seed(seed + 1)
+        q_nope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_NOPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+        q_rope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_ROPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+
+        topk_indices = _build_topk_indices(
+            qo_len, seq_lens, topk=TOPK, device=self.device, seed=seed + 2
+        )
+
+        # page_table: identity mapping, logical position i == physical kv slot i.
+        page_table = torch.arange(num_kv, dtype=torch.int32, device=self.device)
+        if is_prefill:
+            assert extend_lens is not None
+            page_table_2d = page_table.unsqueeze(0).expand(len(extend_lens), -1)
+            block_tables_1 = transform_index_page_table_prefill(
+                page_table=page_table_2d,
+                topk_indices=topk_indices,
+                extend_lens_cpu=extend_lens,
+                page_size=1,
+                output_num_tokens=qo_len,
+                page_table_is_expanded=False,
+            )
+        else:
+            page_table_2d = page_table.unsqueeze(0).expand(qo_len, -1)
+            block_tables_1 = transform_index_page_table_decode(
+                page_table=page_table_2d, topk_indices=topk_indices, page_size=1
+            )
+        block_tables = block_tables_1.unsqueeze(1)  # (qo_len, 1, topk)
+
+        bmm1_scale = 1.0 / (DIM_TOTAL**0.5)
+        q = torch.cat([q_nope, q_rope], dim=-1).view(qo_len, 1, NUM_HEADS, DIM_TOTAL)
+        # Real page geometry (num_pages, 1, 64, 656) like sglang's
+        # _forward_trtllm: page_block_size==64 is REQUIRED for the dedicated
+        # decode kernels to be dispatchable; a page-size-1 view mis-routes
+        # decode batches into the prefill orchestrator (num_tokens>64 check).
+        # Token-slot indices in block_tables stay valid: the binding derives
+        # (page, offset) from the tensor geometry.
+        kv = packed_pool.view(torch.uint8).reshape(-1, 64, 656).unsqueeze(1)
+        seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32, device=self.device)
+
+        out = self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+            query=q,
+            kv_cache=kv,
+            workspace_buffer=self.workspace_buffer,
+            qk_nope_head_dim=DIM_NOPE,
+            kv_lora_rank=DIM_NOPE,
+            qk_rope_head_dim=DIM_ROPE,
+            block_tables=block_tables,
+            seq_lens=seq_lens_t,
+            max_seq_len=num_kv,
+            sparse_mla_top_k=TOPK,
+            bmm1_scale=bmm1_scale,
+            backend="auto",
+            kv_scale_format="arbitrary_fp32",
+            skip_softmax_threshold_scale_factor=None,
+        )
+        out = out.view(qo_len, NUM_HEADS, DIM_NOPE)
+
+        ref = _torch_reference(
+            q_nope, q_rope, k_nope_ref, k_rope_ref, topk_indices, bmm1_scale
+        )
+        torch.testing.assert_close(
+            out.float(), ref.float(), atol=0.05, rtol=0.05, equal_nan=False
+        )
+
+    def test_decode_small_batch(self):
+        # bs=4, seq_len well under topk -- exercises the -1-padding skip.
+        # num_kv must be a multiple of 64 (real page geometry, see _run_case).
+        self._run_case(seq_lens=[100, 100, 100, 100], num_kv=128, is_prefill=False)
+
+    def test_decode_seq_len_exceeds_topk(self):
+        # seq_len (4096) > topk (2048): sglang passes the UNCLAMPED
+        # cache_seqlens for decode -- the kernel must clamp internally.
+        self._run_case(seq_lens=[4096, 4096], num_kv=4096, is_prefill=False)
+
+    def test_decode_variable_seq_lens(self):
+        self._run_case(seq_lens=[50, 500, 2500, 4096], num_kv=4096, is_prefill=False)
+
+    def test_prefill_large_extend(self):
+        # >64 extend tokens: routes into flashinfer's prefill orchestrator
+        # rather than the <=64-token warp-specialized decode kernels.
+        extend_lens = [96]
+        qo_len = sum(extend_lens)
+        self._run_case(
+            seq_lens=[3000] * qo_len,
+            num_kv=4096,
+            is_prefill=True,
+            extend_lens=extend_lens,
+        )
+
+    def test_graph_capture_and_replay(self):
+        seq_lens = [128, 128]
+        num_kv = 4096
+        qo_len = len(seq_lens)
+        packed_pool, k_nope_ref, k_rope_ref = _build_kv_pool(
+            num_kv, device=self.device, seed=42
+        )
+        g = torch.Generator(device="cpu").manual_seed(43)
+        q_nope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_NOPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+        q_rope = (
+            torch.randn((qo_len, NUM_HEADS, DIM_ROPE), generator=g, dtype=torch.float32)
+            .to(self.device)
+            .to(torch.bfloat16)
+        )
+        topk_indices = _build_topk_indices(
+            qo_len, seq_lens, topk=TOPK, device=self.device, seed=44
+        )
+        page_table = torch.arange(num_kv, dtype=torch.int32, device=self.device)
+        page_table_2d = page_table.unsqueeze(0).expand(qo_len, -1)
+        block_tables = transform_index_page_table_decode(
+            page_table=page_table_2d, topk_indices=topk_indices, page_size=1
+        ).unsqueeze(1)
+
+        bmm1_scale = 1.0 / (DIM_TOTAL**0.5)
+        q = torch.cat([q_nope, q_rope], dim=-1).view(qo_len, 1, NUM_HEADS, DIM_TOTAL)
+        # Real page geometry (num_pages, 1, 64, 656) like sglang's
+        # _forward_trtllm: page_block_size==64 is REQUIRED for the dedicated
+        # decode kernels to be dispatchable; a page-size-1 view mis-routes
+        # decode batches into the prefill orchestrator (num_tokens>64 check).
+        # Token-slot indices in block_tables stay valid: the binding derives
+        # (page, offset) from the tensor geometry.
+        kv = packed_pool.view(torch.uint8).reshape(-1, 64, 656).unsqueeze(1)
+        seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32, device=self.device)
+
+        call_kwargs = dict(
+            query=q,
+            kv_cache=kv,
+            workspace_buffer=self.workspace_buffer,
+            qk_nope_head_dim=DIM_NOPE,
+            kv_lora_rank=DIM_NOPE,
+            qk_rope_head_dim=DIM_ROPE,
+            block_tables=block_tables,
+            seq_lens=seq_lens_t,
+            max_seq_len=num_kv,
+            sparse_mla_top_k=TOPK,
+            bmm1_scale=bmm1_scale,
+            backend="auto",
+            kv_scale_format="arbitrary_fp32",
+            skip_softmax_threshold_scale_factor=None,
+        )
+
+        # Warmup outside the graph (required before capture on most kernels).
+        for _ in range(2):
+            _ = self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+                **call_kwargs
+            )
+        torch.cuda.synchronize()
+
+        eager_out = self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+            **call_kwargs
+        )
+
+        graph = torch.cuda.CUDAGraph()
+        holder = {}
+        with torch.cuda.graph(graph):
+            holder["out"] = (
+                self.flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla(
+                    **call_kwargs
+                )
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.isfinite(holder["out"]).all())
+        torch.testing.assert_close(
+            holder["out"].float(), eager_out.float(), atol=0.05, rtol=0.05
+        )
+
+        # Replay again unchanged (static inputs) -- must be deterministic.
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            holder["out"].float(), eager_out.float(), atol=0.05, rtol=0.05
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_backend_trtllm_sm12x_kwargs.py
+++ b/test/registered/unit/layers/attention/test_dsa_backend_trtllm_sm12x_kwargs.py
@@ -1,0 +1,221 @@
+"""Hermetic unit tests for DeepseekSparseAttnBackend._forward_trtllm's SM12x
+kwarg selection to flashinfer's dispatcher.
+
+On SM120/SM121 (consumer Blackwell) there is no trtllm-gen kernel; the dsa
+"trtllm" backend must instead route to flashinfer's native sparse-MLA kernel:
+`backend="auto"` (flashinfer's dispatcher then picks its "sparse" kernel for
+cc==12 + sparse_mla_top_k>0), a `torch.uint8` view of the packed KV buffer,
+`kv_scale_format="arbitrary_fp32"` (sglang's quantize_k_cache writes
+amax/448 arbitrary fp32 tile scales, not pow2/ue8m0), and
+`skip_softmax_threshold_scale_factor=None` and
+`multi_ctas_kv_counter_buffer=None` (both unsupported by the sparse
+backend, which raises on non-None values). On any other arch/config the
+call must stay byte-identical to upstream ("trtllm-gen" / "auto" scale
+format / the raw kv view / the skip-softmax env value / the persistent
+counter buffer).
+
+This is exercised by monkeypatching flashinfer.decode's dispatcher (via
+sys.modules, so the test does not require flashinfer to be installed) and
+calling `_forward_trtllm` against a lightweight fake backend object -- no
+GPU, no real model weights.
+
+`get_platform()` is patched directly, the same way as the other module-level
+accessors below (`dsa_use_prefill_cp`, `grow_multi_ctas_kv_counter_buffer_
+if_needed`): upstream's platform-facts refactor removed the module-level
+`_IS_SM120` and folded it into a live `get_platform().is_sm120` read.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention import dsa_backend as db
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _install_fake_flashinfer_decode(captured: dict):
+    """Replace flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla with a
+    kwarg-capturing stub via sys.modules, independent of whether the real
+    flashinfer package is installed in this environment."""
+
+    def _fake_call(**kwargs):
+        captured.update(kwargs)
+        return torch.zeros(1)
+
+    fake_decode = types.ModuleType("flashinfer.decode")
+    fake_decode.trtllm_batch_decode_with_kv_cache_mla = _fake_call
+    fake_flashinfer = types.ModuleType("flashinfer")
+    fake_flashinfer.decode = fake_decode
+    return mock.patch.dict(
+        sys.modules, {"flashinfer": fake_flashinfer, "flashinfer.decode": fake_decode}
+    )
+
+
+def _fake_backend(*, dsa_kv_cache_store_fp8: bool):
+    """A minimal stand-in for a DeepseekSparseAttnBackend instance, providing
+    just enough surface for _forward_trtllm to reach the flashinfer call
+    without touching a GPU or real model weights."""
+    real_page_size = 1
+    kv_cache_dim = 8
+    num_tokens = 4  # decode: one token per sequence
+
+    k_cache = torch.zeros(
+        num_tokens, real_page_size, kv_cache_dim, dtype=torch.bfloat16
+    )
+    page_table = torch.zeros((num_tokens, 1), dtype=torch.int32)
+
+    return SimpleNamespace(
+        forward_metadata=SimpleNamespace(max_seq_len_k=128),
+        # bf16, not fp8: keeps the (unrelated) fused rope+fp8-quantize branch
+        # off regardless of _sparse_sm120, isolating the kwarg selection.
+        kv_cache_dtype=torch.bfloat16,
+        dsa_kv_cache_store_fp8=dsa_kv_cache_store_fp8,
+        token_to_kv_pool=SimpleNamespace(get_key_buffer=lambda layer_id: k_cache),
+        real_page_size=real_page_size,
+        kv_cache_dim=kv_cache_dim,
+        use_fused_topk=True,
+        _get_fused_topk_page_table=lambda topk_indices: page_table,
+        workspace_buffer=object(),
+        qk_nope_head_dim=6,
+        kv_lora_rank=2,
+        qk_rope_head_dim=2,
+        dsa_index_topk=2048,
+        device="cpu",
+        num_q_heads=1,
+        _multi_ctas_kv_counter_buffer=torch.zeros(8, dtype=torch.uint8),
+    )
+
+
+def _fake_layer():
+    return SimpleNamespace(
+        tp_q_head_num=1,
+        head_dim=4,
+        v_head_dim=4,
+        scaling=1.0,
+        is_cross_attention=False,
+        layer_id=0,
+    )
+
+
+def _fake_forward_batch():
+    return SimpleNamespace(attn_cp_metadata=None)
+
+
+class TestForwardTrtllmSM12xKwargs(CustomTestCase):
+    def _run(self, *, is_sm120: bool, dsa_kv_cache_store_fp8: bool):
+        captured: dict = {}
+        num_tokens = 4
+        q = torch.zeros(num_tokens, 4)
+        seq_lens = torch.ones(num_tokens, dtype=torch.int32)
+        backend = _fake_backend(dsa_kv_cache_store_fp8=dsa_kv_cache_store_fp8)
+        fake_platform = SimpleNamespace(is_sm120=is_sm120)
+
+        with (
+            mock.patch.object(db, "get_platform", lambda: fake_platform),
+            mock.patch.object(db, "dsa_use_prefill_cp", lambda forward_batch: False),
+            # Sizing the counter buffer needs flashinfer + a CUDA device;
+            # keep the caller-owned buffer as-is so the test stays hermetic.
+            mock.patch.object(
+                db,
+                "grow_multi_ctas_kv_counter_buffer_if_needed",
+                lambda buffer, device, num_q_heads, batch_size: buffer,
+            ),
+            _install_fake_flashinfer_decode(captured),
+        ):
+            db.DeepseekSparseAttnBackend._forward_trtllm(
+                backend,
+                q=q,
+                k=None,
+                v=None,
+                layer=_fake_layer(),
+                forward_batch=_fake_forward_batch(),
+                seq_lens=seq_lens,
+                save_kv_cache=False,
+                q_rope=None,
+                k_rope=None,
+            )
+        return captured, backend
+
+    def test_sm12x_fp8_pool_selects_sparse_kwargs(self):
+        captured, _ = self._run(is_sm120=True, dsa_kv_cache_store_fp8=True)
+        self.assertEqual(captured["backend"], "auto")
+        self.assertEqual(captured["kv_scale_format"], "arbitrary_fp32")
+        self.assertIsNone(captured["skip_softmax_threshold_scale_factor"])
+        # flashinfer's sparse backend raises on a non-None counter buffer
+        # (trtllm-gen only).
+        self.assertIsNone(captured["multi_ctas_kv_counter_buffer"])
+        self.assertEqual(captured["kv_cache"].dtype, torch.uint8)
+
+    def test_sm100_fp8_pool_keeps_upstream_kwargs(self):
+        # Datacenter Blackwell: is_sm120 False -> byte-identical to upstream
+        # even though the pool happens to hold the packed fp8 layout.
+        captured, backend = self._run(is_sm120=False, dsa_kv_cache_store_fp8=True)
+        self.assertEqual(captured["backend"], "trtllm-gen")
+        self.assertEqual(captured["kv_scale_format"], "auto")
+        self.assertEqual(
+            captured["skip_softmax_threshold_scale_factor"],
+            envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+        )
+        self.assertIs(
+            captured["multi_ctas_kv_counter_buffer"],
+            backend._multi_ctas_kv_counter_buffer,
+        )
+        self.assertNotEqual(captured["kv_cache"].dtype, torch.uint8)
+
+    def test_sm12x_bf16_pool_keeps_upstream_kwargs(self):
+        # SM12x but dsa_kv_cache_store_fp8 False (e.g. bf16 KV cache): the
+        # pool does not hold the packed layout the sparse kernel needs, so
+        # the gate (is_sm120 AND dsa_kv_cache_store_fp8) must stay False.
+        captured, backend = self._run(is_sm120=True, dsa_kv_cache_store_fp8=False)
+        self.assertEqual(captured["backend"], "trtllm-gen")
+        self.assertEqual(captured["kv_scale_format"], "auto")
+        self.assertEqual(
+            captured["skip_softmax_threshold_scale_factor"],
+            envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+        )
+        self.assertIs(
+            captured["multi_ctas_kv_counter_buffer"],
+            backend._multi_ctas_kv_counter_buffer,
+        )
+        self.assertNotEqual(captured["kv_cache"].dtype, torch.uint8)
+
+    def test_sm12x_sparse_route_rejects_prefill_cp(self):
+        # Prefill context parallelism has only been exercised against the
+        # trtllm-gen fp8-quantize-fused-rope path, which the SM12x sparse
+        # route skips entirely -- must fail loudly, not silently mis-route.
+        # flashinfer is stubbed too even though the dispatcher is never
+        # reached: `import flashinfer.decode` is the function's first
+        # statement, executed before this guard.
+        fake_platform = SimpleNamespace(is_sm120=True)
+        with (
+            mock.patch.object(db, "get_platform", lambda: fake_platform),
+            mock.patch.object(db, "dsa_use_prefill_cp", lambda forward_batch: True),
+            _install_fake_flashinfer_decode({}),
+        ):
+            with self.assertRaises(NotImplementedError):
+                db.DeepseekSparseAttnBackend._forward_trtllm(
+                    _fake_backend(dsa_kv_cache_store_fp8=True),
+                    q=torch.zeros(4, 4),
+                    k=None,
+                    v=None,
+                    layer=_fake_layer(),
+                    forward_batch=_fake_forward_batch(),
+                    seq_lens=torch.ones(4, dtype=torch.int32),
+                    save_kv_cache=False,
+                    q_rope=None,
+                    k_rope=None,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_backend_trtllm_sm12x_kwargs.py
+++ b/test/registered/unit/layers/attention/test_dsa_backend_trtllm_sm12x_kwargs.py
@@ -1,0 +1,214 @@
+"""Hermetic unit tests for DeepseekSparseAttnBackend._forward_trtllm's SM12x
+kwarg selection to flashinfer's dispatcher.
+
+On SM120/SM121 (consumer Blackwell) there is no trtllm-gen kernel; the dsa
+"trtllm" backend must instead route to flashinfer's native sparse-MLA kernel:
+`backend="auto"` (flashinfer's dispatcher then picks its "sparse" kernel for
+cc==12 + sparse_mla_top_k>0), a `torch.uint8` view of the packed KV buffer,
+`kv_scale_format="arbitrary_fp32"` (sglang's quantize_k_cache writes
+amax/448 arbitrary fp32 tile scales, not pow2/ue8m0), and
+`skip_softmax_threshold_scale_factor=None` and
+`multi_ctas_kv_counter_buffer=None` (both unsupported by the sparse
+backend, which raises on non-None values). On any other arch/config the
+call must stay byte-identical to upstream ("trtllm-gen" / "auto" scale
+format / the raw kv view / the skip-softmax env value / the persistent
+counter buffer).
+
+This is exercised by monkeypatching flashinfer.decode's dispatcher (via
+sys.modules, so the test does not require flashinfer to be installed) and
+calling `_forward_trtllm` against a lightweight fake backend object -- no
+GPU, no real model weights.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention import dsa_backend as db
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _install_fake_flashinfer_decode(captured: dict):
+    """Replace flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla with a
+    kwarg-capturing stub via sys.modules, independent of whether the real
+    flashinfer package is installed in this environment."""
+
+    def _fake_call(**kwargs):
+        captured.update(kwargs)
+        return torch.zeros(1)
+
+    fake_decode = types.ModuleType("flashinfer.decode")
+    fake_decode.trtllm_batch_decode_with_kv_cache_mla = _fake_call
+    fake_flashinfer = types.ModuleType("flashinfer")
+    fake_flashinfer.decode = fake_decode
+    return mock.patch.dict(
+        sys.modules, {"flashinfer": fake_flashinfer, "flashinfer.decode": fake_decode}
+    )
+
+
+def _fake_backend(*, dsa_kv_cache_store_fp8: bool):
+    """A minimal stand-in for a DeepseekSparseAttnBackend instance, providing
+    just enough surface for _forward_trtllm to reach the flashinfer call
+    without touching a GPU or real model weights."""
+    real_page_size = 1
+    kv_cache_dim = 8
+    num_tokens = 4  # decode: one token per sequence
+
+    k_cache = torch.zeros(
+        num_tokens, real_page_size, kv_cache_dim, dtype=torch.bfloat16
+    )
+    page_table = torch.zeros((num_tokens, 1), dtype=torch.int32)
+
+    return SimpleNamespace(
+        forward_metadata=SimpleNamespace(max_seq_len_k=128),
+        # bf16, not fp8: keeps the (unrelated) fused rope+fp8-quantize branch
+        # off regardless of _sparse_sm120, isolating the kwarg selection.
+        kv_cache_dtype=torch.bfloat16,
+        dsa_kv_cache_store_fp8=dsa_kv_cache_store_fp8,
+        token_to_kv_pool=SimpleNamespace(get_key_buffer=lambda layer_id: k_cache),
+        real_page_size=real_page_size,
+        kv_cache_dim=kv_cache_dim,
+        use_fused_topk=True,
+        _get_fused_topk_page_table=lambda topk_indices: page_table,
+        workspace_buffer=object(),
+        qk_nope_head_dim=6,
+        kv_lora_rank=2,
+        qk_rope_head_dim=2,
+        dsa_index_topk=2048,
+        device="cpu",
+        num_q_heads=1,
+        _multi_ctas_kv_counter_buffer=torch.zeros(8, dtype=torch.uint8),
+    )
+
+
+def _fake_layer():
+    return SimpleNamespace(
+        tp_q_head_num=1,
+        head_dim=4,
+        v_head_dim=4,
+        scaling=1.0,
+        is_cross_attention=False,
+        layer_id=0,
+    )
+
+
+def _fake_forward_batch():
+    return SimpleNamespace(attn_cp_metadata=None)
+
+
+class TestForwardTrtllmSM12xKwargs(CustomTestCase):
+    def _run(self, *, is_sm120: bool, dsa_kv_cache_store_fp8: bool):
+        captured: dict = {}
+        num_tokens = 4
+        q = torch.zeros(num_tokens, 4)
+        seq_lens = torch.ones(num_tokens, dtype=torch.int32)
+        backend = _fake_backend(dsa_kv_cache_store_fp8=dsa_kv_cache_store_fp8)
+
+        with (
+            mock.patch.object(db, "_IS_SM120", is_sm120),
+            mock.patch.object(db, "dsa_use_prefill_cp", lambda forward_batch: False),
+            # Sizing the counter buffer needs flashinfer + a CUDA device;
+            # keep the caller-owned buffer as-is so the test stays hermetic.
+            mock.patch.object(
+                db,
+                "grow_multi_ctas_kv_counter_buffer_if_needed",
+                lambda buffer, device, num_q_heads, batch_size: buffer,
+            ),
+            _install_fake_flashinfer_decode(captured),
+        ):
+            db.DeepseekSparseAttnBackend._forward_trtllm(
+                backend,
+                q=q,
+                k=None,
+                v=None,
+                layer=_fake_layer(),
+                forward_batch=_fake_forward_batch(),
+                seq_lens=seq_lens,
+                save_kv_cache=False,
+                q_rope=None,
+                k_rope=None,
+            )
+        return captured, backend
+
+    def test_sm12x_fp8_pool_selects_sparse_kwargs(self):
+        captured, _ = self._run(is_sm120=True, dsa_kv_cache_store_fp8=True)
+        self.assertEqual(captured["backend"], "auto")
+        self.assertEqual(captured["kv_scale_format"], "arbitrary_fp32")
+        self.assertIsNone(captured["skip_softmax_threshold_scale_factor"])
+        # flashinfer's sparse backend raises on a non-None counter buffer
+        # (trtllm-gen only).
+        self.assertIsNone(captured["multi_ctas_kv_counter_buffer"])
+        self.assertEqual(captured["kv_cache"].dtype, torch.uint8)
+
+    def test_sm100_fp8_pool_keeps_upstream_kwargs(self):
+        # Datacenter Blackwell: _IS_SM120 False -> byte-identical to upstream
+        # even though the pool happens to hold the packed fp8 layout.
+        captured, backend = self._run(is_sm120=False, dsa_kv_cache_store_fp8=True)
+        self.assertEqual(captured["backend"], "trtllm-gen")
+        self.assertEqual(captured["kv_scale_format"], "auto")
+        self.assertEqual(
+            captured["skip_softmax_threshold_scale_factor"],
+            envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+        )
+        self.assertIs(
+            captured["multi_ctas_kv_counter_buffer"],
+            backend._multi_ctas_kv_counter_buffer,
+        )
+        self.assertNotEqual(captured["kv_cache"].dtype, torch.uint8)
+
+    def test_sm12x_bf16_pool_keeps_upstream_kwargs(self):
+        # SM12x but dsa_kv_cache_store_fp8 False (e.g. bf16 KV cache): the
+        # pool does not hold the packed layout the sparse kernel needs, so
+        # the gate (_IS_SM120 AND dsa_kv_cache_store_fp8) must stay False.
+        captured, backend = self._run(is_sm120=True, dsa_kv_cache_store_fp8=False)
+        self.assertEqual(captured["backend"], "trtllm-gen")
+        self.assertEqual(captured["kv_scale_format"], "auto")
+        self.assertEqual(
+            captured["skip_softmax_threshold_scale_factor"],
+            envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+        )
+        self.assertIs(
+            captured["multi_ctas_kv_counter_buffer"],
+            backend._multi_ctas_kv_counter_buffer,
+        )
+        self.assertNotEqual(captured["kv_cache"].dtype, torch.uint8)
+
+    def test_sm12x_sparse_route_rejects_prefill_cp(self):
+        # Prefill context parallelism has only been exercised against the
+        # trtllm-gen fp8-quantize-fused-rope path, which the SM12x sparse
+        # route skips entirely -- must fail loudly, not silently mis-route.
+        # flashinfer is stubbed too even though the dispatcher is never
+        # reached: `import flashinfer.decode` is the function's first
+        # statement, executed before this guard.
+        with (
+            mock.patch.object(db, "_IS_SM120", True),
+            mock.patch.object(db, "dsa_use_prefill_cp", lambda forward_batch: True),
+            _install_fake_flashinfer_decode({}),
+        ):
+            with self.assertRaises(NotImplementedError):
+                db.DeepseekSparseAttnBackend._forward_trtllm(
+                    _fake_backend(dsa_kv_cache_store_fp8=True),
+                    q=torch.zeros(4, 4),
+                    k=None,
+                    v=None,
+                    layer=_fake_layer(),
+                    forward_batch=_fake_forward_batch(),
+                    seq_lens=torch.ones(4, dtype=torch.int32),
+                    save_kv_cache=False,
+                    q_rope=None,
+                    k_rope=None,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsa_kv_cache_dim_sm12x.py
+++ b/test/registered/unit/mem_cache/test_dsa_kv_cache_dim_sm12x.py
@@ -1,0 +1,108 @@
+"""Hermetic unit test for the SM12x carve-out in calculate_mla_kv_cache_dim.
+
+On SM120/SM121 (consumer Blackwell: DGX Spark GB10, RTX PRO/50-series) the
+dsa "trtllm" backend does not dispatch to the datacenter trtllm-gen kernel;
+it is routed to flashinfer's native sparse-MLA kernel instead (see
+DeepseekSparseAttnBackend._forward_trtllm), which consumes the 656-byte
+packed inline-scale layout rather than the plain kv_lora_rank +
+qk_rope_head_dim layout trtllm-gen expects. `calculate_mla_kv_cache_dim`
+must therefore skip its trtllm early-return on SM12x (module-level
+`_is_sm120`, mocked here) so the packed layout is computed, while leaving
+SM100/SM103 byte-identical.
+
+Pure Python (no GPU): `_is_sm120` is patched directly; no CUDA context is
+touched. Runs on any PR-CI lane.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.mem_cache import kv_cache_configurator as kcc
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+# GlmMoeDsaForCausalLM is one of the is_deepseek_dsa-recognized architectures;
+# index_topk must be present for is_deepseek_dsa to return True.
+_DSA_HF_CONFIG = {"architectures": ["GlmMoeDsaForCausalLM"], "index_topk": 2048}
+_KV_LORA_RANK = 512
+_QK_ROPE_HEAD_DIM = 64
+# 512 (fp8 nope) + 512 // 128 * 4 (fp32 tile scales) + 64 * 2 (bf16 rope) = 656
+_PACKED_DIM = 656
+_PLAIN_DIM = _KV_LORA_RANK + _QK_ROPE_HEAD_DIM  # 576
+
+
+def _model_config():
+    return SimpleNamespace(
+        hf_config=_DSA_HF_CONFIG,
+        kv_lora_rank=_KV_LORA_RANK,
+        qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+    )
+
+
+def _server_args(*, dsa_prefill_backend="trtllm", dsa_decode_backend="trtllm"):
+    return SimpleNamespace(
+        dsa_prefill_backend=dsa_prefill_backend,
+        dsa_decode_backend=dsa_decode_backend,
+    )
+
+
+class TestCalculateMlaKvCacheDimSM12x(CustomTestCase):
+    def test_sm12x_fp8_trtllm_uses_packed_layout(self):
+        # The change under test: SM12x + fp8 KV + trtllm dsa backend must NOT
+        # early-return the plain layout -- the sparse kernel needs the packed
+        # inline-scale layout.
+        with mock.patch.object(kcc, "_is_sm120", True):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.float8_e4m3fn,
+                server_args=_server_args(),
+            )
+        self.assertEqual(dim, _PACKED_DIM)
+
+    def test_sm12x_bf16_trtllm_stays_plain_layout(self):
+        # bf16 KV cache never uses the packed fp8 layout, on any arch: the
+        # trtllm early-return is skipped on SM12x, but the fall-through fp8
+        # check below it is false, so the plain layout still results.
+        with mock.patch.object(kcc, "_is_sm120", True):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.bfloat16,
+                server_args=_server_args(),
+            )
+        self.assertEqual(dim, _PLAIN_DIM)
+
+    def test_sm100_fp8_trtllm_keeps_plain_layout(self):
+        # Datacenter Blackwell (SM100/103) uses the real trtllm-gen kernel,
+        # which dequants via a scalar bmm1 k_scale and expects the plain
+        # layout regardless of kv_cache_dtype -- byte-identical to upstream.
+        with mock.patch.object(kcc, "_is_sm120", False):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.float8_e4m3fn,
+                server_args=_server_args(),
+            )
+        self.assertEqual(dim, _PLAIN_DIM)
+
+    def test_sm12x_non_trtllm_backend_unaffected(self):
+        # _is_sm120 must only change behavior for the trtllm branch; a
+        # non-trtllm dsa backend on SM12x falls through to the normal fp8
+        # scaled-layout computation, same as upstream.
+        with mock.patch.object(kcc, "_is_sm120", True):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.float8_e4m3fn,
+                server_args=_server_args(
+                    dsa_prefill_backend="flashinfer_gather",
+                    dsa_decode_backend="flashinfer_gather",
+                ),
+            )
+        self.assertEqual(dim, _PACKED_DIM)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsa_kv_cache_dim_sm12x.py
+++ b/test/registered/unit/mem_cache/test_dsa_kv_cache_dim_sm12x.py
@@ -1,0 +1,122 @@
+"""Hermetic unit test for the SM12x carve-out in calculate_mla_kv_cache_dim.
+
+On SM120/SM121 (consumer Blackwell: DGX Spark GB10, RTX PRO/50-series) the
+dsa "trtllm" backend does not dispatch to the datacenter trtllm-gen kernel;
+it is routed to flashinfer's native sparse-MLA kernel instead (see
+DeepseekSparseAttnBackend._forward_trtllm), which consumes the 656-byte
+packed inline-scale layout rather than the plain kv_lora_rank +
+qk_rope_head_dim layout trtllm-gen expects. `calculate_mla_kv_cache_dim`
+must therefore skip its trtllm early-return on SM12x (checked live via
+`get_platform().is_sm120`, overridden here through `override_platform`) so
+the packed layout is computed, while leaving SM100/SM103 byte-identical.
+
+`dsa_prefill_backend`/`dsa_decode_backend` are read off the published config
+bag (`get_exec().kernel.*`), not a `server_args` parameter, so a dummy
+ServerArgs is published per case via the sanctioned
+`get_context().override_server_args(...)` test hook (same pattern as
+test_pool_configurator.py's `_publish_config`).
+
+Pure Python (no GPU): both overrides are scoped context managers; no CUDA
+context is touched. Runs on any PR-CI lane.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache import kv_cache_configurator as kcc
+from sglang.srt.runtime_context import get_context, override_platform
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+# GlmMoeDsaForCausalLM is one of the is_deepseek_dsa-recognized architectures;
+# index_topk must be present for is_deepseek_dsa to return True.
+_DSA_HF_CONFIG = {"architectures": ["GlmMoeDsaForCausalLM"], "index_topk": 2048}
+_KV_LORA_RANK = 512
+_QK_ROPE_HEAD_DIM = 64
+# 512 (fp8 nope) + 512 // 128 * 4 (fp32 tile scales) + 64 * 2 (bf16 rope) = 656
+_PACKED_DIM = 656
+_PLAIN_DIM = _KV_LORA_RANK + _QK_ROPE_HEAD_DIM  # 576
+
+
+def _model_config():
+    return SimpleNamespace(
+        hf_config=_DSA_HF_CONFIG,
+        kv_lora_rank=_KV_LORA_RANK,
+        qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+    )
+
+
+def _publish_dsa_backends(
+    testcase, *, dsa_prefill_backend="trtllm", dsa_decode_backend="trtllm"
+):
+    """Publish a dummy ServerArgs carrying the given DSA backend choice, so
+    get_exec().kernel.dsa_prefill_backend/dsa_decode_backend read it back.
+    Installed per call, restored on the calling case's cleanup."""
+    override = get_context().override_server_args(
+        dsa_prefill_backend=dsa_prefill_backend,
+        dsa_decode_backend=dsa_decode_backend,
+    )
+    override.install()
+    testcase.addCleanup(override.restore)
+
+
+class TestCalculateMlaKvCacheDimSM12x(CustomTestCase):
+    def test_sm12x_fp8_trtllm_uses_packed_layout(self):
+        # The change under test: SM12x + fp8 KV + trtllm dsa backend must NOT
+        # early-return the plain layout -- the sparse kernel needs the packed
+        # inline-scale layout.
+        _publish_dsa_backends(self)
+        with override_platform(is_sm120=True):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.float8_e4m3fn,
+            )
+        self.assertEqual(dim, _PACKED_DIM)
+
+    def test_sm12x_bf16_trtllm_stays_plain_layout(self):
+        # bf16 KV cache never uses the packed fp8 layout, on any arch: the
+        # trtllm early-return is skipped on SM12x, but the fall-through fp8
+        # check below it is false, so the plain layout still results.
+        _publish_dsa_backends(self)
+        with override_platform(is_sm120=True):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.bfloat16,
+            )
+        self.assertEqual(dim, _PLAIN_DIM)
+
+    def test_sm100_fp8_trtllm_keeps_plain_layout(self):
+        # Datacenter Blackwell (SM100/103) uses the real trtllm-gen kernel,
+        # which dequants via a scalar bmm1 k_scale and expects the plain
+        # layout regardless of kv_cache_dtype -- byte-identical to upstream.
+        _publish_dsa_backends(self)
+        with override_platform(is_sm120=False):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.float8_e4m3fn,
+            )
+        self.assertEqual(dim, _PLAIN_DIM)
+
+    def test_sm12x_non_trtllm_backend_unaffected(self):
+        # is_sm120 must only change behavior for the trtllm branch; a
+        # non-trtllm dsa backend on SM12x falls through to the normal fp8
+        # scaled-layout computation, same as upstream.
+        _publish_dsa_backends(
+            self,
+            dsa_prefill_backend="flashmla_sparse",
+            dsa_decode_backend="flashmla_sparse",
+        )
+        with override_platform(is_sm120=True):
+            dim = kcc.calculate_mla_kv_cache_dim(
+                model_config=_model_config(),
+                kv_cache_dtype=torch.float8_e4m3fn,
+            )
+        self.assertEqual(dim, _PACKED_DIM)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_deepseek_mla_fuse_rope_trtllm_sm12x.py
+++ b/test/registered/unit/models/test_deepseek_mla_fuse_rope_trtllm_sm12x.py
@@ -1,0 +1,88 @@
+"""Hermetic unit test for the SM12x carve-out in
+DeepseekMLAForwardMixin._fuse_rope_for_trtllm_mla (dsa/nsa branch), the mixin
+DeepseekV2AttentionMLA inherits its MLA forward methods from.
+
+Regression guard for the FIRST LIVE DEPLOY LESSON: on SM120/SM121, the dsa
+"trtllm" backend routes to flashinfer's native sparse-MLA kernel, which
+requires a BF16 query and dequantizes the KV cache itself via inline
+per-block scales. The datacenter-Blackwell fused rope+fp8-quantize path
+(`mla_quantize_and_rope_for_fp8` in dsa_backend.py's _forward_trtllm) hands
+that kernel an fp8 query, which it rejects
+("... expects BF16 query, got torch.float8_e4m3fn"). This method must
+therefore return False on SM12x for the dsa/nsa branch (rope stays in
+forward_absorb_prepare, query reaches _forward_trtllm as bf16) regardless of
+the dsa_decode_backend/dsa_prefill_backend/kv_cache_dtype combination that
+upstream (SM100/103) uses to decide the fused path.
+
+Pure Python (no GPU): `_IS_SM120` is patched directly.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.models.deepseek_common.attention_forward_methods import (
+    forward_mla as fm,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _fake_self(current_attention_backend: str):
+    return SimpleNamespace(current_attention_backend=current_attention_backend)
+
+
+class TestFuseRopeForTrtllmMlaSM12x(CustomTestCase):
+    def _call(self, *, is_sm120: bool, dsa_decode_backend: str, kv_cache_dtype):
+        fake_exec = SimpleNamespace(
+            kernel=SimpleNamespace(
+                dsa_decode_backend=dsa_decode_backend,
+                dsa_prefill_backend="not_trtllm",
+            )
+        )
+        fake_attn_backend = SimpleNamespace(kv_cache_dtype=kv_cache_dtype)
+        with (
+            mock.patch.object(fm, "_IS_SM120", is_sm120),
+            mock.patch.object(fm, "get_exec", lambda: fake_exec),
+            mock.patch.object(fm, "get_attn_backend", lambda: fake_attn_backend),
+        ):
+            return fm.DeepseekMLAForwardMixin._fuse_rope_for_trtllm_mla(
+                _fake_self("dsa"), forward_batch=SimpleNamespace()
+            )
+
+    def test_sm12x_dsa_trtllm_fp8_stays_unfused(self):
+        # The exact upstream-fused config (trtllm backend + fp8 kv cache) --
+        # on SM12x this must now return False, not True.
+        result = self._call(
+            is_sm120=True,
+            dsa_decode_backend="trtllm",
+            kv_cache_dtype=torch.float8_e4m3fn,
+        )
+        self.assertFalse(result)
+
+    def test_sm100_dsa_trtllm_fp8_keeps_fused_upstream(self):
+        # Datacenter Blackwell: byte-identical to upstream -- fused path taken.
+        result = self._call(
+            is_sm120=False,
+            dsa_decode_backend="trtllm",
+            kv_cache_dtype=torch.float8_e4m3fn,
+        )
+        self.assertTrue(result)
+
+    def test_sm12x_dsa_non_trtllm_stays_unfused(self):
+        # Non-trtllm dsa backend: upstream would also return False here; make
+        # sure the SM12x carve-out doesn't accidentally flip it to True.
+        result = self._call(
+            is_sm120=True,
+            dsa_decode_backend="flashinfer_gather",
+            kv_cache_dtype=torch.float8_e4m3fn,
+        )
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_deepseek_mla_fuse_rope_trtllm_sm12x.py
+++ b/test/registered/unit/models/test_deepseek_mla_fuse_rope_trtllm_sm12x.py
@@ -1,0 +1,93 @@
+"""Hermetic unit test for the SM12x carve-out in
+DeepseekMLAForwardMixin._fuse_rope_for_trtllm_mla (dsa/nsa branch), the mixin
+DeepseekV2AttentionMLA inherits its MLA forward methods from.
+
+Regression guard for the FIRST LIVE DEPLOY LESSON: on SM120/SM121, the dsa
+"trtllm" backend routes to flashinfer's native sparse-MLA kernel, which
+requires a BF16 query and dequantizes the KV cache itself via inline
+per-block scales. The datacenter-Blackwell fused rope+fp8-quantize path
+(`mla_quantize_and_rope_for_fp8` in dsa_backend.py's _forward_trtllm) hands
+that kernel an fp8 query, which it rejects
+("... expects BF16 query, got torch.float8_e4m3fn"). This method must
+therefore return False on SM12x for the dsa/nsa branch (rope stays in
+forward_absorb_prepare, query reaches _forward_trtllm as bf16) regardless of
+the dsa_decode_backend/dsa_prefill_backend/kv_cache_dtype combination that
+upstream (SM100/103) uses to decide the fused path.
+
+Pure Python (no GPU): `get_platform()` is patched directly. Upstream's
+platform-facts refactor removed the module-level `_IS_SM120` and folded it
+into a live `get_platform().is_sm120` read, so the fact is now mocked the
+same way as the other module-level accessors below, `get_exec`/
+`get_attn_backend`.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.models.deepseek_common.attention_forward_methods import (
+    forward_mla as fm,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _fake_self(current_attention_backend: str):
+    return SimpleNamespace(current_attention_backend=current_attention_backend)
+
+
+class TestFuseRopeForTrtllmMlaSM12x(CustomTestCase):
+    def _call(self, *, is_sm120: bool, dsa_decode_backend: str, kv_cache_dtype):
+        fake_exec = SimpleNamespace(
+            kernel=SimpleNamespace(
+                dsa_decode_backend=dsa_decode_backend,
+                dsa_prefill_backend="not_trtllm",
+            )
+        )
+        fake_attn_backend = SimpleNamespace(kv_cache_dtype=kv_cache_dtype)
+        fake_platform = SimpleNamespace(is_sm120=is_sm120)
+        with (
+            mock.patch.object(fm, "get_platform", lambda: fake_platform),
+            mock.patch.object(fm, "get_exec", lambda: fake_exec),
+            mock.patch.object(fm, "get_attn_backend", lambda: fake_attn_backend),
+        ):
+            return fm.DeepseekMLAForwardMixin._fuse_rope_for_trtllm_mla(
+                _fake_self("dsa"), forward_batch=SimpleNamespace()
+            )
+
+    def test_sm12x_dsa_trtllm_fp8_stays_unfused(self):
+        # The exact upstream-fused config (trtllm backend + fp8 kv cache) --
+        # on SM12x this must now return False, not True.
+        result = self._call(
+            is_sm120=True,
+            dsa_decode_backend="trtllm",
+            kv_cache_dtype=torch.float8_e4m3fn,
+        )
+        self.assertFalse(result)
+
+    def test_sm100_dsa_trtllm_fp8_keeps_fused_upstream(self):
+        # Datacenter Blackwell: byte-identical to upstream -- fused path taken.
+        result = self._call(
+            is_sm120=False,
+            dsa_decode_backend="trtllm",
+            kv_cache_dtype=torch.float8_e4m3fn,
+        )
+        self.assertTrue(result)
+
+    def test_sm12x_dsa_non_trtllm_stays_unfused(self):
+        # Non-trtllm dsa backend: upstream would also return False here; make
+        # sure the SM12x carve-out doesn't accidentally flip it to True.
+        result = self._call(
+            is_sm120=True,
+            dsa_decode_backend="flashinfer_gather",
+            kv_cache_dtype=torch.float8_e4m3fn,
+        )
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem

`attention_backend=dsa` with `dsa_decode_backend/dsa_prefill_backend=trtllm` crashes on SM120/SM121 (DGX Spark GB10, RTX PRO Blackwell) with `TllmGenFmhaRunner ... Unsupported architecture`: `_forward_trtllm` hardcodes `backend="trtllm-gen"`, which only exists for datacenter Blackwell (SM100/103).

flashinfer (>= 0.6.x) already ships a native SM120/121 sparse-MLA implementation (`flashinfer/mla/_sparse_mla_sm120.py`, `@supported_compute_capability([120, 121])`, DSv3.2/GLM model types, warp-spec decode kernels for `num_tokens <= 64` plus a prefill orchestrator above), and its dispatcher `trtllm_batch_decode_with_kv_cache_mla` routes `cc == 12 && sparse_mla_top_k > 0` to it automatically — but only with `backend="auto"`. Three small changes make the whole DSA path (decode AND prefill) work on consumer Blackwell.

### Changes

All SM12x gating uses the existing `is_sm120_supported()` util (covers SM120 and SM121 via `major == 12`); SM100/SM103 behaviour is byte-identical (every conditional keeps the upstream value on the non-SM12x side).

1. **`mem_cache/kv_cache_configurator.py::calculate_mla_kv_cache_dim`** — do not early-return the plain `kv_lora_rank + qk_rope_head_dim` layout for trtllm backends on SM12x. The SM120 sparse kernel consumes the 656-byte packed inline-scale layout (512 fp8 nope + 4× fp32 tile scales + 64 bf16 rope) that `quantize_k_cache` already writes; `dsa_kv_cache_store_fp8` then derives `True` automatically.
2. **`dsa_backend.py::_forward_trtllm`** — on SM12x with the packed pool: `backend="auto"` (flashinfer picks the sparse backend), pass the KV cache as a `uint8` view (required by the sm120 checker), `kv_scale_format="arbitrary_fp32"` (sglang's `quantize_k_cache` writes amax/448 **arbitrary** fp32 tile scales, not pow2/ue8m0 — the default "auto" would misread them as DSv3.2 pow2 scales), `skip_softmax_threshold_scale_factor=None` and `multi_ctas_kv_counter_buffer=None` (both trtllm-gen-only; the sparse backend raises on non-None values), and skip the fused rope+fp8-query-quantize branch — the sparse kernel requires a **BF16 query** and dequants KV itself via the inline scales. DSA prefill context-parallelism raises an explicit `NotImplementedError` on this path instead of silently mis-routing (its rope rebuild and KV all-gather live inside the skipped fp8 branch).
3. **`deepseek_common/attention_forward_methods/forward_mla.py::_fuse_rope_for_trtllm_mla`** — return `False` for the dsa branch on SM12x so rope stays in `forward_absorb_prepare` and the query reaches `_forward_trtllm` in bf16.

### Evidence

Live on a 4× DGX Spark (GB10, SM121) cluster serving `GlmMoeDsaForCausalLM` (504B REAP cut, NVFP4, TP4, fp8 KV): boot clean, decode graph capture 18 s, decode 8.4 tok/s single-stream with cuda-graph, prefill 873 tok/s input on a 7-seq/2240-token batch, GSM8K 2-shot n=20 conc 8 = 85% with 0 errors/restarts; MTP/NEXTN target-verify runs through the same kernel (accept length ~2.1). Kernel-level (real `quantize_k_cache` pool vs a torch dequant+softmax reference): decode bs=4 topk=2048 max|diff| 0.008 @ 0.072 ms/call; prefill 2400 extend tokens max|diff| 0.016; `seq_lens > topk` clamps safely; `-1` padding skipped natively; cuda-graph capture+replay works directly.

### Tests

- `test/registered/unit/mem_cache/test_dsa_kv_cache_dim_sm12x.py` — layout matrix (sm12x+fp8+trtllm → 656 packed; sm12x+bf16 → 576; sm100+trtllm → 576; non-trtllm unaffected). Mocked arch — runs anywhere.
- `test/registered/unit/layers/attention/test_dsa_backend_trtllm_sm12x_kwargs.py` — monkeypatches `flashinfer.decode` and calls the real `_forward_trtllm`, asserting kwarg selection on the SM12x path, unchanged upstream kwargs on the non-SM12x path, and the CP guard. Runs anywhere.
- `test/registered/unit/models/test_deepseek_mla_fuse_rope_trtllm_sm12x.py` — isolated regression test for the "expects BF16 query, got float8_e4m3fn" crash. Runs anywhere.
- `test/registered/kernels/test_dsa_sparse_mla_sm12x.py` — SM120/121-gated (skips elsewhere): builds a real packed pool via `quantize_k_cache` and compares flashinfer's sparse kernel vs a torch masked-softmax reference (decode small/overshoot/variable, prefill > 64 tokens, cuda-graph capture+replay).

**11/11 CI-safe unit tests pass anywhere; 5/5 kernel tests pass on GB10 (SM121).**

Re-validated after rebasing onto current main (flashinfer pin 0.6.15.post1, `multi_ctas_kv_counter_buffer` kwarg, config-namespace accessors): 11/11 unit tests, and 5/5 kernel tests on GB10 against flashinfer 0.6.16 — the sparse dispatch semantics are identical across 0.6.15.post1/0.6.16.

### Notes

- Requires flashinfer >= 0.6.x with `mla/_sparse_mla_sm120.py` (prebuilt in current wheels).
- Companion PR (the indexer side for SM12x): #31480 — neither alone boots DSA on consumer Blackwell; independent to review/merge.
- Longer-term, the layout coupling in `calculate_mla_kv_cache_dim` ("plain iff a backend is named trtllm") might better key on the actually-selected kernel; this PR keeps the minimal change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35708104539](https://github.com/sgl-project/sglang/actions/runs/35708104539)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35708104212](https://github.com/sgl-project/sglang/actions/runs/35708104212)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35708104424](https://github.com/sgl-project/sglang/actions/runs/35708104424)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
