### PR TITLE
docs: fix broken development guide link in CONTRIBUTING.md

### DIFF
--- a/docs_new/CONTRIBUTING.md
+++ b/docs_new/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to our documentation! This guide wil
 6. Preview your changes at `http://localhost:3000`
 7. Commit your changes and submit a pull request
 
-For more details on local development, see our [development guide](development.mdx).
+For more details on local development, see our [development guide](docs/developer_guide/overview).
 
 ## Writing guidelines
 


### PR DESCRIPTION
## Description
`docs_new/CONTRIBUTING.md` links to `[development guide](development.mdx)`, but no such file exists — the link 404s. The Developer Guide landing page is `docs_new/docs/developer_guide/overview.mdx`, so the link is updated to point there (extensionless, matching the repo's existing link style).

Verified with a local relative-link checker: 0 broken internal links after the change (was 1).

## Type of change
- [x] Documentation

## Checklist
- [x] The change is a documentation fix with no behavior change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29648697688](https://github.com/sgl-project/sglang/actions/runs/29648697688)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29648697569](https://github.com/sgl-project/sglang/actions/runs/29648697569)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->