### PR TITLE
[DeepSeek] Eliminate per-step elementwise kernels on the BF16 MLA-absorb path (follow-up to #31604)

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -496,6 +496,14 @@ class DeepseekMLAForwardMixin:
                             dtype=torch.bfloat16,
                         )
 
+                    elif self.w_scale is None:
+                        # BF16 MLA-absorb: the constant scale was folded into
+                        # w_kc at load time, so the per-step dequant
+                        # (w_kc.to(bf16) * w_scale) is skipped entirely.
+                        q_nope_out = torch.bmm(
+                            q_nope.to(torch.bfloat16).transpose(0, 1),
+                            self.w_kc,
+                        )
                     else:
                         q_nope_out = torch.bmm(
                             q_nope.to(torch.bfloat16).transpose(0, 1),
@@ -869,6 +877,25 @@ class DeepseekMLAForwardMixin:
                         transpose_bm_in=True,
                         dtype=torch.bfloat16,
                     )
+                elif self.w_scale is None:
+                    # BF16 MLA-absorb: the constant scale was folded into w_vc
+                    # at load time, so the per-step dequant
+                    # (w_vc.to(bf16) * w_scale) is skipped entirely. Write the
+                    # BMM straight into a (batch, heads, vdim) buffer through a
+                    # transposed view so the downstream transpose+flatten is a
+                    # free view instead of a copy (mirrors the uint8/fp8 absorb
+                    # paths above).
+                    x = attn_output.to(torch.bfloat16).transpose(0, 1)
+                    B_heads, M_batch = x.shape[0], x.shape[1]
+                    N_vdim = self.w_vc.shape[2]
+                    _bmm_buf = torch.empty(
+                        M_batch,
+                        B_heads,
+                        N_vdim,
+                        device=x.device,
+                        dtype=torch.bfloat16,
+                    )
+                    torch.bmm(x, self.w_vc, out=_bmm_buf.transpose(0, 1))
                 else:
                     attn_bmm_output = torch.bmm(
                         attn_output.to(torch.bfloat16).transpose(0, 1),

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -65,6 +65,7 @@ if _use_aiter_gfx95:
     from sglang.srt.layers.quantization.quark.utils import quark_post_load_weights
 
 logger = logging.getLogger(__name__)
+_MLA_ABSORB_BF16_LOGGED = []  # one-shot guard for the MLA-absorb BF16 log line
 
 # Optional quantization for DeepSeek nvfp4 checkpoint
 NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]
