### PR TITLE
fix(marlin_nvfp4): only apply routed_scaling_factor in moe_sum_reduce

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -369,7 +369,12 @@ class FusedMoE(torch.nn.Module):
             self.moe_runner_config.inplace = False
 
         self.should_fuse_routed_scaling_factor_in_topk = (
-            isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
+            (
+                isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
+                and not getattr(
+                    self.quant_method, "_moe_runner_backend", get_moe_runner_backend()
+                ).is_marlin()
+            )
             or (
                 isinstance(self.quant_method, Fp8MoEMethod)
                 and (


### PR DESCRIPTION
## Motivation

`routed_scaling_factor` is used for routed experts weights. 

However, in marlin nvfp4, this param is computed repeatly in topk and moe_sum_reduce, contributing to garbage output text.

topk:

https://github.com/sgl-project/sglang/blob/50c118704a0ec53eee7984dd51ff7dc2be922af5/python/sglang/srt/models/deepseek_v2.py#L631-L674

moe_sum_reduce:

https://github.com/sgl-project/sglang/blob/9668d9ea72ae9385c96f8dc1202df38222b98208/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py#L313-L320



## Modifications

set `should_fuse_routed_scaling_factor_in_topk` as `False` for marlin_nvfp4 situations.


## Accuracy Tests
take $GLM5.2_NVFP4 (https://huggingface.co/nvidia/GLM-5.2-NVFP4) as an example

```shell
# 8 x H800 server
sglang serve \
	--model-path $GLM52_NVFP4   \
	--tp 8   \
	--moe-runner-backend marlin   \
	--quantization modelopt_fp4 \
	--chunked-prefill-size 8192   \
	--mem-fraction-static 0.85   \
	--host 0.0.0.0   \
	--port 30000 \
	--disable-shared-experts-fusion \
	--kv-cache-dtype fp8_e4m3 \
	--cuda-graph-max-bs-decode 2 \
	--reasoning-parser glm45 \
	--tool-call-parser glm47
```

Before:
<img width="1271" height="974" alt="image" src="https://github.com/user-attachments/assets/7e97172b-6984-497c-a9c8-8f9df73fd05f" />


After:

<img width="1276" height="824" alt="image" src="https://github.com/user-attachments/assets/68436e7f-a24c-49fb-b90d-1f1a24ded2a5" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29726436055](https://github.com/sgl-project/sglang/actions/runs/29726436055)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29726435962](https://github.com/sgl-project/sglang/actions/runs/29726435962)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->