### PR TITLE
Fix malformed Harmony output for gpt-oss + reasoning + json_schema (#31019)

### DIFF
--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -35,10 +35,19 @@ class ReasonerGrammarObject(BaseGrammarObject):
     """Wraps a grammar object to handle reasoning (think/generation) phases.
 
     State machine (must call maybe_init_reasoning before use):
-      THINKING (tokens_in_think >= 0, tokens_after_end == -1)
+      THINKING (tokens_in_think >= 0, tokens_in_header == -1, tokens_after_end == -1)
         -> grammar not consulted, optional token filtering
+      HEADER (tokens_in_header >= 0, tokens_after_end == -1); only when
+      content_start_ids is set (Harmony/GPT-OSS)
+        -> grammar not consulted, so the channel header
+           (``<|start|>assistant<|channel|>final<|message|>``) can be emitted
+           freely; entered at think_end_id, left once the accepted tokens end
+           with content_start_ids (issue #31019)
       GENERATION (tokens_after_end >= 0)
         -> grammar consulted for accept/fill/rollback
+
+    Without content_start_ids the HEADER phase is skipped entirely and
+    think_end_id moves straight to GENERATION (<think></think>-style formats).
 
     When enable_token_filter=True (strict mode), fill_vocab_mask filters
     excluded tokens during THINKING and enforces max_think_tokens budget.
@@ -59,6 +68,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
         allocate_vocab_mask_fn=None,
         move_vocab_mask_fn=None,
         apply_vocab_mask_fn=None,
+        content_start_ids: Optional[List[int]] = None,
     ):
         super().__init__()
         self.grammar = grammar
@@ -71,11 +81,16 @@ class ReasonerGrammarObject(BaseGrammarObject):
         self.move_vocab_mask_fn = move_vocab_mask_fn
         self.apply_vocab_mask_fn = apply_vocab_mask_fn
         self._think_end_id_list = [think_end_id]
+        self.content_start_ids = content_start_ids
 
         self.tokens_in_think = -1
+        self.tokens_in_header = -1
         self.tokens_after_end = -1
+        self._header_tokens: List[int] = []
 
     def maybe_init_reasoning(self, reasoning: bool):
+        self.tokens_in_header = -1
+        self._header_tokens = []
         if reasoning:
             self.tokens_in_think = 0
             self.tokens_after_end = -1
@@ -84,7 +99,14 @@ class ReasonerGrammarObject(BaseGrammarObject):
             self.tokens_after_end = 0
 
     def _is_thinking(self):
-        return self.tokens_in_think >= 0 and self.tokens_after_end == -1
+        return (
+            self.tokens_in_think >= 0
+            and self.tokens_in_header == -1
+            and self.tokens_after_end == -1
+        )
+
+    def _is_header(self):
+        return self.tokens_in_header >= 0 and self.tokens_after_end == -1
 
     def _is_generation(self):
         return self.tokens_after_end >= 0
@@ -92,21 +114,43 @@ class ReasonerGrammarObject(BaseGrammarObject):
     def transfer_state(self, token: int) -> None:
         if self._is_thinking():
             if token == self.think_end_id:
-                self.tokens_after_end = 0
+                if self.content_start_ids is None:
+                    self.tokens_after_end = 0
+                else:
+                    self.tokens_in_header = 0
+                    self._header_tokens = []
             else:
                 self.tokens_in_think += 1
+        elif self._is_header():
+            self._header_tokens.append(token)
+            self.tokens_in_header += 1
+            if (
+                self._header_tokens[-len(self.content_start_ids) :]
+                == self.content_start_ids
+            ):
+                self.tokens_after_end = 0
         elif self._is_generation():
             self.tokens_after_end += 1
 
     def rollback_state(self):
-        if self._is_thinking():
-            if self.tokens_in_think > 0:
-                self.tokens_in_think -= 1
-        elif self._is_generation():
+        if self._is_generation():
             if self.tokens_after_end == 0:
                 self.tokens_after_end = -1
+                if self.tokens_in_header >= 0 and self._header_tokens:
+                    self._header_tokens.pop()
+                    self.tokens_in_header -= 1
             elif self.tokens_after_end > 0:
                 self.tokens_after_end -= 1
+        elif self._is_header():
+            if self.tokens_in_header == 0:
+                self.tokens_in_header = -1
+                self._header_tokens = []
+            elif self.tokens_in_header > 0:
+                self.tokens_in_header -= 1
+                self._header_tokens.pop()
+        elif self._is_thinking():
+            if self.tokens_in_think > 0:
+                self.tokens_in_think -= 1
 
     def accept_token(self, token: int):
         # Track the last accepted token on the wrapper itself (mirroring
@@ -154,6 +198,8 @@ class ReasonerGrammarObject(BaseGrammarObject):
                     vocab_mask, self._think_end_id_list, idx, is_allowed=True
                 )
             return
+        if self._is_header():
+            return
         if self._is_generation() and self.grammar is not None:
             self.grammar.fill_vocab_mask(vocab_mask, idx)
 
@@ -188,9 +234,12 @@ class ReasonerGrammarObject(BaseGrammarObject):
             self.allocate_vocab_mask_fn,
             self.move_vocab_mask_fn,
             self.apply_vocab_mask_fn,
+            self.content_start_ids,
         )
         new_obj.tokens_in_think = self.tokens_in_think
+        new_obj.tokens_in_header = self.tokens_in_header
         new_obj.tokens_after_end = self.tokens_after_end
+        new_obj._header_tokens = list(self._header_tokens)
         new_obj._finished = self._finished
         return new_obj
 
@@ -248,6 +297,9 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
                 "must encode to exactly one token for constrained reasoning."
             )
         self.think_end_id = think_end_ids[0]
+        self.content_start_ids = self._get_content_start_ids(
+            reasoning_parser, tokenizer
+        )
         self._enable_strict_thinking = enable_strict_thinking
         self.think_excluded_token_ids = self._get_think_excluded_token_ids(
             reasoning_parser, tokenizer
@@ -293,6 +345,24 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
             excluded_ids += new_ids
         return excluded_ids
 
+    def _get_content_start_ids(
+        self,
+        reasoning_parser: ReasoningParser,
+        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+    ) -> Optional[List[int]]:
+        content_start_token = reasoning_parser.detector.structured_content_start_token
+        if not content_start_token:
+            return None
+        content_start_ids = tokenizer.encode(
+            content_start_token, add_special_tokens=False
+        )
+        if not content_start_ids:
+            raise ValueError(
+                f"structured_content_start_token '{content_start_token}' could "
+                f"not be encoded by the tokenizer."
+            )
+        return content_start_ids
+
     def _make_grammar_object(
         self, grammar: Optional[BaseGrammarObject], reasoning: bool
     ) -> ReasonerGrammarObject:
@@ -306,6 +376,7 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
             allocate_vocab_mask_fn=self.grammar_backend.allocate_vocab_mask,
             move_vocab_mask_fn=self.grammar_backend.move_vocab_mask,
             apply_vocab_mask_fn=self.grammar_backend.apply_vocab_mask,
+            content_start_ids=self.content_start_ids,
         )
         obj.maybe_init_reasoning(reasoning)
         return obj

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -48,6 +48,7 @@ class BaseReasoningFormatDetector:
         self._buffer = ""
         self.stripped_think_start = False
         self.think_start_self_label = ""
+        self.structured_content_start_token = None
 
         self._force_nonempty_content = force_nonempty_content
         self._accumulated_reasoning = ""
@@ -451,6 +452,9 @@ class GptOssDetector(BaseReasoningFormatDetector):
             previous_content=previous_content,
             force_nonempty_content=force_nonempty_content,
         )
+        # Defer grammar enforcement until that final-channel header completes,
+        # so the header is not masked away.
+        self.structured_content_start_token = "<|channel|>final<|message|>"
         self.parser = HarmonyParser()
 
     def detect_and_parse(self, text: str) -> StreamingParseResult:

--- a/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+++ b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
@@ -128,11 +128,12 @@ class TestReasonerGrammarBackend(unittest.TestCase):
         else:
             os.environ["SGLANG_MAX_THINK_TOKENS"] = self._prev_budget
 
-    def _make_parser(self):
+    def _make_parser(self, structured_content_start_token=None):
         detector = SimpleNamespace(
             think_start_token="<think>",
             think_end_token="</think>",
             think_excluded_tokens=["<tool_call>", "</tool_call>"],
+            structured_content_start_token=structured_content_start_token,
         )
         return SimpleNamespace(detector=detector)
 
@@ -509,6 +510,182 @@ class TestReasonerGrammarObjectCurrentToken(unittest.TestCase):
 
         # Guard must have fired -> no second accept of 4913 into the inner grammar.
         inner_grammar.accept_token.assert_not_called()
+
+
+# Harmony (GPT-OSS) token ids, per the openai/gpt-oss-20b tokenizer.
+_H_END = 200007  # <|end|>
+_H_MESSAGE = 200008  # <|message|>
+_H_CHANNEL = 200005  # <|channel|>
+_H_START = 200006  # <|start|>
+_H_ASSISTANT = 173781  # assistant
+_H_FINAL = 17196  # final
+_H_ANALYSIS = 35644  # analysis
+_H_COMMENTARY = [12606, 815]  # commentary -> "comment", "ary"
+# "<|channel|>final<|message|>"
+_H_CONTENT_START = [_H_CHANNEL, _H_FINAL, _H_MESSAGE]
+
+
+class TestReasonerGrammarObjectHarmonyHeader(unittest.TestCase):
+    """HEADER phase for Harmony/GPT-OSS (issue #31019).
+
+    ``<|end|>`` only closes the analysis channel; the answer is still preceded by
+    ``<|start|>assistant<|channel|>final<|message|>``. Enforcing the grammar at
+    ``<|end|>`` masks that header away and emits malformed Harmony, so
+    enforcement must wait for the content-start sequence.
+    """
+
+    def _make_object(self, content_start_ids=_H_CONTENT_START):
+        inner_grammar = MagicMock()
+        inner_grammar.is_terminated.return_value = False
+        obj = ReasonerGrammarObject(
+            grammar=inner_grammar,
+            think_end_id=_H_END,
+            content_start_ids=content_start_ids,
+        )
+        obj.maybe_init_reasoning(True)
+        return obj, inner_grammar
+
+    def _accept_analysis(self, obj):
+        # <|channel|>analysis<|message|> ... <|end|>
+        for token in (_H_CHANNEL, _H_ANALYSIS, _H_MESSAGE, 111, 222, _H_END):
+            obj.accept_token(token)
+
+    def test_analysis_message_token_does_not_start_enforcement(self):
+        obj, inner_grammar = self._make_object()
+        # The analysis header contains <|message|> too; it must not be mistaken
+        # for the start of the answer.
+        for token in (_H_CHANNEL, _H_ANALYSIS, _H_MESSAGE, 111):
+            obj.accept_token(token)
+
+        self.assertTrue(obj._is_thinking())
+        inner_grammar.accept_token.assert_not_called()
+
+    def test_header_is_not_masked_and_answer_is_enforced(self):
+        obj, inner_grammar = self._make_object()
+        self._accept_analysis(obj)
+
+        # <|end|> only enters HEADER: the grammar must stay off so the model can
+        # emit the final channel header.
+        self.assertTrue(obj._is_header())
+
+        for token in (_H_START, _H_ASSISTANT, _H_CHANNEL, _H_FINAL):
+            obj.accept_token(token)
+        self.assertTrue(obj._is_header())
+        inner_grammar.accept_token.assert_not_called()
+
+        # The content-start sequence completes -> GENERATION.
+        obj.accept_token(_H_MESSAGE)
+        self.assertTrue(obj._is_generation())
+        # The header itself is never fed to the grammar.
+        inner_grammar.accept_token.assert_not_called()
+
+        # Only the answer body reaches the grammar.
+        obj.accept_token(4913)
+        inner_grammar.accept_token.assert_called_once_with(4913)
+
+    def test_header_phase_does_not_mask_vocab(self):
+        obj, inner_grammar = self._make_object()
+        self._accept_analysis(obj)
+        self.assertTrue(obj._is_header())
+
+        obj.fill_vocab_mask(torch.zeros((1, 8), dtype=torch.int32), 0)
+        inner_grammar.fill_vocab_mask.assert_not_called()
+
+    def test_commentary_channel_does_not_start_enforcement(self):
+        obj, inner_grammar = self._make_object()
+        self._accept_analysis(obj)
+
+        # A commentary/tool header must not be mistaken for the final channel.
+        for token in (
+            [_H_START, _H_ASSISTANT, _H_CHANNEL]
+            + _H_COMMENTARY
+            + [
+                _H_MESSAGE,
+                55,
+            ]
+        ):
+            obj.accept_token(token)
+
+        self.assertTrue(obj._is_header())
+        inner_grammar.accept_token.assert_not_called()
+
+        # A subsequent final channel still starts enforcement.
+        for token in (_H_START, _H_ASSISTANT, _H_CHANNEL, _H_FINAL, _H_MESSAGE):
+            obj.accept_token(token)
+        self.assertTrue(obj._is_generation())
+
+    def test_rollback_at_header_generation_boundary_returns_to_header(self):
+        obj, inner_grammar = self._make_object()
+        self._accept_analysis(obj)
+        for token in (_H_START, _H_ASSISTANT, _H_CHANNEL, _H_FINAL, _H_MESSAGE):
+            obj.accept_token(token)
+        self.assertTrue(obj._is_generation())
+
+        obj.rollback(1)
+        self.assertTrue(obj._is_header())
+        # No generation tokens were accepted, so the inner grammar is untouched.
+        inner_grammar.rollback.assert_not_called()
+
+        # Re-accepting the content-start token must match again.
+        obj.accept_token(_H_MESSAGE)
+        self.assertTrue(obj._is_generation())
+
+    def test_without_content_start_ids_think_end_goes_straight_to_generation(self):
+        obj, inner_grammar = self._make_object(content_start_ids=None)
+        obj.accept_token(111)
+        obj.accept_token(_H_END)
+
+        self.assertTrue(obj._is_generation())
+        obj.accept_token(4913)
+        inner_grammar.accept_token.assert_called_once_with(4913)
+
+
+class TestReasonerGrammarBackendContentStart(unittest.TestCase):
+    def _make_tokenizer(self):
+        return _DummyTokenizer(
+            {
+                "<|channel|>analysis<|message|>": [
+                    _H_CHANNEL,
+                    _H_ANALYSIS,
+                    _H_MESSAGE,
+                ],
+                "<|end|>": [_H_END],
+                "<|channel|>final<|message|>": _H_CONTENT_START,
+            }
+        )
+
+    def _make_harmony_parser(self):
+        detector = SimpleNamespace(
+            think_start_token="<|channel|>analysis<|message|>",
+            think_end_token="<|end|>",
+            think_excluded_tokens=None,
+            structured_content_start_token="<|channel|>final<|message|>",
+        )
+        return SimpleNamespace(detector=detector)
+
+    def test_content_start_ids_taken_from_detector(self):
+        reasoner = ReasonerGrammarBackend(
+            _DummyGrammarBackend(support_token_filter=True),
+            self._make_harmony_parser(),
+            self._make_tokenizer(),
+        )
+        self.assertEqual(reasoner.think_end_id, _H_END)
+        self.assertEqual(reasoner.content_start_ids, _H_CONTENT_START)
+
+    def test_content_start_ids_none_when_detector_declares_no_token(self):
+        detector = SimpleNamespace(
+            think_start_token="<think>",
+            think_end_token="</think>",
+            think_excluded_tokens=None,
+            structured_content_start_token=None,
+        )
+        tokenizer = _DummyTokenizer({"<think>": [1], "</think>": [2]})
+        reasoner = ReasonerGrammarBackend(
+            _DummyGrammarBackend(support_token_filter=True),
+            SimpleNamespace(detector=detector),
+            tokenizer,
+        )
+        self.assertIsNone(reasoner.content_start_ids)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation
Fixes #31019. When gpt-oss is served with `--reasoning-parser` gpt-oss and a client sends a response_format: json_schema request, the raw Harmony output drops the `<|start|>assistant<|channel|>final<|message|>` header between the reasoning block and the JSON. Downstream Harmony parsers then no longer separate `reasoning_content` from the final answer.

- Expected: <|channel|>analysis<|message|>…<|end|><|start|>assistant<|channel|>final<|message|>{…}
- Actual:   <|channel|>analysis<|message|>…<|end|>{…}

### Root cause
`ReasonerGrammarObject` is a two-state machine (THINKING → GENERATION) that starts JSON enforcement the moment the `think-end` token is accepted. For gpt-oss, the think-end token is `<|end|>`, but the final-channel header comes after `<|end|>` and before the JSON. The grammar gate flips on one step too early, so the header tokens get masked away. The boundary the code treats as "reasoning ends → JSON begins" is really "reasoning ends → header → JSON begins"; the middle phase was unaccounted for.


## Modifications
Add a mask-free HEADER phase between "reasoning done" and "JSON starts":
- Before: THINKING -- (see <|end|>) → GENERATION[mask JSON]
- After:  THINKING  -- (see <|end|>) → HEADER[no mask] -- (see <|channel|>final<|message|>) → GENERATION[mask JSON]

## Accuracy Tests
- Reproduced the bug and verified the fix on H100 (gpt-oss-20b): the `<|start|>assistant<|channel|>final<|message|>` header is restored, and JSON enforcement is confirmed still active (unconstrained → 1123 chars of prose; constrained → exactly the schema object). 
- New unit tests cover the HEADER phase, the commentary/tool-channel non-trigger, rollback across the boundary, and the legacy (no content-start) path.

## Speed Tests and Profiling
N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29601327157](https://github.com/sgl-project/sglang/actions/runs/29601327157)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29601326968](https://github.com/sgl-project/sglang/actions/runs/29601326968)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->