### PR TITLE
[AMD] register 8 JIT kernel benchmarks to jit-kernel-benchmark-test-amd

### DIFF
--- a/test/registered/jit/benchmark/bench_custom_all_reduce.py
+++ b/test/registered/jit/benchmark/bench_custom_all_reduce.py
@@ -29,7 +29,7 @@ from sglang.jit_kernel.benchmark import marker
 from sglang.jit_kernel.benchmark.utils import get_benchmark_range, multigpu_bench_main
 from sglang.jit_kernel.mp import register_comm_cleanup
 from sglang.jit_kernel.utils import cache_once, is_arch_support_pdl
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
@@ -37,6 +37,7 @@ register_cuda_ci(
     runner_config="1-gpu-large",
     disabled="requires multi-GPU, self-skips in CI",
 )
+register_amd_ci(est_time=120, stage="jit-kernel-benchmark", runner_config="amd")
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/jit/benchmark/bench_fp8_blockwise_gemm.py
+++ b/test/registered/jit/benchmark/bench_fp8_blockwise_gemm.py
@@ -8,13 +8,14 @@ import triton
 from sglang.jit_kernel.benchmark.utils import get_benchmark_range, run_benchmark
 from sglang.jit_kernel.fp8_blockwise_gemm import fp8_blockwise_scaled_mm
 from sglang.srt.utils import is_sm120_supported
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=5,
     stage="base-b-kernel-benchmark",
     runner_config="1-gpu-large",
 )
+register_amd_ci(est_time=5, stage="jit-kernel-benchmark", runner_config="amd")
 
 
 def _make_inputs(m: int, n: int, k: int, device: str = "cuda"):

--- a/test/registered/jit/benchmark/bench_post_reorder_deepgemm.py
+++ b/test/registered/jit/benchmark/bench_post_reorder_deepgemm.py
@@ -5,11 +5,12 @@ from sglang.kernels.ops.moe.ep_moe_kernels import (
     post_reorder_deepgemm,
     post_reorder_triton_kernel,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=8, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
 )
+register_amd_ci(est_time=8, stage="jit-kernel-benchmark", runner_config="amd")
 
 HIDDEN = 6144
 NUM_EXPERTS = 129

--- a/test/registered/jit/benchmark/bench_symm_mem_all_gather.py
+++ b/test/registered/jit/benchmark/bench_symm_mem_all_gather.py
@@ -33,7 +33,7 @@ from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
     all_gather_inner,
     create_state,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
@@ -41,6 +41,7 @@ register_cuda_ci(
     runner_config="1-gpu-large",
     disabled="requires multi-GPU, self-skips in CI",
 )
+register_amd_ci(est_time=120, stage="jit-kernel-benchmark", runner_config="amd")
 
 # ---------------------------------------------------------------------------
 # Sweep parameters

--- a/test/registered/jit/benchmark/bench_tp_qknorm.py
+++ b/test/registered/jit/benchmark/bench_tp_qknorm.py
@@ -37,7 +37,7 @@ from sglang.jit_kernel.utils import cache_once, get_ci_test_range
 from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
     CustomAllReduceV2,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=120,
@@ -45,6 +45,7 @@ register_cuda_ci(
     runner_config="1-gpu-large",
     disabled="requires multi-GPU, self-skips in CI",
 )
