### PR TITLE
[AMD] Fix DeepSeek MLA prefill shape mismatch on HIP eager fallback (missing mha_companion_layers)

### DIFF
--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -317,6 +317,7 @@ class EagerRunner(BaseRunner):
                         model_runner.moe_layers,
                         model_runner.moe_fusions,
                         dsa_indexers=model_runner.dsa_indexers,
+                        mha_companion_layers=model_runner.mha_companion_layers,
                     ),
                 ):
                     ret = model_runner.model.forward(


### PR DESCRIPTION

## Motivation
PR31391, DeepSeek MLA prefill on AMD (HIP) crashes when the prefill runner uses `tc_piecewise`:
    RuntimeError: shape '[-1, 16, 576]' is invalid for input of size 36003840
    
failed run : https://github.com/sgl-project/sglang/actions/runs/29644059344/job/88079191396
### Root cause
PR #31391 replaced the per-layer `_pcg_mha_companion` attribute (used to swap `attn_mqa` -> `attn_mha` so the attention backend sees the correct head/dim metadata on the MHA path, `save_kv_cache=False`) with a context-threaded `mha_companion_layers` list. It updated the three `set_tc_piecewise_forward_context(...)` call sites in `prefill_cuda_graph_runner.py`, but missed the HIP PCG eager-fallback call site in `eager_runner.py`.
On the AMD eager-fallback path `context.mha_companion_layers` is therefore `None`, so `unified_attention_with_output` in `radix_attention.py` never swaps to `attn_mha`. The backend then reshapes the MHA q (head_dim = qk_nope_head_dim + qk_rope_head_dim = 128 + 64 = 192) using `attn_mqa`'s `qk_head_dim` (kv_lora_rank + qk_rope_head_dim = 512 + 64 = 576), and the view fails (36003840 = 16 * 192 * 11720 is not divisible by 16 * 576).
## Modifications
Pass `mha_companion_layers=model_runner.mha_companion_layers` to `set_tc_piecewise_forward_context` in the HIP eager-fallback path of `eager_runner.py`, matching the three call sites already fixed in `prefill_cuda_graph_runner.py`. `model_runner.mha_companion_layers` is populated in `capture_prefill_graph` alongside `attention_layers` / `moe_layers` / `dsa_indexers`, and this branch is guarded by `pcg_runner is not None`, so the attribute is always available here.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29654131446](https://github.com/sgl-project/sglang/actions/runs/29654131446)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29654131305](https://github.com/sgl-project/sglang/actions/runs/29654131305)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->