### PR TITLE
[flashinfer] Pass window_left at plan time for the SWA paged prefill wrapper

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1894,7 +1894,8 @@ class FlashInferIndicesUpdaterPrefill:
                         prefix_lens, seq_lens, effective_start
                     )
                 else:
-                    # window attention use paged only
+                    # window attention use paged only; the trim below is
+                    # request-granular, exactness comes from plan-time window_left
                     paged_kernel_lens = torch.minimum(
                         seq_lens,
                         sliding_window_size + seq_lens - prefix_lens,
@@ -1927,6 +1928,13 @@ class FlashInferIndicesUpdaterPrefill:
                 fixed_split_size=fixed_split_size,
                 multi_item_params=multi_item_params,
                 cross_attention_custom_mask=swa_paged_custom_mask,
+                # paged-only SWA path only; ragged keeps its custom prefix
+                # mask, spec-verify keeps its tree mask
+                window_left=(
+                    sliding_window_size
+                    if (wrapper_id == 0 and not use_ragged and spec_info is None)
+                    else -1
+                ),
             )
 
     def _build_swa_prefix_custom_mask(
@@ -2043,6 +2051,7 @@ class FlashInferIndicesUpdaterPrefill:
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
         seq_lens_cpu: Optional[torch.Tensor] = None,
         custom_kv_indices: Optional[torch.Tensor] = None,
+        window_left: int = -1,
     ):
         bs = len(seq_lens)
         if spec_info is None:
@@ -2177,6 +2186,10 @@ class FlashInferIndicesUpdaterPrefill:
                 max_q_len=num_tokens_per_req,
                 max_kv_len=int(seq_lens_cpu_i32.max()),
             )
+
+        if window_left >= 0:
+            # selects the module with the per-element window mask compiled in
+            paged_plan_kwargs["window_left"] = window_left
 
         wrapper_paged.begin_forward(
             qo_indptr,

--- a/test/registered/attention/unittests/swa/test_flashinfer.py
+++ b/test/registered/attention/unittests/swa/test_flashinfer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.utils import is_flashinfer_available
 from sglang.test.test_utils import CustomTestCase
@@ -44,6 +45,21 @@ class TestFlashInferSWAAttentionBackendCorrectness(CustomTestCase):
     CASES = make_swa_no_prefix_input_config_cases(
         "flashinfer"
     ) + make_swa_prefix_input_config_cases("flashinfer")
+    # Paged-only prefill has no ragged pass / custom prefix mask, so the kernel
+    # must enforce the window; the long case puts tokens past the window.
+    PAGED_MODE_CASES = CASES + (
+        DenseAttentionCase(
+            name="swa_extend_no_prefix_above_window_long",
+            backend="flashinfer",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=4,
+            page_size=16,
+            prefix_lens=(0, 0, 0),
+            extend_lens=(6, 8, 12),
+            sliding_window_size=4,
+        ),
+    )
     # Above-window decode case requires the `extend_window` reference rule
     # (window+1 keys), not the `min_seq_len_window` rule — FlashInfer's
     # decode metadata uses `clamp(seq_lens, max=window+1)` per
@@ -137,6 +153,17 @@ class TestFlashInferSWAAttentionBackendCorrectness(CustomTestCase):
                     head_dim=self.HEAD_DIM,
                     hidden_size=self.HIDDEN_SIZE,
                 )
+
+    def test_projected_swa_attention_cases_paged_mode(self):
+        for case in self.PAGED_MODE_CASES:
+            with self.subTest(case=case.name, backend=case.backend, mode="paged"):
+                with envs.SGLANG_FLASHINFER_USE_PAGED.override(True):
+                    run_dense_attention_case(
+                        self,
+                        case,
+                        head_dim=self.HEAD_DIM,
+                        hidden_size=self.HIDDEN_SIZE,
+                    )
 
     # Layout-robustness. See dense/test_triton.py for the full rationale.
     # The default `shuffled_pages` is already exercised by


### PR DESCRIPTION
## What

