### PR TITLE
[Fix] Record the WAR read-done event in-graph to cover replay-time metadata reads

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -98,6 +98,15 @@ class AttentionBackend(ABC):
     # object during capture, and refresh its dynamic fields before each replay.
     use_captured_forward_metadata_for_breakable_cuda_graph: bool = False
 
+    # Most ``init_forward_metadata_in_graph`` bodies read only private
+    # static-shape buffers at replay, so all shared req_to_token / KV-mapping
+    # reads finish by the pre-replay snapshot point. Backends whose captured
+    # metadata kernel indexes the LIVE shared buffers on every replay opt in
+    # here: a pre-replay read-done event is invalid for them, so the WAR
+    # barrier must record its event in-graph (right after the metadata hook)
+    # or after replay.
+    in_graph_metadata_reads_shared_buffers: bool = False
+
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         """Init the global shared states for cuda graph."""
         raise NotImplementedError()

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -98,13 +98,10 @@ class AttentionBackend(ABC):
     # object during capture, and refresh its dynamic fields before each replay.
     use_captured_forward_metadata_for_breakable_cuda_graph: bool = False
 
-    # Most ``init_forward_metadata_in_graph`` bodies read only private
-    # static-shape buffers at replay, so all shared req_to_token / KV-mapping
-    # reads finish by the pre-replay snapshot point. Backends whose captured
-    # metadata kernel indexes the LIVE shared buffers on every replay opt in
-    # here: a pre-replay read-done event is invalid for them, so the WAR
-    # barrier must record its event in-graph (right after the metadata hook)
-    # or after replay.
+    # Backends whose captured metadata kernel indexes the LIVE shared
+    # req_to_token / KV-mapping buffers on every replay opt in here: a
+    # pre-replay read-done event is invalid for them, so the WAR barrier
+    # records its event in-graph or after replay.
     in_graph_metadata_reads_shared_buffers: bool = False
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -75,6 +75,15 @@ class HybridAttnBackend(AttentionBackend):
         backend = self._select_backend(forward_batch.forward_mode)
         backend.init_forward_metadata_in_graph(forward_batch)
 
+    @property
+    def in_graph_metadata_reads_shared_buffers(self) -> bool:
+        # Conservative OR: graphs may route to either sub-backend depending on
+        # the forward mode.
+        return (
+            self.decode_backend.in_graph_metadata_reads_shared_buffers
+            or self.prefill_backend.in_graph_metadata_reads_shared_buffers
+        )
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         backend = self._select_backend(forward_batch.forward_mode)
         backend.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -77,8 +77,7 @@ class HybridAttnBackend(AttentionBackend):
 
     @property
     def in_graph_metadata_reads_shared_buffers(self) -> bool:
-        # Conservative OR: graphs may route to either sub-backend depending on
-        # the forward mode.
+        # Conservative OR: graphs may route to either sub-backend.
         return (
             self.decode_backend.in_graph_metadata_reads_shared_buffers
             or self.prefill_backend.in_graph_metadata_reads_shared_buffers

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -127,8 +127,7 @@ class TboAttnBackend(AttentionBackend):
 
     @property
     def in_graph_metadata_reads_shared_buffers(self) -> bool:
-        # Forward the capability from whichever wrapped backend records the
-        # in-graph metadata (primary always does; children when they replay).
+        # Forward from whichever wrapped backend records in-graph metadata.
         return self.primary.in_graph_metadata_reads_shared_buffers or any(
             child.in_graph_metadata_reads_shared_buffers for child in self.children
         )

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -125,6 +125,14 @@ class TboAttnBackend(AttentionBackend):
                         forward_batch=forward_batch_child
                     )
 
