### PR TITLE
[Feat] Add W4A16Sparse24 dense-dequant fallback for compressed-tensors int4

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -44,6 +44,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsMxInt4MoE,
     CompressedTensorsW4A4Fp4,
     CompressedTensorsW4A4Nvfp4MoE,
+    CompressedTensorsW4A16Sparse24,
     CompressedTensorsW4AFP8MoE,
     CompressedTensorsW8A8Fp8,
     CompressedTensorsW8A8Fp8MoE,
@@ -589,8 +590,25 @@ class CompressedTensorsConfig(QuantizationConfig):
                     actorder=weight_quant.actorder,
                 )
             else:
-                raise ImportError(
-                    "Other method (CompressedTensorsW4A16Sparse24) is not supported now"
+                # Dense-dequant fallback for INT (W4A16) weights; non-int 4-bit
+                # (e.g. float4/NVFP4) stays a loud NotImplementedError (uint4b8
+                # bias is only valid for int).
+                if (
+                    weight_quant.num_bits == 4
+                    and weight_quant.type == QuantizationType.INT
+                ):
+                    return CompressedTensorsW4A16Sparse24(
+                        num_bits=weight_quant.num_bits,
+                        strategy=weight_quant.strategy,
+                        group_size=weight_quant.group_size,
+                        symmetric=weight_quant.symmetric,
+                        quant_type=weight_quant.type,
+                    )
+                raise NotImplementedError(
+                    f"Unsupported weight-only scheme: num_bits="
+                    f"{weight_quant.num_bits}, type={weight_quant.type}, "
+                    f"strategy={weight_quant.strategy}, "
+                    f"format={self.quant_format}"
                 )
 
         if is_activation_quantization_format(self.quant_format):

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -9,6 +9,7 @@ from .compressed_tensors_w4a4_nvfp4 import CompressedTensorsW4A4Fp4
 from .compressed_tensors_w4a4_nvfp4_moe import CompressedTensorsW4A4Nvfp4MoE
 from .compressed_tensors_w4a8_fp8_moe import CompressedTensorsW4AFP8MoE
 from .compressed_tensors_w4a8_int8_moe import NPUCompressedTensorsW4A8Int8DynamicMoE
+from .compressed_tensors_w4a16_sparse24 import CompressedTensorsW4A16Sparse24
 from .compressed_tensors_w8a8_fp8 import CompressedTensorsW8A8Fp8
 from .compressed_tensors_w8a8_fp8_moe import CompressedTensorsW8A8Fp8MoE
 from .compressed_tensors_w8a8_int8 import (
@@ -40,6 +41,7 @@ __all__ = [
     "WNA16_SUPPORTED_BITS",
     "CompressedTensorsW4A4Fp4",
     "CompressedTensorsW4A4Nvfp4MoE",
+    "CompressedTensorsW4A16Sparse24",
     "NPUCompressedTensorsW4A8Int8DynamicMoE",
     "CompressedTensorsMxInt4MoE",
     "CompressedTensorsW4AFP8MoE",

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_sparse24.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_sparse24.py
@@ -1,0 +1,176 @@
+# Adapted from https://github.com/vllm-project/vllm/tree/main/vllm/model_executor/layers/quantization/compressed_tensors
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""W4A16 dense-dequant fallback for compressed-tensors weight-only int4
+checkpoints whose ``format`` is not ``pack_quantized``. Unblocks loading by
+unpacking the 4-bit integer weights, dequantizing with per-group/channel
+scales (and optional zero points) into a dense float tensor and running
+``torch.nn.functional.linear`` (no fused 2:4-sparse kernel; lossless dequant).
+
+Only integer (``QuantizationType.INT``) 4-bit weights are handled; float4 /
+NVFP4 stay a loud ``NotImplementedError`` at dispatch (the uint4b8 bias is
+only valid for int quantization, not microscaling FP4).
+"""
+
+from typing import Callable, Optional
+
+import torch
+import torch.nn.functional as F
+from compressed_tensors.quantization import QuantizationType
+
+from sglang.srt.layers.parameter import (
+    BasevLLMParameter,
+    ChannelQuantScaleParameter,
+    GroupQuantScaleParameter,
+    PackedvLLMParameter,
+)
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsLinearScheme,
+)
+from sglang.srt.layers.quantization.utils import unpack_cols
+
+__all__ = ["CompressedTensorsW4A16Sparse24"]
+
+
+class CompressedTensorsW4A16Sparse24(CompressedTensorsLinearScheme):
+    """Dense-dequant fallback for weight-only int4 (W4A16) compressed-tensors
+    checkpoints outside the Marlin ``pack_quantized`` path."""
+
+    def __init__(
+        self,
+        num_bits: int,
+        strategy: str,
+        quant_type: QuantizationType,
+        group_size: Optional[int] = None,
+        symmetric: bool = True,
+    ):
+        assert num_bits == 4, "CompressedTensorsW4A16Sparse24 only supports num_bits=4"
+        assert strategy in (
+            "channel",
+            "group",
+        ), f"Unsupported strategy: {strategy!r} (expected 'channel' or 'group')"
+        # uint4b8 dequant is only valid for int weights; reject float4/NVFP4.
+        assert quant_type == QuantizationType.INT, (
+            f"CompressedTensorsW4A16Sparse24 only supports INT weight "
+            f"quantization, got type={quant_type!r}"
+        )
+        self.num_bits = num_bits
+        self.strategy = strategy
+        self.quant_type = quant_type
+        self.symmetric = symmetric
+        self.group_size = -1 if group_size is None else group_size
+        self.pack_factor = 32 // num_bits
+        # Symmetric int4: unsigned [0,15] + implicit bias (uint4b8).
+        self._bias = 2 ** (num_bits - 1)
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 0
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_size: int,
+        input_size: int,
+        output_partition_sizes: list[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader: Callable,
+        **kwargs,
+    ):
+        self._params_dtype = params_dtype
+        output_size_per_partition = sum(output_partition_sizes)
+        # group_size == -1 = channelwise; scales partition-aware under row-parallel.
+        group_size = self.group_size if self.group_size != -1 else input_size
+        row_parallel = input_size != input_size_per_partition
+        scales_and_zp_size = input_size // group_size
+        if row_parallel and self.group_size != -1:
+            assert input_size_per_partition % group_size == 0
+            scales_and_zp_size = input_size_per_partition // group_size
+
+        weight = PackedvLLMParameter(
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+            packed_factor=self.pack_factor,
+            packed_dim=1,
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.pack_factor,
+                dtype=torch.int32,
+            ),
+        )
+        weight_scale_args = {
+            "weight_loader": weight_loader,
+            "data": torch.empty(
+                output_size_per_partition, scales_and_zp_size, dtype=params_dtype
+            ),
+        }
+        if self.group_size == -1:
+            weight_scale = ChannelQuantScaleParameter(output_dim=0, **weight_scale_args)
+        else:
+            weight_scale = GroupQuantScaleParameter(
+                output_dim=0, input_dim=1, **weight_scale_args
+            )
+        weight_shape = BasevLLMParameter(
+            data=torch.empty(2, dtype=torch.int64), weight_loader=weight_loader
+        )
+        layer.register_parameter("weight_packed", weight)
+        layer.register_parameter("weight_scale", weight_scale)
+        layer.register_parameter("weight_shape", weight_shape)
+        if not self.symmetric:
+            # Asymmetric: packed int4 zero point [out // pack_factor, n_groups], packed_dim=0 (WNA16 axis).
+            weight_zero_point = PackedvLLMParameter(
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+                packed_factor=self.pack_factor,
+                packed_dim=0,
+                data=torch.zeros(
+                    output_size_per_partition // self.pack_factor,
+                    scales_and_zp_size,
+                    dtype=torch.int32,
+                ),
+            )
+            layer.register_parameter("weight_zero_point", weight_zero_point)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        weight_packed = layer.weight_packed
+        weight_scale = layer.weight_scale
+        # weight_packed is [out, in // pack_factor]; unpack to [out, in].
+        out_features = weight_packed.shape[0]
+        in_features = weight_packed.shape[1] * self.pack_factor
+        q = unpack_cols(
+            weight_packed,
+            num_bits=self.num_bits,
+            size_k=out_features,
+            size_n=in_features,
+        ).to(torch.float32)
+        group_size = self.group_size if self.group_size != -1 else in_features
+        scales_exp = weight_scale.to(torch.float32).repeat_interleave(group_size, dim=1)
+        if self.symmetric:
+            w = (q - self._bias) * scales_exp
+        else:
+            weight_zero_point = layer.weight_zero_point
+            # zero point packed [out // pack_factor, n_groups] (packed_dim=0);
+            # unpack to [n_groups, out], transpose to [out, n_groups], expand.
+            n_groups = scales_exp.shape[1] // group_size
+            zp = unpack_cols(
+                weight_zero_point.t().contiguous(),
+                num_bits=self.num_bits,
+                size_k=n_groups,
+                size_n=out_features,
+            )
+            zp = zp.t().to(torch.float32).repeat_interleave(group_size, dim=1)
+            w = (q - zp) * scales_exp
+        target_dtype = getattr(self, "_params_dtype", torch.float16)
+        layer.weight = torch.nn.Parameter(w.to(target_dtype), requires_grad=False)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return F.linear(x, layer.weight, bias)

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_w4a16_sparse24.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_w4a16_sparse24.py
@@ -1,0 +1,437 @@
+"""CPU regression test for the W4A16 dense-dequant fallback scheme.
+
+The compressed-tensors dispatch in ``_get_scheme_from_parts`` used to raise
+``ImportError: Other method (CompressedTensorsW4A16Sparse24) is not supported
+now`` for weight-only 4-bit integer group/channel quantized checkpoints whose
+format is not ``pack_quantized`` (or otherwise fall outside the Marlin WNA16
+path). The checkpoint could not load at all.
+``CompressedTensorsW4A16Sparse24`` is a *correctness* fallback that unpacks
+the 4-bit integer weights, dequantizes them with the per-group scales (and
+optional zero points) into a dense float tensor, and runs a plain
+``torch.nn.functional.linear`` -- no fused 2:4-sparse GEMM kernel.
+
+These tests pin four contracts on CPU (no kernels run):
+  1. A weight-only int4 group/channel config in a non ``pack_quantized``
+     format dispatches to ``CompressedTensorsW4A16Sparse24`` instead of raising
+     ``ImportError``.
+  2. A weight-only float4 config (NVFP4-style) does NOT dispatch to the scheme
+     -- it stays a loud ``NotImplementedError``, because the uint4b8 bias
+     convention is only valid for integer weights.
+  3. The dense dequant + ``F.linear`` forward reproduces a reference
+     dequantized matmul bit-for-bit for both group and channelwise scales.
+  4. The asymmetric (zero-point) dequant path is correct for both group and
+     channel strategies -- the reference subtracts the zero point, not the
+     symmetric bias.
+"""
+
+import unittest
+
+import torch
+import torch.nn as nn
+from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.quantization import QuantizationType
+from compressed_tensors.quantization.lifecycle.forward import dequantize, quantize
+from compressed_tensors.quantization.utils.helpers import calculate_qparams
+
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsW4A16Sparse24,
+    CompressedTensorsWNA16,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+_W4A16_DENSE_CONFIG = {
+    "quant_method": "compressed-tensors",
+    "format": "dense",
+    "config_groups": {
+        "group_0": {
+            "targets": ["re:.*"],
+            "weights": {
+                "num_bits": 4,
+                "type": "int",
+                "symmetric": True,
+                "strategy": "group",
+                "group_size": 128,
+            },
+            "input_activations": None,
+        },
+    },
+    "ignore": [],
+}
+
+# A weight-only float4 (NVFP4-style) config: same shape as the int4 config but
+# type=float. This must NOT be dequantized by the int4 fallback.
+_W4A16_FLOAT4_DENSE_CONFIG = {
+    "quant_method": "compressed-tensors",
+    "format": "dense",
+    "config_groups": {
+        "group_0": {
+            "targets": ["re:.*"],
+            "weights": {
+                "num_bits": 4,
+                "type": "float",
+                "symmetric": True,
+                "strategy": "group",
+                "group_size": 128,
+            },
+            "input_activations": None,
+        },
+    },
+    "ignore": [],
+}
+
+
+def _pack_int4(q: torch.Tensor, num_bits: int) -> torch.Tensor:
+    """Pack [out, in] int4 values into [out, in//pack_factor] int32 along dim=1."""
+    pack_factor = 32 // num_bits
+    out_f, in_f = q.shape
+    packed = torch.zeros(out_f, in_f // pack_factor, dtype=torch.int32)
+    for j in range(in_f):
+        col = j // pack_factor
+        slot = j % pack_factor
+        packed[:, col] |= q[:, j] << (num_bits * slot)
+    return packed
+
+
+def _pack_int4_dim0(q: torch.Tensor, num_bits: int) -> torch.Tensor:
+    """Pack [out, n_groups] int4 values into [out//pack_factor, n_groups] int32
+    along dim=0, matching the weight_zero_point axis convention
+    (packed_dim=0)."""
+    pack_factor = 32 // num_bits
+    out_f, n_groups = q.shape
+    packed = torch.zeros(out_f // pack_factor, n_groups, dtype=torch.int32)
+    for o in range(out_f):
+        row = o // pack_factor
+        slot = o % pack_factor
+        packed[row, :] |= q[o, :] << (num_bits * slot)
+    return packed
+
+
+def _make_synthetic_layer(scheme, out_f, in_f, dtype, symmetric=True):
+    """Create weights and populate them with a known quantized weight + scales
+    (and, for asymmetric, a non-trivial zero point). Returns (layer, w_ref)
+    where w_ref is the independently-computed dequantized reference."""
+    torch.manual_seed(0)
+    group_size = scheme.group_size if scheme.group_size != -1 else in_f
+    w_true = torch.randn(out_f, in_f, dtype=torch.float32)
+    n_groups = in_f // group_size
+    scales = torch.rand(out_f, n_groups, dtype=torch.float32) * 0.1 + 0.05
+    scales_exp = scales.repeat_interleave(group_size, dim=1)
+    if symmetric:
+        # Symmetric int4 is stored as unsigned [0, 15] with an implicit bias
+        # of 8.
+        q = torch.clamp(torch.round(w_true / scales_exp) + 8, 0, 15).to(torch.int32)
+        w_ref = (q.float() - 8) * scales_exp
+    else:
+        # Asymmetric quantization carries an explicit (non-zero) zero point;
+        # the dequant reference must subtract the zero point, NOT the bias.
+        zp_true = torch.randint(1, 8, (out_f, n_groups), dtype=torch.int32)
+        zp_exp = zp_true.repeat_interleave(group_size, dim=1).to(torch.float32)
+        q = torch.clamp(torch.round(w_true / scales_exp) + zp_exp, 0, 15).to(
+            torch.int32
+        )
+        w_ref = (q.float() - zp_exp) * scales_exp
+    packed = _pack_int4(q, scheme.num_bits)
+    layer = nn.Module()
+    scheme.create_weights(
+        layer,
+        input_size=in_f,
+        input_size_per_partition=in_f,
+        output_partition_sizes=[out_f],
+        output_size=out_f,
+        params_dtype=dtype,
+        weight_loader=None,
+    )
+    layer.weight_packed = nn.Parameter(packed.clone(), requires_grad=False)
+    layer.weight_scale = nn.Parameter(scales.clone(), requires_grad=False)
+    if not symmetric:
+        zp_packed = _pack_int4_dim0(zp_true, scheme.num_bits)
+        layer.weight_zero_point = nn.Parameter(zp_packed.clone(), requires_grad=False)
+    return layer, w_ref
+
+
+class TestW4A16Sparse24Dispatch(CustomTestCase):
+    """Dispatch contract: the int4 Sparse24 path returns a scheme, float4
+    does not."""
+
+    def test_dispatch_returns_sparse24_scheme(self):
+        qc = CompressedTensorsConfig.from_config(_W4A16_DENSE_CONFIG)
+        layer = nn.Module()
+        scheme_dict = qc.get_scheme_dict(layer, "model.layers.0.self_attn.q_proj")
+        weight_quant = scheme_dict["weights"]
+        input_quant = scheme_dict["input_activations"]
+
+        # The weight-only int4 group/channel predicate must match, and the
+        # format is intentionally not pack_quantized.
+        self.assertTrue(qc._is_wNa16_group_channel(weight_quant, input_quant))
+        self.assertNotEqual(qc.quant_format, CompressionFormat.pack_quantized.value)
+        self.assertEqual(weight_quant.type, QuantizationType.INT)
+
+        # The pack_quantized variant still dispatches to the Marlin WNA16 path
+        # (the change is strictly additive inside the `else`; the `if` branch is
+        # untouched).
+        pack_cfg = dict(_W4A16_DENSE_CONFIG)
+        pack_cfg["format"] = CompressionFormat.pack_quantized.value
+        pack_qc = CompressedTensorsConfig.from_config(pack_cfg)
+        pack_sd = pack_qc.get_scheme_dict(nn.Module(), "model.layers.0.mlp.gate")
+        self.assertIsInstance(
+            pack_qc._get_scheme_from_parts(
+                pack_sd["weights"], pack_sd["input_activations"]
+            ),
+            CompressedTensorsWNA16,
+        )
+
+        # The dense variant dispatches to the new W4A16Sparse24 fallback
+        # instead of raising ImportError.
+        scheme = qc._get_scheme_from_parts(weight_quant, input_quant)
+        self.assertIsInstance(scheme, CompressedTensorsW4A16Sparse24)
+        self.assertEqual(scheme.num_bits, 4)
+        self.assertEqual(scheme.group_size, 128)
+        self.assertTrue(scheme.symmetric)
+        self.assertEqual(scheme.quant_type, QuantizationType.INT)
+
+    def test_float4_dispatch_raises_not_implemented(self):
+        # A weight-only float4 (NVFP4-style) config enters the same wNa16
+        # group/channel branch but must NOT be dequantized by the int4 fallback
+        # (the uint4b8 bias convention is invalid for float weights). It stays
+        # a loud NotImplementedError instead of silently wrong numbers.
+        qc = CompressedTensorsConfig.from_config(_W4A16_FLOAT4_DENSE_CONFIG)
+        layer = nn.Module()
+        scheme_dict = qc.get_scheme_dict(layer, "model.layers.0.self_attn.q_proj")
+        weight_quant = scheme_dict["weights"]
+        input_quant = scheme_dict["input_activations"]
+
+        self.assertTrue(qc._is_wNa16_group_channel(weight_quant, input_quant))
+        self.assertNotEqual(qc.quant_format, CompressionFormat.pack_quantized.value)
+        self.assertEqual(weight_quant.type, QuantizationType.FLOAT)
+        self.assertEqual(weight_quant.num_bits, 4)
+
+        with self.assertRaises(NotImplementedError) as ctx:
+            qc._get_scheme_from_parts(weight_quant, input_quant)
+        # The error message must name the type so the gap is diagnosable.
+        self.assertIn("type=", str(ctx.exception))
+
+
+class TestW4A16Sparse24Dequant(CustomTestCase):
+    """Correctness contract: dense dequant + F.linear matches a reference."""
+
+    def _check_forward(self, strategy, group_size, symmetric=True):
+        out_f, in_f = (8, 16)
+        dtype = torch.float16
+        scheme = CompressedTensorsW4A16Sparse24(
+            num_bits=4,
+            strategy=strategy,
+            quant_type=QuantizationType.INT,
+            group_size=group_size,
+            symmetric=symmetric,
+        )
+        layer, w_ref = _make_synthetic_layer(
+            scheme, out_f, in_f, dtype, symmetric=symmetric
+        )
+        scheme.process_weights_after_loading(layer)
+        self.assertTrue(
+            torch.allclose(layer.weight.data, w_ref.to(dtype), atol=0.001),
+            "dequantized weight diverges from reference",
+        )
+        x = torch.randn(3, in_f, dtype=dtype)
+        out = scheme.apply_weights(layer, x, bias=None)
+        ref = torch.nn.functional.linear(x, w_ref.to(dtype), None)
+        self.assertTrue(torch.allclose(out, ref, atol=0.01))
+
+    def test_group_dequant_forward(self):
+        self._check_forward(strategy="group", group_size=8, symmetric=True)
+
+    def test_channelwise_dequant_forward(self):
+        self._check_forward(strategy="channel", group_size=None, symmetric=True)
+
+    def test_group_asymmetric_dequant_forward(self):
+        # Asymmetric path: the reference dequant subtracts the (non-zero) zero
+        # point, NOT the symmetric bias. Exercises the weight_zero_point unpack
+        # + transpose axis convention.
+        self._check_forward(strategy="group", group_size=8, symmetric=False)
+
+    def test_channelwise_asymmetric_dequant_forward(self):
+        self._check_forward(strategy="channel", group_size=None, symmetric=False)
+
+
+def _library_quantized_layer(strategy, group_size, symmetric, out_f=16, in_f=128):
+    """Build a W4A16 layer whose ``weight_packed`` / ``weight_scale`` /
+    ``weight_zero_point`` are produced by compressed-tensors' OWN quantization
+    API (``calculate_qparams`` + ``quantize`` + ``pack_to_int32``), NOT by the
+    hand-rolled ``_pack_int4`` helpers used above.
+
+    This breaks the circularity the self-referential dequant tests carry: there
+    the packed weights were manufactured with the same bias-8 / explicit
+    zero-point convention the implementation assumes, so they only proved the
+    scheme agrees with itself. Here the quantized values, scales, zero points
+    and the int32 packing all come from the library, so the scheme's dequant is
+    checked against an independent ground truth.
+
+    Returns ``(layer, scheme, w_orig, ref_dequant)`` where ``w_orig`` is the
+    pre-quantization dense FP32 weight and ``ref_dequant`` is the library's own
+    ``dequantize()`` of the same packed weight (an independent reference).
+    """
+    torch.manual_seed(0)
+    cfg = {
+        "quant_method": "compressed-tensors",
+        "format": "dense",
+        "config_groups": {
+            "group_0": {
+                "targets": ["re:.*"],
+                "weights": {
+                    "num_bits": 4,
+                    "type": "int",
+                    "symmetric": symmetric,
+                    "strategy": strategy,
+                    "group_size": group_size if strategy == "group" else None,
+                },
+                "input_activations": None,
+            },
+        },
+        "ignore": [],
+    }
+    # Parse the scheme through the library's own config parser so the
+    # QuantizationArgs (num_bits / type / strategy / symmetric / group_size)
+    # match exactly what compressed-tensors attaches to a real checkpoint.
+    qc = CompressedTensorsConfig.from_config(cfg)
+    scheme_dict = qc.get_scheme_dict(nn.Module(), "model.layers.0.self_attn.q_proj")
+    weight_args = scheme_dict["weights"]
+
+    w_orig = torch.randn(out_f, in_f, dtype=torch.float32) * 0.2
+    # Observer step: per-group / per-channel min & max fed to the library's
+    # qparams calculator. This plain reduction is not the dequant convention
+    # under test; all of the scale / zero-point / int32-packing math below is
+    # the library's own.
+    if strategy == "group":
+        n_groups = in_f // group_size
+        wg = w_orig.reshape(out_f, n_groups, group_size)
+        min_vals, max_vals = wg.amin(-1), wg.amax(-1)
+    else:
+        min_vals, max_vals = w_orig.amin(1, keepdim=True), w_orig.amax(1, keepdim=True)
+
+    scale, zero_point = calculate_qparams(min_vals, max_vals, weight_args)
+    # Library quantize() -> signed int8 in [-8, 7]; library pack_to_int32() then
+    # adds the implicit +8 bias (uint4b8), which is exactly the convention the
+    # scheme's ``self._bias = 2 ** (num_bits - 1)`` assumes. Verifying the scheme
+    # reproduces the original dense weight here checks that agreement for real.
+    q_int8 = quantize(
+        x=w_orig,
+        scale=scale,
+        zero_point=zero_point,
+        args=weight_args,
+        dtype=torch.int8,
+    )
+    weight_packed = pack_to_int32(q_int8, weight_args.num_bits)
+    ref_dequant = dequantize(
+        x_q=q_int8,
+        scale=scale,
+        zero_point=zero_point if not symmetric else None,
+    )
+
+    scheme = CompressedTensorsW4A16Sparse24(
+        num_bits=4,
+        strategy=strategy,
+        quant_type=QuantizationType.INT,
+        group_size=group_size if strategy == "group" else None,
+        symmetric=symmetric,
+    )
+    layer = nn.Module()
+    scheme.create_weights(
+        layer,
+        input_size=in_f,
+        input_size_per_partition=in_f,
+        output_partition_sizes=[out_f],
+        output_size=out_f,
+        params_dtype=torch.float16,
+        weight_loader=None,
+    )
+    layer.weight_packed = nn.Parameter(weight_packed.clone(), requires_grad=False)
+    layer.weight_scale = nn.Parameter(scale.clone(), requires_grad=False)
+    if not symmetric:
+        zp_packed = pack_to_int32(zero_point, weight_args.num_bits, packed_dim=0)
+        layer.weight_zero_point = nn.Parameter(zp_packed.clone(), requires_grad=False)
+    return layer, scheme, w_orig, ref_dequant
+
+
+class TestW4A16Sparse24DequantFromLibrary(CustomTestCase):
+    """Independent dequant correctness.
+
+    Unlike ``TestW4A16Sparse24Dequant`` (whose packed weights are manufactured by
+    this file's own ``_pack_int4`` and therefore only prove the scheme agrees
+    with itself), the inputs here are produced by compressed-tensors' own
+    quantization API. The scheme must (1) reproduce the library's own
+    ``dequantize()`` to fp16 precision -- the real "lossless dequant" claim --
+    and (2) reconstruct the original dense weight within int4 quantization
+    error, for both symmetric and asymmetric configs and both group and channel
+    strategies.
+    """
+
+    # fp16 rounding from the scale / weight casts (verified ~2.4e-4 worst case).
+    _ATOL_VS_LIB = 2e-3
+    # int4 quantization error dominates vs the pre-quantization dense weight
+    # (q step ~= scale/2; verified <6e-2 worst case for these small weights).
+    _ATOL_VS_ORIG = 1e-1
+
+    def _check(self, strategy, group_size, symmetric):
+        layer, scheme, w_orig, ref_dequant = _library_quantized_layer(
+            strategy, group_size, symmetric
+        )
+        scheme.process_weights_after_loading(layer)
+        w = layer.weight.data
+        ref_fp16 = ref_dequant.to(torch.float16)
+        orig_fp16 = w_orig.to(torch.float16)
+
+        # (1) The scheme's unpack+dequant matches the library's own dequantize()
+        # to fp16 precision -- checked against an independent reference, not the
+        # scheme's own packer.
+        self.assertTrue(
+            torch.allclose(w, ref_fp16, atol=self._ATOL_VS_LIB),
+            f"scheme dequant diverges from library dequantize: max="
+            f"{(w - ref_fp16).abs().max().item():.6g} "
+            f"(strategy={strategy} symmetric={symmetric})",
+        )
+        # (2) The dequantized weight reconstructs the original dense weight
+        # within int4 quantization error.
+        self.assertTrue(
+            torch.allclose(w, orig_fp16, atol=self._ATOL_VS_ORIG),
+            f"dequantized weight diverges from original dense weight: max="
+            f"{(w - orig_fp16).abs().max().item():.6g} "
+            f"(strategy={strategy} symmetric={symmetric})",
+        )
+        # (3) The F.linear forward on the dequantized weight matches a reference
+        # matmul on the library's dequantized weight.
+        x = torch.randn(3, w_orig.shape[1], dtype=torch.float16)
+        out = scheme.apply_weights(layer, x, bias=None)
+        ref_out = torch.nn.functional.linear(x, ref_fp16, None)
+        self.assertTrue(
+            torch.allclose(out, ref_out, atol=self._ATOL_VS_LIB),
+            f"forward diverges from reference: max="
+            f"{(out - ref_out).abs().max().item():.6g} "
+            f"(strategy={strategy} symmetric={symmetric})",
+        )
+
+    def test_group_symmetric(self):
+        self._check("group", 32, True)
+
+    def test_group_asymmetric(self):
+        # The asymmetric path's weight_zero_point is packed by the library
+        # (packed_dim=0) and unpacked by the scheme's unpack_cols(.t() ...);
+        # this independently exercises that axis convention.
+        self._check("group", 32, False)
+
+    def test_channel_symmetric(self):
+        self._check("channel", None, True)
+
+    def test_channel_asymmetric(self):
+        self._check("channel", None, False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Loading a weight-only 4-bit **integer** compressed-tensors checkpoint whose `format` is **not** `pack_quantized` fails hard at model load:

```
ImportError: Other method (CompressedTensorsW4A16Sparse24) is not supported now
```

raised from `CompressedTensorsConfig._get_scheme_from_parts` in `python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py`. The `W4A16Sparse24` method slot exists in the compressed-tensors dispatch table, but no implementation class backs it, so the checkpoint cannot load at all — the model is unusable, not merely slow. The guard is an explicit "not supported now" placeholder for unimplemented work, not a feature request. See #31248; its traceback ends exactly at the `else` branch this PR touches.

This PR fills that slot for the **weight-only INT4** case and unblocks loading + correct inference. It is deliberately **not** the float4 / NVFP4 path. #31248's specific model (`unsloth/gemma-4-26B-A4B-it-NVFP4`) carries microscaling FP4 weights, and applying this scheme's `uint4b8` integer dequant (bias = 8) to float4 codes would be silently wrong — float4 codes are not unsigned integers offset by 8. The dispatch therefore gates on `type == QuantizationType.INT` and leaves float4 / NVFP4 a loud `NotImplementedError` (whose message names `num_bits`, `type`, `strategy`, `format`). That is strictly better than the pre-fix generic `ImportError`: the gap stays diagnosable rather than becoming silent garbage. This PR does **not** close #31248 (its float4 model still raises `NotImplementedError`); it implements the INT4 arm of the method slot #31248 surfaced.

## Modifications

- **New scheme `CompressedTensorsW4A16Sparse24`** (`schemes/compressed_tensors_w4a16_sparse24.py`): a *correctness* fallback that unpacks the 4-bit packed integer weights, dequantizes them with the per-group / per-channel scales (and, for asymmetric configs, an explicit zero point) into a dense float tensor, and runs `torch.nn.functional.linear`. The dequant is lossless — the forward reproduces a reference dense matmul. `get_min_capability()` returns `0` because no GPU kernel is required to run, so the path works on CPU and on capability tiers without a `cutlass_24` / Marlin floor.
- **Dispatch wiring** (`compressed_tensors.py`, `_get_scheme_from_parts`): the `else` branch (reached when `_is_wNa16_group_channel` is true but the format is not `pack_quantized`) previously raised `ImportError`. For `num_bits == 4` **and** `type == QuantizationType.INT` it now returns the new scheme; for any other 4-bit `type` (e.g. float4/NVFP4) or bit width it raises a clearer `NotImplementedError` reporting the offending config. The scheme `__init__` additionally asserts `quant_type == QuantizationType.INT`, so the scheme cannot be constructed for float weights even by a direct caller. The `if` branch (`pack_quantized` → Marlin `CompressedTensorsWNA16`) is untouched — the change is strictly additive inside the `else`.
- Re-export the scheme from `schemes/__init__.py`.

On the naming: the class is called `CompressedTensorsW4A16Sparse24` because that is the method name in the compressed-tensors dispatch (the string the original guard reported). The implementation is a dense dequant + `F.linear`, **not** a 2:4-structured-sparse kernel — see "Speed Tests and Profiling".

> **Size note.** Functional (production) code is ~200 LoC (scheme 176 + dispatch 20 + re-export 2 ≈ 198); the 635-line diff total is test-dominated — 437 LoC of CPU regression tests, ~140 of which is the `TestW4A16Sparse24DequantFromLibrary` class added to ground the lossless-dequant claim against the compressed-tensors library's own quantization API rather than the scheme's own packer (see Accuracy Tests). Splitting the tests into a separate PR would decouple the regression coverage from the code it pins, so they ship together.

## Accuracy Tests

The dequant is mathematically lossless (unpack int4 → subtract bias / zero-point → multiply by scales → `F.linear`), so there is **no accuracy delta** to measure against a dense reference — correctness reduces to "does the dequant reproduce the reference matmul". 10 CPU tests pin that (registered via `register_cpu_ci`, no GPU kernels execute).

Dispatch contract (red on `main`, green on this branch):
```
test_dispatch_returns_sparse24_scheme          PASSED  (int4 dense config -> scheme; red on main)
test_float4_dispatch_raises_not_implemented    PASSED  (float4 config -> loud NotImplementedError)
```

Dequant correctness, two independent witnesses:

**1. `TestW4A16Sparse24Dequant`** — packs weights with this file's own `_pack_int4` / `_pack_int4_dim0` helpers and pins the scheme's internal packer↔dequant agreement for both symmetric and asymmetric, group and channel:
```
test_group_dequant_forward                     PASSED  (symmetric group, allclose ref, atol=1e-3)
test_channelwise_dequant_forward               PASSED  (symmetric channel)
test_group_asymmetric_dequant_forward          PASSED  (asymmetric zero-point, group)
test_channelwise_asymmetric_dequant_forward    PASSED  (asymmetric zero-point, channel)
```

**2. `TestW4A16Sparse24DequantFromLibrary`** — **independent of the scheme's own packer**: the packed weights, scales, and zero points are produced by the compressed-tensors library's own `calculate_qparams` / `quantize` / `pack_to_int32` API, then the scheme must (a) reproduce the library's own `dequantize()` to fp16 precision (`atol=2e-3`) and (b) reconstruct the original dense weight within int4 quantization error, for both symmetric and asymmetric × group and channel:
```
test_group_symmetric                           PASSED  (allclose library dequantize, atol=2e-3)
test_group_asymmetric                          PASSED  (library-packed zero point, packed_dim=0 path)
test_channel_symmetric                         PASSED
test_channel_asymmetric                        PASSED
```

The second class is the load-bearing correctness witness: because it does not share a packer with the implementation, an `allclose` pass means the scheme's dequant agrees with an independent reference (the library's own dequant path), not merely with itself. The asymmetric library tests additionally exercise the `weight_zero_point` packed-dim-0 unpack + transpose path against library-produced (not hand-rolled) zero points.

`process_weights_after_loading` reconstructs `layer.weight` to match the reference dequantized weight, and `apply_weights` matches `F.linear(x, w_ref)`. An end-to-end accuracy run on a large int4 checkpoint is intentionally not included: it would add no correctness signal (lossless dequant has no accuracy regression by construction) and requires a checkpoint plus GPU outside this PR's scope. The maintainer-facing expectation is addressed directly below.

## Speed Tests and Profiling

This PR is a **correctness fallback, not a performance kernel**, and is deliberately scoped that way. The expected maintainer pushback is exactly the one this PR pre-empts:

> W4A16Sparse24 needs a 2:4-structured-sparse fused dequant+GEMM Triton/DeepGEMM kernel, not just a Python scheme wrapper that calls torch.sparse — show me the kernel and accuracy numbers on Gemma4-26B-A4B before I review.

This PR ships **no** fused 2:4-sparse (Triton / DeepGEMM / `cutlass_24`) kernel — and notably does not call `torch.sparse` either; the dequant is dense (`unpack_cols` → scale → `F.linear`). It trades speed for portability: it unblocks loading and correct inference on paths where no sparse kernel exists (CPU, and GPU capability tiers without a `cutlass_24` / Marlin floor). Throughput on a fused sparse kernel remains future work (scope-OUT, not a claim). `get_min_capability()` returns `0` precisely because no kernel is required to run.

On the "accuracy numbers on Gemma4-26B-A4B" part of that pushback: that model is float4 (NVFP4), which this PR deliberately leaves as `NotImplementedError`, so there is no code path here to benchmark for it. For the INT4 case this PR *does* serve, the dequant is lossless, so the 10 CPU tests — in particular the library-grounded `TestW4A16Sparse24DequantFromLibrary` class, which checks the scheme reproduces the compressed-tensors library's own `dequantize()` and the original dense weight — are the correctness gate. There is no accuracy regression to measure. The value proposition is the load-blocker, not throughput: today these INT4 checkpoints cannot load at all, and a correct (if slow) path is strictly better than an `ImportError` on the critical path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`black-jupyter` rev 26.1.0, `ruff --select F401,F821,UP037`, and `isort` all pass via `pre-commit run` on the four touched files.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — `test/registered/unit/layers/quantization/test_compressed_tensors_w4a16_sparse24.py`, 10 tests registered for CPU CI via `register_cpu_ci`.
- [ ] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — internal quant scheme; no user-facing surface to document.
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — see sections above (lossless dequant pinned by 10 unit tests incl. a library-grounded independent witness; no perf kernel by design).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Refs #31248







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29561425913](https://github.com/sgl-project/sglang/actions/runs/29561425913)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29561425728](https://github.com/sgl-project/sglang/actions/runs/29561425728)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->