### PR TITLE
Fix ROCm fused KV and KDA paths

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/chunk_intra.py
+++ b/python/sglang/kernels/ops/attention/fla/chunk_intra.py
@@ -429,6 +429,8 @@ def chunk_kda_fwd_kernel_inter_solve_fused(
         tl.store(p_Akkd11, b_Akk_d1.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akkd22, b_Akk_d2.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
         tl.store(p_Akkd33, b_Akk_d3.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+        # Forward substitution reloads these global tiles across warps below.
+        tl.debug_barrier()
 
         b_Ai00 = b_Akk_d0
         b_Ai11 = b_Akk_d1

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -324,9 +324,14 @@ def create_fused_set_kv_buffer_arg(
         )
     else:
         page_size = token_to_kv_pool.page_size
+        # A unified (non-hybrid) pool has no full->SWA remap: SWA and full layers
+        # share one slot space indexed directly by out_cache_loc (as --disable-hybrid-swa-memory
+        # gives). Leaving swa_slot_mapping=None makes the fused store write at
+        # out_cache_loc, matching the CUDA path (which never fuses the hybrid pool).
+        full_to_swa = getattr(token_to_kv_pool, "full_to_swa_index_mapping", None)
         slot_mapping_swa = (
-            token_to_kv_pool.full_to_swa_index_mapping.long()
-            if layer.sliding_window_size > 0
+            full_to_swa.long()
+            if layer.sliding_window_size > 0 and full_to_swa is not None
             else None
         )
         # SHUFFLE 5D pools (k_buffer.ndim == 5) consumed natively by

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -25,6 +25,7 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
+from sglang.jit_kernel.rope import FusedSetKVBufferArg
 from sglang.srt.environ import envs
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
@@ -306,8 +307,6 @@ def create_fused_set_kv_buffer_arg(
     layer: RadixAttention,
     forward_batch: ForwardBatch,
 ):
-    from sglang.jit_kernel.rope import FusedSetKVBufferArg
-
     layer_id = layer.layer_id
     token_to_kv_pool = get_token_to_kv_pool()
 
@@ -315,6 +314,7 @@ def create_fused_set_kv_buffer_arg(
     v_buffer = token_to_kv_pool.get_value_buffer(layer_id)
 
     if not _is_hip:
+        # CUDA path.
         assert layer.k_scale is None and layer.v_scale is None, "scale not supported"
         return FusedSetKVBufferArg(
             value=value,
@@ -323,12 +323,17 @@ def create_fused_set_kv_buffer_arg(
             cache_loc=forward_batch.out_cache_loc,
         )
     else:
+        # ROCm path.
         page_size = token_to_kv_pool.page_size
         # A unified (non-hybrid) pool has no full->SWA remap: SWA and full layers
         # share one slot space indexed directly by out_cache_loc (as --disable-hybrid-swa-memory
         # gives). Leaving swa_slot_mapping=None makes the fused store write at
         # out_cache_loc, matching the CUDA path (which never fuses the hybrid pool).
-        full_to_swa = getattr(token_to_kv_pool, "full_to_swa_index_mapping", None)
+        full_to_swa = (
+            token_to_kv_pool.full_to_swa_index_mapping
+            if isinstance(token_to_kv_pool, SWAKVPool)
+            else None
+        )
         slot_mapping_swa = (
             full_to_swa.long()
             if layer.sliding_window_size > 0 and full_to_swa is not None

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -325,7 +325,7 @@ def create_fused_set_kv_buffer_arg(
     else:
         # ROCm path.
         page_size = token_to_kv_pool.page_size
-        # A unified (non-hybrid) pool has no full->SWA remap: SWA and full layers
+        # A non-hybrid pool has no full->SWA remap: SWA and full layers
         # share one slot space indexed directly by out_cache_loc (as --disable-hybrid-swa-memory
         # gives). Leaving swa_slot_mapping=None makes the fused store write at
         # out_cache_loc, matching the CUDA path (which never fuses the hybrid pool).


### PR DESCRIPTION
## Summary

- Add a barrier after KDA fused stores before forward substitution reloads the tiles across warps.
- Handle unified SWA/full KV pools in the HIP fused KV cache setup by only passing an SWA remap when the pool provides one.

## Porting notes

- Adapted the KDA change to the current upstream FLA kernel path: `python/sglang/kernels/ops/attention/fla/chunk_intra.py`.
- Skipped files: none.

## Original commits

- `df9c7186c3`
- `24dcf1b82d`

## Testing

- `python3 -m py_compile python/sglang/kernels/ops/attention/fla/chunk_intra.py python/sglang/srt/models/utils.py`
- `with-proxy uv run pre-commit run --files python/sglang/kernels/ops/attention/fla/chunk_intra.py python/sglang/srt/models/utils.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29697308603](https://github.com/sgl-project/sglang/actions/runs/29697308603)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29697308537](https://github.com/sgl-project/sglang/actions/runs/29697308537)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->