### PR TITLE
Fix the perf regression of zeroing of TensorRT-LLM MLA (and sparse) workspace

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -52,6 +52,10 @@ from sglang.srt.layers.attention.dsa.utils import (
     pad_dsa_cache_seqlens,
     should_use_dsa_fused_topk,
 )
+from sglang.srt.layers.attention.trtllm_mla_backend import (
+    grow_multi_ctas_kv_counter_buffer_if_needed,
+    make_persistent_multi_ctas_kv_counter_buffer,
+)
 from sglang.srt.layers.utils.cp_utils import (
     cp_all_gather_rerange_output,
     cp_split_and_rebuild_position,
@@ -458,8 +462,16 @@ class DeepseekSparseAttnBackend(
                     device=model_runner.device,
                 ),
             )
+            self._multi_ctas_kv_counter_buffer = (
+                make_persistent_multi_ctas_kv_counter_buffer(
+                    torch.device(self.device),
+                    self.num_q_heads,
+                    max_batch_size=model_runner.max_running_requests,
+                )
+            )
         else:
             self.workspace_buffer = None
+            self._multi_ctas_kv_counter_buffer = None
 
     def _make_aiter_dsa_decode_metadata_buffer(
         self,
@@ -2719,6 +2731,15 @@ class DeepseekSparseAttnBackend(
         batch_size = page_table_1.shape[0]
         _, num_heads, head_dim = q_all.shape
 
+        self._multi_ctas_kv_counter_buffer = (
+            grow_multi_ctas_kv_counter_buffer_if_needed(
+                self._multi_ctas_kv_counter_buffer,
+                torch.device(self.device),
+                self.num_q_heads,
+                batch_size,
+            )
+        )
+
         q = q_all.view(batch_size, 1, num_heads, head_dim)
         kv = kv_cache.view(-1, 1, self.real_page_size, self.kv_cache_dim)
         block_tables = page_table_1.unsqueeze(1)
@@ -2747,6 +2768,7 @@ class DeepseekSparseAttnBackend(
             bmm1_scale=bmm1_scale,
             backend="trtllm-gen",
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+            multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
         )
 
         return out

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -61,6 +61,35 @@ DEFAULT_WORKSPACE_SIZE_MB = 150  # Memory workspace size in MB
 # compute the LCM with other padding constraints.
 TRTLLM_BLOCK_CONSTRAINT = 128
 
+TRTLLM_MLA_MAX_BATCH_SIZE = 8192
+
+
+def _multi_ctas_kv_counter_bytes(
+    device: torch.device, num_q_heads: int, batch_size: int
+) -> int:
+    sm_count = flashinfer.utils.get_device_sm_count(device)
+    return flashinfer.utils.get_trtllm_gen_multi_ctas_kv_counter_bytes(
+        batch_size, num_q_heads, sm_count
+    )
+
+
+def make_persistent_multi_ctas_kv_counter_buffer(
+    device: torch.device, num_q_heads: int, max_batch_size: int
+) -> torch.Tensor:
+    num_bytes = _multi_ctas_kv_counter_bytes(
+        device, num_q_heads, max(TRTLLM_MLA_MAX_BATCH_SIZE, max_batch_size)
+    )
+    return torch.zeros(num_bytes, dtype=torch.uint8, device=device)
+
+
+def grow_multi_ctas_kv_counter_buffer_if_needed(
+    buffer: torch.Tensor, device: torch.device, num_q_heads: int, batch_size: int
+) -> torch.Tensor:
+    required_bytes = _multi_ctas_kv_counter_bytes(device, num_q_heads, batch_size)
+    if buffer.numel() >= required_bytes:
+        return buffer
+    return torch.zeros(required_bytes, dtype=torch.uint8, device=device)
+
 
 def _quantize_fp8_qkv(q, k, v, layer):
     q = q.to(torch.float8_e4m3fn)
@@ -188,6 +217,14 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     device=model_runner.device,
                 ),
             )
