### PR TITLE
[Docs] Mistral Medium 3.5 cookbook: replace stale day-0 dev images with latest

### DIFF
--- a/docs_new/cookbook/autoregressive/Mistral/Mistral-Medium-3.5.mdx
+++ b/docs_new/cookbook/autoregressive/Mistral/Mistral-Medium-3.5.mdx
@@ -41,14 +41,7 @@ The HuggingFace repo ships both the mistral native layout (`params.json` + `cons
 
 Refer to the [official SGLang installation guide](../../../docs/get-started/install).
 
-**Docker Images by Hardware:**
-
-| Hardware | Docker Image |
-| --- | --- |
-| H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:dev-mistral-medium-3.5` |
-| B200 / B300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:dev-cu13-mistral-medium-3.5` |
-
-> Day-0 support for Mistral Medium 3.5 is not yet in `lmsysorg/sglang:latest` — pull one of the tags above (matching your GPU's CUDA driver) until the changes propagate to the next stable release.
+**Docker Image:** `lmsysorg/sglang:latest` covers all the GPUs in this cookbook (H100 / H200 / B200 / B300).
 
 ---
 


### PR DESCRIPTION
## Motivation

The Mistral Medium 3.5 cookbook still points at the day-0 images `lmsysorg/sglang:dev-mistral-medium-3.5` / `dev-cu13-mistral-medium-3.5`. These tags were last built on 2026-04-29 and miss later fixes that are already in stable releases (e.g. #29111, Ministral3 init argument forwarding). Model support has been included in stable releases for a while, so the day-0 tags and the "not yet in latest" caveat are outdated.

## Modifications

- Point the install section at the standard `lmsysorg/sglang:latest` image (multi-arch, covers H100 / H200 / B200 / B300), matching the single-image convention used by other cookbook pages (e.g. DeepSeek V4).
- Drop the per-hardware image table and the day-0 caveat.

`mint validate` passes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests as outlined in the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29549328013](https://github.com/sgl-project/sglang/actions/runs/29549328013)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29549327874](https://github.com/sgl-project/sglang/actions/runs/29549327874)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->