### PR TITLE
Allow runtime schedule_policy switching via /set_internal_state

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -784,6 +784,7 @@ async def get_load():
 
 # example usage:
 # curl -s -X POST http://localhost:30000/set_internal_state -H "Content-Type: application/json" -d '{"server_args": {"pp_max_micro_batch_size": 8}}'
+# curl -s -X POST http://localhost:30000/set_internal_state -H "Content-Type: application/json" -d '{"server_args": {"schedule_policy": "lpm"}}'
 @app.api_route("/set_internal_state", methods=["POST", "PUT"])
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def set_internal_state(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1846,7 +1846,8 @@ class GetInternalStateReqOutput(BaseReq, kw_only=True):
 
 
 class SetInternalStateReq(BaseReq, kw_only=True):
-    # Only numeric scheduler knobs are accepted (see Scheduler.set_internal_state).
+    # Only allowlisted scheduler knobs are accepted (see
+    # Scheduler.set_internal_state): a few numeric knobs plus schedule_policy.
     server_args: Dict[str, Union[int, float]]
 
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1848,7 +1848,7 @@ class GetInternalStateReqOutput(BaseReq, kw_only=True):
 class SetInternalStateReq(BaseReq, kw_only=True):
     # Only allowlisted scheduler knobs are accepted (see
     # Scheduler.set_internal_state): a few numeric knobs plus schedule_policy.
-    server_args: Dict[str, Union[int, float]]
+    server_args: Dict[str, Union[int, float, str]]
 
 
 class SetInternalStateReqOutput(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -172,6 +172,8 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.managers.schedule_policy import (
     AddReqResult,
+    CacheAgnosticPolicy,
+    CacheAwarePolicy,
     PrefillAdder,
     SchedulePolicy,
 )
@@ -3910,6 +3912,7 @@ class Scheduler(
                 "speculative_accept_threshold_acc",
                 "dspark_force_budget_frac",
                 "dspark_clear_info_records",
+                "schedule_policy",
             ]
         )
 
@@ -3951,6 +3954,17 @@ class Scheduler(
                     )
                     if_success = False
                     break
+            elif k == "schedule_policy":
+                valid_policies = {p.value for p in CacheAwarePolicy} | {
+                    p.value for p in CacheAgnosticPolicy
+                }
+                if v not in valid_policies:
+                    logging.warning(
+                        f"Updating schedule_policy to {v!r} is rejected; "
+                        f"valid policies: {sorted(valid_policies)}."
+                    )
+                    if_success = False
+                    break
 
         if if_success:
             if (
@@ -3977,6 +3991,21 @@ class Scheduler(
                 self.draft_worker.clear_info_records()
             if remaining:
                 get_server_args().override(source="update_server_args", **remaining)
+            if "schedule_policy" in server_args_dict:
+                # The policy object is pure CPU-side state (no CUDA graphs or
+                # memory layouts depend on it), so it can be rebuilt between
+                # scheduling passes. Requests already in the waiting queue are
+                # re-ordered by the new policy on the next pass.
+                new_policy = server_args_dict["schedule_policy"]
+                self.schedule_policy = new_policy
+                self.policy = SchedulePolicy(
+                    new_policy,
+                    self.tree_cache,
+                    self.enable_hierarchical_cache,
+                    self.enable_priority_scheduling,
+                    self.schedule_low_priority_values_first,
+                )
+                logger.info(f"Schedule policy switched to {new_policy!r} at runtime.")
             logger.info(f"Global server args updated! {get_server_args()=}")
 
         return SetInternalStateReqOutput(updated=if_success)

--- a/test/registered/core/test_srt_endpoint.py
+++ b/test/registered/core/test_srt_endpoint.py
@@ -555,6 +555,52 @@ class TestSRTEndpoint(CustomTestCase):
         version = response_json["version"]
         self.assertIsInstance(version, str)
 
+    def test_set_schedule_policy_runtime(self):
+        """schedule_policy can be switched at runtime via /set_internal_state."""
+        try:
+            for policy in ["lpm", "dfs-weight", "fcfs"]:
+                response = requests.post(
+                    self.base_url + "/set_internal_state",
+                    json={"server_args": {"schedule_policy": policy}},
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), [True])
+
+                # The server keeps scheduling and serving under the new policy.
+                gen = requests.post(
+                    self.base_url + "/generate",
+                    json={
+                        "text": "The capital of France is",
+                        "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                    },
+                )
+                self.assertEqual(gen.status_code, 200)
+        finally:
+            # Restore the default so other tests are unaffected.
+            requests.post(
+                self.base_url + "/set_internal_state",
+                json={"server_args": {"schedule_policy": "fcfs"}},
+            )
+
+    def test_set_schedule_policy_invalid(self):
+        """Unknown schedule_policy values are rejected without side effects."""
+        response = requests.post(
+            self.base_url + "/set_internal_state",
+            json={"server_args": {"schedule_policy": "not-a-policy"}},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [False])
+
+        # The server still serves after the rejected update.
+        gen = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+            },
+        )
+        self.assertEqual(gen.status_code, 200)
+
     def test_logit_bias(self):
         """Test that a very high logit bias forces sampling of a specific token."""
         # Choose a token ID to bias (using 5 as an example)

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -620,5 +620,24 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             req.normalize_batch_and_arguments()
 
 
+class TestSetInternalStateReqSerialization(CustomTestCase):
+    """SetInternalStateReq must round-trip string knobs (e.g. schedule_policy)
+    through msgspec — the annotation was previously Dict[str, Union[int, float]]
+    and silently rejected string values at request validation."""
+
+    def test_string_and_numeric_values_roundtrip(self):
+        import msgspec
+
+        from sglang.srt.managers.io_struct import SetInternalStateReq
+
+        req = SetInternalStateReq(
+            server_args={"schedule_policy": "lpm", "pp_max_micro_batch_size": 8}
+        )
+        encoded = msgspec.msgpack.encode(req)
+        decoded = msgspec.msgpack.decode(encoded, type=SetInternalStateReq)
+        self.assertEqual(decoded.server_args["schedule_policy"], "lpm")
+        self.assertEqual(decoded.server_args["pp_max_micro_batch_size"], 8)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

We run mixed traffic on single SGLang instances: high-throughput batch jobs and low-latency realtime requests for the same model. The right waiting-queue policy differs by mode and by time of day, but `--schedule-policy` is fixed at boot — changing it costs a full engine reload (minutes of weight loading plus radix-cache re-warm), which is too disruptive to do on a live server. We'd like to toggle the scheduling mode at runtime, and eventually automate the toggle on load signals.

## The concrete issue that motivated this

Serving GLM-5.2-NVFP4 on 8x B300 with production traffic (~115K-token mean input, agentic workload, ~96% radix cache hit rate under `slru` eviction), we compared `fcfs` and `lpm`:

- **`lpm`** delivers excellent median TTFT (~0.7s — warm-prefix requests are scheduled onto their cached prefixes), but it **systematically starves cache-miss requests**: a cold request with zero prefix match sorts last on every scheduling pass, and at high hit rates fresh warm-prefix arrivals keep jumping the queue indefinitely. Our TTFT histogram showed a 20–60s tail (~5% of requests) contributing ~75% of total accumulated TTFT.
- **`fcfs`** bounds the tail (fair ordering) but gives up lpm's cache-locality preference, which is measurably valuable in quiet periods.

Neither policy is right all day. Since `SchedulePolicy` is pure CPU-side state — no CUDA graphs or memory layouts depend on it (unlike e.g. speculative tiers) — switching it live is safe and cheap.

## What this PR does

Adds `schedule_policy` to the `set_internal_state` allowlist:

```bash
curl -s -X POST http://localhost:30000/set_internal_state \
  -H "Content-Type: application/json" \
  -d '{"server_args": {"schedule_policy": "lpm"}}'
```

- The value is validated against the `CacheAwarePolicy` / `CacheAgnosticPolicy` enum values; invalid values are rejected with a warning (same pattern as the existing knobs).
- On success, the scheduler rebuilds its `SchedulePolicy` with the same constructor arguments used at init, between scheduling passes. Requests already in the waiting queue are simply re-ordered by the new policy on the next pass.
- The global server args are updated through the existing `override()` path, so `/get_server_args`-style introspection reflects the change.

Diff is 32 lines across `scheduler.py`, `io_struct.py` (comment), and `http_server.py` (usage example).

## Testing

- Validated the request flow against the existing `set_internal_state` plumbing (endpoint → TokenizerManager → scheduler dispatch) by inspection; syntax-checked.
- We plan to exercise this on our production-shadow GLM-5.2 deployment (fcfs under load, lpm off-peak) and can report results on this PR.
- Happy to add a CI test if maintainers can point at the preferred harness for `set_internal_state` coverage (we did not find existing endpoint-level tests for it).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29696101624](https://github.com/sgl-project/sglang/actions/runs/29696101624)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29696101555](https://github.com/sgl-project/sglang/actions/runs/29696101555)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->