+    @property
+    def in_graph_metadata_reads_shared_buffers(self) -> bool:
+        # Forward the capability from whichever wrapped backend records the
+        # in-graph metadata (primary always does; children when they replay).
+        return self.primary.in_graph_metadata_reads_shared_buffers or any(
+            child.in_graph_metadata_reads_shared_buffers for child in self.children
+        )
+
     def init_forward_metadata(self, forward_batch: "ForwardBatch"):
         self.primary.init_forward_metadata(forward_batch=forward_batch)
         if forward_batch.tbo_children is not None:

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -87,11 +87,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
     supports_ragged_verify_graph: bool = True
 
-    # The fused in-graph metadata build (``_apply_cuda_graph_metadata`` ->
-    # ``update_trtllm_mha_graph_metadata``) is recorded into the captured
-    # graph and indexes the live ``req_to_token`` / full->SWA mapping on
-    # every replay, so shared-buffer reads do NOT end at the pre-replay
-    # snapshot point.
+    # The fused in-graph metadata kernel indexes the live req_to_token /
+    # full->SWA mapping on every replay.
     in_graph_metadata_reads_shared_buffers: bool = True
 
     def __init__(
@@ -1152,8 +1149,7 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
     # decide_needs_cpu_seq_lens sees a consistent target + draft value.
     needs_cpu_seq_lens: bool = False
 
-    # Delegates in-graph metadata to per-step TRTLLMHAAttnBackend instances,
-    # whose fused kernel indexes live shared buffers on every replay.
+    # Per-step TRTLLMHAAttnBackend kernels index live shared buffers in-graph.
     in_graph_metadata_reads_shared_buffers: bool = True
 
     def __init__(

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -87,6 +87,13 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
     supports_ragged_verify_graph: bool = True
 
+    # The fused in-graph metadata build (``_apply_cuda_graph_metadata`` ->
+    # ``update_trtllm_mha_graph_metadata``) is recorded into the captured
+    # graph and indexes the live ``req_to_token`` / full->SWA mapping on
+    # every replay, so shared-buffer reads do NOT end at the pre-replay
+    # snapshot point.
+    in_graph_metadata_reads_shared_buffers: bool = True
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -1144,6 +1151,10 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
     # Per-step backends build the page table on-device (sync-free); mirror that so
     # decide_needs_cpu_seq_lens sees a consistent target + draft value.
     needs_cpu_seq_lens: bool = False
+
+    # Delegates in-graph metadata to per-step TRTLLMHAAttnBackend instances,
+    # whose fused kernel indexes live shared buffers on every replay.
+    in_graph_metadata_reads_shared_buffers: bool = True
 
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -159,6 +159,7 @@ from sglang.srt.model_executor.runner import (
     EagerRunner,
     get_batch_sizes_to_capture,
 )
+from sglang.srt.model_executor.runner_utils import make_war_read_done_event
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
@@ -332,6 +333,11 @@ class ModelRunner:
         # load_batch; the scheduler's WAR barrier waits on it (then clears it)
         # instead of the whole-forward wait_stream. None -> whole-forward fallback.
         self.war_fastpath_read_done_event: Optional[torch.cuda.Event] = None
+        # Persistent external event the graph runners record in-graph at the
+        # snapshot-completion point and publish above; None when unsupported.
+        self.war_read_done_event = make_war_read_done_event(
+            torch.get_device_module(self.device)
+        )
 
         # CPU offload
         set_offloader(

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -76,9 +76,6 @@ from sglang.srt.model_executor.runner.shape_key import ShapeKey
 from sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend import (
     BreakableCudaGraphBackend,
 )
-from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
-    FullCudaGraphBackend,
-)
 from sglang.srt.model_executor.runner_backend.utils import resolve_decode_backend
 from sglang.srt.model_executor.runner_backend_utils import (
     CUDA_GRAPH_CAPTURE_FAILED_MSG,
@@ -99,7 +96,6 @@ from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
-    is_cuda,
     require_attn_tp_gather,
     require_mlp_tp_gather,
 )
@@ -192,34 +188,59 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
     pluggable self.backend that handles the actual capture/replay.
     """
 
-    # WAR-barrier read-done event, recorded as a node inside each captured
-    # graph at the snapshot-completion point. Class-level defaults keep
-    # subclasses with hand-rolled __init__ on the fallback paths.
-    war_read_done_event: Optional[torch.cuda.Event] = None
+    # True once the model_runner's WAR read-done event is recorded as a node
+    # inside this runner's captured graphs; class-level default keeps
+    # non-planting subclasses on the fallback paths.
     _war_read_done_node_planted: bool = False
 
-    @staticmethod
-    def _make_war_read_done_event(device_module):
-        """External event whose in-capture record() becomes a graph node that
-        re-arms on every replay; None when unsupported (fallback paths)."""
-        if not is_cuda():
-            return None
-        try:
-            return device_module.Event(external=True)
-        except TypeError:
-            return None
-
     def _plant_war_read_done_node(self):
-        """Record the read-done event in-graph, right after the in-graph
-        metadata hook. Only full-graph capture records run_once wholesale;
-        other backends stay on the fallback paths."""
+        """Record the read-done event as a graph node right after the in-graph
+        metadata hook. Safe for both full and breakable capture: capture is
+        active here (breakable opens segment 1 on context entry) and every
+        segment replays, re-arming the node. Non-capturing runs (warmup,
+        debug-eager, no external-event support) leave the flag unset and stay
+        on the fallback paths."""
         if (
-            self.war_read_done_event is not None
-            and isinstance(self.backend, FullCudaGraphBackend)
+            self.model_runner.war_read_done_event is not None
             and torch.cuda.is_current_stream_capturing()
         ):
-            self.war_read_done_event.record()
+            self.model_runner.war_read_done_event.record()
             self._war_read_done_node_planted = True
+
+    def _war_read_done_policy(self, attn_backend, forward_mode) -> str:
+        """Where the WAR read-done record lands for this replay.
+
+        - "in_graph": preferred -- the graph re-arms the node on every replay;
+          publish after launch so the scheduler's wait pairs with this
+          replay's record.
+        - "post_replay": pre-replay is too early -- captured-metadata verify
+          replays re-read req_to_token throughout the graph; likewise flagged
+          backends with no node planted.
+        - "pre_replay": snapshot backends with no node finish all shared reads
+          before launch.
+        """
+        if (
+            forward_mode.is_target_verify()
+            and attn_backend.use_captured_forward_metadata_for_breakable_cuda_graph
+        ) or (
+            not self._war_read_done_node_planted
+            and attn_backend.in_graph_metadata_reads_shared_buffers
+        ):
+            return "post_replay"
+        if self._war_read_done_node_planted:
+            return "in_graph"
+        return "pre_replay"
+
+    def _publish_war_read_done(self, in_graph: bool):
+        """Publish the read-done event the scheduler's WAR barrier waits on."""
+        if in_graph:
+            self.model_runner.war_fastpath_read_done_event = (
+                self.model_runner.war_read_done_event
+            )
+        else:
+            read_done = self.device_module.Event()
+            read_done.record()
+            self.model_runner.war_fastpath_read_done_event = read_done
 
     def __init__(
         self,
@@ -230,7 +251,6 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         speculative_num_draft_tokens: Optional[int] = None,
     ):
         super().__init__(model_runner)
-        self.war_read_done_event = self._make_war_read_done_event(self.device_module)
         # --- core state ------------------------------------------------
         self.enable_torch_compile = get_flags().capture.enable_torch_compile
         self.disable_padding = model_runner.server_args.disable_cuda_graph_padding
@@ -1259,25 +1279,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             forward_batch.forward_mode.is_target_verify()
             and self.model_runner.spec_algorithm.is_dflash_family()
         )
-        # Exception: breakable-graph verify replays (captured forward metadata)
-        # re-read req_to_token *during* replay, so the pre-replay snapshot is
-        # too early -- record the event after replay instead. Same for backends
-        # reading live shared buffers in-graph with no record node planted.
-        read_done_post_replay = publish_read_done and (
-            (
-                forward_batch.forward_mode.is_target_verify()
-                and self.attn_backend.use_captured_forward_metadata_for_breakable_cuda_graph
-            )
-            or (
-                not self._war_read_done_node_planted
-                and self.attn_backend.in_graph_metadata_reads_shared_buffers
-            )
-        )
-        # Preferred: the captured graph re-arms the read-done node every replay.
-        use_in_graph_read_done = (
-            publish_read_done
-            and not read_done_post_replay
-            and self._war_read_done_node_planted
+        war_policy = (
+            self._war_read_done_policy(self.attn_backend, forward_batch.forward_mode)
+            if publish_read_done
+            else None
         )
         with timer_ctx, self.backend.replay_session():
             self.load_batch(forward_batch, pp_proxy_tensors)
@@ -1295,25 +1300,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                         else ""
                     ),
                 )
