### PR TITLE
Fix DeepSeek-V4/DeepSeek-V4-Pro DP-attention gather semantics

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1854,7 +1854,9 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
             if _do_shared_local and local_hidden_states.shape[0] > 0:
                 _shared_local = self.mlp._forward_shared_experts(local_hidden_states)
-            dp_gather_partial(hidden_states, local_hidden_states, forward_batch)
+            # self_attn has already reduced across attention TP, so these hidden
+            # states are replicated and must not be summed by a partial gather.
+            dp_gather_replicate(hidden_states, local_hidden_states, forward_batch)
         _a2a_scatter_chunks: Optional[List[torch.Tensor]] = None
         if _use_tp_attn_a2a_scatter:
             s, r = get_parallel().attn_tp_size, get_parallel().attn_tp_rank
@@ -2372,7 +2374,10 @@ class DeepseekV4Model(nn.Module):
             )
             # Token ids are replicated within an attention-TP group. Use replicate
             # gather here to avoid summing duplicated ids when attention_tp_size > 1.
-            dp_gather_replicate(input_ids_global, input_ids[:, None], forward_batch)
+            # Clone because the MAX_LEN gather may zero its local input in place.
+            dp_gather_replicate(
+                input_ids_global, input_ids[:, None].clone(), forward_batch
+            )
             input_ids_global = input_ids_global.squeeze(-1)
         else:
             input_ids_global = input_ids

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -14,7 +14,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_prefill_cp_round_robin_split,
 )
 from sglang.srt.layers.dp_attention import (
-    dp_gather_partial,
+    dp_gather_replicate,
     get_global_dp_buffer_len,
     is_dp_attention_enabled,
 )
@@ -162,7 +162,12 @@ class DeepseekV4ModelNextN(nn.Module):
                 dtype=input_ids.dtype,
                 device=input_ids.device,
             )
-            dp_gather_partial(input_ids_global, input_ids[:, None], forward_batch)
+            # Token IDs are replicated within an attention-TP group. Use replicate
+            # gather to avoid summing duplicated IDs when attention_tp_size > 1.
+            # Clone because the MAX_LEN gather may zero its local input in place.
+            dp_gather_replicate(
+                input_ids_global, input_ids[:, None].clone(), forward_batch
+            )
             input_ids_global = input_ids_global.squeeze(-1)
         else:
             input_ids_global = input_ids


### PR DESCRIPTION
## Motivation

Fixes #31699.

DeepSeek-V4 DP-attention produces numerically invalid output when
`moe_a2a_backend=none`, `data_parallel_size>1`, and `attn_tp_size>1`.

By the time the MoE gather runs, `self_attn` has already reduced its output
across the attention-TP group. The hidden states are therefore replicated
across attention-TP ranks.

The existing `dp_gather_partial` calls treat those tensors as unreduced partial
contributions. Their reduce-scatter sums the replicated values, multiplying the
hidden-state magnitude by `attn_tp_size` at every MoE layer.

The same replicated-versus-partial distinction applies to the NextN input-ID
gather.

## Modifications

- Use `dp_gather_replicate` for the normal post-attention hidden-state gather.
- Use `dp_gather_replicate` for the NextN input-ID gather.
- Clone input IDs before both main-model and NextN replicate gathers. The
  MAX_LEN implementation can zero its local input on non-leader attention-TP
  ranks, and `input_ids[:, None]` otherwise aliases the caller-owned tensor.

The hidden-state inputs are not cloned because they are dead after their
gathers; cloning those large activations once per layer would add unnecessary
overhead.

## Reproduction

### Environment

The captured A/B used:

- Two hosts with 8 NVIDIA H200 GPUs each: 16 GPUs total
- `nvidia/DeepSeek-V4-Pro-NVFP4`
- SGLang revision `a9cf5e68e`
- Container `lmsysorg/sglang:nightly-dev-cu13-20260715-50d1edaa`
- Global tensor parallel size 16
- Data parallel size 4, producing attention TP4 x DP4 within those 16 ranks
- `moe_a2a_backend` omitted, so it defaults to `none`
- `SGLANG_SHARED_EXPERT_TP1=1`
- `--enable-dp-lm-head`, to exclude the LM-head path as a confounding variable
- No explicit `--quantization`; checkpoint quantization is auto-detected

The same failure was independently reproduced with attention TP8 x DP2 and on
two hosts with 8 H100 GPUs each.

The PR diff applies cleanly to the tested `a9cf5e68e` revision. Use the
unmodified revision for the failing run and the same revision with this PR diff
applied for the passing run. Keep the checkpoint and every launch argument
identical.

Stage the checkpoint on a login or transfer host, not in the GPU allocation:

```bash
python3 -m venv /shared/venvs/huggingface
/shared/venvs/huggingface/bin/python -m pip install --upgrade huggingface_hub
/shared/venvs/huggingface/bin/hf download \
  nvidia/DeepSeek-V4-Pro-NVFP4 \
  --local-dir /shared/models/DeepSeek-V4-Pro-NVFP4
```

The model and source checkout must be visible at the same paths on both GPU
hosts.

