### PR TITLE
CI: launch test servers in their own sessions and kill by process group

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import logging
 import os
+import signal
 
 # Registered tests run with the strict config-mutation guard: bare
 # server_args assignments after resolution raise (use ServerArgs.override).
@@ -774,7 +775,9 @@ def _subprocess_popen_with_outputs(
         torch.cuda.empty_cache()
 
     if not return_stdout_stderr:
-        return subprocess.Popen(command, stdout=None, stderr=None, env=env)
+        return subprocess.Popen(
+            command, stdout=None, stderr=None, env=env, start_new_session=True
+        )
 
     process = subprocess.Popen(
         command,
@@ -783,6 +786,7 @@ def _subprocess_popen_with_outputs(
         env=env,
         text=True,
         bufsize=1,
+        start_new_session=True,
     )
 
     def _dump(src, sinks):
@@ -882,6 +886,32 @@ def _wait_for_server_health(
     return False, "Server failed to start within the timeout period"
 
 
+_launched_servers_by_port: dict = {}
+
+
+def _kill_server_session(pid: int):
+    """SIGKILL every process in a launched server's session.
+
+    Servers are launched with ``start_new_session=True``, so the launcher's
+    pid is also the session's process-group id, and ``os.killpg`` reaches
+    schedulers that detached from the process tree (reparented to PID 1) —
+    the ones ``kill_process_tree``'s tree walk misses. Pids of dead leaders
+    cannot be recycled while the group has members, so a stale pid either
+    hits the right group or raises ProcessLookupError.
+    """
+    if pid == os.getpgid(0):
+        return
+    try:
+        if os.getpgid(pid) != pid:
+            return
+    except ProcessLookupError:
+        pass
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
 def popen_launch_server(
     model: str,
     base_url: str,
@@ -931,6 +961,11 @@ def popen_launch_server(
     # kill_process_tree() while GPU teardown completes; give CI launches
     # teardown-sized patience (see wait_port_available).
     env.setdefault("SGLANG_WAIT_PORT_TIMEOUT", "120")
+
+    _, _, _port_str = base_url.split(":")
+    predecessor = _launched_servers_by_port.get(int(_port_str))
+    if predecessor is not None:
+        _kill_server_session(predecessor.pid)
 
     # Store per-run marker path for potential invalidation
     per_run_marker_path = None
@@ -985,6 +1020,7 @@ def popen_launch_server(
 
     # First launch attempt
     process = _launch_server_process(command, env, return_stdout_stderr, model)
+    _launched_servers_by_port[int(_port_str)] = process
     success, error_msg = _wait_for_server_health(process, base_url, api_key, timeout)
 
     # If offline launch failed and offline was enabled, retry with online mode
@@ -997,7 +1033,8 @@ def popen_launch_server(
         try:
             if process.poll() is None:
                 kill_process_tree(process.pid)
-            else:
+            _kill_server_session(process.pid)
+            if process.poll() is None:
                 process.wait(timeout=5)
         except Exception as e:
             print(f"CI_OFFLINE: Error cleaning up failed offline process: {e}")
@@ -1013,6 +1050,7 @@ def popen_launch_server(
         # Retry with online mode
         env["HF_HUB_OFFLINE"] = "0"
         process = _launch_server_process(command, env, return_stdout_stderr, model)
+        _launched_servers_by_port[int(_port_str)] = process
         success, error_msg = _wait_for_server_health(
             process, base_url, api_key, timeout
         )


### PR DESCRIPTION
Follow-up to #31281 — reworked per review feedback: **no process-table scanning, no name/age matching**.

## Problem

sglang schedulers detach from the launcher's process tree during startup (reparented to PID 1), so `kill_process_tree()`'s parent→child walk cannot enumerate them. A scheduler that is never signalled keeps the port plan derived from `--port` alive **indefinitely** (>1h observed on GB300), failing every later launch on the runner with `rpc_port ... is used by a process already` — a wait of any length (#31281's 120s included) cannot outlive a process that was never killed. [Production example](https://github.com/sgl-project/sglang/actions/runs/29456519822/job/87517758763): the 120s wait ran to exhaustion against a leftover from a job an hour earlier. [Second example on main with both merged fixes](https://github.com/sgl-project/sglang/actions/runs/29665021534/job/88133917295): test class 1 passed, its teardown left a hung scheduler, class 2 waited the full 120s and died.

## Fix — make the kill exact instead of collecting garbage

- **Launch each test server with `start_new_session=True`**: the launcher's pid is then also the process-group id, which every descendant keeps no matter how it reparents. `os.killpg()` is the one signal that reliably reaches all of them.
- **Before launching on a port, `killpg` the previous server this test process launched on the same port** (exact per-port bookkeeping — covers the class→class handoff above). PD-disagg sibling servers run on different ports and are never touched.
- **The offline→online retry `killpg`s the failed launch** before reusing the same port plan.

The already-merged 120s port wait absorbs the bounded GPU teardown that follows the signal. Job→job leftovers are additionally covered at the infra level by a runner pre-job cleanup hook (deployed on gb300-4-gpu-02, no repo code).

~55 lines, harness-only. Possible future follow-up at a lower level: teach `kill_process_tree` itself to signal the target's process group when the target is a session leader, which would fix the blind spot for all callers (incl. `tearDownClass`).

## Same root cause, second symptom: leaked GPU memory tripping the idle guard

The `rpc_port` squat is one symptom of a scheduler that outlived its job; leaked **GPU memory** is another. A reparented scheduler that is never signalled keeps its CUDA context — and its 36–72 GiB of device memory — allocated long after the job that launched it finished. The next job to land on that runner then trips the `[CI GPU Idle]` preflight guard in `setUpClass` and errors before it can start. [Example](https://github.com/sgl-project/sglang/actions/runs/29642449950/job/88159672103): both reruns of an `extra-b-test-4-gpu-h100` shard landed on the same host — attempt 1 hit GPUs 0–3 at ~36 GiB each (a leftover TP=4 server), attempt 2 hit GPU 4 at 71.49 GiB with no visible process (the owner was in a sibling container's PID namespace). `start_new_session=True` + `killpg` frees that memory at teardown for the intra-job / class→class handoffs this PR covers; a purely **job→job** leftover (an orphan already on the GPUs before the shard's first test starts) is not caught here and still depends on the runner-level pre-job cleanup hook.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29678966964](https://github.com/sgl-project/sglang/actions/runs/29678966964)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29678966905](https://github.com/sgl-project/sglang/actions/runs/29678966905)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->