### PR TITLE
Add anti-starvation aging to the lpm schedule policy (--lpm-aging-tokens-per-pass)

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -210,8 +210,15 @@ class SchedulePolicy:
                 waiting_queue, policy
             )
             if policy == CacheAwarePolicy.LPM:
+                aging_step = get_server_args().lpm_aging_tokens_per_pass
+                if aging_step > 0:
+                    # Count completed passes in which each request was seen but
+                    # not scheduled. Starts at 0 on the first pass; requests
+                    # leave the queue when scheduled, so no reset is needed.
+                    for r in waiting_queue:
+                        r.lpm_waiting_passes = getattr(r, "lpm_waiting_passes", -1) + 1
                 SchedulePolicy._sort_by_longest_prefix(
-                    waiting_queue, temporary_deprioritized
+                    waiting_queue, temporary_deprioritized, aging_step
                 )
             elif policy == CacheAwarePolicy.DFS_WEIGHT:
                 SchedulePolicy._sort_by_dfs_weight(waiting_queue, self.tree_cache)
@@ -310,16 +317,31 @@ class SchedulePolicy:
 
     @staticmethod
     def _sort_by_longest_prefix(
-        waiting_queue: List[Req], temporary_deprioritized: Set[int]
+        waiting_queue: List[Req],
+        temporary_deprioritized: Set[int],
+        aging_tokens_per_pass: int = 0,
     ) -> None:
