### PR TITLE
[Fix] Stop string/token must beat the max_new_tokens cap under speculative decode

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1481,31 +1481,40 @@ class Req(ReqDllmMixin):
             self.to_finish = None
             return
 
-        if len(self.output_ids) >= self.sampling_params.max_new_tokens:
-            self.finished_reason = FINISH_LENGTH(
-                length=self.sampling_params.max_new_tokens
-            )
-            self.finished_len = self.sampling_params.max_new_tokens
-            return
-
+        # Evaluate the definitive finishes (invalid token, stop string, stop
+        # token, grammar completion) on the accepted tokens BEFORE the
+        # max_new_tokens cap. Speculative decoding accepts >1 token per step, so a
+        # single chunk can push len(output_ids) past the cap while a stop landed
+        # earlier inside the budget; checking the cap first would mask that stop,
+        # mislabel the finish as FINISH_LENGTH, and leak the tokens after it.
         new_accepted_tokens = self.output_ids[-new_accepted_len:]
-
         # Sanitize out-of-range / NaN token ids before any decode.
-        if self._check_vocab_boundary_finish(new_accepted_tokens):
-            return
-
-        # Stop string beats EOS/stop-token matched in the same step (speculative
-        # decoding can accept >1 token): token-based would trim only the last
-        # token and leak the stop string.
-        if self._check_str_based_finish(new_accepted_len):
-            return
-
-        if self._check_token_based_finish(new_accepted_tokens):
-            return
-
-        if self.grammar is not None and self.grammar.is_terminated():
+        if not self._check_vocab_boundary_finish(new_accepted_tokens):
+            # Stop string beats EOS/stop-token matched in the same step: token
+            # based would trim only the last token and leak the stop string.
+            if not self._check_str_based_finish(new_accepted_len):
+                self._check_token_based_finish(new_accepted_tokens)
+        if (
+            not self.finished()
+            and self.grammar is not None
+            and self.grammar.is_terminated()
+        ):
             self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
-            return
+
+        # The length cap wins only when it lands at or before the finish above (a
+        # stop past the cap, i.e. a spec chunk overshooting the budget, still
+        # finishes at the cap). Some finishes emit the full output with
+        # finished_len left None (grammar completion, or a stop matched only in
+        # decoded_text); the cap still applies to those when over budget,
+        # preserving the prior behavior.
+        max_new_tokens = self.sampling_params.max_new_tokens
+        if len(self.output_ids) >= max_new_tokens and (
+            not self.finished()
+            or self.finished_len is None
+            or max_new_tokens < self.finished_len
+        ):
+            self.finished_reason = FINISH_LENGTH(length=max_new_tokens)
+            self.finished_len = max_new_tokens
 
     def reset_for_retract(self):
         # Increment retraction count before resetting other state. We should not reset this

--- a/test/registered/unit/managers/test_stop_str_speculative.py
+++ b/test/registered/unit/managers/test_stop_str_speculative.py
@@ -50,8 +50,14 @@ class _MockTokenizerForNormalize:
         return list(range(len(s)))  # One "token" per character
 
 
