### PR TITLE
Fix stop boundaries for grammar-constrained speculative decoding

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1489,11 +1489,6 @@ class Req(ReqDllmMixin):
             self.finished_len = self.sampling_params.max_new_tokens
             return
 
-        if self.grammar is not None:
-            if self.grammar.is_terminated():
-                self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
-                return
-
         new_accepted_tokens = self.output_ids[-new_accepted_len:]
 
         # Sanitize out-of-range / NaN token ids before any decode.
@@ -1507,6 +1502,10 @@ class Req(ReqDllmMixin):
             return
 
         if self._check_token_based_finish(new_accepted_tokens):
+            return
+
+        if self.grammar is not None and self.grammar.is_terminated():
+            self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
             return
 
     def reset_for_retract(self):

--- a/test/registered/unit/managers/test_grammar_stop_speculative.py
+++ b/test/registered/unit/managers/test_grammar_stop_speculative.py
@@ -1,0 +1,69 @@
+"""Regression tests for grammar termination during speculative decoding."""
+
+import unittest
+from array import array
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+EOS_TOKEN_ID = 2
+STOP_TOKEN_ID = 17
+
+
+class _FakeTokenizer:
+    eos_token_id = -1
+    additional_stop_token_ids = None
+
+
+class _TerminatedGrammar:
+    @staticmethod
+    def is_terminated():
+        return True
+
+
+def _make_req(stop_token_ids=None):
+    sampling_params = SamplingParams(
+        max_new_tokens=1_000,
+        stop_token_ids=stop_token_ids,
+    )
+    sampling_params.normalize(tokenizer=_FakeTokenizer())
+    req = Req(
+        rid="grammar-stop",
+        origin_input_text="",
+        origin_input_ids=array("q", [0]),
+        sampling_params=sampling_params,
+        eos_token_ids={EOS_TOKEN_ID},
+        vocab_size=100,
+    )
+    req.tokenizer = _FakeTokenizer()
+    req.grammar = _TerminatedGrammar()
+    req.output_ids = array("q", [11, 13, STOP_TOKEN_ID, EOS_TOKEN_ID])
+    return req
+
+
+class TestGrammarStopSpeculative(unittest.TestCase):
+    def test_requested_stop_token_wins_over_trailing_eos(self):
+        req = _make_req(stop_token_ids=[STOP_TOKEN_ID])
+
+        req.update_finish_state(new_accepted_len=4)
+
+        self.assertEqual(req.finished_reason.matched, STOP_TOKEN_ID)
+        self.assertEqual(req.finished_len, 3)
+        self.assertEqual(list(req.output_ids_through_stop), [11, 13, STOP_TOKEN_ID])
+
+    def test_tokenizer_stop_token_wins_over_trailing_eos(self):
+        req = _make_req()
+        req.tokenizer.additional_stop_token_ids = {STOP_TOKEN_ID}
+
+        req.update_finish_state(new_accepted_len=4)
+
+        self.assertEqual(req.finished_reason.matched, STOP_TOKEN_ID)
+        self.assertEqual(req.finished_len, 3)
+        self.assertEqual(list(req.output_ids_through_stop), [11, 13, STOP_TOKEN_ID])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Run existing stop-string and stop-token checks before using grammar termination as the finish fallback. This preserves the earliest registered stop boundary when speculative decoding accepts multiple tokens.

## Root cause

Previously, Req.update_finish_state used this ordering:

    max length
    -> grammar terminated: use last token and return
    -> stop-string checks
    -> stop-token/EOS checks

The grammar return therefore skipped normal stop handling. This was effectively harmless for single-token decoding because the grammar terminal token was also the last accepted token.

Grammar-constrained speculative decoding exposes the incorrect assumption that the last accepted token is always the finish boundary.

    registered stop token: STOP
    newly accepted tokens: [STOP, EOS]
    grammar terminated: true

| Result | Old behavior | Correct behavior |
| --- | --- | --- |
| matched token | EOS (the last token) | STOP (the first registered stop) |
| finished_len | unset | immediately after STOP |
| emitted accepted suffix | [STOP, EOS] | [STOP] |

## Fix

Use this ordering instead:

    max length
    -> stop-string checks
    -> stop-token/EOS checks
    -> grammar termination fallback

The token checker scans newly accepted tokens from left to right, matches STOP before EOS, and sets finished_len at that boundary. output_ids_through_stop then excludes the trailing EOS. Grammar termination remains available when no normal stop condition matches.

The regression covers both request stop_token_ids and tokenizer additional_stop_token_ids.

## Tests

- pytest -q test/registered/unit/managers/test_grammar_stop_speculative.py test/registered/unit/managers/test_stop_str_speculative.py (11 passed)
- pre-commit run --files python/sglang/srt/managers/schedule_batch.py test/registered/unit/managers/test_grammar_stop_speculative.py

## Original commits

- 403a9465e

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29712052862](https://github.com/sgl-project/sglang/actions/runs/29712052862)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29712052788](https://github.com/sgl-project/sglang/actions/runs/29712052788)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->