### PR TITLE
fix: preserve speculative draft weights across release/resume_memory_occupation

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -259,21 +259,34 @@ class SchedulerWeightUpdaterManager:
             )
             del self.stashed_model_static_state
             if self.stashed_draft_model_state is not None:
-                failed = _import_full_state(
-                    _get_draft_model_runner(self.draft_worker).model,
-                    self.stashed_draft_model_state,
-                )
-                self.stashed_draft_model_state = (
-                    dict(tensors=failed) if failed else None
-                )
+                draft_runner = _get_draft_model_runner(self.draft_worker)
+                if draft_runner is not None:
+                    failed = _import_full_state(
+                        draft_runner.model,
+                        self.stashed_draft_model_state,
+                    )
+                    self.stashed_draft_model_state = (
+                        dict(tensors=failed) if failed else None
+                    )
+                else:
+                    self.stashed_draft_model_state = None
 
         if GPU_MEMORY_TYPE_KV_CACHE in tags:
             self.memory_saver_adapter.resume(GPU_MEMORY_TYPE_KV_CACHE)
             if self.stashed_draft_model_state is not None:
-                _import_full_state(
-                    _get_draft_model_runner(self.draft_worker).model,
-                    self.stashed_draft_model_state,
-                )
+                draft_runner = _get_draft_model_runner(self.draft_worker)
+                if draft_runner is not None:
+                    failed = _import_full_state(
+                        draft_runner.model,
+                        self.stashed_draft_model_state,
+                    )
+                    if failed:
+                        logger.warning(
+                            "draft weights restore left %d tensors unrestored "
+                            "after the KV-phase retry, e.g. %s",
+                            len(failed),
+                            [n for n, _ in failed[:3]],
+                        )
                 self.stashed_draft_model_state = None
             scheduler = self.scheduler
             if scheduler is not None:

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -83,6 +83,7 @@ class SchedulerWeightUpdaterManager:
     scheduler: Optional[Any] = None
     metrics_collector: Optional[Any] = None
     offload_tags: set = field(default_factory=set)
+    stashed_draft_model_state: Any = None
     stashed_model_static_state: Any = None
 
     @contextmanager
@@ -196,6 +197,15 @@ class SchedulerWeightUpdaterManager:
         for tag in tags:
             self.offload_tags.add(tag)
 
+        if GPU_MEMORY_TYPE_WEIGHTS in tags and self.draft_worker is not None:
+            # Stash the draft model BEFORE any region is paused: the target's
+            # weights are rewritten by a subsequent update_weights, but nothing
+            # ever rewrites the draft — without this stash/restore, speculative
+            # decoding silently degrades to accept_length ~= 1.0 after resume.
+            draft_runner = _get_draft_model_runner(self.draft_worker)
+            if draft_runner is not None:
+                self.stashed_draft_model_state = _export_full_state(draft_runner.model)
+
         if GPU_MEMORY_TYPE_KV_CACHE in tags:
             scheduler = self.scheduler
             if scheduler is not None:
@@ -248,9 +258,23 @@ class SchedulerWeightUpdaterManager:
                 self.stashed_model_static_state,
             )
             del self.stashed_model_static_state
+            if self.stashed_draft_model_state is not None:
+                failed = _import_full_state(
+                    _get_draft_model_runner(self.draft_worker).model,
+                    self.stashed_draft_model_state,
+                )
+                self.stashed_draft_model_state = (
+                    dict(tensors=failed) if failed else None
+                )
 
         if GPU_MEMORY_TYPE_KV_CACHE in tags:
             self.memory_saver_adapter.resume(GPU_MEMORY_TYPE_KV_CACHE)
+            if self.stashed_draft_model_state is not None:
+                _import_full_state(
+                    _get_draft_model_runner(self.draft_worker).model,
+                    self.stashed_draft_model_state,
+                )
+                self.stashed_draft_model_state = None
             scheduler = self.scheduler
             if scheduler is not None:
                 if scheduler.disaggregation_mode == DisaggregationMode.DECODE:
@@ -322,6 +346,39 @@ class SchedulerWeightUpdaterManager:
             pattern=params["pattern"],
             max_size=params["max_size"],
         )
