### PR TITLE
Fix abort request counter accounting for abort_all

### DIFF
--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -106,13 +106,16 @@ class GrammarManager:
             )
         return data
 
-    def abort_requests(self, recv_req: AbortReq):
+    def abort_requests(self, recv_req: AbortReq) -> List[Req]:
+        aborted_reqs = []
         for req in self.grammar_queue:
             if recv_req.abort_all or req.rid.startswith(recv_req.rid):
                 logger.debug(f"Abort grammar queue request. {req.rid=}")
                 if isinstance(req.grammar, futures.Future) and req.grammar:
                     req.grammar.cancel()
                 req.set_finish_with_abort("Aborted by AbortReq.")
+                aborted_reqs.append(req)
+        return aborted_reqs
 
     def _get_request_thinking_budget(self, req: Req) -> int | None:
         custom_params = req.sampling_params.custom_params

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -803,6 +803,10 @@ class Req(ReqDllmMixin):
         # For multi-http worker
         self.http_worker_ipc = http_worker_ipc
 
+        # An AbortReq may find the same request in multiple scheduler structures,
+        # or be retried before the request is removed. Account it only once.
+        self._abort_metric_accounted = False
+
         # Require reasoning for the request
         self.require_reasoning = require_reasoning
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2620,6 +2620,7 @@ class Scheduler(
         self.chunked_req = None
         self._pending_chunked_abort_req = None
         self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+        self._account_aborted_request(req)
         logger.debug(f"Abort chunked prefill request. {req.rid=}")
 
     def _build_hisparse_decode_batch(self, reqs):
@@ -4026,6 +4027,7 @@ class Scheduler(
             # This only works for requests that have not started anything.
             # We still need to send something back to TokenizerManager to clean up the state.
             req = self.waiting_queue.pop(i)
+            self._account_aborted_request(req)
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
@@ -4059,7 +4061,8 @@ class Scheduler(
         # Abort method 2: call `set_finish_with_abort`
         # The request will still run one prefill forward pass.
         # In this case, we change the input_ids to be only one token to make this prefill cheap.
-        self.grammar_manager.abort_requests(recv_req)
+        for req in self.grammar_manager.abort_requests(recv_req):
+            self._account_aborted_request(req)
 
         # Delete requests not in the waiting queue when PD disaggregation is enabled
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -4072,6 +4075,7 @@ class Scheduler(
 
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
+                        self._account_aborted_request(req)
 
             # Abort in-flight requests
             for req in self.disagg_prefill_inflight_queue:
@@ -4079,6 +4083,7 @@ class Scheduler(
                     logger.debug(f"Abort inflight queue request. {req.rid=}")
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
+                        self._account_aborted_request(req)
 
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             # Abort requests that have not yet finished preallocation
@@ -4086,12 +4091,14 @@ class Scheduler(
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    self._account_aborted_request(decode_req.req)
 
             # Abort requests waiting for kvcache to release tree cache
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    self._account_aborted_request(decode_req.req)
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:
@@ -4103,6 +4110,7 @@ class Scheduler(
                         self.ipc_channels.send_to_tokenizer.send_output(
                             AbortReq(rid=decode_req.rid), decode_req
                         )
+                        self._account_aborted_request(decode_req)
                     else:
                         remaining_retracted.append(decode_req)
                 self.disagg_decode_prealloc_queue.retracted_queue = remaining_retracted
@@ -4123,6 +4131,27 @@ class Scheduler(
                 # Then we reuse all existing code to clean up the KV cache allocation.
                 logger.debug(f"Abort running request. {req.rid=}")
                 req.to_finish = FINISH_ABORT()
+                self._account_aborted_request(req)
+
+    def _account_aborted_request(self, req: Req) -> None:
+        if req._abort_metric_accounted:
+            return
+        req._abort_metric_accounted = True
+
+        # Every TP/PP rank mirrors the request and handles AbortReq. Preserve the
+        # old one-request/one-sample behavior by emitting only on the primary
+        # scheduler rank of each DP replica.
+        if (
+            not self.metrics_reporter.enable_metrics
+            or self.ps.pp_rank != 0
+            or self.ps.attn_tp_rank != 0
+            or self.ps.attn_cp_rank != 0
+        ):
+            return
+
+        # TODO: Include request custom labels once they are propagated to Scheduler.
+        labels = dict(self.metrics_collector.aborted_request_labels)
+        self.metrics_collector.observe_one_aborted_request(labels)
 
     def _pause_engine(self) -> Tuple[List[Req], int]:
         raise NotImplementedError()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1721,11 +1721,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             return
         req = AbortReq(rid=rid, abort_all=abort_all)
         self._dispatch_to_scheduler(req)
-        if self.enable_metrics:
-            # TODO: also use custom_labels from the request
-            self.metrics_collector.observe_one_aborted_request(
-                self.metrics_collector.labels
-            )
 
     async def pause_generation(self, obj: PauseGenerationReqInput):
         async with self.is_pause_cond:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -41,6 +41,25 @@ SGLANG_TEST_REQUEST_TIME_STATS = get_bool_env_var("SGLANG_TEST_REQUEST_TIME_STAT
 logger = logging.getLogger(__name__)
 
 
+def _build_aborted_request_labels(
+    labels: Dict[str, str], server_args: Optional[ServerArgs]
+) -> Dict[str, str]:
+    if server_args is None:
+        return dict(labels)
+
+    aborted_request_labels = {
+        "model_name": server_args.served_model_name,
+        "engine_type": DisaggregationMode.to_engine_type(
+            server_args.disaggregation_mode
+        ),
+    }
+    if "priority" in labels:
+        aborted_request_labels["priority"] = ""
+    if server_args.extra_metric_labels:
+        aborted_request_labels.update(server_args.extra_metric_labels)
+    return aborted_request_labels
+
+
 @dataclass
 class QueueCount:
     """Holds both the total count and optional per-priority breakdown for a queue."""
@@ -257,6 +276,7 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         Summary = self._summary_cls or _PromSummary
 
         self.labels = labels
+        self.aborted_request_labels = _build_aborted_request_labels(labels, server_args)
         self.enable_lora = enable_lora
         self.enable_hierarchical_cache = enable_hierarchical_cache
         self.enable_streaming_session = enable_streaming_session
@@ -266,6 +286,11 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         # =================================================================
         # Basics
         # =================================================================
+        self.num_aborted_requests_total = Counter(
+            name="sglang:num_aborted_requests_total",
+            documentation="Number of requests aborted.",
+            labelnames=self.aborted_request_labels.keys(),
+        )
         self.num_running_reqs = Gauge(
             name="sglang:num_running_reqs",
             documentation="The number of running requests.",
@@ -1398,6 +1423,9 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             )
         self.num_grammar_total.labels(**self.labels).inc(1)
 
+    def observe_one_aborted_request(self, labels: Dict[str, str]) -> None:
+        self.num_aborted_requests_total.labels(**labels).inc(1)
+
     def emit_constants(
         self,
         max_total_num_tokens: int,
@@ -1543,12 +1571,6 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.num_so_requests_total = Counter(
             name="sglang:num_so_requests_total",
             documentation="Number of structured output requests processed.",
-            labelnames=labels.keys(),
-        )
-
-        self.num_aborted_requests_total = Counter(
-            name="sglang:num_aborted_requests_total",
-            documentation="Number of requests aborted.",
             labelnames=labels.keys(),
         )
 
@@ -1731,9 +1753,6 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
             if adjusted_interval <= bound:
                 his._buckets[i].inc(num_new_tokens)
                 break
-
-    def observe_one_aborted_request(self, labels: Dict[str, str]):
-        self.num_aborted_requests_total.labels(**labels).inc(1)
 
 
 @dataclass

--- a/test/registered/unit/managers/test_scheduler_abort_metrics.py
+++ b/test/registered/unit/managers/test_scheduler_abort_metrics.py
@@ -1,0 +1,215 @@
+"""Unit tests for request-level abort metric accounting."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.io_struct import AbortReq
+from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.observability.metrics_collector import (
+    SchedulerMetricsCollector,
+    _build_aborted_request_labels,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _make_req(
+    rid: str,
+    *,
+    priority=None,
+):
+    return Req(
+        rid=rid,
+        origin_input_text="",
+        origin_input_ids=array("q", [1]),
+        sampling_params=SamplingParams(),
+        priority=priority,
+    )
+
+
+def _make_scheduler(*, enable_metrics=True, enable_priority_scheduling=False):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.chunked_req = None
+    scheduler.waiting_queue = []
+    scheduler.running_batch = SimpleNamespace(reqs=[])
+    scheduler.last_batch = None
+    scheduler.grammar_manager = MagicMock()
+    scheduler.grammar_manager.abort_requests.return_value = []
+    scheduler.enable_hicache_storage = False
+    scheduler.disaggregation_mode = DisaggregationMode.NULL
+    scheduler.ipc_channels = MagicMock()
+    scheduler.ps = SimpleNamespace(
+        pp_size=1,
+        pp_rank=0,
+        attn_tp_rank=0,
+        attn_cp_rank=0,
+    )
+    scheduler.metrics_reporter = SimpleNamespace(enable_metrics=enable_metrics)
+    scheduler.metrics_collector = MagicMock()
+    scheduler.metrics_collector.aborted_request_labels = {
+        "model_name": "test-model",
+        "engine_type": "unified",
+    }
+    scheduler.enable_priority_scheduling = enable_priority_scheduling
+    return scheduler
+
+
+class TestSchedulerAbortMetrics(CustomTestCase):
+    def test_abort_all_counts_each_matched_request(self):
+        scheduler = _make_scheduler()
+        waiting_reqs = [_make_req("waiting-0"), _make_req("waiting-1")]
+        running_req = _make_req("running-0")
+        scheduler.waiting_queue = list(waiting_reqs)
+        scheduler.running_batch.reqs = [running_req]
+
+        scheduler.abort_request(AbortReq(rid="", abort_all=True))
+
+        self.assertEqual(scheduler.waiting_queue, [])
+        self.assertIsInstance(running_req.to_finish, FINISH_ABORT)
+        self.assertEqual(
+            scheduler.metrics_collector.observe_one_aborted_request.call_count,
+            3,
+        )
+        for req in [*waiting_reqs, running_req]:
+            self.assertTrue(req._abort_metric_accounted)
+
+    def test_prefix_abort_counts_each_matching_request(self):
+        scheduler = _make_scheduler()
+        matching_reqs = [_make_req("batch-0"), _make_req("batch-1")]
+        other_req = _make_req("other-0")
+        scheduler.waiting_queue = [*matching_reqs, other_req]
+
+        scheduler.abort_request(AbortReq(rid="batch-", abort_all=False))
+
+        self.assertEqual(scheduler.waiting_queue, [other_req])
+        self.assertEqual(
+            scheduler.metrics_collector.observe_one_aborted_request.call_count,
+            2,
+        )
+        for req in matching_reqs:
+            self.assertTrue(req._abort_metric_accounted)
+        self.assertFalse(other_req._abort_metric_accounted)
+
+    def test_non_matching_abort_is_not_counted(self):
+        scheduler = _make_scheduler()
+        running_req = _make_req("other-rid")
+        scheduler.running_batch.reqs = [running_req]
+
+        scheduler.abort_request(AbortReq(rid="missing-rid", abort_all=False))
+
+        scheduler.metrics_collector.observe_one_aborted_request.assert_not_called()
+        self.assertFalse(running_req._abort_metric_accounted)
+        self.assertIsNone(running_req.to_finish)
+
+    def test_repeated_abort_of_running_request_is_counted_once(self):
+        scheduler = _make_scheduler()
+        running_req = _make_req("request-0")
+        scheduler.running_batch.reqs = [running_req]
+        abort_req = AbortReq(rid="request-0", abort_all=False)
+
+        scheduler.abort_request(abort_req)
+        scheduler.abort_request(abort_req)
+
+        scheduler.metrics_collector.observe_one_aborted_request.assert_called_once()
+
+    def test_non_primary_scheduler_ranks_do_not_emit(self):
+        for rank_name in ("pp_rank", "attn_tp_rank", "attn_cp_rank"):
+            with self.subTest(rank_name=rank_name):
+                scheduler = _make_scheduler()
+                setattr(scheduler.ps, rank_name, 1)
+                req = _make_req("request-0")
+
+                scheduler._account_aborted_request(req)
+
+                self.assertTrue(req._abort_metric_accounted)
+                observe_abort = scheduler.metrics_collector.observe_one_aborted_request
+                observe_abort.assert_not_called()
+
+    def test_metrics_disabled_does_not_emit(self):
+        scheduler = _make_scheduler(enable_metrics=False)
+        req = _make_req("request-0")
+
+        scheduler._account_aborted_request(req)
+
+        self.assertTrue(req._abort_metric_accounted)
+        scheduler.metrics_collector.observe_one_aborted_request.assert_not_called()
+
+
+class TestTokenizerAbortMetrics(CustomTestCase):
+    def test_tokenizer_only_dispatches_abort(self):
+        tokenizer_manager = TokenizerManager.__new__(TokenizerManager)
+        tokenizer_manager.server_args = SimpleNamespace(tokenizer_worker_num=1)
+        tokenizer_manager.rid_to_state = {"request-0": object()}
+        tokenizer_manager._dispatch_to_scheduler = MagicMock()
+        tokenizer_manager.enable_metrics = True
+        tokenizer_manager.metrics_collector = MagicMock()
+
+        tokenizer_manager.abort_request(rid="request-0")
+
+        tokenizer_manager._dispatch_to_scheduler.assert_called_once_with(
+            AbortReq(rid="request-0", abort_all=False)
+        )
+        observe_abort = tokenizer_manager.metrics_collector.observe_one_aborted_request
+        observe_abort.assert_not_called()
+
+
+class TestAbortMetricCollector(CustomTestCase):
+    def test_build_labels_without_server_args_returns_copy(self):
+        labels = {"model_name": "test-model", "tp_rank": 0}
+
+        aborted_labels = _build_aborted_request_labels(labels, None)
+
+        self.assertEqual(aborted_labels, labels)
+        self.assertIsNot(aborted_labels, labels)
+
+    def test_build_labels_uses_service_level_dimensions(self):
+        labels = {
+            "model_name": "test-model",
+            "engine_type": "unified",
+            "tp_rank": 3,
+            "pp_rank": 2,
+            "priority": "",
+        }
+        server_args = SimpleNamespace(
+            served_model_name="test-model",
+            disaggregation_mode=DisaggregationMode.NULL.value,
+            extra_metric_labels={"cluster": "prod-a"},
+        )
+
+        aborted_labels = _build_aborted_request_labels(labels, server_args)
+
+        self.assertEqual(
+            aborted_labels,
+            {
+                "model_name": "test-model",
+                "engine_type": "unified",
+                "priority": "",
+                "cluster": "prod-a",
+            },
+        )
+
+    def test_scheduler_collector_increments_abort_counter(self):
+        collector = SchedulerMetricsCollector.__new__(SchedulerMetricsCollector)
+        collector.num_aborted_requests_total = MagicMock()
+        labels = {"model_name": "test-model", "engine_type": "unified"}
+
+        collector.observe_one_aborted_request(labels)
+
+        collector.num_aborted_requests_total.labels.assert_called_once_with(**labels)
+        bound_counter = collector.num_aborted_requests_total.labels.return_value
+        bound_counter.inc.assert_called_once_with(1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
When tokenizerManager send abort req to scheduler and set abort_all = true, the observe_one_aborted_request just count only once ,even all request were aborted, this is a mistake.

## Modifications
I move the observe_one_aborted_request counter to scheduler's abort_request, only when a request really matchs AbortReq and clear resources, observe_one_aborted_request counter is incremented.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29631044470](https://github.com/sgl-project/sglang/actions/runs/29631044470)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29631044361](https://github.com/sgl-project/sglang/actions/runs/29631044361)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->