### PR TITLE
ci: run nvidia nightly every 2 days at 14:00 UTC (7am PT)

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -2,7 +2,7 @@ name: Nightly Test (Nvidia)
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 14 */2 * *'
   workflow_dispatch:
     inputs:
       job_filter:


### PR DESCRIPTION
Reduce nightly load on the saturated GPU pools: `nightly-test-nvidia` moves from daily 00:00 UTC to every 2 days at 14:00 UTC (7am PT), off the peak PR-CI backlog window. `workflow_dispatch` remains for on-demand runs.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29720015425](https://github.com/sgl-project/sglang/actions/runs/29720015425)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29720015350](https://github.com/sgl-project/sglang/actions/runs/29720015350)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->