### PR TITLE
[Mamba] Backport #27998 to inkling-support: guard None mamba_next_track_idx (fixes Inkling MTP spec-v2 crash)

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1664,9 +1664,15 @@ def set_mamba_track_indices_from_reqs(batch):
     all_buffers = req_to_token_pool.req_index_to_mamba_ping_pong_track_buffer_mapping[
         batch.req_pool_indices
     ]  # (bs, ping_pong_size), int64, on device
+    # Guard: mamba_next_track_idx may be None for requests that haven't
+    # gone through _alloc_ping_pong_buffer yet (e.g., spec v2 verify path).
+    # Default to 0 (first ping-pong slot) to avoid TypeError.
     idx = (
         torch.tensor(
-            [req.mamba_next_track_idx for req in batch.reqs],
+            [
+                req.mamba_next_track_idx if req.mamba_next_track_idx is not None else 0
+                for req in batch.reqs
+            ],
             dtype=torch.int64,
             pin_memory=True,
         )


### PR DESCRIPTION
## Summary
Backports #27998 onto `inkling-support` (cherry-pick of the merged commit).

## Why
Without this guard, **Inkling + MTP (EAGLE spec-v2) + Mamba `extra_buffer`** crashes under real traffic:

```
TypeError: 'NoneType' object cannot be interpreted as an integer
  set_mamba_track_indices_from_reqs (schedule_batch.py)
  <- eagle_prepare_for_verify <- multi_layer_eagle_worker_v2.verify
```

`req.mamba_next_track_idx` is `None` for requests that haven't gone through `_alloc_ping_pong_buffer` on the spec-v2 verify path, so building the int64 tensor raises. The scheduler dies and the server restarts (crash-loop).

Reproduced in production across **all replicas** of an Inkling FP4 (B200/B300) deployment once real forked traffic hit the triggering request pattern; disabling MTP is the only workaround today.

## Fix
Cherry-picks the one-line guard from #27998 (default to slot `0`):
```python
req.mamba_next_track_idx if req.mamba_next_track_idx is not None else 0
```

## Context
#27998 is merged to `main`, but `inkling-support` (which the Inkling cookbook install + `lmsysorg/sglang:inkling-cu*` images track) diverged before it, so those builds still crash. This lands the same guard on `inkling-support` so MTP can be re-enabled.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29658664048](https://github.com/sgl-project/sglang/actions/runs/29658664048)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29658663991](https://github.com/sgl-project/sglang/actions/runs/29658663991)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->