### PR TITLE
fix(pd): align input limits across heterogeneous prefill/decode workers

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1006,6 +1006,7 @@ class Engine(EngineScoreMixin, EngineBase):
                 **self._scheduler_init_result.scheduler_infos[0],
                 "internal_states": internal_states,
                 "version": __version__,
+                "supports_disagg_max_req_input_len": True,
             }
         )
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -747,6 +747,7 @@ async def server_info():
             **_global_state.scheduler_info,
             "internal_states": internal_states,
             "version": __version__,
+            "supports_disagg_max_req_input_len": True,
             # Structured KV-event publisher descriptor for KV-aware routers.
             # `None` when publishing is disabled or misconfigured; see
             # `ServerArgs.describe_kv_events_publisher` for the precise contract.

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -368,6 +368,8 @@ class CompletionRequest(BaseModel):
     bootstrap_host: Optional[Union[List[str], str]] = None
     bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
     bootstrap_room: Optional[Union[List[int], int]] = None
+    # Router-coordinated maximum prompt length for a selected P/D pair.
+    disagg_max_req_input_len: Optional[int] = None
 
     # For DP routing — external router assigns a specific DP worker
     routed_dp_rank: Optional[int] = None
@@ -764,6 +766,8 @@ class ChatCompletionRequest(BaseModel):
     bootstrap_host: Optional[Union[List[str], str]] = None
     bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
     bootstrap_room: Optional[Union[List[int], int]] = None
+    # Router-coordinated maximum prompt length for a selected P/D pair.
+    disagg_max_req_input_len: Optional[int] = None
 
     # For DP routing — external router assigns a specific DP worker
     routed_dp_rank: Optional[int] = None

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -23,6 +23,7 @@ from fastapi import Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 from jsonschema import Draft202012Validator, SchemaError
 
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.entrypoints.openai import encoding_dsv4, encoding_dsv32
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
@@ -515,11 +516,18 @@ class OpenAIServingChat(OpenAIServingBase):
 
         max_output_tokens = request.max_completion_tokens or request.max_tokens
         server_context_length = self.tokenizer_manager.server_args.context_length
