### PR TITLE
[Session] Finalize queued streaming-session turns on abort

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2835,7 +2835,12 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
-                self._finalize_queued_session_turn(req)
+                slot_owned_state = self._finalize_queued_session_turn(req)
+                # A request that never ran still owns any Mamba state the cache
+                # allocated for it, and nothing else will free it. State on loan
+                # from a session slot is skipped: the slot keeps owning it.
+                if req.mamba_pool_idx is not None and not slot_owned_state:
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason={

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2786,6 +2786,16 @@ class Scheduler(
                 req_to_abort = candidate_req
                 message = "The request is aborted by a higher priority request."
 
+        # Terminal for `req_to_abort`, whether it is the incoming turn that was
+        # never admitted or an existing queued turn evicted by a higher priority
+        # one, so both need the same finalization as an explicit abort.
+        slot_owned_state = self._finalize_queued_session_turn(req_to_abort)
+        # A turn that never ran still owns any Mamba state allocated for it, and
+        # nothing else will free it. State on loan from a session slot is
+        # skipped: the slot keeps owning it for the next turn.
+        if req_to_abort.mamba_pool_idx is not None and not slot_owned_state:
+            release_kv_cache(req_to_abort, self.tree_cache, is_insert=False)
+
         self.ipc_channels.send_to_tokenizer.send_output(
             AbortReq(
                 finished_reason={

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2800,6 +2800,29 @@ class Scheduler(
         req_to_abort.time_stats.trace_ctx.abort(abort_info={"reason": message})
         return req_to_abort.rid == recv_req.rid
 
+    def _finalize_queued_session_turn(self, req: Req) -> bool:
+        """Finalize a streaming-session turn removed before it ever ran.
+
+        Returns whether the request's req-pool/KV/Mamba state is on loan from
+        the session's slot, in which case the caller must not release it.
+
+        The turn produced nothing, so it must not reach `Session.finish_req`
+        and become committed history: leaving `req_nodes` and the committed
+        lengths untouched is what lets the next turn's `_share_token_arrays`
+        trim the aborted prompt back off. `req.session` deliberately stays
+        attached so that any later cleanup keeps routing through
+        `StreamingSession` instead of the raw cache, which would free state the
+        slot still owns.
+        """
+        session = req.session
+        if session is None:
+            return False
+        # `SessionSlot.restore_to_req` is the only way a queued request holds a
+        # req-pool slot, and it lends the slot's state rather than handing it over.
+        slot_owned_state = req.req_pool_idx is not None
+        session.abort_req()
+        return slot_owned_state
+
     def _abort_on_waiting_timeout(self):
         if (timeout_s := envs.SGLANG_REQ_WAITING_TIMEOUT.get()) <= 0:
             return
@@ -2812,6 +2835,7 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
+                self._finalize_queued_session_turn(req)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason={
@@ -4439,6 +4463,7 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
+            slot_owned_state = self._finalize_queued_session_turn(req)
             self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
@@ -4457,9 +4482,12 @@ class Scheduler(
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
 
-            # For mamba radix cache
+            # For mamba radix cache. Skip state on loan from a session slot:
+            # the slot keeps owning it for the next turn, and releasing would
+            # commit this turn through StreamingSession.cache_finished_req.
             if (
                 req.mamba_pool_idx is not None
+                and not slot_owned_state
                 and self.disaggregation_mode != DisaggregationMode.DECODE
             ):
                 release_kv_cache(req, self.tree_cache, is_insert=False)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2524,6 +2524,16 @@ class Scheduler(
                 req_to_abort = candidate_req
                 message = "The request is aborted by a higher priority request."
 
+        # Terminal for `req_to_abort`, whether it is the incoming turn that was
+        # never admitted or an existing queued turn evicted by a higher priority
+        # one, so both need the same finalization as an explicit abort.
+        slot_owned_state = self._finalize_queued_session_turn(req_to_abort)
+        # A turn that never ran still owns any Mamba state allocated for it, and
+        # nothing else will free it. State on loan from a session slot is
+        # skipped: the slot keeps owning it for the next turn.
+        if req_to_abort.mamba_pool_idx is not None and not slot_owned_state:
+            release_kv_cache(req_to_abort, self.tree_cache, is_insert=False)
+
         self.ipc_channels.send_to_tokenizer.send_output(
             AbortReq(
                 finished_reason={

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2573,7 +2573,12 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
-                self._finalize_queued_session_turn(req)
+                slot_owned_state = self._finalize_queued_session_turn(req)
+                # A request that never ran still owns any Mamba state the cache
+                # allocated for it, and nothing else will free it. State on loan
+                # from a session slot is skipped: the slot keeps owning it.
+                if req.mamba_pool_idx is not None and not slot_owned_state:
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason={

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2538,6 +2538,29 @@ class Scheduler(
         req_to_abort.time_stats.trace_ctx.abort(abort_info={"reason": message})
         return req_to_abort.rid == recv_req.rid
 
+    def _finalize_queued_session_turn(self, req: Req) -> bool:
+        """Finalize a streaming-session turn removed before it ever ran.
+
+        Returns whether the request's req-pool/KV/Mamba state is on loan from
+        the session's slot, in which case the caller must not release it.
+
+        The turn produced nothing, so it must not reach `Session.finish_req`
+        and become committed history: leaving `req_nodes` and the committed
+        lengths untouched is what lets the next turn's `_share_token_arrays`
+        trim the aborted prompt back off. `req.session` deliberately stays
+        attached so that any later cleanup keeps routing through
+        `StreamingSession` instead of the raw cache, which would free state the
+        slot still owns.
+        """
+        session = req.session
+        if session is None:
+            return False
+        # `SessionSlot.restore_to_req` is the only way a queued request holds a
+        # req-pool slot, and it lends the slot's state rather than handing it over.
+        slot_owned_state = req.req_pool_idx is not None
+        session.abort_req()
+        return slot_owned_state
+
     def _abort_on_waiting_timeout(self):
         if (timeout_s := envs.SGLANG_REQ_WAITING_TIMEOUT.get()) <= 0:
             return
@@ -2550,6 +2573,7 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
+                self._finalize_queued_session_turn(req)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason={
@@ -4136,6 +4160,7 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
+            slot_owned_state = self._finalize_queued_session_turn(req)
             self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
@@ -4154,9 +4179,12 @@ class Scheduler(
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
 
-            # For mamba radix cache
+            # For mamba radix cache. Skip state on loan from a session slot:
+            # the slot keeps owning it for the next turn, and releasing would
+            # commit this turn through StreamingSession.cache_finished_req.
             if (
                 req.mamba_pool_idx is not None
+                and not slot_owned_state
                 and self.disaggregation_mode != DisaggregationMode.DECODE
             ):
                 release_kv_cache(req, self.tree_cache, is_insert=False)

--- a/test/registered/sessions/test_streaming_session.py
+++ b/test/registered/sessions/test_streaming_session.py
@@ -5,7 +5,11 @@ Other variants (Retract / Eagle / EagleV2 / EagleRetractLargePage) live in
 test_streaming_session_extra.py.
 """
 
+import concurrent.futures
+import time
 import unittest
+
+import requests
 
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.streaming_session_kit import (
@@ -77,6 +81,164 @@ class TestStreamingSessionAbortLeakRepro(
         "--log-level",
         "info",
     ]
+
+
+class TestStreamingSessionQueuedAbort(StreamingSessionServerBase):
+    """Aborting a session turn while it is still queued must not wedge the session.
+
+    A capped running-request budget plus a blocker request that fills it is
+    what makes queue placement deterministic. The scheduler then confirms the
+    placement itself: only its waiting-queue removal path reports
+    "Abort in waiting queue".
+    """
+
+    # A held SessionSlot keeps one req-pool slot between turns, so the cap must
+    # leave one more for the blocker; `--decode-log-interval 1` refreshes
+    # num_running_reqs every decode step (the default is too stale to sync on).
+    extra_args = [
+        "--max-running-requests",
+        "2",
+        "--enable-metrics",
+        "--decode-log-interval",
+        "1",
+    ]
+
+    BLOCKER_RID = "queued-abort-blocker"
+    TARGET_RID = "queued-abort-target"
+    BLOCKER_TOKENS = 512
+    WAIT_S = 60
+
+    def _running_reqs(self):
+        response = requests.get(self.base_url + "/metrics", timeout=10)
+        self.assertEqual(response.status_code, 200, response.text)
+        for line in response.text.splitlines():
+            if line.startswith("sglang:num_running_reqs{"):
+                return float(line.rsplit(" ", 1)[1])
+        self.fail("metric sglang:num_running_reqs missing from /metrics")
+
+    def _generate(self, input_ids, session_id, rid=None, max_new_tokens=8):
+        payload = {
+            "input_ids": input_ids,
+            "session_params": {"id": session_id},
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": max_new_tokens,
+            },
+        }
+        if rid is not None:
+            payload["rid"] = rid
+        return requests.post(self.base_url + "/generate", json=payload, timeout=180)
+
+    def _abort(self, rid):
+        return requests.post(
+            self.base_url + "/abort_request", json={"rid": rid}, timeout=30
+        )
+
+    def _run_blocker(self):
+        return requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "Count slowly starting from one:",
+                "rid": self.BLOCKER_RID,
+                "sampling_params": {
+                    "temperature": 0,
+                    # Long enough to hold the slot across the abort below, short
+                    # enough to retire on its own: aborting a *running* request
+                    # under --max-running-requests 1 is not what this test covers.
+                    "max_new_tokens": self.BLOCKER_TOKENS,
+                    # Without this the blocker stops at EOS, frees the slot, and
+                    # the session turn is admitted instead of queued.
+                    "ignore_eos": True,
+                },
+            },
+            timeout=180,
+        )
+
+    def _await_running(self, expected, what):
+        deadline = time.time() + self.WAIT_S
+        observed = None
+        while time.time() < deadline:
+            observed = self._running_reqs()
+            if observed == expected:
+                return
+            time.sleep(0.05)
+        self.fail(f"timed out waiting for {what}; num_running_reqs={observed}")
+
+    def test_queued_session_turn_abort_keeps_session_usable(self):
+        requests.post(self.base_url + "/flush_cache")
+        session_id = requests.post(
+            self.base_url + "/open_session",
+            json={"capacity_of_str_len": 1000, "streaming": True},
+        ).json()
+        self.addCleanup(
+            requests.post,
+            self.base_url + "/close_session",
+            json={"session_id": session_id},
+        )
+
+        turn1_ids = self.tokenizer.encode("The capital of France is")
+        aborted_ids = self.tokenizer.encode(" Ignore this sentence entirely.")[1:]
+        turn3_ids = self.tokenizer.encode(" Now say something else.")[1:]
+
+        # Turn 1 is served normally and becomes the session's committed prefix.
+        turn1 = self._generate(turn1_ids, session_id)
+        self.assertEqual(turn1.status_code, 200, turn1.text)
+        turn1_meta = turn1.json()["meta_info"]
+        committed_len = turn1_meta["prompt_tokens"] + turn1_meta["completion_tokens"]
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+        try:
+            pool.submit(self._run_blocker)
+            # Once the blocker is running it holds the only slot, so the turn
+            # submitted next can only sit in the waiting queue.
+            self._await_running(1, "the blocker to start running")
+
+            target = pool.submit(
+                self._generate, aborted_ids, session_id, self.TARGET_RID
+            )
+            # /generate only returns once the turn is done, so retry the abort
+            # until it lands. The turn cannot progress while the slot is held.
+            deadline = time.time() + self.WAIT_S
+            while not target.done() and time.time() < deadline:
+                self.assertEqual(self._abort(self.TARGET_RID).status_code, 200)
+                time.sleep(0.1)
+            self.assertTrue(target.done(), "queued session turn was never aborted")
+            target_body = target.result(timeout=self.WAIT_S).json()
+        finally:
+            # The blocker retires on its own; just join it.
+            pool.shutdown(wait=True)
+
+        finish_reason = target_body["meta_info"]["finish_reason"]
+        self.assertEqual(finish_reason["type"], "abort", target_body["meta_info"])
+        # Only Scheduler.abort_request's waiting-queue branch reports this, so
+        # it is the server's own confirmation that the turn never started.
+        self.assertEqual(finish_reason["message"], "Abort in waiting queue")
+        self.assertEqual(target_body["output_ids"], [])
+
+        self._await_running(0, "the server to drain")
+
+        # The session must still accept turns.
+        turn3 = self._generate(turn3_ids, session_id)
+        self.assertEqual(turn3.status_code, 200, turn3.text)
+        turn3_meta = turn3.json()["meta_info"]
+
+        turn3_finish = turn3_meta.get("finish_reason") or {}
+        self.assertNotEqual(
+            turn3_finish.get("type"),
+            "abort",
+            f"follow-up turn was rejected: {turn3_finish.get('message')!r}",
+        )
+
+        # Distinguishes both wrong fixes: discarding the committed prefix gives
+        # len(turn3_ids), and committing the aborted prompt adds len(aborted_ids).
+        self.assertEqual(
+            turn3_meta["prompt_tokens"],
+            committed_len + len(turn3_ids),
+            "turn 3 context is not exactly the committed prefix plus its own prompt",
+        )
+
+        health = requests.get(self.base_url + "/health", timeout=10)
+        self.assertEqual(health.status_code, 200, "server unhealthy after queued abort")
 
 
 if __name__ == "__main__":

--- a/test/registered/sessions/test_streaming_session.py
+++ b/test/registered/sessions/test_streaming_session.py
@@ -27,8 +27,8 @@ from sglang.test.test_utils import (
     DEFAULT_TARGET_MODEL_EAGLE3,
 )
 
-register_cuda_ci(est_time=691, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=691, suite="stage-b-test-1-gpu-large-amd")
+register_cuda_ci(est_time=811, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=811, suite="stage-b-test-1-gpu-large-amd")
 
 
 class TestStreamingSession(StreamingSessionServerBase, StreamingSessionKitMixin):
@@ -83,13 +83,119 @@ class TestStreamingSessionAbortLeakRepro(
     ]
 
 
-class TestStreamingSessionQueuedAbort(StreamingSessionServerBase):
+class QueuedSessionTurnMixin:
+    """Helpers for putting a session turn in the waiting queue and watching it.
+
+    A capped running-request budget plus a blocker request that fills it is what
+    makes queue placement deterministic, and the scheduler's own gauges say when
+    each step has actually landed, so no step is timed.
+    """
+
+    BLOCKER_RID = "queued-session-blocker"
+    BLOCKER_TOKENS = 512
+    WAIT_S = 60
+
+    def _gauge_total(self, name):
+        """Read a scheduler gauge's total series.
+
+        Under priority scheduling the same gauge also carries a per-priority
+        breakdown; the total is the series with the default `priority=""`.
+        """
+        response = requests.get(self.base_url + "/metrics", timeout=10)
+        self.assertEqual(response.status_code, 200, response.text)
+        for line in response.text.splitlines():
+            if not line.startswith(name + "{"):
+                continue
+            labels, value = line[len(name) + 1 :].rsplit("}", 1)
+            if 'priority="' in labels and 'priority=""' not in labels:
+                continue
+            return float(value)
+        self.fail(f"metric {name} missing from /metrics")
+
+    def _running_reqs(self):
+        return self._gauge_total("sglang:num_running_reqs")
+
+    def _queued_reqs(self):
+        return self._gauge_total("sglang:num_queue_reqs")
+
+    def _generate(
+        self, input_ids, session_id, rid=None, max_new_tokens=8, priority=None
+    ):
+        payload = {
+            "input_ids": input_ids,
+            "session_params": {"id": session_id},
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": max_new_tokens,
+            },
+        }
+        if rid is not None:
+            payload["rid"] = rid
+        if priority is not None:
+            payload["priority"] = priority
+        return requests.post(self.base_url + "/generate", json=payload, timeout=180)
+
+    def _abort(self, rid):
+        return requests.post(
+            self.base_url + "/abort_request", json={"rid": rid}, timeout=30
+        )
+
+    def _run_blocker(self, priority=None):
+        payload = {
+            "text": "Count slowly starting from one:",
+            "rid": self.BLOCKER_RID,
+            "sampling_params": {
+                "temperature": 0,
+                # Long enough to hold the slot across the removal below, short
+                # enough to retire on its own: removing a *running* request is
+                # not what these tests cover.
+                "max_new_tokens": self.BLOCKER_TOKENS,
+                # Without this the blocker stops at EOS, frees the slot, and
+                # the session turn is admitted instead of queued.
+                "ignore_eos": True,
+            },
+        }
+        if priority is not None:
+            payload["priority"] = priority
+        return requests.post(self.base_url + "/generate", json=payload, timeout=180)
+
+    def _await_gauge(self, read, expected, what):
+        deadline = time.time() + self.WAIT_S
+        observed = None
+        while time.time() < deadline:
+            observed = read()
+            if observed == expected:
+                return
+            time.sleep(0.05)
+        self.fail(f"timed out waiting for {what}; observed={observed}")
+
+    def _await_running(self, expected, what):
+        self._await_gauge(self._running_reqs, expected, what)
+
+    def _await_queued(self, expected, what):
+        self._await_gauge(self._queued_reqs, expected, what)
+
+    def _open_session(self):
+        requests.post(self.base_url + "/flush_cache")
+        session_id = requests.post(
+            self.base_url + "/open_session",
+            json={"capacity_of_str_len": 1000, "streaming": True},
+        ).json()
+        self.addCleanup(
+            requests.post,
+            self.base_url + "/close_session",
+            json={"session_id": session_id},
+        )
+        return session_id
+
+
+class TestStreamingSessionQueuedAbort(
+    StreamingSessionServerBase, QueuedSessionTurnMixin
+):
     """Aborting a session turn while it is still queued must not wedge the session.
 
-    A capped running-request budget plus a blocker request that fills it is
-    what makes queue placement deterministic. The scheduler then confirms the
-    placement itself: only its waiting-queue removal path reports
-    "Abort in waiting queue".
+    The scheduler confirms the queue placement itself: only its waiting-queue
+    removal path reports "Abort in waiting queue".
     """
 
     # A held SessionSlot keeps one req-pool slot between turns, so the cap must
@@ -103,78 +209,10 @@ class TestStreamingSessionQueuedAbort(StreamingSessionServerBase):
         "1",
     ]
 
-    BLOCKER_RID = "queued-abort-blocker"
     TARGET_RID = "queued-abort-target"
-    BLOCKER_TOKENS = 512
-    WAIT_S = 60
-
-    def _running_reqs(self):
-        response = requests.get(self.base_url + "/metrics", timeout=10)
-        self.assertEqual(response.status_code, 200, response.text)
-        for line in response.text.splitlines():
-            if line.startswith("sglang:num_running_reqs{"):
-                return float(line.rsplit(" ", 1)[1])
-        self.fail("metric sglang:num_running_reqs missing from /metrics")
-
-    def _generate(self, input_ids, session_id, rid=None, max_new_tokens=8):
-        payload = {
-            "input_ids": input_ids,
-            "session_params": {"id": session_id},
-            "sampling_params": {
-                "temperature": 0,
-                "max_new_tokens": max_new_tokens,
-            },
-        }
-        if rid is not None:
-            payload["rid"] = rid
-        return requests.post(self.base_url + "/generate", json=payload, timeout=180)
-
-    def _abort(self, rid):
-        return requests.post(
-            self.base_url + "/abort_request", json={"rid": rid}, timeout=30
-        )
-
-    def _run_blocker(self):
-        return requests.post(
-            self.base_url + "/generate",
-            json={
-                "text": "Count slowly starting from one:",
-                "rid": self.BLOCKER_RID,
-                "sampling_params": {
-                    "temperature": 0,
-                    # Long enough to hold the slot across the abort below, short
-                    # enough to retire on its own: aborting a *running* request
-                    # under --max-running-requests 1 is not what this test covers.
-                    "max_new_tokens": self.BLOCKER_TOKENS,
-                    # Without this the blocker stops at EOS, frees the slot, and
-                    # the session turn is admitted instead of queued.
-                    "ignore_eos": True,
-                },
-            },
-            timeout=180,
-        )
-
-    def _await_running(self, expected, what):
-        deadline = time.time() + self.WAIT_S
-        observed = None
-        while time.time() < deadline:
-            observed = self._running_reqs()
-            if observed == expected:
-                return
-            time.sleep(0.05)
-        self.fail(f"timed out waiting for {what}; num_running_reqs={observed}")
 
     def test_queued_session_turn_abort_keeps_session_usable(self):
-        requests.post(self.base_url + "/flush_cache")
-        session_id = requests.post(
-            self.base_url + "/open_session",
-            json={"capacity_of_str_len": 1000, "streaming": True},
-        ).json()
-        self.addCleanup(
-            requests.post,
-            self.base_url + "/close_session",
-            json={"session_id": session_id},
-        )
+        session_id = self._open_session()
 
         turn1_ids = self.tokenizer.encode("The capital of France is")
         aborted_ids = self.tokenizer.encode(" Ignore this sentence entirely.")[1:]
@@ -239,6 +277,134 @@ class TestStreamingSessionQueuedAbort(StreamingSessionServerBase):
 
         health = requests.get(self.base_url + "/health", timeout=10)
         self.assertEqual(health.status_code, 200, "server unhealthy after queued abort")
+
+
+class TestStreamingSessionPriorityEviction(
+    StreamingSessionServerBase, QueuedSessionTurnMixin
+):
+    """A session turn evicted by the queue limit must not wedge the session.
+
+    `_abort_on_queued_limit` is the other way a turn leaves the waiting queue
+    without ever running: with priority scheduling on and the queue at its cap,
+    an arriving higher-priority request evicts the queued lower-priority one.
+    That removal is as final as an explicit abort, so it needs the same session
+    finalization.
+    """
+
+    # `--max-queued-requests 1` means the queue holds exactly the session turn,
+    # so the arriving request must displace it rather than queue behind it.
+    # The priorities below stay within
+    # `--priority-scheduling-preemption-threshold` (default 10) so the running
+    # blocker is never preempted: this exercises the queue limit, nothing else.
+    extra_args = [
+        "--max-running-requests",
+        "2",
+        "--max-queued-requests",
+        "1",
+        "--enable-priority-scheduling",
+        "--default-priority-value",
+        "1",
+        "--enable-metrics",
+        "--decode-log-interval",
+        "1",
+    ]
+
+    EVICTED_RID = "priority-eviction-target"
+    PREEMPTOR_RID = "priority-eviction-preemptor"
+    LOW_PRIORITY = 1
+    HIGH_PRIORITY = 5
+
+    def _run_preemptor(self):
+        """The arrival that finds the queue full and outranks what is in it."""
+        return requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "Say hello:",
+                "rid": self.PREEMPTOR_RID,
+                "priority": self.HIGH_PRIORITY,
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+            },
+            timeout=180,
+        )
+
+    def test_priority_evicted_session_turn_keeps_session_usable(self):
+        session_id = self._open_session()
+
+        turn1_ids = self.tokenizer.encode("The capital of France is")
+        evicted_ids = self.tokenizer.encode(" Ignore this sentence entirely.")[1:]
+        turn3_ids = self.tokenizer.encode(" Now say something else.")[1:]
+
+        # Turn 1 is served normally and becomes the session's committed prefix.
+        turn1 = self._generate(turn1_ids, session_id, priority=self.LOW_PRIORITY)
+        self.assertEqual(turn1.status_code, 200, turn1.text)
+        turn1_meta = turn1.json()["meta_info"]
+        committed_len = turn1_meta["prompt_tokens"] + turn1_meta["completion_tokens"]
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+        try:
+            pool.submit(self._run_blocker, self.HIGH_PRIORITY)
+            # Once the blocker is running it holds the only slot, so the turn
+            # submitted next can only sit in the waiting queue.
+            self._await_running(1, "the blocker to start running")
+
+            evicted = pool.submit(
+                self._generate,
+                evicted_ids,
+                session_id,
+                self.EVICTED_RID,
+                priority=self.LOW_PRIORITY,
+            )
+            # Wait for the turn to actually reach the queue, so the request sent
+            # next finds the queue full and at a lower priority than itself.
+            # This only sequences the two submissions; what proves the eviction
+            # path ran is the abort message the scheduler sends back below.
+            self._await_queued(1, "the session turn to reach the waiting queue")
+
+            preemptor = pool.submit(self._run_preemptor)
+            evicted_response = evicted.result(timeout=self.WAIT_S)
+            self.assertEqual(preemptor.result(timeout=self.WAIT_S).status_code, 200)
+        finally:
+            # The blocker retires on its own; just join it.
+            pool.shutdown(wait=True)
+
+        # Unlike an explicit abort, the queue limit aborts with
+        # SERVICE_UNAVAILABLE, so the turn comes back as an HTTP error instead
+        # of a finished generation -- it produced no tokens at all.
+        self.assertEqual(evicted_response.status_code, 503, evicted_response.text)
+        # Only the priority branch of _abort_on_queued_limit reports this, so it
+        # is the server's own confirmation of which path removed the turn. A
+        # plain queue-limit rejection would say "The request queue is full."
+        self.assertEqual(
+            evicted_response.json()["message"],
+            "The request is aborted by a higher priority request.",
+        )
+
+        self._await_running(0, "the server to drain")
+
+        # The session must still accept turns, i.e. it is not left in-flight.
+        turn3 = self._generate(turn3_ids, session_id, priority=self.LOW_PRIORITY)
+        self.assertEqual(turn3.status_code, 200, turn3.text)
+        turn3_meta = turn3.json()["meta_info"]
+
+        turn3_finish = turn3_meta.get("finish_reason") or {}
+        self.assertNotEqual(
+            turn3_finish.get("type"),
+            "abort",
+            f"follow-up turn was rejected: {turn3_finish.get('message')!r}",
+        )
+
+        # Distinguishes both wrong fixes: discarding the committed prefix gives
+        # len(turn3_ids), and committing the evicted prompt adds len(evicted_ids).
+        self.assertEqual(
+            turn3_meta["prompt_tokens"],
+            committed_len + len(turn3_ids),
+            "turn 3 context is not exactly the committed prefix plus its own prompt",
+        )
+
+        health = requests.get(self.base_url + "/health", timeout=10)
+        self.assertEqual(
+            health.status_code, 200, "server unhealthy after priority eviction"
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_timeouts.py
+++ b/test/registered/unit/managers/test_scheduler_timeouts.py
@@ -28,6 +28,8 @@ class _FakeReq:
     def __init__(self, rid, wait_entry=0.0, forward_entry=0.0, is_finished=False):
         self.rid = rid
         self.to_finish = None
+        self.session = None
+        self.mamba_pool_idx = None
         self._finished = is_finished
         self.time_stats = SimpleNamespace(
             wait_queue_entry_time=wait_entry,

--- a/test/registered/unit/session/test_session_abort_lifecycle.py
+++ b/test/registered/unit/session/test_session_abort_lifecycle.py
@@ -1,0 +1,460 @@
+"""Regression tests for aborting a streaming-session turn that is still queued.
+
+`Session.create_req` marks a streaming session in-flight so that only one turn
+at a time may borrow the session's `SessionSlot`. A turn that is removed from
+`Scheduler.waiting_queue` before it ever runs must clear that flag, must not be
+committed as a finished turn, and must leave the slot (and the prefix it holds)
+intact for the next turn.
+
+These tests drive the real `Scheduler.abort_request` and
+`Scheduler._abort_on_waiting_timeout` against a real `Session`, so they fail if
+either removal path stops finalizing the session correctly.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.io_struct import AbortReq, SessionParams
+from sglang.srt.managers.schedule_batch import get_parallel
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.session.session_controller import Session
+from sglang.srt.session.streaming_session import SessionSlot, StreamingSession
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+VOCAB_SIZE = 32000
+
+
+def _make_recv_req(rid, input_ids, session_id):
+    """Minimal stand-in for TokenizedGenerateReqInput.
+
+    Only carries the attributes `Session.create_req` reads; the request object
+    it builds is a real `Req`.
+    """
+    sampling_params = SamplingParams(max_new_tokens=8)
+    sampling_params.normalize(None)
+    return SimpleNamespace(
+        rid=rid,
+        input_ids=list(input_ids),
+        session_params=SessionParams(id=session_id),
+        sampling_params=sampling_params,
+        lora_id=None,
+        custom_logit_processor=None,
+        stream=True,
+        return_logprob=False,
+        top_logprobs_num=0,
+        token_ids_logprob=None,
+        return_sampling_mask=False,
+        require_reasoning=None,
+        return_hidden_states=False,
+        return_routed_experts=False,
+        routed_experts_start_len=None,
+        priority=None,
+        routing_key=None,
+        extra_key=None,
+        http_worker_ipc=None,
+        time_stats=None,
+    )
+
+
+class _RecordingTreeCache:
+    """Tree cache that records release calls instead of performing them.
+
+    A queued session turn borrows its req-pool / KV / Mamba state from the
+    `SessionSlot`, so any release reaching this object would be operating on
+    state the slot still owns.
+    """
+
+    def __init__(self):
+        self.cache_finished_req_calls = []
+        self.released_aborted_rids = []
+
+    def cache_finished_req(self, req, **kwargs):
+        self.cache_finished_req_calls.append(req.rid)
+
+    def release_aborted_request(self, rid):
+        self.released_aborted_rids.append(rid)
+
+
+def _make_scheduler(tree_cache, *, waiting_queue):
+    """Smallest `Scheduler` exposing the real queued-abort paths."""
+    s = Scheduler.__new__(Scheduler)
+    s.chunked_req = None
+    s._pending_chunked_abort_req = None
+    s.waiting_queue = waiting_queue
+    s.tree_cache = tree_cache
+    s.enable_hicache_storage = False
+    s.enable_hierarchical_cache = False
+    s.disaggregation_mode = DisaggregationMode.NULL
+    s.ipc_channels = MagicMock()
+    s.grammar_manager = MagicMock()
+    s.ps = SimpleNamespace(pp_size=1)
+    s.running_batch = None
+    s.last_batch = None
+    s.dllm_config = None
+    return s
+
+
+def _queue_turn(session, scheduler, rid, input_ids, session_id="s0"):
+    req = session.create_req(
+        _make_recv_req(rid, input_ids, session_id), None, VOCAB_SIZE
+    )
+    req.mamba_pool_idx = None
+    req.req_pool_idx = None
+    req.kv = None
+    scheduler.waiting_queue.append(req)
+    return req
+
+
+def _finish_turn(session, req, output_ids):
+    """Mark a turn successfully finished the way the streaming cache does."""
+    req.output_ids = list(output_ids)
+    session.finish_req(req)
+
+
+class TestQueuedSessionAbortLifecycle(CustomTestCase):
+    def setUp(self):
+        self._parallel_override = get_parallel().override(tp_rank=0)
+        self._parallel_override.__enter__()
+        self.addCleanup(self._parallel_override.__exit__, None, None, None)
+
+    # -- explicit abort -------------------------------------------------
+
+    def test_queued_abort_releases_streaming_session(self):
+        """Real abort_request must clear _inflight so the session continues."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        first = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        _finish_turn(session, first, [91, 92])
+        scheduler.waiting_queue.clear()
+
+        queued = _queue_turn(session, scheduler, "r2", [44, 55, 66])
+        self.assertTrue(session._inflight)
+
+        scheduler.abort_request(AbortReq(rid="r2"))
+
+        self.assertNotIn(queued, scheduler.waiting_queue)
+        self.assertFalse(session._inflight)
+
+        follow_up = session.create_req(
+            _make_recv_req("r3", [77, 88], "s0"), None, VOCAB_SIZE
+        )
+        self.assertIsNone(follow_up.to_finish)
+
+    def test_queued_abort_does_not_commit_the_turn(self):
+        """The aborted prompt must not enter the session's committed history."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        first = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        _finish_turn(session, first, [91, 92])
+        scheduler.waiting_queue.clear()
+        committed_len = session.committed_origin_len
+
+        _queue_turn(session, scheduler, "r2", [44, 55, 66])
+        scheduler.abort_request(AbortReq(rid="r2"))
+
+        # finish_req would have advanced the rollback point over the
+        # never-executed prompt.
+        self.assertEqual(session.committed_origin_len, committed_len)
+
+        follow_up = session.create_req(
+            _make_recv_req("r3", [77, 88], "s0"), None, VOCAB_SIZE
+        )
+        context = list(follow_up.origin_input_ids)
+        self.assertEqual(context, [11, 12, 13, 91, 92, 77, 88])
+        for token in (44, 55, 66):
+            self.assertNotIn(token, context)
+
+    def test_queued_abort_preserves_committed_prefix(self):
+        """The slot's committed prefix must survive a queued abort."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        first = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        _finish_turn(session, first, [91, 92])
+        scheduler.waiting_queue.clear()
+
+        _queue_turn(session, scheduler, "r2", [44, 55, 66])
+        scheduler.abort_request(AbortReq(rid="r2"))
+
+        # req_nodes still points at the last successful turn, and nothing was
+        # handed to the cache for release.
+        self.assertEqual(list(session.req_nodes), ["r1"])
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+
+        follow_up = session.create_req(
+            _make_recv_req("r3", [77, 88], "s0"), None, VOCAB_SIZE
+        )
+        self.assertEqual(list(follow_up.origin_input_ids)[:5], [11, 12, 13, 91, 92])
+
+    def test_first_turn_queued_abort_is_safe(self):
+        """Aborting before any turn committed must leave the session reusable."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        scheduler.abort_request(AbortReq(rid="r1"))
+
+        self.assertFalse(session._inflight)
+        self.assertEqual(dict(session.req_nodes), {})
+        self.assertIsNone(session.committed_origin_len)
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+
+        retry = session.create_req(
+            _make_recv_req("r2", [21, 22], "s0"), None, VOCAB_SIZE
+        )
+        self.assertIsNone(retry.to_finish)
+        self.assertEqual(list(retry.origin_input_ids), [21, 22])
+
+    # -- waiting timeout ------------------------------------------------
+
+    def test_waiting_timeout_releases_streaming_session(self):
+        """The timeout path must finalize the session like an explicit abort."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        first = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        _finish_turn(session, first, [91, 92])
+        scheduler.waiting_queue.clear()
+
+        timed_out = _queue_turn(session, scheduler, "r2", [44, 55, 66])
+        # Entry time far enough in the past that any positive timeout fires.
+        timed_out.time_stats = SimpleNamespace(wait_queue_entry_time=1e-6)
+
+        with unittest.mock.patch(
+            "sglang.srt.managers.scheduler.envs.SGLANG_REQ_WAITING_TIMEOUT.get",
+            return_value=1,
+        ):
+            scheduler._abort_on_waiting_timeout()
+
+        self.assertNotIn(timed_out, scheduler.waiting_queue)
+        self.assertFalse(session._inflight)
+
+        follow_up = session.create_req(
+            _make_recv_req("r3", [77, 88], "s0"), None, VOCAB_SIZE
+        )
+        self.assertIsNone(follow_up.to_finish)
+        context = list(follow_up.origin_input_ids)
+        self.assertEqual(context, [11, 12, 13, 91, 92, 77, 88])
+
+    # -- non-session traffic --------------------------------------------
+
+    def test_non_session_queued_abort_unchanged(self):
+        """Requests without a session must keep their existing behaviour."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        plain = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        plain.session = None
+
+        scheduler.abort_request(AbortReq(rid="r1"))
+
+        self.assertEqual(scheduler.waiting_queue, [])
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+        # The session was never notified, because the request no longer owned one.
+        self.assertTrue(session._inflight)
+
+
+class _RawCachePathGuard:
+    """Inner cache standing behind a real `StreamingSession`.
+
+    Delegation to `cache_finished_req` here means the request stopped looking
+    like a streaming request and reached the raw cache, which would free state
+    the `SessionSlot` still owns.
+    """
+
+    def __init__(self, req_to_token_pool, allocator, page_size):
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = allocator
+        self.page_size = page_size
+        self.disable = False
+        self.metrics_collector = None
+
+    def cache_finished_req(self, *args, **kwargs):
+        raise AssertionError("session-owned request reached the raw cache path")
+
+    def dec_lock_ref(self, node, *args, **kwargs):
+        raise AssertionError("queued abort must not unlock the session's tree node")
+
+    def supports_mamba(self):
+        return True
+
+    def sanity_check(self):
+        return None
+
+
+class _RecordingAllocator:
+    def __init__(self):
+        self.freed = []
+
+    def free(self, index):
+        self.freed.append(index)
+
+
+def _make_streaming_cache(num_slots=8, max_context=64, page_size=1):
+    """Real `StreamingSession` over a fake inner cache and pools."""
+    mamba_allocator = _RecordingAllocator()
+    req_to_token_pool = SimpleNamespace(
+        req_to_token=torch.zeros((num_slots, max_context), dtype=torch.int32),
+        mamba_allocator=mamba_allocator,
+        free_slots=[],
+    )
+    inner = _RawCachePathGuard(req_to_token_pool, _RecordingAllocator(), page_size)
+    return StreamingSession(inner), mamba_allocator
+
+
+class TestQueuedSessionAbortMambaOwnership(CustomTestCase):
+    """A restored turn borrows its Mamba/req-pool state from the SessionSlot.
+
+    These drive the real `StreamingSession`, so the pre-fix path really did
+    reach `Session.finish_req`.
+    """
+
+    def setUp(self):
+        self._parallel_override = get_parallel().override(tp_rank=0)
+        self._parallel_override.__enter__()
+        self.addCleanup(self._parallel_override.__exit__, None, None, None)
+
+    def _build(self):
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        streaming_cache, mamba_allocator = _make_streaming_cache()
+        scheduler = _make_scheduler(streaming_cache, waiting_queue=[])
+
+        first = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        _finish_turn(session, first, [91, 92])
+        scheduler.waiting_queue.clear()
+
+        # The slot the finished turn left behind, holding the committed prefix.
+        slot = SessionSlot(
+            req_pool_idx=3,
+            kv_committed_len=5,
+            kv=SimpleNamespace(kv_allocated_len=5, swa_evicted_seqlen=0),
+            mamba_pool_idx=torch.tensor([2], dtype=torch.int64),
+        )
+        streaming_cache.slots["s0"] = slot
+        return session, scheduler, streaming_cache, slot, mamba_allocator
+
+    def _restored_turn(self, session, scheduler, slot, rid, input_ids):
+        """Queue a turn holding slot-borrowed state, as `restore_to_req` leaves it."""
+        req = _queue_turn(session, scheduler, rid, input_ids)
+        slot.restore_to_req(req)
+        return req
+
+    def test_slot_owned_state_is_not_released(self):
+        session, scheduler, streaming_cache, slot, mamba_allocator = self._build()
+        self._restored_turn(session, scheduler, slot, "r2", [44, 55, 66])
+
+        scheduler.abort_request(AbortReq(rid="r2"))
+
+        # The slot keeps every resource it lent out.
+        self.assertIn("s0", streaming_cache.slots)
+        self.assertEqual(slot.req_pool_idx, 3)
+        self.assertIsNotNone(slot.mamba_pool_idx)
+        self.assertEqual(mamba_allocator.freed, [])
+        self.assertEqual(streaming_cache.inner.token_to_kv_pool_allocator.freed, [])
+        self.assertEqual(streaming_cache.req_to_token_pool.free_slots, [])
+        self.assertFalse(session._inflight)
+
+    def test_mamba_turn_history_is_not_committed(self):
+        session, scheduler, _cache, slot, _alloc = self._build()
+        committed_len = session.committed_origin_len
+
+        self._restored_turn(session, scheduler, slot, "r2", [44, 55, 66])
+        scheduler.abort_request(AbortReq(rid="r2"))
+
+        self.assertEqual(session.committed_origin_len, committed_len)
+        self.assertEqual(list(session.req_nodes), ["r1"])
+
+        follow_up = session.create_req(
+            _make_recv_req("r3", [77, 88], "s0"), None, VOCAB_SIZE
+        )
+        self.assertEqual(list(follow_up.origin_input_ids), [11, 12, 13, 91, 92, 77, 88])
+
+    def test_waiting_timeout_preserves_slot_owned_state(self):
+        session, scheduler, streaming_cache, slot, mamba_allocator = self._build()
+        timed_out = self._restored_turn(session, scheduler, slot, "r2", [44, 55, 66])
+        timed_out.time_stats = SimpleNamespace(wait_queue_entry_time=1e-6)
+
+        with unittest.mock.patch(
+            "sglang.srt.managers.scheduler.envs.SGLANG_REQ_WAITING_TIMEOUT.get",
+            return_value=1,
+        ):
+            scheduler._abort_on_waiting_timeout()
+
+        self.assertIn("s0", streaming_cache.slots)
+        self.assertEqual(mamba_allocator.freed, [])
+        self.assertFalse(session._inflight)
+        self.assertEqual(list(session.req_nodes), ["r1"])
+
+    def test_first_turn_exclusive_mamba_state_is_released(self):
+        """Without a slot the Mamba state is the request's own and must be freed."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        req = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        # Early Mamba allocation happens before any req-pool slot is taken.
+        req.req_pool_idx = None
+        req.kv = None
+        req.mamba_pool_idx = torch.tensor([2], dtype=torch.int64)
+
+        released = []
+        tree_cache.supports_mamba = lambda: True
+        tree_cache.req_to_token_pool = SimpleNamespace(
+            mamba_allocator=SimpleNamespace(free=released.append)
+        )
+
+        scheduler.abort_request(AbortReq(rid="r1"))
+
+        self.assertEqual([t.tolist() for t in released], [[[2]]])
+        self.assertIsNone(req.mamba_pool_idx)
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+        self.assertFalse(session._inflight)
+
+
+class TestQueuedSessionAbortIdempotence(CustomTestCase):
+    def setUp(self):
+        self._parallel_override = get_parallel().override(tp_rank=0)
+        self._parallel_override.__enter__()
+        self.addCleanup(self._parallel_override.__exit__, None, None, None)
+
+    def test_repeated_abort_does_not_clear_a_newer_turn(self):
+        """A second abort for a removed rid must not disturb the next turn."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        scheduler.abort_request(AbortReq(rid="r1"))
+        self.assertFalse(session._inflight)
+
+        # The next turn is admitted and is genuinely active.
+        newer = _queue_turn(session, scheduler, "r2", [21, 22])
+        self.assertTrue(session._inflight)
+
+        # Re-aborting the already removed request must be inert.
+        scheduler.abort_request(AbortReq(rid="r1"))
+        self.assertTrue(session._inflight)
+        self.assertIn(newer, scheduler.waiting_queue)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/session/test_session_abort_lifecycle.py
+++ b/test/registered/unit/session/test_session_abort_lifecycle.py
@@ -404,6 +404,42 @@ class TestQueuedSessionAbortMambaOwnership(CustomTestCase):
         self.assertFalse(session._inflight)
         self.assertEqual(list(session.req_nodes), ["r1"])
 
+    def test_waiting_timeout_releases_first_turn_mamba_state(self):
+        """The timeout path must free request-owned Mamba state like abort does.
+
+        A streaming session's first turn has no slot yet, so a Mamba index the
+        cache allocated during match_prefix belongs to the request. The
+        admission-rejection path deliberately keeps it for session requests, so
+        a request can sit in the waiting queue holding it until it times out.
+        """
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+
+        req = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        req.req_pool_idx = None
+        req.kv = None
+        req.mamba_pool_idx = torch.tensor([2], dtype=torch.int64)
+        req.time_stats = SimpleNamespace(wait_queue_entry_time=1e-6)
+
+        released = []
+        tree_cache.supports_mamba = lambda: True
+        tree_cache.req_to_token_pool = SimpleNamespace(
+            mamba_allocator=SimpleNamespace(free=released.append)
+        )
+
+        with unittest.mock.patch(
+            "sglang.srt.managers.scheduler.envs.SGLANG_REQ_WAITING_TIMEOUT.get",
+            return_value=1,
+        ):
+            scheduler._abort_on_waiting_timeout()
+
+        self.assertEqual(scheduler.waiting_queue, [])
+        self.assertEqual([t.tolist() for t in released], [[[2]]])
+        self.assertIsNone(req.mamba_pool_idx)
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+        self.assertFalse(session._inflight)
+
     def test_first_turn_exclusive_mamba_state_is_released(self):
         """Without a slot the Mamba state is the request's own and must be freed."""
         session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)

--- a/test/registered/unit/session/test_session_abort_lifecycle.py
+++ b/test/registered/unit/session/test_session_abort_lifecycle.py
@@ -102,17 +102,40 @@ def _make_scheduler(tree_cache, *, waiting_queue):
     s.running_batch = None
     s.last_batch = None
     s.dllm_config = None
+    # Queue-limit admission control; tests that exercise it raise the limit.
+    s.max_queued_requests = None
+    s.enable_priority_scheduling = False
+    s.schedule_low_priority_values_first = False
     return s
 
 
-def _queue_turn(session, scheduler, rid, input_ids, session_id="s0"):
+def _new_turn(session, rid, input_ids, session_id="s0"):
+    """Build a real turn without queueing it, as `_add_request_to_queue` sees it."""
     req = session.create_req(
         _make_recv_req(rid, input_ids, session_id), None, VOCAB_SIZE
     )
     req.mamba_pool_idx = None
     req.req_pool_idx = None
     req.kv = None
+    return req
+
+
+def _queue_turn(session, scheduler, rid, input_ids, session_id="s0"):
+    req = _new_turn(session, rid, input_ids, session_id)
     scheduler.waiting_queue.append(req)
+    return req
+
+
+def _plain_req(rid, input_ids, priority=None):
+    """Ordinary non-session traffic, which also flows through the queue limit."""
+    req = _new_turn(
+        Session(capacity_of_str_len=0, session_id=rid, streaming=True),
+        rid,
+        input_ids,
+        session_id=rid,
+    )
+    req.session = None
+    req.priority = priority
     return req
 
 
@@ -462,6 +485,195 @@ class TestQueuedSessionAbortMambaOwnership(CustomTestCase):
 
         self.assertEqual([t.tolist() for t in released], [[[2]]])
         self.assertIsNone(req.mamba_pool_idx)
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+        self.assertFalse(session._inflight)
+
+
+class TestQueueLimitSessionRemoval(CustomTestCase):
+    """`_abort_on_queued_limit` is the third terminal waiting-queue path.
+
+    It removes a turn either by rejecting an incoming request once the queue is
+    full, or -- under priority scheduling -- by evicting an existing, lower
+    priority one. Both removals are as final as an explicit abort, so both need
+    the same session finalization. Only the `DisaggregationMode.NULL` branch of
+    `_add_request_to_queue` consults the limit, so the PD queues never reach it.
+    """
+
+    def setUp(self):
+        self._parallel_override = get_parallel().override(tp_rank=0)
+        self._parallel_override.__enter__()
+        self.addCleanup(self._parallel_override.__exit__, None, None, None)
+
+    def _committed_session(self, tree_cache, *, priority_scheduling=False):
+        """A session with one committed turn, and a scheduler at its queue limit."""
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+        scheduler.max_queued_requests = 1
+        scheduler.enable_priority_scheduling = priority_scheduling
+
+        first = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        _finish_turn(session, first, [91, 92])
+        scheduler.waiting_queue.clear()
+        return session, scheduler
+
+    # -- incoming request rejected --------------------------------------
+
+    def test_queue_limit_rejection_finalizes_the_session(self):
+        """A turn refused admission must release the session it borrowed."""
+        tree_cache = _RecordingTreeCache()
+        session, scheduler = self._committed_session(tree_cache)
+        scheduler.waiting_queue.append(_plain_req("other", [1, 2]))
+
+        # The queue is already full, so this turn never joins it.
+        incoming = _new_turn(session, "r2", [44, 55, 66])
+        self.assertTrue(session._inflight)
+
+        with unittest.mock.patch.object(
+            session, "abort_req", wraps=session.abort_req
+        ) as abort_spy:
+            rejected = scheduler._abort_on_queued_limit(incoming)
+
+        self.assertTrue(rejected)
+        self.assertEqual(abort_spy.call_count, 1)
+        self.assertFalse(session._inflight)
+        self.assertNotIn(incoming, scheduler.waiting_queue)
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+
+        # Non-session traffic on the same path keeps its existing behaviour.
+        self.assertTrue(scheduler._abort_on_queued_limit(_plain_req("p1", [3, 4])))
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+
+    def test_queue_limit_rejection_does_not_commit_the_turn(self):
+        """A rejected prompt never ran, so it must not become session history."""
+        tree_cache = _RecordingTreeCache()
+        session, scheduler = self._committed_session(tree_cache)
+        scheduler.waiting_queue.append(_plain_req("other", [1, 2]))
+        committed_len = session.committed_origin_len
+
+        scheduler._abort_on_queued_limit(_new_turn(session, "r2", [44, 55, 66]))
+
+        self.assertEqual(session.committed_origin_len, committed_len)
+        self.assertEqual(list(session.req_nodes), ["r1"])
+
+        follow_up = session.create_req(
+            _make_recv_req("r3", [77, 88], "s0"), None, VOCAB_SIZE
+        )
+        self.assertIsNone(follow_up.to_finish)
+        context = list(follow_up.origin_input_ids)
+        self.assertEqual(context, [11, 12, 13, 91, 92, 77, 88])
+        for token in (44, 55, 66):
+            self.assertNotIn(token, context)
+
+    # -- existing request evicted by priority ---------------------------
+
+    def test_priority_eviction_finalizes_the_evicted_session_turn(self):
+        """The evicted turn, not the admitted one, must be finalized."""
+        tree_cache = _RecordingTreeCache()
+        session, scheduler = self._committed_session(
+            tree_cache, priority_scheduling=True
+        )
+
+        queued = _queue_turn(session, scheduler, "r2", [44, 55, 66])
+        queued.priority = 1
+        self.assertTrue(session._inflight)
+
+        # Larger values rank higher by default, so this preempts the queued turn.
+        incoming = _plain_req("hi", [7, 8], priority=9)
+
+        with unittest.mock.patch.object(
+            session, "abort_req", wraps=session.abort_req
+        ) as abort_spy:
+            rejected = scheduler._abort_on_queued_limit(incoming)
+
+        # The incoming request was admitted, so it is the queued turn that went.
+        self.assertFalse(rejected)
+        self.assertNotIn(queued, scheduler.waiting_queue)
+        self.assertEqual(abort_spy.call_count, 1)
+        self.assertFalse(session._inflight)
+        self.assertEqual(tree_cache.cache_finished_req_calls, [])
+
+    def test_priority_eviction_does_not_commit_the_turn(self):
+        """Eviction must leave the last committed prefix as the session's tail."""
+        tree_cache = _RecordingTreeCache()
+        session, scheduler = self._committed_session(
+            tree_cache, priority_scheduling=True
+        )
+        committed_len = session.committed_origin_len
+
+        queued = _queue_turn(session, scheduler, "r2", [44, 55, 66])
+        queued.priority = 1
+        scheduler._abort_on_queued_limit(_plain_req("hi", [7, 8], priority=9))
+
+        self.assertEqual(session.committed_origin_len, committed_len)
+        self.assertEqual(list(session.req_nodes), ["r1"])
+
+        follow_up = session.create_req(
+            _make_recv_req("r3", [77, 88], "s0"), None, VOCAB_SIZE
+        )
+        self.assertIsNone(follow_up.to_finish)
+        context = list(follow_up.origin_input_ids)
+        self.assertEqual(context, [11, 12, 13, 91, 92, 77, 88])
+        for token in (44, 55, 66):
+            self.assertNotIn(token, context)
+
+    def test_priority_eviction_preserves_slot_owned_state(self):
+        """State the evicted turn borrowed from its slot stays with the slot."""
+        streaming_cache, mamba_allocator = _make_streaming_cache()
+        session, scheduler = self._committed_session(
+            streaming_cache, priority_scheduling=True
+        )
+
+        slot = SessionSlot(
+            req_pool_idx=3,
+            kv_committed_len=5,
+            kv=SimpleNamespace(kv_allocated_len=5, swa_evicted_seqlen=0),
+            mamba_pool_idx=torch.tensor([2], dtype=torch.int64),
+        )
+        streaming_cache.slots["s0"] = slot
+
+        queued = _queue_turn(session, scheduler, "r2", [44, 55, 66])
+        slot.restore_to_req(queued)
+        queued.priority = 1
+
+        scheduler._abort_on_queued_limit(_plain_req("hi", [7, 8], priority=9))
+
+        self.assertIn("s0", streaming_cache.slots)
+        self.assertEqual(slot.req_pool_idx, 3)
+        self.assertIsNotNone(slot.mamba_pool_idx)
+        self.assertEqual(mamba_allocator.freed, [])
+        self.assertEqual(streaming_cache.inner.token_to_kv_pool_allocator.freed, [])
+        self.assertEqual(streaming_cache.req_to_token_pool.free_slots, [])
+        self.assertFalse(session._inflight)
+        self.assertEqual(list(session.req_nodes), ["r1"])
+
+    def test_priority_eviction_releases_first_turn_mamba_state(self):
+        """Eviction is the last chance to free a first turn's own Mamba state.
+
+        `get_new_batch_prefill` deliberately leaves a session request's Mamba
+        index alone when it declines to admit it, so a first turn can sit in the
+        waiting queue still owning one.
+        """
+        session = Session(capacity_of_str_len=0, session_id="s0", streaming=True)
+        tree_cache = _RecordingTreeCache()
+        scheduler = _make_scheduler(tree_cache, waiting_queue=[])
+        scheduler.max_queued_requests = 1
+        scheduler.enable_priority_scheduling = True
+
+        queued = _queue_turn(session, scheduler, "r1", [11, 12, 13])
+        queued.priority = 1
+        queued.mamba_pool_idx = torch.tensor([2], dtype=torch.int64)
+
+        released = []
+        tree_cache.supports_mamba = lambda: True
+        tree_cache.req_to_token_pool = SimpleNamespace(
+            mamba_allocator=SimpleNamespace(free=released.append)
+        )
+
+        scheduler._abort_on_queued_limit(_plain_req("hi", [7, 8], priority=9))
+
+        self.assertEqual(scheduler.waiting_queue, [])
+        self.assertEqual([t.tolist() for t in released], [[[2]]])
+        self.assertIsNone(queued.mamba_pool_idx)
         self.assertEqual(tree_cache.cache_finished_req_calls, [])
         self.assertFalse(session._inflight)
 


### PR DESCRIPTION
## Motivation

When a streaming-session request is removed from the scheduler waiting queue before it ever runs, the request is dropped without completing the session lifecycle. There are three such terminal removals: an explicit abort, `SGLANG_REQ_WAITING_TIMEOUT`, and `_abort_on_queued_limit` (which either rejects an arriving request once `--max-queued-requests` is reached, or, under priority scheduling, evicts an existing lower-priority queued request in favour of a higher-priority arrival). The session stays marked as having an active request, so every later turn on it fails with:

```text
Streaming session already has an active request.
```

The session does not recover on its own, so the client has to create a new session to continue.

There is a second variant on hybrid-Mamba models. When the queued turn was restored from an existing session slot, the same removal path calls `release_kv_cache`, which reaches `StreamingSession.try_cache_finished_req`. Because the queued request never had `finished_reason` set, that method does not take its `FINISH_ABORT` branch and instead follows the normal completion path to `Session.finish_req`, committing a turn that never executed.

Closes #31765

## Modifications

`Scheduler` gains one narrow helper, `_finalize_queued_session_turn`, used by every path that terminally removes a request from the waiting queue (`abort_request`, `_abort_on_waiting_timeout`, and `_abort_on_queued_limit`):

- notifies the session via `Session.abort_req()`, clearing the in-flight state exactly once
- leaves `req_nodes` and the committed lengths untouched, so the next turn's `Session._share_token_arrays` trims the aborted prompt back off and the previously committed prefix stays intact
- reports whether the request's req-pool/KV/Mamba state is on loan from a `SessionSlot`, so the Mamba release is skipped for borrowed state
- release first-turn request-owned Mamba state when a queued session turn is removed, while preserving state borrowed from an existing `SessionSlot`

In `_abort_on_queued_limit` the finalization runs once, after the branch has chosen which request is going: it therefore covers both the arriving request rejected on a full queue and the existing queued request evicted by a higher-priority arrival. `get_new_batch_prefill` deliberately leaves a session request's Mamba index alone when it declines to admit it, so an evicted first turn really can still own one, and this is its last chance to be freed.

`restore_to_req` is the only way a queued request holds a req-pool slot, and it lends the slot's state rather than transferring it, so `req.req_pool_idx is not None` identifies borrowed state. First-turn requests own their early-allocated Mamba state and keep the existing release. `req.session` is deliberately left attached so any later cleanup keeps routing through `StreamingSession` rather than the raw cache.

`Session.finish_req` and `release_session` are not used for a queued turn that never ran; `release_session` would discard the committed prefix, which is correct for a mid-generation abort but not for this case.

Behaviour for non-session requests, running-request aborts, PD, HiCache, and the grammar queue is unchanged. The queue limit is only consulted on the `DisaggregationMode.NULL` branch of `_add_request_to_queue`, so the PD queues never reach the new code.

Tests added:

- `test/registered/unit/session/test_session_abort_lifecycle.py` — 18 scheduler-level cases driving the real `Scheduler.abort_request`, `Scheduler._abort_on_waiting_timeout` and `Scheduler._abort_on_queued_limit` against a real `Session`, including a real `StreamingSession` for the Mamba ownership cases. Six of these cover the queue limit: rejection of an arriving turn and priority eviction of an existing one, each checked for session finalization, for not committing the prompt, and for slot-borrowed versus request-owned Mamba state.
- `test/registered/sessions/test_streaming_session.py` — two real-server end-to-end regressions, one for the queued abort and one for priority eviction. Their shared setup (a capped running-request budget, a blocker request, and the scheduler's own gauges as the readiness signal) now lives in a `QueuedSessionTurnMixin`; no step is timed.

## Accuracy Tests

Not applicable. This change does not touch kernels or model forward code; it only affects scheduler-side session lifecycle bookkeeping.

## Speed Tests and Profiling

Not applicable. The added work is one `is not None` check per request removed from the waiting queue, on the abort and timeout paths only. There is no per-token or per-forward cost.

## Testing

Rebased onto current `main` and revalidated there.

CPU lifecycle regression (`test/registered/unit/session/test_session_abort_lifecycle.py`):

```text
without the fix: 17 failed, 1 passed
with the fix:    18 passed
```

The six queue-limit cases were also checked on their own: they fail 6/6 with only the `_abort_on_queued_limit` change reverted, and pass with it applied.

Nearby CPU suites:

```text
test_streaming_session_unit.py         4 passed
test_decode_queue_cleanup.py           5 passed
test_scheduler_chunked_req_gate.py     3 passed
test_prefill_adder.py                 19 passed
```

Real-server end-to-end regressions, run locally against the committed HEAD:

```text
TestStreamingSessionQueuedAbort::test_queued_session_turn_abort_keeps_session_usable        3/3 passed
TestStreamingSessionPriorityEviction::test_priority_evicted_session_turn_keeps_session_usable  3/3 passed
```

Both were run on a single consumer GPU with `Qwen/Qwen2.5-0.5B-Instruct` substituted for the fixture's default model, which is gated and unavailable in that environment; the committed tests use the standard fixture model, so CI exercises the default. The substitution is only the launch model — the scheduler paths under test are unaffected by it.

Each test lets the server prove which removal path ran, rather than inferring it from queue counts. The queued-abort test asserts `finish_reason` is `{"type": "abort", "message": "Abort in waiting queue"}` with empty `output_ids`. The priority-eviction test asserts the evicted turn comes back as HTTP 503 with `"The request is aborted by a higher priority request."`, which only the priority branch of `_abort_on_queued_limit` emits — a plain queue-limit rejection reports `"The request queue is full."` instead. Both then assert the follow-up turn's `prompt_tokens` equals the committed prefix plus its own prompt, which fails both if the prefix is discarded and if the removed prompt is retained, and both finish with a `/health` check.

The other classes in `test_streaming_session.py` were not re-run locally, since their models are unavailable in that environment; they are unchanged by this PR apart from the shared mixin extraction, and CI covers them.

The hybrid-Mamba ownership path is covered by the scheduler-level tests using a real `StreamingSession`; the end-to-end tests do not use a hybrid-Mamba model.

Also run locally on the committed HEAD: Python compilation, Ruff lint with the repository's CI selection, Black 26.1.0 `--check` (the formatter the pre-commit config pins), `scripts/ci/check_registered_tests.py`, and `git diff --check`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31523411378](https://github.com/sgl-project/sglang/actions/runs/31523411378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31523411098](https://github.com/sgl-project/sglang/actions/runs/31523411098)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