-            if (
-                publish_read_done
-                and not read_done_post_replay
-                and not use_in_graph_read_done
-            ):
-                read_done = self.device_module.Event()
-                read_done.record()
-                self.model_runner.war_fastpath_read_done_event = read_done
+            if war_policy == "pre_replay":
+                self._publish_war_read_done(in_graph=False)
             output = self.backend.replay(self._replay_graph_key, forward_batch)
-            if read_done_post_replay:
-                read_done = self.device_module.Event()
-                read_done.record()
-                self.model_runner.war_fastpath_read_done_event = read_done
-            elif use_in_graph_read_done:
-                # Publish after the launch so the scheduler's wait pairs with
-                # this replay's re-armed record.
-                self.model_runner.war_fastpath_read_done_event = (
-                    self.war_read_done_event
-                )
+            if war_policy == "post_replay":
+                self._publish_war_read_done(in_graph=False)
+            elif war_policy == "in_graph":
+                self._publish_war_read_done(in_graph=True)
 
         if isinstance(output, LogitsProcessorOutput):
             if self.is_dllm:

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -213,8 +213,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         """Record the read-done event in-graph, right after the in-graph
         metadata hook. Only full-graph capture records run_once wholesale;
         other backends stay on the fallback paths."""
-        if self.war_read_done_event is not None and isinstance(
-            self.backend, FullCudaGraphBackend
+        if (
+            self.war_read_done_event is not None
+            and isinstance(self.backend, FullCudaGraphBackend)
+            and torch.cuda.is_current_stream_capturing()
         ):
             self.war_read_done_event.record()
             self._war_read_done_node_planted = True

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -76,6 +76,9 @@ from sglang.srt.model_executor.runner.shape_key import ShapeKey
 from sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend import (
     BreakableCudaGraphBackend,
 )
+from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+    FullCudaGraphBackend,
+)
 from sglang.srt.model_executor.runner_backend.utils import resolve_decode_backend
 from sglang.srt.model_executor.runner_backend_utils import (
     CUDA_GRAPH_CAPTURE_FAILED_MSG,
@@ -96,6 +99,7 @@ from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
+    is_cuda,
     require_attn_tp_gather,
     require_mlp_tp_gather,
 )