+register_amd_ci(est_time=120, stage="jit-kernel-benchmark", runner_config="amd")
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
+++ b/test/registered/jit/benchmark/diffusion/bench_causal_conv3d_cat_pad.py
@@ -9,7 +9,7 @@ from sglang.jit_kernel.diffusion.causal_conv3d_cat_pad import (
 from sglang.jit_kernel.diffusion.triton.causal_conv3d_pad import (
     fused_causal_conv3d_cat_pad as fused_causal_conv3d_cat_pad_triton,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=20,
@@ -17,6 +17,7 @@ register_cuda_ci(
     runner_config="1-gpu-large",
     disabled="standalone benchmark",
 )
+register_amd_ci(est_time=20, stage="jit-kernel-benchmark", runner_config="amd")
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16

--- a/test/registered/jit/benchmark/diffusion/bench_group_norm_silu.py
+++ b/test/registered/jit/benchmark/diffusion/bench_group_norm_silu.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 import triton.testing
 
 from sglang.jit_kernel.diffusion.triton.group_norm_silu import triton_group_norm_silu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.utils import is_in_ci
 
 register_cuda_ci(
@@ -20,6 +20,7 @@ register_cuda_ci(
     runner_config="1-gpu-large",
     disabled="standalone benchmark",
 )
+register_amd_ci(est_time=45, stage="jit-kernel-benchmark", runner_config="amd")
 
 DEVICE = "cuda"
 EPS = 1e-5

--- a/test/registered/jit/benchmark/diffusion/bench_norm_impls.py
+++ b/test/registered/jit/benchmark/diffusion/bench_norm_impls.py
@@ -19,7 +19,7 @@ from sglang.jit_kernel.diffusion.triton.rmsnorm_onepass import triton_one_pass_r
 from sglang.jit_kernel.norm import fused_add_rmsnorm as jit_fused_add_rmsnorm
 from sglang.jit_kernel.norm import rmsnorm as jit_rmsnorm
 from sglang.jit_kernel.utils import KERNEL_PATH
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.utils import is_in_ci
 
 register_cuda_ci(
@@ -28,6 +28,7 @@ register_cuda_ci(
     runner_config="1-gpu-large",
     disabled="self-skips in CI, standalone tool",
 )
+register_amd_ci(est_time=120, stage="jit-kernel-benchmark", runner_config="amd")
 
 os.environ.setdefault("FLASHINFER_DISABLE_VERSION_CHECK", "1")
 


### PR DESCRIPTION
## Summary
Follow-up to #30307. Extends AMD JIT-kernel benchmark coverage by registering **8 more** device-agnostic kernel benchmarks to the dedicated `jit-kernel-benchmark-test-amd` stage (same 2-line pattern: `register_amd_ci(est_time=…, stage="jit-kernel-benchmark", runner_config="amd")` next to the CUDA registration).

NVIDIA-hardware-specific benches (nvfp4 / mxfp8 / sm90 / dsv4-fp4-indexer) remain CUDA-only.

## Selection (empirical, both ROCm lanes)
After #30307 the `test/registered/jit/benchmark/` gap was **30 CUDA-only portable benches**. All 30 were probed on both ROCm 7.0 and 7.2; **both lanes agreed exactly: 24/46 passed** (46 = the 16 already-registered + 30 probed). Of the 30 probed, **8 pass** and are kept here; the 22 that fail (CUDA-only kernel source, missing ROCm `sgl_kernel` ops, or missing libs like `flashinfer`/`deep_gemm`) stay CUDA-only pending ROCm porting.

Probe runs (all 30, `continue_on_error=true`):
- ROCm 7.2 → https://github.com/sgl-project/sglang/actions/runs/29527101966 (24/46)
- ROCm 7.0 → https://github.com/sgl-project/sglang/actions/runs/29527103971 (24/46)

### Kept (8) — per-bench runtime on ROCm (MI325)

| # | Bench | elapsed (s) |
| - | ----- | ----------: |
| 1 | `bench_custom_all_reduce.py` | 3 |
| 2 | `bench_fp8_blockwise_gemm.py` | 3 |
| 3 | `bench_post_reorder_deepgemm.py` | 5 |
| 4 | `bench_symm_mem_all_gather.py` | 4 |
| 5 | `bench_tp_qknorm.py` | 3 |
| 6 | `diffusion/bench_causal_conv3d_cat_pad.py` | 9 |
| 7 | `diffusion/bench_group_norm_silu.py` | 4 |
| 8 | `diffusion/bench_norm_impls.py` | 13 |
| | **Total** | **~44** |

<details>
<summary>Dropped (22) — remain CUDA-only, failed on both ROCm lanes (follow-up porting work)</summary>

`bench_awq_dequantize`, `bench_concat_mla`, `bench_dsv3_fused_a_gemm`, `bench_fused_fp8_qkv_kv_cache`, `bench_fused_qknorm_rope`, `bench_hadamard`, `bench_moe_fused_gate`, `bench_norm`, `bench_per_tensor_quant_fp8`, `bench_per_token_group_quant_8bit`, `bench_per_token_group_quant_8bit_v2`, `bench_qknorm`, `bench_qknorm_across_heads`, `bench_renorm`, `bench_rope`, `bench_set_mla_kv_buffer`, `bench_topk`, `diffusion/bench_fused_norm_scale_shift`, `diffusion/bench_ltx2_qknorm_split_rope`, `diffusion/bench_qknorm_rope`, `diffusion/bench_residual_gate_add`, `minimax/bench_minimax_qknorm_rope`

</details>

## Verification (trimmed subset, `continue_on_error=false` — true gate)
Suite `jit-kernel-benchmark-test-amd` is green on **both ROCm targets — Test Summary 24/24 passed** (16 already-registered + the 8 added):
- ROCm 7.2 (`pr-test-amd-rocm720.yml`) → https://github.com/sgl-project/sglang/actions/runs/29558992642
- ROCm 7.0 (`pr-test-amd.yml`) → https://github.com/sgl-project/sglang/actions/runs/29544860325

## Test plan
- [x] Both gate runs green — suite `jit-kernel-benchmark-test-amd` passes 24/24 on ROCm 7.0 and 7.2.
- [x] Ready for review.
