### PR TITLE
[Fix] Release hierarchical cache host pool on graceful shutdown

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1460,6 +1460,11 @@ class Scheduler(
         # HostKVCache.destroy. Called from run_scheduler_process's finally.
         if self.hisparse_coordinator is not None:
             self.hisparse_coordinator.destroy()
+        # A plain HiRadixCache (no hisparse) also holds a large pinned host KV
+        # pool; unregister it here too, else the kernel unpins it during reclaim.
+        host_pool = getattr(self.tree_cache, "token_to_kv_pool_host", None)
+        if host_pool is not None:
+            host_pool.destroy()
 
     def run_event_loop(self) -> None:
         """Run the scheduler's event loop.

--- a/test/registered/hicache/test_hicache_storage.py
+++ b/test/registered/hicache/test_hicache_storage.py
@@ -3,6 +3,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 register_cuda_ci(est_time=99, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=300, suite="stage-b-test-1-gpu-small-amd")
 
+import subprocess
 import time
 import unittest
 
@@ -47,6 +48,14 @@ class TestHiCache(CustomTestCase, MMLUMixin):
 
     @classmethod
     def tearDownClass(cls):
+        # Graceful stop first so the server unregisters its large pinned host KV
+        # pool in userspace; a bare SIGKILL leaves the kernel to unpin it during
+        # reclaim, holding GPU memory long enough to fail the next test.
+        cls.process.terminate()
+        try:
+            cls.process.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            pass
         kill_process_tree(cls.process.pid)
         time.sleep(5)
 


### PR DESCRIPTION
## Summary
- A plain `HiRadixCache` (no hisparse) never unregisters its large `cudaHostRegister`'d host KV pool on shutdown.
- Under a SIGKILL teardown the kernel unpins that pool during reclaim, stalling the scheduler in uninterruptible sleep for tens of seconds while it keeps holding GPU memory.
- This trips the next test's GPU-idle precheck on the same runner, failing an unrelated test.

## Symptom
Observed in CI ([base-b-test-1-gpu-small](https://github.com/sgl-project/sglang/actions/runs/29708653098/job/88262678501)): `test_hicache_storage.py` **passes**, then the next test on the same runner errors in `setUpClass` because the hicache scheduler process is still alive holding the GPU:

```
End (1/13): test_hicache_storage.py ... passed

[CI GPU Idle] Waiting for GPU to become idle: GPU 2 uses 25.30 GiB (pid=1117859 24.81 GiB)
[CI GPU Idle] Waiting for GPU to become idle: GPU 2 uses 25.30 GiB (pid=1117859 24.81 GiB)
... (same pid holds 24.81 GiB across the whole 30s window) ...
RuntimeError: GPU(s) still not idle after waiting 30s before setUpClass:
  GPU 2 uses 25.30 GiB (no other compute processes; self pid=1118381 holds 0.00 GiB)
```

The pinned pool is large and slow to (un)register — startup alone spends ~60s registering it:

```
[03:21:43] Allocating 100.00 GB host memory for hierarchical KV cache.
[03:22:43] Creating storage backend 'file' (...HiCacheFile)   # ~60s later
```

## Root cause
- `Scheduler.release_host_resources()` only `destroy()`s `hisparse_coordinator`; for a normal `HiRadixCache` the host pool's `cudaHostUnregister` (`HostKVCache.destroy`) is never wired in.
- Even so, it only runs on graceful exit (`gracefully_exit`), and the hicache storage test tears down with a bare `kill_process_tree` (SIGKILL), which skips the graceful path entirely — so the kernel is left to unpin the pool during reclaim.

## Fix
- Wire the `HiRadixCache` host-pool `destroy()` into `Scheduler.release_host_resources` (guarded via `getattr`, so non-hierarchical caches are skipped).
- Make `test_hicache_storage.py` tear down gracefully (SIGTERM + wait, SIGKILL fallback) so the userspace unregister actually runs before the process exits.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29717150786](https://github.com/sgl-project/sglang/actions/runs/29717150786)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29717150691](https://github.com/sgl-project/sglang/actions/runs/29717150691)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
