### PR TITLE
[CP] Migrate MLA prefill CP (DeepSeek V3) to CP-v2 zigzag strategy

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -995,17 +995,24 @@ class FlashAttentionBackend(AttentionBackend):
                     else forward_batch.encoder_out_cache_loc
                 )
                 if self.use_mla:
-                    # MLA: under CP, k and k_rope arrive full-sequence
-                    # (rebuild_cp_kv_cache ran upstream in
-                    # forward_absorb_prepare); rank-local otherwise.
-                    # out_cache_loc is never zigzag-split, so the write
-                    # lands in the right slots on every rank in either case.
-                    self.token_to_kv_pool.set_mla_kv_buffer(
-                        layer,
-                        cache_loc,
-                        k,
-                        k_rope,
-                    )
+                    if is_cp_v2_active(forward_batch):
+                        # CP-v2: k/k_rope are rank-local; the strategy gathers
+                        # the latent to full sequence and writes it.
+                        cp_strategy = get_cp_strategy()
+                        assert cp_strategy is not None
+                        cp_strategy.materialize_full_mla_kv(
+                            forward_batch, layer, k, k_rope
+                        )
+                    else:
+                        # CP-v1: k/k_rope arrive full-sequence (rebuild_cp_kv_cache
+                        # ran upstream); rank-local when CP is off. out_cache_loc is
+                        # never zigzag-split, so the write lands in the right slots.
+                        self.token_to_kv_pool.set_mla_kv_buffer(
+                            layer,
+                            cache_loc,
+                            k,
+                            k_rope,
+                        )
                 elif is_cp_mode:
                     # Dense-MHA CP: k, v are still rank-local; backend
                     # all-gathers and writes to the per-rank pool.

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1438,9 +1438,20 @@ class FlashAttentionBackend(AttentionBackend):
                             ver=self.fa_impl_ver,
                         )
 
-                    o = cp_attn_forward_extend(
-                        forward_batch, q_fused, self.device, _mla_cp_attn
-                    )
+                    if is_cp_v2_active(forward_batch):
+                        cp_strategy = get_cp_strategy()
+                        assert cp_strategy is not None
+                        o = cp_strategy.run_attention(
+                            q_fused,
+                            forward_batch,
+                            self.device,
+                            _mla_cp_attn,
+                            attention_backend=CPAttentionBackendKind.FLASH_ATTENTION,
+                        )
+                    else:
+                        o = cp_attn_forward_extend(
+                            forward_batch, q_fused, self.device, _mla_cp_attn
+                        )
                 else:
                     result = flash_attn_with_kvcache(
                         q=q_rope,

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -122,20 +122,6 @@ def get_layer_owner(local_layer_idx: int, shard_size: int, total_layers: int) ->
     )
 
 
-def resolve_cp_forward_model(model):
-    """Return the CausalLM the CP-v2 eager path drives.
-
-    That path drives the sub-module whose ``.model`` is the transformer body and
-    which owns the logits head / input embeddings. Flat CausalLMs are themselves;
-    multimodal wrappers expose their inner CausalLM via the standard
-    ``get_language_model`` accessor (e.g. Kimi K2.5 -> ``language_model``).
-    """
-    get_language_model = getattr(model, "get_language_model", None)
-    if get_language_model is not None:
-        return get_language_model()
-    return model
-
-
 def enable_cp_v2() -> bool:
     """Return whether the CP-v2 path is enabled for this process."""
     from sglang.srt.environ import envs
