### PR TITLE
[AMD] Fix DSV4-Flash dp8ep8 GSM8K regression: row-major Triton FP8 scale on gfx95

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -929,10 +929,19 @@ def aiter_w8a8_block_fp8_linear(
         x_scale = input_scale
         if _use_aiter_bpreshuffle_gfx95 and not use_triton:
             x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
-        # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
-        # Triton needs a row-major view, so adjust strides only. No copy.
+        # Triton's block-FP8 GEMM consumes a row-major per-token scale -- the
+        # same as the `input_scale is None` path below, which quantizes with
+        # transpose_scale=False and hands Triton the raw row-major scale. When
+        # the producer pre-quantized (disagg), input_scale arrives in
+        # bpreshuffle's materialized column-major layout; the previous
+        # as_strided(..., (1, shape[0])) only reinterpreted the strides (leaving
+        # column-major bytes, despite the "row-major" intent), so Triton read
+        # transposed per-token scales -> ~1.3pt GSM8K drop on dp8ep8. Force a
+        # real row-major copy so this matches the (correct) non-disagg path.
+        # (See #31490; layout regressed by #29275. aiter/CK branch is untouched,
+        # so GLM-5.2-FP8 is unaffected.)
         elif use_triton and _use_aiter_bpreshuffle_gfx95:
-            x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
+            x_scale = x_scale.contiguous()
     else:
         materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
         q_input, x_scale = aiter_per1x128_quant(


### PR DESCRIPTION
> ⚠️ **Superseded / not working** — validation on MI355X disagg shows this does NOT recover accuracy (fp8 0.904 / fp4 0.911, still regressed). Kept as a documented negative result; see the run comment below. Do not merge.

## Summary

Candidate fix for #31490 — the DeepSeek-V4-Flash `dp8ep8` GSM8K regression on gfx950 (drops to ~0.912, straddling the 0.91 CI gate; regressed by #29275 @hdt98).

Root cause, localized to the pre-quantized path of `aiter_w8a8_block_fp8_linear`:
- The `input_scale is None` (non-disagg) path quantizes with `transpose_scale=False` and hands the **Triton** block-FP8 GEMM a **raw row-major** per-token scale — correct.
- The `input_scale is not None` (disagg, producer pre-quantized) path receives `input_scale` in bpreshuffle's **materialized column-major** layout, and the Triton branch did `torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))`. That only reinterprets the strides (leaving column-major bytes — despite the "row-major view" comment), so Triton read **transposed** per-token scales → the ~1.3pt drop.

## Fix

Replace the `as_strided` stride-reinterpretation with `x_scale = x_scale.contiguous()` — a real row-major copy — so the pre-quantized Triton path produces the same layout as the already-correct `input_scale is None` Triton path.

- One line in the Triton branch; the **aiter/CK (bpreshuffle) branch is untouched**, so the GLM-5.2-FP8 path that #29275 fixed is unaffected by construction.
- Matches the issue's source-overlay bisect finding that the regression lives in Python source (not the compiled kernel), so it's testable via the disagg CI's checkout-runtime.

## Test plan

- [ ] MI355X 2N 1P1D disagg, `dsv4flash-fp8-1k1k-1p1d-dp8ep8` — expect ~0.925 (was ~0.912/flaky) — dispatched, will link.
- [ ] MI355X 2N 1P1D disagg, `dsv4flash-fp4-1k1k-1p1d-dp8ep8` — expect back above the 0.91 gate (was 0.910 fail).
- [ ] Sanity: non-dp8ep8 DSV4 legs unchanged.
- [ ] GLM-5.2-FP8 (aiter/bpreshuffle path) — unaffected by construction (branch untouched); to be confirmed by #29275/#31490 owners who have that repro.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29617823755](https://github.com/sgl-project/sglang/actions/runs/29617823755)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29617823647](https://github.com/sgl-project/sglang/actions/runs/29617823647)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
