### PR TITLE
[CI] Fix invalid suite name breaking all PR test lanes

### DIFF
--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -6,7 +6,7 @@ from sglang.srt.environ import envs
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):


### PR DESCRIPTION
## Motivation

#22591 registered `test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py` to suite `stage-a-test-cpu`, which is not in `run_suite.py`'s suite list (the CPU suites are `base-{a,b,c}-test-cpu`).

`run_suite.py` validates every registered test before executing any suite (`validate_all_suites`, covering the CUDA/CPU/MUSA/XPU/MLX backends), so since that commit **every PR's test lanes fail at startup** with:

```
ValueError: Tests registered to invalid suites:
  test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py: backend=CPU, suite='stage-a-test-cpu'
```

Main's own push CI does not run these suites, so main stays green while every PR goes red — first noticed on #30547, where the failure named this file in an unrelated MLX lane.

## Modifications

Register the test to `base-a-test-cpu`, matching the sibling files in `test/registered/unit/managers/`. Same class of fix as #25450.

## Checklist

- [x] Verified locally: `validate_all_suites` passes and `python test/run_suite.py --hw mlx --suite stage-a-unit-test-mlx` runs green again (it fails at startup without this fix).
- [x] Format with pre-commit.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29556989570](https://github.com/sgl-project/sglang/actions/runs/29556989570)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29556989487](https://github.com/sgl-project/sglang/actions/runs/29556989487)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->