### PR TITLE
[Fix] Reject incomplete GaugeHistogram bucket writes

### DIFF
--- a/python/sglang/srt/utils/gauge_histogram.py
+++ b/python/sglang/srt/utils/gauge_histogram.py
@@ -62,6 +62,12 @@ class GaugeHistogram:
 
     def set_raw(self, labels: Dict[str, str], values: List[int]):
         """Set bucket counts directly."""
+        if len(values) != len(self._buckets):
+            raise ValueError(
+                "Expected one value for each gauge histogram bucket: "
+                f"expected {len(self._buckets)}, got {len(values)}"
+            )
+
         for (gt, le), count in zip(self._buckets, values):
             self._gauge.labels(**labels, gt=gt, le=le).set(count)
 

--- a/test/registered/unit/utils/test_gauge_histogram.py
+++ b/test/registered/unit/utils/test_gauge_histogram.py
@@ -1,11 +1,13 @@
+import unittest
+from unittest.mock import call, patch
+
+from sglang.srt.utils.gauge_histogram import BucketLabels, GaugeHistogram
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 register_cpu_ci(est_time=7, suite="base-c-test-cpu")
 
-import unittest
-
-from sglang.srt.utils.gauge_histogram import BucketLabels
 
 
 class TestBucketLabels(unittest.TestCase):
@@ -79,6 +81,60 @@ class TestBucketLabelsCounts(unittest.TestCase):
         # 9.9 -> (0,10], 10.1 -> (10,30], 30.5 -> (30,60]
         buckets = BucketLabels([10, 30, 60])
         self.assertEqual(buckets.compute_bucket_counts([9.9, 10.1, 30.5]), [1, 1, 1, 0])
+
+
+class TestGaugeHistogram(CustomTestCase):
+    @patch("prometheus_client.Gauge")
+    def test_set_raw_writes_each_bucket_with_range_labels(self, mock_gauge):
+        metric = mock_gauge.return_value
+        histogram = GaugeHistogram(
+            name="queued_requests",
+            documentation="Queued requests by age",
+            labelnames=["model"],
+            bucket_bounds=[10, 30],
+        )
+
+        histogram.set_raw({"model": "test-model"}, [2, 3, 5])
+
+        mock_gauge.assert_called_once_with(
+            name="queued_requests",
+            documentation="Queued requests by age",
+            labelnames=["model", "gt", "le"],
+            multiprocess_mode="mostrecent",
+        )
+        self.assertEqual(
+            metric.labels.call_args_list,
+            [
+                call(model="test-model", gt="0", le="10"),
+                call(model="test-model", gt="10", le="30"),
+                call(model="test-model", gt="30", le="+Inf"),
+            ],
+        )
+        self.assertEqual(
+            metric.labels.return_value.set.call_args_list,
+            [call(2), call(3), call(5)],
+        )
+
+    @patch("prometheus_client.Gauge")
+    def test_set_by_current_observations_writes_non_cumulative_counts(
+        self, mock_gauge
+    ):
+        metric = mock_gauge.return_value
+        histogram = GaugeHistogram(
+            name="queued_requests",
+            documentation="Queued requests by age",
+            labelnames=[],
+            bucket_bounds=[10, 30],
+        )
+
+        histogram.set_by_current_observations({}, [5, 10, 11, 30, 31])
+
+        self.assertEqual(
+            metric.labels.return_value.set.call_args_list,
+            [call(2), call(2), call(1)],
+        )
+
+
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/utils/test_gauge_histogram.py
+++ b/test/registered/unit/utils/test_gauge_histogram.py
@@ -134,6 +134,22 @@ class TestGaugeHistogram(CustomTestCase):
             [call(2), call(2), call(1)],
         )
 
+    @patch("prometheus_client.Gauge")
+    def test_set_raw_rejects_incomplete_bucket_values(self, mock_gauge):
+        histogram = GaugeHistogram(
+            name="queued_requests",
+            documentation="Queued requests by age",
+            labelnames=["model"],
+            bucket_bounds=[10, 30],
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "expected 3, got 2"
+        ):
+            histogram.set_raw({"model": "test-model"}, [2, 3])
+
+        mock_gauge.return_value.labels.assert_not_called()
+
 
 
 


### PR DESCRIPTION
## Problem
`GaugeHistogram.set_raw()` used `zip()` to pair bucket labels with values. If a caller supplied too few values, SGLang silently wrote only the first buckets, leaving an incomplete Prometheus metric series.

## Change
- Validate that the supplied value count matches the number of histogram buckets before writing any metric.
- Add a regression test that verifies incomplete input raises `ValueError` and performs no partial writes.
- Keep coverage for normal bucket-label writes and observation-to-bucket conversion.

## Validation
- `git diff --check`
- `python -m compileall -q python/sglang/srt/utils/gauge_histogram.py test/registered/unit/utils/test_gauge_histogram.py`
- `SGLANG_USE_CPU_ENGINE=1 PYTHONPATH=python python -m pytest test/registered/unit/utils/test_gauge_histogram.py -v` (WSL Ubuntu, CPU): **16 passed**

Related to #20865.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29633367389](https://github.com/sgl-project/sglang/actions/runs/29633367389)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29633367293](https://github.com/sgl-project/sglang/actions/runs/29633367293)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->