### PR TITLE
[Spec] Add a ctx axis to the adaptive spec _route (BS × ctx → slot)

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -561,8 +561,15 @@ class SchedulerBatchResultProcessor:
         # Feed the adaptive controller now that accept_lens is on CPU,
         # instead of doing a synchronous GPU→CPU copy in the worker hot path.
         # BaseSpecWorker provides a no-op default for non-adaptive workers.
+        if batch.reqs:
+            seqlens = sorted(req.seqlen for req in batch.reqs)
+            ctx_repr = seqlens[len(seqlens) // 2]
+        else:
+            ctx_repr = 0
         self.model_worker.on_verify_complete_cpu(
-            result.num_correct_drafts_per_req_cpu, batch_size=len(batch.reqs)
+            result.num_correct_drafts_per_req_cpu,
+            batch_size=len(batch.reqs),
+            ctx_repr=ctx_repr,
         )
 
         predict_tokens = []

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -742,8 +742,15 @@ class SchedulerBatchResultProcessor:
         # Feed the adaptive controller now that accept_lens is on CPU,
         # instead of doing a synchronous GPU→CPU copy in the worker hot path.
         # BaseSpecWorker provides a no-op default for non-adaptive workers.
+        if batch.reqs:
+            seqlens = sorted(req.seqlen for req in batch.reqs)
+            ctx_repr = seqlens[len(seqlens) // 2]
+        else:
+            ctx_repr = 0
         self.model_worker.on_verify_complete_cpu(
-            result.num_correct_drafts_per_req_cpu, batch_size=len(batch.reqs)
+            result.num_correct_drafts_per_req_cpu,
+            batch_size=len(batch.reqs),
+            ctx_repr=ctx_repr,
         )
 
         # Advance the grammar FSM over this batch's committed tokens (idempotent):

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -110,17 +110,20 @@ class AdaptiveController:
         # Start on the initial step.
         self._activate(self.worker.speculative_num_steps)
 
-    def activate_step_by_batch(self, batch_size: int) -> None:
-        target = self.params.get_steps_for_batch(batch_size)
+    def activate_step_by_batch(self, batch_size: int, ctx_repr: int = 0) -> None:
+        target = self.params.get_steps_for_batch(batch_size, ctx_repr)
         if target != self.worker.speculative_num_steps:
             self._activate(target)
 
     def on_verify_complete(
-        self, num_correct_drafts_per_req: list[int], batch_size: int
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int,
+        ctx_repr: int = 0,
     ) -> None:
         """Feed verify results; switch runtime state if EMA warrants it."""
         new_step = self.params.on_verify_complete(
-            num_correct_drafts_per_req, batch_size
+            num_correct_drafts_per_req, batch_size, ctx_repr
         )
         if new_step is not None:
             self._activate(new_step)

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -119,17 +119,20 @@ class AdaptiveController:
         # Start on the initial step.
         self._activate(self.worker.speculative_num_steps)
 
-    def activate_step_by_batch(self, batch_size: int) -> None:
-        target = self.params.get_steps_for_batch(batch_size)
+    def activate_step_by_batch(self, batch_size: int, ctx_repr: int = 0) -> None:
+        target = self.params.get_steps_for_batch(batch_size, ctx_repr)
         if target != self.worker.speculative_num_steps:
             self._activate(target)
 
     def on_verify_complete(
-        self, num_correct_drafts_per_req: list[int], batch_size: int
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int,
+        ctx_repr: int = 0,
     ) -> None:
         """Feed verify results; switch runtime state if the policy requests it."""
         new_step = self.params.on_verify_complete(
-            num_correct_drafts_per_req, batch_size
+            num_correct_drafts_per_req, batch_size, ctx_repr
         )
         if new_step is not None:
             self._activate(new_step)

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -87,6 +87,41 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
     return None
 
 
+_CTX_BUCKET_MAX = 2**31 - 1
+
+
+def _parse_ctx_bucket_key(key: str) -> tuple[int, int]:
+    if not isinstance(key, str) or "-" not in key:
+        raise ValueError(f"ctx_buckets key must be a 'lo-hi' string, got {key!r}")
+    lo_str, hi_str = key.split("-", 1)
+    try:
+        lo, hi = int(lo_str), int(hi_str)
+    except ValueError as e:
+        raise ValueError(f"ctx_buckets key {key!r} must contain integer 'lo-hi'") from e
+    if lo < 1 or hi < lo:
+        raise ValueError(f"ctx_buckets key {key!r} must satisfy 1 <= lo <= hi")
+    return lo, hi
+
+
+def _validate_ctx_bucket_coverage(
+    bs: int, ordered: list[tuple[int, int, dict]]
+) -> None:
+    if not ordered:
+        raise ValueError(f"BS {bs}: ctx_buckets must not be empty")
+    if ordered[0][0] != 1:
+        raise ValueError(
+            f"BS {bs}: ctx_buckets must start at 1, got lo={ordered[0][0]}"
+        )
+    for i in range(1, len(ordered)):
+        prev_hi = ordered[i - 1][1]
+        cur_lo = ordered[i][0]
+        if cur_lo != prev_hi + 1:
+            raise ValueError(
+                f"BS {bs}: ctx_buckets gap between "
+                f"{prev_hi} and {cur_lo}; ranges must be contiguous"
+            )
+
+
 def _load_adaptive_config(
     cfg_path: str | None,
 ) -> tuple[dict, dict[int, dict]]:
@@ -105,16 +140,40 @@ def _load_adaptive_config(
         if not key.isdigit():
             continue
 
-        steps = entry.get("candidate_steps")
-        if (
-            not isinstance(steps, list)
-            or not steps
-            or not all(isinstance(s, int) and s >= 0 for s in steps)
-        ):
-            raise ValueError(
-                f"BS {key}: candidate_steps must be a list of non-negative ints, "
-                f"got {steps!r}"
-            )
+        ctx_raw = entry.get("ctx_buckets")
+        if ctx_raw is not None:
+            if not isinstance(ctx_raw, dict) or not ctx_raw:
+                raise ValueError(
+                    f"BS {key}: ctx_buckets must be a non-empty dict, "
+                    f"got {ctx_raw!r}"
+                )
+            for bucket_key, bucket_entry in ctx_raw.items():
+                _parse_ctx_bucket_key(bucket_key)
+                steps = (
+                    bucket_entry.get("candidate_steps")
+                    if isinstance(bucket_entry, dict)
+                    else None
+                )
+                if (
+                    not isinstance(steps, list)
+                    or not steps
+                    or not all(isinstance(s, int) and s >= 0 for s in steps)
+                ):
+                    raise ValueError(
+                        f"BS {key} ctx bucket {bucket_key!r}: candidate_steps "
+                        f"must be a list of non-negative ints, got {steps!r}"
+                    )
+        else:
+            steps = entry.get("candidate_steps")
+            if (
+                not isinstance(steps, list)
+                or not steps
+                or not all(isinstance(s, int) and s >= 0 for s in steps)
+            ):
+                raise ValueError(
+                    f"BS {key}: candidate_steps must be a list of non-negative ints, "
+                    f"got {steps!r}"
+                )
         bs_entries[int(key)] = entry
 
     if not bs_entries:
@@ -133,7 +192,12 @@ def resolve_candidate_steps_from_config(
     _, bs_entries = _load_adaptive_config(cfg_path)
     all_steps: set[int] = set()
     for entry in bs_entries.values():
-        all_steps.update(entry["candidate_steps"])
+        ctx_raw = entry.get("ctx_buckets")
+        if ctx_raw is not None:
+            for bucket_entry in ctx_raw.values():
+                all_steps.update(bucket_entry["candidate_steps"])
+        else:
+            all_steps.update(entry["candidate_steps"])
     return sorted(all_steps)
 
 
@@ -260,9 +324,11 @@ class AdaptiveStepSlot:
 
 
 class AdaptiveSpeculativeParams:
-    """Routes ``batch_size`` to the correct per-BS slot.
+    """Routes ``(batch_size, ctx_repr)`` to the correct per-(BS, ctx) slot.
 
-    A slot is a per-BS configuration of adaptive step selection.
+    A slot is a per-(BS, ctx-bucket) configuration of adaptive step
+    selection. Legacy 1D configs (no ``ctx_buckets`` key) degenerate to a
+    single ctx bucket covering ``[0, ∞)`` per BS.
     """
 
     def __init__(
@@ -273,13 +339,43 @@ class AdaptiveSpeculativeParams:
         cfg, bs_entries = _load_adaptive_config(cfg_path)
         self._bs_list: list[int] = sorted(bs_entries)
         self._slots: dict[int, AdaptiveStepSlot] = {}
+        self._ctx_slots_by_bs: dict[int, dict[int, AdaptiveStepSlot]] = {}
+        self._ctx_lo_by_bs: dict[int, list[int]] = {}
+        self._ctx_hi_by_bs: dict[int, list[int]] = {}
         self._cuda_graph_bs: list[int] | None = None
 
         for bs, entry in sorted(bs_entries.items()):
-            self._slots[bs] = AdaptiveStepSlot(
-                initial_steps=initial_steps,
-                cfg={**cfg, **entry},
-            )
+            ctx_raw = entry.get("ctx_buckets")
+            bs_slots: dict[int, AdaptiveStepSlot] = {}
+            los: list[int] = []
+            his: list[int] = []
+            if ctx_raw is None:
+                bs_slots[1] = AdaptiveStepSlot(
+                    initial_steps=initial_steps,
+                    cfg={**cfg, **entry},
+                )
+                los.append(1)
+                his.append(_CTX_BUCKET_MAX)
+            else:
+                ordered: list[tuple[int, int, dict]] = []
+                for bucket_key, bucket_entry in ctx_raw.items():
+                    lo, hi = _parse_ctx_bucket_key(bucket_key)
+                    ordered.append((lo, hi, bucket_entry))
+                ordered.sort(key=lambda t: t[0])
+                _validate_ctx_bucket_coverage(bs, ordered)
+                for lo, hi, bucket_entry in ordered:
+                    merged = {**cfg, **entry, **bucket_entry}
+                    merged.pop("ctx_buckets", None)
+                    bs_slots[lo] = AdaptiveStepSlot(
+                        initial_steps=initial_steps,
+                        cfg=merged,
+                    )
+                    los.append(lo)
+                    his.append(hi)
+            self._ctx_slots_by_bs[bs] = bs_slots
+            self._slots[bs] = bs_slots[los[0]]
+            self._ctx_lo_by_bs[bs] = los
+            self._ctx_hi_by_bs[bs] = his
 
         first_slot = self._slots[self._bs_list[0]]
         log_info_on_rank0(
@@ -291,23 +387,33 @@ class AdaptiveSpeculativeParams:
 
     @cached_property
     def candidate_steps(self) -> list[int]:
-        """Union of all BS slots' candidate steps."""
-        return sorted({s for p in self._slots.values() for s in p.candidate_steps})
+        """Union of all (BS, ctx) slots' candidate steps."""
+        return sorted(
+            {
+                s
+                for buckets in self._ctx_slots_by_bs.values()
+                for slot in buckets.values()
+                for s in slot.candidate_steps
+            }
+        )
 
     def set_cuda_graph_bs(self, cuda_graph_bs: list[int] | None) -> None:
         self._cuda_graph_bs = sorted(cuda_graph_bs) if cuda_graph_bs else None
 
-    def get_steps_for_batch(self, batch_size: int) -> int:
-        return self._route(batch_size).current_steps
+    def get_steps_for_batch(self, batch_size: int, ctx_repr: int = 0) -> int:
+        return self._route(batch_size, ctx_repr).current_steps
 
     def on_verify_complete(
-        self, num_correct_drafts_per_req: list[int], batch_size: int
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int,
+        ctx_repr: int = 0,
     ) -> int | None:
-        """Feed verify results to the matching BS slot's EMA.
+        """Feed verify results to the matching (BS, ctx) slot's EMA.
 
         Returns the new step if a switch is warranted, else ``None``.
         """
-        params = self._route(batch_size)
+        params = self._route(batch_size, ctx_repr)
         if params.update(num_correct_drafts_per_req):
             return params.current_steps
         return None
@@ -316,21 +422,40 @@ class AdaptiveSpeculativeParams:
         """Return cuda_graph_bs values that can reach *step* at runtime.
 
         Returns ``None`` when CUDA graphs are disabled (``set_cuda_graph_bs``
-        was never called or was called with ``None``).
+        was never called or was called with ``None``). Under the 2D schema
+        the reachable step set at a given BS is the union of every ctx
+        bucket's ``candidate_steps`` — the capture set is BS-only, so the
+        pruning shape matches the 1D-union config.
         """
         if self._cuda_graph_bs is None:
             return None
         return [
             v
             for v in self._cuda_graph_bs
-            if step in self._slots[self._find_closest_bs(v)].candidate_steps
+            if step in self._steps_reachable_at_bs(self._find_closest_bs(v))
         ]
 
-    def _route(self, batch_size: int) -> AdaptiveStepSlot:
-        """Map *batch_size* → pad to CUDA-graph BS → closest slot."""
-        return self._slots[
-            self._find_closest_bs(self._pad_to_cuda_graph_bs(batch_size))
-        ]
+    def _steps_reachable_at_bs(self, bs: int) -> set[int]:
+        return {
+            s
+            for slot in self._ctx_slots_by_bs[bs].values()
+            for s in slot.candidate_steps
+        }
+
+    def _route(self, batch_size: int, ctx_repr: int = 0) -> AdaptiveStepSlot:
+        """Map *(batch_size, ctx_repr)* → pad to CUDA-graph BS → slot."""
+        bs = self._find_closest_bs(self._pad_to_cuda_graph_bs(batch_size))
+        return self._slot_for_ctx(bs, ctx_repr)
+
+    def _slot_for_ctx(self, bs: int, ctx_repr: int) -> AdaptiveStepSlot:
+        buckets = self._ctx_slots_by_bs[bs]
+        if len(buckets) == 1:
+            return next(iter(buckets.values()))
+        his = self._ctx_hi_by_bs[bs]
+        idx = bisect.bisect_left(his, ctx_repr)
+        if idx == len(his):
+            idx = len(his) - 1
+        return buckets[self._ctx_lo_by_bs[bs][idx]]
 
     def _pad_to_cuda_graph_bs(self, batch_size: int) -> int:
         if self._cuda_graph_bs is None:

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -89,6 +89,41 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
     return None
 
 
+_CTX_BUCKET_MAX = 2**31 - 1
+
+
+def _parse_ctx_bucket_key(key: str) -> tuple[int, int]:
+    if not isinstance(key, str) or "-" not in key:
+        raise ValueError(f"ctx_buckets key must be a 'lo-hi' string, got {key!r}")
+    lo_str, hi_str = key.split("-", 1)
+    try:
+        lo, hi = int(lo_str), int(hi_str)
+    except ValueError as e:
+        raise ValueError(f"ctx_buckets key {key!r} must contain integer 'lo-hi'") from e
+    if lo < 1 or hi < lo:
+        raise ValueError(f"ctx_buckets key {key!r} must satisfy 1 <= lo <= hi")
+    return lo, hi
+
+
+def _validate_ctx_bucket_coverage(
+    bs: int, ordered: list[tuple[int, int, dict]]
+) -> None:
+    if not ordered:
+        raise ValueError(f"BS {bs}: ctx_buckets must not be empty")
+    if ordered[0][0] != 1:
+        raise ValueError(
+            f"BS {bs}: ctx_buckets must start at 1, got lo={ordered[0][0]}"
+        )
+    for i in range(1, len(ordered)):
+        prev_hi = ordered[i - 1][1]
+        cur_lo = ordered[i][0]
+        if cur_lo != prev_hi + 1:
+            raise ValueError(
+                f"BS {bs}: ctx_buckets gap between "
+                f"{prev_hi} and {cur_lo}; ranges must be contiguous"
+            )
+
+
 def _load_adaptive_config(
     cfg_path: str | None,
 ) -> tuple[dict, dict[int, dict]]:
@@ -107,16 +142,39 @@ def _load_adaptive_config(
         if not key.isdigit():
             continue
 
-        steps = entry.get("candidate_steps")
-        if (
-            not isinstance(steps, list)
-            or not steps
-            or not all(isinstance(s, int) and s >= 0 for s in steps)
-        ):
-            raise ValueError(
-                f"BS {key}: candidate_steps must be a list of non-negative ints, "
-                f"got {steps!r}"
-            )
+        ctx_raw = entry.get("ctx_buckets")
+        if ctx_raw is not None:
+            if not isinstance(ctx_raw, dict) or not ctx_raw:
+                raise ValueError(
+                    f"BS {key}: ctx_buckets must be a non-empty dict, got {ctx_raw!r}"
+                )
+            for bucket_key, bucket_entry in ctx_raw.items():
+                _parse_ctx_bucket_key(bucket_key)
+                steps = (
+                    bucket_entry.get("candidate_steps")
+                    if isinstance(bucket_entry, dict)
+                    else None
+                )
+                if (
+                    not isinstance(steps, list)
+                    or not steps
+                    or not all(isinstance(s, int) and s >= 0 for s in steps)
+                ):
+                    raise ValueError(
+                        f"BS {key} ctx bucket {bucket_key!r}: candidate_steps "
+                        f"must be a list of non-negative ints, got {steps!r}"
+                    )
+        else:
+            steps = entry.get("candidate_steps")
+            if (
+                not isinstance(steps, list)
+                or not steps
+                or not all(isinstance(s, int) and s >= 0 for s in steps)
+            ):
+                raise ValueError(
+                    f"BS {key}: candidate_steps must be a list of non-negative ints, "
+                    f"got {steps!r}"
+                )
         bs_entries[int(key)] = entry
 
     if not bs_entries:
@@ -135,7 +193,12 @@ def resolve_candidate_steps_from_config(
     _, bs_entries = _load_adaptive_config(cfg_path)
     all_steps: set[int] = set()
     for entry in bs_entries.values():
-        all_steps.update(entry["candidate_steps"])
+        ctx_raw = entry.get("ctx_buckets")
+        if ctx_raw is not None:
+            for bucket_entry in ctx_raw.values():
+                all_steps.update(bucket_entry["candidate_steps"])
+        else:
+            all_steps.update(entry["candidate_steps"])
     return sorted(all_steps)
 
 
@@ -262,9 +325,11 @@ class AdaptiveStepSlot:
 
 
 class AdaptiveSpeculativeParams:
-    """Routes ``batch_size`` to the correct per-BS slot.
+    """Routes ``(batch_size, ctx_repr)`` to the correct per-(BS, ctx) slot.
 
-    A slot is a per-BS configuration of adaptive step selection.
+    A slot is a per-(BS, ctx-bucket) configuration of adaptive step
+    selection. Legacy 1D configs (no ``ctx_buckets`` key) degenerate to a
+    single ctx bucket covering ``[0, ∞)`` per BS.
     """
 
     def __init__(
@@ -275,13 +340,43 @@ class AdaptiveSpeculativeParams:
         cfg, bs_entries = _load_adaptive_config(cfg_path)
         self._bs_list: list[int] = sorted(bs_entries)
         self._slots: dict[int, AdaptiveStepSlot] = {}
+        self._ctx_slots_by_bs: dict[int, dict[int, AdaptiveStepSlot]] = {}
+        self._ctx_lo_by_bs: dict[int, list[int]] = {}
+        self._ctx_hi_by_bs: dict[int, list[int]] = {}
         self._cuda_graph_bs: list[int] | None = None
 
         for bs, entry in sorted(bs_entries.items()):
-            self._slots[bs] = AdaptiveStepSlot(
-                initial_steps=initial_steps,
-                cfg={**cfg, **entry},
-            )
+            ctx_raw = entry.get("ctx_buckets")
+            bs_slots: dict[int, AdaptiveStepSlot] = {}
+            los: list[int] = []
+            his: list[int] = []
+            if ctx_raw is None:
+                bs_slots[1] = AdaptiveStepSlot(
+                    initial_steps=initial_steps,
+                    cfg={**cfg, **entry},
+                )
+                los.append(1)
+                his.append(_CTX_BUCKET_MAX)
+            else:
+                ordered: list[tuple[int, int, dict]] = []
+                for bucket_key, bucket_entry in ctx_raw.items():
+                    lo, hi = _parse_ctx_bucket_key(bucket_key)
+                    ordered.append((lo, hi, bucket_entry))
+                ordered.sort(key=lambda t: t[0])
+                _validate_ctx_bucket_coverage(bs, ordered)
+                for lo, hi, bucket_entry in ordered:
+                    merged = {**cfg, **entry, **bucket_entry}
+                    merged.pop("ctx_buckets", None)
+                    bs_slots[lo] = AdaptiveStepSlot(
+                        initial_steps=initial_steps,
+                        cfg=merged,
+                    )
+                    los.append(lo)
+                    his.append(hi)
+            self._ctx_slots_by_bs[bs] = bs_slots
+            self._slots[bs] = bs_slots[los[0]]
+            self._ctx_lo_by_bs[bs] = los
+            self._ctx_hi_by_bs[bs] = his
 
         first_slot = self._slots[self._bs_list[0]]
         log_info_on_rank0(
@@ -293,23 +388,33 @@ class AdaptiveSpeculativeParams:
 
     @cached_property
     def candidate_steps(self) -> list[int]:
-        """Union of all BS slots' candidate steps."""
-        return sorted({s for p in self._slots.values() for s in p.candidate_steps})
+        """Union of all (BS, ctx) slots' candidate steps."""
+        return sorted(
+            {
+                s
+                for buckets in self._ctx_slots_by_bs.values()
+                for slot in buckets.values()
+                for s in slot.candidate_steps
+            }
+        )
 
     def set_cuda_graph_bs(self, cuda_graph_bs: list[int] | None) -> None:
         self._cuda_graph_bs = sorted(cuda_graph_bs) if cuda_graph_bs else None
 
-    def get_steps_for_batch(self, batch_size: int) -> int:
-        return self._route(batch_size).current_steps
+    def get_steps_for_batch(self, batch_size: int, ctx_repr: int = 0) -> int:
+        return self._route(batch_size, ctx_repr).current_steps
 
     def on_verify_complete(
-        self, num_correct_drafts_per_req: list[int], batch_size: int
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int,
+        ctx_repr: int = 0,
     ) -> int | None:
-        """Feed verify results to the matching BS slot's EMA.
+        """Feed verify results to the matching (BS, ctx) slot's EMA.
 
         Returns the new step if a switch is warranted, else ``None``.
         """
-        params = self._route(batch_size)
+        params = self._route(batch_size, ctx_repr)
         if params.update(num_correct_drafts_per_req):
             return params.current_steps
         return None
@@ -318,21 +423,40 @@ class AdaptiveSpeculativeParams:
         """Return cuda_graph_bs values that can reach *step* at runtime.
 
         Returns ``None`` when CUDA graphs are disabled (``set_cuda_graph_bs``
-        was never called or was called with ``None``).
+        was never called or was called with ``None``). Under the 2D schema
+        the reachable step set at a given BS is the union of every ctx
+        bucket's ``candidate_steps`` — the capture set is BS-only, so the
+        pruning shape matches the 1D-union config.
         """
         if self._cuda_graph_bs is None:
             return None
         return [
             v
             for v in self._cuda_graph_bs
-            if step in self._slots[self._find_closest_bs(v)].candidate_steps
+            if step in self._steps_reachable_at_bs(self._find_closest_bs(v))
         ]
 
-    def _route(self, batch_size: int) -> AdaptiveStepSlot:
-        """Map *batch_size* → pad to CUDA-graph BS → closest slot."""
-        return self._slots[
-            self._find_closest_bs(self._pad_to_cuda_graph_bs(batch_size))
-        ]
+    def _steps_reachable_at_bs(self, bs: int) -> set[int]:
+        return {
+            s
+            for slot in self._ctx_slots_by_bs[bs].values()
+            for s in slot.candidate_steps
+        }
+
+    def _route(self, batch_size: int, ctx_repr: int = 0) -> AdaptiveStepSlot:
+        """Map *(batch_size, ctx_repr)* → pad to CUDA-graph BS → slot."""
+        bs = self._find_closest_bs(self._pad_to_cuda_graph_bs(batch_size))
+        return self._slot_for_ctx(bs, ctx_repr)
+
+    def _slot_for_ctx(self, bs: int, ctx_repr: int) -> AdaptiveStepSlot:
+        buckets = self._ctx_slots_by_bs[bs]
+        if len(buckets) == 1:
+            return next(iter(buckets.values()))
+        his = self._ctx_hi_by_bs[bs]
+        idx = bisect.bisect_left(his, ctx_repr)
+        if idx == len(his):
+            idx = len(his) - 1
+        return buckets[self._ctx_lo_by_bs[bs][idx]]
 
     def _pad_to_cuda_graph_bs(self, batch_size: int) -> int:
         if self._cuda_graph_bs is None:

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -115,7 +115,10 @@ class BaseSpecWorker(ABC):
         return True, "Succeeded to update model weights."
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
+        ctx_repr: int = 0,
     ) -> None:
         """Hook called after verify finishes and accept counts are on CPU.
 
@@ -132,7 +135,7 @@ class BaseSpecWorker(ABC):
         """
         pass
 
-    def activate_step_by_batch(self, batch_size: int) -> None:
+    def activate_step_by_batch(self, batch_size: int, ctx_repr: int = 0) -> None:
         """Activate the optimal adaptive step for the current batch size.
 
         Default no-op. Adaptive-aware workers override this to switch

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -328,7 +328,10 @@ class BaseSpecWorker(ABC):
         return True, "Succeeded to update model weights."
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
+        ctx_repr: int = 0,
     ) -> None:
         """Hook called after verify finishes and accept counts are on CPU.
 
@@ -345,7 +348,7 @@ class BaseSpecWorker(ABC):
         """
         pass
 
-    def activate_step_by_batch(self, batch_size: int) -> None:
+    def activate_step_by_batch(self, batch_size: int, ctx_repr: int = 0) -> None:
         """Activate the optimal adaptive step for the current batch size.
 
         Default no-op. Adaptive-aware workers override this to switch

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1157,7 +1157,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
                 return batch_output
         else:
-            self.activate_step_by_batch(batch.seq_lens.shape[0])
+            if batch.reqs:
+                seqlens = sorted(req.seqlen for req in batch.reqs)
+                ctx_repr = seqlens[len(seqlens) // 2]
+            else:
+                ctx_repr = 0
+            self.activate_step_by_batch(batch.seq_lens.shape[0], ctx_repr)
 
             if batch.spec_info is None:
                 capture_mode = (
@@ -1302,16 +1307,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
+        ctx_repr: int = 0,
     ) -> None:
         if self.adaptive_controller is not None:
             self.adaptive_controller.on_verify_complete(
-                num_correct_drafts_per_req, batch_size=batch_size
+                num_correct_drafts_per_req,
+                batch_size=batch_size,
+                ctx_repr=ctx_repr,
             )
 
-    def activate_step_by_batch(self, batch_size: int) -> None:
+    def activate_step_by_batch(self, batch_size: int, ctx_repr: int = 0) -> None:
         if self.adaptive_controller is not None:
-            self.adaptive_controller.activate_step_by_batch(batch_size)
+            self.adaptive_controller.activate_step_by_batch(batch_size, ctx_repr)
 
     # -- Adaptive speculative decoding protocol --
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1311,7 +1311,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
                 return batch_output
         else:
-            self.activate_step_by_batch(batch.seq_lens.shape[0])
+            if batch.reqs:
+                seqlens = sorted(req.seqlen for req in batch.reqs)
+                ctx_repr = seqlens[len(seqlens) // 2]
+            else:
+                ctx_repr = 0
+            self.activate_step_by_batch(batch.seq_lens.shape[0], ctx_repr)
 
             if batch.spec_info is None:
                 capture_mode = (
@@ -1454,16 +1459,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
+        ctx_repr: int = 0,
     ) -> None:
         if self.adaptive_controller is not None:
             self.adaptive_controller.on_verify_complete(
-                num_correct_drafts_per_req, batch_size=batch_size
+                num_correct_drafts_per_req,
+                batch_size=batch_size,
+                ctx_repr=ctx_repr,
             )
 
-    def activate_step_by_batch(self, batch_size: int) -> None:
+    def activate_step_by_batch(self, batch_size: int, ctx_repr: int = 0) -> None:
         if self.adaptive_controller is not None:
-            self.adaptive_controller.activate_step_by_batch(batch_size)
+            self.adaptive_controller.activate_step_by_batch(batch_size, ctx_repr)
 
     # -- Adaptive speculative decoding protocol --
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -743,7 +743,12 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
                 )
                 return batch_output
         else:
-            self.activate_step_by_batch(batch.seq_lens.shape[0])
+            if batch.reqs:
+                seqlens = sorted(req.seqlen for req in batch.reqs)
+                ctx_repr = seqlens[len(seqlens) // 2]
+            else:
+                ctx_repr = 0
+            self.activate_step_by_batch(batch.seq_lens.shape[0], ctx_repr)
 
             if batch.spec_info is None:
                 batch.spec_info = self.draft_worker._idle_seed()

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -781,7 +781,12 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
                 )
                 return batch_output
         else:
-            self.activate_step_by_batch(batch.seq_lens.shape[0])
+            if batch.reqs:
+                seqlens = sorted(req.seqlen for req in batch.reqs)
+                ctx_repr = seqlens[len(seqlens) // 2]
+            else:
+                ctx_repr = 0
+            self.activate_step_by_batch(batch.seq_lens.shape[0], ctx_repr)
 
             if batch.spec_info is None:
                 batch.spec_info = self.draft_worker._idle_seed()

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -195,7 +195,10 @@ class NGRAMWorker(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
+        ctx_repr: int = 0,
     ) -> None:
         # Signature must match BaseSpecWorker.on_verify_complete_cpu; the
         # result processor calls it with batch_size as a keyword argument.

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -232,7 +232,10 @@ class NGRAMWorker(BaseSpecWorker):
             )
 
     def on_verify_complete_cpu(
-        self, num_correct_drafts_per_req: list[int], batch_size: int = 0
+        self,
+        num_correct_drafts_per_req: list[int],
+        batch_size: int = 0,
+        ctx_repr: int = 0,
     ) -> None:
         # Signature must match BaseSpecWorker.on_verify_complete_cpu; the
         # result processor calls it with batch_size as a keyword argument.

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -419,6 +419,228 @@ class TestResolveCandidateSteps(unittest.TestCase):
             steps = resolve_candidate_steps_from_config(cfg_path=f.name)
         self.assertEqual(steps, [1, 3, 5, 7])
 
+    def test_unions_and_dedups_across_ctx_buckets(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
+            json.dump(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "1-2047": {"candidate_steps": [0, 1]},
+                            "2048-32768": {"candidate_steps": [3, 7]},
+                        },
+                    },
+                },
+                f,
+            )
+            f.flush()
+            steps = resolve_candidate_steps_from_config(cfg_path=f.name)
+        self.assertEqual(steps, [0, 1, 3, 7])
+
+
+class TestTwoDSchemaParsing(unittest.TestCase):
+    def _params(self, cfg):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(cfg, f)
+            f.flush()
+            return AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+
+    def test_2d_schema_loads(self):
+        params = self._params(
+            {
+                "1": {"candidate_steps": [1, 3, 7]},
+                "8": {
+                    "ctx_buckets": {
+                        "1-2047": {"candidate_steps": [0, 1, 3]},
+                        "2048-32768": {"candidate_steps": [1, 3]},
+                    },
+                },
+            }
+        )
+        self.assertEqual(params._bs_list, [1, 8])
+        self.assertEqual(params._slots[1].candidate_steps, [1, 3, 7])
+        self.assertEqual(params._slots[8].candidate_steps, [0, 1, 3])
+
+    def test_2d_bucket_gap_raises(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "1-1023": {"candidate_steps": [3]},
+                            "2048-32768": {"candidate_steps": [1]},
+                        },
+                    },
+                }
+            )
+
+    def test_2d_bucket_must_start_at_one(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "512-2047": {"candidate_steps": [3]},
+                            "2048-32768": {"candidate_steps": [1]},
+                        },
+                    },
+                }
+            )
+
+    def test_2d_bucket_zero_lo_rejected(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "0-2047": {"candidate_steps": [3]},
+                            "2048-32768": {"candidate_steps": [1]},
+                        },
+                    },
+                }
+            )
+
+    def test_2d_bucket_key_must_be_lo_hi_ints(self):
+        with self.assertRaises(ValueError):
+            self._params({"8": {"ctx_buckets": {"0_2047": {"candidate_steps": [3]}}}})
+
+    def test_2d_bucket_empty_dict_raises(self):
+        with self.assertRaises(ValueError):
+            self._params({"8": {"ctx_buckets": {}}})
+
+    def test_2d_bucket_empty_steps_raises(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {"1-32768": {"candidate_steps": []}},
+                    },
+                }
+            )
+
+
+class TestTwoDRouting(unittest.TestCase):
+    def _params(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [1, 3, 7]},
+                    "8": {
+                        "ctx_buckets": {
+                            "1-2047": {"candidate_steps": [0, 1, 3]},
+                            "2048-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "32": {
+                        "ctx_buckets": {
+                            "1-767": {"candidate_steps": [0]},
+                            "768-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "64": {"candidate_steps": [0]},
+                },
+                f,
+            )
+            f.flush()
+            return AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+
+    def test_ctx_switches_slot_within_bs(self):
+        params = self._params()
+        low = params._route(8, 500)
+        high = params._route(8, 3000)
+        self.assertEqual(low.candidate_steps, [0, 1, 3])
+        self.assertEqual(high.candidate_steps, [1, 3])
+        self.assertIsNot(low, high)
+
+    def test_ctx_bucket_boundary_inclusive_upper(self):
+        params = self._params()
+        self.assertEqual(params._route(8, 2047).candidate_steps, [0, 1, 3])
+        self.assertEqual(params._route(8, 2048).candidate_steps, [1, 3])
+
+    def test_ctx_beyond_last_hi_uses_last_bucket(self):
+        params = self._params()
+        self.assertEqual(params._route(8, 10**9).candidate_steps, [1, 3])
+
+    def test_legacy_bs_ignores_ctx(self):
+        params = self._params()
+        for ctx in (0, 500, 3000, 10**9):
+            self.assertEqual(params._route(1, ctx).candidate_steps, [1, 3, 7])
+            self.assertEqual(params._route(64, ctx).candidate_steps, [0])
+
+    def test_default_ctx_matches_first_bucket(self):
+        params = self._params()
+        self.assertEqual(params._route(8).candidate_steps, [0, 1, 3])
+        self.assertEqual(params._route(32).candidate_steps, [0])
+
+    def test_get_steps_for_batch_differs_by_ctx(self):
+        params = self._params()
+        self.assertNotEqual(
+            params.get_steps_for_batch(32, 100),
+            params.get_steps_for_batch(32, 5000),
+        )
+
+    def test_on_verify_complete_isolates_ctx_slots(self):
+        params = self._params()
+        low_slot = params._route(8, 500)
+        high_slot = params._route(8, 3000)
+        untouched_ema = high_slot.ema_accept_len
+        for _ in range(40):
+            params.on_verify_complete([3, 3, 3], batch_size=8, ctx_repr=500)
+        self.assertGreaterEqual(low_slot.ema_accept_len, 1.0)
+        self.assertEqual(high_slot.ema_accept_len, untouched_ema)
+
+    def test_cuda_graph_bs_for_step_uses_union_of_2d_buckets(self):
+        params = self._params()
+        params.set_cuda_graph_bs([4, 8, 16, 32])
+        self.assertEqual(params.cuda_graph_bs_for_step(3), [4, 8, 16, 32])
+
+    def test_capture_set_identical_to_1d_union(self):
+        # "capture set stays BS-only": for any 2D config, cuda_graph_bs_for_step
+        # returns the same list as the 1D config whose candidate_steps at each
+        # BS is the union of that BS's 2D bucket palettes. Proves no new K
+        # regime is introduced by the ctx axis.
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [1, 3, 7]},
+                    "8": {
+                        "ctx_buckets": {
+                            "1-2047": {"candidate_steps": [0, 1, 3]},
+                            "2048-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "32": {
+                        "ctx_buckets": {
+                            "1-767": {"candidate_steps": [0]},
+                            "768-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "64": {"candidate_steps": [0]},
+                },
+                f,
+            )
+            f.flush()
+            params_2d = AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [1, 3, 7]},
+                    "8": {"candidate_steps": [0, 1, 3]},
+                    "32": {"candidate_steps": [0, 1, 3]},
+                    "64": {"candidate_steps": [0]},
+                },
+                f,
+            )
+            f.flush()
+            params_1d = AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+        params_2d.set_cuda_graph_bs([4, 8, 16, 32])
+        params_1d.set_cuda_graph_bs([4, 8, 16, 32])
+        for step in (0, 1, 3, 7):
+            self.assertEqual(
+                params_2d.cuda_graph_bs_for_step(step),
+                params_1d.cuda_graph_bs_for_step(step),
+            )
+        self.assertEqual(params_2d.candidate_steps, params_1d.candidate_steps)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -420,6 +420,228 @@ class TestResolveCandidateSteps(CustomTestCase):
             steps = resolve_candidate_steps_from_config(cfg_path=f.name)
         self.assertEqual(steps, [1, 3, 5, 7])
 
+    def test_unions_and_dedups_across_ctx_buckets(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
+            json.dump(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "1-2047": {"candidate_steps": [0, 1]},
+                            "2048-32768": {"candidate_steps": [3, 7]},
+                        },
+                    },
+                },
+                f,
+            )
+            f.flush()
+            steps = resolve_candidate_steps_from_config(cfg_path=f.name)
+        self.assertEqual(steps, [0, 1, 3, 7])
+
+
+class TestTwoDSchemaParsing(unittest.TestCase):
+    def _params(self, cfg):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(cfg, f)
+            f.flush()
+            return AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+
+    def test_2d_schema_loads(self):
+        params = self._params(
+            {
+                "1": {"candidate_steps": [1, 3, 7]},
+                "8": {
+                    "ctx_buckets": {
+                        "1-2047": {"candidate_steps": [0, 1, 3]},
+                        "2048-32768": {"candidate_steps": [1, 3]},
+                    },
+                },
+            }
+        )
+        self.assertEqual(params._bs_list, [1, 8])
+        self.assertEqual(params._slots[1].candidate_steps, [1, 3, 7])
+        self.assertEqual(params._slots[8].candidate_steps, [0, 1, 3])
+
+    def test_2d_bucket_gap_raises(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "1-1023": {"candidate_steps": [3]},
+                            "2048-32768": {"candidate_steps": [1]},
+                        },
+                    },
+                }
+            )
+
+    def test_2d_bucket_must_start_at_one(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "512-2047": {"candidate_steps": [3]},
+                            "2048-32768": {"candidate_steps": [1]},
+                        },
+                    },
+                }
+            )
+
+    def test_2d_bucket_zero_lo_rejected(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {
+                            "0-2047": {"candidate_steps": [3]},
+                            "2048-32768": {"candidate_steps": [1]},
+                        },
+                    },
+                }
+            )
+
+    def test_2d_bucket_key_must_be_lo_hi_ints(self):
+        with self.assertRaises(ValueError):
+            self._params({"8": {"ctx_buckets": {"0_2047": {"candidate_steps": [3]}}}})
+
+    def test_2d_bucket_empty_dict_raises(self):
+        with self.assertRaises(ValueError):
+            self._params({"8": {"ctx_buckets": {}}})
+
+    def test_2d_bucket_empty_steps_raises(self):
+        with self.assertRaises(ValueError):
+            self._params(
+                {
+                    "8": {
+                        "ctx_buckets": {"1-32768": {"candidate_steps": []}},
+                    },
+                }
+            )
+
+
+class TestTwoDRouting(unittest.TestCase):
+    def _params(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [1, 3, 7]},
+                    "8": {
+                        "ctx_buckets": {
+                            "1-2047": {"candidate_steps": [0, 1, 3]},
+                            "2048-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "32": {
+                        "ctx_buckets": {
+                            "1-767": {"candidate_steps": [0]},
+                            "768-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "64": {"candidate_steps": [0]},
+                },
+                f,
+            )
+            f.flush()
+            return AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+
+    def test_ctx_switches_slot_within_bs(self):
+        params = self._params()
+        low = params._route(8, 500)
+        high = params._route(8, 3000)
+        self.assertEqual(low.candidate_steps, [0, 1, 3])
+        self.assertEqual(high.candidate_steps, [1, 3])
+        self.assertIsNot(low, high)
+
+    def test_ctx_bucket_boundary_inclusive_upper(self):
+        params = self._params()
+        self.assertEqual(params._route(8, 2047).candidate_steps, [0, 1, 3])
+        self.assertEqual(params._route(8, 2048).candidate_steps, [1, 3])
+
+    def test_ctx_beyond_last_hi_uses_last_bucket(self):
+        params = self._params()
+        self.assertEqual(params._route(8, 10**9).candidate_steps, [1, 3])
+
+    def test_legacy_bs_ignores_ctx(self):
+        params = self._params()
+        for ctx in (0, 500, 3000, 10**9):
+            self.assertEqual(params._route(1, ctx).candidate_steps, [1, 3, 7])
+            self.assertEqual(params._route(64, ctx).candidate_steps, [0])
+
+    def test_default_ctx_matches_first_bucket(self):
+        params = self._params()
+        self.assertEqual(params._route(8).candidate_steps, [0, 1, 3])
+        self.assertEqual(params._route(32).candidate_steps, [0])
+
+    def test_get_steps_for_batch_differs_by_ctx(self):
+        params = self._params()
+        self.assertNotEqual(
+            params.get_steps_for_batch(32, 100),
+            params.get_steps_for_batch(32, 5000),
+        )
+
+    def test_on_verify_complete_isolates_ctx_slots(self):
+        params = self._params()
+        low_slot = params._route(8, 500)
+        high_slot = params._route(8, 3000)
+        untouched_ema = high_slot.ema_accept_len
+        for _ in range(40):
+            params.on_verify_complete([3, 3, 3], batch_size=8, ctx_repr=500)
+        self.assertGreaterEqual(low_slot.ema_accept_len, 1.0)
+        self.assertEqual(high_slot.ema_accept_len, untouched_ema)
+
+    def test_cuda_graph_bs_for_step_uses_union_of_2d_buckets(self):
+        params = self._params()
+        params.set_cuda_graph_bs([4, 8, 16, 32])
+        self.assertEqual(params.cuda_graph_bs_for_step(3), [4, 8, 16, 32])
+
+    def test_capture_set_identical_to_1d_union(self):
+        # "capture set stays BS-only": for any 2D config, cuda_graph_bs_for_step
+        # returns the same list as the 1D config whose candidate_steps at each
+        # BS is the union of that BS's 2D bucket palettes. Proves no new K
+        # regime is introduced by the ctx axis.
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [1, 3, 7]},
+                    "8": {
+                        "ctx_buckets": {
+                            "1-2047": {"candidate_steps": [0, 1, 3]},
+                            "2048-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "32": {
+                        "ctx_buckets": {
+                            "1-767": {"candidate_steps": [0]},
+                            "768-32768": {"candidate_steps": [1, 3]},
+                        },
+                    },
+                    "64": {"candidate_steps": [0]},
+                },
+                f,
+            )
+            f.flush()
+            params_2d = AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [1, 3, 7]},
+                    "8": {"candidate_steps": [0, 1, 3]},
+                    "32": {"candidate_steps": [0, 1, 3]},
+                    "64": {"candidate_steps": [0]},
+                },
+                f,
+            )
+            f.flush()
+            params_1d = AdaptiveSpeculativeParams(initial_steps=3, cfg_path=f.name)
+        params_2d.set_cuda_graph_bs([4, 8, 16, 32])
+        params_1d.set_cuda_graph_bs([4, 8, 16, 32])
+        for step in (0, 1, 3, 7):
+            self.assertEqual(
+                params_2d.cuda_graph_bs_for_step(step),
+                params_1d.cuda_graph_bs_for_step(step),
+            )
+        self.assertEqual(params_2d.candidate_steps, params_1d.candidate_steps)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Long-context decode is memory-bandwidth-bound on the per-step KV read; verifying K drafted tokens amortizes that read across K+1 tokens, so the optimal K depends on ctx as well as BS. A batch-only palette has to pick one K per BS and either leaves ctx-amortization on the table for long sequences or over-drafts short ones.

This is the SGLang side of the mechanism described in vLLM RFC #48627 (sibling implementation in vLLM PR #48944).

## Modifications

### Config schema (`adaptive_spec_params.py`)
- Each per-BS entry may hold `ctx_buckets: {"lo-hi": {"candidate_steps": ..., ...}}`. Ranges are 1-indexed, inclusive on both ends, and must cover `[1, +inf)` with no gaps (validated at load time).
- Legacy 1D entries (no `ctx_buckets` key) still parse; internally the single virtual bucket is `[1, INT_MAX]`, and `_slot_for_ctx` takes a `len(buckets) == 1` fast path.

### Routing
- `AdaptiveSpeculativeParams._route(batch_size, ctx_repr=0)` extends the BS-only closest-slot lookup with `_slot_for_ctx(bs, ctx_repr)` (bisect on the per-BS `ctx_hi` list).
- `get_steps_for_batch`, `on_verify_complete` grow a `ctx_repr` kwarg, default 0 (inert for legacy 1D configs).
- `cuda_graph_bs_for_step` reachability check now unions each BS's ctx buckets' `candidate_steps`; the CUDA-graph capture set stays BS-only.

### Wiring — ctx_repr computation stays fully CPU-side
- `adaptive_runtime_state.py`: `AdaptiveController.activate_step_by_batch` and `on_verify_complete` thread `ctx_repr` through to the params.
- `base_spec_worker.py` / `eagle_worker_v2.py` / `ngram_worker.py`: `on_verify_complete_cpu` and `activate_step_by_batch` grow `ctx_repr` (default 0), matching `BaseSpecWorker` signature.
- `eagle_worker_v2.py:forward_batch_generation`, `frozen_kv_mtp_worker_v2.py:forward_batch_generation`, and `scheduler_components/batch_result_processor.py` compute `ctx_repr` from `batch.reqs` (CPU-side list already in memory): `sorted(req.seqlen for req in batch.reqs)[n//2]`. `Req.seqlen` is a pure-Python property (`len(origin_input_ids) + len(output_ids)`) — same physical quantity as `seq_lens_cpu[i]`, no tensor allocation, no host-device sync in the decode hot path. This matches the no-sync design principle stated in vLLM RFC #48627.

## Accuracy Tests

`test/registered/unit/spec/test_adaptive_spec_params.py` adds 15 new cases (46 total, all passing):

**Schema parsing (6):** gap/start/key/empty/steps validation, 1-index rule.

**Routing (8):** ctx-switch within BS, boundary inclusivity, ctx above last hi, legacy 1D inert to ctx, default ctx, differ-by-ctx `get_steps`, `on_verify_complete` slot isolation, `cuda_graph_bs` union.

**Capture-set identity (1):** `test_capture_set_identical_to_1d_union` proves capture-set BS-only invariance: for any 2D config C2 and its 1D-union equivalent C1 (per-BS `candidate_steps` = union of C2's ctx buckets), C1 and C2 return identical `cuda_graph_bs_for_step(step)` for every step and identical `candidate_steps`.

Plus `resolve_candidate_steps_unions_across_ctx_buckets` for the buffer sizing path. Existing 31 cases in the same file unchanged and pass.

## Live-server smoke (2D routing works end-to-end)

- Hardware: H100 NVL 94GB, driver 580.159 / CUDA 13.0
- Target: `meta-llama/Llama-3.1-8B-Instruct` (bf16)
- Draft: `lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B` (bf16)
- Server: `python -m sglang.launch_server --speculative-algorithm EAGLE3 --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --speculative-adaptive --speculative-adaptive-config /tmp/adaptive_2d.json --context-length 8192 --enable-metrics`
- 2D config:
  ```json
  {
    "1": {"candidate_steps": [3]},
    "8": {"ctx_buckets": {
      "1-100":      {"candidate_steps": [0]},
      "101-100000": {"candidate_steps": [3]}
    }}
  }
  ```
- Observed via `sglang:spec_num_steps` gauge:
  | Case | BS | Prompt len | Expected slot | Observed `spec_num_steps` |
  |---|---|---|---|---|
  | 1 | 1 | ~10 tokens | BS=1 slot → K=3 | 3.0 ✓ |
  | 2 | 8 concurrent | ~3 tokens | BS=8 ctx<100 → K=0 | 0.0 ✓ |
  | 3 | 8 concurrent | 262 tokens | BS=8 ctx≥101 → K=3 | 3.0 ✓ |

The "Switch adaptive runtime state: steps 0 → 3" log line fires on the BS=8 long-prompt case, confirming ctx-based routing takes effect end-to-end. Case 3 also demonstrates the RFC #48627 dose-response prediction (higher K helps at long ctx even under high BS) holds in SGLang.

### Note on the interim commits

Commits `c6fa6ce1` (elif GPU fallback) and `7d2825af` (CPU-native rewrite) resolve a bug the smoke exposed: `batch.seq_lens_cpu` is `None` during CUDA-graph decode, so the initial `seq_lens_cpu.median().item()` path silently returned `ctx_repr=0` and 2D routing never fired for the K>0 side. The fallback commit added a `seq_lens.median().item()` branch that fixed correctness but introduced a per-iter host-device sync — flagged by gemini-code-assist as an anti-pattern. `7d2825af` supersedes both by computing the median from `batch.reqs` (CPU-side), which is correctness-safe under CUDA graphs and free of any tensor sync. History kept for review traceability; happy to squash before merge if preferred.

## Speed Tests and Profiling

Routing overhead is a single `bisect.bisect_left` per verify complete + activate (already CPU-side). Legacy 1D configs skip the bisect via the `len(buckets) == 1` fast path. CUDA-graph capture set does not change (proved by the capture-set identity test), so no additional graph memory or compile cost. `ctx_repr` computation is `sorted()` over `len(batch.reqs)` Python ints — O(B log B) with B ≤ max_running_requests, dwarfed by the verify step's compute.

End-to-end tok/s comparison against a batch-only palette on real workload traces is out of scope here and will be reported in a follow-up once a workload harness is agreed on.

## References

- vLLM RFC #48627 — Context-length-aware K in DSD (no-sync design principle)
- vLLM PR #48944 — sibling implementation
- gemini-code-assist review — flagged the sync-in-hot-path anti-pattern; applied in `7d2825af`

---

**AI-assistance disclosure** (per `AGENTS.md`): this patch was prepared and end-to-end verified with Claude Code. Every diff was reviewed by the author; unit tests and the live-server smoke above were executed against the patched module before proposing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34394616578](https://github.com/sgl-project/sglang/actions/runs/34394616578)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34394616098](https://github.com/sgl-project/sglang/actions/runs/34394616098)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34394616381](https://github.com/sgl-project/sglang/actions/runs/34394616381)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
