### PR TITLE
Fix MiniMax sparse prefill score buffer OOB on stale max_seqlen_k

### DIFF
--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -1,5 +1,6 @@
 # Copyright 2025 XunhaoLai. All rights reserved.
 
+import logging
 from typing import Optional
 
 import torch
@@ -7,6 +8,8 @@ import triton
 import triton.language as tl
 
 from ..common.utils import _bitonic_merge, get_cu_seqblocks, robust_allocator
+
+logger = logging.getLogger(__name__)
 
 
 @triton.heuristics(
@@ -472,6 +475,17 @@ def flash_prefill_with_topk_index(
         cu_seqblocks_q, max_seqblock_q, all_seqblock_q, _, _, _ = get_cu_seqblocks(
             cu_seqlens, max_seqlen_q, block_size_q, block_size_k
         )
+    actual_max_seqlen_k = int(seq_lens.max().item())
+    if max_seqlen_k < actual_max_seqlen_k:
+        logger.warning(
+            "flash_prefill_with_topk_index: max_seqlen_k=%d underestimates "
+            "max(seq_lens)=%d; enlarging score buffer from %d to %d block-columns",
+            max_seqlen_k,
+            actual_max_seqlen_k,
+            triton.cdiv(max_seqlen_k, block_size_k),
+            triton.cdiv(actual_max_seqlen_k, block_size_k),
+        )
+        max_seqlen_k = actual_max_seqlen_k
     max_seqblock_k = triton.cdiv(max_seqlen_k, block_size_k)
     if disable_index_value:
         o = None

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -441,6 +441,7 @@ def flash_prefill_with_topk_index(
     cu_seqblocks_q: Optional[torch.Tensor] = None,
     max_seqblock_q: Optional[int] = None,
     all_seqblock_q: Optional[int] = None,
+    seq_lens_cpu: Optional[torch.Tensor] = None,
 ):
     assert score_type in (
         "max",
@@ -475,17 +476,18 @@ def flash_prefill_with_topk_index(
         cu_seqblocks_q, max_seqblock_q, all_seqblock_q, _, _, _ = get_cu_seqblocks(
             cu_seqlens, max_seqlen_q, block_size_q, block_size_k
         )
-    actual_max_seqlen_k = int(seq_lens.max().item())
-    if max_seqlen_k < actual_max_seqlen_k:
-        logger.warning(
-            "flash_prefill_with_topk_index: max_seqlen_k=%d underestimates "
-            "max(seq_lens)=%d; enlarging score buffer from %d to %d block-columns",
-            max_seqlen_k,
-            actual_max_seqlen_k,
-            triton.cdiv(max_seqlen_k, block_size_k),
-            triton.cdiv(actual_max_seqlen_k, block_size_k),
-        )
-        max_seqlen_k = actual_max_seqlen_k
+    if seq_lens_cpu is not None:
+        actual_max_seqlen_k = int(seq_lens_cpu.max().item())
+        if max_seqlen_k < actual_max_seqlen_k:
+            logger.warning(
+                "flash_prefill_with_topk_index: max_seqlen_k=%d underestimates "
+                "max(seq_lens)=%d; enlarging score buffer from %d to %d block-columns",
+                max_seqlen_k,
+                actual_max_seqlen_k,
+                triton.cdiv(max_seqlen_k, block_size_k),
+                triton.cdiv(actual_max_seqlen_k, block_size_k),
+            )
+            max_seqlen_k = actual_max_seqlen_k
     max_seqblock_k = triton.cdiv(max_seqlen_k, block_size_k)
     if disable_index_value:
         o = None

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -346,6 +346,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             disable_index_value=disable_value,
             use_msa=self.use_msa,
             seqlens_cpu=forward_batch.extend_seq_lens_cpu,
+            seq_lens_cpu=forward_batch.seq_lens_cpu,
         )
 
         if actual_num_tokens < original_num_tokens:

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -67,6 +67,7 @@ def minimax_sparse_prefill(
     max_seqblock_q: Optional[int] = None,
     all_seqblock_q: Optional[int] = None,
     seqlens_cpu: Optional[List[int]] = None,
+    seq_lens_cpu: Optional[torch.Tensor] = None,
 ):
     """Run MiniMax-M3 sparse prefill.
 
@@ -106,6 +107,7 @@ def minimax_sparse_prefill(
         cu_seqblocks_q=cu_seqblocks_q,
         max_seqblock_q=max_seqblock_q,
         all_seqblock_q=all_seqblock_q,
+        seq_lens_cpu=seq_lens_cpu,
     )
     # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
     num_idx_heads = idx_q.shape[1]

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_prefill_with_topk_idx.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_prefill_with_topk_idx.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.minimax_sparse.prefill.flash_with_topk_idx import (
+    flash_prefill_with_topk_index,
+)
+
+
+@pytest.mark.parametrize("score_type", ["max", "lse"])
+def test_prefill_stale_max_seqlen_k(score_type):
+    """A stale max_seqlen_k must not undersize the score buffer."""
+    device = "cuda"
+    torch.manual_seed(0)
+
+    seq_lens = torch.tensor([64, 4096], dtype=torch.int32, device=device)
+    cu_seqlens = torch.tensor([0, 64, 4160], dtype=torch.int32, device=device)
+    q = torch.randn(4160, 1, 128, dtype=torch.bfloat16, device=device)
+    k_cache = torch.randn(8192, 1, 128, dtype=torch.bfloat16, device=device)
+    req_to_token = torch.arange(8192, dtype=torch.int32, device=device).view(2, 4096)
+    slot_ids = torch.arange(2, dtype=torch.int64, device=device)
+    prefix_lens = torch.zeros(2, dtype=torch.int32, device=device)
+
+    def run(max_seqlen_k):
+        _, topk_idx = flash_prefill_with_topk_index(
+            q=q,
+            k_cache=k_cache,
+            v_cache=None,
+            sink=None,
+            req_to_token=req_to_token,
+            slot_ids=slot_ids,
+            cu_seqlens=cu_seqlens,
+            seq_lens=seq_lens,
+            prefix_lens=prefix_lens,
+            max_seqlen_q=4096,
+            max_seqlen_k=max_seqlen_k,
+            block_size_q=128,
+            block_size_k=128,
+            topk=16,
+            init_blocks=1,
+            local_blocks=2,
+            score_type=score_type,
+            disable_index_value=True,
+        )
+        return topk_idx.clone()
+
+    expected = run(4096)
+    actual = run(64)
+    torch.cuda.synchronize()
+
+    assert torch.equal(actual, expected)

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_prefill_with_topk_idx.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_prefill_with_topk_idx.py
@@ -13,6 +13,7 @@ def test_prefill_stale_max_seqlen_k(score_type):
     torch.manual_seed(0)
 
     seq_lens = torch.tensor([64, 4096], dtype=torch.int32, device=device)
+    seq_lens_cpu = seq_lens.cpu()
     cu_seqlens = torch.tensor([0, 64, 4160], dtype=torch.int32, device=device)
     q = torch.randn(4160, 1, 128, dtype=torch.bfloat16, device=device)
     k_cache = torch.randn(8192, 1, 128, dtype=torch.bfloat16, device=device)
@@ -40,6 +41,7 @@ def test_prefill_stale_max_seqlen_k(score_type):
             local_blocks=2,
             score_type=score_type,
             disable_index_value=True,
+            seq_lens_cpu=seq_lens_cpu,
         )
         return topk_idx.clone()
 


### PR DESCRIPTION
## Motivation

Fixes #31133.

`flash_prefill_with_topk_index` allocates the temporary `score` buffer from the caller-provided `max_seqlen_k`, while the Triton kernel computes the per-request K-block width from the live `seq_lens` tensor.

When `max_seqlen_k` is stale and smaller than the current max sequence length, the score buffer can be undersized. The kernel then writes block scores past the allocated K-block dimension, which may corrupt `topk_idx` or trigger an out-of-bounds GPU write.

## Modifications

- Thread CPU-side `seq_lens_cpu` metadata into the MiniMax sparse prefill topk wrapper.
- Guard `flash_prefill_with_topk_index` by comparing `max_seqlen_k` with `seq_lens_cpu.max()` before allocating `score`.
- If `max_seqlen_k` underestimates the CPU-side max sequence length, enlarge the score buffer and log a warning without adding a GPU-to-CPU synchronization in the kernel wrapper.
- Add a regression test that calls the prefill topk kernel with stale `max_seqlen_k=64` while the CPU-side max sequence length is 4096, and checks that the result matches the correctly-sized path.

## Accuracy Tests

Added a deterministic CUDA unit test:

`pytest python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_prefill_with_topk_idx.py`

The test compares `flash_prefill_with_topk_index` outputs between:

- correct path: `max_seqlen_k=4096`
- stale path: `max_seqlen_k=64`

and verifies that the returned `topk_idx` is identical for both `score_type="max"` and `score_type="lse"`.

## Speed Tests and Profiling

Not run. This change only adds a safety guard using CPU-side sequence length metadata. The normal path where `max_seqlen_k` already covers `seq_lens_cpu.max()` keeps the same score buffer shape and kernel behavior, and the guard avoids introducing a CUDA tensor `.item()` synchronization in the wrapper.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29648124079](https://github.com/sgl-project/sglang/actions/runs/29648124079)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29648124045](https://github.com/sgl-project/sglang/actions/runs/29648124045)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->