### PR TITLE
fix(minimax-m2): stop detect_and_parse crash on non-finite number literal

### DIFF
--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import re
 from typing import Any, Dict, List, Tuple
 
@@ -178,9 +179,14 @@ class MinimaxM2Detector(BaseFormatDetector):
             elif param_type in ["number", "float"]:
                 try:
                     val = float(value)
-                    return val if val != int(val) else int(val)
                 except (ValueError, TypeError):
                     continue
+                # A non-finite literal ("1e999" -> inf, "nan") would make
+                # int(val) raise (crashing detect_and_parse) or serialize as
+                # invalid `Infinity`/`NaN` JSON; keep the raw string instead.
+                if not math.isfinite(val):
+                    return value
+                return val if val != int(val) else int(val)
             elif param_type in ["boolean", "bool"]:
                 lower_val = value.lower().strip()
                 if lower_val in ["true", "1", "yes", "on"]:

--- a/test/registered/unit/function_call/test_minimax_m2_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m2_detector.py
@@ -1,0 +1,67 @@
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _tool():
+    return Tool(
+        type="function",
+        function=Function(
+            name="search",
+            description="Search the web",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "ratio": {"type": "number"},
+                },
+                "required": ["query"],
+            },
+        ),
+    )
+
+
+def _wire(ratio):
+    return (
+        "<minimax:tool_call>"
+        '<invoke name="search">'
+        '<parameter name="query">hi</parameter>'
+        f'<parameter name="ratio">{ratio}</parameter>'
+        "</invoke>"
+        "</minimax:tool_call>"
+    )
+
+
+class TestMinimaxM2NumberConversion(CustomTestCase):
+    def setUp(self):
+        self.tools = [_tool()]
+
+    def test_normal_number_parses(self):
+        result = MinimaxM2Detector().detect_and_parse(_wire("0.5"), self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(json.loads(result.calls[0].parameters)["ratio"], 0.5)
+
+    def test_overflow_literal_does_not_crash_and_stays_valid_json(self):
+        # "1e999" -> inf; int(inf) raised OverflowError and crashed
+        # detect_and_parse. It must now degrade to the raw string and the
+        # arguments must remain valid JSON (no `Infinity`).
+        result = MinimaxM2Detector().detect_and_parse(_wire("1e999"), self.tools)
+        self.assertEqual(len(result.calls), 1)
+        args = json.loads(result.calls[0].parameters)  # must not raise
+        self.assertEqual(args["ratio"], "1e999")
+
+    def test_nan_literal_stays_valid_json(self):
+        result = MinimaxM2Detector().detect_and_parse(_wire("nan"), self.tools)
+        self.assertEqual(len(result.calls), 1)
+        args = json.loads(result.calls[0].parameters)  # must not raise
+        self.assertEqual(args["ratio"], "nan")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sibling of #31511 (same root bug, other detector). `int(float("1e999"))` raises `OverflowError`; the number branch only caught `ValueError, TypeError`. Unlike m3, `MinimaxM2Detector.detect_and_parse` doesn't wrap `_extract`, so a non-finite literal crashes the non-streaming parse outright.

Guard with `math.isfinite` and keep the raw string — that both stops the crash and avoids the fallback emitting invalid `Infinity`/`NaN` JSON.

Before: `detect_and_parse` on a `number` param with value `1e999` → `OverflowError`.
After: `{"ratio": "1e999"}` (valid JSON), normal numbers unchanged.

Test: new `test_minimax_m2_detector.py` (m2 had no detector unit test) — normal number parses, overflow/nan degrade to valid JSON.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29553269945](https://github.com/sgl-project/sglang/actions/runs/29553269945)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29553269843](https://github.com/sgl-project/sglang/actions/runs/29553269843)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->