### PR TITLE
docs(cookbook): move rolling :dev pages to :latest where support shipped in v0.5.15

### DIFF
--- a/docs_new/cookbook/autoregressive/Baidu/Unlimited-OCR.mdx
+++ b/docs_new/cookbook/autoregressive/Baidu/Unlimited-OCR.mdx
@@ -33,7 +33,7 @@ Then run the **Python** output of the command panel below in that environment.
 <Tab title="Docker">
 
 ```bash Command
-docker pull lmsysorg/sglang:dev
+docker pull lmsysorg/sglang:latest
 ```
 
 For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.

--- a/docs_new/cookbook/autoregressive/LiquidAI/LFM2.5.mdx
+++ b/docs_new/cookbook/autoregressive/LiquidAI/LFM2.5.mdx
@@ -35,7 +35,7 @@ Then run the **Python** output of the command panel below in that environment.
 LFM2.5 support ships in the pinned SGLang dev image:
 
 ```bash Command
-docker pull lmsysorg/sglang:dev-cu13
+docker pull lmsysorg/sglang:latest
 ```
 
 For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). A minimal example (substitute the inner `sglang serve ...` with whatever the command generator below produces):
@@ -47,7 +47,7 @@ docker run --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     --env "HF_TOKEN=<your-hf-token>" \
     --ipc=host \
-    lmsysorg/sglang:dev-cu13 \
+    lmsysorg/sglang:latest \
     sglang serve <use args below>
 ```
 

--- a/docs_new/cookbook/autoregressive/OpenBMB/MiniCPM-V-4_6.mdx
+++ b/docs_new/cookbook/autoregressive/OpenBMB/MiniCPM-V-4_6.mdx
@@ -27,14 +27,14 @@ OpenBMB ships two variants on HuggingFace:
 
 ## 2. SGLang Installation
 
-Pull the nightly Docker image (rolling tag, tracks `main`):
+Pull the stable Docker image:
 
 ```bash
 # CUDA 13 (Hopper / Blackwell, default)
-docker pull lmsysorg/sglang:dev
+docker pull lmsysorg/sglang:latest
 
 # CUDA 12 (Ampere or older drivers)
-docker pull lmsysorg/sglang:dev-cu12
+docker pull lmsysorg/sglang:latest-cu129
 ```
 
 For the general SGLang installation guide (PyPI, source, Docker) see the [official SGLang installation guide](../../../docs/get-started/install).

--- a/docs_new/src/snippets/configs/LiquidAI/lfm2.5.jsx
+++ b/docs_new/src/snippets/configs/LiquidAI/lfm2.5.jsx
@@ -132,12 +132,12 @@ sgl-eval run aime25 \\
     "vl-450m": { mmmu_pct: 30.56 },
   },
 
-  // LFM2.5 support (model classes + the `lfm2` tool-call parser) ships in the
-  // SGLang dev image; not yet in a tagged release.
+  // LFM2.5 support (model classes + the `lfm2` tool-call parser) shipped in
+  // v0.5.15, so lmsysorg/sglang:latest (cu13) carries it.
   dockerImages: {
-    h100: "lmsysorg/sglang:dev-cu13",
-    h200: "lmsysorg/sglang:dev-cu13",
-    b200: "lmsysorg/sglang:dev-cu13",
+    h100: "lmsysorg/sglang:latest",
+    h200: "lmsysorg/sglang:latest",
+    b200: "lmsysorg/sglang:latest",
   },
 
   // Pre-selects the issue template's `model` dropdown on "Submit verified cell".

--- a/docs_new/src/snippets/configs/baidu/unlimited-ocr.jsx
+++ b/docs_new/src/snippets/configs/baidu/unlimited-ocr.jsx
@@ -43,7 +43,7 @@ export const config = {
 }'`,
 
   dockerImages: {
-    h100: "lmsysorg/sglang:dev",
+    h100: "lmsysorg/sglang:latest",
   },
 
   github: {


### PR DESCRIPTION
## Motivation

Follow-up to #31610 — that PR was squash-merged before this last commit landed, so these three pages were left on the rolling `:dev` channel even though their model support has since shipped in the stable release.

Ancestry-checked each against `v0.5.15.post1` (the release `:latest` tracks); support that made the release cut moves to the stable tag:

| Page | Support PR | In v0.5.15.post1 | Change |
|---|---|---|---|
| Baidu Unlimited-OCR | #29186 | ✅ | `:dev` → `:latest` |
| LFM2.5 | #29659 | ✅ | `:dev-cu13` → `:latest` (+ stale config comment fixed) |
| MiniCPM-V-4.6 | #24855 | ✅ | `:dev` → `:latest`, `:dev-cu12` → `:latest-cu129` |

MiniCPM's CUDA-12 (Ampere / older-driver) path stays on the matching stable tag `:latest-cu129` rather than the cu13 `:latest`.

## Left on `:dev` intentionally (support NOT in the release cut)

- **LongCat-2.0** — FP8 support #30275 merged Jul 7 but isn't in `.post1` (patch release cut selectively; ancestry check, not date, is authoritative)
- **Hy3** — HunyuanV3 NextN/MTP draft-head fix #30331 isn't in the release, and MTP is a headline feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29630050662](https://github.com/sgl-project/sglang/actions/runs/29630050662)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29630050610](https://github.com/sgl-project/sglang/actions/runs/29630050610)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->