### PR TITLE
CI: synchronize prefill graph test fixtures

### DIFF
--- a/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
+++ b/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
@@ -33,6 +33,7 @@ class TestMultimodalPiecewiseCudaGraph(CustomTestCase):
         runner.prefill_backend_name = backend
         runner.has_mha_companion_layers = backend == Backend.BREAKABLE
         runner.capture_hidden_mode = CaptureHiddenMode.NULL
+        runner.capture_num_tokens = [4, 16]
         runner.max_num_tokens = 16
         return runner
 

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_padding.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_padding.py
@@ -1,6 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
@@ -18,6 +19,8 @@ class TestPrefillCudaGraphPadding(CustomTestCase):
     def _make_runner(self):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         runner._is_full_backend = False
+        runner.prefill_backend_name = Backend.TC_PIECEWISE
+        runner.has_mha_companion_layers = False
         runner.capture_hidden_mode = CaptureHiddenMode.NULL
         runner.capture_num_tokens = [4, 16]
         runner.max_num_tokens = 16


### PR DESCRIPTION
## Summary

Synchronize the lightweight `PrefillCudaGraphRunner` test fixtures with the state now read by `can_run_graph()`:

- initialize `capture_num_tokens` in the multimodal piecewise CUDA graph fixture;
- initialize `prefill_backend_name` and `has_mha_companion_layers` in the prefill-padding fixture.

## Root cause

#31391 and #31487 were developed from the same older `main` revision and each added runner state plus a lightweight fixture built with `__new__()`:

- #31391 added the backend/MHA-prefix state and multimodal graph tests;
- #31487 added the capture-bucket padding guard and padding tests.

Each PR's CPU tests passed in isolation because its fixture only needed the state present on that shared base. After both changes landed, `can_run_graph()` read both sets of fields, exposing symmetric fixture drift: the multimodal fixture lacked `capture_num_tokens`, while the padding fixture lacked the backend/MHA state.

The fixtures now explicitly model `tc_piecewise` behavior and the `[4, 16]` capture buckets used by these tests.

## Impact

Test-only; runtime behavior is unchanged. This unblocks the affected `base-a-test-cpu` shard on current `main` and dependent PRs.

## Validation

- `pre-commit run --files test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py test/registered/unit/model_executor/runner/test_prefill_cuda_graph_padding.py`
- `git diff --check`
- targeted runtime test deferred to CI because the local macOS environment lacks the SGLang Python dependencies (`numpy` is unavailable)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29641154932](https://github.com/sgl-project/sglang/actions/runs/29641154932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29641154868](https://github.com/sgl-project/sglang/actions/runs/29641154868)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
