### PR TITLE
[DeepSeek] Add SGLANG_MLA_ABSORB_FP8: per-tensor FP8 MLA-absorb weights (follow-up to #31604)

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -212,3 +212,34 @@ def quark_post_load_weights(self_attn: nn.Module, w: torch.Tensor, quant_format:
             w_s_vc = w_s_vc.contiguous().transpose(1, 2)
 
         return w_kc, w_s_kc, w_vc, w_s_vc
+
+
+def quark_mla_absorb_to_fp8(self_attn: nn.Module, w: torch.Tensor):
+    """Quantize the MLA-absorb ``kv_b_proj`` weight to per-tensor FP8 (e4m3).
+
+    Mirrors :func:`quark_post_load_weights` (the MXFP4 path): if the checkpoint
+    stores ``kv_b_proj`` as packed MXFP4 (uint8), dequantize it to BF16 first,
+    then apply the standard tensor-wise FP8 quantization.
+
+    Returns ``(w_kc, w_vc, w_scale)`` where ``w ~= w_fp8 * w_scale`` and
+    ``w_scale`` is a single per-tensor dequant multiplier of shape ``(1,)``
+    consumed by the gfx950 FP8 batched-GEMM absorb kernel.
+    """
+    from sglang.srt.layers.quantization.fp8_utils import input_to_float8
+
+    if w.dtype == torch.uint8:
+        # MXFP4-serialized checkpoint: upcast to BF16 (packed fp4 * e8m0 scale)
+        # before requantizing, matching the uint8 branch of
+        # quark_post_load_weights.
+        w = mxfp4_to_f32(w, True).to(torch.bfloat16)
+        w_scales = self_attn.kv_b_proj.weight_scale.repeat_interleave(32, dim=-1)
+        w_scales = e8m0_to_f32(w_scales).to(torch.bfloat16)
+        w = w * w_scales
+
+    # Tensor-wise FP8 (e4m3) quant; a single shared scale for w_kc and w_vc (the
+    # absorb kernel takes one per-tensor w_scale of shape (1,)).
+    w_fp8, w_scale = input_to_float8(w, torch.float8_e4m3fn)
+    w_kc, w_vc = w_fp8.unflatten(
+        0, (-1, self_attn.qk_nope_head_dim + self_attn.v_head_dim)
+    ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
+    return w_kc, w_vc, w_scale.reshape(1)

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -65,6 +65,7 @@ if _use_aiter_gfx95:
     from sglang.srt.layers.quantization.quark.utils import quark_post_load_weights
 
 logger = logging.getLogger(__name__)
+_MLA_ABSORB_BF16_LOGGED = []  # one-shot guard for the MLA-absorb BF16 log line
 
 # Optional quantization for DeepSeek nvfp4 checkpoint
 NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]
@@ -630,12 +631,25 @@ class DeepseekV2WeightLoaderMixin:
             ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
 
             if (
+                get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
+                and _use_aiter_gfx95
+                and self.quant_config is not None
+                and self.quant_config.get_name() == "quark"
+                and not _MLA_ABSORB_BF16_LOGGED
+            ):
+                _MLA_ABSORB_BF16_LOGGED.append(1)
+                log_info_on_rank0(
+                    logger,
+                    "SGLANG_MLA_ABSORB_BF16=1: keeping kv_b_proj MLA-absorb weights in BF16 (skipping quark mxfp4 re-quant)",
+                )
+            if (
                 _use_aiter_gfx95
                 and self.quant_config is not None
                 and self.quant_config.get_name() == "quark"
                 and self.config.architectures
                 and self.config.architectures[0]
                 == "DeepseekV3ForCausalLM"  # Avoid processing other models like GlmMoeDsaForCausalLM
+                and not get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
             ):
                 w_kc, self_attn.w_scale_k, w_vc, self_attn.w_scale_v = (
                     quark_post_load_weights(self_attn, w, "mxfp4")

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -62,10 +62,14 @@ from sglang.srt.models.deepseek_common.utils import (
 from sglang.srt.utils import bind_or_assign, get_bool_env_var, log_info_on_rank0
 
 if _use_aiter_gfx95:
-    from sglang.srt.layers.quantization.quark.utils import quark_post_load_weights
+    from sglang.srt.layers.quantization.quark.utils import (
+        quark_mla_absorb_to_fp8,
+        quark_post_load_weights,
+    )
 
 logger = logging.getLogger(__name__)
 _MLA_ABSORB_BF16_LOGGED = []  # one-shot guard for the MLA-absorb BF16 log line
+_MLA_ABSORB_FP8_LOGGED = []  # one-shot guard for the MLA-absorb FP8 log line
 
 # Optional quantization for DeepSeek nvfp4 checkpoint
 NVFP4_CKPT_FP8_ATTN_QUANT_MODULES = ["q_b_proj"]
@@ -642,15 +646,27 @@ class DeepseekV2WeightLoaderMixin:
                     logger,
                     "SGLANG_MLA_ABSORB_BF16=1: keeping kv_b_proj MLA-absorb weights in BF16 (skipping quark mxfp4 re-quant)",
                 )
-            if (
+            _quark_gfx95_absorb = (
                 _use_aiter_gfx95
                 and self.quant_config is not None
                 and self.quant_config.get_name() == "quark"
                 and self.config.architectures
-                and self.config.architectures[0]
-                == "DeepseekV3ForCausalLM"  # Avoid processing other models like GlmMoeDsaForCausalLM
-                and not get_bool_env_var("SGLANG_MLA_ABSORB_BF16")
-            ):
+                # Avoid processing other models like GlmMoeDsaForCausalLM
+                and self.config.architectures[0] == "DeepseekV3ForCausalLM"
+            )
+            if _quark_gfx95_absorb and get_bool_env_var("SGLANG_MLA_ABSORB_FP8"):
+                # FP8 absorb: requantize kv_b_proj MLA-absorb weights to per-tensor
+                # FP8 (e4m3) -- a middle precision between BF16 (accurate) and
+                # MXFP4 (smallest); consumed by the gfx950 FP8 batched-GEMM
+                # absorb path.
+                w_kc, w_vc, self_attn.w_scale = quark_mla_absorb_to_fp8(self_attn, w)
+                if not _MLA_ABSORB_FP8_LOGGED:
+                    _MLA_ABSORB_FP8_LOGGED.append(1)
+                    log_info_on_rank0(
+                        logger,
+                        "SGLANG_MLA_ABSORB_FP8=1: requantizing kv_b_proj MLA-absorb weights to FP8 (e4m3)",
+                    )
+            elif _quark_gfx95_absorb and not get_bool_env_var("SGLANG_MLA_ABSORB_BF16"):
                 w_kc, self_attn.w_scale_k, w_vc, self_attn.w_scale_v = (
                     quark_post_load_weights(self_attn, w, "mxfp4")
                 )

--- a/test/registered/unit/test_mla_absorb_fp8.py
+++ b/test/registered/unit/test_mla_absorb_fp8.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``quark_mla_absorb_to_fp8`` (SGLANG_MLA_ABSORB_FP8).
+
+Validates the per-tensor FP8 (e4m3) requantization of the DeepSeek MLA-absorb
+``kv_b_proj`` weight: output dtypes/shapes, the single shared per-tensor scale,
+and that dequantizing (``w_fp8.float() * w_scale``) reconstructs the original
+BF16 weight within FP8 (e4m3) tolerance.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.quantization.quark.utils import quark_mla_absorb_to_fp8
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestQuarkMlaAbsorbToFp8(CustomTestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.H = 8  # heads
+        self.qk_nope = 16
+        self.v = 12
+        self.L = 32  # kv_lora_rank
+        self.self_attn = SimpleNamespace(
+            qk_nope_head_dim=self.qk_nope, v_head_dim=self.v
+        )
+
+    def _make_bf16_w(self):
+        # kv_b_proj weight shape: (H * (qk_nope + v), L)
+        return torch.randn(
+            self.H * (self.qk_nope + self.v), self.L, dtype=torch.bfloat16
+        )
+
+    def test_output_dtypes_shapes_and_scale(self):
+        w = self._make_bf16_w()
+        w_kc, w_vc, w_scale = quark_mla_absorb_to_fp8(self.self_attn, w)
+
+        self.assertEqual(w_kc.dtype, torch.float8_e4m3fn)
+        self.assertEqual(w_vc.dtype, torch.float8_e4m3fn)
+        # Split back into per-head (kc, vc) blocks.
+        self.assertEqual(tuple(w_kc.shape), (self.H, self.qk_nope, self.L))
+        self.assertEqual(tuple(w_vc.shape), (self.H, self.v, self.L))
+        # A single shared per-tensor scale of shape (1,).
+        self.assertEqual(tuple(w_scale.shape), (1,))
+        self.assertTrue(torch.isfinite(w_scale).all())
+        self.assertGreater(float(w_scale), 0.0)
+
+    def test_dequant_reconstructs_within_fp8_tolerance(self):
+        w = self._make_bf16_w()
+        w_kc, w_vc, w_scale = quark_mla_absorb_to_fp8(self.self_attn, w)
+
+        # Reference: the same head-split of the original BF16 weight.
+        ref_kc, ref_vc = w.unflatten(0, (-1, self.qk_nope + self.v)).split(
+            [self.qk_nope, self.v], dim=1
+        )
+        deq_kc = w_kc.float() * w_scale
+        deq_vc = w_vc.float() * w_scale
+
+        # e4m3 has ~2 bits of mantissa; relative error per element is bounded.
+        # Compare on normalized (by amax) tensors with a generous but meaningful
+        # tolerance.
+        amax = w.abs().float().amax().clamp(min=1e-12)
+        self.assertLess((deq_kc - ref_kc.float()).abs().max().item() / amax, 0.10)
+        self.assertLess((deq_vc - ref_vc.float()).abs().max().item() / amax, 0.10)
+
+    def test_scale_matches_e4m3_dynamic_range(self):
+        # The per-tensor scale should map the weight amax near e4m3 max (448).
+        w = self._make_bf16_w()
+        _, _, w_scale = quark_mla_absorb_to_fp8(self.self_attn, w)
+        amax = w.abs().float().amax().clamp(min=1e-12)
+        # w_scale is the dequant multiplier ~= amax / 448.
+        self.assertAlmostEqual(float(w_scale), float(amax) / 448.0, delta=float(amax) * 0.02)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_mla_absorb_fp8.py
+++ b/test/registered/unit/test_mla_absorb_fp8.py
@@ -74,7 +74,9 @@ class TestQuarkMlaAbsorbToFp8(CustomTestCase):
         _, _, w_scale = quark_mla_absorb_to_fp8(self.self_attn, w)
         amax = w.abs().float().amax().clamp(min=1e-12)
         # w_scale is the dequant multiplier ~= amax / 448.
-        self.assertAlmostEqual(float(w_scale), float(amax) / 448.0, delta=float(amax) * 0.02)
+        self.assertAlmostEqual(
+            float(w_scale), float(amax) / 448.0, delta=float(amax) * 0.02
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

**Follow-up to #31604 (`SGLANG_MLA_ABSORB_BF16`).** That PR added BF16 as an
opt-in precision for the DeepSeek MLA-absorb `kv_b_proj` weights on the
gfx95 / AITER quark path, where they are otherwise forced to MXFP4. This PR adds
a **middle precision — per-tensor FP8 (e4m3)** — between BF16 (most accurate,
largest) and MXFP4 (smallest), selectable via `SGLANG_MLA_ABSORB_FP8=1`.

The gfx950 FP8 batched-GEMM absorb path already exists in `forward_mla.py`
(`self.w_kc.dtype == torch.float8_e4m3fn` → `batched_gemm_a8w8_...` with a single
per-tensor `w_scale`); this PR just produces weights in that format at load time,
so **no forward change is needed.**

## Changes

- **`quark/utils.py`** — new `quark_mla_absorb_to_fp8()`. For MXFP4-serialized
  checkpoints (uint8 `kv_b_proj`) it dequantizes to BF16 first (matching the
  uint8 branch of `quark_post_load_weights`), then applies tensor-wise FP8
  (e4m3) quant, returning `(w_kc, w_vc, w_scale)` with a single per-tensor scale
  of shape `(1,)`.
- **`deepseek_weight_loader.py`** — gate on `SGLANG_MLA_ABSORB_FP8`; requantize
  the absorb weights to FP8 when set, otherwise fall back to the existing MXFP4
  requant (and BF16 when `SGLANG_MLA_ABSORB_BF16` is set, per #31604). One-shot
  log line, consistent with the BF16 path.

## Validation

**Unit test** (`test/registered/unit/test_mla_absorb_fp8.py`, CPU) — output
dtypes/shapes, the single shared per-tensor scale, dequant reconstruction within
FP8 (e4m3) tolerance, and scale vs the e4m3 dynamic range:

```
$ python3 -m unittest -v test_mla_absorb_fp8
test_dequant_reconstructs_within_fp8_tolerance ... ok
test_output_dtypes_shapes_and_scale ... ok
test_scale_matches_e4m3_dynamic_range ... ok
----------------------------------------------------------------------
Ran 3 tests in 0.009s

OK
```

**GSM8k accuracy** (DeepSeek-R1-MXFP4, MI355X TP8, `--num-questions 2000
--parallel 1000`, 3 runs each):

| run | FP8 absorb (`SGLANG_MLA_ABSORB_FP8=1`) | MXFP4 baseline (default) |
|-----|----------------------------------------|--------------------------|
| 1 | 0.939 | 0.939 |
| 2 | 0.936 | 0.940 |
| 3 | 0.936 | 0.935 |
| mean | **0.937** | 0.938 |

Invalid 0.000 across all runs. FP8 absorb is at **accuracy parity** with the
default MXFP4 (and is the higher-precision option for accuracy-sensitive cases,
below BF16).

**Serving perf** (ISL=1024 / OSL=1024), FP8 vs the MXFP4 default baseline:

| conc | out tok/s (mxfp4 → fp8) | median TPOT ms (mxfp4 → fp8) |
|------|------------------------|------------------------------|
| 4 | 524 → 516 | 7.68 → 7.77 |
| 8 | 960 → 944 | 8.42 → 8.55 |
| 16 | 1648 → 1633 | 9.89 → 9.87 |
| 32 | 2720 → 2752 | 12.01 → 11.85 |

Performance is **on par** with MXFP4 (within run-to-run noise) — as expected,
this is a precision option, not a throughput change.

## Note

Stacked on #31604 — the first commit shown is #31604 and will drop out of the
diff once it merges (I'll rebase). The FP8 mode composes with the BF16 gate:
`FP8` → fp8, else `BF16` → kept bf16, else → MXFP4 (default).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29624786615](https://github.com/sgl-project/sglang/actions/runs/29624786615)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29624786529](https://github.com/sgl-project/sglang/actions/runs/29624786529)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->