### PR TITLE
[LoRA] Size column-parallel LoRA-B buffers via an output-axis shard probe

### DIFF
--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -481,9 +481,14 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         return A
 
     def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+        # Slice by the base layer's own partition rank, not the global
+        # `tp_rank`: replicated base layers (e.g. dense-layer and
+        # shared-expert projections under `--moe-dense-tp-size 1`) keep the
+        # full output dim on every rank, so B must not be sliced.
+        shard_rank = self.base_layer.tp_rank
         shard_size = self.base_layer.output_partition_sizes[0]
-        start_idx = tp_rank * shard_size
-        end_idx = (tp_rank + 1) * shard_size
+        start_idx = shard_rank * shard_size
+        end_idx = start_idx + shard_size
         B = B[start_idx:end_idx, :]
         return B
 
@@ -577,12 +582,17 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         return A
 
     def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+        # Slice by the base layer's own partition rank, not the global
+        # `tp_rank`: replicated base layers (e.g. dense-layer and
+        # shared-expert `gate_up_proj` under `--moe-dense-tp-size 1`) keep
+        # the full output dim on every rank, so B must not be sliced.
+        shard_rank = self.base_layer.tp_rank
         partition_sizes = self.base_layer.output_partition_sizes
         output_sizes = self.base_layer.output_sizes
         slices = []
         offset = 0
         for full_size, part_size in zip(output_sizes, partition_sizes):
-            start_idx = tp_rank * part_size
+            start_idx = shard_rank * part_size
             end_idx = start_idx + part_size
             slices.append(B[offset + start_idx : offset + end_idx, :])
             offset += full_size
@@ -645,15 +655,19 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         return A
 
     def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int) -> torch.Tensor:
+        # Slice by the base layer's own partition rank, not the global
+        # `tp_rank`: a replicated base layer keeps the full output dim on
+        # every rank, so B must not be sliced.
         base_layer = self.base_layer
+        shard_rank = base_layer.tp_rank
         q_proj_shard_size = base_layer.q_proj_shard_size
         kv_proj_shard_size = base_layer.kv_proj_shard_size
         num_kv_head_replicas = base_layer.num_kv_head_replicas
 
-        q_start_idx = q_proj_shard_size * tp_rank
+        q_start_idx = q_proj_shard_size * shard_rank
         q_end_idx = q_start_idx + q_proj_shard_size
 
-        kv_shard_id = tp_rank // num_kv_head_replicas
+        kv_shard_id = shard_rank // num_kv_head_replicas
         kv_start_idx = kv_proj_shard_size * kv_shard_id
         kv_end_idx = kv_start_idx + kv_proj_shard_size
 

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -20,6 +20,7 @@ from sglang.srt.distributed import (
     get_pp_group,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.linear import ColumnParallelLinear
 from sglang.srt.lora.eviction_policy import get_eviction_policy
 from sglang.srt.lora.layers import BaseLayerWithLoRA
 from sglang.srt.lora.lora import LoRAAdapter
@@ -225,6 +226,11 @@ class LoRAMemoryPool:
                     self.lm_head_shard_indices = module.shard_indices
                     break
 
+        # Probed output-axis shard counts of column-parallel modules, keyed
+        # by `(module_name, layer_idx)` so `init_buffers` walks the model at
+        # most once per buffer.
+        self._column_parallel_shard_counts: Dict[Tuple[str, int], int] = {}
+
         self.init_buffers(base_model)
 
     def can_support(self, config: Union[LoRAConfig, Iterable[LoRAConfig]]) -> bool:
@@ -406,6 +412,62 @@ class LoRAMemoryPool:
             input_dim,
         )
 
