### PR TITLE
ci: lower VL PP gsm8k threshold to 0.60 (0.65 has zero margin on H100)

### DIFF
--- a/test/registered/pp/test_pp_single_node_extra.py
+++ b/test/registered/pp/test_pp_single_node_extra.py
@@ -66,7 +66,7 @@ class TestQwenVLPPAccuracy(unittest.TestCase):
         metrics = run_eval(args)
         print(f"{metrics=}")
 
-        self.assertGreaterEqual(metrics["score"], 0.65)
+        self.assertGreaterEqual(metrics["score"], 0.60)
         # Wait a little bit so that the memory check happens.
         time.sleep(4)
 


### PR DESCRIPTION
## Summary

`TestQwenVLPPAccuracy.test_gsm8k` fails intermittently on H100 CI runners (`0.64/0.645 not >= 0.65`, e.g. [Jul 16 run](https://github.com/sgl-project/sglang/actions/runs/29541874051/job/87765660157)). Root cause is not a regression: 0.65 leaves zero margin on H100 hardware.

## Measurements (100 runs per cell, exact test config: Qwen3-VL-2B-Thinking, tp1/pp4, gsm8k n=200)

| | 5/29 introduction engine (`fba083c80f`) | current main |
|---|---|---|
| **H200** (devbox) | mean 0.6813, std 0.0056, min 0.670 | mean 0.6818, std 0.0070, min 0.665 |
| **H100** (delabeled CI runner, 4×H100) | mean 0.6762, std 0.0093, min 0.655 | mean 0.6755, std 0.0096, **min 0.650** |

- **No engine effect**: introduction commit vs main is statistically identical on both GPUs — no regression to find.
- **Hardware effect**: H100 scores ~0.006 lower and ~40% wider than H200; its tail touches 0.650 exactly. CI's 0.64s are that tail under shared-host load.
- Additionally, the full-1319-question gsm8k accuracy is **0.642** (n=200 slices the easier first questions — `_lines[:num_examples]`), so 0.65 gates above the model's true score. Raising `num_examples` would make the test fail deterministically.

## Change

Threshold 0.65 → 0.60: below the observed H100 tail and the full-set score, while still failing loudly on real breakage (observed genuine failure modes score 0.02–0.33).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29677185648](https://github.com/sgl-project/sglang/actions/runs/29677185648)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29677185530](https://github.com/sgl-project/sglang/actions/runs/29677185530)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->