### PR TITLE
Revert "Fix mamba track-boundary seqlen under overlap scheduler (#31369)"

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -956,20 +956,13 @@ class SchedulerBatchResultProcessor:
     def _mamba_check_track_boundary(self, req, batch, result, i):
         """Check if this decode step crosses a mamba track interval boundary.
 
-        Returns (at_boundary, track_seqlen).  ``track_seqlen`` must equal the
-        seq_len the forward's tracking mask used, so the tracked state and its
-        recorded ``mamba_last_track_seqlen`` describe the same token position.
-        That seq_len is a pure function of the tokens the request has produced:
-        ``len(origin_input_ids) + len(output_ids) - 1`` (the just-decoded token
-        is already appended to ``output_ids`` before this runs).
-
-        ``kv_committed_len`` must NOT be used here: under the overlap scheduler,
-        ``prepare_for_decode`` for the *next* batch increments it before this
-        result is processed, so it leads seq_len by a jittering lookahead
-        (0 or 1 depending on prefill interleaving). Using it fires the boundary
-        one decode step early on most steps, mislabeling the tracked mamba
-        state; a later request that reuses/donates that tracked prefix then
-        extends from a state a cold prefill recompute would not produce.
+        Returns (at_boundary, track_seqlen).  The boundary condition
+        matches what the forward's tracking mask used:
+        ``prepare_for_decode`` increments both ``seq_lens_cpu`` and
+        ``kv_committed_len`` by 1, then checks
+        ``seq_lens_cpu % interval == 0``.  Using ``kv_committed_len``
+        here reproduces that check exactly, and the value is always a
+        multiple of ``interval`` (hence page-aligned).
 
         For spec decode, the boundary is detected by comparing the
         accepted seq_len range against interval boundaries.
@@ -977,9 +970,8 @@ class SchedulerBatchResultProcessor:
         interval = get_server_args().mamba_track_interval
 
         if batch.spec_algorithm.is_none():
-            seq_len = len(req.origin_input_ids) + len(req.output_ids) - 1
-            if seq_len % interval == 0:
-                return True, seq_len
+            if req.kv_committed_len % interval == 0:
+                return True, req.kv_committed_len
         elif result.num_correct_drafts_per_req_cpu is not None:
             cur = req.seqlen - 1
             prev = cur - result.num_correct_drafts_per_req_cpu[i] - 1


### PR DESCRIPTION
## Problem

Reverts #31369, which introduced a **deterministic correctness regression** on `main`: the Qwen3-Next decode-cache-hit logprobs diverge from a cold recompute, failing the nightly `4-gpu-h100` test since 2026-07-17:

```
test/registered/models_e2e/test_qwen3_next_models.py::test_input_output_logprobs_match_decode_cache_hit_helper
AssertionError: avg_kl_div=0.006489 > threshold=0.002 for Qwen/Qwen3-Next-80B-A3B-Instruct
```

(identical kl_div on every retry → deterministic, not flaky).

## Bisect

Pinned to #31369 (`0675d3033f`):
- kl_div was ≤0.0005 (pass) at `dc0b3eb` and jumped to 0.0065 (fail) at `681c2235`; #31369 is **absent in the good run, present in the bad run**.
- It is the **only** commit in that window touching `_mamba_check_track_boundary` / `batch_result_processor.py` / the mamba track-boundary logic.
- It rewrites the exact function that records the mamba tracking boundary for cache-hit decode — which is precisely what the failing test validates.

## Why it regressed

#31369 changed the boundary seqlen from `req.kv_committed_len` to `len(req.origin_input_ids) + len(req.output_ids) - 1`. That new seqlen mislabels the mamba track boundary for the decode-cache-hit case, so a reused/donated tracked prefix extends from a state a cold prefill recompute would not produce — exactly the mismatch the test catches (and the symptom #31369's own description warns about).

## Scope

Reverting restores the previously-passing behavior. The original overlap-scheduler boundary issue #31369 aimed at should re-land through the open #29792 ("Fix Mamba track-boundary bookkeeping under overlap scheduling"), which targets the same code with the correct bookkeeping.

Hardware A/B confirmation (revert → kl_div back under threshold) on a 4×H100 devbox is in progress; will update this PR with the before/after numbers.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29619940928](https://github.com/sgl-project/sglang/actions/runs/29619940928)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29619940825](https://github.com/sgl-project/sglang/actions/runs/29619940825)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->