+        is_router_coordinated_prefill = (
+            request.disagg_max_req_input_len is not None
+            and self.tokenizer_manager.disaggregation_mode == DisaggregationMode.PREFILL
+        )
         if (
             max_output_tokens
             and server_context_length
             and max_output_tokens > server_context_length
-        ) and not self.tokenizer_manager.server_args.allow_auto_truncate:
+        ) and not (
+            self.tokenizer_manager.server_args.allow_auto_truncate
+            or is_router_coordinated_prefill
+        ):
             return (
                 f"max_completion_tokens is too large: {max_output_tokens}."
                 f"This model supports at most {server_context_length} completion tokens."
@@ -614,6 +622,7 @@ class OpenAIServingChat(OpenAIServingBase):
             bootstrap_host=request.bootstrap_host,
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
+            disagg_max_req_input_len=request.disagg_max_req_input_len,
             routed_dp_rank=effective_routed_dp_rank,
             disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
             return_hidden_states=request.return_hidden_states,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -119,6 +119,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             bootstrap_host=request.bootstrap_host,
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
+            disagg_max_req_input_len=request.disagg_max_req_input_len,
             routed_dp_rank=effective_routed_dp_rank,
             disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
             return_hidden_states=request.return_hidden_states,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -247,6 +247,8 @@ class GenerateReqInput:
     bootstrap_room: Optional[Union[List[Optional[int]], int]] = None
     bootstrap_pair_key: Optional[Union[List[Optional[str]], str]] = None
     decode_tp_size: Optional[Union[List[Optional[int]], int]] = None
+    # Router-coordinated maximum prompt length for a selected P/D pair.
+    disagg_max_req_input_len: Optional[int] = None
 
     # For DP routing — external router assigns a specific DP worker
     routed_dp_rank: Optional[int] = None
@@ -762,6 +764,7 @@ class GenerateReqInput:
             decode_tp_size=(
                 self.decode_tp_size[i] if self.decode_tp_size is not None else None
             ),
+            disagg_max_req_input_len=self.disagg_max_req_input_len,
             routed_dp_rank=self.routed_dp_rank,
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
@@ -838,6 +841,8 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     bootstrap_room: Optional[int] = None
     bootstrap_pair_key: Optional[str] = None
     decode_tp_size: Optional[int] = None
+    # Router-coordinated maximum prompt length for a selected P/D pair.
+    disagg_max_req_input_len: Optional[int] = None
 
     # For DP routing
     routed_dp_rank: Optional[int] = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -225,6 +225,7 @@ from sglang.srt.managers.utils import (
     EmbeddingBatchResult,
     GenerationBatchResult,
     is_health_check_generate_req,
+    resolve_disagg_max_req_input_len,
     validate_input_length,
 )
 from sglang.srt.mem_cache import kv_cache_builder
@@ -2182,6 +2183,24 @@ class Scheduler(
 
         self._maybe_namespace_elastic_radix_cache(req)
 
+        (
+            effective_max_req_input_len,
+            input_limit_error,
+            input_limit_status,
+        ) = resolve_disagg_max_req_input_len(
+            self.max_req_input_len,
+            recv_req.disagg_max_req_input_len,
+        )
+        if input_limit_error is not None:
+            logger.error("%s rid=%s", input_limit_error, req.rid)
+            recv_req.time_stats.trace_ctx.abort(
+                abort_info={"reason": input_limit_error}
+            )
+            prepare_abort(req, input_limit_error, status_code=input_limit_status)
+            self.output_streamer.stream_output([req], req.return_logprob)
+            return
+        assert effective_max_req_input_len is not None
+
         if self.spec_algorithm.is_dflash_family():
             error_msg = validate_dflash_request(req, self.enable_overlap)
             if error_msg is not None:
@@ -2258,30 +2277,41 @@ class Scheduler(
             req.extend_image_inputs(image_inputs)
             self._maybe_compute_mrope_positions(req)
 
-            if len(req.origin_input_ids) >= self.max_req_input_len:
+            if len(req.origin_input_ids) >= effective_max_req_input_len:
                 req.set_finish_with_abort(
                     error_msg=(
                         "Multimodal prompt is too long after expanding multimodal tokens. "
-                        f"After expanding {len(req.origin_input_ids_unpadded)=} => {len(req.origin_input_ids)} >= {self.max_req_input_len}."
+                        f"After expanding {len(req.origin_input_ids_unpadded)=} => {len(req.origin_input_ids)} >= {effective_max_req_input_len}."
                     )
                 )
                 self.init_req_max_new_tokens(req)
                 self._add_request_to_queue(req)
                 return
 
-        # initialize before returning
-        self.init_req_max_new_tokens(req)
+        # Preserve the legacy initialization order for non-PD requests. For a
+        # router-coordinated PD request, defer it until after shared-limit
+        # truncation so the output budget uses the final paired prompt length.
+        has_shared_input_limit = recv_req.disagg_max_req_input_len is not None
+        if not has_shared_input_limit:
+            self.init_req_max_new_tokens(req)
 
         # Validate prompt length
         error_msg = validate_input_length(
             req,
-            self.max_req_input_len,
+            effective_max_req_input_len,
             self.server_args.allow_auto_truncate,
         )
         if error_msg:
+            if has_shared_input_limit:
+                self.init_req_max_new_tokens(req)
             req.set_finish_with_abort(error_msg)
             self._add_request_to_queue(req)
             return
+
+        if has_shared_input_limit:
+            # Initialize the output budget after any auto-truncation so it is
+            # based on the final prompt length shared by the selected P/D pair.
+            self.init_req_max_new_tokens(req)
 
         if not recv_req.return_logprob and recv_req.logprob_start_len != -1:
             # When return_logprob is False, logprob_start_len should be ignored

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -93,7 +93,10 @@ from sglang.srt.managers.schedule_batch import MultimodalDataItem
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
 from sglang.srt.managers.tokenizer_manager_score_mixin import TokenizerManagerScoreMixin
-from sglang.srt.managers.utils import is_health_check_generate_req
+from sglang.srt.managers.utils import (
+    is_health_check_generate_req,
+    resolve_disagg_max_req_input_len,
+)
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
 from sglang.srt.observability.metrics_collector import (
     STAT_LOGGER_ROLE_TOKENIZER,
@@ -830,6 +833,36 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         obj: Union[GenerateReqInput, EmbeddingReqInput],
     ):
         """Tokenize one request."""
+        disagg_input_limit = None
+        if (
+            isinstance(obj, GenerateReqInput)
+            and obj.disagg_max_req_input_len is not None
+        ):
+            if self.max_req_input_len is None:
+                raise fastapi.HTTPException(
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                    detail=(
+                        "PD shared input limit cannot be validated before the local "
+                        "max_req_input_len is initialized."
+                    ),
+                )
+
+            (
+                disagg_input_limit,
+                input_limit_error,
+                input_limit_status,
+            ) = resolve_disagg_max_req_input_len(
+                self.max_req_input_len,
+                obj.disagg_max_req_input_len,
+            )
+            if input_limit_error is not None:
+                if input_limit_status == HTTPStatus.BAD_REQUEST:
+                    raise ValueError(input_limit_error)
+                raise fastapi.HTTPException(
+                    status_code=input_limit_status or HTTPStatus.INTERNAL_SERVER_ERROR,
+                    detail=input_limit_error,
+                )
+
         # Tokenize
         input_embeds = None
         input_text = obj.text
@@ -909,7 +942,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         audio_data=obj.audio_data,
                         input_text=(input_text or input_ids),
                         request_obj=obj,
-                        max_req_input_len=self.max_req_input_len,
+                        max_req_input_len=(
+                            disagg_input_limit
+                            if disagg_input_limit is not None
+                            else self.max_req_input_len
+                        ),
                     )
             elif (
                 self.server_args.language_only
@@ -924,7 +961,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     audio_data=obj.audio_data,
                     input_text=(input_text or input_ids),
                     request_obj=obj,
-                    max_req_input_len=self.max_req_input_len,
+                    max_req_input_len=(
+                        disagg_input_limit
+                        if disagg_input_limit is not None
+                        else self.max_req_input_len
+                    ),
                 )
 
             if mm_inputs and mm_inputs.input_ids is not None:
@@ -975,40 +1016,68 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         else:
             mm_inputs = None
 
-        self._validate_one_request(obj, input_ids)
+        self._validate_one_request(
+            obj,
+            input_ids,
+            max_req_input_len=disagg_input_limit,
+        )
         return self._create_tokenized_object(
             obj, input_text, input_ids, input_embeds, mm_inputs, token_type_ids
         )
 
     def _validate_one_request(
-        self, obj: Union[GenerateReqInput, EmbeddingReqInput], input_ids: List[int]
+        self,
+        obj: Union[GenerateReqInput, EmbeddingReqInput],
+        input_ids: List[int],
+        max_req_input_len: Optional[int] = None,
     ) -> None:
         """Validates that the input token count and the requested token count doesn't exceed the model's context length."""
         # FIXME: unify the length validation logic with the one in the scheduler.
         _max_req_len = self.context_len
+        input_limit = (
+            max_req_input_len if max_req_input_len is not None else self.context_len
+        )
         input_token_num = len(input_ids) if input_ids is not None else 0
         input_token_num += self.num_reserved_tokens
 
         # Validate input length
-        if input_token_num >= self.context_len:
+        if input_token_num >= input_limit:
             if self.allow_auto_truncate:
-                logger.warning(
-                    f"The input ({input_token_num} tokens) is longer than the "
-                    f"model's context length ({self.context_len} tokens). "
-                    "Truncating the input."
-                )
-                del input_ids[_max_req_len:]
+                if max_req_input_len is None:
+                    logger.warning(
+                        f"The input ({input_token_num} tokens) is longer than the "
+                        f"model's context length ({self.context_len} tokens). "
+                        "Truncating the input."
+                    )
+                else:
+                    logger.warning(
+                        f"The input ({input_token_num} tokens) reached or exceeded "
+                        f"the PD shared input limit ({input_limit} tokens). "
+                        "Truncating the input."
+                    )
+                del input_ids[input_limit:]
                 input_token_num = len(input_ids)
             else:
+                if max_req_input_len is None:
+                    raise ValueError(
+                        f"The input ({input_token_num} tokens) is longer than the "
+                        f"model's context length ({self.context_len} tokens)."
+                    )
                 raise ValueError(
-                    f"The input ({input_token_num} tokens) is longer than the "
-                    f"model's context length ({self.context_len} tokens)."
+                    f"Input length ({input_token_num} tokens) exceeds "
+                    f"the PD shared input limit ({input_limit} tokens). "
+                    "Use a shorter input or enable --allow-auto-truncate."
                 )
 
         # Validate total tokens (input + max_new_tokens)
         max_new_tokens = obj.sampling_params.get("max_new_tokens")
+        is_router_coordinated_prefill = (
+            max_req_input_len is not None
+            and self.disaggregation_mode == DisaggregationMode.PREFILL
+        )
         if (
             self.validate_total_tokens
+            and not is_router_coordinated_prefill
             and max_new_tokens is not None
             and (max_new_tokens + input_token_num) > _max_req_len
         ):
@@ -1198,6 +1267,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 bootstrap_host=obj.bootstrap_host,
                 bootstrap_port=obj.bootstrap_port,
                 bootstrap_room=bootstrap_room,
+                disagg_max_req_input_len=obj.disagg_max_req_input_len,
                 lora_id=obj.lora_id,
                 input_embeds=input_embeds,
                 positional_embed_overrides=obj.positional_embed_overrides,

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import torch
 
@@ -20,6 +21,34 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_disagg_max_req_input_len(
+    local_max_req_input_len: int,
+    disagg_max_req_input_len: Optional[int],
+) -> Tuple[Optional[int], Optional[str], Optional[HTTPStatus]]:
+    """Resolve the prompt limit shared by a router-selected P/D pair."""
+    if disagg_max_req_input_len is None:
+        return local_max_req_input_len, None, None
+
+    if disagg_max_req_input_len <= 0:
+        return (
+            None,
+            "Invalid disagg_max_req_input_len: the value must be positive, "
+            f"got {disagg_max_req_input_len}.",
+            HTTPStatus.BAD_REQUEST,
+        )
+
+    if disagg_max_req_input_len > local_max_req_input_len:
+        return (
+            None,
+            "PD shared input limit exceeds this worker's local capacity: "
+            f"disagg_max_req_input_len={disagg_max_req_input_len}, "
+            f"local_max_req_input_len={local_max_req_input_len}.",
+            HTTPStatus.SERVICE_UNAVAILABLE,
+        )
+
+    return disagg_max_req_input_len, None, None
 
 
 def _async_d2h(t: torch.Tensor) -> torch.Tensor:

--- a/sgl-model-gateway/src/core/mod.rs
+++ b/sgl-model-gateway/src/core/mod.rs
@@ -34,8 +34,9 @@ pub use job_queue::{Job, JobQueue, JobQueueConfig};
 pub use model_card::{ModelCard, ProviderType};
 pub use retry::{is_retryable_status, RetryExecutor};
 pub use worker::{
-    AttachedBody, BasicWorker, ConnectionMode, HealthConfig, RuntimeType, Worker, WorkerLoadGuard,
-    WorkerType,
+    is_pd_input_limit_metadata_label, AttachedBody, BasicWorker, ConnectionMode, HealthConfig,
+    RuntimeType, Worker, WorkerLoadGuard, WorkerType, MAX_REQ_INPUT_LEN_LABEL,
+    SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL,
 };
 pub use worker_builder::{BasicWorkerBuilder, DPAwareWorkerBuilder};
 pub use worker_manager::{LoadMonitor, WorkerManager};

--- a/sgl-model-gateway/src/core/steps/worker/local/create_worker.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/create_worker.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use tracing::debug;
+use tracing::{debug, warn};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use crate::{
@@ -12,8 +12,9 @@ use crate::{
         circuit_breaker::CircuitBreakerConfig,
         model_card::ModelCard,
         steps::workflow_data::LocalWorkerWorkflowData,
-        worker::{HealthConfig, RuntimeType, WorkerType},
-        BasicWorkerBuilder, ConnectionMode, DPAwareWorkerBuilder, Worker, UNKNOWN_MODEL_ID,
+        worker::{is_pd_input_limit_metadata_label, HealthConfig, RuntimeType, WorkerType},
+        BasicWorkerBuilder, ConnectionMode, DPAwareWorkerBuilder, Worker, MAX_REQ_INPUT_LEN_LABEL,
+        SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL, UNKNOWN_MODEL_ID,
     },
     protocols::worker_spec::WorkerConfigRequest,
 };
@@ -46,6 +47,16 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
             })?;
         let discovered_labels = &context.data.discovered_labels;
 
