### PR TITLE
fix(function-call): stream DeepSeek-V3 tool-call args when whole call in one chunk

### DIFF
--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -146,54 +146,55 @@ class DeepSeekV3Detector(BaseFormatDetector):
                         "name": func_name,
                         "arguments": {},
                     }
-                else:
-                    argument_diff = (
-                        func_args_raw[len(self._last_arguments) :]
-                        if func_args_raw.startswith(self._last_arguments)
-                        else func_args_raw
+
+                # Stream argument bytes in the same increment as (not only after)
+                # the name. Emitting the name must not short-circuit argument
+                # streaming: when a whole tool call arrives in a single chunk,
+                # the arguments would otherwise never be emitted and the stored
+                # arguments would stay "{}".
+                argument_diff = (
+                    func_args_raw[len(self._last_arguments) :]
+                    if func_args_raw.startswith(self._last_arguments)
+                    else func_args_raw
+                )
+
+                if argument_diff:
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters=argument_diff,
+                        )
                     )
+                    self._last_arguments += argument_diff
+                    self.streamed_args_for_tool[self.current_tool_id] += argument_diff
 
-                    if argument_diff:
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=None,
-                                parameters=argument_diff,
-                            )
-                        )
-                        self._last_arguments += argument_diff
-                        self.streamed_args_for_tool[
-                            self.current_tool_id
-                        ] += argument_diff
+                if _is_complete_json(func_args_raw):
+                    # Update the stored arguments
+                    try:
+                        parsed_args = json.loads(func_args_raw)
+                        self.prev_tool_call_arr[self.current_tool_id][
+                            "arguments"
+                        ] = parsed_args
+                    except json.JSONDecodeError:
+                        pass
 
-                    if _is_complete_json(func_args_raw):
-                        # Update the stored arguments
-                        try:
-                            parsed_args = json.loads(func_args_raw)
-                            self.prev_tool_call_arr[self.current_tool_id][
-                                "arguments"
-                            ] = parsed_args
-                        except json.JSONDecodeError:
-                            pass
+                    # Find the end of the current tool call and remove only that part from buffer
+                    tool_call_end_pattern = (
+                        r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
+                    )
+                    match = re.search(tool_call_end_pattern, current_text, re.DOTALL)
+                    if match:
+                        # Remove the completed tool call from buffer, keep any remaining content
+                        self._buffer = current_text[match.end() :]
+                    else:
+                        self._buffer = ""
 
-                        # Find the end of the current tool call and remove only that part from buffer
-                        tool_call_end_pattern = (
-                            r"<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>"
-                        )
-                        match = re.search(
-                            tool_call_end_pattern, current_text, re.DOTALL
-                        )
-                        if match:
-                            # Remove the completed tool call from buffer, keep any remaining content
-                            self._buffer = current_text[match.end() :]
-                        else:
-                            self._buffer = ""
-
-                        result = StreamingParseResult(normal_text="", calls=calls)
-                        self.current_tool_id += 1
-                        self._last_arguments = ""
-                        self.current_tool_name_sent = False
-                        return result
+                    result = StreamingParseResult(normal_text="", calls=calls)
+                    self.current_tool_id += 1
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    return result
 
             return StreamingParseResult(normal_text="", calls=calls)
 

--- a/test/registered/unit/function_call/test_deepseekv3_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv3_detector.py
@@ -1,0 +1,91 @@
+"""Unit tests for DeepSeekV3Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+BOT = "<｜tool▁calls▁begin｜>"
+CB = "<｜tool▁call▁begin｜>"
+SEP = "<｜tool▁sep｜>"
+CE = "<｜tool▁call▁end｜>"
+EOT = "<｜tool▁calls▁end｜>"
+
+
+def _make_call(name: str, args_json: str) -> str:
+    return f"{CB}function{SEP}{name}\n```json\n{args_json}\n```{CE}"
+
+
+class TestDeepSeekV3Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "location": {"type": "string"},
+                        },
+                        "required": ["location"],
+                    },
+                ),
+            ),
+        ]
+
+    def _run_stream(self, chunks):
+        detector = DeepSeekV3Detector()
+        names = []
+        streamed_args = ""
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            for call in result.calls:
+                if call.name:
+                    names.append(call.name)
+                if call.parameters:
+                    streamed_args += call.parameters
+        return detector, names, streamed_args
+
+    def test_streaming_whole_call_in_single_increment_preserves_arguments(self):
+        """A complete tool call delivered in one streaming increment must still
+        emit its arguments. Previously only the name was emitted and the
+        arguments were dropped (stored as ``{}``)."""
+        text = BOT + _make_call("get_weather", '{"location": "Tokyo"}') + EOT
+        detector, names, streamed_args = self._run_stream([text])
+
+        self.assertEqual(names, ["get_weather"])
+        self.assertEqual(json.loads(streamed_args), {"location": "Tokyo"})
+        self.assertEqual(
+            detector.prev_tool_call_arr[0]["arguments"], {"location": "Tokyo"}
+        )
+
+    def test_streaming_token_by_token_still_works(self):
+        """Regression: token-by-token delivery keeps streaming name then args."""
+        chunks = [
+            BOT,
+            CB,
+            "function",
+            SEP,
+            "get_weather\n```json\n",
+            '{"location": ',
+            '"Tokyo"}',
+            "\n```",
+            CE,
+            EOT,
+        ]
+        detector, names, streamed_args = self._run_stream(chunks)
+
+        self.assertEqual(names, ["get_weather"])
+        self.assertEqual(json.loads(streamed_args), {"location": "Tokyo"})
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

`DeepSeekV3Detector.parse_streaming_increment` drops tool-call **arguments** when a complete tool call arrives in a single streaming increment.

The method emitted the tool **name** and the **argument bytes** in mutually-exclusive branches:

```python
if not self.current_tool_name_sent:
    calls.append(ToolCallItem(name=func_name, parameters=""))
    self.current_tool_name_sent = True
    self.prev_tool_call_arr[...] = {"name": func_name, "arguments": {}}
else:
    # argument streaming + completion handling
```

The first increment that matches a tool call sends only the name (`parameters=""`) and returns. Arguments are streamed only on a *later* call via the `else` branch. When one increment carries the whole call (common for short calls, or non-token-by-token transports), the `else` branch never runs, so:

- no argument delta is ever emitted to the client, and
- `prev_tool_call_arr[i]["arguments"]` stays `{}` (breaks the non-streaming/completions view and anything consuming stored args).

## Fix

After sending the name, always fall through to the argument-diff / `_is_complete_json` finalize logic in the **same** increment instead of gating it behind `else`. The diff is almost entirely de-indentation; token-by-token behavior is unchanged.

## Test plan

- [x] New unit test `test_streaming_whole_call_in_single_increment_preserves_arguments` — a full call in one increment now yields `{"location": "Tokyo"}` for both the streamed delta and `prev_tool_call_arr[0]["arguments"]` (fails on `main`, passes with fix).
- [x] New regression test `test_streaming_token_by_token_still_works` — token-by-token delivery still streams name then args correctly.
- [x] Verified against the real detector (no model/server) that `main` loses args (`streamed_args=''`, `arguments={}`) and the fix restores them.

## Known limitation (out of scope, pre-existing)

Two tool calls in a *single* increment still only surface the last call's args (greedy `(.*)<｜tool▁sep｜>(.*)` regex + return-after-first-finalize). This is pre-existing on `main` and not introduced or worsened here; happy to follow up separately.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29631725726](https://github.com/sgl-project/sglang/actions/runs/29631725726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29631725657](https://github.com/sgl-project/sglang/actions/runs/29631725657)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->