### PR TITLE
Avoid DSA MQA chunking caused by cached CUDA memory

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -1097,6 +1097,25 @@ class Indexer(MultiPlatformOp):
         logits_budget_bytes = self._get_mqa_logits_budget_bytes(device_index)
 
         need_chunk = logits_bytes > logits_budget_bytes
+        if need_chunk:
+            # Return unused blocks held by PyTorch's caching allocator to CUDA,
+            # then re-evaluate with the refreshed amount of free device memory.
+            # This does not release memory occupied by live tensors.
+            free_mem_before_empty_cache, _ = torch.cuda.mem_get_info(device_index)
+            torch.cuda.empty_cache()
+            free_mem, total_mem = torch.cuda.mem_get_info(device_index)
+            need_chunk = (logits_bytes * 2 > free_mem) or (
+                logits_bytes > total_mem * self._MQA_LOGITS_TOTAL_MEM_FRACTION
+            )
+            logger.info(
+                "DSA MQA logits released unused PyTorch CUDA cache: "
+                "free memory %.2f GiB -> %.2f GiB, logits %.2f GiB, "
+                "need_chunk=%s",
+                free_mem_before_empty_cache / (1024**3),
+                free_mem / (1024**3),
+                logits_bytes / (1024**3),
+                need_chunk,
+            )
         return need_chunk, logits_budget_bytes
 
     def _get_topk_ragged(


### PR DESCRIPTION
## Summary

- release unused blocks from PyTorch's CUDA caching allocator before falling back to chunked DSA MQA logits computation
- re-check free device memory after the cache release
- log the before/after free-memory values and the final chunking decision

## Problem

The cached MQA logits budget can trigger chunked computation when CUDA memory is available but temporarily held in unused PyTorch cache blocks. This unnecessary chunking increases inference latency.

## Impact

When the initial budget check requests chunking, the implementation now returns unused cached blocks to CUDA and re-evaluates the memory guard. Chunking is skipped when the refreshed free-memory and total-memory limits can safely accommodate the logits allocation. Live tensor memory is not released.

## Validation

- `python -m py_compile python/sglang/srt/layers/attention/dsa/dsa_indexer.py`
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #29685523843](https://github.com/sgl-project/sglang/actions/runs/29685523843)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #29685523780](https://github.com/sgl-project/sglang/actions/runs/29685523780)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->