### PR TITLE
[AMD] fix: support both 4-arg and 6-arg vllm fused_add_rms_norm API

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -110,6 +110,18 @@ elif _is_hip:
         # Fallback: vllm not available, will use forward_native
         _has_vllm_rms_norm = False
 
+# ROCm/vllm dev branches use a 6-arg fused_add_rms_norm(out, input,
+# residual_out, residual, weight, eps); vllm-project/vllm uses 4 args.
+# Auto-detect which variant is installed.
+_hip_fused_rms_6arg = False
+if _is_hip and not _use_aiter and _has_vllm_rms_norm:
+    try:
+        import inspect
+
+        _hip_fused_rms_6arg = len(inspect.signature(fused_add_rms_norm).parameters) == 6
+    except (ValueError, TypeError):
+        _hip_fused_rms_6arg = False
+
 if _is_hip:
     try:
         from sglang.jit_kernel.minimax_m3.rmsnorm import (
@@ -465,14 +477,23 @@ class RMSNorm(MultiPlatformOp):
             # NOTE: Remove this if aiter kernel supports discontinuous input
             x = x.contiguous()
         if residual is not None:
-            out = torch.empty_like(x)
-            residual_out = torch.empty_like(x)
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
-            fused_add_rms_norm(
-                out, x, residual_out, residual, self.weight.data, self.variance_epsilon
-            )
-            return out, residual_out
+            if _hip_fused_rms_6arg:
+                out = torch.empty_like(x)
+                residual_out = torch.empty_like(x)
+                fused_add_rms_norm(
+                    out,
+                    x,
+                    residual_out,
+                    residual,
+                    self.weight.data,
+                    self.variance_epsilon,
+                )
+                return out, residual_out
+            else:
+                fused_add_rms_norm(x, residual, self.weight.data, self.variance_epsilon)
+                return x, residual
         out = torch.empty_like(x)
         rms_norm(out, x, self.weight.data, self.variance_epsilon)
         return out
@@ -788,19 +809,23 @@ class GemmaRMSNorm(MultiPlatformOp):
             return self.forward_native(x, residual, post_residual_addition)
         else:
             w = self.gemma_weight
-            # vllm API: rms_norm(out, input, weight, eps) -> None (in-place)
-            #           fused_add_rms_norm(out, input, residual_out, residual, weight, eps)
+            # vllm API: rms_norm(out, input, weight, eps) -> None
+            # fused_add_rms_norm: 6-arg or 4-arg depending on vllm version
             if not x.is_contiguous():
                 x = x.contiguous()
             if residual is not None:
-                out = torch.empty_like(x)
-                residual_out = torch.empty_like(x)
                 if post_residual_addition is not None:
                     residual = residual + post_residual_addition
-                fused_add_rms_norm(
-                    out, x, residual_out, residual, w, self.variance_epsilon
-                )
-                return out, residual_out
+                if _hip_fused_rms_6arg:
+                    out = torch.empty_like(x)
+                    residual_out = torch.empty_like(x)
+                    fused_add_rms_norm(
+                        out, x, residual_out, residual, w, self.variance_epsilon
+                    )
+                    return out, residual_out
+                else:
+                    fused_add_rms_norm(x, residual, w, self.variance_epsilon)
+                    return x, residual
             out = torch.empty_like(x)
             rms_norm(out, x, w, self.variance_epsilon)
             return out


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

AMD's ROCm/vllm dev branches (e.g. `355_wip`, used in AMD CI docker images) use a 6-arg out-of-place `fused_add_rms_norm` API, while standard `vllm-project/vllm` uses a 4-arg in-place API. This has been reverted back and forth — #13727 changed to 4-arg but broke AMD CI, then #13814 reverted to 6-arg unconditionally, which broke standard vllm users (see [comment](https://github.com/sgl-project/sglang/pull/13814#issuecomment-2514982041)). Related: #10032.

The current main branch unconditionally uses the 6-arg API in `forward_hip`, so anyone on standard vllm hits:
TypeError: fused_add_rms_norm() takes 4 positional arguments but 6 were given

## Modifications

- **Auto-detect API variant at import time** via `inspect.signature`, stored in `_hip_fused_rms_6arg`. Runs once at module load with zero runtime overhead.
- **Dispatch in `RMSNorm.forward_hip` and `GemmaRMSNorm.forward_hip`** based on the detected variant.
- **Skip detection when aiter is enabled** (`_use_aiter`), since the aiter path uses its own kernel and never calls vllm's `fused_add_rms_norm`.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29560895959](https://github.com/sgl-project/sglang/actions/runs/29560895959)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29560895715](https://github.com/sgl-project/sglang/actions/runs/29560895715)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->