### PR TITLE
[DCP] Auto-disable tc_piecewise and breakable prefill CUDA graphs under DCP

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3651,6 +3651,13 @@ class ServerArgs:
                 "DSA prefill context parallelism",
                 lambda: self.enable_dsa_prefill_context_parallel,
             ),
+            # The piecewise prefill capture builds a dummy extend forward with
+            # attn_dcp_metadata=None, which the MLA prepare path dereferences
+            # (dcp_local_prefix_kv_indices) and crashes under DCP.
+            (
+                "decode context parallel (dcp_size > 1)",
+                lambda: self.dcp_size > 1,
+            ),
         ]
         for _name, predicate in rules:
             if predicate():
@@ -3678,6 +3685,12 @@ class ServerArgs:
             (
                 "context parallel (attn_cp_size > 1)",
                 lambda: self._resolved().attn_cp_size > 1,
+            ),
+            # DCP extend takes a metadata-dependent attn-forward path that the
+            # BCG capture path does not build (attn_dcp_metadata=None).
+            (
+                "decode context parallel (dcp_size > 1)",
+                lambda: self.dcp_size > 1,
             ),
             # BCG capture + LoRA adapter weights exceed host RAM headroom.
             ("LoRA", lambda: bool(self.lora_paths) or bool(self.enable_lora)),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3651,9 +3651,7 @@ class ServerArgs:
                 "DSA prefill context parallelism",
                 lambda: self.enable_dsa_prefill_context_parallel,
             ),
-            # The piecewise prefill capture builds a dummy extend forward with
-            # attn_dcp_metadata=None, which the MLA prepare path dereferences
-            # (dcp_local_prefix_kv_indices) and crashes under DCP.
+            # Capture builds a dummy extend forward with attn_dcp_metadata=None.
             (
                 "decode context parallel (dcp_size > 1)",
                 lambda: self.dcp_size > 1,
@@ -3686,8 +3684,7 @@ class ServerArgs:
                 "context parallel (attn_cp_size > 1)",
                 lambda: self._resolved().attn_cp_size > 1,
             ),
-            # DCP extend takes a metadata-dependent attn-forward path that the
-            # BCG capture path does not build (attn_dcp_metadata=None).
+            # Capture builds a dummy extend forward with attn_dcp_metadata=None.
             (
                 "decode context parallel (dcp_size > 1)",
                 lambda: self.dcp_size > 1,


### PR DESCRIPTION
## Summary

When decode context parallel (DCP, `dcp_size > 1`) is enabled, the extend
attention path is metadata-dependent (`attn_dcp_metadata` /
`dcp_local_prefix_kv_indices`). Both prefill CUDA graph capture backends
build a *dummy* extend forward batch with `attn_dcp_metadata=None`, so the
MLA prepare logic dereferences `None` and crashes at capture time.

This PR gates both prefill CUDA graph backends off DCP in `server_args`:

- `_disable_tc_piecewise_cudagraph_if_incompatible`: disable when `dcp_size > 1`
- `_disable_breakable_cudagraph_if_incompatible`: disable when `dcp_size > 1`

Previously users had to manually pass `--disable-piecewise-cuda-graph`
(as done in the Kimi K2.5 NVFP4 and DSV3.1 DCP tests). This makes the
gating automatic and mirrors how prefill context parallelism already
disables these backends.

## Test plan

- [ ] Launch a DCP model (e.g. Kimi K2.5 NVFP4 or DSV3.1, `--dcp-size 8`)
      *without* `--disable-piecewise-cuda-graph` and confirm the server
      boots (no `dcp_local_prefix_kv_indices` NoneType crash at capture).
- [ ] Confirm non-DCP runs still capture prefill CUDA graphs as before.

Made with [Cursor](https://cursor.com)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29556008708](https://github.com/sgl-project/sglang/actions/runs/29556008708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29556008485](https://github.com/sgl-project/sglang/actions/runs/29556008485)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->