### PR TITLE
[Test] Cover both seq-lens variants in DSV4 runner-mode kit tests

### DIFF
--- a/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
+++ b/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
@@ -252,19 +252,27 @@ class TestDSV4AttentionBackendCorrectness(CustomTestCase):
     )
 
     def test_runner_mode_eagle_verify_cuda_graph_cases(self):
+        # Both seq-lens variants: gpu-only (default sync-free path) and the
+        # mirrored fallback (dspark exemption / online-c128 keep the CPU
+        # mirror alive in production).
         for case in self.EAGLE_VERIFY_CUDA_GRAPH_CASES:
-            with self.subTest(
-                case=case.name,
-                backend=case.backend,
-                compress_ratio=case.compress_ratio,
-            ):
-                run_dsv4_eagle_verify_cuda_graph_case(
-                    self, case, topk=1, force_gpu_only_seq_lens=True
-                )
+            for force_gpu_only_seq_lens in (False, True):
+                with self.subTest(
+                    case=case.name,
+                    backend=case.backend,
+                    compress_ratio=case.compress_ratio,
+                    force_gpu_only_seq_lens=force_gpu_only_seq_lens,
+                ):
+                    run_dsv4_eagle_verify_cuda_graph_case(
+                        self,
+                        case,
+                        topk=1,
+                        force_gpu_only_seq_lens=force_gpu_only_seq_lens,
+                    )
 
-    def test_eagle_draft_extend_without_cpu_seq_lens(self):
+    def test_eagle_draft_extend_seq_lens_variants(self):
         case = DSV4AttentionCase(
-            name="dsv4_swa_eagle_draft_extend_gpu_only_seq_lens",
+            name="dsv4_swa_eagle_draft_extend",
             backend="dsv4",
             forward_mode=ForwardMode.DRAFT_EXTEND_V2,
             num_heads=64,
@@ -272,11 +280,13 @@ class TestDSV4AttentionBackendCorrectness(CustomTestCase):
             prefix_lens=(64, 96),
             extend_lens=(4, 4),
         )
-        run_dsv4_draft_extend_attention_case(
-            self,
-            case,
-            force_gpu_only_seq_lens=True,
-        )
+        for force_gpu_only_seq_lens in (False, True):
+            with self.subTest(force_gpu_only_seq_lens=force_gpu_only_seq_lens):
+                run_dsv4_draft_extend_attention_case(
+                    self,
+                    case,
+                    force_gpu_only_seq_lens=force_gpu_only_seq_lens,
+                )
 
     # Production EAGLE draft graph runner (chain only, SWA only). The runner
     # routes through `DeepseekV4MultiStepBackend` (one `DeepseekV4AttnBackend`
@@ -296,12 +306,17 @@ class TestDSV4AttentionBackendCorrectness(CustomTestCase):
 
     def test_runner_mode_production_eagle_draft_cuda_graph_runner_cases(self):
         for case in self.PRODUCTION_EAGLE_DRAFT_RUNNER_CASES:
-            with self.subTest(case=case.name, backend=case.backend):
-                run_dsv4_eagle_draft_cuda_graph_runner_case(
-                    self,
-                    case,
-                    force_gpu_only_seq_lens=True,
-                )
+            for force_gpu_only_seq_lens in (False, True):
+                with self.subTest(
+                    case=case.name,
+                    backend=case.backend,
+                    force_gpu_only_seq_lens=force_gpu_only_seq_lens,
+                ):
+                    run_dsv4_eagle_draft_cuda_graph_runner_case(
+                        self,
+                        case,
+                        force_gpu_only_seq_lens=force_gpu_only_seq_lens,
+                    )
 
 
 class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):


### PR DESCRIPTION
Parametrize the DSV4 runner-mode kit tests over force_gpu_only_seq_lens so the mirrored seq-lens fallback path keeps coverage alongside the gpu-only default.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828648191](https://github.com/sgl-project/sglang/actions/runs/34828648191)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828648001](https://github.com/sgl-project/sglang/actions/runs/34828648001)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34828648033](https://github.com/sgl-project/sglang/actions/runs/34828648033)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->