### PR TITLE
[Fix] Update PR #25015 revert for fused topk=1 draft postprocess

### DIFF
--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -7,14 +7,6 @@ from typing import Dict
 from sglang.srt.debug_utils.source_patcher import apply_patches_from_config
 from sglang.srt.environ import envs
 
-# PR #25015 moved the draft-loop position advance from *before* the forward
-# (buggy: draft steps read positions off by one) to *after* it. The revert
-# re-introduces the early advance and cancels the correct post-forward advance
-# so the canary fires a verify_position violation. PR #30947 fused the
-# post-forward advance for the topk=1 CUDA chain into
-# ``draft_topk1_postprocess``; that fused advance can't be deleted from
-# ``draft_forward`` source, so we subtract it back after the kernel call to
-# leave only the (mis-timed) early advance.
 _PR_REVERT_YAML_25015 = """
 patches:
   - target: sglang.srt.speculative.eagle_worker_v2.EagleDraftWorker.draft_forward

--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -7,6 +7,14 @@ from typing import Dict
 from sglang.srt.debug_utils.source_patcher import apply_patches_from_config
 from sglang.srt.environ import envs
 
+# PR #25015 moved the draft-loop position advance from *before* the forward
+# (buggy: draft steps read positions off by one) to *after* it. The revert
+# re-introduces the early advance and cancels the correct post-forward advance
+# so the canary fires a verify_position violation. PR #30947 fused the
+# post-forward advance for the topk=1 CUDA chain into
+# ``draft_topk1_postprocess``; that fused advance can't be deleted from
+# ``draft_forward`` source, so we subtract it back after the kernel call to
+# leave only the (mis-timed) early advance.
 _PR_REVERT_YAML_25015 = """
 patches:
   - target: sglang.srt.speculative.eagle_worker_v2.EagleDraftWorker.draft_forward
@@ -19,10 +27,14 @@ patches:
           forward_batch.positions.add_(1)
           spec_info.hidden_states = hidden_states
       - match: |
-          hidden_states = logits_output.hidden_states
-          forward_batch.positions.add_(1)
-        replacement: |
-          hidden_states = logits_output.hidden_states
+          topk_p, topk_index = draft_topk1_postprocess(
+              logits_output.next_token_logits,
+              forward_batch.positions,
+              draft_tokens_topk1,
+              i + 1,
+          )
+        append: |
+          forward_batch.positions.sub_(1)
 
   - target: sglang.srt.speculative.eagle_draft_cuda_graph_runner.EAGLEDraftCudaGraphRunner.capture_one_shape
     edits:

--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -27,6 +27,21 @@ patches:
           )
         append: |
           forward_batch.positions.sub_(1)
+      - match: |
+          draft_probs_list.append(probs)
+          forward_batch.positions.add_(1)
+        replacement: |
+          draft_probs_list.append(probs)
+      - match: |
+          topk_p = torch.ones_like(topk_index, dtype=torch.float32)
+          forward_batch.positions.add_(1)
+        replacement: |
+          topk_p = torch.ones_like(topk_index, dtype=torch.float32)
+      - match: |
+          topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+          forward_batch.positions.add_(1)
+        replacement: |
+          topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
 
   - target: sglang.srt.speculative.eagle_draft_cuda_graph_runner.EAGLEDraftCudaGraphRunner.capture_one_shape
     edits:


### PR DESCRIPTION
## Motivation

`main` is failing `test/registered/kv_canary/test_self_e2e_pr_25015.py`. The culprit is #30947 (`[1/3] [EAGLE] perf: Fuse topk=1 draft postprocess`), though not via a functional regression in the perf change itself.

The `#25015` canary regression test reverts that historical position fix at server startup by **source-patching** `EagleDraftWorker.draft_forward` via `pr_fix_toggle.py` (`SGLANG_DEBUG_REVERT_PR=25015`), then asserts the KV canary fires a `verify_position` violation. The revert relies on exact source-text matching, and on a failed match `source_patcher._find_match` raises `PatchApplicationError`, so the server never starts and the test errors.

#30947 refactored `draft_forward`: the single post-forward `forward_batch.positions.add_(1)` was removed from the loop tail and **fused into the new `draft_topk1_postprocess` Triton kernel** for the topk=1 CUDA chain path. The revert's second edit matched:

```
hidden_states = logits_output.hidden_states
forward_batch.positions.add_(1)
```

which no longer exists, producing:

```
[source_patcher] patching ...EagleDraftWorker.draft_forward
PatchApplicationError: match text not found in source:
hidden_states = logits_output.hidden_states
forward_batch.positions.add_(1)
```

## Changes

Update `_PR_REVERT_YAML_25015`:
- Keep the first edit (inject an early, mis-timed `positions.add_(1)` **before** the forward).
- Replace the now-dead second edit with one that appends `forward_batch.positions.sub_(1)` right after the `draft_topk1_postprocess(...)` call. The kernel performs the correct post-forward advance internally and can't be deleted from `draft_forward` source, so subtracting it back leaves only the early advance — faithfully reproducing the pre-#25015 off-by-one bug so the canary fires `verify_position`.
- The `capture_one_shape` edit is untouched (that file wasn't affected by #30947).

## Validation

Ran on a B200 GPU:

```
============ 2 passed, 1 skipped, 15 warnings in 126.76s (0:02:06) =============
```

- `TestEaglePositionsMatchWithFix` (fix in place → no violation): PASSED
- `TestEaglePositionsMisalignRegression` (revert #25015 → canary fires `verify_position`): PASSED
- The abstract `_EaglePositionsBase` is the 1 skip.

## Note

These "revert-a-historical-fix" canary tests are tightly coupled to the exact source text of the functions they patch, so future refactors of `draft_forward` (e.g. the merged #30948 and the open #30949) can silently break them again. Worth updating the corresponding `pr_fix_toggle` revert in the same PR when refactoring that method.

Made with [Cursor](https://cursor.com)































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29554680000](https://github.com/sgl-project/sglang/actions/runs/29554680000)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29554679830](https://github.com/sgl-project/sglang/actions/runs/29554679830)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->