sglang's FlashInfer backend plans the sliding-window **paged** prefill wrapper without `window_left`, so flashinfer selects the fa2 module with `use_sliding_window=False` — the per-element left-window mask is **compiled out**. The `window_left` passed later at `forward()` silently overwrites flashinfer's plan/run consistency check and only drives the coarse per-CTA-tile KV-start skip, so every token past the window attends to stale keys on SWA layers in paged-only prefill mode. On sm100 the plan/run mismatch is worse than the tile-granular leak: outputs are grossly wrong from the first positions, not just past the window.

Paged-only prefill (`use_ragged=False`) is reached via `SGLANG_FLASHINFER_USE_PAGED=1`, `--enable-deterministic-inference`, piecewise CUDA-graph prefill, multimodal models (e.g. Gemma3 VLMs), and multi-item scoring — any SWA model served through one of these paths is affected.

Fix: pass `window_left` for the SWA paged wrapper at plan time — normal extend only (ragged mode keeps its exact custom prefix mask; spec-verify keeps its pre-existing tree-mask behavior). This also makes flashinfer's plan/run consistency assert genuinely hold.

## Verification

New regression test in `test/registered/attention/unittests/swa/test_flashinfer.py` (`test_projected_swa_attention_cases_paged_mode`): the existing SWA window-edge cases plus a long no-prefix above-window case (extend 6/8/12, window 4), run under `SGLANG_FLASHINFER_USE_PAGED=1` against the exact SDPA sliding-window reference.

```bash
cd test/registered/attention/unittests/swa
python test_flashinfer.py -k paged_mode   # regression test only
python test_flashinfer.py                 # full SWA flashinfer suite (7 tests)
```

Pre-fix check: same commands with the parent commit's `flashinfer_backend.py` swapped in (`git checkout HEAD~1 -- .../flashinfer_backend.py`).

| | pre-fix | with fix |
|---|---|---|
| paged-mode SWA cases (sm100) | FAILED — 30.3% mismatched elements, max abs diff 0.40 (tol 0.03) | OK — full test file 7/7 |

E2E on `google/gemma-3-1b-it` (sliding_window=512), 1500-token prompt, per-position prompt logprobs vs the triton backend as exact-mask reference (GB300 / sm100):

```bash
# server under test (pre-fix vs fixed, otherwise identical):
SGLANG_FLASHINFER_USE_PAGED=1 python -m sglang.launch_server \
  --model-path google/gemma-3-1b-it --attention-backend flashinfer \
  --dtype bfloat16 --context-length 4096 --disable-cuda-graph --random-seed 0
# reference server: same flags, --attention-backend triton, no env flag
# probe: POST /generate with 1500 input_ids, max_new_tokens=64, temperature=0,
#        return_logprob=true, logprob_start_len=0; diff input_token_logprobs per position
```

| comparison | inside window (pos <512) | past window | greedy output |
|---|---|---|---|
| unfixed paged vs triton | mean \|Δlogp\| 2.3, max 17.9 | mean 8.6, max 33.3 | diverges at token 0 |
| fixed paged vs triton | mean 0.045 (cross-backend bf16 noise) | mean 0.040 | identical |


lm-eval on the same setup — `gsm8k`, 5-shot, limit 200 (GB300 / sm100):

```bash
lm_eval --model local-completions \
  --model_args model=google/gemma-3-1b-it,base_url=http://127.0.0.1:30111/v1/completions,num_concurrent=64,tokenized_requests=False \
  --tasks gsm8k --num_fewshot 5 --limit 200 --gen_kwargs max_gen_toks=256 --seed 0
```

| server | exact_match (strict) |
|---|---|
| flashinfer paged, pre-fix | 0.130 ± 0.024 |
| flashinfer paged, this PR | 0.255 ± 0.031 |
| triton (reference) | 0.275 ± 0.032 |


## Original commits

- `e306cd211`
- `23a53115a`
- `c81195e62`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29631972224](https://github.com/sgl-project/sglang/actions/runs/29631972224)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29631972120](https://github.com/sgl-project/sglang/actions/runs/29631972120)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->