### PR TITLE
[DeepSeek-V4] Fix idle-rank dummy-extend sparse-prefill crash under DP breakable CUDA graph

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -94,6 +94,8 @@ def _get_logical_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
     # from a reused/padded ForwardBatch turn an empty rank into TARGET_VERIFY.
     if forward_batch.forward_mode.is_idle():
         return forward_batch.forward_mode
+    if forward_batch.forward_mode == ForwardMode.EXTEND:
+        return forward_batch.forward_mode
     return (
         getattr(forward_batch, "_original_forward_mode", None)
         or forward_batch.forward_mode


### PR DESCRIPTION
## Problem

`test_deepseek_v4_flash_fp4_b200.py` (base-c b200 deepep, BCG recipe: TP4/DP4/DeepEP, `--enable-mixed-chunk --cuda-graph-backend-prefill breakable`) crashes deterministically on idle DP ranks:

```
_forward_prefill_sparse: assert core_attn_metadata.c4_sparse_raw_indices is not None
AssertionError: sparse-prefill c4 path requires c4_sparse_raw_indices
```

## Root cause

Latent defect from #30898, surfaced by #31487.

Under DP attention + breakable prefill CUDA graph (#30898), an idle rank is padded into a fabricated dummy EXTEND: `forward_batch_info` stashes the real mode in `_original_forward_mode` (IDLE) and sets `forward_mode = EXTEND`. `_get_logical_forward_mode` returns the stale IDLE, so metadata is built via the decode branch (no `c4_sparse_raw_indices`, gated on `is_prefill=True`), while the forward keys off `forward_mode = EXTEND` and runs `_forward_prefill_sparse` (default-on since #29775) → assertion.

Latent since 7-12; #31487 ("avoid excessive prefill CUDA graph padding") then made DP prefill land on the small capture buckets (4/16) where the dummy extend actually fires, flipping the job green→red (bisected: last green `0ad0ff2e9e`, first red `216b750c`).

## Fix

Build metadata for the mode the forward actually runs: when `forward_mode == EXTEND`, return it instead of the stale `_original_forward_mode`, so extend metadata is built and `c4_sparse_raw_indices` is allocated. The fabricated batch already carries valid extend fields. `TARGET_VERIFY` overwrites (MTP hybrid SSM) still prefer `_original_forward_mode`.

## Validation

Reproduced + fixed on a 4×B200 devbox at `216b750c` (exact BCG args, shipped code): before, crashes under load (idle ranks DP1/2/3); after, 204/204 requests OK, 0 assertions. Crash/liveness verified under synthetic load; gsm8k accuracy left to CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29680415456](https://github.com/sgl-project/sglang/actions/runs/29680415456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29680415363](https://github.com/sgl-project/sglang/actions/runs/29680415363)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->