@@ -236,7 +222,6 @@ __all__ = [
     "cp_gather_after_forward",
     "cp_split_before_forward",
     "prepare_cp_forward",
-    "resolve_cp_forward_model",
     "is_glm_dsa_cache_layer_split_enabled",
     "get_glm_dsa_cp_layer_shard_info",
     "get_glm_dsa_layer_split_effective_num_layers",

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -38,12 +38,13 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 # Pure-MLA/GQA archs only; DSA archs (DeepseekV32/DeepseekV4) are excluded as
-# CP-v2 does not yet cover DSA, and Kimi K2.5 needs separate wiring for its
-# ``.language_model`` wrapper.
+# CP-v2 does not yet cover DSA. Kimi K2.5 drives its inner CausalLM via
+# get_cp_model() (see resolve_cp_forward_model).
 CP_V2_DEFAULT_MODEL_CLASSES = frozenset(
     {
         "Qwen3MoeForCausalLM",
         "DeepseekV3ForCausalLM",
+        "KimiK25ForConditionalGeneration",
     }
 )
 
@@ -122,6 +123,19 @@ def get_layer_owner(local_layer_idx: int, shard_size: int, total_layers: int) ->
         f"Invalid local_layer_idx={local_layer_idx} for "
         f"shard_size={shard_size}, total_layers={total_layers}"
     )
+
+
+def resolve_cp_forward_model(model):
+    """Return the CausalLM the CP-v2 eager path drives.
+
+    That path drives the sub-module whose ``.model`` is the transformer body and
+    which owns the logits head / input embeddings. Flat CausalLMs are themselves;
+    multimodal wrappers (e.g. Kimi K2.5) expose it via ``get_cp_model``.
+    """
+    resolver = getattr(model, "get_cp_model", None)
+    if resolver is not None:
+        return resolver()
+    return model
 
 
 def enable_cp_v2() -> bool:
