### PR TITLE
[AMD] Fix stale fp8_kernel import path in test_fused_fp8_kv_write after kernels migration

### DIFF
--- a/test/registered/attention/test_fused_fp8_kv_write.py
+++ b/test/registered/attention/test_fused_fp8_kv_write.py
@@ -31,10 +31,10 @@ def _fp32_divide_write(k, v, k_cache, v_cache, loc, k_scale, v_scale, fp8_dtype)
 @unittest.skipUnless(_HAS_CUDA, "Triton kernels require a GPU")
 class TestFusedFp8KvWrite(unittest.TestCase):
     def _run(self, num_tokens, num_heads, head_dim, total_slots=None, seed=0xC0FFEE):
+        from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
         from sglang.srt.layers.attention.utils import (
             launch_reshape_and_cache_flash,
         )
-        from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 
         torch.manual_seed(seed)
         dev = "cuda"
@@ -232,7 +232,7 @@ class TestAiterFp8KvDispatch(unittest.TestCase):
         v_scale falls back to self.v_scale (not self.k_scale)."""
         from unittest import mock
 
-        from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
+        from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 
         dev = "cuda"
         heads, dim, n = 2, 64, 4
@@ -280,7 +280,7 @@ class TestAiterFp8KvDispatch(unittest.TestCase):
         K's head_dim for V)."""
         from unittest import mock
 
-        from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
+        from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 
         dev = "cuda"
         heads, qk_dim, v_dim, n = 2, 64, 32, 4  # qk_head_dim != v_head_dim
@@ -337,7 +337,7 @@ class TestAiterFp8KvDispatch(unittest.TestCase):
         without scale args (its signature takes no scales)."""
         from unittest import mock
 
-        from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
+        from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 
         dev = "cuda"
         heads, dim, n = 2, 64, 4
@@ -389,8 +389,8 @@ class TestUseFusedFp8KvWritePredicate(unittest.TestCase):
     """Unit test for the shared _use_fused_fp8_kv_write predicate."""
 
     def _backend(self, **overrides):
+        from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
         from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
-        from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 
         be = AiterAttnBackend.__new__(AiterAttnBackend)
         be.kv_cache_dtype = overrides.get("kv_cache_dtype", fp8_dtype)


### PR DESCRIPTION
## Motivation

The AMD PR CI (`stage-b-test-1-gpu-small-amd`) fails with:

```
ModuleNotFoundError: No module named 'sglang.srt.layers.quantization.fp8_kernel'
```
https://github.com/sgl-project/sglang/actions/runs/29544840981/job/87774755645#step:6:17403

Root cause is a semantic merge conflict between two PRs that modified different files, so git did not flag a textual conflict:
- #30784 (`874fc07`, "[Kernel] Migrate scattered quantization kernels to sglang.kernels, Phase 2.5, 1/7") moved `fp8_kernel` from `sglang.srt.layers.quantization` to `sglang.kernels.ops.quantization` and updated all references existing at that time.
- #26852 (`01b0032`, "[AMD] Reuse fused FP8 KV cache write ...") was based on top of #30784 but added `test/registered/attention/test_fused_fp8_kv_write.py` using the old import path, which no longer existed when it landed.
Because the imports are lazy (inside test methods), only `test_decode_head_dim_mismatch_falls_back_to_set_kv_buffer` surfaced the error in CI, but all 5 occurrences in the file are broken.
## Modifications
Update the 5 import sites in `test/registered/attention/test_fused_fp8_kv_write.py` (lines 37, 235, 283, 340, 393):
```python
- from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
+ from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
```
Test-only change; no production code is modified.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.












<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29563628093](https://github.com/sgl-project/sglang/actions/runs/29563628093)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29563627987](https://github.com/sgl-project/sglang/actions/runs/29563627987)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->