### PR TITLE
[Fix] Honor wait_port_available timeout in seconds

### DIFF
--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -51,6 +51,8 @@ def find_process_using_port(port: int) -> Optional[psutil.Process]:
 
 
 MAX_VALID_PORT = 65535
+_PORT_WAIT_POLL_INTERVAL_S = 0.1
+_PORT_WAIT_POLLS_PER_SECOND = int(1 / _PORT_WAIT_POLL_INTERVAL_S)
 
 
 def wait_port_available(
@@ -72,11 +74,12 @@ def wait_port_available(
         )
 
     error_message = f"{port_name} at {port} is not available"
-    for i in range(timeout_s):
+    for poll in range(timeout_s * _PORT_WAIT_POLLS_PER_SECOND):
         if is_port_available(port):
             return True
 
-        if i > 10 and i % 5 == 0:
+        elapsed_s = poll // _PORT_WAIT_POLLS_PER_SECOND
+        if elapsed_s >= 10 and poll % (5 * _PORT_WAIT_POLLS_PER_SECOND) == 0:
             process = find_process_using_port(port)
             if process is None:
                 logger.warning(
@@ -86,9 +89,9 @@ def wait_port_available(
                 pid = process.pid
                 error_message = f"{port_name} is used by a process already. {process.name()=}' {process.cmdline()=} {process.status()=} {pid=}"
                 logger.info(
-                    f"port {port} is in use. Waiting for {i} seconds for {port_name} to be available. {error_message}"
+                    f"port {port} is in use. Waiting for {elapsed_s} seconds for {port_name} to be available. {error_message}"
                 )
-        time.sleep(0.1)
+        time.sleep(_PORT_WAIT_POLL_INTERVAL_S)
 
     if raise_exception:
         raise ValueError(

--- a/test/registered/unit/utils/test_network.py
+++ b/test/registered/unit/utils/test_network.py
@@ -1,0 +1,31 @@
+"""Unit tests for network utility helpers."""
+
+import unittest
+from unittest.mock import call, patch
+
+from sglang.srt.utils.network import wait_port_available
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class TestWaitPortAvailable(CustomTestCase):
+    @patch("sglang.srt.utils.network.time.sleep")
+    @patch("sglang.srt.utils.network.is_port_available", return_value=False)
+    def test_polls_for_the_full_timeout(self, mock_is_port_available, mock_sleep):
+        self.assertFalse(
+            wait_port_available(
+                port=12345,
+                port_name="test port",
+                timeout_s=3,
+                raise_exception=False,
+            )
+        )
+
+        self.assertEqual(mock_is_port_available.call_count, 30)
+        self.assertEqual(mock_sleep.call_args_list, [call(0.1)] * 30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`wait_port_available(..., timeout_s=N)` polled once per loop but slept only 0.1 seconds. As a result, a configured 30-second timeout waited for roughly 3 seconds. The progress log also reported the loop count as seconds.

This affects the port cleanup window used before server relaunches, making transient process teardown look like a permanent port conflict.

## Change
- Poll ten times per second so `timeout_s` is measured in real seconds.
- Use elapsed seconds for the diagnostic log.
- Add a CPU unit test with mocked availability and sleep, verifying a three-second timeout makes thirty 0.1-second polls.

## Validation
- `git diff --check`
- `python -m compileall -q python/sglang/srt/utils/network.py test/registered/unit/utils/test_network.py`
- `ruff check python/sglang/srt/utils/network.py test/registered/unit/utils/test_network.py`
- `SGLANG_USE_CPU_ENGINE=1 PYTHONPATH=python python -m pytest test/registered/unit/utils/test_network.py -v` (WSL Ubuntu, CPU): **1 passed**

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29633690411](https://github.com/sgl-project/sglang/actions/runs/29633690411)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29633690360](https://github.com/sgl-project/sglang/actions/runs/29633690360)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->