Run one `sglang.launch_server` process on each host. Both processes use global
`--tensor-parallel-size 16`; this is 16 total ranks across the two hosts, not 16
GPUs per host.

On host 0:

```bash
export NODE_RANK=0
export HEAD_NODE='<host-0 hostname or IP>'
```

On host 1:

```bash
export NODE_RANK=1
export HEAD_NODE='<host-0 hostname or IP>'
```

Then run this command inside the SGLang container/environment on both hosts:

```bash
export SGLANG_SHARED_EXPERT_TP1=1

python3 -m sglang.launch_server \
  --model-path /shared/models/DeepSeek-V4-Pro-NVFP4 \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 16 \
  --data-parallel-size 4 \
  --enable-dp-attention \
  --enable-dp-lm-head \
  --nnodes 2 \
  --node-rank "$NODE_RANK" \
  --dist-init-addr "$HEAD_NODE:29500" \
  --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend marlin \
  --fp4-gemm-backend marlin \
  --chunked-prefill-size 4096 \
  --disable-flashinfer-autotune \
  --mem-fraction-static 0.85 \
  --context-length 2200 \
  --cuda-graph-max-bs 256 \
  --max-running-requests 256 \
  --disable-radix-cache \
  --host 0.0.0.0 \
  --port 8000
```

Do not pass `--quantization` or `--moe-a2a-backend`.

Once host 0 reports ready, send:

```bash
curl -s "http://$HEAD_NODE:8000/v1/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "deepseek-ai/DeepSeek-V4-Pro",
    "messages": [{"role": "user", "content": "What is the capital of France?"}],
    "temperature": 0,
    "max_tokens": 128
  }'
```

For attention TP8 x DP2 on the same 16 GPUs, change only
`--data-parallel-size 4` to `--data-parallel-size 2`.

A single 8-GPU H200 host can run flat TP8, but flat TP does not exercise this
DP-attention gather and is not the demonstrated reproduction.

## Accuracy Tests

### Before: unpatched source fails

The unpatched server reports healthy and returns successful, well-formed JSON,
but the generated content is numerically corrupted.

For `What is the capital of France?` at `temperature=0`, captured pre-fix
content included:

```text
" +1 dep voquest m LH(-- _mi(zip bell {,PPTkinsagastruct C bell financially
BOuye em A_->TR,s. gland Amar [-]-bBuff ia Jol ke quer occurring ,holt PB
sakcka..."
```

For `What is 4 times 5 plus 2? Answer with just the number.` the pre-fix server
returned:

```text
"ffbs, bottles--> basisryl YusDL prime Scale Giber late pus , reckpp Cochrane
elem hydro Hugtered verte Jez-"
```

Neither response answers its prompt. The failure occurred with no server
exception and no request error.

### After: patched source passes

With the patch applied, the same deterministic checks returned:

```text
What is the capital of France?
=> The capital of France is Paris.

What is 4 times 5 plus 2?
=> 4 * 5 + 2 = 20 + 2 = 22

A store had 15 apples, sold 6, and received 20 more. How many now?
=> 29
```

Results:

- 3/3 prompts produced the same correct answer as the coherent flat-TP16
  baseline.
- The checks were repeated across seven independent patched server launches.
- Both TP4 x DP4 and TP8 x DP2 produced coherent output after the fix.
- No patched launch regressed to the pre-fix token-soup behavior.
- Generated-text samples were inspected throughout the 1K and 8K sweeps.
- The complete 8K sweep finished all ten concurrency levels, 1 through 512,
  with zero request errors and coherent generated text.

The synchronous path was exercised directly. The NextN call site was not enabled\nin these runtime tests; it was changed because it has the same replicated-input\ncollective semantics.

Local checks against current `main`:

- Ruff 0.15.1: passed
- Black 26.1.0: passed
- isort 7.0.0: passed
- `py_compile`: passed
- `git diff --check`: passed

## Speed Tests and Profiling

The patched TP4 x DP4 8K-input/1K-output run completed its full sweep:

| Concurrency | Completed | Total token throughput | Throughput/GPU |
|---:|---:|---:|---:|
| 1 | 10/10 | 281.34 tok/s | 17.584 tok/s/GPU |
| 8 | 80/80 | 1,811.15 tok/s | 113.197 tok/s/GPU |
| 64 | 640/640 | 6,936.50 tok/s | 433.531 tok/s/GPU |
| 256 | 2,560/2,560 | 10,468.91 tok/s | 654.307 tok/s/GPU |
| 512 | 5,120/5,120 | 12,274.31 tok/s | 767.144 tok/s/GPU |

A pre-fix performance comparison is not meaningful because every pre-fix
generated response was numerically invalid. Those jobs were stopped after the
correctness failure was confirmed.

## Checklist

- [x] Format the code according to the pre-commit configuration.
- [x] The affected path requires distributed attention-TP and
  DP collectives; it was validated on two-node, 16-GPU systems.
- [x] No user-facing documentation change is required.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code-style guidance.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30963574545](https://github.com/sgl-project/sglang/actions/runs/30963574545)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30963574465](https://github.com/sgl-project/sglang/actions/runs/30963574465)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->