### PR TITLE
[Fix] Publish idle scheduler metrics immediately when the running-reqs gauge is stale

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -1100,9 +1100,18 @@ class SchedulerMetricsReporter:
 
     def _maybe_log_idle_metrics(self):
         """Collect and log metrics every 30 seconds during idle."""
+        if not self.current_scheduler_metrics_enabled:
+            return
+        # The running-reqs gauge holds the last batch report until the next
+        # one (on PD prefill that is the last forward-batch snapshot, which
+        # no later report zeroes). If it disagrees with running_batch -- the
+        # true idle value -- publish now instead of waiting out the window.
+        gauge_stale = self.stats.num_running_reqs.total != len(
+            self.scheduler.running_batch.reqs
+        )
         if (
-            not self.current_scheduler_metrics_enabled
-            or time.perf_counter() <= self.metrics_collector.last_log_time + 30
+            not gauge_stale
+            and time.perf_counter() <= self.metrics_collector.last_log_time + 30
         ):
             return
 


### PR DESCRIPTION
After #31495 the num_running_reqs gauge on disagg prefill servers snapshots the last forward batch, and no later report ever zeroes it -- the gauge holds a stale non-zero value for the whole 30s idle-log window (breaking test_retract_pause_no_leak_on_prefill, which asserts 0 shortly after abort). Bypass the idle-log rate limit when the published gauge disagrees with running_batch, so the busy -> idle transition is published immediately.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29553203722](https://github.com/sgl-project/sglang/actions/runs/29553203722)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29553203640](https://github.com/sgl-project/sglang/actions/runs/29553203640)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->