### PR TITLE
[Fix] PureSWARadixCache: do not re-cache window-evicted KV (stale-KV read + double-free)

### DIFF
--- a/python/sglang/srt/mem_cache/pure_swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/pure_swa_radix_cache.py
@@ -102,6 +102,15 @@ class PureSWARadixCache(RadixCache):
 
         if swa_evict_floor > 0:
             insert_end = min(swa_evict_floor, keys_len)
+        elif swa_evicted_seqlen > old_prefix_len:
+            # Non-prefill-aware SWA (swa_evict_floor == 0): decode's
+            # free_swa_out_of_window_slots already freed the out-of-window range
+            # [old_prefix_len, swa_evicted_seqlen). Only [0, old_prefix_len) is
+            # still a live, contiguous prefix -- inserting past it re-adds freed
+            # slots, which a later match_prefix would hand out as a "cache hit"
+            # (stale KV, since the allocator has recycled those slots) and which
+            # evict() would then free a second time (double-free of the pool).
+            insert_end = min(old_prefix_len, keys_len)
         else:
             insert_end = keys_len
 
@@ -119,9 +128,16 @@ class PureSWARadixCache(RadixCache):
             if alive_start < keys_len:
                 self.token_to_kv_pool_allocator.free(kv_indices[alive_start:keys_len])
         else:
