### PR TITLE
feat(gateway): support /abort_request in sgl-model-gateway

### DIFF
--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -346,12 +346,18 @@ impl Router {
         worker_url.to_string()
     }
 
-    // Generic simple routing for GET/POST without JSON body
+    // Fan out to *all* workers — the router does not track which worker owns
+    // a given id, so every worker must be probed. `wait_all` drains all
+    // workers before returning (needed for /abort_request: early-return would
+    // cancel the abort on the worker that owns the rid); otherwise returns on
+    // the first success.
     async fn route_simple_request(
         &self,
         headers: Option<&HeaderMap>,
         endpoint: &str,
         method: Method,
+        body: Option<&serde_json::Value>,
+        wait_all: bool,
     ) -> Response {
         // TODO: currently the sglang worker is using in-memory state management, so this implementation has to fan out to all workers.
         // Eventually, we need to have router to manage the chat history with a proper database, will update this implementation accordingly.
@@ -368,6 +374,8 @@ impl Router {
             })
             .unwrap_or_default();
 
+        // Send + read body inside the future so body reads overlap across
+        // workers. Ok(2xx) / Err(otherwise) — both fully-built Responses.
         let futures: Vec<_> = workers
             .into_iter()
             .map(|worker| {
@@ -393,6 +401,10 @@ impl Router {
                         }
                     };
 
+                    if let Some(body) = body {
+                        request_builder = request_builder.json(body);
+                    }
+
                     if let Some(key) = api_key {
                         let mut auth_header = String::with_capacity(7 + key.len());
                         auth_header.push_str("Bearer ");
@@ -404,55 +416,69 @@ impl Router {
                         request_builder = request_builder.header(name.clone(), value.clone());
                     }
 
-                    request_builder.send().await.map_err(convert_reqwest_error)
-                }
-            })
-            .collect();
+                    let res = match request_builder.send().await {
+                        Ok(res) => res,
+                        Err(e) => return Err(convert_reqwest_error(e)),
+                    };
 
-        // Now execute the collected futures concurrently
-        let mut stream = stream::iter(futures).buffer_unordered(32);
-        let mut last_response: Option<Response> = None;
-
-        while let Some(result) = stream.next().await {
-            match result {
-                Ok(res) => {
                     let status = StatusCode::from_u16(res.status().as_u16())
                         .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-
                     let response_headers = header_utils::preserve_response_headers(res.headers());
-
                     match res.bytes().await {
                         Ok(body) => {
                             let mut response = Response::new(Body::from(body));
                             *response.status_mut() = status;
                             *response.headers_mut() = response_headers;
-
                             if status.is_success() {
-                                return response;
+                                Ok(response)
+                            } else {
+                                Err(response)
                             }
-                            last_response = Some(response);
                         }
-                        Err(e) => {
-                            last_response = Some(error::internal_error(
-                                "read_response_failed",
-                                format!("Failed to read response: {}", e),
-                            ));
-                        }
+                        Err(e) => Err(error::internal_error(
+                            "read_response_failed",
+                            format!("Failed to read response: {}", e),
+                        )),
                     }
                 }
-                Err(e) => {
-                    last_response = Some(e);
+            })
+            .collect();
+
+        if !wait_all {
+            let mut stream = stream::iter(futures).buffer_unordered(32);
+            let mut last_response: Option<Response> = None;
+            while let Some(result) = stream.next().await {
+                match result {
+                    Ok(response) => return response,
+                    Err(response) => last_response = Some(response),
                 }
             }
+            return last_response
+                .unwrap_or_else(|| error::bad_gateway("no_worker_response", "No worker response"));
         }
 
-        last_response
+        // Track success and failure separately: a success must win over a
+        // later failure regardless of input order.
+        let mut first_success: Option<Response> = None;
+        let mut last_failure: Option<Response> = None;
+        for result in futures_util::future::join_all(futures).await {
+            match result {
+                Ok(response) => {
+                    if first_success.is_none() {
+                        first_success = Some(response);
+                    }
+                }
+                Err(response) => last_failure = Some(response),
+            }
+        }
+        first_success
+            .or(last_failure)
             .unwrap_or_else(|| error::bad_gateway("no_worker_response", "No worker response"))
     }
 
     // Route a GET request with provided headers to a specific endpoint
     async fn route_get_request(&self, headers: Option<&HeaderMap>, endpoint: &str) -> Response {
-        self.route_simple_request(headers, endpoint, Method::GET)
+        self.route_simple_request(headers, endpoint, Method::GET, None, false)
             .await
     }
 
