### PR TITLE
[AMD] Mark disable_custom_all_reduce / enable_aiter_allreduce_fusion resolvable for MiniMax-M3 ROCm override

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1617,7 +1617,10 @@ class ServerArgs:
     ] = False
     disable_custom_all_reduce: A[
         bool,
-        "Disable the custom all-reduce kernel and fall back to NCCL.",
+        Arg(
+            help="Disable the custom all-reduce kernel and fall back to NCCL.",
+            resolvable=True,
+        ),
     ] = False
     enable_mscclpp: A[
         bool,
@@ -1657,7 +1660,10 @@ class ServerArgs:
             resolvable=True,
         ),
     ] = None
-    enable_aiter_allreduce_fusion: A[bool, "Enable Aiter AllReduce Fusion."] = False
+    enable_aiter_allreduce_fusion: A[
+        bool,
+        Arg(help="Enable Aiter AllReduce Fusion.", resolvable=True),
+    ] = False
 
     # -------------------------------------------------------------------------
     # Torch compile and torchao

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -84,6 +84,8 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "decode_attention_backend",
                     "flashinfer_allreduce_fusion_backend",
                     "fp8_gemm_runner_backend",
+                    "disable_custom_all_reduce",
+                    "enable_aiter_allreduce_fusion",
                 }
             ),
         )


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
On ROCm, the MiniMax-M3 model override (`_minimax_m3_overrides` in `python/sglang/srt/arg_groups/overrides.py`) declares two fields:
- `disable_custom_all_reduce = True` when aiter all-reduce fusion is off, and
- `enable_aiter_allreduce_fusion = False` on the standard-EP path.
However, neither field was in the resolvable whitelist (they were declared with a bare help-string, i.e. `resolvable` defaulted to `False`). 
The declaration gate `validate_declarations` therefore rejects them and the server crashes during argument parsing, before the model is ever loaded:
```
ValueError: _minimax_m3_overrides: ['disable_custom_all_reduce'] not model-overridable; declarations are limited to the fields the publish gate accepts.
```
This blocks every MiniMax-M3 launch on ROCm (e.g. MI35x MXFP8 TP4). The bug went unnoticed because the `is_hip()` branch that writes these fields is only reached on ROCm, and there was no ROCm MiniMax-M3 CI coverage exercising it through the
strict gate.

## Modifications
Add `resolvable=True` to the `Arg` metadata of `disable_custom_all_reduce` and `enable_aiter_allreduce_fusion` in `ServerArgs`, so the model override can write them through the declaration gate. This matches the existing pattern used by other model overrides (e.g. `disable_hybrid_swa_memory`, `enable_tf32_matmul`, `enable_multi_layer_eagle`).
No behavioral change on any previously-working path: these fields are only written by the MiniMax-M3 ROCm override, and this simply lets the intended override values materialize instead of raising.
### Scope 
The metadata edit is on the shared `ServerArgs` class, but the effective
behavior change is limited to the MiniMax-M3 ROCm path. The `resolvable`
whitelist has only two consumers:
- `validate_declarations` — only *relaxes* which fields an override may declare
  (adds two entries); it never adds restrictions.
- `ServerArgs.override()` — routes a resolvable field to the declaration stash
  instead of the runtime-mutation log; the value written via `setattr` is
  identical either way.
These two fields are only written through the declaration mechanism by the
MiniMax-M3 ROCm override. Every other writer uses a plain assignment, which is
independent of the `resolvable` flag:

| Writer | Mechanism | Affected by this change |
| --- | --- | --- |
| MiniMax-M3 ROCm override | declaration gate | Yes (the fix) |
| Deterministic inference (`server_args.py`) | bare `self.x = ...` | No |
| NPU (`hardware_backend/npu/utils.py`) | bare `args.x = ...` | No |
| CLI `--disable-custom-all-reduce` / `--enable-aiter-allreduce-fusion` | argparse | No |

CLI generation is unchanged: `A[bool, "help"]` is treated as
`Arg(help="help")`, so the bool `store_true` argument is produced identically to
`A[bool, Arg(help="help", resolvable=True)]`. No behavior changes for non-M3
models, non-ROCm hardware, deterministic inference, or the CLI.

## Accuracy Tests
No accuracy impact. This is a configuration-declaration whitelist fix; it does not touch any kernel or model forward code. Verified that `resolvable_fields(ServerArgs)` now includes both fields and the MiniMax-M3 override no longer trips `validate_declarations`.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29726777522](https://github.com/sgl-project/sglang/actions/runs/29726777522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29726777307](https://github.com/sgl-project/sglang/actions/runs/29726777307)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->