### PR TITLE
[CP] Add TRTLLM MHA zigzag prefill CP for MiMo V2.5

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from sglang.kernels.ops.attention.utils import canonicalize_stride
+from sglang.kernels.ops.attention.utils import (
+    canonicalize_stride,
+    create_flashinfer_kv_indices_triton,
+)
 from sglang.kernels.ops.kvcache.trtllm_mha_graph_metadata import (
     Q_MODE_NONE,
     Q_MODE_STRIDED,
@@ -25,6 +28,8 @@ from sglang.srt.layers.attention.flashinfer_backend import (
     FlashInferAttnBackend,
     FlashInferMultiStepDraftBackend,
 )
+from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
+from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     KVCacheAttentionAccessKind,
 )
@@ -54,8 +59,171 @@ if TYPE_CHECKING:
 # Default workspace size in MB for TRTLLM MHA
 # Can be configured via SGLANG_FLASHINFER_WORKSPACE_SIZE environment variable
 DEFAULT_WORKSPACE_SIZE_MB = 512
+MAX_TRTLLM_RAGGED_BATCH_SIZE = 128
 
 # Reuse this workspace buffer across all TRTLLM MHA wrappers
+
+
+def _compute_ragged_kv_ranges(
+    q_lens: torch.Tensor,
+    kv_lens: torch.Tensor,
+    window_left: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return compact-cache starts and lengths for a ragged prefill call.
+
+    The compact K/V range must end at each query chunk's last token so the
+    TensorRT ragged kernel's bottom-right causal alignment remains unchanged.
+    For sliding-window attention, the first query additionally needs
+    ``window_left`` preceding keys.
+    """
+    if q_lens.shape != kv_lens.shape:
+        raise ValueError(
+            f"q_lens and kv_lens must have the same shape, got "
+            f"{tuple(q_lens.shape)} and {tuple(kv_lens.shape)}"
+        )
+    if q_lens.dtype != kv_lens.dtype or q_lens.device != kv_lens.device:
+        raise ValueError("q_lens and kv_lens must have matching dtype and device")
+
+    if window_left < 0:
+        starts = torch.zeros_like(kv_lens)
+    else:
+        starts = torch.clamp(kv_lens - q_lens - window_left, min=0)
+    return starts, kv_lens - starts
+
+
+def _compute_per_query_window_geometry(
+    q_lens: torch.Tensor,
+    kv_lens: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    window_left: int,
+    *,
+    total_q_tokens: Optional[int] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Expand a query chunk into exact single-query sliding-window sequences."""
+    if window_left < 0:
+        raise ValueError("Per-query window geometry requires a non-negative window")
+    if q_lens.shape != kv_lens.shape:
+        raise ValueError("Q and KV lengths must have the same shape")
+    if req_pool_indices.numel() != q_lens.numel():
+        raise ValueError("Request indices must match the ragged batch size")
+
+    batch_ids = torch.arange(q_lens.numel(), device=q_lens.device)
+    expanded_batch_ids = torch.repeat_interleave(
+        batch_ids,
+        q_lens.to(torch.int64),
+        output_size=total_q_tokens,
+    )
+    expanded_req_pool_indices = req_pool_indices.index_select(0, expanded_batch_ids)
+
+    cu_seqlens_q = torch.nn.functional.pad(
+        torch.cumsum(q_lens, dim=0, dtype=torch.int32), (1, 0)
+    )
+    q_offsets = cu_seqlens_q[:-1].index_select(0, expanded_batch_ids)
+    local_q_positions = (
+        torch.arange(
+            expanded_batch_ids.numel(), device=q_lens.device, dtype=torch.int32
+        )
+        - q_offsets
+    )
+    prefix_lens = (kv_lens - q_lens).index_select(0, expanded_batch_ids)
+    query_positions = prefix_lens + local_q_positions
+    starts = torch.clamp(query_positions - window_left, min=0)
+    window_lens = query_positions - starts + 1
+    cu_seqlens_kv = torch.nn.functional.pad(
+        torch.cumsum(window_lens, dim=0, dtype=torch.int32), (1, 0)
+    )
+    return expanded_req_pool_indices, starts, window_lens, cu_seqlens_kv
+
+
+def _sum_per_query_window_kv_tokens(
+    q_lens: list[int],
+    kv_lens: list[int],
+    window_left: int,
+) -> int:
+    """Return the expanded KV row count without a device-to-host sync."""
+    if window_left < 0:
+        raise ValueError("Per-query window geometry requires a non-negative window")
+    if len(q_lens) != len(kv_lens):
+        raise ValueError("Q and KV length lists must have the same size")
+
+    total = 0
+    for q_len, kv_len in zip(q_lens, kv_lens):
+        if q_len <= 0 or kv_len < q_len:
+            raise ValueError(f"Invalid ragged lengths q_len={q_len}, kv_len={kv_len}")
+        prefix_len = kv_len - q_len
+        ramp_tokens = min(q_len, max(window_left - prefix_len, 0))
+        total += ramp_tokens * (prefix_len + 1)
+        total += ramp_tokens * (ramp_tokens - 1) // 2
+        total += (q_len - ramp_tokens) * (window_left + 1)
+    return total
+
+
+def _compute_per_query_window_kv_offsets(
+    q_lens: list[int],
+    kv_lens: list[int],
+    window_left: int,
+) -> list[int]:
+    """Return host KV offsets for flattened one-query SWA sequences."""
+    if window_left < 0:
+        raise ValueError("Per-query window geometry requires a non-negative window")
+    if len(q_lens) != len(kv_lens):
+        raise ValueError("Q and KV length lists must have the same size")
+
+    offsets = [0]
+    for q_len, kv_len in zip(q_lens, kv_lens):
+        if q_len <= 0 or kv_len < q_len:
+            raise ValueError(f"Invalid ragged lengths q_len={q_len}, kv_len={kv_len}")
+        prefix_len = kv_len - q_len
+        for local_q_pos in range(q_len):
+            query_position = prefix_len + local_q_pos
+            offsets.append(offsets[-1] + min(query_position, window_left) + 1)
+    return offsets
+
+
+def _gather_ragged_cache_rows(
+    cache: torch.Tensor,
+    kv_indices: torch.Tensor,
+    *,
+    page_size: int,
+    head_num: int,
+    head_dim: int,
+    cache_layout: Optional[str] = None,
+) -> torch.Tensor:
+    """Gather logical token rows from NHD, HND, or page-major KV views."""
+    if cache.ndim == 3:
+        expected_tail = (head_num, head_dim)
+        if tuple(cache.shape[1:]) != expected_tail:
+            raise ValueError(
+                f"Invalid NHD cache shape {tuple(cache.shape)}; expected "
+                f"[slots, {head_num}, {head_dim}]"
+            )
+        return cache.index_select(0, kv_indices).contiguous()
+
+    if cache.ndim != 4:
+        raise ValueError(
+            f"Unsupported KV cache rank {cache.ndim}; expected an NHD or paged view"
+        )
+
+    is_hnd = tuple(cache.shape[1:]) == (head_num, page_size, head_dim)
+    is_page_major = tuple(cache.shape[1:]) == (page_size, head_num, head_dim)
+    if cache_layout is not None:
+        if cache_layout == "hnd":
+            is_page_major = False
+        elif cache_layout in ("nhd", "page_major", "page_major_layer_major"):
+            is_hnd = False
+        else:
+            raise ValueError(f"Unsupported KV cache layout {cache_layout!r}")
+
+    page_indices = torch.div(kv_indices, page_size, rounding_mode="floor")
+    page_offsets = torch.remainder(kv_indices, page_size)
+    if is_hnd:
+        return cache[page_indices, :, page_offsets, :].contiguous()
+    if is_page_major:
+        return cache[page_indices, page_offsets, :, :].contiguous()
+    raise ValueError(
+        f"Invalid paged cache shape {tuple(cache.shape)} for page_size={page_size}, "
+        f"head_num={head_num}, head_dim={head_dim}"
+    )
 
 
 @dataclass
@@ -879,6 +1047,437 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         self.forward_metadata = metadata
 
+    def _get_layer_cache_layout(self, layer: RadixAttention) -> Optional[str]:
+        pool = self.token_to_kv_pool
+        if isinstance(pool, SWAKVPool):
+            _, is_swa = pool.layers_mapping[layer.layer_id]
+            pool = pool.swa_kv_pool if is_swa else pool.full_kv_pool
+        return getattr(pool, "kv_cache_layout", None)
+
+    def _gather_compact_ragged_kv(
+        self,
+        *,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        q_lens: torch.Tensor,
+        kv_lens: torch.Tensor,
+        q_lens_host: list[int],
+        kv_lens_host: list[int],
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        int,
+    ]:
+        """Gather prefix-aware native K/V rows for one ragged attention call."""
+        batch_size = len(q_lens_host)
+        if len(kv_lens_host) != batch_size:
+            raise ValueError("Host Q and KV length lists must have the same size")
+        if q_lens.numel() != batch_size or kv_lens.numel() != batch_size:
+            raise ValueError("Device Q and KV lengths must match the host batch size")
+
+        window_left = layer.sliding_window_size
+        starts, effective_lens = _compute_ragged_kv_ranges(q_lens, kv_lens, window_left)
+        starts_host = (
+            [0] * batch_size
+            if window_left < 0
+            else [
+                max(0, kv_len - q_len - window_left)
+                for q_len, kv_len in zip(q_lens_host, kv_lens_host)
+            ]
+        )
+        effective_lens_host = [
+            kv_len - start for start, kv_len in zip(starts_host, kv_lens_host)
+        ]
+        total_kv_tokens = sum(effective_lens_host)
+        if total_kv_tokens <= 0:
+            raise ValueError("TRTLLM ragged prefill requires at least one KV token")
+
+        cu_seqlens_kv = torch.nn.functional.pad(
+            torch.cumsum(effective_lens, dim=0, dtype=torch.int32), (1, 0)
+        )
+        kv_indices = torch.empty(
+            total_kv_tokens,
+            dtype=torch.int32,
+            device=kv_lens.device,
+        )
+        create_flashinfer_kv_indices_triton[(batch_size,)](
+            self.req_to_token,
+            forward_batch.req_pool_indices,
+            effective_lens,
+            cu_seqlens_kv,
+            starts,
+            kv_indices,
+            self.req_to_token.shape[1],
+        )
+
+        if self._swa_kv_pool is not None:
+            _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
+            if is_swa:
+                kv_indices = self._swa_kv_pool.translate_loc_from_full_to_swa(
+                    kv_indices
+                )
+
+        kv_indices = kv_indices.to(torch.int64)
+        k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+        cache_layout = self._get_layer_cache_layout(layer)
+        k = _gather_ragged_cache_rows(
+            k_cache,
+            kv_indices,
+            page_size=self.page_size,
+            head_num=layer.tp_k_head_num,
+            head_dim=layer.qk_head_dim,
+            cache_layout=cache_layout,
+        )
+        v = _gather_ragged_cache_rows(
+            v_cache,
+            kv_indices,
+            page_size=self.page_size,
+            head_num=layer.tp_v_head_num,
+            head_dim=layer.v_head_dim,
+            cache_layout=cache_layout,
+        )
+        return k, v, effective_lens, cu_seqlens_kv, max(effective_lens_host)
+
+    def _gather_per_query_window_ragged_kv(
+        self,
+        *,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        q_lens: torch.Tensor,
+        kv_lens: torch.Tensor,
+        q_lens_host: list[int],
+        kv_lens_host: list[int],
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        int,
+    ]:
+        """Gather each query token's exact window as one ragged KV sequence.
+
+        FlashInfer's SM100 TRTLLM-GEN ragged launcher does not expose a native
+        192/192/128 specialization for a multi-query finite window. Representing
+        each query as a one-token sequence preserves MiMo's exact SWA mask while
+        keeping the call on the TRTLLM-GEN backend.
+        """
+        window_left = layer.sliding_window_size
+        if window_left < 0:
+            raise ValueError("Per-query KV gathering is only valid for SWA layers")
+
+        total_q_tokens = sum(q_lens_host)
+        total_kv_tokens = _sum_per_query_window_kv_tokens(
+            q_lens_host, kv_lens_host, window_left
+        )
+        expanded_req_indices, starts, window_lens, cu_seqlens_kv = (
+            _compute_per_query_window_geometry(
+                q_lens,
+                kv_lens,
+                forward_batch.req_pool_indices,
+                window_left,
+                total_q_tokens=total_q_tokens,
+            )
+        )
+        kv_indices = torch.empty(
+            total_kv_tokens,
+            dtype=torch.int32,
+            device=kv_lens.device,
+        )
+        create_flashinfer_kv_indices_triton[(total_q_tokens,)](
+            self.req_to_token,
+            expanded_req_indices,
+            window_lens,
+            cu_seqlens_kv,
+            starts,
+            kv_indices,
+            self.req_to_token.shape[1],
+        )
+
+        if self._swa_kv_pool is not None:
+            _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
+            if is_swa:
+                kv_indices = self._swa_kv_pool.translate_loc_from_full_to_swa(
+                    kv_indices
+                )
+
+        kv_indices = kv_indices.to(torch.int64)
+        k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+        cache_layout = self._get_layer_cache_layout(layer)
+        k = _gather_ragged_cache_rows(
+            k_cache,
+            kv_indices,
+            page_size=self.page_size,
+            head_num=layer.tp_k_head_num,
+            head_dim=layer.qk_head_dim,
+            cache_layout=cache_layout,
+        )
+        v = _gather_ragged_cache_rows(
+            v_cache,
+            kv_indices,
+            page_size=self.page_size,
+            head_num=layer.tp_v_head_num,
+            head_dim=layer.v_head_dim,
+            cache_layout=cache_layout,
+        )
+        max_kv_len = max(min(window_left + 1, kv_len) for kv_len in kv_lens_host)
+        return k, v, window_lens, cu_seqlens_kv, max_kv_len
+
+    def _run_asymmetric_ragged_attention(
+        self,
+        q: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        attention_sink: Optional[torch.Tensor],
+        cu_seqlens_q: torch.Tensor,
+        kv_lens: torch.Tensor,
+        max_seqlen_q: int,
+        q_lens_host: list[int],
+        kv_lens_host: list[int],
+    ) -> torch.Tensor:
+        q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+        actual_q_tokens = sum(q_lens_host)
+        if actual_q_tokens > q.shape[0]:
+            raise RuntimeError(
+                "TRTLLM MHA query geometry exceeds the padded query tensor: "
+                f"actual={actual_q_tokens}, padded={q.shape[0]}"
+            )
+        window_left = layer.sliding_window_size
+        compact_starts_host = (
+            [0] * len(q_lens_host)
+            if window_left < 0
+            else [
+                max(0, kv_len - q_len - window_left)
+                for q_len, kv_len in zip(q_lens_host, kv_lens_host)
+            ]
+        )
+        compact_max_kv_len = max(
+            kv_len - start for start, kv_len in zip(compact_starts_host, kv_lens_host)
+        )
+        expand_per_query_window = (
+            window_left >= 0 and compact_max_kv_len > window_left + 1
+        )
+
+        if expand_per_query_window:
+            k, v, effective_lens, cu_seqlens_kv, max_kv_len = (
+                self._gather_per_query_window_ragged_kv(
+                    layer=layer,
+                    forward_batch=forward_batch,
+                    q_lens=q_lens,
+                    kv_lens=kv_lens,
+                    q_lens_host=q_lens_host,
+                    kv_lens_host=kv_lens_host,
+                )
+            )
+            kernel_cu_seqlens_q = torch.arange(
+                actual_q_tokens + 1,
+                device=q.device,
+                dtype=torch.int32,
+            )
+            kernel_max_seqlen_q = 1
+            kernel_batch_size = actual_q_tokens
+            per_query_kv_offsets = _compute_per_query_window_kv_offsets(
+                q_lens_host, kv_lens_host, window_left
+            )
+            if (
+                len(per_query_kv_offsets) != actual_q_tokens + 1
+                or per_query_kv_offsets[-1] != k.shape[0]
+            ):
+                raise RuntimeError(
+                    "TRTLLM MHA expanded SWA host/device geometry is inconsistent"
+                )
+        else:
+            k, v, effective_lens, cu_seqlens_kv, max_kv_len = (
+                self._gather_compact_ragged_kv(
+                    layer=layer,
+                    forward_batch=forward_batch,
+                    q_lens=q_lens,
+                    kv_lens=kv_lens,
+                    q_lens_host=q_lens_host,
+                    kv_lens_host=kv_lens_host,
+                )
+            )
+            kernel_cu_seqlens_q = cu_seqlens_q
+            kernel_max_seqlen_q = max_seqlen_q
+            kernel_batch_size = len(q_lens_host)
+            per_query_kv_offsets = None
+
+        kernel_window_left = window_left
+        bmm1_scale, bmm2_scale = self._get_bmm_scales(layer)
+        out_shape = (q.shape[0], layer.tp_q_head_num, layer.v_head_dim)
+        out = (
+            q.new_zeros(out_shape, dtype=self.q_data_type)
+            if actual_q_tokens < q.shape[0]
+            else q.new_empty(out_shape, dtype=self.q_data_type)
+        )
+        if attention_sink is not None and attention_sink.dtype != torch.float32:
+            attention_sink = attention_sink.float()
+
+        def _run_kernel(
+            q_chunk: torch.Tensor,
+            k_chunk: torch.Tensor,
+            v_chunk: torch.Tensor,
+            seq_lens_chunk: torch.Tensor,
+            cu_seqlens_q_chunk: torch.Tensor,
+            cu_seqlens_kv_chunk: torch.Tensor,
+            out_chunk: torch.Tensor,
+            batch_size: int,
+        ) -> None:
+            flashinfer.prefill.trtllm_ragged_attention_deepseek(
+                query=q_chunk.contiguous(),
+                key=k_chunk,
+                value=v_chunk,
+                workspace_buffer=self.workspace_buffer,
+                seq_lens=seq_lens_chunk,
+                max_q_len=kernel_max_seqlen_q,
+                max_kv_len=max_kv_len,
+                bmm1_scale=bmm1_scale,
+                bmm2_scale=bmm2_scale,
+                o_sf_scale=1.0,
+                batch_size=batch_size,
+                window_left=kernel_window_left,
+                cum_seq_lens_q=cu_seqlens_q_chunk,
+                cum_seq_lens_kv=cu_seqlens_kv_chunk,
+                enable_pdl=False,
+                is_causal=True,
+                return_lse=False,
+                attention_sinks=attention_sink,
+                skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get(),
+                out=out_chunk,
+                backend="trtllm-gen",
+            )
+
+        if per_query_kv_offsets is None:
+            _run_kernel(
+                q[:actual_q_tokens],
+                k,
+                v,
+                effective_lens,
+                kernel_cu_seqlens_q,
+                cu_seqlens_kv,
+                out[:actual_q_tokens],
+                kernel_batch_size,
+            )
+            return out
+
+        # Bound the persistent SM103 kernel's ragged batch while retaining the
+        # already packed exact-window K/V and the TRTLLM-GEN implementation.
+        for q_start in range(0, actual_q_tokens, MAX_TRTLLM_RAGGED_BATCH_SIZE):
+            q_end = min(q_start + MAX_TRTLLM_RAGGED_BATCH_SIZE, actual_q_tokens)
+            kv_start = per_query_kv_offsets[q_start]
+            kv_end = per_query_kv_offsets[q_end]
+            _run_kernel(
+                q[q_start:q_end],
+                k[kv_start:kv_end],
+                v[kv_start:kv_end],
+                effective_lens[q_start:q_end],
+                kernel_cu_seqlens_q[q_start : q_end + 1] - q_start,
+                cu_seqlens_kv[q_start : q_end + 1] - kv_start,
+                out[q_start:q_end],
+                q_end - q_start,
+            )
+        return out
+
+    def _forward_asymmetric_ragged_prefill(
+        self,
+        q: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        attention_sink: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if (layer.qk_head_dim, layer.v_head_dim) != (192, 128):
+            raise NotImplementedError(
+                "TRTLLM MHA asymmetric ragged prefill currently supports only "
+                "Q/K/V head dimensions 192/192/128."
+            )
+        if self.data_type not in (torch.bfloat16, torch.float16):
+            raise NotImplementedError(
+                "TRTLLM MHA asymmetric ragged prefill currently requires BF16 "
+                "or FP16 KV cache; use --kv-cache-dtype auto for MiMo-V2.5."
+            )
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ):
+            raise NotImplementedError(
+                "TRTLLM MHA asymmetric ragged attention supports regular prefill "
+                "only; use FA4 for speculative verification/decode."
+            )
+
+        if (
+            is_cp_v2_active(forward_batch)
+            and forward_batch.attn_cp_metadata is not None
+        ):
+            cp_strategy = get_cp_strategy()
+            assert cp_strategy is not None
+            meta = forward_batch.attn_cp_metadata
+            host_geometries = iter(
+                (
+                    (meta.actual_seq_q_prev_list, meta.kv_len_prev_list),
+                    (meta.actual_seq_q_next_list, meta.kv_len_next_list),
+                )
+            )
+
+            def _trt_ragged_cp_attn(
+                q_chunk,
+                cu_seqlens_q_cp,
+                cache_seqlens_cp,
+                max_seqlen_q_cp,
+            ):
+                q_lens_host, kv_lens_host = next(host_geometries)
+                return self._run_asymmetric_ragged_attention(
+                    q_chunk,
+                    layer,
+                    forward_batch,
+                    attention_sink,
+                    cu_seqlens_q_cp,
+                    cache_seqlens_cp,
+                    max_seqlen_q_cp,
+                    q_lens_host,
+                    kv_lens_host,
+                )
+
+            return cp_strategy.run_attention(
+                q,
+                forward_batch,
+                self.device,
+                _trt_ragged_cp_attn,
+                attention_backend=CPAttentionBackendKind.TRTLLM_MHA,
+            )
+
+        q_lens_host = getattr(forward_batch, "extend_seq_lens_cpu", None)
+        prefix_lens_host = getattr(forward_batch, "extend_prefix_lens_cpu", None)
+        if q_lens_host is None:
+            raise RuntimeError(
+                "TRTLLM MHA asymmetric ragged prefill requires host extend lengths."
+            )
+        q_lens_host = [int(length) for length in q_lens_host]
+        if prefix_lens_host is not None:
+            kv_lens_host = [
+                int(prefix) + q_len
+                for prefix, q_len in zip(prefix_lens_host, q_lens_host)
+            ]
+        else:
+            seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+            if seq_lens_cpu is None:
+                raise RuntimeError(
+                    "TRTLLM MHA asymmetric ragged prefill requires host KV lengths."
+                )
+            kv_lens_host = [int(length) for length in seq_lens_cpu]
+
+        return self._run_asymmetric_ragged_attention(
+            q,
+            layer,
+            forward_batch,
+            attention_sink,
+            self.forward_metadata.cu_seqlens_q,
+            self.forward_metadata.cache_seqlens_int32,
+            self.forward_metadata.max_seq_len_q,
+            q_lens_host,
+            kv_lens_host,
+        )
+
     def _reshape_paged_kv_cache(
         self,
         k_cache: torch.Tensor,
@@ -929,6 +1528,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         **kwargs,
     ) -> torch.Tensor:
         """Run forward for decode using TRTLLM MHA kernel."""
+        if layer.qk_head_dim != layer.v_head_dim:
+            raise RuntimeError(
+                "TRTLLM MHA paged decode does not support asymmetric Q/K and V "
+                "head dimensions. For MiMo-V2.5, use "
+                "--decode-attention-backend fa4."
+            )
         cache_loc = forward_batch.out_cache_loc
 
         use_fused_fp8_path = self._should_use_fused_fp8_path(save_kv_cache, k)
@@ -1020,8 +1625,17 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
 
         cache_loc = forward_batch.out_cache_loc
+        cp_active = (
+            is_cp_v2_active(forward_batch)
+            and forward_batch.attn_cp_metadata is not None
+        )
+        cp_strategy = get_cp_strategy() if cp_active else None
 
-        use_fused_fp8_path = self._should_use_fused_fp8_path(save_kv_cache, k)
+        # CP needs the post-RoPE rank-local tensors for all-gather, so it cannot
+        # use the fused QKV-to-cache path that consumes K/V in place.
+        use_fused_fp8_path = (
+            self._should_use_fused_fp8_path(save_kv_cache, k) and not cp_active
+        )
         use_fused_qkv = use_fused_fp8_path and not self.is_xqa_impl
 
         if use_fused_fp8_path:
@@ -1033,16 +1647,25 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             k = None
             v = None
         else:
-            # Use original set_kv_buffer path
             if save_kv_cache and k is not None:
-                self.token_to_kv_pool.set_kv_buffer(
-                    layer,
-                    KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
-                    k,
-                    v,
-                    layer.k_scale,
-                    layer.v_scale,
-                )
+                if cp_active:
+                    assert cp_strategy is not None
+                    cp_strategy.materialize_full_kv(
+                        forward_batch,
+                        layer,
+                        k,
+                        v,
+                        swa_loc=self.forward_metadata.swa_out_cache_loc,
+                    )
+                else:
+                    self.token_to_kv_pool.set_kv_buffer(
+                        layer,
+                        KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                        k,
+                        v,
+                        layer.k_scale,
+                        layer.v_scale,
+                    )
 
         q_scale = 1.0
         if (
@@ -1055,24 +1678,24 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         ):
             q = q.to(torch.float8_e4m3fn)
         q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
-        # [num_pages, page_size, num_kv_heads, head_dim] -> [num_pages, num_kv_heads, page_size, head_dim]
+
+        # FlashInfer's paged TRT kernels assume V has the Q/K head dimension.
+        # MiMo's native 192/128 cache instead uses the TRT ragged prefill kernel.
+        attention_sink = kwargs.get("sinks", None)
+        if layer.qk_head_dim != layer.v_head_dim:
+            if not save_kv_cache:
+                raise NotImplementedError(
+                    "TRTLLM MHA asymmetric ragged prefill requires KV cache writes."
+                )
+            o = self._forward_asymmetric_ragged_prefill(
+                q, layer, forward_batch, attention_sink
+            )
+            return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
         k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
-        k_cache = k_cache.view(
-            -1, self.page_size, layer.tp_k_head_num, layer.head_dim
-        ).permute(0, 2, 1, 3)
-        v_cache = v_cache.view(
-            -1, self.page_size, layer.tp_v_head_num, layer.head_dim
-        ).permute(0, 2, 1, 3)
-
-        if layer.tp_k_head_num == 1:
-            k_cache = canonicalize_stride(k_cache)
-        if layer.tp_v_head_num == 1:
-            v_cache = canonicalize_stride(v_cache)
-
-        kv_cache = (k_cache, v_cache)
+        kv_cache = self._reshape_paged_kv_cache(k_cache, v_cache, layer, layer.head_dim)
 
         # sink: additional value per head in the denominator of the softmax.
-        attention_sink = kwargs.get("sinks", None)
         bmm1_scale, bmm2_scale = self._get_bmm_scales(layer, q_scale)
 
         page_table = self._get_layer_page_table(layer, forward_batch)
@@ -1116,24 +1739,52 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     q_len_per_req=self.forward_metadata.max_seq_len_q,
                 )
         else:
