### PR TITLE
feat: KVarN KV-cache compression for long-context inference

### DIFF
--- a/docker/kvarn-cpu-test.Dockerfile
+++ b/docker/kvarn-cpu-test.Dockerfile
@@ -1,0 +1,13 @@
+# Minimal CPU container for KVarN unit tests (config, sinkhorn, store, dequant).
+# No sglang installation required — the test conftest.shim handles imports.
+FROM python:3.12-slim
+
+WORKDIR /workspace/sglang
+
+RUN pip install --no-cache-dir --timeout 120 --retries 5 \
+    torch==2.6.0 \
+    pytest==8.3.4 \
+    numpy && \
+    pip install --no-cache-dir --timeout 120 --retries 5 triton==3.2.0
+
+CMD ["bash"]

--- a/docker/kvarn-gpu-test.Dockerfile
+++ b/docker/kvarn-gpu-test.Dockerfile
@@ -1,0 +1,28 @@
+# GPU test container for KVarN integration with SGLang.
+# Uses NVIDIA PyTorch base image for GPU + torch + triton support.
+#
+# Build:  docker build -t kvarn-gpu-test -f docker/kvarn-gpu-test.Dockerfile .
+# Run:    docker run --gpus all --rm -v $(pwd):/workspace/sglang kvarn-gpu-test \
+#             python -m pytest tests/kvarn/ -v --tb=short
+
+FROM nvcr.io/nvidia/pytorch:25.05-py3
+
+WORKDIR /workspace/sglang
+
+# Install sglang dependencies (lightweight — the base image already has torch + triton)
+RUN pip install --no-cache-dir \
+    pytest==8.3.4 \
+    requests \
+    pybase64 \
+    transformers \
+    huggingface_hub \
+    aiohttp
+
+# Install sglang in editable mode
+COPY python /workspace/sglang/python
+COPY sgl-kernel /workspace/sglang/sgl-kernel
+COPY scripts /workspace/sglang/scripts
+
+ENV PYTHONPATH=/workspace/sglang/python
+
+CMD ["bash"]

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1616,6 +1616,13 @@ def _attention_backend_default(view: Any) -> dict:
     ):  # override the default attention backend
         return {"attention_backend": view.prefill_attention_backend}
     if view.attention_backend is None:
+        # KVarN KV cache dtype requires the kvarn attention backend.
+        if view.kv_cache_dtype.startswith("kvarn_"):
+            logger.info(
+                f"KVarN KV cache dtype ({view.kv_cache_dtype}) detected. "
+                f"Using kvarn attention backend."
+            )
+            return {"attention_backend": "kvarn"}
         backend = view._get_default_attn_backend(
             view.use_mla_backend(), view.get_model_config()
         )
@@ -1863,6 +1870,27 @@ def _attention_backend_dual_chunk(view: Any) -> dict:
 
 @register_post_process
 def _page_size_default(view: Any) -> dict:
+    # KVarN requires page_size to match the tile group size, regardless
+    # of whether another subsystem (e.g. DSA) already set it.
+    if view.kv_cache_dtype.startswith("kvarn_"):
+        from sglang.srt.layers.quantization.kvarn.config import (
+            KVARN_PRESETS,
+        )
+        preset = KVARN_PRESETS.get(view.kv_cache_dtype, {})
+        kvarn_group = preset.get("group", 128)
+        if view.page_size != kvarn_group:
+            logger.info(
+                f"Overriding page_size={view.page_size} -> {kvarn_group} "
+                f"for KVarN (kv_cache_dtype={view.kv_cache_dtype})."
+            )
+            return {"page_size": kvarn_group}
+        else:
+            logger.info(
+                f"Setting page_size={view.page_size} for KVarN "
+                f"(kv_cache_dtype={view.kv_cache_dtype})."
+            )
+        return {}
+
     if view.page_size is not None:
         return {}
 

--- a/python/sglang/srt/configs/mamba_utils.py
+++ b/python/sglang/srt/configs/mamba_utils.py
@@ -65,7 +65,15 @@ def mamba2_state_dtype(config=None) -> Mamba2StateDType:
         "bfloat16": torch.bfloat16,
         "float16": torch.float16,
     }
-    conv_dtype = dtype_map.get(envs.SGLANG_MAMBA_CONV_DTYPE.get(), torch.bfloat16)
+    # Default conv dtype matches the model dtype to avoid Triton kernel
+    # type mismatches (e.g. bf16 conv state vs fp16 model input).
+    # Override via SGLANG_MAMBA_CONV_DTYPE env var.
+    default_conv_dtype = torch.bfloat16
+    if config is not None:
+        cfg_dtype = getattr(getattr(config, "text_config", config), "dtype", None)
+        if cfg_dtype == "float16" or cfg_dtype == torch.float16:
+            default_conv_dtype = torch.float16
+    conv_dtype = dtype_map.get(envs.SGLANG_MAMBA_CONV_DTYPE.get(), default_conv_dtype)
 
     # Get SSM dtype: default -> config -> env var
     ssm_dtype = torch.float32  # Step 1: Default value

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -172,6 +172,36 @@ def create_triton_backend(runner):
     return TritonAttnBackend(runner)
 
 
+@register_attention_backend("kvarn")
+def create_kvarn_backend(runner):
+    """KVarN attention backend — wraps Triton with Hadamard rotation.
+
+    Requires ``--kv-cache-dtype kvarn_*`` to be set.
+    """
+    assert not runner.model_config.is_encoder_decoder, (
+        "Cross attention is not supported in the KVarN attention backend."
+    )
+    assert runner.server_args.kv_cache_dtype.startswith("kvarn_"), (
+        "KVarN attention backend requires --kv-cache-dtype kvarn_*"
+    )
+    from sglang.srt.layers.attention.kvarn_backend import KVarNAttnBackend
+    from sglang.srt.layers.quantization.kvarn.config import KVarNConfig
+
+    kvarn_config = KVarNConfig.from_cache_dtype(
+        runner.server_args.kv_cache_dtype,
+        head_dim=runner.model_config.head_dim,
+    )
+    backend = KVarNAttnBackend(runner, kvarn_config)
+
+    # Wire up HiCache support: let the NoOp pool call back to the KVarN
+    # backend for get_cpu_copy / load_cpu_copy (KV save/restore on evict).
+    token_to_kv_pool = getattr(runner, "token_to_kv_pool", None)
+    if token_to_kv_pool is not None and hasattr(token_to_kv_pool, "set_kvarn_backend"):
+        token_to_kv_pool.set_kvarn_backend(backend)
+
+    return backend
+
+
 @register_attention_backend("torch_native")
 def create_torch_native_backend(runner):
     from sglang.srt.layers.attention.torch_native_backend import TorchNativeAttnBackend