-            free_end = (
-                min(swa_evict_floor, keys_len) if swa_evict_floor > 0 else keys_len
-            )
+            if swa_evict_floor > 0:
+                free_end = min(swa_evict_floor, keys_len)
+            elif swa_evicted_seqlen > old_prefix_len:
+                # Same freed-hole boundary as the insert path: [old_prefix_len,
+                # swa_evicted_seqlen) was already freed during decode, so freeing
+                # up to keys_len here would double-free that range (and the
+                # still-alive tail, freed again below).
+                free_end = min(old_prefix_len, keys_len)
+            else:
+                free_end = keys_len
             if free_end > old_prefix_len:
                 self.token_to_kv_pool_allocator.free(
                     kv_indices[old_prefix_len:free_end]

--- a/test/registered/unit/mem_cache/test_pure_swa_radix_refree.py
+++ b/test/registered/unit/mem_cache/test_pure_swa_radix_refree.py
@@ -1,0 +1,180 @@
+"""Regression test: PureSWARadixCache must not re-cache window-evicted KV.
+
+Bug: on a non-prefill-aware all-SWA model, ``req.swa_evict_floor`` stays 0, so
+``PureSWARadixCache.cache_finished_req`` took its ``else`` branch and set
+``insert_end = keys_len``, inserting the ENTIRE prefix [0, keys_len). But during
+decode ``free_swa_out_of_window_slots`` already freed the out-of-window range
+[cache_protected_len, swa_evicted_seqlen). Re-inserting those freed slots made
+``match_prefix`` hand them out as a "cache hit" (stale KV -- the single-pool
+``PureSWATokenToKVPoolAllocator`` recycles ``free``/``free_swa`` from the same
+pool) and made ``evict()`` free them a second time (double-free).
+
+Fix: mirror decode's protection boundary -- when a freed hole exists
+(swa_evicted_seqlen > cache_protected_len) only [0, cache_protected_len) is a
+live contiguous prefix, so cache no further. The still-in-window tail is freed
+back to the allocator as before.
+
+Uses real tree/allocator/pool with a mock Req, mirroring
+test_swa_eviction_boundary.py.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.allocator.swa import PureSWATokenToKVPoolAllocator
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.common import free_swa_out_of_window_slots
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.pure_swa_radix_cache import PureSWARadixCache
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.utils import get_device
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+
+
+def _build_pure_swa_tree(sliding_window_size, kv_size_swa=512):
+    """All-SWA model: every layer is sliding-window; page_size == 1."""
+    head_num, head_dim, num_layers = 8, 128, 8
+    dtype = torch.bfloat16
+    device = get_device()
+    pool = ReqToTokenPool(
+        size=8, max_context_len=2048, device=device, enable_memory_saver=False
+    )
+    kv_pool = SWAKVPool(
+        size=0,
+        size_swa=kv_size_swa,
+        page_size=1,
+        dtype=dtype,
+        head_num=head_num,
+        head_dim=head_dim,
+        swa_attention_layer_ids=list(range(num_layers)),
+        full_attention_layer_ids=[],
+        device=device,
+    )
+    allocator = PureSWATokenToKVPoolAllocator(
+        kv_size_swa,
+        page_size=1,
+        dtype=dtype,
+        device=device,
+        kvcache=kv_pool,
+        need_sort=False,
+    )
+    tree = PureSWARadixCache(
+        params=CacheInitParams(
+            req_to_token_pool=pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+            disable=False,
+            is_eagle=False,
+            sliding_window_size=sliding_window_size,
+        ),
+    )
+    return tree, allocator, pool
+
+
+def _make_req(req_pool_idx, token_ids, tree):
+    return SimpleNamespace(
+        req_pool_idx=req_pool_idx,
+        origin_input_ids=token_ids,
+        output_ids=[],
+        cache_protected_len=0,
+        swa_evict_floor=0,  # non-prefill-aware all-SWA model
+        kv=SimpleNamespace(swa_evicted_seqlen=0),
+        extra_key=None,
+        last_node=tree.root_node,
+    )
+
+
+class TestPureSWARadixRefree(unittest.TestCase):
+    def _decode_evict(self, tree, allocator, pool, req, seq_len, window):
+        """Drive the real decode-time SWA eviction (frees out-of-window slots)."""
+        free_swa_out_of_window_slots(
+            req,
+            seq_len - 1,
+            sliding_window_size=window,
+            page_size=1,
+            req_to_token_pool=pool,
+            token_to_kv_pool_allocator=allocator,
+        )
+
+    def test_window_evicted_prefix_not_refree_or_realiased(self):
+        window = 4
+        tree, allocator, pool = _build_pure_swa_tree(window)
+        cap = allocator.swa_available_size()  # free capacity (robust to reserved slots)
+
+        seq_len = 32  # >> window, so decode evicts an out-of-window prefix
+        kv = allocator.alloc(seq_len)
+        self.assertIsNotNone(kv)
+        pool.write((0, slice(0, seq_len)), kv)
+
+        req = _make_req(0, list(range(seq_len)), tree)
+        self._decode_evict(tree, allocator, pool, req, seq_len, window)
+        evicted = req.kv.swa_evicted_seqlen
+        self.assertGreater(evicted, 0, "decode should have window-evicted a prefix")
+
+        tree.cache_finished_req(req, is_insert=True, kv_len_to_handle=seq_len)
+
+        # The freed out-of-window prefix must NOT be re-cached: with a hole, no
+        # contiguous prefix survives (cache_protected_len == 0), so nothing new
+        # is evictable, and no slot is both allocator-free and tree-referenced.
+        self.assertEqual(
+            tree.evictable_size(),
+            0,
+            "window-evicted prefix must not be re-inserted into the tree",
+        )
+        # Conservation: a slot double-counted (free-list AND tree) would push the
+        # sum above the pool capacity -- exactly the aliasing/double-free bug.
+        self.assertEqual(
+            allocator.swa_available_size() + tree.evictable_size(),
+            cap,
+            "every slot must be either free or tree-held, never both",
+        )
+
+    def test_deterministic_mode_no_double_free(self):
+        # is_insert=False (deterministic mode) took the same buggy free_end path.
+        window = 4
+        tree, allocator, pool = _build_pure_swa_tree(window)
+        cap = allocator.swa_available_size()
+
+        seq_len = 32
+        kv = allocator.alloc(seq_len)
+        pool.write((0, slice(0, seq_len)), kv)
+        req = _make_req(0, list(range(seq_len)), tree)
+        self._decode_evict(tree, allocator, pool, req, seq_len, window)
+        self.assertGreater(req.kv.swa_evicted_seqlen, 0)
+
+        tree.cache_finished_req(req, is_insert=False, kv_len_to_handle=seq_len)
+
+        # Nothing cached; all slots freed exactly once (a double-free would make
+        # available exceed capacity).
+        self.assertEqual(tree.evictable_size(), 0)
+        self.assertEqual(allocator.swa_available_size(), cap)
+
+    def test_short_request_still_fully_cached(self):
+        # Positive control (no caching regression): a request that never leaves
+        # the window (swa_evicted_seqlen stays 0) must still cache its whole prefix.
+        window = 8
+        tree, allocator, pool = _build_pure_swa_tree(window)
+        cap = allocator.swa_available_size()
+
+        seq_len = 5  # < window -> decode evicts nothing
+        kv = allocator.alloc(seq_len)
+        pool.write((0, slice(0, seq_len)), kv)
+        req = _make_req(0, list(range(seq_len)), tree)
+        self._decode_evict(tree, allocator, pool, req, seq_len, window)
+        self.assertEqual(req.kv.swa_evicted_seqlen, 0)
+
+        tree.cache_finished_req(req, is_insert=True, kv_len_to_handle=seq_len)
+
+        self.assertEqual(
+            tree.evictable_size(), seq_len, "full prefix must remain cached"
+        )
+        self.assertEqual(allocator.swa_available_size() + tree.evictable_size(), cap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On an all-SWA model whose attention backend is not prefill-aware, `req.swa_evict_floor` stays `0`, so `PureSWARadixCache.cache_finished_req` sets `insert_end = keys_len` and inserts the whole prefix `[0, keys_len)` into the radix tree.

But decode already freed the out-of-window range `[cache_protected_len, swa_evicted_seqlen)` via `free_swa_out_of_window_slots`, and `PureSWATokenToKVPoolAllocator` is single-pool (`full_attn_allocator is swa_attn_allocator`), so those slots are back in the free list. Re-inserting them means:

- `match_prefix` returns them as a cache hit, but the allocator has already recycled them to other requests, giving stale KV / wrong output;
- when the node is later evicted, `evict()` frees the same slots a second time (double-free of the pool).

The deterministic-mode (`is_insert=False`) branch has the same root cause and additionally double-frees the still-in-window tail within the same call.

This is reachable for any all-SWA model (`full_tokens_per_layer == 0`, selected in `registry.py`) with `prefill_aware_swa` disabled (the default) on any request longer than its sliding window.

## Modifications

Mirror decode's protection boundary. When a freed hole exists (`swa_evicted_seqlen > cache_protected_len`), only `[0, cache_protected_len)` is a live, contiguous prefix, so cache no further; the still-in-window tail is freed back to the allocator as before. When nothing was window-evicted the whole prefix is still cached, so short requests are unaffected, and the prefill-aware (`swa_evict_floor > 0`) path is unchanged.

## Tests

`test_pure_swa_radix_refree.py` (real tree/allocator/pool + mock Req, mirroring `test_swa_eviction_boundary.py`):
- after decode window-eviction, the freed prefix is not re-inserted and no slot is both allocator-free and tree-held (conservation);
- the `is_insert=False` path frees every slot exactly once;
- a short request (never leaves the window) still caches its full prefix.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29527148380](https://github.com/sgl-project/sglang/actions/runs/29527148380)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29527148152](https://github.com/sgl-project/sglang/actions/runs/29527148152)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->