### PR TITLE
fix(minimax-m3): stop streaming crash on non-finite number literal

### DIFF
--- a/python/sglang/srt/function_call/minimax_m3.py
+++ b/python/sglang/srt/function_call/minimax_m3.py
@@ -458,8 +458,11 @@ class MinimaxM3Detector(BaseFormatDetector):
         if schema_types & NUMBER_TYPES:
             try:
                 parsed = float(value)
+                # int(parsed) raises OverflowError for inf and ValueError for
+                # nan, so a non-finite literal (e.g. "1e999") falls through to
+                # the verbatim return instead of crashing the stream.
                 return parsed if parsed != int(parsed) else int(parsed)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
                 pass
 
         if schema_types & BOOLEAN_TYPES:

--- a/test/registered/unit/function_call/test_minimax_m3_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m3_detector.py
@@ -526,6 +526,26 @@ class TestMinimaxM3Malformed(CustomTestCase):
         for seg in _segments(*segments):
             detector.parse_streaming_increment(seg, self.tools)
 
+    def test_overflow_number_literal_does_not_crash_streaming(self):
+        # A non-finite number literal ("1e999" -> inf) made int() raise
+        # OverflowError in the scalar path; streaming crashed while
+        # detect_and_parse degraded to content. Both must now agree.
+        segments = (
+            "<tool_call>",
+            '<invoke name="search">',
+            "<query>hi",
+            "</query>",
+            "<ratio>1e999",
+            "</ratio>",
+            "</invoke>",
+            "</tool_call>",
+        )
+        detector = MinimaxM3Detector()
+        for seg in _segments(*segments):
+            detector.parse_streaming_increment(seg, self.tools)
+        # non-streaming path already tolerated it
+        MinimaxM3Detector().detect_and_parse(_wire(*segments), self.tools)
+
 
 def _parse_segments_text(text, tools):
     detector = MinimaxM3Detector()


### PR DESCRIPTION
`int(float("1e999"))` raises `OverflowError` (inf can't convert to int). The scalar path only caught `TypeError, ValueError`, so a non-finite number literal crashed streaming — `detect_and_parse` swallowed it and degraded to content, but `parse_streaming_increment` propagated it up the stream.

Added `OverflowError` to the except; the value now falls through to the verbatim string on both paths, so they agree.

Repro (before): streaming a `number` param with value `1e999` throws `OverflowError`; non-streaming returns it as content.

Test: `test_overflow_number_literal_does_not_crash_streaming` in the minimax detector suite.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29550705379](https://github.com/sgl-project/sglang/actions/runs/29550705379)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29550705207](https://github.com/sgl-project/sglang/actions/runs/29550705207)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->