### PR TITLE
[JIT] Fuse FP8 KV-cache quantization into the store kernel

### DIFF
--- a/python/sglang/kernels/jit/csrc/elementwise/kvcache.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/kvcache.cuh
@@ -1,6 +1,7 @@
 #include <sgl_kernel/tensor.h>
 #include <sgl_kernel/utils.h>
 
+#include <sgl_kernel/math.cuh>
 #include <sgl_kernel/tile.cuh>
 #include <sgl_kernel/utils.cuh>
 #include <sgl_kernel/vec.cuh>
@@ -315,6 +316,194 @@ struct StoreKVCacheKernel {
     const auto num_blocks = div_ceil(num_elements * num_split, kNumWarps);
     LaunchKernel(num_blocks, kThreadsPerBlock, device.unwrap())  //
         .enable_pdl(kUsePDL)(kernel, params);
+  }
+};
+
+struct StoreKVCacheQuantParams {
+  const void* __restrict__ k;
+  const void* __restrict__ v;
+  void* __restrict__ k_cache;
+  void* __restrict__ v_cache;
+  const void* __restrict__ indices;
+  // Per-tensor scales, either as a device scalar (preferred: no host sync when
+  // the caller holds them as 0-dim GPU tensors) or as host-precomputed
+  // reciprocals. A null pointer selects the host value.
+  const float* __restrict__ k_scale;
+  const float* __restrict__ v_scale;
+  float k_inv_scale;
+  float v_inv_scale;
+  int64_t stride_k;  // source/cache row strides, in elements
+  int64_t stride_v;
+  int64_t stride_cache;
+  int64_t stride_indices;
+  uint32_t batch_size;
+  int64_t size_limit;
+  int64_t reserved_skip_index;  // reserved sink; -1 disables skipping
+};
+
+/**
+ * \brief Kernel to quantize key-value pairs to FP8 and store them into the KV
+ * cache in a single pass. Fuses the unfused eager sequence
+ * ``k.div_(scale); k.to(fp8)`` + byte store (5 kernel launches with scales)
+ * into one launch. One warp handles one item.
+ * \tparam kRowElems The number of elements per key/value row.
+ * \tparam TSrc The source data type (`bf16_t`, `fp16_t` or `fp32_t`).
+ * \tparam TDst The quantized cache data type (`fp8_e4m3_t`).
+ * \tparam kUsePDL Whether to use PDL feature.
+ * \tparam T The data type of the indices (`int32_t` or `int64_t`).
+ */
+template <int64_t kRowElems, typename TSrc, typename TDst, bool kUsePDL, typename T>
+__global__ void store_kvcache_quant(const __grid_constant__ StoreKVCacheQuantParams params) {
+  using namespace device;
+  constexpr uint32_t kVecElems = 16 / sizeof(TSrc);
+  using src_vec_t = AlignedVector<TSrc, kVecElems>;
+  using dst_vec_t = AlignedVector<TDst, kVecElems>;
+  constexpr int64_t kVecsPerRow = kRowElems / kVecElems;
+  constexpr int64_t kLoopCount = kVecsPerRow / kWarpThreads;
+  constexpr int64_t kTailVecs = kVecsPerRow % kWarpThreads;
+
+  const uint32_t item_id = blockIdx.x * kNumWarps + threadIdx.x / kWarpThreads;
+  if (item_id >= params.batch_size) return;
+
+  const auto index_ptr = static_cast<const T*>(params.indices) + item_id * params.stride_indices;
+  PDLWaitPrimary<kUsePDL>();
+
+  const auto index = *index_ptr;
+  // A stale/OOB slot id would cause an illegal memory access in the store below;
+  // fail fast at the culprit instead. always-on (kvcache JIT compiles without NDEBUG).
+  assert(index >= 0 && index < params.size_limit);
+  if (index == params.reserved_skip_index) {
+    PDLTriggerSecondary<kUsePDL>();
+    return;
+  }
+
+  const float k_inv = params.k_scale != nullptr ? 1.0f / *params.k_scale : params.k_inv_scale;
+  const float v_inv = params.v_scale != nullptr ? 1.0f / *params.v_scale : params.v_inv_scale;
+
+  const auto k_src = static_cast<const TSrc*>(params.k) + item_id * params.stride_k;
+  const auto v_src = static_cast<const TSrc*>(params.v) + item_id * params.stride_v;
+  const auto k_dst = static_cast<TDst*>(params.k_cache) + index * params.stride_cache;
+  const auto v_dst = static_cast<TDst*>(params.v_cache) + index * params.stride_cache;
+
+  const auto gmem_src = tile::Memory<src_vec_t>::warp();
+  const auto gmem_dst = tile::Memory<dst_vec_t>::warp();
+
+  // Clip to the finite FP8 range before conversion (same convention as
+  // per_tensor_quant_fp8): saturate instead of overflowing to NaN.
+  const auto quant_vec = [&](const src_vec_t& in, const float inv_scale) {
+    dst_vec_t out;
+#pragma unroll
+    for (uint32_t j = 0; j < kVecElems; ++j) {
+      const float value = static_cast<float>(in[j]) * inv_scale;
+      out[j] = static_cast<TDst>(math::max(math::min(value, math::FP8_E4M3_MAX), -math::FP8_E4M3_MAX));
+    }
+    return out;
+  };
+
+#pragma unroll
+  for (int64_t i = 0; i < kLoopCount; ++i) {
+    gmem_dst.store(k_dst, quant_vec(gmem_src.load(k_src, i), k_inv), i);
+    gmem_dst.store(v_dst, quant_vec(gmem_src.load(v_src, i), v_inv), i);
+  }
+
+  // handle the epilogue if any
+  if constexpr (kTailVecs > 0) {
+    if (gmem_src.in_bound(kVecsPerRow, kLoopCount)) {
+      gmem_dst.store(k_dst, quant_vec(gmem_src.load(k_src, kLoopCount), k_inv), kLoopCount);
+      gmem_dst.store(v_dst, quant_vec(gmem_src.load(v_src, kLoopCount), v_inv), kLoopCount);
+    }
+  }
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+template <int64_t kRowElems, typename TSrc, typename TDst, bool kUsePDL>
+struct StoreKVCacheQuantKernel {
+  static constexpr uint32_t kVecElems = 16 / sizeof(TSrc);
+  static_assert(kRowElems > 0 && kRowElems % kVecElems == 0, "Row must be a multiple of the vector width");
+
+  template <typename T>
+  static constexpr auto kernel = store_kvcache_quant<kRowElems, TSrc, TDst, kUsePDL, T>;
+
+  static void
+  run(const tvm::ffi::TensorView k,
+      const tvm::ffi::TensorView v,
+      const tvm::ffi::TensorView k_cache,
+      const tvm::ffi::TensorView v_cache,
+      const tvm::ffi::TensorView indices,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> k_scale,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> v_scale,
+      const double k_inv_scale,
+      const double v_inv_scale,
+      const int64_t size_limit,
+      const int64_t reserved_skip_index) {
+    using namespace host;
+    auto B = SymbolicSize{"batch_size"};
+    auto D = SymbolicSize{"element_size"};
+    auto KS = SymbolicSize{"k_stride"};
+    auto VS = SymbolicSize{"v_stride"};
+    auto S = SymbolicSize{"cache_stride"};
+    auto I = SymbolicSize{"indices_stride"};
+    auto device = SymbolicDevice{};
+    auto indice_dtype = SymbolicDType{};
+    // CUDA only: the fp8 conversion relies on the __nv_fp8 conversion
+    // operators; on ROCm fp8_e4m3_t is a plain byte type (see utils.cuh).
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({B, D})  //
+        .with_strides({KS, 1})
+        .with_dtype<TSrc>()
+        .with_device(device)
+        .verify(k);
+    TensorMatcher({B, D})  //
+        .with_strides({VS, 1})
+        .with_dtype<TSrc>()
+        .with_device(device)
+        .verify(v);
+    TensorMatcher({-1, D})  //
+        .with_strides({S, 1})
+        .with_dtype<TDst>()
+        .with_device(device)
+        .verify(k_cache)
+        .verify(v_cache);
+    TensorMatcher({B})  //
+        .with_strides({I})
+        .with_dtype<int32_t, int64_t>(indice_dtype)
+        .with_device(device)
+        .verify(indices);
+    for (const auto& scale : {k_scale, v_scale}) {
+      if (scale.has_value()) {
+        TensorMatcher({1})  //
+            .with_dtype<float>()
+            .with_device(device)
+            .verify(scale.value());
+      }
+    }
+
+    RuntimeCheck(kRowElems == D.unwrap());
+
+    const auto params = StoreKVCacheQuantParams{
+        .k = k.data_ptr(),
+        .v = v.data_ptr(),
+        .k_cache = k_cache.data_ptr(),
+        .v_cache = v_cache.data_ptr(),
+        .indices = indices.data_ptr(),
+        .k_scale = k_scale.has_value() ? static_cast<const float*>(k_scale.value().data_ptr()) : nullptr,
+        .v_scale = v_scale.has_value() ? static_cast<const float*>(v_scale.value().data_ptr()) : nullptr,
+        .k_inv_scale = static_cast<float>(k_inv_scale),
+        .v_inv_scale = static_cast<float>(v_inv_scale),
+        .stride_k = KS.unwrap(),
+        .stride_v = VS.unwrap(),
+        .stride_cache = S.unwrap(),
+        .stride_indices = I.unwrap(),
+        .batch_size = static_cast<uint32_t>(B.unwrap()),
+        .size_limit = size_limit,
+        .reserved_skip_index = reserved_skip_index,
+    };
+    const auto use_int32 = indice_dtype.is_type<int32_t>();
+    const auto kernel_ptr = use_int32 ? kernel<int32_t> : kernel<int64_t>;
+    const auto num_blocks = div_ceil(static_cast<uint32_t>(B.unwrap()), kNumWarps);
+    LaunchKernel(num_blocks, kThreadsPerBlock, device.unwrap())  //
+        .enable_pdl(kUsePDL)(kernel_ptr, params);
   }
 };
 

--- a/python/sglang/kernels/ops/kvcache/kvcache.py
+++ b/python/sglang/kernels/ops/kvcache/kvcache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -15,6 +15,19 @@ from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
+
+# The fused quant-store kernel relies on the __nv_fp8 conversion operators;
+# on ROCm fp8_e4m3_t is a plain byte type, and only e4m3 has a clip constant.
+QUANT_SRC_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+QUANT_DST_DTYPES = (torch.float8_e4m3fn,)
+
+
+def is_store_cache_quant_aligned(k: torch.Tensor, v: torch.Tensor) -> bool:
+    return all(
+        tensor.data_ptr() % 16 == 0
+        and tensor.stride(0) * tensor.element_size() % 16 == 0
+        for tensor in (k, v)
+    )
 
 
 @cache_once
@@ -105,6 +118,107 @@ def store_cache(
         v_cache,
         indices,
         num_split,
+        size_limit,
+        reserved_skip_index,
+    )
+
+
+@cache_once
+def _jit_kvcache_quant_module(
+    row_elems: int, src_dtype: torch.dtype, dst_dtype: torch.dtype
+) -> Module:
+    args = make_cpp_args(row_elems, src_dtype, dst_dtype, is_arch_support_pdl())
+    return load_jit(
+        "kvcache_quant",
+        *args,
+        cuda_files=["elementwise/kvcache.cuh"],
+        cuda_wrappers=[("store_cache_quant", f"StoreKVCacheQuantKernel<{args}>::run")],
+    )
+
+
+@cache_once
+def can_use_store_cache_quant(
+    row_elems: int, src_dtype: torch.dtype, dst_dtype: torch.dtype
+) -> bool:
+    logger = logging.getLogger(__name__)
+    if src_dtype not in QUANT_SRC_DTYPES or dst_dtype not in QUANT_DST_DTYPES:
+        return False
+    vec_elems = 16 // src_dtype.itemsize
+    if row_elems % vec_elems != 0:
+        logger.warning(
+            f"Unsupported row_elems={row_elems} for JIT quant KV-Cache kernel:"
+            f" must be multiple of {vec_elems} for {src_dtype}"
+        )
+        return False
+    try:
+        _jit_kvcache_quant_module(row_elems, src_dtype, dst_dtype)
+        return True
+    except Exception as e:
+        logger.warning(
+            f"Failed to load JIT quant KV-Cache kernel "
+            f"with row_elems={row_elems}: {e}"
+        )
+        return False
+
+
+@register_custom_op(mutates_args=["k_cache", "v_cache"])
+def store_cache_quant(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    indices: torch.Tensor,
+    k_scale: Optional[torch.Tensor] = None,
+    v_scale: Optional[torch.Tensor] = None,
+    *,
+    k_inv_scale: float = 1.0,
+    v_inv_scale: float = 1.0,
+    size_limit: int = 0,
+    reserved_skip_index: int = 0,
+) -> None:
+    """Quantize key and value tensors to FP8 and store them into the KV cache
+    at specified indices in a single fused kernel. Unlike the unfused eager
+    path (in-place div + dtype cast + byte store), the inputs are not mutated.
+
+    Per-tensor scales come in one of two forms: a 1-element float32 GPU tensor
+    (``k_scale`` / ``v_scale``, read on device — no host sync) or a
+    host-precomputed reciprocal (``k_inv_scale`` / ``v_inv_scale``, used when
+    the tensor form is None). Values are divided by the scale, clipped to the
+    finite FP8 range, and round-to-nearest converted.
+
+    Args:
+        k (torch.Tensor): Key tensor of shape (batch_size, H * D), bf16/fp16/fp32.
+        v (torch.Tensor): Value tensor of shape (batch_size, H * D).
+        k_cache (torch.Tensor): Key cache tensor of shape (num_pages, H * D), fp8.
+        v_cache (torch.Tensor): Value cache tensor of shape (num_pages, H * D), fp8.
+        indices (torch.Tensor): Indices tensor of shape (batch_size,).
+        size_limit (int): Valid slot bound (cache row count = real slots + the
+            reserved padding slot); an index outside [0, size_limit) fails fast
+            (device assert) instead of an illegal memory access. Defaults to the
+            cache row count when 0.
+        reserved_skip_index (int): If nonnegative, writes targeting this index
+            are skipped. Defaults to the reserved CUDA-graph padding slot 0;
+            pass -1 to disable skipping, matching store_cache.
+    """
+    if k.shape[0] == 0:
+        return
+    if not is_store_cache_quant_aligned(k, v):
+        raise ValueError(
+            "store_cache_quant requires 16-byte-aligned source bases and row strides"
+        )
+    module = _jit_kvcache_quant_module(k.shape[-1], k.dtype, k_cache.dtype)
+    if size_limit <= 0:
+        size_limit = k_cache.shape[0]
+    module.store_cache_quant(
+        k,
+        v,
+        k_cache,
+        v_cache,
+        indices,
+        k_scale,
+        v_scale,
+        k_inv_scale,
+        v_inv_scale,
         size_limit,
         reserved_skip_index,
     )

--- a/python/sglang/kernels/ops/kvcache/kvcache.py
+++ b/python/sglang/kernels/ops/kvcache/kvcache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -15,6 +15,11 @@ from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
+
+# The fused quant-store kernel relies on the __nv_fp8 conversion operators;
+# on ROCm fp8_e4m3_t is a plain byte type, and only e4m3 has a clip constant.
+QUANT_SRC_DTYPES = (torch.bfloat16, torch.float16, torch.float32)
+QUANT_DST_DTYPES = (torch.float8_e4m3fn,)
 
 
 @cache_once
@@ -105,6 +110,103 @@ def store_cache(
         v_cache,
         indices,
         num_split,
+        size_limit,
+        reserved_skip_index,
+    )
+
+
+@cache_once
+def _jit_kvcache_quant_module(
+    row_elems: int, src_dtype: torch.dtype, dst_dtype: torch.dtype
+) -> Module:
+    args = make_cpp_args(row_elems, src_dtype, dst_dtype, is_arch_support_pdl())
+    return load_jit(
+        "kvcache_quant",
+        *args,
+        cuda_files=["elementwise/kvcache.cuh"],
+        cuda_wrappers=[("store_cache_quant", f"StoreKVCacheQuantKernel<{args}>::run")],
+    )
+
+
+@cache_once
+def can_use_store_cache_quant(
+    row_elems: int, src_dtype: torch.dtype, dst_dtype: torch.dtype
+) -> bool:
+    logger = logging.getLogger(__name__)
+    if src_dtype not in QUANT_SRC_DTYPES or dst_dtype not in QUANT_DST_DTYPES:
+        return False
+    vec_elems = 16 // src_dtype.itemsize
+    if row_elems % vec_elems != 0:
+        logger.warning(
+            f"Unsupported row_elems={row_elems} for JIT quant KV-Cache kernel:"
+            f" must be multiple of {vec_elems} for {src_dtype}"
+        )
+        return False
+    try:
+        _jit_kvcache_quant_module(row_elems, src_dtype, dst_dtype)
+        return True
+    except Exception as e:
+        logger.warning(
+            f"Failed to load JIT quant KV-Cache kernel "
+            f"with row_elems={row_elems}: {e}"
+        )
+        return False
+
+
+@register_custom_op(mutates_args=["k_cache", "v_cache"])
+def store_cache_quant(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    indices: torch.Tensor,
+    k_scale: Optional[torch.Tensor] = None,
+    v_scale: Optional[torch.Tensor] = None,
+    *,
+    k_inv_scale: float = 1.0,
+    v_inv_scale: float = 1.0,
+    size_limit: int = 0,
+    reserved_skip_index: int = 0,
+) -> None:
+    """Quantize key and value tensors to FP8 and store them into the KV cache
+    at specified indices in a single fused kernel. Unlike the unfused eager
+    path (in-place div + dtype cast + byte store), the inputs are not mutated.
+
+    Per-tensor scales come in one of two forms: a 1-element float32 GPU tensor
+    (``k_scale`` / ``v_scale``, read on device — no host sync) or a
+    host-precomputed reciprocal (``k_inv_scale`` / ``v_inv_scale``, used when
+    the tensor form is None). Values are divided by the scale, clipped to the
+    finite FP8 range, and round-to-nearest converted.
+
+    Args:
+        k (torch.Tensor): Key tensor of shape (batch_size, H * D), bf16/fp16/fp32.
+        v (torch.Tensor): Value tensor of shape (batch_size, H * D).
+        k_cache (torch.Tensor): Key cache tensor of shape (num_pages, H * D), fp8.
+        v_cache (torch.Tensor): Value cache tensor of shape (num_pages, H * D), fp8.
+        indices (torch.Tensor): Indices tensor of shape (batch_size,).
+        size_limit (int): Valid slot bound (cache row count = real slots + the
+            reserved padding slot); an index outside [0, size_limit) fails fast
+            (device assert) instead of an illegal memory access. Defaults to the
+            cache row count when 0.
+        reserved_skip_index (int): If nonnegative, writes targeting this index
+            are skipped. Defaults to the reserved CUDA-graph padding slot 0;
+            pass -1 to disable skipping, matching store_cache.
+    """
+    if k.shape[0] == 0:
+        return
+    module = _jit_kvcache_quant_module(k.shape[-1], k.dtype, k_cache.dtype)
+    if size_limit <= 0:
+        size_limit = k_cache.shape[0]
+    module.store_cache_quant(
+        k,
+        v,
+        k_cache,
+        v_cache,
+        indices,
+        k_scale,
+        v_scale,
+        k_inv_scale,
+        v_inv_scale,
         size_limit,
         reserved_skip_index,
     )

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -47,7 +47,13 @@ from sglang.kernels.ops.kvcache.cache_move import (
     set_kv_buffer_prefix_valid_tiled,
     store_cache_4d,
 )
-from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache, store_cache
+from sglang.kernels.ops.kvcache.kvcache import (
+    can_use_store_cache,
+    can_use_store_cache_quant,
+    is_store_cache_quant_aligned,
+    store_cache,
+    store_cache_quant,
+)
 from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
@@ -136,6 +142,41 @@ def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
     if isinstance(t, list):
         return sum(get_tensor_size_bytes(x) for x in t)
     return np.prod(t.shape) * t.dtype.itemsize
+
+
+def _store_cache_quant_scales(
+    k_scale: Optional[Union[float, torch.Tensor]],
+    v_scale: Optional[Union[float, torch.Tensor]],
+) -> Optional[dict[str, Any]]:
+    """Normalize per-tensor KV scales into store_cache_quant keyword args.
+
+    Callers hand scales in two shapes: a python float (e.g. ``layer.k_scale_float``)
+    or a 1-element float32 GPU tensor (e.g. the ``layer.k_scale`` parameter).
+    Floats become host-side reciprocals; tensors are passed through and read on
+    device, avoiding a host sync. Returns None when a scale has a form the
+    fused kernel does not support (caller falls back to the unfused path).
+    """
+    kwargs = {}
+    for name, scale in (("k", k_scale), ("v", v_scale)):
+        if scale is None:
+            kwargs[f"{name}_scale"] = None
+            kwargs[f"{name}_inv_scale"] = 1.0
+        elif isinstance(scale, (float, int)):
+            if scale == 0:
+                return None
+            kwargs[f"{name}_scale"] = None
+            kwargs[f"{name}_inv_scale"] = 1.0 / scale
+        elif (
+            isinstance(scale, torch.Tensor)
+            and scale.numel() == 1
+            and scale.dtype == torch.float32
+            and scale.is_cuda
+        ):
+            kwargs[f"{name}_scale"] = scale.reshape(1)
+            kwargs[f"{name}_inv_scale"] = 1.0
+        else:
+            return None
+    return kwargs
 
 
 def _set_kv_buffer_impl(
@@ -1860,6 +1901,17 @@ class MHATokenToKVPool(KVCache):
         # for store_cache JIT kernel
         self.row_dim = self.head_num * self.head_dim
         self.v_row_dim = self.head_num * self.v_head_dim
+        # for the fused store_cache_quant JIT kernel (FP8 KV cache): layouts
+        # that diverge before _store_kv_layer's store_cache branch keep the
+        # unfused quantize-then-store path.
+        self.enable_quant_store = (
+            _is_cuda
+            and not self.use_hnd
+            and self.kv_cache_layout == "nhd"
+            and self.store_dtype == torch.uint8
+            and self.dtype == torch.float8_e4m3fn
+            and self.row_dim == self.v_row_dim
+        )
 
     def _init_kv_copy_and_warmup(self):
         # Zero-layer pool (e.g. all-SWA model's full sub-pool) has no buffers.
@@ -2337,6 +2389,33 @@ class MHATokenToKVPool(KVCache):
             return
 
         if cache_k.dtype != self.dtype:
+            quant_k = quant_v = None
+            quant_scales = None
+            if (
+                self.enable_quant_store
+                and dcp_kv_mask is None
+                and can_use_store_cache_quant(self.row_dim, cache_k.dtype, self.dtype)
+            ):
+                quant_k = cache_k.view(-1, self.row_dim)
+                quant_v = cache_v.view(-1, self.row_dim)
+                if is_store_cache_quant_aligned(quant_k, quant_v):
+                    quant_scales = _store_cache_quant_scales(
+                        k_scale=k_scale, v_scale=v_scale
+                    )
+            if quant_scales is not None:
+                # Fused scale + FP8 cast + scatter store in one kernel launch;
+                # unlike the eager path below it does not mutate cache_k/cache_v.
+                layer_idx = layer_id - self.start_layer
+                store_cache_quant(
+                    quant_k,
+                    quant_v,
+                    self.k_buffer[layer_idx].view(self.dtype).view(-1, self.row_dim),
+                    self.v_buffer[layer_idx].view(self.dtype).view(-1, self.row_dim),
+                    loc,
+                    **quant_scales,
+                    size_limit=self.size + self.page_size,
+                )
+                return
             if k_scale is not None:
                 cache_k.div_(k_scale)
             if v_scale is not None:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -48,7 +48,12 @@ from sglang.kernels.ops.kvcache.cache_move import (
     set_kv_buffer_prefix_valid_tiled,
     store_cache_4d,
 )
-from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache, store_cache
+from sglang.kernels.ops.kvcache.kvcache import (
+    can_use_store_cache,
+    can_use_store_cache_quant,
+    store_cache,
+    store_cache_quant,
+)
 from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
@@ -136,6 +141,41 @@ def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
     if isinstance(t, list):
         return sum(get_tensor_size_bytes(x) for x in t)
     return np.prod(t.shape) * t.dtype.itemsize
+
+
+def _store_cache_quant_scales(
+    k_scale: Optional[Union[float, torch.Tensor]],
+    v_scale: Optional[Union[float, torch.Tensor]],
+) -> Optional[dict[str, Any]]:
+    """Normalize per-tensor KV scales into store_cache_quant keyword args.
+
+    Callers hand scales in two shapes: a python float (e.g. ``layer.k_scale_float``)
+    or a 1-element float32 GPU tensor (e.g. the ``layer.k_scale`` parameter).
+    Floats become host-side reciprocals; tensors are passed through and read on
+    device, avoiding a host sync. Returns None when a scale has a form the
+    fused kernel does not support (caller falls back to the unfused path).
+    """
+    kwargs = {}
+    for name, scale in (("k", k_scale), ("v", v_scale)):
+        if scale is None:
+            kwargs[f"{name}_scale"] = None
+            kwargs[f"{name}_inv_scale"] = 1.0
+        elif isinstance(scale, (float, int)):
+            if scale == 0:
+                return None
+            kwargs[f"{name}_scale"] = None
+            kwargs[f"{name}_inv_scale"] = 1.0 / scale
+        elif (
+            isinstance(scale, torch.Tensor)
+            and scale.numel() == 1
+            and scale.dtype == torch.float32
+            and scale.is_cuda
+        ):
+            kwargs[f"{name}_scale"] = scale.reshape(1)
+            kwargs[f"{name}_inv_scale"] = 1.0
+        else:
+            return None
+    return kwargs
 
 
 def _set_kv_buffer_impl(
@@ -1825,6 +1865,17 @@ class MHATokenToKVPool(KVCache):
         # for store_cache JIT kernel
         self.row_dim = self.head_num * self.head_dim
         self.v_row_dim = self.head_num * self.v_head_dim
+        # for the fused store_cache_quant JIT kernel (FP8 KV cache): layouts
+        # that diverge before _store_kv_layer's store_cache branch keep the
+        # unfused quantize-then-store path.
+        self.enable_quant_store = (
+            _is_cuda
+            and not self.use_hnd
+            and self.kv_cache_layout == "nhd"
+            and self.store_dtype == torch.uint8
+            and self.dtype == torch.float8_e4m3fn
+            and self.row_dim == self.v_row_dim
+        )
 
     def _init_kv_copy_and_warmup(self):
         # Zero-layer pool (e.g. all-SWA model's full sub-pool) has no buffers.
@@ -2302,6 +2353,31 @@ class MHATokenToKVPool(KVCache):
             return
 
         if cache_k.dtype != self.dtype:
+            quant_scales = (
+                _store_cache_quant_scales(k_scale=k_scale, v_scale=v_scale)
+                if (
+                    self.enable_quant_store
+                    and dcp_kv_mask is None
+                    and can_use_store_cache_quant(
+                        self.row_dim, cache_k.dtype, self.dtype
+                    )
+                )
+                else None
+            )
+            if quant_scales is not None:
+                # Fused scale + FP8 cast + scatter store in one kernel launch;
+                # unlike the eager path below it does not mutate cache_k/cache_v.
+                layer_idx = layer_id - self.start_layer
+                store_cache_quant(
+                    cache_k.view(-1, self.row_dim),
+                    cache_v.view(-1, self.row_dim),
+                    self.k_buffer[layer_idx].view(self.dtype).view(-1, self.row_dim),
+                    self.v_buffer[layer_idx].view(self.dtype).view(-1, self.row_dim),
+                    loc,
+                    **quant_scales,
+                    size_limit=self.size + self.page_size,
+                )
+                return
             if k_scale is not None:
                 cache_k.div_(k_scale)
             if v_scale is not None:

--- a/test/registered/kernels/benchmark/bench_store_cache_quant.py
+++ b/test/registered/kernels/benchmark/bench_store_cache_quant.py
@@ -1,0 +1,86 @@
+import torch
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import DEFAULT_DEVICE, create_random
+from sglang.kernels.ops.kvcache.kvcache import store_cache, store_cache_quant
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=9, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+QUANT_DST = torch.float8_e4m3fn
+
+
+def eager_quant_store_cache(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    indices: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+) -> None:
+    # The unfused MHATokenToKVPool.set_kv_buffer sequence this kernel replaces:
+    # in-place div + dtype cast per tensor, then the byte store.
+    k.div_(k_scale)
+    v.div_(v_scale)
+    k8 = k.to(QUANT_DST)
+    v8 = v.to(QUANT_DST)
+    store_cache(
+        k8.view(torch.uint8),
+        v8.view(torch.uint8),
+        k_cache.view(torch.uint8),
+        v_cache.view(torch.uint8),
+        indices,
+    )
+
+
+def fused_quant_store_cache(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    indices: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+) -> None:
+    store_cache_quant(k, v, k_cache, v_cache, indices, k_scale, v_scale)
+
+
+CACHE_SIZE = 2 * 1024 * 1024
+FN_MAP = {
+    "jit_fused": fused_quant_store_cache,
+    "eager": eager_quant_store_cache,
+}
+
+
+@marker.parametrize("item_size", [64, 128, 256, 512, 1024], [1024])
+@marker.parametrize("batch_size", [2**n for n in range(0, 15)], [16])
+@marker.benchmark("impl", ["jit_fused", "eager"])
+def benchmark(batch_size: int, item_size: int, impl: str):
+    torch.manual_seed(42)
+    k = create_random(batch_size, item_size)
+    v = create_random(batch_size, item_size)
+    k_cache = torch.empty(
+        (CACHE_SIZE, item_size), dtype=QUANT_DST, device=DEFAULT_DEVICE
+    )
+    v_cache = torch.empty(
+        (CACHE_SIZE, item_size), dtype=QUANT_DST, device=DEFAULT_DEVICE
+    )
+    indices = torch.randperm(CACHE_SIZE, device=DEFAULT_DEVICE)[:batch_size]
+    k_scale = torch.tensor([1.7], dtype=torch.float32, device=DEFAULT_DEVICE)
+    v_scale = torch.tensor([0.9], dtype=torch.float32, device=DEFAULT_DEVICE)
+    return marker.do_bench(
+        FN_MAP[impl],
+        input_args=(k, v, k_cache, v_cache, indices, k_scale, v_scale),
+        # k / v are read (and mutated by the eager path) -> clone per iter;
+        # the caches are large enough not to stay L2-hot.
+        graph_clone_args=(0, 1, 4),
+        memory_args=(k, v, indices),  # k_cache / v_cache excluded
+        memory_output=(k_cache[:batch_size], v_cache[:batch_size]),  # fp8 rows written
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/ops/kvcache/test_store_cache.py
+++ b/test/registered/kernels/ops/kvcache/test_store_cache.py
@@ -5,7 +5,12 @@ import pytest
 import torch
 
 from sglang.kernels.jit.utils import get_ci_test_range
-from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache, store_cache
+from sglang.kernels.ops.kvcache.kvcache import (
+    can_use_store_cache,
+    can_use_store_cache_quant,
+    store_cache,
+    store_cache_quant,
+)
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -45,7 +50,7 @@ def test_store_cache(batch_size: int, element_dim: int) -> None:
 # Smaller subset for targeted tests below
 REPR_BS = get_ci_test_range([1, 7, 128], [1, 128])
 REPR_DIMS = get_ci_test_range([64, 128, 512, 1024, 96], [64, 1024, 96])
-SMALL_CACHE = 4096
+SMALL_CACHE = 4097  # 4096 usable slots plus reserved CUDA-graph padding slot 0
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
@@ -266,6 +271,228 @@ def test_can_use_store_cache() -> None:
     assert can_use_store_cache(384, 256)
     assert can_use_store_cache(256, 384)
     assert can_use_store_cache(1024, 0) == can_use_store_cache(1024)
+
+
+# --- store_cache_quant (fused FP8 quantize + store) ---
+
+QUANT_DST = torch.float8_e4m3fn
+QUANT_SRC_DTYPES_TESTED = [torch.bfloat16, torch.float16, torch.float32]
+requires_cuda_quant = pytest.mark.skipif(
+    torch.version.hip is not None, reason="store_cache_quant is CUDA-only"
+)
+# 104 is not a multiple of vec_width * warp_size -> exercises the epilogue tail
+QUANT_DIMS = get_ci_test_range([64, 128, 512, 1024, 96, 104], [64, 1024, 104])
+QUANT_BS = get_ci_test_range([1, 7, 128, 4096], [1, 128])
+
+
+@requires_cuda_quant
+def test_store_cache_quant_empty_batch() -> None:
+    k = torch.empty((0, 64), dtype=DTYPE, device=DEVICE)
+    v = torch.empty_like(k)
+    k_cache = torch.zeros((1, 64), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros_like(k_cache)
+
+    store_cache_quant(
+        k,
+        v,
+        k_cache,
+        v_cache,
+        torch.empty(0, dtype=torch.int64, device=DEVICE),
+    )
+
+    assert k_cache.view(torch.uint8).sum().item() == 0
+    assert v_cache.view(torch.uint8).sum().item() == 0
+
+
+def _quant_ref(x: torch.Tensor, inv_scale: torch.Tensor) -> torch.Tensor:
+    """fp32 multiply by the reciprocal, clip to the finite range, RNE convert —
+    the kernel's documented conversion order."""
+    fp8_max = torch.finfo(QUANT_DST).max
+    xf = x.float() * inv_scale
+    return torch.clamp(xf, -fp8_max, fp8_max).to(QUANT_DST)
+
+
+@pytest.mark.parametrize("src_dtype", QUANT_SRC_DTYPES_TESTED)
+@pytest.mark.parametrize(
+    "batch_size,element_dim",
+    list(itertools.product(QUANT_BS, QUANT_DIMS)),
+)
+@requires_cuda_quant
+def test_store_cache_quant(
+    batch_size: int, element_dim: int, src_dtype: torch.dtype
+) -> None:
+    assert can_use_store_cache_quant(element_dim, src_dtype, QUANT_DST)
+    k = torch.randn((batch_size, element_dim), dtype=src_dtype, device=DEVICE) * 3
+    v = torch.randn((batch_size, element_dim), dtype=src_dtype, device=DEVICE) * 3
+    k_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:batch_size] + 1
+
+    store_cache_quant(k, v, k_cache, v_cache, indices)
+
+    one = torch.ones((), dtype=torch.float32, device=DEVICE)
+    k_ref = _quant_ref(k, one)
+    v_ref = _quant_ref(v, one)
+    assert torch.equal(k_cache[indices].view(torch.uint8), k_ref.view(torch.uint8))
+    assert torch.equal(v_cache[indices].view(torch.uint8), v_ref.view(torch.uint8))
+    # untouched rows stay zero (scatter must not smear across rows)
+    mask = torch.ones(SMALL_CACHE, dtype=torch.bool, device=DEVICE)
+    mask[indices] = False
+    assert k_cache.view(torch.uint8)[mask].sum().item() == 0
+
+
+@pytest.mark.parametrize("scale_form", ["tensor", "host_reciprocal"])
+@requires_cuda_quant
+def test_store_cache_quant_scale_forms(scale_form: str) -> None:
+    """The kernel accepts scales as a device scalar (read on GPU, no host sync)
+    or a host-precomputed reciprocal; both must scale before the FP8 convert."""
+    batch_size, element_dim = 128, 1024
+    k_scale, v_scale = 1.7, 0.9
+    k = torch.randn((batch_size, element_dim), dtype=DTYPE, device=DEVICE) * 3
+    v = torch.randn((batch_size, element_dim), dtype=DTYPE, device=DEVICE) * 3
+    k_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:batch_size] + 1
+
+    if scale_form == "tensor":
+        k_scale_t = torch.tensor([k_scale], dtype=torch.float32, device=DEVICE)
+        v_scale_t = torch.tensor([v_scale], dtype=torch.float32, device=DEVICE)
+        store_cache_quant(k, v, k_cache, v_cache, indices, k_scale_t, v_scale_t)
+        k_inv = 1.0 / k_scale_t
+        v_inv = 1.0 / v_scale_t
+    else:
+        store_cache_quant(
+            k,
+            v,
+            k_cache,
+            v_cache,
+            indices,
+            k_inv_scale=1.0 / k_scale,
+            v_inv_scale=1.0 / v_scale,
+        )
+        k_inv = torch.tensor(1.0 / k_scale, dtype=torch.float32, device=DEVICE)
+        v_inv = torch.tensor(1.0 / v_scale, dtype=torch.float32, device=DEVICE)
+
+    k_ref = _quant_ref(k, k_inv)
+    v_ref = _quant_ref(v, v_inv)
+    assert torch.equal(k_cache[indices].view(torch.uint8), k_ref.view(torch.uint8))
+    assert torch.equal(v_cache[indices].view(torch.uint8), v_ref.view(torch.uint8))
+
+
+@requires_cuda_quant
+def test_store_cache_quant_does_not_mutate_inputs() -> None:
+    """Unlike the eager quantize path (in-place div_), the fused kernel must
+    leave k/v untouched — callers reuse them for the attention compute."""
+    k = torch.randn((16, 1024), dtype=DTYPE, device=DEVICE)
+    v = torch.randn((16, 1024), dtype=DTYPE, device=DEVICE)
+    k_orig, v_orig = k.clone(), v.clone()
+    k_cache = torch.zeros((SMALL_CACHE, 1024), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, 1024), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:16] + 1
+    scale = torch.tensor([1.7], dtype=torch.float32, device=DEVICE)
+
+    store_cache_quant(k, v, k_cache, v_cache, indices, scale, scale)
+
+    assert torch.equal(k, k_orig)
+    assert torch.equal(v, v_orig)
+
+
+@requires_cuda_quant
+def test_store_cache_quant_clips_out_of_range() -> None:
+    """Values beyond the finite FP8 range must saturate to +-448, not overflow
+    to NaN (the eager .to(fp8) path NaNs; the kernel clips first)."""
+    fp8_max = torch.finfo(QUANT_DST).max
+    k = torch.full((1, 64), 30000.0, dtype=DTYPE, device=DEVICE)
+    v = torch.full((1, 64), -30000.0, dtype=DTYPE, device=DEVICE)
+    k_cache = torch.zeros((SMALL_CACHE, 64), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, 64), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.tensor([3], device=DEVICE)
+
+    store_cache_quant(k, v, k_cache, v_cache, indices)
+
+    assert torch.all(k_cache[indices].float() == fp8_max)
+    assert torch.all(v_cache[indices].float() == -fp8_max)
+
+
+@requires_cuda_quant
+def test_store_cache_quant_int32_indices() -> None:
+    k = torch.randn((64, 512), dtype=DTYPE, device=DEVICE)
+    v = torch.randn((64, 512), dtype=DTYPE, device=DEVICE)
+    k_cache = torch.zeros((SMALL_CACHE, 512), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, 512), dtype=QUANT_DST, device=DEVICE)
+    # int32 indices exercise a different CUDA template instantiation than default int64
+    indices = (torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:64] + 1).to(torch.int32)
+
+    store_cache_quant(k, v, k_cache, v_cache, indices)
+
+    one = torch.ones((), dtype=torch.float32, device=DEVICE)
+    assert torch.equal(
+        k_cache[indices.long()].view(torch.uint8), _quant_ref(k, one).view(torch.uint8)
+    )
+    assert torch.equal(
+        v_cache[indices.long()].view(torch.uint8), _quant_ref(v, one).view(torch.uint8)
+    )
+
+
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize("reserved_skip_index", [None, -1])
+@requires_cuda_quant
+def test_store_cache_quant_reserved_skip_index(
+    index_dtype: torch.dtype, reserved_skip_index: int | None
+) -> None:
+    element_dim = 64
+    k = torch.randn((2, element_dim), dtype=DTYPE, device=DEVICE)
+    v = torch.randn((2, element_dim), dtype=DTYPE, device=DEVICE)
+    k_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros_like(k_cache)
+    indices = torch.tensor([0, 3], dtype=index_dtype, device=DEVICE)
+    one = torch.ones((), dtype=torch.float32, device=DEVICE)
+
+    if reserved_skip_index is None:
+        store_cache_quant(k, v, k_cache, v_cache, indices)
+    else:
+        store_cache_quant(
+            k,
+            v,
+            k_cache,
+            v_cache,
+            indices,
+            reserved_skip_index=reserved_skip_index,
+        )
+
+    if reserved_skip_index is None:
+        assert torch.equal(
+            k_cache[0].view(torch.uint8),
+            torch.zeros(element_dim, dtype=torch.uint8, device=DEVICE),
+        )
+        assert torch.equal(
+            v_cache[0].view(torch.uint8),
+            torch.zeros(element_dim, dtype=torch.uint8, device=DEVICE),
+        )
+    else:
+        assert torch.equal(
+            k_cache[0].view(torch.uint8), _quant_ref(k[:1], one).view(torch.uint8)[0]
+        )
+        assert torch.equal(
+            v_cache[0].view(torch.uint8), _quant_ref(v[:1], one).view(torch.uint8)[0]
+        )
+    assert torch.equal(
+        k_cache[3].view(torch.uint8), _quant_ref(k[1:], one).view(torch.uint8)[0]
+    )
+    assert torch.equal(
+        v_cache[3].view(torch.uint8), _quant_ref(v[1:], one).view(torch.uint8)[0]
+    )
+
+
+@requires_cuda_quant
+def test_can_use_store_cache_quant() -> None:
+    assert can_use_store_cache_quant(1024, torch.bfloat16, QUANT_DST)
+    assert can_use_store_cache_quant(104, torch.bfloat16, QUANT_DST)
+    # row not a multiple of the vector width (16B / itemsize)
+    assert not can_use_store_cache_quant(100, torch.bfloat16, QUANT_DST)
+    # unsupported source/destination dtypes fall back to the unfused path
+    assert not can_use_store_cache_quant(1024, torch.bfloat16, torch.float8_e5m2)
+    assert not can_use_store_cache_quant(1024, torch.int8, QUANT_DST)
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/ops/kvcache/test_store_cache.py
+++ b/test/registered/kernels/ops/kvcache/test_store_cache.py
@@ -5,7 +5,13 @@ import pytest
 import torch
 
 from sglang.kernels.jit.utils import get_ci_test_range
