### PR TITLE
[Performance] Enable CUDA IPC pool handle cache by default

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -1961,8 +1961,8 @@ SGLang supports various environment variables that can be used to configure its 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_USE_IPC_POOL_HANDLE_CACHE</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Cache CUDA IPC pool handles.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>When CUDA IPC multimodal feature transport is selected, reuse mappings to its existing bounded pool. This does not enable CUDA IPC transport or reserve another pool.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>true</code></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_MM_FEATURE_CACHE_MB</code></td>

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -788,7 +788,9 @@ class Envs:
 
     # VLM Item CUDA IPC Transport
     SGLANG_USE_CUDA_IPC_TRANSPORT = EnvBool(False)
-    SGLANG_USE_IPC_POOL_HANDLE_CACHE = EnvBool(False)
+    # Reuse the mapping for the already-allocated bounded CUDA IPC pool. This
+    # has no effect unless CUDA IPC feature transport is explicitly selected.
+    SGLANG_USE_IPC_POOL_HANDLE_CACHE = EnvBool(True)
     SGLANG_MM_FEATURE_CACHE_MB = EnvInt(1 * 1024)
     SGLANG_MM_ITEM_MEM_POOL_RECYCLE_INTERVAL_SEC = EnvFloat(0.05)
 

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -42,8 +42,6 @@ _is_cpu = is_cpu()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 
-_IPC_POOL_HANDLE_CACHE = envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.get()
-
 
 @dataclasses.dataclass
 class BaseMultiModalProcessorOutput:
@@ -198,6 +196,9 @@ class BaseMultimodalProcessor(ABC):
             else "cpu"
         )
         self.use_cuda_ipc = self.mm_feature_transport == "cuda_ipc"
+        self.use_ipc_pool_handle_cache = (
+            self.use_cuda_ipc and envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.get()
+        )
         self.disable_fast_image_processor = server_args.disable_fast_image_processor
         self.skip_tokenizer_init = server_args.skip_tokenizer_init
 
@@ -1255,7 +1256,7 @@ class BaseMultimodalProcessor(ABC):
                 sync_buffer_meta=sync_flag,
                 pool_ipc_handle=(
                     self.cudaipc_mmfeature_pool._pool_ipc_handle
-                    if _IPC_POOL_HANDLE_CACHE
+                    if self.use_ipc_pool_handle_cache
                     else None
                 ),
                 pool_byte_offset=byte_offset,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6365,6 +6365,16 @@ class ServerArgs:
                 self.base_gpu_id,
                 self.tokenizer_worker_num,
             )
+            logger.info(
+                "CUDA IPC pool-handle caching is %s. It reuses mappings to the "
+                "existing bounded pool without reserving another pool; set "
+                "SGLANG_USE_IPC_POOL_HANDLE_CACHE=0 to disable it.",
+                (
+                    "enabled"
+                    if envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.get()
+                    else "disabled"
+                ),
+            )
 
         self.mm_feature_transport = requested_transport
         # The bounded IPC pool owns device residency. Do not retain unpooled

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
@@ -128,7 +129,7 @@ class TestMultimodalFeatureTransportRuntime(unittest.TestCase):
         # transport policy must still resolve from the instance's ServerArgs.
         from sglang.srt.multimodal.processors import base_processor
 
