### PR TITLE
Fix num_running_reqs gauge on disagg prefill servers

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -635,7 +635,17 @@ class SchedulerMetricsReporter:
             )
 
             # Basics
-            self.stats.num_running_reqs = prefill_stats.num_running_reqs
+            if (
+                self.scheduler.disaggregation_mode == DisaggregationMode.PREFILL
+                and batch is not None
+            ):
+                # running_batch is never populated in PD prefill, so count the
+                # current forward batch instead.
+                self.stats.num_running_reqs = QueueCount.from_reqs(
+                    batch.reqs, priority_enabled
+                )
+            else:
+                self.stats.num_running_reqs = prefill_stats.num_running_reqs
             self.stats.num_queue_reqs = QueueCount.from_reqs(
                 self.scheduler.waiting_queue, priority_enabled
             )


### PR DESCRIPTION
`sglang:num_running_reqs` is always 0 on PD prefill servers.

The gauge reads `prefill_stats.num_running_reqs`, which is a snapshot of `running_batch` — and PD prefill never fills `running_batch` (there's no decode phase).

Fix: on prefill servers, report the current prefill batch size (`batch.reqs`) instead.

Note: dashboards/alerts on `num_running_reqs` filtered to `engine_type="prefill"` will go from 0 to real numbers.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29539714964](https://github.com/sgl-project/sglang/actions/runs/29539714964)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29539717346](https://github.com/sgl-project/sglang/actions/runs/29539717346)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->