### PR TITLE
[Fix] Wake RWLock readers after writer cancellation

### DIFF
--- a/python/sglang/srt/utils/aio_rwlock.py
+++ b/python/sglang/srt/utils/aio_rwlock.py
@@ -60,14 +60,20 @@ class RWLock:
         async with self._lock:
             # Increment the count of writers waiting
             self._waiting_writers += 1
+            acquired = False
             try:
                 # Wait while either a writer is active or readers are present
                 while self._writer_active or self._readers > 0:
                     await self._cond.wait()
                 self._writer_active = True
+                acquired = True
             finally:
-                # Decrement waiting writers only after we've acquired the writer lock
+                # Keep the count correct whether acquisition succeeds or is cancelled.
                 self._waiting_writers -= 1
+                if not acquired:
+                    # A cancelled writer changes reader admission. Wake readers that
+                    # were blocked only to preserve writer fairness.
+                    self._cond.notify_all()
 
     async def release_writer(self):
         async with self._lock:

--- a/test/registered/unit/utils/test_aio_rwlock.py
+++ b/test/registered/unit/utils/test_aio_rwlock.py
@@ -1,0 +1,48 @@
+"""Regression tests for the cancellation behavior of the async reader-writer lock."""
+
+import asyncio
+import contextlib
+import unittest
+
+from sglang.srt.utils.aio_rwlock import RWLock
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class TestRWLock(CustomTestCase):
+    def test_cancelled_writer_unblocks_waiting_reader(self):
+        asyncio.run(self._cancelled_writer_unblocks_waiting_reader())
+
+    async def _cancelled_writer_unblocks_waiting_reader(self):
+        lock = RWLock()
+        await lock.acquire_reader()
+
+        writer = asyncio.create_task(lock.acquire_writer())
+        while lock._waiting_writers != 1:
+            await asyncio.sleep(0)
+
+        blocked_reader = asyncio.create_task(lock.acquire_reader())
+        await asyncio.sleep(0)
+
+        writer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await writer
+
+        try:
+            await asyncio.wait_for(asyncio.shield(blocked_reader), timeout=0.1)
+        except asyncio.TimeoutError:
+            unblocked = False
+        else:
+            unblocked = True
+        finally:
+            await lock.release_reader()
+            await blocked_reader
+            await lock.release_reader()
+
+        self.assertTrue(unblocked)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`RWLock` gives waiting writers priority over new readers. If such a writer is cancelled while it waits, its `finally` block decrements `_waiting_writers` but does not notify readers blocked only by that count. Those readers remain asleep until an unrelated lock transition.

## Change
- Notify condition waiters when a writer leaves the wait queue without acquiring the writer lock.
- Preserve writer priority when a writer successfully acquires the lock.
- Add a CPU regression test that queues an active reader, a waiting writer, and a waiting reader; then cancels the writer and verifies the reader proceeds before the original reader releases.

## Validation
- `git diff --check`
- `python -m compileall -q python/sglang/srt/utils/aio_rwlock.py test/registered/unit/utils/test_aio_rwlock.py`
- `ruff check python/sglang/srt/utils/aio_rwlock.py test/registered/unit/utils/test_aio_rwlock.py`
- `SGLANG_USE_CPU_ENGINE=1 PYTHONPATH=python python -m pytest test/registered/unit/utils/test_aio_rwlock.py -v` (WSL Ubuntu, CPU): **1 passed**

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29633571750](https://github.com/sgl-project/sglang/actions/runs/29633571750)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29633571645](https://github.com/sgl-project/sglang/actions/runs/29633571645)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->