### PR TITLE
[Spec][Test] Add adaptive speculative decoding CI coverage

### DIFF
--- a/test/registered/spec/eagle/test_adaptive_speculative.py
+++ b/test/registered/spec/eagle/test_adaptive_speculative.py
@@ -254,7 +254,10 @@ class TestAdaptiveSpeculativeServer(_AdaptiveEagleServerBase):
                 stream=True,
                 timeout=180,
             ) as resp:
-                self.assertEqual(resp.status_code, 200, resp.text)
+                if resp.status_code != 200:
+                    self.fail(
+                        f"stream request failed ({resp.status_code}): {resp.text}"
+                    )
                 for raw in resp.iter_lines(decode_unicode=True):
                     if not raw or not raw.startswith("data:"):
                         continue

--- a/test/registered/spec/eagle/test_adaptive_speculative.py
+++ b/test/registered/spec/eagle/test_adaptive_speculative.py
@@ -1,7 +1,9 @@
 import json
 import os
 import tempfile
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import SimpleNamespace
 
 import requests
@@ -18,8 +20,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=160, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=240, suite="stage-b-test-1-gpu-large-amd")
+register_cuda_ci(est_time=700, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=1000, suite="stage-b-test-1-gpu-large-amd")
 
 HIGH_ACCEPT_PROMPT = (
     "Output exactly 128 new lines. "
@@ -36,28 +38,32 @@ MAX_UPSHIFT_ATTEMPTS = 4
 MAX_DOWNSHIFT_ATTEMPTS = 6
 
 
-class TestAdaptiveSpeculativeServer(CustomTestCase):
-    """Test adaptive speculative decoding with state switching and GSM8K accuracy."""
+class _AdaptiveEagleServerBase(CustomTestCase):
+    """Shared scaffold for the adaptive-EAGLE test servers: launch on the triton
+    backend with adaptive speculative decoding + a temp config, and drive/observe
+    tier switches. Subclasses set ``adaptive_config`` (defaults to the [1, 3] fast
+    switcher) plus optional ``extra_launch_args`` / ``launch_env``."""
 
     model = DEFAULT_TARGET_MODEL_EAGLE
     draft_model = DEFAULT_DRAFT_MODEL_EAGLE
     base_url = DEFAULT_URL_FOR_TEST
 
+    adaptive_config = {
+        "1": {
+            "candidate_steps": [1, 3],
+            "ema_alpha": 1.0,
+            "warmup_batches": 1,
+            "update_interval": 1,
+            "up_hysteresis": 0.0,
+        },
+    }
+    extra_launch_args = ()
+    launch_env = None
+
     @classmethod
     def setUpClass(cls):
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
-            json.dump(
-                {
-                    "1": {
-                        "candidate_steps": [1, 3],
-                        "ema_alpha": 1.0,
-                        "warmup_batches": 1,
-                        "update_interval": 1,
-                        "up_hysteresis": 0.0,
-                    },
-                },
-                f,
-            )
+            json.dump(cls.adaptive_config, f)
             cls.adaptive_config_path = f.name
 
         try:
@@ -65,6 +71,7 @@ class TestAdaptiveSpeculativeServer(CustomTestCase):
                 cls.model,
                 cls.base_url,
                 timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                env=cls.launch_env,
                 other_args=[
                     "--trust-remote-code",
                     "--attention-backend",
@@ -76,10 +83,10 @@ class TestAdaptiveSpeculativeServer(CustomTestCase):
                     "--speculative-adaptive",
                     "--speculative-adaptive-config",
                     cls.adaptive_config_path,
-                    "--enable-metrics",
                     "--skip-server-warmup",
                     "--mem-fraction-static",
                     "0.7",
+                    *cls.extra_launch_args,
                 ],
             )
         except Exception:
