### PR TITLE
[spec decoding] fix page-align EAGLE KV allocation

### DIFF
--- a/python/sglang/srt/debug_utils/pr_fix_toggle.py
+++ b/python/sglang/srt/debug_utils/pr_fix_toggle.py
@@ -88,12 +88,14 @@ patches:
   - target: sglang.srt.mem_cache.allocation_sizing.get_req_to_token_extra_context_len
     edits:
       - match: |
-          if (
-              server_args.speculative_algorithm is not None
-              and server_args.page_size > 1
-              and (server_args.speculative_eagle_topk or 1) > 1
-          ):
-              extra = max(extra, get_alloc_reserve_per_decode(server_args))
+          if server_args.speculative_algorithm is not None and server_args.page_size > 1:
+              # kv_allocated_len is page-aligned (eagle_prepare_for_decode), so near
+              # the context limit the aligned reserve can overshoot by page_size - 1;
+              # without the headroom the row write silently lands in the neighbor row.
+              extra = max(
+                  extra,
+                  get_alloc_reserve_per_decode(server_args) + server_args.page_size - 1,
+              )
         replacement: ""
 """
 

--- a/python/sglang/srt/mem_cache/allocation_sizing.py
+++ b/python/sglang/srt/mem_cache/allocation_sizing.py
@@ -51,10 +51,12 @@ def get_req_to_token_extra_context_len(server_args: ServerArgs) -> int:
     """
     # FIXME(lsyin): temporary fix for the context length issue under spec decoding
     extra = 4 + (server_args.max_speculative_num_draft_tokens or 0)
-    if (
-        server_args.speculative_algorithm is not None
-        and server_args.page_size > 1
-        and (server_args.speculative_eagle_topk or 1) > 1
-    ):
-        extra = max(extra, get_alloc_reserve_per_decode(server_args))
+    if server_args.speculative_algorithm is not None and server_args.page_size > 1:
+        # kv_allocated_len is page-aligned (eagle_prepare_for_decode), so near
+        # the context limit the aligned reserve can overshoot by page_size - 1;
+        # without the headroom the row write silently lands in the neighbor row.
+        extra = max(
+            extra,
+            get_alloc_reserve_per_decode(server_args) + server_args.page_size - 1,
+        )
     return extra

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -374,10 +374,7 @@ class KVCacheConfigurator:
         # The full sub-pool is page-aware (via `MultiEndedAllocator(page_size=...)`);
         # the mamba sub-pool stays page=1.
         assert self.page_size >= 1, f"page_size must be >= 1, got {self.page_size}"