@@ -188,6 +192,48 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
     pluggable self.backend that handles the actual capture/replay.
     """
 
+    # WAR-barrier read-done event, recorded as a node INSIDE each captured
+    # graph (right after the in-graph metadata hook) so the event always fires
+    # at the true snapshot-completion point: at the graph head for backends
+    # whose in-graph hook is a no-op, and right after the fused metadata
+    # kernel for backends that build the snapshot in-graph (e.g. trtllm_mha).
+    # Class-level defaults keep subclasses with hand-rolled __init__ (which
+    # skip super().__init__) on the pre/post-replay fallback path.
+    war_read_done_event: Optional[torch.cuda.Event] = None
+    _war_read_done_node_planted: bool = False
+
+    @staticmethod
+    def _make_war_read_done_event(device_module):
+        """WAR-barrier read-done event recordable INSIDE cuda-graph capture.
+
+        ``external=True`` turns a ``record()`` during capture into a graph
+        event-record node that re-arms on every replay. Returns None when
+        unsupported (non-CUDA platforms, older torch), selecting the
+        pre/post-replay fallback.
+        """
+        if not is_cuda():
+            return None
+        try:
+            return device_module.Event(external=True)
+        except TypeError:
+            return None
+
+    def _plant_war_read_done_node(self):
+        """Record the read-done event inside the graph being captured.
+
+        Call from ``run_once`` right after ``init_forward_metadata_in_graph``
+        so every shared req_to_token / mapping read -- including in-graph
+        metadata kernels -- is ordered before the record node. Only
+        full-graph capture records ``run_once`` wholesale; breakable /
+        piecewise backends capture in segments where the record's placement
+        is not reliable, so they stay on the fallback path.
+        """
+        if self.war_read_done_event is not None and isinstance(
+            self.backend, FullCudaGraphBackend
+        ):
+            self.war_read_done_event.record()
+            self._war_read_done_node_planted = True
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -197,6 +243,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         speculative_num_draft_tokens: Optional[int] = None,
     ):
         super().__init__(model_runner)
+        self.war_read_done_event = self._make_war_read_done_event(self.device_module)
         # --- core state ------------------------------------------------
         self.enable_torch_compile = get_flags().capture.enable_torch_compile
         self.disable_padding = model_runner.server_args.disable_cuda_graph_padding
@@ -945,6 +992,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 # run eagerly in `init_forward_metadata_out_graph` (replay-prep), so
                 # the captured graph reads already-physical locs. Base no-op for triton.
                 attn_backend.init_forward_metadata_in_graph(forward_batch)
+                self._plant_war_read_done_node()
 
                 # No invalidate_loc_cache() here: the unified pool translates its
                 # locs in `init_forward_metadata_out_graph`, so no cache to invalidate.
@@ -1226,11 +1274,25 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         )
         # Exception: breakable-graph verify replays (captured forward metadata)
         # re-read req_to_token *during* replay, so the pre-replay snapshot is
-        # too early -- record the event after replay instead.
-        read_done_post_replay = (
+        # too early -- record the event after replay instead. Same when the
+        # backend's captured metadata kernel indexes live shared buffers on
+        # every replay (e.g. trtllm_mha) and no in-graph record node covers it.
+        read_done_post_replay = publish_read_done and (
+            (
+                forward_batch.forward_mode.is_target_verify()
+                and self.attn_backend.use_captured_forward_metadata_for_breakable_cuda_graph
+            )
+            or (
+                not self._war_read_done_node_planted
+                and self.attn_backend.in_graph_metadata_reads_shared_buffers
+            )
+        )
+        # Preferred path: the captured graph carries an in-graph record node at
+        # the snapshot-completion point, re-armed by every replay.
+        use_in_graph_read_done = (
             publish_read_done
-            and forward_batch.forward_mode.is_target_verify()
-            and self.attn_backend.use_captured_forward_metadata_for_breakable_cuda_graph
+            and not read_done_post_replay
+            and self._war_read_done_node_planted
         )
         with timer_ctx, self.backend.replay_session():
             self.load_batch(forward_batch, pp_proxy_tensors)
@@ -1248,7 +1310,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                         else ""
                     ),
                 )
-            if publish_read_done and not read_done_post_replay:
+            if (
+                publish_read_done
+                and not read_done_post_replay
+                and not use_in_graph_read_done
+            ):
                 read_done = self.device_module.Event()
                 read_done.record()
                 self.model_runner.war_fastpath_read_done_event = read_done
@@ -1257,6 +1323,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 read_done = self.device_module.Event()
                 read_done.record()
                 self.model_runner.war_fastpath_read_done_event = read_done
+            elif use_in_graph_read_done:
+                # The record node inside this replay re-armed the external
+                # event; publish only after the launch is enqueued so the
+                # scheduler's wait pairs with THIS replay's record.
+                self.model_runner.war_fastpath_read_done_event = (
+                    self.war_read_done_event
+                )
 
         if isinstance(output, LogitsProcessorOutput):
             if self.is_dllm:

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -192,25 +192,16 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
     pluggable self.backend that handles the actual capture/replay.
     """
 
