### PR TITLE
Add houseroad to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -685,6 +685,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "houseroad": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "htzo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Summary
- Add `houseroad` to `.github/CI_PERMISSIONS.json` with CI trigger/rerun permissions (0 min cooldown, custom override)
- Inserted in the correct alphabetical position (between `hnyls2002` and `htzo`)

## Test plan
- N/A (config-only change)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29692679984](https://github.com/sgl-project/sglang/actions/runs/29692679984)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29692679933](https://github.com/sgl-project/sglang/actions/runs/29692679933)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->