-from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache, store_cache
+from sglang.kernels.ops.kvcache.kvcache import (
+    can_use_store_cache,
+    can_use_store_cache_quant,
+    is_store_cache_quant_aligned,
+    store_cache,
+    store_cache_quant,
+)
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -45,7 +51,7 @@ def test_store_cache(batch_size: int, element_dim: int) -> None:
 # Smaller subset for targeted tests below
 REPR_BS = get_ci_test_range([1, 7, 128], [1, 128])
 REPR_DIMS = get_ci_test_range([64, 128, 512, 1024, 96], [64, 1024, 96])
-SMALL_CACHE = 4096
+SMALL_CACHE = 4097  # 4096 usable slots plus reserved CUDA-graph padding slot 0
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
@@ -266,6 +272,243 @@ def test_can_use_store_cache() -> None:
     assert can_use_store_cache(384, 256)
     assert can_use_store_cache(256, 384)
     assert can_use_store_cache(1024, 0) == can_use_store_cache(1024)
+
+
+# --- store_cache_quant (fused FP8 quantize + store) ---
+
+QUANT_DST = torch.float8_e4m3fn
+QUANT_SRC_DTYPES_TESTED = [torch.bfloat16, torch.float16, torch.float32]
+requires_cuda_quant = pytest.mark.skipif(
+    torch.version.hip is not None, reason="store_cache_quant is CUDA-only"
+)
+# 104 is not a multiple of vec_width * warp_size -> exercises the epilogue tail
+QUANT_DIMS = get_ci_test_range([64, 128, 512, 1024, 96, 104], [64, 1024, 104])
+QUANT_BS = get_ci_test_range([1, 7, 128, 4096], [1, 128])
+
+
+@requires_cuda_quant
+def test_store_cache_quant_empty_batch() -> None:
+    k = torch.empty((0, 64), dtype=DTYPE, device=DEVICE)
+    v = torch.empty_like(k)
+    k_cache = torch.zeros((1, 64), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros_like(k_cache)
+
+    store_cache_quant(
+        k,
+        v,
+        k_cache,
+        v_cache,
+        torch.empty(0, dtype=torch.int64, device=DEVICE),
+    )
+
+    assert k_cache.view(torch.uint8).sum().item() == 0
+    assert v_cache.view(torch.uint8).sum().item() == 0
+
+
+def _quant_ref(x: torch.Tensor, inv_scale: torch.Tensor) -> torch.Tensor:
+    """fp32 multiply by the reciprocal, clip to the finite range, RNE convert —
+    the kernel's documented conversion order."""
+    fp8_max = torch.finfo(QUANT_DST).max
+    xf = x.float() * inv_scale
+    return torch.clamp(xf, -fp8_max, fp8_max).to(QUANT_DST)
+
+
+@pytest.mark.parametrize("src_dtype", QUANT_SRC_DTYPES_TESTED)
+@pytest.mark.parametrize(
+    "batch_size,element_dim",
+    list(itertools.product(QUANT_BS, QUANT_DIMS)),
+)
+@requires_cuda_quant
+def test_store_cache_quant(
+    batch_size: int, element_dim: int, src_dtype: torch.dtype
+) -> None:
+    assert can_use_store_cache_quant(element_dim, src_dtype, QUANT_DST)
+    k = torch.randn((batch_size, element_dim), dtype=src_dtype, device=DEVICE) * 3
+    v = torch.randn((batch_size, element_dim), dtype=src_dtype, device=DEVICE) * 3
+    k_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:batch_size] + 1
+
+    store_cache_quant(k, v, k_cache, v_cache, indices)
+
+    one = torch.ones((), dtype=torch.float32, device=DEVICE)
+    k_ref = _quant_ref(k, one)
+    v_ref = _quant_ref(v, one)
+    assert torch.equal(k_cache[indices].view(torch.uint8), k_ref.view(torch.uint8))
+    assert torch.equal(v_cache[indices].view(torch.uint8), v_ref.view(torch.uint8))
+    # untouched rows stay zero (scatter must not smear across rows)
+    mask = torch.ones(SMALL_CACHE, dtype=torch.bool, device=DEVICE)
+    mask[indices] = False
+    assert k_cache.view(torch.uint8)[mask].sum().item() == 0
+
+
+@pytest.mark.parametrize("scale_form", ["tensor", "host_reciprocal"])
+@requires_cuda_quant
+def test_store_cache_quant_scale_forms(scale_form: str) -> None:
+    """The kernel accepts scales as a device scalar (read on GPU, no host sync)
+    or a host-precomputed reciprocal; both must scale before the FP8 convert."""
+    batch_size, element_dim = 128, 1024
+    k_scale, v_scale = 1.7, 0.9
+    k = torch.randn((batch_size, element_dim), dtype=DTYPE, device=DEVICE) * 3
+    v = torch.randn((batch_size, element_dim), dtype=DTYPE, device=DEVICE) * 3
+    k_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:batch_size] + 1
+
+    if scale_form == "tensor":
+        k_scale_t = torch.tensor([k_scale], dtype=torch.float32, device=DEVICE)
+        v_scale_t = torch.tensor([v_scale], dtype=torch.float32, device=DEVICE)
+        store_cache_quant(k, v, k_cache, v_cache, indices, k_scale_t, v_scale_t)
+        k_inv = 1.0 / k_scale_t
+        v_inv = 1.0 / v_scale_t
+    else:
+        store_cache_quant(
+            k,
+            v,
+            k_cache,
+            v_cache,
+            indices,
+            k_inv_scale=1.0 / k_scale,
+            v_inv_scale=1.0 / v_scale,
+        )
+        k_inv = torch.tensor(1.0 / k_scale, dtype=torch.float32, device=DEVICE)
+        v_inv = torch.tensor(1.0 / v_scale, dtype=torch.float32, device=DEVICE)
+
+    k_ref = _quant_ref(k, k_inv)
+    v_ref = _quant_ref(v, v_inv)
+    assert torch.equal(k_cache[indices].view(torch.uint8), k_ref.view(torch.uint8))
+    assert torch.equal(v_cache[indices].view(torch.uint8), v_ref.view(torch.uint8))
+
+
+@requires_cuda_quant
+def test_store_cache_quant_does_not_mutate_inputs() -> None:
+    """Unlike the eager quantize path (in-place div_), the fused kernel must
+    leave k/v untouched — callers reuse them for the attention compute."""
+    k = torch.randn((16, 1024), dtype=DTYPE, device=DEVICE)
+    v = torch.randn((16, 1024), dtype=DTYPE, device=DEVICE)
+    k_orig, v_orig = k.clone(), v.clone()
+    k_cache = torch.zeros((SMALL_CACHE, 1024), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, 1024), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:16] + 1
+    scale = torch.tensor([1.7], dtype=torch.float32, device=DEVICE)
+
+    store_cache_quant(k, v, k_cache, v_cache, indices, scale, scale)
+
+    assert torch.equal(k, k_orig)
+    assert torch.equal(v, v_orig)
+
+
+@requires_cuda_quant
+def test_store_cache_quant_rejects_misaligned_source_rows() -> None:
+    storage_k = torch.randn(259, dtype=torch.float16, device=DEVICE)
+    storage_v = torch.randn(259, dtype=torch.float16, device=DEVICE)
+    k = torch.as_strided(storage_k, (4, 1, 64), (65, 64, 1)).view(-1, 64)
+    v = torch.as_strided(storage_v, (4, 1, 64), (65, 64, 1)).view(-1, 64)
+    k_cache = torch.zeros((SMALL_CACHE, 64), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros_like(k_cache)
+    indices = torch.arange(1, 5, dtype=torch.int64, device=DEVICE)
+
+    assert not is_store_cache_quant_aligned(k, v)
+    with pytest.raises(ValueError, match="16-byte-aligned"):
+        store_cache_quant(k, v, k_cache, v_cache, indices)
+
+
+@requires_cuda_quant
+def test_store_cache_quant_clips_out_of_range() -> None:
+    """Values beyond the finite FP8 range must saturate to +-448, not overflow
+    to NaN (the eager .to(fp8) path NaNs; the kernel clips first)."""
+    fp8_max = torch.finfo(QUANT_DST).max
+    k = torch.full((1, 64), 30000.0, dtype=DTYPE, device=DEVICE)
+    v = torch.full((1, 64), -30000.0, dtype=DTYPE, device=DEVICE)
+    k_cache = torch.zeros((SMALL_CACHE, 64), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, 64), dtype=QUANT_DST, device=DEVICE)
+    indices = torch.tensor([3], device=DEVICE)
+
+    store_cache_quant(k, v, k_cache, v_cache, indices)
+
+    assert torch.all(k_cache[indices].float() == fp8_max)
+    assert torch.all(v_cache[indices].float() == -fp8_max)
+
+
+@requires_cuda_quant
+def test_store_cache_quant_int32_indices() -> None:
+    k = torch.randn((64, 512), dtype=DTYPE, device=DEVICE)
+    v = torch.randn((64, 512), dtype=DTYPE, device=DEVICE)
+    k_cache = torch.zeros((SMALL_CACHE, 512), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros((SMALL_CACHE, 512), dtype=QUANT_DST, device=DEVICE)
+    # int32 indices exercise a different CUDA template instantiation than default int64
+    indices = (torch.randperm(SMALL_CACHE - 1, device=DEVICE)[:64] + 1).to(torch.int32)
+
+    store_cache_quant(k, v, k_cache, v_cache, indices)
+
+    one = torch.ones((), dtype=torch.float32, device=DEVICE)
+    assert torch.equal(
+        k_cache[indices.long()].view(torch.uint8), _quant_ref(k, one).view(torch.uint8)
+    )
+    assert torch.equal(
+        v_cache[indices.long()].view(torch.uint8), _quant_ref(v, one).view(torch.uint8)
+    )
+
+
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize("reserved_skip_index", [None, -1])
+@requires_cuda_quant
+def test_store_cache_quant_reserved_skip_index(
+    index_dtype: torch.dtype, reserved_skip_index: int | None
+) -> None:
+    element_dim = 64
+    k = torch.randn((2, element_dim), dtype=DTYPE, device=DEVICE)
+    v = torch.randn((2, element_dim), dtype=DTYPE, device=DEVICE)
+    k_cache = torch.zeros((SMALL_CACHE, element_dim), dtype=QUANT_DST, device=DEVICE)
+    v_cache = torch.zeros_like(k_cache)
+    indices = torch.tensor([0, 3], dtype=index_dtype, device=DEVICE)
+    one = torch.ones((), dtype=torch.float32, device=DEVICE)
+
+    if reserved_skip_index is None:
+        store_cache_quant(k, v, k_cache, v_cache, indices)
+    else:
+        store_cache_quant(
+            k,
+            v,
+            k_cache,
+            v_cache,
+            indices,
+            reserved_skip_index=reserved_skip_index,
+        )
+
+    if reserved_skip_index is None:
+        assert torch.equal(
+            k_cache[0].view(torch.uint8),
+            torch.zeros(element_dim, dtype=torch.uint8, device=DEVICE),
+        )
+        assert torch.equal(
+            v_cache[0].view(torch.uint8),
+            torch.zeros(element_dim, dtype=torch.uint8, device=DEVICE),
+        )
+    else:
+        assert torch.equal(
+            k_cache[0].view(torch.uint8), _quant_ref(k[:1], one).view(torch.uint8)[0]
+        )
+        assert torch.equal(
+            v_cache[0].view(torch.uint8), _quant_ref(v[:1], one).view(torch.uint8)[0]
+        )
+    assert torch.equal(
+        k_cache[3].view(torch.uint8), _quant_ref(k[1:], one).view(torch.uint8)[0]
+    )
+    assert torch.equal(
+        v_cache[3].view(torch.uint8), _quant_ref(v[1:], one).view(torch.uint8)[0]
+    )
+
+
+@requires_cuda_quant
+def test_can_use_store_cache_quant() -> None:
+    assert can_use_store_cache_quant(1024, torch.bfloat16, QUANT_DST)
+    assert can_use_store_cache_quant(104, torch.bfloat16, QUANT_DST)
+    # row not a multiple of the vector width (16B / itemsize)
+    assert not can_use_store_cache_quant(100, torch.bfloat16, QUANT_DST)
+    # unsupported source/destination dtypes fall back to the unfused path
+    assert not can_use_store_cache_quant(1024, torch.bfloat16, torch.float8_e5m2)
+    assert not can_use_store_cache_quant(1024, torch.int8, QUANT_DST)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_asymmetric_mha_pool.py
+++ b/test/registered/unit/mem_cache/test_asymmetric_mha_pool.py
@@ -33,11 +33,13 @@ NUM_WRITES = 16
 ASYM_DIM_PAIRS = [(192, 128), (128, 192), (512, 256)]
 
 
-def _build_pool(head_dim: int, v_head_dim: int) -> MHATokenToKVPool:
+def _build_pool(
+    head_dim: int, v_head_dim: int, dtype: torch.dtype = DTYPE
+) -> MHATokenToKVPool:
     return MHATokenToKVPool(
         size=POOL_SIZE,
         page_size=1,
-        dtype=DTYPE,
+        dtype=dtype,
         head_num=HEAD_NUM,
         head_dim=head_dim,
         v_head_dim=v_head_dim,
@@ -60,6 +62,10 @@ class TestAsymmetricMHAPoolRowDims(unittest.TestCase):
     def test_v_row_dim_defaults_to_row_dim_when_symmetric(self):
         pool = _build_pool(128, 128)
         self.assertEqual(pool.v_row_dim, pool.row_dim)
+
+    def test_quant_store_requires_equal_row_width(self):
+        pool = _build_pool(192, 128, dtype=torch.float8_e4m3fn)
+        self.assertFalse(pool.enable_quant_store)
 
     def test_swa_dims_override_row_dims(self):
         # A hybrid sliding-window model builds a second pool through the swa_*

--- a/test/registered/unit/mem_cache/test_asymmetric_mha_pool.py
+++ b/test/registered/unit/mem_cache/test_asymmetric_mha_pool.py
@@ -15,7 +15,10 @@ from types import SimpleNamespace
 
 import torch
 
-from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache
+from sglang.kernels.ops.kvcache.kvcache import (
+    can_use_store_cache,
+    is_store_cache_quant_aligned,
+)
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -33,12 +36,17 @@ NUM_WRITES = 16
 ASYM_DIM_PAIRS = [(192, 128), (128, 192), (512, 256)]
 
 
-def _build_pool(head_dim: int, v_head_dim: int) -> MHATokenToKVPool:
+def _build_pool(
+    head_dim: int,
+    v_head_dim: int,
+    dtype: torch.dtype = DTYPE,
+    head_num: int = HEAD_NUM,
+) -> MHATokenToKVPool:
     return MHATokenToKVPool(
         size=POOL_SIZE,
         page_size=1,
-        dtype=DTYPE,
-        head_num=HEAD_NUM,
+        dtype=dtype,
+        head_num=head_num,
         head_dim=head_dim,
         v_head_dim=v_head_dim,
         layer_num=1,
@@ -60,6 +68,10 @@ class TestAsymmetricMHAPoolRowDims(unittest.TestCase):
     def test_v_row_dim_defaults_to_row_dim_when_symmetric(self):
         pool = _build_pool(128, 128)
         self.assertEqual(pool.v_row_dim, pool.row_dim)
+
+    def test_quant_store_requires_equal_row_width(self):
+        pool = _build_pool(192, 128, dtype=torch.float8_e4m3fn)
+        self.assertFalse(pool.enable_quant_store)
 
     def test_swa_dims_override_row_dims(self):
         # A hybrid sliding-window model builds a second pool through the swa_*
@@ -161,6 +173,46 @@ class TestAsymmetricMHAPoolSetKVBuffer(unittest.TestCase):
 
     def test_symmetric_roundtrip_unchanged(self):
         self._run_roundtrip(128, 128)
+
+    def test_quant_store_falls_back_for_misaligned_source_rows(self):
+        pool = _build_pool(64, 64, dtype=torch.float8_e4m3fn, head_num=1)
+        storage_k = torch.randn(259, dtype=torch.float16, device="cuda")
+        storage_v = torch.randn(259, dtype=torch.float16, device="cuda")
+        cache_k = torch.as_strided(storage_k, (4, 1, 64), (65, 64, 1))
+        cache_v = torch.as_strided(storage_v, (4, 1, 64), (65, 64, 1))
+        loc = torch.arange(1, 5, dtype=torch.int64, device="cuda")
+        expected_k = cache_k.to(torch.float8_e4m3fn).view(torch.uint8)
+        expected_v = cache_v.to(torch.float8_e4m3fn).view(torch.uint8)
+
+        self.assertTrue(pool.enable_quant_store)
+        self.assertFalse(
+            is_store_cache_quant_aligned(
+                cache_k.view(-1, pool.row_dim), cache_v.view(-1, pool.row_dim)
+            )
+        )
+        pool.set_kv_buffer(SimpleNamespace(layer_id=0), loc, cache_k, cache_v)
+
+        self.assertTrue(torch.equal(pool.k_buffer[0][loc], expected_k))
+        self.assertTrue(torch.equal(pool.v_buffer[0][loc], expected_v))
+
+    def test_quant_store_contiguous_fused_canary(self):
+        pool = _build_pool(64, 64, dtype=torch.float8_e4m3fn, head_num=1)
+        cache_k = torch.randn((4, 1, 64), dtype=torch.float16, device="cuda")
+        cache_v = torch.randn((4, 1, 64), dtype=torch.float16, device="cuda")
+        loc = torch.arange(1, 5, dtype=torch.int64, device="cuda")
+        expected_k = cache_k.to(torch.float8_e4m3fn).view(torch.uint8)
+        expected_v = cache_v.to(torch.float8_e4m3fn).view(torch.uint8)
+
+        self.assertTrue(pool.enable_quant_store)
+        self.assertTrue(
+            is_store_cache_quant_aligned(
+                cache_k.view(-1, pool.row_dim), cache_v.view(-1, pool.row_dim)
+            )
+        )
+        pool.set_kv_buffer(SimpleNamespace(layer_id=0), loc, cache_k, cache_v)
+
+        self.assertTrue(torch.equal(pool.k_buffer[0][loc], expected_k))
+        self.assertTrue(torch.equal(pool.v_buffer[0][loc], expected_v))
 
 
 @unittest.skipUnless(_HAS_CUDA, "prefix-valid tiled kernel requires CUDA")


### PR DESCRIPTION
## Motivation

Fixes #30815.

With `--kv-cache-dtype fp8_e4m3`, `MHATokenToKVPool.set_kv_buffer` quantizes K/V eagerly before the store: in-place `div_` on k and v, two dtype casts, then the byte store. That is 5 kernel launches per layer per decode step with checkpoint KV scales (3 without), where bf16 KV takes a single fused JIT store. Measured on main 67e7f8d1 (RTX PRO 6000, SM120, CUDA 13, bs=1 decode, 8 kv-heads x 128, idle GPU):

| KV path | kernels / layer / step | latency (eager, min-of-medians) |
|---|---|---|
| bf16 | 1 | 22.4 us |
| fp8_e4m3 + scales, current | 5 | 57.2 us |
| fp8_e4m3 + scales, this PR | 1 | 30.7 us |

## Modifications

- `store_cache_quant` in `kernels/jit/csrc/elementwise/kvcache.cuh`: fused scale + FP8 cast + scatter store, one warp per row, vectorized 16B loads. Conversion follows the `per_tensor_quant_fp8` convention: fp32 multiply by the reciprocal, clip to the finite range, RNE convert (the eager `.to(fp8)` overflows to NaN instead of saturating). CUDA-only — on ROCm `fp8_e4m3_t` is a plain byte type, so HIP keeps the unfused path.
- Scales are accepted in the two forms callers actually pass: a 1-element float32 GPU tensor (`layer.k_scale`, read on device, no host sync) or a host float (`layer.k_scale_float`, reciprocal precomputed host-side).
- `set_kv_buffer` routes the fp8_e4m3 NHD CUDA path through the fused kernel; hnd/page-major/vectorized_5d layouts, dcp masks, e5m2, non-vector-multiple rows, and unsupported scale forms all keep the existing unfused fallback. Unlike the eager path, the fused kernel does not mutate `cache_k`/`cache_v` (callers currently `.clone()` to defend against that mutation; those clones can be dropped in a follow-up once this is the only engaged path).
- Tests in `test/registered/kernels/ops/kvcache/test_store_cache.py` (bit-exact vs the fp32 reference across batch sizes, row dims including epilogue-tail rows, both scale forms, int32 indices, input non-mutation, out-of-range saturation, `can_use` negative cases) and a benchmark `bench_store_cache_quant.py` (fused vs the eager sequence).

`set_kv_buffer_prefix_valid` (the prefill commit path) has the same unfused sequence with a 2-D loc shape; left for a follow-up to keep this PR one kernel.

## Accuracy Tests

- Unit tests: fused output is bit-exact against the fp32 reference (`clamp(x.float() * inv_scale, +-448).to(fp8)`) for all tested shapes and scale forms; 411 focused tests plus 9 subtests pass across `test_store_cache.py` and `test_asymmetric_mha_pool.py` on current main.
- Alignment safety: misaligned source bases or row strides take the eager fallback; the direct op rejects before launch, and a contiguous canary remains fused.
- Pool-level A/B through `set_kv_buffer` (stock vs fused, identical inputs): max difference is 1 fp8 code ulp on ~2% of elements — expected, the eager path rounds twice (bf16 divide, then convert) while the fused kernel rounds once in fp32, so the fused result is the more accurate of the two.

Current-main rebuild: based directly on `567d5925fe896a7b70043271f5621d6fe6e650d4` as `97d99726b143a908946a53730aa6d18351684fca`; fresh outcome verification is `CONFIRMED`. The performance measurements below were not rerun and remain historical from the original implementation.

## Speed Tests and Profiling

Kernel benchmark (`bench_store_cache_quant.py`, CUDA-graph timing, bf16 -> fp8_e4m3 with tensor scales, row 1024): fused 5.4 us vs eager 10.8 us at bs=1, 5.4 vs 13.5 at bs=16, 12.5 vs 44.0 at bs=4096 — 2.0-3.5x.

End-to-end `bench_one_batch`, Qwen2.5-1.5B-Instruct, bs=1, `--kv-cache-dtype fp8_e4m3`, interleaved stock/fused runs on an idle GPU:

- Eager decode (`--disable-cuda-graph`): median decode latency 7.95-8.36 ms stock vs 7.30-7.59 ms fused; fused faster in all three interleaved pairs (~8-11%), consistent with 26.5 us/layer x 28 layers.
- CUDA-graph decode: torch traces show the fused kernel engaged (28 `store_kvcache_quant` per step) and the KV-store kernel cluster down from 109.9 us to 44.7 us per 8 steps (2.46x); the whole-step effect at bs=1 on this small model (~0.3% of step GPU time) is below end-to-end run noise, so I am not claiming an end-to-end graph-mode win here. The launch-bound eager numbers above are where the reported ITL regression comes from.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35434491405](https://github.com/sgl-project/sglang/actions/runs/35434491405)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35434491181](https://github.com/sgl-project/sglang/actions/runs/35434491181)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35434491349](https://github.com/sgl-project/sglang/actions/runs/35434491349)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