@@ -224,6 +238,7 @@ __all__ = [
     "cp_gather_after_forward",
     "cp_split_before_forward",
     "prepare_cp_forward",
+    "resolve_cp_forward_model",
     "is_glm_dsa_cache_layer_split_enabled",
     "get_glm_dsa_cp_layer_shard_info",
     "get_glm_dsa_layer_split_effective_num_layers",

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -41,7 +41,6 @@ CP_V2_DEFAULT_MODEL_CLASSES = frozenset(
     {
         "Qwen3MoeForCausalLM",
         "DeepseekV3ForCausalLM",
-        "KimiK25ForConditionalGeneration",
     }
 )
 

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -37,9 +37,13 @@ from sglang.srt.runtime_context import get_parallel
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
+# Pure-MLA/GQA archs only; DSA archs (DeepseekV32/DeepseekV4) are excluded as
+# CP-v2 does not yet cover DSA, and Kimi K2.5 needs separate wiring for its
+# ``.language_model`` wrapper.
 CP_V2_DEFAULT_MODEL_CLASSES = frozenset(
     {
         "Qwen3MoeForCausalLM",
+        "DeepseekV3ForCausalLM",
     }
 )
 

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -127,11 +127,12 @@ def resolve_cp_forward_model(model):
 
     That path drives the sub-module whose ``.model`` is the transformer body and
     which owns the logits head / input embeddings. Flat CausalLMs are themselves;
-    multimodal wrappers (e.g. Kimi K2.5) expose it via ``get_cp_model``.
+    multimodal wrappers expose their inner CausalLM via the standard
+    ``get_language_model`` accessor (e.g. Kimi K2.5 -> ``language_model``).
     """
-    resolver = getattr(model, "get_cp_model", None)
-    if resolver is not None:
-        return resolver()
+    get_language_model = getattr(model, "get_language_model", None)
+    if get_language_model is not None:
+        return get_language_model()
     return model
 
 

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -37,9 +37,6 @@ from sglang.srt.runtime_context import get_parallel
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
-# Pure-MLA/GQA archs only; DSA archs (DeepseekV32/DeepseekV4) are excluded as
-# CP-v2 does not yet cover DSA. Kimi K2.5 drives its inner CausalLM via
-# get_cp_model() (see resolve_cp_forward_model).
 CP_V2_DEFAULT_MODEL_CLASSES = frozenset(
     {
         "Qwen3MoeForCausalLM",

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -357,13 +357,6 @@ class ZigzagCPStrategy(ContextParallelStrategy):
     def materialize_full_mla_kv(
         self, forward_batch, layer: Any, k_nope: Any, k_rope: Any
     ) -> None:
-        """Gather rank-local MLA latent KV to full token order and write it.
-
-        MLA stores a single latent (compressed KV + rope) instead of separate
-        K/V heads, so the two tensors are fused for one all-gather and split
-        back before the paged write. out_cache_loc spans the full sequence, so
-        every rank writes the same full latent to the same slots.
-        """
         kv_lora_rank = k_nope.shape[-1]
         latent = torch.cat([k_nope, k_rope], dim=-1).contiguous()
         latent_full = self.gather_kv_cache(

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -354,6 +354,28 @@ class ZigzagCPStrategy(ContextParallelStrategy):
             layer.v_scale,
         )
 
+    def materialize_full_mla_kv(
+        self, forward_batch, layer: Any, k_nope: Any, k_rope: Any
+    ) -> None:
+        """Gather rank-local MLA latent KV to full token order and write it.
+
+        MLA stores a single latent (compressed KV + rope) instead of separate
+        K/V heads, so the two tensors are fused for one all-gather and split
+        back before the paged write. out_cache_loc spans the full sequence, so
+        every rank writes the same full latent to the same slots.
+        """
+        kv_lora_rank = k_nope.shape[-1]
+        latent = torch.cat([k_nope, k_rope], dim=-1).contiguous()
+        latent_full = self.gather_kv_cache(
+            latent, forward_batch, torch.cuda.current_stream()
+        )
+        get_token_to_kv_pool().set_mla_kv_buffer(
+            layer,
+            forward_batch.out_cache_loc,
+            latent_full[..., :kv_lora_rank],
+            latent_full[..., kv_lora_rank:],
+        )
+
     def _all_gather_reorganized(self, x: torch.Tensor, forward_batch, stream):
         meta = forward_batch.attn_cp_metadata
         max_len = meta.max_rank_len[0]

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -29,7 +29,6 @@ from sglang.srt.layers.cp.utils import (
     cp_split_before_forward,
     is_cp_v2_active,
     prepare_cp_forward,
-    resolve_cp_forward_model,
 )
 from sglang.srt.layers.pooler import EmbeddingPoolerOutput
 from sglang.srt.model_executor.cuda_graph_buffer_registry import (
@@ -286,9 +285,15 @@ class EagerRunner(BaseRunner):
             model_runner.attn_backend.init_forward_metadata(forward_batch)
 
         cp_v2_active = is_cp_v2_active(forward_batch)
-        cp_model = (
-            resolve_cp_forward_model(model_runner.model) if cp_v2_active else None
-        )
+        cp_model = None
+        if cp_v2_active:
+            # The CP-v2 path drives the CausalLM whose .model is the transformer
+            # body. Multimodal wrappers (e.g. Kimi) expose it via the standard
+            # get_language_model accessor; flat CausalLMs are themselves.
+            cp_model = model_runner.model
+            get_language_model = getattr(cp_model, "get_language_model", None)
+            if get_language_model is not None:
+                cp_model = get_language_model()
         forward_positions = forward_batch.positions
         if cp_v2_active:
             prepare_cp_forward(forward_batch)

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -29,6 +29,7 @@ from sglang.srt.layers.cp.utils import (
     cp_split_before_forward,
     is_cp_v2_active,
     prepare_cp_forward,
+    resolve_cp_forward_model,
 )
 from sglang.srt.layers.pooler import EmbeddingPoolerOutput
 from sglang.srt.model_executor.cuda_graph_buffer_registry import (
@@ -285,12 +286,15 @@ class EagerRunner(BaseRunner):
             model_runner.attn_backend.init_forward_metadata(forward_batch)
 
         cp_v2_active = is_cp_v2_active(forward_batch)
+        cp_model = (
+            resolve_cp_forward_model(model_runner.model) if cp_v2_active else None
+        )
         forward_positions = forward_batch.positions
         if cp_v2_active:
             prepare_cp_forward(forward_batch)
             complete_hidden_states = kwargs.get("input_embeds")
             if complete_hidden_states is None:
-                embed_layer = model_runner.model.get_input_embeddings()
+                embed_layer = cp_model.get_input_embeddings()
                 complete_hidden_states = embed_layer(forward_batch.input_ids)
             sharded_hidden_states, sharded_positions = cp_split_before_forward(
                 complete_hidden_states,
@@ -341,7 +345,7 @@ class EagerRunner(BaseRunner):
                     )
             elif cp_v2_active:
                 # CP-V2: drive .model directly to gather across CP ranks before logits.
-                hidden_states = model_runner.model.model(
+                hidden_states = cp_model.model(
                     forward_batch.input_ids,
                     forward_positions,
                     forward_batch,
@@ -350,20 +354,20 @@ class EagerRunner(BaseRunner):
                 )
                 aux_hidden_states = None
                 capture_aux_hidden_states = getattr(
-                    model_runner.model, "capture_aux_hidden_states", False
+                    cp_model, "capture_aux_hidden_states", False
                 )
                 if capture_aux_hidden_states:
                     hidden_states, aux_hidden_states = hidden_states
-                if model_runner.model.pp_group.is_last_rank:
+                if cp_model.pp_group.is_last_rank:
                     hidden_states = cp_gather_after_forward(
                         hidden_states,
                         forward_batch,
                         torch.cuda.current_stream(),
                     )
-                    ret = model_runner.model.logits_processor(
+                    ret = cp_model.logits_processor(
                         forward_batch.input_ids,
                         hidden_states,
-                        model_runner.model.lm_head,
+                        cp_model.lm_head,
                         forward_batch,
                         aux_hidden_states,
                     )

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -285,30 +285,7 @@ class EagerRunner(BaseRunner):
             model_runner.attn_backend.init_forward_metadata(forward_batch)
 
         cp_v2_active = is_cp_v2_active(forward_batch)
-        cp_model = None
-        if cp_v2_active:
-            # The CP-v2 path drives the CausalLM whose .model is the transformer
-            # body. Multimodal wrappers (e.g. Kimi) expose it via the standard
-            # get_language_model accessor; flat CausalLMs are themselves.
-            cp_model = model_runner.model
-            get_language_model = getattr(cp_model, "get_language_model", None)
-            if get_language_model is not None:
-                cp_model = get_language_model()
-        forward_positions = forward_batch.positions
-        if cp_v2_active:
-            prepare_cp_forward(forward_batch)
-            complete_hidden_states = kwargs.get("input_embeds")
-            if complete_hidden_states is None:
-                embed_layer = cp_model.get_input_embeddings()
-                complete_hidden_states = embed_layer(forward_batch.input_ids)
-            sharded_hidden_states, sharded_positions = cp_split_before_forward(
-                complete_hidden_states,
-                forward_batch.positions,
-                forward_batch,
-            )
-            kwargs["input_embeds"] = sharded_hidden_states
-            forward_positions = sharded_positions
-        else:
+        if not cp_v2_active:
             forward_batch.attn_cp_metadata = None
 
         category = (
@@ -344,50 +321,66 @@ class EagerRunner(BaseRunner):
                 ):
                     ret = model_runner.model.forward(
                         forward_batch.input_ids,
-                        forward_positions,
+                        forward_batch.positions,
                         forward_batch,
                         **kwargs,
                     )
             elif cp_v2_active:
-                # CP-V2: drive .model directly to gather across CP ranks before logits.
-                hidden_states = cp_model.model(
-                    forward_batch.input_ids,
-                    forward_positions,
-                    forward_batch,
-                    input_embeds=kwargs.get("input_embeds"),
-                    pp_proxy_tensors=kwargs.get("pp_proxy_tensors"),
-                )
-                aux_hidden_states = None
-                capture_aux_hidden_states = getattr(
-                    cp_model, "capture_aux_hidden_states", False
-                )
-                if capture_aux_hidden_states:
-                    hidden_states, aux_hidden_states = hidden_states
-                if cp_model.pp_group.is_last_rank:
-                    hidden_states = cp_gather_after_forward(
-                        hidden_states,
-                        forward_batch,
-                        torch.cuda.current_stream(),
-                    )
-                    ret = cp_model.logits_processor(
-                        forward_batch.input_ids,
-                        hidden_states,
-                        cp_model.lm_head,
-                        forward_batch,
-                        aux_hidden_states,
-                    )
-                elif capture_aux_hidden_states:
-                    ret = hidden_states, aux_hidden_states
-                else:
-                    ret = hidden_states
+                ret = self._execute_extend_cp_v2(forward_batch, kwargs)
             else:
                 ret = model_runner.model.forward(
                     forward_batch.input_ids,
-                    forward_positions,
+                    forward_batch.positions,
                     forward_batch,
                     **kwargs,
                 )
         return ret
+
+    def _execute_extend_cp_v2(
+        self, forward_batch: ForwardBatch, kwargs: dict
+    ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
+        """CP-v2 extend: shard inputs at the model boundary, run the body on the
+        rank-local slice, then gather hidden states before the logits step.
+        """
+        model = self.model_runner.model
+
+        prepare_cp_forward(forward_batch)
+        input_embeds = kwargs.get("input_embeds")
+        if input_embeds is None:
+            input_embeds = model.get_input_embeddings()(forward_batch.input_ids)
+        input_embeds, positions = cp_split_before_forward(
+            input_embeds, forward_batch.positions, forward_batch
+        )
+
+        hidden_states = model.model(
+            forward_batch.input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
+            pp_proxy_tensors=kwargs.get("pp_proxy_tensors"),
+        )
+        capture_aux_hidden_states = getattr(model, "capture_aux_hidden_states", False)
+        aux_hidden_states = None
+        if capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+
+        if not model.pp_group.is_last_rank:
+            return (
+                (hidden_states, aux_hidden_states)
+                if capture_aux_hidden_states
+                else hidden_states
+            )
+
+        hidden_states = cp_gather_after_forward(
+            hidden_states, forward_batch, torch.cuda.current_stream()
+        )
+        return model.logits_processor(
+            forward_batch.input_ids,
+            hidden_states,
+            model.lm_head,
+            forward_batch,
+            aux_hidden_states,
+        )
 
     def _execute_idle(
         self, forward_batch: ForwardBatch, pp_proxy_tensors=None

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -19,6 +19,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_graph_dsa_split_op_surface,
 )
 from sglang.srt.layers.communicator import get_attn_tp_context
+from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.dcp import (
     all_gather_kv_cache_for_mla_extend,
     all_gather_q_for_mla_decode,
@@ -565,8 +566,13 @@ class DeepseekMLAForwardMixin:
             dsa_prefill_cp=dsa_prefill_cp,
             fuse_rope_for_trtllm_mla=fuse_rope_for_trtllm_mla,
         )
-        if (dsa_prefill_cp or mla_prefill_cp) and not defer_kv_gather_until_after_rope:
-            # support allgather+rerrange
+        if (
+            (dsa_prefill_cp or mla_prefill_cp)
+            and not defer_kv_gather_until_after_rope
+            and not is_cp_v2_active(forward_batch)
+        ):
+            # CP-v1 gathers the latent here; CP-v2 gathers it in the attention
+            # backend via the strategy (materialize_full_mla_kv).
             k_nope, k_pe = self.rebuild_cp_kv_cache(
                 latent_cache, forward_batch, k_nope, k_pe
             )

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -253,11 +253,11 @@ class DeepseekModelNextN(nn.Module):
                     hidden_states = self.eh_proj(eh_input)
 
             # CP-v2 shards/gathers at the eager-runner boundary instead.
-            use_cp = (
+            use_cp_v1 = (
                 dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
                 or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
             ) and not is_cp_v2_active(forward_batch)
-            if use_cp:
+            if use_cp_v1:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
                 positions = cp_split_and_rebuild_position(forward_batch, positions)
             residual = None
@@ -288,7 +288,7 @@ class DeepseekModelNextN(nn.Module):
                 else:
                     hidden_states = self.shared_head.norm(hidden_states)
 
-                if use_cp:
+                if use_cp_v1:
                     local_num_tokens = hidden_states.shape[0]
                     hidden_states = cp_all_gather_rerange_output(
                         hidden_states,

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -35,6 +35,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_enable_prefill_cp,
     is_dsa_prefill_cp_round_robin_split,
 )
+from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
@@ -251,9 +252,11 @@ class DeepseekModelNextN(nn.Module):
                 else:
                     hidden_states = self.eh_proj(eh_input)
 
-            use_cp = dsa_use_prefill_cp(
-                forward_batch, self.dsa_enable_prefill_cp
-            ) or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+            # CP-v2 shards/gathers at the eager-runner boundary instead.
+            use_cp = (
+                dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
+                or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+            ) and not is_cp_v2_active(forward_batch)
             if use_cp:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
                 positions = cp_split_and_rebuild_position(forward_batch, positions)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -77,6 +77,7 @@ from sglang.srt.layers.communicator_dsa_cp import (
     DSACPLayerCommunicator,
     maybe_prefetch_next_full_attention_kv,
 )
+from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.dcp.planner import (
     prepare_decode_context_parallel_metadata,
 )
@@ -2546,9 +2547,11 @@ class DeepseekV2Model(nn.Module):
             else None
         )
 
-        if dsa_use_prefill_cp(
-            forward_batch, self.dsa_enable_prefill_cp
-        ) or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp):
+        if (
+            dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
+            or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+        ) and not is_cp_v2_active(forward_batch):
+            # CP-v2 shards at the eager-runner boundary instead.
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
@@ -2651,10 +2654,15 @@ class DeepseekV2Model(nn.Module):
                 else:
                     hidden_states, _ = self.norm(hidden_states, residual)
 
-        if self.pp_group.is_last_rank and (
-            dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
-            or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+        if (
+            self.pp_group.is_last_rank
+            and (
+                dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
+                or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
+            )
+            and not is_cp_v2_active(forward_batch)
         ):
+            # CP-v2 gathers at the eager-runner boundary instead.
             # allgather + rerrange
             hidden_states = cp_all_gather_rerange_output(
                 hidden_states,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2547,11 +2547,13 @@ class DeepseekV2Model(nn.Module):
             else None
         )
 
-        if (
+        # CP-v2 shards/gathers at the eager-runner boundary instead.
+        use_cp_v1 = (
             dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
             or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
-        ) and not is_cp_v2_active(forward_batch):
-            # CP-v2 shards at the eager-runner boundary instead.
+        ) and not is_cp_v2_active(forward_batch)
+
+        if use_cp_v1:
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
@@ -2654,15 +2656,7 @@ class DeepseekV2Model(nn.Module):
                 else:
                     hidden_states, _ = self.norm(hidden_states, residual)
 
-        if (
-            self.pp_group.is_last_rank
-            and (
-                dsa_use_prefill_cp(forward_batch, self.dsa_enable_prefill_cp)
-                or mla_use_prefill_cp(forward_batch, self.mla_enable_prefill_cp)
-            )
-            and not is_cp_v2_active(forward_batch)
-        ):
-            # CP-v2 gathers at the eager-runner boundary instead.
+        if self.pp_group.is_last_rank and use_cp_v1:
             # allgather + rerrange
             hidden_states = cp_all_gather_rerange_output(
                 hidden_states,

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -687,6 +687,11 @@ class KimiK25ForConditionalGeneration(nn.Module):
         # CUDA graph gate, which checks `hasattr(model, "model")`.
         return self.language_model
 
+    def get_cp_model(self):
+        # The CP-v2 eager path drives the inner CausalLM (whose .model is the
+        # transformer body and which owns the logits head), not this wrapper.
+        return self.language_model
+
     def __setattr__(self, name, value):
         # Skip redundant self.model.model assignment in runner to avoid duplicate
         # nn.Module registration.

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -687,9 +687,6 @@ class KimiK25ForConditionalGeneration(nn.Module):
         # CUDA graph gate, which checks `hasattr(model, "model")`.
         return self.language_model
 
-    def get_language_model(self) -> torch.nn.Module:
-        return self.language_model
-
     def __setattr__(self, name, value):
         # Skip redundant self.model.model assignment in runner to avoid duplicate
         # nn.Module registration.

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -687,9 +687,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
         # CUDA graph gate, which checks `hasattr(model, "model")`.
         return self.language_model
 
-    def get_cp_model(self):
-        # The CP-v2 eager path drives the inner CausalLM (whose .model is the
-        # transformer body and which owns the logits head), not this wrapper.
+    def get_language_model(self) -> torch.nn.Module:
         return self.language_model
 
     def __setattr__(self, name, value):


### PR DESCRIPTION
## Motivation

Part of the Prefill CP refactor roadmap (#27252) and the Context Parallelism roadmap (#21788). #28421 landed the CP-v2 `ZigzagCPStrategy` for GQA/MHA (Qwen3) and the model-agnostic eager-runner boundary. This PR ports **MLA prefill CP for DeepSeek V3/R1** (originally #23292) onto that abstraction and makes the strategy own the MLA latent all-gather.

`DeepseekV3ForCausalLM` is added to `CP_V2_DEFAULT_MODEL_CLASSES`, so CP-v2 is its default (like `Qwen3MoeForCausalLM`). The legacy cp_utils v1 path stays intact and reachable via `SGLANG_ENABLE_CP_V2=0`.

## Modifications

**Boundary migration (v1↔v2 coexist):**
- `layers/cp/utils.py` — add `DeepseekV3ForCausalLM` to `CP_V2_DEFAULT_MODEL_CLASSES`.
- `models/deepseek_v2.py` / `models/deepseek_nextn.py` — gate the in-model CP entry split + exit gather to v1-only (`use_cp_v1`); the eager runner owns them under v2.
- `layers/attention/flashattention_backend.py` — MLA CP attention dispatches through `cp_strategy.run_attention` under v2, else the v1 `cp_attn_forward_extend`.
- `model_executor/runner/eager_runner.py` — CP-v2 extend is a single self-contained `_execute_extend_cp_v2` (shard at the boundary, run the body on the rank-local slice, gather before logits).

**Decision A — strategy owns the MLA latent all-gather (v2):**
- `models/.../forward_mla.py` — skip the upstream `rebuild_cp_kv_cache` under v2 (k_nope/k_pe stay rank-local).
- `flashattention_backend.py` — the MLA KV write dispatches to `cp_strategy.materialize_full_mla_kv` under v2 (gather rank-local latent → full, then `set_mla_kv_buffer`); v1 keeps the upstream-rebuilt full write.
- `layers/cp/zigzag.py` — add `materialize_full_mla_kv` (fuse compressed-KV + rope, one all-gather via `gather_kv_cache`, split back for the paged write).

**Already handled (no change needed):** the `seq_lens_k` padding flagged on #28421 — zigzag `build_metadata` bakes `pad_len` (#28421) and the FA backend widens `page_table` by `pad_delta` (#23292). Decision A's gather preserves the same padded length.

## Accuracy Tests

Existing `test/registered/cp/test_deepseek_v3_cp_single_node.py` (`tp=8, dp=2, attn-cp=4`, DeepSeek-V3-0324, GSM8k ≥ 0.935) now runs CP-v2 via the default-class enablement. Verified on 8×H200:

| Config | GSM8k |
|---|---|
| v1 (`SGLANG_ENABLE_CP_V2=0`) | 0.966 |
| v2 + Decision A (strategy latent gather) | 0.96 / 0.962 |
| v2, final (eager-runner extraction) | **0.964** |

Non-regression: v1 MLA CP unchanged (0.966); NSA/DSA and MHA CP paths are no-ops under default `SGLANG_ENABLE_CP_V2=0`.

## Out of scope (follow-ups)

- **Kimi K2.5** — CP-v2 for the multimodal wrapper (resolving its inner `language_model`) is deferred to a follow-up PR.
- MTP (nextn) + CP-v2 and DSA + CP-v2 remain out of scope (v1-only `use_cp_v1` gates make v2 a no-op there).

## Checklist

- [x] Format with pre-commit
- [x] Accuracy verified for DeepSeek V3 (see table)
- [ ] Speed/profiling (TODO)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29629808219](https://github.com/sgl-project/sglang/actions/runs/29629808219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29629808052](https://github.com/sgl-project/sglang/actions/runs/29629808052)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->