### PR TITLE
[Fix] Deflake score engine determinism tests

### DIFF
--- a/test/registered/prefill_only/test_score_engine.py
+++ b/test/registered/prefill_only/test_score_engine.py
@@ -227,13 +227,10 @@ class TestCausalLMScoring(CustomTestCase):
             self.assertAlmostEqual(sum(row), 1.0, places=6)
 
     def test_score_deterministic(self):
-        """Identical calls return equivalent scores (within GPU float tolerance).
+        """Identical calls return equivalent scores (guards stale output buffers).
 
-        Guards against stale output buffers / cross-request contamination,
-        which produce order-of-magnitude differences.  The cache is flushed
-        between the two calls so both take the fresh-prefill path; the
-        remaining batch-composition nondeterminism only causes bf16-level
-        noise, covered by the relative tolerance.
+        Cache is flushed between calls so both take the fresh-prefill path;
+        the loose relative tolerance covers bf16 batch-composition noise.
         """
         kwargs = dict(query="Choose:", items=["A", "B", "C"], label_token_ids=[1, 2, 3])
         scores_a = self.engine.score(**kwargs).scores
@@ -277,9 +274,7 @@ class TestSeqClsScoring(CustomTestCase):
         cls.engine = Engine(
             model_path=_SEQCLS_MODEL,
             disable_radix_cache=True,
-            # The classification head is randomly initialised; pin the seed so
-            # its weights (and hence the numerical sensitivity of the scores)
-            # are reproducible across CI runs.
+            # Pin the seed so the randomly initialised head is reproducible.
             random_seed=42,
             json_model_override_args=json.dumps(
                 {
@@ -332,12 +327,8 @@ class TestSeqClsScoring(CustomTestCase):
                 self.assertIsInstance(v, (int, float))
 
     def test_score_deterministic(self):
-        """Identical inputs yield near-identical raw logits (bf16 tolerance).
-
-        Guards against stale output buffers / cross-request contamination.
-        Batch-composition nondeterminism between the two calls causes
-        bf16-level noise on the O(1) raw logits, so the tolerance is loose.
-        """
+        """Identical inputs yield near-identical raw logits (guards stale output
+        buffers); loose delta covers bf16 batch-composition noise."""
         kwargs = dict(query="Evaluate:", items=["alpha", "beta", "gamma"])
         scores1 = self.engine.score(**kwargs).scores
         scores2 = self.engine.score(**kwargs).scores

--- a/test/registered/prefill_only/test_score_engine.py
+++ b/test/registered/prefill_only/test_score_engine.py
@@ -227,15 +227,23 @@ class TestCausalLMScoring(CustomTestCase):
             self.assertAlmostEqual(sum(row), 1.0, places=6)
 
     def test_score_deterministic(self):
-        """Identical calls return numerically equivalent scores (within GPU float tolerance)."""
+        """Identical calls return equivalent scores (within GPU float tolerance).
+
+        Guards against stale output buffers / cross-request contamination,
+        which produce order-of-magnitude differences.  The cache is flushed
+        between the two calls so both take the fresh-prefill path; the
+        remaining batch-composition nondeterminism only causes bf16-level
+        noise, covered by the relative tolerance.
+        """
         kwargs = dict(query="Choose:", items=["A", "B", "C"], label_token_ids=[1, 2, 3])
         scores_a = self.engine.score(**kwargs).scores
+        self.engine.flush_cache()
         scores_b = self.engine.score(**kwargs).scores
         self.assertEqual(len(scores_a), len(scores_b))
         for row_a, row_b in zip(scores_a, scores_b):
             self.assertEqual(len(row_a), len(row_b))
             for a, b in zip(row_a, row_b):
-                self.assertAlmostEqual(a, b, places=5)
+                self.assertAlmostEqual(a, b, delta=max(1e-4, 0.1 * abs(b)))
 
     def test_score_error_handling(self):
         """Invalid argument types raise ValueError or TypeError."""
@@ -269,6 +277,10 @@ class TestSeqClsScoring(CustomTestCase):
         cls.engine = Engine(
             model_path=_SEQCLS_MODEL,
             disable_radix_cache=True,
+            # The classification head is randomly initialised; pin the seed so
+            # its weights (and hence the numerical sensitivity of the scores)
+            # are reproducible across CI runs.
+            random_seed=42,
             json_model_override_args=json.dumps(
                 {
                     "architectures": ["Qwen3ForSequenceClassification"],
@@ -320,14 +332,19 @@ class TestSeqClsScoring(CustomTestCase):
                 self.assertIsInstance(v, (int, float))
 
     def test_score_deterministic(self):
-        """Identical inputs yield near-identical scores (fp16 tolerance)."""
+        """Identical inputs yield near-identical raw logits (bf16 tolerance).
+
+        Guards against stale output buffers / cross-request contamination.
+        Batch-composition nondeterminism between the two calls causes
+        bf16-level noise on the O(1) raw logits, so the tolerance is loose.
+        """
         kwargs = dict(query="Evaluate:", items=["alpha", "beta", "gamma"])
         scores1 = self.engine.score(**kwargs).scores
         scores2 = self.engine.score(**kwargs).scores
         self.assertEqual(len(scores1), len(scores2))
         for s1, s2 in zip(scores1, scores2):
             for v1, v2 in zip(s1, s2):
-                self.assertAlmostEqual(v1, v2, places=1)
+                self.assertAlmostEqual(v1, v2, delta=0.2)
 
     def test_score_tokenized_inputs(self):
         """Pre-tokenized query/items match text input scores."""

--- a/test/registered/prefill_only/test_score_engine.py
+++ b/test/registered/prefill_only/test_score_engine.py
@@ -227,11 +227,7 @@ class TestCausalLMScoring(CustomTestCase):
             self.assertAlmostEqual(sum(row), 1.0, places=6)
 
     def test_score_deterministic(self):
-        """Identical calls return equivalent scores (guards stale output buffers).
-
-        Cache is flushed between calls so both take the fresh-prefill path;
-        the loose relative tolerance covers bf16 batch-composition noise.
-        """
+        """Identical calls (cache flushed between) match within bf16 noise."""
         kwargs = dict(query="Choose:", items=["A", "B", "C"], label_token_ids=[1, 2, 3])
         scores_a = self.engine.score(**kwargs).scores
         self.engine.flush_cache()
@@ -274,7 +270,7 @@ class TestSeqClsScoring(CustomTestCase):
         cls.engine = Engine(
             model_path=_SEQCLS_MODEL,
             disable_radix_cache=True,
-            # Pin the seed so the randomly initialised head is reproducible.
+            # Deterministic init for the random classification head.
             random_seed=42,
             json_model_override_args=json.dumps(
                 {
@@ -327,8 +323,7 @@ class TestSeqClsScoring(CustomTestCase):
                 self.assertIsInstance(v, (int, float))
 
     def test_score_deterministic(self):
-        """Identical inputs yield near-identical raw logits (guards stale output
-        buffers); loose delta covers bf16 batch-composition noise."""
+        """Identical inputs yield raw logits matching within bf16 noise."""
         kwargs = dict(query="Evaluate:", items=["alpha", "beta", "gamma"])
         scores1 = self.engine.score(**kwargs).scores
         scores2 = self.engine.score(**kwargs).scores


### PR DESCRIPTION
## Summary
Fix flaky `test_score_deterministic` in `test_score_engine.py` (fixes #30523).

- `TestCausalLMScoring`: flush cache between the two calls so both take the fresh-prefill path (previously the second call hit the radix cache prefix, a different kernel path with bf16-level divergence), and replace `places=5` with a relative tolerance
- `TestSeqClsScoring`: pin `random_seed=42` so the randomly initialised classification head is reproducible across CI runs, and loosen `places=1` to `delta=0.2` on the raw bf16 logits

The determinism checks still guard their real failure mode (stale output buffers / cross-request contamination, which produce order-of-magnitude differences); the looser tolerances only absorb benign bf16 batch-composition noise.

## Verification
`/rerun-test test_score_engine.py` dispatched 10x on this PR, 10/10 test pass:
[1](https://github.com/sgl-project/sglang/actions/runs/29535555147)
[2](https://github.com/sgl-project/sglang/actions/runs/29536254922)
[3](https://github.com/sgl-project/sglang/actions/runs/29537336952)
[4](https://github.com/sgl-project/sglang/actions/runs/29537522944)
[5](https://github.com/sgl-project/sglang/actions/runs/29538081083)
[6](https://github.com/sgl-project/sglang/actions/runs/29538288700)
[7](https://github.com/sgl-project/sglang/actions/runs/29538505019)
[8](https://github.com/sgl-project/sglang/actions/runs/29538754048)
[9](https://github.com/sgl-project/sglang/actions/runs/29538964243)
[10](https://github.com/sgl-project/sglang/actions/runs/29539162206)

Run 10 shows red only because its `write-back-result` step hit a GitHub API 503 outage; the test job itself passed.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29540203657](https://github.com/sgl-project/sglang/actions/runs/29540203657)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29540203497](https://github.com/sgl-project/sglang/actions/runs/29540203497)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
