### PR TITLE
[Fix] Align KV cache eviction priority direction with scheduler when --schedule-low-priority-values-first is enabled

### DIFF
--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -27,6 +27,7 @@ class CacheInitParams:
     attn_tp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     pp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     eviction_policy: str = "lru"
+    schedule_low_priority_values_first: bool = False
     disable_finished_insert: bool = False
 
     enable_metrics: bool = False

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -39,11 +39,21 @@ class FILOStrategy(EvictionStrategy):
 
 
 class PriorityStrategy(EvictionStrategy):
-    """Priority-aware eviction: lower priority values evicted first, then LRU within same priority."""
+    """Priority-aware eviction: lower priority values evicted first, then LRU within same priority.
+
+    When *low_values_first* is True, the direction is inverted: smaller priority values
+    are treated as *more important* and are retained longer, matching the scheduler's
+    ``--schedule-low-priority-values-first`` mode.
+    """
+
+    def __init__(self, low_values_first: bool = False):
+        self._low_values_first = low_values_first
 
     def get_priority(self, node: TreeNode) -> Tuple[int, float]:
-        # Return (priority, last_access_time) so lower priority nodes are evicted first
-        return (node.priority, node.last_access_time)
+        # Invert priority so that smaller (more important) values map to larger
+        # eviction keys (retained longer) when low_values_first is enabled.
+        p = -node.priority if self._low_values_first else node.priority
+        return (p, node.last_access_time)
 
 
 class SLRUStrategy(EvictionStrategy):

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1808,7 +1808,7 @@ class HiRadixCache(RadixCache):
         while len(key) > 0 and child_key in node.children.keys():
             node = node.children[child_key]
             node.last_access_time = time.monotonic()
-            node.priority = max(node.priority, priority)
+            self._aggregate_priority(node, priority)
             prefix_len = node.key.match(key, page_size=self.page_size)
 
             if prefix_len == len(node.key):
@@ -1827,8 +1827,8 @@ class HiRadixCache(RadixCache):
             else:
                 # partial match, split the node
                 new_node = self._split_node(node.key, node, prefix_len)
