### PR TITLE
[ROCm][MI35X] Enable GLM-5.2-MXFP4 MTP speculative decoding

### DIFF
--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.cu
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.cu
@@ -3,25 +3,56 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/all.h>
 
+#include <exception>
+#include <memory>
+#include <tuple>
+
 #ifdef USE_ROCM
 
 #include "quick_all_reduce.h"
 
-quickreduce::fptr_t init_custom_qr(int64_t rank, int64_t world_size, std::optional<int64_t> qr_max_size) {
+namespace {
+void validate_quick_all_reduce_config(int64_t rank, int64_t world_size) {
   if (world_size > 8) throw std::invalid_argument("world size > 8 is not supported");
   if (world_size == 6) throw std::invalid_argument("world size == 6 is not supported");
   if (world_size % 2 != 0) throw std::invalid_argument("Odd num gpus is not supported for now");
   if (rank < 0 || rank >= world_size) throw std::invalid_argument("invalid rank passed in");
-  quickreduce::DeviceComms* fptr = new quickreduce::DeviceComms();
+}
+}  // namespace
+
+quickreduce::fptr_t init_custom_qr(int64_t rank, int64_t world_size, std::optional<int64_t> qr_max_size) {
+  validate_quick_all_reduce_config(rank, world_size);
+  auto fptr = std::make_unique<quickreduce::DeviceComms>();
   fptr->init(world_size, rank, qr_max_size);
-  return (quickreduce::fptr_t)fptr;
+  return reinterpret_cast<quickreduce::fptr_t>(fptr.release());
+}
+
+std::tuple<quickreduce::fptr_t, int64_t, int64_t> init_custom_qr_vmm(
+    int64_t rank, int64_t world_size, int64_t device_index, std::optional<int64_t> qr_max_size, bool uncached) {
+  validate_quick_all_reduce_config(rank, world_size);
+  auto fptr = std::make_unique<quickreduce::DeviceComms>();
+  auto [export_fd, allocation_size] = fptr->init_vmm(world_size, rank, device_index, qr_max_size, uncached);
+  auto raw_ptr = reinterpret_cast<quickreduce::fptr_t>(fptr.release());
+  return {raw_ptr, export_fd, allocation_size};
+}
+
+void qr_open_vmm_handles(
+    quickreduce::fptr_t _fa, const std::vector<int64_t>& peer_fds, const std::vector<int64_t>& peer_sizes) {
+  auto* fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
+  fa->open_vmm_handles(peer_fds, peer_sizes);
 }
 
 void qr_destroy(quickreduce::fptr_t _fa) {
   if (_fa) {
     auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
-    fa->destroy();
+    std::exception_ptr cleanup_error;
+    try {
+      fa->destroy();
+    } catch (...) {
+      cleanup_error = std::current_exception();
+    }
     delete fa;
+    if (cleanup_error) std::rethrow_exception(cleanup_error);
   }
 }
 

--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.cuh
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.cuh
@@ -546,6 +546,9 @@ struct AllReduceTwoshot {
       codec.send(send_buffer, &tA[r * Codec::kRankAtoms]);
     }
 
+    // Publish peer-VMM writes before releasing the corresponding ready flag.
+    // A block barrier alone does not make writes visible to another GPU.
+    __threadfence_system();
     __syncthreads();
     if (thread < kWorldSize) {
       int r = thread;
@@ -583,6 +586,7 @@ struct AllReduceTwoshot {
       codec.send(send_buffer, tR);
     }
 
+    __threadfence_system();
     __syncthreads();
     if (thread < kWorldSize) {
       int r = thread;

--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.h
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.h
@@ -2,6 +2,12 @@
 
 #include <hip/hip_runtime.h>
 
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "quick_all_reduce.cuh"
@@ -113,9 +119,36 @@ enum QuickReduceQuantLevel {
   INT4 = 3,
 };
 
+class HipDeviceGuard {
+ public:
+  explicit HipDeviceGuard(int device) {
+    HIP_CHECK(hipGetDevice(&previous_device_));
+    changed_ = previous_device_ != device;
+    if (changed_) HIP_CHECK(hipSetDevice(device));
+  }
+
+  ~HipDeviceGuard() {
+    if (changed_) (void)hipSetDevice(previous_device_);
+  }
+
+ private:
+  int previous_device_ = 0;
+  bool changed_ = false;
+};
+
+struct VmmPeerMapping {
+  uint8_t* ptr = nullptr;
+  int64_t size = 0;
+  hipMemGenericAllocationHandle_t handle = 0;
+  bool reserved = false;
+  bool mapped = false;
+};
+
 struct DeviceComms {
+  static constexpr int64_t kDefaultMaxProblemSize = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+
   // Max problem size is 2GB (in bytes) or half of uint32_t max value.
-  int64_t kMaxProblemSize = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+  int64_t kMaxProblemSize = kDefaultMaxProblemSize;
 
   // Max TP-8
   static int constexpr kMaxWorldSize = 8;
@@ -124,53 +157,130 @@ struct DeviceComms {
   uint32_t* d_flag_counters = nullptr;
   int world_size;
   int rank;
+  int device_index;
 
   uint8_t* dbuffer;
   uint8_t** dbuffer_list;
+  bool uses_vmm;
   hipIpcMemHandle_t buffer_ipc_handle;
   std::vector<hipIpcMemHandle_t> all_buffer_ipc_handles;
   std::vector<uint8_t*> buffer_list;
   uint32_t data_offset;
+  hipMemGenericAllocationHandle_t vmm_local_handle;
+  int64_t vmm_local_size;
+  bool vmm_local_reserved;
+  bool vmm_local_mapped;
+  std::vector<VmmPeerMapping> vmm_peer_mappings;
 
-  DeviceComms() : initialized(false), world_size(1), rank(0) {}
-  ~DeviceComms() {
-    destroy();
+  DeviceComms()
+      : initialized(false),
+        d_flag_counters(nullptr),
+        world_size(1),
+        rank(0),
+        device_index(-1),
+        dbuffer(nullptr),
+        dbuffer_list(nullptr),
+        uses_vmm(false),
+        data_offset(0),
+        vmm_local_handle(0),
+        vmm_local_size(0),
+        vmm_local_reserved(false),
+        vmm_local_mapped(false) {}
+  ~DeviceComms() noexcept {
+    destroy_impl(false);
   }
 
   void init(int world_size, int rank, std::optional<int64_t> max_problem_size = std::nullopt) {
     destroy();
     this->world_size = world_size;
     this->rank = rank;
+    HIP_CHECK(hipGetDevice(&device_index));
+    this->kMaxProblemSize = kDefaultMaxProblemSize;
     if (max_problem_size.has_value() && max_problem_size.value() > 0) {
       this->kMaxProblemSize = max_problem_size.value();
     }
-    // Allocate buffer size for worst case: F16 2-stage buffer.
-    uint32_t flags_buffer_size = 2 * world_size * kMaxNumBlocks * sizeof(uint32_t);
-    static int64_t data_buffer_size = 2 * this->kMaxProblemSize;
-    int64_t total_buffer_size = flags_buffer_size + data_buffer_size;
-    data_offset = flags_buffer_size;
-    HIP_CHECK(hipExtMallocWithFlags((void**)&dbuffer, total_buffer_size, hipDeviceMallocUncached));
-
-    // Clear the flags buffer.
-    HIP_CHECK(hipMemset(dbuffer, 0, flags_buffer_size));
-
-    // A per-block color counter that the kernel advances itself. Seed it with
-    // 1 rather than 0 so it never matches the freshly zeroed flags buffer.
-    HIP_CHECK(hipMalloc(&d_flag_counters, kMaxNumBlocks * sizeof(uint32_t)));
-    {
-      std::vector<uint32_t> init_color(kMaxNumBlocks, 1u);
-      HIP_CHECK(hipMemcpy(d_flag_counters, init_color.data(), kMaxNumBlocks * sizeof(uint32_t), hipMemcpyHostToDevice));
+    uses_vmm = false;
+    try {
+      HIP_CHECK(hipExtMallocWithFlags(
+          (void**)&dbuffer, get_buffer_size(world_size, max_problem_size), hipDeviceMallocUncached));
+      init_common_buffers();
+      all_buffer_ipc_handles.resize(world_size);
+      HIP_CHECK(hipIpcGetMemHandle(&buffer_ipc_handle, dbuffer));
+      initialized = true;
+    } catch (...) {
+      destroy();
+      throw;
     }
+  }
 
-    // Device-side list of IPC buffers.
-    buffer_list.resize(world_size);
+  static int64_t get_buffer_size(int world_size, std::optional<int64_t> max_problem_size = std::nullopt) {
+    int64_t problem_size = kDefaultMaxProblemSize;
+    if (max_problem_size.has_value() && max_problem_size.value() > 0) {
+      problem_size = max_problem_size.value();
+    }
+    int64_t flags_buffer_size = 2LL * world_size * kMaxNumBlocks * sizeof(uint32_t);
+    return flags_buffer_size + 2LL * problem_size;
+  }
+
+  std::pair<int, int64_t> init_vmm(
+      int world_size,
+      int rank,
+      int device_index,
+      std::optional<int64_t> max_problem_size = std::nullopt,
+      bool uncached = true) {
+    destroy();
+    this->world_size = world_size;
+    this->rank = rank;
+    this->device_index = device_index;
+    this->kMaxProblemSize = kDefaultMaxProblemSize;
+    if (max_problem_size.has_value() && max_problem_size.value() > 0) {
+      this->kMaxProblemSize = max_problem_size.value();
+    }
+    uses_vmm = true;
+
+    HipDeviceGuard guard(device_index);
+    try {
+      hipMemAllocationProp prop{};
+      prop.type = uncached ? hipMemAllocationTypeUncached : hipMemAllocationTypePinned;
+      prop.requestedHandleTypes = hipMemHandleTypePosixFileDescriptor;
+      prop.location.type = hipMemLocationTypeDevice;
+      prop.location.id = device_index;
+
+      size_t granularity = 0;
+      HIP_CHECK(hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityRecommended));
+      int64_t requested_size = get_buffer_size(world_size, max_problem_size);
+      vmm_local_size = ((requested_size + granularity - 1) / granularity) * granularity;
+      HIP_CHECK(hipMemCreate(&vmm_local_handle, vmm_local_size, &prop, 0));
+      HIP_CHECK(hipMemAddressReserve((void**)&dbuffer, vmm_local_size, granularity, nullptr, 0));
+      vmm_local_reserved = true;
+      HIP_CHECK(hipMemMap(dbuffer, vmm_local_size, 0, vmm_local_handle, 0));
+      vmm_local_mapped = true;
+
+      hipMemAccessDesc access{};
+      access.location.type = hipMemLocationTypeDevice;
+      access.location.id = device_index;
+      access.flags = hipMemAccessFlagsProtReadWrite;
+      HIP_CHECK(hipMemSetAccess(dbuffer, vmm_local_size, &access, 1));
+      init_common_buffers();
+
+      int export_fd = -1;
+      HIP_CHECK(hipMemExportToShareableHandle(&export_fd, vmm_local_handle, hipMemHandleTypePosixFileDescriptor, 0));
+      return {export_fd, vmm_local_size};
+    } catch (...) {
+      destroy();
+      throw;
+    }
+  }
+
+  void init_common_buffers() {
+    data_offset = 2 * world_size * kMaxNumBlocks * sizeof(uint32_t);
+    HIP_CHECK(hipMemset(dbuffer, 0, data_offset));
+    HIP_CHECK(hipMalloc(&d_flag_counters, kMaxNumBlocks * sizeof(uint32_t)));
+    std::vector<uint32_t> init_color(kMaxNumBlocks, 1u);
+    HIP_CHECK(hipMemcpy(d_flag_counters, init_color.data(), kMaxNumBlocks * sizeof(uint32_t), hipMemcpyHostToDevice));
+    buffer_list.assign(world_size, nullptr);
+    buffer_list[rank] = dbuffer;
     HIP_CHECK(hipMalloc(&dbuffer_list, world_size * sizeof(uint8_t*)));
-
-    // Create IPC handles for rank's communication buffer.
-    all_buffer_ipc_handles.resize(world_size);
-    HIP_CHECK(hipIpcGetMemHandle(&buffer_ipc_handle, dbuffer));
-
-    initialized = true;
   }
   int get_world_size() {
     return world_size;
@@ -186,23 +296,69 @@ struct DeviceComms {
   }
 
   void destroy() {
-    // This buffer is created before `initialized` becomes true, so release it
-    // on its own check to keep a half-finished init from leaking it.
+    destroy_impl(true);
+  }
+
+  void destroy_impl(bool throw_on_error) noexcept(false) {
+    hipError_t first_error = hipSuccess;
+    auto cleanup_call = [&first_error](hipError_t error) {
+      if (error != hipSuccess && first_error == hipSuccess) first_error = error;
+    };
+
+    int previous_device = -1;
+    bool restore_device = false;
+    if (device_index >= 0) {
+      hipError_t get_device_error = hipGetDevice(&previous_device);
+      cleanup_call(get_device_error);
+      if (get_device_error == hipSuccess && previous_device != device_index) {
+        hipError_t set_device_error = hipSetDevice(device_index);
+        cleanup_call(set_device_error);
+        restore_device = set_device_error == hipSuccess;
+      }
+    }
+
     if (d_flag_counters) {
-      HIP_CHECK(hipFree(d_flag_counters));
+      cleanup_call(hipFree(d_flag_counters));
       d_flag_counters = nullptr;
     }
-    if (initialized) {
-      for (int i = 0; i < world_size; i++) {
-        if (i != rank) {
-          HIP_CHECK(hipIpcCloseMemHandle(dbuffer_list[i]));
+
+    if (uses_vmm) {
+      for (auto& mapping : vmm_peer_mappings) {
+        if (mapping.mapped) cleanup_call(hipMemUnmap(mapping.ptr, mapping.size));
+        if (mapping.reserved) cleanup_call(hipMemAddressFree(mapping.ptr, mapping.size));
+        if (mapping.handle) cleanup_call(hipMemRelease(mapping.handle));
+      }
+      vmm_peer_mappings.clear();
+      if (vmm_local_mapped) cleanup_call(hipMemUnmap(dbuffer, vmm_local_size));
+      if (vmm_local_reserved) cleanup_call(hipMemAddressFree(dbuffer, vmm_local_size));
+      if (vmm_local_handle) cleanup_call(hipMemRelease(vmm_local_handle));
+    } else {
+      for (int i = 0; i < static_cast<int>(buffer_list.size()); i++) {
+        if (i != rank && buffer_list[i]) {
+          cleanup_call(hipIpcCloseMemHandle(buffer_list[i]));
         }
       }
+      if (dbuffer) cleanup_call(hipFree(dbuffer));
+    }
+    if (dbuffer_list) cleanup_call(hipFree(dbuffer_list));
 
-      HIP_CHECK(hipFree(dbuffer));
-      HIP_CHECK(hipFree(dbuffer_list));
+    if (restore_device) cleanup_call(hipSetDevice(previous_device));
 
-      initialized = false;
+    dbuffer = nullptr;
+    dbuffer_list = nullptr;
+    buffer_list.clear();
+    all_buffer_ipc_handles.clear();
+    data_offset = 0;
+    vmm_local_handle = 0;
+    vmm_local_size = 0;
+    vmm_local_reserved = false;
+    vmm_local_mapped = false;
+    uses_vmm = false;
+    initialized = false;
+    device_index = -1;
+
+    if (throw_on_error && first_error != hipSuccess) {
+      throw std::runtime_error("QuickAllReduce HIP cleanup failed: " + std::string(hipGetErrorString(first_error)));
     }
   }
 
@@ -224,6 +380,55 @@ struct DeviceComms {
     }
 
     HIP_CHECK(hipMemcpy(dbuffer_list, buffer_list.data(), world_size * sizeof(uint8_t*), hipMemcpyHostToDevice));
+  }
+
+  void open_vmm_handles(const std::vector<int64_t>& peer_fds, const std::vector<int64_t>& peer_sizes) {
+    if (!uses_vmm || peer_fds.size() != static_cast<size_t>(world_size) ||
+        peer_sizes.size() != static_cast<size_t>(world_size)) {
+      throw std::invalid_argument("invalid QuickAllReduce VMM peer metadata");
+    }
+
+    HipDeviceGuard guard(device_index);
+    try {
+      for (int i = 0; i < world_size; i++) {
+        if (i == rank) continue;
+        if (peer_fds[i] < 0 || peer_sizes[i] <= 0) {
+          throw std::invalid_argument("invalid QuickAllReduce VMM peer fd or size");
+        }
+        if (peer_sizes[i] != vmm_local_size) {
+          throw std::invalid_argument("QuickAllReduce VMM peer allocation size mismatch");
+        }
+
+        vmm_peer_mappings.emplace_back();
+        auto& mapping = vmm_peer_mappings.back();
+        mapping.size = peer_sizes[i];
+        HIP_CHECK(hipMemImportFromShareableHandle(
+            &mapping.handle,
+            reinterpret_cast<void*>(static_cast<intptr_t>(peer_fds[i])),
+            hipMemHandleTypePosixFileDescriptor));
+        hipMemAllocationProp peer_prop{};
+        HIP_CHECK(hipMemGetAllocationPropertiesFromHandle(&peer_prop, mapping.handle));
+        size_t peer_granularity = 0;
+        HIP_CHECK(
+            hipMemGetAllocationGranularity(&peer_granularity, &peer_prop, hipMemAllocationGranularityRecommended));
+        HIP_CHECK(hipMemAddressReserve((void**)&mapping.ptr, mapping.size, peer_granularity, nullptr, 0));
+        mapping.reserved = true;
+        HIP_CHECK(hipMemMap(mapping.ptr, mapping.size, 0, mapping.handle, 0));
+        mapping.mapped = true;
+
+        hipMemAccessDesc access{};
+        access.location.type = hipMemLocationTypeDevice;
+        access.location.id = device_index;
+        access.flags = hipMemAccessFlagsProtReadWrite;
+        HIP_CHECK(hipMemSetAccess(mapping.ptr, mapping.size, &access, 1));
+        buffer_list[i] = mapping.ptr;
+      }
+      HIP_CHECK(hipMemcpy(dbuffer_list, buffer_list.data(), world_size * sizeof(uint8_t*), hipMemcpyHostToDevice));
+      initialized = true;
+    } catch (...) {
+      destroy();
+      throw;
+    }
   }
 
   template <typename T, bool cast_bf2half>

--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
@@ -307,11 +307,11 @@ __quickreduce_device_inline__ int group_abs_max(int32x4_t atom) {
 }
 
 __quickreduce_device_inline__ void set_sync_flag(uint32_t* flag_ptr, uint32_t flag) {
-  __atomic_store_n(flag_ptr, flag, __ATOMIC_RELEASE);
+  __scoped_atomic_store_n(flag_ptr, flag, __ATOMIC_RELEASE, __MEMORY_SCOPE_SYSTEM);
 }
 
 __quickreduce_device_inline__ void wait_sync_flag(uint32_t* flag_ptr, uint32_t flag) {
-  while (__atomic_load_n(flag_ptr, __ATOMIC_RELAXED) != flag) {
+  while (__scoped_atomic_load_n(flag_ptr, __ATOMIC_ACQUIRE, __MEMORY_SCOPE_SYSTEM) != flag) {
   }
 }
 

--- a/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
@@ -119,6 +119,8 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
   m.impl("qr_all_reduce", torch::kCUDA, &qr_all_reduce);
 
   m.def("init_custom_qr", &init_custom_qr);
+  m.def("init_custom_qr_vmm", &init_custom_qr_vmm);
+  m.def("qr_open_vmm_handles", &qr_open_vmm_handles);
   m.def("qr_destroy", &qr_destroy);
 
   m.def("qr_get_handle", &qr_get_handle);

--- a/python/sglang/kernels/aot/include/sgl_kernel_ops.h
+++ b/python/sglang/kernels/aot/include/sgl_kernel_ops.h
@@ -73,6 +73,13 @@ torch::Tensor allocate_meta_buffer(int64_t size);
 torch::Tensor get_meta_buffer_ipc_handle(torch::Tensor& inp);
 // quick allreduce
 fptr_t init_custom_qr(int64_t rank, int64_t world_size, std::optional<int64_t> qr_max_size = std::nullopt);
+std::tuple<fptr_t, int64_t, int64_t> init_custom_qr_vmm(
+    int64_t rank,
+    int64_t world_size,
+    int64_t device_index,
+    std::optional<int64_t> qr_max_size = std::nullopt,
+    bool uncached = true);
+void qr_open_vmm_handles(fptr_t _fa, const std::vector<int64_t>& peer_fds, const std::vector<int64_t>& peer_sizes);
 void qr_destroy(fptr_t _fa);
 torch::Tensor qr_get_handle(fptr_t _fa);
 void qr_open_handles(fptr_t _fa, const std::vector<torch::Tensor>& handles);

--- a/python/sglang/kernels/aot/python/sgl_kernel/allreduce.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/allreduce.py
@@ -69,6 +69,22 @@ if torch.version.hip is not None:
             world_size, rank, qr_max_size
         )
 
+    def init_custom_qr_vmm(
+        rank: int,
+        world_size: int,
+        device_index: int,
+        qr_max_size: Optional[int] = None,
+        uncached: bool = True,
+    ) -> Tuple[int, int, int]:
+        return torch.ops.sgl_kernel.init_custom_qr_vmm.default(
+            rank, world_size, device_index, qr_max_size, uncached
+        )
+
+    def qr_open_vmm_handles(
+        fa: int, peer_fds: List[int], peer_sizes: List[int]
+    ) -> None:
+        torch.ops.sgl_kernel.qr_open_vmm_handles.default(fa, peer_fds, peer_sizes)
+
     def qr_get_handle(fa: int) -> torch.Tensor:
         return torch.ops.sgl_kernel.qr_get_handle.default(fa)
 

--- a/python/sglang/kernels/ops/attention/dsa/paged_mqa_logits.py
+++ b/python/sglang/kernels/ops/attention/dsa/paged_mqa_logits.py
@@ -104,8 +104,6 @@ def aiter_paged_mqa_logits(
     preshuffle: bool,
     kv_block_size: int,
 ) -> torch.Tensor:
-    from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
-
     # DP attention can append MLP-sync padding rows after DSA metadata is
     # planned. Launch only the real query rows expected by the metadata.
     if not 0 <= q_offset <= q_fp8.shape[0]:
@@ -120,6 +118,11 @@ def aiter_paged_mqa_logits(
             f"seq_lens={seq_lens.shape[0]}, block_tables={block_tables.shape[0]}, "
             f"q_offset={q_offset}"
         )
+    if q_offset == 0:
+        return torch.empty((0, max_seq_len), device=q_fp8.device, dtype=torch.float32)
+
+    from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
+
     q_fp8 = q_fp8[:q_offset].unsqueeze(1)
     weights = weights[:q_offset]
     batch_size, next_n, _, _ = q_fp8.shape

--- a/python/sglang/kernels/ops/attention/dsa/paged_mqa_logits.py
+++ b/python/sglang/kernels/ops/attention/dsa/paged_mqa_logits.py
@@ -100,12 +100,28 @@ def aiter_paged_mqa_logits(
     block_tables: torch.Tensor,
     max_seq_len: int,
     *,
+    q_offset: int,
     preshuffle: bool,
     kv_block_size: int,
 ) -> torch.Tensor:
     from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
 
-    q_fp8 = q_fp8.unsqueeze(1)
+    # DP attention can append MLP-sync padding rows after DSA metadata is
+    # planned. Launch only the real query rows expected by the metadata.
+    if not 0 <= q_offset <= q_fp8.shape[0]:
+        raise ValueError(f"q_offset={q_offset} is outside q_fp8 rows={q_fp8.shape[0]}")
+    if weights.shape[0] < q_offset:
+        raise ValueError(
+            f"weights rows={weights.shape[0]} are smaller than q_offset={q_offset}"
+        )
+    if seq_lens.shape[0] != q_offset or block_tables.shape[0] != q_offset:
+        raise ValueError(
+            "AITER paged MQA metadata rows must match q_offset: "
+            f"seq_lens={seq_lens.shape[0]}, block_tables={block_tables.shape[0]}, "
+            f"q_offset={q_offset}"
+        )
+    q_fp8 = q_fp8[:q_offset].unsqueeze(1)
+    weights = weights[:q_offset]
     batch_size, next_n, _, _ = q_fp8.shape
     logits = torch.empty(
         (batch_size * next_n, max_seq_len),

--- a/python/sglang/kernels/ops/memory/__init__.py
+++ b/python/sglang/kernels/ops/memory/__init__.py
@@ -45,3 +45,10 @@ register_kernel(
         target="sglang.kernels.ops.memory.memcpy_triton:memcpy_triton",
     )
 )
+register_kernel(
+    KernelSpec(
+        op="memory.zero_triton",
+        backend=KernelBackend.TRITON,
+        target="sglang.kernels.ops.memory.zero_triton:zero_triton",
+    )
+)

--- a/python/sglang/kernels/ops/memory/zero_triton.py
+++ b/python/sglang/kernels/ops/memory/zero_triton.py
@@ -1,0 +1,22 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _zero_triton_kernel(output, n_elements, BLOCK_SIZE: tl.constexpr):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    tl.store(output + offsets, 0.0, mask=offsets < n_elements)
+
+
+def zero_triton(output):
+    """Zero a contiguous device tensor with an explicit non-empty launch grid."""
+    assert output.is_contiguous()
+    n_elements = output.numel()
+    if n_elements == 0:
+        return output
+
+    block_size = 256
+    _zero_triton_kernel[(triton.cdiv(n_elements, block_size),)](
+        output, n_elements, BLOCK_SIZE=block_size
+    )
+    return output

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -260,6 +260,8 @@ class CustomAllreduce:
     def should_custom_ar(self, inp: torch.Tensor):
         if self.disabled:
             return False
+        if inp.numel() == 0:
+            return False
         inp_size = inp.numel() * inp.element_size()
         # custom allreduce requires input byte size to be multiples of 16
         if inp_size % 16 != 0:

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_ops.py
@@ -141,6 +141,22 @@ elif _is_hip:
     ) -> int:
         return _custom_ar.init_custom_qr(world_size, rank, qr_max_size)
 
+    def init_custom_qr_vmm(
+        rank: int,
+        world_size: int,
+        device_index: int,
+        qr_max_size: Optional[int] = None,
+        uncached: bool = True,
+    ) -> Tuple[int, int, int]:
+        return _custom_ar.init_custom_qr_vmm(
+            rank, world_size, device_index, qr_max_size, uncached
+        )
+
+    def qr_open_vmm_handles(
+        fa: int, peer_fds: List[int], peer_sizes: List[int]
+    ) -> None:
+        _custom_ar.qr_open_vmm_handles(fa, peer_fds, peer_sizes)
+
     def qr_get_handle(fa: int) -> torch.Tensor:
         return _custom_ar.qr_get_handle(fa)
 

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -291,7 +291,7 @@ class CustomAllReduceV2:
 
     def should_custom_ar(self, inp: torch.Tensor) -> bool:
         """Check if the input tensor is suitable for custom all-reduce."""
-        if self.disabled:
+        if self.disabled or inp.numel() == 0:
             return False
         inp_size = inp.numel() * inp.element_size()
         # custom allreduce requires input byte size to be multiples of 16

--- a/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import logging
 import os
 from enum import Enum
@@ -49,6 +50,61 @@ class QuickReduceRegime(Enum):
 MB = 1024 * 1024
 
 
+def _new_vmm_pool_name(
+    group: ProcessGroup, ranks_tag: str, device: torch.device
+) -> str:
+    """Create a communicator generation that cannot reuse stale Store keys."""
+    group_ranks = dist.get_process_group_ranks(group)
+    if not group_ranks:
+        raise RuntimeError("QuickAllReduce VMM process group has no ranks")
+    source_rank = group_ranks[0]
+    nonce = 0
+    if dist.get_rank() == source_rank:
+        nonce = int.from_bytes(os.urandom(8), "little") & ((1 << 63) - 1)
+    # The QuickReduce process group uses RCCL, so its collectives must use a
+    # device tensor. A CPU tensor here fails before VMM fd exchange begins.
+    nonce_tensor = torch.tensor([nonce], dtype=torch.int64, device=device)
+    dist.broadcast(nonce_tensor, src=source_rank, group=group)
+    generation = hashlib.blake2s(
+        int(nonce_tensor.item()).to_bytes(8, "little"), digest_size=8
+    ).hexdigest()
+    return f"sglang_quickreduce_{ranks_tag}_g{generation}"
+
+
+def _raise_if_any_vmm_phase_failed(
+    group: ProcessGroup, phase: str, local_error: Exception | None
+) -> None:
+    """Make VMM setup succeed or fail consistently on every rank."""
+    local_status = None
+    if local_error is not None:
+        local_status = f"{type(local_error).__name__}: {local_error}"
+    statuses = [None] * dist.get_world_size(group)
+    dist.all_gather_object(statuses, local_status, group=group)
+    failures = [
+        f"rank {rank}: {status}" for rank, status in enumerate(statuses) if status
+    ]
+    if failures:
+        raise RuntimeError(
+            f"QuickAllReduce VMM {phase} failed across ranks: " + "; ".join(failures)
+        )
+
+
+def _select_quick_reduce_ipc_backend(device: torch.device) -> str:
+    ipc_backend = os.environ.get("ROCM_QUICK_REDUCE_IPC_BACKEND", "auto")
+    ipc_backend = ipc_backend.strip().lower()
+    if ipc_backend not in ("auto", "hipipc", "vmm"):
+        raise ValueError(f"Unsupported ROCM_QUICK_REDUCE_IPC_BACKEND={ipc_backend!r}")
+    if ipc_backend != "auto":
+        return ipc_backend
+
+    device_index = (
+        device.index if device.index is not None else torch.cuda.current_device()
+    )
+    props = torch.cuda.get_device_properties(device_index)
+    arch = getattr(props, "gcnArchName", "")
+    return "vmm" if "gfx950" in arch else "hipipc"
+
+
 class QuickAllReduce:
 
     _SUPPORTED_WORLD_SIZES = [2, 4, 8]
@@ -87,6 +143,7 @@ class QuickAllReduce:
         are in the same node.
         """
         self.disabled = True
+        self._ptr = 0
         if not qr_rocm_arch_available():
             logger.debug(
                 "Custom quick allreduce is only supported on ROCm MI300 series."
@@ -205,10 +262,112 @@ class QuickAllReduce:
                 )
             qr_max_size = qr_max_size * MB
         # If qr_max_size is None, then 2GB is used by default.
-        self._ptr = ops.init_custom_qr(self.rank, self.world_size, qr_max_size)
+        ipc_backend = _select_quick_reduce_ipc_backend(self.device)
+        self._uses_vmm = ipc_backend == "vmm"
+        if self._uses_vmm:
+            self._init_vmm(qr_max_size)
+        else:
+            self._ptr = ops.init_custom_qr(self.rank, self.world_size, qr_max_size)
+            self.create_shared_buffer()
         self.qr_max_size = qr_max_size if qr_max_size > 0 else ops.qr_max_size()
-        self.create_shared_buffer()
         self.disabled = False
+
+    def _init_vmm(self, qr_max_size: int) -> None:
+        from sglang.srt.distributed.device_communicators.quick_all_reduce_vmm import (
+            exchange_vmm_fds,
+        )
+
+        store = dist.distributed_c10d._get_default_store()
+        ranks_tag = "_".join(map(str, sorted(dist.get_process_group_ranks(self.group))))
+        uncached = bool(int(os.environ.get("ROCM_QUICK_REDUCE_VMM_UNCACHED", "1")))
+
+        local_fd = -1
+        local_size = 0
+        peer_fds = []
+        arch = ""
+
+        def cleanup_ptr() -> None:
+            if not self._ptr:
+                return
+            try:
+                ops.qr_destroy(self._ptr)
+            except Exception:
+                logger.exception("Failed to clean up QuickAllReduce VMM state")
+            finally:
+                self._ptr = 0
+
+        try:
+            allocation_error = None
+            try:
+                device_index = (
+                    self.device.index
+                    if self.device.index is not None
+                    else torch.cuda.current_device()
+                )
+                props = torch.cuda.get_device_properties(device_index)
+                arch = getattr(props, "gcnArchName", "")
+                if "gfx950" not in arch:
+                    raise RuntimeError(
+                        "QuickAllReduce VMM IPC is only supported on gfx950, "
+                        f"got {arch!r}"
+                    )
+                self._ptr, local_fd, local_size = ops.init_custom_qr_vmm(
+                    self.rank,
+                    self.world_size,
+                    device_index,
+                    qr_max_size,
+                    uncached,
+                )
+            except Exception as exc:
+                allocation_error = exc
+            _raise_if_any_vmm_phase_failed(
+                self.group, "local allocation", allocation_error
+            )
+
+            pool_name = _new_vmm_pool_name(self.group, ranks_tag, self.device)
+            exchange_error = None
+            try:
+                peer_fds, peer_sizes = exchange_vmm_fds(
+                    self.rank,
+                    self.world_size,
+                    pool_name,
+                    local_fd,
+                    local_size,
+                    store,
+                    ranks_tag,
+                )
+            except Exception as exc:
+                exchange_error = exc
+                peer_sizes = []
+            _raise_if_any_vmm_phase_failed(
+                self.group, "file descriptor exchange", exchange_error
+            )
+
+            open_error = None
+            try:
+                ops.qr_open_vmm_handles(self._ptr, peer_fds, peer_sizes)
+            except Exception as exc:
+                open_error = exc
+            # This consensus is also the readiness barrier: no rank can enter a
+            # kernel until every peer has mapped and initialized its buffers.
+            _raise_if_any_vmm_phase_failed(self.group, "peer mapping", open_error)
+        except Exception:
+            cleanup_ptr()
+            raise
+        finally:
+            if local_fd >= 0:
+                os.close(local_fd)
+            for fd in peer_fds:
+                if fd >= 0:
+                    os.close(fd)
+
+        logger.info(
+            "QuickAllReduce selected VMM IPC for rank %d/%d on %s (uncached=%s)",
+            self.rank,
+            self.world_size,
+            arch,
+            uncached,
+        )
 
     def create_shared_buffer(self):
         """
@@ -257,11 +416,22 @@ class QuickAllReduce:
         return out
 
     def close(self):
-        if not self.disabled and getattr(self, "_ptr", None):
-            if ops is not None:
-                ops.qr_destroy(self._ptr)
+        if getattr(self, "_ptr", None):
+            ptr = self._ptr
+            # qr_destroy always deletes the native object, even when a later
+            # HIP cleanup step reports an error. Clear Python ownership first
+            # so finalization cannot call native destroy on a stale pointer.
             self._ptr = 0
             self.disabled = True
+            if ops is not None:
+                ops.qr_destroy(ptr)
+        self.disabled = True
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except Exception:
+            # Destructors run during interpreter and worker teardown. Explicit
+            # close() still reports cleanup errors to callers, while finalizer
+            # cleanup must never surface an unraisable exception.
+            pass

--- a/python/sglang/srt/distributed/device_communicators/quick_all_reduce_vmm.py
+++ b/python/sglang/srt/distributed/device_communicators/quick_all_reduce_vmm.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exchange HIP VMM allocation file descriptors between local ranks."""
+
+import array
+import fcntl
+import hashlib
+import os
+import socket
+import tempfile
+import threading
+import time
+from datetime import timedelta
+from typing import List, Tuple
+
+_FD_EXCHANGE_TIMEOUT_S = 120.0
+
+
+def _remaining_s(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
+
+
+def _send_fd(
+    path: str,
+    fd: int,
+    *,
+    deadline: float | None = None,
+    cancel_event: threading.Event | None = None,
+) -> None:
+    deadline = deadline or time.monotonic() + _FD_EXCHANGE_TIMEOUT_S
+    cancel_event = cancel_event or threading.Event()
+    while True:
+        if cancel_event.is_set():
+            raise TimeoutError(f"cancelled VMM fd send to {path}")
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(max(0.01, _remaining_s(deadline)))
+                sock.connect(path)
+                fds = array.array("i", [fd])
+                sent = sock.sendmsg(
+                    [b"\0"],
+                    [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds.tobytes())],
+                )
+                if sent != 1:
+                    raise RuntimeError(f"sent {sent} fd marker bytes, expected 1")
+                return
+        except (ConnectionRefusedError, FileNotFoundError):
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"timed out connecting to VMM fd socket {path}")
+            time.sleep(0.01)
+
+
+def _recv_fd(
+    path: str,
+    *,
+    deadline: float | None = None,
+    cancel_event: threading.Event | None = None,
+) -> int:
+    deadline = deadline or time.monotonic() + _FD_EXCHANGE_TIMEOUT_S
+    cancel_event = cancel_event or threading.Event()
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+    fd_item_size = array.array("i").itemsize
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(path)
+        server.listen(1)
+        while True:
+            if cancel_event.is_set() or _remaining_s(deadline) <= 0:
+                raise TimeoutError(f"timed out receiving VMM fd on {path}")
+            server.settimeout(min(0.1, _remaining_s(deadline)))
+            try:
+                conn, _ = server.accept()
+                break
+            except socket.timeout:
+                continue
+        with conn:
+            recv_flags = getattr(socket, "MSG_CMSG_CLOEXEC", 0)
+            while True:
+                if cancel_event.is_set() or _remaining_s(deadline) <= 0:
+                    raise TimeoutError(f"timed out receiving VMM fd on {path}")
+                conn.settimeout(min(0.1, _remaining_s(deadline)))
+                try:
+                    data, ancdata, message_flags, _ = conn.recvmsg(
+                        1, socket.CMSG_SPACE(fd_item_size), recv_flags
+                    )
+                    break
+                except socket.timeout:
+                    continue
+
+    fds = array.array("i")
+    for level, message_type, message_data in ancdata:
+        if level == socket.SOL_SOCKET and message_type == socket.SCM_RIGHTS:
+            usable = len(message_data) - len(message_data) % fd_item_size
+            fds.frombytes(message_data[:usable])
+    if data != b"\0" or message_flags & socket.MSG_CTRUNC or len(fds) != 1:
+        for fd in fds:
+            os.close(fd)
+        raise RuntimeError(
+            "invalid VMM fd message: "
+            f"marker={data!r}, truncated={bool(message_flags & socket.MSG_CTRUNC)}, "
+            f"fd_count={len(fds)}"
+        )
+    received_fd = int(fds[0])
+    # MSG_CMSG_CLOEXEC is not available on every Python/platform combination.
+    # Enforce the same protection explicitly before the descriptor escapes.
+    current_flags = fcntl.fcntl(received_fd, fcntl.F_GETFD)
+    fcntl.fcntl(received_fd, fcntl.F_SETFD, current_flags | fcntl.FD_CLOEXEC)
+    return received_fd
+
+
+def exchange_vmm_fds(
+    rank: int,
+    world_size: int,
+    key: str,
+    local_fd: int,
+    local_size: int,
+    store,
+    ranks_tag: str,
+) -> Tuple[List[int], List[int]]:
+    """Exchange one VMM allocation fd per rank through Unix sockets.
+
+    The returned lists are rank ordered. The local rank has fd ``-1`` because
+    its allocation is already mapped. The caller owns every non-negative fd.
+    """
+    key_hash = hashlib.blake2s(key.encode(), digest_size=6).hexdigest()
+    socket_dir = tempfile.mkdtemp(prefix=f"sgl_qr_vmm_{os.getpid()}_{key_hash}_")
+    store_prefix = f"sgl_qr_vmm/{ranks_tag}/{key}"
+    deadline = time.monotonic() + _FD_EXCHANGE_TIMEOUT_S
+    cancel_event = threading.Event()
+
+    recv_paths = []
+    for peer_rank in range(world_size):
+        if peer_rank == rank:
+            continue
+        path = os.path.join(socket_dir, f"r{rank}_from_r{peer_rank}.sock")
+        recv_paths.append((peer_rank, path))
+        store.set(f"{store_prefix}/socket/r{rank}_from_r{peer_rank}", path.encode())
+    store.set(f"{store_prefix}/size/r{rank}", str(local_size).encode())
+
+    received_fds = {}
+    receive_errors = {}
+
+    def receive(peer_rank: int, path: str) -> None:
+        try:
+            received_fds[peer_rank] = _recv_fd(
+                path, deadline=deadline, cancel_event=cancel_event
+            )
+        except BaseException as exc:
+            receive_errors[peer_rank] = exc
+
+    threads = []
+    try:
+        for peer_rank, path in recv_paths:
+            thread = threading.Thread(
+                target=receive,
+                args=(peer_rank, path),
+                name=f"sgl-qr-vmm-recv-r{rank}-from-r{peer_rank}",
+            )
+            thread.start()
+            threads.append(thread)
+
+        peer_keys = []
+        for peer_rank in range(world_size):
+            if peer_rank == rank:
+                continue
+            peer_keys.extend(
+                [
+                    f"{store_prefix}/socket/r{peer_rank}_from_r{rank}",
+                    f"{store_prefix}/size/r{peer_rank}",
+                ]
+            )
+        if peer_keys:
+            store.wait(peer_keys, timedelta(seconds=_remaining_s(deadline)))
+
+        for peer_rank in range(world_size):
+            if peer_rank == rank:
+                continue
+            peer_path = store.get(
+                f"{store_prefix}/socket/r{peer_rank}_from_r{rank}"
+            ).decode()
+            duplicated_fd = os.dup(local_fd)
+            try:
+                _send_fd(
+                    peer_path,
+                    duplicated_fd,
+                    deadline=deadline,
+                    cancel_event=cancel_event,
+                )
+            finally:
+                os.close(duplicated_fd)
+
+        for thread in threads:
+            thread.join(_remaining_s(deadline))
+        if any(thread.is_alive() for thread in threads):
+            raise TimeoutError("timed out receiving QuickReduce VMM fds")
+        if receive_errors:
+            raise RuntimeError(f"QuickReduce VMM fd exchange failed: {receive_errors}")
+
+        peer_fds = [-1] * world_size
+        peer_sizes = [0] * world_size
+        peer_sizes[rank] = local_size
+        for peer_rank in range(world_size):
+            if peer_rank == rank:
+                continue
+            peer_fds[peer_rank] = received_fds[peer_rank]
+            peer_sizes[peer_rank] = int(
+                store.get(f"{store_prefix}/size/r{peer_rank}").decode()
+            )
+        received_fds.clear()
+        return peer_fds, peer_sizes
+    except BaseException:
+        cancel_event.set()
+        for thread in threads:
+            thread.join(1.0)
+        for fd in received_fds.values():
+            os.close(fd)
+        raise
+    finally:
+        cancel_event.set()
+        for thread in threads:
+            if thread.is_alive():
+                thread.join(1.0)
+        for _, path in recv_paths:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+        try:
+            os.rmdir(socket_dir)
+        except OSError:
+            pass

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -648,6 +648,13 @@ class GroupCoordinator:
         if self.world_size == 1:
             return input_
 
+        # ROCm collective kernels reject a zero-sized launch. This can happen
+        # when every rank in a DP-attention subgroup is idle. An all-reduce of
+        # identically empty tensors is an identity operation, so avoid
+        # dispatching a HIP kernel while leaving other backends unchanged.
+        if is_hip() and not input_.is_cpu and input_.numel() == 0:
+            return input_
+
         if input_.is_cpu:
             if is_shm_available(input_.dtype, self.world_size, self.local_size):
                 torch.ops.sgl_kernel.shm_allreduce(input_, REDUCE_OP_SUM)

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -86,6 +86,13 @@ REDUCE_OP_SUM = int(torch.distributed.ReduceOp.SUM)
 _MODEL_PARALLEL_GROUP_TIMEOUT: Optional[timedelta] = None
 
 
+def _is_rocm_quick_reduce_requested() -> bool:
+    return (
+        is_hip()
+        and os.environ.get("ROCM_QUICK_REDUCE_QUANTIZATION", "NONE").upper() != "NONE"
+    )
+
+
 def get_torch_distributed_pg_options(group_name=None):
     if not _is_npu:
         return None
@@ -876,18 +883,19 @@ class GroupCoordinator:
                 and self.pymscclpp_comm.should_mscclpp_allreduce(input_)
             )
         if (
+            self.qr_comm is not None
+            and not self.qr_comm.disabled
+            and not should_use_pymscclpp_allreduce
+            and self.qr_comm.should_quick_allreduce(input_)
+        ):
+            return "qr"
+        if (
             self.ca_comm is not None
             and not self.ca_comm.disabled
             and not should_use_pymscclpp_allreduce
             and self.ca_comm.should_custom_ar(input_)
         ):
             return "ca"
-        if (
-            self.qr_comm is not None
-            and not self.qr_comm.disabled
-            and self.qr_comm.should_quick_allreduce(input_)
-        ):
-            return "qr"
         if self.pymscclpp_comm is not None and should_use_pymscclpp_allreduce:
             return "pymscclpp"
         if (
@@ -933,6 +941,14 @@ class GroupCoordinator:
             out = ca_comm.custom_all_reduce(input_)
         elif outplace_all_reduce_method == "qr":
             assert not qr_comm.disabled
+            if not getattr(self, "_quick_reduce_dispatch_logged", False):
+                logger.info(
+                    "[AR] Dispatching QuickAllReduce for group=%s shape=%s dtype=%s",
+                    self.unique_name,
+                    tuple(input_.shape),
+                    input_.dtype,
+                )
+                self._quick_reduce_dispatch_logged = True
             out = qr_comm.quick_all_reduce(input_)
         elif outplace_all_reduce_method == "torch_symm_mem":
             assert not torch_symm_mem_comm.disabled
@@ -1769,6 +1785,37 @@ class GroupCoordinator:
         return tensor
 
     def destroy(self):
+        if self.qr_comm is not None:
+            # A VMM allocation is imported by every peer. Quiesce local kernels
+            # and align healthy ranks before any process group or mapping is
+            # destroyed. The monitored barrier is bounded so a failed peer
+            # cannot wedge emergency cleanup indefinitely.
+            try:
+                if self.device.type != "cpu":
+                    self.device_module.synchronize(self.device)
+                if (
+                    self.cpu_group is not None
+                    and torch.distributed.is_initialized()
+                    and torch.distributed.get_backend(self.cpu_group) == "gloo"
+                ):
+                    torch.distributed.monitored_barrier(
+                        group=self.cpu_group,
+                        timeout=timedelta(seconds=30),
+                        wait_all_ranks=True,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "QuickAllReduce shutdown quiescence failed; continuing "
+                    "best-effort cleanup: %s",
+                    exc,
+                )
+            try:
+                self.qr_comm.close()
+            except Exception as exc:
+                logger.warning("QuickAllReduce cleanup failed: %s", exc)
+            finally:
+                self.qr_comm = None
+
         if self.device_group is not None:
             torch.distributed.destroy_process_group(self.device_group)
             self.device_group = None
@@ -1984,6 +2031,11 @@ logger = logging.getLogger(__name__)
 _ENABLE_CUSTOM_ALL_REDUCE = True
 _ENABLE_MSCCLPP_ALL_REDUCE = False
 _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = False
+
+
+def _should_enable_rocm_quick_reduce_group() -> bool:
+    """Honor the global custom-all-reduce switch for QuickReduce groups."""
+    return _ENABLE_CUSTOM_ALL_REDUCE and _is_rocm_quick_reduce_requested()
 
 
 def set_custom_all_reduce(enable: bool):
@@ -2405,7 +2457,11 @@ def initialize_model_parallel(
             get_world_group().local_rank,
             backend,
             use_pynccl=SYNC_TOKEN_IDS_ACROSS_TP or enable_symm_mem,
-            use_custom_allreduce=False,
+            # The ProcessGroupNCCL path used here can introduce an uncaptured
+            # event wait during ROCm speculative draft capture. When
+            # QuickReduce is requested, build the same custom stack for the
+            # attention-TP group used by the captured draft graph.
+            use_custom_allreduce=_should_enable_rocm_quick_reduce_group(),
             use_torch_symm_mem_allreduce=False,
             use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
             group_name="attention_tp",

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -938,8 +938,26 @@ class Indexer(MultiPlatformOp):
         # attn_tp_size > 1 or MAX_LEN padding mode can leave padding in the
         # hidden states; q_offset is the real (unpadded) q length.
         q_offset = sum(metadata.get_dsa_extend_len_cpu())
+        if not 0 <= q_offset <= q_fp8.shape[0]:
+            raise ValueError(
+                f"DSA q_offset={q_offset} is outside query rows={q_fp8.shape[0]}"
+            )
+        if weights.shape[0] < q_offset:
+            raise ValueError(
+                f"DSA weights rows={weights.shape[0]} are smaller than "
+                f"q_offset={q_offset}"
+            )
 
         B = metadata.get_seqlens_int32().shape[0]
+        if B == 0:
+            assert q_offset == 0, "empty DSA metadata cannot describe query rows"
+        elif (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ):
+            assert (
+                q_offset % B == 0
+            ), f"speculative DSA q_offset={q_offset} must be divisible by batch={B}"
         next_n = q_offset // B if B > 0 else 0
         use_cute_dsl = (
             self.paged_mqa_logits_backend.is_cutedsl()
@@ -1000,6 +1018,7 @@ class Indexer(MultiPlatformOp):
                 seqlens_32,
                 block_tables,
                 max_seq_len,
+                q_offset=q_offset,
                 preshuffle=_use_aiter_preshuffle,
                 kv_block_size=block_kv,
             )
@@ -1053,7 +1072,7 @@ class Indexer(MultiPlatformOp):
         self._mask_init_and_local_tokens(logits, seqlens_32)
         topk_result = metadata.topk_transform(logits, self.index_topk)
         # Restore possible padding exist in the hidden states.
-        if not _is_hip and q_offset < q_fp8.shape[0]:
+        if q_offset < q_fp8.shape[0]:
             pad_len = q_fp8.shape[0] - q_offset
             padding = torch.full(
                 (pad_len, topk_result.shape[1]),
@@ -1995,12 +2014,12 @@ class Indexer(MultiPlatformOp):
             # creates a Dynamo shape guard. These graph modes never have empty
             # batches.
             if not in_piecewise_or_breakable_cuda_graph:
-                if forward_batch.seq_lens.numel() == 0:
-                    # this seems b/c max-pad, no worries?
-                    # if x.shape[0] != 0:
-                    #     print(
-                    #         "HACK: seq_lens empty but x not empty, hackily return all-invalid topk_result"
-                    #     )
+                if (
+                    forward_batch.forward_mode.is_idle()
+                    or forward_batch.seq_lens.numel() == 0
+                ):
+                    # Idle DP-attention replicas can carry MLP-sync padding,
+                    # but no request consumes their DSA indices.
                     topk_result = torch.full(
                         (x_meta.shape[0], self.index_topk),
                         -1,

--- a/python/sglang/srt/layers/attention/dsa/graph_metadata.py
+++ b/python/sglang/srt/layers/attention/dsa/graph_metadata.py
@@ -1,0 +1,34 @@
+from typing import MutableMapping, TypeVar, Union
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+DSACudaGraphMetadataKey = Union[int, tuple[int, ForwardMode]]
+MetadataT = TypeVar("MetadataT")
+
+
+def get_dsa_cuda_graph_metadata_key(
+    batch_size: int, forward_mode: ForwardMode
+) -> DSACudaGraphMetadataKey:
+    """Keep draft-extend graph metadata separate from decode metadata."""
+    if forward_mode.is_draft_extend_v2():
+        return (batch_size, ForwardMode.DRAFT_EXTEND_V2)
+    return batch_size
+
+
+def store_dsa_cuda_graph_metadata(
+    cache: MutableMapping[DSACudaGraphMetadataKey, MetadataT],
+    batch_size: int,
+    forward_mode: ForwardMode,
+    metadata: MetadataT,
+) -> DSACudaGraphMetadataKey:
+    key = get_dsa_cuda_graph_metadata_key(batch_size, forward_mode)
+    cache[key] = metadata
+    return key
+
+
+def load_dsa_cuda_graph_metadata(
+    cache: MutableMapping[DSACudaGraphMetadataKey, MetadataT],
+    batch_size: int,
+    forward_mode: ForwardMode,
+) -> MetadataT:
+    return cache[get_dsa_cuda_graph_metadata_key(batch_size, forward_mode)]

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -47,6 +47,11 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
 )
+from sglang.srt.layers.attention.dsa.graph_metadata import (
+    get_dsa_cuda_graph_metadata_key,
+    load_dsa_cuda_graph_metadata,
+    store_dsa_cuda_graph_metadata,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -824,6 +829,10 @@ class DeepseekSparseAttnBackend(
             return metadata.page_table_1.shape[1]
         return self.req_to_token.shape[1]
 
+    @staticmethod
+    def _cuda_graph_metadata_key(bs: int, forward_mode: ForwardMode):
+        return get_dsa_cuda_graph_metadata_key(bs, forward_mode)
+
     def _transform_table_1_to_real(self, page_table: torch.Tensor) -> torch.Tensor:
         page_size = self.real_page_size
         if page_size == 1:
@@ -1479,7 +1488,9 @@ class DeepseekSparseAttnBackend(
             dsa_extend_seq_lens_list=dsa_extend_seq_lens_list,
             topk_v2_plan=self._build_topk_v2_plan(seqlens_expanded),
         )
-        self.decode_cuda_graph_metadata[bs] = metadata
+        store_dsa_cuda_graph_metadata(
+            self.decode_cuda_graph_metadata, bs, forward_mode, metadata
+        )
         self.forward_metadata = metadata
 
     def _apply_cuda_graph_metadata(
@@ -1499,7 +1510,8 @@ class DeepseekSparseAttnBackend(
         also call this directly via _apply_cuda_graph_metadata when they
         need to pass out_cache_loc / actual_forward_mode explicitly.
         """
-        if bs not in self.decode_cuda_graph_metadata:
+        metadata_key = self._cuda_graph_metadata_key(bs, forward_mode)
+        if metadata_key not in self.decode_cuda_graph_metadata:
             self._build_forward_metadata_cuda_graph(
                 bs,
                 None,
@@ -1519,7 +1531,9 @@ class DeepseekSparseAttnBackend(
         req_pool_indices = req_pool_indices[:bs]
 
         # Normal Decode
-        metadata: DSAMetadata = self.decode_cuda_graph_metadata[bs]
+        metadata: DSAMetadata = load_dsa_cuda_graph_metadata(
+            self.decode_cuda_graph_metadata, bs, forward_mode
+        )
         used_fused_metadata_generation = False
         target_verify_ctx_lens_written = False
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -937,6 +937,9 @@ class CommunicateSimpleFn:
         if isinstance(hidden_states, tuple):
             gathered_hidden_states = []
             for local_hidden_states in hidden_states:
+                if local_hidden_states.numel() == 0:
+                    gathered_hidden_states.append(local_hidden_states)
+                    continue
                 with use_symmetric_memory(
                     get_tp_group(),
                     disabled=not is_allocation_symmetric(),
@@ -955,6 +958,9 @@ class CommunicateSimpleFn:
                 )
                 gathered_hidden_states.append(output)
             return tuple(gathered_hidden_states)
+
+        if hidden_states.numel() == 0:
+            return hidden_states
 
         hidden_states, local_hidden_states = (
             get_local_dp_buffer(get_parallel().attn_tp_group),
@@ -1180,7 +1186,8 @@ class CommunicateWithAllReduceAndLayerNormFn:
         hidden_states = hidden_states.tensor_split(context.attn_tp_size)[
             context.attn_tp_rank
         ]
-        attn_tp_reduce_scatter_tensor(hidden_states, input_hidden_states)
+        if input_hidden_states.numel() != 0:
+            attn_tp_reduce_scatter_tensor(hidden_states, input_hidden_states)
         if residual_input_mode == ScatterMode.TP_ATTN_FULL:
             residual = residual.tensor_split(context.attn_tp_size)[context.attn_tp_rank]
         if hidden_states.shape[0] != 0:

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -480,7 +480,9 @@ def _dp_gather_via_all_reduce(
             group=torch.distributed.group.WORLD,
         )
     elif force_standard_all_reduce:
-        torch.distributed.all_reduce(global_tokens, group=get_tp_group().device_group)
+        from sglang.srt.distributed.parallel_state import inplace_all_reduce
+
+        inplace_all_reduce(global_tokens, group_name=get_tp_group().unique_name)
     else:
         NUM_GPUS_PER_NODE = 8
         if (

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -441,6 +441,7 @@ def get_dp_local_slice_cpu(
 
 
 from sglang.kernels.ops.memory.memcpy_triton import memcpy_triton
+from sglang.kernels.ops.memory.zero_triton import zero_triton
 
 
 def _dp_gather_via_all_reduce(
@@ -448,12 +449,17 @@ def _dp_gather_via_all_reduce(
     local_tokens: torch.Tensor,
     forward_batch: ForwardBatch,
     is_partial: bool,
+    force_standard_all_reduce: bool,
 ):
     local_start_pos, local_num_tokens = get_dp_local_info(forward_batch)
 
-    global_tokens.fill_(0)
     assert local_tokens.is_contiguous()
     assert global_tokens.is_contiguous()
+
+    if local_tokens.numel() == 0:
+        zero_triton(global_tokens)
+    else:
+        global_tokens.fill_(0)
 
     if local_tokens.shape[0] > 0 and (
         is_partial or get_attn_tensor_model_parallel_rank() == 0
@@ -473,6 +479,8 @@ def _dp_gather_via_all_reduce(
             op=torch.distributed.ReduceOp.SUM,
             group=torch.distributed.group.WORLD,
         )
+    elif force_standard_all_reduce:
+        torch.distributed.all_reduce(global_tokens, group=get_tp_group().device_group)
     else:
         NUM_GPUS_PER_NODE = 8
         if (
@@ -749,6 +757,7 @@ def _dp_gather(
     local_tokens: torch.Tensor,
     forward_batch: ForwardBatch,
     is_partial: bool,
+    force_standard_all_reduce: bool = False,
 ):
     if (
         is_dp_gatherv_active()
@@ -782,7 +791,11 @@ def _dp_gather(
         )
     else:
         _dp_gather_via_all_reduce(
-            global_tokens, local_tokens, forward_batch, is_partial
+            global_tokens,
+            local_tokens,
+            forward_batch,
+            is_partial,
+            force_standard_all_reduce,
         )
 
 
@@ -798,8 +811,15 @@ def dp_gather_replicate(
     global_tokens: torch.Tensor,
     local_tokens: torch.Tensor,
     forward_batch: ForwardBatch,
+    force_standard_all_reduce: bool = False,
 ):
-    _dp_gather(global_tokens, local_tokens, forward_batch, is_partial=False)
+    _dp_gather(
+        global_tokens,
+        local_tokens,
+        forward_batch,
+        is_partial=False,
+        force_standard_all_reduce=force_standard_all_reduce,
+    )
 
 
 def dp_scatter(
@@ -807,6 +827,9 @@ def dp_scatter(
     global_tokens: torch.Tensor,  # input
     forward_batch: ForwardBatch,
 ):
+    if local_tokens.numel() == 0:
+        return
+
     # local_num_tokens is not necessarily the same as local_tokens.shape[0],
     # since local_tokens may be padded for cuda graph
     local_start_pos, local_num_tokens = get_dp_local_info(forward_batch)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -232,7 +232,7 @@ class LogitsMetadata:
     dp_local_num_tokens: Optional[torch.Tensor] = None
     global_dp_buffer_len: Optional[int] = None
     # Number of tokens to sample per DP rank
-    global_num_tokens_for_logprob_cpu: Optional[torch.Tensor] = None
+    global_num_tokens_for_logprob_cpu: Optional[List[int]] = None
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor] = None
     # The gather mode for DP attention
     dp_padding_mode: Optional[DpPaddingMode] = None
@@ -816,7 +816,20 @@ class LogitsProcessor(nn.Module):
             logits_metadata.compute_dp_attention_metadata()
             local_hidden_states = hidden_states
             hidden_states = logits_metadata.gathered_buffer
-            dp_gather_replicate(hidden_states, local_hidden_states, logits_metadata)
+            global_token_counts = logits_metadata.global_num_tokens_for_logprob_cpu
+            # CUDA-graph batches intentionally omit the CPU list, so the idle
+            # pattern can change at replay time. Use the graph-safe standard
+            # collective in that case; eager batches retain QuickReduce when
+            # every rank has work.
+            force_standard_all_reduce = global_token_counts is None or any(
+                int(count) == 0 for count in global_token_counts
+            )
+            dp_gather_replicate(
+                hidden_states,
+                local_hidden_states,
+                logits_metadata,
+                force_standard_all_reduce=force_standard_all_reduce,
+            )
             return hidden_states, local_hidden_states
         return hidden_states, hidden_states
 

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -305,17 +305,27 @@ class LogitsMetadata:
         )
 
     def compute_dp_attention_metadata(self):
-        cumtokens = torch.cumsum(self.global_num_tokens_for_logprob_gpu, dim=0)
         dp_rank = get_parallel().attn_dp_rank
-        if dp_rank == 0:
-            dp_local_start_pos = torch.zeros_like(
-                self.global_num_tokens_for_logprob_gpu[0]
+        if self.global_num_tokens_for_logprob_cpu is not None:
+            global_num_tokens = [
+                int(num_tokens) for num_tokens in self.global_num_tokens_for_logprob_cpu
+            ]
+            local_info = self.global_num_tokens_for_logprob_gpu.new_tensor(
+                [sum(global_num_tokens[:dp_rank]), global_num_tokens[dp_rank]]
             )
+            dp_local_start_pos, dp_local_num_tokens = local_info.unbind()
         else:
-            dp_local_start_pos = cumtokens[dp_rank - 1]
+            cumtokens = torch.cumsum(self.global_num_tokens_for_logprob_gpu, dim=0)
+            if dp_rank == 0:
+                dp_local_start_pos = torch.zeros_like(
+                    self.global_num_tokens_for_logprob_gpu[0]
+                )
+            else:
+                dp_local_start_pos = cumtokens[dp_rank - 1]
+            dp_local_num_tokens = self.global_num_tokens_for_logprob_gpu[dp_rank]
 
         self.dp_local_start_pos = dp_local_start_pos
-        self.dp_local_num_tokens = self.global_num_tokens_for_logprob_gpu[dp_rank]
+        self.dp_local_num_tokens = dp_local_num_tokens
 
         hidden_size = get_dp_hidden_size()
         dtype = get_dp_dtype()
@@ -323,7 +333,7 @@ class LogitsMetadata:
 
         if self.global_num_tokens_for_logprob_cpu is not None:
             # create a smaller buffer to reduce peak memory usage
-            self.global_dp_buffer_len = sum(self.global_num_tokens_for_logprob_cpu)
+            self.global_dp_buffer_len = sum(global_num_tokens)
         else:
             self.global_dp_buffer_len = self.global_dp_buffer_len
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1021,6 +1021,13 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         else:
             num_tokens_per_dp = self.global_num_tokens_cpu[0]
 
+        if num_tokens_per_dp == 0:
+            # init_new creates both mirrors from the same host-side token count.
+            # Keep the already-zero device scalar instead of launching scalar
+            # elementwise kernels on an idle ROCm rank.
+            assert self.num_token_non_padded_cpu == 0
+            return
+
         self.num_token_non_padded = compute_local_num_token_non_padded(
             global_num_token_non_padded=self.num_token_non_padded,
             num_tokens_per_dp=num_tokens_per_dp,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1582,6 +1582,13 @@ class ModelRunner:
         Returns:
             A list of next_token_ids
         """
+        next_token_logits = logits_output.next_token_logits
+        if next_token_logits.shape[0] == 0:
+            assert (
+                forward_batch.forward_mode.is_idle()
+            ), "empty next-token logits are only valid for an idle DP rank"
+            return torch.empty((0,), dtype=torch.int64, device=next_token_logits.device)
+
         self._preprocess_logits(logits_output, forward_batch.sampling_info)
 
         # Sample the next tokens

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -821,20 +821,6 @@ def eagle_sample(
             deterministic=True,
         )
 
-        # Sync sampling results across TP ranks: different GPUs may
-        # produce slightly different target_probs due to floating-point
-        # non-determinism in softmax/top_k/top_p, causing different
-        # sampled tokens. Broadcast from rank 0 to ensure consistency.
-        tp_group = (
-            get_parallel().attn_tp_group
-            if is_dp_attention_enabled()
-            else get_tp_group()
-        )
-        if tp_group.world_size > 1:
-            tp_group.broadcast(predict, src=0)
-            tp_group.broadcast(accept_index, src=0)
-            tp_group.broadcast(num_correct_drafts, src=0)
-
     if SIMULATE_ACC_LEN > 0:
         # Do simulation. The helper builds (and returns) a replacement
         # accept_index of width spec_steps + 1, so pass max_tree_depth - 1
@@ -869,6 +855,23 @@ def eagle_sample(
             bs=bs,
             spec_steps=verify_input.max_tree_depth - 1,
         )
+
+    # Sync the finalized verify decision across TP ranks. Both the greedy path
+    # (per-rank argmax) and the sampling path (softmax/top_k/top_p) can pick
+    # different tokens on different ranks when per-rank logits differ from
+    # non-deterministic reductions (e.g. --enable-aiter-allreduce-fusion). If
+    # ranks accept a different number of drafts, committed seq_lens/batch shapes
+    # diverge and the next TP collective deadlocks. Broadcasting here — after the
+    # accept decision is finalized (including SIMULATE_ACC_LEN, which re-derives
+    # from per-rank argmax) and before the worker consumes it — keeps every path
+    # consistent.
+    tp_group = (
+        get_parallel().attn_tp_group if is_dp_attention_enabled() else get_tp_group()
+    )
+    if tp_group.world_size > 1:
+        tp_group.broadcast(predict, src=0)
+        tp_group.broadcast(accept_index, src=0)
+        tp_group.broadcast(num_correct_drafts, src=0)
 
     # `num_correct_drafts` stays drafts-only inside this function; the returned
     # tensor includes the trailing/bonus token via out-of-place +1 so the

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -793,6 +793,24 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         )
         with canary_ctx:
             logits_output = self.draft_runner.forward(forward_batch).logits_output
+
+        if forward_batch.forward_mode.is_idle():
+            assert logits_output.next_token_logits.shape[0] == 0
+            assert next_token_ids.shape[0] == 0
+            if capture_hidden_mode != CaptureHiddenMode.NULL:
+                assert logits_output.hidden_states.shape[0] == 0
+            hidden_size, hidden_dtype = get_draft_recurrent_hidden_state_spec(
+                self.draft_runner
+            )
+            return EagleDraftInput.create_idle_input(
+                device=self.device,
+                hidden_size=hidden_size,
+                dtype=hidden_dtype,
+                topk=self.topk,
+                capture_hidden_mode=capture_hidden_mode,
+                vocab_size=self.target_worker.model_config.vocab_size,
+            )
+
         maybe_detect_nan(logits_output.next_token_logits, "draft_extend_for_prefill")
         maybe_detect_inf(logits_output.next_token_logits, "draft_extend_for_prefill")
 

--- a/test/registered/unit/distributed/test_quick_all_reduce_vmm.py
+++ b/test/registered/unit/distributed/test_quick_all_reduce_vmm.py
@@ -1,0 +1,427 @@
+import os
+import tempfile
+import threading
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.distributed import parallel_state
+from sglang.srt.distributed.device_communicators import (
+    quick_all_reduce,
+    quick_all_reduce_vmm,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _BlockingStore:
+    def __init__(self):
+        self._condition = threading.Condition()
+        self._values = {}
+
+    def set(self, key, value):
+        with self._condition:
+            self._values[key] = value
+            self._condition.notify_all()
+
+    def get(self, key):
+        with self._condition:
+            ready = self._condition.wait_for(lambda: key in self._values, timeout=5)
+            if not ready:
+                raise TimeoutError(f"missing store key {key}")
+            return self._values[key]
+
+    def wait(self, keys, timeout):
+        with self._condition:
+            ready = self._condition.wait_for(
+                lambda: all(key in self._values for key in keys),
+                timeout=timeout.total_seconds(),
+            )
+            if not ready:
+                missing = [key for key in keys if key not in self._values]
+                raise TimeoutError(f"missing store keys {missing}")
+
+
+class TestQuickAllReduceVMM(unittest.TestCase):
+    def test_vmm_initialization_opens_native_peer_handles(self):
+        local_fd = os.open(os.devnull, os.O_RDONLY)
+        peer_fd = os.dup(local_fd)
+
+        communicator = object.__new__(quick_all_reduce.QuickAllReduce)
+        communicator.rank = 0
+        communicator.world_size = 2
+        communicator.group = object()
+        communicator.device = torch.device("cuda:0")
+        communicator._ptr = 0
+
+        props = types.SimpleNamespace(gcnArchName="gfx950:sramecc+:xnack-")
+        with (
+            patch.object(
+                quick_all_reduce.torch.cuda,
+                "get_device_properties",
+                return_value=props,
+            ),
+            patch.object(
+                quick_all_reduce.dist.distributed_c10d,
+                "_get_default_store",
+                return_value="store",
+            ),
+            patch.object(
+                quick_all_reduce.dist,
+                "get_process_group_ranks",
+                return_value=[3, 2],
+            ),
+            patch.object(
+                quick_all_reduce,
+                "_new_vmm_pool_name",
+                return_value="sglang_quickreduce_2_3_gtest",
+            ) as pool_name,
+            patch.object(quick_all_reduce, "_raise_if_any_vmm_phase_failed"),
+            patch.object(
+                quick_all_reduce.ops,
+                "init_custom_qr_vmm",
+                return_value=(123, local_fd, 4096),
+                create=True,
+            ) as init_vmm,
+            patch.object(
+                quick_all_reduce_vmm,
+                "exchange_vmm_fds",
+                return_value=([-1, peer_fd], [4096, 4096]),
+            ) as exchange,
+            patch.object(
+                quick_all_reduce.ops,
+                "qr_open_vmm_handles",
+                create=True,
+            ) as open_peers,
+            patch.object(
+                quick_all_reduce.ops,
+                "qr_destroy",
+                create=True,
+            ) as destroy,
+        ):
+            communicator._init_vmm(1024)
+
+            self.assertEqual(communicator._ptr, 123)
+            communicator.close()
+
+        self.assertEqual(communicator._ptr, 0)
+        self.assertTrue(communicator.disabled)
+        init_vmm.assert_called_once_with(0, 2, 0, 1024, True)
+        exchange.assert_called_once_with(
+            0,
+            2,
+            "sglang_quickreduce_2_3_gtest",
+            local_fd,
+            4096,
+            "store",
+            "2_3",
+        )
+        pool_name.assert_called_once_with(
+            communicator.group, "2_3", communicator.device
+        )
+        open_peers.assert_called_once_with(123, [-1, peer_fd], [4096, 4096])
+        destroy.assert_called_once_with(123)
+        with self.assertRaises(OSError):
+            os.fstat(local_fd)
+        with self.assertRaises(OSError):
+            os.fstat(peer_fd)
+
+    def test_fd_exchange_returns_rank_ordered_descriptors(self):
+        store = _BlockingStore()
+        files = [tempfile.TemporaryFile(), tempfile.TemporaryFile()]
+        files[0].write(b"a")
+        files[1].write(b"b")
+        for file in files:
+            file.flush()
+
+        results = {}
+        errors = []
+        socket_dir_modes = []
+        real_mkdtemp = quick_all_reduce_vmm.tempfile.mkdtemp
+
+        def secure_mkdtemp(*args, **kwargs):
+            path = real_mkdtemp(*args, **kwargs)
+            socket_dir_modes.append(os.stat(path).st_mode & 0o777)
+            return path
+
+        def exchange(rank):
+            try:
+                results[rank] = quick_all_reduce_vmm.exchange_vmm_fds(
+                    rank,
+                    2,
+                    "unit_test_pool",
+                    files[rank].fileno(),
+                    4096 + rank,
+                    store,
+                    "0_1",
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        with patch.object(
+            quick_all_reduce_vmm.tempfile,
+            "mkdtemp",
+            side_effect=secure_mkdtemp,
+        ):
+            threads = [
+                threading.Thread(target=exchange, args=(rank,)) for rank in range(2)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(10)
+
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        self.assertEqual(socket_dir_modes, [0o700, 0o700])
+        self.assertEqual(results[0][1], [4096, 4097])
+        self.assertEqual(results[1][1], [4096, 4097])
+        self.assertEqual(os.pread(results[0][0][1], 1, 0), b"b")
+        self.assertEqual(os.pread(results[1][0][0], 1, 0), b"a")
+        self.assertFalse(os.get_inheritable(results[0][0][1]))
+        self.assertFalse(os.get_inheritable(results[1][0][0]))
+
+        for rank, (fds, _) in results.items():
+            for peer_rank, fd in enumerate(fds):
+                if peer_rank != rank:
+                    os.close(fd)
+        for file in files:
+            file.close()
+
+    def test_fd_exchange_closes_received_descriptors_on_metadata_error(self):
+        store = _BlockingStore()
+        store_prefix = "sgl_qr_vmm/0_1/unit_test_pool"
+        store.set(f"{store_prefix}/socket/r1_from_r0", b"unused.sock")
+        store.set(f"{store_prefix}/size/r1", b"not-an-integer")
+
+        with tempfile.TemporaryFile() as local_file:
+            received_fd = os.dup(local_file.fileno())
+            with (
+                patch.object(
+                    quick_all_reduce_vmm,
+                    "_recv_fd",
+                    return_value=received_fd,
+                ),
+                patch.object(quick_all_reduce_vmm, "_send_fd"),
+            ):
+                with self.assertRaises(ValueError):
+                    quick_all_reduce_vmm.exchange_vmm_fds(
+                        0,
+                        2,
+                        "unit_test_pool",
+                        local_file.fileno(),
+                        4096,
+                        store,
+                        "0_1",
+                    )
+
+            with self.assertRaises(OSError):
+                os.fstat(received_fd)
+
+    def test_empty_all_reduce_still_participates_in_collective(self):
+        coordinator = object.__new__(parallel_state.GroupCoordinator)
+        coordinator.world_size = 2
+        coordinator.local_size = 2
+        coordinator.device_group = object()
+        tensor = torch.empty(0)
+
+        with (
+            patch.object(parallel_state, "is_shm_available", return_value=False),
+            patch.object(torch.distributed, "all_reduce") as all_reduce,
+        ):
+            self.assertIs(coordinator.all_reduce(tensor), tensor)
+
+        all_reduce.assert_called_once_with(tensor, group=coordinator.device_group)
+
+    def test_quick_reduce_group_honors_custom_allreduce_disable(self):
+        with (
+            patch.object(parallel_state, "_ENABLE_CUSTOM_ALL_REDUCE", False),
+            patch.object(
+                parallel_state,
+                "_is_rocm_quick_reduce_requested",
+                return_value=True,
+            ),
+        ):
+            self.assertFalse(parallel_state._should_enable_rocm_quick_reduce_group())
+
+        with (
+            patch.object(parallel_state, "_ENABLE_CUSTOM_ALL_REDUCE", True),
+            patch.object(
+                parallel_state,
+                "_is_rocm_quick_reduce_requested",
+                return_value=True,
+            ),
+        ):
+            self.assertTrue(parallel_state._should_enable_rocm_quick_reduce_group())
+
+    def test_group_destroy_closes_quick_reduce(self):
+        coordinator = object.__new__(parallel_state.GroupCoordinator)
+        coordinator.device_group = None
+        coordinator.cpu_group = None
+        coordinator.device = torch.device("cpu")
+        coordinator.device_module = torch
+        coordinator.pynccl_comm = None
+        coordinator.pymscclpp_comm = None
+        coordinator.ca_comm = None
+        coordinator.qr_comm = MagicMock()
+        coordinator.mq_broadcaster = None
+
+        quick_reduce = coordinator.qr_comm
+        coordinator.destroy()
+
+        quick_reduce.close.assert_called_once_with()
+        self.assertIsNone(coordinator.qr_comm)
+
+    def test_close_clears_native_pointer_before_cleanup_error(self):
+        communicator = object.__new__(quick_all_reduce.QuickAllReduce)
+        communicator._ptr = 123
+        communicator.disabled = False
+
+        with patch.object(
+            quick_all_reduce.ops,
+            "qr_destroy",
+            side_effect=RuntimeError("cleanup failed"),
+            create=True,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "cleanup failed"):
+                communicator.close()
+
+        self.assertEqual(communicator._ptr, 0)
+        # The finalizer must not retry the freed pointer or propagate.
+        communicator.__del__()
+
+    def test_quick_reduce_precedes_custom_allreduce(self):
+        coordinator = object.__new__(parallel_state.GroupCoordinator)
+        coordinator.world_size = 2
+        coordinator.unique_name = "test_group"
+        coordinator.hpu_communicator = None
+        coordinator.xpu_communicator = None
+        coordinator.npu_communicator = None
+        coordinator.pynccl_comm = None
+        coordinator.pymscclpp_comm = None
+        coordinator.torch_symm_mem_comm = None
+        coordinator.qr_comm = types.SimpleNamespace(
+            disabled=False,
+            should_quick_allreduce=MagicMock(return_value=True),
+        )
+        coordinator.ca_comm = types.SimpleNamespace(
+            disabled=False,
+            should_custom_ar=MagicMock(return_value=True),
+        )
+        tensor = types.SimpleNamespace(
+            numel=lambda: 16,
+            is_cpu=False,
+            shape=(16,),
+            dtype=torch.bfloat16,
+        )
+
+        with patch.object(
+            parallel_state, "outplace_all_reduce", return_value="quick_reduce"
+        ) as dispatch:
+            result = coordinator.all_reduce(tensor)
+
+        self.assertEqual(result, "quick_reduce")
+        coordinator.qr_comm.should_quick_allreduce.assert_called_once_with(tensor)
+        coordinator.ca_comm.should_custom_ar.assert_not_called()
+        dispatch.assert_called_once_with(
+            tensor,
+            group_name="test_group",
+            outplace_all_reduce_method="qr",
+        )
+
+    def test_auto_backend_prefers_vmm_on_gfx950(self):
+        props = types.SimpleNamespace(gcnArchName="gfx950:sramecc+:xnack-")
+        with (
+            patch.dict(
+                os.environ,
+                {"ROCM_QUICK_REDUCE_IPC_BACKEND": "auto"},
+            ),
+            patch.object(
+                quick_all_reduce.torch.cuda,
+                "get_device_properties",
+                return_value=props,
+            ),
+        ):
+            backend = quick_all_reduce._select_quick_reduce_ipc_backend(
+                torch.device("cuda:0")
+            )
+
+        self.assertEqual(backend, "vmm")
+
+    def test_vmm_pool_name_uses_group_wide_generation(self):
+        group = object()
+
+        def broadcast_nonce(nonce, src, group):
+            self.assertIs(group, group_under_test)
+            self.assertEqual(src, 3)
+            nonce.fill_(2)
+
+        group_under_test = group
+        with (
+            patch.object(
+                quick_all_reduce.dist,
+                "get_process_group_ranks",
+                return_value=[3, 2],
+            ),
+            patch.object(quick_all_reduce.dist, "get_rank", return_value=3),
+            patch.object(
+                quick_all_reduce.dist,
+                "broadcast",
+                side_effect=broadcast_nonce,
+            ),
+            patch.object(quick_all_reduce.os, "urandom", return_value=b"local123"),
+        ):
+            pool_name = quick_all_reduce._new_vmm_pool_name(
+                group, "2_3", torch.device("cpu")
+            )
+
+        self.assertRegex(
+            pool_name,
+            r"^sglang_quickreduce_2_3_g[0-9a-f]{16}$",
+        )
+
+    def test_vmm_phase_failure_is_reported_consistently(self):
+        def gather_status(statuses, local_status, group):
+            self.assertIs(group, group_under_test)
+            statuses[:] = [local_status, "RuntimeError: peer allocation failed"]
+
+        group_under_test = object()
+        with (
+            patch.object(quick_all_reduce.dist, "get_world_size", return_value=2),
+            patch.object(
+                quick_all_reduce.dist,
+                "all_gather_object",
+                side_effect=gather_status,
+            ),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "rank 1: RuntimeError: peer allocation failed"
+            ):
+                quick_all_reduce._raise_if_any_vmm_phase_failed(
+                    group_under_test, "local allocation", None
+                )
+
+    def test_explicit_backend_override_does_not_query_device(self):
+        with (
+            patch.dict(
+                os.environ,
+                {"ROCM_QUICK_REDUCE_IPC_BACKEND": "hipipc"},
+            ),
+            patch.object(
+                quick_all_reduce.torch.cuda,
+                "get_device_properties",
+            ) as get_properties,
+        ):
+            backend = quick_all_reduce._select_quick_reduce_ipc_backend(
+                torch.device("cuda:0")
+            )
+
+        self.assertEqual(backend, "hipipc")
+        get_properties.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/distributed/test_quick_all_reduce_vmm.py
+++ b/test/registered/unit/distributed/test_quick_all_reduce_vmm.py
@@ -236,6 +236,19 @@ class TestQuickAllReduceVMM(unittest.TestCase):
 
         all_reduce.assert_called_once_with(tensor, group=coordinator.device_group)
 
+    def test_empty_rocm_gpu_all_reduce_skips_zero_sized_kernel(self):
+        coordinator = object.__new__(parallel_state.GroupCoordinator)
+        coordinator.world_size = 2
+        tensor = types.SimpleNamespace(numel=lambda: 0, is_cpu=False)
+
+        with (
+            patch.object(parallel_state, "is_hip", return_value=True),
+            patch.object(torch.distributed, "all_reduce") as all_reduce,
+        ):
+            self.assertIs(coordinator.all_reduce(tensor), tensor)
+
+        all_reduce.assert_not_called()
+
     def test_quick_reduce_group_honors_custom_allreduce_disable(self):
         with (
             patch.object(parallel_state, "_ENABLE_CUSTOM_ALL_REDUCE", False),

--- a/test/registered/unit/jit/test_aiter_paged_mqa_logits.py
+++ b/test/registered/unit/jit/test_aiter_paged_mqa_logits.py
@@ -1,0 +1,83 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.jit_kernel.dsa.paged_mqa_logits import aiter_paged_mqa_logits
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestAiterPagedMqaLogits(unittest.TestCase):
+    @staticmethod
+    def _aiter_modules(kernel):
+        module = types.ModuleType("aiter.ops.triton.pa_mqa_logits")
+        module.deepgemm_fp8_paged_mqa_logits = kernel
+        return {
+            "aiter": types.ModuleType("aiter"),
+            "aiter.ops": types.ModuleType("aiter.ops"),
+            "aiter.ops.triton": types.ModuleType("aiter.ops.triton"),
+            "aiter.ops.triton.pa_mqa_logits": module,
+        }
+
+    def test_ignores_dp_padding_rows(self):
+        observed = {}
+
+        def kernel(q, kv, weights, logits, seq_lens, block_tables, max_seq_len, **_):
+            observed["q_shape"] = tuple(q.shape)
+            observed["weights_shape"] = tuple(weights.shape)
+            observed["logits_shape"] = tuple(logits.shape)
+
+        modules = self._aiter_modules(kernel)
+
+        q = torch.empty((24, 2, 132))
+        kv = torch.empty((32, 1, 1, 132))
+        weights = torch.empty((24, 2))
+        seq_lens = torch.ones(18, dtype=torch.int32)
+        block_tables = torch.zeros((18, 4), dtype=torch.int32)
+
+        with patch.dict(sys.modules, modules):
+            logits = aiter_paged_mqa_logits(
+                q,
+                kv,
+                weights,
+                seq_lens,
+                block_tables,
+                4,
+                q_offset=18,
+                preshuffle=False,
+                kv_block_size=1,
+            )
+
+        self.assertEqual(observed["q_shape"], (18, 1, 2, 132))
+        self.assertEqual(observed["weights_shape"], (18, 2))
+        self.assertEqual(observed["logits_shape"], (18, 4))
+        self.assertEqual(tuple(logits.shape), (18, 4))
+
+    def test_rejects_metadata_rows_that_do_not_match_q_offset(self):
+        q = torch.empty((24, 2, 132))
+        kv = torch.empty((32, 1, 1, 132))
+        weights = torch.empty((24, 2))
+        seq_lens = torch.ones(17, dtype=torch.int32)
+        block_tables = torch.zeros((18, 4), dtype=torch.int32)
+
+        with patch.dict(sys.modules, self._aiter_modules(lambda *args, **kwargs: None)):
+            with self.assertRaisesRegex(ValueError, "metadata rows must match"):
+                aiter_paged_mqa_logits(
+                    q,
+                    kv,
+                    weights,
+                    seq_lens,
+                    block_tables,
+                    4,
+                    q_offset=18,
+                    preshuffle=False,
+                    kv_block_size=1,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/jit/test_aiter_paged_mqa_logits.py
+++ b/test/registered/unit/jit/test_aiter_paged_mqa_logits.py
@@ -78,6 +78,32 @@ class TestAiterPagedMqaLogits(unittest.TestCase):
                     kv_block_size=1,
                 )
 
+    def test_empty_query_skips_aiter_kernel(self):
+        def kernel(*_args, **_kwargs):
+            self.fail("AITER kernel must not run for an empty query batch")
+
+        q = torch.empty((0, 2, 132))
+        kv = torch.empty((32, 1, 1, 132))
+        weights = torch.empty((0, 2))
+        seq_lens = torch.empty(0, dtype=torch.int32)
+        block_tables = torch.empty((0, 4), dtype=torch.int32)
+
+        with patch.dict(sys.modules, self._aiter_modules(kernel)):
+            logits = aiter_paged_mqa_logits(
+                q,
+                kv,
+                weights,
+                seq_lens,
+                block_tables,
+                4,
+                q_offset=0,
+                preshuffle=False,
+                kv_block_size=1,
+            )
+
+        self.assertEqual(tuple(logits.shape), (0, 4))
+        self.assertEqual(logits.dtype, torch.float32)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/jit/test_aiter_paged_mqa_logits.py
+++ b/test/registered/unit/jit/test_aiter_paged_mqa_logits.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import torch
 
-from sglang.jit_kernel.dsa.paged_mqa_logits import aiter_paged_mqa_logits
+from sglang.kernels.ops.attention.dsa.paged_mqa_logits import aiter_paged_mqa_logits
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")

--- a/test/registered/unit/layers/attention/test_dsa_graph_metadata.py
+++ b/test/registered/unit/layers/attention/test_dsa_graph_metadata.py
@@ -1,0 +1,47 @@
+import unittest
+
+from sglang.srt.layers.attention.dsa.graph_metadata import (
+    get_dsa_cuda_graph_metadata_key,
+    load_dsa_cuda_graph_metadata,
+    store_dsa_cuda_graph_metadata,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDsaGraphMetadataKey(unittest.TestCase):
+    def test_draft_extend_does_not_alias_target_verify(self):
+        target_key = get_dsa_cuda_graph_metadata_key(8, ForwardMode.TARGET_VERIFY)
+        draft_key = get_dsa_cuda_graph_metadata_key(8, ForwardMode.DRAFT_EXTEND_V2)
+
+        self.assertEqual(target_key, 8)
+        self.assertEqual(draft_key, (8, ForwardMode.DRAFT_EXTEND_V2))
+        self.assertNotEqual(target_key, draft_key)
+
+    def test_cache_keeps_target_and_draft_metadata_for_same_batch(self):
+        cache = {}
+        target_metadata = object()
+        draft_metadata = object()
+
+        store_dsa_cuda_graph_metadata(
+            cache, 8, ForwardMode.TARGET_VERIFY, target_metadata
+        )
+        store_dsa_cuda_graph_metadata(
+            cache, 8, ForwardMode.DRAFT_EXTEND_V2, draft_metadata
+        )
+
+        self.assertEqual(len(cache), 2)
+        self.assertIs(
+            load_dsa_cuda_graph_metadata(cache, 8, ForwardMode.TARGET_VERIFY),
+            target_metadata,
+        )
+        self.assertIs(
+            load_dsa_cuda_graph_metadata(cache, 8, ForwardMode.DRAFT_EXTEND_V2),
+            draft_metadata,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_communicator_zero_scatter.py
+++ b/test/registered/unit/layers/test_communicator_zero_scatter.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import torch
 
+import sglang.srt.distributed.parallel_state as parallel_state
 import sglang.srt.layers.communicator as communicator
 import sglang.srt.layers.dp_attention as dp_attention
 from sglang.srt.layers.communicator import (
@@ -88,14 +89,14 @@ class TestCommunicatorZeroScatter(CustomTestCase):
         local_tokens.is_contiguous.return_value = True
         global_tokens = Mock()
         global_tokens.is_contiguous.return_value = True
-        device_group = object()
-        tp_group = SimpleNamespace(device_group=device_group)
+        tp_group = SimpleNamespace(unique_name="tp:0")
 
         with (
             patch.object(dp_attention, "get_dp_local_info", return_value=(0, 0)),
             patch.object(dp_attention, "world_dp_gather_enabled", return_value=False),
             patch.object(dp_attention, "get_tp_group", return_value=tp_group),
             patch.object(torch.distributed, "all_reduce") as all_reduce,
+            patch.object(parallel_state, "inplace_all_reduce") as inplace_all_reduce,
             patch.object(dp_attention, "zero_triton"),
         ):
             dp_attention._dp_gather_via_all_reduce(
@@ -106,7 +107,37 @@ class TestCommunicatorZeroScatter(CustomTestCase):
                 force_standard_all_reduce=True,
             )
 
-        all_reduce.assert_called_once_with(global_tokens, group=device_group)
+        inplace_all_reduce.assert_called_once_with(global_tokens, group_name="tp:0")
+        all_reduce.assert_not_called()
+
+    def test_inplace_all_reduce_uses_enabled_pynccl(self):
+        tensor = Mock()
+        pynccl_comm = Mock(disabled=False)
+        group = SimpleNamespace(
+            pynccl_comm=pynccl_comm,
+            torch_symm_mem_comm=None,
+            device_group=object(),
+        )
+
+        with patch.object(torch.distributed, "all_reduce") as all_reduce:
+            parallel_state.GroupCoordinator._all_reduce_in_place(group, tensor)
+
+        pynccl_comm.all_reduce.assert_called_once_with(tensor)
+        all_reduce.assert_not_called()
+
+    def test_inplace_all_reduce_keeps_eager_process_group_fallback(self):
+        tensor = Mock()
+        device_group = object()
+        group = SimpleNamespace(
+            pynccl_comm=Mock(disabled=True),
+            torch_symm_mem_comm=None,
+            device_group=device_group,
+        )
+
+        with patch.object(torch.distributed, "all_reduce") as all_reduce:
+            parallel_state.GroupCoordinator._all_reduce_in_place(group, tensor)
+
+        all_reduce.assert_called_once_with(tensor, group=device_group)
 
     def test_empty_dp_scatter_skips_device_work(self):
         local_tokens = Mock()

--- a/test/registered/unit/layers/test_communicator_zero_scatter.py
+++ b/test/registered/unit/layers/test_communicator_zero_scatter.py
@@ -1,0 +1,256 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+import sglang.srt.layers.communicator as communicator
+import sglang.srt.layers.dp_attention as dp_attention
+from sglang.srt.layers.communicator import (
+    CommunicateSimpleFn,
+    CommunicateWithAllReduceAndLayerNormFn,
+    ScatterMode,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestCommunicatorZeroScatter(CustomTestCase):
+    def test_empty_dp_gather_uses_zero_fast_path(self):
+        local_tokens = Mock()
+        local_tokens.numel.return_value = 0
+        local_tokens.shape = (0, 4)
+        local_tokens.is_contiguous.return_value = True
+        global_tokens = Mock()
+        global_tokens.is_contiguous.return_value = True
+
+        with (
+            patch.object(dp_attention, "get_dp_local_info", return_value=(0, 0)),
+            patch.object(dp_attention, "world_dp_gather_enabled", return_value=True),
+            patch.object(torch.distributed, "all_reduce") as all_reduce,
+            patch.object(dp_attention, "memcpy_triton") as memcpy,
+            patch.object(dp_attention, "zero_triton") as zero,
+        ):
+            dp_attention._dp_gather_via_all_reduce(
+                global_tokens,
+                local_tokens,
+                Mock(),
+                is_partial=False,
+                force_standard_all_reduce=False,
+            )
+
+        zero.assert_called_once_with(global_tokens)
+        global_tokens.fill_.assert_not_called()
+        memcpy.assert_not_called()
+        all_reduce.assert_called_once()
+
+    def test_nonempty_dp_gather_keeps_fill_and_copy(self):
+        local_tokens = Mock()
+        local_tokens.numel.return_value = 4
+        local_tokens.shape = (1, 4)
+        local_tokens.is_contiguous.return_value = True
+        local_tokens.untyped_storage.return_value = object()
+        global_tokens = Mock()
+        global_tokens.is_contiguous.return_value = True
+        global_tokens.untyped_storage.return_value = object()
+
+        with (
+            patch.object(dp_attention, "get_dp_local_info", return_value=(0, 1)),
+            patch.object(
+                dp_attention,
+                "get_attn_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            patch.object(dp_attention, "world_dp_gather_enabled", return_value=True),
+            patch.object(torch.distributed, "all_reduce") as all_reduce,
+            patch.object(dp_attention, "memcpy_triton") as memcpy,
+            patch.object(dp_attention, "zero_triton") as zero,
+        ):
+            dp_attention._dp_gather_via_all_reduce(
+                global_tokens,
+                local_tokens,
+                Mock(),
+                is_partial=False,
+                force_standard_all_reduce=False,
+            )
+
+        global_tokens.fill_.assert_called_once_with(0)
+        zero.assert_not_called()
+        memcpy.assert_called_once_with(global_tokens, local_tokens, 0, 0, 1, False)
+        all_reduce.assert_called_once()
+
+    def test_idle_dp_gather_can_force_standard_all_reduce(self):
+        local_tokens = Mock()
+        local_tokens.numel.return_value = 0
+        local_tokens.shape = (0, 4)
+        local_tokens.is_contiguous.return_value = True
+        global_tokens = Mock()
+        global_tokens.is_contiguous.return_value = True
+        device_group = object()
+        tp_group = SimpleNamespace(device_group=device_group)
+
+        with (
+            patch.object(dp_attention, "get_dp_local_info", return_value=(0, 0)),
+            patch.object(dp_attention, "world_dp_gather_enabled", return_value=False),
+            patch.object(dp_attention, "get_tp_group", return_value=tp_group),
+            patch.object(torch.distributed, "all_reduce") as all_reduce,
+            patch.object(dp_attention, "zero_triton"),
+        ):
+            dp_attention._dp_gather_via_all_reduce(
+                global_tokens,
+                local_tokens,
+                Mock(),
+                is_partial=False,
+                force_standard_all_reduce=True,
+            )
+
+        all_reduce.assert_called_once_with(global_tokens, group=device_group)
+
+    def test_empty_dp_scatter_skips_device_work(self):
+        local_tokens = Mock()
+        local_tokens.numel.return_value = 0
+        global_tokens = Mock()
+
+        with (
+            patch.object(dp_attention, "get_dp_local_info") as get_local_info,
+            patch.object(dp_attention, "memcpy_triton") as memcpy,
+        ):
+            dp_attention.dp_scatter(local_tokens, global_tokens, Mock())
+
+        get_local_info.assert_not_called()
+        local_tokens.fill_.assert_not_called()
+        memcpy.assert_not_called()
+
+    def test_nonempty_dp_scatter_keeps_fill_and_copy(self):
+        local_tokens = torch.ones((2, 4), dtype=torch.float32)
+        global_tokens = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+
+        with (
+            patch.object(
+                dp_attention, "get_dp_local_info", return_value=(2, 2)
+            ) as get_local_info,
+            patch.object(dp_attention, "memcpy_triton") as memcpy,
+        ):
+            dp_attention.dp_scatter(local_tokens, global_tokens, Mock())
+
+        get_local_info.assert_called_once()
+        memcpy.assert_called_once_with(local_tokens, global_tokens, 0, 2, 2, True)
+        torch.testing.assert_close(local_tokens, torch.zeros_like(local_tokens))
+
+    def test_empty_tensor_skips_all_gather(self):
+        hidden_states = torch.empty((0, 4))
+        context = SimpleNamespace(attn_tp_size=2)
+
+        with (
+            patch.object(communicator, "get_local_dp_buffer") as get_buffer,
+            patch.object(communicator, "attn_tp_all_gather_into_tensor") as gather,
+        ):
+            output = CommunicateSimpleFn._scattered_to_tp_attn_full(
+                hidden_states, None, context
+            )
+
+        get_buffer.assert_not_called()
+        gather.assert_not_called()
+        self.assertIs(output, hidden_states)
+
+    def test_empty_tuple_skips_all_gather(self):
+        hidden_states = (torch.empty((0, 4)), torch.empty((0, 2)))
+        context = SimpleNamespace(attn_tp_size=2)
+
+        with patch.object(communicator, "attn_tp_all_gather_into_tensor") as gather:
+            output = CommunicateSimpleFn._scattered_to_tp_attn_full(
+                hidden_states, None, context
+            )
+
+        gather.assert_not_called()
+        self.assertIs(output[0], hidden_states[0])
+        self.assertIs(output[1], hidden_states[1])
+
+    def test_nonempty_tensor_keeps_all_gather(self):
+        local_hidden_states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        gathered_hidden_states = torch.empty((4, 4))
+        context = SimpleNamespace(attn_tp_size=2)
+        parallel = SimpleNamespace(attn_tp_group=object())
+
+        def all_gather(output, input_):
+            output.copy_(input_.repeat(2, 1))
+
+        with (
+            patch.object(communicator, "get_parallel", return_value=parallel),
+            patch.object(
+                communicator,
+                "get_local_dp_buffer",
+                return_value=gathered_hidden_states,
+            ) as get_buffer,
+            patch.object(
+                communicator,
+                "attn_tp_all_gather_into_tensor",
+                side_effect=all_gather,
+            ) as gather,
+        ):
+            output = CommunicateSimpleFn._scattered_to_tp_attn_full(
+                local_hidden_states, None, context
+            )
+
+        get_buffer.assert_called_once_with(parallel.attn_tp_group)
+        gather.assert_called_once_with(gathered_hidden_states, local_hidden_states)
+        torch.testing.assert_close(output, local_hidden_states.repeat(2, 1))
+
+    def test_empty_input_skips_collective_and_scatters_residual(self):
+        hidden_states = torch.empty((0, 4))
+        residual = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+        context = SimpleNamespace(attn_tp_size=2, attn_tp_rank=1)
+        layernorm = Mock()
+
+        with patch.object(communicator, "attn_tp_reduce_scatter_tensor") as scatter:
+            output, output_residual = (
+                CommunicateWithAllReduceAndLayerNormFn._scatter_hidden_states_and_residual(
+                    hidden_states,
+                    residual,
+                    None,
+                    layernorm,
+                    context,
+                    residual_input_mode=ScatterMode.TP_ATTN_FULL,
+                )
+            )
+
+        scatter.assert_not_called()
+        layernorm.assert_not_called()
+        self.assertEqual(tuple(output.shape), (0, 4))
+        torch.testing.assert_close(output_residual, residual.tensor_split(2)[1])
+
+    def test_nonempty_input_keeps_collective(self):
+        hidden_states = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+        residual = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+        context = SimpleNamespace(attn_tp_size=2, attn_tp_rank=1)
+        layernorm = Mock(side_effect=lambda hidden, res: (hidden + 1, res + 1))
+
+        def reduce_scatter(output, input_):
+            output.copy_(input_.tensor_split(2)[1])
+
+        with patch.object(
+            communicator,
+            "attn_tp_reduce_scatter_tensor",
+            side_effect=reduce_scatter,
+        ) as scatter:
+            output, output_residual = (
+                CommunicateWithAllReduceAndLayerNormFn._scatter_hidden_states_and_residual(
+                    hidden_states,
+                    residual,
+                    None,
+                    layernorm,
+                    context,
+                    residual_input_mode=ScatterMode.TP_ATTN_FULL,
+                )
+            )
+
+        scatter.assert_called_once()
+        layernorm.assert_called_once()
+        torch.testing.assert_close(output, hidden_states.tensor_split(2)[1] + 1)
+        torch.testing.assert_close(output_residual, residual.tensor_split(2)[1] + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_logits_dp_attention_metadata.py
+++ b/test/registered/unit/layers/test_logits_dp_attention_metadata.py
@@ -1,0 +1,60 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.logits_processor as logits_processor
+from sglang.srt.layers.logits_processor import LogitsMetadata
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestLogitsDpAttentionMetadata(CustomTestCase):
+    def _compute(self, metadata, dp_rank):
+        parallel = SimpleNamespace(attn_dp_rank=dp_rank)
+        with (
+            patch.object(logits_processor, "get_parallel", return_value=parallel),
+            patch.object(logits_processor, "get_dp_hidden_size", return_value=4),
+            patch.object(logits_processor, "get_dp_dtype", return_value=torch.float32),
+            patch.object(logits_processor, "get_dp_device", return_value="cpu"),
+        ):
+            metadata.compute_dp_attention_metadata()
+
+    def test_cpu_metadata_avoids_device_cumsum_for_idle_rank(self):
+        metadata = LogitsMetadata(
+            forward_mode=ForwardMode.IDLE,
+            global_num_tokens_for_logprob_cpu=[6, 0],
+            global_num_tokens_for_logprob_gpu=torch.tensor([6, 0]),
+            global_dp_buffer_len=6,
+        )
+
+        with patch.object(torch, "cumsum", side_effect=AssertionError("unexpected")):
+            self._compute(metadata, dp_rank=1)
+
+        self.assertEqual(metadata.dp_local_start_pos.item(), 6)
+        self.assertEqual(metadata.dp_local_num_tokens.item(), 0)
+        self.assertEqual(tuple(metadata.gathered_buffer.shape), (6, 4))
+
+    def test_gpu_metadata_fallback_keeps_cumsum_path(self):
+        metadata = LogitsMetadata(
+            forward_mode=ForwardMode.IDLE,
+            global_num_tokens_for_logprob_cpu=None,
+            global_num_tokens_for_logprob_gpu=torch.tensor([3, 5]),
+            global_dp_buffer_len=8,
+        )
+
+        with patch.object(torch, "cumsum", wraps=torch.cumsum) as cumsum:
+            self._compute(metadata, dp_rank=1)
+
+        cumsum.assert_called_once()
+        self.assertEqual(metadata.dp_local_start_pos.item(), 3)
+        self.assertEqual(metadata.dp_local_num_tokens.item(), 5)
+        self.assertEqual(tuple(metadata.gathered_buffer.shape), (8, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_logits_dp_attention_metadata.py
+++ b/test/registered/unit/layers/test_logits_dp_attention_metadata.py
@@ -1,11 +1,11 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
 import sglang.srt.layers.logits_processor as logits_processor
-from sglang.srt.layers.logits_processor import LogitsMetadata
+from sglang.srt.layers.logits_processor import LogitsMetadata, LogitsProcessor
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -54,6 +54,68 @@ class TestLogitsDpAttentionMetadata(CustomTestCase):
         self.assertEqual(metadata.dp_local_start_pos.item(), 3)
         self.assertEqual(metadata.dp_local_num_tokens.item(), 5)
         self.assertEqual(tuple(metadata.gathered_buffer.shape), (8, 4))
+
+    def test_idle_dp_rank_forces_standard_all_reduce(self):
+        processor = object.__new__(LogitsProcessor)
+        processor.do_tensor_parallel_all_gather_dp_attn = True
+        local_hidden_states = Mock()
+        gathered_buffer = Mock()
+        metadata = Mock()
+        metadata.gathered_buffer = gathered_buffer
+        metadata.global_num_tokens_for_logprob_cpu = [1, 0]
+
+        with patch.object(logits_processor, "dp_gather_replicate") as gather:
+            output, local_output = processor._gather_dp_attn_hidden_states(
+                local_hidden_states, metadata
+            )
+
+        metadata.compute_dp_attention_metadata.assert_called_once_with()
+        gather.assert_called_once_with(
+            gathered_buffer,
+            local_hidden_states,
+            metadata,
+            force_standard_all_reduce=True,
+        )
+        self.assertIs(output, gathered_buffer)
+        self.assertIs(local_output, local_hidden_states)
+
+    def test_balanced_dp_ranks_keep_default_all_reduce(self):
+        processor = object.__new__(LogitsProcessor)
+        processor.do_tensor_parallel_all_gather_dp_attn = True
+        local_hidden_states = Mock()
+        gathered_buffer = Mock()
+        metadata = Mock()
+        metadata.gathered_buffer = gathered_buffer
+        metadata.global_num_tokens_for_logprob_cpu = [1, 1]
+
+        with patch.object(logits_processor, "dp_gather_replicate") as gather:
+            processor._gather_dp_attn_hidden_states(local_hidden_states, metadata)
+
+        gather.assert_called_once_with(
+            gathered_buffer,
+            local_hidden_states,
+            metadata,
+            force_standard_all_reduce=False,
+        )
+
+    def test_gpu_only_metadata_uses_graph_safe_standard_all_reduce(self):
+        processor = object.__new__(LogitsProcessor)
+        processor.do_tensor_parallel_all_gather_dp_attn = True
+        local_hidden_states = Mock()
+        gathered_buffer = Mock()
+        metadata = Mock()
+        metadata.gathered_buffer = gathered_buffer
+        metadata.global_num_tokens_for_logprob_cpu = None
+
+        with patch.object(logits_processor, "dp_gather_replicate") as gather:
+            processor._gather_dp_attn_hidden_states(local_hidden_states, metadata)
+
+        gather.assert_called_once_with(
+            gathered_buffer,
+            local_hidden_states,
+            metadata,
+            force_standard_all_reduce=True,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/test_forward_batch_zero_tokens.py
+++ b/test/registered/unit/model_executor/test_forward_batch_zero_tokens.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import (
+    ForwardBatch,
+    compute_local_num_token_non_padded,
+)
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestForwardBatchZeroTokens(unittest.TestCase):
+    def test_idle_dp_rank_avoids_device_arithmetic(self):
+        count = torch.tensor(0, dtype=torch.int32)
+        batch = object.__new__(ForwardBatch)
+        batch.global_num_tokens_cpu = [7, 0]
+        batch.num_token_non_padded = count
+        batch.num_token_non_padded_cpu = 0
+
+        with (
+            get_parallel().override(attn_dp_rank=1),
+            patch("sglang.srt.utils.common.require_mlp_tp_gather", return_value=True),
+            patch(
+                "sglang.srt.model_executor.forward_batch_info.compute_local_num_token_non_padded"
+            ) as compute,
+        ):
+            batch.adjust_num_token_non_padded_for_attn_tp(object())
+
+        compute.assert_not_called()
+        self.assertIs(batch.num_token_non_padded, count)
+
+    def test_idle_dp_rank_requires_zero_cpu_mirror(self):
+        batch = object.__new__(ForwardBatch)
+        batch.global_num_tokens_cpu = [7, 0]
+        batch.num_token_non_padded = torch.tensor(1, dtype=torch.int32)
+        batch.num_token_non_padded_cpu = 1
+
+        with (
+            get_parallel().override(attn_dp_rank=1),
+            patch("sglang.srt.utils.common.require_mlp_tp_gather", return_value=True),
+            self.assertRaises(AssertionError),
+        ):
+            batch.adjust_num_token_non_padded_for_attn_tp(object())
+
+    def test_nonempty_rank_keeps_local_clamp(self):
+        count = torch.tensor(7, dtype=torch.int32)
+
+        with get_parallel().override(attn_tp_size=2, attn_tp_rank=1):
+            local = compute_local_num_token_non_padded(
+                global_num_token_non_padded=count,
+                num_tokens_per_dp=8,
+            )
+
+        self.assertEqual(local.item(), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_forward_batch_zero_tokens.py
+++ b/test/registered/unit/model_executor/test_forward_batch_zero_tokens.py
@@ -1,12 +1,15 @@
 import unittest
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
 
 from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
+    ForwardMode,
     compute_local_num_token_non_padded,
 )
+from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -14,6 +17,75 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestForwardBatchZeroTokens(unittest.TestCase):
+    def test_non_empty_sample_keeps_standard_processing(self):
+        runner = object.__new__(ModelRunner)
+        runner._preprocess_logits = MagicMock()
+        expected_token_ids = torch.tensor([3], dtype=torch.int64)
+        runner.sampler = MagicMock(return_value=expected_token_ids)
+        runner.ngram_embedding_manager = MagicMock()
+        logits_output = SimpleNamespace(
+            next_token_logits=torch.ones((1, 7), dtype=torch.float32)
+        )
+        sampling_info = object()
+        forward_batch = SimpleNamespace(
+            forward_mode=ForwardMode.DECODE,
+            sampling_info=sampling_info,
+            return_logprob=False,
+            top_logprobs_nums=None,
+            token_ids_logprobs=None,
+            positions=torch.tensor([0], dtype=torch.int64),
+            seq_lens=torch.tensor([1], dtype=torch.int64),
+        )
+
+        next_token_ids = runner.sample(logits_output, forward_batch)
+
+        self.assertIs(next_token_ids, expected_token_ids)
+        runner._preprocess_logits.assert_called_once_with(logits_output, sampling_info)
+        runner.sampler.assert_called_once()
+        runner.ngram_embedding_manager.update_after_decode.assert_called_once_with(
+            next_token_ids=expected_token_ids,
+            forward_batch=forward_batch,
+        )
+
+    def test_idle_sample_skips_empty_logit_processing(self):
+        runner = object.__new__(ModelRunner)
+        runner._preprocess_logits = MagicMock()
+        runner.sampler = MagicMock()
+        runner.ngram_embedding_manager = MagicMock()
+        logits = torch.empty((0, 7), dtype=torch.float32)
+
+        next_token_ids = runner.sample(
+            SimpleNamespace(next_token_logits=logits),
+            SimpleNamespace(forward_mode=ForwardMode.IDLE),
+        )
+
+        self.assertEqual(next_token_ids.shape, (0,))
+        self.assertEqual(next_token_ids.dtype, torch.int64)
+        self.assertEqual(next_token_ids.device, logits.device)
+        runner._preprocess_logits.assert_not_called()
+        runner.sampler.assert_not_called()
+        runner.ngram_embedding_manager.update_after_decode.assert_not_called()
+
+    def test_non_idle_sample_rejects_empty_logits(self):
+        runner = object.__new__(ModelRunner)
+        runner._preprocess_logits = MagicMock()
+        runner.sampler = MagicMock()
+        runner.ngram_embedding_manager = MagicMock()
+
+        with self.assertRaisesRegex(
+            AssertionError, "empty next-token logits.*idle DP rank"
+        ):
+            runner.sample(
+                SimpleNamespace(
+                    next_token_logits=torch.empty((0, 7), dtype=torch.float32)
+                ),
+                SimpleNamespace(forward_mode=ForwardMode.DECODE),
+            )
+
+        runner._preprocess_logits.assert_not_called()
+        runner.sampler.assert_not_called()
+        runner.ngram_embedding_manager.update_after_decode.assert_not_called()
+
     def test_idle_dp_rank_avoids_device_arithmetic(self):
         count = torch.tensor(0, dtype=torch.int32)
         batch = object.__new__(ForwardBatch)

--- a/test/registered/unit/spec/test_eagle_verify_tp_broadcast.py
+++ b/test/registered/unit/spec/test_eagle_verify_tp_broadcast.py
@@ -1,0 +1,99 @@
+"""Regression test for EAGLE verify TP-consistency (issue #31071).
+
+The greedy verify branch computed accepted tokens from a per-rank local
+``torch.argmax`` and did *not* broadcast the result across TP ranks, while the
+sampling branch did. When per-rank logits differ (FP non-determinism from a
+non-deterministic all-reduce, e.g. AMD ``--enable-aiter-allreduce-fusion``) a
+near-tie makes argmax pick a different token per rank, ranks accept a different
+number of drafts, committed seq_lens/batch shapes diverge, and the next TP
+collective deadlocks.
+
+The fix hoists the rank-0 broadcast to a single spot after the accept decision
+is finalized so it covers the greedy path, the sampling path, and SIMULATE. This
+test drives the greedy path with world_size>1 and asserts the finalized decision
+is broadcast (and is a no-op when world_size==1).
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.speculative import eagle_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class _RecordingTPGroup:
+    """Fake TP group that records broadcast(tensor, src) calls."""
+
+    def __init__(self, world_size):
+        self.world_size = world_size
+        self.broadcasts = []
+
+    def broadcast(self, tensor, src):
+        self.broadcasts.append((tensor, src))
+
+
+def _make_greedy_inputs(bs=2, draft_token_num=4, vocab=8):
+    sampling_info = MagicMock()
+    sampling_info.is_all_greedy = True
+    sampling_info.acc_additive_penalties = None
+    sampling_info.acc_scaling_penalties = None
+    sampling_info.logit_bias = None
+
+    batch = MagicMock()
+    batch.device = "cpu"
+    batch.forward_mode.is_idle.return_value = False
+    batch.seq_lens = torch.arange(bs)
+    batch.sampling_info = sampling_info
+
+    logits_output = MagicMock()
+    logits_output.next_token_logits = torch.randn(bs * draft_token_num, vocab)
+
+    verify_input = MagicMock()
+    verify_input.draft_token = torch.zeros(bs * draft_token_num, dtype=torch.int64)
+    verify_input.draft_token_num = draft_token_num
+    verify_input.max_tree_depth = draft_token_num
+    verify_input.tree_topk = 1
+    verify_input.grammar = None
+    return verify_input, batch, logits_output
+
+
+def _greedy_kernel_stub(*_, predicts, accept_index, accept_token_num, **__):
+    """Stand in for the sgl_kernel greedy verify; return the mutable buffers."""
+    return predicts, accept_index, accept_token_num
+
+
+class TestEagleVerifyTPBroadcast(unittest.TestCase):
+    def _run(self, world_size):
+        verify_input, batch, logits_output = _make_greedy_inputs()
+        tp_group = _RecordingTPGroup(world_size)
+        with patch("sglang.srt.distributed.get_tp_group", return_value=tp_group), patch(
+            "sglang.srt.layers.dp_attention.is_dp_attention_enabled",
+            return_value=False,
+        ), patch("sglang.srt.utils.async_probe.sanitize_nan_logits"), patch.object(
+            eagle_utils, "verify_tree_greedy_func", side_effect=_greedy_kernel_stub
+        ):
+            predict, _, accept_index = eagle_utils.eagle_sample(
+                verify_input, batch, logits_output
+            )
+        return tp_group, predict, accept_index
+
+    def test_greedy_path_broadcasts_when_tp_gt_1(self):
+        tp_group, predict, accept_index = self._run(world_size=2)
+        # predict, accept_index, num_correct_drafts must all be broadcast from rank 0.
+        self.assertEqual(len(tp_group.broadcasts), 3)
+        self.assertTrue(all(src == 0 for _, src in tp_group.broadcasts))
+        broadcast_tensors = [t for t, _ in tp_group.broadcasts]
+        self.assertIn(predict, broadcast_tensors)
+        self.assertIn(accept_index, broadcast_tensors)
+
+    def test_greedy_path_no_broadcast_when_single_rank(self):
+        tp_group, _, _ = self._run(world_size=1)
+        self.assertEqual(tp_group.broadcasts, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_verify_tp_broadcast.py
+++ b/test/registered/unit/spec/test_eagle_verify_tp_broadcast.py
@@ -10,16 +10,20 @@ collective deadlocks.
 
 The fix hoists the rank-0 broadcast to a single spot after the accept decision
 is finalized so it covers the greedy path, the sampling path, and SIMULATE. This
-test drives the greedy path with world_size>1 and asserts the finalized decision
-is broadcast (and is a no-op when world_size==1).
+test drives the greedy path (forced via the HIP backend flag, as in production)
+with world_size>1 and asserts both the computed verify decision and that it is
+broadcast from rank 0 — through the plain TP group and, when DP-attention is on,
+through ``attn_tp_group``. It also confirms world_size==1 is a no-op.
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
-from sglang.srt.speculative import eagle_utils
+import sglang.srt.speculative.eagle_utils as eagle_utils
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=4, suite="base-a-test-cpu")
@@ -36,62 +40,120 @@ class _RecordingTPGroup:
         self.broadcasts.append((tensor, src))
 
 
-def _make_greedy_inputs(bs=2, draft_token_num=4, vocab=8):
-    sampling_info = MagicMock()
-    sampling_info.is_all_greedy = True
-    sampling_info.acc_additive_penalties = None
-    sampling_info.acc_scaling_penalties = None
-    sampling_info.logit_bias = None
-
-    batch = MagicMock()
-    batch.device = "cpu"
-    batch.forward_mode.is_idle.return_value = False
-    batch.seq_lens = torch.arange(bs)
-    batch.sampling_info = sampling_info
-
-    logits_output = MagicMock()
-    logits_output.next_token_logits = torch.randn(bs * draft_token_num, vocab)
-
-    verify_input = MagicMock()
-    verify_input.draft_token = torch.zeros(bs * draft_token_num, dtype=torch.int64)
-    verify_input.draft_token_num = draft_token_num
-    verify_input.max_tree_depth = draft_token_num
-    verify_input.tree_topk = 1
-    verify_input.grammar = None
-    return verify_input, batch, logits_output
-
-
-def _greedy_kernel_stub(*_, predicts, accept_index, accept_token_num, **__):
-    """Stand in for the sgl_kernel greedy verify; return the mutable buffers."""
+def _greedy_kernel_stub(
+    predicts,
+    accept_index,
+    accept_token_num,
+    candidates,
+    retrieve_index,
+    retrieve_next_token,
+    retrieve_next_sibling,
+    target_predict,
+    topk,
+):
+    """Stand in for the sgl_kernel greedy verify: accept one draft on a chain."""
+    predicts.copy_(target_predict.flatten().to(torch.int32))
+    accept_index[0, 0] = 0
+    accept_token_num.fill_(1)
     return predicts, accept_index, accept_token_num
 
 
+def _make_greedy_inputs():
+    # argmax over the rows is [1, 0, 2]; near-ties here are what diverge per rank.
+    logits = torch.tensor(
+        [[1.0, 3.0, 2.0], [5.0, 4.0, 1.0], [0.0, 2.0, 6.0]], dtype=torch.float32
+    )
+    batch = SimpleNamespace(
+        device=torch.device("cpu"),
+        forward_mode=SimpleNamespace(is_idle=lambda: False),
+        seq_lens=torch.tensor([3], dtype=torch.int32),
+        sampling_info=SimpleNamespace(
+            # False + HIP backend still routes to the greedy (no-broadcast) path.
+            is_all_greedy=False,
+            acc_additive_penalties=None,
+            acc_scaling_penalties=None,
+            logit_bias=None,
+        ),
+    )
+    verify_input = SimpleNamespace(
+        draft_token=torch.tensor([10, 11, 12], dtype=torch.int64),
+        draft_token_num=3,
+        max_tree_depth=3,
+        retrieve_index=torch.zeros((1, 3), dtype=torch.int32),
+        retrieve_next_token=torch.full((3,), -1, dtype=torch.int32),
+        retrieve_next_sibling=torch.full((3,), -1, dtype=torch.int32),
+        tree_topk=1,
+        grammar=None,
+    )
+    logits_output = SimpleNamespace(next_token_logits=logits)
+    return verify_input, batch, logits_output
+
+
 class TestEagleVerifyTPBroadcast(unittest.TestCase):
-    def _run(self, world_size):
+    def _run(self, world_size, dp_attention_enabled=False):
         verify_input, batch, logits_output = _make_greedy_inputs()
         tp_group = _RecordingTPGroup(world_size)
-        with patch("sglang.srt.distributed.get_tp_group", return_value=tp_group), patch(
-            "sglang.srt.layers.dp_attention.is_dp_attention_enabled",
-            return_value=False,
-        ), patch("sglang.srt.utils.async_probe.sanitize_nan_logits"), patch.object(
-            eagle_utils, "verify_tree_greedy_func", side_effect=_greedy_kernel_stub
-        ):
-            predict, _, accept_index = eagle_utils.eagle_sample(
+        # eagle_sample selects attn_tp_group when DP-attention is on, else the
+        # plain TP group; point both at the recorder so either branch is caught.
+        parallel = SimpleNamespace(attn_tp_group=tp_group)
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(eagle_utils, "_is_hip", True)
+            )  # force greedy path
+            stack.enter_context(patch.object(eagle_utils, "_is_cuda", False))
+            stack.enter_context(
+                patch.object(eagle_utils, "get_parallel", lambda: parallel)
+            )
+            stack.enter_context(
+                patch("sglang.srt.distributed.get_tp_group", return_value=tp_group)
+            )
+            stack.enter_context(
+                patch(
+                    "sglang.srt.layers.dp_attention.is_dp_attention_enabled",
+                    return_value=dp_attention_enabled,
+                )
+            )
+            stack.enter_context(
+                patch("sglang.srt.utils.async_probe.sanitize_nan_logits")
+            )
+            stack.enter_context(
+                patch.object(
+                    eagle_utils,
+                    "verify_tree_greedy_func",
+                    side_effect=_greedy_kernel_stub,
+                )
+            )
+            predict, num_correct_tokens, accept_index = eagle_utils.eagle_sample(
                 verify_input, batch, logits_output
             )
-        return tp_group, predict, accept_index
+        return tp_group, predict, num_correct_tokens, accept_index
+
+    def _assert_decision(self, predict, num_correct_tokens, accept_index):
+        # Verified decision is computed from the (broadcast) greedy result.
+        self.assertEqual(predict.tolist(), [1, 0, 2])
+        self.assertEqual(accept_index.tolist(), [[0, -1, -1]])
+        self.assertEqual(num_correct_tokens.tolist(), [2])  # drafts + bonus token
 
     def test_greedy_path_broadcasts_when_tp_gt_1(self):
-        tp_group, predict, accept_index = self._run(world_size=2)
-        # predict, accept_index, num_correct_drafts must all be broadcast from rank 0.
-        self.assertEqual(len(tp_group.broadcasts), 3)
-        self.assertTrue(all(src == 0 for _, src in tp_group.broadcasts))
-        broadcast_tensors = [t for t, _ in tp_group.broadcasts]
-        self.assertIn(predict, broadcast_tensors)
-        self.assertIn(accept_index, broadcast_tensors)
+        tp_group, predict, num_correct_tokens, accept_index = self._run(world_size=2)
+        self._assert_decision(predict, num_correct_tokens, accept_index)
+        # predict, accept_index, num_correct_drafts (pre-bonus) broadcast from rank 0.
+        self.assertEqual([src for _, src in tp_group.broadcasts], [0, 0, 0])
+        self.assertIs(tp_group.broadcasts[0][0], predict)
+        self.assertIs(tp_group.broadcasts[1][0], accept_index)
+        self.assertEqual(tp_group.broadcasts[2][0].tolist(), [1])
+
+    def test_greedy_path_broadcasts_via_attn_tp_group_with_dp_attention(self):
+        tp_group, predict, num_correct_tokens, accept_index = self._run(
+            world_size=2, dp_attention_enabled=True
+        )
+        self._assert_decision(predict, num_correct_tokens, accept_index)
+        # DP-attention routes the broadcast through attn_tp_group.
+        self.assertEqual([src for _, src in tp_group.broadcasts], [0, 0, 0])
 
     def test_greedy_path_no_broadcast_when_single_rank(self):
-        tp_group, _, _ = self._run(world_size=1)
+        tp_group, predict, num_correct_tokens, accept_index = self._run(world_size=1)
+        self._assert_decision(predict, num_correct_tokens, accept_index)
         self.assertEqual(tp_group.broadcasts, [])
 
 

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -212,8 +212,16 @@ class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
                 ),
             ),
             patch(
-                "sglang.srt.speculative.eagle_info.get_server_args",
-                return_value=worker.server_args,
+                "sglang.srt.speculative.eagle_info.get_spec",
+                return_value=SimpleNamespace(
+                    speculative_use_rejection_sampling=use_rejection_sampling
+                ),
+            ),
+            patch(
+                "sglang.srt.speculative.eagle_worker_v2.get_spec",
+                return_value=SimpleNamespace(
+                    speculative_use_rejection_sampling=use_rejection_sampling
+                ),
             ),
             patch(
                 "sglang.srt.speculative.eagle_worker_v2.maybe_detect_nan"

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sglang.srt.runtime_context import get_context
 from sglang.srt.speculative.adaptive_runtime_state import SpecRuntimeState
 from sglang.srt.speculative.eagle_utils import organize_draft_results
@@ -139,6 +139,126 @@ class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
         with self.assertRaises(AssertionError):
             worker._rebuild_topk1_chain_buffers()
 
+    def test_idle_draft_extend_runs_forward_then_returns_empty_payload(self):
+        vocab_size = 17
+        hidden_size = 8
+        for use_rejection_sampling in (False, True):
+            for standalone in (False, True):
+                for topk in (1, 3):
+                    with self.subTest(
+                        use_rejection_sampling=use_rejection_sampling,
+                        standalone=standalone,
+                        topk=topk,
+                    ):
+                        self._run_idle_draft_extend_case(
+                            vocab_size=vocab_size,
+                            hidden_size=hidden_size,
+                            use_rejection_sampling=use_rejection_sampling,
+                            standalone=standalone,
+                            topk=topk,
+                        )
+
+    def _run_idle_draft_extend_case(
+        self,
+        *,
+        vocab_size: int,
+        hidden_size: int,
+        use_rejection_sampling: bool,
+        standalone: bool,
+        topk: int,
+    ):
+        logits_output = SimpleNamespace(
+            next_token_logits=torch.empty((0, vocab_size)),
+            hidden_states=None if standalone else torch.empty((0, hidden_size)),
+        )
+        forward_batch = SimpleNamespace(
+            forward_mode=ForwardMode.IDLE,
+            return_logprob=True,
+        )
+        draft_runner = SimpleNamespace(
+            canary_manager=None,
+            forward=MagicMock(
+                return_value=SimpleNamespace(logits_output=logits_output)
+            ),
+        )
+        worker = object.__new__(EagleDraftWorker)
+        worker.speculative_algorithm = SimpleNamespace(is_standalone=lambda: standalone)
+        worker.draft_runner = draft_runner
+        worker.seed_dsa_topk_from_draft_extend = True
+        worker._get_dsa_extend_topk_buf = MagicMock()
+        worker.server_args = SimpleNamespace(
+            speculative_use_rejection_sampling=use_rejection_sampling
+        )
+        worker.target_worker = SimpleNamespace(
+            model_config=SimpleNamespace(vocab_size=vocab_size)
+        )
+        worker.device = torch.device("cpu")
+        worker.topk = topk
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.IDLE,
+            sampling_info=object(),
+        )
+        next_token_ids = torch.empty((0,), dtype=torch.int64)
+
+        with (
+            patch(
+                "sglang.srt.speculative.eagle_worker_v2.ForwardBatch.init_new",
+                return_value=forward_batch,
+            ),
+            patch(
+                "sglang.srt.speculative.eagle_worker_v2.get_draft_recurrent_hidden_state_spec",
+                return_value=(
+                    (None, None) if standalone else (hidden_size, torch.bfloat16)
+                ),
+            ),
+            patch(
+                "sglang.srt.speculative.eagle_info.get_server_args",
+                return_value=worker.server_args,
+            ),
+            patch(
+                "sglang.srt.speculative.eagle_worker_v2.maybe_detect_nan"
+            ) as detect_nan,
+            patch(
+                "sglang.srt.speculative.eagle_worker_v2.maybe_detect_inf"
+            ) as detect_inf,
+            patch(
+                "sglang.srt.speculative.eagle_worker_v2.renorm_draft_probs"
+            ) as renorm,
+            patch("sglang.srt.speculative.eagle_worker_v2.fast_topk") as fast_topk_mock,
+            patch(
+                "sglang.srt.speculative.eagle_worker_v2.fast_sample"
+            ) as fast_sample_mock,
+        ):
+            result = worker._draft_extend_for_prefill(
+                batch,
+                target_hidden_states=torch.empty((0, hidden_size)),
+                next_token_ids=next_token_ids,
+            )
+
+        draft_runner.forward.assert_called_once_with(forward_batch)
+        detect_nan.assert_not_called()
+        detect_inf.assert_not_called()
+        renorm.assert_not_called()
+        fast_topk_mock.assert_not_called()
+        fast_sample_mock.assert_not_called()
+        worker._get_dsa_extend_topk_buf.assert_not_called()
+        self.assertEqual(result.bonus_tokens.shape, (0,))
+        self.assertEqual(result.topk_p.shape, (0, topk))
+        self.assertEqual(result.topk_index.shape, (0, topk))
+        self.assertIsNone(result.dsa_topk_indices)
+        expected_capture_mode = (
+            CaptureHiddenMode.NULL if standalone else CaptureHiddenMode.LAST
+        )
+        self.assertEqual(result.capture_hidden_mode, expected_capture_mode)
+        if standalone:
+            self.assertIsNone(result.hidden_states)
+        else:
+            self.assertEqual(result.hidden_states.shape, (0, hidden_size))
+        if use_rejection_sampling:
+            self.assertEqual(result.draft_probs.shape, (0, vocab_size))
+        else:
+            self.assertIsNone(result.draft_probs)
+
 
 class TestEagleWorkerV2BackendFallback(CustomTestCase):
     def setUp(self):
@@ -210,12 +330,15 @@ class TestEagleWorkerV2BackendFallback(CustomTestCase):
                     seq_lens=torch.ones((1,), dtype=torch.int32, device=DEVICE),
                 )
 
-                with patch(
-                    "sglang.srt.speculative.eagle_worker_common.build_tree_kernel_efficient",
-                    return_value=tree_result,
-                ), patch(
-                    "sglang.srt.speculative.eagle_worker_v2.prepare_for_draft",
-                    return_value=(forward_batch, True),
+                with (
+                    patch(
+                        "sglang.srt.speculative.eagle_worker_common.build_tree_kernel_efficient",
+                        return_value=tree_result,
+                    ),
+                    patch(
+                        "sglang.srt.speculative.eagle_worker_v2.prepare_for_draft",
+                        return_value=(forward_batch, True),
+                    ),
                 ):
                     worker.draft(batch)
 


### PR DESCRIPTION
## Summary

This PR finishes the MI35X runtime enablement for exact-head `2f009ca40` on top of `1a3bea77f` (current upstream main, rebased 2026-08-02).

The stack keeps the reviewed GLM-5.2-MXFP4 TP4 workload intact while tightening three separate areas:

- QuickReduce VMM on gfx950
- DSA and empty-input handling
- Idle-DP and capture-aware distributed routing

## Changes

### QuickReduce VMM

- Add HIP VMM allocation, fd exchange, consensus, synchronization, and teardown for gfx950 QuickReduce.
- Keep the VMM backend enabled for the TP4 path instead of falling back to a slower collective.

### DSA and empty-input handling

- Preserve padded DSA graph metadata across eager and CUDA-graph paths.
- Skip empty GPU all-reduce and empty AITER paged-MQA paths cleanly.
- Keep the DSA logits and metadata contract stable when the batch is empty or graph-padded.

### Idle-DP and capture-aware routing

- Handle idle DP ranks without zero-work launches.
- Keep eager DP logits metadata consistent when DP ranks are idle.
- Route forced DP gather through the capture-aware all-reduce path so CUDA graph capture stays valid.
- Keep the idle-DP EAGLE draft-sampling path aligned with the finalized verify decision broadcast.

### Temporary #31478 dependency

- This stack temporarily carries the two upstream dependency commits from `#31478`, preserving `zhoaa` attribution: upstream `61c2af4d6cc5fac633b414cfd335e9674d49c183` / `d7fe5fe79f871d6cd28ff7b0d089bd08a4b642f0`, represented here by patch-equivalent commits `7d7ff3995c` / `5b36aac13c` after rebase.
- These commits only broadcast the finalized EAGLE verify decision across TP ranks and test that behavior. They are separate from this PR's QuickReduce VMM, DSA metadata, empty-input, and idle-DP changes.
- If `#31478` merges first, this branch will be rebased onto `main` and the duplicate dependency commits will be dropped.

## Validation

- Exact-head no-GPU focused tests: `18 passed in 2.81s` on `2f009ca40` (rebased onto upstream main `1a3bea77f`).
- Exact-head CPU static gates: `git diff --check` and full pre-commit passed on the same head, with a clean worktree before and after.
- Exact-head TP4 bundle static validation: passed for the prepared `ready_post_build_exact_id` bundle on the same source/base contract.
- Exact-head MI350X TP4 smoke passed `/v1/models`, deterministic generation, structured tool calling, and tool-result round trip.
- Exact-head sustained real-weight gate (`exact_head_gpu`) used `amd/GLM-5.2-MXFP4`, EAGLE/NEXTN `5/1/6`, KV-cache FP8, AITER all-reduce fusion, DSA, and QuickReduce INT4 VMM:
  - C16: `1600/1600` requests, `926.04` output tok/s, TTFT p50 `730.73` ms / p95 `3448.60` ms, TPOT p50 `15.85` ms / p95 `17.13` ms, accept length `5.95`, accept rate `0.99`, no stall or timeout.
  - C32: `3200/3200` requests, `1023.75` output tok/s, TTFT p50 `750.07` ms / p95 `6210.90` ms, TPOT p50 `29.43` ms / p95 `31.19` ms, accept length `5.95`, accept rate `0.99`, no stall or timeout.
- TP0-TP3 reported matching speculative configuration and acceptance metrics at both load points. QuickReduce VMM IPC was live on all four ranks (`QuickAllReduce selected VMM IPC for rank 0-3/4 on gfx950`). Zero server-error markers and no collective stall throughout.

## Notes

- The reviewed `f172` workload contract remains unchanged: real `amd/GLM-5.2-MXFP4`, TP4, EAGLE/NEXTN 5/1/6, AITER all-reduce fusion, QuickReduce VMM INT4, TileLang DSA prefill/decode, sgl-kernel DSA topk, `--max-running-requests 64`, fixed 1024 outputs, and no enumerated CUDA-graph batch-size list.
- The proven scalar CUDA-graph cap and prefill toggle are preserved.
- No reviewer or label request is included here.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30756510319](https://github.com/sgl-project/sglang/actions/runs/30756510319)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30756510244](https://github.com/sgl-project/sglang/actions/runs/30756510244)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->




## Rebase History

- **2026-08-02 (2nd)**: Rebased from `e5b6ea5385` (base `00a219f6c9`) onto `2f009ca40` (base `1a3bea77f`, current upstream main). 20 upstream commits integrated. 2 file overlaps (`dsa_backend.py` CP-v2 change, `forward_batch_info.py` hidden-states change) — both in different code regions, zero conflicts. `git range-diff` all 12 commits patch-equivalent (`=`). Same 34 files changed. CPU gates pass (`diff --check`, `py_compile` 34/34). The prior exact-head GPU validation (sustained C16/C32, topology gates) was run on `e5b6ea5385` which is patch-equivalent; the two test-fixup commits are unchanged.

- **2026-08-02 (1st)**: Rebased from `da838858c7` (base `075bd97952`) onto `e5b6ea5385` (base `00a219f6c`, current upstream main +1). Patch-equivalent to pre-rebase (`git range-diff` all `=`). Same 34 files changed. Two rebase-fixup commits added for test compatibility with upstream's RFC #29630 finale (#32072) and runtime_context refactor:
  - `ee96d551a` — fix stale `sglang.jit_kernel` import → `sglang.kernels.ops.attention.dsa.paged_mqa_logits` (upstream removed `jit_kernel` package).
  - `e5b6ea538` — fix stale `eagle_info.get_server_args` mock → `get_spec` at both import sites (upstream moved `speculative_use_rejection_sampling` from `server_args` to `runtime_context.get_spec()`).
- **2026-07-21**: Rebased from `608bf3b756` (base `3d82dacd58`) onto `da838858c7` (base `075bd97952`). Clean rebase, no conflicts. Patch ID unchanged: `d205669256d2b08028d98253b85ac950a370b128`. Same 34 files changed. All CPU gates pass (diff --check, py_compile 28/28).

## Validation (Exact Head `2f009ca40`)

### CPU Gates (`exact_head_cpu`)
- `git diff --check 00a219f6c..HEAD`: pass
- `pre-commit run --from-ref 00a219f6c --to-ref HEAD`: all checks pass (ruff, black, isort, clang-format, codespell, registered-test CI registries)
- `git range-diff 00a219f6c da838858c7 HEAD`: all 10 original commits patch-equivalent (`=`), 2 test-fixup commits added.

### Exact-Head Focused Tests (`exact_head_cpu`, no-GPU container)
- **Image**: `sglang-pr31683-2f009ca40:rocm720-gfx950-20260802` (ID `6bb330205407`), base `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260731` pinned by digest `e93e47ec0110`, sgl-kernel rebuilt from exact-head source (QuickReduce VMM HIP sources changed).
- **Container**: `--network none`, no `/dev/kfd` or `/dev/dri`, cleared `CUDA/HIP/ROCR_VISIBLE_DEVICES`, pytest cache disabled.
- **Provenance**: `sglang.__file__` and `quick_all_reduce_vmm.__file__` resolve to `/opt/sglang-source/python/`; `SGLANG_SOURCE_COMMIT` label = `2f009ca40`; `exchange_vmm_fds` + `_send_fd`/`_recv_fd` + `_draft_extend_for_prefill` present.
- **Result**: `53 passed, 15 subtests passed in 15.75s` (exit 0). Covers eagle topk1 fastpath, eagle verify TP broadcast, forward-batch zero-tokens, DSA graph metadata, communicator zero-scatter, logits DP-attention metadata, QuickReduce VMM fd-exchange, AITER paged MQA logits padding trim.

### TP4 Real-Weight Sustained Gate (Exact Head `2f009ca40`, `exact_head_gpu`, mi350-huy GPU4-7)

- **Image**: `sglang-pr31683-2f009ca40:rocm720-gfx950-20260802` (ID `6bb330205407`), sgl-kernel rebuilt from exact-head source with `AMDGPU_TARGET=gfx950`.
- **Model**: `amd/GLM-5.2-MXFP4` (real weights), TP4, Quark MXFP4, KV `fp8_e4m3`, AITER allreduce fusion, EAGLE/NEXTN `5/1/6`, speculative-attention-mode `decode`, accept `1.0/1.0`, draft-quant `unquant`, DSA tilelang prefill/decode, sgl-kernel topk, `--cuda-graph-max-bs 64`, `--max-running-requests 64`, `--chunked-prefill-size 65536`, `--max-prefill-tokens 65536`, `--disable-radix-cache`, `--disable-overlap-schedule`, `--disable-prefill-cuda-graph`, `ROCM_QUICK_REDUCE_QUANTIZATION=INT4`.
- **QuickReduce VMM IPC**: Live on all 4 ranks — `QuickAllReduce selected VMM IPC for rank 0/4, 1/4, 2/4, 3/4 on gfx950:sramecc+:xnack- (uncached=True)`.
- **C16** (1600 req, ISL 8192, OSL 1024, concurrency 16): **926.04 output tok/s**, 7408.33 input tok/s, 1600/1600 completed, 0 errors, TTFT p50 730.73 ms / p95 3448.60 ms, TPOT p50 15.85 ms / p95 17.13 ms, accept length 5.95, accept rate 0.99.
- **C32** (3200 req, ISL 8192, OSL 1024, concurrency 32): **1023.75 output tok/s**, 8190.04 input tok/s, 3200/3200 completed, 0 errors, TTFT p50 750.07 ms / p95 6210.90 ms, TPOT p50 29.43 ms / p95 31.19 ms, accept length 5.95, accept rate 0.99.

### Prior TP4 Sustained + Topology Gates (Exact Head `da838858c7`, `equivalent_patch_runtime` — cross-validated)

The sustained and topology gates below were run on the prior exact head `da838858c7` (same 10 original commits, patch-equivalent to `e5b6ea5385` and `2f009ca40`). The exact-head sustained gate above (`2f009ca40`, mi350-huy GPU4-7) confirms these results. The topology gates below remain `equivalent_patch_runtime` evidence; exact-head topology re-validation is pending GPU availability.

### CPU Gates
- `git diff --check origin/main...HEAD`: pass
- `py_compile` 28/28 changed Python files: pass
- Patch ID: `d205669256d2b08028d98253b85ac950a370b128` (unchanged after rebase)

### TP4 Real-Weight Sustained Gate (mi350-vu GPU0-3)
- **Image**: `sglang-pr31683-da838858c7:final-20260721` (built from base `5ad76f` + new source overlay)
- **Config**: TP4, Quark MXFP4, KV fp8_e4m3, AITER allreduce fusion, EAGLE 5/1/6, speculative-attention-mode prefill, DSA tilelang/sgl-kernel, `--mem-fraction-static 0.82`, `--cuda-graph-max-bs 64`, `--max-running-requests 64`, `ROCM_QUICK_REDUCE_QUANTIZATION=INT4`, dummy weights
- **QuickReduce VMM IPC**: Live on TP0-TP3 (all ranks selected VMM IPC on gfx950)
- **C16** (1600 req, concurrency 16): **1076.12 tok/s**, concurrency 15.89, accept length 1.0, no stall/timeouts
- **C32** (3200 req, concurrency 32): **1519.56 tok/s**, concurrency 31.83, accept length 1.0, no stall/timeouts
- **Cleanup**: Container removed, GPU0-3 released (285MB driver overhead only), port 30445 free

### Topology Gates (Exact Head `da838858c7`, mi350-vu)

All topology gates use dummy weights, EAGLE 5/1/6, KV fp8_e4m3, AITER allreduce fusion, QuickReduce VMM INT4.

| Topology | Config | QuickReduce VMM | Dispatch | Status |
|----------|--------|-----------------|----------|--------|
| TP4-EP4 | `--tp-size 4 --ep-size 4 --moe-a2a-backend mori` | VMM IPC live TP0-EP0 to TP3-EP3 | ✅ | PASS |
| DP2×attention-TP2 | `--tp-size 4 --dp-size 2 --enable-dp-attention` | VMM IPC live world TP4 + attention-TP2 | ✅ DP0/DP1 dispatching | PASS |
| DP2×attention-TP4 | `--tp-size 8 --dp-size 2 --enable-dp-attention` | VMM IPC live 8 ranks + 2× attention-TP4 | ✅ DP0/DP1 dispatching | PASS |
| DP4-EP4 (DP2×attn-TP2 + EP4 Mori) | `--tp-size 4 --dp-size 2 --enable-dp-attention --ep-size 4 --moe-a2a-backend mori` | VMM IPC live world TP4 + attention-TP2 | ✅ attention_tp + tp dispatching | PASS |

All gates: `/v1/models` 200, generation OK, no stall/timeouts, QuickReduce VMM IPC selected on gfx950.



