### PR TITLE
[Fix] Hoist $defs for named tool_choice JSON schema constraint

### DIFF
--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -394,6 +394,12 @@ def get_json_schema_constraint(
                 }
                 if not parallel_tool_calls:
                     schema["maxItems"] = 1
+                # Hoist the tool's $defs to the schema root so any
+                # "#/$defs/..." refs inside its parameters stay resolvable,
+                # matching the "required" branch below.
+                json_schema_defs = _get_tool_schema_defs([tool])
+                if json_schema_defs:
+                    schema["$defs"] = json_schema_defs
                 return schema
         return None
     elif tool_choice == "required":

--- a/test/registered/unit/function_call/test_json_schema_constraint.py
+++ b/test/registered/unit/function_call/test_json_schema_constraint.py
@@ -582,6 +582,135 @@ class TestJsonSchemaConstraint(unittest.TestCase):
         self.assertIn("complex_tool", tool_names)
         self.assertIn("another_simple_tool", tool_names)
 
+    def test_specific_tool_choice_with_defs(self):
+        """Specific tool choice must hoist the tool's $defs so its $ref resolves.
+
+        A named tool whose parameters use "#/$defs/..." references produced a
+        schema with a dangling $ref because $defs were only kept nested under
+        items/properties/parameters instead of at the schema root (the
+        "required" branch already hoists them). check_schema does not resolve
+        internal refs, so this only shows up when validating an instance.
+        """
+        tools_with_defs = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "location": {"$ref": "#/$defs/Location"},
+                        },
+                        "required": ["location"],
+                        "$defs": {
+                            "Location": {
+                                "type": "object",
+                                "properties": {
+                                    "lat": {"type": "number"},
+                                    "lon": {"type": "number"},
+                                },
+                                "required": ["lat", "lon"],
+                            },
+                        },
+                    },
+                ),
+            ),
+        ]
+
+        tool_choice = ToolChoice(
+            type="function", function=ToolChoiceFuncName(name="get_weather")
+        )
+        schema = get_json_schema_constraint(tools_with_defs, tool_choice)
+
+        self.assertIsNotNone(schema)
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+        # $defs must be hoisted to the root so the ref inside parameters resolves.
+        self.assertIn("$defs", schema)
+        self.assertIn("Location", schema["$defs"])
+
+        # A valid instance must validate without a RefResolutionError.
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(
+            [
+                {
+                    "name": "get_weather",
+                    "parameters": {"location": {"lat": 1.0, "lon": 2.0}},
+                }
+            ]
+        )
+        # The referenced definition still constrains the instance.
+        with self.assertRaises(jsonschema.ValidationError):
+            validator.validate(
+                [{"name": "get_weather", "parameters": {"location": {"lat": 1.0}}}]
+            )
+
+    def test_specific_tool_choice_nested_defs(self):
+        """Nested $defs must resolve for a specific tool choice as well."""
+        tools_with_nested_defs = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="complex_tool",
+                    description="Tool with nested $defs",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "user": {"$ref": "#/$defs/User"},
+                        },
+                        "required": ["user"],
+                        "$defs": {
+                            "User": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"},
+                                    "profile": {"$ref": "#/$defs/Profile"},
+                                },
+                                "required": ["id"],
+                            },
+                            "Profile": {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                                "required": ["name"],
+                            },
+                        },
+                    },
+                ),
+            ),
+        ]
+
+        tool_choice = ToolChoice(
+            type="function", function=ToolChoiceFuncName(name="complex_tool")
+        )
+        schema = get_json_schema_constraint(tools_with_nested_defs, tool_choice)
+
+        self.assertIsNotNone(schema)
+        jsonschema.Draft202012Validator.check_schema(schema)
+        self.assertIn("$defs", schema)
+        self.assertIn("User", schema["$defs"])
+        self.assertIn("Profile", schema["$defs"])
+
+        validator = jsonschema.Draft202012Validator(schema)
+        validator.validate(
+            [
+                {
+                    "name": "complex_tool",
+                    "parameters": {"user": {"id": "u1", "profile": {"name": "Ada"}}},
+                }
+            ]
+        )
+
+    def test_specific_tool_choice_no_defs_omits_defs_key(self):
+        """A specific tool without $defs should not gain an empty $defs key."""
+        tool_choice = ToolChoice(
+            type="function", function=ToolChoiceFuncName(name="get_weather")
+        )
+        schema = get_json_schema_constraint(self.tools, tool_choice)
+
+        self.assertIsNotNone(schema)
+        self.assertNotIn("$defs", schema)
+
     def test_tools_with_defs_but_no_refs(self):
         """Test tools with $defs but no $ref usage"""
         tools_with_unused_defs = [


### PR DESCRIPTION
Named `tool_choice` produced a JSON schema constraint whose `#/$defs/...` refs were unresolvable: `get_json_schema_constraint` embeds the tool's `parameters` (with their `$defs`) under `items/properties/parameters` but — unlike the `tool_choice="required"` branch — does not hoist `$defs` to the schema root. Any `$defs`/`$ref` in the tool's parameters (standard for nested/Pydantic args) then points at a root `$defs` that doesn't exist.

Reachable from `serving_chat.py`: a request with `tool_choice={"type":"function","function":{"name":X}}` whose parameters use `$defs` hands the grammar backend a malformed constraint schema.

Hoists `$defs` to the schema root in the named branch, mirroring the `required` branch. Adds regression tests that validate an instance against the produced schema (the existing specific-choice tests only call `check_schema`, which doesn't resolve internal refs — which is why this slipped through).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29672031302](https://github.com/sgl-project/sglang/actions/runs/29672031302)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29672031211](https://github.com/sgl-project/sglang/actions/runs/29672031211)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->