### PR TITLE
[Fix] Streaming detokenization duplicates a character when sent_offset retreats

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -365,7 +365,16 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                     # commit (token offsets stay so the next iteration retries
                     # with more tokens).
                     printable = find_printable_text(new_text)
-                    s.sent_offset = s.decoded_text_len + len(printable)
+                    # Never let sent_offset retreat. find_printable_text is
+                    # non-monotonic across consecutive "�"-recovery steps: its
+                    # penultimate-CJK branch emits through the trailing CJK char
+                    # while the later last-space branch retreats to an earlier
+                    # space, so len(printable) can shrink. A shrinking sent_offset
+                    # makes the next clean step's `pending` too small and re-emits
+                    # already-streamed text (duplicated output to the client).
+                    s.sent_offset = max(
+                        s.sent_offset, s.decoded_text_len + len(printable)
+                    )
                     output_strs.append(printable[pending:] if pending else printable)
                 continue
 

--- a/test/registered/unit/managers/test_detokenizer_stream_offset.py
+++ b/test/registered/unit/managers/test_detokenizer_stream_offset.py
@@ -1,0 +1,100 @@
+"""Regression test for streaming detokenization offset bookkeeping.
+
+Bug: across consecutive incomplete-UTF-8 ("�") recovery steps, sent_offset was
+set to decoded_text_len + len(find_printable_text(new_text)). find_printable_text
+is non-monotonic: its penultimate-CJK branch emits through a trailing CJK char
+while the later last-space branch retreats to an earlier space, so len(printable)
+can shrink between steps. The shrinking sent_offset made the next clean step's
+`pending` too small, so it re-emitted already-streamed text and the client saw a
+duplicated character (e.g. a CJK char duplicated in multilingual streaming).
+
+Fix: sent_offset must never retreat within a recovery run (max with the prior
+value). This drives the real DetokenizerManager._decode_batch_token_id_output;
+only the tokenizer is mocked (the bug is in the offset arithmetic).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.detokenizer_manager import DetokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _TableTokenizer:
+    """decode(ids) -> string keyed by the exact id tuple. Used when no clean
+    commit advances the read window (surr_ids stays empty), so only whole-prefix
+    tuples are ever queried."""
+
+    def __init__(self, table):
+        self.table = table
+
+    def decode(self, ids, skip_special_tokens=True, spaces_between_special_tokens=True):
+        return self.table[tuple(ids)]
+
+
+class _ConcatTokenizer:
+    """decode(ids) -> concatenation of per-id pieces. Consistent for any slice,
+    so it survives the middle-slice surr_ids that appear after clean commits."""
+
+    def __init__(self, pieces):
+        self.pieces = pieces
+
+    def decode(self, ids, skip_special_tokens=True, spaces_between_special_tokens=True):
+        return "".join(self.pieces[i] for i in ids)
+
+
+def _recv(decode_ids):
+    # Duck-typed BatchTokenIDOutput: only the fields the streaming branch reads.
+    return SimpleNamespace(
+        rids=["r1"],
+        decoded_texts=[""],
+        decode_ids=[decode_ids],
+        read_offsets=[0],
+        finished_reasons=[None],  # streaming
+        no_stop_trim=[False],
+        skip_special_tokens=[True],
+        spaces_between_special_tokens=[True],
+    )
+
+
+class TestDetokenizerStreamOffset(CustomTestCase):
+    def _make_manager(self, tokenizer):
+        mgr = DetokenizerManager.__new__(DetokenizerManager)
+        mgr.decode_status = {}
+        mgr.disable_tokenizer_batch_decode = True
+        mgr.tokenizer = tokenizer
+        return mgr
+
+    def _stream(self, mgr):
+        client = ""
+        for step_ids in ([0], [1], [2]):  # step 1 seeds [0]; 2/3 extend the window
+            client += mgr._decode_batch_token_id_output(_recv(step_ids))[0]
+        return client
+
+    def test_recovery_retreat_does_not_duplicate(self):
+        # new_text deltas "A 世�", "A 世a�", "A 世ab": a CJK char then a byte-split
+        # codepoint (-> "�") resolving to a non-CJK char after the last space, so
+        # find_printable_text retreats from "A 世" (len 3) to "A " (len 2). No clean
+        # commit happens until the last step, so surr_ids stays empty and only the
+        # whole-prefix tuples below are queried.
+        tok = _TableTokenizer(
+            {(): "", (0,): "A 世�", (0, 1): "A 世a�", (0, 1, 2): "A 世ab"}
+        )
+        client = self._stream(self._make_manager(tok))
+        self.assertEqual(
+            client, "A 世ab", f"streaming stream must not duplicate, got {client!r}"
+        )
+
+    def test_normal_ascii_streaming_unaffected(self):
+        # A plain non-CJK stream that commits every step must be byte-exact
+        # (the fix is a no-op when sent_offset never retreats).
+        tok = _ConcatTokenizer({0: "hello", 1: " wor", 2: "ld"})
+        client = self._stream(self._make_manager(tok))
+        self.assertEqual(client, "hello world")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #31598

## Motivation

In the streaming branch of `DetokenizerManager._decode_batch_token_id_output`, across consecutive incomplete-UTF-8 (`�`) recovery steps, `sent_offset` is set to `decoded_text_len + len(find_printable_text(new_text))`. `find_printable_text` is **non-monotonic**: its penultimate-CJK branch (`utils.py:388`) emits through a trailing CJK char, while the later last-space branch (`utils.py:392`) retreats to an earlier space, so `len(printable)` can shrink from one recovery step to the next. A shrinking `sent_offset` makes the next clean step's `pending = sent_offset - decoded_text_len` too small, so it re-emits already-streamed text and the client sees a **duplicated character**.

Concrete: the `new_text` deltas `"A 世�"`, `"A 世a�"`, `"A 世ab"` (a CJK char, then a byte-split codepoint resolving to a non-CJK char after the last space) make step 1 emit `"A 世"` (`sent_offset=3`), step 2 retreat to `sent_offset=2`, and step 3 re-emit from offset 2, so the client stream is `"A 世世ab"` instead of `"A 世ab"`. This is realistic multilingual streaming (CJK plus a byte-BPE tokenizer that splits a following multibyte codepoint across tokens). Non-streaming requests are unaffected: they materialize the full string once from the committed text.

## Modifications

Clamp `sent_offset` so it never retreats within a recovery run: `max(sent_offset, decoded_text_len + len(printable))`. The emission slice already yields `""` when `printable` is shorter than what was sent; the fix stops the offset itself from moving backward.

## Tests

`test_detokenizer_stream_offset.py` drives the real `_decode_batch_token_id_output` (only the tokenizer is mocked): the CJK recovery-retreat case must not duplicate (fails on pre-fix code, which produces `"A 世世ab"`), and a plain ASCII stream (which commits every step) stays byte-exact.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29563762049](https://github.com/sgl-project/sglang/actions/runs/29563762049)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29563761936](https://github.com/sgl-project/sglang/actions/runs/29563761936)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->