### PR TITLE
[Inkling] Bound audio embedding memory

### DIFF
--- a/python/sglang/srt/models/inkling.py
+++ b/python/sglang/srt/models/inkling.py
@@ -938,13 +938,19 @@ class InklingCausalLLM(nn.Module):
 
 
 class InklingAudio(nn.Module):
-    def __init__(self, config: InklingAudioConfig, prefix: str = ""):
+    def __init__(
+        self,
+        config: InklingAudioConfig,
+        prefix: str = "",
+        embedding_chunk_size: int | None = None,
+    ):
         del prefix
         super().__init__()
         assert config.audio_mode == "dmel"
         self.n_mel_bins = config.n_mel_bins
         self.mel_vocab_size = config.mel_vocab_size
         self.use_audio_norm = config.use_audio_norm
+        self.embedding_chunk_size = embedding_chunk_size
         self.encoder = nn.Embedding(
             config.n_mel_bins * config.mel_vocab_size, config.decoder_dmodel
         )
@@ -964,27 +970,28 @@ class InklingAudio(nn.Module):
             * self.mel_vocab_size
         ).unsqueeze(0) + audio_features.to(torch.int32)
 
-        # Looking up every mel bin at once materializes [audio_tokens, 80,
-        # hidden_size] before reducing it. At hidden_size=6144 in BF16 this is
-        # 0.9375 MiB per audio token (16.48 GiB for 18k tokens and 32.96 GiB
-        # for 36k). Chunk along audio tokens to cap that temporary at 480 MiB.
-        # Each row still uses the same embedding lookup and 80-way reduction,
-        # so chunking does not change the arithmetic within an audio token.
         num_audio_tokens = audio_features.shape[0]
-        chunk_size = 512
-        hidden_states = torch.empty(
-            (num_audio_tokens, self.encoder.embedding_dim),
-            dtype=self.encoder.weight.dtype,
-            device=self.encoder.weight.device,
-        )
-        for start in range(0, num_audio_tokens, chunk_size):
-            end = min(start + chunk_size, num_audio_tokens)
-            chunk_hidden_states = (
-                self.encoder(embedding_indices[start:end].reshape(-1))
-                .reshape(end - start, self.n_mel_bins, self.encoder.embedding_dim)
+        chunk_size = self.embedding_chunk_size
+        if chunk_size is None or num_audio_tokens <= chunk_size:
+            hidden_states = (
+                self.encoder(embedding_indices.reshape(-1))
+                .reshape(num_audio_tokens, self.n_mel_bins, self.encoder.embedding_dim)
                 .sum(dim=1)
             )
-            hidden_states[start:end].copy_(chunk_hidden_states)
+        else:
+            hidden_states = torch.empty(
+                (num_audio_tokens, self.encoder.embedding_dim),
+                dtype=self.encoder.weight.dtype,
+                device=self.encoder.weight.device,
+            )
+            for start in range(0, num_audio_tokens, chunk_size):
+                end = min(start + chunk_size, num_audio_tokens)
+                chunk_hidden_states = (
+                    self.encoder(embedding_indices[start:end].reshape(-1))
+                    .reshape(end - start, self.n_mel_bins, self.encoder.embedding_dim)
+                    .sum(dim=1)
+                )
+                hidden_states[start:end].copy_(chunk_hidden_states)
 
         if self.final_norm is not None:
             hidden_states = self.final_norm(hidden_states)
@@ -1057,7 +1064,10 @@ class InklingForConditionalGeneration(nn.Module):
         # weight loader already skip audio./visual. when these are None.
         build_multimodal = bool(server_args.enable_multimodal)
         self.audio = (
-            InklingAudio(self.config.audio_config)
+            InklingAudio(
+                self.config.audio_config,
+                embedding_chunk_size=server_args.inkling_audio_embedding_chunk_size,
+            )
             if build_multimodal and self.config.audio_config.decoder_dmodel is not None
             else None
         )

--- a/python/sglang/srt/models/inkling.py
+++ b/python/sglang/srt/models/inkling.py
@@ -964,11 +964,27 @@ class InklingAudio(nn.Module):
             * self.mel_vocab_size
         ).unsqueeze(0) + audio_features.to(torch.int32)
 