@@ -462,7 +488,7 @@ impl Router {
         headers: Option<&HeaderMap>,
         endpoint: &str,
     ) -> Response {
-        self.route_simple_request(headers, endpoint, Method::POST)
+        self.route_simple_request(headers, endpoint, Method::POST, None, false)
             .await
     }
 
@@ -799,6 +825,15 @@ impl RouterTrait for Router {
     async fn cancel_response(&self, headers: Option<&HeaderMap>, response_id: &str) -> Response {
         let endpoint = format!("v1/responses/{}/cancel", response_id);
         self.route_post_empty_request(headers, &endpoint).await
+    }
+
+    async fn abort_request(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &serde_json::Value,
+    ) -> Response {
+        self.route_simple_request(headers, "abort_request", Method::POST, Some(body), true)
+            .await
     }
 
     async fn route_embeddings(

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -145,6 +145,20 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
+    /// Abort an in-flight request by rid. Fans out to all workers and waits
+    /// for every one (unlike `cancel_response`, which returns on first
+    /// success) so the abort reaches the worker that owns the rid.
+    ///
+    /// Only the regular HTTP router implements this; PD/gRPC fall back to 501
+    /// (PD needs the abort fanned across prefill+decode — follow-up).
+    async fn abort_request(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &serde_json::Value,
+    ) -> Response {
+        (StatusCode::NOT_IMPLEMENTED, "Abort request not implemented").into_response()
+    }
+
     /// Delete a response by id
     async fn delete_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
         (

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -645,6 +645,19 @@ impl RouterTrait for RouterManager {
         }
     }
 
+    async fn abort_request(&self, headers: Option<&HeaderMap>, body: &Value) -> Response {
+        let router = self.select_router_for_request(headers, None);
+        if let Some(router) = router {
+            router.abort_request(headers, body).await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                "No router available to abort request",
+            )
+                .into_response()
+        }
+    }
+
     async fn delete_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
         (
             StatusCode::NOT_IMPLEMENTED,

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -271,6 +271,14 @@ async fn v1_responses_cancel(
         .await
 }
 
+async fn abort_request(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    state.router.abort_request(Some(&headers), &body).await
+}
+
 async fn v1_responses_delete(
     State(state): State<Arc<AppState>>,
     Path(response_id): Path<String>,
@@ -549,6 +557,7 @@ pub fn build_app(
         .route("/v1/responses", post(v1_responses))
         .route("/v1/embeddings", post(v1_embeddings))
         .route("/v1/classify", post(v1_classify))
+        .route("/abort_request", post(abort_request))
         .route("/v1/responses/{response_id}", get(v1_responses_get))
         .route(
             "/v1/responses/{response_id}/cancel",

--- a/sgl-model-gateway/tests/api/abort_request_test.rs
+++ b/sgl-model-gateway/tests/api/abort_request_test.rs
@@ -85,8 +85,8 @@ mod abort_request_tests {
         ctx.shutdown().await;
     }
 
-    // Guards the wait_all semantics: a failure on one worker must not mask a
-    // success on another.
+    // Fan-out must reach every worker — including the failing one — and a
+    // success on any worker must win over a failure on another.
     #[tokio::test]
     #[serial]
     async fn test_abort_request_success_wins_over_partial_failure() {
@@ -121,9 +121,13 @@ mod abort_request_tests {
             "a success on any worker must win over a failure on another"
         );
 
-        // The healthy worker must still have received the abort — fan-out
-        // reaches every worker regardless of individual outcomes.
+        // Fan-out reaches every worker regardless of individual outcomes —
+        // the failing worker is probed too (the mock records before failing).
         let ports: Vec<u16> = get_aborts_received().iter().map(|(p, _)| *p).collect();
+        assert!(
+            ports.contains(&18511),
+            "failing worker 18511 missing: {ports:?}"
+        );
         assert!(
             ports.contains(&18512),
             "healthy worker 18512 missing: {ports:?}"

--- a/sgl-model-gateway/tests/api/abort_request_test.rs
+++ b/sgl-model-gateway/tests/api/abort_request_test.rs
@@ -1,0 +1,134 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header::CONTENT_TYPE, StatusCode},
+};
+use serde_json::json;
+use serial_test::serial;
+use tower::ServiceExt;
+
+use crate::common::{
+    mock_worker::{clear_aborts_received, get_aborts_received, MockWorkerConfig},
+    AppTestContext,
+};
+
+#[cfg(test)]
+mod abort_request_tests {
+    use super::*;
+
+    // All three tests share a process-global abort tracker, so they must run
+    // serially to avoid clearing/reading each other's records.
+    #[tokio::test]
+    #[serial]
+    async fn test_abort_request_fans_out_to_all_workers_with_body() {
+        clear_aborts_received();
+        let ctx = AppTestContext::new(vec![
+            MockWorkerConfig {
+                port: 18501,
+                ..MockWorkerConfig::default()
+            },
+            MockWorkerConfig {
+                port: 18502,
+                ..MockWorkerConfig::default()
+            },
+        ])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let payload = json!({"rid": "req-abc-123", "abort_all": false});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/abort_request")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Both workers must have received the abort — the rid may live on
+        // either worker, so the gateway must fan out to all of them rather
+        // than returning on the first success.
+        let aborts = get_aborts_received();
+        let ports: Vec<u16> = aborts.iter().map(|(p, _)| *p).collect();
+        assert!(ports.contains(&18501), "worker 18501 missing: {ports:?}");
+        assert!(ports.contains(&18502), "worker 18502 missing: {ports:?}");
+
+        // Body must be forwarded intact to every worker.
+        for (_port, body) in &aborts {
+            assert_eq!(body, &json!({"rid": "req-abc-123", "abort_all": false}));
+        }
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_abort_request_no_workers_returns_unavailable() {
+        clear_aborts_received();
+        let ctx = AppTestContext::new(vec![]).await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({"rid": "req-xyz", "abort_all": false});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/abort_request")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(get_aborts_received().is_empty());
+
+        ctx.shutdown().await;
+    }
+
+    // Guards the wait_all semantics: a failure on one worker must not mask a
+    // success on another.
+    #[tokio::test]
+    #[serial]
+    async fn test_abort_request_success_wins_over_partial_failure() {
+        clear_aborts_received();
+        let ctx = AppTestContext::new(vec![
+            MockWorkerConfig {
+                port: 18511,
+                fail_rate: 1.0, // always 500 — simulates a worker that errors
+                ..MockWorkerConfig::default()
+            },
+            MockWorkerConfig {
+                port: 18512,
+                ..MockWorkerConfig::default()
+            },
+        ])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let payload = json!({"rid": "req-partial", "abort_all": false});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/abort_request")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a success on any worker must win over a failure on another"
+        );
+
+        // The healthy worker must still have received the abort — fan-out
+        // reaches every worker regardless of individual outcomes.
+        let ports: Vec<u16> = get_aborts_received().iter().map(|(p, _)| *p).collect();
+        assert!(
+            ports.contains(&18512),
+            "healthy worker 18512 missing: {ports:?}"
+        );
+
+        ctx.shutdown().await;
+    }
+}

--- a/sgl-model-gateway/tests/api/mod.rs
+++ b/sgl-model-gateway/tests/api/mod.rs
@@ -1,5 +1,6 @@
 //! API endpoint integration tests
 
+mod abort_request_test;
 mod api_endpoints_test;
 mod parser_endpoints_test;
 mod request_formats_test;

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -96,6 +96,7 @@ impl MockWorker {
             )
             .route("/flush_cache", post(flush_cache_handler))
             .route("/v1/models", get(v1_models_handler))
+            .route("/abort_request", post(abort_request_handler))
             .with_state(config);
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1469,6 +1470,49 @@ async fn responses_cancel_handler(
 // Configured via a global map keyed by worker port so that tests
 // can enable slow streaming WITHOUT relying on the request payload
 // (the gateway deserializes/re-serializes the body, dropping unknown fields).
+
+// Records every /abort_request body received per worker port, so tests can
+// assert the gateway fanned the abort out to ALL workers with the body intact.
+static ABORTS_RECEIVED: OnceLock<Mutex<Vec<(u16, serde_json::Value)>>> = OnceLock::new();
+
+fn aborts_received() -> &'static Mutex<Vec<(u16, serde_json::Value)>> {
+    ABORTS_RECEIVED.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Clear the recorded aborts (call at the start of a test).
+pub fn clear_aborts_received() {
+    aborts_received().lock().unwrap().clear();
+}
+
+/// Snapshot of (port, body) pairs for every /abort_request received.
+pub fn get_aborts_received() -> Vec<(u16, serde_json::Value)> {
+    aborts_received().lock().unwrap().clone()
+}
+
+async fn abort_request_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    body: Json<serde_json::Value>,
+) -> Response {
+    let config = config.read().await;
+    let port = config.port;
+
+    // Record arrival before the failure check — fan-out must reach every
+    // worker regardless of the response it then returns.
+    aborts_received()
+        .lock()
+        .unwrap()
+        .push((port, body.0.clone()));
+
+    if should_fail(&config).await {
+        return (
+            fail_status_code(port),
+            Json(json!({"error": "Random failure for testing"})),
+        )
+            .into_response();
+    }
+
+    Json(json!({"aborted": true})).into_response()
+}
 
 static SLOW_STREAM_CONFIG: OnceLock<Mutex<HashMap<u16, usize>>> = OnceLock::new();
 


### PR DESCRIPTION
Closes #6531.

## Motivation

`/abort_request` exists on the sglang HTTP server but not on `sgl-model-gateway`, so multi-worker deployments behind the router cannot abort an in-flight request from outside. Two prior attempts (#6790, #20160) were abandoned (the former targeted the old `sgl-router`; the latter got no review in 4 months).

## Modifications

- Add `abort_request` to `RouterTrait` (default 501), `RouterManager`, the regular HTTP `Router`, and a `POST /abort_request` handler in `server.rs`.
- Fan out to **all** workers and wait for every one (not first-success): the router does not track which worker owns a rid, so the abort must reach all of them; a success on any worker wins over failures. The worker-side `/abort_request` matches rid by `startswith` and is a no-op for rids it does not own, so fan-out is safe.
- Generalize `route_simple_request` with an optional JSON body and a `wait_all` flag (it previously dropped the body). `cancel_response`/`get`/`delete` keep their first-success behavior; `abort_request` uses `wait_all`.
- PD/gRPC routers fall back to 501 — PD needs the abort fanned across prefill+decode, left to a follow-up.

## Tests

- `test_abort_request_fans_out_to_all_workers_with_body` — both workers receive the abort, body intact.
- `test_abort_request_no_workers_returns_unavailable` — 503 when no workers.
- `test_abort_request_success_wins_over_partial_failure` — one worker 500, one 200; gateway returns 200 (guards wait_all success-over-failure).

## Checklist

- [x] Format with pre-commit (`cargo +nightly fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` all clean locally; the only failing test is the pre-existing `test_redis_server_start_stop` which needs `redis-server` installed)
- [x] Add unit tests (3 integration tests)
- [ ] Update documentation (none needed — endpoint mirrors the worker-side `/abort_request`)
- [ ] Accuracy / speed benchmarks (N/A — control-plane route, no model forward change)
- [x] Follow SGLang code style (`route_simple_request` generalized, no duplication)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29669130804](https://github.com/sgl-project/sglang/actions/runs/29669130804)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29669130732](https://github.com/sgl-project/sglang/actions/runs/29669130732)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->