### PR TITLE
docs(cookbook): fix stale/pruned Docker image tags

### DIFF
--- a/docs_new/cookbook/autoregressive/NVIDIA/Nemotron3-Super.mdx
+++ b/docs_new/cookbook/autoregressive/NVIDIA/Nemotron3-Super.mdx
@@ -28,7 +28,7 @@ SGLang from the main branch is required for Nemotron3-Super. You can install fro
 uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 
 # Or use Docker
-docker pull lmsysorg/sglang:nightly-dev-20260310-0fd9a57d
+docker pull lmsysorg/sglang:latest
 ```
 
 For the full Docker setup and other installation methods, please refer to the [official SGLang installation guide](../../../docs/get-started/install).

--- a/docs_new/cookbook/autoregressive/StepFun/Step-3.7-Flash.mdx
+++ b/docs_new/cookbook/autoregressive/StepFun/Step-3.7-Flash.mdx
@@ -19,14 +19,14 @@ Step-3.7-Flash is currently available in SGLang via Docker image install.
 ### Docker (NVIDIA)
 ```bash Command
 # Pull the docker image
-docker pull lmsysorg/sglang:dev-step-3.7-flash
+docker pull lmsysorg/sglang:latest
 
 # Launch the container
 docker run -it --gpus all \
   --shm-size=32g \
   --ipc=host \
   --network=host \