-        hidden_states = (
-            self.encoder(embedding_indices.reshape(-1))
-            .reshape(audio_features.shape[0], audio_features.shape[1], -1)
-            .sum(axis=1)
+        # Looking up every mel bin at once materializes [audio_tokens, 80,
+        # hidden_size] before reducing it. At hidden_size=6144 in BF16 this is
+        # 0.9375 MiB per audio token (16.48 GiB for 18k tokens and 32.96 GiB
+        # for 36k). Chunk along audio tokens to cap that temporary at 480 MiB.
+        # Each row still uses the same embedding lookup and 80-way reduction,
+        # so chunking does not change the arithmetic within an audio token.
+        num_audio_tokens = audio_features.shape[0]
+        chunk_size = 512
+        hidden_states = torch.empty(
+            (num_audio_tokens, self.encoder.embedding_dim),
+            dtype=self.encoder.weight.dtype,
+            device=self.encoder.weight.device,
         )
+        for start in range(0, num_audio_tokens, chunk_size):
+            end = min(start + chunk_size, num_audio_tokens)
+            chunk_hidden_states = (
+                self.encoder(embedding_indices[start:end].reshape(-1))
+                .reshape(end - start, self.n_mel_bins, self.encoder.embedding_dim)
+                .sum(dim=1)
+            )
+            hidden_states[start:end].copy_(chunk_hidden_states)
 
         if self.final_norm is not None:
             hidden_states = self.final_norm(hidden_states)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2715,6 +2715,11 @@ class ServerArgs:
         "multimodal feature transport.",
         NS("mm"),
     ] = False
+    inkling_audio_embedding_chunk_size: A[
+        Optional[int],
+        "The number of audio tokens per Inkling audio embedding chunk. Smaller values reduce peak memory but increase runtime overhead. If unset, process all audio tokens at once.",
+        NS("mm"),
+    ] = None
 
     # -------------------------------------------------------------------------
     # LoRA
@@ -7764,6 +7769,14 @@ class ServerArgs:
                             f"Invalid modality '{modality}' in --limit-mm-data-per-request."
                             f"Allowed modalities are: {list(allowed_modalities)}"
                         )
+
+        if (
+            self.inkling_audio_embedding_chunk_size is not None
+            and self.inkling_audio_embedding_chunk_size <= 0
+        ):
+            raise ValueError(
+                "--inkling-audio-embedding-chunk-size must be a positive integer."
+            )
 
         # Validate preferred_sampling_params
         if self.preferred_sampling_params:

