### PR TITLE
fix(weight-checker): skip _skip_weight_check tensors in _reset_tensors

### DIFF
--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -97,6 +97,8 @@ class WeightChecker:
         for name, param in self._model_state():
             if _is_non_persistent_buffer_name(name):
                 continue
+            if getattr(param, "_skip_weight_check", False):
+                continue
             param.copy_(_random_like(param))
 
     def _compare(self, allow_quant_error: bool = False):


### PR DESCRIPTION
## Motivation

`WeightChecker` (the `--check-weight-update-equal` weight-refit self-test) snapshots all tensors, resets them to random noise, relies on the weight update to restore them, then compares against the snapshot.

`_compare` and `_compute_checksum` both exclude tensors marked `_skip_weight_check` (e.g. fp8 KV-cache `k_scale`/`v_scale` set in `python/sglang/srt/layers/quantization/kv_cache.py`). `_reset_tensors` does not — it overwrites those tensors with noise as well.

Since those tensors are excluded from verification, resetting them serves no purpose. And if the weight update does not restore them (derived parameters, or partial-parameter updates), they are silently left as random noise while the self-test still reports success.

## Modifications

`_reset_tensors` now skips tensors marked `_skip_weight_check`, so the reset set matches what `_compare` / `_compute_checksum` verify:

```python
def _reset_tensors(self):
    for name, param in self._model_state():
        if _is_non_persistent_buffer_name(name):
            continue
        if getattr(param, "_skip_weight_check", False):
            continue
        param.copy_(_random_like(param))
```

## Accuracy Tests

No model-output changes. This only affects the `--check-weight-update-equal` diagnostic path; the forward/kernel code is untouched.

## Speed Tests and Profiling

N/A — no inference-path changes.

## Testing

- Added `TestResetTensors.test_preserves_tensors_excluded_from_weight_check`.
- Local targeted reset-symmetry harness: PASS (marked tensor preserved; checked tensor randomized).
- Current-head CI lint: passed. Full gated suites still require the maintainer-only `run-ci` label.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [x] Documentation applicability reviewed ([guide](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations)): **N/A** — this restores the existing `_skip_weight_check` contract inside the weight-update diagnostic; it adds no CLI option or public API. No separate documentation change was made.
- [x] Accuracy and speed benchmark applicability reviewed ([accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy), [speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed)): **N/A** — no model-forward/kernel or inference-speed change. Validation targets preservation of excluded tensors in the reset diagnostic, as reported above. No model accuracy evaluation or GPU speed benchmark was run.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35063321136](https://github.com/sgl-project/sglang/actions/runs/35063321136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35063320819](https://github.com/sgl-project/sglang/actions/runs/35063320819)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35063321118](https://github.com/sgl-project/sglang/actions/runs/35063321118)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->