-            o = flashinfer.prefill.trtllm_batch_context_with_kv_cache(
-                query=q,
-                kv_cache=kv_cache,
-                workspace_buffer=self.workspace_buffer,
-                block_tables=page_table,
-                seq_lens=self.forward_metadata.cache_seqlens_int32,
-                max_q_len=self.forward_metadata.max_seq_len_q,
-                max_kv_len=self.max_context_len,
-                bmm1_scale=bmm1_scale,
-                bmm2_scale=bmm2_scale,
-                batch_size=self.forward_metadata.cu_seqlens_q.shape[0] - 1,
-                cum_seq_lens_q=self.forward_metadata.cu_seqlens_q,
-                cum_seq_lens_kv=self.forward_metadata.cu_seqlens_k,
-                window_left=layer.sliding_window_size,
-                sinks=attention_sink,
-                skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get(),
-                out_dtype=self.q_data_type,  # model_runner.dtype
-            )
+
+            def _trt_paged_context(
+                q_chunk,
+                cu_seqlens_q,
+                cache_seqlens,
+                max_seqlen_q,
+            ):
+                cu_seqlens_kv = torch.nn.functional.pad(
+                    torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32),
+                    (1, 0),
+                )
+                return flashinfer.prefill.trtllm_batch_context_with_kv_cache(
+                    query=q_chunk,
+                    kv_cache=kv_cache,
+                    workspace_buffer=self.workspace_buffer,
+                    block_tables=page_table,
+                    seq_lens=cache_seqlens,
+                    max_q_len=max_seqlen_q,
+                    max_kv_len=self.max_context_len,
+                    bmm1_scale=bmm1_scale,
+                    bmm2_scale=bmm2_scale,
+                    batch_size=cu_seqlens_q.shape[0] - 1,
+                    cum_seq_lens_q=cu_seqlens_q,
+                    cum_seq_lens_kv=cu_seqlens_kv,
+                    window_left=layer.sliding_window_size,
+                    sinks=attention_sink,
+                    skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get(),
+                    out_dtype=self.q_data_type,
+                )
+
+            if cp_active:
+                assert cp_strategy is not None
+                o = cp_strategy.run_attention(
+                    q,
+                    forward_batch,
+                    self.device,
+                    _trt_paged_context,
+                    attention_backend=CPAttentionBackendKind.TRTLLM_MHA,
+                )
+            else:
+                o = _trt_paged_context(
+                    q,
+                    self.forward_metadata.cu_seqlens_q,
+                    self.forward_metadata.cache_seqlens_int32,
+                    self.forward_metadata.max_seq_len_q,
+                )
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 

