### PR TITLE
[Fix] Step3Detector drops tool-call parameters whose values contain '<'

### DIFF
--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -71,7 +71,7 @@ class Step3Detector(BaseFormatDetector):
             r'<steptml:invoke name="([^"]+)">(.+?)</steptml:invoke>', re.DOTALL
         )
         self.param_regex = re.compile(
-            r'<steptml:parameter name="([^"]+)">([^<]*)</steptml:parameter>', re.DOTALL
+            r'<steptml:parameter name="([^"]+)">(.*?)</steptml:parameter>', re.DOTALL
         )
 
         # Streaming state variables

--- a/test/registered/unit/function_call/test_step3_detector_param_values.py
+++ b/test/registered/unit/function_call/test_step3_detector_param_values.py
@@ -1,0 +1,138 @@
+"""Unit tests for Step3Detector parameter-value parsing - no server, no model loading.
+
+Regression tests for parameter values that contain '<' (code snippets,
+comparisons, HTML/XML fragments), which the previous ``[^<]*`` value regex
+silently dropped in both one-shot and streaming parsing.
+"""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.step3_detector import Step3Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="run_code",
+                description="Run a code snippet",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "code": {"type": "string", "description": "Code to run"},
+                        "lang": {"type": "string", "description": "Language"},
+                    },
+                    "required": ["code"],
+                },
+            ),
+        ),
+    ]
+
+
+def _wrap_tool_call(detector, invoke_body):
+    return (
+        f"{detector.bot_token}{detector.tool_call_begin}"
+        f"function{detector.tool_sep}{invoke_body}"
+        f"{detector.tool_call_end}{detector.eot_token}"
+    )
+
+
+def _collect_streamed_tool_calls(all_calls):
+    """Accumulate streaming ToolCallItems (name + arg-JSON fragments) by tool_index."""
+    tools = {}
+    for c in all_calls:
+        idx = c.tool_index
+        if idx not in tools:
+            tools[idx] = {"name": c.name or "", "parameters": c.parameters or ""}
+        else:
+            if c.name:
+                tools[idx]["name"] += c.name
+            if c.parameters:
+                tools[idx]["parameters"] += c.parameters
+    return [tools[i] for i in sorted(tools.keys())]
+
+
+class TestStep3DetectorParamValuesWithLt(CustomTestCase):
+    def setUp(self):
+        self.detector = Step3Detector()
+        self.tools = _make_tools()
+
+    def test_detect_and_parse_value_containing_lt(self):
+        invoke_body = (
+            '<steptml:invoke name="run_code">'
+            '<steptml:parameter name="code">if a < b: print(a)</steptml:parameter>'
+            '<steptml:parameter name="lang">python</steptml:parameter>'
+            "</steptml:invoke>"
+        )
+        text = _wrap_tool_call(self.detector, invoke_body)
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "run_code")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["code"], "if a < b: print(a)")
+        self.assertEqual(args["lang"], "python")
+
+    def test_detect_and_parse_multiline_value_with_lt(self):
+        invoke_body = (
+            '<steptml:invoke name="run_code">'
+            '<steptml:parameter name="code">x = 1\nif x < 2:\n    print(x)</steptml:parameter>'
+            "</steptml:invoke>"
+        )
+        text = _wrap_tool_call(self.detector, invoke_body)
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["code"], "x = 1\nif x < 2:\n    print(x)")
+
+    def test_detect_and_parse_multi_param_pairing_unchanged(self):
+        # Non-greedy matching must not swallow the boundary between
+        # adjacent parameters.
+        invoke_body = (
+            '<steptml:invoke name="run_code">'
+            '<steptml:parameter name="code">print(1)</steptml:parameter>'
+            '<steptml:parameter name="lang">python</steptml:parameter>'
+            "</steptml:invoke>"
+        )
+        text = _wrap_tool_call(self.detector, invoke_body)
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args, {"code": "print(1)", "lang": "python"})
+
+    def test_streaming_value_containing_lt(self):
+        invoke_body = (
+            '<steptml:invoke name="run_code">'
+            '<steptml:parameter name="code">if a < b: print(a)</steptml:parameter>'
+            '<steptml:parameter name="lang">python</steptml:parameter>'
+            "</steptml:invoke>"
+        )
+        text = _wrap_tool_call(self.detector, invoke_body)
+
+        all_calls = []
+        chunk_size = 8
+        for i in range(0, len(text), chunk_size):
+            result = self.detector.parse_streaming_increment(
+                text[i : i + chunk_size], self.tools
+            )
+            all_calls.extend(result.calls)
+
+        collected = _collect_streamed_tool_calls(all_calls)
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0]["name"], "run_code")
+        args = json.loads(collected[0]["parameters"])
+        self.assertEqual(args["code"], "if a < b: print(a)")
+        self.assertEqual(args["lang"], "python")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`Step3Detector` silently drops any tool-call parameter whose value contains `<`, in both one-shot parsing (`detect_and_parse`) and streaming (`parse_streaming_increment`). Values like code snippets (`if a < b: print(a)`), comparisons, or HTML/XML fragments are common for code-execution / browsing tools, and the tool ends up being invoked with those arguments simply missing — with no warning or error.

Root cause: `param_regex` captures the value with the negated character class `([^<]*)`:

```python
self.param_regex = re.compile(
    r'<steptml:parameter name="([^"]+)">([^<]*)</steptml:parameter>', re.DOTALL
)
```

`[^<]*` stops at the first `<` inside the value, so the closing `</steptml:parameter>` tag can never be reached, `finditer` yields no match for that parameter, and it is silently omitted from `params`. (The `re.DOTALL` flag was dead code with the negated class, which suggests the original intent was to match arbitrary content up to the closing tag.)

Repro on `main`: parsing

```
<steptml:invoke name="run_code"><steptml:parameter name="code">if a < b: print(a)</steptml:parameter><steptml:parameter name="lang">python</steptml:parameter></steptml:invoke>
```

returns arguments `{"lang": "python"}` — the `code` parameter is gone. The streaming path reconstructs the same truncated arguments.

## Modifications

- `python/sglang/srt/function_call/step3_detector.py`: change the value group from `([^<]*)` to the non-greedy `(.*?)`, anchored on the literal `</steptml:parameter>` closing tag (with the already-present `re.DOTALL`). This still only matches complete parameters (closing tag required), so the streaming path's complete-only matching semantics are preserved, and non-greedy matching keeps adjacent parameters paired correctly.
- `test/registered/unit/function_call/test_step3_detector_param_values.py`: new CPU unit tests (registered in `base-a-test-cpu`) covering:
  - one-shot parsing of a value containing `<`
  - a multiline value containing `<` (exercises `re.DOTALL`)
  - multi-parameter pairing is unchanged by the non-greedy match
  - chunked streaming reconstruction of a value containing `<`

All four tests fail on `main` (3 errors + pairing check passes, as expected) and pass with the fix:

```
$ python -m pytest test/registered/unit/function_call/test_step3_detector_param_values.py \
    test/registered/unit/function_call/test_hermes_detector.py \
    test/registered/unit/function_call/test_mistral_detector.py -q
34 passed, 4 warnings in 7.11s
```

Note: this is independent of #30253, which fixes a separate type-coercion issue in this detector and does not touch `param_regex`.

## Accuracy Tests

N/A — parser-only change; no kernel or model forward code affected.

## Speed Tests and Profiling

N/A — a non-greedy regex anchored on a literal closing tag; no measurable impact on parsing.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29560029521](https://github.com/sgl-project/sglang/actions/runs/29560029521)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29560029419](https://github.com/sgl-project/sglang/actions/runs/29560029419)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->