### PR TITLE
[Bugfix] Reject incomplete trailing HiCache storage hits

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -89,6 +89,27 @@ class PoolHitPolicy(str, Enum):
     TRAILING_PAGES = "trailing_pages"
 
 
+def find_prefix_hit_boundary(
+    page_exists: List[bool],
+    policy: PoolHitPolicy,
+    trailing_pages: int = 1,
+) -> int:
+    """Return the longest usable prefix for an auxiliary pool hit policy."""
+    if policy == PoolHitPolicy.ALL_PAGES:
+        try:
+            return page_exists.index(False)
+        except ValueError:
+            return len(page_exists)
+
+    if policy == PoolHitPolicy.TRAILING_PAGES:
+        trailing_pages = max(1, trailing_pages)
+        for prefix_len in range(len(page_exists), trailing_pages - 1, -1):
+            if all(page_exists[prefix_len - trailing_pages : prefix_len]):
+                return prefix_len
+
+    return 0
+
+
 @dataclass
 class PoolTransfer:
     """Unified per-pool transfer descriptor for batch v2 interface.

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -16,10 +16,10 @@ from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorage,
     HiCacheStorageConfig,
     HiCacheStorageExtraInfo,
-    PoolHitPolicy,
     PoolName,
     PoolTransfer,
     PoolTransferResult,
+    find_prefix_hit_boundary,
 )
 from sglang.srt.mem_cache.pool_host import HostKVCache, HostTensorAllocator
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
@@ -801,21 +801,11 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 ]
             else:
                 page_exists = [False] * kv_pages
-            boundary = 0
-            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
-                try:
-                    boundary = page_exists.index(False)
-                except ValueError:
-                    boundary = kv_pages
-            elif transfer.hit_policy == PoolHitPolicy.TRAILING_PAGES:
-                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                for prefix_len in range(kv_pages, 0, -1):
-                    if all(
-                        page_exists[i]
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
+            boundary = find_prefix_hit_boundary(
+                page_exists,
+                transfer.hit_policy,
+                len(transfer.keys) if transfer.keys else 1,
+            )
             if boundary:
                 hit_count[transfer.name] = boundary
             final_pages = min(final_pages, boundary)

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -6,6 +6,7 @@ import torch
 
 from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageConfig,
+    PoolHitPolicy,
     PoolName,
     PoolTransfer,
 )
@@ -271,6 +272,30 @@ def _make_store(
 
 
 class TestMooncakeGroupSemantics(CustomTestCase):
+    def test_v2_rejects_partial_trailing_window(self):
+        store, _ = _make_store(enable_group_semantics=False)
+        store.register_mem_pool_host(FakeHostKVCache(objects_per_page=2))
+        store.register_mem_host_pool_v2(
+            FakeHostKVCache(objects_per_page=2), PoolName.SWA
+        )
+        store.batch_exists = lambda keys, extra_info=None: len(keys)
+        store._get_hybrid_page_component_keys = lambda keys, transfer: (keys, 1)
+        store._batch_exist = lambda keys: [1] * len(keys)
+
+        result = store.batch_exists_v2(
+            ["page0", "page1"],
+            [
+                PoolTransfer(
+                    name=PoolName.SWA,
+                    keys=["window0", "window1", "window2"],
+                    hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                )
+            ],
+        )
+
+        self.assertEqual(result.kv_hit_pages, 0)
+        self.assertNotIn(PoolName.SWA, result.extra_pool_hit_pages)
+
     def test_group_id_detection_uses_class_attribute_without_instantiating(self):
         fake_store_cls = _fake_store_class()
         with patch.dict(

--- a/test/registered/unit/mem_cache/test_pool_hit_policy.py
+++ b/test/registered/unit/mem_cache/test_pool_hit_policy.py
@@ -10,6 +10,22 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestPoolHitPolicy(unittest.TestCase):
+    def test_all_pages_returns_leading_contiguous_prefix(self):
+        self.assertEqual(
+            find_prefix_hit_boundary(
+                [True, True, False, True], PoolHitPolicy.ALL_PAGES
+            ),
+            2,
+        )
+
+    def test_single_trailing_page_accepts_mamba_hit(self):
+        self.assertEqual(
+            find_prefix_hit_boundary(
+                [False, False, True], PoolHitPolicy.TRAILING_PAGES, trailing_pages=1
+            ),
+            3,
+        )
+
     def test_trailing_window_rejects_short_prefix(self):
         self.assertEqual(
             find_prefix_hit_boundary(
@@ -34,6 +50,16 @@ class TestPoolHitPolicy(unittest.TestCase):
                 trailing_pages=3,
             ),
             4,
+        )
+
+    def test_trailing_window_falls_back_to_earlier_complete_window(self):
+        self.assertEqual(
+            find_prefix_hit_boundary(
+                [True, True, True, False],
+                PoolHitPolicy.TRAILING_PAGES,
+                trailing_pages=3,
+            ),
+            3,
         )
 
 

--- a/test/registered/unit/mem_cache/test_pool_hit_policy.py
+++ b/test/registered/unit/mem_cache/test_pool_hit_policy.py
@@ -1,0 +1,41 @@
+import unittest
+
+from sglang.srt.mem_cache.hicache_storage import (
+    PoolHitPolicy,
+    find_prefix_hit_boundary,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestPoolHitPolicy(unittest.TestCase):
+    def test_trailing_window_rejects_short_prefix(self):
+        self.assertEqual(
+            find_prefix_hit_boundary(
+                [True, True], PoolHitPolicy.TRAILING_PAGES, trailing_pages=3
+            ),
+            0,
+        )
+
+    def test_trailing_window_accepts_complete_window(self):
+        self.assertEqual(
+            find_prefix_hit_boundary(
+                [True, True, True], PoolHitPolicy.TRAILING_PAGES, trailing_pages=3
+            ),
+            3,
+        )
+
+    def test_trailing_window_finds_longest_complete_suffix(self):
+        self.assertEqual(
+            find_prefix_hit_boundary(
+                [False, True, True, True],
+                PoolHitPolicy.TRAILING_PAGES,
+                trailing_pages=3,
+            ),
+            4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

HiCache storage can report a trailing-pool hit for a KV prefix shorter than the required SWA window. The controller then shortens the sidecar key list to the available prefix while retaining the full-window host allocation. Mooncake rejects that inconsistent descriptor because the key count no longer matches the allocated page count, terminating the storage prefetch worker.

## Modifications

- Add a shared helper for computing the longest prefix accepted by an auxiliary-pool hit policy.
- Require `TRAILING_PAGES` hits to contain the complete requested trailing window.
- Use the helper in Mooncake `batch_exists_v2`, causing incomplete SWA windows to fall back to a cache miss instead of entering storage I/O with mismatched keys and pages.
- Add policy and mocked Mooncake regression coverage for SWA, Mamba, earlier complete windows, and `ALL_PAGES` behavior.

## Accuracy Tests

Incomplete SWA state is no longer eligible for publication. It falls back to normal recomputation, preserving model output semantics.

Unit tests:

```text
PYTHONPATH=python python3 test/registered/unit/mem_cache/test_pool_hit_policy.py
Ran 6 tests: OK
```

The mocked Mooncake integration regression is registered in `base-a-test-cpu` for CI.

## Speed Tests and Profiling

No benchmark was run. Complete trailing-window hits follow the existing path. A partial trailing-window hit now becomes a cache miss and is recomputed rather than crashing the prefetch worker.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable: no user-facing configuration or API change.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Unit coverage is included; no model benchmark was run.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29659273455](https://github.com/sgl-project/sglang/actions/runs/29659273455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29659273382](https://github.com/sgl-project/sglang/actions/runs/29659273382)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->