### PR TITLE
[kv-canary] Scatter req token ids by (request × column-block) instead of per-token owner search

### DIFF
--- a/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
+++ b/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
@@ -5,9 +5,9 @@ import triton
 import triton.language as tl
 
 # Column tile width. Each program copies a contiguous COL_BLOCK-wide slice of one
-# request's segment: a coalesced int64 load -> int32 store, guarded by a single
-# ``col < write_len`` mask. 1024 keeps every program busy without over-tiling the
-# common (short-context) case.
+# request's segment: a coalesced int64 load -> int32 store, guarded by request-length
+# and flat-buffer bounds. 1024 keeps every program busy without over-tiling the common
+# (short-context) case.
 _SCATTER_COL_BLOCK: int = 1024
 
 

--- a/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
+++ b/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
@@ -143,19 +143,21 @@ def _scatter_req_token_ids_kernel(
     # which truncates each segment at max_context_len).
     write_len = tl.minimum(seg_len, pool_max_context_len)  # int64
 
-    # The grid width is sized to the longest segment in the batch; a request shorter
-    # than that gets tiles past its write_len that have nothing to copy -- return
-    # before touching req_pool_indices / building addresses.
+    # The grid uses a batch-wide host-known upper bound (min(max_context_len,
+    # num_tokens)). A request shorter than that bound receives excess column tiles;
+    # return before touching req_pool_indices / building copy addresses.
     col_base = cblk * COL_BLOCK
     if col_base >= write_len:
         return
 
     col = col_base + tl.arange(0, COL_BLOCK)  # [COL_BLOCK] int32
-    # Bound the load by write_len AND the flat length, so a malformed offsets tensor
-    # can never read past flat_in (matches the previous kernel's tid<num_tokens guard).
-    mask = (col < write_len) & (start + col < num_tokens)  # [COL_BLOCK] bool
+    flat_idx = start + col  # [COL_BLOCK] int64
+    # Bound the load to the request's write_len AND to a valid flat_in index (both
+    # ends), so a malformed offsets tensor can never read outside flat_in. Matches the
+    # previous kernel's tid<num_tokens guard and additionally rejects negative starts.
+    mask = (col < write_len) & (flat_idx >= 0) & (flat_idx < num_tokens)  # bool
 
-    val = tl.load(flat_in_ptr + start + col, mask=mask, other=0).to(
+    val = tl.load(flat_in_ptr + flat_idx, mask=mask, other=0).to(
         tl.int32
     )  # [COL_BLOCK] int32
     rp = tl.load(req_pool_indices_ptr + r)  # int64

--- a/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
+++ b/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
@@ -40,7 +40,9 @@ def launch_scatter_req_token_ids_kernel(
         - The grid is ``(bs, num_col_blocks)``: one axis per request, one per
           column tile. Each program loads ``offsets[r]`` / ``offsets[r + 1]`` once
           (``O(1)`` per program) and copies its slice directly -- no per-token
-          owner search, and no cap on ``bs``.
+          owner search, and no cap on ``bs``. A program whose column tile falls past a
+          (shorter) request's ``write_len`` returns before any copy, so a single long
+          request among many short ones does not make the short ones pay for empty tiles.
     """
     if flat_in.dim() != 1:
         raise ValueError(
@@ -89,7 +91,6 @@ def launch_scatter_req_token_ids_kernel(
             f"kv-canary: scatter_req_token_ids offsets length {offsets.shape[0]} != "
             f"bs+1 ({bs + 1})"
         )
-
     num_tokens = int(flat_in.shape[0])
     if bs == 0 or num_tokens == 0:
         return
@@ -97,9 +98,10 @@ def launch_scatter_req_token_ids_kernel(
     pool_stride0 = int(pool_out.stride(0))
     pool_max_context_len = int(pool_out.shape[1])
 
-    # A request can write at most ``min(seg_len, pool_max_context_len)`` columns, and
-    # no segment is longer than ``num_tokens``; grid only as many column tiles as the
-    # tighter of the two bounds needs (all host-known, so no device sync).
+    # A request can write at most ``min(seg_len, pool_max_context_len)`` columns, and no
+    # segment is longer than ``num_tokens``; grid only as many column tiles as the tighter
+    # bound needs (host-known, no device sync). Programs that land past a shorter request's
+    # ``write_len`` return early in-kernel, so no host-side per-req max is needed.
     effective_cols = min(pool_max_context_len, num_tokens)
     if effective_cols <= 0:
         return
@@ -111,6 +113,7 @@ def launch_scatter_req_token_ids_kernel(
         offsets,
         req_pool_indices,
         pool_out,
+        num_tokens=num_tokens,
         pool_stride0=pool_stride0,
         pool_max_context_len=pool_max_context_len,
         COL_BLOCK=_SCATTER_COL_BLOCK,
@@ -123,6 +126,7 @@ def _scatter_req_token_ids_kernel(
     offsets_ptr,  # [num_batch + 1] int64
     req_pool_indices_ptr,  # [num_batch] int64
     pool_out_ptr,  # [num_rows, pool_max_context_len] int32, row stride = pool_stride0
+    num_tokens,  # scalar int32 (length of flat_in)
     pool_stride0,  # scalar int32 (row stride of pool_out in elements)
     pool_max_context_len,  # scalar int32 (dim-1 length of pool_out)
     COL_BLOCK: tl.constexpr,
@@ -139,8 +143,17 @@ def _scatter_req_token_ids_kernel(
     # which truncates each segment at max_context_len).
     write_len = tl.minimum(seg_len, pool_max_context_len)  # int64
 
-    col = cblk * COL_BLOCK + tl.arange(0, COL_BLOCK)  # [COL_BLOCK] int32
-    mask = col < write_len  # [COL_BLOCK] bool
+    # The grid width is sized to the longest segment in the batch; a request shorter
+    # than that gets tiles past its write_len that have nothing to copy -- return
+    # before touching req_pool_indices / building addresses.
+    col_base = cblk * COL_BLOCK
+    if col_base >= write_len:
+        return
+
+    col = col_base + tl.arange(0, COL_BLOCK)  # [COL_BLOCK] int32
+    # Bound the load by write_len AND the flat length, so a malformed offsets tensor
+    # can never read past flat_in (matches the previous kernel's tid<num_tokens guard).
+    mask = (col < write_len) & (start + col < num_tokens)  # [COL_BLOCK] bool
 
     val = tl.load(flat_in_ptr + start + col, mask=mask, other=0).to(
         tl.int32

--- a/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
+++ b/python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py
@@ -4,12 +4,11 @@ import torch
 import triton
 import triton.language as tl
 
-_SCATTER_TOKEN_BLOCK: int = 256
-# Upper bound on bs+1 the kernel can scan per program. Owner-req lookup uses an
-# outer-product tile of shape ``[TOKEN_BLOCK, BATCH_BLOCK]``; keep this small so
-# the tile stays in registers (256 x 512 = 128 KiB i1, well below the SM trap-
-# inducing budget that bites at the 1M cell mark).
-_SCATTER_BATCH_BLOCK: int = 512
+# Column tile width. Each program copies a contiguous COL_BLOCK-wide slice of one
+# request's segment: a coalesced int64 load -> int32 store, guarded by a single
+# ``col < write_len`` mask. 1024 keeps every program busy without over-tiling the
+# common (short-context) case.
+_SCATTER_COL_BLOCK: int = 1024
 
 
 def launch_scatter_req_token_ids_kernel(
@@ -21,13 +20,12 @@ def launch_scatter_req_token_ids_kernel(
 ) -> None:
     """Scatter a flat per-req int64 object sequence into a 2-D int32 pool.
 
-    For each global object index ``t`` in ``[0, total_tokens)``:
+    For each request ``r`` in ``[0, bs)``:
 
-    - find ``r`` = largest req index s.t. ``offsets[r] <= t``
-    - ``pos = t - offsets[r]``
+    - ``start, end = offsets[r], offsets[r + 1]``
     - ``rp = req_pool_indices[r]``
-    - if ``pos < pool_max_context_len``:
-      ``pool_out[rp, pos] = flat_in[t].to(int32)``
+    - ``write_len = min(end - start, pool_max_context_len)``
+    - ``pool_out[rp, :write_len] = flat_in[start:start + write_len].to(int32)``
 
     Args:
         flat_in: ``[total_tokens]`` int64 device tensor of objects, flattened
@@ -39,8 +37,10 @@ def launch_scatter_req_token_ids_kernel(
             Mutated in-place; rows not addressed by ``req_pool_indices`` are untouched.
 
     Implementation notes:
-        - Linear scan over ``offsets`` (``BATCH_BLOCK >= bs + 1``); fits easily in
-          registers for the workloads kv-canary handles (``bs <= a few thousand``).
+        - The grid is ``(bs, num_col_blocks)``: one axis per request, one per
+          column tile. Each program loads ``offsets[r]`` / ``offsets[r + 1]`` once
+          (``O(1)`` per program) and copies its slice directly -- no per-token
+          owner search, and no cap on ``bs``.
     """
     if flat_in.dim() != 1:
         raise ValueError(
@@ -89,31 +89,31 @@ def launch_scatter_req_token_ids_kernel(
             f"kv-canary: scatter_req_token_ids offsets length {offsets.shape[0]} != "
             f"bs+1 ({bs + 1})"
         )
-    if bs + 1 > _SCATTER_BATCH_BLOCK:
-        raise ValueError(
-            f"kv-canary: scatter_req_token_ids bs+1={bs + 1} exceeds BATCH_BLOCK="
-            f"{_SCATTER_BATCH_BLOCK}; bump _SCATTER_BATCH_BLOCK if real workloads need this"
-        )
 
     num_tokens = int(flat_in.shape[0])
-    if num_tokens == 0:
+    if bs == 0 or num_tokens == 0:
         return
 
     pool_stride0 = int(pool_out.stride(0))
     pool_max_context_len = int(pool_out.shape[1])
 
-    grid = (triton.cdiv(num_tokens, _SCATTER_TOKEN_BLOCK),)
+    # A request can write at most ``min(seg_len, pool_max_context_len)`` columns, and
+    # no segment is longer than ``num_tokens``; grid only as many column tiles as the
+    # tighter of the two bounds needs (all host-known, so no device sync).
+    effective_cols = min(pool_max_context_len, num_tokens)
+    if effective_cols <= 0:
+        return
+
+    num_col_blocks = triton.cdiv(effective_cols, _SCATTER_COL_BLOCK)
+    grid = (bs, num_col_blocks)
     _scatter_req_token_ids_kernel[grid](
         flat_in,
         offsets,
         req_pool_indices,
         pool_out,
-        num_tokens=num_tokens,
-        num_batch=bs,
         pool_stride0=pool_stride0,
         pool_max_context_len=pool_max_context_len,
-        TOKEN_BLOCK=_SCATTER_TOKEN_BLOCK,
-        BATCH_BLOCK=_SCATTER_BATCH_BLOCK,
+        COL_BLOCK=_SCATTER_COL_BLOCK,
     )
 
 
@@ -123,47 +123,30 @@ def _scatter_req_token_ids_kernel(
     offsets_ptr,  # [num_batch + 1] int64
     req_pool_indices_ptr,  # [num_batch] int64
     pool_out_ptr,  # [num_rows, pool_max_context_len] int32, row stride = pool_stride0
-    num_tokens,  # scalar int32
-    num_batch,  # scalar int32
     pool_stride0,  # scalar int32 (row stride of pool_out in elements)
     pool_max_context_len,  # scalar int32 (dim-1 length of pool_out)
-    TOKEN_BLOCK: tl.constexpr,
-    BATCH_BLOCK: tl.constexpr,
+    COL_BLOCK: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    tids = pid * TOKEN_BLOCK + tl.arange(0, TOKEN_BLOCK)  # [TOKEN_BLOCK] int32
-    tid_mask = tids < num_tokens  # [TOKEN_BLOCK] bool
+    r = tl.program_id(0)  # request index
+    cblk = tl.program_id(1)  # column-block index within the request
 
-    bs_offs = tl.arange(0, BATCH_BLOCK)  # [BATCH_BLOCK] int32
-    bs_mask = bs_offs < (num_batch + 1)  # [BATCH_BLOCK] bool
-    offs_vals = tl.load(  # [BATCH_BLOCK] int64
-        offsets_ptr + bs_offs,
-        mask=bs_mask,
-        other=(1 << 62),
-    )
-
-    # find owning req for each tid via reduce-sum: req_idx = (count of offsets <= tid) - 1
-    le = offs_vals[None, :] <= tids[:, None]  # [TOKEN_BLOCK, BATCH_BLOCK] bool
-    req_idx = tl.sum(le.to(tl.int32), axis=1) - 1  # [TOKEN_BLOCK] int32
-
-    safe_req_idx = tl.where(tid_mask, req_idx, 0)  # [TOKEN_BLOCK] int32
-    starts = tl.load(
-        offsets_ptr + safe_req_idx, mask=tid_mask, other=0
-    )  # [TOKEN_BLOCK] int64
-    pos = tids - starts  # [TOKEN_BLOCK] int64
-    rp = tl.load(
-        req_pool_indices_ptr + safe_req_idx, mask=tid_mask, other=0
-    )  # [TOKEN_BLOCK] int64
+    start = tl.load(offsets_ptr + r)  # int64
+    end = tl.load(offsets_ptr + r + 1)  # int64
+    seg_len = end - start  # int64
 
     # Bound writes by the pool's max_context_len so a token sequence longer than the
-    # ReqToTokenPool row never spills into an adjacent row.
-    in_row = pos < pool_max_context_len  # [TOKEN_BLOCK] bool
-    write_mask = tid_mask & in_row  # [TOKEN_BLOCK] bool
+    # ReqToTokenPool row never spills into an adjacent row (matches the reference,
+    # which truncates each segment at max_context_len).
+    write_len = tl.minimum(seg_len, pool_max_context_len)  # int64
 
-    val = tl.load(flat_in_ptr + tids, mask=tid_mask, other=0).to(
+    col = cblk * COL_BLOCK + tl.arange(0, COL_BLOCK)  # [COL_BLOCK] int32
+    mask = col < write_len  # [COL_BLOCK] bool
+
+    val = tl.load(flat_in_ptr + start + col, mask=mask, other=0).to(
         tl.int32
-    )  # [TOKEN_BLOCK] int32
-    tl.store(pool_out_ptr + rp * pool_stride0 + pos, val, mask=write_mask)
+    )  # [COL_BLOCK] int32
+    rp = tl.load(req_pool_indices_ptr + r)  # int64
+    tl.store(pool_out_ptr + rp * pool_stride0 + col, val, mask=mask)
 
 
 def scatter_req_token_ids_torch_reference(

--- a/test/registered/kernels/benchmark/kv_canary/bench_scatter_req_token_ids.py
+++ b/test/registered/kernels/benchmark/kv_canary/bench_scatter_req_token_ids.py
@@ -49,19 +49,20 @@ _X_NAMES = ["bs", "seq_len"]
 _X_VALS = [(c.bs, c.seq_len) for c in _build_cases()]
 
 
-def _build_inputs(*, bs: int, seq_len: int, device: torch.device) -> dict:
+def _inputs_from_lens(lens: torch.Tensor, device: torch.device) -> dict:
+    """Build kernel inputs from a per-req length vector (uniform or skewed)."""
+    bs = int(lens.shape[0])
     max_reqs = max(bs + 1, 4)
-    max_context_len = max(seq_len + 1, 1)
-    total_tokens = bs * seq_len
+    max_context_len = max(int(lens.max().item()) + 1, 1) if bs else 1
+    total_tokens = int(lens.sum().item())
 
     flat = torch.randint(
         low=0,
         high=1 << 30,
-        size=(total_tokens,),
+        size=(max(total_tokens, 1),),
         dtype=torch.int64,
         device=device,
-    )
-    lens = torch.full((bs,), seq_len, dtype=torch.int64, device=device)
+    )[:total_tokens]
     offsets = torch.zeros(bs + 1, dtype=torch.int64, device=device)
     offsets[1:] = torch.cumsum(lens, dim=0)
 
@@ -73,6 +74,41 @@ def _build_inputs(*, bs: int, seq_len: int, device: torch.device) -> dict:
         req_pool_indices=req_pool_indices,
         pool_out=pool,
     )
+
+
+def _build_inputs(*, bs: int, seq_len: int, device: torch.device) -> dict:
+    lens = torch.full((bs,), seq_len, dtype=torch.int64, device=device)
+    return _inputs_from_lens(lens, device)
+
+
+# Skewed workloads: a few long requests among many short/empty ones. These are the
+# shapes the (request, column-block) grid + per-request early-return are designed for,
+# and that the uniform bs x seq_len grid above does not cover.
+_SKEWED_FULL: list[str] = [
+    "one_long_among_short_bs256",
+    "one_long_among_short_bs64",
+    "few_long_among_short_bs256",
+    "many_medium_bs256",
+]
+_SKEWED_CI: list[str] = ["one_long_among_short_bs256", "many_medium_bs256"]
+
+
+def _build_skewed_lens(name: str, device: torch.device) -> torch.Tensor:
+    g = torch.Generator(device=device).manual_seed(0)
+    if name == "one_long_among_short_bs256":
+        lens = torch.randint(0, 4, (256,), generator=g, device=device)
+        lens[128] = 32768
+    elif name == "one_long_among_short_bs64":
+        lens = torch.randint(0, 4, (64,), generator=g, device=device)
+        lens[32] = 32768
+    elif name == "few_long_among_short_bs256":
+        lens = torch.randint(0, 4, (256,), generator=g, device=device)
+        lens[::64] = 16384
+    elif name == "many_medium_bs256":
+        lens = torch.full((256,), 64, dtype=torch.int64, device=device)
+    else:
+        raise ValueError(f"unknown skewed workload {name}")
+    return lens.to(torch.int64)
 
 
 @triton.testing.perf_report(
@@ -95,5 +131,28 @@ def benchmark(bs: int, seq_len: int, provider: str) -> tuple[float, float, float
     )
 
 
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["workload"],
+        x_vals=get_benchmark_range(full_range=_SKEWED_FULL, ci_range=_SKEWED_CI),
+        line_arg="provider",
+        line_vals=["triton"],
+        line_names=["Triton"],
+        styles=[("green", "-")],
+        ylabel="time (us)",
+        plot_name="kv-canary-scatter-req-token-ids-skewed",
+        args={},
+    )
+)
+def benchmark_skewed(workload: str, provider: str) -> tuple[float, float, float]:
+    device = torch.device(DEFAULT_DEVICE)
+    lens = _build_skewed_lens(workload, device)
+    inputs = _inputs_from_lens(lens, device)
+    return run_benchmark_no_cudagraph(
+        lambda: launch_scatter_req_token_ids_kernel(**inputs)
+    )
+
+
 if __name__ == "__main__":
     benchmark.run(print_data=True)
+    benchmark_skewed.run(print_data=True)

--- a/test/registered/kernels/ops/kv_canary/test_scatter_req_token_ids.py
+++ b/test/registered/kernels/ops/kv_canary/test_scatter_req_token_ids.py
@@ -285,6 +285,42 @@ class TestScatterReqTokenIds(CustomTestCase):
         torch.cuda.synchronize()
         self.assertTrue(torch.equal(triton_pool, ref_pool))
 
+    def test_scatter_one_long_among_many_short(self) -> None:
+        """A long request among 200 short/empty ones is byte-equal (early-return path).
+
+        The grid width is set by the longest segment, so the short requests receive
+        column tiles past their write_len; those programs must return without writing.
+        """
+        rng = random.Random(3)
+        max_context_len = 4096
+        # One long request (spans multiple COL_BLOCK tiles) among short/empty ones.
+        lens = [3000] + [rng.randint(0, 4) for _ in range(200)]
+        bs = len(lens)
+        max_reqs = bs + 1
+        rp = rng.sample(range(1, max_reqs), k=bs)
+        seqs = [[rng.randint(0, 1 << 30) for _ in range(n)] for n in lens]
+
+        flat = _build_flat(seqs)
+        offsets = _build_offsets(lens)
+        req_pool_indices = torch.tensor(rp, dtype=torch.int64, device=_DEVICE)
+        triton_pool = _build_pool(max_reqs=max_reqs, max_context_len=max_context_len)
+        ref_pool = _build_pool(max_reqs=max_reqs, max_context_len=max_context_len)
+
+        launch_scatter_req_token_ids_kernel(
+            flat_in=flat,
+            offsets=offsets,
+            req_pool_indices=req_pool_indices,
+            pool_out=triton_pool,
+        )
+        scatter_req_token_ids_torch_reference(
+            flat_in=flat,
+            offsets=offsets,
+            req_pool_indices=req_pool_indices,
+            pool_out=ref_pool,
+        )
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(triton_pool, ref_pool))
+
 
 class TestScatterInputValidation(CustomTestCase):
     """Cover the strict input checks in launch_scatter_req_token_ids_kernel."""

--- a/test/registered/kernels/ops/kv_canary/test_scatter_req_token_ids.py
+++ b/test/registered/kernels/ops/kv_canary/test_scatter_req_token_ids.py
@@ -288,8 +288,8 @@ class TestScatterReqTokenIds(CustomTestCase):
     def test_scatter_one_long_among_many_short(self) -> None:
         """A long request among 200 short/empty ones is byte-equal (early-return path).
 
-        The grid width is set by the longest segment, so the short requests receive
-        column tiles past their write_len; those programs must return without writing.
+        The grid uses a batch-wide upper bound, so the short requests receive column
+        tiles past their write_len; those programs must return without writing.
         """
         rng = random.Random(3)
         max_context_len = 4096

--- a/test/registered/kernels/ops/kv_canary/test_scatter_req_token_ids.py
+++ b/test/registered/kernels/ops/kv_canary/test_scatter_req_token_ids.py
@@ -6,7 +6,6 @@ import unittest
 import torch
 
 from sglang.kernels.ops.kv_canary.scatter_req_token_ids import (
-    _SCATTER_BATCH_BLOCK,
     launch_scatter_req_token_ids_kernel,
     scatter_req_token_ids_torch_reference,
 )
@@ -212,6 +211,80 @@ class TestScatterReqTokenIds(CustomTestCase):
             torch.cuda.synchronize()
             self.assertTrue(torch.equal(triton_pool, ref_pool))
 
+    def test_scatter_large_batch_non_uniform(self) -> None:
+        """A large, non-uniform batch (bs=1024, past any per-program batch cap) is byte-equal.
+
+        The (request, column-block) grid scales directly with bs, so there is no
+        upper bound on the number of requests. Segment lengths vary widely and
+        some are empty, so this also fuzzes the offsets handling at scale.
+        """
+        rng = random.Random(1)
+        bs = 1024
+        max_reqs = bs + 1
+        max_context_len = 40
+
+        lens = [rng.randint(0, max_context_len) for _ in range(bs)]
+        rp = rng.sample(range(1, max_reqs), k=bs)
+        seqs = [[rng.randint(0, 1 << 30) for _ in range(n)] for n in lens]
+
+        flat = _build_flat(seqs)
+        offsets = _build_offsets(lens)
+        req_pool_indices = torch.tensor(rp, dtype=torch.int64, device=_DEVICE)
+        triton_pool = _build_pool(max_reqs=max_reqs, max_context_len=max_context_len)
+        ref_pool = _build_pool(max_reqs=max_reqs, max_context_len=max_context_len)
+
+        launch_scatter_req_token_ids_kernel(
+            flat_in=flat,
+            offsets=offsets,
+            req_pool_indices=req_pool_indices,
+            pool_out=triton_pool,
+        )
+        scatter_req_token_ids_torch_reference(
+            flat_in=flat,
+            offsets=offsets,
+            req_pool_indices=req_pool_indices,
+            pool_out=ref_pool,
+        )
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(triton_pool, ref_pool))
+
+    def test_scatter_multi_column_block_and_truncation(self) -> None:
+        """Requests longer than one column tile (and than max_context_len) stay byte-equal.
+
+        Mixes a very long request (spanning several column blocks and truncated at
+        max_context_len) with short ones, at randomized non-uniform offsets, so the
+        cblk>0 tiles and the per-request truncation boundary are both exercised.
+        """
+        rng = random.Random(2)
+        max_context_len = 2048  # forces >1 column block (COL_BLOCK=1024)
+        # One request far longer than max_context_len, plus assorted shorter ones.
+        lens = [3000, 0, 1, 1025, 500, 2048, 2049, 7]
+        bs = len(lens)
+        max_reqs = 32
+        rp = rng.sample(range(1, max_reqs), k=bs)
+        seqs = [[rng.randint(0, 1 << 30) for _ in range(n)] for n in lens]
+
+        flat = _build_flat(seqs)
+        offsets = _build_offsets(lens)
+        req_pool_indices = torch.tensor(rp, dtype=torch.int64, device=_DEVICE)
+        triton_pool = _build_pool(max_reqs=max_reqs, max_context_len=max_context_len)
+        ref_pool = _build_pool(max_reqs=max_reqs, max_context_len=max_context_len)
+
+        launch_scatter_req_token_ids_kernel(
+            flat_in=flat,
+            offsets=offsets,
+            req_pool_indices=req_pool_indices,
+            pool_out=triton_pool,
+        )
+        scatter_req_token_ids_torch_reference(
+            flat_in=flat,
+            offsets=offsets,
+            req_pool_indices=req_pool_indices,
+            pool_out=ref_pool,
+        )
+        torch.cuda.synchronize()
+        self.assertTrue(torch.equal(triton_pool, ref_pool))
+
 
 class TestScatterInputValidation(CustomTestCase):
     """Cover the strict input checks in launch_scatter_req_token_ids_kernel."""
@@ -259,14 +332,13 @@ class TestScatterInputValidation(CustomTestCase):
                 pool_out=pool,
             )
 
-    def test_raises_on_bs_plus_one_exceeds_batch_block(self) -> None:
-        """bs+1 must fit in _SCATTER_BATCH_BLOCK; exceeding it triggers a ValueError."""
-        bs = _SCATTER_BATCH_BLOCK
-        flat = torch.empty(0, dtype=torch.int64, device=_DEVICE)
-        offsets = torch.zeros(bs + 1, dtype=torch.int64, device=_DEVICE)
-        req_pool_indices = torch.zeros(bs, dtype=torch.int64, device=_DEVICE)
+    def test_raises_on_wrong_dtype_flat_in(self) -> None:
+        """A flat_in with non-int64 dtype triggers a TypeError."""
+        flat = torch.tensor([10, 20], dtype=torch.int32, device=_DEVICE)
+        offsets = torch.tensor([0, 2], dtype=torch.int64, device=_DEVICE)
+        req_pool_indices = torch.tensor([1], dtype=torch.int64, device=_DEVICE)
         pool = _build_pool(max_reqs=4, max_context_len=4)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             launch_scatter_req_token_ids_kernel(
                 flat_in=flat,
                 offsets=offsets,


### PR DESCRIPTION
## Motivation

`launch_scatter_req_token_ids_kernel` copies a flat, per-request int64 token-id stream into
the 2-D int32 `ReqToTokenPool`. The current kernel parallelizes over the **flat token
stream**: each program owns a `TOKEN_BLOCK`-wide slice and, to find which request each token
belongs to, builds a `[TOKEN_BLOCK, BATCH_BLOCK]` boolean tile of `offsets <= tid` and
`tl.sum`-reduces it. That is an **O(bs) reduction per token**, and it forces a hard cap —
`bs + 1 <= BATCH_BLOCK (512)` — because the owner-search tile must stay in registers.

The mapping is already known without any search: `offsets[r]` and `offsets[r+1]` delimit
request `r`'s contiguous segment. We don't need to *recover* the owner per token — we can
grid *by* request.

## Modifications

Replace the owner-search kernel in
`python/sglang/kernels/ops/kv_canary/scatter_req_token_ids.py` with a 2-D grid
`(bs, num_col_blocks)`:

- **program axis 0** = request `r`; **axis 1** = a `COL_BLOCK`-wide column tile.
- each program loads `start = offsets[r]`, `end = offsets[r+1]` **once**, computes
  `write_len = min(end - start, max_context_len)`, and copies its contiguous slice with a
  `col < write_len` mask — a coalesced int64 load → int32 store.

Consequences:

- **No per-token owner search.** O(1) offset loads per program instead of an O(bs) reduction
  per token.
- **No batch-size cap.** The grid scales directly with `bs`; the `bs + 1 <= 512`
  `BATCH_BLOCK` limit (and the `_SCATTER_BATCH_BLOCK` / `_SCATTER_TOKEN_BLOCK` constants)
  are gone. Batches larger than 512 requests now work instead of raising.
- **Same semantics.** One row per request via `req_pool_indices`, int64→int32 cast, and
  truncation at `max_context_len` (a sequence longer than the pool row is silently dropped,
  never spilling into an adjacent row) — all preserved. The kernel is **byte-identical** to
  both the plain-PyTorch reference and the previous kernel on every workload where the
  previous kernel can run.

Three details keep the grid tight and safe on skewed batches:

- **Grid width.** The grid uses the existing host-known upper bound
  `min(max_context_len, num_tokens)` column tiles per request (no segment is longer than the
  whole stream) — host-known, so **no device sync**, and the public signature is unchanged.
  A host-side maximum-length hint (`max(seq_lens_cpu)`) was evaluated to shrink the launch on
  skewed batches, but **omitted**: its host-side reduction was a net regression on both A100
  and H100 (geomean 1.87→1.37 on A100), because this kernel is launch/host-overhead bound at
  these sizes, so the reduction the idle GPU waits through costs more than the empty tiles it
  removes.
- **Per-request early-return.** A request shorter than that batch-wide bound gets column
  tiles past its `write_len`; those programs `return` before touching `req_pool_indices` or
  building any address, so a single long request among many short ones doesn't make the short
  ones pay for empty tiles — the skew win at zero host cost.
- **Bounds-safe load.** The load index `flat_idx = start + col` is masked by
  `col < write_len` **and** `0 <= flat_idx < num_tokens`, preserving the previous kernel's
  `tid < num_tokens` guard (and additionally rejecting a negative `start`) so a malformed
  `offsets` tensor can never read outside `flat_in`.

All existing input validation (dtype / dim / `offsets` length checks) is unchanged. Public
signature, keyword-only args, and the torch reference are unchanged.

## Accuracy Tests

`test/registered/kernels/ops/kv_canary/test_scatter_req_token_ids.py` keeps the existing
byte-equal, empty-batch, single-req, truncation, mixed-empty, randomized, and
input-validation cases, and adds:

- **`test_scatter_large_batch_non_uniform`** — `bs=1024` (past the old 512 cap), random
  non-uniform and empty segments, byte-equal to the reference. This batch used to raise.
- **`test_scatter_multi_column_block_and_truncation`** — a request spanning several
  `COL_BLOCK` tiles and truncated at `max_context_len`, mixed with short requests at
  randomized offsets, byte-equal to the reference.
- **`test_scatter_one_long_among_many_short`** — a long request among 200 short/empty ones,
  byte-equal to the reference; exercises the per-request early-return.

The obsolete `test_raises_on_bs_plus_one_exceeds_batch_block` (which asserted the removed
cap) is dropped and replaced with a `flat_in`-dtype validation test.

Byte-equality is checked against the PyTorch reference **and** against the previous kernel on
every workload where the previous kernel can run: **26/26 configs byte-equal on both
A100-SXM4-80GB and H100-80GB**.

## Speed Tests and Profiling

Standalone before/after microbenchmark (torch + triton, one GPU). Speedup =
`before_ms / after_ms`, CUDA-event median of 50 iters, mean over 5 repeats.
`test/registered/kernels/benchmark/kv_canary/bench_scatter_req_token_ids.py` keeps the
uniform `bs × seq_len` grid and adds a `benchmark_skewed` report (one/few long requests among
many short ones, and a many-medium-length batch) so the skew the redesign targets is
measured, not just uniform shapes.

**A100-SXM4-80GB** · torch 2.12 / triton 3.7 · geomean **1.74×** (range 1.09–17.7×):

| workload | bs | seq_len | before (µs) | after (µs) | speedup |
|---|--:|--:|--:|--:|--:|
| `bs1_seq128` | 1 | 128 | 49.4 | 45.7 | 1.09× |
| `bs8_seq8192` | 8 | 8192 | 65.7 | 39.1 | 1.68× |
| `bs64_seq2048` | 64 | 2048 | 90.1 | 39.3 | 2.29× |
| `bs64_seq8192` | 64 | 8192 | 242.9 | 39.1 | 6.21× |
| `bs256_seq512` | 256 | 512 | 78.8 | 39.5 | 2.00× |
| `bs256_seq2048` | 256 | 2048 | 205.6 | 39.9 | 5.15× |
| `bs256_seq8192` | 256 | 8192 | 712.3 | 40.1 | **17.75×** |
| `nonuniform_bs256` (skew) | 256 | ~1024 | 145.4 | 40.1 | 3.64× |
| `one_long_among_short_bs256` (skew) | 256 | 1×32768 | 52.8 | 41.4 | 1.28× |
| `few_long_among_short_bs256` (skew) | 256 | 4×16384 | 66.8 | 38.9 | 1.72× |
| `many_medium_bs256` (skew) | 256 | 64 | 46.1 | 38.9 | 1.18× |
| `large_bs1024` | 1024 | 512 | — (raises) | 39.1 | — |
| `large_bs4096` | 4096 | 256 | — (raises) | 40.1 | — |

**H100-80GB** confirms it: geomean **1.82×**, peak **19.8×** at `bs256_seq8192`
(446 → 22.5 µs). Full per-workload tables (all 26 rows, both GPUs) are in the harness output.

The win is largest at high request counts and long contexts, where the old kernel's per-token
owner-search reduction dominates; the new kernel does a flat coalesced copy. On skewed batches
the per-request early-return keeps the short requests cheap (still 1.2–1.7×). Large batches
(`bs > 512`) have **no BEFORE number** because the old kernel rejects them.

Note on scope: `scatter_req_token_ids` runs only when the KV-canary token-id verification
assert is enabled (`SGLANG_KV_CANARY_ENABLE_VERIFY_TOKEN_ASSERT`), so this is an off-hot-path
correctness tool; the change keeps it cheap and lifts the batch-size ceiling.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`pre-commit run --files <changed files>` is clean.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing behavior or API change; the only externally visible difference is that `bs > 512` no longer raises.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

This change was prepared with AI assistance (Claude). A human reviewed every changed line and
ran the tests and benchmarks above on A100 and H100 hardware.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30898638993](https://github.com/sgl-project/sglang/actions/runs/30898638993)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30898640173](https://github.com/sgl-project/sglang/actions/runs/30898640173)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