--- a/python/sglang/srt/layers/attention/kvarn_backend.py
+++ b/python/sglang/srt/layers/attention/kvarn_backend.py
@@ -1,0 +1,1608 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN attention backend for SGLang.
+
+Implements compressed KV-cache attention with a dual-pool architecture
+matching the KVarN algorithm:
+
+  1. **Hadamard rotation** of Q, K, V before attention and storage.
+  2. **Tail pool** (fp16, small): stores ROTATED K/V for in-progress blocks
+     and sink blocks. Each block occupies one tail-pool slot:
+     ``[pool_slots, group, num_kv_heads, head_dim]``.
+  3. **Compressed cache** (int4, uint8): stores flushed (fully-written) blocks
+     as quantized tiles: ``[num_blocks, num_kv_heads, tile_bytes]`` per layer.
+  4. **Block-to-slot mapping**: translates scheduler page block_ids to
+     tail-pool slots. Flushed blocks have their slot freed and live in int4.
+  5. **Decode/Extend**: gather K/V from both sources (int4 dequant + fp16 tail
+     pool), un-rotate, then run SDPA per request. This is the "slow path"
+     (materialize + SDPA) — the fused Triton kernel is future work.
+  6. **Un-rotate** the output after attention.
+
+The scheduler sees ``max_total_num_tokens = num_blocks * page_size`` — the
+compressed cache capacity — while the actual GPU memory is dominated by the
+small fp16 tail pool + the int4 compressed cache, yielding the 3.5×
+compression ratio. The standard ``token_to_kv_pool`` is a NoOp pool (large
+logical size, tiny physical allocation) used only for the scheduler's
+capacity accounting; the real K/V storage lives in the KVarN backend's
+tail pool and compressed cache.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.quantization.kvarn.config import KVarNConfig
+from sglang.srt.layers.quantization.kvarn.flush_manager import KVarNFlushManager
+from sglang.srt.layers.quantization.kvarn.hadamard import build_hadamard
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+logger = logging.getLogger(__name__)
+
+# Number of sink blocks (first pages) kept in fp16 tail pool, never flushed.
+# Default: 1 sink block = first page.
+KVaRN_SINK_BLOCKS = 1
+
+
+class KVarNAttnBackend(AttentionBackend):
+    """KVarN attention backend with dual-pool (tail + int4) architecture."""
+
+    needs_cpu_seq_lens: bool = False
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        """Block sizes (page sizes) the KVarN kernels support."""
+        return [128, 64]
+
+    @staticmethod
+    def get_preferred_block_size() -> int:
+        """Preferred block size for KVarN — matches the tile group size."""
+        return 128
+
+    @staticmethod
+    def supports_head_size(head_size: int) -> bool:
+        """KVarN supports power-of-2 head dimensions (Hadamard requirement)."""
+        return head_size > 0 and (head_size & (head_size - 1)) == 0
+
+    @staticmethod
+    def supports_kv_cache_dtype(kv_cache_dtype: str) -> bool:
+        """Check if a kv_cache_dtype string is supported by KVarN."""
+        return kv_cache_dtype.startswith("kvarn_")
+
+    def __init__(
+        self, model_runner: ModelRunner, kvarn_config: Optional[KVarNConfig] = None
+    ):
+        super().__init__()
+
+        self.model_runner = model_runner
+        self.server_args = model_runner.server_args
+        self.device = model_runner.device
+
+        # Expose pool references for the scheduler / hybrid backend.
+        # The token_to_kv_pool is a NoOpMHATokenToKVPool (large logical size,
+        # tiny physical allocation) — real K/V storage lives in the KVarN
+        # backend's tail pool + int4 compressed cache.
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
+        self.req_to_token_pool = model_runner.req_to_token_pool
+
+        # Get KVarN config
+        if kvarn_config is not None:
+            kvarn_cfg = kvarn_config
+        else:
+            kvarn_cfg = getattr(model_runner, "kvarn_config", None)
+            if kvarn_cfg is None:
+                quant_config = getattr(model_runner, "quant_config", None)
+                if quant_config is not None:
+                    kvarn_cfg = getattr(quant_config, "kvarn_config", None)
+
+        if kvarn_cfg is None:
+            raise RuntimeError(
+                "KVarNAttnBackend requires a KVarNConfig. "
+                "Set --quantization kvarn-k4v4g128 or similar."
+            )
+        self.cfg: KVarNConfig = kvarn_cfg
+        self.group = self.cfg.group
+
+        # Validate head_dim — KVarN supports power-of-2 head dims
+        model_config = model_runner.model_config
+        if model_config.head_dim & (model_config.head_dim - 1) != 0:
+            raise RuntimeError(
+                f"KVarN requires power-of-2 head_dim, got {model_config.head_dim}"
+            )
+
+        # Model config
+        model_config = model_runner.model_config
+        self.num_heads = (
+            model_config.get_total_num_attention_heads() // model_runner.ps.tp_size
+        )
+        self.num_kv_heads = model_config.get_num_kv_heads(model_runner.ps.tp_size)
+        self.head_dim = model_config.head_dim
+        self.v_head_dim = model_config.v_head_dim
+        if self.v_head_dim is None:
+            self.v_head_dim = self.head_dim
+        self.scale = (
+            float(model_config.scaling)
+            if hasattr(model_config, "scaling")
+            else 1.0 / (self.head_dim**0.5)
+        )
+
+        # For hybrid models (e.g. Qwen3.5 GDN), only the full-attention layers
+        # use the KV cache.  Linear/SSM layers have their own state and must NOT
+        # be allocated compressed-cache buffers — otherwise we waste 4x memory
+        # on models where 48/64 layers are linear attention.
+        # Check both model_config and the HF config (hybrid GDN models like
+        # Qwen3.5 expose full_attention_layer_ids on the HF config, not on
+        # model_config since they're not "hybrid SWA" models).
+        full_attn_ids = getattr(model_config, "full_attention_layer_ids", None)
+        if full_attn_ids is None:
+            # Hybrid GDN models (Qwen3.5) expose full_attention_layer_ids on
+            # the HF text config, not on model_config.
+            hf_config = getattr(model_config, "hf_config", None)
+            if hf_config is not None:
+                text_config = getattr(hf_config, "text_config", hf_config)
+                full_attn_ids = getattr(text_config, "full_attention_layer_ids", None)
+        if full_attn_ids is not None and len(full_attn_ids) > 0:
+            self.num_layers = len(full_attn_ids)
+            self.full_attn_layer_ids = list(full_attn_ids)
+            # Map absolute layer_id -> compressed-cache index (0..N-1)
+            self._layer_id_to_idx = {lid: i for i, lid in enumerate(full_attn_ids)}
+        else:
+            self.num_layers = model_config.num_attention_layers
+            self.full_attn_layer_ids = None
+            self._layer_id_to_idx = None  # identity mapping
+
+        # Hadamard rotation matrix (shared across all layers)
+        self._H: Optional[torch.Tensor] = None  # [D, D] fp32, lazy
+
+        # Tail pool: per-layer fp16 buffers
+        # Allocated in _init_pools, called from init_forward_metadata
+        self.tail_K: list[torch.Tensor] = (
+            []
+        )  # [num_layers][pool_slots, group, Hk, D] fp16
+        self.tail_V: list[torch.Tensor] = []
+        self.pool_slots = 0
+
+        # Compressed cache: per-layer uint8 buffers
+        self.kv_cache_int4: list[torch.Tensor] = (
+            []
+        )  # [num_layers][num_blocks, Hk, tile_bytes] uint8
+        self.num_blocks = 0
+
+        # Block-to-slot mapping
+        self._block_to_slot: dict[int, int] = {}  # block_id -> tail pool slot
+        self._slot_to_block: dict[int, int] = {}  # tail pool slot -> block_id
+        self._free_slots: list[int] = []
+        self._block_fill: dict[int, int] = {}  # block_id -> token count in tail pool
+
+        # Sink blocks: block_ids that stay in fp16, never flushed
+        self._sink_block_ids: set[int] = set()
+        # Retired sinks: finished requests' sink blocks, kept fp16-resident
+        # for future prefix-cache hits. Lazily evicted (flushed to int4) when
+        # pool slots run dry, oldest first.
+        self._retired_sinks: dict[int, None] = {}
+
+        # Flush manager
+        self.flush_manager = KVarNFlushManager(
+            cfg=self.cfg,
+            num_layers=self.num_layers,
+            num_kv_heads=self.num_kv_heads,
+            head_dim=self.head_dim,
+            v_head_dim=self.v_head_dim,
+            sink_blocks=KVaRN_SINK_BLOCKS,
+        )
+
+        # Page size (= group)
+        self.page_size = model_runner.page_size
+
+        logger.info(
+            f"KVarNAttnBackend: group={self.group}, num_kv_heads={self.num_kv_heads}, "
+            f"head_dim={self.head_dim}, num_layers={self.num_layers}, "
+            f"full_attn_layer_ids={self.full_attn_layer_ids}, "
+            f"pool_slots={self.pool_slots} (allocated later), "
+            f"page_size={self.page_size}"
+        )
+
+    def _li(self, layer_id: int) -> int:
+        """Map absolute layer_id to compressed-cache index."""
+        if self._layer_id_to_idx is not None:
+            return self._layer_id_to_idx[layer_id]
+        return layer_id
+
+    def _get_hadamard(self, device: torch.device) -> torch.Tensor:
+        """Get or build the Hadamard rotation matrix."""
+        if self._H is None or self._H.device != device:
+            self._H = build_hadamard(self.head_dim, device)
+        return self._H
+
+    def _init_pools(self):
+        """Allocate tail pool and compressed cache tensors."""
+        if self.pool_slots > 0:
+            return  # Already initialized
+
+        # Cache SM count for split-K auto-enable heuristic in the Triton kernel.
+        if not hasattr(self, "_sm_count") or self._sm_count == 0:
+            self._sm_count = torch.cuda.get_device_properties(
+                self.device
+            ).multi_processor_count
+
+        mr = self.model_runner
+        max_running = mr.server_args.max_running_requests or 256
+        max_prefill_tokens = mr.server_args.max_prefill_tokens or 16384
+
+        # Tail pool size: 2 * max_running (sink + in-progress tail per request)
+        # + prefill_blocks + headroom.
+        prefill_blocks = (max_prefill_tokens + self.group - 1) // self.group
+        self.pool_slots = max(2 * max_running + prefill_blocks + 8, 8)
+
+        # Compressed cache: one slot per scheduler page
+        self.num_blocks = mr.max_total_num_tokens // self.page_size
+
+        device = self.device
+
+        # Allocate per-layer tail pool buffers
+        self.tail_K = []
+        self.tail_V = []
+        for _ in range(self.num_layers):
+            self.tail_K.append(
+                torch.zeros(
+                    self.pool_slots,
+                    self.group,
+                    self.num_kv_heads,
+                    self.head_dim,
+                    dtype=torch.float16,
+                    device=device,
+                )
+            )
+            self.tail_V.append(
+                torch.zeros(
+                    self.pool_slots,
+                    self.group,
+                    self.num_kv_heads,
+                    self.v_head_dim,
+                    dtype=torch.float16,
+                    device=device,
+                )
+            )
+
+        # Allocate per-layer compressed cache buffers
+        self.kv_cache_int4 = []
+        tile_bytes = self.cfg.tile_bytes_aligned
+        for _ in range(self.num_layers):
+            self.kv_cache_int4.append(
+                torch.zeros(
+                    self.num_blocks,
+                    self.num_kv_heads,
+                    tile_bytes,
+                    dtype=torch.uint8,
+                    device=device,
+                )
+            )
+
+        # Initialize free slots
+        self._free_slots = list(range(self.pool_slots))
+
+        # Block-to-slot GPU lookup tensor (used by Triton kernels)
+        self._block_lookup_size = self.num_blocks
+        self._block_to_slot_t = torch.full(
+            (self.num_blocks,),
+            -1,
+            dtype=torch.int32,
+            device=device,
+        )
+
+        # Store tail pool strides for Triton kernel launches
+        self._tail_K_stride0 = self.tail_K[0].stride(0)
+        self._tail_K_stride1 = self.tail_K[0].stride(1)
+        self._tail_K_stride2 = self.tail_K[0].stride(2)
+
+        # Pre-allocated rotation scratch (avoids allocation during CUDA graph capture)
+        max_batched_tokens = mr.server_args.max_prefill_tokens or 16384
+        self._k_rot_scratch = torch.empty(
+            max_batched_tokens,
+            self.num_kv_heads,
+            self.head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+        self._v_rot_scratch = torch.empty_like(self._k_rot_scratch)
+
+        # Cached fp16 Hadamard for fast matmul in store path
+        self._H_fp16 = self._get_hadamard(device).to(torch.float16).contiguous()
+
+        # Pre-allocated Q rotation buffer (CUDA graph capture-safe)
+        # The decode driver reshapes Q from [B, Hq, D] to [B*Hq, D] and does
+        # torch.mm(q_flat, H16) → [B*Hq, D]. So the buffer must be sized
+        # [max_decode_rows, D] where max_decode_rows = max_running * Hq
+        # (sized for max decode batch).
+        max_decode_tokens = max(max_running * 1, 1)
+        max_prefill = max_prefill_tokens or 16384
+        # Decode: B*Hq rows of D; Prefill: max_prefill rows of D.
+        # Take the max of both to cover any code path.
+        max_decode_rows = max(max_decode_tokens * self.num_heads, max_prefill)
+        self._q_rot_fp16_buf = torch.empty(
+            max_decode_rows,
+            self.head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+
+        # Pre-allocated fused-decode output + split-K mid buffers
+        # (CUDA graph capture-safe; reused across layers + steps).
+        # Sized for the decode regime: max_running * Hq rows (flat N = B*Hq).
+        # Layout: mid_o is [N, max_splits, D], mid_lse is [N, max_splits].
+        _max_n = max(max_running * self.num_heads, 1)
+        from sglang.srt.layers.attention.kvarn_ops.triton_decode import (
+            KVARN_MAX_KV_SPLITS,
+        )
+
+        self._fused_out_buf = torch.empty(
+            _max_n,
+            self.head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+        self._mid_o_buf = torch.empty(
+            _max_n,
+            KVARN_MAX_KV_SPLITS,
+            self.head_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+        self._mid_lse_buf = torch.empty(
+            _max_n,
+            KVARN_MAX_KV_SPLITS,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        logger.info(
+            f"KVarN pools allocated: tail_pool_slots={self.pool_slots}, "
+            f"compressed_blocks={self.num_blocks}, "
+            f"tail_pool_bytes={self.pool_slots * self.group * self.num_kv_heads * self.head_dim * 2 * self.num_layers / 1e9:.2f} GB, "
+            f"compressed_cache_bytes={self.num_blocks * tile_bytes * self.num_kv_heads * self.num_layers / 1e9:.2f} GB"
+        )
+
+    def _alloc_slot(self, block_id: int) -> int:
+        """Allocate a tail pool slot for a block.
+
+        If no free slots are available, evicts the oldest retired sink
+        (flushes it to int4 so future prefix-cache hits still find a valid
+        tile) and reuses its slot.
+        """
+        if not self._free_slots:
+            # Evict oldest retired sink
+            if self._retired_sinks:
+                old = next(iter(self._retired_sinks))
+                self._retired_sinks.pop(old)
+                self._flush_block(old)
+                self._sink_block_ids.discard(old)
+            if not self._free_slots:
+                raise RuntimeError("KVarN tail pool exhausted — no free slots")
+        slot = self._free_slots.pop()
+        self._block_to_slot[block_id] = slot
+        self._slot_to_block[slot] = block_id
+        self._block_fill[block_id] = 0
+        # Update GPU lookup tensor
+        if self._block_to_slot_t is not None and block_id < self._block_lookup_size:
+            self._block_to_slot_t[block_id] = slot
+        return slot
+
+    def _free_slot(self, block_id: int):
+        """Free a tail pool slot (block has been flushed to int4)."""
+        slot = self._block_to_slot.pop(block_id, None)
+        if slot is not None:
+            self._slot_to_block.pop(slot, None)
+            self._block_fill.pop(block_id, None)
+            self._free_slots.append(slot)
+            # Update GPU lookup tensor: -1 means block is in int4 cache
+            if self._block_to_slot_t is not None and block_id < self._block_lookup_size:
+                self._block_to_slot_t[block_id] = -1
+
+    def get_slot_for_block(self, block_id: int) -> Optional[int]:
+        """Get the tail pool slot for a block, or None if flushed."""
+        return self._block_to_slot.get(block_id)
+
+    def get_kv_cache_int4(self, layer_id: int) -> torch.Tensor:
+        """Get the compressed int4 cache tensor for a layer."""
+        return self.kv_cache_int4[self._li(layer_id)]
+
+    def get_tail_pool(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Get the tail pool K/V tensors for a layer."""
+        li = self._li(layer_id)
+        return self.tail_K[li], self.tail_V[li]
+
+    # ── AttentionBackend interface ─────────────────────────────────────────
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        """Eager entry point. Initialize pools, flush blocks, allocate slots."""
+        if self.pool_slots == 0:
+            self._init_pools()
+
+        # Flush any full blocks from the tail pool to int4 cache.
+        self._maybe_flush_blocks(forward_batch)
+
+        # Pre-allocate tail pool slots for new blocks
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if out_cache_loc is not None:
+            self._ensure_slots_for_tokens(out_cache_loc)
+
+    def init_forward_metadata_out_graph(
+        self,
+        forward_batch: ForwardBatch,
+        in_capture: bool = False,
+    ):
+        """Per-iter metadata prep (outside graph). Allocates slots, flushes
+        blocks, and fills static block_table/seq_lens/cu_seqlens buffers."""
+        if self.pool_slots == 0:
+            self._init_pools()
+
+        # Flush full blocks from tail pool to int4 cache
+        self._maybe_flush_blocks(forward_batch)
+
+        # Pre-allocate tail pool slots for new blocks in this batch
+        # (must happen before the captured forward_decode scatter store)
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if out_cache_loc is not None:
+            self._ensure_slots_for_tokens(out_cache_loc)
+
+        # Build block_table/seq_lens/cu_seqlens into static buffers
+        if hasattr(self, "_cg_block_table"):
+            self._fill_cg_buffers(forward_batch)
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
+        """Graph-recordable GPU ops. No-op — the fused decode kernel reads
+        from static buffers filled in init_forward_metadata_out_graph."""
+        pass
+
+    def _fill_cg_buffers(self, forward_batch: ForwardBatch):
+        """Fill pre-allocated CUDA graph buffers with current batch data."""
+        B = forward_batch.batch_size
+        if B > self._cg_max_batch_size:
+            raise RuntimeError(
+                f"Batch size {B} exceeds CUDA graph max {self._cg_max_batch_size}"
+            )
+
+        seq_lens = forward_batch.seq_lens
+        req_pool_indices = forward_batch.req_pool_indices
+        req_to_token = self.model_runner.req_to_token_pool.req_to_token
+
+        # Zero-fill unused entries
+        self._cg_block_table[:B].zero_()
+        self._cg_seq_lens[:B].zero_()
+        self._cg_cu_seqlens.zero_()
+
+        if B > 0:
+            # Fill seq_lens
+            self._cg_seq_lens[:B] = seq_lens.to(torch.int32)[:B]
+
+            # Vectorized block_table construction
+            max_blocks = min(self._cg_max_blocks, self._cg_block_table.shape[1])
+            col_offsets = torch.arange(max_blocks, device=self.device) * self.page_size
+            req_indices = req_pool_indices.long()
+            token_positions = col_offsets.unsqueeze(0).expand(B, max_blocks)
+            max_token_pos = req_to_token.shape[1] - 1
+            token_positions = token_positions.clamp(max=max_token_pos)
+            slots = req_to_token[req_indices.unsqueeze(1), token_positions]
+            self._cg_block_table[:B, :max_blocks] = (slots // self.page_size).to(
+                torch.int32
+            )
+
+            # Fill cu_seqlens
+            self._cg_cu_seqlens[1 : B + 1] = torch.cumsum(self._cg_seq_lens[:B], dim=0)
+
+    def init_cuda_graph_state(self, max_batch_size: int, max_num_token: int):
+        """Pre-allocate CUDA graph state (static buffers for block_table, etc.)."""
+        if self.pool_slots == 0:
+            self._init_pools()
+
+        # Pre-allocate static buffers for CUDA graph
+        max_blocks_per_req = max(
+            self.model_runner.model_config.context_len // self.page_size, 1
+        )
+        self._cg_block_table = torch.zeros(
+            max_batch_size,
+            max_blocks_per_req,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self._cg_seq_lens = torch.zeros(
+            max_batch_size, dtype=torch.int32, device=self.device
+        )
+        self._cg_cu_seqlens = torch.zeros(
+            max_batch_size + 1, dtype=torch.int32, device=self.device
+        )
+        self._cg_max_batch_size = max_batch_size
+        self._cg_max_blocks = max_blocks_per_req
+
+        # Warm up scatter store kernel (fast). The fused decode kernel has
+        # autotuning configs that can take a long time on first run — let
+        # it autotune during normal serving (first request is slow, then fast).
+        self._warmup_kernels(max_batch_size, max_blocks_per_req)
+
+    def _warmup_kernels(self, max_batch_size: int, max_blocks_per_req: int):
+        """Warm up all Triton kernels with dummy inputs to trigger JIT compilation."""
+        from sglang.srt.layers.attention.kvarn_ops.triton_decode import (
+            kvarn_decode_attention,
+            kvarn_scatter_store,
+        )
+
+        device = self.device
+        B = min(max_batch_size, 4)
+        D = self.head_dim
+        Hk = self.num_kv_heads
+        Hq = self.num_heads
+        G = self.group
+
+        # Warm up scatter store
+        dummy_k = torch.zeros(B, Hk, D, dtype=torch.float16, device=device)
+        dummy_v = torch.zeros(B, Hk, D, dtype=torch.float16, device=device)
+        dummy_loc = torch.zeros(B, dtype=torch.int32, device=device)
+        kvarn_scatter_store(
+            dummy_k,
+            dummy_v,
+            dummy_loc,
+            self._block_to_slot_t,
+            self.tail_K[0],
+            self.tail_V[0],
+            G,
+            D,
+            self._block_lookup_size,
+        )
+
+        # Warm up fused decode
+        dummy_q = torch.zeros(B, Hq, D, dtype=torch.float16, device=device)
+        dummy_bt = torch.zeros(B, max_blocks_per_req, dtype=torch.int32, device=device)
+        dummy_sl = torch.ones(B, dtype=torch.int32, device=device)
+        dummy_cs = torch.zeros(B + 1, dtype=torch.int32, device=device)
+        dummy_cs[1:] = torch.cumsum(dummy_sl, dim=0)
+        try:
+            _ = kvarn_decode_attention(
+                query=dummy_q,
+                kv_cache=self.kv_cache_int4[0],
+                tail_K=self.tail_K[0],
+                tail_V=self.tail_V[0],
+                hadamard=self._H_fp16.float(),
+                scale=self.scale,
+                cfg=self.cfg,
+                impl=self,
+                block_table=dummy_bt,
+                seq_lens=dummy_sl,
+                cu_seqlens=dummy_cs,
+            )
+        except Exception as e:
+            logger.warning(f"KVarN kernel warmup failed (non-fatal): {e}")
+
+        logger.info("KVarN Triton kernels warmed up")
+
+    def get_cuda_graph_seq_len_fill_value(self) -> int:
+        return 1
+
+    def clear(self):
+        """Clear all mappings. Called when the scheduler resets."""
+        self._block_to_slot.clear()
+        self._slot_to_block.clear()
+        self._block_fill.clear()
+        self._free_slots = list(range(self.pool_slots))
+        self._sink_block_ids.clear()
+        self._retired_sinks.clear()
+
+    # ── Forward methods ─────────────────────────────────────────────────────
+
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        sinks=None,
+    ) -> torch.Tensor:
+        """Decode forward: one token per request.
+
+        Uses the fused Triton decode kernel when KVARN_FUSED_DECODE=1 (default):
+        dequant int4 in registers + online-softmax flash-decode.
+        Falls back to Python gather + SDPA when KVARN_FUSED_DECODE=0.
+        """
+        from sglang.srt.layers.attention.kvarn_ops.triton_decode import (
+            kvarn_decode_attention,
+            kvarn_scatter_store,
+        )
+
+        layer_id = layer.layer_id
+        N = q.shape[0]
+        H = self._get_hadamard(self.device)
+
+        q_3d = q.view(N, self.num_heads, self.head_dim)
+        k_3d = k.view(N, self.num_kv_heads, self.head_dim)
+        v_3d = v.view(N, self.num_kv_heads, self.v_head_dim)
+
+        # Store K/V to tail pool (slots already allocated in init_forward_metadata_out_graph)
+        if save_kv_cache:
+            use_triton_store = True
+            if use_triton_store:
+                # Use pre-allocated scratch + cached fp16 Hadamard (capture-safe)
+                k_rot = self._k_rot_scratch[:N]
+                v_rot = self._v_rot_scratch[:N]
+                torch.matmul(k_3d.to(torch.float16), self._H_fp16, out=k_rot)
+                torch.matmul(v_3d.to(torch.float16), self._H_fp16, out=v_rot)
+                kvarn_scatter_store(
+                    k_rot,
+                    v_rot,
+                    forward_batch.out_cache_loc.to(torch.int32),
+                    self._block_to_slot_t,
+                    self.tail_K[self._li(layer_id)],
+                    self.tail_V[self._li(layer_id)],
+                    self.group,
+                    self.head_dim,
+                    self._block_lookup_size,
+                )
+            else:
+                self._store_to_tail_pool(
+                    layer_id, k_3d, v_3d, forward_batch.out_cache_loc
+                )
+
+        use_fused_decode = True
+        if use_fused_decode:
+            # Fused Triton decode kernel
+            # Use static CUDA graph buffers if available, otherwise build fresh
+            if hasattr(self, "_cg_block_table") and N <= self._cg_max_batch_size:
+                block_table = self._cg_block_table[:N]
+                seq_lens_t = self._cg_seq_lens[:N]
+                cu_seqlens = self._cg_cu_seqlens[: N + 1]
+            else:
+                block_table, seq_lens_t, cu_seqlens = self._build_block_table(
+                    forward_batch
+                )
+
+            out = kvarn_decode_attention(
+                query=q_3d,
+                kv_cache=self.kv_cache_int4[self._li(layer_id)],
+                tail_K=self.tail_K[self._li(layer_id)],
+                tail_V=self.tail_V[self._li(layer_id)],
+                hadamard=H,
+                scale=self.scale,
+                cfg=self.cfg,
+                impl=self,
+                block_table=block_table,
+                seq_lens=seq_lens_t,
+                cu_seqlens=cu_seqlens,
+                sliding_window=(
+                    getattr(layer, "sliding_window_size", -1)
+                    if getattr(layer, "sliding_window_size", -1) > 0
+                    else 0
+                ),
+            )
+
+            return out.view(N, self.num_heads * self.head_dim)
+        else:
+            # Python gather + SDPA fallback
+            q_rot = (q_3d.float() @ H).to(q.dtype)
+            out = torch.empty(
+                N, self.num_heads, self.head_dim, dtype=q.dtype, device=q.device
+            )
+            req_pool_indices = forward_batch.req_pool_indices
+            seq_lens = forward_batch.seq_lens
+            req_to_token = self.model_runner.req_to_token_pool.req_to_token
+
+            for i in range(N):
+                req_idx = int(req_pool_indices[i].item())
+                seq_len = int(seq_lens[i].item())
+                block_ids = self._get_block_ids_for_request(
+                    req_idx, seq_len, req_to_token
+                )
+                K_full, V_full = self._gather_request_kv(layer_id, block_ids, seq_len)
+
+                q_i = q_rot[i : i + 1].transpose(0, 1).unsqueeze(0).float()
+                K_t = K_full.transpose(0, 1).unsqueeze(0).float()
+                V_t = V_full.transpose(0, 1).unsqueeze(0).float()
+                o = F.scaled_dot_product_attention(
+                    q_i,
+                    K_t,
+                    V_t,
+                    is_causal=False,
+                    scale=self.scale,
+                    enable_gqa=self.num_kv_heads < self.num_heads,
+                )
+                o = o[0, :, 0, :].to(q.dtype)
+                out[i] = (o.float() @ H.T).to(q.dtype)
+
+            return out.view(N, self.num_heads * self.head_dim)
+
+    def forward_extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        sinks=None,
+    ) -> torch.Tensor:
+        """Extend forward: prefill, chunked-prefill, or target_verify.
+
+        For target_verify (speculative decode), uses the fused verify kernel
+        (kvarn_verify_attention) which reads int4 + fp16 pool directly per
+        token with VQ_INDIRECT=True — no fp16 materialization.
+
+        For prefill/extend, uses build_packed_kv Triton kernel + SDPA.
+        """
+        from sglang.srt.layers.attention.kvarn_ops.triton_decode import (
+            _kvarn_build_packed_kv_kernel,
+            kvarn_scatter_store,
+        )
+
+        layer_id = layer.layer_id
+        N = q.shape[0]
+        H = self._get_hadamard(self.device)
+
+        q_3d = q.view(N, self.num_heads, self.head_dim)
+        k_3d = k.view(N, self.num_kv_heads, self.head_dim)
+        v_3d = v.view(N, self.num_kv_heads, self.v_head_dim)
+
+        # Store K/V to tail pool (slots already allocated in init_forward_metadata_out_graph)
+        if save_kv_cache:
+            use_triton_store = True
+            if use_triton_store:
+                k_rot = self._k_rot_scratch[:N]
+                v_rot = self._v_rot_scratch[:N]
+                torch.matmul(k_3d.to(torch.float16), self._H_fp16, out=k_rot)
+                torch.matmul(v_3d.to(torch.float16), self._H_fp16, out=v_rot)
+                kvarn_scatter_store(
+                    k_rot,
+                    v_rot,
+                    forward_batch.out_cache_loc.to(torch.int32),
+                    self._block_to_slot_t,
+                    self.tail_K[self._li(layer_id)],
+                    self.tail_V[self._li(layer_id)],
+                    self.group,
+                    self.head_dim,
+                    self._block_lookup_size,
+                )
+            else:
+                self._store_to_tail_pool(
+                    layer_id, k_3d, v_3d, forward_batch.out_cache_loc
+                )
+
+        # Check if this is a target_verify (speculative decode) batch
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_verify = (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_target_verify")
+            and forward_mode.is_target_verify()
+        )
+
+        if is_verify:
+            return self._fused_verify_path(q_3d, layer, forward_batch, H)
+
+        # Rotate Q
+        q_rot = (q_3d.float() @ H).to(torch.float16)
+
+        # Normal extend path: build_packed_kv + flash_attn_varlen
+        # Build block_table, seq_lens, cu_seqlens
+        block_table, seq_lens_t, cu_seqlens = self._build_block_table(forward_batch)
+
+        # Materialize K/V via build_packed_kv Triton kernel
+        B = forward_batch.batch_size
+        max_blocks = block_table.shape[1]
+        total_tokens = int(cu_seqlens[-1].item())
+
+        K_packed = torch.empty(
+            total_tokens,
+            self.num_kv_heads,
+            self.head_dim,
+            dtype=torch.float16,
+            device=self.device,
+        )
+        V_packed = torch.empty(
+            total_tokens,
+            self.num_kv_heads,
+            self.v_head_dim,
+            dtype=torch.float16,
+            device=self.device,
+        )
+
+        use_triton_extend = True
+
+        if use_triton_extend and total_tokens > 0:
+            _kvarn_build_packed_kv_kernel[(B * max_blocks, self.num_kv_heads)](
+                block_table,
+                seq_lens_t,
+                cu_seqlens,
+                self._block_to_slot_t,
+                self.kv_cache_int4[self._li(layer_id)],
+                self.tail_K[self._li(layer_id)],
+                self.tail_V[self._li(layer_id)],
+                K_packed,
+                V_packed,
+                block_table.stride(0),
+                self.kv_cache_int4[self._li(layer_id)].stride(0),
+                self.kv_cache_int4[self._li(layer_id)].stride(1),
+                self._tail_K_stride0,
+                self._tail_K_stride1,
+                self._tail_K_stride2,
+                K_packed.stride(0),
+                K_packed.stride(1),
+                MAX_BLOCKS_PER_REQ=max_blocks,
+                D=self.head_dim,
+                GROUP=self.group,
+                K_BITS=self.cfg.key_bits,
+                V_BITS=self.cfg.value_bits,
+                NUM_BLOCKS_LOOKUP=self._block_lookup_size,
+                K_PACKED_OFFSET=self.cfg.k_packed_offset,
+                K_S_COL_OFFSET=self.cfg.k_s_col_offset,
+                K_ZP_OFFSET=self.cfg.k_zp_offset,
+                K_S_ROW_OFFSET=self.cfg.k_s_row_offset,
+                V_PACKED_OFFSET=self.cfg.v_packed_offset,
+                V_S_COL_OFFSET=self.cfg.v_s_col_offset,
+                V_S_ROW_OFFSET=self.cfg.v_s_row_offset,
+                V_ZP_OFFSET=self.cfg.v_zp_offset,
+                num_warps=4,
+                num_stages=2,
+            )
+        else:
+            # Python gather fallback
+            req_pool_indices = forward_batch.req_pool_indices
+            req_to_token = self.model_runner.req_to_token_pool.req_to_token
+            token_offset = 0
+            for i in range(B):
+                req_idx = int(req_pool_indices[i].item())
+                seq_len = int(seq_lens_t[i].item())
+                if seq_len <= 0:
+                    continue
+                block_ids = self._get_block_ids_for_request(
+                    req_idx, seq_len, req_to_token
+                )
+                K_full, V_full = self._gather_request_kv(layer_id, block_ids, seq_len)
+                K_packed[token_offset : token_offset + seq_len] = K_full
+                V_packed[token_offset : token_offset + seq_len] = V_full
+                token_offset += seq_len
+
+        # Run attention via flash_attn_varlen (batched, no Python loop)
+        # Cached multiquery path: one flash_attn_varlen
+        # call for the whole batch instead of per-request SDPA.
+        out = torch.empty(
+            N, self.num_heads, self.head_dim, dtype=q.dtype, device=q.device
+        )
+
+        extend_seq_lens = getattr(forward_batch, "extend_seq_lens", None)
+        extend_prefix_lens = getattr(forward_batch, "extend_prefix_lens", None)
+
+        if extend_seq_lens is not None:
+            # Extend mode: each request has prefix (cached) + new tokens
+            qlens = extend_seq_lens.to(torch.int32)
+            prefix_lens = (
+                extend_prefix_lens.to(torch.int32)
+                if extend_prefix_lens is not None
+                else torch.zeros_like(qlens)
+            )
+            seq_lens_full = (prefix_lens + qlens).to(torch.int32)
+        else:
+            # Pure prefill: all tokens are new
+            qlens = seq_lens_t[:B].to(torch.int32)
+            prefix_lens = torch.zeros_like(qlens)
+            seq_lens_full = qlens
+
+        # Build cu_seqlens for flash_attn_varlen
+        cu_q = torch.zeros(B + 1, dtype=torch.int32, device=self.device)
+        cu_q[1:] = torch.cumsum(qlens, dim=0)
+        cu_k = torch.zeros(B + 1, dtype=torch.int32, device=self.device)
+        cu_k[1:] = torch.cumsum(seq_lens_full, dim=0)
+
+        try:
+            from flash_attn_interface import flash_attn_varlen_func as _fa_varlen
+
+            _has_flash = True
+        except ImportError:
+            try:
+                from sgl_kernel.flash_attn import flash_attn_varlen_func as _fa_varlen
+
+                _has_flash = True
+            except ImportError:
+                _has_flash = False
+
+        use_flash = _has_flash and total_tokens > 0
+
+        if use_flash:
+            # flash_attn_varlen: q [N, Hq, D], K [total_k, Hk, D], V [total_k, Hk, vD]
+            # For GQA: Hq must be a multiple of Hk
+            # Causal mask is bottom-right aligned: query token t attends to keys <= prefix+t
+            # This matches the extend semantics when seqlen_q < seqlen_k
+            q_for_fa = q_rot[:N].contiguous()
+            K_for_fa = K_packed[:total_tokens].contiguous()
+            V_for_fa = V_packed[:total_tokens].contiguous()
+
+            fa_out = _fa_varlen(
+                q_for_fa,
+                K_for_fa,
+                V_for_fa,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_k,
+                max_seqlen_q=int(qlens.max().item()) if B > 0 else 1,
+                max_seqlen_k=int(seq_lens_full.max().item()) if B > 0 else 1,
+                softmax_scale=self.scale,
+                causal=True,
+            )
+            # flash_attn_interface returns (output, lse); sgl_kernel returns output
+            if isinstance(fa_out, tuple):
+                fa_out = fa_out[0]
+            # fa_out may be [N, Hq, D] or [N, Hq*D] depending on implementation
+            if fa_out.dim() == 2:
+                fa_out = fa_out.view(N, self.num_heads, self.head_dim)
+            # Un-rotate each head: [N, Hq, D] @ [D, D]^T = [N, Hq, D]
+            out[:] = (fa_out.float() @ H.T).to(q.dtype)
+        else:
+            # Fallback: per-request SDPA
+            if extend_seq_lens is not None:
+                token_offset = 0
+                for i in range(extend_seq_lens.shape[0]):
+                    ext_len = int(extend_seq_lens[i].item())
+                    prefix_len = (
+                        int(extend_prefix_lens[i].item())
+                        if extend_prefix_lens is not None
+                        else 0
+                    )
+                    seq_len = prefix_len + ext_len
+
+                    q_start = token_offset
+                    q_end = token_offset + ext_len
+                    token_offset = q_end
+
+                    if ext_len <= 0:
+                        continue
+
+                    kv_start = int(cu_seqlens[i].item())
+                    kv_end = kv_start + seq_len
+
+                    q_i = q_rot[q_start:q_end].transpose(0, 1).unsqueeze(0).float()
+                    K_t = K_packed[kv_start:kv_end].transpose(0, 1).unsqueeze(0).float()
+                    V_t = V_packed[kv_start:kv_end].transpose(0, 1).unsqueeze(0).float()
+
+                    if prefix_len == 0:
+                        o = F.scaled_dot_product_attention(
+                            q_i,
+                            K_t,
+                            V_t,
+                            is_causal=True,
+                            scale=self.scale,
+                            enable_gqa=self.num_kv_heads < self.num_heads,
+                        )
+                    else:
+                        q_len = ext_len
+                        q_pos = (
+                            torch.arange(q_len, device=q.device).unsqueeze(1)
+                            + prefix_len
+                        )
+                        k_pos = torch.arange(seq_len, device=q.device).unsqueeze(0)
+                        mask = k_pos <= q_pos
+                        o = F.scaled_dot_product_attention(
+                            q_i,
+                            K_t,
+                            V_t,
+                            attn_mask=mask,
+                            scale=self.scale,
+                            enable_gqa=self.num_kv_heads < self.num_heads,
+                        )
+
+                    o = o[0].transpose(0, 1)
+                    out[q_start:q_end] = (o.float() @ H.T).to(q.dtype)
+            else:
+                seq_lens = forward_batch.seq_lens
+                token_offset = 0
+                for i in range(seq_lens.shape[0]):
+                    seq_len = int(seq_lens[i].item())
+                    q_start = token_offset
+                    q_end = token_offset + seq_len
+                    token_offset = q_end
+                    if seq_len <= 0:
+                        continue
+
+                    kv_start = int(cu_seqlens[i].item())
+                    kv_end = kv_start + seq_len
+
+                    q_i = q_rot[q_start:q_end].transpose(0, 1).unsqueeze(0).float()
+                    K_t = K_packed[kv_start:kv_end].transpose(0, 1).unsqueeze(0).float()
+                    V_t = V_packed[kv_start:kv_end].transpose(0, 1).unsqueeze(0).float()
+
+                    o = F.scaled_dot_product_attention(
+                        q_i,
+                        K_t,
+                        V_t,
+                        is_causal=True,
+                        scale=self.scale,
+                        enable_gqa=self.num_kv_heads < self.num_heads,
+                    )
+                    o = o[0].transpose(0, 1)
+                    out[q_start:q_end] = (o.float() @ H.T).to(q.dtype)
+
+        return out.view(N, self.num_heads * self.head_dim)
+
+    def _fused_verify_path(
+        self,
+        q_3d: torch.Tensor,  # [NQ, Hq, D]
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        H: torch.Tensor,  # [D, D] fp32 Hadamard
+    ) -> torch.Tensor:
+        """Speculative-decode verify via the fused dual-source kernel.
+
+        Each query token becomes a virtual kernel row with its own
+        bottom-right causal length (cached_len + idx + 1) and an indirection
+        to its request's block-table row — so the verify step reads int4
+        tiles + the fp16 pool directly without materializing the whole
+        context to fp16 scratch.
+
+        Eager-only (verify steps are not graph-captured): fresh small
+        tensors per call are fine.
+        """
+        from sglang.srt.layers.attention.kvarn_ops.triton_decode import (
+            kvarn_verify_attention,
+        )
+
+        layer_id = layer.layer_id
+        NQ = q_3d.shape[0]
+        device = q_3d.device
+
+        # Build block_table, seq_lens for the verify kernel
+        block_table, seq_lens_t, cu_seqlens = self._build_block_table(forward_batch)
+        B = block_table.shape[0]
+        max_ctx_blocks = block_table.shape[1]
+
+        # Build per-token vq_req and vq_seqlen
+        extend_seq_lens = forward_batch.extend_seq_lens
+        extend_prefix_lens = forward_batch.extend_prefix_lens
+
+        # query_start_loc: cumulative sum of extend_seq_lens
+        if extend_seq_lens is not None:
+            qlens = extend_seq_lens.to(torch.long)
+            qsl = torch.zeros(B + 1, dtype=torch.long, device=device)
+            qsl[1:] = torch.cumsum(qlens, dim=0)
+        else:
+            # Fallback: treat all tokens as one per request
+            qlens = torch.ones(B, dtype=torch.long, device=device)
+            qsl = torch.arange(B + 1, dtype=torch.long, device=device)
+
+        # vq_req: which request each token belongs to
+        vq_req_long = torch.repeat_interleave(
+            torch.arange(B, device=device),
+            qlens,
+        )
+        vq_req = vq_req_long.to(torch.int32)
+
+        # pos_in_req: position of each token within its request
+        pos_in_req = torch.arange(NQ, device=device) - qsl[:-1][vq_req_long]
+
+        # committed = seq_len - qlen (the cached prefix length)
+        committed = seq_lens_t[:B].to(torch.long) - qlens
+
+        # vq_seqlen: causal length = committed + pos + 1
+        vq_seqlen = (committed[vq_req_long] + pos_in_req + 1).to(torch.int32)
+
+        sliding_window = getattr(layer, "sliding_window_size", -1)
+        if sliding_window is None or sliding_window <= 0:
+            sliding_window = 0
+
+        out = kvarn_verify_attention(
+            query=q_3d,
+            kv_cache=self.kv_cache_int4[self._li(layer_id)],
+            tail_K=self.tail_K[self._li(layer_id)],
+            tail_V=self.tail_V[self._li(layer_id)],
+            hadamard=H,
+            scale=self.scale,
+            cfg=self.cfg,
+            impl=self,
+            block_table=block_table,
+            vq_req=vq_req,
+            vq_seqlen=vq_seqlen,
+            max_ctx_blocks=max_ctx_blocks,
+            sliding_window=sliding_window,
+        )
+
+        return out.view(NQ, self.num_heads * self.head_dim)
+
+    # ── Store path ──────────────────────────────────────────────────────────
+
+    def _ensure_slots_for_tokens(self, out_cache_loc: torch.Tensor):
+        """Pre-allocate tail pool slots for any new blocks in this batch.
+        Must be called BEFORE the Triton scatter store kernel.
+
+        Note: _block_fill is NOT updated here — it's already set correctly
+        by _maybe_flush_blocks from the committed boundary computation.
+        Fill tracking lives in the builder, not the store path.
+        """
+        # Compute block_ids for all tokens (vectorized on GPU)
+        block_ids_t = out_cache_loc // self.page_size  # [N] on GPU
+        # Find unique block_ids that need slots (CPU)
+        block_ids_cpu = block_ids_t.cpu()
+        unique_new = set()
+        for bid in block_ids_cpu.tolist():
+            if bid >= 0 and bid not in self._block_to_slot:
+                unique_new.add(bid)
+
+        for bid in unique_new:
+            self._alloc_slot(bid)
+            if bid < KVaRN_SINK_BLOCKS:
+                self._sink_block_ids.add(bid)
+
+    def _update_block_fill(self, out_cache_loc: torch.Tensor):
+        """Update block fill tracking after scatter store. Called after
+        the Triton scatter store to track which blocks are full."""
+        loc_cpu = out_cache_loc.cpu()
+        for i in range(loc_cpu.shape[0]):
+            slot_idx = int(loc_cpu[i].item())
+            if slot_idx < 0:
+                continue
+            block_id = slot_idx // self.page_size
+            # Allocate a tail pool slot for new blocks
+            if block_id not in self._block_to_slot:
+                self._alloc_slot(block_id)
+                if block_id < KVaRN_SINK_BLOCKS:
+                    self._sink_block_ids.add(block_id)
+            self._block_fill[block_id] = self._block_fill.get(block_id, 0) + 1
+
+    def _store_to_tail_pool(
+        self,
+        layer_id: int,
+        k: torch.Tensor,  # [N, Hk, D] bf16/fp16 (NOT yet rotated)
+        v: torch.Tensor,  # [N, Hk, vD] bf16/fp16
+        out_cache_loc: torch.Tensor,  # [N] slot indices
+    ):
+        """Rotate K/V and store to tail pool using block-to-slot mapping.
+
+        Assumes slots have already been allocated by _ensure_slots_for_tokens.
+        Uses vectorized index_put_ for the scatter.
+        """
+        H = self._get_hadamard(self.device)
+
+        # Rotate K/V in fp32 for precision, cast to fp16 for storage
+        k_rot = (k.float() @ H).to(torch.float16)  # [N, Hk, D]
+        v_rot = (v.float() @ H).to(torch.float16)  # [N, Hk, vD]
+
+        # Compute block_id and pos_in_block for each token
+        loc = out_cache_loc  # [N] on GPU
+        block_ids = loc // self.page_size  # [N]
+        pos_in_block = loc % self.page_size  # [N]
+
+        # Build tail pool slot indices for each token using the CPU dict
+        tail_slots = torch.empty_like(loc, dtype=torch.long)
+        for i in range(loc.shape[0]):
+            bid = int(block_ids[i].item())
+            tail_slots[i] = self._block_to_slot[bid]
+
+        # Scatter to tail pool via linear index: slot * group + pos_in_block
+        linear_idx = tail_slots * self.group + pos_in_block
+
+        K_flat = self.tail_K[self._li(layer_id)].view(
+            self.pool_slots * self.group, self.num_kv_heads, self.head_dim
+        )
+        V_flat = self.tail_V[self._li(layer_id)].view(
+            self.pool_slots * self.group, self.num_kv_heads, self.v_head_dim
+        )
+        K_flat.index_put_((linear_idx,), k_rot, accumulate=False)
+        V_flat.index_put_((linear_idx,), v_rot, accumulate=False)
+
+    # ── Gather path ─────────────────────────────────────────────────────────
+
+    def _get_block_ids_for_request(
+        self,
+        req_idx: int,
+        seq_len: int,
+        req_to_token: torch.Tensor,
+    ) -> list[int]:
+        """Get the list of block_ids for a request's sequence.
+
+        Uses req_to_token_pool to find the first slot of each page,
+        then computes block_id = slot // page_size.
+        """
+        num_blocks = (seq_len + self.page_size - 1) // self.page_size
+        block_ids = []
+        for b in range(num_blocks):
+            token_pos = b * self.page_size
+            slot = int(req_to_token[req_idx, token_pos].item())
+            if slot < 0:
+                block_ids.append(-1)
+            else:
+                block_id = slot // self.page_size
+                block_ids.append(block_id)
+        return block_ids
+
+    def _build_block_table(
+        self,
+        forward_batch: ForwardBatch,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build block_table, seq_lens, cu_seqlens for the fused Triton kernel.
+
+        block_table: [B, max_blocks] int32 — block_id per (request, block)
+        seq_lens: [B] int32 — sequence length per request
+        cu_seqlens: [B+1] int32 — prefix sum of seq_lens
+        """
+        B = forward_batch.batch_size
+        seq_lens = forward_batch.seq_lens
+        req_pool_indices = forward_batch.req_pool_indices
+        req_to_token = self.model_runner.req_to_token_pool.req_to_token
+
+        max_seq_len = int(seq_lens.max().item()) if B > 0 else 1
+        max_blocks = (max_seq_len + self.page_size - 1) // self.page_size
+        max_blocks = max(max_blocks, 1)
+
+        # Vectorized block_table construction:
+        # For each request, get the first slot of each page from req_to_token
+        # block_id = slot // page_size
+        block_table = torch.zeros(B, max_blocks, dtype=torch.int32, device=self.device)
+        seq_lens_t = seq_lens.to(torch.int32)
+
+        if B > 0:
+            # Build column indices: [0, page_size, 2*page_size, ...]
+            col_offsets = torch.arange(max_blocks, device=self.device) * self.page_size
+            # For each request, get req_idx
+            req_indices = req_pool_indices.long()
+            # Gather first slot of each page: req_to_token[req_idx, col_offset]
+            # Shape: [B, max_blocks]
+            token_positions = col_offsets.unsqueeze(0).expand(B, max_blocks)
+            # Clamp to valid range to avoid OOB
+            max_token_pos = req_to_token.shape[1] - 1
+            token_positions = token_positions.clamp(max=max_token_pos)
+            slots = req_to_token[req_indices.unsqueeze(1), token_positions]
+            # block_id = slot // page_size (negative slots → negative block_id → ignored by kernel)
+            block_table = (slots // self.page_size).to(torch.int32)
+
+        cu_seqlens = torch.zeros(B + 1, dtype=torch.int32, device=self.device)
+        if B > 0:
+            cu_seqlens[1:] = torch.cumsum(seq_lens_t, dim=0)
+
+        return block_table, seq_lens_t, cu_seqlens
+
+    def _gather_request_kv(
+        self,
+        layer_id: int,
+        block_ids: list[int],
+        seq_len: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Gather full K/V for a request from tail pool (fp16) + int4 cache.
+
+        Returns (K [seq_len, Hk, D] fp16, V [seq_len, Hk, vD] fp16) in the
+        ROTATED frame (Hadamard rotation applied, matching Q which is also
+        rotated). Attention is computed in the rotated frame; the output
+        is un-rotated by the caller.
+        """
+        group = self.group
+        n_full = seq_len // group
+        tail_len = seq_len % group
+        D = self.head_dim
+        vD = self.v_head_dim
+        device = self.device
+
+        K_parts: list[torch.Tensor] = []
+        V_parts: list[torch.Tensor] = []
+
+        for i in range(n_full):
+            block_id = block_ids[i]
+            slot = self._block_to_slot.get(block_id)
+            if slot is not None:
+                # Block is in tail pool (in-progress or sink) — already rotated
+                K_parts.append(self.tail_K[self._li(layer_id)][slot])
+                V_parts.append(self.tail_V[self._li(layer_id)][slot])
+            else:
+                # Block is flushed to int4 cache — dequant returns rotated frame
+                K_blk, V_blk = self._read_block_dequantized(layer_id, block_id)
+                K_parts.append(K_blk)
+                V_parts.append(V_blk)
+
+        if tail_len > 0:
+            block_id = block_ids[n_full]
+            slot = self._block_to_slot.get(block_id)
+            if slot is not None:
+                K_parts.append(self.tail_K[self._li(layer_id)][slot, :tail_len])
+                V_parts.append(self.tail_V[self._li(layer_id)][slot, :tail_len])
+            else:
+                K_parts.append(
+                    torch.zeros(
+                        tail_len,
+                        self.num_kv_heads,
+                        D,
+                        dtype=torch.float16,
+                        device=device,
+                    )
+                )
+                V_parts.append(
+                    torch.zeros(
+                        tail_len,
+                        self.num_kv_heads,
+                        vD,
+                        dtype=torch.float16,
+                        device=device,
+                    )
+                )
+
+        K = (
+            torch.cat(K_parts, dim=0)
+            if K_parts
+            else torch.empty(
+                0,
+                self.num_kv_heads,
+                D,
+                dtype=torch.float16,
+                device=device,
+            )
+        )
+        V = torch.cat(V_parts, dim=0) if V_parts else torch.empty_like(K)
+        return K, V
+
+    def _read_block_dequantized(
+        self,
+        layer_id: int,
+        block_id: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Read a block from the int4 compressed cache and dequantize to fp16.
+
+        Returns (K [group, Hk, D] fp16, V [group, Hk, vD] fp16) in the
+        ROTATED frame (as stored in the compressed cache — no un-rotation).
+        The caller uses this in the rotated-frame attention computation.
+        """
+        K_blk, V_blk = self.flush_manager.dequant_block(
+            block_id,
+            self.kv_cache_int4,
+            layer_id,
+        )
+        return K_blk, V_blk
+
+    # ── Flush path ──────────────────────────────────────────────────────────
+
+    def _maybe_flush_blocks(self, forward_batch: ForwardBatch):
+        """Flush full blocks from tail pool to int4 compressed cache.
+
+        Uses the committed-token boundary (seq_len - query_len) to determine
+        which blocks are safe to flush — never quantizes speculative tokens
+        that may be rejected. Walks backward from the committed boundary
+        while blocks still hold pool slots.
+
+        Also reclaims slots from finished requests: complete blocks are
+        flushed (so prefix cache hits find valid int4 tiles), partial blocks
+        are discarded (scheduler never prefix-caches partial blocks).
+
+        Sink blocks are NEVER flushed — they stay fp16 for the request's
+        lifetime, preserving KVarN's fp16-sink accuracy on multi-turn traffic.
+        When a request finishes, its sink is RETIRED (kept fp16-resident for
+        future prefix-cache hits) and lazily evicted (flushed to int4) only
+        when pool slots run dry.
+        """
+        GROUP = self.group
+        B = forward_batch.batch_size
+        seq_lens = forward_batch.seq_lens
+        req_pool_indices = forward_batch.req_pool_indices
+        req_to_token = self.model_runner.req_to_token_pool.req_to_token
+
+        # --- Query lengths (CPU) ---
+        extend_seq_lens = getattr(forward_batch, "extend_seq_lens", None)
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+
+        if (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_decode")
+            and forward_mode.is_decode()
+        ):
+            query_lens_cpu = [1] * B
+        elif extend_seq_lens is not None:
+            query_lens_cpu = extend_seq_lens.cpu().tolist()
+        else:
+            # CUDA graph replay or unknown mode → treat as decode (q_len=1).
+            query_lens_cpu = [1] * B
+
+        seq_lens_cpu = seq_lens.cpu().tolist()
+
+        # --- Vectorized block_table construction (one GPU→CPU transfer) ---
+        # Replaces the per-block .item() loop that caused O(context) CUDA
+        # syncs per decode step (the throughput regression at long context).
+        # CPU block table from scheduler metadata.
+        if B > 0:
+            max_seq = max(seq_lens_cpu) if seq_lens_cpu else 0
+            max_blocks = max((max_seq + self.page_size - 1) // self.page_size, 1)
+            col_offsets = torch.arange(max_blocks, device=self.device) * self.page_size
+            req_indices = req_pool_indices.long()
+            token_positions = col_offsets.unsqueeze(0).expand(B, max_blocks)
+            max_token_pos = req_to_token.shape[1] - 1
+            token_positions = token_positions.clamp(max=max_token_pos)
+            slots = req_to_token[req_indices.unsqueeze(1), token_positions]
+            block_table_rows = (slots // self.page_size).cpu().tolist()
+        else:
+            block_table_rows = []
+
+        # --- blocks_needed: blocks written this step ---
+        # committed = tokens already in pool before this step = sl - q_len.
+        # For the first chunk of a fresh prefill: committed=0 → range starts
+        # at k=0 → ALL blocks (including block 0) are covered, block 0 gets
+        # marked as a sink and _block_fill set correctly.  For decode:
+        # committed = sl-1 → only the current boundary block.
+        blocks_needed: set[int] = set()
+        for b in range(B):
+            sl = seq_lens_cpu[b]
+            if sl <= 0 or b >= len(block_table_rows):
+                continue
+            row = block_table_rows[b]
+            q_len = query_lens_cpu[b] if b < len(query_lens_cpu) else 1
+            committed = max(sl - q_len, 0)
+            for k in range(
+                committed // GROUP, min((sl - 1) // GROUP, len(row) - 1) + 1
+            ):
+                bid = row[k] if k < len(row) else -1
+                if bid >= 0:
+                    blocks_needed.add(bid)
+                    self._block_fill[bid] = min(sl, (k + 1) * GROUP) - k * GROUP
+
+        # Safety superset: every block receiving a write this step is needed
+        # (slot_mapping superset).
+        # Prevents the reclaim loop from discarding a block that was just
+        # written to but not covered by the committed-boundary range above.
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if out_cache_loc is not None:
+            for s in out_cache_loc.cpu().tolist():
+                if s >= 0:
+                    blocks_needed.add(s // self.page_size)
+
+        # --- Sink marking (block_table[r][0]) ---
+        # A sink is an fp16-resident block kept for the request's lifetime.
+        # LIVE sinks (already marked) MUST be re-added to blocks_needed every
+        # step so the reclaim loop never touches them — without this lifeline,
+        # a sink whose _block_fill=0 (block 0 of any >128-token prompt, never
+        # updated by the committed-boundary range) would be discarded on the
+        # first decode step, freeing its tail slot without writing int4.
+        # The decode kernel would then read block 0 from the zero-initialized
+        # int4 cache → tokens 0-127 (system prompt + tool schemas) vanish →
+        # the model cannot see its tools. (Fixed
+        # by the same lifeline; the port had dropped it.)
+        row0_set: set[int] = set()
+        for b in range(B):
+            if b >= len(block_table_rows) or not block_table_rows[b]:
+                continue
+            s0 = block_table_rows[b][0]
+            if s0 < 0:
+                continue
+            row0_set.add(s0)
+            if s0 in self._sink_block_ids:
+                blocks_needed.add(s0)  # lifeline: keep slot for request's lifetime
+            elif s0 in blocks_needed:  # written this step → fresh sink
+                self._sink_block_ids.add(s0)
+
+        # Un-retire any retired sink named this step
+        for bid in [b for b in self._retired_sinks if b in blocks_needed]:
+            self._retired_sinks.pop(bid, None)
+            if bid not in row0_set and bid in self._sink_block_ids:
+                self._sink_block_ids.discard(bid)
+
+        # --- Flush walk: full-but-unflushed blocks below committed boundary ---
+        flush_block_ids: list[int] = []
+        flush_seen: set[int] = set()
+        for b in range(B):
+            if b >= len(block_table_rows):
+                continue
+            sl = seq_lens_cpu[b]
+            row = block_table_rows[b]
+            if sl <= 0:
+                continue
+            q_len = query_lens_cpu[b] if b < len(query_lens_cpu) else 1
+            committed_len = max(sl - q_len, 0)
+            k = min(committed_len // GROUP - 1, len(row) - 1)
+            while 1 <= k:
+                bid = row[k] if k < len(row) else -1
+                if (
+                    bid < 0
+                    or bid in flush_seen
+                    or bid in self._sink_block_ids
+                    or bid not in self._block_to_slot
+                ):
+                    break
+                flush_seen.add(bid)
+                flush_block_ids.append(bid)
+                k -= 1
+
+        # --- Reclaim: slot-holding blocks of finished/preempted requests ---
+        discard_ids: list[int] = []
+        for bid in [
+            b
+            for b in self._block_to_slot
+            if b not in blocks_needed and b not in flush_seen
+        ]:
+            full = self._block_fill.get(bid, 0) >= GROUP
+            if full and bid in self._sink_block_ids:
+                # Retire the sink — keep fp16-resident for future prefix-cache hits
+                self._retired_sinks[bid] = None
+                continue
+            if full:
+                flush_seen.add(bid)
+                flush_block_ids.append(bid)
+            else:
+                discard_ids.append(bid)
+            if bid in self._sink_block_ids:
+                self._sink_block_ids.discard(bid)
+
+        # Execute flushes — batch all blocks across all layers in one Sinkhorn+RTN
+        if flush_block_ids:
+            slots = [self._block_to_slot[bid] for bid in flush_block_ids]
+            self.flush_manager.flush_batched_fast(
+                block_ids=flush_block_ids,
+                tail_K=self.tail_K,
+                tail_V=self.tail_V,
+                slots=slots,
+                compressed_cache=self.kv_cache_int4,
+            )
+            # Free the flushed blocks' slots
+            for bid in flush_block_ids:
+                self._free_slot(bid)
+
+        # Free discarded partial blocks
+        for bid in discard_ids:
+            self._free_slot(bid)
+
+    def _flush_block(self, block_id: int):
+        """Compress a block from tail pool to int4 cache and free the slot."""
+        slot = self._block_to_slot.get(block_id)
+        if slot is None:
+            return  # Already flushed
+
+        self.flush_manager.flush_block(
+            block_id=block_id,
+            tail_K=self.tail_K,
+            tail_V=self.tail_V,
+            slot=slot,
+            compressed_cache=self.kv_cache_int4,
+        )
+
+        # Free the tail pool slot
+        self._free_slot(block_id)
+        logger.debug(f"Flushed block {block_id} to int4 cache")
+
+    # ── Rotation helpers ────────────────────────────────────────────────────
+
+    def _rotate(self, x: torch.Tensor, H: torch.Tensor) -> torch.Tensor:
+        """Apply Hadamard rotation: x_rot = x @ H"""
+        return (x.float() @ H).to(x.dtype)
+
+    def _unrotate(self, x: torch.Tensor, H: torch.Tensor) -> torch.Tensor:
+        """Apply inverse Hadamard rotation: x = x_rot @ H^T"""
+        return (x.float() @ H.T).to(x.dtype)
+
+    # ── Compatibility stubs ─────────────────────────────────────────────────
+
+    def get_forward_metadata(self):
+        return None
+
+    def get_kv_cache_shape(self):
+        """Return the KV cache shape for this backend."""
+        # Used by model_runner to size the pool. For KVarN, the pool is NoOp
+        # and the real storage is in the backend's tail pool + int4 cache.
+        return self.num_blocks, self.num_kv_heads, self.head_dim
+
+    def get_q_scale(self):
+        return self.scale
+
+    def set_kv_buffer(self, layer, loc, k, v, *args, **kwargs):
+        """Direct set_kv_buffer — used by some codepaths. Redirect to tail pool."""
+        self._store_to_tail_pool(layer.layer_id, k, v, loc)
+
+    def get_kv_buffer(self, layer_id: int):
+        """Get KV buffer — returns tail pool for this layer."""
+        return self.tail_K[self._li(layer_id)], self.tail_V[self._li(layer_id)]
+
+    # ── HiCache support: gather/scatter for CPU offload ────────────────────
+
+    # ── HiCache support: raw int4 tile copy ────────────────────────────────
+
+    def flush_block_for_hicache(self, block_id: int):
+        """Flush a block from tail pool to int4 cache if not already flushed.
+
+        Called by KVarNHostKVCache.backup_from_device_all_layer before
+        copying tiles to CPU, ensuring the CPU copy always gets compact
+        int4 tiles (not fp16). Sink blocks are also flushed — HiCache
+        eviction means the request is done, so the sink no longer needs
+        fp16 residency.
+        """
+        if block_id in self._block_to_slot:
+            self._flush_block(block_id)
+            self._sink_block_ids.discard(block_id)

--- a/python/sglang/srt/layers/attention/kvarn_ops/__init__.py
+++ b/python/sglang/srt/layers/attention/kvarn_ops/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN Triton ops for SGLang."""

--- a/python/sglang/srt/layers/attention/kvarn_ops/triton_decode.py
+++ b/python/sglang/srt/layers/attention/kvarn_ops/triton_decode.py
@@ -1,0 +1,1307 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN Triton decode kernels for SGLang.
+
+Contains:
+  - ``_kvarn_build_packed_kv_kernel``: block_table-driven dequant + pool gather
+    → packed fp16 K/V for FlashAttention.
+  - ``_kvarn_fused_decode_kernel``: fused dequant + online-softmax flash-decode
+    (never materializes fp16 K/V to HBM).
+  - ``_kvarn_fused_decode_stage1`` + ``_kvarn_fused_decode_stage2``: split-K
+    flash-decoding for long-context / low-batch regimes.
+  - ``_kvarn_scatter_store_kernel``: scatter fp16 K/V into the tail pool.
+
+Uses ``import triton`` / ``import triton.language as tl``
+directly.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+# Number of KV-sequence splits for the split-K flash-decoding kernel.
+KVARN_NUM_KV_SPLITS = 16
+KVARN_MAX_KV_SPLITS = 64
+
+# Autotune configs for the fused decode kernel.  Applied lazily so the module
+# can be imported on CPU-only machines without a Triton driver.
+_KVARN_DECODE_CONFIGS = [
+    triton.Config({"BLOCK_N": 16}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=2),
+]
+
+
+def _maybe_autotune(kernel):
+    """Decorate with triton.autotune if a GPU driver is available.
+
+    This allows the module to be imported on CPU-only machines (e.g. for
+    unit tests of the non-Triton code) without raising.
+    """
+    try:
+        return triton.autotune(
+            configs=_KVARN_DECODE_CONFIGS,
+            key=["D", "GROUP", "Q_PER_KV", "K_BITS", "V_BITS"],
+        )(kernel)
+    except RuntimeError:
+        # No GPU driver — return the bare JIT kernel.
+        return kernel
+
+
+def _maybe_autotune_verify(kernel):
+    """Decorate verify kernel with triton.autotune (includes QLEN in key)."""
+    try:
+        return triton.autotune(
+            configs=_KVARN_DECODE_CONFIGS,
+            key=["D", "GROUP", "Q_PER_KV", "QLEN", "K_BITS", "V_BITS"],
+        )(kernel)
+    except RuntimeError:
+        return kernel
+
+
+def adaptive_num_kv_splits(max_blocks_per_req: int) -> int:
+    """Context-adaptive split-K count."""
+    if max_blocks_per_req <= 80:
+        return 16
+    if max_blocks_per_req <= 256:
+        return 32
+    return KVARN_MAX_KV_SPLITS
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scatter store: writes (already-rotated) k, v into the tail pool.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _kvarn_scatter_store_kernel(
+    K_in_ptr,  # [N, Hk, D]                    fp16 (already rotated)
+    V_in_ptr,  # [N, Hk, D]                    fp16
+    Slot_mapping_ptr,  # [N]                           int32   (slot < 0 ⇒ pad)
+    Block_to_slot_ptr,  # [num_blocks_lookup]           int32   (-1 = no slot)
+    Pool_K_ptr,  # [POOL_SIZE, group, Hk, D]     fp16
+    Pool_V_ptr,  # [POOL_SIZE, group, Hk, D]     fp16
+    # strides
+    stride_in_n,
+    stride_in_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    # constexprs
+    GROUP: tl.constexpr,
+    D: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+):
+    """Scatter one (token, kv_head) row from k, v into pool[slot, pos, hk, :]."""
+    i = tl.program_id(0)
+    hk = tl.program_id(1)
+
+    sm = tl.load(Slot_mapping_ptr + i)
+    if sm < 0:
+        return
+
+    block_id = sm // GROUP
+    pos = (sm % GROUP).to(tl.int64)
+    in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+    if not in_range:
+        return
+    pool_slot = tl.load(Block_to_slot_ptr + block_id)
+    if pool_slot < 0:
+        return
+
+    d = tl.arange(0, D)
+    src_offs = i * stride_in_n + hk * stride_in_h + d
+    k_row = tl.load(K_in_ptr + src_offs)
+    v_row = tl.load(V_in_ptr + src_offs)
+
+    dst_offs = (
+        pool_slot.to(tl.int64) * stride_pool_b
+        + pos * stride_pool_t
+        + hk * stride_pool_h
+        + d
+    )
+    tl.store(Pool_K_ptr + dst_offs, k_row)
+    tl.store(Pool_V_ptr + dst_offs, v_row)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Block-table-driven build-packed-KV kernel (materialize path).
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _kvarn_build_packed_kv_kernel(
+    Block_table_ptr,  # [B, max_blocks]                          int32
+    Seq_lens_ptr,  # [B]                                      int32
+    Cu_seqlens_ptr,  # [B+1]                                    int32
+    Block_to_slot_ptr,  # [num_blocks_lookup]                      int32
+    KV_cache_ptr,  # [num_blocks, num_kv_heads, TILE_BYTES]   uint8
+    Tail_K_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16
+    Tail_V_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16
+    K_out_ptr,  # [max_total_tokens, Hk, D]                fp16
+    V_out_ptr,  # [max_total_tokens, Hk, D]                fp16
+    # strides
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_out_t,
+    stride_out_h,
+    # constexprs
+    MAX_BLOCKS_PER_REQ: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+):
+    """Grid: (B * MAX_BLOCKS_PER_REQ, Hk). One (request-block, head) per program."""
+    bk = tl.program_id(0)
+    hk = tl.program_id(1)
+    b = bk // MAX_BLOCKS_PER_REQ
+    k = bk % MAX_BLOCKS_PER_REQ
+
+    seq_len = tl.load(Seq_lens_ptr + b)
+    rem = seq_len - k * GROUP
+    n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+    if n_tok <= 0:
+        return
+
+    block_id = tl.load(Block_table_ptr + b * stride_bt_b + k)
+    dst_base = tl.load(Cu_seqlens_ptr + b).to(tl.int64) + k.to(tl.int64) * GROUP
+
+    d_offs = tl.arange(0, D)
+    g_offs = tl.arange(0, GROUP)
+    g_mask = g_offs < n_tok
+
+    in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+    safe_bid = tl.where(in_range, block_id, 0)
+    pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+
+    out_addrs = (
+        (dst_base + g_offs)[:, None] * stride_out_t
+        + hk * stride_out_h
+        + d_offs[None, :]
+    )
+
+    if pool_slot >= 0:
+        pool_base = pool_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+        src_addrs = pool_base + g_offs[:, None] * stride_pool_t + d_offs[None, :]
+        K_chunk = tl.load(Tail_K_pool_ptr + src_addrs, mask=g_mask[:, None], other=0.0)
+        V_chunk = tl.load(Tail_V_pool_ptr + src_addrs, mask=g_mask[:, None], other=0.0)
+        tl.store(K_out_ptr + out_addrs, K_chunk, mask=g_mask[:, None])
+        tl.store(V_out_ptr + out_addrs, V_chunk, mask=g_mask[:, None])
+    else:
+        PACK_K: tl.constexpr = 8 // K_BITS
+        PACK_V: tl.constexpr = 8 // V_BITS
+        MASK_K: tl.constexpr = (1 << K_BITS) - 1
+        MASK_V: tl.constexpr = (1 << V_BITS) - 1
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+        g_byte_k = g_offs // PACK_K
+        g_shift_k = (g_offs % PACK_K) * K_BITS
+        d_byte_v = d_offs // PACK_V
+        d_shift_v = (d_offs % PACK_V) * V_BITS
+
+        sk_lo = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        sk_hi = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_K = ((sk_lo | (sk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        zk_lo = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        zk_hi = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        zp_K = ((zk_lo | (zk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        srk_lo = tl.load(KV_cache_ptr + tile_base + K_S_ROW_OFFSET + g_offs * 2).to(
+            tl.uint16
+        )
+        srk_hi = tl.load(KV_cache_ptr + tile_base + K_S_ROW_OFFSET + g_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_row_K = ((srk_lo | (srk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+
+        k_addrs = (
+            tile_base
+            + K_PACKED_OFFSET
+            + d_offs[:, None] * (GROUP // PACK_K)
+            + g_byte_k[None, :]
+        )
+        k_bytes = tl.load(KV_cache_ptr + k_addrs).to(tl.int32)
+        q_K = ((k_bytes >> g_shift_k[None, :]) & MASK_K).to(tl.float32)
+        K_rot = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[None, :]
+        K_rot_out = tl.trans(K_rot)
+
+        scv_lo = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        scv_hi = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_V = ((scv_lo | (scv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        srv_lo = tl.load(KV_cache_ptr + tile_base + V_S_ROW_OFFSET + g_offs * 2).to(
+            tl.uint16
+        )
+        srv_hi = tl.load(KV_cache_ptr + tile_base + V_S_ROW_OFFSET + g_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_row_V = ((srv_lo | (srv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        zpv_lo = tl.load(KV_cache_ptr + tile_base + V_ZP_OFFSET + g_offs * 2).to(
+            tl.uint16
+        )
+        zpv_hi = tl.load(KV_cache_ptr + tile_base + V_ZP_OFFSET + g_offs * 2 + 1).to(
+            tl.uint16
+        )
+        zp_V = ((zpv_lo | (zpv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+
+        v_addrs = (
+            tile_base
+            + V_PACKED_OFFSET
+            + g_offs[:, None] * (D // PACK_V)
+            + d_byte_v[None, :]
+        )
+        v_bytes = tl.load(KV_cache_ptr + v_addrs).to(tl.int32)
+        q_V = ((v_bytes >> d_shift_v[None, :]) & MASK_V).to(tl.float32)
+        V_rot = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[None, :]
+
+        tl.store(K_out_ptr + out_addrs, K_rot_out.to(tl.float16), mask=g_mask[:, None])
+        tl.store(V_out_ptr + out_addrs, V_rot.to(tl.float16), mask=g_mask[:, None])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fused decode kernel: dequant int4 in registers + online-softmax flash-decode.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@_maybe_autotune
+@triton.jit
+def _kvarn_fused_decode_kernel(
+    Q_ptr,  # [B, Hq, D]                               fp16 (rotated)
+    Req_row_ptr,  # [B] int32 — block-table row per program row
+    Block_table_ptr,  # [B, max_blocks]                          int32
+    Seq_lens_ptr,  # [B]                                      int32
+    Block_to_slot_ptr,  # [num_blocks_lookup]                      int32 (-1 = int4)
+    KV_cache_ptr,  # [num_blocks, num_kv_heads, TILE_BYTES]   uint8
+    Tail_K_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16 (rotated)
+    Tail_V_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16
+    Out_ptr,  # [B, Hq, D]                               fp16 (rotated out)
+    scale,
+    # strides
+    stride_q_b,
+    stride_q_h,
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_o_b,
+    stride_o_h,
+    # constexprs
+    MAX_BLOCKS_PER_REQ: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    Q_PER_KV: tl.constexpr,
+    Q_PER_KV_PAD: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+    VQ_INDIRECT: tl.constexpr,
+):
+    b = tl.program_id(0)
+    hk = tl.program_id(1)
+    qh = tl.arange(0, Q_PER_KV_PAD)
+    qmask = qh < Q_PER_KV
+    hq0 = hk * Q_PER_KV
+
+    bt_row = b
+    if VQ_INDIRECT:
+        bt_row = tl.load(Req_row_ptr + b)
+    seq_len = tl.load(Seq_lens_ptr + b)
+    if seq_len <= 0:
+        return
+
+    d_offs = tl.arange(0, D)
+    PACK_K: tl.constexpr = 8 // K_BITS
+    PACK_V: tl.constexpr = 8 // V_BITS
+    MASK_K: tl.constexpr = (1 << K_BITS) - 1
+    MASK_V: tl.constexpr = (1 << V_BITS) - 1
+    d_byte_v = d_offs // PACK_V
+    d_shift_v = (d_offs % PACK_V) * V_BITS
+
+    q = tl.load(
+        Q_ptr + b * stride_q_b + (hq0 + qh)[:, None] * stride_q_h + d_offs[None, :],
+        mask=qmask[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    m_i = tl.full([Q_PER_KV_PAD], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([Q_PER_KV_PAD], dtype=tl.float32)
+    acc = tl.zeros([Q_PER_KV_PAD, D], dtype=tl.float32)
+
+    n_blocks = (seq_len + GROUP - 1) // GROUP
+    win_start = 0
+    blk_lo = 0
+    if SLIDING_WINDOW > 0:
+        win_start = tl.maximum(seq_len - SLIDING_WINDOW, 0)
+        blk_lo = win_start // GROUP
+    for k in range(blk_lo, n_blocks):
+        rem = seq_len - k * GROUP
+        n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+
+        block_id = tl.load(Block_table_ptr + bt_row * stride_bt_b + k)
+        in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+        safe_bid = tl.where(in_range, block_id, 0)
+        pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+        safe_slot = tl.where(pool_slot >= 0, pool_slot, 0)
+        pool_base = safe_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+
+        sk_lo = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        sk_hi = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_K = ((sk_lo | (sk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        zk_lo = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        zk_hi = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        zp_K = ((zk_lo | (zk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        scv_lo = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        scv_hi = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_V = ((scv_lo | (scv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+
+        for c0 in range(0, GROUP, BLOCK_N):
+            cols = c0 + tl.arange(0, BLOCK_N)
+            cmask = cols < n_tok
+            if SLIDING_WINDOW > 0:
+                cmask = cmask & ((k * GROUP + cols) >= win_start)
+
+            if pool_slot >= 0:
+                src = pool_base + cols[:, None] * stride_pool_t + d_offs[None, :]
+                Kc = tl.load(Tail_K_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                Vc = tl.load(Tail_V_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                K_dg = tl.trans(Kc)
+            else:
+                cb_k = cols // PACK_K
+                cs_k = (cols % PACK_K) * K_BITS
+                srk_lo = tl.load(
+                    KV_cache_ptr + tile_base + K_S_ROW_OFFSET + cols * 2
+                ).to(tl.uint16)
+                srk_hi = tl.load(
+                    KV_cache_ptr + tile_base + K_S_ROW_OFFSET + cols * 2 + 1
+                ).to(tl.uint16)
+                s_row_K = ((srk_lo | (srk_hi << 8)).to(tl.float16, bitcast=True)).to(
+                    tl.float32
+                )
+                k_addrs = (
+                    tile_base
+                    + K_PACKED_OFFSET
+                    + d_offs[:, None] * (GROUP // PACK_K)
+                    + cb_k[None, :]
+                )
+                k_bytes = tl.load(KV_cache_ptr + k_addrs).to(tl.int32)
+                q_K = ((k_bytes >> cs_k[None, :]) & MASK_K).to(tl.float32)
+                K_dg = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[None, :]
+
+                srv_lo = tl.load(
+                    KV_cache_ptr + tile_base + V_S_ROW_OFFSET + cols * 2
+                ).to(tl.uint16)
+                srv_hi = tl.load(
+                    KV_cache_ptr + tile_base + V_S_ROW_OFFSET + cols * 2 + 1
+                ).to(tl.uint16)
+                s_row_V = ((srv_lo | (srv_hi << 8)).to(tl.float16, bitcast=True)).to(
+                    tl.float32
+                )
+                zpv_lo = tl.load(KV_cache_ptr + tile_base + V_ZP_OFFSET + cols * 2).to(
+                    tl.uint16
+                )
+                zpv_hi = tl.load(
+                    KV_cache_ptr + tile_base + V_ZP_OFFSET + cols * 2 + 1
+                ).to(tl.uint16)
+                zp_V = ((zpv_lo | (zpv_hi << 8)).to(tl.float16, bitcast=True)).to(
+                    tl.float32
+                )
+                v_addrs = (
+                    tile_base
+                    + V_PACKED_OFFSET
+                    + cols[:, None] * (D // PACK_V)
+                    + d_byte_v[None, :]
+                )
+                v_bytes = tl.load(KV_cache_ptr + v_addrs).to(tl.int32)
+                q_V = ((v_bytes >> d_shift_v[None, :]) & MASK_V).to(tl.float32)
+                Vc = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[None, :]
+
+            scores = tl.dot(q, K_dg)
+            scores = tl.where(cmask[None, :], scores * scale, -float("inf"))
+            m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+            p = tl.exp(scores - m_new[:, None])
+            alpha = tl.exp(m_i - m_new)
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            acc = acc * alpha[:, None] + tl.dot(p, Vc)
+            m_i = m_new
+
+    out = (acc / l_i[:, None]).to(tl.float16)
+    tl.store(
+        Out_ptr + b * stride_o_b + (hq0 + qh)[:, None] * stride_o_h + d_offs[None, :],
+        out,
+        mask=qmask[:, None],
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Split-K stage 1 + stage 2
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _kvarn_fused_decode_stage1(
+    Q_ptr,
+    Req_row_ptr,
+    Block_table_ptr,
+    Seq_lens_ptr,
+    Block_to_slot_ptr,
+    KV_cache_ptr,
+    Tail_K_pool_ptr,
+    Tail_V_pool_ptr,
+    MidO_ptr,  # [N, NUM_KV_SPLITS, D]            fp32
+    MidLse_ptr,  # [N, NUM_KV_SPLITS]               fp32
+    scale,
+    stride_q_b,
+    stride_q_h,
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_mo_n,
+    stride_mo_s,
+    stride_ml_n,
+    MAX_BLOCKS_PER_REQ: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    Q_PER_KV: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    HQ: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    Q_PER_KV_PAD: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+    VQ_INDIRECT: tl.constexpr,
+):
+    b = tl.program_id(0)
+    hk = tl.program_id(1)
+    split = tl.program_id(2)
+    qh = tl.arange(0, Q_PER_KV_PAD)
+    qmask = qh < Q_PER_KV
+    hq0 = hk * Q_PER_KV
+
+    bt_row = b
+    if VQ_INDIRECT:
+        bt_row = tl.load(Req_row_ptr + b)
+    seq_len = tl.load(Seq_lens_ptr + b)
+    n_blocks = (seq_len + GROUP - 1) // GROUP
+    blocks_per_split = (n_blocks + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
+    blk_lo = split * blocks_per_split
+    blk_hi = tl.minimum(blk_lo + blocks_per_split, n_blocks)
+
+    d_offs = tl.arange(0, D)
+    PACK_K: tl.constexpr = 8 // K_BITS
+    PACK_V: tl.constexpr = 8 // V_BITS
+    MASK_K: tl.constexpr = (1 << K_BITS) - 1
+    MASK_V: tl.constexpr = (1 << V_BITS) - 1
+    d_byte_v = d_offs // PACK_V
+    d_shift_v = (d_offs % PACK_V) * V_BITS
+    q = tl.load(
+        Q_ptr + b * stride_q_b + (hq0 + qh)[:, None] * stride_q_h + d_offs[None, :],
+        mask=qmask[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    m_i = tl.full([Q_PER_KV_PAD], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([Q_PER_KV_PAD], dtype=tl.float32)
+    acc = tl.zeros([Q_PER_KV_PAD, D], dtype=tl.float32)
+
+    for k in range(blk_lo, blk_hi):
+        rem = seq_len - k * GROUP
+        n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+        block_id = tl.load(Block_table_ptr + bt_row * stride_bt_b + k)
+        in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+        safe_bid = tl.where(in_range, block_id, 0)
+        pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+        safe_slot = tl.where(pool_slot >= 0, pool_slot, 0)
+        pool_base = safe_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+
+        sk_lo = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        sk_hi = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_K = ((sk_lo | (sk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        zk_lo = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        zk_hi = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        zp_K = (zk_lo | (zk_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+        scv_lo = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        scv_hi = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_V = ((scv_lo | (scv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+
+        for c0 in range(0, GROUP, BLOCK_N):
+            cols = c0 + tl.arange(0, BLOCK_N)
+            cmask = cols < n_tok
+            if SLIDING_WINDOW > 0:
+                cmask = cmask & (
+                    (k * GROUP + cols) >= tl.maximum(seq_len - SLIDING_WINDOW, 0)
+                )
+            if pool_slot >= 0:
+                src = pool_base + cols[:, None] * stride_pool_t + d_offs[None, :]
+                Kc = tl.load(Tail_K_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                Vc = tl.load(Tail_V_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                K_dg = tl.trans(Kc)
+            else:
+                cb_k = cols // PACK_K
+                cs_k = (cols % PACK_K) * K_BITS
+                srk_lo = tl.load(
+                    KV_cache_ptr + tile_base + K_S_ROW_OFFSET + cols * 2
+                ).to(tl.uint16)
+                srk_hi = tl.load(
+                    KV_cache_ptr + tile_base + K_S_ROW_OFFSET + cols * 2 + 1
+                ).to(tl.uint16)
+                s_row_K = ((srk_lo | (srk_hi << 8)).to(tl.float16, bitcast=True)).to(
+                    tl.float32
+                )
+                k_addrs = (
+                    tile_base
+                    + K_PACKED_OFFSET
+                    + d_offs[:, None] * (GROUP // PACK_K)
+                    + cb_k[None, :]
+                )
+                k_bytes = tl.load(KV_cache_ptr + k_addrs).to(tl.int32)
+                q_K = ((k_bytes >> cs_k[None, :]) & MASK_K).to(tl.float32)
+                K_dg = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[None, :]
+                srv_lo = tl.load(
+                    KV_cache_ptr + tile_base + V_S_ROW_OFFSET + cols * 2
+                ).to(tl.uint16)
+                srv_hi = tl.load(
+                    KV_cache_ptr + tile_base + V_S_ROW_OFFSET + cols * 2 + 1
+                ).to(tl.uint16)
+                s_row_V = ((srv_lo | (srv_hi << 8)).to(tl.float16, bitcast=True)).to(
+                    tl.float32
+                )
+                zpv_lo = tl.load(KV_cache_ptr + tile_base + V_ZP_OFFSET + cols * 2).to(
+                    tl.uint16
+                )
+                zpv_hi = tl.load(
+                    KV_cache_ptr + tile_base + V_ZP_OFFSET + cols * 2 + 1
+                ).to(tl.uint16)
+                zp_V = ((zpv_lo | (zpv_hi << 8)).to(tl.float16, bitcast=True)).to(
+                    tl.float32
+                )
+                v_addrs = (
+                    tile_base
+                    + V_PACKED_OFFSET
+                    + cols[:, None] * (D // PACK_V)
+                    + d_byte_v[None, :]
+                )
+                v_bytes = tl.load(KV_cache_ptr + v_addrs).to(tl.int32)
+                q_V = ((v_bytes >> d_shift_v[None, :]) & MASK_V).to(tl.float32)
+                Vc = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[None, :]
+
+            scores = tl.dot(q, K_dg)
+            scores = tl.where(cmask[None, :], scores * scale, -float("inf"))
+            m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+            p = tl.exp(scores - m_new[:, None])
+            alpha = tl.exp(m_i - m_new)
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            acc = acc * alpha[:, None] + tl.dot(p, Vc)
+            m_i = m_new
+
+    nonempty = l_i > 0
+    O_s = acc / tl.where(nonempty, l_i, 1.0)[:, None]
+    lse_s = tl.where(
+        nonempty, m_i + tl.log(tl.where(nonempty, l_i, 1.0)), -float("inf")
+    )
+    rows = b * HQ + hq0 + qh
+    tl.store(
+        MidO_ptr + rows[:, None] * stride_mo_n + split * stride_mo_s + d_offs[None, :],
+        O_s,
+        mask=qmask[:, None],
+    )
+    tl.store(MidLse_ptr + rows * stride_ml_n + split, lse_s, mask=qmask)
+
+
+@triton.jit
+def _kvarn_fused_decode_stage2(
+    MidO_ptr,  # [N, NUM_KV_SPLITS, D] fp32
+    MidLse_ptr,  # [N, NUM_KV_SPLITS]    fp32
+    Out_ptr,  # [N, D] fp16
+    stride_mo_n,
+    stride_mo_s,
+    stride_ml_n,
+    stride_o_n,
+    D: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+):
+    n = tl.program_id(0)
+    d_offs = tl.arange(0, D)
+    s_offs = tl.arange(0, NUM_KV_SPLITS)
+    lse = tl.load(MidLse_ptr + n * stride_ml_n + s_offs)
+    g = tl.max(lse, axis=0)
+    w = tl.exp(lse - g)
+    denom = tl.sum(w, axis=0)
+    O = tl.load(
+        MidO_ptr + n * stride_mo_n + s_offs[:, None] * stride_mo_s + d_offs[None, :]
+    )
+    out = tl.sum(w[:, None] * O, axis=0) / denom
+    tl.store(Out_ptr + n * stride_o_n + d_offs, out.to(tl.float16))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Python driver: kvarn_decode_attention
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def kvarn_decode_attention(
+    query: torch.Tensor,  # [B, Hq, D]   fp16/bf16
+    kv_cache: torch.Tensor,  # [num_blocks, num_kv_heads, TILE_BYTES] uint8
+    tail_K: torch.Tensor,  # [POOL_SIZE, group, Hk, D] fp16 (layer-specific)
+    tail_V: torch.Tensor,  # [POOL_SIZE, group, Hk, D] fp16 (layer-specific)
+    hadamard: torch.Tensor,  # [D, D]       fp32
+    scale: float,
+    cfg,
+    impl,  # KVarNAttnBackend (has block_to_slot_t + strides)
+    block_table: torch.Tensor,  # [B, max_blocks] int32
+    seq_lens: torch.Tensor,  # [B] int32
+    cu_seqlens: torch.Tensor,  # [B+1] int32 (prefix sum)
+    sliding_window: int = 0,  # 0 = no sliding window
+) -> torch.Tensor:
+    """Fused decode driver — dequant int4 in registers + online-softmax.
+
+    Never materializes a full fp16 K/V buffer to HBM. Moves ~int4 (0.25x FP16)
+    KV traffic for the bulk history.
+
+    Output: [B, Hq, D] in query's dtype, un-rotated frame.
+    """
+    B, Hq, D = query.shape
+    Hk = kv_cache.shape[1]
+    device = query.device
+    out_dtype = query.dtype
+    group = cfg.group
+    N = B * Hq
+
+    # 1. Q rotation — fp16 matmul
+    # Use pre-allocated buffer when available (CUDA graph capture-safe)
+    H16 = hadamard.to(torch.float16)
+    if hasattr(impl, "_q_rot_fp16_buf") and impl._q_rot_fp16_buf is not None:
+        q_rot_fp16 = impl._q_rot_fp16_buf[:N]
+        torch.mm(query.reshape(N, D).to(torch.float16), H16, out=q_rot_fp16)
+    else:
+        q_rot_fp16 = torch.mm(query.reshape(N, D).to(torch.float16), H16)
+
+    # 2. Fused decode kernel
+    max_blocks_per_req = block_table.shape[1]
+    _qpk = Hq // Hk
+    _qpk_pad = 1 << (_qpk - 1).bit_length() if _qpk > 1 else 1
+
+    fused_out = torch.empty(N, D, dtype=torch.float16, device=device)
+
+    use_fused = True
+
+    common = dict(
+        MAX_BLOCKS_PER_REQ=max_blocks_per_req,
+        D=D,
+        GROUP=group,
+        Q_PER_KV=_qpk,
+        Q_PER_KV_PAD=_qpk_pad,
+        SLIDING_WINDOW=sliding_window,
+        K_BITS=cfg.key_bits,
+        V_BITS=cfg.value_bits,
+        NUM_BLOCKS_LOOKUP=impl._block_lookup_size,
+        K_PACKED_OFFSET=cfg.k_packed_offset,
+        K_S_COL_OFFSET=cfg.k_s_col_offset,
+        K_ZP_OFFSET=cfg.k_zp_offset,
+        K_S_ROW_OFFSET=cfg.k_s_row_offset,
+        V_PACKED_OFFSET=cfg.v_packed_offset,
+        V_S_COL_OFFSET=cfg.v_s_col_offset,
+        V_S_ROW_OFFSET=cfg.v_s_row_offset,
+        V_ZP_OFFSET=cfg.v_zp_offset,
+        VQ_INDIRECT=False,
+    )
+
+    if use_fused:
+        # Split-K (two-stage flash-decoding): only a win in the LOW-batch /
+        # long-context regime (few (B,Hk) programs → the KV-split dim adds the
+        # missing parallelism). At BURST (high batch) the single-stage (B,Hk)
+        # grid already saturates the GPU.
+        #
+        # Auto-enable when context is long (>= 16 blocks) AND the single-stage
+        # grid (B*Hk) doesn't already fill the SMs.
+        #  Sliding-window layers read only
+        # ~window/GROUP blocks so never split them.
+        _sw = int(getattr(impl, "sliding_window", 0) or 0) or sliding_window
+        sm_count = (
+            getattr(impl, "_sm_count", 0)
+            or torch.cuda.get_device_properties(device).multi_processor_count
+        )
+        use_split = (_sw <= 0) and (max_blocks_per_req >= 16) and (B * Hk <= sm_count)
+        if use_split:
+            kv_splits = adaptive_num_kv_splits(max_blocks_per_req)
+            # Use pre-allocated buffers (CUDA graph capture-safe)
+            mid_O = impl._mid_o_buf[:N, :kv_splits, :]
+            mid_lse = impl._mid_lse_buf[:N, :kv_splits]
+            fused_out = impl._fused_out_buf[:N]
+            _bn = 16
+            _nw = 4
+            _ns = 2
+            _kvarn_fused_decode_stage1[(B, Hk, kv_splits)](
+                q_rot_fp16.view(B, Hq, D),
+                seq_lens,
+                block_table,
+                seq_lens,
+                impl._block_to_slot_t,
+                kv_cache,
+                tail_K,
+                tail_V,
+                mid_O,
+                mid_lse,
+                scale,
+                Hq * D,
+                D,
+                block_table.stride(0),
+                kv_cache.stride(0),
+                kv_cache.stride(1),
+                impl._tail_K_stride0,
+                impl._tail_K_stride1,
+                impl._tail_K_stride2,
+                mid_O.stride(0),
+                mid_O.stride(1),
+                mid_lse.stride(0),
+                MAX_BLOCKS_PER_REQ=max_blocks_per_req,
+                D=D,
+                GROUP=group,
+                BLOCK_N=_bn,
+                Q_PER_KV=_qpk,
+                Q_PER_KV_PAD=_qpk_pad,
+                NUM_KV_SPLITS=kv_splits,
+                HQ=Hq,
+                SLIDING_WINDOW=sliding_window,
+                K_BITS=cfg.key_bits,
+                V_BITS=cfg.value_bits,
+                NUM_BLOCKS_LOOKUP=impl._block_lookup_size,
+                K_PACKED_OFFSET=cfg.k_packed_offset,
+                K_S_COL_OFFSET=cfg.k_s_col_offset,
+                K_ZP_OFFSET=cfg.k_zp_offset,
+                K_S_ROW_OFFSET=cfg.k_s_row_offset,
+                V_PACKED_OFFSET=cfg.v_packed_offset,
+                V_S_COL_OFFSET=cfg.v_s_col_offset,
+                V_S_ROW_OFFSET=cfg.v_s_row_offset,
+                V_ZP_OFFSET=cfg.v_zp_offset,
+                VQ_INDIRECT=False,
+                num_warps=_nw,
+                num_stages=_ns,
+            )
+            _kvarn_fused_decode_stage2[(N,)](
+                mid_O,
+                mid_lse,
+                fused_out,
+                mid_O.stride(0),
+                mid_O.stride(1),
+                mid_lse.stride(0),
+                fused_out.stride(0),
+                D=D,
+                NUM_KV_SPLITS=kv_splits,
+                num_warps=2,
+            )
+            output_rot = fused_out
+        else:
+            # Single-stage fused decode: (B, Hk) grid, online softmax
+            _kvarn_fused_decode_kernel[(B, Hk)](
+                q_rot_fp16.view(B, Hq, D),
+                seq_lens,
+                block_table,
+                seq_lens,
+                impl._block_to_slot_t,
+                kv_cache,
+                tail_K,
+                tail_V,
+                fused_out.view(B, Hq, D),
+                scale,
+                Hq * D,
+                D,
+                block_table.stride(0),
+                kv_cache.stride(0),
+                kv_cache.stride(1),
+                impl._tail_K_stride0,
+                impl._tail_K_stride1,
+                impl._tail_K_stride2,
+                Hq * D,
+                D,
+                **common,
+            )
+            output_rot = fused_out
+    else:
+        # Materialize path: build packed fp16 K/V then SDPA
+        total_tokens = cu_seqlens[-1].item()
+        K_packed = torch.empty(total_tokens, Hk, D, dtype=torch.float16, device=device)
+        V_packed = torch.empty(total_tokens, Hk, D, dtype=torch.float16, device=device)
+
+        _kvarn_build_packed_kv_kernel[(B * max_blocks_per_req, Hk)](
+            block_table,
+            seq_lens,
+            cu_seqlens,
+            impl._block_to_slot_t,
+            kv_cache,
+            tail_K,
+            tail_V,
+            K_packed,
+            V_packed,
+            block_table.stride(0),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            impl._tail_K_stride0,
+            impl._tail_K_stride1,
+            impl._tail_K_stride2,
+            K_packed.stride(0),
+            K_packed.stride(1),
+            MAX_BLOCKS_PER_REQ=max_blocks_per_req,
+            D=D,
+            GROUP=group,
+            K_BITS=cfg.key_bits,
+            V_BITS=cfg.value_bits,
+            NUM_BLOCKS_LOOKUP=impl._block_lookup_size,
+            K_PACKED_OFFSET=cfg.k_packed_offset,
+            K_S_COL_OFFSET=cfg.k_s_col_offset,
+            K_ZP_OFFSET=cfg.k_zp_offset,
+            K_S_ROW_OFFSET=cfg.k_s_row_offset,
+            V_PACKED_OFFSET=cfg.v_packed_offset,
+            V_S_COL_OFFSET=cfg.v_s_col_offset,
+            V_S_ROW_OFFSET=cfg.v_s_row_offset,
+            V_ZP_OFFSET=cfg.v_zp_offset,
+            num_warps=4,
+            num_stages=2,
+        )
+        # Use SDPA for the attention
+        output_rot = torch.empty(B, Hq, D, dtype=torch.float16, device=device)
+        for i in range(B):
+            seq_len = int(seq_lens[i].item())
+            q_i = (
+                q_rot_fp16.view(B, Hq, D)[i : i + 1]
+                .transpose(0, 1)
+                .unsqueeze(0)
+                .float()
+            )
+            K_t = (
+                K_packed[cu_seqlens[i] : cu_seqlens[i] + seq_len]
+                .transpose(0, 1)
+                .unsqueeze(0)
+                .float()
+            )
+            V_t = (
+                V_packed[cu_seqlens[i] : cu_seqlens[i] + seq_len]
+                .transpose(0, 1)
+                .unsqueeze(0)
+                .float()
+            )
+            o = F.scaled_dot_product_attention(
+                q_i,
+                K_t,
+                V_t,
+                is_causal=False,
+                scale=scale,
+                enable_gqa=Hk < Hq,
+            )
+            output_rot[i] = o[0, :, 0, :].to(torch.float16)
+
+    # 3. Un-rotate output
+    out_unrot = torch.mm(output_rot.reshape(N, D), H16)
+    return out_unrot.view(B, Hq, D).to(out_dtype)
+
+
+def kvarn_scatter_store(
+    k_rot: torch.Tensor,  # [N, Hk, D] fp16 (already rotated)
+    v_rot: torch.Tensor,  # [N, Hk, D] fp16
+    slot_mapping: torch.Tensor,  # [N] int32 (out_cache_loc)
+    block_to_slot_t: torch.Tensor,  # [num_blocks_lookup] int32
+    pool_K: torch.Tensor,  # [POOL_SIZE, group, Hk, D] fp16
+    pool_V: torch.Tensor,  # [POOL_SIZE, group, Hk, D] fp16
+    group: int,
+    D: int,
+    num_blocks_lookup: int,
+):
+    """Scatter already-rotated K/V into the tail pool via block_to_slot lookup."""
+    N = k_rot.shape[0]
+    Hk = k_rot.shape[1]
+    _kvarn_scatter_store_kernel[(N, Hk)](
+        k_rot,
+        v_rot,
+        slot_mapping,
+        block_to_slot_t,
+        pool_K,
+        pool_V,
+        k_rot.stride(0),
+        k_rot.stride(1),
+        pool_K.stride(0),
+        pool_K.stride(1),
+        pool_K.stride(2),
+        GROUP=group,
+        D=D,
+        NUM_BLOCKS_LOOKUP=num_blocks_lookup,
+        num_warps=2,
+        num_stages=2,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Speculative decode verify driver: kvarn_verify_attention
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def kvarn_verify_attention(
+    query: torch.Tensor,  # [NQ, Hq, D]  fp16/bf16 (token-major)
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, TILE_BYTES] uint8
+    tail_K: torch.Tensor,  # [POOL_SIZE, group, Hk, D] fp16
+    tail_V: torch.Tensor,  # [POOL_SIZE, group, Hk, D] fp16
+    hadamard: torch.Tensor,  # [D, D] fp32
+    scale: float,
+    cfg,
+    impl,  # KVarNAttnBackend
+    block_table: torch.Tensor,  # [B, max_blocks] int32
+    vq_req: torch.Tensor,  # [NQ] int32 — block-table row per token
+    vq_seqlen: torch.Tensor,  # [NQ] int32 — causal len: cached+i+1
+    max_ctx_blocks: int,  # ceil(max context / group) upper bound
+    sliding_window: int = 0,
+) -> torch.Tensor:
+    """Fused multi-query verify (speculative decode), reading int4 tiles +
+    the fp16 tail pool directly — no fp16 materialization of the context.
+
+    Each query token becomes a virtual kernel row with its own causal length
+    and block-table row indirection (VQ_INDIRECT=True).
+
+    Output: [NQ, Hq, D] in query's dtype, un-rotated frame.
+    """
+    NQ, Hq, D = query.shape
+    Hk = kv_cache.shape[1]
+    device = query.device
+    out_dtype = query.dtype
+    group = cfg.group
+    Nrows = NQ * Hq
+
+    H16 = hadamard.to(torch.float16)
+    q_rot = torch.mm(query.reshape(Nrows, D).to(torch.float16), H16)
+
+    _qpk = Hq // Hk
+    _qpk_pad = 1 << (_qpk - 1).bit_length() if _qpk > 1 else 1
+
+    common = dict(
+        MAX_BLOCKS_PER_REQ=max_ctx_blocks,
+        D=D,
+        GROUP=group,
+        Q_PER_KV=_qpk,
+        Q_PER_KV_PAD=_qpk_pad,
+        SLIDING_WINDOW=sliding_window,
+        K_BITS=cfg.key_bits,
+        V_BITS=cfg.value_bits,
+        NUM_BLOCKS_LOOKUP=impl._block_lookup_size,
+        K_PACKED_OFFSET=cfg.k_packed_offset,
+        K_S_COL_OFFSET=cfg.k_s_col_offset,
+        K_ZP_OFFSET=cfg.k_zp_offset,
+        K_S_ROW_OFFSET=cfg.k_s_row_offset,
+        V_PACKED_OFFSET=cfg.v_packed_offset,
+        V_S_COL_OFFSET=cfg.v_s_col_offset,
+        V_S_ROW_OFFSET=cfg.v_s_row_offset,
+        V_ZP_OFFSET=cfg.v_zp_offset,
+        VQ_INDIRECT=True,
+    )
+
+    out_rot = torch.empty(NQ, Hq, D, dtype=torch.float16, device=device)
+
+    _kvarn_fused_decode_kernel[(NQ, Hk)](
+        q_rot,
+        vq_req,
+        block_table,
+        vq_seqlen,
+        impl._block_to_slot_t,
+        kv_cache,
+        tail_K,
+        tail_V,
+        out_rot,
+        scale,
+        Hq * D,
+        D,
+        block_table.stride(0),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        impl._tail_K_stride0,
+        impl._tail_K_stride1,
+        impl._tail_K_stride2,
+        Hq * D,
+        D,
+        **common,
+    )
+
+    out_unrot = torch.mm(out_rot.reshape(Nrows, D), H16)
+    return out_unrot.view(NQ, Hq, D).to(out_dtype)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shared-dequant verify kernel: one program per (REQUEST, kv-head, split)
+# All QLEN verify tokens of a request share each block's dequant.
+# Q tile is [QLEN * Q_PER_KV_PAD, D] with per-row causal limit.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@_maybe_autotune_verify
+@triton.jit
+def _kvarn_fused_verify_stage1(
+    Q_ptr,
+    Block_table_ptr,
+    Seq_lens_ptr,
+    Block_to_slot_ptr,
+    KV_cache_ptr,
+    Tail_K_pool_ptr,
+    Tail_V_pool_ptr,
+    MidO_ptr,
+    MidLse_ptr,
+    scale,
+    stride_q_t,
+    stride_q_h,
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_mo_n,
+    stride_mo_s,
+    stride_ml_n,
+    MAX_BLOCKS_PER_REQ: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    QLEN: tl.constexpr,
+    Q_PER_KV: tl.constexpr,
+    Q_PER_KV_PAD: tl.constexpr,
+    HQ: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+):
+    b = tl.program_id(0)
+    hk = tl.program_id(1)
+    split = tl.program_id(2)
+
+    seq_len = tl.load(Seq_lens_ptr + b * QLEN + (QLEN - 1))
+    if seq_len <= 0:
+        return
+
+    M: tl.constexpr = QLEN * Q_PER_KV_PAD
+    r = tl.arange(0, M)
+    j = r // Q_PER_KV_PAD
+    lane = r % Q_PER_KV_PAD
+    rmask = lane < Q_PER_KV
+    limit = seq_len - QLEN + j + 1
+    hq0 = hk * Q_PER_KV
+    d_offs = tl.arange(0, D)
+
+    PACK_K: tl.constexpr = 8 // K_BITS
+    PACK_V: tl.constexpr = 8 // V_BITS
+    MASK_K: tl.constexpr = (1 << K_BITS) - 1
+    MASK_V: tl.constexpr = (1 << V_BITS) - 1
+    d_byte_v = d_offs // PACK_V
+    d_shift_v = (d_offs % PACK_V) * V_BITS
+
+    tok_row = b * QLEN + j
+    q = tl.load(
+        Q_ptr
+        + tok_row[:, None] * stride_q_t
+        + (hq0 + lane)[:, None] * stride_q_h
+        + d_offs[None, :],
+        mask=rmask[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    m_i = tl.full([M], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([M], dtype=tl.float32)
+    acc = tl.zeros([M, D], dtype=tl.float32)
+
+    n_blocks = (seq_len + GROUP - 1) // GROUP
+    blocks_per_split = (n_blocks + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
+    blk_lo = split * blocks_per_split
+    blk_hi = tl.minimum(blk_lo + blocks_per_split, n_blocks)
+
+    for k in range(blk_lo, blk_hi):
+        rem = seq_len - k * GROUP
+        n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+        block_id = tl.load(Block_table_ptr + b * stride_bt_b + k)
+        in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+        safe_bid = tl.where(in_range, block_id, 0)
+        pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+        safe_slot = tl.where(pool_slot >= 0, pool_slot, 0)
+        pool_base = safe_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+
+        s_col_K = tl.load(
+            (KV_cache_ptr + tile_base + K_S_COL_OFFSET).to(tl.pointer_type(tl.float16))
+            + d_offs
+        ).to(tl.float32)
+        zp_K = tl.load(
+            (KV_cache_ptr + tile_base + K_ZP_OFFSET).to(tl.pointer_type(tl.float16))
+            + d_offs
+        ).to(tl.float32)
+        s_col_V = tl.load(
+            (KV_cache_ptr + tile_base + V_S_COL_OFFSET).to(tl.pointer_type(tl.float16))
+            + d_offs
+        ).to(tl.float32)
+
+        for c0 in range(0, GROUP, BLOCK_N):
+            cols = c0 + tl.arange(0, BLOCK_N)
+            cmask = cols < n_tok
+            kvpos = k * GROUP + cols
+
+            if pool_slot >= 0:
+                src = pool_base + cols[:, None] * stride_pool_t + d_offs[None, :]
+                Kc = tl.load(Tail_K_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                Vc = tl.load(Tail_V_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                K_dg = tl.trans(Kc)
+            else:
+                cb_k = cols // PACK_K
+                cs_k = (cols % PACK_K) * K_BITS
+                s_row_K = tl.load(
+                    (KV_cache_ptr + tile_base + K_S_ROW_OFFSET).to(
+                        tl.pointer_type(tl.float16)
+                    )
+                    + cols
+                ).to(tl.float32)
+                k_addrs = (
+                    tile_base
+                    + K_PACKED_OFFSET
+                    + d_offs[:, None] * (GROUP // PACK_K)
+                    + cb_k[None, :]
+                )
+                k_bytes = tl.load(KV_cache_ptr + k_addrs).to(tl.int32)
+                q_K = ((k_bytes >> cs_k[None, :]) & MASK_K).to(tl.float32)
+                K_dg = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[None, :]
+                s_row_V = tl.load(
+                    (KV_cache_ptr + tile_base + V_S_ROW_OFFSET).to(
+                        tl.pointer_type(tl.float16)
+                    )
+                    + cols
+                ).to(tl.float32)
+                zp_V = tl.load(
+                    (KV_cache_ptr + tile_base + V_ZP_OFFSET).to(
+                        tl.pointer_type(tl.float16)
+                    )
+                    + cols
+                ).to(tl.float32)
+                v_addrs = (
+                    tile_base
+                    + V_PACKED_OFFSET
+                    + cols[:, None] * (D // PACK_V)
+                    + d_byte_v[None, :]
+                )
+                v_bytes = tl.load(KV_cache_ptr + v_addrs).to(tl.int32)
+                q_V = ((v_bytes >> d_shift_v[None, :]) & MASK_V).to(tl.float32)
+                Vc = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[None, :]
+
+            scores = tl.dot(q, K_dg)
+            smask = cmask[None, :] & (kvpos[None, :] < limit[:, None])
+            if SLIDING_WINDOW > 0:
+                smask = smask & (
+                    kvpos[None, :] >= tl.maximum(limit[:, None] - SLIDING_WINDOW, 0)
+                )
+            scores = tl.where(smask, scores * scale, -float("inf"))
+            m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+            p = tl.exp(scores - m_new[:, None])
+            alpha = tl.exp(m_i - m_new)
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            acc = acc * alpha[:, None] + tl.dot(p, Vc)
+            m_i = m_new
+
+    nonempty = l_i > 0
+    O_s = acc / tl.where(nonempty, l_i, 1.0)[:, None]
+    lse_s = tl.where(
+        nonempty, m_i + tl.log(tl.where(nonempty, l_i, 1.0)), -float("inf")
+    )
+    rows = tok_row * HQ + hq0 + lane
+    tl.store(
+        MidO_ptr + rows[:, None] * stride_mo_n + split * stride_mo_s + d_offs[None, :],
+        O_s,
+        mask=rmask[:, None],
+    )
+    tl.store(MidLse_ptr + rows * stride_ml_n + split, lse_s, mask=rmask)

--- a/python/sglang/srt/layers/attention/kvarn_ops/triton_sinkhorn.py
+++ b/python/sglang/srt/layers/attention/kvarn_ops/triton_sinkhorn.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Triton fused log-domain iterative variance-normalization for KVarN.
+
+One Triton program per ``[R, C]`` tile.
+
+For ``R = C = 128`` the full tile is 64 KB fp32 — fits in a single Triton
+block's register/SMEM budget.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.quantization.kvarn.sinkhorn import (
+    variance_normalize_batched,
+)
+
+_CLIP_STD_MIN = 1e-3
+_CLIP_STD_MAX = 1e3
+_LOG_S_MIN = -0.3
+_LOG_S_MAX = 10.0
+
+
+@triton.jit
+def _sinkhorn_log_kernel(
+    Tile_ptr,  # [N, R, C] fp32 input
+    Balanced_ptr,  # [N, R, C] fp32 output
+    SCol_ptr,  # [N, C] fp32 output
+    SRow_ptr,  # [N, R] fp32 output
+    stride_tn,
+    stride_tr,
+    stride_bn,
+    stride_br,
+    stride_sc_n,
+    stride_sr_n,
+    R: tl.constexpr,
+    C: tl.constexpr,
+    ITERATIONS: tl.constexpr,
+    CLIP_STD_MIN: tl.constexpr,
+    CLIP_STD_MAX: tl.constexpr,
+    LOG_S_MIN: tl.constexpr,
+    LOG_S_MAX: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    r_offs = tl.arange(0, R)
+    c_offs = tl.arange(0, C)
+
+    tile_base = pid * stride_tn
+    tile_ptrs = Tile_ptr + tile_base + r_offs[:, None] * stride_tr + c_offs[None, :]
+    tile = tl.load(tile_ptrs).to(tl.float32)
+
+    log_s_col = tl.zeros([C], dtype=tl.float32)
+    log_s_row = tl.zeros([R], dtype=tl.float32)
+
+    cur = tile
+
+    col_mean0 = tl.sum(cur, axis=0) / R
+    col_var0 = tl.sum(cur * cur, axis=0) / R - col_mean0 * col_mean0
+    col_std0 = tl.sqrt(tl.maximum(col_var0 * R / (R - 1), 0.0))
+    row_mean0 = tl.sum(cur, axis=1) / C
+    row_var0 = tl.sum(cur * cur, axis=1) / C - row_mean0 * row_mean0
+    row_std0 = tl.sqrt(tl.maximum(row_var0 * C / (C - 1), 0.0))
+
+    col_max0 = tl.max(col_std0)
+    col_min0 = tl.maximum(tl.min(col_std0), 1e-8)
+    row_max0 = tl.max(row_std0)
+    row_min0 = tl.maximum(tl.min(row_std0), 1e-8)
+    imb_best = col_max0 / col_min0 + row_max0 / row_min0
+
+    sc_best = tl.exp(log_s_col)
+    sr_best = tl.exp(log_s_row)
+
+    for _ in tl.static_range(ITERATIONS):
+        col_mean = tl.sum(cur, axis=0) / R
+        col_var = tl.sum(cur * cur, axis=0) / R - col_mean * col_mean
+        col_std = tl.sqrt(tl.maximum(col_var * R / (R - 1), 0.0))
+        col_std_clipped = tl.maximum(tl.minimum(col_std, CLIP_STD_MAX), CLIP_STD_MIN)
+        log_s_col = log_s_col + tl.log(col_std_clipped)
+        log_s_col = tl.maximum(tl.minimum(log_s_col, LOG_S_MAX), LOG_S_MIN)
+        s_col_lin = tl.exp(log_s_col)
+        s_row_lin = tl.exp(log_s_row)
+        cur = tile / s_col_lin[None, :] / s_row_lin[:, None]
+
+        row_mean = tl.sum(cur, axis=1) / C
+        row_var = tl.sum(cur * cur, axis=1) / C - row_mean * row_mean
+        row_std = tl.sqrt(tl.maximum(row_var * C / (C - 1), 0.0))
+        row_std_clipped = tl.maximum(tl.minimum(row_std, CLIP_STD_MAX), CLIP_STD_MIN)
+        log_s_row = log_s_row + tl.log(row_std_clipped)
+        log_s_row = tl.maximum(tl.minimum(log_s_row, LOG_S_MAX), LOG_S_MIN)
+        s_col_lin = tl.exp(log_s_col)
+        s_row_lin = tl.exp(log_s_row)
+        cur = tile / s_col_lin[None, :] / s_row_lin[:, None]
+
+        col_mean_n = tl.sum(cur, axis=0) / R
+        col_var_n = tl.sum(cur * cur, axis=0) / R - col_mean_n * col_mean_n
+        col_std_n = tl.sqrt(tl.maximum(col_var_n * R / (R - 1), 0.0))
+        row_mean_n = tl.sum(cur, axis=1) / C
+        row_var_n = tl.sum(cur * cur, axis=1) / C - row_mean_n * row_mean_n
+        row_std_n = tl.sqrt(tl.maximum(row_var_n * C / (C - 1), 0.0))
+        col_max_n = tl.max(col_std_n)
+        col_min_n = tl.maximum(tl.min(col_std_n), 1e-8)
+        row_max_n = tl.max(row_std_n)
+        row_min_n = tl.maximum(tl.min(row_std_n), 1e-8)
+        imb = col_max_n / col_min_n + row_max_n / row_min_n
+
+        better = imb <= imb_best
+        sc_best = tl.where(better, s_col_lin, sc_best)
+        sr_best = tl.where(better, s_row_lin, sr_best)
+        imb_best = tl.where(better, imb, imb_best)
+
+    balanced = tile / sc_best[None, :] / sr_best[:, None]
+    bal_ptrs = (
+        Balanced_ptr + pid * stride_bn + r_offs[:, None] * stride_br + c_offs[None, :]
+    )
+    tl.store(bal_ptrs, balanced)
+    tl.store(SCol_ptr + pid * stride_sc_n + c_offs, sc_best)
+    tl.store(SRow_ptr + pid * stride_sr_n + r_offs, sr_best)
+
+
+def kvarn_sinkhorn_triton(
+    tiles: torch.Tensor,
+    iterations: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Triton driver for ``_sinkhorn_log_kernel``.
+
+    Args:
+        tiles: ``[N, R, C]`` fp32 (or any real dtype, cast inside). Both R
+            and C must be compile-time-constant power-of-2 values.
+        iterations: number of alternating col/row passes (default 16).
+
+    Returns:
+        balanced: ``[N, R, C]`` fp32.
+        s_col:    ``[N, C]`` fp32.
+        s_row:    ``[N, R]`` fp32.
+    """
+    assert tiles.ndim == 3
+    N, R, C = tiles.shape
+    tiles = tiles.contiguous().to(torch.float32)
+    device = tiles.device
+
+    if max(R, C) > 256:
+        bal, s_col_b, s_row_b = variance_normalize_batched(tiles, iterations=iterations)
+        return (
+            bal.contiguous(),
+            s_col_b.reshape(N, C).contiguous(),
+            s_row_b.reshape(N, R).contiguous(),
+        )
+
+    balanced = torch.empty(N, R, C, dtype=torch.float32, device=device)
+    s_col = torch.empty(N, C, dtype=torch.float32, device=device)
+    s_row = torch.empty(N, R, dtype=torch.float32, device=device)
+
+    _sinkhorn_log_kernel[(N,)](
+        tiles,
+        balanced,
+        s_col,
+        s_row,
+        tiles.stride(0),
+        tiles.stride(1),
+        balanced.stride(0),
+        balanced.stride(1),
+        s_col.stride(0),
+        s_row.stride(0),
+        R=R,
+        C=C,
+        ITERATIONS=iterations,
+        CLIP_STD_MIN=_CLIP_STD_MIN,
+        CLIP_STD_MAX=_CLIP_STD_MAX,
+        LOG_S_MIN=_LOG_S_MIN,
+        LOG_S_MAX=_LOG_S_MAX,
+        num_warps=8,
+        num_stages=2,
+    )
+    return balanced, s_col, s_row

--- a/python/sglang/srt/layers/quantization/kvarn/__init__.py
+++ b/python/sglang/srt/layers/quantization/kvarn/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN KV-cache quantization for SGLang."""
+
+from sglang.srt.layers.quantization.kvarn.config import (
+    KVARN_PRESETS,
+    KVarNConfig,
+)
+
+__all__ = ["KVARN_PRESETS", "KVarNConfig"]

--- a/python/sglang/srt/layers/quantization/kvarn/config.py
+++ b/python/sglang/srt/layers/quantization/kvarn/config.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN configuration.
+
+KVarN = Hadamard rotation + iterative variance
+normalization (Sinkhorn-like) + asymmetric RTN quantization.
+
+The configuration object is pure (no framework imports) so it can be
+unit-tested in isolation.
+"""
+
+import math
+import os
+from dataclasses import dataclass
+
+# Named KVarN presets: each maps to a frozen set of config parameters.
+# The trailing g<N> encodes the variance-normalization tile size, which must
+# equal the page size. g128 is the current design point; g64 trades a little
+# compression (more per-tile scale overhead) for finer quantization granularity.
+KVARN_PRESETS: dict[str, dict] = {
+    "kvarn_k4v2_g128": {"key_bits": 4, "value_bits": 2, "group": 128},
+    "kvarn_k4v4_g128": {"key_bits": 4, "value_bits": 4, "group": 128},
+    "kvarn_k4v2_g64": {"key_bits": 4, "value_bits": 2, "group": 64},
+    "kvarn_k4v4_g64": {"key_bits": 4, "value_bits": 4, "group": 64},
+}
+
+
+def is_kvarn_dtype(dtype_str: str) -> bool:
+    """Return True if *dtype_str* is a KVarN preset name."""
+    return isinstance(dtype_str, str) and dtype_str.startswith("kvarn_")
+
+
+@dataclass
+class KVarNConfig:
+    """Configuration for KVarN KV-cache quantization.
+
+    Pipeline per (block, head):
+      1. Hadamard rotation along head_dim.
+      2. Iterative log-domain variance-normalization (Sinkhorn-like).
+      3. Asymmetric per-row RTN at key_bits / value_bits.
+      4. Absorb the per-row RTN scale and zero-point into the matching
+         sinkhorn scale axis.
+
+    Cache layout (per (block, head)) is a single packed record — see
+    ``tile_bytes`` / ``tile_bytes_aligned``.
+    """
+
+    head_dim: int = 128
+    key_bits: int = 4
+    value_bits: int = 4
+    group: int = 128
+    sinkhorn_iters: int = 8
+    sink_tokens: int = 128
+    boundary_skip_layers: int = 0
+
+    # ── derived: storage layout ──────────────────────────────────────────────
+    @property
+    def k_packed_bytes(self) -> int:
+        return math.ceil(self.head_dim * self.group * self.key_bits / 8)
+
+    @property
+    def v_packed_bytes(self) -> int:
+        return math.ceil(self.group * self.head_dim * self.value_bits / 8)
+
+    @property
+    def k_scale_bytes(self) -> int:
+        """fp16 bytes for K scales: s_col_K' [D] + zp_K' [D] + s_row_K [group]."""
+        return (2 * self.head_dim + self.group) * 2
+
+    @property
+    def v_scale_bytes(self) -> int:
+        """fp16 bytes for V scales: s_col_V [D] + s_row_V' [group] + zp_V' [group]."""
+        return (self.head_dim + 2 * self.group) * 2
+
+    @property
+    def tile_bytes(self) -> int:
+        return (
+            self.k_packed_bytes
+            + self.k_scale_bytes
+            + self.v_packed_bytes
+            + self.v_scale_bytes
+        )
+
+    @property
+    def tile_bytes_aligned(self) -> int:
+        """tile_bytes rounded up for nicer Triton loads."""
+        if self.head_dim >= 256:
+            slot = math.ceil(self.tile_bytes / self.group)
+            slot_pow2 = 1 << (slot - 1).bit_length()
+            return slot_pow2 * self.group
+        return ((self.tile_bytes + 7) // 8) * 8
+
+    # ── slot byte offsets within one tile (used by the kernels) ──────────────
+    @property
+    def k_packed_offset(self) -> int:
+        return 0
+
+    @property
+    def k_s_col_offset(self) -> int:
+        return self.k_packed_offset + self.k_packed_bytes
+
+    @property
+    def k_zp_offset(self) -> int:
+        return self.k_s_col_offset + self.head_dim * 2
+
+    @property
+    def k_s_row_offset(self) -> int:
+        return self.k_zp_offset + self.head_dim * 2
+
+    @property
+    def v_packed_offset(self) -> int:
+        return self.k_s_row_offset + self.group * 2
+
+    @property
+    def v_s_col_offset(self) -> int:
+        return self.v_packed_offset + self.v_packed_bytes
+
+    @property
+    def v_s_row_offset(self) -> int:
+        return self.v_s_col_offset + self.head_dim * 2
+
+    @property
+    def v_zp_offset(self) -> int:
+        return self.v_s_row_offset + self.group * 2
+
+    # ── fp16 tail-pool sizing ────────────────────────────────────────────────
+    POOL_MEM_FRAC_DEFAULT = 0.08
+    POOL_USABLE_SHARE_DEFAULT = 0.5
+
+    def _slot_bytes_per_layer(self, num_kv_heads: int) -> int:
+        return self.group * num_kv_heads * self.head_dim * 4
+
+    def pool_slots(self, max_num_seqs: int, max_num_batched_tokens: int) -> int:
+        prefill_blocks = (max_num_batched_tokens + self.group - 1) // self.group
+        return max(2 * max_num_seqs + prefill_blocks + 8, 8)
+
+    def pool_budget_bytes(
+        self,
+        total_gpu_bytes: int,
+        gpu_memory_utilization: float | None = None,
+        weight_bytes: int | None = None,
+    ) -> int:
+        if weight_bytes is not None and gpu_memory_utilization is not None:
+            share = self.POOL_USABLE_SHARE_DEFAULT
+            usable = gpu_memory_utilization * total_gpu_bytes - weight_bytes
+            return max(0, int(share * usable))
+        return int(total_gpu_bytes * self.POOL_MEM_FRAC_DEFAULT)
+
+    def max_supported_seqs(
+        self,
+        total_gpu_bytes: int,
+        num_kv_heads: int,
+        num_layers: int,
+        max_num_batched_tokens: int,
+        frac: float | None = None,
+        gpu_memory_utilization: float | None = None,
+        weight_bytes: int | None = None,
+    ) -> int:
+        if frac is not None:
+            budget = int(total_gpu_bytes * frac)
+        else:
+            budget = self.pool_budget_bytes(
+                total_gpu_bytes, gpu_memory_utilization, weight_bytes
+            )
+        slot_bytes = self._slot_bytes_per_layer(num_kv_heads) * max(num_layers, 1)
+        max_slots = int(budget / slot_bytes)
+        prefill_blocks = (max_num_batched_tokens + self.group - 1) // self.group
+        return max(1, (max_slots - prefill_blocks - 8) // 2)
+
+    def pool_bytes(
+        self,
+        max_num_seqs: int,
+        max_num_batched_tokens: int,
+        num_kv_heads: int,
+        num_layers: int,
+    ) -> int:
+        slots = self.pool_slots(max_num_seqs, max_num_batched_tokens)
+        return slots * self._slot_bytes_per_layer(num_kv_heads) * max(num_layers, 1)
+
+    @staticmethod
+    def num_kvarn_layers(model_config, parallel_config=None) -> int:
+        """Number of layers the KVarN fp16 tail pool actually spans = the
+        full-attention layers. On a hybrid model (Qwen3.5/3.6, Jamba, ...) the
+        Mamba/linear-attention layers have no KVarN pool, so sizing the pool by
+        ALL layers over-reserves it ~Nx and starves the Mamba/KV caches (OOM or
+        cap collapse). For a dense transformer this equals total layers, so the
+        dense path is unchanged. Falls back to total layers if the per-type
+        count is unavailable."""
+        try:
+            if hasattr(model_config, "get_num_layers_by_block_type"):
+                n = model_config.get_num_layers_by_block_type(
+                    parallel_config, "attention"
+                )
+                if n and n > 0:
+                    return n
+            if hasattr(model_config, "num_attention_layers"):
+                n = model_config.num_attention_layers
+                if n and n > 0:
+                    return n
+        except Exception:
+            pass
+
+        # Fallback: total layers
+        if hasattr(model_config, "num_layers"):
+            return model_config.num_layers
+        if hasattr(model_config, "get_num_layers"):
+            return (
+                model_config.get_num_layers(parallel_config)
+                if parallel_config
+                else model_config.get_num_layers()
+            )
+        return 24  # Safe default
+
+    @staticmethod
+    def estimate_weight_bytes(model: str, tensor_parallel_size: int = 1) -> int | None:
+        """Best-effort per-rank model weight size in bytes, read from the
+        checkpoint files on disk (exact, and cheap, with no CUDA context).
+        Returns None if the files can't be located, so the caller falls back
+        to the legacy budget.
+
+        Resolves a local directory directly, or the local HF cache snapshot for
+        a repo id (never downloads). Prefers the shards named in a
+        ``*.safetensors.index.json`` manifest, which is exactly the set the
+        loader reads. This avoids double-counting a repo that ships both a
+        single consolidated checkpoint and the sharded HF set. Divides by the
+        tensor-parallel degree (weights shard ~evenly across ranks)."""
+        import glob as _glob
+        import json as _json
+
+        try:
+            d = model
+            if not os.path.isdir(d):
+                try:
+                    from huggingface_hub import snapshot_download
+
+                    d = snapshot_download(model, local_files_only=True)
+                except Exception:
+                    return None
+
+            # 1) Prefer the loader's own manifest
+            for ext in ("safetensors", "bin"):
+                indexes = _glob.glob(
+                    os.path.join(d, "**", f"*.{ext}.index.json"), recursive=True
+                )
+                if not indexes:
+                    continue
+                try:
+                    with open(indexes[0]) as fh:
+                        weight_map = _json.load(fh).get("weight_map", {})
+                    base = os.path.dirname(indexes[0])
+                    names = sorted(set(weight_map.values()))
+                    shards = [os.path.join(base, s) for s in names]
+                    if names and all(os.path.exists(p) for p in shards):
+                        total = sum(os.path.getsize(p) for p in shards)
+                        if total > 0:
+                            return total // max(tensor_parallel_size, 1)
+                except Exception:
+                    pass
+
+            # 2) No usable manifest: prefer a canonical single-file checkpoint
+            for single in ("model.safetensors", "consolidated.safetensors"):
+                p = os.path.join(d, single)
+                if os.path.exists(p):
+                    total = os.path.getsize(p)
+                    if total > 0:
+                        return total // max(tensor_parallel_size, 1)
+
+            # 3) Fallback: sum whatever weight shards are present
+            files = _glob.glob(os.path.join(d, "**", "*.safetensors"), recursive=True)
+            if not files:
+                files = _glob.glob(os.path.join(d, "**", "*.bin"), recursive=True)
+            if not files:
+                return None
+            total = sum(os.path.getsize(f) for f in files)
+            if total <= 0:
+                return None
+            return total // max(tensor_parallel_size, 1)
+        except Exception:
+            return None
+
+    @staticmethod
+    def get_boundary_skip_layers(num_layers: int, n: int = 2) -> list[str]:
+        if n <= 0 or num_layers <= 0:
+            return []
+        n = min(n, num_layers // 2)
+        first = list(range(n))
+        last = list(range(num_layers - n, num_layers))
+        return [str(i) for i in sorted(set(first + last))]
+
+    @staticmethod
+    def from_cache_dtype(cache_dtype: str, head_dim: int) -> "KVarNConfig":
+        """Create a config from a preset string like ``"kvarn_k4v4_g128"``."""
+        if cache_dtype not in KVARN_PRESETS:
+            valid = ", ".join(KVARN_PRESETS.keys())
+            raise ValueError(
+                f"Unknown KVarN cache dtype: {cache_dtype!r}. Valid: {valid}"
+            )
+        preset = KVARN_PRESETS[cache_dtype]
+        return KVarNConfig(
+            head_dim=head_dim,
+            key_bits=preset["key_bits"],
+            value_bits=preset["value_bits"],
+            group=preset["group"],
+            sinkhorn_iters=8,
+            sink_tokens=128,
+        )

--- a/python/sglang/srt/layers/quantization/kvarn/dequant.py
+++ b/python/sglang/srt/layers/quantization/kvarn/dequant.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN tile-level dequant reference (pure PyTorch).
+
+Inverse of the store functions.
+
+Dequant identities:
+    K_rot[d, g] = (q_K[d, g] * s_col_K[d] + zp_K[d]) * s_row_K[g]
+    V_rot[g, d] = (q_V[g, d] * s_row_V[g] + zp_V[g]) * s_col_V[d]
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def _unpack_4bit(packed: torch.Tensor, original_last_dim: int) -> torch.Tensor:
+    """Inverse of ``_pack_4bit``."""
+    assert original_last_dim % 2 == 0
+    lo = packed & 0xF
+    hi = (packed >> 4) & 0xF
+    out = torch.empty(
+        *packed.shape[:-1],
+        original_last_dim,
+        dtype=torch.uint8,
+        device=packed.device,
+    )
+    out[..., 0::2] = lo
+    out[..., 1::2] = hi
+    return out
+
+
+def _unpack_lowbit(
+    packed: torch.Tensor, original_last_dim: int, bits: int
+) -> torch.Tensor:
+    """Inverse of ``_pack_lowbit`` for any ``bits`` in {2, 4}."""
+    if bits == 4:
+        return _unpack_4bit(packed, original_last_dim)
+    pack = 8 // bits
+    mask = (1 << bits) - 1
+    assert original_last_dim % pack == 0
+    out = torch.empty(
+        *packed.shape[:-1],
+        original_last_dim,
+        dtype=torch.uint8,
+        device=packed.device,
+    )
+    for j in range(pack):
+        out[..., j::pack] = (packed >> (j * bits)) & mask
+    return out
+
+
+def kvarn_dequant_tile_k(
+    q_packed_uint8: torch.Tensor,
+    s_col_K: torch.Tensor,
+    zp_K: torch.Tensor,
+    s_row_K: torch.Tensor,
+    group: int,
+    bits: int = 4,
+) -> torch.Tensor:
+    """Dequantize one K tile back to the rotated ``[D, group]`` frame.
+
+    Args:
+        q_packed_uint8 : ``[D, group // (8//bits)]`` uint8.
+        s_col_K        : ``[D]`` fp16
+        zp_K           : ``[D]`` fp16
+        s_row_K        : ``[group]`` fp16
+        group          : tile width in tokens.
+        bits           : quant bit-width of K (default 4).
+
+    Returns:
+        ``[D, group]`` fp32 dequantized tile in the rotated frame.
+    """
+    q = _unpack_lowbit(q_packed_uint8, group, bits).float()
+    s_col = s_col_K.float().unsqueeze(-1)
+    zp = zp_K.float().unsqueeze(-1)
+    s_row = s_row_K.float().unsqueeze(0)
+    return (q * s_col + zp) * s_row
+
+
+def kvarn_dequant_tile_v(
+    q_packed_uint8: torch.Tensor,
+    s_col_V: torch.Tensor,
+    s_row_V: torch.Tensor,
+    zp_V: torch.Tensor,
+    head_dim: int,
+    bits: int = 4,
+) -> torch.Tensor:
+    """Dequantize one V tile back to the rotated ``[group, D]`` frame.
+
+    Args:
+        q_packed_uint8 : ``[group, D // (8//bits)]`` uint8.
+        s_col_V        : ``[D]``     fp16
+        s_row_V        : ``[group]`` fp16
+        zp_V           : ``[group]`` fp16
+        head_dim       : tile width in channels.
+        bits           : quant bit-width of V (default 4).
+
+    Returns:
+        ``[group, D]`` fp32 dequantized tile in the rotated frame.
+    """
+    q = _unpack_lowbit(q_packed_uint8, head_dim, bits).float()
+    s_row = s_row_V.float().unsqueeze(-1)
+    zp = zp_V.float().unsqueeze(-1)
+    s_col = s_col_V.float().unsqueeze(0)
+    return (q * s_row + zp) * s_col
+
+
+def kvarn_dequant_tile_k_batch(
+    q_packed_uint8: torch.Tensor,
+    s_col_K: torch.Tensor,
+    zp_K: torch.Tensor,
+    s_row_K: torch.Tensor,
+    group: int,
+    bits: int = 4,
+) -> torch.Tensor:
+    """Batched dequant.  q_packed_uint8: ``[N, D, group/pack]``.
+
+    Returns ``[N, D, group]`` fp32.
+    """
+    q = _unpack_lowbit(q_packed_uint8, group, bits).float()
+    s_col = s_col_K.float().unsqueeze(-1)
+    zp = zp_K.float().unsqueeze(-1)
+    s_row = s_row_K.float().unsqueeze(1)
+    return (q * s_col + zp) * s_row
+
+
+def kvarn_dequant_tile_v_batch(
+    q_packed_uint8: torch.Tensor,
+    s_col_V: torch.Tensor,
+    s_row_V: torch.Tensor,
+    zp_V: torch.Tensor,
+    head_dim: int,
+    bits: int = 4,
+) -> torch.Tensor:
+    """Batched dequant.  q_packed_uint8: ``[N, group, D/pack]``.
+
+    Returns ``[N, group, D]`` fp32.
+    """
+    q = _unpack_lowbit(q_packed_uint8, head_dim, bits).float()
+    s_row = s_row_V.float().unsqueeze(-1)
+    zp = zp_V.float().unsqueeze(-1)
+    s_col = s_col_V.float().unsqueeze(1)
+    return (q * s_row + zp) * s_col

--- a/python/sglang/srt/layers/quantization/kvarn/flush_manager.py
+++ b/python/sglang/srt/layers/quantization/kvarn/flush_manager.py
@@ -1,0 +1,430 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN tile flush manager.
+
+Manages the lifecycle of KV cache blocks in the dual-pool architecture:
+  - **Tail pool** (fp16): stores rotated K/V for in-progress + sink blocks.
+    Each block occupies one tail-pool slot: ``[pool_slots, group, Hk, D]``.
+  - **Compressed cache** (int4/uint8): stores flushed blocks as packed tiles.
+    ``[num_blocks, Hk, tile_bytes]`` per layer.
+
+Flush = compress fp16 tail pool → int4 cache, then free the tail pool slot.
+Dequant = read int4 cache → fp16 (on demand, for attention).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from sglang.srt.layers.quantization.kvarn.config import KVarNConfig
+from sglang.srt.layers.quantization.kvarn.dequant import (
+    kvarn_dequant_tile_k,
+    kvarn_dequant_tile_v,
+)
+from sglang.srt.layers.quantization.kvarn.sinkhorn import variance_normalize_batched
+from sglang.srt.layers.quantization.kvarn.store import (
+    kvarn_store_tile_k_batch_from_sinkhorn,
+    kvarn_store_tile_v_batch_from_sinkhorn,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KVarNFlushManager:
+    """Manages the fp16 tail pool ↔ int4 compressed cache lifecycle."""
+
+    def __init__(
+        self,
+        cfg: KVarNConfig,
+        num_layers: int,
+        num_kv_heads: int,
+        head_dim: int,
+        v_head_dim: int,
+        sink_blocks: int = 1,
+    ):
+        self.cfg = cfg
+        self.num_layers = num_layers
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.v_head_dim = v_head_dim if v_head_dim else head_dim
+        self.group = cfg.group
+        self.tile_bytes = cfg.tile_bytes_aligned
+        self.sink_blocks = sink_blocks
+
+    def flush_block(
+        self,
+        block_id: int,
+        tail_K: list[torch.Tensor],  # per-layer [pool_slots, group, Hk, D] fp16
+        tail_V: list[torch.Tensor],  # per-layer [pool_slots, group, Hk, vD] fp16
+        slot: int,
+        compressed_cache: list[
+            torch.Tensor
+        ],  # per-layer [num_blocks, Hk, tile_bytes] uint8
+    ):
+        """Compress one block from the tail pool to the int4 cache.
+
+        Reads K/V from tail_K[layer][slot] / tail_V[layer][slot] (shape
+        ``[group, Hk, D]``), applies Sinkhorn + RTN, and writes packed tiles
+        to compressed_cache[layer][block_id].
+        """
+        cfg = self.cfg
+        Hk = self.num_kv_heads
+        D = self.head_dim
+        vD = self.v_head_dim
+        G = self.group
+
+        for layer_id in range(self.num_layers):
+            K_blk = tail_K[layer_id][slot]  # [G, Hk, D] fp16 (rotated)
+            V_blk = tail_V[layer_id][slot]  # [G, Hk, vD] fp16 (rotated)
+
+            # K tile orientation: [D, group] per head (channels × tokens)
+            # K_blk is [group, Hk, D] → per-head [group, D] → transpose to [D, group]
+            K_per_head = K_blk.permute(1, 2, 0)  # [Hk, D, group]
+            # V tile orientation: [group, D] per head (tokens × channels)
+            V_per_head = V_blk.permute(1, 0, 2)  # [Hk, group, vD]
+
+            # Sinkhorn variance normalization (batched over heads)
+            K_bal, K_sc, K_sr = variance_normalize_batched(
+                K_per_head, iterations=cfg.sinkhorn_iters
+            )
+            V_bal, V_sc, V_sr = variance_normalize_batched(
+                V_per_head, iterations=cfg.sinkhorn_iters
+            )
+
+            # RTN quantization + scale absorption + packing
+            K_out = kvarn_store_tile_k_batch_from_sinkhorn(
+                K_bal,
+                K_sc.squeeze(1),  # [Hk, group]
+                K_sr.squeeze(2),  # [Hk, D]
+                bits=cfg.key_bits,
+            )
+            V_out = kvarn_store_tile_v_batch_from_sinkhorn(
+                V_bal,
+                V_sc.squeeze(1),  # [Hk, vD]
+                V_sr.squeeze(2),  # [Hk, group]
+                bits=cfg.value_bits,
+            )
+
+            # Write packed tiles to compressed cache
+            cache = compressed_cache[layer_id]
+            for h in range(Hk):
+                self._write_packed_tile_k(
+                    cache,
+                    block_id,
+                    h,
+                    K_out["q_packed_uint8"][h],
+                    K_out["s_col_K"][h],
+                    K_out["zp_K"][h],
+                    K_out["s_row_K"][h],
+                )
+                self._write_packed_tile_v(
+                    cache,
+                    block_id,
+                    h,
+                    V_out["q_packed_uint8"][h],
+                    V_out["s_col_V"][h],
+                    V_out["s_row_V"][h],
+                    V_out["zp_V"][h],
+                )
+
+    def flush_blocks_batched(
+        self,
+        block_ids: list[int],
+        tail_K: list[torch.Tensor],
+        tail_V: list[torch.Tensor],
+        slots: list[int],
+        compressed_cache: list[torch.Tensor],
+    ):
+        """Compress multiple blocks in a batched fashion for efficiency."""
+        if not block_ids:
+            return
+
+        cfg = self.cfg
+        Hk = self.num_kv_heads
+        D = self.head_dim
+        vD = self.v_head_dim
+        G = self.group
+        nB = len(block_ids)
+
+        for layer_id in range(self.num_layers):
+            # Gather all blocks' K/V data
+            K_blocks = torch.stack([tail_K[layer_id][slots[i]] for i in range(nB)])
+            # K_blocks: [nB, G, Hk, D] → permute to [nB*Hk, D, G] for K path
+            K_per_head = K_blocks.permute(0, 2, 3, 1)  # [nB, Hk, D, G]
+            K_tiles = K_per_head.reshape(nB * Hk, D, G)
+
+            V_blocks = torch.stack([tail_V[layer_id][slots[i]] for i in range(nB)])
+            # V_blocks: [nB, G, Hk, vD] → permute to [nB*Hk, G, vD] for V path
+            V_per_head = V_blocks.permute(0, 2, 1, 3)  # [nB, Hk, G, vD]
+            V_tiles = V_per_head.reshape(nB * Hk, G, vD)
+
+            # Sinkhorn + RTN
+            K_bal, K_sc, K_sr = variance_normalize_batched(
+                K_tiles, iterations=cfg.sinkhorn_iters
+            )
+            V_bal, V_sc, V_sr = variance_normalize_batched(
+                V_tiles, iterations=cfg.sinkhorn_iters
+            )
+
+            K_out = kvarn_store_tile_k_batch_from_sinkhorn(
+                K_bal,
+                K_sc.squeeze(1),  # [nB*Hk, G]
+                K_sr.squeeze(2),  # [nB*Hk, D]
+                bits=cfg.key_bits,
+            )
+            V_out = kvarn_store_tile_v_batch_from_sinkhorn(
+                V_bal,
+                V_sc.squeeze(1),  # [nB*Hk, vD]
+                V_sr.squeeze(2),  # [nB*Hk, G]
+                bits=cfg.value_bits,
+            )
+
+            cache = compressed_cache[layer_id]
+            for i, bid in enumerate(block_ids):
+                for h in range(Hk):
+                    idx = i * Hk + h
+                    self._write_packed_tile_k(
+                        cache,
+                        bid,
+                        h,
+                        K_out["q_packed_uint8"][idx],
+                        K_out["s_col_K"][idx],
+                        K_out["zp_K"][idx],
+                        K_out["s_row_K"][idx],
+                    )
+                    self._write_packed_tile_v(
+                        cache,
+                        bid,
+                        h,
+                        V_out["q_packed_uint8"][idx],
+                        V_out["s_col_V"][idx],
+                        V_out["s_row_V"][idx],
+                        V_out["zp_V"][idx],
+                    )
+
+        logger.info(f"KVarN flush: {nB} blocks compressed to int4")
+
+    def flush_batched_fast(
+        self,
+        block_ids: list[int],
+        tail_K: list[torch.Tensor],
+        tail_V: list[torch.Tensor],
+        slots: list[int],
+        compressed_cache: list[torch.Tensor],
+    ):
+        """Batched flush with vectorized write — one index_select gather +
+        one index_copy scatter per (layer, chunk), replacing the per-(block,head)
+        Python write loop. Numerically identical to flush_blocks_batched.
+
+        Assembles packed cache records via
+        tensor concatenation in config-offset order and writes with a single
+        scatter.
+        """
+        if not block_ids:
+            return
+
+        cfg = self.cfg
+        Hk = self.num_kv_heads
+        D = self.head_dim
+        vD = self.v_head_dim
+        G = self.group
+        T = cfg.tile_bytes_aligned
+        kpb = cfg.k_packed_bytes
+        vpb = cfg.v_packed_bytes
+        nB = len(block_ids)
+
+        # Chunk to bound transient gather memory
+        CHUNK_BLOCKS = max(1, 2048 // max(Hk, 1))
+
+        slots_dev = torch.as_tensor(slots, dtype=torch.long, device=tail_K[0].device)
+        bids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=tail_K[0].device)
+
+        for layer_id in range(self.num_layers):
+            kvc = compressed_cache[layer_id]
+            for c0 in range(0, nB, CHUNK_BLOCKS):
+                bchunk = block_ids[c0 : c0 + CHUNK_BLOCKS]
+                slot_t = slots_dev[c0 : c0 + CHUNK_BLOCKS]
+                bid_t = bids_dev[c0 : c0 + CHUNK_BLOCKS]
+                nBc = len(bchunk)
+
+                # One gather per chunk
+                K_rot = (
+                    tail_K[layer_id].index_select(0, slot_t).float()
+                )  # [nBc, G, Hk, D]
+                V_rot = tail_V[layer_id].index_select(0, slot_t).float()
+
+                # Tiles: K [N, D, G] (absorb=channel), V [N, G, D] (absorb=token)
+                K_tiles = K_rot.permute(0, 2, 3, 1).reshape(nBc * Hk, D, G)
+                V_tiles = V_rot.permute(0, 2, 1, 3).reshape(nBc * Hk, G, vD)
+
+                # Sinkhorn + RTN (fused when square, else separate)
+                if K_tiles.shape[1:] == V_tiles.shape[1:]:
+                    # Square: fuse into one Sinkhorn launch
+                    K_bal, K_sc, K_sr = variance_normalize_batched(
+                        torch.cat([K_tiles, V_tiles], dim=0),
+                        iterations=cfg.sinkhorn_iters,
+                    )
+                    nk = nBc * Hk
+                    K_out = kvarn_store_tile_k_batch_from_sinkhorn(
+                        K_bal[:nk], K_sc[:nk], K_sr[:nk], bits=cfg.key_bits
+                    )
+                    V_out = kvarn_store_tile_v_batch_from_sinkhorn(
+                        K_bal[nk:], K_sc[nk:], K_sr[nk:], bits=cfg.value_bits
+                    )
+                else:
+                    # Non-square (e.g. head_dim=256, group=128): separate launches
+                    K_bal, K_sc, K_sr = variance_normalize_batched(
+                        K_tiles, iterations=cfg.sinkhorn_iters
+                    )
+                    V_bal, V_sc, V_sr = variance_normalize_batched(
+                        V_tiles, iterations=cfg.sinkhorn_iters
+                    )
+                    K_out = kvarn_store_tile_k_batch_from_sinkhorn(
+                        K_bal, K_sc.squeeze(1), K_sr.squeeze(2), bits=cfg.key_bits
+                    )
+                    V_out = kvarn_store_tile_v_batch_from_sinkhorn(
+                        V_bal, V_sc.squeeze(1), V_sr.squeeze(2), bits=cfg.value_bits
+                    )
+
+                # Assemble packed cache record [nBc*Hk, tile_bytes] via concatenation
+                M = nBc * Hk
+                parts = [
+                    K_out["q_packed_uint8"].reshape(M, kpb),
+                    K_out["s_col_K"].contiguous().view(torch.uint8),
+                    K_out["zp_K"].contiguous().view(torch.uint8),
+                    K_out["s_row_K"].contiguous().view(torch.uint8),
+                    V_out["q_packed_uint8"].reshape(M, vpb),
+                    V_out["s_col_V"].contiguous().view(torch.uint8),
+                    V_out["s_row_V"].contiguous().view(torch.uint8),
+                    V_out["zp_V"].contiguous().view(torch.uint8),
+                ]
+                rec = torch.cat(parts, dim=1)  # [M, tile_bytes]
+                if rec.shape[1] < T:
+                    rec = torch.nn.functional.pad(rec, (0, T - rec.shape[1]))
+
+                # One scatter per chunk
+                kvc[bid_t] = rec.view(nBc, Hk, T)
+
+    def dequant_block(
+        self,
+        block_id: int,
+        compressed_cache: list[torch.Tensor],
+        layer_id: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Read a block from int4 cache and dequantize.
+
+        Returns (K [group, Hk, D] fp16, V [group, Hk, vD] fp16) in the
+        ROTATED frame (caller must apply H^-1 if un-rotated data is needed).
+        """
+        cfg = self.cfg
+        Hk = self.num_kv_heads
+        D = self.head_dim
+        vD = self.v_head_dim
+        G = self.group
+        pack_k = 8 // cfg.key_bits
+        pack_v = 8 // cfg.value_bits
+
+        cache = compressed_cache[layer_id][block_id]  # [Hk, tile_bytes] uint8
+
+        K_out = torch.zeros(G, Hk, D, dtype=torch.float16, device=cache.device)
+        V_out = torch.zeros(G, Hk, vD, dtype=torch.float16, device=cache.device)
+
+        for h in range(Hk):
+            # Dequant K tile: packed as [D, G // pack_k]
+            off = cfg.k_packed_offset
+            k_packed = cache[h, off : off + D * (G // pack_k)].reshape(D, G // pack_k)
+            off = cfg.k_s_col_offset
+            s_col_K = cache[h, off : off + D * 2].view(torch.float16)
+            off = cfg.k_zp_offset
+            zp_K = cache[h, off : off + D * 2].view(torch.float16)
+            off = cfg.k_s_row_offset
+            s_row_K = cache[h, off : off + G * 2].view(torch.float16)
+
+            K_deq = kvarn_dequant_tile_k(
+                k_packed,
+                s_col_K,
+                zp_K,
+                s_row_K,
+                group=G,
+                bits=cfg.key_bits,
+            )
+            # K_deq is [D, G] in rotated frame → transpose to [G, D]
+            K_out[:, h, :] = K_deq.t().to(torch.float16)
+
+            # Dequant V tile: packed as [G, D // pack_v]
+            off = cfg.v_packed_offset
+            v_packed = cache[h, off : off + G * (vD // pack_v)].reshape(G, vD // pack_v)
+            off = cfg.v_s_col_offset
+            s_col_V = cache[h, off : off + vD * 2].view(torch.float16)
+            off = cfg.v_s_row_offset
+            s_row_V = cache[h, off : off + G * 2].view(torch.float16)
+            off = cfg.v_zp_offset
+            zp_V = cache[h, off : off + G * 2].view(torch.float16)
+
+            V_deq = kvarn_dequant_tile_v(
+                v_packed,
+                s_col_V,
+                s_row_V,
+                zp_V,
+                head_dim=vD,
+                bits=cfg.value_bits,
+            )
+            # V_deq is [G, vD] in rotated frame
+            V_out[:, h, :] = V_deq.to(torch.float16)
+
+        return K_out, V_out
+
+    def _write_packed_tile_k(
+        self,
+        cache: torch.Tensor,
+        block_id: int,
+        head_id: int,
+        q_packed: torch.Tensor,
+        s_col: torch.Tensor,
+        zp: torch.Tensor,
+        s_row: torch.Tensor,
+    ):
+        """Write one packed K tile to the compressed cache."""
+        cfg = self.cfg
+        off = cfg.k_packed_offset
+        cache[block_id, head_id, off : off + q_packed.numel()].copy_(q_packed.flatten())
+        off = cfg.k_s_col_offset
+        cache[block_id, head_id, off : off + s_col.numel() * 2].copy_(
+            s_col.view(torch.uint8).flatten()
+        )
+        off = cfg.k_zp_offset
+        cache[block_id, head_id, off : off + zp.numel() * 2].copy_(
+            zp.view(torch.uint8).flatten()
+        )
+        off = cfg.k_s_row_offset
+        cache[block_id, head_id, off : off + s_row.numel() * 2].copy_(
+            s_row.view(torch.uint8).flatten()
+        )
+
+    def _write_packed_tile_v(
+        self,
+        cache: torch.Tensor,
+        block_id: int,
+        head_id: int,
+        q_packed: torch.Tensor,
+        s_col: torch.Tensor,
+        s_row: torch.Tensor,
+        zp: torch.Tensor,
+    ):
+        """Write one packed V tile to the compressed cache."""
+        cfg = self.cfg
+        off = cfg.v_packed_offset
+        cache[block_id, head_id, off : off + q_packed.numel()].copy_(q_packed.flatten())
+        off = cfg.v_s_col_offset
+        cache[block_id, head_id, off : off + s_col.numel() * 2].copy_(
+            s_col.view(torch.uint8).flatten()
+        )
+        off = cfg.v_s_row_offset
+        cache[block_id, head_id, off : off + s_row.numel() * 2].copy_(
+            s_row.view(torch.uint8).flatten()
+        )
+        off = cfg.v_zp_offset
+        cache[block_id, head_id, off : off + zp.numel() * 2].copy_(
+            zp.view(torch.uint8).flatten()
+        )

--- a/python/sglang/srt/layers/quantization/kvarn/hadamard.py
+++ b/python/sglang/srt/layers/quantization/kvarn/hadamard.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hadamard matrix utilities for KVarN.
+
+Generates a normalised Sylvester-type Hadamard matrix
+of size ``d × d`` where ``d`` is a power of 2.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+
+import torch
+
+
+@functools.cache
+def hadamard_cached(d: int, device_str: str) -> torch.Tensor:
+    """Sylvester Hadamard, normalised, cached per (d, device).
+
+    ``d`` must be a power of 2.
+    """
+    H = torch.ones(1, 1)
+    while H.shape[0] < d:
+        H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
+    return (H / math.sqrt(d)).to(torch.device(device_str)).float()
+
+
+def build_hadamard(d: int, device: torch.device) -> torch.Tensor:
+    """Build a normalised Hadamard matrix of size ``d × d``."""
+    return hadamard_cached(d, str(device))

--- a/python/sglang/srt/layers/quantization/kvarn/sinkhorn.py
+++ b/python/sglang/srt/layers/quantization/kvarn/sinkhorn.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Log-domain iterative variance-normalization for KVarN (pure PyTorch).
+
+No framework dependencies so it can be unit-tested
+in isolation.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_DEFAULT_ITERATIONS = 16
+_CLIP_STD_MIN = 1e-3
+_CLIP_STD_MAX = 1e3
+_LOG_S_MIN = -0.3
+_LOG_S_MAX = 10.0
+
+
+def _imbalance(tile: torch.Tensor) -> torch.Tensor:
+    """Sum of column-std spread and row-std spread.
+
+    Lower is better; a perfectly balanced tile has ``imbalance == 2``.
+    """
+    sc = tile.std(dim=-2)  # along rows ⇒ per-column std
+    sr = tile.std(dim=-1)  # along cols ⇒ per-row std
+    return sc.amax(dim=-1) / sc.amin(dim=-1).clamp_min(1e-8) + sr.amax(
+        dim=-1
+    ) / sr.amin(dim=-1).clamp_min(1e-8)
+
+
+def variance_normalize(
+    tile: torch.Tensor,
+    iterations: int = _DEFAULT_ITERATIONS,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Single-tile log-domain Sinkhorn balancing.
+
+    Args:
+        tile: [R, C] fp32 (or any real dtype; cast to fp32 internally).
+        iterations: number of alternating col/row passes (default 16).
+
+    Returns:
+        balanced [R, C] fp32
+        s_col    [1, C] fp32
+        s_row    [R, 1] fp32
+    """
+    m = tile.float()
+    R, C = m.shape
+    dev = m.device
+
+    log_s_col = torch.zeros(1, C, device=dev)
+    log_s_row = torch.zeros(R, 1, device=dev)
+
+    cur = m / log_s_col.exp() / log_s_row.exp()
+    imb_best = _imbalance(cur)
+    sc_best = log_s_col.exp().clone()
+    sr_best = log_s_row.exp().clone()
+
+    for _ in range(iterations):
+        col_std = cur.std(dim=0, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_col = (log_s_col + col_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        row_std = cur.std(dim=1, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_row = (log_s_row + row_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        imb = _imbalance(cur)
+        if imb <= imb_best:
+            imb_best = imb
+            sc_best = log_s_col.exp().clone()
+            sr_best = log_s_row.exp().clone()
+
+    balanced = m / sc_best / sr_best
+    return balanced, sc_best, sr_best
+
+
+def variance_normalize_batched(
+    tiles: torch.Tensor,
+    iterations: int = _DEFAULT_ITERATIONS,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Batched version: tiles is [N, R, C].
+
+    Returns:
+        balanced [N, R, C] fp32
+        s_col    [N, 1, C] fp32
+        s_row    [N, R, 1] fp32
+    """
+    m = tiles.float()
+    N, R, C = m.shape
+    dev = m.device
+
+    log_s_col = torch.zeros(N, 1, C, device=dev)
+    log_s_row = torch.zeros(N, R, 1, device=dev)
+
+    cur = m / log_s_col.exp() / log_s_row.exp()
+    imb_best = _imbalance(cur)  # [N]
+    sc_best = log_s_col.exp().clone()
+    sr_best = log_s_row.exp().clone()
+
+    for _ in range(iterations):
+        col_std = cur.std(dim=1, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_col = (log_s_col + col_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        row_std = cur.std(dim=2, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_row = (log_s_row + row_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        imb = _imbalance(cur)  # [N]
+        better = imb <= imb_best
+        if better.any():
+            mask = better.view(N, 1, 1).to(log_s_col.dtype)
+            sc_best = mask * log_s_col.exp() + (1 - mask) * sc_best
+            sr_best = mask * log_s_row.exp() + (1 - mask) * sr_best
+            imb_best = torch.where(better, imb, imb_best)
+
+    balanced = m / sc_best / sr_best
+    return balanced, sc_best, sr_best

--- a/python/sglang/srt/layers/quantization/kvarn/store.py
+++ b/python/sglang/srt/layers/quantization/kvarn/store.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KVarN tile-level store (pure PyTorch).
+
+Quantizes one tile of K (or V) per call.
+
+Inputs to the K path are tile-shaped ``[D, group]`` (channels × tokens —
+the KIVI K-axis orientation) **after** Hadamard rotation.  Inputs to the
+V path are tile-shaped ``[group, D]`` (tokens × channels — the KIVI
+V-axis orientation) also after Hadamard rotation.
+
+The output is a packed record matching the cache layout from
+``KVarNConfig``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.layers.quantization.kvarn.sinkhorn import (
+    variance_normalize,
+)
+
+
+def _rtn_range(t: torch.Tensor, dim: int):
+    """Per-row range (min/max)."""
+    return t.amin(dim=dim, keepdim=True), t.amax(dim=dim, keepdim=True)
+
+
+def _asymmetric_rtn_per_row(
+    tile: torch.Tensor, bits: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-row asymmetric RTN over the full row.
+
+    Args:
+        tile: [R, C] fp32.
+        bits: 2, 3 or 4.
+
+    Returns:
+        q     [R, C] int32 in [0, 2^bits - 1]
+        scale [R, 1] fp32
+        zp    [R, 1] fp32  (= row minimum)
+    """
+    qmax = (1 << bits) - 1
+    lo = tile.amin(dim=1, keepdim=True)
+    hi = tile.amax(dim=1, keepdim=True)
+    scale = ((hi - lo) / qmax).clamp_min(1e-10)
+    zp = lo
+    q = torch.clamp(torch.round((tile - zp) / scale), 0, qmax).to(torch.int32)
+    return q, scale, zp
+
+
+def _pack_4bit(q: torch.Tensor) -> torch.Tensor:
+    """Pack 4-bit ints (last dim even) into uint8 pairs, two-per-byte."""
+    assert q.shape[-1] % 2 == 0
+    q = q.to(torch.uint8) & 0xF
+    lo = q[..., 0::2]
+    hi = q[..., 1::2]
+    return (lo | (hi << 4)).to(torch.uint8)
+
+
+def _pack_lowbit(q: torch.Tensor, bits: int) -> torch.Tensor:
+    """Pack `bits`-bit ints into uint8, PACK=8//bits values per byte."""
+    pack = 8 // bits
+    C = q.shape[-1]
+    assert C % pack == 0, f"last dim {C} must be divisible by {pack} for {bits}-bit"
+    q = (q.to(torch.uint8) & ((1 << bits) - 1)).reshape(*q.shape[:-1], C // pack, pack)
+    out = q[..., 0].clone()
+    for j in range(1, pack):
+        out = out | (q[..., j] << (j * bits))
+    return out.to(torch.uint8)
+
+
+# ─── K tile store: per-channel RTN, [D, group] orientation ──────────────────
+
+
+def kvarn_store_tile_k(
+    k_tile_rotated: torch.Tensor,
+    bits: int,
+    sinkhorn_iters: int = 16,
+) -> dict[str, torch.Tensor]:
+    """Quantize one rotated K tile ``[D, group]``.
+
+    Returns dict with:
+        q_packed_uint8 : ``[D, group/2]`` uint8
+        s_col_K        : ``[D]``        fp16
+        zp_K           : ``[D]``        fp16
+        s_row_K        : ``[group]``    fp16
+    """
+    assert bits == 4, "Stage 3a only validates 4-bit; lower-bit follow-ups TBD"
+    tile = k_tile_rotated.float()
+    D, G = tile.shape
+
+    balanced, s_col_sinkhorn, s_row_sinkhorn = variance_normalize(
+        tile, iterations=sinkhorn_iters
+    )
+    s_chan = s_row_sinkhorn  # [D, 1]
+    s_tok = s_col_sinkhorn  # [1, G]
+
+    q, rtn_scale, rtn_zp = _asymmetric_rtn_per_row(balanced, bits=bits)
+
+    s_col_K = (s_chan * rtn_scale).squeeze(-1)  # [D]
+    zp_K = (s_chan * rtn_zp).squeeze(-1)  # [D]
+    s_row_K = s_tok.squeeze(0)  # [G]
+
+    q_packed = _pack_4bit(q)  # [D, G/2]
+
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_K": s_col_K.to(torch.float16),
+        "zp_K": zp_K.to(torch.float16),
+        "s_row_K": s_row_K.to(torch.float16),
+    }
+
+
+def kvarn_store_tile_k_batch_from_sinkhorn(
+    balanced: torch.Tensor,
+    s_col: torch.Tensor,
+    s_row: torch.Tensor,
+    bits: int,
+) -> dict[str, torch.Tensor]:
+    """Batched K-path RTN + scale absorption + 4-bit packing.
+
+    Args:
+        balanced : ``[N, D, group]`` fp32 — sinkhorn-balanced K tiles.
+        s_col    : ``[N, group]`` fp32 — per-token sinkhorn scale (axis-1).
+        s_row    : ``[N, D]``     fp32 — per-channel sinkhorn scale (axis-0).
+        bits     : key bit-width (4).
+    """
+    qmax = (1 << bits) - 1
+    N, R, C = balanced.shape
+    lo, hi = _rtn_range(balanced, dim=2)
+    scale = ((hi - lo) / qmax).clamp_min(1e-10)
+    zp = lo
+    q = torch.clamp(torch.round((balanced - zp) / scale), 0, qmax).to(torch.int32)
+    s_col_K = (s_row * scale.squeeze(-1)).to(torch.float16)  # [N, D]
+    zp_K = (s_row * zp.squeeze(-1)).to(torch.float16)
+    s_row_K = s_col.to(torch.float16)  # [N, group]
+    q_packed = _pack_lowbit(q, bits)
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_K": s_col_K,
+        "zp_K": zp_K,
+        "s_row_K": s_row_K,
+    }
+
+
+# ─── V tile store: per-token RTN, [group, D] orientation ────────────────────
+
+
+def kvarn_store_tile_v(
+    v_tile_rotated: torch.Tensor,
+    bits: int,
+    sinkhorn_iters: int = 16,
+) -> dict[str, torch.Tensor]:
+    """Quantize one rotated V tile ``[group, D]``.
+
+    Returns dict with:
+        q_packed_uint8 : ``[group, D/2]`` uint8
+        s_col_V        : ``[D]``          fp16
+        s_row_V        : ``[group]``      fp16
+        zp_V           : ``[group]``      fp16
+    """
+    assert bits == 4, "Stage 3a only validates 4-bit; lower-bit follow-ups TBD"
+    tile = v_tile_rotated.float()
+    G, D = tile.shape
+
+    balanced, s_col_sinkhorn, s_row_sinkhorn = variance_normalize(
+        tile, iterations=sinkhorn_iters
+    )
+    s_chan = s_col_sinkhorn  # [1, D]
+    s_tok = s_row_sinkhorn  # [G, 1]
+
+    q, rtn_scale, rtn_zp = _asymmetric_rtn_per_row(balanced, bits=bits)
+
+    s_row_V = (s_tok * rtn_scale).squeeze(-1)  # [G]
+    zp_V = (s_tok * rtn_zp).squeeze(-1)  # [G]
+    s_col_V = s_chan.squeeze(0)  # [D]
+
+    q_packed = _pack_4bit(q)  # [G, D/2]
+
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_V": s_col_V.to(torch.float16),
+        "s_row_V": s_row_V.to(torch.float16),
+        "zp_V": zp_V.to(torch.float16),
+    }
+
+
+def kvarn_store_tile_v_batch_from_sinkhorn(
+    balanced: torch.Tensor,
+    s_col: torch.Tensor,
+    s_row: torch.Tensor,
+    bits: int,
+) -> dict[str, torch.Tensor]:
+    """Batched V-path RTN + scale absorption + 4-bit packing.
+
+    Args:
+        balanced : ``[N, group, D]`` fp32 — sinkhorn-balanced V tiles.
+        s_col    : ``[N, D]``     fp32 — per-channel sinkhorn scale (axis-1).
+        s_row    : ``[N, group]`` fp32 — per-token-in-tile sinkhorn scale (axis-0).
+        bits     : value bit-width (4).
+    """
+    qmax = (1 << bits) - 1
+    N, R, C = balanced.shape
+    lo, hi = _rtn_range(balanced, dim=2)
+    scale = ((hi - lo) / qmax).clamp_min(1e-10)
+    zp = lo
+    q = torch.clamp(torch.round((balanced - zp) / scale), 0, qmax).to(torch.int32)
+    s_row_V = (s_row * scale.squeeze(-1)).to(torch.float16)  # [N, group]
+    zp_V = (s_row * zp.squeeze(-1)).to(torch.float16)
+    s_col_V = s_col.to(torch.float16)  # [N, D]
+    q_packed = _pack_lowbit(q, bits)
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_V": s_col_V,
+        "s_row_V": s_row_V,
+        "zp_V": zp_V,
+    }

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1143,10 +1143,92 @@ class _PlainKvStrategy(StackStrategy):
         )
 
 
+class _KVarNNopaStrategy(StackStrategy):
+    """HiCache strategy for KVarN with hybrid GDN models.
+
+    The NoOpMHATokenToKVPool handles full-attention layers via KVarN's own
+    compressed int4 + fp16 tail pool. It exposes get_cpu_copy/load_cpu_copy
+    that delegate to the KVarN backend for HiCache eviction/loading. The
+    mamba/linear-attention layers use the standard mamba pool.
+    """
+
+    def matches(self, kvcache, components):
+        from sglang.srt.mem_cache.memory_pool import NoOpMHATokenToKVPool
+
+        return isinstance(kvcache, NoOpMHATokenToKVPool) and components == {
+            ComponentType.FULL,
+            ComponentType.MAMBA,
+        }
+
+    def build(
+        self,
+        *,
+        cache,
+        kvcache,
+        params,
+        server_args,
+        load_cache_event,
+        attn_cp_group=None,
+        attn_tp_group=None,
+        storage_backend=None,
+        storage_backend_extra_config=None,
+        prefetch_threshold=256,
+        model_name=None,
+        enable_storage_metrics=False,
+    ):
+        from sglang.srt.mem_cache.base_prefix_cache import EvictParams
+
+        # Build full_layer_mapping: model layer ID -> 0-based pool layer index.
+        # The KVarN backend stores the actual full attention layer IDs from the
+        # model config (e.g. [3, 7, 11, 15, 19, ...] for Qwen3.5). We map each
+        # to its 0-based compressed layer index (0, 1, 2, ...).
+        kvarn_backend = getattr(kvcache, "_kvarn_backend", None)
+        assert kvarn_backend is not None, (
+            "KVarNNopaStrategy requires the NoOp pool to have a KVarN backend"
+        )
+        full_attn_ids = kvarn_backend.full_attn_layer_ids
+        full_layer_mapping = {model_id: pool_id for pool_id, model_id in enumerate(full_attn_ids)}
+        mamba_layer_mapping = dict(params.req_to_token_pool.mamba_map)
+        host_pool_group, cache_controller = build_hybrid_mamba_stack(
+            params=params,
+            server_args=server_args,
+            kv_pool=kvcache,
+            mamba_pool=params.req_to_token_pool.mamba_pool,
+            full_layer_mapping=full_layer_mapping,
+            mamba_layer_mapping=mamba_layer_mapping,
+            page_size=cache.page_size,
+            tp_group=params.tp_cache_group,
+            load_cache_event=load_cache_event,
+            attn_cp_group=attn_cp_group,
+            attn_tp_group=attn_tp_group,
+            pp_group=params.pp_cache_group,
+            storage_backend=storage_backend,
+            use_mla=False,
+            host_mamba_evict_fn=lambda n: cache.evict_host(n, ComponentType.MAMBA),
+            device_mamba_evict_fn=lambda n: cache.evict(EvictParams(mamba_num=n)),
+            prefetch_threshold=prefetch_threshold,
+            model_name=model_name,
+            storage_backend_extra_config=storage_backend_extra_config,
+            enable_storage_metrics=enable_storage_metrics,
+        )
+        return StackBuildResult(
+            host_pool_group=host_pool_group,
+            cache_controller=cache_controller,
+            component_host_pools={
+                ComponentType.FULL: host_pool_group.get_pool(PoolName.KV),
+                ComponentType.MAMBA: host_pool_group.get_pool(PoolName.MAMBA),
+            },
+            register_req_to_token_counter=True,
+            transfer_layer_num=max(max(full_layer_mapping), max(mamba_layer_mapping)) + 1,
+            pools_desc="KVarN KV + MAMBA",
+        )
+
+
 # Resolved first-to-last; _PlainKvStrategy is the catch-all fallback.
 _STRATEGIES: list[StackStrategy] = [
     _DeepSeekV4Strategy(),
     _MambaStrategy(),
+    _KVarNNopaStrategy(),
     _SwaStrategy(),
     _DsaStrategy(),
     _MiniMaxSparseStrategy(),

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -742,6 +742,13 @@ class KVCacheConfigurator:
                 c128_state_dtype=sizes.c128_state_dtype,
                 req_to_token_pool=req_to_token_pool,
             )
+        elif self.server_args.kv_cache_dtype.startswith("kvarn_"):
+            # KVarN: use NoOp pool. The real K/V storage is in the KVarN
+            # backend's tail pool (fp16, small) + int4 compressed cache.
+            token_to_kv_pool = self._build_kvarn_kv_pool(
+                max_total_num_tokens=sizes.max_total_num_tokens,
+                req_to_token_pool=req_to_token_pool,
+            )
         elif current_platform.is_out_of_tree() and not self.mambaish_config:
             if self.use_mla_backend and is_dsa_model:
                 token_to_kv_pool = self._build_oot_dsa_kv_pool(
@@ -1278,6 +1285,59 @@ class KVCacheConfigurator:
             enable_alt_stream=not self.server_args.enable_pdmux,
             enable_kv_cache_copy=(self.server_args.speculative_algorithm is not None),
             **pool_kwargs,
+        )
+        return token_to_kv_pool
+
+    def _build_kvarn_kv_pool(
+        self,
+        *,
+        max_total_num_tokens: int,
+        req_to_token_pool: ReqToTokenPool,
+    ) -> KVCache:
+        """Build the KV pool for KVarN.
+
+        KVarN uses a NoOp pool as the scheduler-facing pool (full logical
+        capacity), while the real K/V storage lives in the KVarN backend's
+        tail pool (fp16) + int4 compressed cache. Using the standard pool
+        (HybridLinearKVPool for hybrid models, MHATokenToKVPool for dense)
+        would double-allocate GPU memory.
+        """
+        from sglang.srt.layers.quantization.kvarn.config import KVarNConfig
+
+        kvarn_config = KVarNConfig.from_cache_dtype(
+            self.server_args.kv_cache_dtype,
+            head_dim=self.model_config.head_dim,
+        )
+
+        if self.mambaish_config is not None:
+            # Hybrid GDN model: NoOp pool covers only the full-attention layers.
+            full_attn_ids = (
+                [0]
+                if self.is_draft_worker
+                else [
+                    i
+                    for i in self.mambaish_config.full_attention_layer_ids
+                    if self.layer_info.start_layer <= i < self.layer_info.end_layer
+                ]
+            )
+            layer_num = len(full_attn_ids)
+        else:
+            layer_num = self.layer_info.num_effective_layers
+
+        token_to_kv_pool = NoOpMHATokenToKVPool(
+            max_total_num_tokens,
+            page_size=self.server_args.page_size,
+            dtype=self.model_dtype,
+            head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
+            head_dim=self.model_config.head_dim,
+            v_head_dim=self.model_config.v_head_dim,
+            layer_num=layer_num,
+            device=self.device,
+            enable_memory_saver=self.server_args.enable_memory_saver,
+            start_layer=self.layer_info.start_layer,
+            end_layer=self.layer_info.end_layer,
+            enable_alt_stream=not self.server_args.enable_pdmux,
+            enable_kv_cache_copy=(self.server_args.speculative_algorithm is not None),
         )
         return token_to_kv_pool
 

--- a/python/sglang/srt/mem_cache/kv_cache_dtype.py
+++ b/python/sglang/srt/mem_cache/kv_cache_dtype.py
@@ -70,6 +70,11 @@ def configure_kv_cache_dtype(
                 "torch.float4_e2m1fn_x2 support. Please use PyTorch 2.8.0+ "
                 "with CUDA 12.8+."
             )
+    elif server_args_kv_cache_dtype.startswith("kvarn_"):
+        # KVarN: use the model dtype for the tail pool. The compressed
+        # int4 cache uses uint8 storage, managed by the KVarN backend.
+        kv_cache_dtype = model_dtype
+        logger.info("KVarN KV cache enabled: %s", server_args_kv_cache_dtype)
     else:
         raise ValueError(f"Unsupported kv_cache_dtype: {server_args_kv_cache_dtype}.")
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2602,6 +2602,17 @@ class NoOpMHATokenToKVPool(MHATokenToKVPool):
             "preconditions are met."
         )
 
+    # ── HiCache support (KVarN) ───────────────────────────────────────────
+    # A reference to the KVarNAttnBackend is set via `set_kvarn_backend()`
+    # after the backend is created. The actual HiCache transfer is handled
+    # by KVarNHostKVCache (in pool_host/), which reads int4 tiles directly
+    # from the backend's kv_cache_int4 buffers. The NoOp pool just needs to
+    # expose the backend reference so the host pool can find it.
+    _kvarn_backend = None
+
+    def set_kvarn_backend(self, backend):
+        self._kvarn_backend = backend
+
     def get_key_buffer(self, layer_id: int):
         # Return the placeholder. The FA backend reads this before taking the
         # fa_skip_kv_cache branch (which does not use it); the placeholder shape

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -1230,12 +1230,208 @@ class AsymmetricMHATokenToKVPoolHost(MHATokenToKVPoolHost):
         )
 
 
-def get_mha_host_pool_cls(device_pool: MHATokenToKVPool) -> type:
-    """Pick the right MHA host-pool class based on the device pool's K/V dims.
+class KVarNHostKVCache(HostKVCache):
+    """Host KV cache for KVarN that stores raw int4 tiles instead of fp16.
 
-    Returns ``AsymmetricMHATokenToKVPoolHost`` when ``head_dim != v_head_dim``
+    The standard MHATokenToKVPoolHost allocates fp16 K/V buffers and copies
+    dequantized data. For KVarN, this wastes 4x memory (fp16 is 4x larger
+    than int4 tiles) and requires dequant->requant on every eviction/restore.
+
+    This class stores raw uint8 tiles (same layout as the GPU int4 cache):
+    [page_num, layer_num, Hk, tile_bytes] uint8. Backup flushes blocks from
+    the GPU tail pool to int4, then copies tiles. Restore writes tiles
+    directly back to the GPU int4 cache. No dequantization needed.
+    """
+
+    def __init__(
+        self,
+        device_pool,
+        host_to_device_ratio,
+        host_size,
+        page_size,
+        layout,
+        pin_memory=True,
+        device="cpu",
+        allocator_type="default",
+    ):
+        # Read KVarN config from the device pool's backend reference.
+        # set_kvarn_backend() is called during attention backend init,
+        # which happens before HiCache pool construction.
+        kvarn_backend = getattr(device_pool, "_kvarn_backend", None)
+        assert kvarn_backend is not None, (
+            "KVarNHostKVCache requires the NoOp pool to have a KVarN backend "
+            "reference. Call set_kvarn_backend() first."
+        )
+        self._kvarn_backend = kvarn_backend
+        self._tile_bytes = kvarn_backend.cfg.tile_bytes_aligned
+        self._hk = kvarn_backend.num_kv_heads
+        self._num_compressed_layers = kvarn_backend.num_layers
+
+        super().__init__(
+            device_pool,
+            host_to_device_ratio,
+            host_size,
+            page_size,
+            layout,  # pass through; we ignore it for tile storage
+            pin_memory,
+            device,
+            allocator_type,
+        )
+
+    def get_size_per_token(self):
+        """Bytes per token across all compressed layers.
+
+        Each block (page_size tokens) stores Hk * tile_bytes per layer.
+        With L layers: per_token = Hk * tile_bytes * L / page_size
+        """
+        return (
+            self._hk * self._tile_bytes * self._num_compressed_layers // self.page_size
+        )
+
+    def init_kv_buffer(self):
+        """Allocate uint8 tile storage: [page_num, layer_num, Hk, tile_bytes]."""
+        dims = (self.page_num, self._num_compressed_layers, self._hk, self._tile_bytes)
+        alloc_func = ALLOC_MEMORY_FUNCS[self.device]
+        buffer = alloc_func(
+            dims,
+            dtype=torch.uint8,
+            device=self.device,
+            pin_memory=self.pin_memory,
+            allocator=self.allocator,
+        )
+        return buffer
+
+    def backup_from_device_all_layer(
+        self, device_pool, host_indices, device_indices, io_backend
+    ):
+        """Flush blocks to int4 on GPU, then copy tiles to host for all layers.
+
+        host_indices and device_indices are token-level and positionally aligned:
+        host_indices[i] receives data from device_indices[i]. Both are page-aligned
+        (HiCache operates in full pages). We derive the block<->host-page mapping
+        from this positional correspondence.
+        """
+        from sglang.srt.platforms import current_platform
+
+        current_platform.synchronize()
+        backend = self._kvarn_backend
+
+        # Build block_id -> host_page_id mapping from positional correspondence
+        device_blocks = device_indices // self.page_size
+        host_pages = host_indices // self.page_size
+        # Each token in a page maps to the same host page, so any representative works
+        block_to_host_page = {}
+        for db, hp in zip(device_blocks.tolist(), host_pages.tolist()):
+            block_to_host_page[db] = hp
+
+        unique_block_ids = torch.tensor(
+            sorted(block_to_host_page.keys()),
+            dtype=torch.long,
+            device=device_indices.device,
+        )
+        host_page_ids = torch.tensor(
+            [block_to_host_page[b] for b in unique_block_ids.tolist()],
+            dtype=torch.long,
+            device=device_indices.device,
+        )
+
+        # Flush any blocks still in the tail pool to int4 so we copy compact tiles
+        for bid in unique_block_ids.tolist():
+            backend.flush_block_for_hicache(int(bid))
+
+        # Copy int4 tiles from GPU to host for all layers
+        for li in range(self._num_compressed_layers):
+            gpu_tiles = backend.kv_cache_int4[li][
+                unique_block_ids
+            ]  # [n_blocks, Hk, tile_bytes]
+            self.kv_buffer[host_page_ids, li] = gpu_tiles.to(
+                self.device, non_blocking=True
+            )
+
+        current_platform.synchronize()
+
+    def load_to_device_per_layer(
+        self, device_pool, host_indices, device_indices, layer_id, io_backend
+    ):
+        """Copy int4 tiles from host to GPU int4 cache for one layer.
+
+        host_indices and device_indices are positionally aligned token-level
+        tensors. layer_id is 0-based into the compressed layer range (0..15).
+        """
+        backend = self._kvarn_backend
+
+        if layer_id < 0 or layer_id >= self._num_compressed_layers:
+            return
+
+        # Build block_id -> host_page_id mapping
+        device_blocks = device_indices // self.page_size
+        host_pages = host_indices // self.page_size
+        block_to_host_page = {}
+        for db, hp in zip(device_blocks.tolist(), host_pages.tolist()):
+            block_to_host_page[db] = hp
+
+        unique_block_ids = torch.tensor(
+            sorted(block_to_host_page.keys()),
+            dtype=torch.long,
+            device=device_indices.device,
+        )
+        host_page_ids = torch.tensor(
+            [block_to_host_page[b] for b in unique_block_ids.tolist()],
+            dtype=torch.long,
+            device=device_indices.device,
+        )
+
+        # Copy tiles from host to GPU
+        host_tiles = self.kv_buffer[
+            host_page_ids, layer_id
+        ]  # [n_blocks, Hk, tile_bytes] uint8
+        gpu_tiles = host_tiles.to(backend.device, non_blocking=True)
+        backend.kv_cache_int4[layer_id][unique_block_ids] = gpu_tiles
+
+    def get_data_page(self, index, flat: bool = True):
+        """Get a page of tiles from the host buffer (for storage backend)."""
+        page_idx = index // self.page_size
+        data_page = self.kv_buffer[page_idx]  # [layer_num, Hk, tile_bytes] uint8
+        if flat:
+            data_page = data_page.flatten()
+        return data_page
+
+    def get_dummy_flat_data_page(self):
+        """Dummy page for prefetching (all zeros)."""
+        return torch.zeros(
+            (self._num_compressed_layers, self._hk, self._tile_bytes),
+            dtype=torch.uint8,
+            device=self.device,
+            pin_memory=self.pin_memory,
+        ).flatten()
+
+    def set_from_flat_data_page(self, index: int, data_page: torch.Tensor):
+        """Set a page of tiles in the host buffer (for storage backend)."""
+        page_idx = index // self.page_size
+        self.kv_buffer[page_idx] = data_page.reshape(
+            self._num_compressed_layers, self._hk, self._tile_bytes
+        )
+
+    def is_stride_page_aligned(self, page_size_bytes: int = 4096) -> bool:
+        """Check if per-page tile stride is OS-page-aligned."""
+        stride = self._hk * self._tile_bytes * self._num_compressed_layers
+        return stride % page_size_bytes == 0
+
+
+def get_mha_host_pool_cls(device_pool: MHATokenToKVPool) -> type:
+    """Pick the right MHA host-pool class based on the device pool.
+
+    Returns ``KVarNHostKVCache`` for NoOp pools with a KVarN backend,
+    ``AsymmetricMHATokenToKVPoolHost`` when ``head_dim != v_head_dim``
     (e.g. MiMo-V2), else the default ``MHATokenToKVPoolHost``.
     """
+    from sglang.srt.mem_cache.memory_pool import NoOpMHATokenToKVPool
+
+    if (
+        isinstance(device_pool, NoOpMHATokenToKVPool)
+        and getattr(device_pool, "_kvarn_backend", None) is not None
+    ):
+        return KVarNHostKVCache
     if device_pool.head_dim != device_pool.v_head_dim:
         return AsymmetricMHATokenToKVPoolHost
     return MHATokenToKVPoolHost

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -275,6 +275,32 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 )
                 # FP4 prefill uses one shared FP8 dequant workspace across layers.
                 cell_size += n * k * 2 * kv_size
+            elif kvc.server_args.kv_cache_dtype.startswith("kvarn_"):
+                # KVarN dual-pool: the NoOp pool has a large logical size for
+                # the scheduler, but actual GPU memory = tail pool (small fp16)
+                # + int4 compressed cache. The cell_size should reflect the
+                # compressed cost per token to size the compressed cache capacity.
+                from sglang.srt.layers.quantization.kvarn.config import (
+                    KVarNConfig,
+                )
+
+                kvarn_cfg = KVarNConfig.from_cache_dtype(
+                    kvc.server_args.kv_cache_dtype, head_dim=model_config.head_dim
+                )
+                n = model_config.get_num_kv_heads(tp_size)
+                G = kvarn_cfg.group
+                # Compressed bytes per token (K+V) per layer:
+                # tile_bytes covers group tokens for one head and already
+                # includes both K and V (packed + scales). Divide by group for
+                # per-token, multiply by n heads.
+                compressed_per_token = (
+                    kvarn_cfg.tile_bytes_aligned * n // G
+                )
+                # Tail pool overhead: small constant, ~2*max_num_seqs blocks.
+                # Per-token cost is dominated by the compressed cache.
+                # Add ~30% overhead for the tail pool + runtime allocations.
+                overhead = 0.30
+                cell_size = int(compressed_per_token * num_layers * (1 + overhead))
 
         return cell_size
 

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -29,6 +29,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.mem_cache.memory_pool import NoOpMHATokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.model_executor.runner import get_is_capture_mode
@@ -292,6 +293,7 @@ def enable_fused_set_kv_buffer(forward_batch: ForwardBatch):
         _is_cuda
         and pool.dtype == torch.bfloat16
         and not isinstance(pool, SWAKVPool)
+        and not isinstance(pool, NoOpMHATokenToKVPool)
         and not is_prefill_context_parallel_enabled()
         and getattr(forward_batch, "dcp_kv_mask", None) is None
     ) or (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -618,6 +618,11 @@ class ServerArgs:
                 "nvfp4",
                 "fp4_mx_block16",
                 "fp4_e2m1",
+                # KVarN presets (see KVARN_PRESETS in kvarn/config.py)
+                "kvarn_k4v2_g128",
+                "kvarn_k4v4_g128",
+                "kvarn_k4v2_g64",
+                "kvarn_k4v4_g64",
             ],
             resolvable=True,
         ),
@@ -3666,6 +3671,12 @@ class ServerArgs:
                 "decode context parallel (dcp_size > 1)",
                 lambda: self.dcp_size > 1,
             ),
+            # KVarN: the Triton backend (inner) doesn't support EXTEND mode
+            # for piecewise CUDA graph replay. Disable prefill CUDA graph.
+            (
+                "KVarN attention backend",
+                lambda: self._resolved().kv_cache_dtype.startswith("kvarn_"),
+            ),
         ]
         for _name, predicate in rules:
             if predicate():
@@ -3713,6 +3724,12 @@ class ServerArgs:
                 "multimodal model",
                 lambda: self.get_model_config().is_multimodal
                 and not self.get_model_config().is_multimodal_breakable_cuda_graph_supported,
+            ),
+            # KVarN: the Triton backend (inner) doesn't support EXTEND mode
+            # for piecewise/breakable CUDA graph replay. Disable prefill CUDA graph.
+            (
+                "KVarN attention backend",
+                lambda: self._resolved().kv_cache_dtype.startswith("kvarn_"),
             ),
         ]
         for name, predicate in rules:

--- a/tests/kvarn/conftest.py
+++ b/tests/kvarn/conftest.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test bootstrap for KVarN unit tests.
+
+These tests only need torch + triton.  The kvarn modules under test have
+no sglang framework imports, so we create synthetic namespace packages
+for the sglang parent chain (which normally has heavy __init__ side
+effects) and let Python's normal import mechanism handle the kvarn
+sub-packages themselves.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent.parent / "python"
+
+# Add python/ to sys.path so Python can find leaf sub-packages.
+sys.path.insert(0, str(_PKG_ROOT))
+
+# Shim the *parent* packages that have heavy __init__.py side effects.
+# The leaf kvarn/kvarn_ops packages have lightweight __init__.py and will be
+# imported normally by Python's import machinery.
+_chain = [
+    "sglang",
+    "sglang.srt",
+    "sglang.srt.layers",
+    "sglang.srt.layers.quantization",
+    "sglang.srt.layers.attention",
+]
+
+for _pkg in _chain:
+    if _pkg in sys.modules:
+        continue
+    _mod = types.ModuleType(_pkg)
+    _dir = _PKG_ROOT / _pkg.replace(".", "/")
+    _mod.__path__ = [str(_dir)]
+    _mod.__package__ = _pkg
+    sys.modules[_pkg] = _mod
+    if "." in _pkg:
+        _parent, _child = _pkg.rsplit(".", 1)
+        setattr(sys.modules[_parent], _child, _mod)

--- a/tests/kvarn/run_e2e_gpu_test.sh
+++ b/tests/kvarn/run_e2e_gpu_test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# KVarN end-to-end GPU test script.
+#
+# Requires: a GPU with CUDA support, sglang installed, and a small model
+# (e.g. meta-llama/Llama-3.2-1B-Instruct or Qwen/Qwen2.5-0.5B-Instruct).
+#
+# Usage:
+#   KVARN_MODEL=Qwen/Qwen2.5-0.5B-Instruct bash tests/kvarn/run_e2e_gpu_test.sh
+#
+# What it tests:
+#   1. Server starts with --kv-cache-dtype kvarn_k4v4_g128
+#   2. Basic completion request succeeds
+#   3. Output is coherent (not garbage)
+#   4. Server can handle multiple concurrent requests
+#   5. Prefill + decode both work
+#   6. Comparison with fp16 baseline (optional)
+
+set -euo pipefail
+
+MODEL="${KVARN_MODEL:-Qwen/Qwen2.5-0.5B-Instruct}"
+KVARN_DTYPE="${KVARN_DTYPE:-kvarn_k4v4_g128}"
+PORT="${KVARN_PORT:-30000}"
+TIMEOUT="${KVARN_TIMEOUT:-120}"
+
+echo "=== KVarN E2E GPU Test ==="
+echo "Model: $MODEL"
+echo "KV cache dtype: $KVARN_DTYPE"
+echo "Port: $PORT"
+echo ""
+
+# Start server with KVarN
+echo ">>> Starting sglang server with KVarN..."
+python -m sglang.launch_server \
+    --model-path "$MODEL" \
+    --kv-cache-dtype "$KVARN_DTYPE" \
+    --attention-backend kvarn \
+    --port "$PORT" \
+    --log-level info \
+    --disable-radix-cache \
+    --context-length 2048 &
+SERVER_PID=$!
+
+cleanup() {
+    echo ">>> Cleaning up server (PID $SERVER_PID)..."
+    kill $SERVER_PID 2>/dev/null || true
+    wait $SERVER_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for server to be ready
+echo ">>> Waiting for server to be ready..."
+for i in $(seq 1 $TIMEOUT); do
+    if curl -s http://localhost:$PORT/health | grep -q "ok" 2>/dev/null; then
+        echo ">>> Server is ready (after ${i}s)"
+        break
+    fi
+    if ! kill -0 $SERVER_PID 2>/dev/null; then
+        echo ">>> ERROR: Server process died"
+        exit 1
+    fi
+    sleep 1
+    if [ $i -eq $TIMEOUT ]; then
+        echo ">>> ERROR: Server failed to start within ${TIMEOUT}s"
+        exit 1
+    fi
+done
+
+# Test 1: Basic completion
+echo ""
+echo ">>> Test 1: Basic completion"
+RESPONSE=$(curl -s http://localhost:$PORT/generate \
+    -H "Content-Type: application/json" \
+    -d '{
+        "text": "The capital of France is",
+        "sampling_params": {"max_new_tokens": 16, "temperature": 0}
+    }')
+echo "Response: $RESPONSE"
+TEXT=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['text'])" 2>/dev/null || echo "")
+if [ -z "$TEXT" ]; then
+    echo ">>> FAIL: Empty response"
+    exit 1
+fi
+echo ">>> PASS: Got non-empty response"
+
+# Test 2: Coherence check (should mention Paris)
+echo ""
+echo ">>> Test 2: Coherence check"
+if echo "$TEXT" | grep -qi "paris" 2>/dev/null; then
+    echo ">>> PASS: Response mentions Paris"
+else
+    echo ">>> WARN: Response does not mention Paris (may be OK for small models)"
+    echo "    Response was: $TEXT"
+fi
+
+# Test 3: Multiple concurrent requests
+echo ""
+echo ">>> Test 3: Multiple concurrent requests"
+for i in 1 2 3 4; do
+    curl -s http://localhost:$PORT/generate \
+        -H "Content-Type: application/json" \
+        -d "{\"text\": \"Hello $i\", \"sampling_params\": {\"max_new_tokens\": 8, \"temperature\": 0}}" &
+done
+wait
+echo ">>> PASS: Concurrent requests completed"
+
+# Test 4: Longer context (tests prefill + multiple decode blocks)
+echo ""
+echo ">>> Test 4: Longer context"
+LONG_TEXT="Once upon a time, there was a little robot named Pi who lived in a big city. Pi loved to explore and learn new things. One day, Pi decided to go on an adventure to find the tallest building in the city. Along the way, Pi met many friends who helped with directions. The story continues with"
+RESPONSE=$(curl -s http://localhost:$PORT/generate \
+    -H "Content-Type: application/json" \
+    -d "{\"text\": \"$LONG_TEXT\", \"sampling_params\": {\"max_new_tokens\": 32, \"temperature\": 0}}")
+echo "Response: $(echo $RESPONSE | python3 -c 'import sys,json; print(json.load(sys.stdin)["text"][:200])' 2>/dev/null || echo 'parse error')"
+echo ">>> PASS: Long context request completed"
+
+# Test 5: Multi-turn (tests KV cache reuse)
+echo ""
+echo ">>> Test 5: Multi-turn conversation"
+RESPONSE1=$(curl -s http://localhost:$PORT/generate \
+    -H "Content-Type: application/json" \
+    -d '{"text": "My name is Alice.", "sampling_params": {"max_new_tokens": 8, "temperature": 0}}')
+echo "Turn 1: $RESPONSE1"
+RESPONSE2=$(curl -s http://localhost:$PORT/generate \
+    -H "Content-Type: application/json" \
+    -d '{"text": "What is my name?", "sampling_params": {"max_new_tokens": 16, "temperature": 0}}')
+echo "Turn 2: $RESPONSE2"
+echo ">>> PASS: Multi-turn completed"
+
+echo ""
+echo "=== All tests passed! ==="
+echo ""
+echo "KVarN is working end-to-end with:"
+echo "  - Model: $MODEL"
+echo "  - KV cache dtype: $KVARN_DTYPE"
+echo "  - Attention backend: kvarn (Hadamard rotation + fp16 tail pool)"

--- a/tests/kvarn/test_kvarn_core.py
+++ b/tests/kvarn/test_kvarn_core.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for KVarN config, sinkhorn, store, and dequant (CPU-only).
+
+Run:
+    python -m pytest tests/kvarn/test_kvarn_core.py -v
+"""
+
+import pytest
+import torch
+
+from sglang.srt.layers.quantization.kvarn.config import (
+    KVARN_PRESETS,
+    KVarNConfig,
+    is_kvarn_dtype,
+)
+from sglang.srt.layers.quantization.kvarn.dequant import (
+    _unpack_lowbit,
+    kvarn_dequant_tile_k,
+    kvarn_dequant_tile_v,
+)
+from sglang.srt.layers.quantization.kvarn.sinkhorn import (
+    variance_normalize,
+    variance_normalize_batched,
+)
+from sglang.srt.layers.quantization.kvarn.store import (
+    _pack_4bit,
+    kvarn_store_tile_k,
+    kvarn_store_tile_v,
+)
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+
+class TestKVarNConfig:
+    def test_presets_exist(self):
+        assert "kvarn_k4v4_g128" in KVARN_PRESETS
+        assert "kvarn_k4v2_g128" in KVARN_PRESETS
+
+    def test_is_kvarn_dtype(self):
+        assert is_kvarn_dtype("kvarn_k4v4_g128")
+        assert is_kvarn_dtype("kvarn_k4v2_g64")
+        assert not is_kvarn_dtype("fp8_e4m3")
+        assert not is_kvarn_dtype("auto")
+
+    def test_from_cache_dtype(self):
+        cfg = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+        assert cfg.key_bits == 4
+        assert cfg.value_bits == 4
+        assert cfg.group == 128
+        assert cfg.head_dim == 128
+
+    def test_from_cache_dtype_invalid(self):
+        with pytest.raises(ValueError, match="Unknown KVarN"):
+            KVarNConfig.from_cache_dtype("invalid", head_dim=128)
+
+    def test_tile_bytes_positive(self):
+        cfg = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+        assert cfg.tile_bytes > 0
+        assert cfg.tile_bytes_aligned >= cfg.tile_bytes
+
+    def test_tile_bytes_alignment(self):
+        cfg = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+        assert cfg.tile_bytes_aligned % 8 == 0
+
+    @pytest.mark.parametrize("preset", list(KVARN_PRESETS.keys()))
+    def test_all_presets(self, preset):
+        cfg = KVarNConfig.from_cache_dtype(preset, head_dim=128)
+        assert cfg.group in (64, 128)
+        assert cfg.key_bits in (2, 4)
+        assert cfg.value_bits in (2, 4)
+
+    def test_slot_offsets_consistent(self):
+        cfg = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+        assert cfg.k_s_col_offset == cfg.k_packed_offset + cfg.k_packed_bytes
+        assert cfg.k_zp_offset == cfg.k_s_col_offset + cfg.head_dim * 2
+        assert cfg.k_s_row_offset == cfg.k_zp_offset + cfg.head_dim * 2
+        assert cfg.v_packed_offset == cfg.k_s_row_offset + cfg.group * 2
+        assert cfg.v_s_col_offset == cfg.v_packed_offset + cfg.v_packed_bytes
+        assert cfg.v_s_row_offset == cfg.v_s_col_offset + cfg.head_dim * 2
+        assert cfg.v_zp_offset == cfg.v_s_row_offset + cfg.group * 2
+        assert cfg.v_zp_offset + cfg.group * 2 == cfg.tile_bytes
+
+
+# ─── Sinkhorn ────────────────────────────────────────────────────────────────
+
+
+class TestSinkhorn:
+    def test_identity_tile(self):
+        """An already-balanced tile should remain near-identity."""
+        torch.manual_seed(42)
+        tile = torch.randn(128, 128) * 0.1 + 1.0  # roughly uniform scale
+        balanced, s_col, s_row = variance_normalize(tile, iterations=16)
+        assert balanced.shape == tile.shape
+        # The balanced tile should have lower max/min std ratio than original
+        orig_col_std = tile.std(dim=0)
+        bal_col_std = balanced.std(dim=0)
+        assert (
+            bal_col_std.max() / bal_col_std.min()
+            <= orig_col_std.max() / orig_col_std.min() + 0.1
+        )
+
+    def test_reduces_imbalance(self):
+        """Sinkhorn should reduce the imbalance metric."""
+        torch.manual_seed(0)
+        # Create an imbalanced tile: scale rows by varying amounts
+        tile = torch.randn(128, 128)
+        scales = torch.linspace(0.1, 10.0, 128).unsqueeze(1)
+        tile = tile * scales
+
+        def imbalance(t):
+            sc = t.std(dim=-2)
+            sr = t.std(dim=-1)
+            return sc.max() / sc.min().clamp_min(1e-8) + sr.max() / sr.min().clamp_min(
+                1e-8
+            )
+
+        orig_imb = imbalance(tile.float())
+        balanced, _, _ = variance_normalize(tile, iterations=16)
+        new_imb = imbalance(balanced)
+        assert new_imb < orig_imb
+
+    def test_batched_matches_single(self):
+        torch.manual_seed(123)
+        tiles = torch.randn(4, 128, 128)
+        bal_b, sc_b, sr_b = variance_normalize_batched(tiles, iterations=8)
+        for i in range(4):
+            bal_s, sc_s, sr_s = variance_normalize(tiles[i], iterations=8)
+            torch.testing.assert_close(bal_b[i], bal_s, rtol=1e-4, atol=1e-4)
+
+    def test_reconstruction(self):
+        """tile ≈ balanced * s_col * s_row"""
+        torch.manual_seed(42)
+        tile = torch.randn(128, 128)
+        balanced, s_col, s_row = variance_normalize(tile, iterations=16)
+        reconstructed = balanced * s_col * s_row
+        torch.testing.assert_close(reconstructed, tile, rtol=1e-3, atol=1e-3)
+
+
+# ─── Store + Dequant roundtrip ───────────────────────────────────────────────
+
+
+class TestStoreDequant:
+    @pytest.mark.parametrize("bits", [4])
+    def test_k_roundtrip(self, bits):
+        torch.manual_seed(42)
+        D, G = 128, 128
+        tile = torch.randn(D, G, dtype=torch.float32)
+
+        result = kvarn_store_tile_k(tile, bits=bits, sinkhorn_iters=8)
+        dequant = kvarn_dequant_tile_k(
+            result["q_packed_uint8"],
+            result["s_col_K"],
+            result["zp_K"],
+            result["s_row_K"],
+            group=G,
+            bits=bits,
+        )
+
+        # 4-bit quantization should give reasonable SNR
+        err = (dequant - tile).abs().mean()
+        mag = tile.abs().mean()
+        assert err / mag < 0.3, f"K roundtrip error too high: {err/mag}"
+
+    @pytest.mark.parametrize("bits", [4])
+    def test_v_roundtrip(self, bits):
+        torch.manual_seed(42)
+        G, D = 128, 128
+        tile = torch.randn(G, D, dtype=torch.float32)
+
+        result = kvarn_store_tile_v(tile, bits=bits, sinkhorn_iters=8)
+        dequant = kvarn_dequant_tile_v(
+            result["q_packed_uint8"],
+            result["s_col_V"],
+            result["s_row_V"],
+            result["zp_V"],
+            head_dim=D,
+            bits=bits,
+        )
+
+        err = (dequant - tile).abs().mean()
+        mag = tile.abs().mean()
+        assert err / mag < 0.3, f"V roundtrip error too high: {err/mag}"
+
+    def test_pack4_unpack4(self):
+        """4-bit pack/unpack roundtrips correctly."""
+        torch.manual_seed(0)
+        q = torch.randint(0, 16, (4, 128), dtype=torch.int32)
+        packed = _pack_4bit(q)
+        unpacked = _unpack_lowbit(packed, 128, bits=4)
+        torch.testing.assert_close(unpacked, q.to(torch.uint8))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/kvarn/test_kvarn_e2e_gpu.py
+++ b/tests/kvarn/test_kvarn_e2e_gpu.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end GPU test: launch sglang server with KVarN and verify it works.
+
+Requires a GPU and a small model.  Set KVARN_MODEL env var to override
+the default model.
+
+Run:
+    KVARN_MODEL=Qwen/Qwen2.5-0.5B-Instruct \
+    python -m pytest tests/kvarn/test_kvarn_e2e_gpu.py -v -s --timeout 180
+"""
+
+import os
+import subprocess
+import time
+
+import pytest
+
+if not os.environ.get("KVARN_E2E_GPU", "0") == "1":
+    pytest.skip("Set KVARN_E2E_GPU=1 to run E2E GPU tests", allow_module_level=True)
+
+
+MODEL = os.environ.get("KVARN_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+KVARN_DTYPE = os.environ.get("KVARN_DTYPE", "kvarn_k4v4_g128")
+PORT = int(os.environ.get("KVARN_PORT", "30000"))
+
+
+@pytest.fixture(scope="module")
+def sglang_server():
+    """Launch and manage a sglang server with KVarN enabled."""
+    cmd = [
+        "python",
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        MODEL,
+        "--kv-cache-dtype",
+        KVARN_DTYPE,
+        "--port",
+        str(PORT),
+        "--log-level",
+        "info",
+        "--disable-radix-cache",
+        "--context-length",
+        "2048",
+    ]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    try:
+        # Wait for server
+        import requests
+
+        for _ in range(120):
+            if proc.poll() is not None:
+                # Server died
+                output = proc.stdout.read().decode()
+                pytest.fail(f"Server died:\n{output[-2000:]}")
+            try:
+                r = requests.get(f"http://localhost:{PORT}/health", timeout=2)
+                if r.status_code == 200:
+                    break
+            except Exception:
+                pass
+            time.sleep(1)
+        else:
+            output = proc.stdout.read().decode()
+            pytest.fail(f"Server failed to start:\n{output[-2000:]}")
+
+        yield f"http://localhost:{PORT}"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def test_server_health(sglang_server):
+    import requests
+
+    r = requests.get(f"{sglang_server}/health")
+    assert r.status_code == 200
+
+
+def test_basic_completion(sglang_server):
+    import requests
+
+    r = requests.post(
+        f"{sglang_server}/generate",
+        json={
+            "text": "The capital of France is",
+            "sampling_params": {"max_new_tokens": 16, "temperature": 0},
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "text" in data
+    assert len(data["text"]) > 0
+    assert "Paris" in data["text"]
+
+
+def test_long_context(sglang_server):
+    import requests
+
+    text = "Once upon a time, there was a little robot named Pi. " * 10
+    r = requests.post(
+        f"{sglang_server}/generate",
+        json={
+            "text": text,
+            "sampling_params": {"max_new_tokens": 32, "temperature": 0},
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["text"]) > 0
+
+
+def test_concurrent_requests(sglang_server):
+    """Test that multiple concurrent requests work correctly."""
+    import threading
+
+    import requests
+
+    results = [None] * 4
+
+    def make_request(i):
+        r = requests.post(
+            f"{sglang_server}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"max_new_tokens": 16, "temperature": 0},
+            },
+        )
+        results[i] = r.json()
+
+    threads = [threading.Thread(target=make_request, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for r in results:
+        assert r is not None
+        assert "Paris" in r["text"]
+
+
+def test_repeated_requests_consistency(sglang_server):
+    """Test that the same prompt produces consistent output (deterministic)."""
+    import requests
+
+    r1 = requests.post(
+        f"{sglang_server}/generate",
+        json={
+            "text": "The capital of France is",
+            "sampling_params": {"max_new_tokens": 16, "temperature": 0},
+        },
+    )
+    r2 = requests.post(
+        f"{sglang_server}/generate",
+        json={
+            "text": "The capital of France is",
+            "sampling_params": {"max_new_tokens": 16, "temperature": 0},
+        },
+    )
+    assert r1.json()["text"] == r2.json()["text"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/kvarn/test_kvarn_flush.py
+++ b/tests/kvarn/test_kvarn_flush.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for KVarN flush manager (CPU-only)."""
+
+import pytest
+import torch
+
+from sglang.srt.layers.quantization.kvarn.config import KVarNConfig
+from sglang.srt.layers.quantization.kvarn.flush_manager import KVarNFlushManager
+
+
+@pytest.fixture
+def cfg():
+    return KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+
+
+@pytest.fixture
+def manager(cfg):
+    return KVarNFlushManager(
+        cfg=cfg,
+        num_layers=2,
+        num_kv_heads=4,
+        head_dim=128,
+        v_head_dim=128,
+        sink_blocks=1,
+    )
+
+
+def _make_tail_pools(num_layers, pool_slots, group, hk, d, device="cpu"):
+    tail_K = [
+        torch.randn(pool_slots, group, hk, d, dtype=torch.float16, device=device)
+        for _ in range(num_layers)
+    ]
+    tail_V = [
+        torch.randn(pool_slots, group, hk, d, dtype=torch.float16, device=device)
+        for _ in range(num_layers)
+    ]
+    return tail_K, tail_V
+
+
+def _make_compressed_cache(num_layers, num_blocks, hk, tile_bytes, device="cpu"):
+    return [
+        torch.zeros(num_blocks, hk, tile_bytes, dtype=torch.uint8, device=device)
+        for _ in range(num_layers)
+    ]
+
+
+class TestFlushManager:
+    def test_init(self, manager, cfg):
+        assert manager.num_layers == 2
+        assert manager.num_kv_heads == 4
+        assert manager.head_dim == 128
+        assert manager.group == cfg.group
+        assert manager.tile_bytes > 0
+
+    def test_flush_writes_nonzero(self, manager, cfg):
+        G, Hk, D = cfg.group, 4, 128
+        pool_slots = 4
+        tail_K, tail_V = _make_tail_pools(2, pool_slots, G, Hk, D)
+        cache = _make_compressed_cache(2, 8, Hk, manager.tile_bytes)
+
+        assert cache[0][0, 0].sum().item() == 0
+        manager.flush_block(0, tail_K, tail_V, slot=0, compressed_cache=cache)
+        assert cache[0][0, 0].sum().item() > 0
+
+    def test_flush_batched_writes_nonzero(self, manager, cfg):
+        G, Hk, D = cfg.group, 4, 128
+        pool_slots = 4
+        tail_K, tail_V = _make_tail_pools(2, pool_slots, G, Hk, D)
+        cache = _make_compressed_cache(2, 8, Hk, manager.tile_bytes)
+
+        assert cache[0][0, 0].sum().item() == 0
+        manager.flush_blocks_batched([0, 1], tail_K, tail_V, [0, 1], cache)
+        assert cache[0][0, 0].sum().item() > 0
+        assert cache[0][1, 0].sum().item() > 0
+
+    def test_dequant_roundtrip(self, manager, cfg):
+        """Flush then dequant should approximately recover the original data."""
+        G, Hk, D = cfg.group, 4, 128
+        pool_slots = 2
+        tail_K, tail_V = _make_tail_pools(2, pool_slots, G, Hk, D)
+        cache = _make_compressed_cache(2, 8, Hk, manager.tile_bytes)
+
+        # Save originals for comparison
+        orig_k = tail_K[0][0].clone()  # [G, Hk, D]
+        orig_v = tail_V[0][0].clone()
+
+        # Flush block 0 to int4
+        manager.flush_block(0, tail_K, tail_V, slot=0, compressed_cache=cache)
+
+        # Dequant back
+        K_deq, V_deq = manager.dequant_block(0, cache, layer_id=0)
+        # K_deq, V_deq are [G, Hk, D] in rotated frame
+
+        # Check shapes
+        assert K_deq.shape == (G, Hk, D)
+        assert V_deq.shape == (G, Hk, D)
+
+        # Check approximate recovery (within 4-bit quantization error)
+        k_err = (K_deq.float() - orig_k.float()).abs().mean()
+        k_mag = orig_k.float().abs().mean()
+        rel_err = k_err / k_mag
+        assert rel_err < 0.5, f"K dequant roundtrip error too high: {rel_err:.3f}"
+
+    def test_no_flush_empty(self, manager, cfg):
+        G, Hk, D = cfg.group, 4, 128
+        pool_slots = 2
+        tail_K, tail_V = _make_tail_pools(2, pool_slots, G, Hk, D)
+        cache = _make_compressed_cache(2, 8, Hk, manager.tile_bytes)
+        # Just verify it doesn't crash with empty batch
+        manager.flush_blocks_batched([], tail_K, tail_V, [], cache)
+        assert cache[0][0, 0].sum().item() == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/kvarn/test_kvarn_hadamard.py
+++ b/tests/kvarn/test_kvarn_hadamard.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for KVarN Hadamard utilities (CPU-only)."""
+
+import math
+
+import pytest
+import torch
+
+from sglang.srt.layers.quantization.kvarn.hadamard import (
+    build_hadamard,
+    hadamard_cached,
+)
+
+
+class TestHadamard:
+    @pytest.mark.parametrize("d", [16, 32, 64, 128, 256])
+    def test_orthonormal(self, d):
+        """H * H^T should be identity (orthonormal)."""
+        H = build_hadamard(d, torch.device("cpu"))
+        I = torch.mm(H, H.t())
+        torch.testing.assert_close(I, torch.eye(d), rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.parametrize("d", [16, 32, 64, 128])
+    def test_symmetric(self, d):
+        """Sylvester Hadamard matrices are symmetric."""
+        H = build_hadamard(d, torch.device("cpu"))
+        torch.testing.assert_close(H, H.t(), rtol=1e-6, atol=1e-6)
+
+    def test_cached(self):
+        """hadamard_cached returns the same tensor for the same (d, device)."""
+        H1 = hadamard_cached(128, "cpu")
+        H2 = hadamard_cached(128, "cpu")
+        assert H1 is H2
+
+    def test_values(self):
+        """Entries should be ±1/sqrt(d)."""
+        d = 128
+        H = build_hadamard(d, torch.device("cpu"))
+        expected = 1.0 / math.sqrt(d)
+        assert H.abs().min().item() == pytest.approx(expected, rel=1e-6)
+        assert H.abs().max().item() == pytest.approx(expected, rel=1e-6)
+
+    def test_rotation_preserves_norm(self):
+        """Rotating a vector by H should preserve its L2 norm."""
+        torch.manual_seed(42)
+        d = 128
+        H = build_hadamard(d, torch.device("cpu"))
+        x = torch.randn(d)
+        x_rot = torch.mv(H, x)
+        assert x_rot.norm().item() == pytest.approx(x.norm().item(), rel=1e-4)
+
+    def test_rotation_preserves_dot_product(self):
+        """QK^T should be invariant under Hadamard rotation: (QH)(KH)^T = Q(HH^T)K^T = QK^T."""
+        torch.manual_seed(42)
+        d = 128
+        H = build_hadamard(d, torch.device("cpu"))
+        q = torch.randn(1, d)
+        k = torch.randn(4, d)
+        score_orig = torch.mm(q, k.t())
+        q_rot = torch.mm(q, H)
+        k_rot = torch.mm(k, H)
+        score_rot = torch.mm(q_rot, k_rot.t())
+        torch.testing.assert_close(score_rot, score_orig, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/kvarn/test_kvarn_imports.py
+++ b/tests/kvarn/test_kvarn_imports.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Import smoke tests for KVarN sglang integration modules.
+
+These tests verify that the KVarN modules can be imported without errors.
+They use the conftest.py shim to avoid pulling in the full sglang package.
+
+Run:
+    python -m pytest tests/kvarn/test_kvarn_imports.py -v
+"""
+
+import pytest
+
+# These imports rely on the conftest.py shim for the parent packages.
+# The kvarn sub-packages themselves have no heavy deps.
+
+
+def test_import_config():
+    from sglang.srt.layers.quantization.kvarn.config import KVARN_PRESETS, KVarNConfig
+
+    assert "kvarn_k4v4_g128" in KVARN_PRESETS
+    cfg = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+    assert cfg.key_bits == 4
+
+
+def test_import_sinkhorn():
+    from sglang.srt.layers.quantization.kvarn.sinkhorn import variance_normalize
+
+    assert callable(variance_normalize)
+
+
+def test_import_store():
+    from sglang.srt.layers.quantization.kvarn.store import kvarn_store_tile_k
+
+    assert callable(kvarn_store_tile_k)
+
+
+def test_import_dequant():
+    from sglang.srt.layers.quantization.kvarn.dequant import kvarn_dequant_tile_k
+
+    assert callable(kvarn_dequant_tile_k)
+
+
+def test_import_hadamard():
+    from sglang.srt.layers.quantization.kvarn.hadamard import build_hadamard
+
+    assert callable(build_hadamard)
+
+
+def test_import_triton_sinkhorn():
+    from sglang.srt.layers.attention.kvarn_ops.triton_sinkhorn import (
+        kvarn_sinkhorn_triton,
+    )
+
+    assert callable(kvarn_sinkhorn_triton)
+
+
+def test_import_triton_decode():
+    from sglang.srt.layers.attention.kvarn_ops.triton_decode import (
+        _kvarn_build_packed_kv_kernel,
+        _kvarn_fused_decode_kernel,
+        _kvarn_fused_verify_stage1,
+        _kvarn_scatter_store_kernel,
+        kvarn_decode_attention,
+        kvarn_scatter_store,
+        kvarn_verify_attention,
+    )
+
+    # These are Triton JIT kernels — just verify they're decorated.
+    assert _kvarn_scatter_store_kernel is not None
+    assert _kvarn_build_packed_kv_kernel is not None
+    assert _kvarn_fused_decode_kernel is not None
+    assert _kvarn_fused_verify_stage1 is not None
+    assert callable(kvarn_decode_attention)
+    assert callable(kvarn_verify_attention)
+    assert callable(kvarn_scatter_store)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/kvarn/test_kvarn_pipeline.py
+++ b/tests/kvarn/test_kvarn_pipeline.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration test: verify QK^T invariance under the full KVarN pipeline.
+
+The key mathematical invariant of KVarN is:
+
+    QK^T = (Q @ H) @ (K_rot)^T = (Q @ H) @ (dequant(quant(K @ H)))^T
+
+Since H is orthonormal, QK^T is preserved if dequant∘quant is a good
+approximation of the identity.  This test verifies that the full pipeline
+(rotation → sinkhorn → RTN → pack → unpack → dequant → un-rotation)
+preserves attention scores within an acceptable error bound.
+"""
+
+import math
+
+import pytest
+import torch
+
+from sglang.srt.layers.quantization.kvarn.config import KVarNConfig
+from sglang.srt.layers.quantization.kvarn.dequant import (
+    kvarn_dequant_tile_k,
+    kvarn_dequant_tile_v,
+)
+from sglang.srt.layers.quantization.kvarn.hadamard import build_hadamard
+from sglang.srt.layers.quantization.kvarn.store import (
+    kvarn_store_tile_k,
+    kvarn_store_tile_v,
+)
+
+
+class TestPipelineInvariance:
+    """Test that the full KVarN pipeline preserves attention scores."""
+
+    @pytest.mark.parametrize("bits", [4])
+    def test_qk_score_preservation(self, bits):
+        """QK^T scores should be preserved within ~30% relative error at 4-bit."""
+        torch.manual_seed(42)
+        D = 128
+        G = 128
+        cfg = KVarNConfig(head_dim=D, key_bits=bits, value_bits=bits, group=G)
+
+        H = build_hadamard(D, torch.device("cpu"))
+
+        # Simulate one head's K tile: [D, G] (channels × tokens)
+        k_tile = torch.randn(D, G, dtype=torch.float32) * 0.1
+        # Simulate query: [1, D]
+        q = torch.randn(1, D, dtype=torch.float32) * 0.1
+
+        # Original scores
+        scores_orig = torch.mm(q, k_tile)  # [1, G]
+
+        # Rotate
+        k_rot = torch.mm(H, k_tile)  # [D, G]
+        q_rot = torch.mm(q, H)  # [1, D]
+
+        # Store (quantize)
+        stored = kvarn_store_tile_k(k_rot, bits=bits, sinkhorn_iters=8)
+
+        # Dequant
+        k_rot_dequant = kvarn_dequant_tile_k(
+            stored["q_packed_uint8"],
+            stored["s_col_K"],
+            stored["zp_K"],
+            stored["s_row_K"],
+            group=G,
+            bits=bits,
+        )
+
+        # Scores in rotated frame
+        scores_rot = torch.mm(q_rot, k_rot_dequant)  # [1, G]
+
+        # Compare
+        err = (scores_rot - scores_orig).abs().mean()
+        mag = scores_orig.abs().mean()
+        rel_err = err / mag
+        assert rel_err < 0.5, f"QK score relative error too high: {rel_err:.3f}"
+
+    @pytest.mark.parametrize("bits", [4])
+    def test_attention_output_preservation(self, bits):
+        """Full attention output (QK^T * V) should be preserved within tolerance."""
+        torch.manual_seed(42)
+        D = 128
+        G = 128
+        cfg = KVarNConfig(head_dim=D, key_bits=bits, value_bits=bits, group=G)
+        H = build_hadamard(D, torch.device("cpu"))
+
+        k_tile = torch.randn(D, G, dtype=torch.float32) * 0.1  # [D, G]
+        v_tile = torch.randn(G, D, dtype=torch.float32) * 0.1  # [G, D]
+        q = torch.randn(1, D, dtype=torch.float32) * 0.1  # [1, D]
+
+        # Original attention: softmax(QK^T / sqrt(D)) @ V
+        scores = torch.mm(q, k_tile) / math.sqrt(D)  # [1, G]
+        attn = torch.softmax(scores, dim=-1)  # [1, G]
+        out_orig = torch.mm(attn, v_tile)  # [1, D]
+
+        # Rotate
+        k_rot = torch.mm(H, k_tile)  # [D, G]
+        v_rot = torch.mm(v_tile, H)  # [G, D]
+        q_rot = torch.mm(q, H)  # [1, D]
+
+        # Store + dequant
+        k_stored = kvarn_store_tile_k(k_rot, bits=bits, sinkhorn_iters=8)
+        k_deq = kvarn_dequant_tile_k(
+            k_stored["q_packed_uint8"],
+            k_stored["s_col_K"],
+            k_stored["zp_K"],
+            k_stored["s_row_K"],
+            group=G,
+            bits=bits,
+        )
+        v_stored = kvarn_store_tile_v(v_rot, bits=bits, sinkhorn_iters=8)
+        v_deq = kvarn_dequant_tile_v(
+            v_stored["q_packed_uint8"],
+            v_stored["s_col_V"],
+            v_stored["s_row_V"],
+            v_stored["zp_V"],
+            head_dim=D,
+            bits=bits,
+        )
+
+        # Rotated attention
+        scores_rot = torch.mm(q_rot, k_deq) / math.sqrt(D)  # [1, G]
+        attn_rot = torch.softmax(scores_rot, dim=-1)  # [1, G]
+        out_rot = torch.mm(attn_rot, v_deq)  # [1, D]
+
+        # Un-rotate output
+        out_unrot = torch.mm(out_rot, H)  # [1, D]
+
+        err = (out_unrot - out_orig).abs().mean()
+        mag = out_orig.abs().mean()
+        rel_err = err / mag
+        # Attention output is more sensitive than raw scores due to softmax
+        assert rel_err < 0.7, f"Attention output relative error too high: {rel_err:.3f}"
+
+    def test_compression_ratio(self):
+        """Verify the storage savings: fp16 → int4 should be ~4x smaller."""
+        cfg = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+        D, G = cfg.head_dim, cfg.group
+
+        # fp16 K tile: D * G * 2 bytes
+        fp16_k_bytes = D * G * 2
+        # fp16 V tile: G * D * 2 bytes
+        fp16_v_bytes = G * D * 2
+        fp16_total = fp16_k_bytes + fp16_v_bytes
+
+        # KVarN tile: tile_bytes (includes scales)
+        kvarn_bytes = cfg.tile_bytes
+
+        ratio = fp16_total / kvarn_bytes
+        # K4V4: packed K = D*G*4/8, packed V = G*D*4/8, plus scales
+        # Should be roughly 3-5x compression
+        assert ratio > 2.5, f"Compression ratio too low: {ratio:.2f}x"
+        assert ratio < 6.0, f"Compression ratio unexpectedly high: {ratio:.2f}x"
+
+    @pytest.mark.parametrize("preset", ["kvarn_k4v4_g128", "kvarn_k4v2_g128"])
+    def test_store_dequant_roundtrip_improves_with_sinkhorn(self, preset):
+        """Sinkhorn should improve roundtrip accuracy vs. plain RTN."""
+        torch.manual_seed(42)
+        cfg = KVarNConfig.from_cache_dtype(preset, head_dim=128)
+        D, G = cfg.head_dim, cfg.group
+
+        tile = torch.randn(D, G, dtype=torch.float32) * 0.1
+
+        # With sinkhorn
+        stored_s = kvarn_store_tile_k(tile, bits=cfg.key_bits, sinkhorn_iters=8)
+        deq_s = kvarn_dequant_tile_k(
+            stored_s["q_packed_uint8"],
+            stored_s["s_col_K"],
+            stored_s["zp_K"],
+            stored_s["s_row_K"],
+            group=G,
+            bits=cfg.key_bits,
+        )
+        err_s = (deq_s - tile).abs().mean()
+
+        # Without sinkhorn (1 iteration ≈ minimal balancing)
+        stored_n = kvarn_store_tile_k(tile, bits=cfg.key_bits, sinkhorn_iters=1)
+        deq_n = kvarn_dequant_tile_k(
+            stored_n["q_packed_uint8"],
+            stored_n["s_col_K"],
+            stored_n["zp_K"],
+            stored_n["s_row_K"],
+            group=G,
+            bits=cfg.key_bits,
+        )
+        err_n = (deq_n - tile).abs().mean()
+
+        # Sinkhorn should be at least as good (usually better)
+        # We use <= rather than < to avoid flakiness on easy tiles
+        assert (
+            err_s <= err_n * 1.1
+        ), f"Sinkhorn ({err_s:.6f}) should be <= plain RTN ({err_n:.6f}) * 1.1"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/kvarn/test_kvarn_pool_gpu.py
+++ b/tests/kvarn/test_kvarn_pool_gpu.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for KVarN memory pool integration.
+
+Tests the KVarNTokenToKVPool class directly, without launching a full
+sglang server.  Requires GPU for tensor allocation.
+
+Run:
+    KVARN_POOL_GPU=1 python -m pytest tests/kvarn/test_kvarn_pool_gpu.py -v
+"""
+
+import os
+
+import pytest
+import torch
+
+if not os.environ.get("KVARN_POOL_GPU", "0") == "1":
+    pytest.skip("Set KVARN_POOL_GPU=1 to run KVarN pool tests", allow_module_level=True)
+
+if not torch.cuda.is_available():
+    pytest.skip("No CUDA GPU available", allow_module_level=True)
+
+
+def test_kvarn_pool_basic():
+    """Test that KVarNTokenToKVPool can be instantiated and stores fp16."""
+    from sglang.srt.layers.quantization.kvarn.config import KVarNConfig
+    from sglang.srt.mem_cache.memory_pool import KVarNTokenToKVPool
+
+    cfg = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+    pool = KVarNTokenToKVPool(
+        size=1024,
+        page_size=128,
+        dtype=torch.uint8,  # marker dtype
+        head_num=8,
+        head_dim=128,
+        layer_num=4,
+        device="cuda",
+        enable_memory_saver=False,
+        kvarn_config=cfg,
+        v_head_dim=128,
+    )
+    assert pool.head_num == 8
+    assert pool.head_dim == 128
+    assert pool.dtype == torch.float16  # overridden from uint8
+    assert pool.store_dtype == torch.float16
+
+    # Check buffers are fp16
+    for buf in pool.k_buffer:
+        assert buf.dtype == torch.float16
+        assert buf.shape == (1024 + 128, 8, 128)
+    for buf in pool.v_buffer:
+        assert buf.dtype == torch.float16
+        assert buf.shape == (1024 + 128, 8, 128)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/kvarn/test_kvarn_triton_gpu.py
+++ b/tests/kvarn/test_kvarn_triton_gpu.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GPU tests for KVarN Triton kernels.
+
+These tests require a CUDA GPU and will be skipped if no GPU is available.
+
+Run:
+    python -m pytest tests/kvarn/test_kvarn_triton_gpu.py -v --tb=short
+"""
+
+import pytest
+import torch
+
+# Skip all tests in this module if no GPU is available
+if not torch.cuda.is_available():
+    pytest.skip("No CUDA GPU available", allow_module_level=True)
+
+from sglang.srt.layers.attention.kvarn_ops.triton_sinkhorn import (
+    kvarn_sinkhorn_triton,
+)
+from sglang.srt.layers.quantization.kvarn.dequant import (
+    kvarn_dequant_tile_k,
+    kvarn_dequant_tile_v,
+)
+from sglang.srt.layers.quantization.kvarn.hadamard import build_hadamard
+from sglang.srt.layers.quantization.kvarn.sinkhorn import (
+    variance_normalize_batched,
+)
+from sglang.srt.layers.quantization.kvarn.store import (
+    kvarn_store_tile_k,
+    kvarn_store_tile_v,
+)
+
+DEVICE = torch.device("cuda")
+D = 128
+G = 128
+
+
+class TestTritonSinkhornGPU:
+    """Test the Triton Sinkhorn kernel against the PyTorch reference."""
+
+    @pytest.mark.parametrize("batch_size", [1, 4, 16])
+    def test_triton_matches_reference(self, batch_size):
+        """Triton Sinkhorn output should match PyTorch reference (within fp32 tolerance)."""
+        torch.manual_seed(42)
+        tiles = torch.randn(batch_size, D, G, device=DEVICE, dtype=torch.float32)
+
+        # PyTorch reference
+        bal_ref, sc_ref, sr_ref = variance_normalize_batched(tiles, iterations=16)
+
+        # Triton
+        bal_tri, sc_tri, sr_tri = kvarn_sinkhorn_triton(tiles, iterations=16)
+
+        # Triton returns [N, C] and [N, R], PyTorch returns [N, 1, C] and [N, R, 1]
+        torch.testing.assert_close(bal_tri, bal_ref, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(sc_tri, sc_ref.squeeze(1), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(sr_tri, sr_ref.squeeze(-1), rtol=1e-2, atol=1e-2)
+
+    def test_reduces_imbalance_gpu(self):
+        """Triton Sinkhorn should reduce the imbalance metric."""
+        torch.manual_seed(0)
+        tile = torch.randn(D, G, device=DEVICE, dtype=torch.float32)
+        scales = torch.linspace(0.1, 10.0, D, device=DEVICE).unsqueeze(1)
+        tile = tile * scales
+
+        def imbalance(t):
+            sc = t.std(dim=-2)
+            sr = t.std(dim=-1)
+            return (
+                sc.max() / sc.min().clamp_min(1e-8)
+                + sr.max() / sr.min().clamp_min(1e-8)
+            ).item()
+
+        orig_imb = imbalance(tile)
+        tiles = tile.unsqueeze(0)
+        bal, _, _ = kvarn_sinkhorn_triton(tiles, iterations=16)
+        new_imb = imbalance(bal[0])
+        assert new_imb < orig_imb
+
+    def test_reconstruction_gpu(self):
+        """tile ≈ balanced * s_col * s_row"""
+        torch.manual_seed(42)
+        tiles = torch.randn(4, D, G, device=DEVICE, dtype=torch.float32)
+        bal, sc, sr = kvarn_sinkhorn_triton(tiles, iterations=16)
+        reconstructed = bal * sc.unsqueeze(1) * sr.unsqueeze(2)
+        torch.testing.assert_close(reconstructed, tiles, rtol=1e-2, atol=1e-2)
+
+
+class TestStoreDequantGPU:
+    """Test store/dequant roundtrip on GPU."""
+
+    def test_k_roundtrip_gpu(self):
+        torch.manual_seed(42)
+        tile = torch.randn(D, G, device=DEVICE, dtype=torch.float32)
+        result = kvarn_store_tile_k(tile, bits=4, sinkhorn_iters=16)
+        dequant = kvarn_dequant_tile_k(
+            result["q_packed_uint8"],
+            result["s_col_K"],
+            result["zp_K"],
+            result["s_row_K"],
+            group=G,
+            bits=4,
+        )
+        err = (dequant - tile).abs().mean()
+        mag = tile.abs().mean()
+        assert err / mag < 0.3
+
+    def test_v_roundtrip_gpu(self):
+        torch.manual_seed(42)
+        tile = torch.randn(G, D, device=DEVICE, dtype=torch.float32)
+        result = kvarn_store_tile_v(tile, bits=4, sinkhorn_iters=16)
+        dequant = kvarn_dequant_tile_v(
+            result["q_packed_uint8"],
+            result["s_col_V"],
+            result["s_row_V"],
+            result["zp_V"],
+            head_dim=D,
+            bits=4,
+        )
+        err = (dequant - tile).abs().mean()
+        mag = tile.abs().mean()
+        assert err / mag < 0.3
+
+
+class TestHadamardRotationGPU:
+    """Test Hadamard rotation on GPU."""
+
+    def test_orthonormal_gpu(self):
+        H = build_hadamard(D, DEVICE)
+        I = torch.mm(H, H.t())
+        torch.testing.assert_close(I, torch.eye(D, device=DEVICE), rtol=1e-4, atol=1e-4)
+
+    def test_rotation_preserves_dot_product_gpu(self):
+        torch.manual_seed(42)
+        H = build_hadamard(D, DEVICE)
+        q = torch.randn(1, D, device=DEVICE)
+        k = torch.randn(4, D, device=DEVICE)
+        score_orig = torch.mm(q, k.t())
+        q_rot = torch.mm(q, H)
+        k_rot = torch.mm(k, H)
+        score_rot = torch.mm(q_rot, k_rot.t())
+        torch.testing.assert_close(score_rot, score_orig, rtol=1e-3, atol=1e-3)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Motivation

Long-context inference is memory-bound: the KV cache grows linearly with sequence length, limiting the number of concurrent requests and the maximum context length on memory-constrained GPUs. KVarN (KV-cache Adaptive Rotation and Normalization) compresses the KV cache ~4x, enabling long-context serving on GPUs that would otherwise be unable to handle it.

## Modifications

KVarN applies three transformations to the KV cache:
1. **Hadamard rotation** of Q, K, V before attention and storage (energy compaction — concentrates signal into fewer components)
2. **Sinkhorn variance normalization** before quantization (balances variance across groups for better int4 packing)
3. **Asymmetric RTN int4 quantization** with per-group scales and zero-points (K and V can have different bit widths)

### Dual-pool architecture

- **Tail pool** (fp16, small): stores rotated K/V for in-progress blocks and sink blocks (first page preserved to prevent tool schema loss)
- **Compressed cache** (int4): stores flushed full blocks as packed uint8 tiles

When a block fills, it is flushed from the tail pool to the compressed cache. Decode uses a fused Triton kernel that dequantizes on-the-fly. Prefill uses a build_packed_kv Triton kernel + `flash_attn_varlen` (memory-efficient, no O(context²) allocation).

### New files

- `layers/quantization/kvarn/`: config, store, dequant, sinkhorn, hadamard, flush_manager (pure PyTorch, unit-testable on CPU)
- `layers/attention/kvarn_backend.py`: `KVarNAttnBackend` — attention backend with dual-pool management
- `layers/attention/kvarn_ops/`: Triton decode + sinkhorn kernels (split-K flash-decoding, auto-enabled at ≥16 blocks when `B*Hk ≤ SM_count`)
- `tests/kvarn/`: 8 test files — CPU unit tests (Hadamard, Sinkhorn, store/dequant roundtrip, pipeline, flush) + GPU tests (Triton kernels, E2E, pool)

### Modified files

- `server_args.py`: KVarN prefill CUDA graph disable rules, `kv_cache_dtype` choices
- `arg_groups/overrides.py`: KVarN attention backend + `page_size` auto-selection
- `mem_cache/memory_pool.py`: `NoOpMHATokenToKVPool` with `_kvarn_backend` hook for hybrid GDN models
- `mem_cache/pool_host/mha.py`: `KVarNHostKVCache` for HiCache (stores raw uint8 int4 tiles)
- `mem_cache/kv_cache_configurator.py`: `_build_kvarn_kv_pool` method
- `mem_cache/hybrid_cache/hybrid_pool_assembler.py`: `_KVarNNopaStrategy`
- `model_executor/pool_configurator.py`: KVarN cell_size calculation
- `configs/mamba_utils.py`: conv_dtype matches model dtype fix
- `models/utils.py`: exclude NoOp pool from fused `set_kv_buffer`
- `layers/attention/attention_registry.py`: `register_attention_backend("kvarn")`
- `mem_cache/kv_cache_dtype.py`: KVarN dtype entries

### Supported presets

| Preset | K bits | V bits | Group |
|--------|--------|--------|-------|
| `kvarn_k4v2_g128` | 4 | 2 | 128 |
| `kvarn_k4v4_g128` | 4 | 4 | 128 |
| `kvarn_k4v2_g64` | 4 | 2 | 64 |
| `kvarn_k4v4_g64` | 4 | 4 | 64 |

### Integration

Works with:
- Hybrid GDN models (e.g. Qwen3.6-27B: 16 full-attention + 48 mamba/GDN layers)
- Hierarchical cache (HiCache) with write-back policy
- CUDA graph for decode path
- Mixed-chunk scheduling
- Tool calling (block-0 sink preservation)
- Speculative decoding verify path

## Accuracy Tests

**Needle-in-haystack retrieval:**
- T3 (4k context): ✅ PASS — correctly found "magic number 42" and "secret code BANANA"
- T6 (22k context): ✅ PASS — correctly found coordinates "37.7749 N, 122.4194 W" at 75% depth

**Tool calling:**
- ✅ PASS — model correctly called `get_weather("San Francisco")` with proper arguments
- Block-0 sink preservation verified (system prompt + tool schemas survive compression)

**Eviction stress test:**
- ✅ PASS — 8 sequential 48k-token requests (384k total, exceeding 374k capacity)
- Server remained stable, no crashes, health check OK

**Concurrent agentic stress test:**
- ✅ PASS — 4 concurrent multi-turn sessions (math+tools, code generation, multi-step reasoning, retrieval)
- 6 parallel dispatch agents all produced correct, coherent responses

## Speed Tests and Profiling

**Test setup:** Qwen3.6-27B-FP8, TP=2 on 2× RTX 3090 (24GB each)

| Metric | Without KVarN | With KVarN |
|--------|--------------|------------|
| Token capacity | 85,504 (12 req) | 374,528 (4 req) |
| Decode tok/s @ 22k ctx | — | 41.1 |
| TTFT @ 22k context | — | 14s |
| Compressed cache size | — | 3.07 GB |
| Tail pool size | — | 0.30 GB |

Split-K flash-decoding auto-enables at ≥16 blocks when `B*Hk ≤ SM_count`, providing 3.8× throughput improvement at long context (10.7 → 41 tok/s).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29656025403](https://github.com/sgl-project/sglang/actions/runs/29656025403)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29656025323](https://github.com/sgl-project/sglang/actions/runs/29656025323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->