-    # WAR-barrier read-done event, recorded as a node INSIDE each captured
-    # graph (right after the in-graph metadata hook) so the event always fires
-    # at the true snapshot-completion point: at the graph head for backends
-    # whose in-graph hook is a no-op, and right after the fused metadata
-    # kernel for backends that build the snapshot in-graph (e.g. trtllm_mha).
-    # Class-level defaults keep subclasses with hand-rolled __init__ (which
-    # skip super().__init__) on the pre/post-replay fallback path.
+    # WAR-barrier read-done event, recorded as a node inside each captured
+    # graph at the snapshot-completion point. Class-level defaults keep
+    # subclasses with hand-rolled __init__ on the fallback paths.
     war_read_done_event: Optional[torch.cuda.Event] = None
     _war_read_done_node_planted: bool = False
 
     @staticmethod
     def _make_war_read_done_event(device_module):
-        """WAR-barrier read-done event recordable INSIDE cuda-graph capture.
-
-        ``external=True`` turns a ``record()`` during capture into a graph
-        event-record node that re-arms on every replay. Returns None when
-        unsupported (non-CUDA platforms, older torch), selecting the
-        pre/post-replay fallback.
-        """
+        """External event whose in-capture record() becomes a graph node that
+        re-arms on every replay; None when unsupported (fallback paths)."""
         if not is_cuda():
             return None
         try:
