### PR TITLE
[Fix] Simple fix: pass tokenizer stop tokens to XGrammar so constrained requests can terminate

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -249,8 +249,21 @@ def create_grammar_backend(
             XGrammarGrammarBackend,
         )
 
-        # Convert Set[int] to List[int] if needed
-        eos_list = list(eos_token_ids) if eos_token_ids else None
+        # XGrammar only ever unmasks stop tokens from this list, so it must
+        # match the EOS set that Req._check_token_based_finish accepts:
+        # model config EOS + tokenizer EOS + additional stop tokens. Any EOS
+        # missing here can never be emitted under a constraint, and the
+        # request runs until max_new_tokens.
+        eos_set = set(eos_token_ids) if eos_token_ids else set()
+        tokenizer_eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        if isinstance(tokenizer_eos_token_id, int):
+            eos_set.add(tokenizer_eos_token_id)
+        additional_stop_token_ids = getattr(
+            tokenizer, "additional_stop_token_ids", None
+        )
+        if isinstance(additional_stop_token_ids, (list, tuple, set)):
+            eos_set.update(additional_stop_token_ids)
+        eos_list = sorted(eos_set) if eos_set else None
 
         try:
             grammar_backend = XGrammarGrammarBackend(

--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -376,8 +376,21 @@ def create_grammar_backend(
             XGrammarGrammarBackend,
         )
 
-        # Convert Set[int] to List[int] if needed
-        eos_list = list(eos_token_ids) if eos_token_ids else None
+        # XGrammar only ever unmasks stop tokens from this list, so it must
+        # match the EOS set that Req._check_token_based_finish accepts:
+        # model config EOS + tokenizer EOS + additional stop tokens. Any EOS
+        # missing here can never be emitted under a constraint, and the
+        # request runs until max_new_tokens.
+        eos_set = set(eos_token_ids) if eos_token_ids else set()
+        tokenizer_eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        if isinstance(tokenizer_eos_token_id, int):
+            eos_set.add(tokenizer_eos_token_id)
+        additional_stop_token_ids = getattr(
+            tokenizer, "additional_stop_token_ids", None
+        )
+        if isinstance(additional_stop_token_ids, (list, tuple, set)):
+            eos_set.update(additional_stop_token_ids)
+        eos_list = sorted(eos_set) if eos_set else None
 
         try:
             grammar_backend = XGrammarGrammarBackend(

--- a/test/registered/unit/constrained/test_base_grammar_backend.py
+++ b/test/registered/unit/constrained/test_base_grammar_backend.py
@@ -314,6 +314,32 @@ class TestCreateGrammarBackend(unittest.TestCase):
         self.assertIs(result, mock_backend)
 
     @patch("sglang.srt.constrained.xgrammar_backend.XGrammarGrammarBackend")
+    def test_xgrammar_stop_tokens_include_tokenizer_eos(self, mock_xgrammar_cls):
+        """Tokenizer-level stop tokens reach XGrammar even when the model
+        config's eos_token_id list omits them."""
+        mock_xgrammar_cls.return_value = MagicMock(spec=BaseGrammarBackend)
+        args = self._make_server_args("xgrammar")
+
+        class Tok:
+            eos_token_id = 151645
+            additional_stop_token_ids = [151646]
+
+        create_grammar_backend(args, Tok(), 32000, {151643})
+        self.assertEqual(
+            mock_xgrammar_cls.call_args.kwargs["model_eos_token_ids"],
+            [151643, 151645, 151646],
+        )
+
+    @patch("sglang.srt.constrained.xgrammar_backend.XGrammarGrammarBackend")
+    def test_xgrammar_no_stop_tokens_passes_none(self, mock_xgrammar_cls):
+        """With no EOS information at all, pass None so XGrammar auto-detects."""
+        mock_xgrammar_cls.return_value = MagicMock(spec=BaseGrammarBackend)
+        args = self._make_server_args("xgrammar")
+
+        create_grammar_backend(args, "tok", 32000, None)
+        self.assertIsNone(mock_xgrammar_cls.call_args.kwargs["model_eos_token_ids"])
+
+    @patch("sglang.srt.constrained.xgrammar_backend.XGrammarGrammarBackend")
     def test_xgrammar_unsupported_tokenizer_falls_back_to_none(self, mock_xgrammar_cls):
         from sglang.srt.constrained.xgrammar_backend import TokenizerNotSupportedError
 

--- a/test/registered/unit/constrained/test_base_grammar_backend.py
+++ b/test/registered/unit/constrained/test_base_grammar_backend.py
@@ -340,6 +340,23 @@ class TestCreateGrammarBackend(unittest.TestCase):
         self.assertIs(result, mock_backend)
 
     @patch("sglang.srt.constrained.xgrammar_backend.XGrammarGrammarBackend")
+    def test_xgrammar_stop_tokens_include_tokenizer_eos(self, mock_xgrammar_cls):
+        """Tokenizer-level stop tokens reach XGrammar even when the model
+        config's eos_token_id list omits them."""
+        mock_xgrammar_cls.return_value = MagicMock(spec=BaseGrammarBackend)
+        args = self._make_server_args("xgrammar")
+
+        class Tok:
+            eos_token_id = 151645
+            additional_stop_token_ids = [151646]
+
+        create_grammar_backend(args, Tok(), 32000, {151643})
+        self.assertEqual(
+            mock_xgrammar_cls.call_args.kwargs["model_eos_token_ids"],
+            [151643, 151645, 151646],
+        )
+
+    @patch("sglang.srt.constrained.xgrammar_backend.XGrammarGrammarBackend")
     def test_xgrammar_unsupported_tokenizer_falls_back_to_none(self, mock_xgrammar_cls):
         from sglang.srt.constrained.xgrammar_backend import TokenizerNotSupportedError
         from sglang.srt.runtime_context import get_context, get_exec


### PR DESCRIPTION
## Motivation

Fixes #31533.

With the xgrammar backend, a structured-outputs request (regex / JSON schema / EBNF) never terminates when the model's real chat EOS is declared only in `tokenizer_config.json` and not in the model config's `eos_token_id` — as with checkpoints fine-tuned from a base model and shipped without `generation_config.json`, where `config.json` keeps the base EOS. XGrammar only unmasks stop tokens from the list SGLang passes it, and `create_grammar_backend` forwarded only `model_config.hf_eos_token_id`, while server-side stop detection (`Req._check_token_based_finish`) additionally honors `tokenizer.eos_token_id` and `tokenizer.additional_stop_token_ids`. Any EOS covered by stop detection but missing from the grammar's list stays masked at accepting states, so the request runs until `max_new_tokens`.

See #31533 for a minimal repro that drives xgrammar exactly as the scheduler does, plus the production symptom (`17\n2\n3\n...` at temperature 0 until the length cap; identical request without the constraint stops at 3 tokens). The fix has been verified end to end on the production setup — see Accuracy Tests below.

Environment where this was hit in production:

- SGLang `lmsysorg/sglang:v0.5.15.post1-cu130` (the affected code path is unchanged on current `main`, 37f94cb)
- NVIDIA B200, CUDA 13.0, speculative decoding disabled, temperature 0
- Model: fine-tuned Qwen3.5-MoE (35B-A3B) checkpoint — `config.json` eos 248044 `<|endoftext|>`, tokenizer eos `<|im_end|>` 248046, no `generation_config.json`
- Grammar backend: xgrammar (default). The same weights and regex served with vLLM v0.22.0 terminate normally.

## Modifications

- `create_grammar_backend` (xgrammar branch): pass the union of model-config EOS ids, `tokenizer.eos_token_id`, and `tokenizer.additional_stop_token_ids` as `model_eos_token_ids` — the same set `Req._check_token_based_finish` accepts. When no EOS information exists at all, keep passing `None` so XGrammar auto-detects from the tokenizer.
- Two unit tests in `test/registered/unit/constrained/test_base_grammar_backend.py` covering the union and the `None` passthrough.

Not addressed (possible follow-up): per-request `sampling_params.stop_token_ids` still does not reach the grammar matcher; supporting that would need per-request `override_stop_tokens` on the `GrammarMatcher`.

## Accuracy Tests

No change to model forward or kernels. Verified end to end on the production setup (B200, SGLang nightly dev build 2026-06-19, xgrammar backend, speculative decoding disabled, temperature 0) by hand-applying the exact stop-token union this PR computes: adding a `generation_config.json` with `"eos_token_id": [248046, 248044]` to the affected checkpoint, which makes `model_config.hf_eos_token_id` contain the tokenizer EOS — the same set `create_grammar_backend` passes to xgrammar after this change. Everything else (image, weights, request) identical:

| Request | Tokenizer EOS missing from stop list (before) | Tokenizer EOS in stop list (after) |
| --- | --- | --- |
| regex-constrained | `17\n2\n3\n...`, `finish_reason=length`, 64/64 tokens | `"17"`, `finish_reason=stop`, 3 tokens |
| unconstrained control | `"17"`, `finish_reason=stop`, 3 tokens | unchanged |

## Speed Tests and Profiling

Not applicable — a few set operations at grammar-backend construction time (once per server start).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34447546015](https://github.com/sgl-project/sglang/actions/runs/34447546015)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34447545847](https://github.com/sgl-project/sglang/actions/runs/34447545847)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34447546000](https://github.com/sgl-project/sglang/actions/runs/34447546000)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->