### PR TITLE
Fix: Forward session_params in /v1/chat/completions adapter

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -621,6 +621,7 @@ class OpenAIServingChat(OpenAIServingBase):
             routed_experts_start_len=request.routed_experts_start_len,
             rid=request.rid,
             session_id=request.session_id,
+            session_params=request.session_params,
             extra_key=self._compute_extra_key(request),
             require_reasoning=require_reasoning,
             priority=request.priority,


### PR DESCRIPTION
## Fix: Forward `session_params` in `/v1/chat/completions` adapter

### Problem

`ChatCompletionRequest` protocol already defines `session_params` (protocol.py L733), and the scheduler reads `session_params.id` to route session-aware requests (scheduler.py L2050-2051). However, the `/v1/chat/completions` handler drops `session_params` when constructing `GenerateReqInput`, making session radix cache unreachable through the OpenAI-compatible chat endpoint.

Currently, session cache only works via the native `/generate` endpoint. Since `/v1/chat/completions` is the mainstream API for agent frameworks and application clients, this gap prevents session-aware KV cache management from being used in production agent workloads.

### Root Cause

In `serving_chat.py` L593-628, `GenerateReqInput` is constructed with `session_id=request.session_id` (L615) but **without** `session_params=request.session_params`. The scheduler only reads `session_params` (not `session_id`) for session cache routing, so the field is silently dropped.

### Fix

One-line addition in `python/sglang/srt/entrypoints/openai/serving_chat.py`:

```python
# after session_id=request.session_id,
adapted_request = GenerateReqInput(
    ...
    session_id=request.session_id,
    session_params=request.session_params,  # ← add this line
    ...
)
```

### Impact

- **No breaking change**: `session_params` defaults to `None`; existing behavior unchanged when not provided.
- **Enables session cache via chat API**: Agent frameworks (OpenHands, Claude Code, etc.) can now use `/v1/chat/completions` with `session_params` to activate session radix cache, without switching to the native `/generate` endpoint.
- **Aligns with protocol**: The field is already defined in `ChatCompletionRequest`; this PR simply forwards it, matching how `session_id` is already forwarded.

### Test Plan

1. Launch server with `--enable-session-radix-cache`
2. Send `/v1/chat/completions` with `session_params: {"id": "test-session"}`
3. Verify scheduler logs show session-aware routing (previously absent)
4. Verify `/close_session` releases KV cache for the session







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29569758462](https://github.com/sgl-project/sglang/actions/runs/29569758462)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29569758230](https://github.com/sgl-project/sglang/actions/runs/29569758230)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->