+    def _column_parallel_shard_count(
+        self,
+        module_name: str,
+        base_model: torch.nn.Module,
+        layer_idx: int,
+    ) -> int:
+        """Output-axis shard count of a non-MoE column-parallel module.
+
+        Probes the live base layer's ``output_size // output_size_per_partition``
+        instead of assuming the static ``tp_size``: models can replicate
+        column-parallel layers on every rank (e.g. dense-layer and
+        shared-expert ``gate_up_proj`` under ``--moe-dense-tp-size 1``), where
+        a ``tp_size`` divide would undersize the LoRA B buffer against the
+        base layer's ``output_partition_sizes`` that ``set_lora_info``
+        validates. The output axis is quantization-independent:
+        ``output_size_per_partition`` is set in
+        :class:`ColumnParallelLinear` ``__init__`` before the quant method
+        runs, whereas quant methods (e.g. ``Fp8LinearMethod.create_weights``)
+        stamp ``input_size_per_partition == input_size`` on column-parallel
+        layers, so the input axis must never be probed. Falls back to
+        ``tp_size`` when no matching layer exists on this rank.
+        """
+        if self.tp_size == 1:
+            return 1
+
+        key = (module_name, layer_idx)
+        cached = self._column_parallel_shard_counts.get(key)
+        if cached is not None:
+            return cached
+
+        layer_marker = f"layers.{layer_idx}."
+        suffix = f".{module_name}"
+        # Prefer the LoRA-wrapped module (the actual target) over same-named
+        # modules elsewhere in the model (e.g. vision towers).
+        wrapped_layer = None
+        raw_layer = None
+        for name, module in base_model.named_modules():
+            if layer_marker not in name or not name.endswith(suffix):
+                continue
+            if isinstance(module, BaseLayerWithLoRA) and isinstance(
+                module.base_layer, ColumnParallelLinear
+            ):
+                wrapped_layer = module.base_layer
+                break
+            if raw_layer is None and isinstance(module, ColumnParallelLinear):
+                raw_layer = module
+
+        layer = wrapped_layer if wrapped_layer is not None else raw_layer
+        shard_count = (
+            layer.output_size // layer.output_size_per_partition
+            if layer is not None
+            else self.tp_size
+        )
+        self._column_parallel_shard_counts[key] = shard_count
+        return shard_count
+
     def _column_parallel_lora_b_per_rank_dim(
         self,
         module_name: str,
@@ -458,9 +520,14 @@ class LoRAMemoryPool:
         _, output_dim = get_hidden_dim(
             module_name, self.base_hf_config, base_model, layer_idx
         )
-        # MoE modules shard along `moe_tp_size`, not the outer `tp_size`.
+        # MoE modules shard along `moe_tp_size`, not the outer `tp_size`;
+        # other modules use the probed output-axis shard count, which differs
+        # from `tp_size` when the base layer is replicated (e.g. dense-layer
+        # and shared-expert `gate_up_proj` under `--moe-dense-tp-size 1`).
         effective_tp_size = (
-            self.moe_tp_size if self.is_moe_module(module_name) else self.tp_size
+            self.moe_tp_size
+            if self.is_moe_module(module_name)
+            else self._column_parallel_shard_count(module_name, base_model, layer_idx)
         )
         if (
             effective_tp_size > 1

--- a/test/registered/unit/lora/test_mem_pool_ep_unit.py
+++ b/test/registered/unit/lora/test_mem_pool_ep_unit.py
@@ -530,6 +530,12 @@ class TestMoeBufferShardsByMoeTp(unittest.TestCase):
         pool.max_loras_per_batch = 2
         pool.tp_size = tp_size
         pool.tp_rank = 0
+        # `get_lora_B_shape` probes the live base layer's output-axis shard
+        # count for non-MoE modules, memoized in this dict (normally created
+        # in `__init__`, which this helper bypasses). The fake model below has
+        # no `layers.{idx}.`-scoped modules, so the probe falls back to
+        # `tp_size` — preserving the static-sharding shapes asserted here.
+        pool._column_parallel_shard_counts = {}
         pool.moe_ep_size = ep_size
         pool.moe_ep_rank = ep_rank
         pool.moe_tp_size = moe_tp_size


### PR DESCRIPTION
## Motivation

`LoRAMemoryPool` sizes column-parallel LoRA-B buffers statically as `output_dim // tp_size`. That breaks whenever a column-parallel base layer's real shard count differs from `tp_size` — most visibly on FP8 (blockwise) base models served with `--moe-dense-tp-size 1`, where the dense-MLP / shared-expert `gate_up_proj` is fully replicated: the buffer comes out `tp_size`-times too small and engine init dies with

```
ValueError: LoRA B output dim 5472 does not match base partition prefix dim 21888 for 2 slices.
```

This blocks LoRA on GLM-5.2-FP8-style deployments (dense first layers + shared experts + blockwise FP8). Ports the intent of sglang-miles #31251 to main, redesigned for main's static shape calculation.

## Modifications

- `lora/mem_pool.py`: new quantization-independent **output-axis shard probe** — `output_size // output_size_per_partition` of the live base module, cached per `(module_name, layer_idx)`. `get_lora_B_shape` uses the probed shard count for column-parallel modules, so replicated base layers get full-size LoRA-B buffers while normally-sharded layers keep `output_dim // tp_size` (probe is a no-op there). The output axis is used because quantized linear methods (e.g. `Fp8LinearMethod.create_weights`) stamp `input_size_per_partition == input_size`, making input-axis probing unreliable, while `output_size_per_partition` is set in `ColumnParallelLinear.__init__` before the quant method runs.
- `lora/layers.py`: `MergedColumnParallelLinearWithLoRA` / `QKVParallelLinearWithLoRA` skip B-slicing when the base is replicated (shard count 1), keeping slice shapes consistent with the probed buffers. The existing kv-head-replication logic in `_column_parallel_lora_b_per_rank_dim` is preserved.

## Accuracy Tests

On 8x H200:

- **Headline A/B** (`deepseek-ai/DeepSeek-V2-Lite-Chat`, `--tp 4 --quantization fp8 --moe-dense-tp-size 1 --enable-lora`, synthetic `gate_proj`/`up_proj` adapter — dense layer-0 MLP + shared experts, same shape as GLM-5.2): **main crashes at LoRA init** with the `ValueError` above on all 4 TP ranks; **this PR serves and generates**, with LoRA numerically active. The probe is visible in the log: dense layer-0 gate_up keeps the full `K=21888` (replicated) while shared_experts stays 4-way sharded at `K=1408` — per-(module, layer) probing works.
- **bf16 no-regression**: same model, plain `--tp 4 --enable-lora` (no fp8, no moe-dense-tp-size): identical behavior to main; probe is a no-op on the sharded path.
- **GQA kv-replication branch**: `Qwen2.5-1.5B-Instruct` (2 kv heads, tp4 → `num_kv_head_replicas=2`) with a q/k/v adapter: load + generation OK.
- `test/registered/unit/lora/test_mem_pool_ep_unit.py`: 28 passed. `test/registered/lora/test_lora_moe_tp_logprob_diff.py`: 2/2 passed (moe_tp arm untouched).

Unrelated pre-existing issue found while testing (identical on main and this branch, not addressed here): `Qwen3.5-4B` + qkv-targeting adapter at tp8 hits `LoRA buffer shape torch.Size([1536, 16]) does not match weight shape torch.Size([1024, 16])` — the hybrid-arch `get_hidden_dim` over-sizes the qkv B buffer.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29554432781](https://github.com/sgl-project/sglang/actions/runs/29554432781)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29558876591](https://github.com/sgl-project/sglang/actions/runs/29558876591)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->