--- a/python/sglang/srt/layers/cp/base.py
+++ b/python/sglang/srt/layers/cp/base.py
@@ -67,14 +67,17 @@ class CPAttentionBackendKind(IntEnum):
     """Attention backend calling convention used by CP strategy dispatch."""
 
     FLASH_ATTENTION = 0
+    TRTLLM_MHA = 1
 
     @classmethod
     def from_string(cls, value: str) -> CPAttentionBackendKind:
         if value in ("fa3", "fa4", "flashinfer"):
             return cls.FLASH_ATTENTION
+        if value == "trtllm_mha":
+            return cls.TRTLLM_MHA
         raise ValueError(
             f"Unsupported attention_backend={value!r} for CP strategy; expected one "
-            "of {'fa3', 'fa4', 'flashinfer'}"
+            "of {'fa3', 'fa4', 'flashinfer', 'trtllm_mha'}"
         )
 
 

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -307,7 +307,10 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         )
 
     def get_supported_attention_backend(self):
-        return [CPAttentionBackendKind.FLASH_ATTENTION]
+        return [
+            CPAttentionBackendKind.FLASH_ATTENTION,
+            CPAttentionBackendKind.TRTLLM_MHA,
+        ]
 
     def run_attention(
         self,

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -120,6 +120,10 @@ class TestCPStrategyUnit(CustomTestCase):
             CPAttentionBackendKind.from_string("fa4"),
             CPAttentionBackendKind.FLASH_ATTENTION,
         )
