### PR TITLE
[AMD][quantization] Add SGLANG_MLA_ABSORB_BF16 to keep MLA-absorb weights in BF16

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -65,6 +65,7 @@ if _use_aiter_gfx95:
     from sglang.srt.layers.quantization.quark.utils import quark_post_load_weights
 
 logger = logging.getLogger(__name__)
+_MLA_ABSORB_BF16_LOGGED = []  # one-shot guard for the MLA-absorb BF16 log line
 
 # Optional quantization for DeepSeek nvfp4 checkpoint
 NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]
@@ -630,12 +631,25 @@ class DeepseekV2WeightLoaderMixin:
             ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
 
             if (
+                get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
+                and _use_aiter_gfx95
+                and self.quant_config is not None
+                and self.quant_config.get_name() == "quark"
+                and not _MLA_ABSORB_BF16_LOGGED
+            ):
+                _MLA_ABSORB_BF16_LOGGED.append(1)
+                log_info_on_rank0(
+                    logger,
+                    "SGLANG_MLA_ABSORB_BF16=1: keeping kv_b_proj MLA-absorb weights in BF16 (skipping quark mxfp4 re-quant)",
+                )
+            if (
                 _use_aiter_gfx95
                 and self.quant_config is not None
                 and self.quant_config.get_name() == "quark"
                 and self.config.architectures
                 and self.config.architectures[0]
                 == "DeepseekV3ForCausalLM"  # Avoid processing other models like GlmMoeDsaForCausalLM
+                and not get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
             ):
                 w_kc, self_attn.w_scale_k, w_vc, self_attn.w_scale_v = (
                     quark_post_load_weights(self_attn, w, "mxfp4")


### PR DESCRIPTION
## Motivation

**This PR adds BF16 as a new, opt-in precision for the DeepSeek MLA-absorb
weights on the gfx95/AITER path — where today they are unconditionally forced
to mxfp4.**

Today, on gfx95 (AITER) with **quark**-quantized DeepSeek checkpoints, the
`kv_b_proj` MLA-absorb weights (`w_kc` / `w_vc`, used in the absorbed attention
bmm) are **always** re-quantized to **mxfp4** via
[`quark_post_load_weights(..., "mxfp4")`][forced-call] — even when the source
tensor is BF16, it is dynamically pushed down to 4 bits
([`b_dynamic_mxfp4_quant`][quark-fn]). There is currently no way to keep this
particular weight in higher precision on this path.

**This is an outlier compared to every other backend / checkpoint path, which
all keep the MLA-absorb weights in BF16 (or accurate blockwise FP8) — never
forced 4-bit:**

- **CUDA / MUSA / XPU, FP8 blockwise** → [`block_quant_dequant(..., torch.bfloat16)`][cuda-bf16],
  i.e. absorb kept in **BF16** (or accurate blockwise FP8 when
  [`SGL_USE_DEEPGEMM_BMM`][deepgemm-sel] selects the deep_gemm bmm path).
- **int8 checkpoints** → [dequantized to **BF16**][int8-bf16] for the bmm.
- **MUSA FP8** → absorb [explicitly upcast back to **BF16**][musa-bf16].
- **NVIDIA nvfp4 checkpoints** → attention low-precision quant is applied only to
  `q_b_proj` ([`NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]`][nvfp4-def],
  [used here][nvfp4-use]); `kv_b_proj` (the MLA-absorb source) is **deliberately
  excluded**, i.e. even the NVIDIA 4-bit path does not push the absorb weights to
  4-bit.

So the gfx95/quark path is the only one that forces MLA-absorb to 4-bit, and it
provides no override. This PR closes that gap by making BF16 selectable, in the
same spirit as the existing [`SGL_USE_DEEPGEMM_BMM`][deepgemm-sel] selector that
already lets the CUDA path choose the absorb-bmm precision.

<!-- permalinks pinned to the PR merge-base (upstream/main @ 67361ff91b) -->
[forced-call]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py#L632-L642
[quark-fn]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/layers/quantization/quark/utils.py#L177-L214
[cuda-bf16]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py#L586-L591
[deepgemm-sel]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py#L579-L585
[int8-bf16]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py#L611-L627
[musa-bf16]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py#L661-L668
[nvfp4-def]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py#L70
[nvfp4-use]: https://github.com/sgl-project/sglang/blob/67361ff91b5ffdc1a1c3955637b4c568a8446aa2/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py#L165

### Why it matters

The mxfp4 absorb loss is negligible on easy/saturated benchmarks, but it becomes
decisive right at a tight accuracy target. On the **MLPerf Inference
DeepSeek-R1** accuracy gate (99% of reference = **80.5446%**), keeping the
MLA-absorb weights in **BF16** recovers the margin needed to pass:

| MLA-absorb dtype | MLPerf accuracy (5-run mean) | Gate 80.5446% |
| --- | --- | --- |
| mxfp4 (default) | **80.2%**| ✗ below |
| BF16 (this PR)  | **80.66%** | ✓ above |

The new env var, `SGLANG_MLA_ABSORB_BF16`, skips the mxfp4 re-quant and keeps
`w_kc` / `w_vc` in BF16. **Default behavior is unchanged** (flag unset → mxfp4
as before). A one-shot rank-0 log line reports when the BF16 path is taken.

## Modifications

- `python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`:
  when `SGLANG_MLA_ABSORB_BF16` is set (and the checkpoint is quark on
  gfx95/AITER `DeepseekV3ForCausalLM`), skip `quark_post_load_weights(..., "mxfp4")`
  for the MLA-absorb weights so `w_kc` / `w_vc` stay BF16. One-shot
  `log_info_on_rank0` when the path is taken. No change when the flag is unset.


## Open question for reviewers

Currently gated by an env var (`SGLANG_MLA_ABSORB_BF16`). Would reviewers
prefer a proper server arg selecting the MLA-absorb dtype, e.g.
`--mla-absorb-dtype {mxfp4,bf16}`? Happy to convert.












<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29601563196](https://github.com/sgl-project/sglang/actions/runs/29601563196)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29601563052](https://github.com/sgl-project/sglang/actions/runs/29601563052)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->