### PR TITLE
perf: avoid FLA l2norm recompilation by token count

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/l2norm.py
+++ b/python/sglang/kernels/ops/attention/fla/l2norm.py
@@ -51,13 +51,12 @@ def l2norm_fwd_kernel1(
 #     ],
 #     key=["D", "NB"],
 # )
-@triton.jit
+@triton.jit(do_not_specialize=["T"])
 def l2norm_fwd_kernel(
     x,
     y,
     eps,
-    NB: tl.constexpr,
-    T: tl.constexpr,
+    T,
     D: tl.constexpr,
     BT: tl.constexpr,
     BD: tl.constexpr,
@@ -91,7 +90,6 @@ def l2norm_fwd(
         raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
 
     if D <= 512:
-        NB = triton.cdiv(T, 2048)
 
         def grid(meta):
             return (triton.cdiv(T, meta["BT"]),)
@@ -100,7 +98,6 @@ def l2norm_fwd(
             x,
             y,
             eps,
-            NB=NB,
             T=T,
             D=D,
             BD=BD,


### PR DESCRIPTION
## Summary

- keep the FLA l2norm token count (`T`) as a runtime value instead of a Triton compile-time constant
- explicitly opt `T` out of specialization
- remove the unused `NB` constexpr argument

Qwen3.6-VL's GDN prefill sees many different token counts with random image sizes. Specializing `l2norm_fwd` on every new `T` caused a fresh Triton compilation in the eager GDN segment. This was the apparent "prefill CUDA graph recompilation" gap: it is Triton JIT specialization, not a PCG/Dynamo recompile.

## PR-before vs PR-after benchmark

Same NVIDIA H200 TP2 server and flags, Qwen3.6-35B-A3B-FP8, SGLang OpenAI chat backend. Each measured run used 8 requests, 4 seeded random JPEGs/request, random 512x512 to 768x1024 resolutions, output length 1, cache flush, and three distinct warmup workloads. Values below are medians of 3 runs. The before tree is the current VLM integration stack at `a4e2fdea`; after is the same tree plus this commit.

| Request rate | Metric | Before | After | Delta |
|---|---:|---:|---:|---:|
| 1 | Mean TTFT | 131.49 ms | 78.82 ms | -40.06% |
| 1 | P99 TTFT | 164.12 ms | 105.22 ms | -35.89% |
| 1 | Request throughput | 0.8847 req/s | 0.8921 req/s | +0.84% |
| 1 | Mean E2E | 131.51 ms | 78.84 ms | -40.05% |
| inf | Mean TTFT | 416.05 ms | 305.59 ms | -26.55% |
| inf | P99 TTFT | 523.58 ms | 367.60 ms | -29.79% |
| inf | Request throughput | 14.8496 req/s | 20.1160 req/s | +35.46% |
| inf | Mean E2E | 416.07 ms | 305.61 ms | -26.55% |

Median vision-token counts were unchanged within one token (rate 1: 15266 vs 15267; inf: 15268 vs 15267), and every request succeeded.

## Compile and trace breakdown

On an NVIDIA H200 with a fresh Triton cache, the first call compiles the kernel in both cases. For subsequent unseen token counts:

| Case | First call | Median subsequent unseen `T` |
|---|---:|---:|
| Before (`T: tl.constexpr`) | 587.30 ms | 70.95 ms |
| After (runtime `T`) | 590.18 ms | 0.107 ms |

In the full-server trace, the 73-76 ms CPU gaps before `l2norm_fwd` kernel launch disappeared (largest remaining gap <= 0.588 ms). The affected high-batch LM-prefill segment fell from roughly 146-155 ms to 76.2-76.5 ms.

## Scope

This benefits dynamic-token workloads that execute this FLA l2norm path, including GDN/KDA models such as Qwen3.6-VL. It can also help language-only models using the same path. It does not claim a benefit for VLMs whose language model does not use this kernel.

NVIDIA-only results are reported here.

## Validation

- FLA/GDN test suite on H200: 29 tests plus 4 subtests passed
- `pre-commit` passed for `python/sglang/kernels/ops/attention/fla/l2norm.py`
- `git diff --check` passed















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29589396662](https://github.com/sgl-project/sglang/actions/runs/29589396662)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29589396113](https://github.com/sgl-project/sglang/actions/runs/29589396113)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->