+
+
+def _export_full_state(model):
+    # Per-tensor guard: FrozenKVMTP-style draft workers hold buffers tied to the
+    # KV-cache memory-saver region; those become unclonable once KV is paused
+    # and are restored by the memory saver itself — skip rather than fail.
+    tensors, skipped = [], []
+    for name, t in list(model.named_parameters()) + list(model.named_buffers()):
+        try:
+            tensors.append((name, t.detach().to("cpu", copy=True)))
+        except Exception:
+            skipped.append(name)
+    if skipped:
+        logger.info(
+            f"draft weights stash skipped {len(skipped)} unclonable tensors, e.g. {skipped[:3]}"
+        )
+    return dict(tensors=tensors)
+
+
+def _import_full_state(model, state):
+    # Two-phase restore: tensors tied to a still-paused region fail here and are
+    # retried after the next region resume instead of failing the request.
+    failed = []
+    with torch.inference_mode():
+        named = dict(model.named_parameters())
+        named.update(dict(model.named_buffers()))
+        for name, t in state["tensors"]:
+            try:
+                named[name][...] = t
+            except Exception:
+                failed.append((name, t))
+    torch.get_device_module().synchronize()
+    return failed
 
 
 def _export_static_state(model):

--- a/test/registered/rl/test_release_memory_occupation_spec.py
+++ b/test/registered/rl/test_release_memory_occupation_spec.py
@@ -56,7 +56,9 @@ class TestDraftStashHelpers(CustomTestCase):
         failed = wu._import_full_state(model, state)
         self.assertEqual(failed, [])
         restored = dict(state["tensors"])
-        self.assertTrue(torch.equal(model.linear.weight.detach(), restored["linear.weight"]))
+        self.assertTrue(
+            torch.equal(model.linear.weight.detach(), restored["linear.weight"])
+        )
         self.assertTrue(torch.equal(model.cache, restored["cache"]))
 
     def test_two_phase_restore_retries_failed_tensors(self):
@@ -104,7 +106,9 @@ class TestManagerDraftOrchestration(CustomTestCase):
         golden = {k: v.clone() for k, v in draft_model.state_dict().items()}
         manager = self._make_manager(draft_model)
 
-        release_req = MagicMock(tags=[GPU_MEMORY_TYPE_WEIGHTS, GPU_MEMORY_TYPE_KV_CACHE])
+        release_req = MagicMock(
+            tags=[GPU_MEMORY_TYPE_WEIGHTS, GPU_MEMORY_TYPE_KV_CACHE]
+        )
         resume_req = MagicMock(tags=[GPU_MEMORY_TYPE_WEIGHTS, GPU_MEMORY_TYPE_KV_CACHE])
 
         with patch.object(torch.distributed, "barrier"):
@@ -131,7 +135,20 @@ class TestManagerDraftOrchestration(CustomTestCase):
 
 
 class TestReleaseResumeWithSpeculativeDecoding(CustomTestCase):
-    """GPU e2e: accept_length must survive a release/resume cycle."""
+    """GPU e2e replicating the RL engine lifecycle: release -> resume -> the
+    TARGET is rewritten by a weight update (as RL frameworks do every cycle),
+    while nothing rewrites the draft. accept_length must survive.
+
+    Design notes (validated empirically on B300, Qwen3-30B-A3B + EAGLE3):
+    - ``enable_weights_cpu_backup`` must stay OFF here: full-region backup
+      restores the draft as a side effect and masks the regression.
+    - The draft-only ``enable_draft_weights_cpu_backup`` flag does NOT protect
+      the draft on this flow (allocator segment reuse) — measured 1.85 -> 1.0
+      without the stash/restore fix, 1.85 -> 2.0 with it.
+    - The weight update must be target-only (``disable_draft_model=True``);
+      the python Engine API does not expose that field yet, so the request is
+      constructed directly.
+    """
 
     PROMPT = "Explain, step by step, why the sky appears blue on a clear day."
 
@@ -139,16 +156,36 @@ class TestReleaseResumeWithSpeculativeDecoding(CustomTestCase):
         info = engine.get_server_info()
         return info["internal_states"][0]["avg_spec_accept_length"]
 
-    def test_accept_length_survives_release_resume(self):
+    def _push_target_weights(self, engine, named_tensors, batch=64):
+        from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
+        from sglang.srt.utils import MultiprocessingSerializer
+
+        for i in range(0, len(named_tensors), batch):
+            chunk = named_tensors[i : i + batch]
+            obj = UpdateWeightsFromTensorReqInput(
+                serialized_named_tensors=[
+                    MultiprocessingSerializer.serialize(chunk)
+                    for _ in range(engine.server_args.tp_size)
+                ],
+                flush_cache=(i + batch >= len(named_tensors)),
+                disable_draft_model=True,
+            )
+            engine.loop.run_until_complete(
+                engine.tokenizer_manager.update_weights_from_tensor(obj, None)
+            )
+
+    def test_accept_length_survives_release_resume_with_target_update(self):
+        from transformers import AutoModelForCausalLM
+
         import sglang as sgl
 
         engine = sgl.Engine(
             model_path=DEFAULT_TARGET_MODEL_EAGLE,
             speculative_algorithm="EAGLE",
             speculative_draft_model_path=DEFAULT_DRAFT_MODEL_EAGLE,
-            speculative_num_steps=3,
-            speculative_eagle_topk=1,
-            speculative_num_draft_tokens=4,
+            speculative_num_steps=5,
+            speculative_eagle_topk=4,
+            speculative_num_draft_tokens=8,
             enable_memory_saver=True,
             mem_fraction_static=0.6,
         )
