### PR TITLE
ci: fix llama8b nvfp4 sm120 test startup OOM; disable pending decode-correctness fix

### DIFF
--- a/test/registered/models_e2e/test_llama8b_nvfp4_kv_cache_sm120.py
+++ b/test/registered/models_e2e/test_llama8b_nvfp4_kv_cache_sm120.py
@@ -6,7 +6,17 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import CustomTestCase, ModelLaunchSettings
 
-register_cuda_ci(est_time=300, stage="extra-a", runner_config="1-gpu-small")
+register_cuda_ci(
+    est_time=300,
+    stage="extra-a",
+    runner_config="1-gpu-small",
+    # Batched (bs>1) decode with NVFP4 KV via trtllm_mha produces corrupted
+    # output on the 32 GB RTX 5090 CI runners (verified on a 5090 devbox with
+    # the CI package stack: sequential gsm8k subset scores 0.75, any
+    # concurrent traffic collapses to ~0.01 with garbage generations).
+    # Re-enable once the SM120 XQA batched-decode correctness bug is fixed.
+    disabled="NVFP4-KV batched decode corrupts output on SM120 (#31641)",
+)
 
 LLAMA8B_NVFP4_MODEL = "nvidia/Llama-3.1-8B-Instruct-NVFP4"
 TP_SIZE = 1
@@ -37,6 +47,13 @@ class TestLlama8BNVFP4KVCacheSM120(CustomTestCase):
                     "--page-size",
                     "64",
                     "--cuda-graph-backend-prefill=disabled",
+                    # The default mem_fraction_static (0.885) leaves ~2.3 GB
+                    # of headroom on the 32 GB RTX 5090 CI runners after
+                    # weights (5.7 GB) + FP4 KV pool (~22.8 GB), which is not
+                    # enough for the FlashInfer FP4-GEMM autotune warmup —
+                    # the server deterministically OOMs at startup.
+                    "--mem-fraction-static",
+                    "0.8",
                 ],
                 variant="NVFP4-GEMM+NVFP4-KV+SM120-XQA",
             )


### PR DESCRIPTION
## Motivation

`test_llama8b_nvfp4_kv_cache_sm120` (added in #21601) has failed every scheduled run since merge ([example](https://github.com/sgl-project/sglang/actions/runs/29620311314/job/88013933103)) — the extra-a suite was skipped on the PR's own CI, so its first execution was on the schedule. Reproduced on an RTX 5090 (32 GB, SM120) devbox with the CI package stack; two independent bugs:

1. **Startup OOM** (what CI shows): default `mem_fraction_static=0.885` leaves 2.26 GB headroom after weights (5.68 GB) + NVFP4 KV pool, and the FlashInfer FP4-GEMM autotune warmup OOMs — deterministic exit -9 on every retry, byte-identical to the CI failure.
2. **Batched-decode corruption**: with the OOM fixed, any concurrent traffic through nvfp4-KV + trtllm_mha decode generates garbage (sequential gsm8k subset 0.75 → 0.005 at 32-way concurrency; not overlap-schedule, not CUDA graphs; `triton` decode crashes on the fp4 dtype). Full experiment matrix in #31641.

## Modifications

- Add `--mem-fraction-static 0.8` to the test's launch args — validated on the devbox: server healthy in ~60s, 5.03 GB post-pool headroom, 520k-token KV pool.
- Disable the registration with a reason pointing at #31641: the gsm8k accuracy check (num_threads=200) cannot pass until the batched-decode bug is fixed. Re-enable there.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29628820240](https://github.com/sgl-project/sglang/actions/runs/29628820240)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29628820166](https://github.com/sgl-project/sglang/actions/runs/29628820166)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->