### PR TITLE
ci: upload runner-utilization report as a run artifact

### DIFF
--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -68,4 +68,18 @@ jobs:
           python scripts/ci/utils/runner_utilization_report.py \
             --repo ${{ github.repository }} \
             --hours ${{ (github.event_name == 'pull_request' && '0.34') || inputs.hours || '24' }} \
+            --output runner-utilization.md \
             ${{ inputs.filter && format('--filter {0}', inputs.filter) || '' }}
+
+      - name: Upload report artifact
+        # The script also appends the report to $GITHUB_STEP_SUMMARY (that
+        # behavior is unchanged); uploading the same file as an artifact makes
+        # the report retrievable via the REST API, which the step summary is
+        # not, so external dashboards can consume it.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runner-utilization-report
+          path: runner-utilization.md
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
## Motivation

The daily Runner Utilization Report is rendered into `$GITHUB_STEP_SUMMARY`, which is only visible by opening each individual run in the web UI — no REST endpoint exposes step-summary content, so the report can't be consumed programmatically (dashboards, archiving, diffing across days).

`runner_utilization_report.py` already supports writing the report to a file via `--output`; this PR passes that flag and uploads the resulting file as a run artifact, which *is* retrievable via the REST API (`listWorkflowRunArtifacts` → `downloadArtifact`).

## Changes

- Pass `--output runner-utilization.md` to the report script (the script's append to `$GITHUB_STEP_SUMMARY` is unconditional, so the run's Summary page is unchanged).
- Add an `actions/upload-artifact@v4` step uploading `runner-utilization.md` as `runner-utilization-report` (30-day retention, `if: always()` + `if-no-files-found: ignore` so a failed report run never fails the upload step).

No behavior change to the report itself — the only stdout difference is the script printing `Report written to runner-utilization.md` instead of echoing the full report.

## Context

We (SemiAnalysis) track OSS inference-engine CI health across hardware vendors in a public dashboard and would like to surface this report there instead of re-deriving the metrics. The PR smoke-run (0.34h window, `run-ci` label) exercises the upload end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29699002966](https://github.com/sgl-project/sglang/actions/runs/29699002966)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29699002890](https://github.com/sgl-project/sglang/actions/runs/29699002890)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->