### PR TITLE
[Fix] Validate stop_token_ids range in SamplingParams.verify (OOB scatter DoS)

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -221,6 +221,18 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
                         f"logit_bias must has keys in [0, {vocab_size - 1}], got "
                         f"{token_id}."
                     )
+        if self.stop_token_ids:
+            # Unchecked out-of-range ids reach the min_new_tokens penalizer's
+            # scatter_add_ over a [vocab_size + 1] tensor; an id >= vocab_size + 1
+            # is an out-of-bounds index (a CUDA device-side assert that takes down
+            # the whole server), and id == vocab_size is silently dropped by the
+            # trailing [:, :vocab_size] slice. Validate like logit_bias keys.
+            for token_id in self.stop_token_ids:
+                if not 0 <= token_id < vocab_size:
+                    raise ValueError(
+                        f"stop_token_ids must be in [0, {vocab_size - 1}], got "
+                        f"{token_id}."
+                    )
 
         grammars = [
             self.json_schema,

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -272,6 +272,37 @@ class TestSamplingParamsVerify(CustomTestCase):
         sp = self._make(logit_bias={"0": 1.0, "31999": -0.5})
         sp.verify(self.VOCAB_SIZE)
 
+    # --- stop_token_ids ---
+    def test_stop_token_ids_exceeds_vocab_raises(self):
+        """verify() must reject an out-of-range stop_token_id.
+
+        An id >= vocab_size + 1 reaches the min_new_tokens penalizer's
+        scatter_add_ over a [vocab_size + 1] tensor as an out-of-bounds index
+        (a CUDA device-side assert that crashes the whole server from one
+        request), so it must be rejected at validation like logit_bias keys.
+        """
+        sp = self._make(stop_token_ids=[self.VOCAB_SIZE + 1000])
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_stop_token_ids_equals_vocab_raises(self):
+        """id == vocab_size is out of range; unchecked it is silently dropped by
+        the penalizer's trailing [:, :vocab_size] slice (stop token never fires)."""
+        sp = self._make(stop_token_ids=[self.VOCAB_SIZE])
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_stop_token_ids_negative_raises(self):
+        """verify() must reject a negative stop_token_id."""
+        sp = self._make(stop_token_ids=[-1])
+        with self.assertRaises(ValueError):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_stop_token_ids_valid_tokens(self):
+        """stop_token_ids within [0, vocab_size) are accepted."""
+        sp = self._make(stop_token_ids=[0, self.VOCAB_SIZE - 1])
+        sp.verify(self.VOCAB_SIZE)
+
     def test_multiple_grammars_raises(self):
         """Test that verify() rejects setting both json_schema and regex (mutually exclusive)."""
         sp = self._make(json_schema='{"type":"object"}', regex="abc")


### PR DESCRIPTION
## Motivation

User-supplied `stop_token_ids` flow into the `min_new_tokens` penalizer, which builds a `scatter_add_` index over a `[vocab_size + 1]` tensor (`penaltylib/min_new_tokens.py:43-58`). `SamplingParams.verify()` validates `logit_bias` keys against `vocab_size` but does **not** range-check `stop_token_ids`, so:

- an id `>= vocab_size + 1` is an out-of-bounds scatter index. On CPU it's a `RuntimeError`; on CUDA it's a device-side assert / illegal memory access that poisons the context and takes down the **whole server process** (all in-flight requests) from a single malformed request. Both `min_new_tokens > 0` and the id are user-controlled (OpenAI `stop_token_ids`), so this is a network-reachable DoS.
- an id `== vocab_size` does not crash but is silently dropped by the trailing `[:, :vocab_size]` slice, so that stop token never fires.

Repro (CPU, no model): `SamplingParams(min_new_tokens=1, stop_token_ids=[100000]).verify(32000)` is accepted today, and driving the real penalizer with that request raises `index 100000 is out of bounds for dimension 1 with size 32001`.

## Modifications

Reject out-of-range `stop_token_ids` in `verify()`, mirroring the existing `logit_bias` key validation, so a malformed request fails cleanly at the validation boundary instead of at the scatter.

## Tests

Four cases added to `test_sampling_params.py::TestSamplingParamsVerify` (CPU): id `>= vocab_size + 1`, id `== vocab_size`, negative id all raise; in-range ids pass. All fail on the pre-fix code.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29597096447](https://github.com/sgl-project/sglang/actions/runs/29597096447)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29597096626](https://github.com/sgl-project/sglang/actions/runs/29597096626)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->