### PR TITLE
[AMD] batch 3: register newly-added JIT kernel benchmarks for jit-kernel-benchmark-test-amd

### DIFF
--- a/test/registered/jit/benchmark/bench_spec_topk1.py
+++ b/test/registered/jit/benchmark/bench_spec_topk1.py
@@ -12,11 +12,12 @@ from sglang.jit_kernel.benchmark.utils import (
     run_benchmark,
 )
 from sglang.kernels.ops.speculative.topk1 import draft_topk1_postprocess
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=30, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
 )
+register_amd_ci(est_time=30, stage="jit-kernel-benchmark", runner_config="amd")
 
 
 BATCH_SIZE_RANGE = get_benchmark_range(

--- a/test/registered/jit/benchmark/bench_vocab_parallel_embedding.py
+++ b/test/registered/jit/benchmark/bench_vocab_parallel_embedding.py
@@ -8,11 +8,12 @@ from sglang.kernels.ops.embeddings.vocab_parallel_embedding import (
     vocab_parallel_embedding,
 )
 from sglang.srt.layers.vocab_parallel_embedding import get_masked_input_and_mask
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=10, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
 )
+register_amd_ci(est_time=10, stage="jit-kernel-benchmark", runner_config="amd")
 
 # Key order must match the perf_report x_names.
 DEFAULTS = dict(


### PR DESCRIPTION
## Summary
Follow-up to #30307 / #31492. Registers the **2 JIT kernel benchmarks added upstream since** those PRs for AMD on the dedicated `jit-kernel-benchmark-test-amd` stage (same 2-line pattern: `register_amd_ci(est_time=…, stage="jit-kernel-benchmark", runner_config="amd")` next to the CUDA registration):

- `bench_spec_topk1.py` (topk=1 speculative decoding helpers)
- `bench_vocab_parallel_embedding.py` (vocab-parallel embedding)

**Both pass on ROCm** — no trim needed.

## Probe (both benches, `continue_on_error=true`)
Both lanes returned **18/18 passed** (16 already-registered + these 2), with both new benches `passed: true`:
- ROCm 7.2 → https://github.com/sgl-project/sglang/actions/runs/29617171083 (18/18)
- ROCm 7.0 → https://github.com/sgl-project/sglang/actions/runs/29617172505 (18/18)

## Verification (`continue_on_error=false` — true gate)
- ROCm 7.2 (`pr-test-amd-rocm720.yml`) → https://github.com/sgl-project/sglang/actions/runs/29622853887
- ROCm 7.0 (`pr-test-amd.yml`) → https://github.com/sgl-project/sglang/actions/runs/29622855068

## Test plan
- [x] Both benches pass on ROCm 7.0 and 7.2 (probe 18/18 on each).
- [x] Strict gate runs green — 18/18 on both lanes.
- [x] Ready for review.

