### PR TITLE
docs: propose commit-gated PD optimistic prefill

### DIFF
--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -815,7 +815,8 @@
                   "docs/developer_guide/development_guide_using_docker",
                   "docs/developer_guide/development_jit_kernel_guide",
                   "docs/developer_guide/quantization_contribution_guide",
-                  "docs/developer_guide/pd_optimistic_prefill_commit_rfc"
+                  "docs/developer_guide/pd_optimistic_prefill_commit_rfc",
+                  "docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix"
                 ]
               },
               {

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -814,7 +814,8 @@
                 "pages": [
                   "docs/developer_guide/development_guide_using_docker",
                   "docs/developer_guide/development_jit_kernel_guide",
-                  "docs/developer_guide/quantization_contribution_guide"
+                  "docs/developer_guide/quantization_contribution_guide",
+                  "docs/developer_guide/pd_optimistic_prefill_commit_rfc"
                 ]
               },
               {

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -815,6 +815,7 @@
                   "docs/developer_guide/development_guide_using_docker",
                   "docs/developer_guide/development_jit_kernel_guide",
                   "docs/developer_guide/quantization_contribution_guide",
+                  "docs/developer_guide/pd_optimistic_prefill_commit_walkthrough",
                   "docs/developer_guide/pd_optimistic_prefill_commit_rfc",
                   "docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix"
                 ]

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
@@ -1,0 +1,1443 @@
+---
+title: "RFC: Commit-gated decode preallocation for PD optimistic prefill"
+description: "Prevent cross-stage capacity inversion—decode preallocation only after prefill scheduler commits the matching request."
+sidebarTitle: "PD commit-gated preallocation"
+tag: "DRAFT"
+---
+
+<Warning>
+  This RFC proposes an experimental protocol. It does not describe an implemented
+  or enabled feature. The existing path must remain unchanged when the new
+  protocol is disabled.
+</Warning>
+
+## Summary
+
+Optimistic prefill lets the prefill worker (P) schedule a request before the
+decode worker (D) finishes bootstrapping. The problem: D can independently
+preallocate decode KV and request slots. This means two requests can grab P and
+D capacity in opposite orders:
+
+```text
+P: request A completed prefill and holds source KV while waiting for D(A)
+D: request B completed preallocation and holds decode KV while waiting for P(B)
+
+P cannot admit B because P capacity is held by A
+D cannot preallocate A because D capacity is held by B
+```
+
+Polling does not resolve this dependency cycle. The system eventually escapes
+through bootstrap timeout, failure cleanup, or unrelated capacity release, so
+this is a timeout-bounded capacity stall rather than a process-level permanent
+deadlock.
+
+This RFC proposes a simple ordering rule:
+
+```text
+P final scheduler admission
+          happens before
+D scarce-capacity preallocation
+```
+
+SMG still dispatches the P and D HTTP requests concurrently. D may create a
+receiver and bounded control state immediately, but it remains `D_REGISTERED`
+and owns no model capacity. D enters the existing preallocation queue only
+after its scheduler verifies an immutable `COMMITTED` result produced by the P
+scheduler for the exact request pair.
+
+D owns retries for both commit notification and transfer completion. P stores
+immutable scheduler snapshots and never runs a per-request reliable outbox.
+The protocol uses complete pair identity, serving-epoch fencing, bounded
+control resources, and local phase deadlines.
+
+Version 1 intentionally disables SMG internal rerouting after the pair reaches
+the `PAIR_BOUND` fence defined below. An ambiguous failure returns an error and
+triggers best-effort identity-bound cancellation; it does not create another
+P/D pair. Safe transparent rerouting requires scheduler-confirmed terminal
+proofs from both workers and is deferred to a follow-up design.
+
+## Status and evidence
+
+- Analysis baseline: SGLang `main` at `b3570a453108`
+- Tracking issue: [#31473](https://github.com/sgl-project/sglang/issues/31473)
+- CPU reproducer: [optimistic capacity inversion reproducer](https://gist.github.com/N3u0ns/419458d91f1329c25062e7584a76a908)
+- Current default: `optimistic_prefill_attempts=0` (feature off by default)
+- Implementation status: not implemented
+- GPU performance: not measured; the real-GPU A/B gate below is required before rollout
+
+The relevant current boundaries already exist in SGLang:
+
+- P can return a still-bootstrapping request from
+  `PrefillBootstrapQueue.pop_bootstrapped()` for optimistic prefill.
+- D acquires request slots, KV, metadata buffers, and related ownership in
+  `DecodePreallocQueue.pop_preallocated()`.
+- SMG already prepares and dispatches the P and D requests concurrently.
+- `bootstrap_pair_key` already exists in the request schema.
+
+The proposal adds an eligibility fence at the existing D preallocation
+boundary without replacing the existing admission or allocation policy, and
+without serializing the P/D HTTP dispatch.
+
+## Goals
+
+Version 1 has four goals:
+
+1. Eliminate the reproduced P/D capacity inversion by construction.
+2. Keep P GPU launch independent of D, the control network, and acknowledgments.
+3. Bound every new queue, correlation, payload, snapshot, and tombstone.
+4. Keep the disabled path behaviorally and measurably unchanged.
+
+## Non-goals
+
+Version 1 explicitly does not cover:
+
+- Transparent SMG rerouting after `PAIR_BOUND`
+- Exactly-once execution across router crashes or client retries
+- NIXL, chunked prefill, PP, DP, multi-rank transfer, retraction, rebootstrap,
+  or runtime topology changes
+- A generic distributed deadlock detector
+- Revocable decode reservations
+- A new Mooncake data-plane executor or transfer-service fairness guarantee
+- New hard timeouts for requests already in `D_RUNNING`
+
+These exclusions keep the first implementation focused on the resource-ordering
+fix and local failure handling. They don't weaken the core safety invariant.
+
+## Maintainer decisions requested
+
+The first review needs decisions on nine points:
+
+1. Use `P final admission -> D scarce preallocation` as the ordering rule.
+2. Accept the proposed no-retraction P scheduler hook in the narrow support cell.
+3. Confirm `D_REGISTERED` receiver/topology setup owns no listed model capacity.
+4. Bind compatibility to canonical role-capability and actual pair-policy
+   digests, not protocol-version equality.
+5. Disable post-`PAIR_BOUND` rerouting and make the first enforcement PR change
+   the current `RetryExecutor`/early-error supervisor behavior.
+6. Use an isolated V1 Mooncake metadata/status namespace with scheduler-only
+   state transitions.
+7. Reserve the complete deduplicated wait/metadata/status channel lease set
+   before D eligibility.
+8. Use fixed logical sequences plus scheduler-owned success/cancel
+   terminalization and replay.
+9. Require the reservation, deadline, correctness, and performance gates below
+   before rollout.
+
+If decisions 1-4, complete pre-eligibility control reservation, or the
+scheduler single-writer rule cannot hold, the correctness contract is
+incomplete. Implementation should stop rather than add acknowledgments or
+silently weaken a support cell.
+
+## Version 1 support cell
+
+The first enforceable cell is intentionally narrow:
+
+| Dimension | Version 1 requirement |
+| --- | --- |
+| Transfer backend | Mooncake |
+| Parallelism | `TP=CP=PP=DP=EP=1` |
+| Prefill | Non-chunked |
+| Scheduler | Normal scheduler; overlap is a separate rollout cell |
+| Decode radix cache | Disabled in the first rollout cell |
+| Request expansion | `batch=1`, `n=1` |
+| Generation | Finite positive `max_new_tokens` |
+| Tokenizer | One tokenizer |
+| Optimistic attempts | `optimistic_prefill_attempts=1` |
+| Router | SGLang Model Gateway HTTP PD router |
+| Retraction and rebootstrap | Disabled |
+| Runtime mutation and active-pair pause | Disabled |
+| Staging, HiCache, speculative decoding | Disabled |
+| SMG post-`PAIR_BOUND` reroute | Disabled |
+| Clock discipline | Actual SMG/P/D wall-clock offset is bounded by the selected `max_clock_skew_ms` |
+
+A new experimental flag, separate from
+`optimistic_prefill_attempts`, enables the protocol. The flag name is an
+implementation decision. Unsupported combinations fail closed or use the
+existing protocol before either worker request is sent. A request must never
+be partially enabled.
+
+## Core invariant and progress argument
+
+### What P_COMMITTED means
+
+`P_COMMITTED` does not mean that the HTTP request was received, that the request
+was queued, or that a Mooncake sender was created.
+
+The P scheduler may only commit when all of the following hold:
+
+1. The request is in the final admitted prefill batch.
+2. Its request slot and source KV have been acquired.
+3. The non-chunked request will not require another P admission to complete
+   prefill.
+4. The supported scheduler path will not retract, yield, or rebootstrap it.
+5. The GPU forward has not been launched yet.
+
+The transition and batch admission occur in the same scheduler thread:
+
+```python
+entry = pair_registry.must_get(req.request_uid)
+assert entry.state == P_PRECOMMIT
+assert req_is_in_final_admitted_batch(req)
+assert req_will_not_need_another_prefill_admission(req)
+
+entry.state = P_COMMITTED
+entry.commit_generation = 1
+entry.post_commit_readiness_deadline = now() + p_post_commit_readiness_timeout
+control_mailbox.mark_ready(entry)  # O(1), local, non-blocking
+
+launch_forward(batch)
+```
+
+The commit hook performs no socket I/O, RPC, collective, allocator operation,
+or wait. If an SGLang scheduler mode cannot provide this linearization point,
+that mode cannot advertise support for version 1.
+
+### D scarce capacity
+
+Before verifying the matching commitment, D must not:
+
+- obtain a slot from `req_to_token_pool`;
+- allocate device or host KV;
+- reserve decode tokens or a model metadata buffer;
+- lock a radix node or start cache loadback;
+- enter the existing decode preallocation queue;
+- enter a running batch or generate a token.
+
+D may create bounded identity state, receiver topology, transport handles, and
+logical control correlations. These are control resources, not model capacity,
+and are covered by separate hard budgets.
+
+### Why the capacity cycle is impossible
+
+The enforce path guarantees:
+
+```text
+D holds scarce capacity
+  → D state ≥ D_ELIGIBLE
+  → D verified COMMITTED (same request, same generation)
+  → P completed final admission for that request
+  → P doesn't need more admission capacity to finish it
+```
+
+Now suppose D holds capacity for B while waiting for P(B). The invariant tells
+us P already finished final admission for B—but that contradicts the original
+capacity-cycle condition where P could not admit B because A was holding its
+capacity.
+
+D might still wait on transfer or fail, but every post-commit phase has a local
+deadline and cleanup path. The cross-stage capacity cycle is gone by design.
+
+## State machines
+
+P owns the following scheduler state:
+
+```text
+P_EMPTY -> P_REGISTERED -> P_PRECOMMIT
+P_EMPTY ----------------> P_PRECOMMIT
+P_PRECOMMIT -> P_COMMITTED -> P_TRANSFERRING
+  -> P_SUCCESS_CLEANUP -> P_TERMINAL(SUCCESS)
+
+any nonterminal state
+  -> P_CANCELLING -> P_TERMINAL(FAILED|CANCELLED)
+```
+
+D owns:
+
+```text
+D_EMPTY -> D_REGISTERED -> D_COMMIT_RECEIVED -> D_ELIGIBLE
+                       \----------------------> D_ELIGIBLE
+  -> D_PREALLOCATED -> D_TRANSFERRING -> D_RUNNING
+  -> D_SUCCESS_CLEANUP -> D_TERMINAL(SUCCESS)
+
+any nonterminal state
+  -> D_CANCELLING -> D_TERMINAL(FAILED|CANCELLED)
+```
+
+`D_REGISTERED` performs receiver/topology setup and commit waiting in parallel.
+`D_COMMIT_RECEIVED` is used when commitment wins that race; if local setup is
+already ready, the scheduler may atomically go from `D_REGISTERED` to
+`D_ELIGIBLE` while recording the same validated commitment.
+`D_ELIGIBLE` is the only state allowed to enter the existing decode
+preallocation queue.
+
+`P_REGISTERED` is the control-only WAIT-first state. It owns no request slot,
+KV, cache lock, model metadata buffer, or runnable batch membership. A matching
+HTTP body may merge it into `P_PRECOMMIT`; an expired, cancelled, or mismatched
+body may not bypass it or create a second entry.
+
+`P_COMMITTED` is a two-condition rendezvous, not proof that prefill compute has
+finished. Its scheduler entry contains monotonic `prefill_compute_done` and
+`metadata_ready` bits. GPU/batch completion and metadata registration set those
+bits through scheduler commands in either order. Only the scheduler may enter
+`P_TRANSFERRING`, and only when both are true; metadata that arrives while the
+committed forward is still running never starts an early KV transfer.
+
+Each request has exactly one protocol state and at most one primary admission
+queue. Auxiliary batch, inflight, result, transport, and cleanup ownership is
+tracked explicitly by the ownership ledger. Protocol-state and primary-queue
+movement are atomic scheduler-thread operations.
+
+### One acquisition graph
+
+The state names above correspond to four gates; individual message handlers do
+not invent additional resource-acquisition rules:
+
+```text
+P WAIT first -> bounded P_REGISTERED subset, zero model capacity
+P HTTP accepted -> P_FULL_CONTROL_READY -> P_PRECOMMIT
+P final scheduler admission/allocation -> P_COMMITTED -> GPU launch
+
+D HTTP accepted -> D_FULL_CONTROL_READY -> D_REGISTERED
+D commitment + receiver/channel readiness -> D_ELIGIBLE
+D allocator entry -> D_PREALLOCATED
+```
+
+`P_FULL_CONTROL_READY` means that the full P row in the reservation table is
+owned. It is required before `P_PRECOMMIT`, whether HTTP or WAIT arrived first,
+and therefore before P can acquire model capacity. `D_FULL_CONTROL_READY` means
+that the full D row, including the complete channel lease set, is owned before
+`D_REGISTERED`. `D_ELIGIBLE` additionally requires the matching immutable
+commitment and ready non-scarce receiver/channel setup.
+
+After either full-control gate and until P terminalizes or D enters
+`D_RUNNING`/earlier terminal cleanup, a protocol phase may consume or release
+only the pair's reserved resources. It may not acquire a generic command slot,
+correlation, response handle, payload byte, control-channel entry, cleanup slot,
+or tombstone slot. Existing decode-generation scheduling after `D_RUNNING` and
+application output backpressure are not new protocol resources. A failure at
+either gate terminalizes a zero-model-capacity entry. This single acquisition
+graph applies to normal progress, duplicate and reconnected waits, success,
+failure, cancel, and deadline cleanup.
+
+The end-to-end lifecycle is therefore fixed:
+
+| Event | Scheduler transition | Model-capacity effect |
+| --- | --- | --- |
+| Valid unknown commit wait at P | `P_EMPTY -> P_REGISTERED` | None |
+| Matching P HTTP body and full-control gate | `P_EMPTY/P_REGISTERED -> P_PRECOMMIT` | None |
+| P final admission/allocation | `P_PRECOMMIT -> P_COMMITTED` | P acquires; no later P admission required |
+| Valid D HTTP body and full-control gate | `D_EMPTY -> D_REGISTERED` | None |
+| Matching commitment plus local readiness | `D_REGISTERED/D_COMMIT_RECEIVED -> D_ELIGIBLE` | None |
+| Existing D preallocator accepts eligible request | `D_ELIGIBLE -> D_PREALLOCATED` | D acquires |
+| D arms transfer and submits V1 metadata | `D_PREALLOCATED -> D_TRANSFERRING` | No new generic control resource |
+| P forward completion or matching metadata arrives first | Set one `P_COMMITTED` readiness bit | No transfer yet |
+| Both P readiness bits are true | `P_COMMITTED -> P_TRANSFERRING` | Submit transfer and arm transfer deadline |
+| First immutable SUCCESS | P cleanup/terminal; `D_TRANSFERRING -> D_RUNNING` | P releases; D retains runtime ownership |
+| Failure, cancel, or phase deadline | Current nonterminal -> cancelling -> terminal | Release every local owner exactly once |
+
+An event that is not valid for the current state can only replay an already
+fixed result or be rejected/dropped as stale. It cannot take an alternative
+transition, reacquire a released owner, or create an entry in another queue.
+
+## Pair identity and serving-epoch fence
+
+SMG generates a random 128-bit `bootstrap_pair_key` after selecting P and D.
+It injects a private, role-specific envelope into both worker requests:
+
+```text
+dispatch_protocol_version
+request_schema_version
+role
+bootstrap_room
+bootstrap_pair_key
+expected_p_instance_epoch
+expected_d_instance_epoch
+expected_p_capability_digest
+expected_d_capability_digest
+pair_policy_version
+pair_policy_digest
+support_cell_id
+issued_at_unix_ms
+not_after_unix_ms
+pair_cancel_protocol_version
+wait_commit_protocol_version
+metadata_protocol_version
+transfer_status_protocol_version
+p_wait_commit_endpoint
+p_metadata_v1_endpoint
+p_transfer_status_endpoint
+p_pair_cancel_endpoint
+d_pair_cancel_endpoint
+```
+
+Each worker publishes a random, non-reused serving epoch and one immutable,
+role-specific capability digest. The digest binds every setting that can change
+the commit hook, ownership lifecycle, wire interpretation, or deadline proof:
+
+```text
+capability_digest = BLAKE2b-256(canonical_tuple(
+  capability_schema_version,
+  role,
+  dispatch/request/cancel/wait/metadata/transfer-status protocol versions,
+  transfer_backend,
+  metadata_and_status_framing,
+  KV_layout_page_size_and_dtype,
+  model_identity_and_immutable_weight_generation,
+  TP_CP_PP_DP_EP,
+  scheduler_event_loop_mode,
+  radix_mode,
+  chunk_retract_rebootstrap_flags,
+  staging_HiCache_speculative_and_runtime_mutation_flags,
+  request_expansion_and_max_new_tokens_policy,
+  deadline_policy_id,
+  max_clock_skew_ms_and_clock_health_policy,
+  metadata_size_policy_id,
+  control_endpoint_protocol_suite,
+  control_channel_and_budget_capability_limits,
+))
+
+pair_policy_digest = BLAKE2b-256(canonical_tuple(
+  pair_policy_schema_version,
+  pair_policy_version,
+  allowed_p_capability_digest,
+  allowed_d_capability_digest,
+  selected_deadline_and_replay_policy,
+  selected_control_channel_and_metadata_budgets,
+  selected_v1_support_cell_restrictions,
+))
+
+support_cell_id = BLAKE2b-256(canonical_tuple(
+  "sglang-pd-support-v1",
+  p_capability_digest,
+  d_capability_digest,
+  pair_policy_digest,
+))
+```
+
+`pair_policy_version` selects a canonical policy schema; it is not itself proof
+that two processes loaded identical policy contents. `pair_policy_digest` binds
+the actual immutable record, including the allowed P/D capability pair, timeout
+and replay-TTL relationships, selected control/channel/metadata budgets, and
+version 1 support-cell restrictions. SMG pins both discovery records, verifies
+that the digest pair and selected limits are allowed by the policy, computes the
+policy and support-cell digests, and injects them into each role envelope.
+
+P and D independently recompute their local role digest, verify the expected
+local digest, verify that the expected peer digest is allowed by the same pair
+policy, verify that every selected budget/deadline can be enforced locally,
+recompute `pair_policy_digest`, and then recompute `support_cell_id`. Any
+mismatch is rejected before tokenization, pair entry, waiter creation, or model
+allocation. Equal protocol or policy version numbers alone never make two
+workers compatible.
+
+Each discovery record also publishes the configured `max_clock_skew_ms` and a
+current bounded clock-health result. The configured bound is immutable and
+digest-bound; the health result is dynamic readiness state. SMG may select an
+enforce pair only while its own clock and both pinned worker clocks report that
+their maximum offset/uncertainty is within the selected bound. A stale or
+unhealthy result removes that support cell from new enforce dispatch before
+either role request is sent. Each worker rechecks its local health before
+creating unknown enforce state; a later health failure does not invalidate or
+resurrect an existing matching LIVE/tombstone entry.
+
+All cross-language hashes use a versioned canonical tuple encoding with fixed
+field order. Unsigned integers use fixed-width big-endian encoding, booleans use
+one byte, enums use assigned integer IDs, and every byte/string field uses a
+big-endian length prefix followed by raw bytes. UTF-8 is the only string
+encoding. Rust/Python runtime dictionaries, default JSON serialization, native
+integer layout, and delimiter-joined strings are not valid digest inputs.
+
+The request UID is derived from the complete pair identity, not from a user
+`rid`. Version 1 encodes `bootstrap_room` as unsigned 64-bit big-endian,
+`bootstrap_pair_key` and both epochs as 16 raw bytes, and `support_cell_id` as
+32 raw bytes inside the canonical tuple:
+
+```text
+request_uid = BLAKE2b-128(canonical_tuple(
+  "sglang-pd-commit-v1",
+  bootstrap_room,
+  bootstrap_pair_key,
+  expected_p_instance_epoch,
+  expected_d_instance_epoch,
+  support_cell_id,
+))
+```
+
+The domain string and tuple schema version are part of the encoded input. P, D,
+and SMG must pass shared golden vectors before advertising version 1 readiness.
+A worker rejects an envelope before pair creation if the local epoch,
+capability digests, pair policy, support cell, protocol versions, or expiry do
+not match.
+
+In later message schemas, `identity` is shorthand for the complete immutable
+set below; implementations send the fields explicitly rather than serializing
+an opaque language object:
+
+```text
+request_uid
+bootstrap_room
+bootstrap_pair_key
+p_instance_epoch
+d_instance_epoch
+support_cell_id
+```
+
+Terminal and cancel-first tombstones are retained until at least:
+
+```text
+max(
+  not_after + max_clock_skew_ms,
+  terminal_time + terminal_tombstone_ttl,
+)
+```
+
+At the first accepted envelope, each worker validates the wall-clock acceptance
+window once and converts its remaining duration, including the skew allowance,
+to a non-refreshable local monotonic retention deadline. The symbolic
+`not_after + max_clock_skew_ms` term above refers to that stored conversion; GC
+does not repeatedly compare wall clock. The accepted delivery window is capped
+by pair policy, so a forward wall-clock jump cannot create a negative deadline
+and a backward jump cannot extend retention.
+
+A body that arrives after the dispatch-expiry term is rejected by expiry even
+if its tombstone was later collected. A restarted worker has a new epoch and
+cannot accept an old envelope.
+
+Although SMG v1 never resends a role HTTP request after `PAIR_BOUND`, worker
+ingress is still duplicate-safe. A second body with the same complete identity
+and dispatch times receives a bounded duplicate-in-progress/terminal response
+from the existing scheduler entry; it cannot create another `Req`, queue owner,
+long-lived response producer, or model execution. Conflicting bodies are
+`INCOMPATIBLE`. A body matching a cancel-first or terminal tombstone replays the
+stored disposition and never resurrects execution.
+
+Private envelope fields must be overwritten by SMG and transported over a
+trusted internal path. The pair key is correlation data, not authentication.
+The two cancel endpoints are pinned with the selected serving epochs before
+`PAIR_BOUND`; SMG never rediscovers a target while cancelling the bound pair.
+
+## Commit protocol
+
+D is the only retry owner for worker-to-worker commit and transfer-status
+operations. After entering `D_REGISTERED`, it starts one logical long poll on
+the P endpoint pinned in the dispatch envelope:
+
+```text
+WaitCommitRequest {
+  versions,
+  request_uid,
+  bootstrap_room,
+  bootstrap_pair_key,
+  expected_p_instance_epoch,
+  expected_d_instance_epoch,
+  expected_p_capability_digest,
+  expected_d_capability_digest,
+  pair_policy_version,
+  pair_policy_digest,
+  support_cell_id,
+  dispatch_issued_at_unix_ms,
+  dispatch_not_after_unix_ms,
+  wait_seq,
+}
+```
+
+P returns one of:
+
+```text
+WaitCommitResponse {
+  identity,
+  wait_seq,
+  result: COMMITTED | RETRY_LATER | TERMINAL | EXPIRED | INCOMPATIBLE,
+  commit_generation?,
+  p_commit_time_unix_ms?,
+  p_post_commit_readiness_not_after_unix_ms?,
+  terminal_kind?,
+  retry_after_ms?,
+  reason?,
+}
+```
+
+Ordering rules:
+
+- If the D wait arrives first for an unknown identity, P may create bounded
+  `P_REGISTERED` only after validating the full identity, capability/policy
+  digests, both dispatch times, the maximum accepted delivery window, and
+  current time against `dispatch_not_after_unix_ms` plus the configured
+  clock-skew rule. The entry stores both times, owns only the WAIT-first subset
+  of the P reservation row, and starts its non-refreshable admission deadline.
+- When the matching P HTTP body arrives for `P_REGISTERED`, the scheduler must
+  validate the same identity and times and atomically upgrade to
+  `P_FULL_CONTROL_READY` before entering `P_PRECOMMIT`. If the upgrade cannot be
+  obtained, P terminalizes the zero-model-capacity waiter; it does not retain
+  the body for a later capacity race.
+- If the P HTTP request arrives first, P atomically obtains
+  `P_FULL_CONTROL_READY` and creates `P_PRECOMMIT`; the wait later attaches only
+  if both dispatch times and the full identity exactly match the stored
+  envelope.
+- If P is committed, duplicate waits replay the same immutable commitment.
+- If P is terminal, duplicate waits replay the same terminal result.
+- While P is `P_REGISTERED`/`P_PRECOMMIT`, the logical wait remains attached or
+  receives non-terminal RETRY_LATER. If a pre-running failure has entered
+  `P_CANCELLING`, P does not replay a stale COMMITTED response to a new wait; it
+  returns RETRY_LATER until local ownership is gone and TERMINAL is publishable.
+- For a matching existing LIVE or terminal entry, a wait may be answered after
+  `dispatch_not_after_unix_ms`; expiry prevents creation of unknown state, not
+  replay for an already accepted pair.
+- An unknown wait that is already outside the dispatch acceptance window
+  returns `EXPIRED` and creates no waiter, tombstone, or execution state.
+- A transient control-budget failure returns `RETRY_LATER`; it is not terminal
+  proof and cannot change identity.
+- `TERMINAL` is emitted only from a matching scheduler-owned terminal entry or
+  tombstone whose cleanup/ownership rule has completed. READY-state overload,
+  missing generic capacity, HTTP status, and transport failure can never be
+  translated into `TERMINAL`.
+- Identity, protocol, epoch, capability, policy, or support-cell mismatch
+  returns `INCOMPATIBLE` and cannot modify an existing entry.
+
+D accepts `COMMITTED` only with `commit_generation=1`. It treats `RETRY_LATER`
+as retryable only within the unchanged admission deadline. D accepts
+`TERMINAL`, `EXPIRED`, or `INCOMPATIBLE` only when the response wrapper itself
+matches the bound request and `wait_seq`; it then terminalizes its
+zero-scarce-capacity state and makes the D HTTP request return an enforce-pair
+error. SMG then best-effort cancels both originally pinned role endpoints and
+returns the error without rerouting. A response whose wrapper does not match is
+stale input and is dropped while the unchanged logical wait continues to its
+admission deadline.
+
+D keeps at most one logical in-flight wait. In version 1, `wait_seq=1`
+identifies that logical wait and remains unchanged across timeout, reconnect,
+backoff, and transport retry. Reconnect rebinds the same logical correlation;
+it does not create a new waiter or sequence. P does not maintain a reliable
+network outbox. A lost response is recovered by D repeating the identical
+logical wait and P replaying the immutable scheduler snapshot.
+
+Readiness requires a dedicated terminal commit-response replay window that
+covers D's complete admission-wait retry window:
+
+```text
+commit_terminal_replay_ttl
+>= D admission timeout
+ + maximum commit-wait retry backoff
+ + commit-response delivery margin
+```
+
+This bound is measured from P terminalization and is conservative: D's
+admission deadline began earlier. It ensures that loss of the first matching
+TERMINAL response cannot turn completed P cleanup into a D admission timeout.
+For a P tombstone that can answer a commit wait, retention is the maximum of the
+normal tombstone formula and
+`terminal_time + commit_terminal_replay_ttl`; unrelated D terminal tombstones
+do not pay this longer retention.
+
+The immutable COMMITTED snapshot fixes `p_commit_time_unix_ms` and
+`p_post_commit_readiness_not_after_unix_ms`; retries replay the same values. After
+validating COMMITTED, D requires enough policy-defined remaining time, including
+`max_clock_skew_ms` and a conservative preallocation/metadata-submit margin. It
+converts P's advertised wall-clock boundary once and atomically replaces its
+admission deadline with a positive, non-refreshable local monotonic post-commit
+deadline no later than that boundary. If the margin is already insufficient, D
+terminalizes before scarce allocation. A later clock adjustment never extends
+the stored deadline.
+
+D enters `D_ELIGIBLE` only after both the commitment and local non-scarce
+receiver preparation are ready. The existing preallocator must recheck the
+effective deadline and current receiver/channel readiness immediately before
+`_pre_alloc()`; queueing or a known disconnect cannot let an expired/unready
+commitment allocate. A reconnecting pair stays deadline-covered and owns zero
+scarce capacity until its already reserved lease is ready again. At P, metadata
+acceptance, committed-forward completion, and post-commit readiness timeout are
+serialized. The first readiness event only sets its bit and retains the
+post-commit deadline; the event that makes both bits true arms the transfer
+deadline before invalidating it. Timeout accepted first fixes FAILED, rejects a
+late readiness event, and cleans up. No wall-clock field replaces the local
+monotonic timers; it only fences cross-worker validity under the configured
+skew bound.
+
+The cross-worker fence assumes:
+
+```text
+actual wall-clock offset among SMG, P, and D <= max_clock_skew_ms
+```
+
+Rollout therefore requires NTP, chrony, or an equivalent monitored clock
+discipline. If any participant cannot prove the selected bound, SMG stops new
+enforce dispatch for the affected support cell. Already bound pairs continue
+under their unchanged local monotonic deadlines and scheduler-owned cleanup;
+clock-health loss is not terminal proof and does not cause rerouting. Wall
+clock is used only to reject a cross-worker commit or unknown late ingress.
+Safety, ownership release, and finite local retention never depend on wall-clock
+time moving forward or remaining synchronized.
+
+### Persistent peer-channel lease set
+
+D uses a hard-bounded cache of persistent multiplexed channels for
+`WAIT_COMMIT`, metadata, and `WAIT_TRANSFER_STATUS`. Its immutable discovery
+capability publishes a positive `max_pd_peer_channels` and the physical
+authority/protocol binding for every logical endpoint.
+
+The cache key includes normalized physical peer authority, P serving epoch, and
+the service/protocol suite. If multiple logical endpoints are carried by the
+same physical multiplexed connection, normalization deduplicates them to one
+key. If they use different authorities or transports, they require distinct
+keys. A new P epoch at the same address never inherits the old epoch's channel
+identity.
+
+Admission into `D_REGISTERED` atomically reserves the complete set of cache
+entries/leases required by the pinned `p_wait_commit_endpoint`,
+`p_metadata_v1_endpoint`, and `p_transfer_status_endpoint`. Connection setup may
+then run in parallel with P queueing, but every channel in the reserved set must
+be ready before `D_ELIGIBLE`. Receiving `COMMITTED` while setup is incomplete
+only moves D to deadline-covered `D_COMMIT_RECEIVED`; it does not permit
+preallocation.
+
+If any lease or reserved cache slot is unavailable, D releases the partial set
+and terminalizes the pair before acquiring scarce capacity. It must not wait
+until `D_PREALLOCATED` to acquire a metadata or status channel, borrow a generic
+channel slot, or create a temporary unbounded socket. Thus a pair that owns D
+model capacity already owns every peer-channel resource required to finish the
+transfer protocol.
+
+Each pre-running D pair holds one logical lease/refcount for each key in the
+deduplicated set. After D accepts a matching SUCCESS and atomically enters
+`D_RUNNING`, it releases the pair's complete lease set; no post-success control
+send owns or extends that lease. A failed pair releases its complete set during
+terminal cleanup. Only
+zero-refcount idle channels may be evicted, using bounded idle TTL/LRU. The
+budget includes file descriptors, socket buffers, reconnect state, reserved but
+not-yet-connected entries, idle cache entries, and the bounded old/new socket
+overlap needed to reconnect one key. Reconnect reuses the same entry/lease; it
+cannot temporarily allocate an uncharged second cache entry. Cache exhaustion
+returns an error through SMG without rerouting the enforce request.
+
+For the first SGLang/Mooncake cell, the preferred mapping is one bidirectional,
+multiplexed control service per P authority/epoch; the three logical operations
+then deduplicate to one physical key. The protocol still defines a lease set so
+an implementation cannot silently add a second endpoint later and acquire it
+after preallocation. The current endpoint-keyed `_socket_cache` has no hard
+entry/memory bound and therefore cannot be used unchanged for enforce traffic.
+
+Readiness also checks the deployment topology: the configured cache capacity
+must cover the maximum number of distinct P authority/epoch keys that SMG may
+route concurrently to one D, including the allowed old/new-epoch overlap during
+rollout. If it cannot, that routing cell is unsupported rather than relying on
+steady-state cache-exhaustion errors. Multiple pairs to one key share a physical
+channel and hold separate logical refcounts; the design never creates one socket
+per request.
+
+## Destination metadata and transfer completion
+
+The enforce path uses a versioned metadata namespace. It never appends optional
+fields to the legacy room-based Mooncake frame.
+
+```text
+PD_COMMITTED_METADATA_V1 {
+  metadata_protocol_version,
+  declared_total_frame_bytes,
+  reserved_metadata_credit_bytes,
+  identity,
+  commit_generation,
+  transfer_generation,
+  endpoint_and_session,
+  destination_kv_indices,
+  destination_state_indices,
+  required_destination_count,
+  decode_prefix_len,
+}
+```
+
+P validates version, declared sizes, complete identity, epochs, support cell,
+and generations before changing any Mooncake or scheduler table. Enforce
+metadata is keyed by `request_uid`. The legacy room-keyed
+`transfer_infos`, `request_status`, and related tables remain isolated and can
+only serve the feature-disabled path.
+
+On first acceptance, P computes and stores a fixed canonical digest of every
+semantic metadata field and destination/state index byte. An exact duplicate
+for the same identity/generation is an idempotent no-op. A same-generation frame
+with different content cannot replace
+the registration: while the pair is active it is a protocol invariant violation
+that fixes FAILED, starts scheduler cleanup, and removes the support cell from
+new dispatch; after the pair left that state it is stale-dropped. Digest storage
+is fixed-size and charged to the metadata-register reservation.
+
+Before submitting metadata, D transitions to `D_TRANSFERRING`, chooses the
+non-reused `transfer_generation=1`, and arms its transfer deadline. It also
+starts one logical transfer-status wait:
+
+```text
+WaitTransferStatusRequest {
+  transfer_status_protocol_version,
+  identity,
+  commit_generation,
+  transfer_generation,
+  status_wait_seq,
+}
+
+PD_TRANSFER_STATUS_V1 {
+  transfer_status_protocol_version,
+  identity,
+  commit_generation,
+  transfer_generation,
+  status_wait_seq,
+  result: SNAPSHOT | RETRY_LATER | UNKNOWN | INCOMPATIBLE,
+  status_seq?,
+  prefill_rank?,
+  status?: SUCCESS | FAILED,
+  failure_reason?,
+}
+```
+
+Only `result=SNAPSHOT` carries `status_seq`, rank, and the immutable semantic
+SUCCESS/FAILED result. `RETRY_LATER` and `UNKNOWN` never advance D and never
+constitute terminal proof; D repeats the same logical wait within its unchanged
+transfer deadline. For a matching LIVE entry, `RETRY_LATER` means only that the
+bounded long-poll interval ended before a snapshot was fixed; it uses the
+pair-reserved response credit and can never mean generic-capacity overload.
+`UNKNOWN` creates no P state and covers an otherwise valid identity for which P
+has no LIVE/tombstone snapshot. A matching
+`INCOMPATIBLE` response makes D enter cancellation and return an error for the
+bound pair. A mismatching response wrapper is stale input and is dropped. None
+of these control dispositions permits SMG worker reselection in version 1.
+
+### Logical sequence and immutable replay contract
+
+Logical sequence numbers identify one pair-level operation, not a socket or
+transport attempt. Version 1 fixes:
+
+```text
+wait_seq = 1
+commit_generation = 1
+transfer_generation = 1
+status_wait_seq = 1
+status_seq = 1
+cancel_seq = 1
+```
+
+`wait_seq`, `status_wait_seq`, and `cancel_seq` remain unchanged across timeout,
+reconnect, backoff, duplicate delivery, and transport retry. A different value
+for the same version 1 pair/operation is `INCOMPATIBLE` and cannot allocate a
+second correlation or mutate the pair.
+
+The transport may use an ephemeral local attempt/handle token solely to close
+and replace sockets. It is not sent as protocol identity and is never stored in
+an immutable semantic snapshot. Scheduler attach/rebind atomically swaps the
+single response handle owned by the logical credit and closes the old handle;
+simultaneous duplicate attempts cannot retain two long-poll correlations.
+
+The immutable commit snapshot contains the semantic result, identity,
+`commit_generation`, commit time, and fixed P post-commit validity deadline; it
+does not contain transport-attempt state. A
+`WaitCommitResponse` wrapper echoes `wait_seq` from the matching validated
+request. The immutable transfer snapshot contains the semantic status,
+identity, both generations, `status_seq`, and rank; it does not contain
+transport-attempt state, `status_wait_seq`, or a non-semantic control
+disposition. A `PD_TRANSFER_STATUS_V1` wrapper echoes `status_wait_seq` from the
+matching validated request. This permits the same immutable snapshot to answer
+the original request and every reconnect.
+
+P publishes at most one transfer result for the pair/generation. A duplicate
+identical result is idempotent. A backend completion arriving after the
+scheduler has already left `P_TRANSFERRING` because cancel/timeout fixed the
+result is expected stale input: it is dropped with a bounded metric and never
+overwrites the snapshot. By contrast, conflicting SUCCESS/FAILED while the same
+generation is still the current active transition, a second scheduler
+publication, a second `status_seq`, or a second generation is a local invariant
+violation: P keeps the first immutable snapshot, starts scheduler-owned cleanup,
+and removes the support cell from new enforce dispatch.
+
+An unknown `WaitTransferStatusRequest` never creates a pair, waiter, or
+tombstone. It may only attach to or replay a matching existing LIVE/terminal
+entry, so WAIT-first expiry creation applies only to `WaitCommitRequest`.
+
+The status wait may arrive before P finishes metadata registration. The P
+scheduler serializes both commands against the same pair and generation and
+attaches the early wait using the pair-reserved logical correlation. It does
+not return a false terminal result or allocate an additional waiter.
+
+The P transfer worker only emits a fixed-size `TransferCompletionCommand` to a
+reserved scheduler mailbox. It contains the complete identity, both fixed
+generations, prefill rank, and backend SUCCESS/FAILED outcome; it is never keyed
+only by room. The P scheduler verifies that the pair is still the matching
+`P_TRANSFERRING` generation and publishes one immutable status snapshot. If a
+committed P pair becomes terminal before transfer completes, the scheduler
+publishes `FAILED(P_TERMINAL)` for the same generation.
+
+The D transport thread only emits a fixed-size `TransferStatusCommand` for a
+validated bounded wrapper. Only the D scheduler may perform
+`D_TRANSFERRING -> D_RUNNING`, and only for `result=SNAPSHOT` after validating
+the full identity, both generations, `status_wait_seq`, `status_seq`, semantic
+status, and the required rank set. Version 1 requires rank 0 only. Control
+dispositions follow the retry/cancel rules above and cannot enter `D_RUNNING`.
+
+The current three-part room-only status message remains legacy-only. It cannot
+advance an enforce pair, even if a bootstrap room is reused.
+
+P retains the fixed-size immutable transfer snapshot until:
+
+```text
+max(
+  not_after + max_clock_skew_ms,
+  terminal_time + terminal_tombstone_ttl,
+  transfer_snapshot_time + transfer_status_replay_ttl,
+)
+```
+
+Readiness requires:
+
+```text
+transfer_status_replay_ttl
+>= D transfer timeout
+ + maximum status retry backoff
+ + status delivery margin
+```
+
+This allows D to recover a lost success response without adding a reliable P
+outbox. Version 1 has no post-result acknowledgment and never releases this
+snapshot early. The snapshot contains only the bounded semantic fields listed
+above; admission reserves its count and byte credit for the full worst-case
+retention window. Snapshot-budget exhaustion rejects a new pair at the full
+control gate before either role acquires model capacity.
+
+## Scheduler and transport ownership
+
+The P and D scheduler threads are the only writers of:
+
+- pair registry state;
+- queue membership;
+- ownership bits;
+- deadlines;
+- waiter membership;
+- immutable commit and transfer snapshots;
+- terminal tombstones.
+
+HTTP and transport threads may authenticate, apply fixed-size parsing limits,
+enqueue bounded commands, and send scheduler-produced responses. They may not
+call allocators, mutate scheduler queues, write pair state, or advance an
+enforce request from a room-only status table.
+
+Every control frame has a protocol-defined maximum byte size before parsing.
+Endpoint/authority lengths are bounded by discovery policy, and `reason` or
+`failure_reason` is a fixed enum/diagnostic code rather than an unbounded
+string. Oversized or malformed unknown input uses only the untrusted parse
+budget and cannot retain a pair-reserved correlation or payload owner.
+
+Every scheduler inbox uses bounded, budgeted draining. Deadline processing is
+`O(expired + fixed_budget)` through a heap, timer wheel, or equivalent; the hot
+loop must not scan all live pairs.
+
+## Success and cancellation ownership closure
+
+### Successful P transfer
+
+When the backend reports transfer success, the P scheduler performs one
+serialized transition:
+
+1. Validate the full identity, current `P_TRANSFERRING` state, and fixed
+   generations/rank.
+2. Publish the immutable `SUCCESS(status_seq=1)` transfer snapshot.
+3. Arm the worker cleanup deadline, enter `P_SUCCESS_CLEANUP`, and invalidate
+   the transfer deadline in the same scheduler transition.
+4. Remove the request from every bootstrap, waiting, batch, inflight, transfer,
+   and result owner.
+5. Release sender, source KV, request slot, cache/radix lock, metadata payload
+   references, and all other ownership exactly once through explicit ownership
+   bits/refcounts.
+6. Replace the LIVE entry with `P_TERMINAL(SUCCESS)`, retaining only the bounded
+   identity, terminal disposition, and immutable transfer snapshot until the
+   replay-retention formula expires.
+
+The transfer-status response and P role HTTP success may be produced from the
+immutable semantic snapshot before source cleanup finishes; neither is local
+terminal proof and version 1 never uses an HTTP 2xx to reroute. Only the
+scheduler terminal tombstone waits for actual source ownership to be released.
+A cleanup timeout never rewrites a published SUCCESS snapshot; it isolates the
+worker/support cell and continues scheduler-owned cleanup.
+
+After D validates that SUCCESS, it atomically commits transferred ownership to
+the request, releases the pair's complete control-channel lease set, and enters
+`D_RUNNING` without further network I/O. On
+normal generation completion or stream EOF, D enters `D_SUCCESS_CLEANUP`,
+removes the request from all scheduler/result owners, releases request slot, KV,
+metadata buffer, and cache locks exactly once, then replaces the LIVE entry with
+`D_TERMINAL(SUCCESS)`. D terminal replay state is bounded by the same dispatch
+expiry/tombstone policy; it does not retain P's transfer snapshot.
+
+### Failed transfer and other pre-running failures
+
+Every failure follows the same ownership graph rather than a message-specific
+shortcut:
+
+- Before `P_COMMITTED`, P publishes only the immutable commit-terminal
+  disposition, enters `P_CANCELLING`, releases its owners, and then creates the
+  terminal tombstone. No transfer snapshot exists.
+- At or after `P_COMMITTED`, if no transfer result has been fixed, P first
+  publishes immutable `FAILED(status_seq=1)` for the fixed generation, then
+  enters `P_CANCELLING`. Backend failure, metadata rejection, phase deadline,
+  and cancel all use this rule. If SUCCESS or FAILED was already fixed, cleanup
+  preserves that first semantic snapshot.
+- A D pair that validates FAILED, or reaches any deadline before `D_RUNNING`,
+  enters `D_CANCELLING`, removes itself from registered/eligible/preallocation/
+  transfer owners, releases every reserved control and scarce owner exactly
+  once, and publishes terminal only after release.
+
+A semantic FAILED response may be replayed while P cleanup is in progress, but
+neither role advertises scheduler-terminal state before its ownership ledger is
+empty. A late success/failure/cancel event for an older state or generation is
+idempotently dropped or treated as the invariant conflict defined above; it
+never selects a second cleanup path.
+
+### Identity-bound cancel
+
+Version 1 uses the following minimum scheduler-backed cancel contract:
+
+```text
+PairCancelRequest {
+  pair_cancel_protocol_version,
+  role,
+  request_uid,
+  bootstrap_room,
+  bootstrap_pair_key,
+  expected_p_instance_epoch,
+  expected_d_instance_epoch,
+  expected_p_capability_digest,
+  expected_d_capability_digest,
+  pair_policy_version,
+  pair_policy_digest,
+  support_cell_id,
+  dispatch_issued_at_unix_ms,
+  dispatch_not_after_unix_ms,
+  cancel_seq,
+}
+
+PairCancelResponse {
+  pair_cancel_protocol_version,
+  role,
+  request_uid,
+  bootstrap_room,
+  bootstrap_pair_key,
+  p_instance_epoch,
+  d_instance_epoch,
+  support_cell_id,
+  cancel_seq,
+  result: ACCEPTED | ALREADY_TERMINAL | RETRY_LATER | EXPIRED | INCOMPATIBLE,
+  terminal_kind?,
+}
+```
+
+`cancel_seq=1` is the fixed logical cancel operation for version 1 and is reused
+across reconnect and retry. The response echoes it. `ACCEPTED` means only that
+the matching scheduler accepted or is processing cancellation; it is not
+terminal proof and does not assert that allocator cleanup completed.
+`ALREADY_TERMINAL` is emitted only from a scheduler terminal tombstone, but
+version 1 still does not use a one-sided response to start a replacement pair.
+
+Retry ownership is unique per operation: D owns commit/status-wait retries;
+SMG owns at most one logical cancel operation per pinned role endpoint. SMG may
+make a bounded number of same-endpoint transport retries with the identical
+`cancel_seq=1`, but it has no reliable cancel outbox and cancellation delivery
+does not delay the user-visible error indefinitely. If SMG or its client task
+disappears, the workers' non-refreshable local deadlines remain the cleanup
+backstop.
+
+The ingress thread validates fixed framing and enqueues a bounded command. The
+scheduler recomputes and matches the full identity and serializes cancel with
+HTTP entry, WAIT, commitment, metadata registration, transfer completion,
+deadline expiry, and success cleanup. Identity mismatch never modifies an
+existing entry. If a transfer snapshot was already fixed, cancel may change the
+local execution/terminal disposition and accelerate cleanup, but it never
+rewrites that semantic SUCCESS/FAILED snapshot.
+
+For a valid unknown identity inside the dispatch acceptance window, cancel may
+atomically create a bounded cancel-first `TERMINAL(CANCELLED)` tombstone. It
+stores both dispatch times and is retained through at least
+`dispatch_not_after_unix_ms + max_clock_skew_ms`; a later matching HTTP body or
+WAIT cannot create execution. If the independent cancel-first tombstone budget
+is full, P/D returns `RETRY_LATER` without state and SMG may retry the same
+logical cancel. An expired unknown cancel returns `EXPIRED` without state. For
+an existing LIVE/terminal entry, both dispatch times must exactly match the
+stored envelope even when current time is past `not_after`.
+
+For an existing request, cancel and deadline cleanup must remove or mark the
+request in every possible owner before terminalization. Version 1 explicitly
+includes:
+
+- P WAIT-first, bootstrap, precommit/waiting, final batch, transferring,
+  success-cleanup, inflight, and result state;
+- D `D_REGISTERED`, `D_COMMIT_RECEIVED`, eligible, existing preallocation,
+  transfer, running/current/last batch, success-cleanup, and result state;
+- channel lease sets, correlations, metadata payload owners, request/KV slots,
+  cache/radix locks, sender/receiver state, and deadline entries.
+
+The current decode abort path must therefore be extended to address the new
+registered/commit-received owners by `request_uid`; scanning only the existing
+preallocation and transfer queues is insufficient. Each allocator/owner has one
+release bit/refcount, so duplicate cancel, timeout, disconnect, and success
+races release it at most once. The scheduler publishes
+`P/D_TERMINAL(FAILED|CANCELLED)` only after all actual local ownership is gone.
+Deadline expiry uses the same cleanup routine and ownership ledger as cancel.
+
+## Progress-resource reservation
+
+The full per-role credit inventory, release points, byte-accounting rules, and
+reservation fault tests are normative and live in the
+[reservation and validation appendix](/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix).
+
+Before either role can acquire model capacity, its full-control gate atomically
+reserves the bounded LIVE/tombstone state, logical wait/response correlations,
+scheduler commands, deadline/cleanup capacity, retained payload bytes, and
+cancel path needed for every later transition. D also reserves its complete
+deduplicated peer-channel lease set and receiver/session capacity. A partial
+reservation fails before model allocation.
+
+Duplicates and reconnects rebind the pair's existing logical credits. Unknown
+or malformed input uses a separate bounded ingress budget and cannot consume a
+live pair's completion resources. Count limits are accompanied by conservative
+per-pair and process-wide byte limits, including retained request/receiver
+objects, transport buffers, zero-copy owners, decoded heap expansion, and fixed
+transfer snapshots.
+
+The reservation claim covers the new control/protocol path. It does not reserve
+a Mooncake executor thread or change data-plane scheduling; those delays remain
+covered by local transfer deadlines and cannot recreate the cross-stage
+capacity cycle after P has committed.
+
+## Deadlines and failure closure
+
+Every pre-running live phase has exactly one positive, non-refreshable local
+deadline:
+
+| Deadline | Starts | Covers | Expiry action |
+| --- | --- | --- | --- |
+| Dispatch expiry | SMG creates envelope | Body not accepted by worker | Reject before pair creation |
+| Admission | First local pair/waiter entry | `P_REGISTERED`, `P_PRECOMMIT`, `D_REGISTERED`, commit retries | Scheduler cleanup and tombstone |
+| P post-commit readiness | P publishes `COMMITTED` | Commit delivery, committed forward completion, and metadata rendezvous | Fix FAILED and enter P scheduler cleanup |
+| D post-commit | D accepts `COMMITTED` | `D_COMMIT_RECEIVED`, receiver readiness, eligibility, preallocation, metadata submit | D scheduler cleanup |
+| P transfer | Both committed-forward and metadata readiness bits are true | Submitted KV transfer | Enter cancelling and publish a failed snapshot if no result was fixed |
+| D transfer | Before D submits metadata | KV transfer and status replay | D scheduler cleanup |
+| Worker cleanup | First entry to success-cleanup or cancelling | Queue removal and actual ownership release | Isolate the support cell/epoch; do not publish terminal until release completes |
+
+Readiness checks deadline sizing against the maximum request shape admitted by
+the support cell. In particular, P post-commit readiness must cover the larger
+of the configured committed-prefill runtime bound and worst-case commit
+delivery + D preallocation/metadata-submit budget, plus scheduling/skew margin.
+D transfer timeout must cover remaining committed-prefill runtime, metadata
+handoff, Mooncake transfer, status retry/backoff, and delivery margin. A request
+whose declared shape is outside those bounds uses legacy behavior before
+dispatch or fails closed; it is not allowed to enter enforce and predictably
+timeout on long prompts.
+
+A transition arms the successor deadline before invalidating the previous one.
+Retries, reconnects, and queue movement cannot refresh a deadline. Scheduler
+deadline and cleanup work must run while idle and before any scheduler pause
+fast path. A phase timeout atomically enters cancelling and arms the worker
+cleanup deadline; normal D completion arms the same cleanup deadline before
+entering `D_SUCCESS_CLEANUP`. If cleanup exceeds that deadline, the worker stops
+accepting new enforce pairs for the affected support cell/epoch but continues
+cleanup and serves matching immutable commit/status replays from already
+reserved resources. Timeout alone never fabricates terminal state.
+
+The finite-cleanup claim assumes that the worker scheduler and backend cleanup
+path continue to execute. A worker process crash releases its process-local
+resources and is fenced by a new serving epoch. Permanent GPU/driver hangs,
+permanent scheduler stalls, and exactly-once recovery after router state loss
+are outside the version 1 guarantee. A timeout may request cleanup, but the
+worker must not publish local terminal state until actual ownership is released
+or the process epoch is retired.
+
+### Router pair-bound fence
+
+SMG uses one pair-level linearization point for enforce requests:
+
+```text
+UNBOUND
+  -> select and pin P/D workers, epochs, capabilities, and endpoints
+  -> create the bootstrap room, pair key, and request UID
+  -> prepare both role-specific requests
+  -> PAIR_BOUND
+  -> either P or D request may perform network I/O
+```
+
+`PAIR_BOUND` occurs immediately before either role request can perform its first
+network I/O. Before that point, selection or preparation may restart only while
+SMG can prove that neither worker request performed I/O. At and after that
+point:
+
+- the logical request must not call `select_pd_pair()` again;
+- SMG must not generate a new pair key, room, request UID, or worker binding;
+- version 1 performs no automatic HTTP resend and does not wrap the pair in an
+  outer retry that can reselect workers;
+- a P or D HTTP error triggers best-effort cancellation of the originally
+  bound pair and returns an error;
+- retries of `WAIT_COMMIT` and `WAIT_TRANSFER_STATUS` remain allowed because
+  they reuse the same identity, endpoint, serving epoch, and logical credit.
+
+SMG is a trusted, non-Byzantine participant in version 1. It derives both role
+bodies from the same immutable typed request before `PAIR_BOUND`; role-specific
+preparation may add only the allowlisted private/routing fields and may not
+change the public prompt, model, sampling, or request-expansion semantics. This
+construction is covered by cross-route tests. Version 1 does not add a second
+full-request canonical hash merely to detect an SMG implementation bug.
+
+The enforce dispatch supervisor is symmetric and fail-fast. Before a successful
+decode response/stream is exposed, a transport error or non-success response
+from either P or D immediately stops waiting for normal completion of the peer,
+starts the same identity-bound cancel on both pinned role endpoints, and returns
+the appropriate error after only the bounded cancel attempt. In particular, it
+must not preserve the current behavior that stores an early D error while
+continuing to wait for P: D may reject at its full-control gate after P has
+committed, and P would otherwise wait until its post-commit deadline for
+metadata that can never arrive. A successful early D response may still wait
+for the P response required by the existing result/logprob merge.
+
+The feature-disabled path retains the current outer `RetryExecutor` behavior.
+If a future enforce version permits same-pair HTTP resend, it must resend the
+identical role envelope to the identical endpoint and serving epoch and prove
+worker-side idempotent merge. That optimization is not part of version 1.
+
+Because version 1 does not create a replacement pair after `PAIR_BOUND`,
+SMG does not need terminal proof as a retry barrier:
+
+- selection or preparation failures before `PAIR_BOUND` may choose another
+  pair only when neither role performed network I/O;
+- at or after `PAIR_BOUND`, generic HTTP errors, timeouts, disconnects, overload,
+  or control failures trigger best-effort cancellation and return an error;
+- streaming responses are never replayed after headers are exposed;
+- worker-local deadlines guarantee finite retention even if SMG crashes or the
+  cancel message is lost.
+
+A future transparent-reroute design must add scheduler-confirmed terminal
+receipts for both P and D and must wait for both before creating a new pair. It
+must not reinterpret HTTP failure, `NOT_FOUND`, epoch mismatch, or transient
+overload as terminal proof.
+
+## Normative invariants
+
+The implementation and tests must preserve all of the following together:
+
+1. **Capability and policy fence before state.** SMG, P, and D agree on the
+   canonical role capabilities, actual pair-policy digest, serving epochs, and
+   support cell before tokenization or execution-capable pair-state creation.
+2. **Commit before D capacity.** D owns a request/KV/metadata slot or cache lock
+   only after its scheduler validates the matching immutable commitment.
+3. **Non-blocking P launch.** P commitment performs only O(1) scheduler-local
+   state publication before GPU launch; it never waits for D or transport.
+4. **One acquisition graph.** P owns its complete P reservation row before
+   `P_PRECOMMIT`; D owns its complete D row before `D_REGISTERED`; and D also
+   verifies commitment and channel/receiver readiness before `D_ELIGIBLE`.
+   No later pre-running protocol phase acquires generic control/protocol
+   capacity; existing Mooncake data-plane service remains deadline-bounded.
+5. **One retry owner and fixed logical sequences.** D retries commit/status waits
+   with the same version 1 sequence; SMG alone retries the bounded same-pair
+   cancel operation. P stores semantic immutable snapshots and no
+   transport-attempt state or reliable outbox.
+6. **No resurrection.** Serving epochs, canonical identity, dispatch expiry,
+   WAIT-first validation, cancel-first tombstones, and terminal retention prevent
+   an unknown late message from recreating an old pair.
+7. **Scheduler single writer.** HTTP, control, metadata, and transfer threads
+   only validate bounded input, enqueue commands, or consume immutable output.
+8. **Terminal means ownership is gone.** Success, cancel, failure, and deadline
+   all use the same ownership ledger; a worker publishes local terminal state
+   only after every actual local owner releases exactly once.
+9. **Continuous deadline coverage.** Every non-running LIVE phase has exactly
+   one non-refreshable local deadline, and each transition arms its successor
+   before invalidating its predecessor.
+10. **No replacement after `PAIR_BOUND`.** Enforce v1 never creates a new worker
+   binding or identity after either role may have performed network I/O.
+11. **Legacy isolation.** Room-only metadata/status cannot create a V1 command
+    or advance an enforce pair, and V1 input never mutates legacy tables.
+12. **Clock-health fail closed.** New enforce dispatch requires the selected
+    SMG/P/D clocks to satisfy the digest-bound `max_clock_skew_ms`. Existing
+    pairs and all cleanup continue using local monotonic deadlines if that
+    readiness condition later fails.
+
+If any implementation shortcut violates one invariant to satisfy another, the
+support cell remains disabled. The capacity-ordering proof alone is necessary
+but not sufficient for rollout.
+
+## Observability contract
+
+The first enforcement implementation must expose low-cardinality metrics that
+let a canary distinguish protocol pressure from scheduler or backend delay. The
+exact metric prefix follows repository conventions, but the following signals
+and bounded dimensions are required:
+
+| Signal | Required bounded dimensions |
+| --- | --- |
+| Pair admission and terminal totals | `role`, `result`, bounded `reason` |
+| Full-control gate rejection totals | `role`, bounded `reason` |
+| Commit/status wait retry totals and latency | `wait_kind`, bounded `result` |
+| Phase and cleanup timeout totals | `role`, `phase` |
+| Peer-channel cache entries and exhaustion | `state=active|idle|reserved`, bounded `reason` |
+| LIVE pair, tombstone, and snapshot count/bytes | `role`, `object_kind` |
+| Post-`PAIR_BOUND` dispatch failures | `role`, bounded `stage` and `reason` |
+| Support-cell isolation and clock-health events | bounded `reason`; allowlisted configured cell version only |
+
+Metrics must be updated in O(1) at the scheduler or bounded transport event; a
+collector must not scan all live pairs. `rid`, `request_uid`, bootstrap room,
+pair key, serving epoch, endpoint, and capability/policy digests are forbidden
+as metric labels. They may appear only in sampled or rate-limited structured
+logs/traces. Reason values are fixed enums, not free-form backend strings.
+
+Canary dashboards must correlate request success/TTFT with gate rejection,
+wait latency/retry, timeout, channel exhaustion, clock-health, and retained-byte
+signals. Hard gates enforce the configured control/channel/snapshot budgets
+independently of alert delivery; budget exhaustion produces bounded rejection,
+not over-allocation. Canary threshold or clock-health violations stop new
+enforce dispatch for the affected support cell. Disabled-path metric updates
+must remain limited to the existing legacy metrics.
+
+## Performance model
+
+The design keeps the useful overlap:
+
+```text
+SMG: concurrently dispatch P and D
+
+D: validate -> receiver/topology -----------------------------+
+               WAIT_COMMIT -----------------------------------+
+P: validate -> queue -> COMMITTED -> GPU launch                |
+                                  \-> control response --------+
+D: verify commit -> ELIGIBLE -> existing preallocation -> metadata
+                                                   \-> WAIT_TRANSFER_STATUS
+P: prefill compute -> KV transfer -> immutable status response
+D: verify status -> RUNNING
+```
+
+P never waits for D or for control delivery. D performs non-scarce receiver
+work before commitment. With an outstanding transfer-status wait, completion
+still has one P-to-D response and does not add a post-completion request RTT.
+Among requests that have become `D_ELIGIBLE`, version 1 preserves the existing
+decode preallocation FIFO/priority policy; the gate does not introduce a second
+cross-request ordering or an EDF scheduler.
+
+The unavoidable cost: control latency shows up for very short or cached prefill.
+
+If P admission takes ~0.3ms and commit delivery + D scheduler mailbox takes
+~0.2ms, D preallocation starts ~0.2ms later. For long prefill this is noise.
+For sub-millisecond cache hits it's visible. D can't hide it by allocating KV
+early—that would just recreate the original capacity cycle.
+
+Required implementation properties:
+
+- Persistent, multiplexed control channels
+- Batched commit and transfer-status messages
+- O(1) P commit hook
+- Bounded D inbox draining (no busy polling)
+- No pair scan in the scheduler hot loop
+- No per-request TCP connections
+- Hard-bounded peer-channel cache with active refcounts and idle eviction
+- No request-identity metric labels
+- Zero envelope/control/registry/deadline work on the disabled path
+
+## Acceptance gates
+
+The feature stays disabled until the first support cell passes deterministic
+correctness tests, fault injection, memory accounting, and a real-GPU A/B run.
+
+Candidate performance gates (subject to maintainer agreement):
+
+| Metric | Enforce relative to baseline |
+| --- | --- |
+| Request throughput | 95% confidence interval lower bound at least `-1%` |
+| p50 TTFT | 95% confidence interval upper bound at most `+1%` |
+| p99 TTFT | 95% confidence interval upper bound at most `+2%` |
+| p99 inter-token latency | Upper bound at most `+1%` |
+| Scheduler CPU/core time | At most `+2%` |
+| GPU utilization | At least `-1%` |
+| Successful request rate before baseline saturation | No new control-budget, channel-budget, or protocol timeout failures |
+| Control and metadata memory | Never exceeds configured hard budgets |
+| Peer-channel FD/socket memory | Never exceeds the configured hard budget |
+
+The matrix must separate prompt lengths `1/8/32/128/1K/8K`, cache-hit ratios
+`0/50/90/100%`, concurrency `1/8/32/saturation`, streaming/non-streaming, and
+available/near-full/inversion D capacity. Short or cache-hit regressions cannot
+be hidden by an average over long prompts.
+
+The disabled-path microbenchmark must show no new control traffic, pair state,
+deadline scan, or statistically significant throughput/latency change.
+
+## Validation plan
+
+The mandatory state, router, protocol/restart, reservation/memory, replay, and
+end-to-end cases are listed in the
+[reservation and validation appendix](/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix).
+Rollout requires the deterministic A/B reproducer, identity/generation and
+cancel races, bounded-memory/fault injection, a cross-process Mooncake test,
+real-GPU A/B results for every enabled support cell, and disabled-path
+regression coverage. Mock transport tests alone cannot enable the feature.
+
+## Implementation plan
+
+This RFC is design-only. Implementation should split into reviewable PRs:
+
+1. **Reproducer and protocol types.** Land the deterministic A/B regression,
+   canonical capability/identity encoding with Rust/Python golden vectors,
+   fixed logical-sequence contracts, cancel types, state-machine types, and
+   pure state tests. No behavior change.
+2. **Shadow protocol.** Exercise commit observation, reservations, and metrics
+   while D still follows the legacy eligibility path. Shadow mode doesn't fix
+   the bug and must not be reported as enforce mode.
+3. **Mooncake single-rank enforcement.** Add D registration/eligibility, P
+   scheduler commitment, success/cancel ownership closure, complete peer-channel
+   lease-set reservation, V1 metadata/status namespaces, and deadlines. In the
+   same PR, add the SMG `PAIR_BOUND` fence and make enforce requests bypass the
+   current outer worker-reselection `RetryExecutor` before the first enforce
+   request can be dispatched. Add fault injection for the first support cell.
+   Default off.
+4. **GPU canary and rollout.** Run the mandatory performance matrix and enable
+   only approved rollout cells.
+5. **Transparent reroute follow-up.** Separately design terminal receipts,
+   router pair state, cancellation reconciliation, and the old-pair terminal
+   barrier. Only after both old roles provide matching scheduler-terminal proof
+   may enforce pairs re-enter worker-reselection retry.
+
+The enforcement PR maps to existing SGLang boundaries as follows:
+
+- In `sgl-model-gateway/src/routers/http/pd_router.rs`, move enforce pair
+  selection/preparation outside the worker-reselection retry closure, pin the
+  envelope and cancel endpoints, and cross `PAIR_BOUND` immediately before the
+  two `.send()` futures can first be polled. Keep the current closure unchanged
+  for the disabled path. Add a symmetric enforce-only dispatch supervisor:
+  unlike the current loop, an early D error must cancel P and finish promptly
+  instead of being cached until P resolves.
+- In the P scheduler path, publish commitment after final `prepare_for_extend()`
+  allocation succeeds and before `run_batch()`/forward can launch. The hook is a
+  scheduler-local registry write plus bounded mailbox-ready mark.
+- In `python/sglang/srt/disaggregation/decode.py`, add a separate registered/
+  commit-received owner. Do not insert enforce requests into the existing
+  `DecodePreallocQueue.queue` until the scheduler predicate is `D_ELIGIBLE`, and
+  guard `_pre_alloc()` itself as a second line of defense.
+- In the Mooncake/control layer, keep legacy room-keyed frames and the current
+  unbounded endpoint socket cache off the enforce namespace. V1 uses the bounded
+  multiplexed channel manager, byte-limited parsing, and fixed scheduler
+  commands defined here. The existing data-plane executor remains unchanged.
+- In `scheduler.py`, extend abort/deadline lookup by `request_uid` across the new
+  registered/commit states and route success, failure, cancel, and timeout
+  through the same ownership ledger.
+
+Expected size for steps 1-4: approximately 3,500-5,500 lines of production code
+plus 3,000-5,000 lines of tests. This is not an acceptance criterion; it
+explains why implementation should remain split into dependent reviewable PRs.
+
+## Alternatives considered
+
+### Wait for P before sending D request
+
+Establishes ordering but serializes D receiver + topology setup. Our proposal
+keeps concurrent dispatch and only delays scarce D allocation.
+
+### P pushes a reliable admission ticket
+
+Reliable P outbox = registration leases + delivery acks + replay + restart
+handling + ack-loss semantics. Version 1 uses a single D retry owner instead.
+A future best-effort P push could be a latency hint, but D wait remains the
+correctness path.
+
+### Allocate on D, revoke under pressure
+
+Safe revocation needs complete ownership tracking across request slots, KV,
+metadata, radix locks, backend transfer state, and ranks. SGLang doesn't
+currently expose an atomic revocable reservation covering all of these.
+
+### Change priority or randomize dispatch
+
+Priority and random order don't establish cross-worker resource ordering.
+Network and scheduler reordering can recreate the same cycle.
+
+### Transparent rerouting in v1
+
+Needs a second distributed guarantee: new pair can't start until both roles of
+the old pair are scheduler-confirmed terminal. Valuable, but independent of the
+capacity-ordering fix, and it materially expands SMG, worker cleanup, tombstone,
+and streaming semantics. Version 1 returns an error rather than risk overlapping
+executions.

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
@@ -1171,8 +1171,9 @@ full-request canonical hash merely to detect an SMG implementation bug.
 The enforce dispatch supervisor is symmetric and fail-fast. Before a successful
 decode response/stream is exposed, a transport error or non-success response
 from either P or D immediately stops waiting for normal completion of the peer,
-starts the same identity-bound cancel on both pinned role endpoints, and returns
-the appropriate error after only the bounded cancel attempt. In particular, it
+starts the same identity-bound cancellation on both pinned role endpoints, and
+returns the appropriate error after only the bounded cancel attempt. In
+particular, it
 must not preserve the current behavior that stores an early D error while
 continuing to wait for P: D may reject at its full-control gate after P has
 committed, and P would otherwise wait until its post-commit deadline for

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
@@ -7,9 +7,12 @@ tag: "DRAFT"
 
 <Warning>
   This RFC proposes an experimental protocol. It does not describe an implemented
-  or enabled feature. The existing path must remain unchanged when the new
-  protocol is disabled.
+  or enabled feature. Allocator-disjoint `LEGACY_ONLY` workers must retain the
+  existing path unchanged.
 </Warning>
+
+For a shorter explanation of the request lifecycle and failure behavior, start
+with the [execution walkthrough](/docs/developer_guide/pd_optimistic_prefill_commit_walkthrough).
 
 ## Summary
 
@@ -38,6 +41,12 @@ P final scheduler admission
           happens before
 D scarce-capacity preallocation
 ```
+
+The rule applies to an entire shared allocator domain, not to a sampled subset
+of requests. Every execution request that can consume a participating P or D
+request/KV/metadata/cache allocator must use the same commit ordering. Legacy
+D-first allocation is allowed only on disjoint legacy worker pools and allocator
+partitions.
 
 SMG still dispatches the P and D HTTP requests concurrently. D may create a
 receiver and bounded control state immediately, but it remains `D_REGISTERED`
@@ -80,12 +89,14 @@ without serializing the P/D HTTP dispatch.
 
 ## Goals
 
-Version 1 has four goals:
+Version 1 has five goals:
 
 1. Eliminate the reproduced P/D capacity inversion by construction.
-2. Keep P GPU launch independent of D, the control network, and acknowledgments.
-3. Bound every new queue, correlation, payload, snapshot, and tombstone.
-4. Keep the disabled path behaviorally and measurably unchanged.
+2. Apply the ordering to every request sharing an enforce allocator domain.
+3. Keep P GPU launch independent of D, the control network, and acknowledgments.
+4. Bound every new queue, correlation, payload, snapshot, and tombstone.
+5. Keep a separate legacy-only allocator domain behaviorally and measurably
+   unchanged.
 
 ## Non-goals
 
@@ -105,22 +116,24 @@ fix and local failure handling. They don't weaken the core safety invariant.
 
 ## Maintainer decisions requested
 
-The first review needs decisions on nine points:
+The first review needs decisions on ten points:
 
 1. Use `P final admission -> D scarce preallocation` as the ordering rule.
-2. Accept the proposed no-retraction P scheduler hook in the narrow support cell.
-3. Confirm `D_REGISTERED` receiver/topology setup owns no listed model capacity.
-4. Bind compatibility to canonical role-capability and actual pair-policy
+2. Enforce that rule for the complete participating allocator domain; do not
+   mix legacy D-first allocation with enforce requests on shared allocators.
+3. Accept the proposed no-retraction P scheduler hook in the narrow support cell.
+4. Confirm `D_REGISTERED` receiver/topology setup owns no listed model capacity.
+5. Bind compatibility to canonical role-capability and actual pair-policy
    digests, not protocol-version equality.
-5. Disable post-`PAIR_BOUND` rerouting and make the first enforcement PR change
+6. Disable post-`PAIR_BOUND` rerouting and make the first enforcement PR change
    the current `RetryExecutor`/early-error supervisor behavior.
-6. Use an isolated V1 Mooncake metadata/status namespace with scheduler-only
+7. Use an isolated V1 Mooncake metadata/status namespace with scheduler-only
    state transitions.
-7. Reserve both sides of the complete deduplicated wait/metadata/status channel
+8. Reserve both sides of the complete deduplicated wait/metadata/status channel
    lease set before D eligibility.
-8. Use fixed logical sequences plus scheduler-owned success/cancel
+9. Use fixed logical sequences plus scheduler-owned success/cancel
    terminalization and replay.
-9. Require the reservation, deadline, correctness, and performance gates below
+10. Require the reservation, deadline, correctness, availability, and performance gates below
    before rollout.
 
 If decisions 1-4, complete pre-eligibility control reservation, or the
@@ -149,12 +162,52 @@ The first enforceable cell is intentionally narrow:
 | Staging, HiCache, speculative decoding | Disabled |
 | SMG post-`PAIR_BOUND` reroute | Disabled |
 | Clock discipline | Actual SMG/P/D wall-clock offset is bounded by the selected `max_clock_skew_ms` |
+| Allocator-domain mode | `ENFORCE_EXCLUSIVE`; legacy execution is forbidden on every participating P/D allocator |
 
 A new experimental flag, separate from
 `optimistic_prefill_attempts`, enables the protocol. The flag name is an
-implementation decision. Unsupported combinations fail closed or use the
-existing protocol before either worker request is sent. A request must never
-be partially enabled.
+implementation decision. It configures a complete allocator domain for one
+serving epoch; it is not a per-request sampling flag. Unsupported combinations
+either fail closed before dispatch or are routed to a disjoint `LEGACY_ONLY`
+worker pool before either role request is sent. They cannot fall back to the
+existing protocol on an `ENFORCE_EXCLUSIVE` worker. A request must never be
+partially enabled.
+
+### Allocator-domain exclusivity
+
+An allocator domain is the smallest local set of request slots, KV pools,
+model/aux metadata buffers, and cache locks whose capacity is shared by
+schedulable execution requests. Each worker publishes a 128-bit
+`allocator_domain_id` and one immutable mode for its serving epoch:
+
+```text
+LEGACY_ONLY
+ENFORCE_EXCLUSIVE
+```
+
+Every execution request admitted by an `ENFORCE_EXCLUSIVE` P or D domain must
+carry a valid V1 envelope. In particular, every path that can reach D
+`_pre_alloc()` in that domain must first pass the commit gate. A missing,
+unsupported, malformed, or legacy envelope is rejected before tokenization,
+execution-capable pair state, scheduler admission, or allocator entry. Health,
+discovery, metrics, and administrative traffic are not execution requests and
+do not consume these allocators.
+
+SMG may route an unsupported request to legacy behavior only by selecting
+workers whose P and D allocator domains are both `LEGACY_ONLY` and disjoint from
+the enforce domains. Process names alone do not prove isolation: shared worker
+processes, request pools, KV allocators, metadata-buffer allocators, or cache
+partitions mean the requests are in the same domain. Request-percentage canary
+sampling inside one domain is forbidden. Canary percentage is implemented by
+routing traffic to a separate `ENFORCE_EXCLUSIVE` worker pool before pair
+selection.
+
+Allocator mode and membership are capability-bound and immutable for a serving
+epoch. Changing `LEGACY_ONLY <-> ENFORCE_EXCLUSIVE`, repartitioning an allocator,
+or moving a worker between rollout pools requires draining execution requests
+and publishing a new serving epoch/domain record before new dispatch. This rule
+prevents a legacy request admitted under the old mode from overlapping an
+enforce request under the new mode.
 
 ## Core invariant and progress argument
 
@@ -229,7 +282,19 @@ and are covered by separate hard budgets.
 
 ### Why the capacity cycle is impossible
 
-The enforce path guarantees:
+This proof is allocator-domain scoped. Its prerequisite is that **every**
+execution request capable of acquiring the shared P or D allocator resources is
+an enforce request. If even one legacy D-first request can use the same domain,
+the original cycle remains possible:
+
+```text
+A (enforce): P(A) is COMMITTED and holds P capacity; D(A) waits for D capacity
+B (legacy):  D(B) preallocated and holds D capacity; P(B) waits for P capacity
+```
+
+The `ENFORCE_EXCLUSIVE` ingress rule prevents B from reaching either shared
+allocator. With that domain-wide prerequisite, every request in the domain
+guarantees:
 
 ```text
 D holds scarce capacity
@@ -245,7 +310,9 @@ capacity-cycle condition where P could not admit B because A was holding its
 capacity.
 
 D might still wait on transfer or fail, but every post-commit phase has a local
-deadline and cleanup path. The cross-stage capacity cycle is gone by design.
+deadline and cleanup path. The cross-stage capacity cycle is therefore gone by
+construction for the complete allocator domain, not merely for the subset of
+requests carrying a V1 envelope.
 
 ## State machines
 
@@ -386,6 +453,10 @@ bootstrap_room
 bootstrap_pair_key
 expected_p_instance_epoch
 expected_d_instance_epoch
+expected_p_allocator_domain_id
+expected_d_allocator_domain_id
+expected_p_allocator_domain_mode
+expected_d_allocator_domain_mode
 expected_p_capability_digest
 expected_d_capability_digest
 pair_policy_version
@@ -405,14 +476,18 @@ p_pair_cancel_endpoint
 d_pair_cancel_endpoint
 ```
 
-Each worker publishes a random, non-reused serving epoch and one immutable,
-role-specific capability digest. The digest binds every setting that can change
-the commit hook, ownership lifecycle, wire interpretation, or deadline proof:
+Each worker publishes a random, non-reused serving epoch, a random non-reused
+128-bit allocator-domain ID for the current allocator incarnation, its immutable
+domain mode/policy digest, and one immutable role-specific capability digest.
+The capability digest binds every setting that can change the commit hook,
+ownership lifecycle, wire interpretation, or deadline proof:
 
 ```text
 capability_digest = BLAKE2b-256(canonical_tuple(
   capability_schema_version,
   role,
+  allocator_domain_mode,
+  allocator_domain_policy_digest,
   dispatch/request/cancel/wait/metadata/transfer-status protocol versions,
   transfer_backend,
   metadata_and_status_framing,
@@ -439,6 +514,10 @@ pair_policy_digest = BLAKE2b-256(canonical_tuple(
   selected_deadline_and_replay_policy,
   selected_control_channel_and_metadata_budgets,
   selected_v1_support_cell_restrictions,
+  selected_p_allocator_domain_mode_and_policy_digest,
+  selected_d_allocator_domain_mode_and_policy_digest,
+  legacy_d_first_forbidden,
+  allocator_domain_isolation_policy_id,
 ))
 
 support_cell_id = BLAKE2b-256(canonical_tuple(
@@ -449,21 +528,35 @@ support_cell_id = BLAKE2b-256(canonical_tuple(
 ))
 ```
 
+`allocator_domain_policy_digest` canonically binds which local request/KV,
+model/metadata-buffer, and cache partitions form the domain; the domain mode;
+whether legacy D-first execution is allowed; and the requirement that every
+execution ingress and allocator entry enforces that mode. It describes the
+isolation policy, while `allocator_domain_id` identifies one live incarnation
+of the resources governed by it.
+
 `pair_policy_version` selects a canonical policy schema; it is not itself proof
 that two processes loaded identical policy contents. `pair_policy_digest` binds
 the actual immutable record, including the allowed P/D capability pair, timeout
-and replay-TTL relationships, selected control/channel/metadata budgets, and
-version 1 support-cell restrictions. SMG pins both discovery records, verifies
-that the digest pair and selected limits are allowed by the policy, computes the
-policy and support-cell digests, and injects them into each role envelope.
+and replay-TTL relationships, selected control/channel/metadata budgets,
+allocator-domain mode/isolation policies, and version 1 support-cell
+restrictions. The actual per-deployment domain IDs are not support-cell
+capabilities: they are pinned discovery identities and are bound into the
+request UID below. SMG pins both discovery records, verifies that the digest
+pair, allocator-domain records, and selected limits are allowed by the policy,
+computes the policy and support-cell digests, and injects them into each role
+envelope. An enforce policy requires both pinned domains to be
+`ENFORCE_EXCLUSIVE` and `legacy_d_first_forbidden=true`; a legacy route must use
+separate `LEGACY_ONLY` domains.
 
 P and D independently recompute their local role digest, verify the expected
-local digest, verify that the expected peer digest is allowed by the same pair
-policy, verify that every selected budget/deadline can be enforced locally,
-recompute `pair_policy_digest`, and then recompute `support_cell_id`. Any
-mismatch is rejected before tokenization, pair entry, waiter creation, or model
-allocation. Equal protocol or policy version numbers alone never make two
-workers compatible.
+local domain ID and mode, verify the expected local digest, verify that the
+expected peer domain/digest is allowed by the same pair policy, verify that
+every selected budget/deadline can be enforced locally, recompute
+`pair_policy_digest`, and then recompute `support_cell_id`. Any mismatch is
+rejected before tokenization, pair entry, waiter creation, or model allocation.
+Equal protocol or policy version numbers alone never make two workers
+compatible.
 
 Each discovery record also publishes the configured `max_clock_skew_ms` and a
 current bounded clock-health result. The configured bound is immutable and
@@ -483,19 +576,19 @@ encoding. Rust/Python runtime dictionaries, default JSON serialization, native
 integer layout, and delimiter-joined strings are not valid digest inputs.
 
 Textual HTTP/discovery fields have one canonical wire representation. A
-16-byte pair key, serving epoch, or request UID is exactly 32 lowercase
-hexadecimal characters. A 32-byte capability, policy, or support-cell digest is
-exactly 64 lowercase hexadecimal characters. Prefixes, separators, uppercase,
-padding, UUID formatting, and alternate base64 encodings are rejected before
-state creation. Binary V1 control frames carry the decoded fixed-width raw
-bytes. Canonical hashes always consume those decoded raw bytes, never the
-textual hex representation. Shared Rust/Python vectors cover valid encoding
-and rejection of every non-canonical textual form.
+16-byte pair key, serving epoch, allocator-domain ID, or request UID is exactly
+32 lowercase hexadecimal characters. A 32-byte capability, policy, or
+support-cell digest is exactly 64 lowercase hexadecimal characters. Prefixes,
+separators, uppercase, padding, UUID formatting, and alternate base64 encodings
+are rejected before state creation. Binary V1 control frames carry the decoded
+fixed-width raw bytes. Canonical hashes always consume those decoded raw bytes,
+never the textual hex representation. Shared Rust/Python vectors cover valid
+encoding and rejection of every non-canonical textual form.
 
 The request UID is derived from the complete pair identity, not from a user
-`rid`. Version 1 encodes `bootstrap_room` as unsigned 64-bit big-endian,
-`bootstrap_pair_key` and both epochs as 16 raw bytes, and `support_cell_id` as
-32 raw bytes inside the canonical tuple:
+`rid`. Version 1 encodes `bootstrap_room` as unsigned 64-bit big-endian;
+`bootstrap_pair_key`, both epochs, and both allocator-domain IDs as 16 raw
+bytes; and `support_cell_id` as 32 raw bytes inside the canonical tuple:
 
 ```text
 request_uid = BLAKE2b-128(canonical_tuple(
@@ -504,6 +597,8 @@ request_uid = BLAKE2b-128(canonical_tuple(
   bootstrap_pair_key,
   expected_p_instance_epoch,
   expected_d_instance_epoch,
+  expected_p_allocator_domain_id,
+  expected_d_allocator_domain_id,
   support_cell_id,
 ))
 ```
@@ -511,8 +606,8 @@ request_uid = BLAKE2b-128(canonical_tuple(
 The domain string and tuple schema version are part of the encoded input. P, D,
 and SMG must pass shared golden vectors before advertising version 1 readiness.
 A worker rejects an envelope before pair creation if the local epoch,
-capability digests, pair policy, support cell, protocol versions, or expiry do
-not match.
+allocator-domain ID/mode, capability digests, pair policy, support cell,
+protocol versions, or expiry do not match.
 
 In later message schemas, `identity` is shorthand for the complete immutable
 set below; implementations send the fields explicitly rather than serializing
@@ -524,6 +619,8 @@ bootstrap_room
 bootstrap_pair_key
 p_instance_epoch
 d_instance_epoch
+p_allocator_domain_id
+d_allocator_domain_id
 support_cell_id
 ```
 
@@ -575,6 +672,10 @@ WaitCommitRequest {
   bootstrap_pair_key,
   expected_p_instance_epoch,
   expected_d_instance_epoch,
+  expected_p_allocator_domain_id,
+  expected_d_allocator_domain_id,
+  expected_p_allocator_domain_mode,
+  expected_d_allocator_domain_mode,
   expected_p_capability_digest,
   expected_d_capability_digest,
   pair_policy_version,
@@ -819,7 +920,7 @@ P validates version, declared sizes, complete identity, epochs, support cell,
 and generations before changing any Mooncake or scheduler table. Enforce
 metadata is keyed by `request_uid`. The legacy room-keyed
 `transfer_infos`, `request_status`, and related tables remain isolated and can
-only serve the feature-disabled path.
+only serve allocator-disjoint `LEGACY_ONLY` domains.
 
 On first acceptance, P computes and stores a fixed canonical digest of every
 semantic metadata field and destination/state index byte. An exact duplicate
@@ -1241,8 +1342,9 @@ delivery + D preallocation/metadata-submit budget, plus scheduling/skew margin.
 D transfer timeout must cover remaining committed-prefill runtime, metadata
 delivery retry/backoff and handoff, Mooncake transfer, status retry/backoff, and
 delivery margin. A request whose declared shape is outside those bounds uses
-legacy behavior before dispatch or fails closed; it is not allowed to enter
-enforce and predictably timeout on long prompts.
+legacy behavior only if SMG routes it before dispatch to allocator-disjoint
+`LEGACY_ONLY` workers; otherwise it fails closed. It is not allowed to enter an
+enforce domain and predictably timeout on long prompts.
 
 A transition arms the successor deadline before invalidating the previous one.
 Retries, reconnects, and queue movement cannot refresh a deadline. Scheduler
@@ -1309,7 +1411,10 @@ its post-commit deadline for metadata that can never arrive. A successful early
 D response may still wait for the P response required by the existing
 result/logprob merge.
 
-The feature-disabled path retains the current outer `RetryExecutor` behavior.
+An allocator-disjoint `LEGACY_ONLY` path retains the current outer
+`RetryExecutor` behavior. Disabling enforce on a serving pool requires draining
+that pool and starting a new legacy-only allocator-domain epoch; it is not a
+per-request branch inside an active `ENFORCE_EXCLUSIVE` domain.
 If a future enforce version permits same-pair HTTP resend, it must resend the
 identical role envelope to the identical endpoint and serving epoch and prove
 worker-side idempotent merge. That optimization is not part of version 1.
@@ -1335,16 +1440,23 @@ overload as terminal proof.
 The implementation and tests must preserve all of the following together:
 
 1. **Capability and policy fence before state.** SMG, P, and D agree on the
-   canonical role capabilities, actual pair-policy digest, serving epochs, and
-   support cell before tokenization or execution-capable pair-state creation.
-2. **Complete P commitment before D capacity.** P commits only after its request
+   canonical role capabilities, allocator-domain IDs/modes, actual pair-policy
+   digest, serving epochs, and support cell before tokenization or
+   execution-capable pair-state creation.
+2. **Allocator-domain ordering.** Commit ordering is a property of the shared
+   allocator domain, not an individual pair. Every execution request capable of
+   acquiring scarce P or D resources in an `ENFORCE_EXCLUSIVE` domain must pass
+   the commit gate. Legacy requests are rejected before execution state or
+   routed before dispatch to disjoint `LEGACY_ONLY` domains; request-level
+   enforce/legacy mixing is forbidden.
+3. **Complete P commitment before D capacity.** P commits only after its request
    slot, source KV, model/aux metadata buffer, cache ownership, sender/session
    tracking, and full-control row are owned, with no later finite per-request P
    prerequisite. D owns a request/KV/metadata slot or cache lock only after its
    scheduler validates that matching immutable commitment.
-3. **Non-blocking P launch.** P commitment performs only O(1) scheduler-local
+4. **Non-blocking P launch.** P commitment performs only O(1) scheduler-local
    state publication before GPU launch; it never waits for D or transport.
-4. **One acquisition graph.** P owns its complete P control row before
+5. **One acquisition graph.** P owns its complete P control row before
    `P_PRECOMMIT` and every finite P model prerequisite before `P_COMMITTED`. D
    owns its request-local control row, including the bounded channel-setup
    operation, before `D_REGISTERED`, then obtains the complete two-sided channel
@@ -1353,27 +1465,28 @@ The implementation and tests must preserve all of the following together:
    `P_COMMITTED` or `D_ELIGIBLE` acquires generic control/protocol capacity or a
    finite per-request prerequisite; existing Mooncake data-plane service remains
    deadline-bounded.
-5. **One retry owner and fixed logical sequences.** D retries commit/status
+6. **One retry owner and fixed logical sequences.** D retries commit/status
    waits and byte-identical metadata delivery with the same version 1 logical
    identity; SMG alone retries the bounded same-pair cancel operation. P stores
    semantic immutable snapshots and no transport-attempt state or reliable
    outbox.
-6. **No resurrection.** Serving epochs, canonical identity, dispatch expiry,
+7. **No resurrection.** Serving epochs, canonical identity, dispatch expiry,
    WAIT-first validation, cancel-first tombstones, and terminal retention prevent
    an unknown late message from recreating an old pair.
-7. **Scheduler single writer.** HTTP, control, metadata, and transfer threads
+8. **Scheduler single writer.** HTTP, control, metadata, and transfer threads
    only validate bounded input, enqueue commands, or consume immutable output.
-8. **Terminal means ownership is gone.** Success, cancel, failure, and deadline
+9. **Terminal means ownership is gone.** Success, cancel, failure, and deadline
    all use the same ownership ledger; a worker publishes local terminal state
    only after every actual local owner releases exactly once.
-9. **Continuous deadline coverage.** Every non-running LIVE phase has exactly
+10. **Continuous deadline coverage.** Every non-running LIVE phase has exactly
    one non-refreshable local deadline, and each transition arms its successor
    before invalidating its predecessor.
-10. **No replacement after `PAIR_BOUND`.** Enforce v1 never creates a new worker
+11. **No replacement after `PAIR_BOUND`.** Enforce v1 never creates a new worker
    binding or identity after either role may have performed network I/O.
-11. **Legacy isolation.** Room-only metadata/status cannot create a V1 command
+12. **Legacy isolation.** Legacy execution cannot share an enforce allocator
+    domain. In addition, room-only metadata/status cannot create a V1 command
     or advance an enforce pair, and V1 input never mutates legacy tables.
-12. **Clock-health fail closed.** New enforce dispatch requires the selected
+13. **Clock-health fail closed.** New enforce dispatch requires the selected
     SMG/P/D clocks to satisfy the digest-bound `max_clock_skew_ms`. Existing
     pairs and all cleanup continue using local monotonic deadlines if that
     readiness condition later fails.
@@ -1393,11 +1506,12 @@ and bounded dimensions are required:
 | --- | --- |
 | Pair admission and terminal totals | `role`, `result`, bounded `reason` |
 | Full-control gate rejection totals | `role`, bounded `reason` |
+| Allocator-domain ingress and isolation decisions | `role`, `mode`, bounded `reason` |
 | Commit/status wait and metadata-delivery retry totals and latency | `operation`, bounded `result` |
 | Phase and cleanup timeout totals | `role`, `phase` |
 | Peer-channel entries and exhaustion on both endpoints | `side=inbound|outbound`, `state=active|idle|reserved`, bounded `reason` |
 | LIVE pair, tombstone, and snapshot count/bytes | `role`, `object_kind` |
-| Post-`PAIR_BOUND` dispatch failures | `role`, bounded `stage` and `reason` |
+| Post-`PAIR_BOUND` dispatch failures and suppressed legacy retries | `role`, bounded `stage`, `reason`, `would_legacy_retry=yes|no` |
 | Support-cell isolation and clock-health events | bounded `reason`; allowlisted configured cell version only |
 
 Metrics must be updated in O(1) at the scheduler or bounded transport event; a
@@ -1405,14 +1519,19 @@ collector must not scan all live pairs. `rid`, `request_uid`, bootstrap room,
 pair key, serving epoch, endpoint, and capability/policy digests are forbidden
 as metric labels. They may appear only in sampled or rate-limited structured
 logs/traces. Reason values are fixed enums, not free-form backend strings.
+The `would_legacy_retry` classification must reuse, or be golden-tested against,
+the same bounded status/error predicate as the current `RetryExecutor`; a second
+hand-maintained interpretation is not acceptable.
 
 Canary dashboards must correlate request success/TTFT with gate rejection,
-wait latency/retry, timeout, channel exhaustion, clock-health, and retained-byte
-signals. Hard gates enforce the configured control/channel/snapshot budgets
-independently of alert delivery; budget exhaustion produces bounded rejection,
-not over-allocation. Canary threshold or clock-health violations stop new
-enforce dispatch for the affected support cell. Disabled-path metric updates
-must remain limited to the existing legacy metrics.
+wait latency/retry, timeout, channel exhaustion, clock-health, retained-byte
+signals, post-pair-bound failures, and the counterfactual number that the legacy
+`RetryExecutor` would have retried. Hard gates enforce the configured
+control/channel/snapshot budgets independently of alert delivery; budget
+exhaustion produces bounded rejection, not over-allocation. Canary threshold or
+clock-health violations stop new enforce dispatch for the affected support
+cell. Legacy-only domains retain only the existing legacy hot-path metrics;
+shadow-only instrumentation is separately gated and must be measured.
 
 ## Performance model
 
@@ -1455,14 +1574,42 @@ Required implementation properties:
 - No per-request TCP connections
 - Hard-bounded two-sided peer-channel managers with active refcounts and idle eviction
 - No request-identity metric labels
-- Zero envelope/control/registry/deadline work on the disabled path
+- Zero envelope/control/registry/deadline work on allocator-disjoint
+  `LEGACY_ONLY` workers
+
+### Availability trade-off
+
+Version 1 prioritizes preventing duplicate or overlapping execution over
+matching legacy transient-failure availability. After `PAIR_BOUND`, a connect
+error, timeout, retryable worker 5xx, or early D control rejection becomes a
+user-visible failure after bounded same-pair cancellation. The legacy
+`RetryExecutor` might instead have selected another pair. Version 1 therefore
+does **not** claim equal availability under transient worker faults.
+
+This is an explicit rollout trade-off, not an unmeasured correctness side
+effect. Shadow and canary stages must measure both
+`post_pair_bound_failure_total` and the subset for which the legacy policy
+would have retried. Controlled fault-load runs must inject transient connection
+failure, retryable P and D 5xx responses, and early D request-control/channel
+rejection at production-representative rates. The resulting added user-visible
+error rate and error-budget burn are hard gates alongside TTFT and throughput.
+
+Before a canary receives traffic, operators must configure both a maximum added
+user-visible error-rate threshold and a maximum fraction of the service error
+budget that suppressed retries may consume. Candidate initial limits are `0.1`
+percentage point and `10%` of the service error budget, respectively, subject
+to maintainer/operator agreement. Exceeding either rolling threshold stops new
+enforce routing, drains the enforce pool, and routes new traffic back to an
+allocator-disjoint `LEGACY_ONLY` pool. Rollback never switches individual
+requests to legacy inside the active enforce domain.
 
 ## Acceptance gates
 
 The feature stays disabled until the first support cell passes deterministic
-correctness tests, fault injection, memory accounting, and a real-GPU A/B run.
+correctness tests, fault injection, memory accounting, controlled fault-load
+availability tests, and a real-GPU A/B run.
 
-Candidate performance gates (subject to maintainer agreement):
+Candidate rollout gates (subject to maintainer agreement):
 
 | Metric | Enforce relative to baseline |
 | --- | --- |
@@ -1473,6 +1620,8 @@ Candidate performance gates (subject to maintainer agreement):
 | Scheduler CPU/core time | At most `+2%` |
 | GPU utilization | At least `-1%` |
 | Successful request rate before baseline saturation | No new control-budget, channel-budget, or protocol timeout failures |
+| Added user-visible error rate under production-weighted transient faults | 95% confidence interval upper bound at most the configured threshold; candidate `0.1` percentage point |
+| Error-budget burn attributable to suppressed post-`PAIR_BOUND` retry | At most the configured fraction; candidate `10%` of the service error budget |
 | Control and metadata memory | Never exceeds configured hard budgets |
 | Inbound and outbound peer-channel FD/socket memory | Never exceeds either configured hard budget |
 
@@ -1481,8 +1630,11 @@ The matrix must separate prompt lengths `1/8/32/128/1K/8K`, cache-hit ratios
 available/near-full/inversion D capacity. Short or cache-hit regressions cannot
 be hidden by an average over long prompts.
 
-The disabled-path microbenchmark must show no new control traffic, pair state,
-deadline scan, or statistically significant throughput/latency change.
+The legacy-only-domain microbenchmark must show no new control traffic, pair
+state, deadline scan, or statistically significant throughput/latency change.
+The fault-load report must show the injected fault distribution, legacy retry
+counterfactual, V1 user-visible error delta, confidence interval, and rollback
+decision; a healthy-workload average cannot mask the known retry difference.
 
 ## Validation plan
 
@@ -1491,33 +1643,53 @@ end-to-end cases are listed in the
 [reservation and validation appendix](/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix).
 Rollout requires the deterministic A/B reproducer, identity/generation and
 cancel races, bounded-memory/fault injection, a cross-process Mooncake test,
-real-GPU A/B results for every enabled support cell, and disabled-path
-regression coverage. Mock transport tests alone cannot enable the feature.
+real-GPU A/B results for every enabled support cell, and regression coverage on
+allocator-disjoint legacy-only workers. Mock transport tests alone cannot
+enable the feature.
 
 ## Implementation plan
 
 This RFC is design-only. Implementation should split into reviewable PRs:
 
-1. **Reproducer and protocol types.** Land the deterministic A/B regression,
-   canonical capability/identity encoding with Rust/Python golden vectors,
-   fixed logical-sequence contracts, cancel types, state-machine types, and
-   pure state tests. No behavior change.
-2. **Shadow protocol.** Exercise commit observation, reservations, and metrics
-   while D still follows the legacy eligibility path. Shadow mode doesn't fix
-   the bug and must not be reported as enforce mode.
-3. **Mooncake single-rank enforcement.** Add D registration/eligibility, P
-   scheduler commitment, success/cancel ownership closure, complete two-sided
-   peer-channel lease-set reservation, idempotent metadata delivery, V1
-   metadata/status namespaces, and deadlines. In the same PR, add the SMG
-   `PAIR_BOUND` fence and make enforce requests bypass the current outer
-   worker-reselection `RetryExecutor` before the first enforce request can be
-   dispatched. Add fault injection for the first support cell. Default off.
-4. **GPU canary and rollout.** Run the mandatory performance matrix and enable
-   only approved rollout cells.
-5. **Transparent reroute follow-up.** Separately design terminal receipts,
+1. **Protocol substrate and allocator-domain declarations.** Land the original
+   and mixed enforce/legacy A/B reproducers; bounded channel managers; canonical
+   capability, allocator-domain, identity, and wire types; Rust/Python golden
+   vectors; and fixed sequence/cancel schemas. No Router or worker may emit or
+   accept an enforce execution request in this PR.
+2. **Registry, ownership, and deadline state machines.** Add P/D registry
+   entries, ownership-ledger primitives, reserved-credit abstractions, deadline
+   transitions, tombstones, and pure/fake-scheduler tests. The D gate remains
+   unreachable and SMG still cannot send V1 execution traffic.
+3. **Shadow observation on a legacy-only domain.** Exercise commit-point
+   observation, would-be eligibility, reservation accounting, metrics, and the
+   legacy-retry counterfactual while the complete test pool remains
+   `LEGACY_ONLY`. Shadow does not fix the bug, must not advertise enforce, and
+   must not coexist with enforce requests on the same allocator domain.
+4. **Router pair binding and cancel supervisor.** Add `PAIR_BOUND`, immutable
+   pair preparation, the symmetric failure supervisor, and bounded same-pair
+   cancellation behind a capability that is still impossible to select for
+   execution. Existing legacy dispatch remains unchanged; partial worker
+   support cannot make enforce traffic reachable.
+5. **Mooncake single-rank commit-gate integration.** Connect the Router, P and D
+   schedulers, registries, two-sided lease-set reservation, idempotent metadata,
+   V1 status namespace, deadlines, terminal cleanup, and D `_pre_alloc()` guard.
+   Enforce dispatch is allowed only for a complete `ENFORCE_EXCLUSIVE` domain
+   and remains default off. Add mixed-domain rejection and fault injection for
+   the first support cell.
+6. **GPU and availability canary.** Route traffic to a separate drained enforce
+   worker pool, run the correctness, performance, memory, and transient-fault
+   gates, and enable only approved allocator domains. Do not random-sample
+   requests between enforce and legacy within one worker pool.
+7. **Transparent reroute follow-up.** Separately design terminal receipts,
    router pair state, cancellation reconciliation, and the old-pair terminal
    barrier. Only after both old roles provide matching scheduler-terminal proof
    may enforce pairs re-enter worker-reselection retry.
+
+PRs 1-4 may land independently because enforce dispatch remains structurally
+unreachable. PR 5 is the first atomic behavior change and must contain every
+participant and guard needed by the proof; it cannot enable only the Router, P,
+or D side. This preserves protocol atomicity without making one review cover
+all infrastructure and integration code.
 
 The enforcement PR maps to existing SGLang boundaries as follows:
 
@@ -1525,9 +1697,9 @@ The enforcement PR maps to existing SGLang boundaries as follows:
   selection/preparation outside the worker-reselection retry closure, pin the
   envelope and cancel endpoints, and cross `PAIR_BOUND` immediately before the
   two `.send()` futures can first be polled. Keep the current closure unchanged
-  for the disabled path. Add a symmetric enforce-only dispatch supervisor:
-  unlike the current loop, an early D error must cancel P and finish promptly
-  instead of being cached until P resolves.
+  for allocator-disjoint legacy-only domains. Add a symmetric enforce-only
+  dispatch supervisor: unlike the current loop, an early D error must cancel P
+  and finish promptly instead of being cached until P resolves.
 - In the P scheduler path, publish commitment after final `prepare_for_extend()`
   allocation succeeds, after asserting the existing P model/aux metadata-buffer
   index and all other finite commit prerequisites, and before
@@ -1549,9 +1721,10 @@ The enforcement PR maps to existing SGLang boundaries as follows:
   registered/commit states and route success, failure, cancel, and timeout
   through the same ownership ledger.
 
-Expected size for steps 1-4: approximately 3,500-5,500 lines of production code
-plus 3,000-5,000 lines of tests. This is not an acceptance criterion; it
-explains why implementation should remain split into dependent reviewable PRs.
+Expected total size for steps 1-6: approximately 3,500-5,500 lines of
+production code plus 3,000-5,000 lines of tests. This is not an acceptance
+criterion; it explains why implementation should remain split into dependent
+reviewable PRs.
 
 ## Alternatives considered
 

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc.mdx
@@ -45,10 +45,10 @@ and owns no model capacity. D enters the existing preallocation queue only
 after its scheduler verifies an immutable `COMMITTED` result produced by the P
 scheduler for the exact request pair.
 
-D owns retries for both commit notification and transfer completion. P stores
-immutable scheduler snapshots and never runs a per-request reliable outbox.
-The protocol uses complete pair identity, serving-epoch fencing, bounded
-control resources, and local phase deadlines.
+D owns retries for commit notification, destination-metadata delivery, and
+transfer completion. P stores immutable scheduler snapshots and never runs a
+per-request reliable outbox. The protocol uses complete pair identity,
+serving-epoch fencing, bounded control resources, and local phase deadlines.
 
 Version 1 intentionally disables SMG internal rerouting after the pair reaches
 the `PAIR_BOUND` fence defined below. An ambiguous failure returns an error and
@@ -58,7 +58,7 @@ proofs from both workers and is deferred to a follow-up design.
 
 ## Status and evidence
 
-- Analysis baseline: SGLang `main` at `b3570a453108`
+- Analysis baseline: SGLang `main` at `35f2d4f76161`
 - Tracking issue: [#31473](https://github.com/sgl-project/sglang/issues/31473)
 - CPU reproducer: [optimistic capacity inversion reproducer](https://gist.github.com/N3u0ns/419458d91f1329c25062e7584a76a908)
 - Current default: `optimistic_prefill_attempts=0` (feature off by default)
@@ -116,8 +116,8 @@ The first review needs decisions on nine points:
    the current `RetryExecutor`/early-error supervisor behavior.
 6. Use an isolated V1 Mooncake metadata/status namespace with scheduler-only
    state transitions.
-7. Reserve the complete deduplicated wait/metadata/status channel lease set
-   before D eligibility.
+7. Reserve both sides of the complete deduplicated wait/metadata/status channel
+   lease set before D eligibility.
 8. Use fixed logical sequences plus scheduler-owned success/cancel
    terminalization and replay.
 9. Require the reservation, deadline, correctness, and performance gates below
@@ -166,11 +166,25 @@ was queued, or that a Mooncake sender was created.
 The P scheduler may only commit when all of the following hold:
 
 1. The request is in the final admitted prefill batch.
-2. Its request slot and source KV have been acquired.
-3. The non-chunked request will not require another P admission to complete
+2. Its request slot, source KV, P-side model/aux metadata-buffer index, and
+   required cache/radix ownership have been acquired.
+3. Its bounded sender/session tracking state and every P full-control protocol
+   resource have already been charged to the pair.
+4. The non-chunked request will not require another P admission or another
+   finite per-request P model/transfer prerequisite to complete
    prefill.
-4. The supported scheduler path will not retract, yield, or rebootstrap it.
-5. The GPU forward has not been launched yet.
+5. The supported scheduler path will not retract, yield, or rebootstrap it.
+6. The GPU forward has not been launched yet.
+
+The only post-commit service that may remain shared rather than pair-reserved is
+the explicitly deadline-bounded Mooncake data-plane executor. Queueing or
+service delay there may fail the bound pair, but P must never wait after commit
+for a finite metadata-buffer slot, sender/session entry, cache lock, command,
+channel, or other per-request prerequisite that another uncommitted pair can
+hold. In the current optimistic path,
+`PrefillBootstrapQueue.ensure_metadata_buffer()` already acquires the P
+metadata-buffer index before the request becomes schedulable; version 1 makes
+that existing ordering a normative commit precondition.
 
 The transition and batch admission occur in the same scheduler thread:
 
@@ -179,6 +193,11 @@ entry = pair_registry.must_get(req.request_uid)
 assert entry.state == P_PRECOMMIT
 assert req_is_in_final_admitted_batch(req)
 assert req_will_not_need_another_prefill_admission(req)
+assert req.req_pool_idx is not None
+assert req_has_source_kv_and_required_cache_ownership(req)
+assert req.metadata_buffer_index >= 0
+assert sender_session_state_is_charged(req)
+assert entry.full_control_ready
 
 entry.state = P_COMMITTED
 entry.commit_generation = 1
@@ -188,9 +207,10 @@ control_mailbox.mark_ready(entry)  # O(1), local, non-blocking
 launch_forward(batch)
 ```
 
-The commit hook performs no socket I/O, RPC, collective, allocator operation,
-or wait. If an SGLang scheduler mode cannot provide this linearization point,
-that mode cannot advertise support for version 1.
+The commit hook verifies already-owned state and performs no socket I/O, RPC,
+collective, allocator operation, or wait. If an SGLang scheduler mode cannot
+provide this linearization point, that mode cannot advertise support for
+version 1.
 
 ### D scarce capacity
 
@@ -257,6 +277,10 @@ any nonterminal state
 `D_COMMIT_RECEIVED` is used when commitment wins that race; if local setup is
 already ready, the scheduler may atomically go from `D_REGISTERED` to
 `D_ELIGIBLE` while recording the same validated commitment.
+`D_CHANNEL_READY` in the acquisition graph is a monotonic readiness bit owned by
+the D scheduler entry, not an additional protocol state or queue. The bounded
+channel manager may report completion only through the pair's reserved command;
+the scheduler validates the same identity/epochs and sets the bit once.
 `D_ELIGIBLE` is the only state allowed to enter the existing decode
 preallocation queue.
 
@@ -271,6 +295,10 @@ finished. Its scheduler entry contains monotonic `prefill_compute_done` and
 bits through scheduler commands in either order. Only the scheduler may enter
 `P_TRANSFERRING`, and only when both are true; metadata that arrives while the
 committed forward is still running never starts an early KV transfer.
+Conversely, forward completion while metadata is absent parks the request in a
+committed-wait owner without releasing or re-admitting it. An enforce request at
+or after `P_COMMITTED` must never call `optimistic_release_and_requeue()`,
+`reset_for_retract()`, or another retry helper that releases source ownership.
 
 Each request has exactly one protocol state and at most one primary admission
 queue. Auxiliary batch, inflight, result, transport, and cleanup ownership is
@@ -285,29 +313,44 @@ not invent additional resource-acquisition rules:
 ```text
 P WAIT first -> bounded P_REGISTERED subset, zero model capacity
 P HTTP accepted -> P_FULL_CONTROL_READY -> P_PRECOMMIT
-P final scheduler admission/allocation -> P_COMMITTED -> GPU launch
+P final scheduler admission/all finite P prerequisites -> P_COMMITTED
+  -> GPU launch
 
-D HTTP accepted -> D_FULL_CONTROL_READY -> D_REGISTERED
+D HTTP accepted -> D_REQUEST_CONTROL_READY -> D_REGISTERED
+D two-sided channel reservation/setup -> D_CHANNEL_READY
 D commitment + receiver/channel readiness -> D_ELIGIBLE
 D allocator entry -> D_PREALLOCATED
 ```
 
 `P_FULL_CONTROL_READY` means that the full P row in the reservation table is
 owned. It is required before `P_PRECOMMIT`, whether HTTP or WAIT arrived first,
-and therefore before P can acquire model capacity. `D_FULL_CONTROL_READY` means
-that the full D row, including the complete channel lease set, is owned before
-`D_REGISTERED`. `D_ELIGIBLE` additionally requires the matching immutable
-commitment and ready non-scarce receiver/channel setup.
+and therefore before P can acquire model capacity. The P model/aux metadata
+buffer is model capacity rather than a control credit: it may be acquired after
+`P_PRECOMMIT`, but it must be owned before `P_COMMITTED`. Bounded P
+sender/session tracking is part of the full-control row.
+`D_REQUEST_CONTROL_READY` means that every request-local D credit needed to
+attempt and retain receiver/channel setup is owned before `D_REGISTERED`.
+While still owning zero model capacity, `D_REGISTERED` obtains the complete
+two-sided channel lease set through that reserved setup operation.
+`D_ELIGIBLE` additionally requires the matching immutable commitment and ready
+non-scarce receiver/channel setup. Thus cross-worker channel establishment is
+not mislabeled as an atomic scheduler-local admission step, but it still cannot
+occur after D scarce allocation.
 
-After either full-control gate and until P terminalizes or D enters
-`D_RUNNING`/earlier terminal cleanup, a protocol phase may consume or release
-only the pair's reserved resources. It may not acquire a generic command slot,
-correlation, response handle, payload byte, control-channel entry, cleanup slot,
-or tombstone slot. Existing decode-generation scheduling after `D_RUNNING` and
-application output backpressure are not new protocol resources. A failure at
-either gate terminalizes a zero-model-capacity entry. This single acquisition
-graph applies to normal progress, duplicate and reconnected waits, success,
-failure, cancel, and deadline cleanup.
+Between `P_FULL_CONTROL_READY` and `P_COMMITTED`, P may acquire only the finite
+model prerequisites enumerated by the commit checklist, in the existing
+metadata-buffer-before-final-admission order. Between
+`D_REQUEST_CONTROL_READY` and `D_ELIGIBLE`, D may consume only its reserved
+receiver and two-sided channel-setup operations while holding zero model
+capacity. After `P_COMMITTED` or `D_ELIGIBLE`, a protocol phase may consume or
+release only the pair's reserved resources. It may not acquire a generic command
+slot, correlation, response handle, payload byte, control-channel entry, cleanup
+slot, tombstone slot, or finite per-request model/transport prerequisite.
+Existing decode-generation scheduling after `D_RUNNING` and application output
+backpressure are not new protocol resources. A request-control/channel gate
+failure terminalizes a zero-model-capacity entry. This single acquisition graph
+applies to normal progress, duplicate and reconnected waits, success, failure,
+cancel, and deadline cleanup.
 
 The end-to-end lifecycle is therefore fixed:
 
@@ -315,8 +358,9 @@ The end-to-end lifecycle is therefore fixed:
 | --- | --- | --- |
 | Valid unknown commit wait at P | `P_EMPTY -> P_REGISTERED` | None |
 | Matching P HTTP body and full-control gate | `P_EMPTY/P_REGISTERED -> P_PRECOMMIT` | None |
-| P final admission/allocation | `P_PRECOMMIT -> P_COMMITTED` | P acquires; no later P admission required |
-| Valid D HTTP body and full-control gate | `D_EMPTY -> D_REGISTERED` | None |
+| P final admission and all finite prerequisites | `P_PRECOMMIT -> P_COMMITTED` | P request/KV/metadata/cache ownership is complete; no later finite P prerequisite |
+| Valid D HTTP body and request-control gate | `D_EMPTY -> D_REGISTERED` | None |
+| Complete two-sided channel reservation/setup | `D_REGISTERED/D_COMMIT_RECEIVED -> same state + D_CHANNEL_READY` | None |
 | Matching commitment plus local readiness | `D_REGISTERED/D_COMMIT_RECEIVED -> D_ELIGIBLE` | None |
 | Existing D preallocator accepts eligible request | `D_ELIGIBLE -> D_PREALLOCATED` | D acquires |
 | D arms transfer and submits V1 metadata | `D_PREALLOCATED -> D_TRANSFERRING` | No new generic control resource |
@@ -356,6 +400,7 @@ transfer_status_protocol_version
 p_wait_commit_endpoint
 p_metadata_v1_endpoint
 p_transfer_status_endpoint
+d_control_peer_authority
 p_pair_cancel_endpoint
 d_pair_cancel_endpoint
 ```
@@ -436,6 +481,16 @@ one byte, enums use assigned integer IDs, and every byte/string field uses a
 big-endian length prefix followed by raw bytes. UTF-8 is the only string
 encoding. Rust/Python runtime dictionaries, default JSON serialization, native
 integer layout, and delimiter-joined strings are not valid digest inputs.
+
+Textual HTTP/discovery fields have one canonical wire representation. A
+16-byte pair key, serving epoch, or request UID is exactly 32 lowercase
+hexadecimal characters. A 32-byte capability, policy, or support-cell digest is
+exactly 64 lowercase hexadecimal characters. Prefixes, separators, uppercase,
+padding, UUID formatting, and alternate base64 encodings are rejected before
+state creation. Binary V1 control frames carry the decoded fixed-width raw
+bytes. Canonical hashes always consume those decoded raw bytes, never the
+textual hex representation. Shared Rust/Python vectors cover valid encoding
+and rejection of every non-canonical textual form.
 
 The request UID is derived from the complete pair identity, not from a user
 `rid`. Version 1 encodes `bootstrap_room` as unsigned 64-bit big-endian,
@@ -564,8 +619,14 @@ Ordering rules:
   `P_FULL_CONTROL_READY` and creates `P_PRECOMMIT`; the wait later attaches only
   if both dispatch times and the full identity exactly match the stored
   envelope.
-- If P is committed, duplicate waits replay the same immutable commitment.
-- If P is terminal, duplicate waits replay the same terminal result.
+- Until matching V1 metadata closes the logical commit operation, a committed P
+  replays the same immutable commitment and a terminal P replays the same
+  terminal result to duplicate waits.
+- Matching V1 metadata proves that D consumed COMMITTED and atomically closes
+  the logical `WAIT_COMMIT` operation. A commit wait/response that arrives after
+  that closure is transport-stale and is dropped before scheduler ingress; it
+  does not allocate or reacquire a response credit. D must stop commit retries
+  before its first metadata delivery attempt.
 - While P is `P_REGISTERED`/`P_PRECOMMIT`, the logical wait remains attached or
   receives non-terminal RETRY_LATER. If a pre-running failure has entered
   `P_CANCELLING`, P does not replay a stale COMMITTED response to a new wait; it
@@ -599,7 +660,10 @@ identifies that logical wait and remains unchanged across timeout, reconnect,
 backoff, and transport retry. Reconnect rebinds the same logical correlation;
 it does not create a new waiter or sequence. P does not maintain a reliable
 network outbox. A lost response is recovered by D repeating the identical
-logical wait and P replaying the immutable scheduler snapshot.
+logical wait and P replaying the immutable scheduler snapshot. D atomically
+closes its commit correlation when it accepts COMMITTED and must drain or
+transport-drop already queued duplicate responses without reacquiring a
+scheduler command credit.
 
 Readiness requires a dedicated terminal commit-response replay window that
 covers D's complete admission-wait retry window:
@@ -658,61 +722,77 @@ clock is used only to reject a cross-worker commit or unknown late ingress.
 Safety, ownership release, and finite local retention never depend on wall-clock
 time moving forward or remaining synchronized.
 
-### Persistent peer-channel lease set
+### Persistent two-sided peer-channel lease set
 
-D uses a hard-bounded cache of persistent multiplexed channels for
-`WAIT_COMMIT`, metadata, and `WAIT_TRANSFER_STATUS`. Its immutable discovery
-capability publishes a positive `max_pd_peer_channels` and the physical
-authority/protocol binding for every logical endpoint.
+Version 1 uses a hard-bounded persistent multiplexed channel service for
+`WAIT_COMMIT`, metadata, and `WAIT_TRANSFER_STATUS`. D discovery publishes a
+positive `max_outbound_pd_peer_channels`; P discovery publishes a positive
+`max_inbound_pd_peer_channels`. Both publish the physical authority/protocol
+binding and reconnect-overlap limit. The selected values and topology policy are
+capability/pair-policy bound.
 
-The cache key includes normalized physical peer authority, P serving epoch, and
-the service/protocol suite. If multiple logical endpoints are carried by the
-same physical multiplexed connection, normalization deduplicates them to one
-key. If they use different authorities or transports, they require distinct
-keys. A new P epoch at the same address never inherits the old epoch's channel
-identity.
+The D-side cache key includes normalized P authority, P serving epoch, and the
+service/protocol suite. The symmetric P-side accepted-channel key includes the
+pinned `d_control_peer_authority`, D serving epoch, and the same suite. Channel
+setup authenticates or otherwise verifies those epoch/authority bindings on the
+trusted internal transport before either side marks the physical entry ready.
+If multiple logical endpoints share one multiplexed connection, normalization
+deduplicates them to one key. Different authorities or transports require
+distinct keys. A new worker epoch at the same address never inherits the old
+epoch's entry.
 
-Admission into `D_REGISTERED` atomically reserves the complete set of cache
-entries/leases required by the pinned `p_wait_commit_endpoint`,
-`p_metadata_v1_endpoint`, and `p_transfer_status_endpoint`. Connection setup may
-then run in parallel with P queueing, but every channel in the reserved set must
-be ready before `D_ELIGIBLE`. Receiving `COMMITTED` while setup is incomplete
-only moves D to deadline-covered `D_COMMIT_RECEIVED`; it does not permit
-preallocation.
+After `D_REQUEST_CONTROL_READY` creates `D_REGISTERED`, D uses the already
+reserved channel-setup command/response credit to run one bounded,
+all-or-nothing reservation transaction for the complete D-side set needed by
+the pinned `p_wait_commit_endpoint`, `p_metadata_v1_endpoint`, and
+`p_transfer_status_endpoint`. A D entry is not ready until P has also granted
+and retained the matching bounded inbound physical entry. The transaction and
+connection setup may run in parallel with P queueing while D owns zero model
+capacity, but every entry in the two-sided set must be ready before
+`D_ELIGIBLE`. Receiving `COMMITTED` while setup is incomplete only moves D to
+deadline-covered `D_COMMIT_RECEIVED`; it does not permit preallocation. Failure
+releases any partial reservation and completes through the request's already
+reserved cleanup path.
 
-If any lease or reserved cache slot is unavailable, D releases the partial set
-and terminalizes the pair before acquiring scarce capacity. It must not wait
-until `D_PREALLOCATED` to acquire a metadata or status channel, borrow a generic
-channel slot, or create a temporary unbounded socket. Thus a pair that owns D
-model capacity already owns every peer-channel resource required to finish the
-transfer protocol.
+When a pair-level wait or metadata operation attaches to a physical channel,
+both endpoint entries hold an active logical refcount for that pair. A
+disconnect does not surrender either reserved entry to a new peer while any
+attached pair may still need commit, metadata, or status replay. Reconnect
+reuses the same two entries and their precharged old/new socket overlap. It may
+replace the physical socket but cannot allocate an uncharged cache entry on
+either endpoint.
 
-Each pre-running D pair holds one logical lease/refcount for each key in the
-deduplicated set. After D accepts a matching SUCCESS and atomically enters
-`D_RUNNING`, it releases the pair's complete lease set; no post-success control
-send owns or extends that lease. A failed pair releases its complete set during
-terminal cleanup. Only
-zero-refcount idle channels may be evicted, using bounded idle TTL/LRU. The
-budget includes file descriptors, socket buffers, reconnect state, reserved but
-not-yet-connected entries, idle cache entries, and the bounded old/new socket
-overlap needed to reconnect one key. Reconnect reuses the same entry/lease; it
-cannot temporarily allocate an uncharged second cache entry. Cache exhaustion
-returns an error through SMG without rerouting the enforce request.
+If any local or remote lease, reserved cache slot, or reconnect-overlap slot is
+unavailable, D releases the partial set and terminalizes before scarce
+allocation. It must not wait until `D_PREALLOCATED` to acquire a metadata or
+status channel, borrow a generic local or P-acceptor slot, or create a temporary
+unbounded socket. Thus a pair that owns D model capacity already owns both
+physical endpoints needed to finish the transfer protocol.
+
+After D accepts matching SUCCESS and atomically enters `D_RUNNING`, it releases
+the pair's D-side refs; the corresponding P-side refs are released when their
+logical commit/status replay operations close. No post-success control send is
+required. A failed pair releases both sides during terminal cleanup/replay
+closure. Only zero-refcount idle entries may be evicted, using bounded idle
+TTL/LRU. Each endpoint budget covers file descriptors, socket buffers,
+connection/handshake state, reserved-but-not-yet-connected entries, idle cache
+entries, and bounded reconnect overlap. Exhaustion returns an error through SMG
+without rerouting the enforce request.
 
 For the first SGLang/Mooncake cell, the preferred mapping is one bidirectional,
-multiplexed control service per P authority/epoch; the three logical operations
-then deduplicate to one physical key. The protocol still defines a lease set so
-an implementation cannot silently add a second endpoint later and acquire it
-after preallocation. The current endpoint-keyed `_socket_cache` has no hard
-entry/memory bound and therefore cannot be used unchanged for enforce traffic.
+multiplexed control service per D/P authority-and-epoch pair; all three logical
+operations then share one physical key. The protocol still defines a set so a
+later implementation cannot silently introduce another endpoint after
+preallocation. The current endpoint-keyed `_socket_cache` has no hard
+entry/memory bound and cannot be used unchanged for enforce traffic.
 
-Readiness also checks the deployment topology: the configured cache capacity
-must cover the maximum number of distinct P authority/epoch keys that SMG may
-route concurrently to one D, including the allowed old/new-epoch overlap during
-rollout. If it cannot, that routing cell is unsupported rather than relying on
-steady-state cache-exhaustion errors. Multiple pairs to one key share a physical
-channel and hold separate logical refcounts; the design never creates one socket
-per request.
+Readiness checks both directions of the deployment topology. D outbound
+capacity must cover every P authority/epoch to which SMG may route that D, and P
+inbound capacity must cover every D authority/epoch that may select that P,
+including allowed old/new-epoch overlap. An unsupported topology is rejected
+before dispatch rather than relying on steady-state cache exhaustion. Multiple
+pairs share a physical channel through bounded refcounts; version 1 never
+creates one socket per request.
 
 ## Destination metadata and transfer completion
 
@@ -750,9 +830,35 @@ that fixes FAILED, starts scheduler cleanup, and removes the support cell from
 new dispatch; after the pair left that state it is stale-dropped. Digest storage
 is fixed-size and charged to the metadata-register reservation.
 
-Before submitting metadata, D transitions to `D_TRANSFERRING`, chooses the
-non-reused `transfer_generation=1`, and arms its transfer deadline. It also
-starts one logical transfer-status wait:
+Metadata delivery is one logical, D-owned operation identified by the bound
+identity plus `transfer_generation=1`; transport attempts do not create a
+second sequence or generation. Before the first attempt, D transitions to
+`D_TRANSFERRING`, arms its transfer deadline, and fixes one canonical bounded
+metadata frame/send buffer under the pair's pre-reserved command and byte
+credit. D retains that logical credit and immutable content until it accepts a
+matching transfer snapshot or enters terminal cleanup. Reconnect, an ambiguous
+send result, or a bounded delivery retry reuses the same frame, generation,
+channel lease, and credit. It cannot reallocate destination indices, rebuild
+different content, or borrow generic send capacity.
+
+Accepting a matching transfer snapshot closes the retry operation and forbids
+another metadata attempt. It does not free an immutable send buffer that an
+already queued transport operation still references. Such fixed-overlap refs
+remain charged auxiliary transport owners until completion/cancellation detaches
+them; only then does the byte credit return to admission. They cannot delay or
+repeat `D_TRANSFERRING -> D_RUNNING`.
+
+A matching P registration is an implicit acknowledgment that D consumed the
+commit result and closes the earlier logical `WAIT_COMMIT` operation at both
+schedulers. It is not a separate metadata acknowledgment: loss ambiguity is
+resolved by a byte-identical metadata resend, which P handles idempotently, and
+the eventual immutable transfer snapshot. Retry is rate-limited by pair policy
+and never refreshes the D transfer or P post-commit deadline. If the immutable
+frame cannot be retained or reconstructed within its original credit, D fails
+the pair rather than sending different metadata.
+
+D also starts one logical transfer-status wait before or concurrently with the
+first metadata attempt:
 
 ```text
 WaitTransferStatusRequest {
@@ -804,9 +910,11 @@ cancel_seq = 1
 ```
 
 `wait_seq`, `status_wait_seq`, and `cancel_seq` remain unchanged across timeout,
-reconnect, backoff, duplicate delivery, and transport retry. A different value
-for the same version 1 pair/operation is `INCOMPATIBLE` and cannot allocate a
-second correlation or mutate the pair.
+reconnect, backoff, duplicate delivery, and transport retry. Metadata delivery
+uses the unchanged `transfer_generation=1` and canonical frame digest as its
+logical identity. A different value or content for the same version 1
+pair/operation is `INCOMPATIBLE` and cannot allocate a second correlation,
+destination registration, or pair mutation.
 
 The transport may use an ephemeral local attempt/handle token solely to close
 and replace sockets. It is not sent as protocol identity and is never stored in
@@ -929,9 +1037,9 @@ serialized transition:
    the transfer deadline in the same scheduler transition.
 4. Remove the request from every bootstrap, waiting, batch, inflight, transfer,
    and result owner.
-5. Release sender, source KV, request slot, cache/radix lock, metadata payload
-   references, and all other ownership exactly once through explicit ownership
-   bits/refcounts.
+5. Release sender/session state, source KV, request slot, the P-side model/aux
+   metadata-buffer index, cache/radix lock, metadata payload references, and all
+   other ownership exactly once through explicit ownership bits/refcounts.
 6. Replace the LIVE entry with `P_TERMINAL(SUCCESS)`, retaining only the bounded
    identity, terminal disposition, and immutable transfer snapshot until the
    replay-retention formula expires.
@@ -944,8 +1052,9 @@ A cleanup timeout never rewrites a published SUCCESS snapshot; it isolates the
 worker/support cell and continues scheduler-owned cleanup.
 
 After D validates that SUCCESS, it atomically commits transferred ownership to
-the request, releases the pair's complete control-channel lease set, and enters
-`D_RUNNING` without further network I/O. On
+the request, releases the pair's D-side control-channel refs, and enters
+`D_RUNNING` without further network I/O. P's bounded replay-side refs close by
+the independent rule above and are never extended by decode lifetime. On
 normal generation completion or stream EOF, D enters `D_SUCCESS_CLEANUP`,
 removes the request from all scheduler/result owners, releases request slot, KV,
 metadata buffer, and cache locks exactly once, then replaces the LIVE entry with
@@ -966,8 +1075,8 @@ shortcut:
   and cancel all use this rule. If SUCCESS or FAILED was already fixed, cleanup
   preserves that first semantic snapshot.
 - A D pair that validates FAILED, or reaches any deadline before `D_RUNNING`,
-  enters `D_CANCELLING`, removes itself from registered/eligible/preallocation/
-  transfer owners, releases every reserved control and scarce owner exactly
+  enters `D_CANCELLING`, removes itself from registered, eligible,
+  preallocation, and transfer owners, releases every reserved control and scarce owner exactly
   once, and publishes terminal only after release.
 
 A semantic FAILED response may be replayed while P cleanup is in progress, but
@@ -1029,6 +1138,15 @@ does not delay the user-visible error indefinitely. If SMG or its client task
 disappears, the workers' non-refreshable local deadlines remain the cleanup
 backstop.
 
+The successor terminal tombstone reserved at pair admission includes one
+compact cancel replay-response credit. A worker retains it for the complete
+tombstone lifetime, not merely until local terminalization. Consequently, loss
+of the first cancel response followed by the same bounded SMG retry can replay
+`ACCEPTED` while cleanup is active or `ALREADY_TERMINAL` afterward without
+competing with unknown requests for generic response capacity. Closing the
+original socket does not release this logical credit. Tombstone GC releases the
+identity, cancel replay credit, and its timer together.
+
 The ingress thread validates fixed framing and enqueues a bounded command. The
 scheduler recomputes and matches the full identity and serializes cancel with
 HTTP entry, WAIT, commitment, metadata registration, transfer completion,
@@ -1055,8 +1173,9 @@ includes:
   success-cleanup, inflight, and result state;
 - D `D_REGISTERED`, `D_COMMIT_RECEIVED`, eligible, existing preallocation,
   transfer, running/current/last batch, success-cleanup, and result state;
-- channel lease sets, correlations, metadata payload owners, request/KV slots,
-  cache/radix locks, sender/receiver state, and deadline entries.
+- channel lease sets, correlations, metadata payload owners, P/D model metadata
+  buffers, request/KV slots, cache/radix locks, sender/receiver state, and
+  deadline entries.
 
 The current decode abort path must therefore be extended to address the new
 registered/commit-received owners by `request_uid`; scanning only the existing
@@ -1072,12 +1191,21 @@ The full per-role credit inventory, release points, byte-accounting rules, and
 reservation fault tests are normative and live in the
 [reservation and validation appendix](/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix).
 
-Before either role can acquire model capacity, its full-control gate atomically
-reserves the bounded LIVE/tombstone state, logical wait/response correlations,
-scheduler commands, deadline/cleanup capacity, retained payload bytes, and
-cancel path needed for every later transition. D also reserves its complete
-deduplicated peer-channel lease set and receiver/session capacity. A partial
-reservation fails before model allocation.
+Before P can acquire model capacity, its full-control gate atomically reserves
+the bounded LIVE/tombstone state, logical wait/response correlations, scheduler
+commands, deadline/cleanup capacity, retained payload bytes, cancel path, and
+sender/session tracking needed for every later transition. Before P commits, it
+must also own the actual P-side model/aux metadata-buffer slot and every other
+finite P prerequisite listed in the commit definition.
+
+D's request-control gate reserves the equivalent request-local row, including a
+bounded channel-reservation operation, before `D_REGISTERED`. While remaining
+in zero-model-capacity registered/commit-received state, D obtains its complete
+two-sided deduplicated peer-channel lease set and finishes receiver/session
+setup. A partial reservation or missing prerequisite fails before the
+corresponding cross-stage capacity transition. After `P_COMMITTED` or
+`D_ELIGIBLE`, no completion step may acquire a new generic control credit or a
+finite per-request model/transport prerequisite.
 
 Duplicates and reconnects rebind the pair's existing logical credits. Unknown
 or malformed input uses a separate bounded ingress budget and cannot consume a
@@ -1111,10 +1239,10 @@ the support cell. In particular, P post-commit readiness must cover the larger
 of the configured committed-prefill runtime bound and worst-case commit
 delivery + D preallocation/metadata-submit budget, plus scheduling/skew margin.
 D transfer timeout must cover remaining committed-prefill runtime, metadata
-handoff, Mooncake transfer, status retry/backoff, and delivery margin. A request
-whose declared shape is outside those bounds uses legacy behavior before
-dispatch or fails closed; it is not allowed to enter enforce and predictably
-timeout on long prompts.
+delivery retry/backoff and handoff, Mooncake transfer, status retry/backoff, and
+delivery margin. A request whose declared shape is outside those bounds uses
+legacy behavior before dispatch or fails closed; it is not allowed to enter
+enforce and predictably timeout on long prompts.
 
 A transition arms the successor deadline before invalidating the previous one.
 Retries, reconnects, and queue movement cannot refresh a deadline. Scheduler
@@ -1158,8 +1286,9 @@ point:
   outer retry that can reselect workers;
 - a P or D HTTP error triggers best-effort cancellation of the originally
   bound pair and returns an error;
-- retries of `WAIT_COMMIT` and `WAIT_TRANSFER_STATUS` remain allowed because
-  they reuse the same identity, endpoint, serving epoch, and logical credit.
+- retries of `WAIT_COMMIT`, byte-identical V1 metadata delivery, and
+  `WAIT_TRANSFER_STATUS` remain allowed because they reuse the same identity,
+  endpoint, serving epoch, and logical credit.
 
 SMG is a trusted, non-Byzantine participant in version 1. It derives both role
 bodies from the same immutable typed request before `PAIR_BOUND`; role-specific
@@ -1173,12 +1302,12 @@ decode response/stream is exposed, a transport error or non-success response
 from either P or D immediately stops waiting for normal completion of the peer,
 starts the same identity-bound cancellation on both pinned role endpoints, and
 returns the appropriate error after only the bounded cancel attempt. In
-particular, it
-must not preserve the current behavior that stores an early D error while
-continuing to wait for P: D may reject at its full-control gate after P has
-committed, and P would otherwise wait until its post-commit deadline for
-metadata that can never arrive. A successful early D response may still wait
-for the P response required by the existing result/logprob merge.
+particular, it must not preserve the current behavior that stores an early D
+error while continuing to wait for P: D may reject at its request-control or
+channel-readiness gate after P has committed, and P would otherwise wait until
+its post-commit deadline for metadata that can never arrive. A successful early
+D response may still wait for the P response required by the existing
+result/logprob merge.
 
 The feature-disabled path retains the current outer `RetryExecutor` behavior.
 If a future enforce version permits same-pair HTTP resend, it must resend the
@@ -1208,19 +1337,27 @@ The implementation and tests must preserve all of the following together:
 1. **Capability and policy fence before state.** SMG, P, and D agree on the
    canonical role capabilities, actual pair-policy digest, serving epochs, and
    support cell before tokenization or execution-capable pair-state creation.
-2. **Commit before D capacity.** D owns a request/KV/metadata slot or cache lock
-   only after its scheduler validates the matching immutable commitment.
+2. **Complete P commitment before D capacity.** P commits only after its request
+   slot, source KV, model/aux metadata buffer, cache ownership, sender/session
+   tracking, and full-control row are owned, with no later finite per-request P
+   prerequisite. D owns a request/KV/metadata slot or cache lock only after its
+   scheduler validates that matching immutable commitment.
 3. **Non-blocking P launch.** P commitment performs only O(1) scheduler-local
    state publication before GPU launch; it never waits for D or transport.
-4. **One acquisition graph.** P owns its complete P reservation row before
-   `P_PRECOMMIT`; D owns its complete D row before `D_REGISTERED`; and D also
-   verifies commitment and channel/receiver readiness before `D_ELIGIBLE`.
-   No later pre-running protocol phase acquires generic control/protocol
-   capacity; existing Mooncake data-plane service remains deadline-bounded.
-5. **One retry owner and fixed logical sequences.** D retries commit/status waits
-   with the same version 1 sequence; SMG alone retries the bounded same-pair
-   cancel operation. P stores semantic immutable snapshots and no
-   transport-attempt state or reliable outbox.
+4. **One acquisition graph.** P owns its complete P control row before
+   `P_PRECOMMIT` and every finite P model prerequisite before `P_COMMITTED`. D
+   owns its request-local control row, including the bounded channel-setup
+   operation, before `D_REGISTERED`, then obtains the complete two-sided channel
+   set and receiver readiness while it still owns zero model capacity. D verifies
+   those resources plus commitment before `D_ELIGIBLE`. No phase after
+   `P_COMMITTED` or `D_ELIGIBLE` acquires generic control/protocol capacity or a
+   finite per-request prerequisite; existing Mooncake data-plane service remains
+   deadline-bounded.
+5. **One retry owner and fixed logical sequences.** D retries commit/status
+   waits and byte-identical metadata delivery with the same version 1 logical
+   identity; SMG alone retries the bounded same-pair cancel operation. P stores
+   semantic immutable snapshots and no transport-attempt state or reliable
+   outbox.
 6. **No resurrection.** Serving epochs, canonical identity, dispatch expiry,
    WAIT-first validation, cancel-first tombstones, and terminal retention prevent
    an unknown late message from recreating an old pair.
@@ -1256,9 +1393,9 @@ and bounded dimensions are required:
 | --- | --- |
 | Pair admission and terminal totals | `role`, `result`, bounded `reason` |
 | Full-control gate rejection totals | `role`, bounded `reason` |
-| Commit/status wait retry totals and latency | `wait_kind`, bounded `result` |
+| Commit/status wait and metadata-delivery retry totals and latency | `operation`, bounded `result` |
 | Phase and cleanup timeout totals | `role`, `phase` |
-| Peer-channel cache entries and exhaustion | `state=active|idle|reserved`, bounded `reason` |
+| Peer-channel entries and exhaustion on both endpoints | `side=inbound|outbound`, `state=active|idle|reserved`, bounded `reason` |
 | LIVE pair, tombstone, and snapshot count/bytes | `role`, `object_kind` |
 | Post-`PAIR_BOUND` dispatch failures | `role`, bounded `stage` and `reason` |
 | Support-cell isolation and clock-health events | bounded `reason`; allowlisted configured cell version only |
@@ -1316,7 +1453,7 @@ Required implementation properties:
 - Bounded D inbox draining (no busy polling)
 - No pair scan in the scheduler hot loop
 - No per-request TCP connections
-- Hard-bounded peer-channel cache with active refcounts and idle eviction
+- Hard-bounded two-sided peer-channel managers with active refcounts and idle eviction
 - No request-identity metric labels
 - Zero envelope/control/registry/deadline work on the disabled path
 
@@ -1337,7 +1474,7 @@ Candidate performance gates (subject to maintainer agreement):
 | GPU utilization | At least `-1%` |
 | Successful request rate before baseline saturation | No new control-budget, channel-budget, or protocol timeout failures |
 | Control and metadata memory | Never exceeds configured hard budgets |
-| Peer-channel FD/socket memory | Never exceeds the configured hard budget |
+| Inbound and outbound peer-channel FD/socket memory | Never exceeds either configured hard budget |
 
 The matrix must separate prompt lengths `1/8/32/128/1K/8K`, cache-hit ratios
 `0/50/90/100%`, concurrency `1/8/32/saturation`, streaming/non-streaming, and
@@ -1369,12 +1506,12 @@ This RFC is design-only. Implementation should split into reviewable PRs:
    while D still follows the legacy eligibility path. Shadow mode doesn't fix
    the bug and must not be reported as enforce mode.
 3. **Mooncake single-rank enforcement.** Add D registration/eligibility, P
-   scheduler commitment, success/cancel ownership closure, complete peer-channel
-   lease-set reservation, V1 metadata/status namespaces, and deadlines. In the
-   same PR, add the SMG `PAIR_BOUND` fence and make enforce requests bypass the
-   current outer worker-reselection `RetryExecutor` before the first enforce
-   request can be dispatched. Add fault injection for the first support cell.
-   Default off.
+   scheduler commitment, success/cancel ownership closure, complete two-sided
+   peer-channel lease-set reservation, idempotent metadata delivery, V1
+   metadata/status namespaces, and deadlines. In the same PR, add the SMG
+   `PAIR_BOUND` fence and make enforce requests bypass the current outer
+   worker-reselection `RetryExecutor` before the first enforce request can be
+   dispatched. Add fault injection for the first support cell. Default off.
 4. **GPU canary and rollout.** Run the mandatory performance matrix and enable
    only approved rollout cells.
 5. **Transparent reroute follow-up.** Separately design terminal receipts,
@@ -1392,16 +1529,22 @@ The enforcement PR maps to existing SGLang boundaries as follows:
   unlike the current loop, an early D error must cancel P and finish promptly
   instead of being cached until P resolves.
 - In the P scheduler path, publish commitment after final `prepare_for_extend()`
-  allocation succeeds and before `run_batch()`/forward can launch. The hook is a
-  scheduler-local registry write plus bounded mailbox-ready mark.
-- In `python/sglang/srt/disaggregation/decode.py`, add a separate registered/
+  allocation succeeds, after asserting the existing P model/aux metadata-buffer
+  index and all other finite commit prerequisites, and before
+  `run_batch()`/forward can launch. The hook is a scheduler-local registry write
+  plus bounded mailbox-ready mark. Guard the existing
+  `optimistic_release_and_requeue()`/retraction helpers so an enforce request at
+  or after commitment instead parks in the explicit committed-wait owner until
+  matching metadata or its non-refreshable deadline.
+- In `python/sglang/srt/disaggregation/decode.py`, add a separate registered and
   commit-received owner. Do not insert enforce requests into the existing
   `DecodePreallocQueue.queue` until the scheduler predicate is `D_ELIGIBLE`, and
   guard `_pre_alloc()` itself as a second line of defense.
 - In the Mooncake/control layer, keep legacy room-keyed frames and the current
-  unbounded endpoint socket cache off the enforce namespace. V1 uses the bounded
-  multiplexed channel manager, byte-limited parsing, and fixed scheduler
-  commands defined here. The existing data-plane executor remains unchanged.
+  unbounded endpoint socket cache off the enforce namespace. V1 uses bounded
+  inbound/outbound multiplexed channel managers, byte-limited parsing,
+  byte-identical metadata retry, and fixed scheduler commands defined here. The
+  existing data-plane executor remains unchanged.
 - In `scheduler.py`, extend abort/deadline lookup by `request_uid` across the new
   registered/commit states and route success, failure, cancel, and timeout
   through the same ownership ledger.

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
@@ -1,0 +1,344 @@
+---
+title: "PD commit-gated preallocation: Reservation and validation appendix"
+description: "Normative resource inventory and validation matrix for the PD optimistic prefill commit-gate RFC."
+sidebarTitle: "PD commit-gate appendix"
+tag: "DRAFT"
+---
+
+<Warning>
+  This is the normative resource and validation appendix to the
+  [commit-gated decode preallocation RFC](/docs/developer_guide/pd_optimistic_prefill_commit_rfc).
+  An inconsistency between the RFC invariants and this appendix blocks
+  implementation or rollout; it must not be resolved by weakening a gate.
+</Warning>
+
+The main RFC contains the problem statement, ordering proof, state machines,
+wire contracts, deadlines, rollout gates, and implementation boundary. This
+appendix keeps the complete per-credit ownership inventory and fault matrix
+available without making the first design review depend on reading every test
+case.
+
+## Progress-resource reservation
+
+Completion must never compete with new requests for a generic control/protocol
+resource after a role crosses its full-control gate. The two gates therefore
+reserve the following logical resources before either role can acquire model
+capacity:
+
+| Role | Reserved before scarce capacity | Released |
+| --- | --- | --- |
+| P | LIVE entry, retained control/request-byte credit, and successor tombstone slot | After request release and tombstone retention, respectively |
+| P | One inbound `WAIT_COMMIT` logical correlation/replay-response credit | After matching V1 metadata proves D accepted the commitment, or after the terminal commit-replay window closes |
+| P | Reusable metadata-register command credit | After immutable transfer snapshot publication or terminal cleanup |
+| P | Metadata receive-byte credit, including retained zero-copy owners and decoded heap expansion | After the last payload reference is released |
+| P | Reusable `TransferCompletionCommand` credit | After the backend callback is detached and every already queued completion command is consumed; local terminal waits for this owner |
+| P | One inbound transfer-status logical correlation/replay-response credit | After the replay window closes; at a pre-commit terminal with no snapshot |
+| P | One fixed-size immutable transfer-status snapshot slot and byte credit | After the full replay-retention formula; at a pre-commit terminal with no snapshot |
+| P | One inbound matching pair-cancel logical correlation/command credit | At local terminal |
+| P | Fixed deadline-node/phase-transition overlap credit | After local terminal |
+| P | Terminal/deadline cleanup command credit | After terminal transition |
+| D | LIVE entry, registered request/receiver retained-byte credit, and successor tombstone slot | After request/receiver release and tombstone retention, respectively |
+| D | Complete deduplicated peer-channel lease set from the hard-bounded shared cache | At `D_RUNNING` or earlier local pair terminal |
+| D | One Mooncake receiver/topology/session creation and tracking credit | At `D_RUNNING` or earlier terminal cleanup |
+| D | One outbound `WAIT_COMMIT` logical correlation and commit-response command credit | At commit acceptance or terminal cleanup |
+| D | Metadata-send command and conservative send-byte credit | After the last send-buffer reference is released |
+| D | One outbound `WAIT_TRANSFER_STATUS` logical correlation credit | At `D_RUNNING` or terminal cleanup |
+| D | `TransferStatusCommand` receive credit | At `D_RUNNING` or terminal cleanup |
+| D | One inbound matching pair-cancel logical correlation/command credit | At local terminal |
+| D | Fixed deadline-node/phase-transition overlap credit | After local terminal |
+| D | Terminal/deadline cleanup command credit | After terminal transition |
+
+Duplicate waits/cancels and reconnects rebind the same logical credit. They do
+not allocate one correlation per transport attempt. P retains the commit-response
+credit until matching metadata proves D received the commitment or the terminal
+commit-replay window closes, and retains the status replay credit for the full
+snapshot replay window. Closing a socket or completing the first response does
+not release those logical credits.
+Unknown or malformed messages use a separate bounded parse/correlation budget
+and cannot consume a live pair's reserved completion resources.
+
+D reserves and charges all non-model receiver/session capacity before
+`D_REGISTERED`, then may perform the already charged initialization while in
+`D_REGISTERED`; readiness is required before `D_ELIGIBLE`. Worker-startup
+registered memory remains shared, but every per-request receiver object and
+reconnect overlap is charged.
+
+This RFC does not reserve a Mooncake executor thread or change the existing
+data-plane transfer scheduler. Backend service delay/failure remains covered by
+the P/D transfer deadlines. That delay cannot recreate the capacity inversion:
+once D owns KV, the matching P has already completed final admission and does
+not need the blocked P capacity. The stronger reservation claim here is limited
+to new control/protocol resources required to reach transfer or release them.
+
+Deadline credit covers either one update-in-place timer node or the fixed
+maximum number of old/new heap nodes created by all V1 phase transitions. A
+transition can therefore arm its successor before invalidating its predecessor
+without allocating from a generic timer pool; stale heap nodes are generation-
+checked and bounded by the fixed state graph. The separately reserved successor
+tombstone slot includes its retention/GC timer node until collection.
+
+Count bounds alone are insufficient for registered requests. The policy also
+sets maximum per-pair entry bytes, retained request-token/envelope bytes,
+receiver/topology bytes, and process-wide live-control bytes. P charges the
+validated request before `P_PRECOMMIT`; D charges its request and receiver upper
+bound before `D_REGISTERED`. Endpoint strings and diagnostic fields have fixed
+protocol maxima. An object whose conservative retained size does not fit is
+rejected at the full-control gate, before model capacity, rather than admitted
+under only a queue-count credit.
+
+An authenticated cancel matching an existing pair uses that pair's reserved
+cancel ingress/response credit; unrelated or unknown cancel traffic cannot
+starve cleanup for a pair that already owns model capacity. Cancel-first
+requests still use the independent bounded pool described below.
+
+The D lease-set reservation is all-or-nothing and precedes `D_ELIGIBLE`; a
+matching `COMMITTED` response does not waive any missing lease. LIVE admission
+also reserves its successor terminal slot, so success, cancel, and deadline do
+not compete with new requests for tombstone capacity. Valid cancel-first
+requests use a separate hard-bounded tombstone pool because they have no LIVE
+predecessor from which to inherit a reserved successor slot.
+
+A WAIT-first P entry does not yet know the validated request length and therefore
+reserves only its bounded waiter/identity, inbound commit correlation, admission
+deadline, and successor tombstone slot. When the matching P HTTP body arrives,
+the scheduler computes and atomically acquires every remaining P command,
+snapshot, metadata-byte, status-replay, cancel, and cleanup credit before
+creating `P_PRECOMMIT` or allowing model admission. An HTTP-first request
+atomically acquires the same complete P row before creating `P_PRECOMMIT`.
+Failure terminalizes an existing waiter without model allocation. D has its
+validated request at `D_REGISTERED` admission and reserves its complete row,
+including the complete channel lease set, before creating that state.
+
+`P_REGISTERED` has its own hard sub-budget and cannot consume capacity reserved
+for accepted HTTP-first/full-control entries or terminal cleanup. Exhausting the
+WAIT-first sub-budget returns non-terminal `RETRY_LATER` with no state; D retains
+the same logical wait and deadline. Thus delayed or duplicated D waits cannot
+turn a valid control-state flood into starvation of bodies already accepted by
+P.
+
+The metadata-byte credit is a deterministic conservative upper bound from the
+pair policy, validated input-token count, finite `max_new_tokens`, and fixed V1
+KV/state layout. P computes it before `P_PRECOMMIT`; D computes it before
+`D_REGISTERED`. The V1 metadata header carries the selected credit, and P
+requires it to equal its stored credit before retaining any variable payload.
+A disagreement fails the pair within the already reserved parse budget. It
+cannot fall back to a larger allocation. For the first support cell, decode
+radix reuse is disabled, so the bound assumes the full prompt and cannot depend
+on a later cache-hit decision.
+
+Metadata is bounded by all of:
+
+- maximum part bytes;
+- maximum logical frame bytes;
+- maximum process-wide in-flight metadata bytes;
+- a conservative per-pair credit that includes transport buffers, retained
+  `np.frombuffer()` owners, decoded Python objects, and handoff overlap.
+
+Limits apply before a variable payload is retained or decoded. If the current
+multipart receive API allocates the complete message before application checks,
+the enforce handler must use a bounded size-delimited receive mechanism or an
+equivalent transport-level hard limit.
+
+## Validation matrix
+
+The protocol and requested decisions end above. The correctness,
+fault-injection, and performance cases below are required before rollout but do
+not introduce additional protocol states.
+
+### State and allocation tests
+
+1. Reproduce the A/B inversion and assert that D(B) owns zero scarce capacity
+   before `COMMITTED(B)`.
+2. Cover P-first, D-first, and simultaneous arrival.
+3. Assert that P launch does not wait for a control response.
+4. Cover metadata-before-forward-completion and forward-completion-before-
+   metadata. P must remain `P_COMMITTED` after the first bit and submit exactly
+   one transfer only after both bits are true.
+5. Guard every D allocator entry with an explicit eligibility predicate that
+   rejects `D_REGISTERED`, `D_COMMIT_RECEIVED`, expired commitment validity, and
+   a reconnecting/unready channel lease; do not rely only on enum ordinal
+   ordering.
+6. Prove that a committed P request cannot re-enter admission in the supported
+   cell.
+7. Verify exact-once ownership release on success, cancel, and every deadline.
+8. Cover WAIT-first `P_REGISTERED`, HTTP-first `P_PRECOMMIT`, and the atomic
+   registered-to-full-control upgrade. A gate failure must own zero model
+   capacity and no event may bypass the failed gate.
+9. Stall success/cancel cleanup past its cleanup deadline and verify that the
+   support cell is isolated while local terminal remains unpublished until all
+   real owners are released.
+
+### Router pair-bound tests
+
+- Before `PAIR_BOUND`, inject selection and request-preparation failures and
+  verify that reselection occurs only when neither role performed network I/O.
+- For every supported route, derive both role bodies from one immutable typed
+  request and assert that preparation changes only the allowlisted private/
+  routing fields, never public prompt/model/sampling/expansion semantics.
+- At every point after either P or D send can perform I/O, inject a transport
+  error and a retryable 5xx; `select_pd_pair()` must be called once and no new
+  pair key, room, request UID, endpoint, or serving epoch may appear.
+- Fail P while the D send is pending, and fail D after P has accepted its body;
+  both races must cancel the originally bound identity and return an error
+  without a replacement dispatch.
+- Make D reject at its full-control gate after P has committed. The enforce
+  supervisor must observe the early D error, cancel both pinned roles, and
+  return without waiting for P's post-commit deadline. Keep the current
+  D-error-waits-for-P behavior only on the disabled path.
+- Break a decode stream after 200/headers. The stream must terminate, cancel the
+  originally pinned pair best-effort, and never enter worker reselection or
+  replay already exposed bytes.
+- Verify that `WAIT_COMMIT` and `WAIT_TRANSFER_STATUS` retry the same bound pair
+  without entering the HTTP pair-selection retry path.
+- With the enforce feature disabled, verify that the current outer
+  `RetryExecutor` still retries retryable worker failures.
+
+### Protocol and restart tests
+
+- Lost, duplicate, delayed, and reordered commit waits/responses.
+- Drop the first matching TERMINAL commit response after P cleanup, retry near
+  D's admission deadline with the unchanged `wait_seq=1`, and require replay
+  from the terminal tombstone rather than a D timeout.
+- Exercise every commit disposition. Only matching `COMMITTED(generation=1)` may
+  enter eligibility; matching TERMINAL/EXPIRED/INCOMPATIBLE must clean up the
+  bound zero-scarce D entry, while RETRY_LATER retains the same deadline/pair.
+- Deliver a valid COMMITTED snapshot with less than the required P-validity
+  margin and expire it while queued for D preallocation. Both cases must fail
+  before `_pre_alloc()` and own zero D scarce capacity. Race P metadata ingress
+  against its post-commit timeout and verify exactly one scheduler transition
+  wins.
+- Timeout/reconnect every commit and status wait and verify `wait_seq=1` and
+  `status_wait_seq=1` remain unchanged; the response wrapper echoes the matching
+  logical sequence while the semantic snapshot remains byte-for-byte stable.
+- Send a different logical sequence, second generation, second `status_seq`,
+  and conflicting SUCCESS/FAILED during the active transition; none may
+  overwrite the first snapshot or allocate a second correlation, and an active
+  conflict must isolate the support cell. Separately deliver backend SUCCESS
+  after timeout/cancel already fixed FAILED; it must be stale-dropped without
+  overwriting the snapshot or isolating a healthy support cell.
+- Exercise transfer-status SNAPSHOT/RETRY_LATER/UNKNOWN/INCOMPATIBLE. Only a
+  matching immutable SUCCESS snapshot may enter `D_RUNNING`; UNKNOWN must create
+  no P state and must not be treated as terminal proof.
+- Accept SUCCESS and FAILED snapshots and verify that neither path sends a
+  post-result acknowledgment or retains a channel lease after D reaches
+  `D_RUNNING` or terminal cleanup. P must retain the same fixed-size immutable
+  snapshot for the full replay window.
+- Wrong pair key, request UID, P/D epoch, support cell, and generation.
+- Replay byte-identical V1 metadata and require a no-op; then change one
+  destination index under the same identity/generation and require immutable
+  registration, FAILED cleanup, and support-cell isolation rather than
+  overwrite or a second transfer.
+- Run shared Rust/Python golden vectors for canonical capability digests,
+  `pair_policy_digest`, `support_cell_id`, and `request_uid`, including integer
+  endianness, UTF-8, length prefixes, and fixed-width raw fields.
+- Keep protocol versions equal while changing each proof-relevant capability
+  in turn: framing, KV layout/model generation, parallelism, event-loop/radix
+  mode, chunk/retract/rebootstrap flag, deadline policy, selected budget, and
+  channel capability limit. Readiness or worker ingress must reject every
+  mismatched pair before state creation.
+- Inject actual SMG/P/D clock offsets just below and above the configured
+  `max_clock_skew_ms`. Healthy clocks may dispatch; an unhealthy or stale
+  clock-health record must stop new enforce dispatch before worker I/O. Existing
+  bound pairs must continue to success or cleanup under unchanged local
+  monotonic deadlines without reroute or fabricated terminal proof.
+- After accepting an envelope or COMMITTED snapshot, step the local wall clock
+  forward and backward. The previously converted monotonic acceptance,
+  post-commit, tombstone, snapshot, and cleanup deadlines must never refresh or
+  move; a clock-health failure may block new pairs but must not strand an
+  existing pair.
+- Reject oversized control frames, endpoint fields, and free-form diagnostic
+  strings before scheduler ingress; only bounded reason enums/codes are valid.
+- WAIT-before-HTTP and HTTP-before-WAIT, including control-budget pressure.
+- Fill the valid WAIT-first sub-budget and verify additional waits receive
+  stateless RETRY_LATER while capacity reserved for HTTP-first/full-control
+  admission and cleanup remains usable.
+- For an unknown identity, accept WAIT-first immediately before the dispatch
+  expiry and reject it immediately after expiry without state. For an existing
+  matching LIVE/tombstone entry, retry after expiry and replay the result.
+  Mismatched dispatch times must not attach to or modify that entry.
+- Worker restart followed by old request, commit, metadata, and status frames.
+- Tombstone expiry and request delivery around `not_after`.
+- Same room reused by a new pair, followed by old V1 and legacy status.
+- Legacy-first, legacy-late, and enforce-late metadata with namespace isolation.
+- Cancel racing commit, metadata registration, transfer completion, and status.
+- Send cancel before HTTP/WAIT, after HTTP, and after terminal; verify fixed
+  `cancel_seq=1`, exact identity/time matching, bounded cancel-first tombstone,
+  `RETRY_LATER` on tombstone-budget exhaustion, and no state for expired unknown
+  cancel.
+- Change discovery after `PAIR_BOUND` and verify SMG still sends every cancel
+  attempt to the originally pinned P/D cancel endpoints and serving epochs.
+- Cancel requests separately from P WAIT/bootstrap/precommit/batch/transfer/
+  success-cleanup and D registered/commit-received/eligible/preallocation/
+  transfer/running/success-cleanup/result owners. Every owner and allocator must
+  release exactly once before local terminal publication.
+- On P transfer success, verify immutable SUCCESS publication, exact source
+  cleanup, LIVE-to-terminal replacement, replay after cleanup, and no retained
+  model ownership. Verify the analogous D running-to-success-cleanup terminal
+  transition after generation completes.
+
+### Reservation and memory tests
+
+- Fill all generic correlation capacity after pair reservation; matching
+  commit, metadata, completion, transfer-status replay, cancel ingress, and
+  terminal cleanup must still finish.
+- Unknown requests receive bounded backpressure and cannot consume pair-reserved
+  credits.
+- Reconnect repeatedly and verify one logical commit/status correlation per
+  pair.
+- Dispatch through many P endpoints and serving epochs; the D peer-channel
+  count, file descriptors, and socket memory must stay below the hard limit.
+- Verify that active-refcount channels are never evicted, idle channels are
+  reclaimed by TTL/LRU, and the same endpoint with a new P epoch cannot reuse
+  the old epoch's channel identity.
+- Verify that accepting matching SUCCESS atomically enters `D_RUNNING` and
+  releases the pair's complete channel lease set without a post-success send;
+  long-running decode must not pin the P channel.
+- Fill the peer-channel cache with active leases and verify that a new pair
+  fails before D scarce allocation without creating a temporary socket or
+  triggering SMG reroute.
+- Use distinct wait, metadata, and status authorities and verify D atomically
+  reserves the complete deduplicated lease set in `D_REGISTERED`. After that
+  reservation, fill all remaining channel capacity, deliver `COMMITTED`, and
+  verify the original pair still reaches metadata/status without acquiring a
+  new cache entry; an incomplete lease set must fail before `_pre_alloc()`.
+- Configure a routing topology whose simultaneous P authority/epoch set exceeds
+  the D channel budget and verify readiness rejects the cell. In a supported
+  topology, reuse a single physical channel across many pair refcounts and
+  verify there is no per-request socket creation.
+- Reject oversized parts, aggregate frames, false declared lengths, truncated
+  payloads, and decoded-object expansion before unbounded retention.
+- Measure RSS, transport buffers, Python heap, and credit ownership at
+  `1/32/128/256/maximum` concurrent parked or preallocated requests.
+- Repeat parked-request tests at minimum and maximum input length and endpoint
+  size. Queue-count capacity must not allow registered request/receiver retained
+  bytes to exceed the process-wide live-control byte budget.
+- Verify all credits return to baseline after success, cancel, timeout,
+  malformed input, and duplicate input.
+- Drive every required observability outcome and verify that counters, gauges,
+  and histograms update without scanning the pair registry. Reject any metric
+  label containing request/pair identity, endpoint, epoch, or an unbounded
+  backend reason string.
+- From the target rollout QPS and worst-case tombstone/replay windows, calculate
+  retained occupancy and either size the hard budget for that fault target or
+  document the earlier backpressure point. Fault injection may produce bounded
+  backpressure, never budget overrun or unbounded growth.
+- At target QPS and the maximum replay TTL, verify fixed-size transfer-snapshot
+  occupancy remains within the advertised count/byte budget. When that budget
+  is full, new pairs must fail at the full-control gate before model allocation;
+  existing snapshot replay and cleanup must continue from reserved credits.
+
+### Transfer-status replay test
+
+Drop the first success response, allow P to publish the immutable success
+snapshot and finish normal cleanup, then retry near the D transfer deadline. P
+must replay the same semantic success snapshot, echo the unchanged
+`status_wait_seq=1` from the retry wrapper, and D must enter `D_RUNNING` exactly
+once.
+
+### End-to-end tests
+
+- A cross-process Mooncake integration test for the complete enforce path.
+- A real-GPU A/B benchmark for each enabled rollout cell.
+- Disabled-path regression tests against the existing legacy behavior.
+
+Mock transport tests alone are not sufficient to enable the feature.

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
@@ -197,31 +197,39 @@ not introduce additional protocol states.
 
 1. Reproduce the A/B inversion and assert that D(B) owns zero scarce capacity
    before `COMMITTED(B)`.
-2. Cover P-first, D-first, and simultaneous arrival.
-3. Assert that P launch does not wait for a control response.
-4. Cover both event orders: metadata before forward completion, and forward
+2. Reproduce the mixed-mode counterexample with A as enforce and B as legacy on
+   the same mocked P/D allocators. Direct legacy ingress to either
+   `ENFORCE_EXCLUSIVE` worker must fail before execution-capable state or
+   allocator entry. The only accepted alternative is routing B before dispatch
+   to P/D workers whose `LEGACY_ONLY` allocator-domain IDs are disjoint from
+   A's domains. Assert that no request slot, KV pool, metadata allocator, or
+   cache partition is shared across those test domains.
+3. Cover P-first, D-first, and simultaneous arrival.
+4. Assert that P launch does not wait for a control response.
+5. Cover both event orders: metadata before forward completion, and forward
    completion before metadata. P must remain `P_COMMITTED` after the first bit and submit exactly
    one transfer only after both bits are true.
-5. Guard every D allocator entry with an explicit eligibility predicate that
+6. Guard every D allocator entry with an explicit eligibility predicate that
    rejects `D_REGISTERED`, `D_COMMIT_RECEIVED`, expired commitment validity, and
-   a reconnecting/unready channel lease; do not rely only on enum ordinal
-   ordering.
-6. Prove that a committed P request cannot re-enter admission in the supported
+   a reconnecting/unready channel lease. In an `ENFORCE_EXCLUSIVE` domain it
+   must also reject any request lacking the matching V1 domain/mode fence; do
+   not rely only on enum ordinal ordering or Router behavior.
+7. Prove that a committed P request cannot re-enter admission in the supported
    cell. Complete its forward before metadata arrives and assert that it parks
    in the committed-wait owner without calling
    `optimistic_release_and_requeue()`, `reset_for_retract()`, or releasing any
    source owner.
-7. Set P model/aux metadata-buffer capacity to one. Let request B own that
+8. Set P model/aux metadata-buffer capacity to one. Let request B own that
    buffer while waiting for D(B), then attempt final admission of request A.
    A must remain `P_PRECOMMIT` and must not publish `COMMITTED(A)` until it owns
    the buffer. In particular, D(A) must never hold scarce capacity while A waits
    for the buffer held by B. Repeat this assertion for every finite prerequisite
    in the normative P commit checklist.
-8. Verify exact-once ownership release on success, cancel, and every deadline.
-9. Cover WAIT-first `P_REGISTERED`, HTTP-first `P_PRECOMMIT`, and the atomic
+9. Verify exact-once ownership release on success, cancel, and every deadline.
+10. Cover WAIT-first `P_REGISTERED`, HTTP-first `P_PRECOMMIT`, and the atomic
    registered-to-full-control upgrade. A gate failure must own zero model
    capacity and no event may bypass the failed gate.
-10. Stall success/cancel cleanup past its cleanup deadline and verify that the
+11. Stall success/cancel cleanup past its cleanup deadline and verify that the
    support cell is isolated while local terminal remains unpublished until all
    real owners are released.
 
@@ -241,14 +249,20 @@ not introduce additional protocol states.
 - Make D reject at its request-control or channel-readiness gate after P has
   committed. The enforce supervisor must observe the early D error, cancel both
   pinned roles, and return without waiting for P's post-commit deadline. Keep
-  the current D-error-waits-for-P behavior only on the disabled path.
+  the current D-error-waits-for-P behavior only on allocator-disjoint
+  `LEGACY_ONLY` workers.
 - Break a decode stream after 200/headers. The stream must terminate, cancel the
   originally pinned pair best-effort, and never enter worker reselection or
   replay already exposed bytes.
 - Verify that `WAIT_COMMIT` and `WAIT_TRANSFER_STATUS` retry the same bound pair
   without entering the HTTP pair-selection retry path.
-- With the enforce feature disabled, verify that the current outer
+- On allocator-disjoint `LEGACY_ONLY` workers, verify that the current outer
   `RetryExecutor` still retries retryable worker failures.
+- Under controlled transient connection errors, retryable P/D 5xx responses,
+  and early D request-control/channel rejection, compare V1 user-visible errors
+  with the legacy `RetryExecutor` counterfactual. Verify that shadow metrics
+  count every post-`PAIR_BOUND` failure and classify whether legacy would have
+  retried it, without adding request-identity labels.
 
 ### Protocol and restart tests
 
@@ -302,14 +316,22 @@ not introduce additional protocol states.
   overwrite or a second transfer.
 - Run shared Rust/Python golden vectors for canonical capability digests,
   `pair_policy_digest`, `support_cell_id`, and `request_uid`, including integer
-  endianness, UTF-8, length prefixes, and fixed-width raw fields. The parsers
-  must reject uppercase hex, prefixed hex, UUID punctuation, base64, padding,
-  and the wrong textual width rather than normalizing alternate identities.
+  endianness, UTF-8, length prefixes, fixed-width raw allocator-domain IDs, and
+  the allocator-domain policy digest. The parsers must reject uppercase hex,
+  prefixed hex, UUID punctuation, base64, padding, and the wrong textual width
+  rather than normalizing alternate identities.
 - Keep protocol versions equal while changing each proof-relevant capability
   in turn: framing, KV layout/model generation, parallelism, event-loop/radix
   mode, chunk/retract/rebootstrap flag, deadline policy, selected budget, and
-  channel capability limit. Readiness or worker ingress must reject every
+  channel capability limit, allocator-domain ID, allocator-domain mode, and
+  allocator-domain policy digest. Readiness or worker ingress must reject every
   mismatched pair before state creation.
+- Attempt per-request enforce sampling inside one allocator domain and require
+  readiness/configuration rejection. Then drain the workers, change the domain
+  mode or membership, publish new serving epochs/domain records, and verify old
+  legacy requests and frames cannot overlap or attach to the new enforce
+  domain. Canary routing must select a separate enforce pool before pair
+  selection.
 - Inject actual SMG/P/D clock offsets just below and above the configured
   `max_clock_skew_ms`. Healthy clocks may dispatch; an unhealthy or stale
   clock-health record must stop new enforce dispatch before worker I/O. Existing
@@ -434,6 +456,14 @@ once.
   including loss/ambiguity of the first metadata send, a two-sided channel
   reconnect, byte-identical retransmission, and exact-once transfer.
 - A real-GPU A/B benchmark for each enabled rollout cell.
-- Disabled-path regression tests against the existing legacy behavior.
+- A production-weighted fault-load run covering transient connect failure,
+  retryable P/D 5xx, and early D rejection. The report must include the legacy
+  retry counterfactual, added V1 user-visible error rate and confidence interval,
+  error-budget burn, and an exercised automatic rollback when either configured
+  threshold is exceeded.
+- An isolated-pool canary that proves `ENFORCE_EXCLUSIVE` and `LEGACY_ONLY`
+  traffic never share request slots, KV pools, metadata allocators, or cache
+  partitions. Random per-request protocol sampling inside one pool must fail.
+- Legacy-only-domain regression tests against the existing legacy behavior.
 
 Mock transport tests alone are not sufficient to enable the feature.

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
@@ -21,30 +21,34 @@ case.
 ## Progress-resource reservation
 
 Completion must never compete with new requests for a generic control/protocol
-resource after a role crosses its full-control gate. The two gates therefore
-reserve the following logical resources before either role can acquire model
-capacity:
+resource after P commits or D becomes eligible. The acquisition graph therefore
+reserves the following logical resources before the corresponding role can
+cross that scarce-capacity boundary. P acquires its control row before
+`P_PRECOMMIT`; D acquires request-local control before `D_REGISTERED` and the
+physical channel row while still registered with zero model capacity:
 
 | Role | Reserved before scarce capacity | Released |
 | --- | --- | --- |
-| P | LIVE entry, retained control/request-byte credit, and successor tombstone slot | After request release and tombstone retention, respectively |
+| P | LIVE entry, retained control/request-byte credit, and successor tombstone slot including compact cancel replay credit | After request release and tombstone retention, respectively |
+| P | Bounded sender/session creation, tracking, and retained-byte credit | After sender/session detachment during cleanup |
 | P | One inbound `WAIT_COMMIT` logical correlation/replay-response credit | After matching V1 metadata proves D accepted the commitment, or after the terminal commit-replay window closes |
 | P | Reusable metadata-register command credit | After immutable transfer snapshot publication or terminal cleanup |
 | P | Metadata receive-byte credit, including retained zero-copy owners and decoded heap expansion | After the last payload reference is released |
 | P | Reusable `TransferCompletionCommand` credit | After the backend callback is detached and every already queued completion command is consumed; local terminal waits for this owner |
 | P | One inbound transfer-status logical correlation/replay-response credit | After the replay window closes; at a pre-commit terminal with no snapshot |
 | P | One fixed-size immutable transfer-status snapshot slot and byte credit | After the full replay-retention formula; at a pre-commit terminal with no snapshot |
-| P | One inbound matching pair-cancel logical correlation/command credit | At local terminal |
+| P | One inbound matching pair-cancel logical correlation/command/response credit | After successor tombstone GC; at pre-entry rejection with no state |
 | P | Fixed deadline-node/phase-transition overlap credit | After local terminal |
 | P | Terminal/deadline cleanup command credit | After terminal transition |
-| D | LIVE entry, registered request/receiver retained-byte credit, and successor tombstone slot | After request/receiver release and tombstone retention, respectively |
-| D | Complete deduplicated peer-channel lease set from the hard-bounded shared cache | At `D_RUNNING` or earlier local pair terminal |
+| D | LIVE entry, registered request/receiver retained-byte credit, and successor tombstone slot including compact cancel replay credit | After request/receiver release and tombstone retention, respectively |
+| D | One bounded two-sided channel-reservation command/response operation | When the complete lease set is ready or terminal cleanup finishes |
+| D | Complete deduplicated two-sided peer-channel lease set from the hard-bounded endpoint managers | D refs at `D_RUNNING` or earlier terminal; P refs at logical replay closure |
 | D | One Mooncake receiver/topology/session creation and tracking credit | At `D_RUNNING` or earlier terminal cleanup |
 | D | One outbound `WAIT_COMMIT` logical correlation and commit-response command credit | At commit acceptance or terminal cleanup |
-| D | Metadata-send command and conservative send-byte credit | After the last send-buffer reference is released |
+| D | One logical metadata-delivery command plus immutable canonical send-buffer and retry-overlap byte credit | Retry operation closes at matching transfer snapshot acceptance or terminal cleanup; bytes return after all transport refs detach |
 | D | One outbound `WAIT_TRANSFER_STATUS` logical correlation credit | At `D_RUNNING` or terminal cleanup |
 | D | `TransferStatusCommand` receive credit | At `D_RUNNING` or terminal cleanup |
-| D | One inbound matching pair-cancel logical correlation/command credit | At local terminal |
+| D | One inbound matching pair-cancel logical correlation/command/response credit | After successor tombstone GC; at pre-entry rejection with no state |
 | D | Fixed deadline-node/phase-transition overlap credit | After local terminal |
 | D | Terminal/deadline cleanup command credit | After terminal transition |
 
@@ -52,16 +56,42 @@ Duplicate waits/cancels and reconnects rebind the same logical credit. They do
 not allocate one correlation per transport attempt. P retains the commit-response
 credit until matching metadata proves D received the commitment or the terminal
 commit-replay window closes, and retains the status replay credit for the full
-snapshot replay window. Closing a socket or completing the first response does
-not release those logical credits.
+snapshot replay window. The successor tombstone retains compact matching-cancel
+response capacity through its complete lifetime. Closing a socket or completing
+the first response does not release those logical credits.
 Unknown or malformed messages use a separate bounded parse/correlation budget
 and cannot consume a live pair's reserved completion resources.
+
+Every release point in the table closes the logical operation and prevents new
+attempts. A payload/response byte credit is returned to an admission pool only
+after every transport reference created by that operation has completed or been
+cancelled and detached. Until then, the fixed old/new-attempt overlap remains an
+explicit auxiliary transport owner; closing scheduler state never frees memory
+still referenced by ZMQ or another backend.
+
+D owns one logical metadata delivery for `transfer_generation=1`. Its reusable
+command and conservative byte credit cover the immutable canonical frame,
+transport-buffer ownership, and bounded send/reconnect overlap for every
+byte-identical retry. A first local send completion releases only an individual
+transport reference; it does not return the pair's logical metadata credit to a
+generic pool. Matching snapshot acceptance or terminal cleanup closes the retry
+operation; its immutable send bytes remain charged until every already queued
+transport reference is detached.
 
 D reserves and charges all non-model receiver/session capacity before
 `D_REGISTERED`, then may perform the already charged initialization while in
 `D_REGISTERED`; readiness is required before `D_ELIGIBLE`. Worker-startup
 registered memory remains shared, but every per-request receiver object and
-reconnect overlap is charged.
+reconnect overlap is charged. P likewise charges per-request sender/session
+tracking before `P_PRECOMMIT`.
+
+The P-side model/aux `metadata_buffer_index` is scarce model capacity, not a
+control credit in the table above. It may be acquired after `P_PRECOMMIT`, but
+the P scheduler must own it, along with the request slot, source KV, required
+cache/radix ownership, and every other finite P prerequisite, before publishing
+`P_COMMITTED`. If the buffer is unavailable, the request remains pre-commit and
+D remains in zero-scarce-capacity state; P cannot commit and wait for that
+buffer later.
 
 This RFC does not reserve a Mooncake executor thread or change the existing
 data-plane transfer scheduler. Backend service delay/failure remains covered by
@@ -73,8 +103,8 @@ to new control/protocol resources required to reach transfer or release them.
 Deadline credit covers either one update-in-place timer node or the fixed
 maximum number of old/new heap nodes created by all V1 phase transitions. A
 transition can therefore arm its successor before invalidating its predecessor
-without allocating from a generic timer pool; stale heap nodes are generation-
-checked and bounded by the fixed state graph. The separately reserved successor
+without allocating from a generic timer pool; stale heap nodes carry generation
+checks and are bounded by the fixed state graph. The separately reserved successor
 tombstone slot includes its retention/GC timer node until collection.
 
 Count bounds alone are insufficient for registered requests. The policy also
@@ -83,20 +113,29 @@ receiver/topology bytes, and process-wide live-control bytes. P charges the
 validated request before `P_PRECOMMIT`; D charges its request and receiver upper
 bound before `D_REGISTERED`. Endpoint strings and diagnostic fields have fixed
 protocol maxima. An object whose conservative retained size does not fit is
-rejected at the full-control gate, before model capacity, rather than admitted
-under only a queue-count credit.
+rejected at its request-control gate, before model capacity, rather than
+admitted under only a queue-count credit.
 
-An authenticated cancel matching an existing pair uses that pair's reserved
-cancel ingress/response credit; unrelated or unknown cancel traffic cannot
-starve cleanup for a pair that already owns model capacity. Cancel-first
-requests still use the independent bounded pool described below.
+An authenticated cancel matching an existing LIVE/tombstone pair uses that
+pair's reserved cancel ingress/response credit; unrelated or unknown cancel
+traffic cannot starve cleanup or `ALREADY_TERMINAL` replay for an accepted pair.
+Cancel-first requests still use the independent bounded pool described below.
 
-The D lease-set reservation is all-or-nothing and precedes `D_ELIGIBLE`; a
-matching `COMMITTED` response does not waive any missing lease. LIVE admission
-also reserves its successor terminal slot, so success, cancel, and deadline do
-not compete with new requests for tombstone capacity. Valid cancel-first
-requests use a separate hard-bounded tombstone pool because they have no LIVE
-predecessor from which to inherit a reserved successor slot.
+The D lease-set reservation is all-or-nothing and precedes `D_ELIGIBLE`; it is
+ready only when the matching P inbound physical entry is also reserved and
+ready. A matching `COMMITTED` response does not waive a missing endpoint lease.
+D discovery bounds outbound P authority/epoch entries, P discovery bounds
+inbound D authority/epoch entries, and support-cell readiness proves both sides
+can cover the complete allowed topology plus old/new-epoch and reconnect
+overlap. An active or disconnected-but-reserved entry with live pair refs cannot
+be evicted or consumed by a new peer.
+
+LIVE admission also reserves its successor terminal slot, so success, cancel,
+deadline, and matching cancel replay do not compete with new requests for
+tombstone capacity. Valid cancel-first requests use a separate hard-bounded
+tombstone pool because they have no LIVE predecessor from which to inherit a
+reserved successor slot; that pool also includes the compact cancel replay
+credit through tombstone GC.
 
 A WAIT-first P entry does not yet know the validated request length and therefore
 reserves only its bounded waiter/identity, inbound commit correlation, admission
@@ -106,8 +145,11 @@ snapshot, metadata-byte, status-replay, cancel, and cleanup credit before
 creating `P_PRECOMMIT` or allowing model admission. An HTTP-first request
 atomically acquires the same complete P row before creating `P_PRECOMMIT`.
 Failure terminalizes an existing waiter without model allocation. D has its
-validated request at `D_REGISTERED` admission and reserves its complete row,
-including the complete channel lease set, before creating that state.
+validated request at `D_REGISTERED` admission and reserves its complete
+request-local row, including the bounded operation used to acquire the
+two-sided channel set, before creating that state. It obtains that physical
+lease set while remaining `D_REGISTERED`/`D_COMMIT_RECEIVED` with zero model
+capacity and must have the full set ready before `D_ELIGIBLE`.
 
 `P_REGISTERED` has its own hard sub-budget and cannot consume capacity reserved
 for accepted HTTP-first/full-control entries or terminal cleanup. Exhausting the
@@ -139,6 +181,12 @@ multipart receive API allocates the complete message before application checks,
 the enforce handler must use a bounded size-delimited receive mechanism or an
 equivalent transport-level hard limit.
 
+The D send-side credit remains logically owned after the first transport send.
+Reconnect or ambiguous completion may retain at most the policy's fixed
+old/new-buffer overlap and must retransmit the exact canonical bytes. No retry
+may serialize a second uncharged frame or recalculate destination indices after
+their ownership has changed.
+
 ## Validation matrix
 
 The protocol and requested decisions end above. The correctness,
@@ -151,20 +199,29 @@ not introduce additional protocol states.
    before `COMMITTED(B)`.
 2. Cover P-first, D-first, and simultaneous arrival.
 3. Assert that P launch does not wait for a control response.
-4. Cover metadata-before-forward-completion and forward-completion-before-
-   metadata. P must remain `P_COMMITTED` after the first bit and submit exactly
+4. Cover both event orders: metadata before forward completion, and forward
+   completion before metadata. P must remain `P_COMMITTED` after the first bit and submit exactly
    one transfer only after both bits are true.
 5. Guard every D allocator entry with an explicit eligibility predicate that
    rejects `D_REGISTERED`, `D_COMMIT_RECEIVED`, expired commitment validity, and
    a reconnecting/unready channel lease; do not rely only on enum ordinal
    ordering.
 6. Prove that a committed P request cannot re-enter admission in the supported
-   cell.
-7. Verify exact-once ownership release on success, cancel, and every deadline.
-8. Cover WAIT-first `P_REGISTERED`, HTTP-first `P_PRECOMMIT`, and the atomic
+   cell. Complete its forward before metadata arrives and assert that it parks
+   in the committed-wait owner without calling
+   `optimistic_release_and_requeue()`, `reset_for_retract()`, or releasing any
+   source owner.
+7. Set P model/aux metadata-buffer capacity to one. Let request B own that
+   buffer while waiting for D(B), then attempt final admission of request A.
+   A must remain `P_PRECOMMIT` and must not publish `COMMITTED(A)` until it owns
+   the buffer. In particular, D(A) must never hold scarce capacity while A waits
+   for the buffer held by B. Repeat this assertion for every finite prerequisite
+   in the normative P commit checklist.
+8. Verify exact-once ownership release on success, cancel, and every deadline.
+9. Cover WAIT-first `P_REGISTERED`, HTTP-first `P_PRECOMMIT`, and the atomic
    registered-to-full-control upgrade. A gate failure must own zero model
    capacity and no event may bypass the failed gate.
-9. Stall success/cancel cleanup past its cleanup deadline and verify that the
+10. Stall success/cancel cleanup past its cleanup deadline and verify that the
    support cell is isolated while local terminal remains unpublished until all
    real owners are released.
 
@@ -173,7 +230,7 @@ not introduce additional protocol states.
 - Before `PAIR_BOUND`, inject selection and request-preparation failures and
   verify that reselection occurs only when neither role performed network I/O.
 - For every supported route, derive both role bodies from one immutable typed
-  request and assert that preparation changes only the allowlisted private/
+  request and assert that preparation changes only the allowlisted private and
   routing fields, never public prompt/model/sampling/expansion semantics.
 - At every point after either P or D send can perform I/O, inject a transport
   error and a retryable 5xx; `select_pd_pair()` must be called once and no new
@@ -181,10 +238,10 @@ not introduce additional protocol states.
 - Fail P while the D send is pending, and fail D after P has accepted its body;
   both races must cancel the originally bound identity and return an error
   without a replacement dispatch.
-- Make D reject at its full-control gate after P has committed. The enforce
-  supervisor must observe the early D error, cancel both pinned roles, and
-  return without waiting for P's post-commit deadline. Keep the current
-  D-error-waits-for-P behavior only on the disabled path.
+- Make D reject at its request-control or channel-readiness gate after P has
+  committed. The enforce supervisor must observe the early D error, cancel both
+  pinned roles, and return without waiting for P's post-commit deadline. Keep
+  the current D-error-waits-for-P behavior only on the disabled path.
 - Break a decode stream after 200/headers. The stream must terminate, cancel the
   originally pinned pair best-effort, and never enter worker reselection or
   replay already exposed bytes.
@@ -210,6 +267,16 @@ not introduce additional protocol states.
 - Timeout/reconnect every commit and status wait and verify `wait_seq=1` and
   `status_wait_seq=1` remain unchanged; the response wrapper echoes the matching
   logical sequence while the semantic snapshot remains byte-for-byte stable.
+- Drop or make ambiguous the first V1 metadata send, fill generic send/correlation
+  capacity, and reconnect. D must retransmit the exact same canonical bytes,
+  digest, identity, and `transfer_generation=1` through its reserved logical
+  delivery credit; P registers once and the pair can still reach `D_RUNNING`.
+  A retry with different content must follow the conflicting-metadata failure
+  rule instead of silently replacing the first frame.
+- After P accepts matching V1 metadata, deliver a late duplicate `WAIT_COMMIT`
+  and an already queued commit response. Both are transport-stale, create no
+  scheduler command or correlation, and cannot restart D's closed commit retry
+  loop.
 - Send a different logical sequence, second generation, second `status_seq`,
   and conflicting SUCCESS/FAILED during the active transition; none may
   overwrite the first snapshot or allocate a second correlation, and an active
@@ -220,9 +287,14 @@ not introduce additional protocol states.
   matching immutable SUCCESS snapshot may enter `D_RUNNING`; UNKNOWN must create
   no P state and must not be treated as terminal proof.
 - Accept SUCCESS and FAILED snapshots and verify that neither path sends a
-  post-result acknowledgment or retains a channel lease after D reaches
-  `D_RUNNING` or terminal cleanup. P must retain the same fixed-size immutable
-  snapshot for the full replay window.
+  post-result acknowledgment. D releases its pair refs at `D_RUNNING` or
+  terminal cleanup. P may retain only the already charged physical-entry ref
+  required by the bounded status-replay operation, and releases it at replay
+  closure independently of decode lifetime. P must retain the same fixed-size
+  immutable snapshot for the full replay window. If a metadata retry send is
+  still queued when the snapshot arrives, D stops retrying and enters the
+  matching state once, but it does not return the send-byte credit until the
+  queued transport reference is cancelled or completes and detaches.
 - Wrong pair key, request UID, P/D epoch, support cell, and generation.
 - Replay byte-identical V1 metadata and require a no-op; then change one
   destination index under the same identity/generation and require immutable
@@ -230,7 +302,9 @@ not introduce additional protocol states.
   overwrite or a second transfer.
 - Run shared Rust/Python golden vectors for canonical capability digests,
   `pair_policy_digest`, `support_cell_id`, and `request_uid`, including integer
-  endianness, UTF-8, length prefixes, and fixed-width raw fields.
+  endianness, UTF-8, length prefixes, and fixed-width raw fields. The parsers
+  must reject uppercase hex, prefixed hex, UUID punctuation, base64, padding,
+  and the wrong textual width rather than normalizing alternate identities.
 - Keep protocol versions equal while changing each proof-relevant capability
   in turn: framing, KV layout/model generation, parallelism, event-loop/radix
   mode, chunk/retract/rebootstrap flag, deadline policy, selected budget, and
@@ -264,7 +338,10 @@ not introduce additional protocol states.
 - Send cancel before HTTP/WAIT, after HTTP, and after terminal; verify fixed
   `cancel_seq=1`, exact identity/time matching, bounded cancel-first tombstone,
   `RETRY_LATER` on tombstone-budget exhaustion, and no state for expired unknown
-  cancel.
+  cancel. Drop the first matching cancel response, fill generic response
+  capacity, and retry the same `cancel_seq=1`; cleanup-in-progress must replay
+  `ACCEPTED` and a terminal tombstone must replay `ALREADY_TERMINAL` from the
+  pair's retained compact response credit.
 - Change discovery after `PAIR_BOUND` and verify SMG still sends every cancel
   attempt to the originally pinned P/D cancel endpoints and serving epochs.
 - Cancel requests separately from the P WAIT, bootstrap, precommit, batch,
@@ -274,36 +351,48 @@ not introduce additional protocol states.
   local terminal publication.
 - On P transfer success, verify immutable SUCCESS publication, exact source
   cleanup, LIVE-to-terminal replacement, replay after cleanup, and no retained
-  model ownership. Verify the analogous D running-to-success-cleanup terminal
-  transition after generation completes.
+  model ownership, including the source KV/request slot, cache/radix ownership,
+  model/aux metadata-buffer index, and sender/session state. Verify the analogous
+  D running-to-success-cleanup terminal transition after generation completes.
 
 ### Reservation and memory tests
 
 - Fill all generic correlation capacity after pair reservation; matching
-  commit, metadata, completion, transfer-status replay, cancel ingress, and
-  terminal cleanup must still finish.
+  commit, byte-identical metadata delivery/retry, completion, transfer-status
+  replay, cancel ingress/replay, and terminal cleanup must still finish.
 - Unknown requests receive bounded backpressure and cannot consume pair-reserved
   credits.
-- Reconnect repeatedly and verify one logical commit/status correlation per
-  pair.
-- Dispatch through many P endpoints and serving epochs; the D peer-channel
-  count, file descriptors, and socket memory must stay below the hard limit.
-- Verify that active-refcount channels are never evicted, idle channels are
-  reclaimed by TTL/LRU, and the same endpoint with a new P epoch cannot reuse
-  the old epoch's channel identity.
+- Reconnect repeatedly and verify one logical commit wait, metadata delivery,
+  and status wait per pair; reconnect must not allocate a second logical credit
+  or retain more than the charged old/new transport overlap.
+- Dispatch through many P endpoints and serving epochs and through many D
+  authorities into one P. D outbound and P inbound channel counts, file
+  descriptors, socket memory, and reconnect overlap must each stay below their
+  separate hard limit.
+- Verify that active-refcount entries on both endpoints are never evicted, idle
+  entries are reclaimed by TTL/LRU, and the same address with a new P or D epoch
+  cannot reuse the old epoch's channel identity.
 - Verify that accepting matching SUCCESS atomically enters `D_RUNNING` and
-  releases the pair's complete channel lease set without a post-success send;
-  long-running decode must not pin the P channel.
-- Fill the peer-channel cache with active leases and verify that a new pair
-  fails before D scarce allocation without creating a temporary socket or
-  triggering SMG reroute.
-- Use distinct wait, metadata, and status authorities and verify D atomically
-  reserves the complete deduplicated lease set in `D_REGISTERED`. After that
-  reservation, fill all remaining channel capacity, deliver `COMMITTED`, and
-  verify the original pair still reaches metadata/status without acquiring a
-  new cache entry; an incomplete lease set must fail before `_pre_alloc()`.
+  releases the pair's D-side refs without a post-success send. The bounded P
+  replay-side ref expires at logical replay closure; a long-running decode must
+  not extend it.
+- Fill either D's outbound manager or P's inbound manager with active leases and
+  verify that a new pair fails before D scarce allocation without creating a
+  temporary socket or triggering SMG reroute.
+- Use distinct wait, metadata, and status authorities and verify the bounded
+  reservation operation in `D_REGISTERED` obtains the complete deduplicated D
+  entries and matching P inbound entries all-or-nothing while D owns zero model
+  capacity. After that reservation, fill all remaining capacity on both sides,
+  deliver `COMMITTED`, and verify the original pair still reaches metadata/status
+  without acquiring a new cache entry; an incomplete two-sided lease set must
+  fail before `_pre_alloc()`.
+- Disconnect after `D_PREALLOCATED`, then admit unrelated peers until every
+  unreserved channel slot is full. They cannot steal either reserved endpoint
+  entry; the matching reconnect must reuse the charged entries and let the
+  original pair finish within its unchanged deadline.
 - Configure a routing topology whose simultaneous P authority/epoch set exceeds
-  the D channel budget and verify readiness rejects the cell. In a supported
+  D's outbound budget, or whose simultaneous D authority/epoch set exceeds P's
+  inbound budget, and verify readiness rejects the cell. In a supported
   topology, reuse a single physical channel across many pair refcounts and
   verify there is no per-request socket creation.
 - Reject oversized parts, aggregate frames, false declared lengths, truncated
@@ -314,7 +403,9 @@ not introduce additional protocol states.
   size. Queue-count capacity must not allow registered request/receiver retained
   bytes to exceed the process-wide live-control byte budget.
 - Verify all credits return to baseline after success, cancel, timeout,
-  malformed input, and duplicate input.
+  malformed input, and duplicate input, including P metadata buffers and
+  sender/session state, both channel endpoint refs, metadata retry buffers, and
+  compact cancel replay credits after their specified replay windows.
 - Drive every required observability outcome and verify that counters, gauges,
   and histograms update without scanning the pair registry. Reject any metric
   label containing request/pair identity, endpoint, epoch, or an unbounded
@@ -325,8 +416,9 @@ not introduce additional protocol states.
   backpressure, never budget overrun or unbounded growth.
 - At target QPS and the maximum replay TTL, verify fixed-size transfer-snapshot
   occupancy remains within the advertised count/byte budget. When that budget
-  is full, new pairs must fail at the full-control gate before model allocation;
-  existing snapshot replay and cleanup must continue from reserved credits.
+  is full, new pairs must fail at the appropriate request-control gate before
+  model allocation; existing snapshot replay and cleanup must continue from
+  reserved credits.
 
 ### Transfer-status replay test
 
@@ -338,7 +430,9 @@ once.
 
 ### End-to-end tests
 
-- A cross-process Mooncake integration test for the complete enforce path.
+- A cross-process Mooncake integration test for the complete enforce path,
+  including loss/ambiguity of the first metadata send, a two-sided channel
+  reconnect, byte-identical retransmission, and exact-once transfer.
 - A real-GPU A/B benchmark for each enabled rollout cell.
 - Disabled-path regression tests against the existing legacy behavior.
 

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix.mdx
@@ -267,10 +267,11 @@ not introduce additional protocol states.
   cancel.
 - Change discovery after `PAIR_BOUND` and verify SMG still sends every cancel
   attempt to the originally pinned P/D cancel endpoints and serving epochs.
-- Cancel requests separately from P WAIT/bootstrap/precommit/batch/transfer/
-  success-cleanup and D registered/commit-received/eligible/preallocation/
-  transfer/running/success-cleanup/result owners. Every owner and allocator must
-  release exactly once before local terminal publication.
+- Cancel requests separately from the P WAIT, bootstrap, precommit, batch,
+  transfer, and success-cleanup owners, and from the D registered,
+  commit-received, eligible, preallocation, transfer, running, success-cleanup,
+  and result owners. Every owner and allocator must release exactly once before
+  local terminal publication.
 - On P transfer success, verify immutable SUCCESS publication, exact source
   cleanup, LIVE-to-terminal replacement, replay after cleanup, and no retained
   model ownership. Verify the analogous D running-to-success-cleanup terminal

--- a/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_walkthrough.mdx
+++ b/docs_new/docs/developer_guide/pd_optimistic_prefill_commit_walkthrough.mdx
@@ -1,0 +1,287 @@
+---
+title: "PD commit-gated preallocation: Execution walkthrough"
+description: "A plain-language walkthrough of the proposed PD optimistic prefill commit gate."
+sidebarTitle: "PD commit-gate walkthrough"
+tag: "DRAFT"
+---
+
+<Warning>
+  This document explains a proposed design. The protocol is not implemented or
+  enabled. The [main RFC](/docs/developer_guide/pd_optimistic_prefill_commit_rfc)
+  remains the normative specification.
+</Warning>
+
+## The design in one sentence
+
+Decode may prepare networking early, but it cannot reserve decode KV or a
+request slot until the prefill scheduler has irrevocably admitted the matching
+request.
+
+In shorthand:
+
+```text
+P final scheduler admission
+          happens before
+D scarce-capacity preallocation
+```
+
+This changes resource ordering without serializing the two HTTP requests or
+making prefill wait for decode.
+
+## Why the current order can stall
+
+There are three participants:
+
+| Participant | Responsibility |
+| --- | --- |
+| SMG | Selects one prefill worker and one decode worker and dispatches both requests |
+| P | Admits the prompt, runs prefill, and owns the source KV until transfer |
+| D | Reserves destination KV, receives transferred KV, and runs decode |
+
+Today, P and D can make their scarce allocations independently. Two requests
+can therefore acquire the two stages in opposite orders:
+
+```text
+Request A:
+  P admitted A and holds P KV
+  D cannot reserve space for A
+
+Request B:
+  D reserved KV for B
+  P cannot admit B
+
+P capacity held by A blocks B
+D capacity held by B blocks A
+```
+
+Neither polling nor another notification breaks that dependency. A timeout or
+unrelated request eventually releases capacity, but until then useful capacity
+is stranded.
+
+## The important scope: one allocator domain
+
+The ordering rule belongs to a shared allocator domain, not to an individual
+request.
+
+An allocator domain is the set of requests that compete for the same request
+slots, KV pools, model/metadata buffers, or cache partitions. A participating
+domain is in one of two modes for its complete serving epoch:
+
+```text
+LEGACY_ONLY        all execution requests use the current D-first-capable path
+ENFORCE_EXCLUSIVE  all execution requests pass the new commit gate
+```
+
+The two modes cannot share allocators. In particular, a canary cannot randomly
+enable the protocol for 10% of requests on the same workers. That would still
+allow this cycle:
+
+```text
+A is enforce: P(A) committed and waits for D capacity
+B is legacy:  D(B) preallocated and waits for P capacity
+```
+
+Instead, a canary routes traffic to a separate, allocator-disjoint worker pool
+before selecting a P/D pair. An unsupported request sent to an enforce worker
+fails before execution-capable state or allocation; it cannot fall back to the
+legacy protocol on that worker.
+
+## Normal request flow
+
+### 1. SMG validates and binds one pair
+
+SMG reads P and D discovery records and verifies that both workers advertise
+the same supported policy, compatible capabilities, healthy serving epochs,
+and `ENFORCE_EXCLUSIVE` allocator domains.
+
+It creates one immutable pair identity, prepares both role-specific requests,
+and crosses `PAIR_BOUND` immediately before either request can perform network
+I/O. P and D HTTP dispatch can then proceed concurrently.
+
+### 2. D registers without taking model capacity
+
+D may receive its request first. It validates the envelope, creates bounded
+control state, initializes the Mooncake receiver/topology, reserves the
+pair's bounded control/channel resources, and starts waiting for P's commit
+result.
+
+At this point D is `D_REGISTERED`. It owns no decode request slot, device or
+host KV, model metadata buffer, or cache lock, and it is not in the existing
+decode preallocation queue.
+
+### 3. P reaches final scheduler admission
+
+P validates its request and lets the existing scheduler decide when it can be
+admitted. Immediately after final admission succeeds, and before launching the
+GPU forward, the scheduler verifies that P already owns every finite
+per-request prerequisite needed to finish prefill:
+
+- request slot and source KV;
+- required model/metadata buffer and cache ownership;
+- sender/session state;
+- bounded protocol commands, correlations, replay state, and cleanup credit.
+
+The scheduler then publishes an immutable `P_COMMITTED` snapshot with an O(1)
+local state change.
+
+`P_COMMITTED` means P will not retract, requeue, or ask for another finite P
+admission resource. It does **not** mean prefill compute has completed.
+
+### 4. P launches immediately
+
+After the local commit publication, P launches the prefill forward. It does not
+wait for D, for a commit response, or for network acknowledgment.
+
+This preserves the useful overlap: while P is computing, D can learn about the
+commit and prepare the destination.
+
+### 5. D becomes eligible and preallocates
+
+D retries the same logical commit wait until it receives P's immutable result
+or its local deadline expires. The D scheduler validates the complete pair
+identity, both serving epochs, allocator-domain records, policy, generation,
+and remaining validity window.
+
+Only when the commit matches and D's non-scarce receiver/channel setup is ready
+does D enter `D_ELIGIBLE`. Only `D_ELIGIBLE` may enter the existing decode
+preallocation queue and call the existing allocator.
+
+The causal chain is now:
+
+```text
+D owns scarce decode capacity
+  => D verified P_COMMITTED for the same pair
+  => P already completed final admission for that request
+  => P does not need another finite P admission resource to finish it
+```
+
+That implication is what removes the cross-request capacity cycle.
+
+### 6. D sends destination metadata
+
+After preallocation, D freezes the destination indices into one immutable V1
+metadata message. It sends that message to P and retries the exact same bytes
+on an ambiguous send or reconnect. A retry does not create a new pair,
+generation, buffer, or logical correlation.
+
+D also starts one logical wait for the transfer result.
+
+### 7. P joins compute and metadata
+
+Two events may arrive in either order:
+
+| First event | P behavior |
+| --- | --- |
+| Prefill compute finishes first | Keep source ownership and wait for destination metadata |
+| Destination metadata arrives first | Register it once and wait for prefill compute |
+
+Both events set scheduler-owned readiness bits. Only when both are true does P
+submit one KV transfer. A transport thread reports completion through a bounded
+scheduler command; it cannot directly change protocol state.
+
+### 8. D validates success and starts decoding
+
+P fixes one immutable `SUCCESS` or `FAILED` transfer snapshot. If the first
+response is lost, D repeats the same logical status wait and P replays the same
+snapshot.
+
+Only a matching `SUCCESS` lets D enter `D_RUNNING`. P releases its source
+request/KV/metadata/cache/session owners exactly once and retains only bounded
+replay state for the specified TTL. Failure, cancellation, and deadlines use
+the same ownership ledger and cleanup path.
+
+The complete fast path is:
+
+```text
+SMG: bind pair -> dispatch P and D concurrently
+
+D: validate -> REGISTERED -> receiver/channel ready -> wait for commit
+P: validate -> scheduler admission -> COMMITTED -> launch prefill
+D: verify commit -> ELIGIBLE -> preallocate -> send metadata -> wait for status
+P: compute done + metadata ready -> transfer -> publish immutable status
+D: verify SUCCESS -> RUNNING
+P: release source ownership -> retain bounded replay snapshot
+```
+
+## What happens when messages race or disappear
+
+The protocol separates a semantic result from a transport attempt:
+
+| Event | Result |
+| --- | --- |
+| D's commit wait arrives before P's HTTP body | P creates bounded control-only waiter state; no model capacity |
+| P's HTTP body arrives first | P creates precommit state; the later wait attaches to it |
+| Commit response is lost | D retries the same logical wait; P replays the immutable commit snapshot |
+| First metadata send is ambiguous | D resends byte-identical metadata through the reserved logical delivery |
+| Transfer-status response is lost | D retries the same logical status wait; P replays the immutable result snapshot |
+| Duplicate or late message | Matching fixed result is replayed, or stale input is rejected; state is not resurrected |
+| Worker restarts | A new serving epoch fences all frames and pair state from the old process |
+
+Logical sequence and generation values are fixed to one in version 1. A
+reconnect changes only the transport attempt, not the logical operation.
+
+## What happens on failure
+
+Every non-running phase has a local, non-refreshable monotonic deadline. A
+retry or reconnect cannot extend the pair's lifetime. On failure, cancel, or
+deadline, the scheduler removes the request from every owner and publishes
+terminal state only after local resources are actually released.
+
+SMG has a separate safety rule:
+
+- Before `PAIR_BOUND`, selection/preparation may retry only if neither worker
+  request performed network I/O.
+- At or after `PAIR_BOUND`, version 1 never selects a replacement P/D pair.
+  It sends bounded best-effort cancellation to the originally pinned workers
+  and returns an error.
+
+The second rule avoids old and new executions overlapping after an ambiguous
+HTTP failure. It also means version 1 may expose more transient worker failures
+than today's Router, which can reselect workers. Safe transparent rerouting is a
+separate follow-up that needs terminal proof from both old workers.
+
+## Performance and availability expectations
+
+P's GPU launch does not wait for the new control exchange. D performs receiver
+and channel setup in parallel, but scarce D preallocation starts only after the
+commit snapshot reaches D's scheduler.
+
+For a long prefill, that control latency is normally hidden under compute. For
+a very short prompt or cache hit, delaying D allocation by a fraction of a
+millisecond can be visible. The implementation therefore requires persistent
+multiplexed channels, O(1) scheduler hooks, bounded mailbox work, and no
+per-request connections or registry scans.
+
+The Router rule is a separate availability trade-off: after `PAIR_BOUND`, a
+transient connect error or retryable 5xx becomes user-visible instead of
+selecting another pair. Rollout must measure this under controlled fault load,
+record how many failures legacy would have retried, and stop or roll back the
+isolated enforce pool if either the configured added-error-rate or error-budget
+threshold is exceeded.
+
+## Safe rollout shape
+
+```text
+legacy traffic  -> LEGACY_ONLY P/D pool  -> existing behavior
+canary traffic  -> ENFORCE_EXCLUSIVE pool -> commit-gated behavior
+```
+
+Workers are drained before changing allocator-domain mode or membership, and a
+new serving epoch/domain record is published after the change. Rollout is not a
+request flag flip inside one pool.
+
+The enforce pool remains disabled until it passes:
+
+1. The original A/B reproducer and a mixed enforce/legacy isolation test.
+2. State, identity, restart, cancellation, replay, and bounded-memory fault
+   tests.
+3. Cross-process Mooncake integration.
+4. Real-GPU throughput, TTFT, inter-token latency, scheduler CPU, and memory
+   gates.
+5. Transient-fault availability and automatic rollback gates.
+
+Detailed wire contracts, resource credits, retention formulas, and the full
+test matrix are intentionally omitted here. See the
+[main RFC](/docs/developer_guide/pd_optimistic_prefill_commit_rfc) and
+[reservation and validation appendix](/docs/developer_guide/pd_optimistic_prefill_commit_rfc_appendix)
+for the normative design.


### PR DESCRIPTION
## Summary

This design-only RFC proposes one ordering rule for the optimistic prefill path tracked in #31473:

```text
P final scheduler admission -> immutable P_COMMITTED -> D scarce-capacity preallocation
```

SMG still dispatches P and D concurrently. D may prepare bounded receiver/control state early, but its scheduler cannot enter the existing preallocation path or acquire request/KV capacity until it validates the matching P commitment.

The ordering is allocator-domain-wide, not per request. Every execution request sharing an `ENFORCE_EXCLUSIVE` P/D allocator must pass the commit gate. Legacy D-first requests must fail before execution state or be routed before dispatch to allocator-disjoint `LEGACY_ONLY` workers. Request-percentage canaries inside one worker pool are forbidden because enforce/legacy mixing recreates the original A/B cycle.

## Version 1 boundary

- Mooncake, single-rank, non-chunked prefill, no retraction/rebootstrap, and a narrow capability-gated support cell.
- Complete pair identity, serving-epoch and allocator-domain fencing, immutable commit/transfer snapshots, fixed logical sequences, and scheduler-only transitions.
- Full bounded control/channel reservation before scarce capacity, with count and byte limits.
- No worker reselection after `PAIR_BOUND`; ambiguous failure cancels the pinned pair best-effort and returns an error.
- Local monotonic phase/cleanup deadlines and exact-once ownership release.
- Default off. Canary rollout uses a separate drained `ENFORCE_EXCLUSIVE` worker pool.

V1 deliberately prioritizes avoiding overlapping execution over matching legacy transient-failure availability. Its rollout gates now include transient connect errors, retryable P/D 5xx responses, early D rejection, the legacy-retry counterfactual, added user-visible error rate, error-budget burn, and automatic rollback thresholds.

## Document structure

- The execution walkthrough explains the normal request flow, races, failures, and rollout in plain language.
- The main RFC contains the normative ordering proof, state machines, identity/wire contracts, deadlines, performance/availability gates, and implementation boundary.
- The appendix contains the complete reservation inventory and fault/validation matrix.

The implementation plan is split into dependent PRs. Protocol/registry/Router infrastructure remains unable to emit enforce traffic until the final P/D/Mooncake integration PR atomically connects every participant and guard.

## Validation

- Repository pre-commit hooks pass for all changed files.
- Mintlify strict build validation passes.
- `docs_new/docs.json` parses, `git diff --check` passes, and MDX code fences/internal links were checked.
- No scheduler, Mooncake, GPU, performance, or availability result is claimed by this documentation-only PR; those remain implementation rollout gates.

## Maintainer decisions requested

1. Is allocator-domain-wide `P final admission -> D scarce preallocation` the right SGLang ordering boundary?
2. Can the narrow P scheduler path provide the non-retracting commit point before forward launch?
3. Is allocator-disjoint pool rollout acceptable, with no same-pool legacy fallback or per-request sampling?
4. Is disabling post-`PAIR_BOUND` worker reselection acceptable for V1 given the explicit availability gates?
5. Is the proposed pre-capacity control/channel reservation boundary acceptable for the first Mooncake support cell?

Related to #31473.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29714524342](https://github.com/sgl-project/sglang/actions/runs/29714524342)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29714524250](https://github.com/sgl-project/sglang/actions/runs/29714524250)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
