### PR TITLE
feat: add per-position speculative acceptance metrics

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -833,6 +833,8 @@ class SchedulerBatchResultProcessor:
                 result.num_correct_drafts,
                 num_block_accept_tokens=result.num_block_accept_tokens,
                 num_cap_tokens=result.num_cap_tokens,
+                num_correct_drafts_per_req=result.num_correct_drafts_per_req_cpu,
+                num_draft_tokens=result.speculative_num_draft_tokens,
             )
         if get_observability().enable_metrics:
             self.metrics_collector.increment_decode_cuda_graph_pass(

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -22,6 +22,7 @@ from sglang.srt.observability.metrics_collector import (
     compute_routing_key_stats,
 )
 from sglang.srt.runtime_context import get_context, get_observability, get_spec
+from sglang.srt.speculative.spec_accept_metrics import SpecAcceptMetrics
 from sglang.srt.utils.device_timer import DeviceTimer
 from sglang.srt.utils.scheduler_status_logger import SchedulerStatusLogger
 
@@ -143,6 +144,7 @@ class SchedulerMetricsReporter:
         self.spec_total_num_forward_ct = 0
         self.spec_num_block_accept_tokens = 0
         self.spec_num_cap_tokens = 0
+        self.spec_accept_metrics = SpecAcceptMetrics()
 
         # For PD disaggregation
         self.kv_transfer_speed_gb_s: float = 0.0
@@ -360,6 +362,8 @@ class SchedulerMetricsReporter:
         num_correct_drafts: int,
         num_block_accept_tokens: int = 0,
         num_cap_tokens: int = 0,
+        num_correct_drafts_per_req: Optional[List[int]] = None,
+        num_draft_tokens: Optional[int] = None,
     ):
         self.spec_num_accept_tokens += num_correct_drafts + bs
         self.spec_num_forward_ct += bs
@@ -368,6 +372,14 @@ class SchedulerMetricsReporter:
 
         # Bonus tokens updated elsewhere
         self.num_generated_tokens += num_correct_drafts
+
+        if num_correct_drafts_per_req is not None and (
+            self.is_stats_logging_rank or self.current_scheduler_metrics_enabled
+        ):
+            self.spec_accept_metrics.observe(
+                num_correct_drafts_per_req,
+                num_draft_tokens,
+            )
 
     def _init_estimated_perf_constants(self) -> None:
         model_config = self.scheduler.model_config
@@ -526,6 +538,7 @@ class SchedulerMetricsReporter:
         self.spec_total_num_forward_ct = 0
         self.spec_num_block_accept_tokens = 0
         self.spec_num_cap_tokens = 0
+        self.spec_accept_metrics.reset()
 
     def report_prefill_stats(
         self,
@@ -739,6 +752,8 @@ class SchedulerMetricsReporter:
         ):
             return
 
+        spec_position_snapshot = self.spec_accept_metrics.snapshot_and_reset_window()
+
         gap_latency = time.perf_counter() - self.last_decode_stats_tic
         self.last_decode_stats_tic = time.perf_counter()
         self.last_gen_throughput = self.num_generated_tokens / gap_latency
@@ -866,6 +881,22 @@ class SchedulerMetricsReporter:
 
         if self.is_stats_logging_rank:
             logger.info(msg)
+            if spec_position_snapshot.window.num_requests > 0:
+                logger.info(
+                    "Decode batch, #window: spec accept rate (per-position): "
+                    "[%s], accept len: %.2f | #lifetime: spec total accept "
+                    "rate (per-position): [%s], accept len: %.2f",
+                    ", ".join(
+                        f"{rate:.2f}"
+                        for rate in spec_position_snapshot.window.accept_rates
+                    ),
+                    spec_position_snapshot.window.mean_accept_length,
+                    ", ".join(
+                        f"{rate:.2f}"
+                        for rate in spec_position_snapshot.lifetime.accept_rates
+                    ),
+                    spec_position_snapshot.lifetime.mean_accept_length,
+                )
         if self.current_scheduler_metrics_enabled:
             priority_enabled = self.scheduler.enable_priority_scheduling
 
@@ -891,6 +922,15 @@ class SchedulerMetricsReporter:
             self.stats.spec_block_accept_length = spec_block_accept_length
             self.stats.spec_num_steps = spec_num_steps
             self.stats.spec_num_draft_tokens = spec_num_draft_tokens
+            self.stats.spec_accept_rate_per_position = list(
+                spec_position_snapshot.window.accept_rates
+            )
+            self.stats.spec_total_accept_rate_per_position = list(
+                spec_position_snapshot.lifetime.accept_rates
+            )
+            self.stats.spec_total_accept_length = (
+                spec_position_snapshot.lifetime.mean_accept_length
+            )
 
             # Retract
             self.stats.num_retracted_reqs = self.num_retracted_reqs

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -111,6 +111,9 @@ class SchedulerStats:
     spec_accept_rate: float = 0.0
     spec_cap_length: float = 0.0
     spec_block_accept_length: float = 0.0
