### PR TITLE
perf(vlm): keep packed MoonViT grid metadata on CPU

### DIFF
--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -666,8 +666,11 @@ def run_dp_sharded_mrope_vision_model(
     # Run the vision model on the local pixel_values_local
     if packed_2d_rope:
         if pixel_values_local is not None and pixel_values_local.shape[0] > 0:
+            # Packed MoonViT reads grid_thw as CPU shape metadata. Placing it
+            # on CUDA would make each .tolist() call synchronize with the host.
             local_grid_thw = torch.tensor(
-                local_grid_thw_list, device=pixel_values_local.device
+                local_grid_thw_list,
+                device=(pixel_values_local.device if rope_type == "rope_2d" else None),
             )
             if rope_type == "rope_2d":
                 image_embeds_local = vision_model(

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -180,6 +180,30 @@ def test_dp_helper_lazily_loads_only_its_local_image_shard():
     assert output.shape == (2, 4, 2)
 
 
+def test_dp_helper_keeps_packed_grid_metadata_on_cpu_for_tp2():
+    class _GatherGroup:
+        def all_gather(self, tensor, dim):
+            return torch.cat([tensor, torch.zeros_like(tensor)], dim=dim)
+
+    tower = _MoonViT3dTower()
+    pixel_values = torch.empty(8, 2, device="meta")
+    parallel = SimpleNamespace(
+        attn_tp_size=2,
+        attn_tp_rank=0,
+        attn_tp_group=_GatherGroup(),
+    )
+
+    with patch("sglang.srt.multimodal.mm_utils.get_parallel", return_value=parallel):
+        run_dp_sharded_mrope_vision_model(
+            tower,
+            pixel_values,
+            [[1, 2, 2], [1, 2, 2]],
+            rope_type="rope_2d_packed",
+        )
+
+    assert tower.grid_thws.device.type == "cpu"
+
+
 def test_kimi_k25_encoder_dp_selects_packed_moonvit_contract():
     model = KimiK25ForConditionalGeneration.__new__(KimiK25ForConditionalGeneration)
     nn.Module.__init__(model)


### PR DESCRIPTION
## Summary

- keep `rope_2d_packed` grid metadata on CPU in the TP>1 encoder-DP path
- preserve the existing CUDA placement required by `rope_2d`
- cover the packed TP2 contract with a device-sensitive meta-tensor test

Kimi-K2.5/K2.7 MoonViT treats `grid_thw` as shape metadata and calls
`.tolist()` three times per encoder forward. Moving this tiny tensor to CUDA
therefore adds three device-to-host synchronizations without moving useful
compute to the GPU. TP=1 already kept this metadata on CPU; this change makes
the TP>1 path consistent.

## Performance

Measured on 8x NVIDIA H200 with Kimi-K2.7-Code, TP8, FA3, breakable prefill
CUDA graphs, encoder DP, and CUDA-IPC multimodal transport. The workload used
8 requests with 4 seeded random images per request (`512x512` to
`768x1024`) and output length 1.

Same-seed TP0 torch-profiler comparison:

| Event | Before | After |
| --- | ---: | ---: |
| `Memcpy DtoH (Device -> Pageable)` | 12 | 0 |
| `cudaStreamSynchronize` | 60 | 48 |
| `cudaMemcpyAsync` | 271 | 259 |

This is 4 MoonViT forwards times 3 removed `.tolist()` synchronizations.
Steady-state `bench_serving` remained within run-to-run noise: across three
seeds, burst throughput was about +0.8%, median TTFT about -0.2%, and rate=4
paired medians stayed within 1.1%. This PR is primarily a host-synchronization
cleanup; it does not claim a material end-to-end serving speedup by itself.

## Validation

- `pre-commit run --files python/sglang/srt/multimodal/mm_utils.py test/registered/unit/models/test_kimi_k25.py`
- H200: `python3 -m pytest -q test/registered/unit/models/test_kimi_k25.py` (9 passed)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29627163085](https://github.com/sgl-project/sglang/actions/runs/29627163085)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29627329002](https://github.com/sgl-project/sglang/actions/runs/29627329002)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->