@@ -163,12 +200,18 @@ class TestReleaseResumeWithSpeculativeDecoding(CustomTestCase):
             engine.release_memory_occupation()
             engine.resume_memory_occupation()
 
+            hf_model = AutoModelForCausalLM.from_pretrained(
+                DEFAULT_TARGET_MODEL_EAGLE, torch_dtype=torch.bfloat16
+            )
+            self._push_target_weights(engine, list(hf_model.named_parameters()))
+            del hf_model
+
             engine.generate(self.PROMPT, sampling)
             accept_after = self._accept_length(engine)
             self.assertGreater(
                 accept_after,
                 accept_before - 0.3,
-                f"accept_length degraded across release/resume: "
+                f"accept_length degraded across release/resume+update: "
                 f"{accept_before:.2f} -> {accept_after:.2f}",
             )
         finally:

--- a/test/registered/rl/test_release_memory_occupation_spec.py
+++ b/test/registered/rl/test_release_memory_occupation_spec.py
@@ -1,0 +1,179 @@
+"""
+Test that speculative-decoding draft weights survive release/resume_memory_occupation.
+
+Without the draft stash/restore in SchedulerWeightUpdaterManager, releasing the
+WEIGHTS region discards the draft model and nothing ever restores it (the
+distributed weight-update path only writes the target), so accept_length
+silently collapses to ~1.0 after the first release/resume cycle — the exact
+lifecycle colocated RL frameworks run every training step.
+
+Two layers of coverage:
+- CPU unit tests for the stash/restore helpers and the manager orchestration
+  (no GPU, mock workers).
+- A GPU end-to-end test: EAGLE engine + memory saver, assert accept_length
+  does not degrade across release/resume.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE, GPU_MEMORY_TYPE_WEIGHTS
+from sglang.srt.managers.scheduler_components import weight_updater as wu
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE,
+    DEFAULT_TARGET_MODEL_EAGLE,
+    CustomTestCase,
+)
+
+register_cuda_ci(est_time=240, stage="base-b", runner_config="1-gpu-large")
+
+
+class _TinyModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4, bias=False)
+        self.register_buffer("cache", torch.arange(4, dtype=torch.float32))
+
+
+class TestDraftStashHelpers(CustomTestCase):
+    """CPU-only: _export_full_state / _import_full_state round-trip semantics."""
+
+    def test_roundtrip_params_and_buffers(self):
+        model = _TinyModule()
+        state = wu._export_full_state(model)
+        names = [n for n, _ in state["tensors"]]
+        self.assertIn("linear.weight", names)
+        self.assertIn("cache", names)
+
+        # clobber, then restore
+        with torch.no_grad():
+            model.linear.weight.fill_(0.0)
+            model.cache.fill_(-1.0)
+        failed = wu._import_full_state(model, state)
+        self.assertEqual(failed, [])
+        restored = dict(state["tensors"])
+        self.assertTrue(torch.equal(model.linear.weight.detach(), restored["linear.weight"]))
+        self.assertTrue(torch.equal(model.cache, restored["cache"]))
+
+    def test_two_phase_restore_retries_failed_tensors(self):
+        model = _TinyModule()
+        state = wu._export_full_state(model)
+        golden_cache = dict(state["tensors"])["cache"].clone()
+
+        # Failure contract: a tensor whose in-place copy raises (here via a
+        # shape mismatch, standing in for a still-paused region) is returned
+        # in `failed` instead of failing the whole restore.
+        state_bad = {"tensors": [("cache", torch.full((5,), 2.0))]}
+        failed = wu._import_full_state(model, state_bad)
+        self.assertEqual([n for n, _ in failed], ["cache"])
+
+        # Retry with the good tensor succeeds — the second phase of the
+        # two-phase restore.
+        failed = wu._import_full_state(model, {"tensors": [("cache", golden_cache)]})
+        self.assertEqual(failed, [])
+        self.assertTrue(torch.equal(model.cache, golden_cache))
+
+
+class TestManagerDraftOrchestration(CustomTestCase):
+    """CPU-only: release stashes the draft; resume restores it (mock workers)."""
+
+    def _make_manager(self, draft_model):
+        draft_worker = MagicMock()
+        draft_worker._draft_worker.draft_runner.model = draft_model
+        # match EAGLEWorkerV2 attribute layout probed by _get_draft_model_runner
+        draft_worker.draft_model_runner = None
+        target_model = _TinyModule()
+        tp_worker = MagicMock()
+        tp_worker.model_runner.model = target_model
+        manager = wu.SchedulerWeightUpdaterManager(
+            tp_worker=tp_worker,
+            draft_worker=draft_worker,
+            tp_cpu_group=MagicMock(),
+            memory_saver_adapter=MagicMock(),
+            flush_cache=MagicMock(return_value=True),
+            is_fully_idle=MagicMock(return_value=True),
+        )
+        return manager
+
+    def test_release_then_resume_restores_draft(self):
+        draft_model = _TinyModule()
+        golden = {k: v.clone() for k, v in draft_model.state_dict().items()}
+        manager = self._make_manager(draft_model)
+
+        release_req = MagicMock(tags=[GPU_MEMORY_TYPE_WEIGHTS, GPU_MEMORY_TYPE_KV_CACHE])
+        resume_req = MagicMock(tags=[GPU_MEMORY_TYPE_WEIGHTS, GPU_MEMORY_TYPE_KV_CACHE])
+
+        with patch.object(torch.distributed, "barrier"):
+            manager.release_memory_occupation(release_req)
+            self.assertIsNotNone(manager.stashed_draft_model_state)
+
+            # simulate the pause discarding draft contents
+            with torch.no_grad():
+                draft_model.linear.weight.fill_(0.0)
+                draft_model.cache.fill_(0.0)
+
+            manager.resume_memory_occupation(resume_req)
+
+        self.assertIsNone(manager.stashed_draft_model_state)
+        for k, v in draft_model.state_dict().items():
+            self.assertTrue(torch.equal(v, golden[k]), f"draft tensor {k} not restored")
+
+    def test_release_without_draft_worker_is_noop(self):
+        manager = self._make_manager(_TinyModule())
+        manager.draft_worker = None
+        with patch.object(torch.distributed, "barrier"):
+            manager.release_memory_occupation(MagicMock(tags=[GPU_MEMORY_TYPE_WEIGHTS]))
+        self.assertIsNone(manager.stashed_draft_model_state)
+
+
+class TestReleaseResumeWithSpeculativeDecoding(CustomTestCase):
+    """GPU e2e: accept_length must survive a release/resume cycle."""
+
+    PROMPT = "Explain, step by step, why the sky appears blue on a clear day."
+
+    def _accept_length(self, engine):
+        info = engine.get_server_info()
+        return info["internal_states"][0]["avg_spec_accept_length"]
+
+    def test_accept_length_survives_release_resume(self):
+        import sglang as sgl
+
+        engine = sgl.Engine(
+            model_path=DEFAULT_TARGET_MODEL_EAGLE,
+            speculative_algorithm="EAGLE",
+            speculative_draft_model_path=DEFAULT_DRAFT_MODEL_EAGLE,
+            speculative_num_steps=3,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=4,
+            enable_memory_saver=True,
+            mem_fraction_static=0.6,
+        )
+        try:
+            sampling = {"temperature": 0.0, "max_new_tokens": 128}
+            engine.generate(self.PROMPT, sampling)
+            accept_before = self._accept_length(engine)
+            self.assertGreater(
+                accept_before, 1.5, "speculative decoding not effective at baseline"
+            )
+
+            engine.release_memory_occupation()
+            engine.resume_memory_occupation()
+
+            engine.generate(self.PROMPT, sampling)
+            accept_after = self._accept_length(engine)
+            self.assertGreater(
+                accept_after,
+                accept_before - 0.3,
+                f"accept_length degraded across release/resume: "
+                f"{accept_before:.2f} -> {accept_after:.2f}",
+            )
+        finally:
+            engine.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Colocated RL frameworks (slime, verl, …) call `release_memory_occupation` / `resume_memory_occupation` on their rollout engines every training cycle. When speculative decoding (EAGLE / MTP) is enabled, this silently kills the draft model:

- `release` pauses the WEIGHTS memory-saver region — discarding **both** target and draft weights.
- On `resume`, the target is made whole again by `_export/_import_static_state` plus the caller's subsequent `update_weights_*` call.
- **Nothing ever restores the draft**: `update_weights_from_distributed` only writes `tp_worker` — unlike `update_weights_from_disk`/`from_ipc`, the distributed path has no draft-worker branch, so draft weights cannot arrive through it even when the trainer does train an MTP layer (Megatron-core supports MTP; typical RL actor configs, including ours, simply don't instantiate it).

Result: from the first post-resume rollout, the draft emits garbage and `spec_accept_length` collapses to ~1.0 — every proposal rejected, speculative decoding becomes pure overhead (we measured **+25% rollout time** vs speculation disabled). The failure is completely silent: no error, no warning, healthy-looking generation.

`--enable-draft-weights-cpu-backup` does **not** fix this: the CPU-backup flag acts at allocation (cudaMalloc segment) granularity, and draft tensors are commonly served from cached segments created earlier under the target's `backup=False` region config.

Note the codebase already special-cases the draft in `check_weights` and `update_weights_from_disk` — `release/resume` is the one pair that forgot it.

**Scope across update paths**: after `resume`, the draft is garbage regardless of which update path follows. `from_disk`/`from_ipc` deployments heal it incidentally (their draft branches fully reload the draft) — but only when a full update actually follows the resume; resume-without-update flows (eval pauses, elastic wake-ups) stay broken. The `from_distributed` path never heals it. This patch makes `resume` self-contained for all of them, and coexists safely with the disk/ipc draft reloads (restore first, overwrite later).

## Modifications

Single file: `scheduler_components/weight_updater.py` (+57).

1. On `release` (before any region is paused): stash the draft runner's parameters **and buffers** to CPU (`_export_full_state`, with a per-tensor guard for unclonable region-tied tensors).
2. On `resume(WEIGHTS)`: restore in place. Tensors tied to a still-paused region (e.g. FrozenKVMTP drafts hold a KV-region buffer) are collected and retried after `resume(KV_CACHE)` — two-phase restore.
3. Shared tensors (embeddings / lm_head) are restored first and then overwritten by the caller's `update_weights`, preserving the correct final state.

Uses the existing `_get_draft_model_runner` helper, so DFlash / FrozenKVMTP / EAGLEWorkerV2 layouts are all covered.

## Measurements

10 nodes × 8 B300, colocated GRPO (slime), 16-GPU dp-attention engines, FP8 weights+KV, per-cycle release/resume + distributed weight update:

| Model (draft type) | accept_length before → after | rollout time |
|---|---|---|
| DeepSeek-V3.2 (EAGLEWorkerV2) | 1.0006 → **2.60** | 335s → **179s (1.87×)** |
| GLM-5.2 (FrozenKVMTP; 1 KV-region buffer deferred to phase 2) | 1.0006 → **3.4–3.6** | stable across 8k–128k contexts |

Draft weight checksums verified **bit-exact** across release/resume via `/weights_checker` (1600/1600 entries unchanged; without the patch all drift).

Root-cause bisection (standalone healthy → debug-rollout-only healthy → lifecycle probes → checksum proof) available on request.

**Verified against current main** (B300, Qwen3-30B-A3B + EAGLE3 `Tengyunw/qwen3_30b_moe_eagle3`, RL-replica flow: release → resume → target-only weight update):

| Configuration | accept_length |
|---|---|
| with this fix | 1.85 → **2.0** ✅ |
| without fix | 1.85 → **1.0** ❌ |
| without fix, `--enable-draft-weights-cpu-backup` | 1.85 → **1.0** ❌ (flag confirmed ineffective on main too) |
| without fix, `--enable-weights-cpu-backup` (full region) | 1.85 → 1.85 (draft restored as a side effect — hence the test keeps this OFF; not viable for RL: full-model host backup per engine) |

**Side observation** (happy to file separately): the python `Engine.update_weights_from_tensor` API does not expose `disable_draft_model`, and the default routing (`draft_worker or tp_worker`) shape-asserts when target-only weights are pushed with a draft attached — RL users of the python API cannot express a target-only update today.

## Checklist

- [x] Format & compile checked
- [x] Validated end-to-end on two models / two draft-worker layouts
- [x] Tests added (`test/registered/rl/test_release_memory_occupation_spec.py`): CPU unit tests for the stash/restore helpers + manager orchestration (mock workers), and a GPU e2e asserting `avg_spec_accept_length` survives a release/resume cycle on an EAGLE engine. Written against the CI environment; not executed on the (GPU-less) dev machine.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29649165074](https://github.com/sgl-project/sglang/actions/runs/29649165074)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29649165005](https://github.com/sgl-project/sglang/actions/runs/29649165005)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
