### PR TITLE
[Fix] Only warn about missing FP8 KV scales when none actually loaded

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -100,12 +100,37 @@ def load_kv_cache_scales(*, model, server_args: ServerArgs) -> None:
                     "model %s does not support loading scaling factors.",
                     model.__class__,
                 )
+        elif _checkpoint_kv_cache_scales_loaded(model):
+            logger.info(
+                "Using FP8 KV cache with per-layer scaling factors "
+                "loaded from the model checkpoint."
+            )
         else:
             logger.warning(
                 "Using FP8 KV cache but no scaling factors "
                 "provided. Defaulting to scaling factors of 1.0. "
                 "This may lead to less accurate results!"
             )
+
+
+def _checkpoint_kv_cache_scales_loaded(model) -> bool:
+    """Whether any attention layer carries per-layer k/v scales loaded from the
+    checkpoint (set by BaseKVCacheMethod.process_weights_after_loading).
+
+    A checkpoint scale of exactly 1.0 is indistinguishable from the no-scales
+    fallback, so it is treated as not loaded: a spurious warning is preferred
+    over silently masking a real fallback.
+    """
+    from sglang.srt.layers.radix_attention import RadixAttention
+
+    for module in model.modules():
+        if (
+            isinstance(module, RadixAttention)
+            and module.k_scale_float is not None
+            and (module.k_scale_float != 1.0 or module.v_scale_float != 1.0)
+        ):
+            return True
+    return False
 
 
 def resolve_sliding_window_size(model, model_config: ModelConfig) -> Optional[int]:

--- a/test/registered/unit/model_executor/model_runner_components/test_load_model_utils.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_load_model_utils.py
@@ -1,0 +1,100 @@
+"""Unit tests for srt/model_executor/model_runner_components/load_model_utils.py"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.model_executor.model_runner_components.load_model_utils import (
+    load_kv_cache_scales,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+LOGGER_NAME = "sglang.srt.model_executor.model_runner_components.load_model_utils"
+FALLBACK_WARNING_SNIPPET = "no scaling factors"
+
+
+def _server_args(kv_cache_dtype="fp8_e4m3", quantization_param_path=None):
+    return SimpleNamespace(
+        kv_cache_dtype=kv_cache_dtype,
+        quantization_param_path=quantization_param_path,
+    )
+
+
+def _attn_layer(k_scale_float=None, v_scale_float=None):
+    layer = RadixAttention(
+        num_heads=1, head_dim=8, scaling=1.0, num_kv_heads=1, layer_id=0
+    )
+    # Mimic BaseKVCacheMethod.process_weights_after_loading, which sets these
+    # floats after weight load (1.0 = no checkpoint scales, else loaded values).
+    layer.k_scale_float = k_scale_float
+    layer.v_scale_float = v_scale_float
+    return layer
+
+
+class _Model(torch.nn.Module):
+    def __init__(self, layers):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(layers)
+
+
+class TestLoadKVCacheScales(CustomTestCase):
+    def test_warns_when_scales_fell_back_to_default(self):
+        model = _Model([_attn_layer(1.0, 1.0), _attn_layer(1.0, 1.0)])
+        with self.assertLogs(LOGGER_NAME, level="WARNING") as logs:
+            load_kv_cache_scales(model=model, server_args=_server_args())
+        self.assertTrue(
+            any(FALLBACK_WARNING_SNIPPET in message for message in logs.output)
+        )
+
+    def test_no_warning_when_checkpoint_scales_loaded(self):
+        """Bug regression (#31224): the "no scaling factors provided" warning
+        used to be gated only on --quantization-param-path, so it fired even
+        when per-layer checkpoint k/v scales were present and loaded, falsely
+        suggesting the scales fell back to 1.0.
+        """
+        # One layer without a kv-cache quant method (floats stay None) plus one
+        # layer with calibrated checkpoint scales: the warning must not fire.
+        model = _Model([_attn_layer(None, None), _attn_layer(0.028, 0.0118)])
+        with self.assertLogs(LOGGER_NAME, level="INFO") as logs:
+            load_kv_cache_scales(model=model, server_args=_server_args())
+        self.assertFalse(
+            any(FALLBACK_WARNING_SNIPPET in message for message in logs.output)
+        )
+        self.assertTrue(
+            any(
+                "loaded from the model checkpoint" in message for message in logs.output
+            )
+        )
+
+    def test_warns_when_no_layer_has_kv_quant_method(self):
+        model = _Model([_attn_layer(None, None)])
+        with self.assertLogs(LOGGER_NAME, level="WARNING") as logs:
+            load_kv_cache_scales(model=model, server_args=_server_args())
+        self.assertTrue(
+            any(FALLBACK_WARNING_SNIPPET in message for message in logs.output)
+        )
+
+    def test_no_logs_for_non_fp8_kv_cache_dtype(self):
+        model = _Model([_attn_layer(1.0, 1.0)])
+        with self.assertNoLogs(LOGGER_NAME):
+            load_kv_cache_scales(
+                model=model, server_args=_server_args(kv_cache_dtype="auto")
+            )
+
+    def test_quantization_param_path_uses_legacy_loader(self):
+        model = MagicMock()
+        load_kv_cache_scales(
+            model=model,
+            server_args=_server_args(quantization_param_path="/tmp/scales.json"),
+        )
+        model.load_kv_cache_scales.assert_called_once_with("/tmp/scales.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #31224. The startup warning "Using FP8 KV cache but no scaling factors provided. Defaulting to scaling factors of 1.0" is gated only on `--quantization-param-path` being unset, so it fires for every `fp8_e4m3` model even when the checkpoint's per-layer `k_scale`/`v_scale` tensors loaded fine through `BaseKVCacheMethod`. That makes the startup log useless as a signal for whether baked KV scales actually took effect.

## Modifications

- `load_kv_cache_scales()` (`model_runner_components/load_model_utils.py`) now checks whether any attention layer actually carries per-layer scales after weight loading. `BaseKVCacheMethod.process_weights_after_loading` sets `k_scale_float`/`v_scale_float` to exactly 1.0 only on the no-scales fallback, so any other value means the checkpoint scales loaded. If they did, it logs an info line instead of the warning; if not, the warning fires exactly as before.
- A checkpoint scale of exactly 1.0 is indistinguishable from the fallback and is treated as not loaded, so the change can only err on the side of a spurious warning, never a missed one (noted in the helper docstring).
- Added CPU unit tests in `test/registered/unit/model_executor/model_runner_components/test_load_model_utils.py` (registered for `base-a-test-cpu`). The regression test fails on current main and passes with the fix; I also mutation-checked that the warning tests catch a degraded check.

## Accuracy Tests

No change to model outputs, this only affects which log line is emitted at startup.

## Speed Tests and Profiling

Not applicable (one walk over model.modules() at load time).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

small disclaimer: I'm a freshman in college trying my best to contribute for the greater good :) I worked through the logic here with Claude Code and ran pre-commit plus the new unit tests locally on CPU (no GPU on my machine, so I could not exercise a real fp8 model end to end). I apologize in advance if there are any obvious errors, I would genuinely love to learn from any mistakes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29635231830](https://github.com/sgl-project/sglang/actions/runs/29635231830)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29635231736](https://github.com/sgl-project/sglang/actions/runs/29635231736)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->