### PR TITLE
[Fix] Validate Manifest.from_dict inputs in model_file_verifier

### DIFF
--- a/python/sglang/srt/utils/model_file_verifier.py
+++ b/python/sglang/srt/utils/model_file_verifier.py
@@ -47,7 +47,20 @@ class Manifest:
                     k: FileInfo(sha256=v, size=-1) for k, v in data["checksums"].items()
                 }
             )
-        return cls(files={k: FileInfo(**v) for k, v in data["files"].items()})
+        if not isinstance(data, dict) or "files" not in data:
+            raise IntegrityError(
+                "Manifest must be a dict containing a 'files' key "
+                "(or the deprecated 'checksums' key)."
+            )
+        files = {}
+        for name, info in data["files"].items():
+            if not isinstance(info, dict) or "sha256" not in info:
+                raise IntegrityError(
+                    f"Manifest file entry {name!r} must be an object "
+                    f"with a 'sha256' field."
+                )
+            files[name] = FileInfo(sha256=info["sha256"], size=info.get("size", -1))
+        return cls(files=files)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/test/registered/unit/utils/test_model_file_verifier.py
+++ b/test/registered/unit/utils/test_model_file_verifier.py
@@ -1,0 +1,46 @@
+import unittest
+
+from sglang.srt.utils.model_file_verifier import (
+    FileInfo,
+    IntegrityError,
+    Manifest,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestManifestFromDict(CustomTestCase):
+    def test_normal_files(self):
+        m = Manifest.from_dict(
+            {"files": {"a.bin": {"sha256": "abc", "size": 10}}}
+        )
+        self.assertEqual(m.files["a.bin"].sha256, "abc")
+        self.assertEqual(m.files["a.bin"].size, 10)
+
+    def test_missing_files_key_raises(self):
+        with self.assertRaises(IntegrityError):
+            Manifest.from_dict({"other": 1})
+        with self.assertRaises(IntegrityError):
+            Manifest.from_dict({})
+
+    def test_non_dict_input_raises(self):
+        with self.assertRaises(IntegrityError):
+            Manifest.from_dict(["not", "a", "dict"])
+
+    def test_malformed_entry_raises(self):
+        with self.assertRaises(IntegrityError):
+            Manifest.from_dict({"files": {"a.bin": "notadict"}})
+        with self.assertRaises(IntegrityError):
+            Manifest.from_dict({"files": {"a.bin": {"size": 10}}})
+
+    def test_deprecated_checksums_still_works(self):
+        with self.assertWarns(DeprecationWarning):
+            m = Manifest.from_dict({"checksums": {"a.bin": "deadbeef"}})
+        self.assertEqual(m.files["a.bin"].sha256, "deadbeef")
+        self.assertEqual(m.files["a.bin"].size, -1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`model_file_verifier.Manifest.from_dict` receives an external manifest dict
(generated or downloaded) but never validates its shape:

- If the dict has neither a `files` nor a `checksums` key,
  `data["files"]` raises a bare `KeyError`.
- If a file entry is not a dict, or is missing `sha256`,
  `FileInfo(**v)` raises a bare `TypeError`.

Both surface as opaque stack traces instead of the module's own
`IntegrityError`, which is what every other failure path in this
file uses. This makes malformed manifest input hard to diagnose.

This mirrors the input-validation hardening done for `GaugeHistogram`
in #31656.

## Change

`from_dict` now:
- raises `IntegrityError` when the top-level dict is missing `files`
  (and is not the deprecated `checksums` format),
- raises `IntegrityError` when a file entry is not an object or
  lacks `sha256`,
- tolerates a missing `size` (defaults to `-1`, same as the
  deprecated path) instead of crashing.

## Test

Added `test/registered/unit/utils/test_model_file_verifier.py`
covering normal parsing, the empty/missing-key case, non-dict
input, malformed entries, and the deprecated `checksums` path.
All CPU-only, no server / model weights / GPU.

```bash
pytest test/registered/unit/utils/test_model_file_verifier.py -v
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29671119673](https://github.com/sgl-project/sglang/actions/runs/29671119673)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29671119603](https://github.com/sgl-project/sglang/actions/runs/29671119603)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->