@@ -89,14 +96,19 @@ class TestAdaptiveSpeculativeServer(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         if hasattr(cls, "process"):
-            kill_process_tree(cls.process.pid)
-        if os.path.exists(cls.adaptive_config_path):
+            kill_process_tree(cls.process.pid, wait_timeout=60)
+        if getattr(cls, "adaptive_config_path", None) and os.path.exists(
+            cls.adaptive_config_path
+        ):
             os.unlink(cls.adaptive_config_path)
 
     def _get_internal_state(self) -> dict:
         response = requests.get(self.base_url + "/server_info", timeout=30)
         self.assertEqual(response.status_code, 200, response.text)
         return response.json()["internal_states"][0]
+
+    def _steps(self) -> int:
+        return self._get_internal_state()["speculative_num_steps"]
 
     def _scrape_metric(self, name: str, **label_filter) -> float | None:
         """Return the value of a Prometheus sample line, or None if absent.
@@ -152,6 +164,27 @@ class TestAdaptiveSpeculativeServer(CustomTestCase):
                 return state
         return state
 
+    def _assert_adaptive_switches(self):
+        """Drive the EMA up (high-accept) then down (low-accept); the active step
+        count must move to 3 and back to 1."""
+        self.assertEqual(
+            self._drive_upshift()["speculative_num_steps"],
+            3,
+            "adaptive never upshifted to steps=3",
+        )
+        self.assertEqual(
+            self._drive_downshift()["speculative_num_steps"],
+            1,
+            "adaptive never downshifted to steps=1",
+        )
+
+
+class TestAdaptiveSpeculativeServer(_AdaptiveEagleServerBase):
+    """State switching + GSM8K accuracy, metric gauges, streaming losslessness,
+    and abort under an active adaptive tier switch (config [1, 3])."""
+
+    extra_launch_args = ("--enable-metrics",)
+
     def test_gsm8k_after_adaptive_switches(self):
         """Exercise up/down/up adaptive switches, then verify GSM8K accuracy."""
         state = self._drive_upshift()
@@ -198,76 +231,118 @@ class TestAdaptiveSpeculativeServer(CustomTestCase):
             "spec_num_draft_tokens gauge has unexpected value",
         )
 
+    def test_streaming_lossless_across_switch(self):
+        """Streamed greedy output is identical before vs after an adaptive tier
+        switch (spec decoding is lossless, so num_steps must not change the
+        result) and arrives in multiple SSE chunks. Guards streaming-path or
+        runtime-state-swap corruption that a non-streaming test would miss."""
+        prompt = "List the numbers from 1 to 40 separated by commas:"
 
-class TestAdaptiveZeroStepBatchSizeServer(CustomTestCase):
-    """steps=0 (nospec) fallback triggered by batch size.
+        def stream_generate():
+            chunks, last_text = 0, ""
+            with requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 48,
+                        "ignore_eos": True,
+                    },
+                    "stream": True,
+                },
+                stream=True,
+                timeout=180,
+            ) as resp:
+                self.assertEqual(resp.status_code, 200, resp.text)
+                for raw in resp.iter_lines(decode_unicode=True):
+                    if not raw or not raw.startswith("data:"):
+                        continue
+                    payload = raw[len("data:") :].strip()
+                    if payload == "[DONE]":
+                        break
+                    last_text = json.loads(payload).get("text", last_text)
+                    chunks += 1
+            return chunks, last_text
+
+        self._drive_downshift()
+        self.assertEqual(self._get_internal_state()["speculative_num_steps"], 1)
+        n_low, text_low = stream_generate()
+        self.assertGreater(n_low, 1, "response did not stream incrementally")
+
+        self._drive_upshift()
+        self.assertEqual(self._get_internal_state()["speculative_num_steps"], 3)
+        n_high, text_high = stream_generate()
+        self.assertGreater(n_high, 1, "response did not stream incrementally")
+
+        self.assertEqual(
+            text_low,
+            text_high,
+            "streamed greedy output changed across an adaptive tier switch "
+            "(spec decoding must be lossless)",
+        )
+
+    def test_abort_around_switch(self):
+        """abort_all with requests in flight under adaptive aborts them cleanly
+        and leaves the server alive and serving. Guards a hang or crash when the
+        abort path races the tier machinery."""
+        self._drive_upshift()  # land at steps=3 so the tier machinery is active
+
+        def long_decode():
+            return requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": "Write a very long story about a magical kingdom.",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 4000,
+                        "ignore_eos": True,
+                    },
+                },
+                timeout=120,
+            ).json()
+
+        with ThreadPoolExecutor(8) as executor:
+            futures = [executor.submit(long_decode) for _ in range(8)]
+            time.sleep(2)
+            requests.post(
+                self.base_url + "/abort_request",
+                json={"abort_all": True},
+                timeout=10,
+            ).raise_for_status()
+            for future in as_completed(futures):
+                meta = future.result()["meta_info"]
+                self.assertEqual(meta["finish_reason"]["type"], "abort")
+
+        self.assertIsNone(self.process.poll(), "server died after abort under adaptive")
+        # The server still serves correctly after the abort storm.
+        self.assertIn("text", self._generate("The capital of France is"))
+
+
+class TestAdaptiveZeroStepBatchSizeServer(_AdaptiveEagleServerBase):
+    """steps=0 (nospec) fallback triggered by batch size, plus logprob and grammar
+    correctness across the steps=3 <-> steps=0 boundary.
 
     Config routes BS>=8 -> steps=0 (drafting disabled) and BS<8 -> steps=3, so the
     server cycles steps=3 -> steps=0 -> steps=3 as load rises and falls.
     """
 
