### PR TITLE
[fix] serialize LoRAUpdateOutput via msgspec_to_builtins on the from_distributed route

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1532,11 +1532,8 @@ async def load_lora_adapter_from_distributed(
     result = await _global_state.tokenizer_manager.load_lora_adapter_from_distributed(
         obj, request
     )
-
-    if result.success:
-        return ORJSONResponse(result, status_code=HTTPStatus.OK)
-    else:
-        return ORJSONResponse(result, status_code=HTTPStatus.BAD_REQUEST)
+    status_code = HTTPStatus.OK if result.success else HTTPStatus.BAD_REQUEST
+    return ORJSONResponse(msgspec_to_builtins(result), status_code=status_code)
 
 
 @app.api_route("/unload_lora_adapter", methods=["POST"])


### PR DESCRIPTION
/load_lora_adapter_from_distributed hands the raw msgspec Struct to ORJSONResponse, so every call fails with "TypeError: Type is not JSON serializable: LoRAUpdateOutput". The sibling LoRA routes already convert via msgspec_to_builtins; this one was missed when LoRAUpdateOutput migrated to msgspec. Only RL weight sync exercises this route, which is why CI never caught it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29722563426](https://github.com/sgl-project/sglang/actions/runs/29722563426)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29722563247](https://github.com/sgl-project/sglang/actions/runs/29722563247)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->