### PR TITLE
[Fix] HiCacheFile eviction: skip un-removable files instead of wedging the cache

### DIFF
--- a/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
+++ b/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
@@ -352,9 +352,17 @@ class LRUFileEvictor:
                 self._on_evict(evict_stem)
         except OSError as e:
             logger.warning(f"HiCacheFile eviction failed for {evict_stem}: {e}")
+            # Re-pin at MRU and skip, exactly like an in-flight write, instead of
+            # stopping the whole eviction loop. A single un-removable file
+            # (EPERM/EACCES/EBUSY/EROFS/EIO on some backends) must not block the
+            # removable newer entries behind it: returning "stop" here -- and
+            # re-pinning the victim at the LRU *front* -- makes every later evict
+            # pass hit it first, reclaim nothing, and leave the cap permanently
+            # exceeded, so reserve() refuses all new writes forever. Skipping lets
+            # the loop reclaim what it can; the bounded skip budget in
+            # _evict_while still terminates when every entry is un-evictable.
             self._lru[evict_stem] = evict_size
-            self._lru.move_to_end(evict_stem, last=False)
-            return "stop", 0
+            return "skipped", 0
         self._total_bytes -= evict_size
         return "evicted", freed
 

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -399,6 +399,67 @@ class TestMinFreeSpaceWatermark(HiCacheFileLRUTestBase):
         self.assertTrue(b.exists("newk"))
 
 
+class TestUnlinkFailureDoesNotWedge(HiCacheFileLRUTestBase):
+    def test_unremovable_lru_front_file_does_not_block_eviction(self):
+        """A single un-removable LRU-front file must not wedge all eviction.
+
+        Regression: when ``os.remove`` raised a non-``FileNotFoundError``
+        ``OSError`` (EPERM/EACCES/EBUSY/EROFS/EIO, plausible on NFS/FUSE/ro
+        remounts), ``_evict_one_lru_locked`` re-pinned the victim at the LRU
+        *front* and returned ``"stop"``. Every later eviction pass then popped
+        that same file first, reclaimed nothing, and left the cap exceeded, so
+        ``reserve`` refused all new writes forever -- one stuck cold file
+        permanently disabled the whole file cache. The un-removable entry must
+        instead be skipped so the removable newer entries behind it still get
+        evicted.
+        """
+        b = self.make_backend(max_size="300", eviction_ratio=1.0)
+        for k in ("a", "b", "c"):
+            self.assertTrue(b.set(k, _t(100)))
+        self.assertEqual(b._evictor._total_bytes, 300)
+        # "a" is the LRU front; make only its unlink fail.
+        a_path = os.path.join(b.file_path, f"{b._get_suffixed_key('a')}.bin")
+        real_remove = os.remove
+
+        def guarded_remove(p):
+            if os.path.abspath(p) == os.path.abspath(a_path):
+                raise PermissionError(13, "simulated EPERM")
+            return real_remove(p)
+
+        with mock.patch("os.remove", side_effect=guarded_remove):
+            admitted = b.set("d", _t(100))
+
+        # New write is admitted (not wedged): eviction skipped the stuck "a" and
+        # reclaimed a removable neighbour instead.
+        self.assertTrue(
+            admitted, "d must be admitted; the stuck file must not wedge eviction"
+        )
+        self.assertTrue(b.exists("d"))
+        self.assertTrue(b.exists("a"), "the un-removable file itself survives on disk")
+        # Exactly one removable neighbour was evicted to make room.
+        self.assertNotEqual(
+            b.exists("b"),
+            b.exists("c"),
+            "exactly one of the removable neighbours (b/c) should be evicted",
+        )
+        self.assertLessEqual(b._evictor._total_bytes, 300)
+
+    def test_all_unremovable_refuses_without_infinite_loop(self):
+        """If every entry is un-removable, reserve refuses (bounded, no spin)."""
+        b = self.make_backend(max_size="200", eviction_ratio=1.0)
+        for k in ("a", "b"):
+            self.assertTrue(b.set(k, _t(100)))
+        self.assertEqual(b._evictor._total_bytes, 200)
+
+        with mock.patch("os.remove", side_effect=PermissionError(13, "EPERM")):
+            # Would spin forever if the skip budget in _evict_while were unbounded.
+            admitted = b.set("c", _t(100))
+
+        self.assertFalse(admitted, "nothing evictable -> refuse the new write")
+        self.assertTrue(b.exists("a") and b.exists("b"))
+        self.assertEqual(b._evictor._total_bytes, 200)
+
+
 class TestPreReservationConcurrency(HiCacheFileLRUTestBase):
     def test_pre_reservation_visible_during_write(self):
         """An in-flight reservation must not be evicted by a concurrent set()."""


### PR DESCRIPTION
## Motivation

`LRUFileEvictor._evict_one_lru_locked` handles an `os.remove` failure by re-pinning the victim at the LRU front and returning `"stop"`. Since `_evict_while` always pops from the front, a single un-removable file (EPERM/EACCES/EBUSY/EROFS/EIO, which occur on NFS/FUSE backends, permission changes, or a read-only remount) gets retried first on every eviction pass, reclaims nothing, and stops the loop before reaching the removable newer files behind it. `_total_bytes` never drops, the cap stays exceeded, and `reserve()` returns `False` for every later write, so one stuck cold file silently disables all new file caching.

## Modifications

Treat an unlink failure like an in-flight write: re-pin at MRU and return `"skipped"` so the loop continues instead of stopping. The bounded skip budget in `_evict_while` still terminates when every entry is un-evictable (correctly refusing the write in that case).

## Tests

Two cases in `test_hicache_file_lru_unit.py`:
- an un-removable LRU-front file no longer wedges eviction: the new write is admitted and a removable neighbour is reclaimed instead;
- when every entry is un-removable, `reserve` refuses without spinning.

Both fail on the pre-fix code and pass after.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29527113127](https://github.com/sgl-project/sglang/actions/runs/29527113127)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29527112868](https://github.com/sgl-project/sglang/actions/runs/29527112868)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->