+    spec_accept_rate_per_position: List[float] = field(default_factory=list)
+    spec_total_accept_rate_per_position: List[float] = field(default_factory=list)
+    spec_total_accept_length: float = 0.0
     # Adaptive speculative decoding (currently active tier).
     spec_num_steps: int = 0
     spec_num_draft_tokens: int = 0
@@ -422,6 +425,24 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         self.spec_accept_rate = Gauge(
             name="sglang:spec_accept_rate",
             documentation="Speculative acceptance rate (`accepted drafts / proposed drafts` in batch).",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.spec_accept_rate_per_position = Gauge(
+            name="sglang:spec_accept_rate_per_position",
+            documentation="Per-position conditional acceptance rate of speculative decoding in the latest reporting window.",
+            labelnames=[*labels.keys(), "position"],
+            multiprocess_mode="mostrecent",
+        )
+        self.spec_total_accept_rate_per_position = Gauge(
+            name="sglang:spec_total_accept_rate_per_position",
+            documentation="Per-position conditional acceptance rate of speculative decoding over the reporter lifetime.",
+            labelnames=[*labels.keys(), "position"],
+            multiprocess_mode="mostrecent",
+        )
+        self.spec_total_accept_length = Gauge(
+            name="sglang:spec_total_accept_length",
+            documentation="Mean speculative acceptance length over the reporter lifetime (accepted drafts plus bonus token).",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -1345,6 +1366,17 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         # Speculative decoding
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)
         self._log_gauge(self.spec_accept_rate, stats.spec_accept_rate)
+        for position, rate in enumerate(stats.spec_accept_rate_per_position, start=1):
+            self.spec_accept_rate_per_position.labels(
+                **self.labels, position=str(position)
+            ).set(rate)
+        for position, rate in enumerate(
+            stats.spec_total_accept_rate_per_position, start=1
+        ):
+            self.spec_total_accept_rate_per_position.labels(
+                **self.labels, position=str(position)
+            ).set(rate)
+        self._log_gauge(self.spec_total_accept_length, stats.spec_total_accept_length)
         self._log_gauge(self.spec_cap_length, stats.spec_cap_length)
         self._log_gauge(self.spec_block_accept_length, stats.spec_block_accept_length)
         self._log_gauge(self.spec_num_steps, stats.spec_num_steps)

--- a/python/sglang/srt/speculative/spec_accept_metrics.py
+++ b/python/sglang/srt/speculative/spec_accept_metrics.py
@@ -1,0 +1,141 @@
+"""Per-position acceptance statistics for speculative decoding.
+
+The aggregate speculative metrics report how many draft tokens were accepted
+overall.  This module additionally tracks the conditional acceptance rate at
+each draft position::
+
+    alpha[j] = P(position j is accepted | positions 0..j-1 are accepted)
+
+The denominator must only include requests whose current speculative budget
+contains position ``j``.  Keeping explicit ``eligible`` and ``accepted``
+counters therefore matters when adaptive speculative decoding changes the
+budget between batches: a position that was not proposed is censored, not
+rejected.
+
+The tracker is intentionally independent of logging and Prometheus.  The
+scheduler metrics reporter owns one instance and publishes its snapshots.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class SpecAcceptMetricsScopeSnapshot:
+    """Acceptance statistics for one scope (window or lifetime)."""
+
+    accept_rates: tuple[float, ...]
+    mean_accept_length: float
+    num_requests: int
+
+
+@dataclass(frozen=True)
+class SpecAcceptMetricsSnapshot:
+    """A decode-window snapshot paired with the lifetime snapshot."""
+
+    window: SpecAcceptMetricsScopeSnapshot
+    lifetime: SpecAcceptMetricsScopeSnapshot
+
+
+@dataclass
+class _PerPositionCounters:
+    # ``eligible[j]``: position j was within the current budget and every
+    # previous draft position was accepted.
+    eligible: list[int] = field(default_factory=list)
+    # ``accepted[j]``: position j itself was also accepted.
+    accepted: list[int] = field(default_factory=list)
+    total_accept_length: int = 0
+    num_requests: int = 0
+
+    def observe(
+        self,
+        num_correct_drafts_per_req: Sequence[int],
+        num_draft_tokens: int,
+    ) -> None:
+        # ``num_draft_tokens`` includes the always-emitted bonus token, so the
+        # number of conditional draft positions is one smaller.
+        num_positions = max(int(num_draft_tokens) - 1, 0)
+        if not num_correct_drafts_per_req:
+            return
+
+        self._ensure_num_positions(num_positions)
+        for raw_num_correct in num_correct_drafts_per_req:
+            # Runtime values are expected to be in range.  Clamp defensively so
+            # metrics cannot make serving fail if a backend reports a bad value.
+            num_correct = min(max(int(raw_num_correct), 0), num_positions)
+            self.total_accept_length += num_correct + 1  # include bonus token
+            self.num_requests += 1
+
+            # If c drafts were accepted, positions 0..c-1 were accepted and
+            # position c was eligible but rejected (unless c filled the budget).
+            for position in range(min(num_correct + 1, num_positions)):
+                self.eligible[position] += 1
+            for position in range(num_correct):
+                self.accepted[position] += 1
+
+    def snapshot(self, width: int | None = None) -> SpecAcceptMetricsScopeSnapshot:
+        width = len(self.eligible) if width is None else width
+        rates = []
+        for position in range(width):
+            eligible = self.eligible[position] if position < len(self.eligible) else 0
+            accepted = self.accepted[position] if position < len(self.accepted) else 0
+            rates.append(accepted / eligible if eligible > 0 else math.nan)
+        mean_accept_length = (
+            self.total_accept_length / self.num_requests
+            if self.num_requests > 0
+            else 0.0
+        )
+        return SpecAcceptMetricsScopeSnapshot(
+            accept_rates=tuple(rates),
+            mean_accept_length=mean_accept_length,
+            num_requests=self.num_requests,
+        )
+
+    def reset(self) -> None:
+        self.eligible.clear()
+        self.accepted.clear()
+        self.total_accept_length = 0
+        self.num_requests = 0
+
+    def _ensure_num_positions(self, num_positions: int) -> None:
+        missing = num_positions - len(self.eligible)
+        if missing > 0:
+            self.eligible.extend([0] * missing)
+            self.accepted.extend([0] * missing)
+
+
+class SpecAcceptMetrics:
+    """Track per-position acceptance over a decode window and process lifetime."""
+
+    def __init__(self) -> None:
+        self._window = _PerPositionCounters()
+        self._lifetime = _PerPositionCounters()
+
+    def observe(
+        self,
+        num_correct_drafts_per_req: Sequence[int],
+        num_draft_tokens: int | None,
+    ) -> None:
+        if num_draft_tokens is None:
+            return
+        self._window.observe(num_correct_drafts_per_req, num_draft_tokens)
+        self._lifetime.observe(num_correct_drafts_per_req, num_draft_tokens)
+
+    def snapshot_and_reset_window(self) -> SpecAcceptMetricsSnapshot:
+        # Pad the window to the lifetime width.  A NaN at a deeper position
+        # explicitly means "not observed in this window" and prevents an old
+        # Prometheus gauge value from looking current after the budget shrinks.
+        width = max(len(self._window.eligible), len(self._lifetime.eligible))
+        snapshot = SpecAcceptMetricsSnapshot(
+            window=self._window.snapshot(width),
+            lifetime=self._lifetime.snapshot(width),
+        )
+        self._window.reset()
+        return snapshot
+
+    def reset(self) -> None:
+        self._window.reset()
+        self._lifetime.reset()

--- a/test/registered/unit/spec/test_spec_accept_metrics.py
+++ b/test/registered/unit/spec/test_spec_accept_metrics.py
@@ -1,0 +1,93 @@
+import math
+import unittest
+
+from sglang.srt.speculative.spec_accept_metrics import SpecAcceptMetrics
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSpecAcceptMetrics(unittest.TestCase):
+    def test_per_position_rates_and_mean_accept_length(self):
+        metrics = SpecAcceptMetrics()
+        metrics.observe([0, 1, 3], num_draft_tokens=4)
+
+        snapshot = metrics.snapshot_and_reset_window()
+
+        self.assertEqual(snapshot.window.num_requests, 3)
+        self.assertEqual(snapshot.window.accept_rates, (2 / 3, 1 / 2, 1.0))
+        self.assertAlmostEqual(snapshot.window.mean_accept_length, 7 / 3)
+        self.assertEqual(snapshot.window, snapshot.lifetime)
+
+    def test_smaller_adaptive_budget_is_censored_at_deeper_positions(self):
+        metrics = SpecAcceptMetrics()
+        # All three positions were eligible and accepted in the first batch.
+        metrics.observe([3], num_draft_tokens=4)
+        metrics.snapshot_and_reset_window()
+
+        # The next batch only proposes position 0.  It must not lower the
+        # lifetime rate at positions 1 and 2.
+        metrics.observe([1], num_draft_tokens=2)
+        snapshot = metrics.snapshot_and_reset_window()
+
+        self.assertEqual(snapshot.lifetime.accept_rates, (1.0, 1.0, 1.0))
+        self.assertEqual(snapshot.window.accept_rates[0], 1.0)
+        self.assertTrue(math.isnan(snapshot.window.accept_rates[1]))
+        self.assertTrue(math.isnan(snapshot.window.accept_rates[2]))
+        self.assertEqual(snapshot.lifetime.mean_accept_length, 3.0)
+
+    def test_rejection_updates_only_positions_that_were_eligible(self):
+        metrics = SpecAcceptMetrics()
+        metrics.observe([0, 1, 2], num_draft_tokens=4)
+
+        rates = metrics.snapshot_and_reset_window().window.accept_rates
+
+        # position 0: 2 / 3; position 1: 1 / 2; position 2: 0 / 1.
+        self.assertAlmostEqual(rates[0], 2 / 3)
+        self.assertAlmostEqual(rates[1], 1 / 2)
+        self.assertEqual(rates[2], 0.0)
+
+    def test_window_resets_but_lifetime_persists(self):
+        metrics = SpecAcceptMetrics()
+        metrics.observe([1, 1], num_draft_tokens=2)
+        first = metrics.snapshot_and_reset_window()
+        self.assertEqual(first.window.num_requests, 2)
+
+        metrics.observe([0], num_draft_tokens=2)
+        second = metrics.snapshot_and_reset_window()
+
+        self.assertEqual(second.window.num_requests, 1)
+        self.assertEqual(second.window.accept_rates, (0.0,))
+        self.assertEqual(second.lifetime.num_requests, 3)
+        self.assertAlmostEqual(second.lifetime.accept_rates[0], 2 / 3)
+
+    def test_reset_clears_window_and_lifetime(self):
+        metrics = SpecAcceptMetrics()
+        metrics.observe([1], num_draft_tokens=2)
+        metrics.reset()
+
+        snapshot = metrics.snapshot_and_reset_window()
+        self.assertEqual(snapshot.window.num_requests, 0)
+        self.assertEqual(snapshot.lifetime.num_requests, 0)
+        self.assertEqual(snapshot.window.accept_rates, ())
+        self.assertEqual(snapshot.lifetime.accept_rates, ())
+
+    def test_missing_budget_is_ignored(self):
+        metrics = SpecAcceptMetrics()
+        metrics.observe([1], num_draft_tokens=None)
+
+        snapshot = metrics.snapshot_and_reset_window()
+        self.assertEqual(snapshot.window.num_requests, 0)
+
+    def test_bonus_only_round_contributes_to_accept_length(self):
+        metrics = SpecAcceptMetrics()
+        metrics.observe([0, 0], num_draft_tokens=1)
+
+        snapshot = metrics.snapshot_and_reset_window()
+        self.assertEqual(snapshot.window.accept_rates, ())
+        self.assertEqual(snapshot.window.num_requests, 2)
+        self.assertEqual(snapshot.window.mean_accept_length, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
The existing speculative decoding metrics mainly expose aggregate acceptance statistics. Per-
position conditional acceptance rates make it easier to understand where draft tokens are
rejected and to diagnose speculative decoding behavior when the draft budget changes dynamically.

## Modifications
- Add `SpecAcceptMetrics` to track per-position conditional acceptance rates for both the latest
reporting window and the reporter lifetime.
- Treat positions outside the current adaptive draft budget as unobserved instead of rejected.
- Add scheduler logging for per-position acceptance rates and mean acceptance length.
- Export the following Prometheus metrics:
  - `sglang:spec_accept_rate_per_position`
  - `sglang:spec_total_accept_rate_per_position`
  - `sglang:spec_total_accept_length`
- Pass per-request accepted draft counts and the current draft-token budget through the scheduler
metrics path.
- Add CPU unit tests covering window resets, lifetime statistics, adaptive budgets, rejected
positions, missing budgets, and bonus-only rounds.

## Accuracy Tests
Not applicable. This is an observability-only change and does not modify model outputs or
speculative decoding decisions.

Unit tests were added in:
`test/registered/unit/spec/test_spec_accept_metrics.py`

## Speed Tests and Profiling
Not benchmarked. The new statistics are collected only when scheduler metrics or statistics
logging is enabled, and the change does not modify model execution or scheduling behavior.

## Checklist
- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/
developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/
developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/
developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://
docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the
speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/
contribution_guide.html#code-style-guidance).

## Review and Merge Process
1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31068702808](https://github.com/sgl-project/sglang/actions/runs/31068702808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31068702689](https://github.com/sgl-project/sglang/actions/runs/31068702689)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->