### PR TITLE
Fix unnecessary gather/scatter on CPU for non-contiguous Mamba statepool

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -481,11 +481,16 @@ class GDNAttnBackend(MambaAttnBackendBase):
         # slot layout, so they silently drop the write to the strided envelope
         # pool. Run them on contiguous per-sequence copies (identity-indexed) and
         # scatter the result back. No-op for the default contiguous pool.
+        # CPU kernels (causal_conv1d_fwd_cpu, chunk_gated_delta_rule_cpu) use
+        # proper indexed writes and handle non-contiguous pools directly via
+        # cache_indices, so the gather/scatter round-trip is unnecessary on CPU.
         # TODO(ch-wan): drop these .contiguous() copies by making the prefill conv
         # and chunk_gated_delta_rule kernels honor the pool's real slot stride +
         # int64 indexing, like packed_decode / causal_conv1d_update already do.
-        needs_state_gather = (not is_target_verify) and (
-            not conv_states.is_contiguous() or not ssm_states.is_contiguous()
+        needs_state_gather = (
+            (not is_target_verify)
+            and (not is_cpu())
+            and (not conv_states.is_contiguous() or not ssm_states.is_contiguous())
         )
         if needs_state_gather:
             conv_states_contig = conv_states[cache_indices].contiguous()


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
On CPU with AMX, the Mamba state pool can be non-contiguous (paged layout), which triggered needs_state_gather. This gathered each request's state into a contiguous scratch buffer, ran the prefill kernels, then scattered the result back via aten::index_put_ — adding significant overhead on every prefill step.

The gather/scatter workaround is only needed for CUDA prefill kernels (causal_conv1d_fwd, chunk_gated_delta_rule), which write state back in-place assuming contiguous slot layout and silently mis-write when the pool is strided. The CPU counterparts (causal_conv1d_fwd_cpu, chunk_gated_delta_rule_cpu) use standard indexed C++ operations and correctly scatter state through cache_indices regardless of memory layout.


## Modifications
Fix: Add not is_cpu() to the needs_state_gather condition so CPU passes the original tensors directly to the kernels, skipping the redundant gather/scatter round-trip.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29898923827](https://github.com/sgl-project/sglang/actions/runs/29898923827)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29898923512](https://github.com/sgl-project/sglang/actions/runs/29898923512)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->