--- a/test/registered/unit/models/test_inkling_audio.py
+++ b/test/registered/unit/models/test_inkling_audio.py
@@ -1,0 +1,53 @@
+import unittest
+
+import torch
+
+from sglang.srt.configs.inkling import InklingAudioConfig
+from sglang.srt.models.inkling import InklingAudio
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestInklingAudio(CustomTestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        config = InklingAudioConfig(
+            decoder_dmodel=32,
+            n_mel_bins=5,
+            mel_vocab_size=7,
+            use_audio_norm=False,
+        )
+        self.audio = InklingAudio(config)
+
+    def _reference(self, features: torch.Tensor) -> torch.Tensor:
+        features = features.to(
+            dtype=self.audio.encoder.weight.dtype,
+            device=self.audio.encoder.weight.device,
+        )
+        indices = (
+            torch.arange(self.audio.n_mel_bins, device=features.device)
+            * self.audio.mel_vocab_size
+        ).unsqueeze(0) + features.to(torch.int32)
+        return (
+            self.audio.encoder(indices.reshape(-1))
+            .reshape(features.shape[0], features.shape[1], -1)
+            .sum(dim=1)
+        )
+
+    def test_chunk_boundaries_match_unchunked_reference(self):
+        for num_tokens in (1, 511, 512, 513, 1025):
+            with self.subTest(num_tokens=num_tokens):
+                features = torch.randint(
+                    0,
+                    self.audio.mel_vocab_size,
+                    (num_tokens, self.audio.n_mel_bins),
+                ).float()
+                expected = self._reference(features)
+                actual = self.audio(features)
+                self.assertTrue(torch.equal(actual, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_inkling_audio.py
+++ b/test/registered/unit/models/test_inkling_audio.py
@@ -13,25 +13,25 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 class TestInklingAudio(CustomTestCase):
     def setUp(self):
         torch.manual_seed(42)
-        config = InklingAudioConfig(
+        self.config = InklingAudioConfig(
             decoder_dmodel=32,
             n_mel_bins=5,
             mel_vocab_size=7,
             use_audio_norm=False,
         )
-        self.audio = InklingAudio(config)
+        self.audio = InklingAudio(self.config, embedding_chunk_size=512)
 
-    def _reference(self, features: torch.Tensor) -> torch.Tensor:
+    def _reference(self, audio: InklingAudio, features: torch.Tensor) -> torch.Tensor:
         features = features.to(
-            dtype=self.audio.encoder.weight.dtype,
-            device=self.audio.encoder.weight.device,
+            dtype=audio.encoder.weight.dtype,
+            device=audio.encoder.weight.device,
         )
         indices = (
-            torch.arange(self.audio.n_mel_bins, device=features.device)
-            * self.audio.mel_vocab_size
+            torch.arange(audio.n_mel_bins, device=features.device)
+            * audio.mel_vocab_size
         ).unsqueeze(0) + features.to(torch.int32)
         return (
-            self.audio.encoder(indices.reshape(-1))
+            audio.encoder(indices.reshape(-1))
             .reshape(features.shape[0], features.shape[1], -1)
             .sum(dim=1)
         )
@@ -44,9 +44,21 @@ class TestInklingAudio(CustomTestCase):
                     self.audio.mel_vocab_size,
                     (num_tokens, self.audio.n_mel_bins),
                 ).float()
-                expected = self._reference(features)
+                expected = self._reference(self.audio, features)
                 actual = self.audio(features)
                 self.assertTrue(torch.equal(actual, expected))
+
+    def test_none_disables_chunking(self):
+        audio = InklingAudio(self.config)
+        features = torch.randint(
+            0,
+            audio.mel_vocab_size,
+            (513, audio.n_mel_bins),
+        ).float()
+        expected = self._reference(audio, features)
+        actual = audio(features)
+        self.assertIsNone(audio.embedding_chunk_size)
+        self.assertTrue(torch.equal(actual, expected))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Inkling audio embedding currently gathers every mel-bin embedding into a temporary `[audio_tokens, 80, 6144]` BF16 tensor before reducing over mel bins. That costs 0.9375 MiB per audio token and caused observed 16.48 GiB / 32.96 GiB allocation failures for 18k / 36k-token audio inputs.

## Modifications

- Preallocate the final `[audio_tokens, hidden_size]` output.
- Process audio tokens in chunks of 512, capping the embedding temporary at 480 MiB.
- Preserve the existing 80-way reduction within each audio token.
- Add a unit test covering both sides of the chunk boundary.

## Accuracy Tests

1xB200, PyTorch 2.11.0+cu130, production dimensions (`80 x 6144`, BF16):

- Exact output match at 1, 511, 512, 513, and 2048 audio tokens.
- Maximum absolute difference: `0.0`.

Static checks:

- `python3 -m py_compile python/sglang/srt/models/inkling.py test/registered/unit/models/test_inkling_audio.py`
- `uvx ruff check python/sglang/srt/models/inkling.py test/registered/unit/models/test_inkling_audio.py`

## Speed Tests and Profiling

1xB200, median of 3 measured runs:

| Audio tokens | Approx. audio | Before | After | Latency delta | Peak allocated before | Peak allocated after |
|---:|---:|---:|---:|---:|---:|---:|
| 18,000 | 15 min | 8.508 ms | 8.807 ms | +3.5% | 17.112 GiB | 0.700 GiB |
| 36,000 | 30 min | 17.145 ms | 17.525 ms | +2.2% | 34.222 GiB | 0.919 GiB |

## Checklist

- [x] Format code and run static checks.
- [x] Add a focused unit test.
- [x] Documentation is not needed; no user-facing interface changes.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30403821377](https://github.com/sgl-project/sglang/actions/runs/30403821377)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30403820979](https://github.com/sgl-project/sglang/actions/runs/30403820979)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->