### PR TITLE
[Fix] Bound top_logprobs_num against vocab size (out-of-range topk DoS)

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1034,6 +1034,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
+            self._validate_logprob_nums(obj)
             if (
                 obj.return_hidden_states
                 and not self.server_args.enable_return_hidden_states
@@ -1113,6 +1114,24 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"token_ids_logprob contains out-of-vocabulary token id "
                     f"{token_id}; valid range is [0, {vocab_size})."
                 )
+
+    def _validate_logprob_nums(self, obj: GenerateReqInput) -> None:
+        # Batch requests are split into per-request sub-objects before this runs,
+        # so top_logprobs_num is a single int here (0 when unset).
+        top_logprobs_num = obj.top_logprobs_num
+        if top_logprobs_num is None:
+            return
+        # top_logprobs_num feeds logprobs.topk(k) over the [*, vocab_size] logits.
+        # k > vocab_size is an out-of-range topk (a CUDA device-side assert that
+        # crashes the whole server), and k < 0 is likewise invalid. Neither the
+        # native /generate path nor the OpenAI logprobs / top_logprobs fields cap
+        # it, so bound it here.
+        vocab_size = self.model_config.vocab_size
+        if not 0 <= top_logprobs_num <= vocab_size:
+            raise ValueError(
+                f"top_logprobs_num must be in [0, {vocab_size}], got "
+                f"{top_logprobs_num}."
+            )
 
     def _validate_input_ids_in_vocab(
         self, input_ids: Union[List[int], List[List[int]]], vocab_size: int

--- a/test/registered/unit/managers/test_tokenizer_manager_logprob_validation.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_logprob_validation.py
@@ -1,0 +1,60 @@
+"""Unit test for TokenizerManager._validate_logprob_nums.
+
+Bug: top_logprobs_num (native /generate) and the OpenAI logprobs / top_logprobs
+fields had no upper bound. The value flows into logprobs.topk(k) over the
+[*, vocab_size] logits; k > vocab_size is an out-of-range topk (on CUDA a
+device-side assert that crashes the whole server) and k < 0 is likewise invalid.
+verify() bounded logit_bias and token_ids_logprob keys but not this count.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+VOCAB_SIZE = 32000
+
+
+def _manager():
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.model_config = SimpleNamespace(vocab_size=VOCAB_SIZE)
+    return tm
+
+
+def _req(top_logprobs_num):
+    obj = Mock(spec=GenerateReqInput)
+    obj.top_logprobs_num = top_logprobs_num
+    return obj
+
+
+class TestValidateLogprobNums(CustomTestCase):
+    def setUp(self):
+        self.tm = _manager()
+
+    def test_above_vocab_raises(self):
+        # k > vocab_size -> topk(k) is out of range (the DoS).
+        with self.assertRaises(ValueError):
+            self.tm._validate_logprob_nums(_req(VOCAB_SIZE + 1))
+        with self.assertRaises(ValueError):
+            self.tm._validate_logprob_nums(_req(2_000_000_000))
+
+    def test_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.tm._validate_logprob_nums(_req(-1))
+
+    def test_in_range_passes(self):
+        for k in (0, 1, 20, VOCAB_SIZE):
+            self.tm._validate_logprob_nums(_req(k))
+
+    def test_none_passes(self):
+        self.tm._validate_logprob_nums(_req(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`top_logprobs_num` has no upper bound anywhere on the request path. It flows into `logprobs.topk(k, dim=-1)` over the `[*, vocab_size]` logits (`layers/utils/logprob.py:37` and `:176`), so `k > vocab_size` is an out-of-range `topk` and `k < 0` is likewise invalid. On CPU this is a `RuntimeError`; on CUDA it is a device-side assert that poisons the context and takes down the whole server (all in-flight requests) from a single request. `verify()` bounds `logit_bias` keys and `token_ids_logprob` against `vocab_size`, but nothing bounded this count.

The field is reachable and unbounded from three entrypoints:
- native `/generate` `top_logprobs_num`;
- OpenAI `/v1/completions` `logprobs` (`protocol.py:328`, no constraint);
- OpenAI `/v1/chat/completions` `top_logprobs` (`protocol.py:665`, no constraint).

Real OpenAI caps `logprobs` at 20; SGLang caps nothing. Repro (CPU, no model): `get_top_logprobs(torch.zeros(1, vocab), [2_000_000_000])` raises `selected index k out of range`; over the network, `POST /generate {"text":"hi","sampling_params":{"max_new_tokens":1},"return_logprob":true,"top_logprobs_num":2000000000}`.

## Modifications

Reject out-of-range `top_logprobs_num` in `_validate_one_request` via a small sibling validator (`_validate_logprob_nums`), next to the existing `_validate_token_ids_logprob`. Since batch requests are split into per-request sub-objects before validation, `top_logprobs_num` is a single int here.

## Tests

`test_tokenizer_manager_logprob_validation.py` drives the real `_validate_logprob_nums`: `k > vocab_size`, `k == vocab_size + 1`, and negative all raise; `[0, vocab_size]` and `None` pass.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29564473075](https://github.com/sgl-project/sglang/actions/runs/29564473075)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29564472775](https://github.com/sgl-project/sglang/actions/runs/29564472775)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->