+        validate_http_pd_input_limit_metadata(
+            connection_mode,
+            config.worker_type.as_deref(),
+            discovered_labels,
+        )
+        .map_err(|message| WorkflowError::StepFailed {
+            step_id: StepId::new("create_worker"),
+            message,
+        })?;
+
         // Check if worker already exists
         if app_context
             .worker_registry
@@ -67,11 +78,9 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
             config_labels.insert("cost".to_string(), cost.to_string());
         }
 
-        // Merge: discovered labels first, then config labels (config takes precedence)
-        let mut final_labels = discovered_labels.clone();
-        for (key, value) in &config_labels {
-            final_labels.insert(key.clone(), value.clone());
-        }
+        // Merge discovered and config labels. Registration values take precedence
+        // except for capability metadata owned by backend discovery.
+        let final_labels = merge_worker_labels(discovered_labels, &config_labels, &config.url);
 
         // Determine model_id: config > served_model_name > model_path > UNKNOWN_MODEL_ID
         let model_id = config
@@ -155,6 +164,67 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         false
     }
+}
+
+fn validate_http_pd_input_limit_metadata(
+    connection_mode: &ConnectionMode,
+    worker_type: Option<&str>,
+    discovered_labels: &HashMap<String, String>,
+) -> Result<(), String> {
+    let is_http_pd_worker = matches!(connection_mode, ConnectionMode::Http)
+        && matches!(worker_type, Some("prefill" | "decode"));
+    if !is_http_pd_worker {
+        return Ok(());
+    }
+
+    let supports_shared_limit = discovered_labels
+        .get(SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL)
+        .is_some_and(|value| value == "true");
+    if !supports_shared_limit {
+        return Err(format!(
+            "HTTP {} worker does not advertise {}=true from /server_info",
+            worker_type.unwrap_or("PD"),
+            SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL
+        ));
+    }
+
+    let max_req_input_len = discovered_labels
+        .get(MAX_REQ_INPUT_LEN_LABEL)
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            format!(
+                "HTTP {} worker has no valid positive {} from /server_info",
+                worker_type.unwrap_or("PD"),
+                MAX_REQ_INPUT_LEN_LABEL
+            )
+        })?;
+
+    debug!(
+        worker_type = worker_type.unwrap_or("PD"),
+        max_req_input_len, "Validated HTTP PD shared input limit metadata"
+    );
+    Ok(())
+}
+
+fn merge_worker_labels(
+    discovered_labels: &HashMap<String, String>,
+    config_labels: &HashMap<String, String>,
+    worker_url: &str,
+) -> HashMap<String, String> {
+    let mut final_labels = discovered_labels.clone();
+    for (key, value) in config_labels {
+        if is_pd_input_limit_metadata_label(key) {
+            warn!(
+                worker_url,
+                label = %key,
+                "Ignoring registration override for router-managed worker metadata"
+            );
+            continue;
+        }
+        final_labels.insert(key.clone(), value.clone());
+    }
+    final_labels
 }
 
 fn build_model_card(
@@ -395,4 +465,70 @@ fn create_single_worker(
     );
 
     vec![worker]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_pd_metadata(max_req_input_len: usize) -> HashMap<String, String> {
+        HashMap::from([
+            (
+                MAX_REQ_INPUT_LEN_LABEL.to_string(),
+                max_req_input_len.to_string(),
+            ),
+            (
+                SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL.to_string(),
+                "true".to_string(),
+            ),
+        ])
+    }
+
+    #[test]
+    fn http_pd_worker_requires_discovered_shared_limit_metadata() {
+        let error = validate_http_pd_input_limit_metadata(
+            &ConnectionMode::Http,
+            Some("prefill"),
+            &HashMap::new(),
+        )
+        .unwrap_err();
+        assert!(error.contains(SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL));
+
+        let metadata = HashMap::from([(
+            SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL.to_string(),
+            "true".to_string(),
+        )]);
+        let error =
+            validate_http_pd_input_limit_metadata(&ConnectionMode::Http, Some("decode"), &metadata)
+                .unwrap_err();
+        assert!(error.contains(MAX_REQ_INPUT_LEN_LABEL));
+    }
+
+    #[test]
+    fn http_pd_worker_accepts_valid_discovered_shared_limit_metadata() {
+        assert!(validate_http_pd_input_limit_metadata(
+            &ConnectionMode::Http,
+            Some("decode"),
+            &valid_pd_metadata(372_277),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn registration_labels_cannot_override_discovered_shared_limit_metadata() {
+        let discovered = valid_pd_metadata(184_949);
+        let config = HashMap::from([
+            (MAX_REQ_INPUT_LEN_LABEL.to_string(), "999999".to_string()),
+            (
+                SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL.to_string(),
+                "false".to_string(),
+            ),
+            ("zone".to_string(), "test".to_string()),
+        ]);
+
+        let merged = merge_worker_labels(&discovered, &config, "http://worker");
+        assert_eq!(merged[MAX_REQ_INPUT_LEN_LABEL], "184949");
+        assert_eq!(merged[SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL], "true");
+        assert_eq!(merged["zone"], "test");
+    }
 }

--- a/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/discover_metadata.rs
@@ -8,11 +8,14 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{debug, warn};
-use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
+use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use super::strip_protocol;
 use crate::{
-    core::{steps::workflow_data::LocalWorkerWorkflowData, ConnectionMode},
+    core::{
+        steps::workflow_data::LocalWorkerWorkflowData, ConnectionMode, MAX_REQ_INPUT_LEN_LABEL,
+        SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL,
+    },
     routers::grpc::client::GrpcClient,
 };
 
@@ -41,6 +44,8 @@ pub struct ServerInfo {
     pub max_prefill_tokens: Option<usize>,
     pub max_running_requests: Option<usize>,
     pub max_num_reqs: Option<usize>,
+    pub max_req_input_len: Option<usize>,
+    pub supports_disagg_max_req_input_len: Option<bool>,
 }
 
 /// Model information returned from /model_info endpoint.
@@ -276,11 +281,33 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
         let (discovered_labels, detected_runtime) = match connection_mode {
             ConnectionMode::Http => {
                 let mut labels = HashMap::new();
+                let is_pd_worker =
+                    matches!(config.worker_type.as_deref(), Some("prefill" | "decode"));
 
                 // Fetch from /server_info for server-related metadata
-                if let Ok(server_info) =
-                    get_server_info(&config.url, config.api_key.as_deref()).await
-                {
+                let server_info =
+                    match get_server_info(&config.url, config.api_key.as_deref()).await {
+                        Ok(server_info) => Some(server_info),
+                        Err(error) if is_pd_worker => {
+                            return Err(WorkflowError::StepFailed {
+                                step_id: StepId::new("discover_metadata"),
+                                message: format!(
+                                    "Failed to discover required HTTP PD metadata from {}: {}",
+                                    config.url, error
+                                ),
+                            });
+                        }
+                        Err(error) => {
+                            warn!(
+                                worker_url = %config.url,
+                                %error,
+                                "Failed to fetch optional HTTP worker server metadata"
+                            );
+                            None
+                        }
+                    };
+
+                if let Some(server_info) = server_info {
                     if let Some(model_path) = server_info.model_path.filter(|s| !s.is_empty()) {
                         labels.insert("model_path".to_string(), model_path);
                     }
@@ -300,6 +327,18 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
                     }
                     if let Some(disaggregation_mode) = server_info.disaggregation_mode {
                         labels.insert("disaggregation_mode".to_string(), disaggregation_mode);
+                    }
+                    if let Some(max_req_input_len) = server_info.max_req_input_len {
+                        labels.insert(
+                            MAX_REQ_INPUT_LEN_LABEL.to_string(),
+                            max_req_input_len.to_string(),
+                        );
+                    }
+                    if server_info.supports_disagg_max_req_input_len == Some(true) {
+                        labels.insert(
+                            SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL.to_string(),
+                            "true".to_string(),
+                        );
                     }
                 }
 
@@ -364,5 +403,22 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_server_info_deserializes_pd_input_limit_metadata() {
+        let server_info: ServerInfo = serde_json::from_value(serde_json::json!({
+            "max_req_input_len": 184949,
+            "supports_disagg_max_req_input_len": true
+        }))
+        .unwrap();
+
+        assert_eq!(server_info.max_req_input_len, Some(184_949));
+        assert_eq!(server_info.supports_disagg_max_req_input_len, Some(true));
     }
 }

--- a/sgl-model-gateway/src/core/steps/worker/local/update_worker_properties.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/update_worker_properties.rs
@@ -3,11 +3,12 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use crate::core::{
-    steps::workflow_data::WorkerUpdateWorkflowData, BasicWorkerBuilder, HealthConfig, Worker,
+    is_pd_input_limit_metadata_label, steps::workflow_data::WorkerUpdateWorkflowData,
+    BasicWorkerBuilder, HealthConfig, Worker,
 };
 
 /// Step to update worker properties.
@@ -48,6 +49,14 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
             let mut updated_labels = worker.metadata().labels.clone();
             if let Some(ref new_labels) = request.labels {
                 for (key, value) in new_labels {
+                    if is_pd_input_limit_metadata_label(key) {
+                        warn!(
+                            worker_url = %worker.url(),
+                            label = %key,
+                            "Ignoring update override for router-managed worker metadata"
+                        );
+                        continue;
+                    }
                     updated_labels.insert(key.clone(), value.clone());
                 }
             }

--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -32,6 +32,19 @@ pub const DEFAULT_WORKER_COST: f32 = 1.0;
 /// Default HTTP client timeout for worker requests (in seconds)
 pub const DEFAULT_WORKER_HTTP_TIMEOUT_SECS: u64 = 30;
 
+/// Router-managed worker metadata discovered from SRT's `/server_info`.
+pub const MAX_REQ_INPUT_LEN_LABEL: &str = "max_req_input_len";
+pub const SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL: &str = "supports_disagg_max_req_input_len";
+
+/// These labels describe backend capabilities and must never be supplied or
+/// overwritten by worker registration/update requests.
+pub fn is_pd_input_limit_metadata_label(key: &str) -> bool {
+    matches!(
+        key,
+        MAX_REQ_INPUT_LEN_LABEL | SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL
+    )
+}
+
 static WORKER_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(DEFAULT_WORKER_HTTP_TIMEOUT_SECS))
@@ -163,6 +176,22 @@ pub trait Worker: Send + Sync + fmt::Debug {
     /// Returns cached port from WorkerType::Prefill
     fn bootstrap_port(&self) -> Option<u16> {
         self.metadata().bootstrap_port
+    }
+
+    /// Maximum prompt length accepted by this worker after tokenization.
+    fn max_req_input_len(&self) -> Option<usize> {
+        self.metadata()
+            .labels
+            .get(MAX_REQ_INPUT_LEN_LABEL)
+            .and_then(|value| value.parse().ok())
+    }
+
+    /// Whether this worker honors the router-provided PD shared input limit.
+    fn supports_disagg_max_req_input_len(&self) -> bool {
+        self.metadata()
+            .labels
+            .get(SUPPORTS_DISAGG_MAX_REQ_INPUT_LEN_LABEL)
+            .is_some_and(|value| value == "true")
     }
 
     /// Check if the worker is currently healthy

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -234,6 +234,62 @@ impl PDRouter {
     const BOOTSTRAP_PORT_KEY: &'static str = "bootstrap_port";
     const BOOTSTRAP_ROOM_KEY: &'static str = "bootstrap_room";
     const DISAGG_PREFILL_DP_RANK_KEY: &'static str = "disagg_prefill_dp_rank";
+    const DISAGG_MAX_REQ_INPUT_LEN_KEY: &'static str = "disagg_max_req_input_len";
+
+    fn route_uses_shared_input_limit(route: &str) -> bool {
+        matches!(
+            route,
+            "/generate" | "/v1/completions" | "/v1/chat/completions"
+        )
+    }
+
+    fn get_shared_input_limit(
+        prefill_worker: &dyn Worker,
+        decode_worker: &dyn Worker,
+    ) -> Result<usize, String> {
+        for (role, worker) in [("prefill", prefill_worker), ("decode", decode_worker)] {
+            if !worker.supports_disagg_max_req_input_len() {
+                return Err(format!(
+                    "{} worker {} does not support the PD shared input limit",
+                    role,
+                    worker.url()
+                ));
+            }
+        }
+
+        let prefill_limit = prefill_worker.max_req_input_len().ok_or_else(|| {
+            format!(
+                "prefill worker {} has no valid max_req_input_len",
+                prefill_worker.url()
+            )
+        })?;
+        let decode_limit = decode_worker.max_req_input_len().ok_or_else(|| {
+            format!(
+                "decode worker {} has no valid max_req_input_len",
+                decode_worker.url()
+            )
+        })?;
+
+        if prefill_limit == 0 || decode_limit == 0 {
+            return Err(format!(
+                "PD worker input limits must be positive: prefill={}, decode={}",
+                prefill_limit, decode_limit
+            ));
+        }
+
+        Ok(prefill_limit.min(decode_limit))
+    }
+
+    fn inject_shared_input_limit(mut original: Value, limit: usize) -> Result<Value, String> {
+        let obj = original
+            .as_object_mut()
+            .ok_or_else(|| "Request must be a JSON object".to_string())?;
+        obj.insert(
+            Self::DISAGG_MAX_REQ_INPUT_LEN_KEY.to_string(),
+            Value::from(limit as u64),
+        );
+        Ok(original)
+    }
 
     fn inject_bootstrap_into_value(
         mut original: Value,
@@ -415,6 +471,26 @@ impl PDRouter {
                             decode.url()
                         );
 
+                        let shared_input_limit = if Self::route_uses_shared_input_limit(route) {
+                            let limit = match Self::get_shared_input_limit(
+                                prefill.as_ref(),
+                                decode.as_ref(),
+                            ) {
+                                Ok(limit) => limit,
+                                Err(e) => return Self::handle_server_selection_error(e),
+                            };
+
+                            debug!(
+                                prefill_max_req_input_len = ?prefill.max_req_input_len(),
+                                decode_max_req_input_len = ?decode.max_req_input_len(),
+                                shared_input_limit = limit,
+                                "Selected PD shared input limit"
+                            );
+                            Some(limit)
+                        } else {
+                            None
+                        };
+
                         let mut json_request = match serde_json::to_value(shared_request.as_ref()) {
                             Ok(v) => v,
                             Err(e) => return Self::handle_serialization_error(e),
@@ -428,6 +504,16 @@ impl PDRouter {
                             Ok(v) => v,
                             Err(e) => return Self::handle_serialization_error(e),
                         };
+
+                        if let Some(shared_input_limit) = shared_input_limit {
+                            json_request = match Self::inject_shared_input_limit(
+                                json_request,
+                                shared_input_limit,
+                            ) {
+                                Ok(v) => v,
+                                Err(e) => return Self::handle_serialization_error(e),
+                            };
+                        }
 
                         let ctx_is_stream = context.is_stream;
                         let response = self
@@ -1715,8 +1801,10 @@ impl RouterTrait for PDRouter {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
-    use crate::core::{BasicWorkerBuilder, DPAwareWorkerBuilder, WorkerType};
+    use crate::core::{BasicWorker, BasicWorkerBuilder, DPAwareWorkerBuilder, WorkerType};
 
     fn create_test_pd_router() -> PDRouter {
         let worker_registry = Arc::new(WorkerRegistry::new());
@@ -1739,6 +1827,79 @@ mod tests {
             .build();
         worker.set_healthy(healthy);
         Box::new(worker)
+    }
+
+    fn create_capable_test_worker(
+        url: &str,
+        worker_type: WorkerType,
+        max_req_input_len: usize,
+    ) -> BasicWorker {
+        let labels = HashMap::from([
+            (
+                "max_req_input_len".to_string(),
+                max_req_input_len.to_string(),
+            ),
+            (
+                "supports_disagg_max_req_input_len".to_string(),
+                "true".to_string(),
+            ),
+        ]);
+        BasicWorkerBuilder::new(url)
+            .worker_type(worker_type)
+            .labels(labels)
+            .build()
+    }
+
+    #[test]
+    fn test_shared_input_limit_uses_smaller_worker_capacity() {
+        let prefill = create_capable_test_worker(
+            "http://prefill",
+            WorkerType::Prefill {
+                bootstrap_port: Some(8998),
+            },
+            184_949,
+        );
+        let decode = create_capable_test_worker("http://decode", WorkerType::Decode, 372_277);
+
+        assert_eq!(
+            PDRouter::get_shared_input_limit(&prefill, &decode).unwrap(),
+            184_949
+        );
+    }
+
+    #[test]
+    fn test_shared_input_limit_requires_worker_capability() {
+        let prefill = BasicWorkerBuilder::new("http://prefill")
+            .worker_type(WorkerType::Prefill {
+                bootstrap_port: Some(8998),
+            })
+            .build();
+        let decode = create_capable_test_worker("http://decode", WorkerType::Decode, 372_277);
+
+        let error = PDRouter::get_shared_input_limit(&prefill, &decode).unwrap_err();
+        assert!(error.contains("does not support"));
+    }
+
+    #[test]
+    fn test_inject_shared_input_limit_overwrites_client_value() {
+        let request = json!({
+            "prompt": "hello",
+            "disagg_max_req_input_len": 999_999,
+        });
+
+        let request = PDRouter::inject_shared_input_limit(request, 184_949).unwrap();
+        assert_eq!(request["disagg_max_req_input_len"], 184_949);
+    }
+
+    #[test]
+    fn test_shared_input_limit_is_only_used_by_generation_routes() {
+        assert!(PDRouter::route_uses_shared_input_limit("/generate"));
+        assert!(PDRouter::route_uses_shared_input_limit("/v1/completions"));
+        assert!(PDRouter::route_uses_shared_input_limit(
+            "/v1/chat/completions"
+        ));
+        assert!(!PDRouter::route_uses_shared_input_limit("/rerank"));
+        assert!(!PDRouter::route_uses_shared_input_limit("/v1/rerank"));
     }
 
     #[test]
@@ -1868,6 +2029,7 @@ mod tests {
             "bootstrap_host": "prefill",
             "bootstrap_port": 8998,
             "bootstrap_room": 1234,
+            "disagg_max_req_input_len": 184_949,
         });
 
         let (prefill_request, decode_request) =
@@ -1880,6 +2042,7 @@ mod tests {
             "http://prefill:30000/v1/completions"
         );
         assert_eq!(prefill_request.body["data_parallel_rank"], 2);
+        assert_eq!(prefill_request.body["disagg_max_req_input_len"], 184_949);
         assert!(prefill_request.body.get("disagg_prefill_dp_rank").is_none());
 
         assert_eq!(
@@ -1889,25 +2052,32 @@ mod tests {
         assert_eq!(decode_request.body["data_parallel_rank"], 1);
         assert_eq!(decode_request.body["disagg_prefill_dp_rank"], 2);
         assert_eq!(decode_request.body["bootstrap_room"], 1234);
+        assert_eq!(decode_request.body["disagg_max_req_input_len"], 184_949);
         assert!(matches!(prefill_request.body, Cow::Owned(_)));
         assert!(matches!(decode_request.body, Cow::Owned(_)));
     }
 
     #[tokio::test]
     async fn test_prepare_pd_worker_requests_preserves_non_dp_workers() {
-        let prefill = BasicWorkerBuilder::new("http://prefill:30000")
-            .worker_type(WorkerType::Prefill {
+        let prefill = create_capable_test_worker(
+            "http://prefill:30000",
+            WorkerType::Prefill {
                 bootstrap_port: Some(8998),
-            })
-            .build();
-        let decode = BasicWorkerBuilder::new("http://decode:30001")
-            .worker_type(WorkerType::Decode)
-            .build();
-        let request = json!({
-            "prompt": "shared prefix",
-            "max_tokens": 8,
-            "bootstrap_room": 1234,
-        });
+            },
+            184_949,
+        );
+        let decode = create_capable_test_worker("http://decode:30001", WorkerType::Decode, 372_277);
+        let shared_input_limit = PDRouter::get_shared_input_limit(&prefill, &decode).unwrap();
+        let request = PDRouter::inject_shared_input_limit(
+            json!({
+                "prompt": "shared prefix",
+                "max_tokens": 8,
+                "bootstrap_room": 1234,
+                "disagg_max_req_input_len": 999_999,
+            }),
+            shared_input_limit,
+        )
+        .unwrap();
 
         let (prefill_request, decode_request) =
             PDRouter::prepare_pd_worker_requests("/v1/completions", &request, &prefill, &decode)
@@ -1925,6 +2095,8 @@ mod tests {
         assert!(prefill_request.body.get("data_parallel_rank").is_none());
         assert!(decode_request.body.get("data_parallel_rank").is_none());
         assert!(decode_request.body.get("disagg_prefill_dp_rank").is_none());
+        assert_eq!(prefill_request.body["disagg_max_req_input_len"], 184_949);
+        assert_eq!(decode_request.body["disagg_max_req_input_len"], 184_949);
         assert!(matches!(prefill_request.body, Cow::Borrowed(_)));
         assert!(matches!(decode_request.body, Cow::Borrowed(_)));
     }

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -264,6 +264,8 @@ async fn server_info_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>
         "min_running_requests": 0,
         "max_running_requests": 2048,
         "max_req_num": 8192,
+        "max_req_input_len": 32767,
+        "supports_disagg_max_req_input_len": true,
         "max_batch_tokens": 32768,
         "schedule_policy": "lpm",
         "schedule_conservativeness": 1.0,

--- a/sgl-model-gateway/tests/common/tls_mock_worker.rs
+++ b/sgl-model-gateway/tests/common/tls_mock_worker.rs
@@ -285,6 +285,8 @@ async fn server_info_handler(State(config): State<Arc<RwLock<TlsMockWorkerConfig
         "port": config.port,
         "host": "127.0.0.1",
         "tls_enabled": true,
+        "max_req_input_len": 32767,
+        "supports_disagg_max_req_input_len": true,
         "version": "0.3.0"
     }))
     .into_response()

--- a/test/registered/unit/managers/test_disagg_input_limit.py
+++ b/test/registered/unit/managers/test_disagg_input_limit.py
@@ -1,0 +1,179 @@
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
+)
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.managers.utils import (
+    resolve_disagg_max_req_input_len,
+    validate_input_length,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_resolve_disagg_input_limit_defaults_to_local_limit():
+    assert resolve_disagg_max_req_input_len(200, None) == (200, None, None)
+
+
+def test_resolve_disagg_input_limit_accepts_smaller_pair_limit():
+    assert resolve_disagg_max_req_input_len(200, 100) == (100, None, None)
+
+
+def test_resolve_disagg_input_limit_rejects_invalid_value():
+    limit, error, status = resolve_disagg_max_req_input_len(200, 0)
+    assert limit is None
+    assert "must be positive" in error
+    assert status == 400
+
+
+def test_resolve_disagg_input_limit_rejects_value_above_local_capacity():
+    limit, error, status = resolve_disagg_max_req_input_len(100, 200)
+    assert limit is None
+    assert "exceeds this worker's local capacity" in error
+    assert status == 503
+
+
+def test_validate_input_length_truncates_to_shared_limit_when_enabled():
+    req = SimpleNamespace(origin_input_ids=list(range(12)))
+    assert validate_input_length(req, 8, allow_auto_truncate=True) is None
+    assert req.origin_input_ids == list(range(8))
+
+
+def test_validate_input_length_rejects_shared_limit_when_disabled():
+    req = SimpleNamespace(origin_input_ids=list(range(12)))
+    error = validate_input_length(req, 8, allow_auto_truncate=False)
+    assert "exceeds the maximum allowed length (8 tokens)" in error
+    assert len(req.origin_input_ids) == 12
+
+
+def _make_tokenizer_manager(
+    *,
+    allow_auto_truncate: bool,
+    context_len: int = 64,
+    disaggregation_mode: DisaggregationMode = DisaggregationMode.NULL,
+):
+    manager = object.__new__(TokenizerManager)
+    manager.context_len = context_len
+    manager.num_reserved_tokens = 0
+    manager.allow_auto_truncate = allow_auto_truncate
+    manager.validate_total_tokens = True
+    manager.disaggregation_mode = disaggregation_mode
+    return manager
+
+
+def test_tokenizer_truncates_to_shared_limit_before_total_token_validation():
+    manager = _make_tokenizer_manager(allow_auto_truncate=True, context_len=20)
+    input_ids = list(range(12))
+    obj = SimpleNamespace(sampling_params={"max_new_tokens": 10})
+
+    manager._validate_one_request(obj, input_ids, max_req_input_len=8)
+
+    assert input_ids == list(range(8))
+    assert obj.sampling_params["max_new_tokens"] == 10
+
+
+def test_tokenizer_rejects_shared_limit_when_auto_truncate_is_disabled():
+    manager = _make_tokenizer_manager(allow_auto_truncate=False)
+    input_ids = list(range(12))
+    obj = SimpleNamespace(sampling_params={"max_new_tokens": 1})
+
+    try:
+        manager._validate_one_request(obj, input_ids, max_req_input_len=8)
+    except ValueError as error:
+        assert "PD shared input limit (8 tokens)" in str(error)
+    else:
+        raise AssertionError("expected the shared input limit to reject the request")
+
+    assert input_ids == list(range(12))
+
+
+def test_prefill_does_not_validate_decode_output_budget_against_local_context():
+    manager = _make_tokenizer_manager(
+        allow_auto_truncate=False,
+        context_len=20,
+        disaggregation_mode=DisaggregationMode.PREFILL,
+    )
+    input_ids = list(range(8))
+    obj = SimpleNamespace(sampling_params={"max_new_tokens": 32})
+
+    manager._validate_one_request(obj, input_ids, max_req_input_len=12)
+
+    assert input_ids == list(range(8))
+    assert obj.sampling_params["max_new_tokens"] == 32
+
+
+def test_decode_still_validates_output_budget_against_local_context():
+    manager = _make_tokenizer_manager(
+        allow_auto_truncate=False,
+        context_len=20,
+        disaggregation_mode=DisaggregationMode.DECODE,
+    )
+    input_ids = list(range(8))
+    obj = SimpleNamespace(sampling_params={"max_new_tokens": 32})
+
+    try:
+        manager._validate_one_request(obj, input_ids, max_req_input_len=12)
+    except ValueError as error:
+        assert "maximum context length" in str(error)
+    else:
+        raise AssertionError("expected decode to validate the full output budget")
+
+
+def test_openai_pd_requests_accept_shared_input_limit():
+    completion = CompletionRequest(
+        model="test-model",
+        prompt="hello",
+        disagg_max_req_input_len=128,
+    )
+    chat = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        disagg_max_req_input_len=128,
+    )
+
+    assert completion.disagg_max_req_input_len == 128
+    assert chat.disagg_max_req_input_len == 128
+
+
+def test_generate_batch_preserves_scalar_shared_input_limit():
+    req = GenerateReqInput(
+        input_ids=[[1, 2, 3], [4, 5, 6]],
+        sampling_params=[{}, {}],
+        disagg_max_req_input_len=128,
+    )
+    req.normalize_batch_and_arguments()
+
+    assert req[0].disagg_max_req_input_len == 128
+    assert req[1].disagg_max_req_input_len == 128
+
+
+def test_chat_prefill_skips_decode_output_budget_precheck():
+    serving = object.__new__(OpenAIServingChat)
+    serving.tokenizer_manager = SimpleNamespace(
+        server_args=SimpleNamespace(
+            context_length=20,
+            allow_auto_truncate=False,
+        ),
+        disaggregation_mode=DisaggregationMode.PREFILL,
+    )
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        max_completion_tokens=32,
+        disagg_max_req_input_len=12,
+    )
+
+    assert serving._validate_request(request) is None
+
+    serving.tokenizer_manager.disaggregation_mode = DisaggregationMode.DECODE
+    assert "too large" in serving._validate_request(request)


### PR DESCRIPTION
## Motivation

HTTP PD disaggregation currently lets the selected prefill and decode workers validate the same request against different local input limits. With heterogeneous workers (for example, a 16K prefill worker paired with a 32K decode worker), decode can accept a prompt whose KV suffix prefill will never produce. This can leave decode waiting on KV transfer and can block later work behind the request.

This fixes that mismatched-P/D input-limit failure mode. It does not attempt to address every possible source of head-of-line blocking.

## Modifications

- Discover each HTTP PD worker's `max_req_input_len` and explicit shared-limit capability from `/server_info` and keep these as router-managed metadata.
- Fail closed when a selected worker does not advertise the required metadata or protocol capability.
- After selecting a P/D pair, compute `min(prefill.max_req_input_len, decode.max_req_input_len)` and inject it into both request bodies for native generate, completion, and chat routes.
- Propagate and enforce the shared limit through OpenAI request conversion, tokenizer validation, multimodal processing, and scheduler validation.
- Preserve rejection when `--allow-auto-truncate` is disabled and consistent truncation when it is enabled.
- Add Python and Rust unit coverage for validation, propagation, metadata discovery, registration/update protection, and pair-limit selection.

The router does not tokenize prompts as part of this change.

## Accuracy Tests

This is request-routing and validation logic; model forward computation is unchanged.

Fresh checks:

- `python3 -m pytest -q test/registered/unit/managers/test_disagg_input_limit.py` — 13 passed.
- Gateway unit-test binary on the target server — 398 passed, 0 failed.
- `cargo fmt --check` — passed.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- `cargo test --features vendored-openssl --no-run` — passed in a Rocky Linux 8 build container on the development machine.
- `cargo build --features vendored-openssl --bin sgl-model-gateway` — passed; the resulting GLIBC 2.28-compatible binary was copied to and executed on the target server.

Manual GPU validation used Qwen3-32B-FP8 with one heterogeneous custom P2P pair (prefill 16K / decode 32K):

- A native request with 20,000 `input_ids` returned HTTP 400 with auto-truncation disabled.
- The same request completed with `prompt_tokens=16378` with auto-truncation enabled.
- Boundary requests at 16,377 / 16,378 / 16,379 tokens followed the expected reject/truncate semantics.
- Short requests before, after, and concurrent with oversized requests completed successfully.
- A false-mode workload of 30 oversized and 80 short requests produced 30/30 expected 400 responses and 80/80 successful short responses, with no transport errors; decode queue gauges subsequently returned to zero.

Earlier route-level checks on the same P16K/D32K setup also covered `/v1/completions` and `/v1/chat/completions` for reject and truncate behavior.

GPU coverage is limited to this single heterogeneous P/D pair; multi-P/multi-D, retry/failover, gRPC, and mixed-version deployments were not exercised.

## Speed Tests and Profiling

No formal throughput benchmark was run. The router adds metadata lookup and a small JSON-field injection after worker selection; it does not add router-side tokenization.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing configuration or CLI change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Scope and test limitations are documented above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29646158879](https://github.com/sgl-project/sglang/actions/runs/29646158879)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29646158817](https://github.com/sgl-project/sglang/actions/runs/29646158817)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->