### PR TITLE
Fix structural tag grammar validation

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -226,9 +226,12 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
             self.json_schema,
             self.regex,
             self.ebnf,
+            self.structural_tag,
         ]  # since mutually exclusive, only one can be set
         if sum(x is not None for x in grammars) > 1:
-            raise ValueError("Only one of regex, json_schema, or ebnf can be set.")
+            raise ValueError(
+                "Only one of regex, json_schema, ebnf, or structural_tag can be set."
+            )
 
     def normalize(self, tokenizer):
         # Process stop strings

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -289,6 +289,17 @@ class TestSamplingParamsVerify(CustomTestCase):
         with self.assertRaises(ValueError):
             sp.verify(self.VOCAB_SIZE)
 
+    def test_structural_tag_with_other_grammar_raises(self):
+        """Test that structural_tag is mutually exclusive with other grammars."""
+        for grammar in ("json_schema", "regex", "ebnf"):
+            with self.subTest(grammar=grammar):
+                sp = self._make(
+                    **{grammar: "constraint"},
+                    structural_tag='{"type":"structural_tag","structures":[]}',
+                )
+                with self.assertRaisesRegex(ValueError, "structural_tag"):
+                    sp.verify(self.VOCAB_SIZE)
+
 
 class TestSamplingParamsNormalize(CustomTestCase):
 


### PR DESCRIPTION
## Motivation

`SamplingParams.verify()` accepted `structural_tag` alongside another grammar constraint, causing one constraint to be silently ignored. Closes #31680.

## Modifications

Include `structural_tag` in grammar mutual-exclusivity validation and cover conflicts with JSON schema, regex, and EBNF.

## Accuracy Tests

N/A; validation-only change.

## Speed Tests and Profiling

N/A; no inference-path change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A for validation-only change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

Maintainer review requested.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29670937563](https://github.com/sgl-project/sglang/actions/runs/29670937563)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29670937509](https://github.com/sgl-project/sglang/actions/runs/29670937509)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->