+        self.assertEqual(
+            CPAttentionBackendKind.from_string("trtllm_mha"),
+            CPAttentionBackendKind.TRTLLM_MHA,
+        )
 
     def test_init_cp_strategy_binds_zigzag_strategy(self):
         init_cp_strategy(
@@ -722,6 +726,56 @@ class TestCPZigzagStrategy(CustomTestCase):
         self.assertEqual(len(calls), 2)
         self.assertTrue(torch.equal(calls[0][0], q[:2]))
         self.assertTrue(torch.equal(calls[1][0], q[2:]))
+        self.assertTrue(torch.equal(out, q + 100))
+
+    def test_zigzag_supports_trtllm_mha_attention(self):
+        strategy = ZigzagCPStrategy(cp_size=2)
+
+        self.assertIn(
+            CPAttentionBackendKind.TRTLLM_MHA,
+            strategy.get_supported_attention_backend(),
+        )
+
+    def test_zigzag_trtllm_mha_dispatches_uneven_batch_geometry(self):
+        cp_size = 2
+        metadata = self._metadata_for_rank(
+            0,
+            cp_size=cp_size,
+            seq_lens=[14, 18],
+            extend_seq_lens=[9, 11],
+        )
+        fb = SimpleNamespace(attn_cp_metadata=metadata)
+        q = torch.arange(10 * 2).view(10, 2)
+        calls = []
+
+        def attn_fn(q_chunk, cu_seqlens_q, cache_seqlens, max_seqlen_q):
+            calls.append(
+                (
+                    q_chunk.clone(),
+                    cu_seqlens_q.clone(),
+                    cache_seqlens.clone(),
+                    max_seqlen_q,
+                )
+            )
+            return q_chunk + 100
+
+        out = ZigzagCPStrategy(cp_size=cp_size).run_attention(
+            q,
+            fb,
+            device=torch.device("cpu"),
+            attn_fn=attn_fn,
+            attention_backend=CPAttentionBackendKind.TRTLLM_MHA,
+        )
+
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(torch.equal(calls[0][0], q[:6]))
+        self.assertEqual(calls[0][1].tolist(), [0, 3, 6])
+        self.assertEqual(calls[0][2].tolist(), [8, 10])
+        self.assertEqual(calls[0][3], 3)
+        self.assertTrue(torch.equal(calls[1][0], q[6:]))
+        self.assertEqual(calls[1][1].tolist(), [0, 2, 4])
+        self.assertEqual(calls[1][2].tolist(), [14, 18])
+        self.assertEqual(calls[1][3], 2)
         self.assertTrue(torch.equal(out, q + 100))
 
 

--- a/test/registered/cp/test_mimo_trtllm_mha_cp.py
+++ b/test/registered/cp/test_mimo_trtllm_mha_cp.py
@@ -1,0 +1,90 @@
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    kill_process_tree,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=400, stage="extra-b", runner_config="4-gpu-b200")
+
+MIMO_V2_MODEL_PATH = "XiaomiMiMo/MiMo-V2.5"
+GSM8K_BASELINE_ACCURACY = 0.93
+
+
+class TestMiMoV2TRTLLMMHAPrefillContextParallel(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = MIMO_V2_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--prefill-attention-backend",
+                "trtllm_mha",
+                "--decode-attention-backend",
+                "fa4",
+                "--mm-attention-backend",
+                "fa4",
+                "--enable-prefill-cp",
+                "--cp-strategy",
+                "zigzag",
+                "--mem-fraction-static",
+                "0.8",
+                "--chunked-prefill-size",
+                "8192",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_attention_backend_configuration(self):
+        response = requests.get(self.base_url + "/server_info", timeout=10)
+        response.raise_for_status()
+        server_info = response.json()
+
+        self.assertEqual(server_info["prefill_attention_backend"], "trtllm_mha")
+        self.assertEqual(server_info["decode_attention_backend"], "fa4")
+        self.assertTrue(server_info["enable_prefill_cp"])
+        self.assertEqual(server_info["cp_strategy"], "zigzag")
+        self.assertEqual(server_info["attn_cp_size"], 4)
+
+    def test_gsm8k(self):
+        metrics = run_eval(
+            SimpleNamespace(
+                model=self.model,
+                eval_name="gsm8k",
+                api="chat",
+                num_shots=5,
+                num_examples=200,
+                max_tokens=4096,
+                num_threads=8,
+                repeat=1,
+                temperature=0.0,
+                top_p=1.0,
+                base_url=self.base_url,
+                host="http://127.0.0.1",
+                port=int(self.base_url.split(":")[-1]),
+            )
+        )
+        print(f"{metrics=}")
+        self.assertGreaterEqual(metrics["score"], GSM8K_BASELINE_ACCURACY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cp/test_trtllm_mha_cp_unit.py
+++ b/test/registered/cp/test_trtllm_mha_cp_unit.py
@@ -1,0 +1,766 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+import sglang.srt.layers.attention.trtllm_mha_backend as trtllm_mha_backend_module
+from sglang.srt.layers.attention.trtllm_mha_backend import (
+    TRTLLMHAAttnBackend,
+    _compute_per_query_window_geometry,
+    _compute_ragged_kv_ranges,
+    _gather_ragged_cache_rows,
+    _sum_per_query_window_kv_tokens,
+)
+from sglang.srt.layers.cp.base import CPAttentionBackendKind
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestComputeRaggedKVRanges(CustomTestCase):
+    def test_full_attention_keeps_every_kv_row(self):
+        q_lens = torch.tensor([3, 1, 4], dtype=torch.int32)
+        kv_lens = torch.tensor([8, 1, 9], dtype=torch.int32)
+
+        starts, effective_lens = _compute_ragged_kv_ranges(
+            q_lens, kv_lens, window_left=-1
+        )
+
+        torch.testing.assert_close(starts, torch.tensor([0, 0, 0], dtype=torch.int32))
+        torch.testing.assert_close(effective_lens, kv_lens)
+
+    def test_sliding_window_keeps_rows_visible_to_uneven_query_chunks(self):
+        q_lens = torch.tensor([3, 5, 2, 1], dtype=torch.int32)
+        kv_lens = torch.tensor([8, 11, 4, 10], dtype=torch.int32)
+
+        starts, effective_lens = _compute_ragged_kv_ranges(
+            q_lens, kv_lens, window_left=2
+        )
+
+        # start_i = max(0, kv_len_i - q_len_i - window_left)
+        torch.testing.assert_close(
+            starts, torch.tensor([3, 4, 0, 7], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            effective_lens, torch.tensor([5, 7, 4, 3], dtype=torch.int32)
+        )
+
+
+class TestGatherRaggedCacheRows(CustomTestCase):
+    page_size = 3
+    head_num = 2
+    head_dim = 2
+    kv_indices = torch.tensor([5, 0, 3, 2], dtype=torch.int64)
+
+    @classmethod
+    def _canonical_nhd_cache(cls):
+        return torch.arange(24, dtype=torch.float32).reshape(6, 2, 2)
+
+    @classmethod
+    def _expected_rows(cls):
+        return torch.tensor(
+            [
+                [[20, 21], [22, 23]],
+                [[0, 1], [2, 3]],
+                [[12, 13], [14, 15]],
+                [[8, 9], [10, 11]],
+            ],
+            dtype=torch.float32,
+        )
+
+    def _assert_gathered_rows(self, cache):
+        actual = _gather_ragged_cache_rows(
+            cache,
+            self.kv_indices,
+            page_size=self.page_size,
+            head_num=self.head_num,
+            head_dim=self.head_dim,
+        )
+        torch.testing.assert_close(actual, self._expected_rows(), rtol=0, atol=0)
+
+    def test_gathers_nhd_slot_major_cache(self):
+        self._assert_gathered_rows(self._canonical_nhd_cache())
+
+    def test_gathers_hnd_paged_cache(self):
+        cache = (
+            self._canonical_nhd_cache()
+            .reshape(2, self.page_size, self.head_num, self.head_dim)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+
+        self._assert_gathered_rows(cache)
+
+    def test_gathers_page_major_paged_cache(self):
+        cache = self._canonical_nhd_cache().reshape(
+            2, self.page_size, self.head_num, self.head_dim
+        )
+
+        self._assert_gathered_rows(cache)
+
+    def test_gathers_production_page_major_cache_layout(self):
+        cache = self._canonical_nhd_cache().reshape(
+            2, self.page_size, self.head_num, self.head_dim
+        )
+
+        actual = _gather_ragged_cache_rows(
+            cache,
+            self.kv_indices,
+            page_size=self.page_size,
+            head_num=self.head_num,
+            head_dim=self.head_dim,
+            cache_layout="page_major_layer_major",
+        )
+
+        torch.testing.assert_close(actual, self._expected_rows(), rtol=0, atol=0)
+
+
+class TestPerQueryWindowGeometry(CustomTestCase):
+    def test_expands_each_query_to_its_exact_sliding_window(self):
+        q_lens = torch.tensor([2, 3], dtype=torch.int32)
+        kv_lens = torch.tensor([2, 7], dtype=torch.int32)
+        req_pool_indices = torch.tensor([5, 9], dtype=torch.int32)
+
+        expanded_req_indices, starts, window_lens, cu_seqlens_kv = (
+            _compute_per_query_window_geometry(
+                q_lens,
+                kv_lens,
+                req_pool_indices,
+                window_left=2,
+            )
+        )
+
+        torch.testing.assert_close(
+            expanded_req_indices,
+            torch.tensor([5, 5, 9, 9, 9], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            starts, torch.tensor([0, 0, 2, 3, 4], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            window_lens, torch.tensor([1, 2, 3, 3, 3], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            cu_seqlens_kv,
+            torch.tensor([0, 1, 3, 6, 9, 12], dtype=torch.int32),
+        )
+        self.assertEqual(
+            _sum_per_query_window_kv_tokens([2, 3], [2, 7], window_left=2),
+            12,
+        )
+
+    def test_gather_chain_preserves_exact_windows_after_swa_translation(self):
+        backend = TRTLLMHAAttnBackend.__new__(TRTLLMHAAttnBackend)
+        backend.req_to_token = torch.stack(
+            [torch.arange(8, dtype=torch.int32), torch.arange(8, 16, dtype=torch.int32)]
+        )
+        backend.page_size = 1
+        k_cache = torch.arange(32 * 192, dtype=torch.float32).view(32, 1, 192)
+        v_cache = torch.arange(32 * 128, dtype=torch.float32).view(32, 1, 128)
+        backend.token_to_kv_pool = SimpleNamespace(
+            get_kv_buffer=lambda _layer_id: (k_cache, v_cache)
+        )
+        backend._swa_kv_pool = SimpleNamespace(
+            layers_mapping={3: (0, True)},
+            translate_loc_from_full_to_swa=lambda indices: indices + 16,
+        )
+        layer = SimpleNamespace(
+            layer_id=3,
+            sliding_window_size=2,
+            tp_k_head_num=1,
+            tp_v_head_num=1,
+            qk_head_dim=192,
+            v_head_dim=128,
+        )
+        forward_batch = SimpleNamespace(
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32)
+        )
+
+        class FakeKVIndexKernel:
+            def __getitem__(self, _grid):
+                def launch(
+                    req_to_token,
+                    req_indices,
+                    lengths,
+                    cu_seqlens,
+                    starts,
+                    output,
+                    _stride,
+                ):
+                    for i in range(req_indices.numel()):
+                        out_start = int(cu_seqlens[i])
+                        out_end = int(cu_seqlens[i + 1])
+                        req = int(req_indices[i])
+                        start = int(starts[i])
+                        output[out_start:out_end] = req_to_token[
+                            req, start : start + int(lengths[i])
+                        ]
+
+                return launch
+
+        with patch.object(
+            trtllm_mha_backend_module,
+            "create_flashinfer_kv_indices_triton",
+            FakeKVIndexKernel(),
+        ):
+            k, v, lengths, cu_seqlens, max_kv_len = (
+                backend._gather_per_query_window_ragged_kv(
+                    layer=layer,
+                    forward_batch=forward_batch,
+                    q_lens=torch.tensor([2, 2], dtype=torch.int32),
+                    kv_lens=torch.tensor([2, 5], dtype=torch.int32),
+                    q_lens_host=[2, 2],
+                    kv_lens_host=[2, 5],
+                )
+            )
+
+        expected_rows = torch.tensor(
+            [16, 16, 17, 25, 26, 27, 26, 27, 28], dtype=torch.int64
+        )
+        torch.testing.assert_close(k, k_cache.index_select(0, expected_rows))
+        torch.testing.assert_close(v, v_cache.index_select(0, expected_rows))
+        torch.testing.assert_close(
+            lengths, torch.tensor([1, 2, 3, 3], dtype=torch.int32)
+        )
+        torch.testing.assert_close(
+            cu_seqlens, torch.tensor([0, 1, 3, 6, 9], dtype=torch.int32)
+        )
+        self.assertEqual(max_kv_len, 3)
+
+
+class _ExtendMode:
+    def is_target_verify(self):
+        return False
+
+    def is_draft_extend_v2(self):
+        return False
+
+    def is_context_parallel_extend(self):
+        return True
+
+
+class TestTRTLLMAsymmetricPrefillDispatch(CustomTestCase):
+    def _make_backend(self):
+        backend = TRTLLMHAAttnBackend.__new__(TRTLLMHAAttnBackend)
+        backend.decode_uses_native_fp4 = False
+        backend.data_type = torch.bfloat16
+        backend.q_data_type = torch.bfloat16
+        backend.is_xqa_impl = False
+        backend.page_size = 1
+        backend.token_to_kv_pool = Mock()
+        backend.forward_metadata = SimpleNamespace(swa_out_cache_loc=None)
+        backend._forward_asymmetric_ragged_prefill = Mock(
+            return_value=torch.arange(2 * 2 * 128, dtype=torch.bfloat16).view(2, 2, 128)
+        )
+        return backend
+
+    @staticmethod
+    def _make_layer():
+        return SimpleNamespace(
+            head_dim=192,
+            qk_head_dim=192,
+            v_head_dim=128,
+            tp_q_head_num=2,
+            tp_k_head_num=1,
+            tp_v_head_num=1,
+            layer_id=3,
+            is_cross_attention=False,
+            sliding_window_size=-1,
+            scaling=192**-0.5,
+            k_scale=None,
+            v_scale=None,
+        )
+
+    @staticmethod
+    def _make_forward_batch():
+        return SimpleNamespace(
+            forward_mode=_ExtendMode(),
+            out_cache_loc=torch.tensor([7, 8]),
+            attn_cp_metadata=object(),
+        )
+
+    def test_non_cp_asymmetric_extend_uses_native_ragged_output_width(self):
+        backend = self._make_backend()
+        layer = self._make_layer()
+        forward_batch = self._make_forward_batch()
+        q = torch.zeros(2, 2 * 192, dtype=torch.bfloat16)
+        k = torch.zeros(2, 1, 192, dtype=torch.bfloat16)
+        v = torch.zeros(2, 1, 128, dtype=torch.bfloat16)
+        sinks = torch.ones(2, dtype=torch.float32)
+
+        with patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+            return_value=False,
+            create=True,
+        ):
+            output = backend.forward_extend(q, k, v, layer, forward_batch, sinks=sinks)
+
+        backend.token_to_kv_pool.set_kv_buffer.assert_called_once()
+        backend._forward_asymmetric_ragged_prefill.assert_called_once()
+        ragged_q, ragged_layer, ragged_batch, ragged_sinks = (
+            backend._forward_asymmetric_ragged_prefill.call_args.args
+        )
+        torch.testing.assert_close(ragged_q, q.view(2, 2, 192))
+        self.assertIs(ragged_layer, layer)
+        self.assertIs(ragged_batch, forward_batch)
+        self.assertIs(ragged_sinks, sinks)
+        self.assertEqual(output.shape, (2, 2 * 128))
+
+    def test_cp_asymmetric_extend_materializes_post_rope_kv(self):
+        backend = self._make_backend()
+        layer = self._make_layer()
+        forward_batch = self._make_forward_batch()
+        q = torch.zeros(2, 2 * 192, dtype=torch.bfloat16)
+        k = torch.zeros(2, 1, 192, dtype=torch.bfloat16)
+        v = torch.zeros(2, 1, 128, dtype=torch.bfloat16)
+        cp_strategy = Mock()
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=True,
+                create=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.get_cp_strategy",
+                return_value=cp_strategy,
+                create=True,
+            ),
+        ):
+            output = backend.forward_extend(q, k, v, layer, forward_batch)
+
+        cp_strategy.materialize_full_kv.assert_called_once_with(
+            forward_batch,
+            layer,
+            k,
+            v,
+            swa_loc=None,
+        )
+        backend.token_to_kv_pool.set_kv_buffer.assert_not_called()
+        backend._forward_asymmetric_ragged_prefill.assert_called_once()
+        self.assertEqual(output.shape, (2, 2 * 128))
+
+    def test_missing_cp_metadata_falls_back_to_non_cp_cache_write(self):
+        backend = self._make_backend()
+        layer = self._make_layer()
+        forward_batch = self._make_forward_batch()
+        forward_batch.attn_cp_metadata = None
+        q = torch.zeros(2, 2 * 192, dtype=torch.bfloat16)
+        k = torch.zeros(2, 1, 192, dtype=torch.bfloat16)
+        v = torch.zeros(2, 1, 128, dtype=torch.bfloat16)
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.get_cp_strategy"
+            ) as get_strategy,
+        ):
+            output = backend.forward_extend(q, k, v, layer, forward_batch)
+
+        get_strategy.assert_not_called()
+        backend.token_to_kv_pool.set_kv_buffer.assert_called_once()
+        backend._forward_asymmetric_ragged_prefill.assert_called_once()
+        self.assertEqual(output.shape, (2, 2 * 128))
+
+    def test_cp_fp8_bypasses_fused_cache_write_before_kv_gather(self):
+        backend = self._make_backend()
+        backend.data_type = torch.float8_e4m3fn
+        backend._should_use_fused_fp8_path = Mock(return_value=True)
+        backend._fused_fp8_qkv_kv_cache = Mock()
+        layer = self._make_layer()
+        forward_batch = self._make_forward_batch()
+        q = torch.zeros(2, 2 * 192, dtype=torch.bfloat16)
+        k = torch.zeros(2, 1, 192, dtype=torch.bfloat16)
+        v = torch.zeros(2, 1, 128, dtype=torch.bfloat16)
+        cp_strategy = Mock()
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.get_cp_strategy",
+                return_value=cp_strategy,
+            ),
+        ):
+            output = backend.forward_extend(q, k, v, layer, forward_batch)
+
+        backend._should_use_fused_fp8_path.assert_called_once()
+        backend._fused_fp8_qkv_kv_cache.assert_not_called()
+        cp_strategy.materialize_full_kv.assert_called_once()
+        self.assertEqual(output.shape, (2, 2 * 128))
+
+    def test_cp_asymmetric_ragged_dispatch_uses_both_host_geometries(self):
+        backend = self._make_backend()
+        backend.device = torch.device("cpu")
+        backend._forward_asymmetric_ragged_prefill = (
+            TRTLLMHAAttnBackend._forward_asymmetric_ragged_prefill.__get__(backend)
+        )
+        backend._run_asymmetric_ragged_attention = Mock(
+            side_effect=lambda q_chunk, *_args: q_chunk[..., :128]
+        )
+        layer = self._make_layer()
+        meta = SimpleNamespace(
+            total_q_prev_tokens=6,
+            actual_seq_q_prev_list=[3, 3],
+            actual_seq_q_next_list=[2, 2],
+            kv_len_prev_list=[8, 10],
+            kv_len_next_list=[14, 18],
+            cu_seqlens_q_prev_tensor=torch.tensor([0, 3, 6], dtype=torch.int32),
+            cu_seqlens_q_next_tensor=torch.tensor([0, 2, 4], dtype=torch.int32),
+            kv_len_prev_tensor=torch.tensor([8, 10], dtype=torch.int32),
+            kv_len_next_tensor=torch.tensor([14, 18], dtype=torch.int32),
+            max_seqlen_q_prev=3,
+            max_seqlen_q_next=2,
+        )
+        forward_batch = self._make_forward_batch()
+        forward_batch.attn_cp_metadata = meta
+        q = torch.zeros(10, 2, 192, dtype=torch.bfloat16)
+        cp_strategy = Mock()
+
+        def run_attention(q_all, fb, device, attn_fn, attention_backend):
+            self.assertIs(fb, forward_batch)
+            self.assertEqual(attention_backend, CPAttentionBackendKind.TRTLLM_MHA)
+            return torch.cat(
+                [
+                    attn_fn(
+                        q_all[:6],
+                        meta.cu_seqlens_q_prev_tensor,
+                        meta.kv_len_prev_tensor,
+                        meta.max_seqlen_q_prev,
+                    ),
+                    attn_fn(
+                        q_all[6:],
+                        meta.cu_seqlens_q_next_tensor,
+                        meta.kv_len_next_tensor,
+                        meta.max_seqlen_q_next,
+                    ),
+                ]
+            )
+
+        cp_strategy.run_attention.side_effect = run_attention
+        with (
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.get_cp_strategy",
+                return_value=cp_strategy,
+            ),
+        ):
+            output = backend._forward_asymmetric_ragged_prefill(
+                q, layer, forward_batch, None
+            )
+
+        self.assertEqual(output.shape, (10, 2, 128))
+        calls = backend._run_asymmetric_ragged_attention.call_args_list
+        self.assertEqual(calls[0].args[-2:], ([3, 3], [8, 10]))
+        self.assertEqual(calls[1].args[-2:], ([2, 2], [14, 18]))
+
+    def test_cp_symmetric_paged_context_uses_both_zigzag_geometries(self):
+        backend = self._make_backend()
+        backend.device = torch.device("cpu")
+        backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+        backend.max_context_len = 64
+        backend._swa_kv_pool = None
+        backend._should_use_fused_fp8_path = Mock(return_value=False)
+        backend._reshape_paged_kv_cache = Mock(return_value=(object(), object()))
+        backend.token_to_kv_pool.get_kv_buffer.return_value = (
+            torch.empty(1),
+            torch.empty(1),
+        )
+        backend.forward_metadata = SimpleNamespace(
+            swa_out_cache_loc=None,
+            swa_page_table=None,
+            page_table=torch.zeros(2, 1, dtype=torch.int32),
+        )
+        layer = self._make_layer()
+        layer.head_dim = 128
+        layer.qk_head_dim = 128
+        layer.v_head_dim = 128
+        q = torch.zeros(10, 2 * 128, dtype=torch.bfloat16)
+        k = torch.zeros(10, 1, 128, dtype=torch.bfloat16)
+        v = torch.zeros(10, 1, 128, dtype=torch.bfloat16)
+        meta = SimpleNamespace(
+            total_q_prev_tokens=6,
+            cu_seqlens_q_prev_tensor=torch.tensor([0, 3, 6], dtype=torch.int32),
+            cu_seqlens_q_next_tensor=torch.tensor([0, 2, 4], dtype=torch.int32),
+            kv_len_prev_tensor=torch.tensor([8, 10], dtype=torch.int32),
+            kv_len_next_tensor=torch.tensor([14, 18], dtype=torch.int32),
+            max_seqlen_q_prev=3,
+            max_seqlen_q_next=2,
+        )
+        forward_batch = self._make_forward_batch()
+        forward_batch.attn_cp_metadata = meta
+        cp_strategy = Mock()
+
+        def run_attention(q_all, fb, device, attn_fn, attention_backend):
+            self.assertIs(fb, forward_batch)
+            self.assertEqual(attention_backend, CPAttentionBackendKind.TRTLLM_MHA)
+            return torch.cat(
+                [
+                    attn_fn(
+                        q_all[:6],
+                        meta.cu_seqlens_q_prev_tensor,
+                        meta.kv_len_prev_tensor,
+                        meta.max_seqlen_q_prev,
+                    ),
+                    attn_fn(
+                        q_all[6:],
+                        meta.cu_seqlens_q_next_tensor,
+                        meta.kv_len_next_tensor,
+                        meta.max_seqlen_q_next,
+                    ),
+                ]
+            )
+
+        cp_strategy.run_attention.side_effect = run_attention
+        kernel = Mock(side_effect=lambda **kwargs: kwargs["query"].clone())
+        fake_flashinfer = SimpleNamespace(
+            prefill=SimpleNamespace(trtllm_batch_context_with_kv_cache=kernel)
+        )
+        with (
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.get_cp_strategy",
+                return_value=cp_strategy,
+            ),
+            patch.object(
+                trtllm_mha_backend_module,
+                "flashinfer",
+                fake_flashinfer,
+                create=True,
+            ),
+        ):
+            output = backend.forward_extend(q, k, v, layer, forward_batch)
+
+        self.assertEqual(output.shape, (10, 2 * 128))
+        self.assertEqual(kernel.call_count, 2)
+        torch.testing.assert_close(
+            kernel.call_args_list[0].kwargs["cum_seq_lens_kv"],
+            torch.tensor([0, 8, 18], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            kernel.call_args_list[1].kwargs["cum_seq_lens_kv"],
+            torch.tensor([0, 14, 32], dtype=torch.int32),
+        )
+
+    def test_asymmetric_decode_has_actionable_fa4_error(self):
+        backend = self._make_backend()
+        with self.assertRaisesRegex(RuntimeError, "--decode-attention-backend fa4"):
+            backend.forward_decode(
+                torch.empty(1, 2 * 192),
+                torch.empty(1, 1, 192),
+                torch.empty(1, 1, 128),
+                self._make_layer(),
+                self._make_forward_batch(),
+            )
+
+    def test_ragged_kernel_receives_fp32_attention_sinks(self):
+        backend = self._make_backend()
+        backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+        backend._gather_compact_ragged_kv = Mock(
+            return_value=(
+                torch.zeros(2, 1, 192, dtype=torch.bfloat16),
+                torch.zeros(2, 1, 128, dtype=torch.bfloat16),
+                torch.tensor([2], dtype=torch.int32),
+                torch.tensor([0, 2], dtype=torch.int32),
+                2,
+            )
+        )
+        layer = self._make_layer()
+        q = torch.zeros(2, 2, 192, dtype=torch.bfloat16)
+        sinks = torch.ones(2, dtype=torch.bfloat16)
+
+        def ragged_kernel(**kwargs):
+            return kwargs["out"]
+
+        kernel = Mock(side_effect=ragged_kernel)
+        fake_flashinfer = SimpleNamespace(
+            prefill=SimpleNamespace(trtllm_ragged_attention_deepseek=kernel)
+        )
+        with patch.object(
+            trtllm_mha_backend_module,
+            "flashinfer",
+            fake_flashinfer,
+            create=True,
+        ):
+            backend._run_asymmetric_ragged_attention(
+                q,
+                layer,
+                self._make_forward_batch(),
+                sinks,
+                torch.tensor([0, 2], dtype=torch.int32),
+                torch.tensor([2], dtype=torch.int32),
+                2,
+                [2],
+                [2],
+            )
+
+        self.assertEqual(
+            kernel.call_args.kwargs["attention_sinks"].dtype, torch.float32
+        )
+        self.assertEqual(kernel.call_args.kwargs["backend"], "trtllm-gen")
+
+    def test_long_swa_uses_exact_per_query_windows_with_finite_mask(self):
+        backend = self._make_backend()
+        backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+        backend._gather_compact_ragged_kv = Mock()
+        backend._gather_per_query_window_ragged_kv = Mock(
+            return_value=(
+                torch.zeros(6, 1, 192, dtype=torch.bfloat16),
+                torch.zeros(6, 1, 128, dtype=torch.bfloat16),
+                torch.tensor([3, 3], dtype=torch.int32),
+                torch.tensor([0, 3, 6], dtype=torch.int32),
+                3,
+            )
+        )
+        layer = self._make_layer()
+        layer.sliding_window_size = 2
+        q = torch.zeros(2, 2, 192, dtype=torch.bfloat16)
+
+        def ragged_kernel(**kwargs):
+            return kwargs["out"]
+
+        kernel = Mock(side_effect=ragged_kernel)
+        fake_flashinfer = SimpleNamespace(
+            prefill=SimpleNamespace(trtllm_ragged_attention_deepseek=kernel)
+        )
+        with patch.object(
+            trtllm_mha_backend_module,
+            "flashinfer",
+            fake_flashinfer,
+            create=True,
+        ):
+            backend._run_asymmetric_ragged_attention(
+                q,
+                layer,
+                self._make_forward_batch(),
+                None,
+                torch.tensor([0, 2], dtype=torch.int32),
+                torch.tensor([4], dtype=torch.int32),
+                2,
+                [2],
+                [4],
+            )
+
+        backend._gather_compact_ragged_kv.assert_not_called()
+        backend._gather_per_query_window_ragged_kv.assert_called_once()
+        kwargs = kernel.call_args.kwargs
+        self.assertEqual(kwargs["batch_size"], 2)
+        self.assertEqual(kwargs["max_q_len"], 1)
+        self.assertEqual(kwargs["max_kv_len"], 3)
+        self.assertEqual(kwargs["window_left"], 2)
+        self.assertEqual(kwargs["backend"], "trtllm-gen")
+        torch.testing.assert_close(
+            kwargs["cum_seq_lens_q"],
+            torch.tensor([0, 1, 2], dtype=torch.int32),
+        )
+
+    def test_long_swa_chunks_large_expanded_ragged_batches(self):
+        backend = self._make_backend()
+        backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+        effective_lens = torch.tensor([1, 2] + [3] * 125 + [1, 2, 3], dtype=torch.int32)
+        cu_seqlens_kv = torch.nn.functional.pad(
+            torch.cumsum(effective_lens, dim=0, dtype=torch.int32), (1, 0)
+        )
+        k = (
+            torch.arange(384, dtype=torch.bfloat16)
+            .view(384, 1, 1)
+            .expand(384, 1, 192)
+            .clone()
+        )
+        v = (
+            torch.arange(384, dtype=torch.bfloat16)
+            .view(384, 1, 1)
+            .expand(384, 1, 128)
+            .clone()
+        )
+        backend._gather_per_query_window_ragged_kv = Mock(
+            return_value=(
+                k,
+                v,
+                effective_lens,
+                cu_seqlens_kv,
+                3,
+            )
+        )
+        layer = self._make_layer()
+        layer.sliding_window_size = 2
+        # CP alignment pads the model input to a multiple of 2 * cp_size even
+        # when a cached-prefix batch is too short to activate CP-v2.
+        q = torch.zeros(136, 2, 192, dtype=torch.bfloat16)
+
+        kernel = Mock()
+
+        def ragged_kernel(**kwargs):
+            kwargs["out"].fill_(kernel.call_count)
+            return kwargs["out"]
+
+        kernel.side_effect = ragged_kernel
+        fake_flashinfer = SimpleNamespace(
+            prefill=SimpleNamespace(trtllm_ragged_attention_deepseek=kernel)
+        )
+        with patch.object(
+            trtllm_mha_backend_module,
+            "flashinfer",
+            fake_flashinfer,
+            create=True,
+        ):
+            output = backend._run_asymmetric_ragged_attention(
+                q,
+                layer,
+                self._make_forward_batch(),
+                None,
+                torch.tensor([0, 127, 130], dtype=torch.int32),
+                torch.tensor([127, 3], dtype=torch.int32),
+                127,
+                [127, 3],
+                [127, 3],
+            )
+
+        self.assertEqual(kernel.call_count, 2)
+        first, second = kernel.call_args_list
+        self.assertEqual(first.kwargs["batch_size"], 128)
+        self.assertEqual(second.kwargs["batch_size"], 2)
+        self.assertEqual(first.kwargs["query"].shape[0], 128)
+        self.assertEqual(second.kwargs["query"].shape[0], 2)
+        self.assertEqual(first.kwargs["key"].shape[0], 379)
+        self.assertEqual(second.kwargs["key"].shape[0], 5)
+        torch.testing.assert_close(
+            second.kwargs["key"][:, 0, 0],
+            torch.arange(379, 384, dtype=torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            second.kwargs["value"][:, 0, 0],
+            torch.arange(379, 384, dtype=torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            second.kwargs["seq_lens"],
+            torch.tensor([2, 3], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            second.kwargs["cum_seq_lens_q"],
+            torch.tensor([0, 1, 2], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            second.kwargs["cum_seq_lens_kv"],
+            torch.tensor([0, 2, 5], dtype=torch.int32),
+        )
+        torch.testing.assert_close(output[:128], torch.ones_like(output[:128]))
+        torch.testing.assert_close(output[128:130], torch.full_like(output[128:130], 2))
+        torch.testing.assert_close(output[130:], torch.zeros_like(output[130:]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #29972. The temporary base branch mirrors the current #29972 head exactly; retarget this PR to main after #29972 merges.

## Summary

- register TRTLLM MHA as a supported zigzag context-parallel attention backend
- all-gather and materialize post-RoPE K/V before cache writes, including hybrid SWA and page-major cache layouts
- add native TRTLLM-GEN ragged prefill for MiMo 192/192/128 attention, with exact per-query sliding windows
- bound expanded SM103 ragged launches to 128 sequences to avoid the large persistent-kernel stall while remaining on TRTLLM-GEN
- handle CP-aligned padding in cached-prefix batches; MiMo decode remains on FA4
- add focused CP/backend unit coverage and a registered 4-GPU MiMo GSM8K e2e test using zigzag

The post-RoPE gather follows the ordering established by #29161. No CUTE-DSL fallback is used because BF16 head dimension 192 is unsupported there.

## Validation

- pre-commit hooks: passed
- GB300 unit suite: 39 passed, 23 subtests passed
- production-shaped TRTLLM-GEN probe: chunked output bit-exact to unchunked output; repeated workspace reuse passed
- exact graph-enabled 4xGB300 server configuration: prefill=trtllm_mha, decode=fa4, mm=fa4, cp_strategy=zigzag, attn_cp_size=4
- decode CUDA graph capture: passed for 50 batch sizes through 512
- GSM8K: 197/200 = 0.985 accuracy, threshold 0.93; 200/200 HTTP 200 responses; no Traceback, RuntimeError, scheduler exception, or CUDA error

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29626863165](https://github.com/sgl-project/sglang/actions/runs/29626863165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29626863100](https://github.com/sgl-project/sglang/actions/runs/29626863100)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->