-        # Mirror the non-shared path's extra_max_context_len computation.
-        extra_max_context_len = 4
-        if self.server_args.speculative_num_draft_tokens is not None:
-            extra_max_context_len += self.server_args.speculative_num_draft_tokens
+        extra_max_context_len = get_req_to_token_extra_context_len(self.server_args)
 
         mamba_layer_ids = [
             i
@@ -444,10 +441,7 @@ class KVCacheConfigurator:
         assert (
             not self.use_mla_backend
         ), "unified memory pool does not support MLA-SWA hybrid yet"
-        # Mirror the non-shared path's extra_max_context_len computation.
-        extra_max_context_len = 4
-        if self.server_args.speculative_num_draft_tokens is not None:
-            extra_max_context_len += self.server_args.speculative_num_draft_tokens
+        extra_max_context_len = get_req_to_token_extra_context_len(self.server_args)
         req_to_token_pool = ReqToTokenPool(
             size=max_num_reqs,
             max_context_len=self.model_config.context_len + extra_max_context_len,

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -26,6 +26,7 @@ from sglang.srt.utils import (
     is_xpu,
 )
 from sglang.srt.utils.async_probe import maybe_detect_oob
+from sglang.srt.utils.common import ceil_align
 
 if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsProcessorOutput
@@ -824,12 +825,7 @@ def eagle_prepare_for_decode(batch: ScheduleBatch):
         # Whole-page accounting: the paged allocator hands out full pages, so
         # round nxt up to the page boundary or the unaligned tail is allocated
         # but never recorded — a stranded-tail leak at page_size > 1.
-        nxt = max(
-            cur,
-            (r.kv_committed_len + double_alloc + page_size - 1)
-            // page_size
-            * page_size,
-        )
+        nxt = max(cur, ceil_align(r.kv_committed_len + double_alloc, page_size))
         cur_kv_lens[i] = cur
         nxt_kv_lens[i] = nxt
         num_needed_tokens += nxt - cur

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -821,7 +821,15 @@ def eagle_prepare_for_decode(batch: ScheduleBatch):
         # max(cur, ...) clamps so adaptive downswitch cannot make nxt < cur.
         # kv_committed_len is honest (bonus committed in resolve, not here),
         # so it lags batch.seq_lens by ~1 verify in overlap; 2*alloc absorbs.
-        nxt = max(cur, r.kv_committed_len + double_alloc)
+        # Whole-page accounting: the paged allocator hands out full pages, so
+        # round nxt up to the page boundary or the unaligned tail is allocated
+        # but never recorded — a stranded-tail leak at page_size > 1.
+        nxt = max(
+            cur,
+            (r.kv_committed_len + double_alloc + page_size - 1)
+            // page_size
+            * page_size,
+        )
         cur_kv_lens[i] = cur
         nxt_kv_lens[i] = nxt
         num_needed_tokens += nxt - cur
@@ -830,17 +838,16 @@ def eagle_prepare_for_decode(batch: ScheduleBatch):
     cur_kv_lens_cpu = torch.tensor(cur_kv_lens, dtype=torch.int32, device="cpu")
     nxt_kv_lens_cpu = torch.tensor(nxt_kv_lens, dtype=torch.int32, device="cpu")
 
-    # Fail fast if the page>1 + topk>1 draft over-allocation
-    # (get_alloc_reserve_per_decode) outgrows the req_to_token row: the write below
-    # would OOB and free would leak KV. The row is widened to hold it in _init_pools
-    # (PR #26972); fail here with a clear error, not on a later cryptic CUDA assert.
-    from sglang.srt.runtime_context import get_server_args
-
-    if page_size > 1 and (get_server_args().speculative_eagle_topk or 1) > 1:
+    # Fail fast if the page>1 draft over-allocation (page-aligned
+    # get_alloc_reserve_per_decode) outgrows the req_to_token row: the write below
+    # would OOB and free would leak KV. The row is widened to hold it in
+    # get_req_to_token_extra_context_len (PR #26972); fail here with a clear
+    # error, not on a later cryptic CUDA assert.
+    if page_size > 1:
         max_alloc_len = int(nxt_kv_lens_cpu.max())
         row_width = batch.req_to_token_pool.req_to_token.shape[1]
         assert max_alloc_len <= row_width, (
-            f"spec v2 page>1 topk>1 draft over-allocation ({max_alloc_len}) exceeds "
+            f"spec v2 page>1 draft over-allocation ({max_alloc_len}) exceeds "
             f"req_to_token row width ({row_width}); page_size={page_size}. Widen the "
             f"row to hold committed + get_alloc_reserve_per_decode (PR #26972)."
         )


### PR DESCRIPTION
## Motivation

Under EAGLE spec decoding with `--page-size > 1`, `eagle_prepare_for_decode` computed the next allocation length as `nxt = kv_committed_len + double_alloc`, which is **not page-aligned** — `kv_committed_len` grows by a variable accept count each verify step. But the paged allocator hands out **whole pages** (`get_num_new_pages` = `ceil(nxt/page) − ceil(cur/page)`), and the decode-memory check (`_new_tokens_required_next_decode_spec_v2`) already estimates in whole pages via `ceil_align`. Recording an unaligned `kv_allocated_len` therefore leaves the tail of the last physical page allocated-but-unrecorded → a **stranded-tail KV leak at `page_size > 1`**.

The page-awareness previously lived only in the `topk > 1` branch of `get_alloc_len_per_decode` (which reserves whole pages + a `page_size − 1` cushion for the tree draft), so the `topk == 1` linear-chain case was left page-unaware — even though the allocator quantizes to pages for **every** topk. The fix therefore has to be topk-independent.

## Modifications

- **`eagle_prepare_for_decode` (`eagle_utils.py`)** — page-align `nxt` up to the page boundary with `ceil_align`, so `kv_allocated_len` is always page-aligned and matches both the allocator's whole-page footprint and the `check_decode_mem` accounting. This closes the stranded-tail leak. It does **not** allocate more physical KV: the number of pages consumed (`ceil(nxt/page)`) is unchanged — the allocator was already handing out the full tail page; we now record the slots it actually took.
- **`get_req_to_token_extra_context_len` (`allocation_sizing.py`)** — the page-aligned `nxt` can overshoot the reserve by up to `page_size − 1` near the context limit, so add that headroom to the `req_to_token` row width. Drop the `topk > 1` gate: the row over-allocation now applies to all topk, not just the tree draft.
- **Fail-fast assertion (`eagle_prepare_for_decode`)** — broaden the guard from `page>1 && topk>1` to `page>1` so it covers every config whose row was widened, update the message, and drop the now-unused in-function `get_server_args` import.
- **Unified mamba / SWA pools (`kv_cache_configurator.py`)** — replace the hardcoded `4 + speculative_num_draft_tokens` with `get_req_to_token_extra_context_len(...)`, so the shared-pool path uses the exact same row sizing as the non-shared path (`_build_req_to_token_pool`). This also fixes an **under-sizing under `--speculative-adaptive`**: the old code used the base `speculative_num_draft_tokens` instead of `max_speculative_num_draft_tokens`, and never included the decode reserve.
- **`pr_fix_toggle.py`** — resync the PR #26972 revert-match to the edited source so `SGLANG_DEBUG_REVERT_PR=26972` still applies.

## Accuracy Tests

<!-- TODO: EAGLE + page_size>1 on GSM8K/MMLU for both topk==1 and topk>1; outputs should match the pre-fix baseline (this is a leak/accounting fix, not a numerics change). -->

## Speed Tests and Profiling

<!-- TODO: the only added per-step work is one integer ceil_align per request (negligible); physical KV allocation is unchanged. Confirm steady-state memory no longer grows over a long run (leak gone). -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29621706901](https://github.com/sgl-project/sglang/actions/runs/29621706901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #29622101698](https://github.com/sgl-project/sglang/actions/runs/29622101698)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