-                # shared-prefix node should also reflect max priority
-                new_node.priority = max(new_node.priority, priority)
+                # shared-prefix node should also reflect aggregated priority
+                self._aggregate_priority(new_node, priority)
                 if new_node.evicted:
                     new_node.value = value[:prefix_len].clone()
                     self.evictable_size_ += len(new_node.value)

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -224,6 +224,7 @@ def build_kv_cache(
         attn_tp_cache_group=attn_tp_cpu_group,
         pp_cache_group=pp_group.cpu_group,
         eviction_policy=server_args.radix_eviction_policy,
+        schedule_low_priority_values_first=server_args.schedule_low_priority_values_first,
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,
         enable_session_radix_cache=server_args.enable_session_radix_cache,

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -288,6 +288,7 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         self.is_eagle = params.is_eagle
         self.disable_finished_insert = params.disable_finished_insert
         self.eviction_policy = params.eviction_policy.lower()
+        self._low_priority_values_first = params.schedule_low_priority_values_first
 
         self.kv_event_queue = []
 
@@ -303,7 +304,10 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         else:
             self.device = torch.device("cpu")
 
-        self.eviction_strategy = get_eviction_strategy(self.eviction_policy)
+        self.eviction_strategy = get_eviction_strategy(
+            self.eviction_policy,
+            low_values_first=params.schedule_low_priority_values_first,
+        )
 
         self.evictable_leaves = set()
         self.reset()
@@ -329,8 +333,12 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
     ##### Public API #####
 
     def reset(self):
-        # Initialize root with minimum priority so any real priority overrides it
-        self.root_node = TreeNode(priority=-sys.maxsize)
+        # Root priority: use the extreme that is *least* important so any real
+        # priority overrides it.  In normal mode that is -sys.maxsize (minimum);
+        # in low-values-first mode it is sys.maxsize (maximum).
+        self.root_node = TreeNode(
+            priority=sys.maxsize if self._low_priority_values_first else -sys.maxsize
+        )
         self.root_node.key = RadixKey(token_ids=array("q"), extra_key=None)
         self.root_node.value = []
         self.root_node.host_value = []
@@ -703,6 +711,17 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
             return
         node.hit_count += 1
 
+    def _aggregate_priority(self, node: TreeNode, priority: int) -> None:
+        """Aggregate priority on a shared prefix node.
+
+        Normal mode: higher priority = more important → use max.
+        Low-values-first mode: lower priority = more important → use min.
+        """
+        if self._low_priority_values_first:
+            node.priority = min(node.priority, priority)
+        else:
+            node.priority = max(node.priority, priority)
+
     def _insert_helper(
         self,
         node: TreeNode,
@@ -716,8 +735,8 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
             priority = 0
         access_time = time.monotonic()
         node.last_access_time = access_time
-        # Update priority along the path (take max to propagate higher priority)
-        node.priority = max(node.priority, priority)
+        # Update priority along the path (aggregate based on direction)
+        self._aggregate_priority(node, priority)
         if len(key) == 0:
             return 0, node
 
@@ -734,11 +753,11 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
 
             if prefix_len < len(node.key):
                 new_node = self._split_node(node.key, node, prefix_len)
-                new_node.priority = max(new_node.priority, priority)
+                self._aggregate_priority(new_node, priority)
                 self._inc_hit_count(new_node, chunked)
                 node = new_node
             else:
-                node.priority = max(node.priority, priority)
+                self._aggregate_priority(node, priority)
                 self._inc_hit_count(node, chunked)
             if len(key):
                 child_key = key.child_key(self.page_size)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -315,7 +315,11 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self.enable_kv_cache_events = params.enable_kv_cache_events
         self.kv_event_queue = []
         self.eviction_policy = params.eviction_policy.lower()
-        self.eviction_strategy = get_eviction_strategy(self.eviction_policy)
+        self._low_priority_values_first = params.schedule_low_priority_values_first
+        self.eviction_strategy = get_eviction_strategy(
+            self.eviction_policy,
+            low_values_first=params.schedule_low_priority_values_first,
+        )
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device
@@ -452,7 +456,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
     def _reset_full(self) -> None:
         """Full reset: destroy entire tree and all state."""
         self.root_node = UnifiedTreeNode(self.tree_components)
-        self.root_node.priority = -sys.maxsize
+        self.root_node.priority = (
+            sys.maxsize if self._low_priority_values_first else -sys.maxsize
+        )
         self.root_node.key = RadixKey(array("q"), None)
         self.root_node.component_data[BASE_COMPONENT_TYPE].value = []
         self.root_node.hash_value = []
@@ -1060,6 +1066,17 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self._update_evictable_leaf_sets(child)
         return new_node
 
+    def _aggregate_priority(self, node: UnifiedTreeNode, priority: int) -> None:
+        """Aggregate priority on a shared prefix node.
+
+        Normal mode: higher priority = more important → use max.
+        Low-values-first mode: lower priority = more important → use min.
+        """
+        if self._low_priority_values_first:
+            node.priority = min(node.priority, priority)
+        else:
+            node.priority = max(node.priority, priority)
+
     def _touch_node(self, node: UnifiedTreeNode):
         node.last_access_time = get_and_increase_time_counter()
         if node != self.root_node:
@@ -1116,7 +1133,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         if priority is None:
             priority = 0
         self._touch_node(node)
-        node.priority = max(node.priority, priority)
+        self._aggregate_priority(node, priority)
         if len(key) == 0:
             return InsertResult(prefix_len=0, mamba_exist=True)
 
@@ -1128,7 +1145,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             prefix_len = node.key.match(key, page_size=self.page_size)
             if prefix_len < len(node.key):
                 node = self._split_node(node.key, node, prefix_len)
-            node.priority = max(node.priority, priority)
+            self._aggregate_priority(node, priority)
 
             if node.evicted:
                 self._unevict_node_on_insert(node, value[:prefix_len])

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -63,10 +63,16 @@ _EVICTION_POLICY_FACTORIES: dict[str, Callable[[], EvictionStrategy]] = {
 }
 
 
-def get_eviction_strategy(eviction_policy: str) -> EvictionStrategy:
+def get_eviction_strategy(
+    eviction_policy: str,
+    low_values_first: bool = False,
+) -> EvictionStrategy:
     policy = eviction_policy.lower()
     try:
-        return _EVICTION_POLICY_FACTORIES[policy]()
+        factory = _EVICTION_POLICY_FACTORIES[policy]
+        if policy == "priority":
+            return factory(low_values_first=low_values_first)
+        return factory()
     except KeyError:
         supported = "', '".join(_EVICTION_POLICY_FACTORIES)
         raise ValueError(

--- a/test/registered/unit/mem_cache/test_evict_policy.py
+++ b/test/registered/unit/mem_cache/test_evict_policy.py
@@ -140,6 +140,35 @@ class TestPriorityStrategy(unittest.TestCase):
         )
 
 
+class TestPriorityStrategyLowValuesFirst(unittest.TestCase):
+    """Eviction direction when scheduler's ``--schedule-low-priority-values-first`` is on."""
+
+    def setUp(self):
+        self.strategy = PriorityStrategy(low_values_first=True)
+
+    def test_priority_is_negated_in_tuple(self):
+        node = _make_node(priority=2, last_access_time=4.0)
+        self.assertEqual(self.strategy.get_priority(node), (-2, 4.0))
+
+    def test_lower_priority_retained_longer(self):
+        """In low-values-first mode, priority 1 (more important) must
+        have a *higher* eviction key than priority 5 (less important)."""
+        important = _make_node(priority=1, last_access_time=10.0)
+        unimportant = _make_node(priority=5, last_access_time=1.0)
+        self.assertGreater(
+            self.strategy.get_priority(important),
+            self.strategy.get_priority(unimportant),
+        )
+
+    def test_same_priority_older_access_evicted_first(self):
+        """Within the same priority, LRU still applies."""
+        old = _make_node(priority=3, last_access_time=1.0)
+        new = _make_node(priority=3, last_access_time=10.0)
+        self.assertLess(
+            self.strategy.get_priority(old), self.strategy.get_priority(new)
+        )
+
+
 class TestSLRUStrategy(unittest.TestCase):
     def setUp(self):
         self.strategy = SLRUStrategy(protected_threshold=2)


### PR DESCRIPTION
## Motivation

When `--schedule-low-priority-values-first` is enabled, the scheduler and 
KV cache eviction use **opposite** priority directions:
- **Scheduler**: lower value = higher priority → scheduled first
- **Cache eviction (PriorityStrategy)**: lower value = evicted first (min-heap)

This means the scheduler's most-preferred requests have their KV cache 
evicted earliest — a cross-component semantic inconsistency.

No existing PR addresses this (confirmed via code/PR search on main).

## Modifications

1. **`evict_policy.py`**: `PriorityStrategy` accepts `low_values_first` param, 
   negating the eviction key when enabled
2. **`utils.py`**: `get_eviction_strategy` passes `low_values_first` through
3. **`cache_init_params.py`**: add `schedule_low_priority_values_first` field
4. **`kv_cache_builder.py`**: wire `ServerArgs` → `CacheInitParams`
5. **`radix_cache.py`**: add `_aggregate_priority` (min for low-values-first, 
   max otherwise), fix root sentinel, replace bare `max()` calls
6. **`hiradix_cache.py`**: use inherited `_aggregate_priority` for shared nodes
7. **`unified_radix_cache.py`**: same aggregation fix + root sentinel
8. **`test_evict_policy.py`**: add `TestPriorityStrategyLowValuesFirst` (3 tests)

## Checklist

- [x] Format code according to the contribution guide
- [x] Add unit tests (`26/26` evict_policy tests passing, including 3 new)
- [ ] Update documentation (N/A — behavior change only under explicit flag)
- [ ] Benchmark (N/A — pure logic fix, no kernel or forward-pass changes)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29722401647](https://github.com/sgl-project/sglang/actions/runs/29722401647)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29722401535](https://github.com/sgl-project/sglang/actions/runs/29722401535)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->