-        with patch.object(
+        with envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.override(True), patch.object(
             base_processor.BaseMultimodalProcessor, "__abstractmethods__", set()
         ), patch.object(base_processor, "MmItemMemoryPool") as memory_pool:
             processor = base_processor.BaseMultimodalProcessor(
@@ -140,12 +141,30 @@ class TestMultimodalFeatureTransportRuntime(unittest.TestCase):
 
         self.assertEqual(processor.mm_feature_transport, "cuda_ipc")
         self.assertTrue(processor.use_cuda_ipc)
+        self.assertTrue(processor.use_ipc_pool_handle_cache)
+        memory_pool.assert_called_once()
+
+    def test_cuda_ipc_pool_handle_cache_can_be_disabled(self):
+        from sglang.srt.multimodal.processors import base_processor
+
+        with envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.override(False), patch.object(
+            base_processor.BaseMultimodalProcessor, "__abstractmethods__", set()
+        ), patch.object(base_processor, "MmItemMemoryPool") as memory_pool:
+            processor = base_processor.BaseMultimodalProcessor(
+                hf_config=MagicMock(),
+                server_args=self._server_args("cuda_ipc"),
+                _processor=self._processor(),
+                transport_mode=None,
+            )
+
+        self.assertTrue(processor.use_cuda_ipc)
+        self.assertFalse(processor.use_ipc_pool_handle_cache)
         memory_pool.assert_called_once()
 
     def test_cpu_transport_does_not_allocate_ipc_pool(self):
         from sglang.srt.multimodal.processors import base_processor
 
-        with patch.object(
+        with envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.override(True), patch.object(
             base_processor.BaseMultimodalProcessor, "__abstractmethods__", set()
         ), patch.object(base_processor, "MmItemMemoryPool") as memory_pool:
             processor = base_processor.BaseMultimodalProcessor(
@@ -157,6 +176,7 @@ class TestMultimodalFeatureTransportRuntime(unittest.TestCase):
 
         self.assertEqual(processor.mm_feature_transport, "cpu")
         self.assertFalse(processor.use_cuda_ipc)
+        self.assertFalse(processor.use_ipc_pool_handle_cache)
         memory_pool.assert_not_called()
 
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -69,7 +69,13 @@ class TestMultimodalFeatureTransport(CustomTestCase):
             base_gpu_id=2,
         )
 
-        with patch.dict(os.environ, {"SGLANG_USE_CUDA_IPC_TRANSPORT": "0"}):
+        with patch.dict(
+            os.environ,
+            {
+                "SGLANG_USE_CUDA_IPC_TRANSPORT": "0",
+                "SGLANG_USE_IPC_POOL_HANDLE_CACHE": "1",
+            },
+        ):
             with self.assertLogs(server_args_module.logger, level="INFO") as logs:
                 server_args._handle_multimodal_feature_transport()
 
@@ -79,6 +85,8 @@ class TestMultimodalFeatureTransport(CustomTestCase):
         output = "\n".join(logs.output)
         self.assertIn("base GPU 2", output)
         self.assertIn("4 tokenizer worker", output)
+        self.assertIn("pool-handle caching is enabled", output)
+        self.assertIn("without reserving another pool", output)
 
     @patch("sglang.srt.server_args.is_cuda", return_value=True)
     def test_legacy_keep_flag_maps_to_cuda_ipc(self, _mock_is_cuda):


### PR DESCRIPTION
## Summary

- enable the existing CUDA IPC pool-handle cache by default
- gate it on the resolved `cuda_ipc` multimodal feature transport mode
- preserve `SGLANG_USE_IPC_POOL_HANDLE_CACHE=0` as an explicit rollback
- log that the cache reuses the existing bounded pool and does not reserve another pool

This does **not** enable CUDA IPC feature transport by default. CPU transport remains the default. Users must still explicitly select `--mm-feature-transport=cuda_ipc`, which reserves the configured bounded pool and reduces KV-cache headroom.

## Root cause

Without the handle cache, every transported multimodal feature reconstructs the same long-lived pool through `torch.UntypedStorage._new_shared_cuda()`. That repeatedly opens and closes the same CUDA IPC mapping on the scheduler critical path.

The pooled transport already carries a stable pool allocation and byte offset. Reusing one consumer mapping for the lifetime of that pool removes the redundant mapping lifecycle. Stale entries retain the existing invalidate-and-retry fallback.

In matched TP4 torch-profiler traces:

| Scheduler operation | Cache off | Cache on |
|---|---:|---:|
| `cudaIpcOpenMemHandle` | 32 calls / 292.94 ms | 0 |
| `cudaIpcCloseMemHandle` | 32 calls / 219.99 ms | 0 |
| CUDA allocation calls | 38 calls / 135.59 ms | 38 calls / 7.14 ms |
| `scheduler.process_input` GPU annotation | 682.04 ms | 22.01 ms |

The ViT and language-model prefill portions were stable in the same traces; the improvement comes from the feature-transport mapping lifecycle.

## PR-before vs PR-after performance

Hardware/model: 4x NVIDIA H100 80GB, TP4, `Qwen/Qwen3.6-35B-A3B-FP8`.

Serving configuration: breakable prefill CUDA graph only (2048/4096/8192-token captures), full decode graph, FA3, multimodal DP encoder, mixed chunk, and a 512 MiB CUDA IPC feature pool. Each request used four seeded random JPEGs sized from 512x512 to 768x1024 and 32 text-input tokens.

Method: A/B/A server sequence (`cache on` / `cache off` / `cache on`), three formal repetitions per sequence after three warmup requests, with the radix cache flushed before every formal run. “After” is the median of all six cache-on repetitions; “before” is the median of the three cache-off repetitions. The source and all launch flags were otherwise byte-identical.

| Workload | Metric | Before: cache off | After: cache on | Change |
|---|---:|---:|---:|---:|
| output=1, burst | Request throughput | 7.55 req/s | 20.43 req/s | **+170.6%** |
| | Mean TTFT | 2808.30 ms | 842.36 ms | **-70.0%** |
| | P99 TTFT | 3142.78 ms | 1145.97 ms | **-63.5%** |
| output=1, rate=4 | Request throughput | 6.11 req/s | 6.59 req/s | +7.9% (arrival-limited) |
| | Mean TTFT | 496.30 ms | 97.70 ms | **-80.3%** |
| | P99 TTFT | 843.24 ms | 160.68 ms | **-80.9%** |
| output=64, burst | Request throughput | 5.59 req/s | 17.17 req/s | **+207.2%** |
| | Output throughput | 191.43 tok/s | 588.05 tok/s | **+207.2%** |
| | Mean TTFT | 1761.37 ms | 360.77 ms | **-79.5%** |
| | Mean E2E | 2007.29 ms | 560.14 ms | **-72.1%** |
| | Mean TPOT | 7.67 ms | 6.45 ms | **-15.9%** |

## Memory gate

Both sides used the same 512 MiB producer pool. The handle cache only retains a mapping to that allocation; it does not allocate a second pool. In the controlled B/A server restart, the four GPUs had identical memory use after the first three-request warmup and before the first formal workload:

`69534 / 68076 / 68058 / 67578 MiB` with cache off and with cache on.

Across all formal-run pre-measurements, per-GPU medians differed by less than 100 MiB between the two configurations. A launch with the environment variable completely unset also logged the default-on policy and started with `68966 / 68022 / 68022 / 67542 MiB`, matching the fresh cache-off server.

The CUDA IPC transport itself still reserves its configured pool and remains opt-in because that reservation can reduce KV-cache capacity.

## Validation

- `test_mm_process_config.py -k MultimodalFeatureTransportRuntime`: 3 passed on NVIDIA H100
- `test_cuda_ipc_transport.py`: cross-process pooled reconstruction passed on NVIDIA H100
- `test_server_args.py -k MultimodalFeatureTransport`: 6 passed on NVIDIA H100
- launch and 24-request random-image serving smoke with `SGLANG_USE_IPC_POOL_HANDLE_CACHE` unset: passed
- pre-commit on all changed files: passed











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29585133436](https://github.com/sgl-project/sglang/actions/runs/29585133436)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29585133351](https://github.com/sgl-project/sglang/actions/runs/29585133351)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->