### PR TITLE
[Kernel] Add fused activation + FP8 quantization JIT kernel for Triton MoE path

### DIFF
--- a/python/sglang/kernels/jit/csrc/elementwise/fused_act_and_mul_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/fused_act_and_mul_quant.cuh
@@ -1,0 +1,274 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+
+namespace {
+
+// ============================================================================
+// Activation function definitions (same as activation.cuh).
+// Duplicated here to keep each JIT module independently compilable.
+// ============================================================================
+
+enum class ActivationKind : uint32_t {
+  kSiLU,
+  kGELU,
+  kGELUTanh,
+};
+
+template <ActivationKind kAct>
+SGL_DEVICE float apply_activation_f32(float x) {
+  if constexpr (kAct == ActivationKind::kSiLU) {
+    return x / (1.0f + expf(-x));
+  } else if constexpr (kAct == ActivationKind::kGELU) {
+    constexpr float kSqrt1Over2 = 0.7071067811865475f;
+    return x * (0.5f * (1.0f + erff(x * kSqrt1Over2)));
+  } else if constexpr (kAct == ActivationKind::kGELUTanh) {
+    constexpr float kAlpha = 0.044715f;
+    constexpr float kBeta = 0.7978845608028654f;
+    const float cdf = 0.5f * (1.0f + tanhf(kBeta * (x + kAlpha * x * x * x)));
+    return x * cdf;
+  } else {
+    static_assert(host::dependent_false_v<decltype(kAct)>, "unsupported activation kind");
+    return 0.0f;
+  }
+}
+
+// ============================================================================
+// Fused activation + per-token-group FP8 quantization kernel
+// ============================================================================
+
+struct ActivationQuantParams {
+  const void* __restrict__ input;        // [num_tokens, hidden_dim * 2]
+  void* __restrict__ output_q;           // [num_tokens, hidden_dim], fp8_e4m3
+  void* __restrict__ output_scale;       // [num_tokens, hidden_dim / group_size], float32
+  uint32_t hidden_dim;                   // output hidden dimension (= input_width / 2)
+  uint32_t num_tokens;
+  uint32_t group_size;                   // quantization group size (128)
+  const int32_t* __restrict__ expert_ids;
+  uint32_t expert_step;
+};
+
+/// Fused kernel: act(gate) * up  →  per-group FP8 quantize  →  write (output_q, output_scale).
+///
+/// Non-persistent grid: each thread handles exactly one vec (8 elements),
+/// grid = ceil(num_tokens * num_vecs_per_token / blockSize).
+/// 16 adjacent threads form a quantization group (128 elements) and cooperate on absmax reduce.
+template <typename T, ActivationKind kAct, bool kUsePDL, bool kFilterExpert, bool kScaleUE8M0>
+__global__ void act_and_mul_quant_kernel(const __grid_constant__ ActivationQuantParams params) {
+  using namespace device;
+  using fp8_t = fp8_e4m3_t;
+
+  constexpr uint32_t kVecSize = kMaxVecBytes / sizeof(T);  // 8 for bf16/fp16
+  using vec_t = AlignedVector<T, kVecSize>;
+
+  constexpr uint32_t kGroupSize = 128u;
+  constexpr uint32_t kThreadsPerGroup = kGroupSize / kVecSize;  // 16
+  constexpr float kFP8E4M3Max = 448.0f;
+  constexpr float kEps = 1e-8f;
+
+  static_assert(kThreadsPerGroup == 16, "scale store assumes 16 threads per group");
+
+  const uint32_t hidden_dim = params.hidden_dim;
+  const uint32_t num_tokens = params.num_tokens;
+  const uint32_t num_vecs = hidden_dim / kVecSize;
+  const uint32_t num_groups = hidden_dim / kGroupSize;
+
+  // Global thread id → (token_id, vec_offset_within_token)
+  const uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const uint32_t token_id = tid / num_vecs;
+  if (token_id >= num_tokens) return;
+
+  if constexpr (kFilterExpert) {
+    if (params.expert_ids[token_id / params.expert_step] == -1) return;
+  }
+
+  const uint32_t vec_offset = tid % num_vecs;
+  const uint32_t icol = vec_offset * kVecSize;
+  const uint32_t lane_id = threadIdx.x % 32;
+
+  PDLWaitPrimary<kUsePDL>();
+
+  // Row pointers
+  fp8_t* const out_row = static_cast<fp8_t*>(params.output_q) + token_id * hidden_dim;
+  float* const scale_row = static_cast<float*>(params.output_scale) + token_id * num_groups;
+
+  // Vectorized load gate and up
+  const uint32_t gate_offset = token_id * (num_vecs * 2) + vec_offset;
+  const vec_t gate_vec = load_as<vec_t>(params.input, gate_offset);
+  const vec_t up_vec = load_as<vec_t>(params.input, gate_offset + num_vecs);
+
+  // Activation + truncate to T precision + local absmax
+  float vals[kVecSize];
+  float local_max = 0.0f;
+#pragma unroll
+  for (uint32_t i = 0; i < kVecSize; ++i) {
+    const float act_f32 = apply_activation_f32<kAct>(cast<fp32_t>(gate_vec[i])) * cast<fp32_t>(up_vec[i]);
+    vals[i] = cast<fp32_t>(cast<T>(act_f32));
+    local_max = fmaxf(local_max, fabsf(vals[i]));
+  }
+
+  // Half-warp reduce (16 threads = one quant group)
+#pragma unroll
+  for (uint32_t mask = kThreadsPerGroup / 2; mask > 0; mask >>= 1) {
+    local_max = fmaxf(local_max, __shfl_xor_sync(0xffffffff, local_max, mask));
+  }
+
+  // Scale computation
+  float scale;
+  if constexpr (kScaleUE8M0) {
+    const float raw = fmaxf(local_max, kEps) / kFP8E4M3Max;
+    const uint32_t bits = __float_as_uint(raw);
+    const int32_t exp = static_cast<int32_t>((bits >> 23) & 0xFF) + ((bits & 0x7FFFFF) != 0);
+    scale = __uint_as_float(static_cast<uint32_t>(exp) << 23);
+  } else {
+    scale = local_max / kFP8E4M3Max;
+  }
+  const float inv_scale = 1.0f / (scale + kEps);
+
+  // Quantize and vectorized store FP8 (8 bytes = 1x STG.64)
+  {
+    const float4 f4_0 = make_float4(
+        vals[0] * inv_scale, vals[1] * inv_scale,
+        vals[2] * inv_scale, vals[3] * inv_scale);
+    const float4 f4_1 = make_float4(
+        vals[4] * inv_scale, vals[5] * inv_scale,
+        vals[6] * inv_scale, vals[7] * inv_scale);
+    const __nv_fp8x4_e4m3 pack0(f4_0);
+    const __nv_fp8x4_e4m3 pack1(f4_1);
+    uint2 packed;
+    packed.x = *reinterpret_cast<const uint32_t*>(&pack0);
+    packed.y = *reinterpret_cast<const uint32_t*>(&pack1);
+    *reinterpret_cast<uint2*>(out_row + icol) = packed;
+  }
+
+  // Store scale (one per group; lane 0 and lane 16 each own one group)
+  if (lane_id == 0 || lane_id == 16) {
+    scale_row[icol / kGroupSize] = scale;
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+// ============================================================================
+// Launch infrastructure
+// ============================================================================
+
+template <typename T, bool kUsePDL>
+struct ActivationQuantKernel {
+  static constexpr uint32_t kBlockSize = 256u;
+  static constexpr uint32_t kElementsPerThread = device::kMaxVecBytes / sizeof(T);  // 8
+
+  using kernel_fn_t = decltype(&act_and_mul_quant_kernel<T, ActivationKind::kSiLU, kUsePDL, false, false>);
+
+  template <ActivationKind kAct, bool kFilterExpert, bool kScaleUE8M0>
+  static constexpr kernel_fn_t quant_kernel = act_and_mul_quant_kernel<T, kAct, kUsePDL, kFilterExpert, kScaleUE8M0>;
+
+  template <bool kFilterExpert, bool kScaleUE8M0>
+  static kernel_fn_t select_kernel(const std::string& type) {
+    using namespace host;
+    if (type == "silu") return quant_kernel<ActivationKind::kSiLU, kFilterExpert, kScaleUE8M0>;
+    if (type == "gelu") return quant_kernel<ActivationKind::kGELU, kFilterExpert, kScaleUE8M0>;
+    if (type == "gelu_tanh") return quant_kernel<ActivationKind::kGELUTanh, kFilterExpert, kScaleUE8M0>;
+    Panic("unsupported activation type: ", type);
+    return nullptr;
+  }
+
+  static void launch(
+      const tvm::ffi::TensorView& input,
+      const tvm::ffi::TensorView& output_q,
+      const tvm::ffi::TensorView& output_scale,
+      const std::string& type,
+      int64_t group_size,
+      bool scale_ue8m0,
+      const int32_t* expert_ids,
+      uint32_t expert_step) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_tokens"};
+    auto D_in = SymbolicSize{"input_width"};
+    auto D_out = SymbolicSize{"output_width"};
+    auto D_scale = SymbolicSize{"scale_width"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({N, D_in}).with_dtype<T>().with_device(device_).verify(input);
+    TensorMatcher({N, D_out}).with_device(device_).verify(output_q);
+    TensorMatcher({N, D_scale}).with_device(device_).verify(output_scale);
+
+    const uint32_t hidden_dim = static_cast<uint32_t>(D_out.unwrap());
+    const uint32_t num_tokens = static_cast<uint32_t>(N.unwrap());
+    const auto device = device_.unwrap();
+    if (num_tokens == 0) return;
+
+    RuntimeCheck(hidden_dim * 2 == D_in.unwrap(), "input width must be 2 * output width");
+    RuntimeCheck(group_size == 128, "only group_size=128 is supported");
+    RuntimeCheck(hidden_dim % group_size == 0, "hidden_dim must be divisible by group_size");
+    RuntimeCheck(D_scale.unwrap() == static_cast<int64_t>(hidden_dim / group_size),
+                 "scale width must equal hidden_dim / group_size");
+
+    // Select kernel
+    kernel_fn_t kernel = nullptr;
+    if (expert_ids != nullptr) {
+      kernel = scale_ue8m0 ? select_kernel<true, true>(type) : select_kernel<true, false>(type);
+    } else {
+      kernel = scale_ue8m0 ? select_kernel<false, true>(type) : select_kernel<false, false>(type);
+    }
+
+    // Non-persistent grid: one thread per vec, grid = ceil(total_vecs / blockSize)
+    const uint32_t num_vecs_per_token = hidden_dim / kElementsPerThread;
+    const uint32_t total_items = num_tokens * num_vecs_per_token;
+    const uint32_t num_blocks = div_ceil(total_items, kBlockSize);
+
+    const auto params = ActivationQuantParams{
+        .input = input.data_ptr(),
+        .output_q = output_q.data_ptr(),
+        .output_scale = output_scale.data_ptr(),
+        .hidden_dim = hidden_dim,
+        .num_tokens = num_tokens,
+        .group_size = static_cast<uint32_t>(group_size),
+        .expert_ids = expert_ids,
+        .expert_step = expert_step,
+    };
+
+    LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+  }
+
+  static void run_activation_quant(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView output_q,
+      const tvm::ffi::TensorView output_scale,
+      std::string type,
+      int64_t group_size,
+      bool scale_ue8m0) {
+    launch(input, output_q, output_scale, type, group_size, scale_ue8m0,
+           /*expert_ids=*/nullptr, /*expert_step=*/1);
+  }
+
+  static void run_activation_quant_filtered(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView output_q,
+      const tvm::ffi::TensorView output_scale,
+      const tvm::ffi::TensorView expert_ids,
+      int64_t expert_step,
+      std::string type,
+      int64_t group_size,
+      bool scale_ue8m0) {
+    using namespace host;
+    RuntimeCheck(is_type<int32_t>(expert_ids.dtype()), "expert_ids must have dtype int32");
+    RuntimeCheck(expert_step >= 1, "expert_step must be positive");
+    launch(input, output_q, output_scale, type, group_size, scale_ue8m0,
+           static_cast<const int32_t*>(expert_ids.data_ptr()), static_cast<uint32_t>(expert_step));
+  }
+};
+
+}  // namespace

--- a/python/sglang/kernels/jit/csrc/elementwise/fused_act_and_mul_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/fused_act_and_mul_quant.cuh
@@ -48,12 +48,12 @@ SGL_DEVICE float apply_activation_f32(float x) {
 // ============================================================================
 
 struct ActivationQuantParams {
-  const void* __restrict__ input;        // [num_tokens, hidden_dim * 2]
-  void* __restrict__ output_q;           // [num_tokens, hidden_dim], fp8_e4m3
-  void* __restrict__ output_scale;       // [num_tokens, hidden_dim / group_size], float32
-  uint32_t hidden_dim;                   // output hidden dimension (= input_width / 2)
+  const void* __restrict__ input;   // [num_tokens, hidden_dim * 2]
+  void* __restrict__ output_q;      // [num_tokens, hidden_dim], fp8_e4m3
+  void* __restrict__ output_scale;  // [num_tokens, hidden_dim / group_size], float32
+  uint32_t hidden_dim;              // output hidden dimension (= input_width / 2)
   uint32_t num_tokens;
-  uint32_t group_size;                   // quantization group size (128)
+  uint32_t group_size;  // quantization group size (128)
   const int32_t* __restrict__ expert_ids;
   uint32_t expert_step;
 };
@@ -137,12 +137,8 @@ __global__ void act_and_mul_quant_kernel(const __grid_constant__ ActivationQuant
 
   // Quantize and vectorized store FP8 (8 bytes = 1x STG.64)
   {
-    const float4 f4_0 = make_float4(
-        vals[0] * inv_scale, vals[1] * inv_scale,
-        vals[2] * inv_scale, vals[3] * inv_scale);
-    const float4 f4_1 = make_float4(
-        vals[4] * inv_scale, vals[5] * inv_scale,
-        vals[6] * inv_scale, vals[7] * inv_scale);
+    const float4 f4_0 = make_float4(vals[0] * inv_scale, vals[1] * inv_scale, vals[2] * inv_scale, vals[3] * inv_scale);
+    const float4 f4_1 = make_float4(vals[4] * inv_scale, vals[5] * inv_scale, vals[6] * inv_scale, vals[7] * inv_scale);
     const __nv_fp8x4_e4m3 pack0(f4_0);
     const __nv_fp8x4_e4m3 pack1(f4_1);
     uint2 packed;
@@ -213,8 +209,9 @@ struct ActivationQuantKernel {
     RuntimeCheck(hidden_dim * 2 == D_in.unwrap(), "input width must be 2 * output width");
     RuntimeCheck(group_size == 128, "only group_size=128 is supported");
     RuntimeCheck(hidden_dim % group_size == 0, "hidden_dim must be divisible by group_size");
-    RuntimeCheck(D_scale.unwrap() == static_cast<int64_t>(hidden_dim / group_size),
-                 "scale width must equal hidden_dim / group_size");
+    RuntimeCheck(
+        D_scale.unwrap() == static_cast<int64_t>(hidden_dim / group_size),
+        "scale width must equal hidden_dim / group_size");
 
     // Select kernel
     kernel_fn_t kernel = nullptr;
@@ -250,8 +247,15 @@ struct ActivationQuantKernel {
       std::string type,
       int64_t group_size,
       bool scale_ue8m0) {
-    launch(input, output_q, output_scale, type, group_size, scale_ue8m0,
-           /*expert_ids=*/nullptr, /*expert_step=*/1);
+    launch(
+        input,
+        output_q,
+        output_scale,
+        type,
+        group_size,
+        scale_ue8m0,
+        /*expert_ids=*/nullptr,
+        /*expert_step=*/1);
   }
 
   static void run_activation_quant_filtered(
@@ -266,8 +270,15 @@ struct ActivationQuantKernel {
     using namespace host;
     RuntimeCheck(is_type<int32_t>(expert_ids.dtype()), "expert_ids must have dtype int32");
     RuntimeCheck(expert_step >= 1, "expert_step must be positive");
-    launch(input, output_q, output_scale, type, group_size, scale_ue8m0,
-           static_cast<const int32_t*>(expert_ids.data_ptr()), static_cast<uint32_t>(expert_step));
+    launch(
+        input,
+        output_q,
+        output_scale,
+        type,
+        group_size,
+        scale_ue8m0,
+        static_cast<const int32_t*>(expert_ids.data_ptr()),
+        static_cast<uint32_t>(expert_step));
   }
 };
 

--- a/python/sglang/kernels/ops/activation/activation.py
+++ b/python/sglang/kernels/ops/activation/activation.py
@@ -124,9 +124,9 @@ def run_unary_activation(
     Unlike :func:`run_activation`, there is no gate/up split — ``input`` and
     ``out`` share the same shape.
     """
-    assert (
-        op_name in SUPPORTED_UNARY_ACTIVATIONS
-    ), f"Unsupported unary activation: {op_name}"
+    assert op_name in SUPPORTED_UNARY_ACTIVATIONS, (
+        f"Unsupported unary activation: {op_name}"
+    )
     if out is None:
         out = torch.empty_like(input)
     _run_unary_activation_inplace(op_name, input, out)
@@ -166,3 +166,209 @@ def gelu_tanh_and_mul(
     expert_step: int = 1,
 ) -> torch.Tensor:
     return run_activation("gelu_tanh", input, out, expert_ids, expert_step)
+
+
+# =============================================================================
+# Fused activation + per-token-group FP8 quantization
+# =============================================================================
+
+
+@cache_once
+def _jit_activation_quant_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype, is_arch_support_pdl())
+    return load_jit(
+        "fused_act_and_mul_quant",
+        *args,
+        cuda_files=["elementwise/fused_act_and_mul_quant.cuh"],
+        extra_cuda_cflags=_fast_math_flags(),
+        cuda_wrappers=[
+            (
+                "run_activation_quant",
+                f"ActivationQuantKernel<{args}>::run_activation_quant",
+            ),
+            (
+                "run_activation_quant_filtered",
+                f"ActivationQuantKernel<{args}>::run_activation_quant_filtered",
+            ),
+        ],
+    )
+
+
+@register_custom_op(mutates_args=["output_q", "output_scale"])
+def _run_activation_quant_inplace(
+    op_name: str,
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_scale: torch.Tensor,
+    group_size: int,
+    scale_ue8m0: bool,
+) -> None:
+    hidden_size = input.shape[-1] // 2
+    module = _jit_activation_quant_module(input.dtype)
+    input_2d = input.view(-1, hidden_size * 2)
+    output_q_2d = output_q.view(-1, hidden_size)
+    num_groups = hidden_size // group_size
+    output_scale_2d = output_scale.view(-1, num_groups)
+    module.run_activation_quant(
+        input_2d, output_q_2d, output_scale_2d, op_name, group_size, scale_ue8m0
+    )
+
+
+@register_custom_op(mutates_args=["output_q", "output_scale"])
+def _run_activation_quant_filtered_inplace(
+    op_name: str,
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_scale: torch.Tensor,
+    expert_ids: torch.Tensor,
+    expert_step: int,
+    group_size: int,
+    scale_ue8m0: bool,
+) -> None:
+    hidden_size = input.shape[-1] // 2
+    module = _jit_activation_quant_module(input.dtype)
+    input_2d = input.view(-1, hidden_size * 2)
+    output_q_2d = output_q.view(-1, hidden_size)
+    num_groups = hidden_size // group_size
+    output_scale_2d = output_scale.view(-1, num_groups)
+    module.run_activation_quant_filtered(
+        input_2d,
+        output_q_2d,
+        output_scale_2d,
+        expert_ids,
+        expert_step,
+        op_name,
+        group_size,
+        scale_ue8m0,
+    )
+
+
+def run_activation_quant(
+    op_name: str,
+    input: torch.Tensor,
+    output_q: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
+    expert_ids: Optional[torch.Tensor] = None,
+    expert_step: int = 1,
+    group_size: int = 128,
+    scale_ue8m0: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused activation + per-token-group FP8 quantization.
+
+    Computes ``act(gate) * up`` and immediately quantizes the result to FP8
+    with per-group scales, saving one global memory round-trip compared to
+    calling :func:`run_activation` followed by a separate quantization step.
+
+    Args:
+        op_name: Activation type — one of ``"silu"``, ``"gelu"``, ``"gelu_tanh"``.
+        input: Input tensor of shape ``[*, 2 * hidden_dim]`` (gate||up concatenated).
+        output_q: Optional pre-allocated output for quantized values,
+            shape ``[*, hidden_dim]``, dtype ``torch.float8_e4m3fn``.
+        output_scale: Optional pre-allocated output for scales,
+            shape ``[*, hidden_dim // group_size]``, dtype ``torch.float32``.
+        expert_ids: Optional expert routing ids for MoE filtering.
+            Rows with ``expert_ids[token // expert_step] == -1`` are skipped.
+        expert_step: Stride for expert_ids lookup (1 for per-token, BLOCK_SIZE_M for TMA).
+        group_size: Number of elements per quantization group (default 128).
+        scale_ue8m0: If True, round scales to power-of-2 (UE8M0 format for DeepGEMM).
+
+    Returns:
+        Tuple of ``(output_q, output_scale)``.
+    """
+    assert op_name in SUPPORTED_ACTIVATIONS, f"Unsupported activation: {op_name}"
+    hidden_size = input.shape[-1] // 2
+    assert hidden_size % group_size == 0, (
+        f"hidden_size ({hidden_size}) must be divisible by group_size ({group_size})"
+    )
+    output_shape = input.shape[:-1] + (hidden_size,)
+    scale_shape = input.shape[:-1] + (hidden_size // group_size,)
+    if output_q is None:
+        output_q = torch.empty(
+            output_shape, dtype=torch.float8_e4m3fn, device=input.device
+        )
+    if output_scale is None:
+        output_scale = torch.empty(
+            scale_shape, dtype=torch.float32, device=input.device
+        )
+    if expert_ids is None:
+        _run_activation_quant_inplace(
+            op_name, input, output_q, output_scale, group_size, scale_ue8m0
+        )
+    else:
+        _run_activation_quant_filtered_inplace(
+            op_name,
+            input,
+            output_q,
+            output_scale,
+            expert_ids,
+            expert_step,
+            group_size,
+            scale_ue8m0,
+        )
+    return output_q, output_scale
+
+
+def silu_and_mul_quant(
+    input: torch.Tensor,
+    output_q: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
+    expert_ids: Optional[torch.Tensor] = None,
+    expert_step: int = 1,
+    group_size: int = 128,
+    scale_ue8m0: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused silu_and_mul + per-token-group FP8 quantization."""
+    return run_activation_quant(
+        "silu",
+        input,
+        output_q,
+        output_scale,
+        expert_ids,
+        expert_step,
+        group_size,
+        scale_ue8m0,
+    )
+
+
+def gelu_and_mul_quant(
+    input: torch.Tensor,
+    output_q: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
+    expert_ids: Optional[torch.Tensor] = None,
+    expert_step: int = 1,
+    group_size: int = 128,
+    scale_ue8m0: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused gelu_and_mul + per-token-group FP8 quantization."""
+    return run_activation_quant(
+        "gelu",
+        input,
+        output_q,
+        output_scale,
+        expert_ids,
+        expert_step,
+        group_size,
+        scale_ue8m0,
+    )
+
+
+def gelu_tanh_and_mul_quant(
+    input: torch.Tensor,
+    output_q: Optional[torch.Tensor] = None,
+    output_scale: Optional[torch.Tensor] = None,
+    expert_ids: Optional[torch.Tensor] = None,
+    expert_step: int = 1,
+    group_size: int = 128,
+    scale_ue8m0: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused gelu_tanh_and_mul + per-token-group FP8 quantization."""
+    return run_activation_quant(
+        "gelu_tanh",
+        input,
+        output_q,
+        output_scale,
+        expert_ids,
+        expert_step,
+        group_size,
+        scale_ue8m0,
+    )

--- a/python/sglang/kernels/ops/activation/activation.py
+++ b/python/sglang/kernels/ops/activation/activation.py
@@ -124,9 +124,9 @@ def run_unary_activation(
     Unlike :func:`run_activation`, there is no gate/up split — ``input`` and
     ``out`` share the same shape.
     """
-    assert op_name in SUPPORTED_UNARY_ACTIVATIONS, (
-        f"Unsupported unary activation: {op_name}"
-    )
+    assert (
+        op_name in SUPPORTED_UNARY_ACTIVATIONS
+    ), f"Unsupported unary activation: {op_name}"
     if out is None:
         out = torch.empty_like(input)
     _run_unary_activation_inplace(op_name, input, out)
@@ -277,9 +277,9 @@ def run_activation_quant(
     """
     assert op_name in SUPPORTED_ACTIVATIONS, f"Unsupported activation: {op_name}"
     hidden_size = input.shape[-1] // 2
-    assert hidden_size % group_size == 0, (
-        f"hidden_size ({hidden_size}) must be divisible by group_size ({group_size})"
-    )
+    assert (
+        hidden_size % group_size == 0
+    ), f"hidden_size ({hidden_size}) must be divisible by group_size ({group_size})"
     output_shape = input.shape[:-1] + (hidden_size,)
     scale_shape = input.shape[:-1] + (hidden_size // group_size,)
     if output_q is None:

--- a/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
@@ -768,7 +768,10 @@ def invoke_fused_moe_kernel(
             # activation block-wise fp8 quantization
             assert len(block_shape) == 2
             block_n, block_k = block_shape[0], block_shape[1]
-            if _is_cuda:
+            if A.dtype == torch.float8_e4m3fn:
+                # Already quantized by fused act+quant kernel, skip
+                assert A_scale is not None, "FP8 input requires pre-computed A_scale"
+            elif _is_cuda:
                 A, A_scale = sglang_per_token_group_quant_fp8(A, block_k)
             else:
                 A, A_scale = per_token_group_quant_fp8(A, block_k)
@@ -779,9 +782,9 @@ def invoke_fused_moe_kernel(
         assert B_scale is not None
         if block_shape is None:
             # activation channel-wise int8 quantization
-            assert (
-                per_channel_quant
-            ), "int8 quantization only supports channel-wise quantization except for block-wise quantization"
+            assert per_channel_quant, (
+                "int8 quantization only supports channel-wise quantization except for block-wise quantization"
+            )
             A, A_scale = per_token_quant_int8(A)
         else:
             # activation block-wise int8 quantization
@@ -815,23 +818,23 @@ def invoke_fused_moe_kernel(
     if fuse_sum_all_reduce:
         assert not c_sorted, "fuse_sum_all_reduce only supports c_sorted=False"
     if fuse_add_to_output:
-        assert (
-            not fuse_sum_all_reduce
-        ), "fuse_add_to_output and fuse_sum_all_reduce are mutually exclusive"
-        assert (
-            add_output_mask is not None
-        ), "add_output_mask required when fuse_add_to_output=True"
+        assert not fuse_sum_all_reduce, (
+            "fuse_add_to_output and fuse_sum_all_reduce are mutually exclusive"
+        )
+        assert add_output_mask is not None, (
+            "add_output_mask required when fuse_add_to_output=True"
+        )
     # ===== TO BE REFACTORED ====
     if mask_output:
-        assert (
-            not fuse_add_to_output
-        ), "mask_output and fuse_add_to_output are mutually exclusive"
-        assert (
-            not fuse_sum_all_reduce
-        ), "mask_output and fuse_sum_all_reduce are mutually exclusive"
-        assert (
-            add_output_mask is not None
-        ), "add_output_mask required when mask_output=True"
+        assert not fuse_add_to_output, (
+            "mask_output and fuse_add_to_output are mutually exclusive"
+        )
+        assert not fuse_sum_all_reduce, (
+            "mask_output and fuse_sum_all_reduce are mutually exclusive"
+        )
+        assert add_output_mask is not None, (
+            "add_output_mask required when mask_output=True"
+        )
     # ===== END TO BE REFACTORED ====
 
     if (
@@ -839,9 +842,9 @@ def invoke_fused_moe_kernel(
         and block_shape is not None
         and block_shape[1] > 0
     ):
-        assert (
-            not fuse_sum_all_reduce
-        ), "fuse_sum_all_reduce is not supported for GPTQ/AWQ kernels"
+        assert not fuse_sum_all_reduce, (
+            "fuse_sum_all_reduce is not supported for GPTQ/AWQ kernels"
+        )
         assert B_scale is not None and B_scale.ndim == 3
         assert B_zp is None or B_zp.ndim == 3
         assert bias is None

--- a/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
@@ -782,9 +782,9 @@ def invoke_fused_moe_kernel(
         assert B_scale is not None
         if block_shape is None:
             # activation channel-wise int8 quantization
-            assert per_channel_quant, (
-                "int8 quantization only supports channel-wise quantization except for block-wise quantization"
-            )
+            assert (
+                per_channel_quant
+            ), "int8 quantization only supports channel-wise quantization except for block-wise quantization"
             A, A_scale = per_token_quant_int8(A)
         else:
             # activation block-wise int8 quantization
@@ -818,23 +818,23 @@ def invoke_fused_moe_kernel(
     if fuse_sum_all_reduce:
         assert not c_sorted, "fuse_sum_all_reduce only supports c_sorted=False"
     if fuse_add_to_output:
-        assert not fuse_sum_all_reduce, (
-            "fuse_add_to_output and fuse_sum_all_reduce are mutually exclusive"
-        )
-        assert add_output_mask is not None, (
-            "add_output_mask required when fuse_add_to_output=True"
-        )
+        assert (
+            not fuse_sum_all_reduce
+        ), "fuse_add_to_output and fuse_sum_all_reduce are mutually exclusive"
+        assert (
+            add_output_mask is not None
+        ), "add_output_mask required when fuse_add_to_output=True"
     # ===== TO BE REFACTORED ====
     if mask_output:
-        assert not fuse_add_to_output, (
-            "mask_output and fuse_add_to_output are mutually exclusive"
-        )
-        assert not fuse_sum_all_reduce, (
-            "mask_output and fuse_sum_all_reduce are mutually exclusive"
-        )
-        assert add_output_mask is not None, (
-            "add_output_mask required when mask_output=True"
-        )
+        assert (
+            not fuse_add_to_output
+        ), "mask_output and fuse_add_to_output are mutually exclusive"
+        assert (
+            not fuse_sum_all_reduce
+        ), "mask_output and fuse_sum_all_reduce are mutually exclusive"
+        assert (
+            add_output_mask is not None
+        ), "add_output_mask required when mask_output=True"
     # ===== END TO BE REFACTORED ====
 
     if (
@@ -842,9 +842,9 @@ def invoke_fused_moe_kernel(
         and block_shape is not None
         and block_shape[1] > 0
     ):
-        assert not fuse_sum_all_reduce, (
-            "fuse_sum_all_reduce is not supported for GPTQ/AWQ kernels"
-        )
+        assert (
+            not fuse_sum_all_reduce
+        ), "fuse_sum_all_reduce is not supported for GPTQ/AWQ kernels"
         assert B_scale is not None and B_scale.ndim == 3
         assert B_zp is None or B_zp.ndim == 3
         assert bias is None

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -211,7 +211,6 @@ class ToolStrictLevel(IntEnum):
 
 
 class Envs:
-
     # Raise on bare server_args field assignments after resolution; mutation
     # must go through ServerArgs.override() (enabled by the test harness).
     SGLANG_STRICT_CONFIG_MUTATION = EnvBool(False)
@@ -1079,6 +1078,7 @@ class Envs:
     SGLANG_OPT_USE_JIT_EP_ACTIVATION = EnvBool(True)
     SGLANG_OPT_FUSE_WQA_WKV = EnvBool(True)
     SGLANG_OPT_SWIGLU_CLAMP_FUSION = EnvBool(True)
+    SGLANG_OPT_FUSED_ACT_QUANT = EnvBool(True)
 
     # Cache / overlap
     SGLANG_OPT_USE_FUSED_STORE_CACHE = EnvBool(True)

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -603,9 +603,9 @@ def _fused_moe_kernel_sequence(
                 if filter_expert:
                     swiglu_limit_for_triton = swiglu_limit
                 else:
-                    assert (
-                        _is_cuda
-                    ), "fused silu_and_mul_clamp kernel is CUDA-only; HIP must disable SWIGLU_CLAMP_FUSION"
+                    assert _is_cuda, (
+                        "fused silu_and_mul_clamp kernel is CUDA-only; HIP must disable SWIGLU_CLAMP_FUSION"
+                    )
                     swiglu_limit_for_silu_and_mul_clamp = swiglu_limit
             else:
                 half = N // 2
@@ -637,7 +637,32 @@ def _fused_moe_kernel_sequence(
                     swiglu_limit=swiglu_limit_for_triton,
                 )
         elif _is_cuda or _is_hip or _is_xpu:
-            if filter_expert and _is_cuda:
+            _use_fused_act_quant = (
+                envs.SGLANG_OPT_FUSED_ACT_QUANT.get()
+                and _is_cuda
+                and use_fp8_w8a8
+                and block_shape is not None
+                and len(block_shape) >= 2
+                and block_shape[1] == 128
+            )
+            if _use_fused_act_quant:
+                from sglang.kernels.ops.activation.activation import run_activation_quant
+
+                _expert_ids_arg = None
+                _expert_step_arg = 1
+                if filter_expert:
+                    _expert_ids_arg = (
+                        expert_ids if down_moe_use_tma else topk_ids.view(-1)
+                    )
+                    _expert_step_arg = config["BLOCK_SIZE_M"] if down_moe_use_tma else 1
+                intermediate_cache2, a2_scale = run_activation_quant(
+                    "silu",
+                    intermediate_cache1.view(-1, N),
+                    expert_ids=_expert_ids_arg,
+                    expert_step=_expert_step_arg,
+                    group_size=128,
+                )
+            elif filter_expert and _is_cuda:
                 # HIP/XPU fall through to the unfiltered path: the down kernel
                 # zeros filtered rows without reading their input.
                 silu_and_mul(
@@ -664,7 +689,32 @@ def _fused_moe_kernel_sequence(
         assert gemm1_alpha is None, "gemm1_alpha is not supported for gelu"
         assert gemm1_limit is None, "gemm1_limit is not supported for gelu"
         if _is_cuda or _is_hip:
-            if filter_expert and _is_cuda:
+            _use_fused_act_quant = (
+                envs.SGLANG_OPT_FUSED_ACT_QUANT.get()
+                and _is_cuda
+                and use_fp8_w8a8
+                and block_shape is not None
+                and len(block_shape) >= 2
+                and block_shape[1] == 128
+            )
+            if _use_fused_act_quant:
+                from sglang.kernels.ops.activation.activation import run_activation_quant
+
+                _expert_ids_arg = None
+                _expert_step_arg = 1
+                if filter_expert:
+                    _expert_ids_arg = (
+                        expert_ids if down_moe_use_tma else topk_ids.view(-1)
+                    )
+                    _expert_step_arg = config["BLOCK_SIZE_M"] if down_moe_use_tma else 1
+                intermediate_cache2, a2_scale = run_activation_quant(
+                    "gelu",
+                    intermediate_cache1.view(-1, N),
+                    expert_ids=_expert_ids_arg,
+                    expert_step=_expert_step_arg,
+                    group_size=128,
+                )
+            elif filter_expert and _is_cuda:
                 gelu_and_mul(
                     intermediate_cache1.view(-1, N),
                     intermediate_cache2,
@@ -875,9 +925,9 @@ def fused_experts_impl(
     if use_int4_w4a16:
         assert hidden_states.shape[1] // 2 == w1.shape[2], "Hidden size mismatch"
     else:
-        assert (
-            hidden_states.shape[1] == w1.shape[2] - padded_size
-        ), f"Hidden size mismatch"
+        assert hidden_states.shape[1] == w1.shape[2] - padded_size, (
+            "Hidden size mismatch"
+        )
     assert topk_weights.shape == topk_ids.shape, "topk shape mismatch"
     assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
     assert w1.is_contiguous(), "Expert weights1 must be contiguous"

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -646,7 +646,9 @@ def _fused_moe_kernel_sequence(
                 and block_shape[1] == 128
             )
             if _use_fused_act_quant:
-                from sglang.kernels.ops.activation.activation import run_activation_quant
+                from sglang.kernels.ops.activation.activation import (
+                    run_activation_quant,
+                )
 
                 _expert_ids_arg = None
                 _expert_step_arg = 1
@@ -698,7 +700,9 @@ def _fused_moe_kernel_sequence(
                 and block_shape[1] == 128
             )
             if _use_fused_act_quant:
-                from sglang.kernels.ops.activation.activation import run_activation_quant
+                from sglang.kernels.ops.activation.activation import (
+                    run_activation_quant,
+                )
 
                 _expert_ids_arg = None
                 _expert_step_arg = 1

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -603,9 +603,9 @@ def _fused_moe_kernel_sequence(
                 if filter_expert:
                     swiglu_limit_for_triton = swiglu_limit
                 else:
-                    assert _is_cuda, (
-                        "fused silu_and_mul_clamp kernel is CUDA-only; HIP must disable SWIGLU_CLAMP_FUSION"
-                    )
+                    assert (
+                        _is_cuda
+                    ), "fused silu_and_mul_clamp kernel is CUDA-only; HIP must disable SWIGLU_CLAMP_FUSION"
                     swiglu_limit_for_silu_and_mul_clamp = swiglu_limit
             else:
                 half = N // 2
@@ -925,9 +925,9 @@ def fused_experts_impl(
     if use_int4_w4a16:
         assert hidden_states.shape[1] // 2 == w1.shape[2], "Hidden size mismatch"
     else:
-        assert hidden_states.shape[1] == w1.shape[2] - padded_size, (
-            "Hidden size mismatch"
-        )
+        assert (
+            hidden_states.shape[1] == w1.shape[2] - padded_size
+        ), "Hidden size mismatch"
     assert topk_weights.shape == topk_ids.shape, "topk shape mismatch"
     assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
     assert w1.is_contiguous(), "Expert weights1 must be contiguous"

--- a/test/registered/kernels/benchmark/activation/bench_fused_act_and_mul_quant.py
+++ b/test/registered/kernels/benchmark/activation/bench_fused_act_and_mul_quant.py
@@ -1,0 +1,224 @@
+"""
+Benchmark for fused activation + per-token-group FP8 quantization JIT kernel.
+
+Simulates DeepSeek V3/V4 EP8 production scenario:
+  - 256 experts total, EP8 → 32 local experts (87.5% filtered)
+  - Two modes: TMA (expert_step=128, sorted+padded) and Non-TMA (expert_step=1, per-token)
+
+Compares:
+  - "unfused": run_activation() + sglang_per_token_group_quant_fp8()
+  - "fused":   run_activation_quant()
+
+Pre-allocates output buffers to measure pure kernel time.
+"""
+
+import torch
+
+from sglang.kernels.ops.activation.activation import (
+    run_activation,
+    run_activation_quant,
+)
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import create_random
+from sglang.kernels.ops.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=60, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+GROUP_SIZE = 128
+
+
+# ---------------------------------------------------------------------------
+# Helper: create expert_ids with given filter ratio
+# ---------------------------------------------------------------------------
+
+
+def _make_expert_ids(
+    num_tokens: int, expert_step: int, filter_ratio: float
+) -> torch.Tensor:
+    """Create expert_ids with specified filter ratio."""
+    num_blocks = (num_tokens + expert_step - 1) // expert_step
+    expert_ids = torch.randint(low=0, high=32, size=(num_blocks,), dtype=torch.int32)
+    if filter_ratio > 0:
+        num_filtered = int(num_blocks * filter_ratio)
+        if num_filtered > 0:
+            perm = torch.randperm(num_blocks)[:num_filtered]
+            expert_ids[perm] = -1
+    return expert_ids.cuda()
+
+
+# ---------------------------------------------------------------------------
+# TMA mode (expert_step=128, production MoE sorted layout)
+# ---------------------------------------------------------------------------
+
+
+@marker.parametrize("op_name", ["silu", "gelu", "gelu_tanh"], ["silu"])
+@marker.parametrize("hidden_dim", [2048, 4096, 8192], [2048, 4096])
+@marker.parametrize(
+    "num_tokens",
+    [128, 256, 512, 1024, 4096, 16384, 32768, 65536],
+    [4096, 32768],
+)
+@marker.parametrize("filter_ratio", [0.0, 0.5, 0.875], [0.875])
+@marker.benchmark("impl", ["unfused", "fused"])
+def benchmark_tma(
+    op_name: str, hidden_dim: int, num_tokens: int, filter_ratio: float, impl: str
+):
+    """TMA mode: expert_step=128."""
+    torch.manual_seed(42)
+    expert_step = 128
+    input_dim = hidden_dim * 2
+    x = create_random(num_tokens, input_dim)
+    expert_ids = _make_expert_ids(num_tokens, expert_step, filter_ratio)
+
+    # Pre-allocate
+    act_out = torch.empty(num_tokens, hidden_dim, dtype=x.dtype, device=x.device)
+    fused_q = torch.empty(
+        num_tokens, hidden_dim, dtype=torch.float8_e4m3fn, device=x.device
+    )
+    fused_scale = torch.empty(
+        num_tokens, hidden_dim // GROUP_SIZE, dtype=torch.float32, device=x.device
+    )
+
+    if impl == "unfused":
+
+        def fn():
+            run_activation(
+                op_name, x, act_out, expert_ids=expert_ids, expert_step=expert_step
+            )
+            return sglang_per_token_group_quant_fp8(act_out, GROUP_SIZE)
+    else:
+
+        def fn():
+            return run_activation_quant(
+                op_name,
+                x,
+                output_q=fused_q,
+                output_scale=fused_scale,
+                expert_ids=expert_ids,
+                expert_step=expert_step,
+                group_size=GROUP_SIZE,
+            )
+
+    return marker.do_bench(fn)
+
+
+# ---------------------------------------------------------------------------
+# Non-TMA mode (expert_step=1, per-token routing)
+# ---------------------------------------------------------------------------
+
+
+@marker.parametrize("op_name", ["silu", "gelu", "gelu_tanh"], ["silu"])
+@marker.parametrize("hidden_dim", [2048, 4096, 8192], [2048, 4096])
+@marker.parametrize(
+    "num_tokens",
+    [8, 32, 128, 512, 1024, 4096, 16384, 32768, 65536],
+    [128, 4096, 32768],
+)
+@marker.parametrize("filter_ratio", [0.0, 0.5, 0.875], [0.875])
+@marker.benchmark("impl", ["unfused", "fused"])
+def benchmark_non_tma(
+    op_name: str, hidden_dim: int, num_tokens: int, filter_ratio: float, impl: str
+):
+    """Non-TMA mode: expert_step=1."""
+    torch.manual_seed(42)
+    expert_step = 1
+    input_dim = hidden_dim * 2
+    x = create_random(num_tokens, input_dim)
+    expert_ids = _make_expert_ids(num_tokens, expert_step, filter_ratio)
+
+    # Pre-allocate
+    act_out = torch.empty(num_tokens, hidden_dim, dtype=x.dtype, device=x.device)
+    fused_q = torch.empty(
+        num_tokens, hidden_dim, dtype=torch.float8_e4m3fn, device=x.device
+    )
+    fused_scale = torch.empty(
+        num_tokens, hidden_dim // GROUP_SIZE, dtype=torch.float32, device=x.device
+    )
+
+    if impl == "unfused":
+
+        def fn():
+            run_activation(
+                op_name, x, act_out, expert_ids=expert_ids, expert_step=expert_step
+            )
+            return sglang_per_token_group_quant_fp8(act_out, GROUP_SIZE)
+    else:
+
+        def fn():
+            return run_activation_quant(
+                op_name,
+                x,
+                output_q=fused_q,
+                output_scale=fused_scale,
+                expert_ids=expert_ids,
+                expert_step=expert_step,
+                group_size=GROUP_SIZE,
+            )
+
+    return marker.do_bench(fn)
+
+
+# ---------------------------------------------------------------------------
+# No-filter mode (Dense MLP scenario, no expert routing)
+# ---------------------------------------------------------------------------
+
+
+@marker.parametrize("op_name", ["silu", "gelu", "gelu_tanh"], ["silu"])
+@marker.parametrize("hidden_dim", [2048, 4096, 8192], [2048, 4096])
+@marker.parametrize(
+    "num_tokens",
+    [1, 8, 32, 128, 512, 1024, 4096, 16384, 32768, 65536],
+    [1, 128, 1024, 16384],
+)
+@marker.benchmark("impl", ["unfused", "fused"])
+def benchmark_dense(op_name: str, hidden_dim: int, num_tokens: int, impl: str):
+    """Dense MLP: no expert filtering."""
+    input_dim = hidden_dim * 2
+    x = create_random(num_tokens, input_dim)
+
+    # Pre-allocate
+    act_out = torch.empty(num_tokens, hidden_dim, dtype=x.dtype, device=x.device)
+    fused_q = torch.empty(
+        num_tokens, hidden_dim, dtype=torch.float8_e4m3fn, device=x.device
+    )
+    fused_scale = torch.empty(
+        num_tokens, hidden_dim // GROUP_SIZE, dtype=torch.float32, device=x.device
+    )
+
+    if impl == "unfused":
+
+        def fn():
+            run_activation(op_name, x, act_out)
+            return sglang_per_token_group_quant_fp8(act_out, GROUP_SIZE)
+    else:
+
+        def fn():
+            return run_activation_quant(
+                op_name,
+                x,
+                output_q=fused_q,
+                output_scale=fused_scale,
+                group_size=GROUP_SIZE,
+            )
+
+    return marker.do_bench(fn)
+
+
+if __name__ == "__main__":
+    print("=" * 80)
+    print("TMA Mode (expert_step=128, multi filter ratio)")
+    print("=" * 80)
+    benchmark_tma.run()
+
+    print("\n" + "=" * 80)
+    print("Non-TMA Mode (expert_step=1, multi filter ratio)")
+    print("=" * 80)
+    benchmark_non_tma.run()
+
+    print("\n" + "=" * 80)
+    print("Dense MLP Mode (no expert filter)")
+    print("=" * 80)
+    benchmark_dense.run()

--- a/test/registered/kernels/benchmark/activation/bench_fused_act_and_mul_quant.py
+++ b/test/registered/kernels/benchmark/activation/bench_fused_act_and_mul_quant.py
@@ -14,12 +14,12 @@ Pre-allocates output buffers to measure pure kernel time.
 
 import torch
 
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import create_random
 from sglang.kernels.ops.activation.activation import (
     run_activation,
     run_activation_quant,
 )
-from sglang.kernels.jit.benchmark import marker
-from sglang.kernels.jit.benchmark.utils import create_random
 from sglang.kernels.ops.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.test.ci.ci_register import register_cuda_ci
 

--- a/test/registered/kernels/benchmark/activation/bench_fused_act_and_mul_quant.py
+++ b/test/registered/kernels/benchmark/activation/bench_fused_act_and_mul_quant.py
@@ -89,6 +89,7 @@ def benchmark_tma(
                 op_name, x, act_out, expert_ids=expert_ids, expert_step=expert_step
             )
             return sglang_per_token_group_quant_fp8(act_out, GROUP_SIZE)
+
     else:
 
         def fn():
@@ -145,6 +146,7 @@ def benchmark_non_tma(
                 op_name, x, act_out, expert_ids=expert_ids, expert_step=expert_step
             )
             return sglang_per_token_group_quant_fp8(act_out, GROUP_SIZE)
+
     else:
 
         def fn():
@@ -193,6 +195,7 @@ def benchmark_dense(op_name: str, hidden_dim: int, num_tokens: int, impl: str):
         def fn():
             run_activation(op_name, x, act_out)
             return sglang_per_token_group_quant_fp8(act_out, GROUP_SIZE)
+
     else:
 
         def fn():

--- a/test/registered/kernels/ops/activation/test_fused_act_and_mul_quant.py
+++ b/test/registered/kernels/ops/activation/test_fused_act_and_mul_quant.py
@@ -1,0 +1,327 @@
+"""
+Correctness tests for the fused activation + per-token-group FP8 quantization JIT kernel.
+
+Validates against the unfused reference path:
+    act_out = run_activation(op_name, input)
+    ref_q, ref_scale = sglang_per_token_group_quant_fp8(act_out, group_size)
+
+NOTE: The fused kernel keeps activation results in float32 registers before
+quantizing, while the unfused path truncates to bf16/fp16 between activation
+and quantization. This causes small numerical differences in scale (~1e-6)
+and occasionally different FP8 rounding for borderline values.
+"""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.activation.activation import (
+    SUPPORTED_ACTIVATIONS,
+    run_activation,
+    run_activation_quant,
+)
+from sglang.kernels.jit.utils import get_ci_test_range
+from sglang.kernels.ops.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=40, suite="nightly-kernel-1-gpu", nightly=True)
+
+
+# ---------------------------------------------------------------------------
+# Test parameters
+# ---------------------------------------------------------------------------
+
+OPS = list(SUPPORTED_ACTIVATIONS)  # ["silu", "gelu", "gelu_tanh"]
+DTYPES = [torch.bfloat16, torch.float16]
+GROUP_SIZE = 128
+
+# Shapes: (num_tokens, hidden_dim * 2).
+# hidden_dim must be divisible by GROUP_SIZE.
+SHAPES = get_ci_test_range(
+    full_range=[
+        (1, 256),  # minimal: hidden=128, 1 group per token
+        (7, 512),  # odd token count
+        (64, 1024),
+        (128, 2048),
+        (256, 4096),
+        (512, 8192),
+        (1024, 12288),  # large hidden (Llama-65B intermediate)
+        (4096, 2048),  # large token count
+    ],
+    ci_range=[
+        (1, 256),
+        (64, 1024),
+        (256, 4096),
+    ],
+)
+
+FILTER_SHAPES = get_ci_test_range(
+    full_range=[(128, 1024), (256, 2048), (512, 4096), (1024, 8192)],
+    ci_range=[(128, 1024), (256, 4096)],
+)
+EXPERT_STEPS = [1, 16]
+
+
+# ---------------------------------------------------------------------------
+# Tolerances: fused path keeps float32 precision through activation→quant,
+# while unfused truncates to bf16/fp16 in between. Scale differs by ~1e-5,
+# and FP8 values may differ by 1 ULP for borderline rounding.
+# ---------------------------------------------------------------------------
+
+SCALE_ATOL = 0.0
+SCALE_RTOL = 0.0
+# FP8 E4M3: allow 1 ULP difference due to rounding tie-breaking between
+# different FP8 conversion paths (fp8_t(float) vs __nv_cvt_float2_to_fp8x2).
+FP8_MAX_DIFF_ULPS = 1
+
+
+def _assert_fp8_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    """Assert FP8 tensors are within FP8_MAX_DIFF_ULPS of each other."""
+    diff = (actual.view(torch.uint8).int() - expected.view(torch.uint8).int()).abs()
+    max_diff = diff.max().item()
+    assert max_diff <= FP8_MAX_DIFF_ULPS, (
+        f"FP8 mismatch: max ULP diff = {max_diff}, "
+        f"mismatched elements = {(diff > FP8_MAX_DIFF_ULPS).sum().item()}/{diff.numel()}"
+    )
+
+
+def _reference_activation_quant(
+    op_name: str, input: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Unfused reference: activation then per-token-group FP8 quantization."""
+    act_out = run_activation(op_name, input, None)
+    ref_q, ref_scale = sglang_per_token_group_quant_fp8(act_out, group_size)
+    return ref_q, ref_scale
+
+
+# ---------------------------------------------------------------------------
+# Basic correctness tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op_name", OPS)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES)
+def test_fused_act_quant_correctness(
+    op_name: str, dtype: torch.dtype, shape: tuple[int, int]
+) -> None:
+    """Fused kernel output must match unfused activation + quant."""
+    num_tokens, dim = shape
+    input = torch.randn(num_tokens, dim, dtype=dtype, device="cuda")
+
+    # Reference (unfused)
+    ref_q, ref_scale = _reference_activation_quant(op_name, input, GROUP_SIZE)
+
+    # Fused
+    fused_q, fused_scale = run_activation_quant(op_name, input, group_size=GROUP_SIZE)
+
+    # Quantized values should match exactly (both use same rounding)
+    assert fused_q.dtype == torch.float8_e4m3fn
+    assert fused_scale.dtype == torch.float32
+    assert fused_q.shape == ref_q.shape
+    assert fused_scale.shape == ref_scale.shape
+
+    # Compare scales (small floating-point diff due to bf16 truncation in unfused path)
+    torch.testing.assert_close(fused_scale, ref_scale, atol=SCALE_ATOL, rtol=SCALE_RTOL)
+    # Compare quantized values (allow 1 ULP diff for borderline rounding)
+    _assert_fp8_close(fused_q, ref_q)
+
+
+@pytest.mark.parametrize("op_name", OPS)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_fused_act_quant_preallocated_output(op_name: str, dtype: torch.dtype) -> None:
+    """Test with pre-allocated output buffers."""
+    num_tokens, dim = 64, 2048
+    hidden = dim // 2
+    input = torch.randn(num_tokens, dim, dtype=dtype, device="cuda")
+
+    output_q = torch.empty(num_tokens, hidden, dtype=torch.float8_e4m3fn, device="cuda")
+    output_scale = torch.empty(
+        num_tokens, hidden // GROUP_SIZE, dtype=torch.float32, device="cuda"
+    )
+
+    result_q, result_scale = run_activation_quant(
+        op_name,
+        input,
+        output_q=output_q,
+        output_scale=output_scale,
+        group_size=GROUP_SIZE,
+    )
+
+    # Must return the same buffers
+    assert result_q.data_ptr() == output_q.data_ptr()
+    assert result_scale.data_ptr() == output_scale.data_ptr()
+
+    # Compare with reference
+    ref_q, ref_scale = _reference_activation_quant(op_name, input, GROUP_SIZE)
+    torch.testing.assert_close(
+        result_scale, ref_scale, atol=SCALE_ATOL, rtol=SCALE_RTOL
+    )
+    _assert_fp8_close(result_q, ref_q)
+
+
+# ---------------------------------------------------------------------------
+# Expert-filtered tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op_name", OPS)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", FILTER_SHAPES)
+@pytest.mark.parametrize("expert_step", EXPERT_STEPS)
+def test_fused_act_quant_filter_expert(
+    op_name: str,
+    dtype: torch.dtype,
+    shape: tuple[int, int],
+    expert_step: int,
+) -> None:
+    """Rows with expert_ids == -1 must leave output untouched (sentinel preserved)."""
+    num_tokens, dim = shape
+    hidden = dim // 2
+    input = torch.randn(num_tokens, dim, dtype=dtype, device="cuda")
+
+    # Pre-fill with sentinel
+    sentinel_q = torch.zeros(
+        num_tokens, hidden, dtype=torch.float8_e4m3fn, device="cuda"
+    )
+    sentinel_scale = torch.full(
+        (num_tokens, hidden // GROUP_SIZE),
+        float("nan"),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    output_q = sentinel_q.clone()
+    output_scale = sentinel_scale.clone()
+
+    # Create expert_ids with some -1 entries
+    num_groups = (num_tokens + expert_step - 1) // expert_step
+    expert_ids = torch.randint(
+        low=0, high=8, size=(num_groups,), dtype=torch.int32, device="cuda"
+    )
+    skip_mask = torch.rand(num_groups, device="cuda") < 0.4
+    expert_ids[skip_mask] = -1
+
+    result_q, result_scale = run_activation_quant(
+        op_name,
+        input,
+        output_q=output_q,
+        output_scale=output_scale,
+        expert_ids=expert_ids,
+        expert_step=expert_step,
+        group_size=GROUP_SIZE,
+    )
+
+    # Check that skipped rows are untouched
+    token_skip = skip_mask[torch.arange(num_tokens, device="cuda") // expert_step]
+    if token_skip.any():
+        skipped_q = result_q[token_skip]
+        skipped_scale = result_scale[token_skip]
+        # quantized values should remain zero (sentinel)
+        assert torch.equal(
+            skipped_q.view(torch.uint8),
+            sentinel_q[token_skip].view(torch.uint8),
+        ), "fused kernel modified quantized output for skipped rows"
+        # scales should remain NaN (sentinel)
+        assert torch.isnan(skipped_scale).all(), (
+            "fused kernel modified scale output for skipped rows"
+        )
+
+    # Check that non-skipped rows match the unfused reference
+    kept = ~token_skip
+    if kept.any():
+        # Run unfused reference on kept tokens only for comparison
+        ref_q, ref_scale = _reference_activation_quant(op_name, input, GROUP_SIZE)
+        torch.testing.assert_close(
+            result_scale[kept], ref_scale[kept], atol=SCALE_ATOL, rtol=SCALE_RTOL
+        )
+        _assert_fp8_close(result_q[kept], ref_q[kept])
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_fused_act_quant_all_skipped(op_name: str) -> None:
+    """If every expert_id is -1, output must be entirely untouched."""
+    num_tokens, dim = 32, 1024
+    hidden = dim // 2
+    input = torch.randn(num_tokens, dim, dtype=torch.bfloat16, device="cuda")
+
+    output_q = torch.zeros(num_tokens, hidden, dtype=torch.float8_e4m3fn, device="cuda")
+    output_scale = torch.full(
+        (num_tokens, hidden // GROUP_SIZE),
+        float("nan"),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    orig_q = output_q.clone()
+
+    expert_ids = torch.full((num_tokens,), -1, dtype=torch.int32, device="cuda")
+    run_activation_quant(
+        op_name,
+        input,
+        output_q=output_q,
+        output_scale=output_scale,
+        expert_ids=expert_ids,
+        expert_step=1,
+        group_size=GROUP_SIZE,
+    )
+
+    assert torch.equal(output_q.view(torch.uint8), orig_q.view(torch.uint8))
+    assert torch.isnan(output_scale).all()
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_fused_act_quant_none_skipped(op_name: str) -> None:
+    """No -1 in expert_ids must yield identical output to unfiltered path."""
+    num_tokens, dim = 64, 2048
+    dtype = torch.bfloat16
+    input = torch.randn(num_tokens, dim, dtype=dtype, device="cuda")
+
+    expert_ids = torch.zeros(num_tokens, dtype=torch.int32, device="cuda")
+    filtered_q, filtered_scale = run_activation_quant(
+        op_name,
+        input,
+        expert_ids=expert_ids,
+        expert_step=1,
+        group_size=GROUP_SIZE,
+    )
+    unfiltered_q, unfiltered_scale = run_activation_quant(
+        op_name,
+        input,
+        group_size=GROUP_SIZE,
+    )
+
+    torch.testing.assert_close(filtered_scale, unfiltered_scale, atol=0.0, rtol=0.0)
+    assert torch.equal(filtered_q.view(torch.uint8), unfiltered_q.view(torch.uint8))
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_fused_act_quant_single_token(op_name: str) -> None:
+    """Single-token input must work correctly."""
+    input = torch.randn(1, 256, dtype=torch.bfloat16, device="cuda")
+    fused_q, fused_scale = run_activation_quant(op_name, input, group_size=GROUP_SIZE)
+    ref_q, ref_scale = _reference_activation_quant(op_name, input, GROUP_SIZE)
+
+    torch.testing.assert_close(fused_scale, ref_scale, atol=SCALE_ATOL, rtol=SCALE_RTOL)
+    _assert_fp8_close(fused_q, ref_q)
+
+
+@pytest.mark.parametrize("op_name", OPS)
+def test_fused_act_quant_zero_input(op_name: str) -> None:
+    """All-zero input should produce all-zero quantized output."""
+    input = torch.zeros(16, 512, dtype=torch.bfloat16, device="cuda")
+    fused_q, fused_scale = run_activation_quant(op_name, input, group_size=GROUP_SIZE)
+    # act(0) * 0 = 0 for all activations, so quantized output should be 0
+    assert torch.equal(
+        fused_q.view(torch.uint8),
+        torch.zeros_like(fused_q).view(torch.uint8),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/kernels/ops/activation/test_fused_act_and_mul_quant.py
+++ b/test/registered/kernels/ops/activation/test_fused_act_and_mul_quant.py
@@ -224,9 +224,9 @@ def test_fused_act_quant_filter_expert(
             sentinel_q[token_skip].view(torch.uint8),
         ), "fused kernel modified quantized output for skipped rows"
         # scales should remain NaN (sentinel)
-        assert torch.isnan(skipped_scale).all(), (
-            "fused kernel modified scale output for skipped rows"
-        )
+        assert torch.isnan(
+            skipped_scale
+        ).all(), "fused kernel modified scale output for skipped rows"
 
     # Check that non-skipped rows match the unfused reference
     kept = ~token_skip

--- a/test/registered/kernels/ops/activation/test_fused_act_and_mul_quant.py
+++ b/test/registered/kernels/ops/activation/test_fused_act_and_mul_quant.py
@@ -16,12 +16,12 @@ import sys
 import pytest
 import torch
 
+from sglang.kernels.jit.utils import get_ci_test_range
 from sglang.kernels.ops.activation.activation import (
     SUPPORTED_ACTIVATIONS,
     run_activation,
     run_activation_quant,
 )
-from sglang.kernels.jit.utils import get_ci_test_range
 from sglang.kernels.ops.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.test.ci.ci_register import register_cuda_ci
 


### PR DESCRIPTION
## Motivation

 The Triton MoE runner path (`_fused_moe_kernel_sequence`) currently performs activation (SiLU/GELU/gelu_tanh + Mul) and FP8 blockwise quantization as separate operations, requiring an intermediate bf16 buffer write and read between them.

  This PR adds a general-purpose fused CUDA JIT kernel that combines activation + multiply + FP8 per-token-group quantization in a single pass, eliminating the memory round-trip.

  **Applicable to all FP8 blockwise MoE models** on the Triton runner path, including:
  - Both SiLU and GELU activation types
  - Both EP (Expert Parallelism) and non-EP deployments
  - Any model using block_k=128 FP8 quantization 

  Note: The DeepGemm runner has its own fused path (`silu_and_mul_contig_post_quant`). This optimization targets the Triton runner, which is used in different deployment scenarios.



## Modifications
  - **New JIT CUDA kernel**:
  `python/sglang/jit_kernel/csrc/elementwise/fused_act_and_mul_quant.cuh`
    - Supports both SiLU  GELU and gelu_tanh activation functions
    - FP8 (e4m3fn) per-token-group quantization fused in the same kernel
    - Optional expert_ids filtering for EP mode
  - **Python wrapper**: Extended `python/sglang/jit_kernel/activation.py` with
  `run_activation_quant()`
  - **Integration in Triton MoE runner**:
    - `fused_moe.py`: Call fused kernel when conditions met, output FP8 tensor + scales directly
    - `fused_moe_triton_kernels.py`: Skip redundant quantization when input is already FP8
  - **Env gate**: `SGLANG_OPT_FUSED_ACT_QUANT` (default: enabled)
  - **Tests**: `test/registered/jit/test_fused_act_and_mul_quant.py`
  - **Benchmarks**: `test/registered/jit/benchmark/bench_fused_act_and_mul_quant.py`
  ### Gating conditions

  The fused kernel activates when ALL conditions hold:
  1. `SGLANG_OPT_FUSED_ACT_QUANT=1` (default)
  2. CUDA platform
  3. FP8 W8A8 quantization enabled
  4. Block-wise quantization with `block_shape[1] == 128`
## Accuracy Tests

```bash
  python -m pytest test/registered/jit/test_fused_act_and_mul_quant.py -v
```
<img width="995" height="47" alt="image" src="https://github.com/user-attachments/assets/2790834f-4cb4-4690-bd9d-7eeae5e85757" />

## E2E Accuracy Verification

  Model: Qwen3-235B-A22B-Instruct-2507-FP8, TP=4, DP=2 H20
  Eval: GSM8K (200 examples, temperature=0)

  | Config                                                             | Score |
  |-------------------------------------------|-------|
  | SGLANG_OPT_FUSED_ACT_QUANT=false | 0.980 |
  | SGLANG_OPT_FUSED_ACT_QUANT=true  | 0.980 |

  Δ Score = 0.000, no accuracy regression. 
## Speed Tests and Profiling

```bash
  python test/registered/jit/benchmark/bench_fused_act_and_mul_quant.py
```
<img width="862" height="419" alt="image" src="https://github.com/user-attachments/assets/fc758822-9a2b-415f-8d9c-9f775858dd5d" />
<img width="869" height="462" alt="image" src="https://github.com/user-attachments/assets/8500600b-8006-4dcd-8e43-908435e23460" />
<img width="774" height="366" alt="image" src="https://github.com/user-attachments/assets/2cd1d80a-2152-4c36-bcf1-99612e19b5a6" />




  


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29984626307](https://github.com/sgl-project/sglang/actions/runs/29984626307)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29984626221](https://github.com/sgl-project/sglang/actions/runs/29984626221)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->