-        """Sorts the waiting queue based on the longest prefix match."""
-        waiting_queue.sort(
-            key=lambda r: (
-                -r.num_matched_prefix_tokens
-                if r.rid not in temporary_deprioritized
-                else float("inf")
-            )
-        )
+        """Sorts the waiting queue based on the longest prefix match.
+
+        With aging enabled (``aging_tokens_per_pass > 0``), every pass a request
+        has already spent waiting adds that many tokens to its effective match
+        length, so a cache-cold request cannot be displaced indefinitely by a
+        continuous stream of cache-hot arrivals. In-batch deprioritized
+        requests are exempt: their setback is one pass by design (they match
+        the group leader's cached prefix on the next pass).
+        """
+
+        def sort_key(r: Req) -> float:
+            if r.rid in temporary_deprioritized:
+                return float("inf")
+            effective = r.num_matched_prefix_tokens
+            if aging_tokens_per_pass > 0:
+                effective += aging_tokens_per_pass * getattr(
+                    r, "lpm_waiting_passes", 0
+                )
+            return -effective
+
+        waiting_queue.sort(key=sort_key)
 
     @staticmethod
     def _sort_by_dfs_weight(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -331,15 +331,22 @@ class SchedulePolicy:
         the group leader's cached prefix on the next pass).
         """
 
-        def sort_key(r: Req) -> float:
-            if r.rid in temporary_deprioritized:
-                return float("inf")
-            effective = r.num_matched_prefix_tokens
-            if aging_tokens_per_pass > 0:
-                effective += aging_tokens_per_pass * getattr(
-                    r, "lpm_waiting_passes", 0
+        if aging_tokens_per_pass > 0:
+
+            def sort_key(r: Req) -> float:
+                if r.rid in temporary_deprioritized:
+                    return float("inf")
+                return -(
+                    r.num_matched_prefix_tokens
+                    + aging_tokens_per_pass * getattr(r, "lpm_waiting_passes", 0)
                 )
-            return -effective
+
+        else:
+
+            def sort_key(r: Req) -> float:
+                if r.rid in temporary_deprioritized:
+                    return float("inf")
+                return -r.num_matched_prefix_tokens
 
         waiting_queue.sort(key=sort_key)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -784,6 +784,10 @@ class ServerArgs:
         float,
         "How conservative the schedule policy is. A larger value means more conservative scheduling. Use a larger value if you see requests being retracted frequently.",
     ] = 1.0
+    lpm_aging_tokens_per_pass: A[
+        int,
+        "Anti-starvation aging for the 'lpm' schedule policy. Each scheduling pass a waiting request is not scheduled, its effective matched-prefix length grows by this many tokens, so cache-cold requests cannot be displaced indefinitely by a stream of cache-hot arrivals. 0 disables aging (previous behavior). Aging is per scheduling pass, so wall-clock behavior scales with the engine iteration rate.",
+    ] = 0
     page_size: A[
         Optional[int],
         Arg(help="The number of tokens in a page.", resolvable=True),

--- a/test/registered/unit/managers/test_schedule_policy_lpm_aging.py
+++ b/test/registered/unit/managers/test_schedule_policy_lpm_aging.py
@@ -66,7 +66,9 @@ class TestLpmAgingSort(CustomTestCase):
         dep = _req("dep", matched=0, waiting_passes=10_000)
         hot = _req("hot", matched=10, waiting_passes=0)
         queue = [dep, hot]
-        SchedulePolicy._sort_by_longest_prefix(queue, set(), aging_tokens_per_pass=aging)
+        SchedulePolicy._sort_by_longest_prefix(
+            queue, set(), aging_tokens_per_pass=aging
+        )
         self.assertEqual([r.rid for r in queue], ["dep", "hot"])
         SchedulePolicy._sort_by_longest_prefix(queue, {"dep"}, aging)
         self.assertEqual([r.rid for r in queue], ["hot", "dep"])

--- a/test/registered/unit/managers/test_schedule_policy_lpm_aging.py
+++ b/test/registered/unit/managers/test_schedule_policy_lpm_aging.py
@@ -1,0 +1,91 @@
+"""Unit tests for LPM anti-starvation aging (--lpm-aging-tokens-per-pass).
+
+Without aging, LPM sorts purely by matched-prefix length, so a cache-cold
+request is displaced indefinitely by a continuous stream of cache-hot
+arrivals (unbounded starvation). With aging, each pass spent waiting adds a
+configurable token bonus to the effective match length, bounding the wait.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.schedule_policy import SchedulePolicy
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+
+def _req(rid: str, matched: int, waiting_passes: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(
+        rid=rid,
+        num_matched_prefix_tokens=matched,
+        lpm_waiting_passes=waiting_passes,
+    )
+
+
+class TestLpmAgingSort(CustomTestCase):
+    def test_no_aging_preserves_pure_match_order(self):
+        """aging=0 (default): match length alone decides; waiting passes are ignored."""
+        cold = _req("cold", matched=0, waiting_passes=1000)
+        hot = _req("hot", matched=100_000, waiting_passes=0)
+        queue = [cold, hot]
+        SchedulePolicy._sort_by_longest_prefix(queue, set())
+        self.assertEqual([r.rid for r in queue], ["hot", "cold"])
+
+    def test_aging_bounds_starvation(self):
+        """With aging, a cold request eventually outranks fresh hot arrivals."""
+        aging = 4096
+        hot_match = 100_000
+        # One pass short of overtaking: still behind.
+        almost = _req("cold", matched=0, waiting_passes=hot_match // aging - 1)
+        hot = _req("hot", matched=hot_match, waiting_passes=0)
+        queue = [almost, hot]
+        SchedulePolicy._sort_by_longest_prefix(queue, set(), aging)
+        self.assertEqual(queue[0].rid, "hot")
+
+        # Enough passes accumulated: the cold request sorts first.
+        aged = _req("cold", matched=0, waiting_passes=hot_match // aging + 1)
+        queue = [aged, _req("hot", matched=hot_match, waiting_passes=0)]
+        SchedulePolicy._sort_by_longest_prefix(queue, set(), aging)
+        self.assertEqual(queue[0].rid, "cold")
+
+    def test_aging_applies_to_effective_match_not_order(self):
+        """Aging composes with match length rather than overriding it."""
+        aging = 1000
+        a = _req("a", matched=5_000, waiting_passes=2)  # effective 7_000
+        b = _req("b", matched=6_000, waiting_passes=0)  # effective 6_000
+        queue = [b, a]
+        SchedulePolicy._sort_by_longest_prefix(queue, set(), aging)
+        self.assertEqual([r.rid for r in queue], ["a", "b"])
+
+    def test_deprioritized_requests_stay_last_despite_aging(self):
+        """In-batch deprioritized requests are exempt from aging (one-pass setback
+        by design; next pass they match the group leader's cached prefix)."""
+        aging = 4096
+        dep = _req("dep", matched=0, waiting_passes=10_000)
+        hot = _req("hot", matched=10, waiting_passes=0)
+        queue = [dep, hot]
+        SchedulePolicy._sort_by_longest_prefix(queue, set(), aging_tokens_per_pass=aging)
+        self.assertEqual([r.rid for r in queue], ["dep", "hot"])
+        SchedulePolicy._sort_by_longest_prefix(queue, {"dep"}, aging)
+        self.assertEqual([r.rid for r in queue], ["hot", "dep"])
+
+    def test_missing_pass_attr_defaults_to_zero(self):
+        """Requests that never went through an aging-enabled pass sort as unaged."""
+        no_attr = SimpleNamespace(rid="fresh", num_matched_prefix_tokens=50)
+        aged = _req("aged", matched=0, waiting_passes=1)
+        queue = [no_attr, aged]
+        SchedulePolicy._sort_by_longest_prefix(queue, set(), 100)
+        self.assertEqual([r.rid for r in queue], ["aged", "fresh"])
+
+
+class TestServerArgsDefault(CustomTestCase):
+    def test_default_is_disabled(self):
+        from sglang.srt.server_args import ServerArgs
+
+        self.assertEqual(ServerArgs.lpm_aging_tokens_per_pass, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`lpm` sorts the waiting queue purely by matched-prefix length — there is no aging or arrival-time term in the sort key. At high radix hit rates this starves cache-cold requests: a cold request (zero prefix match) is re-displaced by *every* cache-hot arrival, and its wait is unbounded as long as hot traffic keeps arriving. The existing `len(waiting_queue) > 128` FCFS fallback bounds per-pass sorting cost, not starvation — shallow queues (where most production serving lives) get the full bias.

We measured this on production traffic (GLM-5.2-NVFP4, 8x B300, agentic workload, ~115K-token mean input, ~96% radix hit rate under slru eviction): median TTFT was 0.7s, but cache-miss requests formed a 20–60s tail (~5% of requests) that contributed ~75% of all accumulated TTFT. Switching to `fcfs` removed the starvation but gives up lpm's cache-locality ordering entirely.

## What this PR does

Adds `--lpm-aging-tokens-per-pass N` (default **0** = exactly the previous behavior):

- Each scheduling pass in which a waiting request is seen but not scheduled increments a per-request pass counter (requests leave the queue when scheduled, so no reset path is needed).
- The lpm sort key becomes `-(num_matched_prefix_tokens + N * waiting_passes)` — aging *composes* with match length instead of overriding it, so fresh cache-hot requests still sort first, but a cold request's effective match grows until it must be scheduled: worst-case displacement is bounded at roughly `ceil(max_match / N)` passes.
- In-batch deprioritized requests (the shared-cold-prefix group followers) are exempt: their setback is one pass by design — the group leader prefills, and they match its cached prefix on the next pass.
- Zero cost when disabled (no counter writes, same sort key as today).

Example: with `N=4096` and 100K-token typical matches, a cold request is scheduled within ~25 passes of being passed over — bounded and tunable, while lpm ordering is otherwise preserved.

## Tests

`test/registered/unit/managers/test_schedule_policy_lpm_aging.py` (CPU suite): starvation bound (one pass below/above the overtake threshold), aging-composes-with-match ordering, deprioritization exemption despite aging, unaged default for requests without the counter attribute, and the disabled-by-default server arg.

## Relation to #31710

Complementary to our runtime `schedule_policy` switching PR (#31710): that one lets operators toggle lpm/fcfs live; this one makes lpm itself safe for mixed cache-hot/cold traffic so the toggle is less necessary. Either stands alone.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29840790883](https://github.com/sgl-project/sglang/actions/runs/29840790883)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29840790789](https://github.com/sgl-project/sglang/actions/runs/29840790789)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->