### PR TITLE
[PD][NIXL] Clean up decode receiver state after failed transfers

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1485,6 +1485,9 @@ class CommonKVReceiver(BaseKVReceiver):
         self.kv_mgr.request_status.pop(self.bootstrap_room, None)
         self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room, None)
         self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
+        rooms = self.kv_mgr.addr_to_rooms_tracker.get(self.bootstrap_addr)
+        if rooms is not None:
+            rooms.discard(self.bootstrap_room)
 
     def abort(self):
         self.kv_mgr.record_failure(

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -152,6 +152,9 @@ class DecodeStagingHandler:
         receiver = self._room_to_receiver.pop(room, None)
         if decode_req is not None:
             self.release_room(room, decode_req, receiver)
+        chunk_writer_counts = getattr(self.kv_manager, "_chunk_writer_counts", None)
+        if chunk_writer_counts is not None:
+            chunk_writer_counts.pop(room, None)
         self.kv_manager._staging_ctx.room_receivers.pop(room, None)
         self.kv_manager._staging_ctx.room_bootstrap.pop(room, None)
 
@@ -250,7 +253,6 @@ class DecodeStagingHandler:
         once all writers for this chunk have reported in. Returns True if scatter
         was submitted.
         """
-        chunk_writer_counts[room][chunk_idx].append((page_start, num_pages, writer_id))
         decode_req = self._room_to_decode_req.get(room)
         if decode_req is None:
             logger.warning(
@@ -259,6 +261,7 @@ class DecodeStagingHandler:
                 chunk_idx,
             )
             return False
+        chunk_writer_counts[room][chunk_idx].append((page_start, num_pages, writer_id))
         writers_arrived = len(chunk_writer_counts[room][chunk_idx])
         num_writers = self.num_writers_for(decode_req)
         if writers_arrived >= num_writers:

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2424,6 +2424,12 @@ class NixlKVManager(CommonKVManager):
                 components = msg.decode("ascii").split("_", 8)
                 room = int(components[0])
                 tag = components[1]
+                if room not in self.request_status:
+                    logger.debug(
+                        f"Ignoring NIXL transfer notification for inactive room {room} "
+                        f"from {peer_name}: {msg!r}"
+                    )
+                    continue
                 if tag == "kv":
                     chunk_id = int(components[2])
                     is_last_chunk = bool(int(components[3]))
@@ -2814,6 +2820,13 @@ class NixlKVReceiver(CommonKVReceiver):
         self.started_transfer = False
         super().__init__(mgr, bootstrap_addr, bootstrap_room)
         self.init_time = None
+
+    def clear(self) -> None:
+        staging_handler = getattr(self.kv_mgr, "_staging_handler", None)
+        if staging_handler is not None:
+            staging_handler.unregister_decode_req(self.bootstrap_room)
+        super().clear()
+        self.kv_mgr.transfer_statuses.pop(self.bootstrap_room, None)
 
     def send_metadata(
         self,

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -13,7 +13,10 @@ import numpy as np
 
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import CommonKVManager
-from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
+from sglang.srt.disaggregation.common.staging_handler import (
+    DecodeStagingHandler,
+    PrefillStagingContext,
+)
 from sglang.srt.disaggregation.common.utils import pack_int_lists
 from sglang.srt.disaggregation.nixl.conn import (
     KVArgsRegisterInfo,
@@ -531,11 +534,17 @@ class TestNixlTransferWorker(CustomTestCase):
 
 
 class TestNixlNotifications(CustomTestCase):
-    def _make_manager(self, messages, required=None):
+    def _rooms_from_messages(self, messages):
+        return {int(msg.split("_", 1)[0]) for msg in messages}
+
+    def _make_manager(self, messages, required=None, active_rooms=None):
         mgr = object.__new__(NixlKVManager)
         mgr.agent = NotificationFakeAgent(messages)
         mgr.transfer_statuses = defaultdict(TransferStatus)
         mgr.required_prefill_response_num_table = required or {}
+        if active_rooms is None:
+            active_rooms = self._rooms_from_messages(messages)
+        mgr.request_status = {room: KVPoll.WaitingForInput for room in active_rooms}
         mgr.enable_staging = False
         mgr._staging_handler = None
         mgr._chunk_writer_counts = defaultdict(lambda: defaultdict(list))
@@ -587,16 +596,125 @@ class TestNixlNotifications(CustomTestCase):
 
         self.assertTrue(mgr.transfer_statuses[8].is_done())
 
+    def test_inactive_room_notification_does_not_affect_active_room(self):
+        mgr = self._make_manager(
+            [
+                "11_kv_0_1_0",
+                "11_kv_1_1_0_part_0_2",
+                "11_stg_2_1_0_3_4_8_inactive_agent",
+                "12_kv_0_1_0",
+                "11_aux",
+                "12_aux",
+                "11_state_0",
+                "12_state_0",
+            ],
+            required={12: 1},
+            active_rooms={12},
+        )
+        mgr.enable_staging = True
+        mgr._staging_handler = MagicMock()
+        mgr._staging_handler.is_staging_room.return_value = False
+        mgr.transfer_statuses[12].expects_state = True
+
+        mgr.update_transfer_status()
+
+        self.assertNotIn(11, mgr.transfer_statuses)
+        self.assertNotIn(11, mgr._chunk_writer_counts)
+        mgr._staging_handler.handle_chunk_arrived.assert_not_called()
+        status = mgr.transfer_statuses[12]
+        self.assertEqual(status.received_kvs_per_pp[0], {0})
+        self.assertEqual(status.expected_kvs_per_pp[0], 1)
+        self.assertTrue(status.received_aux)
+        self.assertEqual(status.received_state_per_pp, {0})
+
+    def test_active_staging_room_notification_updates_and_scatters(self):
+        mgr = self._make_manager(["13_stg_0_1_0_2_4_8_active_agent"], active_rooms={13})
+        mgr.enable_staging = True
+        mgr._staging_handler = MagicMock()
+        mgr._staging_handler.is_staging_room.return_value = True
+
+        mgr.update_transfer_status()
+
+        status = mgr.transfer_statuses[13]
+        self.assertEqual(status.received_kvs_per_pp[0], {0})
+        self.assertEqual(status.expected_kvs_per_pp[0], 1)
+        mgr._staging_handler.handle_chunk_arrived.assert_called_once_with(
+            13, 2, 4, 8, "active_agent", mgr._chunk_writer_counts
+        )
+
+    def test_active_kvpart_notification_waits_for_all_parts(self):
+        mgr = self._make_manager(
+            [
+                "14_kv_0_1_0_part_0_2",
+                "14_kv_0_1_0_part_1_2",
+            ],
+            active_rooms={14},
+        )
+
+        mgr.update_transfer_status()
+
+        status = mgr.transfer_statuses[14]
+        self.assertEqual(status.received_kvs_per_pp[0], {0})
+        self.assertEqual(status.expected_kvs_per_pp[0], 1)
+
+
+class TestDecodeStagingNotifications(CustomTestCase):
+    def _make_handler(self, rooms=None):
+        handler = object.__new__(DecodeStagingHandler)
+        handler._room_to_decode_req = dict(rooms or {})
+        handler.num_writers_for = MagicMock(return_value=1)
+        handler.submit_chunk_scatter = MagicMock(return_value=True)
+        return handler
+
+    def test_unregistered_room_does_not_create_chunk_state_or_scatter(self):
+        handler = self._make_handler()
+        chunk_writer_counts = defaultdict(lambda: defaultdict(list))
+
+        submitted = handler.handle_chunk_arrived(
+            11, 2, 4, 8, "late_agent", chunk_writer_counts
+        )
+
+        self.assertFalse(submitted)
+        self.assertNotIn(11, chunk_writer_counts)
+        handler.num_writers_for.assert_not_called()
+        handler.submit_chunk_scatter.assert_not_called()
+
+    def test_active_room_still_tracks_and_submits_scatter(self):
+        decode_req = object()
+        handler = self._make_handler({12: decode_req})
+        chunk_writer_counts = defaultdict(lambda: defaultdict(list))
+
+        submitted = handler.handle_chunk_arrived(
+            12, 2, 4, 8, "active_agent", chunk_writer_counts
+        )
+
+        self.assertTrue(submitted)
+        handler.num_writers_for.assert_called_once_with(decode_req)
+        handler.submit_chunk_scatter.assert_called_once_with(12, 2, 4, 8)
+        self.assertNotIn(2, chunk_writer_counts[12])
+
 
 class TestNixlReceiverPoll(CustomTestCase):
     def _make_receiver(self, status=KVPoll.WaitingForInput):
         mgr = MagicMock()
         mgr.waiting_timeout = 5
-        mgr.check_status.return_value = status
+        mgr.request_status = {11: status}
+        mgr.required_prefill_response_num_table = {11: 1}
+        mgr.prefill_response_tracker = {11: {0}}
+        mgr.failure_records = {}
+        mgr.failure_lock = threading.Lock()
+        mgr.check_status.side_effect = lambda room: mgr.request_status.get(room, status)
+        mgr.update_status.side_effect = (
+            lambda room, new_status: mgr.request_status.__setitem__(room, new_status)
+        )
+        mgr.record_failure.side_effect = (
+            lambda room, reason: mgr.failure_records.__setitem__(room, reason)
+        )
         mgr.check_transfer_done.return_value = False
+        mgr._staging_handler = None
         mgr.transfer_statuses = {}
         mgr.addr_to_rooms_tracker = defaultdict(set)
-        mgr.addr_to_rooms_tracker["prefill:8998"].add(11)
+        mgr.addr_to_rooms_tracker["prefill:8998"].update({11, 12})
 
         receiver = object.__new__(NixlKVReceiver)
         receiver.kv_mgr = mgr
@@ -607,6 +725,28 @@ class TestNixlReceiverPoll(CustomTestCase):
         receiver.conclude_state = None
         receiver.abort_notified = False
         return receiver, mgr
+
+    def _assert_room_cleared(self, mgr):
+        self.assertNotIn(11, mgr.request_status)
+        self.assertNotIn(11, mgr.required_prefill_response_num_table)
+        self.assertNotIn(11, mgr.prefill_response_tracker)
+        self.assertNotIn(11, mgr.transfer_statuses)
+        self.assertNotIn(11, mgr.addr_to_rooms_tracker["prefill:8998"])
+        self.assertIn(12, mgr.addr_to_rooms_tracker["prefill:8998"])
+
+    def _bind_real_notification_update(self, mgr, messages):
+        mgr.agent = NotificationFakeAgent(messages)
+        mgr.enable_staging = False
+        mgr._staging_handler = None
+        mgr.update_transfer_status = NixlKVManager.update_transfer_status.__get__(
+            mgr, NixlKVManager
+        )
+        mgr._handle_aux_notification = NixlKVManager._handle_aux_notification.__get__(
+            mgr, NixlKVManager
+        )
+        mgr._track_kv_arrival = NixlKVManager._track_kv_arrival.__get__(
+            mgr, NixlKVManager
+        )
 
     def test_returns_existing_conclude_state_without_polling_manager(self):
         receiver, mgr = self._make_receiver()
@@ -675,6 +815,124 @@ class TestNixlReceiverPoll(CustomTestCase):
         self.assertNotIn(11, mgr.transfer_statuses)
         self.assertNotIn(11, mgr.addr_to_rooms_tracker["prefill:8998"])
         self.assertEqual(receiver.conclude_state, KVPoll.Success)
+
+    @patch("sglang.srt.disaggregation.nixl.conn.time.time")
+    def test_failed_abort_and_timeout_clear_remove_room_state(self, mock_time):
+        for scenario in ("failure", "timeout", "abort"):
+            with self.subTest(scenario=scenario):
+                receiver, mgr = self._make_receiver(status=KVPoll.WaitingForInput)
+                mgr.transfer_statuses = {11: TransferStatus()}
+                if scenario == "failure":
+                    mgr.failure_records = {11: "transfer failed"}
+                    with self.assertRaises(Exception):
+                        receiver.failure_exception()
+                elif scenario == "timeout":
+                    mock_time.return_value = 20.0
+                    receiver.started_transfer = True
+                    receiver.init_time = 10.0
+                    self.assertEqual(receiver.poll(), KVPoll.Failed)
+                    with self.assertRaises(Exception):
+                        receiver.failure_exception()
+                else:
+                    receiver.abort()
+
+                receiver.clear()
+
+                self._assert_room_cleared(mgr)
+
+    @patch("sglang.srt.disaggregation.nixl.conn.time.time")
+    def test_clear_is_idempotent_for_edge_states(self, mock_time):
+        for scenario in (
+            "repeat_clear",
+            "missing_transfer_status",
+            "success_then_clear",
+        ):
+            with self.subTest(scenario=scenario):
+                receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+                if scenario == "success_then_clear":
+                    receiver, mgr = self._make_receiver(status=KVPoll.WaitingForInput)
+                    receiver.started_transfer = True
+                    receiver.init_time = 10.0
+                    mock_time.return_value = 12.0
+                    status = TransferStatus()
+                    status.received_aux = True
+                    status.num_pp_ranks_expected = 1
+                    status.expected_kvs_per_pp[0] = 0
+                    mgr.transfer_statuses = {11: status}
+                    mgr.check_transfer_done.return_value = True
+                    self.assertEqual(receiver.poll(), KVPoll.Success)
+                elif scenario == "repeat_clear":
+                    mgr.transfer_statuses = {11: TransferStatus()}
+                else:
+                    mgr.transfer_statuses = {}
+
+                receiver.clear()
+                receiver.clear()
+
+                self._assert_room_cleared(mgr)
+
+    def test_repeated_clear_unregisters_staging_without_double_release(self):
+        receiver, mgr = self._make_receiver(status=KVPoll.WaitingForInput)
+        decode_req = object()
+        other_receiver = object()
+        other_decode_req = object()
+        mgr._staging_ctx = SimpleNamespace(
+            room_receivers={11: receiver, 12: other_receiver},
+            room_bootstrap={11: ["room-11"], 12: ["room-12"]},
+        )
+        mgr._chunk_writer_counts = {
+            11: {0: [(0, 1, "writer")]},
+            12: {0: [(1, 1, "other-writer")]},
+        }
+        staging_handler = object.__new__(DecodeStagingHandler)
+        staging_handler.kv_manager = mgr
+        staging_handler._room_to_decode_req = {
+            11: decode_req,
+            12: other_decode_req,
+        }
+        staging_handler._room_to_receiver = {
+            11: receiver,
+            12: other_receiver,
+        }
+        staging_handler.release_room = MagicMock()
+        mgr._staging_handler = staging_handler
+
+        receiver.clear()
+        receiver.clear()
+
+        staging_handler.release_room.assert_called_once_with(11, decode_req, receiver)
+        self.assertNotIn(11, staging_handler._room_to_decode_req)
+        self.assertNotIn(11, staging_handler._room_to_receiver)
+        self.assertNotIn(11, mgr._staging_ctx.room_receivers)
+        self.assertNotIn(11, mgr._staging_ctx.room_bootstrap)
+        self.assertNotIn(11, mgr._chunk_writer_counts)
+        self.assertIn(12, staging_handler._room_to_decode_req)
+        self.assertIn(12, staging_handler._room_to_receiver)
+        self.assertIn(12, mgr._staging_ctx.room_receivers)
+        self.assertIn(12, mgr._staging_ctx.room_bootstrap)
+        self.assertIn(12, mgr._chunk_writer_counts)
+        self._assert_room_cleared(mgr)
+
+    def test_late_notifications_after_clear_do_not_recreate_room_state(self):
+        for message in (
+            "11_kv_0_1_0",
+            "11_kv_0_1_0_part_0_2",
+            "11_aux",
+            "11_state_0",
+            "11_stg_0_1_0_2_4_8_late_agent",
+        ):
+            with self.subTest(message=message):
+                receiver, mgr = self._make_receiver(status=KVPoll.WaitingForInput)
+                mgr.transfer_statuses = defaultdict(TransferStatus)
+                mgr.transfer_statuses[11]
+                receiver.clear()
+                self._assert_room_cleared(mgr)
+                self._bind_real_notification_update(mgr, [message])
+
+                mgr.update_transfer_status()
+
+                self.assertNotIn(11, mgr.transfer_statuses)
+                self.assertNotIn(11, mgr._chunk_writer_counts)
 
 
 class TestNixlNodeFailure(CustomTestCase):
@@ -749,6 +1007,18 @@ class TestNixlStaging(CustomTestCase):
         )
         mgr.server_args = SimpleNamespace(chunked_prefill_size=4)
         return mgr
+
+    def test_unregistered_staging_request_does_not_allocate_slot(self):
+        mgr = self._make_manager()
+        mgr._staging_handler = SimpleNamespace(_room_to_decode_req={})
+        message = [b"STAGING_REQ", b"11", b"0", b"1", b"session"]
+
+        with patch(
+            "sglang.srt.disaggregation.common.staging_handler.handle_staging_req"
+        ) as mock_handle_staging_req:
+            mgr._handle_staging_req(message)
+
+        mock_handle_staging_req.assert_not_called()
 
     def test_register_buffer_to_engine_groups_kv_memory_kinds_in_one_pass(self):
         agent = StagingFakeAgent(register_result=["desc"])


### PR DESCRIPTION
## Motivation

NIXL decode receiver registers room-scoped transfer bookkeeping for each bootstrap room. The successful poll path clears both `NixlKVReceiver.transfer_statuses` and the shared `addr_to_rooms_tracker` entry.

Before this change, timeout, abort, or connector failure paths could enter `failure_exception()` and `clear()` without clearing the same receiver-side bookkeeping. A late NIXL notification could also access `transfer_statuses` through the defaultdict after a room had already terminated, recreating state for an inactive room. That left stale connector state behind and could affect later requests that reuse the same address or room lifecycle.

## Modifications

- Make `CommonKVReceiver.clear()` discard the current bootstrap room from `addr_to_rooms_tracker` while preserving other active rooms that share the same address.
- Make `NixlKVReceiver.clear()` idempotently remove the current room from `transfer_statuses` and unregister it through the current `DecodeStagingHandler` lifecycle API.
- Make NIXL notification handling ignore inactive rooms before any `defaultdict` write. This covers `kv`, `kvpart`, `aux`, `state`, and `stg` notifications while preserving normal handling for active rooms.
- Remove room-scoped `_chunk_writer_counts` during staging unregister. A late `stg` notification for an unregistered room can no longer recreate chunk state, start scatter, allocate a slot, or restore the room.
- Keep active room notifications, including active staging notifications and other rooms sharing the same bootstrap address, updating normally.
- Add CPU unit coverage for failure, timeout, abort, success, repeated `clear()`, late notification handling, staging unregister/release, and two-room isolation.

The branch was rebased and validated on `main` commit `64eeb153dfaa5f6080039ce76bfd2bfe2a7097b1`. A subsequent read-only drift audit through `b6876fc6520179f6507ba1b076c0ffd00b9d6709` found no intervening changes to the four modified files, no semantic overlap with this fix, and no merge conflict, so the already validated commit was retained.

## Accuracy Tests

This patch does not modify model forward logic, kernels, sampling, tokenization, or successful-path model outputs.

The tests ran in the isolated Python 3.10.20 environment at `/mnt/si0260014qra/default/chengcp/venvs/sglang_pr31589_py310_20260806`, with Transformers 5.12.1 and PyTorch 2.11.0+cu130. `sglang` was imported from the PR worktree, `pip check` passed, user site-packages were disabled, CUDA devices were hidden, and a fresh post-test process reported `torch.cuda.is_initialized() == False` and zero visible CUDA devices.

- `env -u PYTHONPATH PYTHONNOUSERSITE=1 CUDA_VISIBLE_DEVICES=999 /mnt/si0260014qra/default/chengcp/venvs/sglang_pr31589_py310_20260806/bin/python -m pytest -q test/registered/unit/disaggregation/test_nixl_backend_basic.py`: 53 passed, 0 failed, 0 skipped; 13 subtests passed.
- `env -u PYTHONPATH PYTHONNOUSERSITE=1 CUDA_VISIBLE_DEVICES=999 /mnt/si0260014qra/default/chengcp/venvs/sglang_pr31589_py310_20260806/bin/python -m pytest -q test/registered/unit/disaggregation/test_decode_queue_cleanup.py`: 5 passed, 0 failed, 0 skipped.
- `env -u PYTHONPATH PYTHONNOUSERSITE=1 CUDA_VISIBLE_DEVICES=999 /mnt/si0260014qra/default/chengcp/venvs/sglang_pr31589_py310_20260806/bin/python -m pytest -q test/registered/unit/disaggregation/test_nixl_sender_failure_cleanup.py`: 1 passed, 0 failed, 0 skipped.
- The three exact receiver/staging regression selectors passed 3/3 on this patch. A tests-only clean-`main` baseline at `64eeb153dfaa5f6080039ce76bfd2bfe2a7097b1` failed the same 3/3 selectors for the expected reasons: late inactive-room status recreation, late staging chunk-state recreation, and missing staging release during repeated clear. No tests were skipped. The baseline was not rerun at `b6876fc6520179f6507ba1b076c0ffd00b9d6709` because the drift audit found no relevant path or semantic changes.

## Static Checks

- `pre-commit run --files python/sglang/srt/disaggregation/common/conn.py python/sglang/srt/disaggregation/common/staging_handler.py python/sglang/srt/disaggregation/nixl/conn.py test/registered/unit/disaggregation/test_nixl_backend_basic.py`: all applicable hooks passed.
- Ruff (`F401,F821,UP037`): passed.
- Black `--check`: passed; 4 files unchanged.
- isort `--check-only`: passed.
- `python -m py_compile` on all four changed Python files: passed.
- `git diff --check`: passed.

## CI Status

The previous gated workflow did not run its downstream CPU/GPU suites: the `Require run-ci label (optional)` gate step failed because the `run-ci` label was missing, and those downstream jobs were skipped. The separate lint workflow did run and passed. A fresh maintainer-triggered CI run is still needed after this branch update.

## Speed Tests and Profiling

This patch does not modify kernels or the KV data transfer algorithm. The behavior change is limited to room bookkeeping cleanup and filtering notifications for inactive rooms. No performance benchmark was run.

## Validation Limitations

- I did not run a real GPU/NIXL end-to-end test.
- The local environment does not have a NIXL runtime suitable for formal end-to-end integration validation.
- Validation is based on source-level audit, CPU pytest red/green coverage, the cleanup queue regression, and static checks.
- CI or maintainer-run NIXL integration tests are still valuable before merge.

## Checklist

- [x] Format the changed files with the repository pre-commit hooks.
- [x] Add CPU unit tests for receiver cleanup and the current staging lifecycle.
- [x] Run the targeted cleanup tests and static checks listed above.
- [x] Confirm no user-facing documentation update is needed for this internal correctness fix.
- [ ] Run real GPU/NIXL end-to-end validation; not available in the local environment.