### PR TITLE
[Fix] EP-slice ModelOpt NVFP4 input scales on the default MoE runner path

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2141,6 +2141,18 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             return
 
         # Calculate input scales based on strategy
+        def _slice_scale(w):
+            # Per-expert input scales are checkpoint-wide [num_experts]; the
+            # weight scales are already EP-sharded to [num_local_experts].
+            # Slice to the local expert range so the alpha products line up.
+            assert w.shape == (layer.num_experts,)
+            assert layer.moe_ep_size * layer.num_local_experts == layer.num_experts
+            return w[
+                layer.moe_ep_rank
+                * layer.num_local_experts : (layer.moe_ep_rank + 1)
+                * layer.num_local_experts
+            ]
+
         if self.enable_flashinfer_cutlass_moe or self.enable_flashinfer_trtllm_moe:
             w13_input_scale = layer.w13_input_scale.max().to(torch.float32)
             w2_input_scale = layer.w2_input_scale.max().to(torch.float32)
@@ -2153,15 +2165,6 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             )
             w2_input_scale = layer.w2_input_scale
 
-            def _slice_scale(w):
-                assert w.shape == (layer.num_experts,)
-                assert layer.moe_ep_size * layer.num_local_experts == layer.num_experts
-                return w[
-                    layer.moe_ep_rank
-                    * layer.num_local_experts : (layer.moe_ep_rank + 1)
-                    * layer.num_local_experts
-                ]
-
             w13_input_scale = _slice_scale(w13_input_scale)
             w2_input_scale = _slice_scale(w2_input_scale)
 
@@ -2171,6 +2174,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         else:
             w13_input_scale = layer.w13_input_scale.max(dim=-1).values.to(torch.float32)
             w2_input_scale = layer.w2_input_scale
+            if layer.moe_ep_size > 1:
+                w13_input_scale = _slice_scale(w13_input_scale)
+                w2_input_scale = _slice_scale(w2_input_scale)
 
         if self.quant_config.use_per_token_activation:
             # FlashInfer computes activation scales dynamically per token, so


### PR DESCRIPTION
## Motivation

`--quantization modelopt_fp4` with `--ep > 1` crashes during weight post-processing on any MoE runner that takes the default (non-flashinfer) branch of `ModelOptNvFp4FusedMoEMethod.process_weights_after_loading`:

```
RuntimeError: The size of tensor a (256) must match the size of tensor b (32) at non-singleton dimension 0
```

The `flashinfer_cutedsl` branch already EP-slices the per-expert input scales (`_slice_scale`), but the default branch computes checkpoint-wide `[num_experts]` input scales and multiplies them with `w13_weight_scale_2` / `w2_weight_scale_2`, which are already EP-sharded to `[num_local_experts]`.

Context: #24502 (EP+NVFP4 on Blackwell). Related: #21602 (closed, but the default path on main is still unsliced), #23531 (draft PR from April by @jybsuper addressing the same path — this is a focused, up-to-date alternative; happy to defer if that one is picked back up).

## Modifications

- Hoist `_slice_scale` out of the `flashinfer_cutedsl` branch so both branches share it (cutedsl behavior unchanged).
- In the default branch, EP-slice `w13_input_scale` / `w2_input_scale` when `layer.moe_ep_size > 1`. EP=1 behavior is unchanged (guarded).

Single file, +15/−9: `python/sglang/srt/layers/quantization/modelopt_quant.py`.

**Scope**: plain contiguous EP (`moe_ep_size * num_local_experts == num_experts`), same physical=logical expert-layout assumption the cutedsl branch already makes. Fused shared experts in global-slot mode, elastic EP, and EPLB remappings are out of scope — those configurations fail identically before and after this change.

**What this does and does not enable**: on current main the default (non-flashinfer) branch has no functional NVFP4 `apply()` yet, so this PR restores load-time shape consistency between input scales and the EP-sharded weight scales (the contract the cutedsl branch enforces) and removes the first blocker on the default path — it does not by itself enable end-to-end EP serving on that path.

## Accuracy Tests

Loading-path fix only; the EP=1 path is byte-identical. For EP>1 the previous behavior was a startup crash, so there is no baseline to regress.

In April 2026 we verified an equivalent hot-patch on 8× B300 SXM6 (driver 595.58.03, `lukealonso/MiniMax-M2.7-NVFP4`, 256 routed experts, TP=8 EP=8, `--moe-a2a-backend deepep --moe-runner-backend deep_gemm`): weight loading proceeded past this crash (subsequent failures were in unrelated layers — DeepEP LL hidden-size support of that era and the deprecated deep_gemm forward; details in #24502).

We no longer have B300 access, so this PR is not runtime-validated against current main — flagging for GB300 CI validation.

## Speed Tests and Profiling

N/A (startup/loading path only).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