-def _make_req(output_ids, stop=None, stop_regex=None, eos_token_ids=frozenset()):
-    sp = SamplingParams(max_new_tokens=1000, stop=stop, stop_regex=stop_regex)
+def _make_req(
+    output_ids,
+    stop=None,
+    stop_regex=None,
+    eos_token_ids=frozenset(),
+    max_new_tokens=1000,
+):
+    sp = SamplingParams(max_new_tokens=max_new_tokens, stop=stop, stop_regex=stop_regex)
     sp.normalize(tokenizer=_MockTokenizerForNormalize())  # char-based stop_str_max_len
     req = Req(
         rid="t",
@@ -80,6 +86,33 @@ class TestStopStrSpeculative(unittest.TestCase):
         req.update_finish_state(new_accepted_len=6)
         self.assertTrue(req.finished())
         self.assertEqual(req.finished_reason.matched, "STOP")
+        self.assertEqual(req.finished_len, 4)
+
+    # --- max_new_tokens interaction (a spec chunk can overshoot the cap) ---
+    def test_stop_inside_budget_beats_length_cap(self):
+        # Chunk accepts 6 tokens, overshooting max_new_tokens=5, but "STOP" (index
+        # 2) lands inside the budget. The stop must win: finishing as FINISH_LENGTH
+        # here mislabels the reason and leaks the tokens after the stop.
+        req = _make_req([10, 11, STOP_ID, 20, 21, 22], stop=["STOP"], max_new_tokens=5)
+        req.update_finish_state(new_accepted_len=6)
+        self.assertTrue(req.finished())
+        self.assertEqual(req.finished_reason.matched, "STOP")
+        self.assertEqual(req.finished_len, 3)
+
+    def test_stop_beyond_budget_yields_length(self):
+        # "STOP" (index 3) lands at/after max_new_tokens=3, so the length cap is
+        # earlier and must win.
+        req = _make_req([10, 11, 20, STOP_ID, 21], stop=["STOP"], max_new_tokens=3)
+        req.update_finish_state(new_accepted_len=5)
+        self.assertTrue(req.finished())
+        self.assertEqual(type(req.finished_reason).__name__, "FINISH_LENGTH")
+        self.assertEqual(req.finished_len, 3)
+
+    def test_length_cap_only_when_no_stop(self):
+        req = _make_req([10, 11, 12, 13, 14, 15], stop=["STOP"], max_new_tokens=4)
+        req.update_finish_state(new_accepted_len=6)
+        self.assertTrue(req.finished())
+        self.assertEqual(type(req.finished_reason).__name__, "FINISH_LENGTH")
         self.assertEqual(req.finished_len, 4)
 
     def test_stop_str_wins_over_eos_in_same_step(self):


### PR DESCRIPTION
Fixes #31599

## Motivation

`Req.update_finish_state` checked `len(output_ids) >= max_new_tokens` **before** the stop-string / stop-token checks. Speculative decoding accepts more than one token per step (`update_finish_state(new_accepted_len)` runs after the whole accepted chunk is appended), so a single chunk can push `len(output_ids)` past the cap while a stop landed earlier, inside the budget. Checking the cap first masks that stop: the request finishes as `FINISH_LENGTH` (wrong reason) and emits the tokens accepted after the stop.

Non-spec decode is unaffected: output grows one token per step, so `len(output_ids)` can only reach the cap, never overshoot it.

Concrete (real `Req.update_finish_state`, CPU): `output_ids=[10,11,STOP,20,21,22]`, `max_new_tokens=5`, `new_accepted_len=6`. Correct finish is `FINISH_MATCHED_STR` at `finished_len=3` (emit `[10,11,STOP]`); current code returns `FINISH_LENGTH` at `finished_len=5`, leaking `20, 21`. The authors already established that a stop string beats a stop-token in the same step (comment above `_check_str_based_finish`); this extends the same precedence to the length cap.

## Modifications

Evaluate the definitive finishes (grammar completion, invalid token, stop string, stop token) before the cap, then let the cap win only when it lands at or before them, so a stop *past* the budget (a spec chunk overshooting the cap) still finishes at the cap. `finished_len` is `None` for finishes that emit the full output (grammar / stop-token / decoded_text-only stop), so the cap still applies to those when over budget, preserving prior behavior.

## Tests

Three cases in `test_stop_str_speculative.py` (which previously used `max_new_tokens=1000` everywhere, so never co-exercised the cap with a stop): a stop inside the budget beats the cap (fails on pre-fix code); a stop past the budget still yields `FINISH_LENGTH`; and a plain length cap with no stop. The existing stop cases are unchanged.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29850405026](https://github.com/sgl-project/sglang/actions/runs/29850405026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29850404934](https://github.com/sgl-project/sglang/actions/runs/29850404934)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->