+
+        self._multi_ctas_kv_counter_buffer = (
+            make_persistent_multi_ctas_kv_counter_buffer(
+                torch.device(self.device),
+                self.num_q_heads,
+                max_batch_size=model_runner.max_running_requests,
+            )
+        )
 
         # CUDA graph state
         self.decode_cuda_graph_metadata = {}
@@ -637,6 +674,10 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             seq_lens if seq_lens.dtype == torch.int32 else seq_lens.to(torch.int32)
         )
         extra_kwargs = {"backend": self.backend} if self.backend != "trtllm-gen" else {}
+        if self.backend == "trtllm-gen":
+            extra_kwargs["multi_ctas_kv_counter_buffer"] = (
+                self._multi_ctas_kv_counter_buffer
+            )
         return flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
             query=query,
             kv_cache=kv_cache,

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -174,9 +174,10 @@ def flashinfer_autotune_context(model_runner: ModelRunner, *, skip_logits: bool)
             maybe_skip_logits = autotune_dummy_run_mode()
         with torch.inference_mode(), autotune(
             # Autotuning mxfp8_gemm hits an IMA; skip it.
+            # Add trtllm MLA to skip autotune to fix a temporary bug.
             True,
             cache=str(autotune_cache),
-            skip_ops={"mxfp8_gemm"},
+            skip_ops={"mxfp8_gemm", "trtllm_batch_decode_mla"},
         ), maybe_skip_logits:
             yield
     torch.cuda.current_stream().wait_stream(mr.forward_stream)

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -174,10 +174,9 @@ def flashinfer_autotune_context(model_runner: ModelRunner, *, skip_logits: bool)
             maybe_skip_logits = autotune_dummy_run_mode()
         with torch.inference_mode(), autotune(
             # Autotuning mxfp8_gemm hits an IMA; skip it.
-            # Add trtllm MLA to skip autotune to fix a temporary bug.
             True,
             cache=str(autotune_cache),
-            skip_ops={"mxfp8_gemm", "trtllm_batch_decode_mla"},
+            skip_ops={"mxfp8_gemm"},
         ), maybe_skip_logits:
             yield
     torch.cuda.current_stream().wait_stream(mr.forward_stream)

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
@@ -354,6 +354,7 @@ class DSAMockModelRunner(ModelRunner):
             triton_attention_split_tile_size=None,
         )
         self.server_args = self._server_args_override.install()
+        self.max_running_requests = pool_batch_size
         self.req_to_token_pool = ReqToTokenPool(
             size=pool_batch_size,
             max_context_len=max_context_len,

--- a/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
@@ -282,6 +282,7 @@ class MockMLAModelRunner(ModelRunner):
             triton_attention_split_tile_size=None,
         )
         self.server_args = self._server_args_override.install()
+        self.max_running_requests = pool_batch_size
         self.req_to_token_pool = ReqToTokenPool(
             size=pool_batch_size,
             max_context_len=max_context_len,


### PR DESCRIPTION
flashinfer's trtllm_batch_decode_with_kv_cache_mla instantiates a fresh runner per call (even in cuda graph).  Instead use the buffer by multi_ctas_kv_counter_buffer= instead.

For prefill, it will reshape to `(num_tokens, 1, num_heads, head_dim)`. So we also need to grow the workspace, in case some users set chunk prefill larger than 8k. It just grows the buffer once.

note: trtllm ragged prefill deepseek doesn't have this bug. It's recently introduced in https://github.com/sgl-project/sglang/pull/31502 after https://github.com/flashinfer-ai/flashinfer/pull/3949

Main:
<img width="1706" height="892" alt="Screenshot 2026-07-17 at 12 24 02 PM" src="https://github.com/user-attachments/assets/1b4e8ccc-de72-4959-a070-19aeff6c2a93" />

This branch:
<img width="1720" height="804" alt="Screenshot 2026-07-17 at 12 24 21 PM" src="https://github.com/user-attachments/assets/b32ca01c-ab09-4434-99b4-ae8b7593eec8" />











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29622595001](https://github.com/sgl-project/sglang/actions/runs/29622595001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29622594907](https://github.com/sgl-project/sglang/actions/runs/29622594907)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->