-    model = DEFAULT_TARGET_MODEL_EAGLE
-    draft_model = DEFAULT_DRAFT_MODEL_EAGLE
-    base_url = DEFAULT_URL_FOR_TEST
+    adaptive_config = {
+        "1": {"candidate_steps": [3], "warmup_batches": 0},
+        "8": {"candidate_steps": [0], "warmup_batches": 0},
+    }
+    extra_launch_args = (
+        "--speculative-num-steps",
+        "3",
+        "--speculative-eagle-topk",
+        "1",
+        "--speculative-num-draft-tokens",
+        "4",
+        "--max-running-requests",
+        "32",
+    )
 
     COUNT_PROMPT = "Count from 1 to 400, separated by commas. Output only the numbers."
-
-    @classmethod
-    def setUpClass(cls):
-        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
-            json.dump(
-                {
-                    "1": {"candidate_steps": [3], "warmup_batches": 0},
-                    "8": {"candidate_steps": [0], "warmup_batches": 0},
-                },
-                f,
-            )
-            cls.adaptive_config_path = f.name
-
-        try:
-            cls.process = popen_launch_server(
-                cls.model,
-                cls.base_url,
-                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-                other_args=[
-                    "--trust-remote-code",
-                    "--attention-backend",
-                    "triton",
-                    "--speculative-algorithm",
-                    "EAGLE",
-                    "--speculative-draft-model-path",
-                    cls.draft_model,
-                    "--speculative-num-steps",
-                    "3",
-                    "--speculative-eagle-topk",
-                    "1",
-                    "--speculative-num-draft-tokens",
-                    "4",
-                    "--speculative-adaptive",
-                    "--speculative-adaptive-config",
-                    cls.adaptive_config_path,
-                    "--max-running-requests",
-                    "32",
-                    "--skip-server-warmup",
-                    "--mem-fraction-static",
-                    "0.7",
-                ],
-            )
-        except Exception:
-            os.unlink(cls.adaptive_config_path)
-            raise
-
-    @classmethod
-    def tearDownClass(cls):
-        if hasattr(cls, "process"):
-            kill_process_tree(cls.process.pid)
-        if os.path.exists(cls.adaptive_config_path):
-            os.unlink(cls.adaptive_config_path)
-
-    def _steps(self) -> int:
-        r = requests.get(self.base_url + "/server_info", timeout=30)
-        self.assertEqual(r.status_code, 200, r.text)
-        return r.json()["internal_states"][0]["speculative_num_steps"]
 
     def test_batch_size_step_cycle(self):
         """The server cycles steps=3 -> steps=0 -> steps=3 as load rises and falls:
@@ -310,6 +385,165 @@ class TestAdaptiveZeroStepBatchSizeServer(CustomTestCase):
         self.assertGreater(
             m3["spec_accept_rate"], 0.8, f"drafting not restored after steps=0: {m3}"
         )
+
+    def test_logprob_count_across_step_boundary(self):
+        """output_token_logprobs count must equal completion_tokens on BOTH the
+        spec-verify path (steps=3) and the trivial no-spec path (steps=0). A
+        wrong-count regression on either verify path is silent without this."""
+
+        def gen(texts, params):
+            r = requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": texts,
+                    "sampling_params": params,
+                    "return_logprob": True,
+                    "logprob_start_len": 0,
+                },
+                timeout=600,
+            )
+            self.assertEqual(r.status_code, 200, r.text)
+            return r.json()
+
+        sp = {"temperature": 0, "max_new_tokens": 32, "ignore_eos": True}
+
+        # steps=3: BS=1, drafting active.
+        single = gen(self.COUNT_PROMPT, sp)
+        self.assertEqual(self._steps(), 3, "expected steps=3 at BS=1")
+        meta = single["meta_info"]
+        self.assertGreater(meta.get("spec_verify_ct", 0), 0)
+        self.assertEqual(len(meta["output_token_logprobs"]), meta["completion_tokens"])
+
+        # steps=0: a BS>=8 batch routes the worker to nospec.
+        batch = gen([self.COUNT_PROMPT] * 12, [sp] * 12)
+        self.assertEqual(self._steps(), 0, "BS>=8 did not route to steps=0")
+        for res in batch:
+            m = res["meta_info"]
+            self.assertEqual(len(m["output_token_logprobs"]), m["completion_tokens"])
+
+    def test_grammar_json_across_step_boundary(self):
+        """json_schema output stays valid JSON with no trailing tokens on BOTH
+        steps=3 (spec) and steps=0 (no-spec) -- grammar termination must hold
+        whichever verify path the adaptive tier selects."""
+        schema = json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "pattern": "^[\\w ]+$"},
+                    "population": {"type": "integer"},
+                },
+                "required": ["city", "population"],
+            }
+        )
+        prompt = "Return the capital of France and its population as JSON.\n"
+        sp = {"temperature": 0, "max_new_tokens": 64, "json_schema": schema}
+
+        def check(res):
+            text = res["text"]
+            parsed = json.loads(text)
+            self.assertIn("city", parsed)
+            self.assertIn("population", parsed)
+            self.assertTrue(
+                text.strip().endswith("}"), f"trailing tokens past grammar: {text!r}"
+            )
+
+        # steps=3: BS=1.
+        single = requests.post(
+            self.base_url + "/generate",
+            json={"text": prompt, "sampling_params": sp},
+            timeout=600,
+        )
+        self.assertEqual(single.status_code, 200, single.text)
+        self.assertEqual(self._steps(), 3, "expected steps=3 at BS=1")
+        check(single.json())
+
+        # steps=0: BS>=8 batch.
+        batch = requests.post(
+            self.base_url + "/generate",
+            json={"text": [prompt] * 12, "sampling_params": [sp] * 12},
+            timeout=600,
+        )
+        self.assertEqual(batch.status_code, 200, batch.text)
+        self.assertEqual(self._steps(), 0, "BS>=8 did not route to steps=0")
+        for res in batch.json():
+            check(res)
+
+
+class TestAdaptiveDisableOverlapSwitch(_AdaptiveEagleServerBase):
+    """Spec V1 (overlap scheduler off). The accepted-draft counts feed the EMA
+    synchronously instead of through the deferred overlap path, so adaptive
+    switching must still work end-to-end with --disable-overlap-schedule."""
+
+    extra_launch_args = ("--disable-overlap-schedule",)
+
+    def test_switch_under_disable_overlap(self):
+        """Adaptive still up/down-shifts with the overlap scheduler off, where
+        accept counts feed the EMA synchronously rather than via the deferred
+        overlap path."""
+        self._assert_adaptive_switches()
+
+
+class TestAdaptiveEagerSwitch(_AdaptiveEagleServerBase):
+    """Eager mode (cuda graphs disabled). The tier swap has no per-tier cuda graph
+    runners to re-point, so adaptive switching must still work with
+    --disable-cuda-graph."""
+
+    extra_launch_args = ("--disable-cuda-graph",)
+
+    def test_switch_eager(self):
+        """Adaptive still up/down-shifts in eager mode, where the tier swap has
+        no per-tier cuda-graph runners to re-point."""
+        self._assert_adaptive_switches()
+
+
+class TestAdaptiveRetract(_AdaptiveEagleServerBase):
+    """Retract under a tiny KV budget while adaptive is active. Retract and the
+    adaptive tier machinery both mutate KV / runtime state; under load the server
+    must retract and recover without leaking KV or crashing (the strict-mem check
+    asserts no pool leak), and every request must still finish cleanly."""
+
+    extra_launch_args = (
+        "--max-running-requests",
+        "48",
+        "--max-total-tokens",
+        "4500",
+    )
+    launch_env = {
+        "SGLANG_TEST_RETRACT": "1",
+        "SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY": "1",
+    }
+
+    def test_retract_under_adaptive(self):
+        def long_decode():
+            return requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": "Count slowly from 1 to 300, one number per line.",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 256,
+                        "ignore_eos": True,
+                    },
+                },
+                timeout=600,
+            ).json()
+
+        with ThreadPoolExecutor(24) as executor:
+            results = [
+                future.result()
+                for future in as_completed(
+                    [executor.submit(long_decode) for _ in range(24)]
+                )
+            ]
+
+        for res in results:
+            self.assertIn("text", res, f"server error under retract: {res}")
+            self.assertEqual(
+                res["meta_info"]["finish_reason"]["type"],
+                "length",
+                f"request did not finish cleanly under retract: {res['meta_info']}",
+            )
+        self.assertIsNone(self.process.poll(), "server died under retract + adaptive")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extends the adaptive speculative decoding E2E suite to complete the **"CI coverage"** item under Reliability in the Adaptive Speculative Decoding roadmap (#23705): *"test adaptive spec across Spec V1/V2, CUDA graph, streaming, logprob, grammar, abort, and retract."*

Test-only change; no production code is modified.

## Motivation

`test/registered/spec/eagle/test_adaptive_speculative.py` today exercises adaptive tier switching only on the `(spec V2, cuda-graph on, plain generation)` path. This PR adds the missing cells, each framed to guard a **specific interaction with the runtime-state tier swap** — not a happy-path re-run. The table below maps every requirement to the test that covers it:

| Requirement (#23705) | On `main`? | Test that covers it | How it's exercised |
|---|---|---|---|
| **Spec V2** (overlap on) | ✅ existing | `TestAdaptiveSpeculativeServer` / `TestAdaptiveZeroStepBatchSizeServer` (default servers) | overlap scheduler on is the default; existing `test_batch_size_step_cycle` asserts steps `3→0→3` |
| **Spec V1** (overlap off) | ➕ new | `TestAdaptiveDisableOverlapSwitch::test_switch_under_disable_overlap` | `--disable-overlap-schedule`; asserts adaptive still up→3 / down→1 (accept counts feed the EMA synchronously, not via the deferred overlap path) |
| **CUDA graph** (on) | ✅ existing | all default servers | cuda graphs captured by default; every tier swap re-points them |
| **CUDA graph** (off / eager) | ➕ new | `TestAdaptiveEagerSwitch::test_switch_eager` | `--disable-cuda-graph`; asserts switching with no per-tier cuda-graph runners to re-point |
| **streaming** | ➕ new | `TestAdaptiveSpeculativeServer::test_streaming_lossless_across_switch` | streamed greedy output byte-identical at steps=1 vs steps=3 (lossless), and multi-chunk |
| **logprob** | ➕ new | `TestAdaptiveZeroStepBatchSizeServer::test_logprob_count_across_step_boundary` | `len(output_token_logprobs) == completion_tokens` at steps=3 (spec) and steps=0 (no-spec) |
| **grammar** | ➕ new | `TestAdaptiveZeroStepBatchSizeServer::test_grammar_json_across_step_boundary` | `json_schema` output valid JSON, no trailing tokens, at steps=3 and steps=0 |
| **abort** | ➕ new | `TestAdaptiveSpeculativeServer::test_abort_around_switch` | `abort_all` with 8 in-flight requests → each aborts cleanly, server survives and still serves |
| **retract** | ➕ new | `TestAdaptiveRetract::test_retract_under_adaptive` | tiny KV + `SGLANG_TEST_RETRACT` + `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY`; 24-way load forces retract, all finish, no leak/crash |

## Modifications

- Introduce `_AdaptiveEagleServerBase` (launch scaffold + tier-drive helpers); all five adaptive test servers inherit it, configured per class via `adaptive_config` / `extra_launch_args` / `launch_env`. The two pre-existing classes keep their exact behavior.
- New feature cells: streaming-lossless-across-switch and abort-around-switch (on the `[1,3]` switcher); logprob-count and grammar-JSON across the `steps=0` boundary.
- New mode servers: `TestAdaptiveDisableOverlapSwitch` (V1), `TestAdaptiveEagerSwitch` (eager), and `TestAdaptiveRetract` (tiny KV + `SGLANG_TEST_RETRACT` + `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY`, so a KV leak fails the test).
- Bumped `est_time` on the existing `register_cuda_ci` / `register_amd_ci` to reflect the added server launches.

## Validation

CI runs this on the registered `1-gpu-large` (NVIDIA) and `stage-b-test-1-gpu-large-amd` (MI325) lanes.

It was additionally validated end-to-end on real **gfx1151** silicon (AMD Strix Halo / Radeon 8060S) via the `--attention-backend triton` path — **all 10 cases pass** (`10 passed in 432s`), with the retract KV-leak detector armed. Note gfx1151 is a consumer-RDNA target that isn't officially supported yet; local serving there was enabled by the sgl-kernel/runtime enablement in #31137 (part of the consumer-RDNA effort tracked in #30599), which is why this could be exercised on that hardware.

## Accuracy Tests

N/A — test-only; no model output / kernel / forward-path change. The existing gsm8k-after-switch accuracy check is unchanged.

## Speed Tests and Profiling

N/A — no inference-speed impact.

## Checklist

- [x] Format your code according to the Format code with pre-commit (black / isort / ruff green).
- [x] Add unit tests — this PR is CI test coverage.
- [ ] Update documentation — N/A.
- [ ] Provide accuracy and speed benchmark results — N/A (test-only).
- [x] Follow the SGLang code style guidance.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29553732426](https://github.com/sgl-project/sglang/actions/runs/29553732426)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29553732338](https://github.com/sgl-project/sglang/actions/runs/29553732338)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->