### PR TITLE
[NPU] bugfix for W4A8MoE bias 3D dimension mismatch problem

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
@@ -429,7 +429,14 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
                 torch.nn.Parameter(processed_scale, requires_grad=False),
             )
             if bias is not None:
-                setattr(layer, f"{weight_prefix}_scale_bias", bias)
+                setattr(
+                    layer,
+                    f"{weight_prefix}_scale_bias",
+                    torch.nn.Parameter(
+                        bias.data.transpose(1, 2).sum(dim=1).contiguous(),
+                        requires_grad=False,
+                    ),
+                )
 
         # Process weight
         weight = getattr(layer, f"{weight_prefix}_weight")
@@ -453,9 +460,7 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
         scale_bias_name = f"{weight_prefix}_scale_bias"
         if hasattr(layer, scale_bias_name):
             scale_bias = getattr(layer, scale_bias_name)
-            scale_bias.data = (
-                scale_bias.data.transpose(1, 2).contiguous().sum(dim=1)
-            )
+            scale_bias.data = scale_bias.data.transpose(1, 2).contiguous().sum(dim=1)
 
     def _process_scale(
         self,

--- a/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
@@ -419,6 +419,7 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
             if scale_second is not None:
                 delattr(layer, f"{weight_prefix}_weight_scale_second")
                 delattr(layer, f"{weight_prefix}_weight_offset_second")
+            self._update_bias(layer, weight_prefix)
         else:
             # With clip: simple squeeze + unsqueeze
             processed_scale = scale.data.squeeze(-1).unsqueeze(1).contiguous()
@@ -428,14 +429,7 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
                 torch.nn.Parameter(processed_scale, requires_grad=False),
             )
             if bias is not None:
-                setattr(
-                    layer,
-                    f"{weight_prefix}_scale_bias",
-                    torch.nn.Parameter(
-                        bias.data.transpose(1, 2).sum(dim=1).contiguous(),
-                        requires_grad=False,
-                    ),
-                )
+                setattr(layer, f"{weight_prefix}_scale_bias", bias)
 
         # Process weight
         weight = getattr(layer, f"{weight_prefix}_weight")
@@ -450,6 +444,18 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
         # Set dispatcher output dtype
         if weight_prefix == "w13":
             self._set_dispatcher_output_dtype(layer, "int8")
+
+    @staticmethod
+    def _update_bias(
+        layer: torch.nn.Module,
+        weight_prefix: str,
+    ) -> None:
+        scale_bias_name = f"{weight_prefix}_scale_bias"
+        if hasattr(layer, scale_bias_name):
+            scale_bias = getattr(layer, scale_bias_name)
+            scale_bias.data = (
+                scale_bias.data.transpose(1, 2).contiguous().sum(dim=1)
+            )
 
     def _process_scale(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
The refactor of fused NPU MoE introduced in PR #25663 caused a regression, as the bias update logic was missing after bias loading.
In the original implementation, w13_scale_bias was initialized as a 3D tensor. The _update_bias method performed this operation:
layer.w13_scale_bias.data.transpose(1, 2).contiguous().sum(dim=1)
This logic converted the 3D bias tensor into a 2D tensor: it first transposed dimensions 1 and 2, then summed along dimension 1.
This conversion was required because torch.ops.npu.npu_grouped_matmul only accepts 2D bias tensors.
However, the new code added in PR #25663 removed the above transformation. As a result, the bias passed into npu_grouped_matmul remains a 3D tensor, triggering the dimension mismatch error.

```
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/moe/ep_moe/layer.py", line 175, in forward
    return self.forward_impl(hidden_states, topk_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/moe/ep_moe/layer.py", line 184, in forward_impl
    return super().forward_impl(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 1267, in forward_impl
    combine_input = self.run_moe_core(
                    ^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/moe/ep_moe/layer.py", line 211, in run_moe_core
    return super().run_moe_core(dispatch_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 1305, in run_moe_core
    return self.quant_method.apply(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/quantization/modelslim/modelslim.py", line 462, in apply
    return self.runner.run(dispatch_output, quant_info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/moe/moe_runner/runner.py", line 168, in run
    runner_output = self.runner_core.run(
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/layers/moe/moe_runner/ascend.py", line 138, in run
    hidden_states = self.config.layer.w13_kernel.apply(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py", line 516, in apply
    return self.matmul.forward(
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/wzy/sglang/python/sglang/srt/hardware_backend/npu/moe/matmul.py", line 40, in forward
    return torch.ops.npu.npu_grouped_matmul(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/_ops.py", line 1209, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: npu_grouped_matmul:../third_party/op-plugin/op_plugin/ops/opapi/GroupedMatmulKernelNpuOpApi.cpp:339 NPU function error: call aclnnGroupedMatmulV5 failed, error code is 161002
[ERROR] 2026-07-19-08:05:09 (PID:685775, Device:10, RankID:-1) ERR00100 PTA call acl api failed.
[PID: 685775] 2026-07-19-08:05:09.736.656 AclNN_Parameter_Error(EZ1001): bias Dim must be 2, but now is 3.
        TraceBack (most recent call last):
        CheckDimNumAndPerGroupNum failed.
        Invalid bias!
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
For non-clip path, directly applies transpose(1,2).sum(dim=1) method to the existing `{prefix}_scale_bias` on the layer, shrinking the 3D to 2D.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
<img width="972" height="96" alt="image" src="https://github.com/user-attachments/assets/42432c12-35cc-4bfd-a0e4-fb77fdfaa0f2" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29680636630](https://github.com/sgl-project/sglang/actions/runs/29680636630)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29680636465](https://github.com/sgl-project/sglang/actions/runs/29680636465)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->