### PR TITLE
[Fix] Handle BF16 and FP8 DeepEP dispatch in CUTLASS W4A8 MoE

### DIFF
--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -105,6 +105,109 @@ def deepep_permute_triton_kernel(
 
 
 @triton.jit
+def _deepep_permute_fp8_to_per_tensor_quant_kernel(
+    input_ptr,
+    input_scale_ptr,
+    gateup_input_ptr,
+    src2dst_ptr,
+    output_scale_ptr,
+    input_scale_stride_m,
+    input_scale_stride_k,
+    topk,
+    hidden_size,
+    GROUP_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Reorder DeepEP FP8 rows and convert their group scales to one scale."""
+    OutDtype = gateup_input_ptr.dtype.element_ty
+
+    src_idx = tl.program_id(0)
+    src2dst_ptr = src2dst_ptr + src_idx * topk
+    src_ptr = input_ptr + src_idx * hidden_size
+    output_scale_inv = 1.0 / tl.load(output_scale_ptr).to(tl.float32)
+
+    for start_offset in tl.range(0, hidden_size, BLOCK_SIZE):
+        offset = start_offset + tl.arange(0, BLOCK_SIZE)
+        mask = offset < hidden_size
+        input_value = tl.load(src_ptr + offset, mask=mask).to(tl.float32)
+        input_scale = tl.load(
+            input_scale_ptr
+            + src_idx * input_scale_stride_m
+            + (offset // GROUP_SIZE) * input_scale_stride_k,
+            mask=mask,
+        ).to(tl.float32)
+        output_value = input_value * input_scale * output_scale_inv
+
+        for idx in range(topk):
+            dst_idx = tl.load(src2dst_ptr + idx).to(tl.int64)
+            if dst_idx >= 0:
+                dst_ptr = gateup_input_ptr + dst_idx * hidden_size
+                tl.store(dst_ptr + offset, output_value.to(OutDtype), mask=mask)
+
+
+def deepep_permute_fp8_to_per_tensor_quant(
+    input: torch.Tensor,
+    input_scale: torch.Tensor,
+    gateup_input: torch.Tensor,
+    src2dst: torch.Tensor,
+    output_scale: torch.Tensor,
+    topk: int,
+    group_size: int = 128,
+):
+    """Convert DeepEP normal-dispatch FP8 rows to Cutlass static-scale FP8."""
+    if input.dtype != torch.float8_e4m3fn:
+        raise TypeError(f"Expected FP8 input, got {input.dtype}.")
+    if input.dim() != 2 or not input.is_contiguous():
+        raise ValueError(
+            f"Expected contiguous 2D input, got shape={input.shape}, "
+            f"contiguous={input.is_contiguous()}."
+        )
+    if input_scale.dtype != torch.float32 or input_scale.dim() != 2:
+        raise ValueError(
+            "Expected 2D float32 DeepEP group scales, "
+            f"got shape={input_scale.shape}, dtype={input_scale.dtype}."
+        )
+    expected_scale_shape = (input.size(0), input.size(1) // group_size)
+    if input.size(1) % group_size != 0 or input_scale.shape != expected_scale_shape:
+        raise ValueError(
+            f"Expected scale shape {expected_scale_shape} for input shape "
+            f"{tuple(input.shape)} and group_size={group_size}, got "
+            f"{tuple(input_scale.shape)}."
+        )
+    if gateup_input.dtype != torch.float8_e4m3fn:
+        raise TypeError(f"Expected FP8 output, got {gateup_input.dtype}.")
+    if gateup_input.dim() != 2 or gateup_input.size(1) != input.size(1):
+        raise ValueError(
+            f"Expected output shape [N, {input.size(1)}], got "
+            f"{tuple(gateup_input.shape)}."
+        )
+    if src2dst.shape != (input.size(0), topk):
+        raise ValueError(
+            f"Expected src2dst shape {(input.size(0), topk)}, got "
+            f"{tuple(src2dst.shape)}."
+        )
+    if output_scale.dtype != torch.float32 or output_scale.numel() != 1:
+        raise ValueError(
+            "Expected one float32 output scale, "
+            f"got shape={output_scale.shape}, dtype={output_scale.dtype}."
+        )
+
+    _deepep_permute_fp8_to_per_tensor_quant_kernel[(input.size(0),)](
+        input,
+        input_scale,
+        gateup_input,
+        src2dst,
+        output_scale,
+        input_scale.stride(0),
+        input_scale.stride(1),
+        topk,
+        input.size(1),
+        GROUP_SIZE=group_size,
+        BLOCK_SIZE=512,
+    )
+
+
+@triton.jit
 def deepep_post_reorder_triton_kernel(
     down_output_ptr,
     output_ptr,

--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -29,6 +29,7 @@ from sglang.jit_kernel.per_tensor_quant_fp8 import (
 from sglang.kernels.ops.moe.ep_moe_kernels import (
     cutlass_w4_run_moe_ep_preproess,
     deepep_ll_get_cutlass_w4a8_moe_mm_data,
+    deepep_permute_fp8_to_per_tensor_quant,
     deepep_permute_triton_kernel,
     deepep_post_reorder_triton_kernel,
     deepep_run_moe_deep_preprocess,
@@ -243,6 +244,7 @@ def cutlass_w4a8_moe(
 
 def cutlass_w4a8_moe_deepep_normal(
     a: torch.Tensor,
+    a_scales: Optional[torch.Tensor],
     w1_q: torch.Tensor,
     w2_q: torch.Tensor,
     w1_scale: torch.Tensor,
@@ -272,6 +274,8 @@ def cutlass_w4a8_moe_deepep_normal(
     Parameters:
     - a (torch.Tensor): The input tensor to the MoE layer.
         Shape: [M, K]
+    - a_scales (Optional[torch.Tensor]): DeepEP per-token group scales when
+        a is FP8. Must be None when a is BF16/FP16/FP32.
     - w1_q (torch.Tensor): The first set of int4-quantized expert weights.
         Shape: [num_experts, N * 2,  K // 2]
         (the weights are passed transposed and int4-packed)
@@ -332,26 +336,48 @@ def cutlass_w4a8_moe_deepep_normal(
         topk_ids_, num_experts
     )
     num_total_tokens = reorder_topk_ids.numel()
-    gateup_input_pre_reorder = torch.empty(
-        (int(num_total_tokens), a.shape[1]),
-        device=device,
-        dtype=a.dtype,
-    )
-    deepep_permute_triton_kernel[(a.shape[0],)](
-        a,
-        gateup_input_pre_reorder,
-        src2dst,
-        topk_ids_.to(torch.int64),
-        None,
-        topk,
-        a.shape[1],
-        BLOCK_SIZE=512,
-    )
     gateup_input = torch.empty(
-        gateup_input_pre_reorder.shape, dtype=torch.float8_e4m3fn, device=device
+        (int(num_total_tokens), a.shape[1]),
+        dtype=torch.float8_e4m3fn,
+        device=device,
     )
-    per_tensor_quant_fp8(gateup_input_pre_reorder, gateup_input, a1_scale.float(), True)
-    del gateup_input_pre_reorder
+    if a_scales is None:
+        if a.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise TypeError(
+                "DeepEP normal dispatch without scales requires a floating-point "
+                f"input, got {a.dtype}."
+            )
+        gateup_input_pre_reorder = torch.empty(
+            gateup_input.shape,
+            device=device,
+            dtype=a.dtype,
+        )
+        deepep_permute_triton_kernel[(a.shape[0],)](
+            a,
+            gateup_input_pre_reorder,
+            src2dst,
+            topk_ids_.to(torch.int64),
+            None,
+            topk,
+            a.shape[1],
+            BLOCK_SIZE=512,
+        )
+        per_tensor_quant_fp8(
+            gateup_input_pre_reorder,
+            gateup_input,
+            a1_scale.float(),
+            is_static=True,
+        )
+        del gateup_input_pre_reorder
+    else:
+        deepep_permute_fp8_to_per_tensor_quant(
+            input=a,
+            input_scale=a_scales,
+            gateup_input=gateup_input,
+            src2dst=src2dst.view(a.shape[0], topk),
+            output_scale=a1_scale.float(),
+            topk=topk,
+        )
     local_topk_ids = topk_ids_
     local_topk_ids = (
         torch.where(local_topk_ids == -1, num_experts, topk_ids_).to(torch.int32)
@@ -433,7 +459,7 @@ def cutlass_w4a8_moe_deepep_normal(
 
 def cutlass_w4a8_moe_deepep_ll(
     a_states: torch.Tensor,
-    a_scales: torch.Tensor,
+    a_scales: Optional[torch.Tensor],
     w1_q: torch.Tensor,
     w2_q: torch.Tensor,
     w1_scale: torch.Tensor,
@@ -523,13 +549,28 @@ def cutlass_w4a8_moe_deepep_ll(
     )
 
     gateup_input = torch.empty(a_states.shape, dtype=torch.float8_e4m3fn, device=device)
-    fp8_per_token_to_per_tensor_quant_triton(
-        x=a_states,
-        x_scale=a_scales,
-        masked_m=masked_m,
-        output_scale=a1_scale,
-        output=gateup_input,
-    )
+    if a_scales is None:
+        if a_states.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise TypeError(
+                "DeepEP low-latency dispatch without scales requires a "
+                f"floating-point input, got {a_states.dtype}."
+            )
+        per_tensor_quant_fp8(
+            a_states, gateup_input, a1_scale.float(), is_static=True
+        )
+    else:
+        if a_states.dtype != torch.float8_e4m3fn:
+            raise TypeError(
+                "DeepEP low-latency dispatch with scales requires FP8 input, "
+                f"got {a_states.dtype}."
+            )
+        fp8_per_token_to_per_tensor_quant_triton(
+            x=a_states,
+            x_scale=a_scales,
+            masked_m=masked_m,
+            output_scale=a1_scale,
+            output=gateup_input,
+        )
     c1 = torch.empty((num_experts, m, n * 2), device=device, dtype=torch.bfloat16)
     c2 = torch.empty((num_experts, m, k), device=device, dtype=torch.bfloat16)
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -450,6 +450,10 @@ class _DeepEPDispatcherImplBase:
         config = config_map[self.deepep_output_dtype]
         self.use_fp8 = config["use_fp8"]
         self.use_nvfp4 = config["use_nvfp4"]
+        logger.info_once(
+            "DeepEP dispatcher output dtype resolved to "
+            f"{self.deepep_output_dtype.value}."
+        )
 
         # Handle environment variables
         if _is_npu:
@@ -610,6 +614,12 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
         topk_ids: torch.Tensor,
         topk_weights: torch.Tensor,
     ):
+
+        if hidden_states.dtype != torch.bfloat16:
+            raise TypeError(
+                "DeepEP normal combine requires BF16 expert output, "
+                f"got {hidden_states.dtype}."
+            )
 
         if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM or _use_aiter or _is_npu:
             output = hidden_states

--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -371,18 +371,18 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
             cutlass_w4a8_moe_deepep_normal,
         )
 
-        hidden_states, topk_idx, topk_weights = (
+        hidden_states, hidden_states_scale, topk_idx, topk_weights = (
             dispatch_output.hidden_states,
+            dispatch_output.hidden_states_scale,
             dispatch_output.topk_ids,
             dispatch_output.topk_weights,
         )
-        if isinstance(hidden_states, tuple):
-            hidden_states = hidden_states[0]
 
         num_tokens = hidden_states.shape[0]
         if num_tokens > 0:
             return cutlass_w4a8_moe_deepep_normal(
                 hidden_states,
+                hidden_states_scale,
                 layer.w13_weight,
                 layer.w2_weight,
                 layer.w13_weight_scale_inv,
@@ -404,4 +404,6 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
                 layer.w2_input_scale,
             )
         else:
-            return hidden_states
+            # DeepEP normal combine expects BF16 expert output. Keep the empty
+            # path consistent with the non-empty Cutlass result.
+            return torch.empty_like(hidden_states, dtype=torch.bfloat16)

--- a/test/manual/layers/moe/test_w4a8_deepep_dispatch.py
+++ b/test/manual/layers/moe/test_w4a8_deepep_dispatch.py
@@ -1,0 +1,121 @@
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.ep_moe_kernels import (
+    deepep_permute_fp8_to_per_tensor_quant,
+    fp8_per_token_to_per_tensor_quant_triton,
+)
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+)
+from sglang.srt.layers.moe.token_dispatcher.deepep import (
+    DeepEPNormalDispatchOutput,
+)
+from sglang.srt.layers.quantization.w4afp8 import W4AFp8MoEMethod
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("column_major_scales", [False, True])
+def test_deepep_normal_fp8_reorder_and_requantize(column_major_scales):
+    torch.manual_seed(0)
+    num_tokens, hidden_size, topk = 3, 1024, 2
+    source = torch.randn(
+        (num_tokens, hidden_size), device="cuda", dtype=torch.bfloat16
+    )
+    source_fp8, source_scale = sglang_per_token_group_quant_fp8(
+        source,
+        128,
+        column_major_scales=column_major_scales,
+    )
+
+    # One invalid route exercises the same src2dst contract as DeepEP.
+    src2dst = torch.tensor(
+        [[2, -1], [0, 3], [1, 4]], device="cuda", dtype=torch.int64
+    )
+    output_scale = torch.tensor([0.02], device="cuda", dtype=torch.float32)
+    output = torch.zeros(
+        (5, hidden_size), device="cuda", dtype=torch.float8_e4m3fn
+    )
+
+    deepep_permute_fp8_to_per_tensor_quant(
+        input=source_fp8,
+        input_scale=source_scale,
+        gateup_input=output,
+        src2dst=src2dst,
+        output_scale=output_scale,
+        topk=topk,
+    )
+
+    source_dequant = source_fp8.float() * source_scale.float().repeat_interleave(
+        128, dim=1
+    )
+    expected_rows = (source_dequant / output_scale).to(torch.float8_e4m3fn)
+    expected = torch.zeros_like(output)
+    for token_id in range(num_tokens):
+        for route_id in range(topk):
+            dst = src2dst[token_id, route_id].item()
+            if dst >= 0:
+                expected[dst] = expected_rows[token_id]
+
+    torch.testing.assert_close(output.float(), expected.float(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_deepep_low_latency_fp8_requantize():
+    torch.manual_seed(1)
+    num_experts, max_tokens, hidden_size = 2, 5, 1024
+    source = torch.randn(
+        (num_experts, max_tokens, hidden_size),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    source_fp8, source_scale = sglang_per_token_group_quant_fp8(source, 128)
+    masked_m = torch.tensor([5, 3], device="cuda", dtype=torch.int32)
+    output_scale = torch.tensor([0.02], device="cuda", dtype=torch.float32)
+    output = torch.zeros_like(source_fp8)
+
+    fp8_per_token_to_per_tensor_quant_triton(
+        x=source_fp8,
+        x_scale=source_scale,
+        masked_m=masked_m,
+        output_scale=output_scale,
+        output=output,
+    )
+
+    source_dequant = source_fp8.float() * source_scale.float().repeat_interleave(
+        128, dim=2
+    )
+    expected = (source_dequant / output_scale).to(torch.float8_e4m3fn)
+    for expert_id, valid_tokens in enumerate(masked_m.tolist()):
+        torch.testing.assert_close(
+            output[expert_id, :valid_tokens].float(),
+            expected[expert_id, :valid_tokens].float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            output[expert_id, valid_tokens:].float(),
+            torch.zeros_like(output[expert_id, valid_tokens:].float()),
+            rtol=0,
+            atol=0,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_deepep_normal_empty_fp8_dispatch_returns_bf16_for_combine():
+    hidden_size, topk = 1024, 2
+    dispatch_output = DeepEPNormalDispatchOutput(
+        hidden_states=torch.empty(
+            (0, hidden_size), device="cuda", dtype=torch.float8_e4m3fn
+        ),
+        hidden_states_scale=torch.empty((0, hidden_size // 128), device="cuda"),
+        topk_ids=torch.empty((0, topk), device="cuda", dtype=torch.int64),
+        topk_weights=torch.empty((0, topk), device="cuda", dtype=torch.float32),
+        num_recv_tokens_per_expert=[],
+    )
+
+    method = object.__new__(W4AFp8MoEMethod)
+    output = method.apply_deepep_normal(layer=None, dispatch_output=dispatch_output)
+
+    assert output.shape == (0, hidden_size)
+    assert output.dtype == torch.bfloat16


### PR DESCRIPTION
## Motivation

The CUTLASS W4A8 MoE DeepEP paths did not consistently handle the configured dispatcher output dtype.

- Normal mode discarded `hidden_states_scale` when DeepEP returned FP8 activations. It then requantized the raw FP8 values without applying the per-token group scales, causing incorrect outputs.
- Low-latency mode unconditionally assumed FP8 activations with scales. BF16 dispatch produced `hidden_states_scale=None` and failed in the FP8 conversion kernel.
- An empty FP8 normal dispatch was returned unchanged, while DeepEP normal combine expects BF16 expert output.

These issues could be triggered by `--deepep-dispatcher-output-dtype` and by the automatic BF16 selection for the CUTLASS backend.

## Modifications

- Pass `hidden_states_scale` from the normal DeepEP dispatch output into the W4A8 MoE implementation.
- Add a fused Triton kernel that reorders activations, applies per-token group FP8 scales, and requantizes them to the static per-tensor scale expected by CUTLASS.
- Support row-major and column-major FP8 scale layouts through tensor strides.
- Handle both dispatcher output formats in normal and low-latency modes:
  - BF16/FP16/FP32 activations without scales.
  - FP8 activations with per-token group scales.
- Return BF16 for empty normal dispatches.
- Add dtype validation and log the resolved DeepEP dispatcher output dtype.
- Add targeted tests for normal FP8 reorder/requantization, low-latency FP8 conversion, and empty FP8 dispatch.

## Accuracy Tests

Added the following targeted tests:

```bash
python3 -m pytest -q test/manual/layers/moe/test_w4a8_deepep_dispatch.py
```

The tests cover:

- Normal-mode FP8 conversion with row-major and column-major scales.
- Low-latency FP8 per-token-to-per-tensor conversion.
- BF16 output for an empty normal FP8 dispatch.

GPU test execution is pending on a CUDA environment with PyTorch and Triton installed.

## Speed Tests and Profiling

Not benchmarked.

The normal FP8 path performs reorder, group-scale dequantization, and static-scale requantization in one Triton kernel, avoiding an intermediate BF16 activation tensor.

## Checklist

- [ ] Run pre-commit formatting and lint checks.
- [x] Add targeted tests for the affected paths.
- [x] No documentation changes are required.
- [ ] Run the targeted tests on a CUDA GPU.
- [ ] Run W4A8 DeepEP model accuracy tests for normal and low-latency modes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29555607440](https://github.com/sgl-project/sglang/actions/runs/29555607440)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29555607351](https://github.com/sgl-project/sglang/actions/runs/29555607351)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->