### PR TITLE
test: prefetch Qwen3 generation config in AMD CI

### DIFF
--- a/test/registered/amd/test_qwen3_instruct.py
+++ b/test/registered/amd/test_qwen3_instruct.py
@@ -20,7 +20,22 @@ from sglang.test.test_utils import (
 register_amd_ci(est_time=3600, suite="nightly-8-gpu-qwen3-235b", nightly=True)
 
 QWEN3_MODEL_PATH = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+QWEN3_MODEL_REVISION = "ac9c66cc9b46af7306746a9250f23d47083d689e"
 SERVER_LAUNCH_TIMEOUT = 3600
+
+
+def prefetch_qwen3_generation_config_for_ci():
+    if not is_in_ci():
+        return
+
+    from huggingface_hub import hf_hub_download
+
+    generation_config_path = hf_hub_download(
+        repo_id=QWEN3_MODEL_PATH,
+        filename="generation_config.json",
+        revision=QWEN3_MODEL_REVISION,
+    )
+    print(f"Prefetched Qwen3 generation_config.json: {generation_config_path}")
 
 
 class TestQwen3Instruct2507(CustomTestCase):
@@ -28,6 +43,7 @@ class TestQwen3Instruct2507(CustomTestCase):
     def setUpClass(cls):
         cls.model = QWEN3_MODEL_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
+        prefetch_qwen3_generation_config_for_ci()
         other_args = [
             "--tp",
             "8",


### PR DESCRIPTION
## Summary
- AMD ROCm 7.2 Qwen3-235B BF16 GSM8K can start from a runner cache that has the model weights but is missing `generation_config.json`.
- This experiment prefetches `generation_config.json` for the same Qwen3 snapshot before `popen_launch_server()` can enable offline mode for the server subprocess.

## Root cause being tested
- Failed jobs logged `Failed to load generation config ... couldn't find them in the cached files. Proceeding without generation config.`
- Passing jobs logged `Using default chat sampling params from model generation config: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}`.
- The image and AITER version matched across pass/fail; the runner-local `/sgl-data` HF cache did not.

## Testing
- `python3 -m py_compile test/registered/amd/test_qwen3_instruct.py`
- `git diff --check`
- Commit hooks passed, including isort, ruff, and registered test CI registry validation.
- Dispatching `Nightly Test (AMD ROCm 7.2)` with `job_select=nightly-8-gpu-qwen3-235b-rocm720`.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29559704528](https://github.com/sgl-project/sglang/actions/runs/29559704528)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29559704485](https://github.com/sgl-project/sglang/actions/runs/29559704485)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->