-  lmsysorg/sglang:dev-step-3.7-flash bash
+  lmsysorg/sglang:latest bash
 ```
 
 ## 3. Model Deployment

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2-Flash.mdx
@@ -42,7 +42,7 @@ docker run -it --gpus all \
   --shm-size=32g \
   --ipc=host \
   --network=host \
-  lmsysorg/sglang:nightly-dev-20251215-4449c170 bash
+  lmsysorg/sglang:latest bash
 
 # If you already have SGLang installed, uninstall the current SGLang version
 pip uninstall sglang -y

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -54,16 +54,7 @@ tag: NEW
 
 Refer to the [official SGLang installation guide](../../../docs/get-started/install).
 
-**Docker Images by Variant × Hardware:**
-
-| Variant | Hardware | Docker Image |
-| --- | --- | --- |
-| **MiMo-V2.5 (310B)** | H100 / H200 (Hopper) | `lmsysorg/sglang:latest` |
-| **MiMo-V2.5 (310B)** | B200 / GB300 (Blackwell) | `lmsysorg/sglang:latest` |
-| **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper) | `lmsysorg/sglang:latest` |
-| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell) | `lmsysorg/sglang:latest` |
-
-> `lmsysorg/sglang:latest` ships CUDA 13.0 and runs on both Hopper and Blackwell.
+**Docker Image:** All variants (MiMo-V2.5 310B and MiMo-V2.5-Pro 1.02T) use `lmsysorg/sglang:latest`, which ships CUDA 13.0 and runs on both Hopper (H100 / H200) and Blackwell (B200 / GB300).
 
 **TPU (sgl-jax):** MiMo-V2.5-Pro can also be served on TPU via the JAX-based [sgl-jax](https://github.com/sgl-project/sglang-jax) runtime. The container image and `pip install` steps are listed in [§3.3 TPU Deployment](#3-3-tpu-deployment-mimo-v2-5-pro-sgl-jax).
 

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -58,12 +58,12 @@ Refer to the [official SGLang installation guide](../../../docs/get-started/inst
 
 | Variant | Hardware | Docker Image |
 | --- | --- | --- |
-| **MiMo-V2.5 (310B)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:nightly-dev-20260511-044bb88a` |
-| **MiMo-V2.5 (310B)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:nightly-dev-cu13-20260511-044bb88a` |
-| **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:nightly-dev-20260511-044bb88a` |
-| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:nightly-dev-cu13-20260511-044bb88a` |
+| **MiMo-V2.5 (310B)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:latest` |
+| **MiMo-V2.5 (310B)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:latest-cu130` |
+| **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:latest` |
+| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:latest-cu130` |
 
-> Pull the image matching your GPU's CUDA driver. `lmsysorg/sglang:latest` will not load either checkpoint.
+> Pull the image matching your GPU's CUDA driver: `lmsysorg/sglang:latest` (CUDA 12.9) for Hopper, `lmsysorg/sglang:latest-cu130` (CUDA 13.0) for Blackwell.
 
 **TPU (sgl-jax):** MiMo-V2.5-Pro can also be served on TPU via the JAX-based [sgl-jax](https://github.com/sgl-project/sglang-jax) runtime. The container image and `pip install` steps are listed in [§3.3 TPU Deployment](#3-3-tpu-deployment-mimo-v2-5-pro-sgl-jax).
 

--- a/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
+++ b/docs_new/cookbook/autoregressive/Xiaomi/MiMo-V2.5.mdx
@@ -58,12 +58,12 @@ Refer to the [official SGLang installation guide](../../../docs/get-started/inst
 
 | Variant | Hardware | Docker Image |
 | --- | --- | --- |
-| **MiMo-V2.5 (310B)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:latest` |
-| **MiMo-V2.5 (310B)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:latest-cu130` |
-| **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper, CUDA 12.9) | `lmsysorg/sglang:latest` |
-| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell, CUDA 13.0) | `lmsysorg/sglang:latest-cu130` |
+| **MiMo-V2.5 (310B)** | H100 / H200 (Hopper) | `lmsysorg/sglang:latest` |
+| **MiMo-V2.5 (310B)** | B200 / GB300 (Blackwell) | `lmsysorg/sglang:latest` |
+| **MiMo-V2.5-Pro (1.02T)** | H100 / H200 (Hopper) | `lmsysorg/sglang:latest` |
+| **MiMo-V2.5-Pro (1.02T)** | B200 / GB300 (Blackwell) | `lmsysorg/sglang:latest` |
 
-> Pull the image matching your GPU's CUDA driver: `lmsysorg/sglang:latest` (CUDA 12.9) for Hopper, `lmsysorg/sglang:latest-cu130` (CUDA 13.0) for Blackwell.
+> `lmsysorg/sglang:latest` ships CUDA 13.0 and runs on both Hopper and Blackwell.
 
 **TPU (sgl-jax):** MiMo-V2.5-Pro can also be served on TPU via the JAX-based [sgl-jax](https://github.com/sgl-project/sglang-jax) runtime. The container image and `pip install` steps are listed in [§3.3 TPU Deployment](#3-3-tpu-deployment-mimo-v2-5-pro-sgl-jax).
 


### PR DESCRIPTION
## Motivation

Several cookbook pages referenced Docker images that no longer exist on Docker Hub — pruned nightlies and a deleted model-specific dev tag — so `docker pull` fails for anyone following those pages. This bumps them all to the current stable `lmsysorg/sglang:latest` tag.

## Changes

| Page | Was (404 on Docker Hub) | Now |
|---|---|---|
| `Xiaomi/MiMo-V2-Flash` | `nightly-dev-20251215-4449c170` | `latest` |
| `NVIDIA/Nemotron3-Super` | `nightly-dev-20260310-0fd9a57d` | `latest` |
| `Xiaomi/MiMo-V2.5` (Hopper) | `nightly-dev-20260511-044bb88a` | `latest` |
| `Xiaomi/MiMo-V2.5` (Blackwell) | `nightly-dev-cu13-20260511-044bb88a` | `latest` |
| `StepFun/Step-3.7-Flash` | `dev-step-3.7-flash` | `latest` |

For MiMo-V2.5, the table now uses a single uniform `lmsysorg/sglang:latest` for all rows. `latest` is the CUDA 13.0 build (identical digest to `latest-cu130`) and runs on both Hopper and Blackwell, so the previous cu13/cu12.9 split and per-row CUDA labels were dropped. The old note that warned `latest` would not load the checkpoint is replaced with a line noting `latest` ships CUDA 13.0 and runs on both architectures.

## Note / follow-up

Tags were swapped optimistically to unbreak `docker pull`; they still need a run-check to confirm the stable images actually load these models. Highest risk:
- **MiMo-V2.5** — the page previously warned `latest` would not load the checkpoint (support was nightly-only at the time).
- **Step-3.7-Flash** — the deleted `dev-step-3.7-flash` tag had no successor, so `latest` is a best guess.

Out of scope: the Ascend CANN GLM-5.2 doc under `docs/hardware-platforms/` (separate Huawei mirror registry) also has a pruned tag, left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29610194388](https://github.com/sgl-project/sglang/actions/runs/29610194388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29610194208](https://github.com/sgl-project/sglang/actions/runs/29610194208)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->