### PR TITLE
[DSA] Handle partial-DP padding in Decode page-table transform

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -49,6 +49,7 @@ def transform_index_page_table_decode_kernel(
     result_ptr: torch.Tensor,
     page_size: tl.constexpr,
     page_table_row_stride: tl.constexpr,
+    page_table_num_rows,
 ):
     TOPK: tl.constexpr = 2048
     req_id = tl.program_id(0)
@@ -58,7 +59,9 @@ def transform_index_page_table_decode_kernel(
 
     offset = tl.arange(0, TOPK)  # topk should be 2048
     loaded_topk_indices = tl.load(topk_indices_ptr + offset)
-    mask = loaded_topk_indices >= 0
+    # Partial DP attention pads top-k rows to the local query shape, while the
+    # page table retains only rows for real local queries.
+    mask = (req_id < page_table_num_rows) & (loaded_topk_indices >= 0)
     loaded_kv_indices = tl.load(page_table_ptr + loaded_topk_indices, mask=mask)
     tl.store(result_ptr + offset, loaded_kv_indices, mask=mask)
     tl.store(result_ptr + offset, -1, mask=~mask)
@@ -128,14 +131,18 @@ def transform_index_page_table_decode_fast(
     """
     Transform the page table according to topk indices for sparse topk attention.
     Args:
-        page_table: [qo_len, max_seqlen_k], the original page table
-        topk_indices: [qo_len, topk], the topk indices for each query position
+        page_table: [real_qo_len, max_seqlen_k], the original page table
+        topk_indices: [padded_qo_len, topk], the topk indices for each query
+            position. Partial DP padding rows may extend beyond real_qo_len.
     Returns:
-        transformed_page_table: [qo_len, topk], the transformed page table
-        For out-of-bound indices in topk_indices, this should be filled with -1.
+        transformed_page_table: [padded_qo_len, topk], the transformed page table.
+        Padding rows and negative sentinel indices are filled with -1.
     """
     assert page_size == 1
-    assert page_table.shape[0] == topk_indices.shape[0]
+    assert page_table.shape[0] <= topk_indices.shape[0], (
+        f"page_table rows ({page_table.shape[0]}) exceed topk_indices rows "
+        f"({topk_indices.shape[0]})"
+    )
     assert topk_indices.shape[1] == 2048
     qo_len = topk_indices.shape[0]
     if result is None:
@@ -148,6 +155,7 @@ def transform_index_page_table_decode_fast(
         result,
         page_size,
         page_table_row_stride=page_table.stride(0),
+        page_table_num_rows=page_table.shape[0],
     )
     return result
 
@@ -209,17 +217,25 @@ def transform_index_page_table_decode_ref(
     page_size: int = 1,
 ) -> torch.Tensor:
     assert page_size == 1
-    assert page_table.shape[0] == topk_indices.shape[0]
+    assert page_table.shape[0] <= topk_indices.shape[0], (
+        f"page_table rows ({page_table.shape[0]}) exceed topk_indices rows "
+        f"({topk_indices.shape[0]})"
+    )
     if result is None:
         result = torch.empty_like(topk_indices, dtype=torch.int32)
     assert result.shape == topk_indices.shape
-    torch.gather(
-        page_table.to(result.dtype),
-        dim=1,
-        index=topk_indices.clamp(min=0),
-        out=result,
-    )
-    result[topk_indices < 0] = -1
+    result.fill_(-1)
+    real_rows = page_table.shape[0]
+    if real_rows > 0:
+        real_topk = topk_indices[:real_rows]
+        real_result = result[:real_rows]
+        torch.gather(
+            page_table.to(result.dtype),
+            dim=1,
+            index=real_topk.clamp(min=0),
+            out=real_result,
+        )
+        real_result.masked_fill_(real_topk < 0, -1)
     return result
 
 

--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -49,14 +49,22 @@ def transform_index_page_table_decode_kernel(
     result_ptr: torch.Tensor,
     page_size: tl.constexpr,
     page_table_row_stride: tl.constexpr,
+    page_table_num_rows,
 ):
     TOPK: tl.constexpr = 2048
     req_id = tl.program_id(0)
-    page_table_ptr = page_table_ptr + req_id * page_table_row_stride
     topk_indices_ptr = topk_indices_ptr + req_id * TOPK
     result_ptr = result_ptr + req_id * TOPK
 
     offset = tl.arange(0, TOPK)  # topk should be 2048
+    # DP attention can append dummy query rows while keeping request metadata
+    # compact. These rows have no page-table owner and must not form pointers
+    # into the table, regardless of the contents of their top-k buffer.
+    if req_id >= page_table_num_rows:
+        tl.store(result_ptr + offset, -1)
+        return
+
+    page_table_ptr = page_table_ptr + req_id * page_table_row_stride
     loaded_topk_indices = tl.load(topk_indices_ptr + offset)
     mask = loaded_topk_indices >= 0
     loaded_kv_indices = tl.load(page_table_ptr + loaded_topk_indices, mask=mask)
@@ -131,14 +139,18 @@ def transform_index_page_table_decode_fast(
     """
     Transform the page table according to topk indices for sparse topk attention.
     Args:
-        page_table: [qo_len, max_seqlen_k], the original page table
-        topk_indices: [qo_len, topk], the topk indices for each query position
+        page_table: [real_qo_len, max_seqlen_k], the original page table
+        topk_indices: [padded_qo_len, topk], the topk indices for each query
+            position. Partial-DP padding rows may extend beyond real_qo_len.
     Returns:
-        transformed_page_table: [qo_len, topk], the transformed page table
-        For out-of-bound indices in topk_indices, this should be filled with -1.
+        transformed_page_table: [padded_qo_len, topk], the transformed page
+        table. Padding rows and negative sentinel indices are filled with -1.
     """
     assert page_size == 1
-    assert page_table.shape[0] == topk_indices.shape[0]
+    assert page_table.shape[0] <= topk_indices.shape[0], (
+        f"page_table rows ({page_table.shape[0]}) exceed topk_indices rows "
+        f"({topk_indices.shape[0]})"
+    )
     assert topk_indices.shape[1] == 2048
     qo_len = topk_indices.shape[0]
     if result is None:
@@ -151,6 +163,7 @@ def transform_index_page_table_decode_fast(
         result,
         page_size,
         page_table_row_stride=page_table.stride(0),
+        page_table_num_rows=page_table.shape[0],
     )
     return result
 
@@ -212,17 +225,25 @@ def transform_index_page_table_decode_ref(
     page_size: int = 1,
 ) -> torch.Tensor:
     assert page_size == 1
-    assert page_table.shape[0] == topk_indices.shape[0]
+    assert page_table.shape[0] <= topk_indices.shape[0], (
+        f"page_table rows ({page_table.shape[0]}) exceed topk_indices rows "
+        f"({topk_indices.shape[0]})"
+    )
     if result is None:
         result = torch.empty_like(topk_indices, dtype=torch.int32)
     assert result.shape == topk_indices.shape
-    torch.gather(
-        page_table.to(result.dtype),
-        dim=1,
-        index=topk_indices.clamp(min=0),
-        out=result,
-    )
-    result[topk_indices < 0] = -1
+    result.fill_(-1)
+    real_rows = page_table.shape[0]
+    if real_rows > 0:
+        real_topk = topk_indices[:real_rows]
+        real_result = result[:real_rows]
+        torch.gather(
+            page_table.to(result.dtype),
+            dim=1,
+            index=real_topk.clamp(min=0),
+            out=real_result,
+        )
+        real_result.masked_fill_(real_topk < 0, -1)
     return result
 
 

--- a/test/registered/kernels/ops/attention/test_dsa_transform_index.py
+++ b/test/registered/kernels/ops/attention/test_dsa_transform_index.py
@@ -6,6 +6,7 @@ import torch
 import sglang.kernels.ops.attention.dsa.transform_index as transform_index_module
 from sglang.kernels.ops.attention.dsa.transform_index import (
     transform_index_page_table_decode_fast,
+    transform_index_page_table_decode_ref,
     transform_index_page_table_prefill_fast,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -230,6 +231,85 @@ class TestDSATransformIndex(CustomTestCase):
     def test_decode_fast_correctness_and_strides(self):
         self._check_decode_case(17, 8192, provide_result=True)
         self._check_decode_case(17, 8192, zero_row_stride=True)
+
+    def test_decode_fast_partial_dp_padding(self):
+        real_rows = 3
+        padded_rows = 4
+        context_length = 8192
+        page_table = self._make_page_table(real_rows, context_length)
+        topk_indices = torch.cat(
+            [
+                self._make_topk(real_rows, context_length),
+                # The row-domain boundary, rather than a sentinel-only mask,
+                # must keep padding rows from indexing the compact page table.
+                torch.zeros(
+                    (padded_rows - real_rows, TOPK),
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+            ]
+        )
+        expected = torch.full(
+            (padded_rows, TOPK), -1, dtype=torch.int32, device=self.device
+        )
+        real_topk = topk_indices[:real_rows]
+        torch.gather(
+            page_table,
+            dim=1,
+            index=real_topk.clamp(min=0),
+            out=expected[:real_rows],
+        )
+        expected[:real_rows].masked_fill_(real_topk < 0, -1)
+        result = torch.full_like(expected, 12345)
+
+        actual = transform_index_page_table_decode_fast(
+            page_table=page_table,
+            topk_indices=topk_indices,
+            result=result,
+        )
+        torch.cuda.synchronize()
+
+        self.assertIs(actual, result)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+        ref_result = torch.full_like(expected, 12345)
+        ref_actual = transform_index_page_table_decode_ref(
+            page_table=page_table,
+            topk_indices=topk_indices,
+            result=ref_result,
+        )
+
+        self.assertIs(ref_actual, ref_result)
+        torch.testing.assert_close(ref_actual, expected, rtol=0, atol=0)
+
+    def test_decode_fast_all_padding_rows(self):
+        context_length = 8192
+        page_table = self._make_page_table(0, context_length)
+        topk_indices = torch.zeros((4, TOPK), dtype=torch.int64, device=self.device)
+        result = torch.full((4, TOPK), 12345, dtype=torch.int32, device=self.device)
+
+        actual = transform_index_page_table_decode_fast(
+            page_table=page_table,
+            topk_indices=topk_indices,
+            result=result,
+        )
+        torch.cuda.synchronize()
+
+        self.assertIs(actual, result)
+        self.assertTrue(torch.all(actual == -1))
+
+    def test_decode_fast_rejects_extra_page_table_rows(self):
+        page_table = self._make_page_table(4, 8192)
+        topk_indices = self._make_topk(3, 8192)
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"page_table rows \(4\) exceed topk_indices rows \(3\)",
+        ):
+            transform_index_page_table_decode_fast(
+                page_table=page_table,
+                topk_indices=topk_indices,
+            )
 
     def test_decode_fast_extreme_shapes(self):
         self._check_decode_case(8192, 4096)

--- a/test/registered/kernels/test_dsa_transform_index.py
+++ b/test/registered/kernels/test_dsa_transform_index.py
@@ -231,6 +231,58 @@ class TestDSATransformIndex(CustomTestCase):
         self._check_decode_case(17, 8192, provide_result=True)
         self._check_decode_case(17, 8192, zero_row_stride=True)
 
+    def test_decode_fast_partial_dp_padding(self):
+        real_rows = 3
+        padded_rows = 4
+        context_length = 8192
+        page_table = self._make_page_table(real_rows, context_length)
+        topk_indices = torch.cat(
+            [
+                self._make_topk(real_rows, context_length),
+                torch.full(
+                    (padded_rows - real_rows, TOPK),
+                    -1,
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+            ]
+        )
+        expected = torch.full(
+            (padded_rows, TOPK), -1, dtype=torch.int32, device=self.device
+        )
+        real_topk = topk_indices[:real_rows]
+        torch.gather(
+            page_table,
+            dim=1,
+            index=real_topk.clamp(min=0),
+            out=expected[:real_rows],
+        )
+        expected[:real_rows].masked_fill_(real_topk < 0, -1)
+        result = torch.full_like(expected, 12345)
+
+        actual = transform_index_page_table_decode_fast(
+            page_table=page_table,
+            topk_indices=topk_indices,
+            result=result,
+        )
+        torch.cuda.synchronize()
+
+        self.assertIs(actual, result)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_decode_fast_rejects_extra_page_table_rows(self):
+        page_table = self._make_page_table(4, 8192)
+        topk_indices = self._make_topk(3, 8192)
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"page_table rows \(4\) exceed topk_indices rows \(3\)",
+        ):
+            transform_index_page_table_decode_fast(
+                page_table=page_table,
+                topk_indices=topk_indices,
+            )
+
     def test_decode_fast_extreme_shapes(self):
         self._check_decode_case(8192, 4096)
         self._check_decode_case(2, 1_000_000)


### PR DESCRIPTION
## Motivation

DP attention can pad the local query/top-k layout for downstream MLP/EP communication while keeping request metadata compact. The decode transform therefore has two intentional row domains:

- `page_table.shape[0]`: real local request/query rows;
- `topk_indices.shape[0]`: physical rows, including trailing DP padding.

Current `main` requires those row counts to be equal. A valid partial-DP batch such as `page_table=[3, ...]` and `topk_indices=[4, 2048]` consequently fails before the Triton kernel runs. Merely removing the assertion would be unsafe because the padded program could form an out-of-bounds page-table row pointer.

This is a low-level transform contract fix. It is related to, but independent from, #32209: that PR handles TRT-LLM consumer-side trim/restore and DP-rank graph/eager agreement. It does not modify this transform, and this PR does not claim to fix cross-rank collective divergence.

## Changes

- Accept `page_table_rows <= topk_rows`, while rejecting the reverse mismatch.
- Pass the real page-table row count to the Triton kernel as a runtime argument.
- Short-circuit padded programs before page-table pointer arithmetic or top-k global loads.
- Fill every padded output row with the existing `-1` invalid-index sentinel in the same kernel.
- Apply the same contract to the reference implementation.
- Add regressions for:
  - a dirty preallocated output buffer;
  - padding rows containing non-sentinel values, proving row ownership rather than input contents controls validity;
  - an all-padding batch;
  - the invalid reverse mismatch;
  - fast/reference parity for the partial-DP case.

## Why this belongs at the transform boundary

The transform produces a physical-layout tensor consumed by several DSA decode backends. A caller may need the padded shape after attention for later MLP/EP collectives, while the page table remains real-row metadata. Encoding the distinction in the primitive gives every caller the same memory-safe behavior and avoids depending on padded buffers always being freshly initialized to `-1`, which is not a durable CUDA Graph/static-buffer invariant.

For consumers such as TRT-LLM whose `q`, block table, and sequence-length arrays must all use the real-row domain, caller-side trim/restore is still required (#32209). The two fixes are complementary:

```text
producer / DP padding
  -> transform safety and -1 sentinel rows (this PR)
  -> attention consumer domain alignment (for example #32209)
  -> restore physical rows for downstream MLP/EP collectives
```

## Validation

Tested after merging current upstream `main` (`2d6c12e2fd666d5159891249226d6d3a9a07f4e4`) on one NVIDIA H20 with CUDA 13.0 / PyTorch 2.11.0:

```bash
python3 -m pytest -q \
  test/registered/kernels/ops/attention/test_dsa_transform_index.py
```

- Base `main` with the new regression tests: **3 failed, 7 passed, 2 subtests passed**.
- Patched branch: **10 passed, 2 subtests passed**.
- `git diff --check`: passed.
- `python -m compileall`: passed.
- repository Ruff selection (`F401,F821,UP037`): passed.
- isort check: passed.
- GitHub lint workflow: passed.

### Equal-row fast-path microbenchmark

H20, `TOPK=2048`, context length 8192, 500 measured iterations after warmup. Three repeated runs showed no material regression: for representative batch sizes 4-1024, patched/base ratios were approximately `0.99x-1.04x`; at the production-relevant batch size 80 they were `0.987x-1.009x`.

The padded branch also avoids reading 16 KiB of `int64` top-k data for each padding row.

## Scope / non-goals

This PR intentionally does not change:

- DP-wide CUDA Graph/eager eligibility voting;
- seedless IndexShare fallback;
- idle-rank DSA index generation;
- TRT-LLM attention input trim/output restore;
- collective ordering.

Those are higher-level runtime concerns covered by #32209 and its integration-test follow-up #32722. A full GLM-5.2 TP16/DP8/EP16 PD run remains useful integration evidence, but is not required to demonstrate this transform-level regression.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32814915027](https://github.com/sgl-project/sglang/actions/runs/32814915027)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32816248239](https://github.com/sgl-project/sglang/actions/runs/32816248239)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32814915014](https://github.com/sgl-project/sglang/actions/runs/32814915014)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
