### PR TITLE
[LoRA] Guard TMA down path for LoRA hooks

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -473,6 +473,12 @@ def _fused_moe_kernel_sequence(
     topk = topk_ids.shape[1]
     compute_type = tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16
 
+    # LoRA hooks consume and update route-major intermediate buffers. The TMA
+    # down path keeps those buffers in expert-sorted, block-padded order, which
+    # is incompatible with the hook contract.
+    if hooks and (hooks.after_gate_up is not None or hooks.after_down is not None):
+        down_moe_use_tma = False
+
     padded_tokens = (
         min(num_tokens * topk, E + 1) * (config["BLOCK_SIZE_M"] - 1)
         if down_moe_use_tma


### PR DESCRIPTION
## Summary

- Disable the Triton MoE down-projection TMA path when LoRA `after_gate_up` or `after_down` hooks are installed.
- Preserve the TMA fast path for all unhooked MoE invocations. On GPUs without `USE_TMA` tuned configs the flag is already false, so this guard is a no-op there.
- Keep full decode CUDA graph enabled.

This is not a new restriction: hooked MoE invocations never ran on the TMA layout until a refactor accidentally made that combination reachable. The guard reinstates the original invariant at the point where the code paths were merged.

## How the bug was introduced

1. #10567 (2025-10-28) added the down-projection TMA path (`c_sorted` stores, `USE_TMA` tuned configs) — only inside the legacy `fused_experts_impl`, reachable through the fused-func fast path. LoRA never took that path: `MoeRunner.run` gated it with `if self.fused_func is not None and not self.lora_enabled`.
2. #21858 (2026-04-11) introduced the LoRA MoE hooks in `TritonRunnerCore.run`, a route-major implementation containing no TMA code at all. At this point "hooks never see expert-sorted layout" held structurally, so no explicit guard was written.
3. #23019 (2026-04-17) de-duplicated both implementations into the shared `_fused_moe_kernel_sequence`. The unified function passes `c_sorted=down_moe_use_tma` to the gate/up kernel and then fires the hooks on `intermediate_cache1[: num_tokens * topk].view(num_tokens, topk, N)`. This is the regression point: with `c_sorted=True`, rows are stored at their `moe_align_block_size` positions — expert-sorted, with per-expert block padding interleaved — while the hook contract is route-major `(num_tokens, topk, N)`. The in-code comment assumed TMA padding was a tail that the slice removes; it is interleaved, so the slice-and-view silently relabels physical rows. Hooks read and update the wrong token/route rows (including uninitialized padding rows), corrupting both the LoRA deltas and the base activations consumed by the down GEMM.

The corruption triggers when all of the following hold: the tuned down config for the shape has `USE_TMA: true` (today: H200 / H20 / H20-3e fp8 block-quant MoE shapes), Triton supports tensor descriptors, and MoE LoRA hooks are installed. Under CUDA graph the hooks are always captured on a LoRA-enabled server, so captured decode graphs corrupt even for requests without an active adapter. This is the concurrent multi-LoRA `!!!` corruption of #29157.

## Why disable TMA rather than adapt the layout

TMA was never enabled for hooked invocations before #23019, so this guard restores the historical behavior rather than removing an optimization LoRA ever benefited from. A layout-preserving alternative (keep hook-facing intermediates route-major and gather into expert-sorted order only at the down-GEMM boundary) was prototyped and benchmarked against this guard on 8x H200, GLM-5.1 FP8, five adapters, full decode CUDA graph: decode -0.09%, prefill +2.26% — both within run-to-run noise. The TMA gain on hooked calls does not justify the additional layout-transition complexity, so the six-line guard is proposed as the fix, not a stopgap.

## Validation

- `pre-commit run --all-files` passed on the final head after rebasing onto `main@ae3f62613a`.
- End-to-end validation used `main@fec6131844` plus this exact six-line guard patch on 8x H200, GLM-5.1 FP8, Triton MoE, CSGMV LoRA, five adapters, and full decode CUDA graph:
  - Correct `<base>:<adapter>` routing: pristine produced 39/48 exact all-`!` responses; this guard produced 0/48.
  - Bare/inactive routing: pristine produced 28/48 responses with a bang run of at least eight; this guard produced 0/48.
  - Served-base-name control: pristine produced 27/48 responses with a bang run of at least eight; this guard produced 0/48.
  - All three guard-side sweeps completed 48/48 HTTP requests successfully.
- A second, independently scripted rerun on the same hardware reproduced the A/B: pristine 45/48 exact all-`!` (count varies with concurrent batch composition); guard 0/48, plus 0 corruption on separate minimal-trigger bursts (4x same adapter, 3x same adapter, 8x mixed) that reliably garble on pristine.

The bare-name and served-base controls did not load adapter weights; they verify that the captured LoRA-capable graph is also protected when replayed without an active adapter. The guard patch content is unchanged by the rebase.

Fixes the MoE-side corruption in #29157.
<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29772639084](https://github.com/sgl-project/sglang/actions/runs/29772639084)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29772638262](https://github.com/sgl-project/sglang/actions/runs/29772638262)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