@@ -219,15 +210,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             return None
 
     def _plant_war_read_done_node(self):
-        """Record the read-done event inside the graph being captured.
-
-        Call from ``run_once`` right after ``init_forward_metadata_in_graph``
-        so every shared req_to_token / mapping read -- including in-graph
-        metadata kernels -- is ordered before the record node. Only
-        full-graph capture records ``run_once`` wholesale; breakable /
-        piecewise backends capture in segments where the record's placement
-        is not reliable, so they stay on the fallback path.
-        """
+        """Record the read-done event in-graph, right after the in-graph
+        metadata hook. Only full-graph capture records run_once wholesale;
+        other backends stay on the fallback paths."""
         if self.war_read_done_event is not None and isinstance(
             self.backend, FullCudaGraphBackend
         ):
@@ -1274,9 +1259,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         )
         # Exception: breakable-graph verify replays (captured forward metadata)
         # re-read req_to_token *during* replay, so the pre-replay snapshot is
-        # too early -- record the event after replay instead. Same when the
-        # backend's captured metadata kernel indexes live shared buffers on
-        # every replay (e.g. trtllm_mha) and no in-graph record node covers it.
+        # too early -- record the event after replay instead. Same for backends
+        # reading live shared buffers in-graph with no record node planted.
         read_done_post_replay = publish_read_done and (
             (
                 forward_batch.forward_mode.is_target_verify()
@@ -1287,8 +1271,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 and self.attn_backend.in_graph_metadata_reads_shared_buffers
             )
         )
