### PR TITLE
[CI] Exclude current process memory from GPU idle check

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -2201,6 +2201,7 @@ def _visible_gpu_indices(pynvml) -> List[int]:
 
 
 def _collect_busy_gpu_reports(pynvml, gpu_indices: List[int]) -> List[str]:
+    self_pid = os.getpid()
     reports = []
     for index in gpu_indices:
         handle = pynvml.nvmlDeviceGetHandleByIndex(index)
@@ -2209,10 +2210,23 @@ def _collect_busy_gpu_reports(pynvml, gpu_indices: List[int]) -> List[str]:
             continue
         try:
             procs = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
-            proc_info = ", ".join(
-                f"pid={proc.pid} {_format_gib(proc.usedGpuMemory)}" for proc in procs
-            )
         except pynvml.NVMLError:
+            procs = None
+        if procs is not None:
+            # Discount this process's own usage: the torch caching allocator
+            # retains memory across test classes in the same process, and
+            # waiting on ourselves to release it can never succeed.
+            self_used = sum(
+                proc.usedGpuMemory or 0 for proc in procs if proc.pid == self_pid
+            )
+            if used_bytes - self_used < _GPU_IDLE_USED_MEMORY_THRESHOLD:
+                continue
+            proc_info = ", ".join(
+                f"pid={proc.pid} {_format_gib(proc.usedGpuMemory)}"
+                for proc in procs
+                if proc.pid != self_pid
+            )
+        else:
             proc_info = ""
         reports.append(
             f"GPU {index} uses {_format_gib(used_bytes)}"

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -768,10 +768,8 @@ def _subprocess_popen_with_outputs(
     env: Optional[dict],
     return_stdout_stderr: Optional[tuple],
 ) -> subprocess.Popen:
-    # Return this process's allocator-cached GPU memory to the driver before
-    # spawning a server subprocess: cached blocks are reusable in-process but
-    # stay cudaMalloc'd at the driver level, shrinking the child's usable
-    # memory.
+    # Release allocator-cached GPU memory to the driver before spawning a
+    # server: cached blocks stay cudaMalloc'd and shrink the child's memory.
     if torch.cuda.is_initialized():
         torch.cuda.empty_cache()
 
@@ -2220,9 +2218,8 @@ def _collect_busy_gpu_reports(pynvml, gpu_indices: List[int]) -> List[str]:
         except pynvml.NVMLError:
             procs = None
         if procs is not None:
-            # Discount this process's own usage: the torch caching allocator
-            # retains memory across test classes in the same process, and
-            # waiting on ourselves to release it can never succeed.
+            # Discount our own usage: the caching allocator retains memory
+            # across test classes, and waiting on ourselves never succeeds.
             self_used = sum(
                 proc.usedGpuMemory or 0 for proc in procs if proc.pid == self_pid
             )
@@ -2232,6 +2229,9 @@ def _collect_busy_gpu_reports(pynvml, gpu_indices: List[int]) -> List[str]:
                 f"pid={proc.pid} {_format_gib(proc.usedGpuMemory)}"
                 for proc in procs
                 if proc.pid != self_pid
+            ) or (
+                f"no other compute processes;"
+                f" self pid={self_pid} holds {_format_gib(self_used)}"
             )
         else:
             proc_info = ""

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -768,6 +768,13 @@ def _subprocess_popen_with_outputs(
     env: Optional[dict],
     return_stdout_stderr: Optional[tuple],
 ) -> subprocess.Popen:
+    # Return this process's allocator-cached GPU memory to the driver before
+    # spawning a server subprocess: cached blocks are reusable in-process but
+    # stay cudaMalloc'd at the driver level, shrinking the child's usable
+    # memory.
+    if torch.cuda.is_initialized():
+        torch.cuda.empty_cache()
+
     if not return_stdout_stderr:
         return subprocess.Popen(command, stdout=None, stderr=None, env=env)
 


### PR DESCRIPTION
The pre-setUpClass GPU idle check compares whole-device used memory against the threshold, so a single-process unittest that accumulates torch caching-allocator memory across test classes waits on its own process and always times out after 30s (e.g. test_unified_radix_cache_unittest.py). Discount the current process's usage when deciding idleness; real leftover processes are still reported.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29566388446](https://github.com/sgl-project/sglang/actions/runs/29566388446)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29566388262](https://github.com/sgl-project/sglang/actions/runs/29566388262)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->