### PR TITLE
Add nightly test for GLM5.2 LayerSplit

### DIFF
--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -27,7 +27,6 @@ class PDDisaggregationServerBase(CustomTestCase):
     capture_per_side_logs: ClassVar[bool] = False
     extra_prefill_env: ClassVar[dict[str, str]] = {}
     extra_decode_env: ClassVar[dict[str, str]] = {}
-    decode_base_gpu_id: ClassVar[Optional[int]] = 1
     _prefill_stdout_buf: ClassVar[Optional[io.StringIO]] = None
     _prefill_stderr_buf: ClassVar[Optional[io.StringIO]] = None
     _decode_stdout_buf: ClassVar[Optional[io.StringIO]] = None
@@ -118,10 +117,9 @@ class PDDisaggregationServerBase(CustomTestCase):
             cls.bootstrap_port,
             "--tp",
             "1",
-        ]
-        if cls.decode_base_gpu_id is not None:
-            decode_args += ["--base-gpu-id", str(cls.decode_base_gpu_id)]
-        decode_args += list(cls.extra_decode_args)
+            "--base-gpu-id",
+            "1",
+        ] + list(cls.extra_decode_args)
         decode_args += cls.transfer_backend + cls.rdma_devices
         cls.process_decode = popen_launch_pd_server(
             cls.model,

--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -27,6 +27,7 @@ class PDDisaggregationServerBase(CustomTestCase):
     capture_per_side_logs: ClassVar[bool] = False
     extra_prefill_env: ClassVar[dict[str, str]] = {}
     extra_decode_env: ClassVar[dict[str, str]] = {}
+    decode_base_gpu_id: ClassVar[Optional[int]] = 1
     _prefill_stdout_buf: ClassVar[Optional[io.StringIO]] = None
     _prefill_stderr_buf: ClassVar[Optional[io.StringIO]] = None
     _decode_stdout_buf: ClassVar[Optional[io.StringIO]] = None
@@ -117,9 +118,10 @@ class PDDisaggregationServerBase(CustomTestCase):
             cls.bootstrap_port,
             "--tp",
             "1",
-            "--base-gpu-id",
-            "1",
-        ] + list(cls.extra_decode_args)
+        ]
+        if cls.decode_base_gpu_id is not None:
+            decode_args += ["--base-gpu-id", str(cls.decode_base_gpu_id)]
+        decode_args += list(cls.extra_decode_args)
         decode_args += cls.transfer_backend + cls.rdma_devices
         cls.process_decode = popen_launch_pd_server(
             cls.model,

--- a/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
+++ b/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
@@ -29,9 +29,6 @@ register_cuda_ci(
 
 class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
     model = "nvidia/GLM-5.2-NVFP4"
-    extra_prefill_env = {"CUDA_VISIBLE_DEVICES": "0,1,2,3"}
-    extra_decode_env = {"CUDA_VISIBLE_DEVICES": "4,5,6,7"}
-    decode_base_gpu_id = None
 
     # Full GSM8K test set (1319 questions) with a tight accuracy floor.
     gsm8k_accuracy_thres = 0.935
@@ -88,6 +85,8 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
         "1",
         "--speculative-num-draft-tokens",
         "6",
+        "--base-gpu-id",
+        "4",
     ]
 
     @classmethod

--- a/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
+++ b/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
@@ -29,6 +29,9 @@ register_cuda_ci(
 
 class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
     model = "nvidia/GLM-5.2-NVFP4"
+    extra_prefill_env = {"CUDA_VISIBLE_DEVICES": "0,1,2,3"}
+    extra_decode_env = {"CUDA_VISIBLE_DEVICES": "4,5,6,7"}
+    decode_base_gpu_id = None
 
     # Full GSM8K test set (1319 questions) with a tight accuracy floor.
     gsm8k_accuracy_thres = 0.935

--- a/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
+++ b/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
@@ -37,7 +37,7 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
     gsm8k_accuracy_thres = 0.935
     gsm8k_num_questions = 1319
     gsm8k_num_threads = 200
-    gsm8k_num_shots = 0
+    gsm8k_num_shots = 20
 
     # Prefill worker: interleave prefill-CP + DSA cache layer split on 4 GPUs
     # (TP=4 -> attn_cp_size=4, so KV/indexer layers shard 4-way across CP ranks).

--- a/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
+++ b/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
@@ -21,7 +21,7 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
 )
 
 register_cuda_ci(
-    est_time=1200,
+    est_time=450,
     suite="nightly-8-gpu-b200",
     nightly=True,
 )

--- a/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
+++ b/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
@@ -9,8 +9,7 @@ PD-disaggregated GLM-5.2 deployment: a layer-split prefill worker running
 interleave prefill-CP + layer split, and an ordinary decode worker that receives
 full cache shards via PD transfer.
 
-Sized for the 4-GPU B200 runner (prefill TP=2 + decode TP=2) rather than an
-8-GPU deployment, since the 8-gpu-b200 runner is nightly-only.
+Runs nightly on an 8-GPU B200 runner (prefill TP=4 + decode TP=4).
 """
 
 import unittest
@@ -23,9 +22,8 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
 
 register_cuda_ci(
     est_time=1200,
-    stage="extra-b",
-    runner_config="4-gpu-b200",
-    disabled="Temporarily disabled",
+    suite="nightly-8-gpu-b200",
+    nightly=True,
 )
 
 
@@ -38,11 +36,11 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
     gsm8k_num_threads = 200
     gsm8k_num_shots = 0
 
-    # Prefill worker: interleave prefill-CP + DSA cache layer split on 2 GPUs
-    # (TP=2 -> attn_cp_size=2, so KV/indexer layers shard 2-way across CP ranks).
+    # Prefill worker: interleave prefill-CP + DSA cache layer split on 4 GPUs
+    # (TP=4 -> attn_cp_size=4, so KV/indexer layers shard 4-way across CP ranks).
     extra_prefill_args = [
         "--tp",
-        "2",
+        "4",
         "--dsa-prefill-backend",
         "trtllm",
         "--kv-cache-dtype",
@@ -58,11 +56,11 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
         "--max-prefill-tokens",
         "4096",
     ]
-    # Decode worker: ordinary local decode cache on the other 2 GPUs, receives
+    # Decode worker: ordinary local decode cache on the other 4 GPUs, receives
     # full shards via PD transfer.
     extra_decode_args = [
         "--tp",
-        "2",
+        "4",
         "--dsa-decode-backend",
         "trtllm",
         "--kv-cache-dtype",
@@ -70,7 +68,7 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
         "--mem-fraction-static",
         "0.85",
         "--base-gpu-id",
-        "2",
+        "4",
     ]
 
     @classmethod

--- a/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
+++ b/test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py
@@ -41,6 +41,8 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
     extra_prefill_args = [
         "--tp",
         "4",
+        "--attn-cp-size",
+        "4",
         "--dsa-prefill-backend",
         "trtllm",
         "--kv-cache-dtype",
@@ -55,9 +57,17 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
         "4096",
         "--max-prefill-tokens",
         "4096",
+        "--speculative-algorithm",
+        "EAGLE",
+        "--speculative-num-steps",
+        "5",
+        "--speculative-eagle-topk",
+        "1",
+        "--speculative-num-draft-tokens",
+        "6",
     ]
-    # Decode worker: ordinary local decode cache on the other 4 GPUs, receives
-    # full shards via PD transfer.
+    # Decode worker: ordinary local decode cache, receives full shards via PD
+    # transfer.
     extra_decode_args = [
         "--tp",
         "4",
@@ -67,8 +77,14 @@ class TestGLM52DSACacheLayerSplit(PDDisaggregationServerBase, GSM8KMixin):
         "fp8_e4m3",
         "--mem-fraction-static",
         "0.85",
-        "--base-gpu-id",
-        "4",
+        "--speculative-algorithm",
+        "EAGLE",
+        "--speculative-num-steps",
+        "5",
+        "--speculative-eagle-topk",
+        "1",
+        "--speculative-num-draft-tokens",
+        "6",
     ]
 
     @classmethod


### PR DESCRIPTION
## Summary

- register the GLM-5.2 DSA cache-layer-split test in `nightly-8-gpu-b200` and remove the temporary disable
- run prefill and decode with TP=4, with prefill `--attn-cp-size 4`
- enable EAGLE MTP on both nodes with 5 steps, top-k 1, and 6 draft tokens
- place decode on GPUs 4-7 with test-local `--base-gpu-id 4`; leave the shared disaggregation fixture unchanged
- use the standard 20-shot GSM8K prompt required by the existing 0.935 accuracy threshold
- update `est_time` from 1200 to 450 seconds based on the measured test duration

## Validation

- targeted `/rerun-test test/registered/models_e2e/test_dsa_glm52_cache_layer_split.py`: [passed](https://github.com/sgl-project/sglang/actions/runs/29559979558)
  - GSM8K score: 0.9461
  - test elapsed time: 445 seconds (complete job: 8m47s)
- pre-commit hooks, including registered-test CI validation
- Python bytecode compilation
- direct CI-registration and server-argument assertions









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29560905366](https://github.com/sgl-project/sglang/actions/runs/29560905366)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29560905257](https://github.com/sgl-project/sglang/actions/runs/29560905257)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->