### PR TITLE
[LoRA] Skip LoRA wrapper modules in post-load quant weight processing

### DIFF
--- a/python/sglang/srt/checkpoint_engine/checkpoint_engine_worker.py
+++ b/python/sglang/srt/checkpoint_engine/checkpoint_engine_worker.py
@@ -122,10 +122,16 @@ class SGLangCheckpointEngineWorkerExtensionImpl(SGLangCheckpointEngineWorkerExte
         def post_hook():
             # Perform post-processing after weight loading similar to DefaultModelLoader
             try:
+                from sglang.srt.lora.layers import BaseLayerWithLoRA
                 from sglang.srt.model_loader.loader import device_loading_context
 
                 # Process quantization methods after loading weights
                 for _, module in self.model_runner.model.named_modules():
+                    # LoRA wrappers forward `quant_method` but don't own the
+                    # packed params; the inner base layer (yielded separately
+                    # by `named_modules`) handles the post-processing.
+                    if isinstance(module, BaseLayerWithLoRA):
+                        continue
                     quant_method = getattr(module, "quant_method", None)
                     if quant_method is not None:
                         # Move parameters to device if needed for quantization processing

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -837,7 +837,15 @@ class DefaultModelLoader(BaseModelLoader):
                 f"{memory_start - memory_end:.3f}",
             )
 
+        from sglang.srt.lora.layers import BaseLayerWithLoRA
+
         for _, module in model.named_modules():
+            # LoRA wrappers forward `quant_method` for forward-path dispatch but
+            # don't own the packed params; skip them so the inner base layer
+            # (yielded separately by `named_modules`) handles it. Wrappers only
+            # exist when weights are reloaded on a live model with LoRA enabled.
+            if isinstance(module, BaseLayerWithLoRA):
+                continue
             quant_method = getattr(module, "quant_method", None)
             if quant_method is not None:
                 # When quant methods need to process weights after loading
@@ -1052,8 +1060,13 @@ class QuantizedRLModelLoader(DefaultModelLoader):
                         recorded_loader[key][name] = attr
         model.recorded_loader = recorded_loader
 
+        from sglang.srt.lora.layers import BaseLayerWithLoRA
+
         # Apply FP8 quantization (creates new Parameters, loses attributes)
         for _, module in model.named_modules():
+            # Skip LoRA wrappers; the inner base layer owns the packed params.
+            if isinstance(module, BaseLayerWithLoRA):
+                continue
             quant_method = getattr(module, "quant_method", None)
             if quant_method is not None:
                 with device_loading_context(module, target_device):


### PR DESCRIPTION
## Motivation

`/update_weights_from_disk` (and the flash_rl reload path) re-runs `quant_method.process_weights_after_loading(module)` over all modules after loading. On a LoRA-enabled server with quantized MoE, `FusedMoEWithLoRA` forwards `quant_method` from its base layer but does not own the packed parameters, so the hook crashes the scheduler:

```
loader.py:849, in load_weights_and_postprocess
AttributeError: 'FusedMoEWithLoRA' object has no attribute 'w13_weight'
```

which kills any RL flow that refreshes weights on a quantized-MoE + LoRA server. This ports the LoRA-specific fix from the sglang-miles RL weight-processing work (part of the #18565/#28001 series) to main.

## Modifications

- `model_loader/loader.py`: in the two post-load weight-processing loops (`DefaultModelLoader.load_weights_and_postprocess`, `QuantizedRLModelLoader` restore/process), skip `BaseLayerWithLoRA` wrapper modules — the hooks run on the inner base layers, which own the packed params. The skip covers all `BaseLayerWithLoRA` subclasses (today only `FusedMoEWithLoRA` copies `quant_method`, so only quantized-MoE + LoRA actually crashes; the guard is uniform for future wrappers).

## Accuracy Tests

On 8x H200 (`Qwen/Qwen3-30B-A3B-FP8`, `--tp 4 --enable-lora`, adapter targeting attention + MoE experts — FusedMoE is only wrapped when `gate_up_proj`/`down_proj` are targeted, which is required to reproduce the bug):

- **A/B**: on main, the first `/update_weights_from_disk` returns an empty body and the scheduler dies with the `AttributeError` above (health check fails). With this PR, two consecutive updates both succeed; base generations are token-identical before/after both updates, LoRA generations differ from base and are identical across both updates.
- **Initial-load path untouched**: pre-update base and LoRA generations are token-identical between main and this branch.
- Non-LoRA regression `test/registered/rl/test_update_weights_from_disk.py`: 5 passed + 8 subtests; the one failure (`test_update_weights_non_blocking`, RemoteDisconnected under 32 concurrent decodes) reproduces identically on main — pre-existing, unrelated.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828638341](https://github.com/sgl-project/sglang/actions/runs/34828638341)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828638251](https://github.com/sgl-project/sglang/actions/runs/34828638251)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34828638350](https://github.com/sgl-project/sglang/actions/runs/34828638350)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->