### PR TITLE
[Fix] Account zero-logprob sequences correctly in chunked logprob stitching

### DIFF
--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -169,10 +169,8 @@ def get_top_logprobs_chunk(
     Returns:
         int: Number of remaining tokens to process in next chunk
     """
-    # No sequences in the chunk
-    if logprobs.shape[0] == 0:
-        return 0
-
+    # NOTE: an empty chunk (zero input-logprob rows) still walks the sequence
+    # slice so zero-logprob sequences get their empty placeholder entries.
     max_k = max(logits_metadata.top_logprobs_nums)
     ret = logprobs.topk(max_k, dim=1)
     values = ret.values.tolist()
@@ -242,11 +240,8 @@ def get_token_ids_logprobs_chunk(
     Returns:
         int: Number of remaining tokens to process in next chunk
     """
-
-    # No sequences in the chunk
-    if logprobs.shape[0] == 0:
-        return 0
-
+    # NOTE: an empty chunk (zero input-logprob rows) still walks the sequence
+    # slice so zero-logprob sequences get their empty placeholder entries.
     pt = 0
     next_split_pruned_len = 0
     for n, (token_ids, pruned_len) in enumerate(
@@ -541,9 +536,10 @@ class InputLogprobProcessor:
                 chunk_sample_indices = sample_indices[chunk_sample_mask] - start_idx
                 sampled_logits[chunk_sample_mask] = chunk_logits[chunk_sample_indices]
 
-            # If there are no input logprobs in this chunk, skip the rest
-            if chunk_indices.numel() == 0:
-                continue
+            # NOTE: even when this chunk has no input-logprob rows (all rows are
+            # sample-only rows of zero-logprob sequences), the per-sequence
+            # bookkeeping below must still run so those sequences get their
+            # empty placeholder entries exactly once.
 
             # Compute the logprobs of the chunk
             chunk_input_logprobs = chunk_logits[chunk_indices]
@@ -551,9 +547,12 @@ class InputLogprobProcessor:
                 chunk_input_logprobs, dim=-1
             )
 
-            # For each chunk, we need to get the slice of the token_to_seq_idx
+            # Sequences owned by this chunk: the slice must end at the sequence
+            # of the last row INSIDE the chunk. Using token_to_seq_idx[end_idx]
+            # (the first row of the next chunk) would include a sequence whose
+            # rows all live in the next chunk, emitting its entry twice.
             chunk_slice = slice(
-                token_to_seq_idx[start_idx], token_to_seq_idx[end_idx] + 1
+                token_to_seq_idx[start_idx], token_to_seq_idx[end_idx - 1] + 1
             )
 
             # Get the logprob of top-k tokens

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -211,8 +211,8 @@ def get_top_logprobs_chunk(
             idx.append(indices[pt + j][:k])
 
         # Append or extend based on whether the sequence was split across chunks
-        # A continuation of a sequence split by the previous chunk extends its
-        # entry; every other sequence owns a fresh entry.
+        # Split-sequence continuations extend; everyone else owns a fresh
+        # (possibly empty) entry.
         if split_pruned_len > 0:
             input_top_logprobs_val[-1].extend(val)
             input_top_logprobs_idx[-1].extend(idx)
@@ -280,9 +280,8 @@ def get_token_ids_logprobs_chunk(
                 val.append(logprobs[pt + j, token_ids].tolist())
                 idx.append(token_ids)
 
-        # A continuation of a sequence split by the previous chunk extends its
-        # entry; every other sequence owns a fresh entry (empty for
-        # token_ids=None sequences, matching the non-chunked reference).
+        # Split-sequence continuations extend; everyone else owns a fresh
+        # (possibly empty) entry.
         if split_pruned_len > 0:
             input_token_ids_logprobs_val[-1].extend(val)
             input_token_ids_logprobs_idx[-1].extend(idx)

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -169,8 +169,7 @@ def get_top_logprobs_chunk(
     Returns:
         int: Number of remaining tokens to process in next chunk
     """
-    # NOTE: an empty chunk (zero input-logprob rows) still walks the sequence
-    # slice so zero-logprob sequences get their empty placeholder entries.
+    # Empty chunks still walk the slice to emit placeholder entries.
     max_k = max(logits_metadata.top_logprobs_nums)
     ret = logprobs.topk(max_k, dim=1)
     values = ret.values.tolist()
@@ -240,8 +239,7 @@ def get_token_ids_logprobs_chunk(
     Returns:
         int: Number of remaining tokens to process in next chunk
     """
-    # NOTE: an empty chunk (zero input-logprob rows) still walks the sequence
-    # slice so zero-logprob sequences get their empty placeholder entries.
+    # Empty chunks still walk the slice to emit placeholder entries.
     pt = 0
     next_split_pruned_len = 0
     for n, (token_ids, pruned_len) in enumerate(
@@ -536,21 +534,15 @@ class InputLogprobProcessor:
                 chunk_sample_indices = sample_indices[chunk_sample_mask] - start_idx
                 sampled_logits[chunk_sample_mask] = chunk_logits[chunk_sample_indices]
 
-            # NOTE: even when this chunk has no input-logprob rows (all rows are
-            # sample-only rows of zero-logprob sequences), the per-sequence
-            # bookkeeping below must still run so those sequences get their
-            # empty placeholder entries exactly once.
-
+            # Zero-logprob-row chunks still need the per-sequence bookkeeping below.
             # Compute the logprobs of the chunk
             chunk_input_logprobs = chunk_logits[chunk_indices]
             chunk_input_logprobs = torch.nn.functional.log_softmax(
                 chunk_input_logprobs, dim=-1
             )
 
-            # Sequences owned by this chunk: the slice must end at the sequence
-            # of the last row INSIDE the chunk. Using token_to_seq_idx[end_idx]
-            # (the first row of the next chunk) would include a sequence whose
-            # rows all live in the next chunk, emitting its entry twice.
+            # End at the last row inside the chunk; token_to_seq_idx[end_idx]
+            # belongs to the next chunk and would emit its sequence twice.
             chunk_slice = slice(
                 token_to_seq_idx[start_idx], token_to_seq_idx[end_idx - 1] + 1
             )

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -115,6 +115,12 @@ def get_token_ids_logprobs_raw(
                 vals.append([])
                 idxs.append([])
                 continue
+            if token_ids is None:
+                # The sequence's rows still occupy logprobs; step over them.
+                vals.append([])
+                idxs.append([])
+                pt += pruned_len
+                continue
             token_ids_tensor = torch.tensor(token_ids, dtype=torch.long).to(
                 logprobs.device, non_blocking=True
             )
@@ -205,13 +211,14 @@ def get_top_logprobs_chunk(
             idx.append(indices[pt + j][:k])
 
         # Append or extend based on whether the sequence was split across chunks
-        if len(val) > 0:
-            if split_pruned_len > 0:
-                input_top_logprobs_val[-1].extend(val)
-                input_top_logprobs_idx[-1].extend(idx)
-            else:
-                input_top_logprobs_val.append(val)
-                input_top_logprobs_idx.append(idx)
+        # A continuation of a sequence split by the previous chunk extends its
+        # entry; every other sequence owns a fresh entry.
+        if split_pruned_len > 0:
+            input_top_logprobs_val[-1].extend(val)
+            input_top_logprobs_idx[-1].extend(idx)
+        else:
+            input_top_logprobs_val.append(val)
+            input_top_logprobs_idx.append(idx)
 
         pt += pruned_len
     return next_split_pruned_len
@@ -273,14 +280,15 @@ def get_token_ids_logprobs_chunk(
                 val.append(logprobs[pt + j, token_ids].tolist())
                 idx.append(token_ids)
 
-        # Append or extend based on whether the sequence was split across chunks
-        if len(val) > 0:
-            if split_pruned_len > 0:
-                input_token_ids_logprobs_val[-1].extend(val)
-                input_token_ids_logprobs_idx[-1].extend(idx)
-            else:
-                input_token_ids_logprobs_val.append(val)
-                input_token_ids_logprobs_idx.append(idx)
+        # A continuation of a sequence split by the previous chunk extends its
+        # entry; every other sequence owns a fresh entry (empty for
+        # token_ids=None sequences, matching the non-chunked reference).
+        if split_pruned_len > 0:
+            input_token_ids_logprobs_val[-1].extend(val)
+            input_token_ids_logprobs_idx[-1].extend(idx)
+        else:
+            input_token_ids_logprobs_val.append(val)
+            input_token_ids_logprobs_idx.append(idx)
 
         pt += pruned_len
     return next_split_pruned_len

--- a/test/registered/unit/layers/test_logprob_chunk_stitching.py
+++ b/test/registered/unit/layers/test_logprob_chunk_stitching.py
@@ -1,0 +1,143 @@
+"""Chunked input-logprob processing must match the non-chunked reference.
+
+Regression for the cross-chunk stitching accounting: sequences with zero
+input-logprob rows (mixed batches where a request opts out of logprobs, or a
+mid-chunked-prefill segment entirely below logprob_start_len) contribute a
+sample-only row. Chunks made purely of such rows were skipped entirely and a
+zero-row sequence sitting exactly on a chunk boundary was emitted twice, so
+the per-request top-k / token-ids entry counts drifted and tripped the
+scheduler-side length asserts.
+"""
+
+import itertools
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.logprob_processor import InputLogprobProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+VOCAB = 11
+TOPK = 2
+PROBE_TOKEN_IDS = [0, 3]
+
+
+def _build_batch(seq_specs, with_token_ids):
+    """seq_specs: list of (extend_len, logprob_start_len). Mirrors
+    LogitsProcessor._get_pruned_states for the extend-with-logprobs path."""
+    pruned_rows = []
+    token_to_seq_idx = []
+    sample_indices = []
+    input_logprob_indices = []
+    pruned_lens = []
+    sample_pt = -1
+    lp_pt = 0
+    for idx, (extend_len, start) in enumerate(seq_specs):
+        eff_start = start - 1 if extend_len == start else start
+        rows = extend_len - eff_start
+        pruned_rows.append(torch.randn(rows, VOCAB, dtype=torch.float32))
+        token_to_seq_idx.extend([idx] * rows)
+        sample_pt += rows
+        sample_indices.append(sample_pt)
+        n_lp = extend_len - start
+        input_logprob_indices.extend([lp_pt + i for i in range(n_lp)])
+        lp_pt += rows
+        pruned_lens.append(n_lp)
+    token_to_seq_idx.append(len(seq_specs) - 1)
+    metadata = SimpleNamespace(
+        extend_return_top_logprob=True,
+        extend_token_ids_logprob=with_token_ids,
+        top_logprobs_nums=[TOPK] * len(seq_specs),
+        extend_logprob_pruned_lens_cpu=pruned_lens,
+        extend_input_logprob_token_ids_gpu=torch.zeros(
+            len(input_logprob_indices), dtype=torch.int64
+        ),
+        token_ids_logprobs=(
+            [PROBE_TOKEN_IDS] * len(seq_specs)
+            if with_token_ids
+            else [None] * len(seq_specs)
+        ),
+    )
+    return (
+        torch.cat(pruned_rows),
+        torch.tensor(sample_indices, dtype=torch.int64),
+        torch.tensor(input_logprob_indices, dtype=torch.int64),
+        token_to_seq_idx,
+        metadata,
+    )
+
+
+def _run(proc, batch, chunked, chunk_size):
+    pruned_states, sample_indices, input_logprob_indices, t2s, metadata = batch
+    proc.enable_logprobs_chunk = chunked
+    proc.logprobs_chunk_size = chunk_size
+
+    def get_logits_fn(states, lm_head, logits_metadata, **kwargs):
+        return states.float()
+
+    return proc.forward(
+        pruned_states=pruned_states,
+        sample_indices=sample_indices,
+        input_logprob_indices=input_logprob_indices,
+        token_to_seq_idx=t2s,
+        lm_head=None,
+        get_logits_fn=get_logits_fn,
+        logits_metadata=metadata,
+    )
+
+
+class TestLogprobChunkStitching(CustomTestCase):
+    def _sweep(self, with_token_ids):
+        torch.manual_seed(0)
+        proc = InputLogprobProcessor()
+        # (extend_len, start); start == extend_len is the degenerate
+        # zero-logprob-row shape.
+        menu = [(1, 1), (2, 2), (3, 0), (4, 1), (5, 5), (2, 0), (6, 2)]
+        tried = 0
+        for n_seqs in (1, 2, 3, 4):
+            for combo in itertools.product(menu, repeat=n_seqs):
+                batch = _build_batch(list(combo), with_token_ids)
+                total_lp_rows = len(batch[2])
+                for chunk_size in (1, 2, 3, 5):
+                    if total_lp_rows <= chunk_size:
+                        continue
+                    tried += 1
+                    ref, ref_sampled = _run(proc, batch, False, 10**9)
+                    got, got_sampled = _run(proc, batch, True, chunk_size)
+                    label = f"specs={list(combo)} chunk={chunk_size}"
+                    self.assertEqual(
+                        ref.input_top_logprobs_val, got.input_top_logprobs_val, label
+                    )
+                    self.assertEqual(
+                        ref.input_top_logprobs_idx, got.input_top_logprobs_idx, label
+                    )
+                    if with_token_ids:
+                        self.assertEqual(
+                            ref.input_token_ids_logprobs_val,
+                            got.input_token_ids_logprobs_val,
+                            label,
+                        )
+                        self.assertEqual(
+                            ref.input_token_ids_logprobs_idx,
+                            got.input_token_ids_logprobs_idx,
+                            label,
+                        )
+                    torch.testing.assert_close(
+                        ref.input_token_logprobs, got.input_token_logprobs, msg=label
+                    )
+                    torch.testing.assert_close(ref_sampled, got_sampled, msg=label)
+        self.assertGreater(tried, 1000)
+
+    def test_top_logprobs_stitching(self):
+        self._sweep(with_token_ids=False)
+
+    def test_token_ids_logprobs_stitching(self):
+        self._sweep(with_token_ids=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_logprob_chunk_stitching.py
+++ b/test/registered/unit/layers/test_logprob_chunk_stitching.py
@@ -25,7 +25,8 @@ VOCAB = 11
 # Heterogeneous per-sequence parameters: uniform values would hide slice
 # misalignment and the None / k=0 emission paths.
 TOPK_CYCLE = [2, 0, 3]
-TOKEN_IDS_CYCLE = [[0, 3], None, [1]]
+# [] is a valid probe set distinct from None (opt-out).
+TOKEN_IDS_CYCLE = [[0, 3], None, [1], []]
 
 
 def _build_batch(seq_specs, with_token_ids):
@@ -59,7 +60,7 @@ def _build_batch(seq_specs, with_token_ids):
             len(input_logprob_indices), dtype=torch.int64
         ),
         token_ids_logprobs=(
-            [TOKEN_IDS_CYCLE[i % 3] for i in range(len(seq_specs))]
+            [TOKEN_IDS_CYCLE[i % len(TOKEN_IDS_CYCLE)] for i in range(len(seq_specs))]
             if with_token_ids
             else [None] * len(seq_specs)
         ),

--- a/test/registered/unit/layers/test_logprob_chunk_stitching.py
+++ b/test/registered/unit/layers/test_logprob_chunk_stitching.py
@@ -22,8 +22,10 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=30, suite="base-a-test-cpu")
 
 VOCAB = 11
-TOPK = 2
-PROBE_TOKEN_IDS = [0, 3]
+# Heterogeneous per-sequence parameters: uniform values would hide slice
+# misalignment and the None / k=0 emission paths.
+TOPK_CYCLE = [2, 0, 3]
+TOKEN_IDS_CYCLE = [[0, 3], None, [1]]
 
 
 def _build_batch(seq_specs, with_token_ids):
@@ -51,13 +53,13 @@ def _build_batch(seq_specs, with_token_ids):
     metadata = SimpleNamespace(
         extend_return_top_logprob=True,
         extend_token_ids_logprob=with_token_ids,
-        top_logprobs_nums=[TOPK] * len(seq_specs),
+        top_logprobs_nums=[TOPK_CYCLE[i % 3] for i in range(len(seq_specs))],
         extend_logprob_pruned_lens_cpu=pruned_lens,
         extend_input_logprob_token_ids_gpu=torch.zeros(
             len(input_logprob_indices), dtype=torch.int64
         ),
         token_ids_logprobs=(
-            [PROBE_TOKEN_IDS] * len(seq_specs)
+            [TOKEN_IDS_CYCLE[i % 3] for i in range(len(seq_specs))]
             if with_token_ids
             else [None] * len(seq_specs)
         ),

--- a/test/registered/unit/layers/test_logprob_chunk_stitching.py
+++ b/test/registered/unit/layers/test_logprob_chunk_stitching.py
@@ -100,9 +100,10 @@ class TestLogprobChunkStitching(CustomTestCase):
         for n_seqs in (1, 2, 3, 4):
             for combo in itertools.product(menu, repeat=n_seqs):
                 batch = _build_batch(list(combo), with_token_ids)
-                total_lp_rows = len(batch[2])
+                # Same unit as the production gate: grid rows, not logprob rows.
+                total_rows = batch[0].shape[0]
                 for chunk_size in (1, 2, 3, 5):
-                    if total_lp_rows <= chunk_size:
+                    if total_rows <= chunk_size:
                         continue
                     tried += 1
                     ref, ref_sampled = _run(proc, batch, False, 10**9)

--- a/test/registered/unit/layers/test_logprob_chunk_stitching.py
+++ b/test/registered/unit/layers/test_logprob_chunk_stitching.py
@@ -1,12 +1,9 @@
 """Chunked input-logprob processing must match the non-chunked reference.
 
-Regression for the cross-chunk stitching accounting: sequences with zero
-input-logprob rows (mixed batches where a request opts out of logprobs, or a
-mid-chunked-prefill segment entirely below logprob_start_len) contribute a
-sample-only row. Chunks made purely of such rows were skipped entirely and a
-zero-row sequence sitting exactly on a chunk boundary was emitted twice, so
-the per-request top-k / token-ids entry counts drifted and tripped the
-scheduler-side length asserts.
+Regression for the cross-chunk stitching accounting: zero-logprob-row
+sequences (logprob opt-outs in mixed batches, mid-chunked-prefill segments)
+were skipped or double-emitted, drifting the per-request entry counts that
+the scheduler asserts on.
 """
 
 import itertools
@@ -22,8 +19,7 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=30, suite="base-a-test-cpu")
 
 VOCAB = 11
-# Heterogeneous per-sequence parameters: uniform values would hide slice
-# misalignment and the None / k=0 emission paths.
+# Heterogeneous per-sequence parameters; uniform ones hide misalignment.
 TOPK_CYCLE = [2, 0, 3]
 # [] is a valid probe set distinct from None (opt-out).
 TOKEN_IDS_CYCLE = [[0, 3], None, [1], []]


### PR DESCRIPTION
Fixes a scheduler crash (`AssertionError: len(req.logprob.input_top_logprobs_val) == relevant_tokens_len` in `logprob_result_processor.py`) seen on a scheduled run of `test_srt_endpoint.py::test_logprob_mixed`, plus two more defects of the same class found while reviewing the stitching code.

## Background

Sequences with zero input-logprob rows are normal inputs: requests that opt out of logprobs inside a mixed batch, and mid-chunked-prefill segments entirely below `logprob_start_len` — both contribute a sample-only row to the chunk grid. The chunked walkers mishandled exactly this class, drifting the per-request entry counts that the scheduler asserts on, while token-level logprobs (mask-indexed) stayed correct.

## Fixes

- Chunks made purely of sample-only rows were skipped entirely (`chunk_indices.numel() == 0: continue`), so their sequences' empty placeholder entries were never emitted; empty chunks now run the per-sequence bookkeeping.
- The chunk's sequence slice ended at `token_to_seq_idx[end_idx]`, which belongs to the next chunk — a zero-row sequence sitting exactly on a chunk boundary was emitted by both neighboring chunks; the slice now ends at the last row inside the chunk.
- The walkers' `if len(val) > 0` emission guard dropped the entry of a `token_ids=None` sequence that owns rows (and, if that sequence was split across chunks, extended its values onto the previous sequence's entry); emission is now keyed on split-continuation only.
- `get_token_ids_logprobs_raw` (prefill branch, non-chunked path) crashed with `TypeError: torch.tensor(None)` on batches mixing `token_ids_logprob` requests with plain logprob requests; `None` entries now emit an empty entry while still stepping the row cursor over the sequence's rows.

## Regression test

`test/registered/unit/layers/test_logprob_chunk_stitching.py` (CPU, ~12s): enumerates 11k+ batch shapes (sequence length/start combos including degenerate zero-row shapes x chunk sizes x heterogeneous per-sequence `top_logprobs_num` in {0,2,3} x `token_ids_logprob` in {list, None, []}) and compares chunked output against the non-chunked reference for top-k, token-ids, token-level, and sampled outputs. Fails on the pre-fix code for both rounds of bugs.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29632160532](https://github.com/sgl-project/sglang/actions/runs/29632160532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29632160433](https://github.com/sgl-project/sglang/actions/runs/29632160433)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->