@@ -630,12 +631,25 @@ class DeepseekV2WeightLoaderMixin:
             ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
 
             if (
+                get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
+                and _use_aiter_gfx95
+                and self.quant_config is not None
+                and self.quant_config.get_name() == "quark"
+                and not _MLA_ABSORB_BF16_LOGGED
+            ):
+                _MLA_ABSORB_BF16_LOGGED.append(1)
+                log_info_on_rank0(
+                    logger,
+                    "SGLANG_MLA_ABSORB_BF16=1: keeping kv_b_proj MLA-absorb weights in BF16 (skipping quark mxfp4 re-quant)",
+                )
+            if (
                 _use_aiter_gfx95
                 and self.quant_config is not None
                 and self.quant_config.get_name() == "quark"
                 and self.config.architectures
                 and self.config.architectures[0]
                 == "DeepseekV3ForCausalLM"  # Avoid processing other models like GlmMoeDsaForCausalLM
+                and not get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
             ):
                 w_kc, self_attn.w_scale_k, w_vc, self_attn.w_scale_v = (
                     quark_post_load_weights(self_attn, w, "mxfp4")

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -680,6 +680,34 @@ class DeepseekV2WeightLoaderMixin:
                     self_attn.w_vc = (
                         self_attn.w_vc.to(torch.bfloat16) * self_attn.w_scale
                     )
+                elif (
+                    get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
+                    and _use_aiter_gfx95
+                    and self.quant_config is not None
+                    and self.quant_config.get_name() == "quark"
+                    and self_attn.w_kc is not None
+                    and self_attn.w_kc.dtype == torch.bfloat16
+                    and self_attn.w_vc is not None
+                    and self_attn.w_vc.dtype == torch.bfloat16
+                    and self_attn.w_scale is not None
+                ):
+                    # BF16 MLA-absorb: w_kc, w_vc and w_scale are all constant,
+                    # yet the plain-BMM absorb path in forward would otherwise
+                    # recompute `w.to(bfloat16) * w_scale` on every decode step
+                    # (an extra elementwise-multiply kernel per absorb BMM, per
+                    # layer, per step). Fold the scale into the BF16 weights once
+                    # here and drop w_scale so the forward path consumes the
+                    # weights directly. Numerically identical (same constant
+                    # fold); does not affect the FP8/MXFP4/deep_gemm absorb
+                    # paths, which keep quantized weights and fuse dequant
+                    # in-kernel.
+                    self_attn.w_kc = (
+                        self_attn.w_kc.to(torch.bfloat16) * self_attn.w_scale
+                    )
+                    self_attn.w_vc = (
+                        self_attn.w_vc.to(torch.bfloat16) * self_attn.w_scale
+                    )
+                    self_attn.w_scale = None
             else:
                 num_tiles_k = self_attn.qk_nope_head_dim // weight_block_size[1]
                 num_tiles_n = self_attn.v_head_dim // weight_block_size[0]

--- a/test/registered/unit/test_mla_absorb_bf16_prescale.py
+++ b/test/registered/unit/test_mla_absorb_bf16_prescale.py
@@ -1,0 +1,111 @@
+"""Unit tests for the BF16 MLA-absorb prescale-fold + flatten-view optimization.
+
+These validate the two transformations the optimization relies on, both of which
+must be *bit-identical* to the original per-decode-step form:
+
+1. Load-time scale fold: precomputing ``w.to(bfloat16) * w_scale`` once and
+   reusing it produces the same absorb-BMM output as recomputing it every step.
+2. V-absorb flatten-view: writing the BMM into a ``(batch, heads, vdim)`` buffer
+   through a transposed view and flattening it is bit-identical to
+   ``bmm(...).transpose(0, 1).flatten(1, 2)`` and avoids the extra copy (the
+   flatten is a view, not a materialized copy).
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestMlaAbsorbBf16Prescale(CustomTestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        # (num_heads, batch, kv_lora, qk_nope_dim, v_dim) — small but shaped like
+        # the DeepSeek MLA absorb BMMs (batched over heads).
+        self.H, self.M, self.L, self.D, self.Dv = 16, 32, 24, 20, 18
+
+    def test_prescale_fold_is_bitwise_identical(self):
+        """Folding the constant scale into w_kc once == per-step dequant."""
+        H, M, L, D = self.H, self.M, self.L, self.D
+        q_nope = torch.randn(M, H, L, dtype=torch.bfloat16)
+        w_kc = torch.randn(H, L, D, dtype=torch.bfloat16)
+
+        for w_scale in (torch.tensor(1.0), torch.tensor(1.7), torch.tensor(2.0)):
+            x = q_nope.to(torch.bfloat16).transpose(0, 1)  # (H, M, L)
+
+            # Original: recompute dequant every "step".
+            ref = torch.bmm(x, w_kc.to(torch.bfloat16) * w_scale)
+
+            # Optimized: fold once at load, forward consumes it directly.
+            w_kc_folded = w_kc.to(torch.bfloat16) * w_scale
+            got = torch.bmm(x, w_kc_folded)
+
+            self.assertTrue(
+                torch.equal(ref, got),
+                msg=f"prescale fold mismatch at w_scale={float(w_scale)}",
+            )
+
+    def test_vabsorb_flatten_view_is_bitwise_identical_and_copy_free(self):
+        """out=buf.transpose(...) + buf.flatten == transpose(0,1).flatten(1,2)."""
+        H, M, L, Dv = self.H, self.M, self.L, self.Dv
+        attn_output = torch.randn(M, H, L, dtype=torch.bfloat16)
+        w_vc = torch.randn(H, L, Dv, dtype=torch.bfloat16)
+        w_scale = torch.tensor(2.0)
+
+        a = attn_output.to(torch.bfloat16).transpose(0, 1)  # (H, M, L)
+        w_vc_folded = w_vc.to(torch.bfloat16) * w_scale
+
+        # Original: BMM then transpose+flatten (materializes a copy).
+        ref = torch.bmm(a, w_vc_folded).transpose(0, 1).flatten(1, 2)  # (M, H*Dv)
+
+        # Optimized: BMM straight into a (batch, heads, vdim) buffer via a
+        # transposed view, then flatten as a free view.
+        buf = torch.empty(M, H, Dv, dtype=torch.bfloat16)
+        torch.bmm(a, w_vc_folded, out=buf.transpose(0, 1))
+        got = buf.flatten(1, 2)  # (M, H*Dv)
+
+        self.assertEqual(tuple(got.shape), (M, H * Dv))
+        self.assertTrue(torch.equal(ref, got), msg="flatten-view result mismatch")
+
+        # The optimized flatten must be a view over buf's storage (no copy).
+        self.assertEqual(
+            got.untyped_storage().data_ptr(),
+            buf.untyped_storage().data_ptr(),
+            msg="flatten(1, 2) unexpectedly materialized a copy",
+        )
+
+    def test_end_to_end_absorb_equivalence(self):
+        """Both stages combined match the unoptimized reference bit-for-bit."""
+        H, M, L, D, Dv = self.H, self.M, self.L, self.D, self.Dv
+        q_nope = torch.randn(M, H, L, dtype=torch.bfloat16)
+        attn_output = torch.randn(M, H, L, dtype=torch.bfloat16)
+        w_kc = torch.randn(H, L, D, dtype=torch.bfloat16)
+        w_vc = torch.randn(H, L, Dv, dtype=torch.bfloat16)
+        w_scale = torch.tensor(1.7)
+
+        # Reference (per-step dequant + transpose/flatten copy).
+        qx = q_nope.to(torch.bfloat16).transpose(0, 1)
+        ax = attn_output.to(torch.bfloat16).transpose(0, 1)
+        ref_q = torch.bmm(qx, w_kc.to(torch.bfloat16) * w_scale)
+        ref_v = torch.bmm(ax, w_vc.to(torch.bfloat16) * w_scale)
+        ref_v = ref_v.transpose(0, 1).flatten(1, 2)
+
+        # Optimized (folded weights + flatten-view).
+        w_kc_f = w_kc.to(torch.bfloat16) * w_scale
+        w_vc_f = w_vc.to(torch.bfloat16) * w_scale
+        got_q = torch.bmm(qx, w_kc_f)
+        buf = torch.empty(M, H, Dv, dtype=torch.bfloat16)
+        torch.bmm(ax, w_vc_f, out=buf.transpose(0, 1))
+        got_v = buf.flatten(1, 2)
+
+        self.assertTrue(torch.equal(ref_q, got_q), msg="q_nope absorb mismatch")
+        self.assertTrue(torch.equal(ref_v, got_v), msg="v absorb mismatch")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

**Follow-up to #31604 (`SGLANG_MLA_ABSORB_BF16`).** Once the DeepSeek MLA-absorb
weights (`w_kc` / `w_vc`) are kept in **BF16** on the gfx95 / AITER quark path,
the absorbed-attention BMM falls into the plain-`torch.bmm` branch, which on
**every decode step** does redundant, constant work:

1. **Per-step dequant multiply** — `self.w_kc.to(bf16) * self.w_scale` and
   `self.w_vc.to(bf16) * self.w_scale` are recomputed each step even though
   `w_kc`, `w_vc` and `w_scale` are all constant → one extra elementwise-multiply
   kernel per absorb BMM, per layer, per decode step.
2. **Post-BMM transpose→flatten copy** — the V-absorb output is materialized via
   `attn_bmm_output.transpose(0, 1).flatten(1, 2)`, an extra `direct_copy`
   kernel per layer per step.

These are pure overhead on the BF16-absorb path.

## Changes

- **`deepseek_weight_loader.py`** — fold the constant absorb scale into the BF16
  `w_kc`/`w_vc` **once at load** and set `w_scale = None`. Guarded to the exact
  `SGLANG_MLA_ABSORB_BF16` + gfx95 + quark path; other backends / the
  FP8/MXFP4/deep_gemm absorb paths are untouched. Numerically identical (same
  constant fold).
- **`forward_mla.py`** (`forward_absorb_prepare` / `forward_absorb_core`) —
  consume the pre-folded weights directly, and write the V-absorb BMM into a
  `(batch, heads, vdim)` buffer through a transposed view so the downstream
  `transpose+flatten` is a **free view instead of a copy** (mirrors the existing
  uint8/fp8 absorb paths).

Net effect on the BF16-absorb decode path: **two kernels removed per layer per
step** (the BF16 scalar-mul and the `direct_copy`), with no accuracy change.

## Validation

Model: DeepSeek-R1 (quark, BF16 MLA-absorb, `SGLANG_MLA_ABSORB_BF16=1`), MI355X
(gfx950), TP8, aiter, fp8 KV cache.

**GSM8k accuracy (`--num-questions 2000 --parallel 1200`, 3 runs):**

| run | accuracy | invalid |
|-----|----------|---------|
| 1 | 0.933 | 0.000 |
| 2 | 0.935 | 0.000 |
| 3 | 0.927 | 0.000 |

No regression — the fold + flatten-view are bit-identical to the per-step form.

**Serving perf, baseline (#31604 only) vs this PR, ISL=1024 / OSL=1024:**

| conc | out tok/s (base → PR) | Δ | median TPOT ms (base → PR) | median ITL ms (base → PR) |
|------|-----------------------|-----|----------------------------|----------------------------|
| 4 | 476 → 504 | **+5.9%** | 9.38 → 8.38 (−10.7%) | 8.25 → 7.93 (−3.9%) |
| 8 | 875 → 928 | **+6.1%** | 10.01 → 9.08 (−9.3%) | 8.98 → 8.68 (−3.3%) |
| 16 | 1536 → 1600 | **+4.2%** | 11.12 → 10.55 (−5.1%) | 10.33 → 10.04 (−2.8%) |
| 32 | 2624 → 2752 | **+4.9%** | 12.75 → 12.53 (−1.7%) | 12.16 → 11.91 (−2.1%) |

The win is largest at low concurrency, where the (removed) fixed per-layer
kernels are a larger fraction of each decode step.

**Unit test** (`test/registered/unit/test_mla_absorb_bf16_prescale.py`, CPU):
asserts both transformations are **bit-identical** to the per-step form — the
constant-scale fold, and the copy-free flatten view (also checks the flatten
shares storage with the BMM buffer, i.e. no materialized copy).

```
$ python3 -m unittest -v test_mla_absorb_bf16_prescale
test_end_to_end_absorb_equivalence ... ok
test_prescale_fold_is_bitwise_identical ... ok
test_vabsorb_flatten_view_is_bitwise_identical_and_copy_free ... ok
----------------------------------------------------------------------
Ran 3 tests in 0.046s

OK
```

## Note

This PR is **stacked on #31604** — the first commit shown is #31604 and will drop
out of the diff once #31604 merges (I'll rebase). Only the second commit belongs
to this PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29612751985](https://github.com/sgl-project/sglang/actions/runs/29612751985)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29984291921](https://github.com/sgl-project/sglang/actions/runs/29984291921)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->