-        # Preferred path: the captured graph carries an in-graph record node at
-        # the snapshot-completion point, re-armed by every replay.
+        # Preferred: the captured graph re-arms the read-done node every replay.
         use_in_graph_read_done = (
             publish_read_done
             and not read_done_post_replay
@@ -1324,9 +1307,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 read_done.record()
                 self.model_runner.war_fastpath_read_done_event = read_done
             elif use_in_graph_read_done:
-                # The record node inside this replay re-armed the external
-                # event; publish only after the launch is enqueued so the
-                # scheduler's wait pairs with THIS replay's record.
+                # Publish after the launch so the scheduler's wait pairs with
+                # this replay's re-armed record.
                 self.model_runner.war_fastpath_read_done_event = (
                     self.war_read_done_event
                 )

--- a/python/sglang/srt/model_executor/runner_utils/__init__.py
+++ b/python/sglang/srt/model_executor/runner_utils/__init__.py
@@ -26,3 +26,6 @@ from sglang.srt.model_executor.runner_utils.pool import (  # noqa: F401
     get_global_graph_memory_pool,
     set_global_graph_memory_pool,
 )
+from sglang.srt.model_executor.runner_utils.war_event import (  # noqa: F401
+    make_war_read_done_event,
+)

--- a/python/sglang/srt/model_executor/runner_utils/war_event.py
+++ b/python/sglang/srt/model_executor/runner_utils/war_event.py
@@ -1,0 +1,18 @@
+"""WAR-barrier read-done event factory for the CUDA graph runners."""
+
+from typing import Optional
+
+import torch
+
+from sglang.srt.utils import is_cuda
+
+
+def make_war_read_done_event(device_module) -> Optional[torch.cuda.Event]:
+    """External event whose in-capture record() becomes a graph node that
+    re-arms on every replay; None when unsupported (fallback paths)."""
+    if not is_cuda():
+        return None
+    try:
+        return device_module.Event(external=True)
+    except TypeError:
+        return None

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -609,12 +609,8 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
         # Snapshot built -- the forward is done reading the shared pool. Publish
-        # a read-done event the scheduler's WAR barrier waits on. Preferred:
-        # the captured graph carries an in-graph record node at the
-        # snapshot-completion point (published after launch below). Fallbacks:
-        # record after replay when the backend's captured metadata kernel
-        # indexes live shared buffers on every replay (e.g. trtllm_mha), else
-        # the classic pre-replay record.
+        # a read-done event the scheduler's WAR barrier waits on. In-graph node
+        # and post-replay variants are published after replay below.
         use_in_graph_read_done = self._war_read_done_node_planted
         read_done_post_replay = (
             not use_in_graph_read_done
@@ -643,8 +639,8 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             read_done.record()
             self.model_runner.war_fastpath_read_done_event = read_done
         elif use_in_graph_read_done:
-            # The record node inside this replay re-armed the external event;
-            # publish after the launch so the scheduler's wait pairs with it.
+            # Publish after launch so the scheduler's wait pairs with this
+            # replay's re-armed record.
             self.model_runner.war_fastpath_read_done_event = self.war_read_done_event
 
         out = LogitsProcessorOutput(

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -98,7 +98,6 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         # Fields the parent's capture() reads:
         self.device = model_runner.device
         self.device_module = torch.get_device_module(self.device)
-        self.war_read_done_event = self._make_war_read_done_event(self.device_module)
         self.tp_size = model_runner.ps.tp_size
         self.attn_dp_size = model_runner.ps.attn_dp_size
         self.pp_size = model_runner.server_args.pp_size
@@ -611,15 +610,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         # Snapshot built -- the forward is done reading the shared pool. Publish
         # a read-done event the scheduler's WAR barrier waits on. In-graph node
         # and post-replay variants are published after replay below.
-        use_in_graph_read_done = self._war_read_done_node_planted
-        read_done_post_replay = (
-            not use_in_graph_read_done
-            and self.draft_extend_attn_backend.in_graph_metadata_reads_shared_buffers
+        war_policy = self._war_read_done_policy(
+            self.draft_extend_attn_backend, forward_batch.forward_mode
         )
-        if not use_in_graph_read_done and not read_done_post_replay:
-            read_done = self.device_module.Event()
-            read_done.record()
-            self.model_runner.war_fastpath_read_done_event = read_done
+        if war_policy == "pre_replay":
+            self._publish_war_read_done(in_graph=False)
 
         self.raw_bs = raw_bs
         self.bs = bs
@@ -634,14 +629,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         with timer_ctx:
             out = self._replay_graph(shape_key, forward_batch)
 
-        if read_done_post_replay:
-            read_done = self.device_module.Event()
-            read_done.record()
-            self.model_runner.war_fastpath_read_done_event = read_done
-        elif use_in_graph_read_done:
-            # Publish after launch so the scheduler's wait pairs with this
-            # replay's re-armed record.
-            self.model_runner.war_fastpath_read_done_event = self.war_read_done_event
+        if war_policy == "post_replay":
+            self._publish_war_read_done(in_graph=False)
+        elif war_policy == "in_graph":
+            self._publish_war_read_done(in_graph=True)
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -98,6 +98,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         # Fields the parent's capture() reads:
         self.device = model_runner.device
         self.device_module = torch.get_device_module(self.device)
+        self.war_read_done_event = self._make_war_read_done_event(self.device_module)
         self.tp_size = model_runner.ps.tp_size
         self.attn_dp_size = model_runner.ps.attn_dp_size
         self.pp_size = model_runner.server_args.pp_size
@@ -415,6 +416,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
         def run_once():
             self.draft_extend_attn_backend.init_forward_metadata_in_graph(forward_batch)
+            self._plant_war_read_done_node()
 
             # Clean intermediate result cache for DP attention
             forward_batch.dp_local_start_pos = forward_batch.dp_local_num_tokens = None
@@ -607,10 +609,21 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
         # Snapshot built -- the forward is done reading the shared pool. Publish
-        # a read-done event the scheduler's WAR barrier waits on.
-        read_done = self.device_module.Event()
-        read_done.record()
-        self.model_runner.war_fastpath_read_done_event = read_done
+        # a read-done event the scheduler's WAR barrier waits on. Preferred:
+        # the captured graph carries an in-graph record node at the
+        # snapshot-completion point (published after launch below). Fallbacks:
+        # record after replay when the backend's captured metadata kernel
+        # indexes live shared buffers on every replay (e.g. trtllm_mha), else
+        # the classic pre-replay record.
+        use_in_graph_read_done = self._war_read_done_node_planted
+        read_done_post_replay = (
+            not use_in_graph_read_done
+            and self.draft_extend_attn_backend.in_graph_metadata_reads_shared_buffers
+        )
+        if not use_in_graph_read_done and not read_done_post_replay:
+            read_done = self.device_module.Event()
+            read_done.record()
+            self.model_runner.war_fastpath_read_done_event = read_done
 
         self.raw_bs = raw_bs
         self.bs = bs
@@ -624,6 +637,15 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         )
         with timer_ctx:
             out = self._replay_graph(shape_key, forward_batch)
+
+        if read_done_post_replay:
+            read_done = self.device_module.Event()
+            read_done.record()
+            self.model_runner.war_fastpath_read_done_event = read_done
+        elif use_in_graph_read_done:
+            # The record node inside this replay re-armed the external event;
+            # publish after the launch so the scheduler's wait pairs with it.
+            self.model_runner.war_fastpath_read_done_event = self.war_read_done_event
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],


### PR DESCRIPTION
trtllm_mha's fused in-graph metadata kernel re-reads the live req_to_token / full->SWA mapping on every graph replay -- after the WAR fastpath's pre-replay read-done event was recorded -- so scheduler-side writes could overwrite them mid-replay. Record the read-done event as an external-event node inside the captured graph at the snapshot-completion point (for backends with a no-op in-graph hook the node sits at the graph head, preserving today's semantics), with a new backend capability falling back to post-replay recording where in-graph capture is unavailable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29707770973](https://github.com/sgl-project/sglang/actions/runs/29707770973)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29707770880](https://github.com/sgl-project/sglang/actions/runs/29707770880)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->