### PR TITLE
[dLLM] Add JointThresholdInDel algorithm for insertion & deletion decoding

### DIFF
--- a/python/sglang/srt/dllm/algorithm/__init__.py
+++ b/python/sglang/srt/dllm/algorithm/__init__.py
@@ -29,11 +29,12 @@ def import_algorithms():
 
 
 def get_algorithm(config: DllmConfig):
+    name = config.algorithm
     try:
-        name = config.algorithm
-        return algo_name_to_cls[name](config)
-    except:
-        raise RuntimeError(f"Unknown diffusion LLM algorithm: {name}")
+        algorithm_cls = algo_name_to_cls[name]
+    except KeyError as exc:
+        raise RuntimeError(f"Unknown diffusion LLM algorithm: {name}") from exc
+    return algorithm_cls(config)
 
 
 algo_name_to_cls = import_algorithms()

--- a/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
@@ -1,0 +1,227 @@
+from typing import Any, List
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+class JointThresholdInDel(DllmAlgorithm):
+    """Joint-threshold denoising with InDel (insertion & deletion) support.
+
+    Extends JointThreshold to handle edit tokens that modify block structure:
+    DELETE removes a position (block shrinks, padded with mask), SPLIT (insert)
+    expands a position into [mask, original_token].
+    """
+
+    def __init__(self, config: DllmConfig):
+        super().__init__(config)
+        self.threshold = config.algorithm_config.get("threshold", 0.5)
+        self.edit_threshold = config.algorithm_config.get("edit_threshold", 0)
+        self.max_post_edit_steps = config.algorithm_config.get(
+            "max_post_edit_steps", 16
+        )
+        self.delete_token_id = config.delete_token_id
+        self.split_token_id = config.split_token_id
+        if self.delete_token_id is None or self.split_token_id is None:
+            raise RuntimeError(
+                f"JointThresholdInDel requires delete_token_id and split_token_id, "
+                f"got delete_token_id={self.delete_token_id}, "
+                f"split_token_id={self.split_token_id}"
+            )
+
+    def max_steps(self, block_size: int) -> int:
+        return block_size + self.max_post_edit_steps + 1
+
+    def init_step_state(self, forward_batch: ForwardBatch) -> List[Any]:
+        batch_size = forward_batch.batch_size
+        input_ids = forward_batch.input_ids.view(batch_size, self.block_size)
+        return [
+            {
+                "prompt_mask": input_ids[i] != self.mask_id,
+                "is_orig_mask": input_ids[i] == self.mask_id,
+                "post_edit_steps": 0,
+                "finished": False,
+                "seen_input_keys": set(),
+                "sampled_history": {},
+            }
+            for i in range(batch_size)
+        ]
+
+    def _apply_edit_operations(self, block_tokens, old_block_tokens, is_orig_mask):
+        """Process DELETE and SPLIT tokens, tracking which positions were original masks.
+
+        - DELETE: remove the position
+        - SPLIT: expand to [mask_id, old_token]
+        - Pad/truncate result to block_size
+        """
+        result_tokens = []
+        result_tracking = []
+        for i, token in enumerate(block_tokens):
+            if token == self.delete_token_id:
+                continue
+            elif token == self.split_token_id:
+                result_tokens.extend([self.mask_id, old_block_tokens[i]])
+                result_tracking.extend([False, is_orig_mask[i]])
+            else:
+                result_tokens.append(token)
+                result_tracking.append(is_orig_mask[i])
+
+        if len(result_tokens) > self.block_size:
+            result_tokens = result_tokens[: self.block_size]
+            result_tracking = result_tracking[: self.block_size]
+        elif len(result_tokens) < self.block_size:
+            pad_count = self.block_size - len(result_tokens)
+            result_tokens.extend([self.mask_id] * pad_count)
+            result_tracking.extend([False] * pad_count)
+
+        return result_tokens, result_tracking
+
+    def step(
+        self,
+        forward_batch: ForwardBatch,
+        full_logits: torch.Tensor,
+        states: List[Any],
+    ) -> List[bool]:
+        batch_size = forward_batch.batch_size
+        device = forward_batch.input_ids.device
+        done: List[bool] = []
+
+        for i in range(batch_size):
+            state = states[i]
+            if state["finished"]:
+                done.append(True)
+                continue
+            done.append(False)
+
+            block_start = i * self.block_size
+            block_end = block_start + self.block_size
+            curr_input_ids = forward_batch.input_ids[block_start:block_end]
+            curr_logits = full_logits[block_start:block_end]
+            curr_prompt_mask = state["prompt_mask"]
+
+            # Greedy decode: argmax tokens and their confidence
+            x = torch.argmax(curr_logits, dim=-1)
+            p = torch.squeeze(
+                torch.gather(
+                    F.softmax(curr_logits, dim=-1),
+                    dim=-1,
+                    index=torch.unsqueeze(x, -1),
+                ),
+                -1,
+            )
+
+            mask_index = curr_input_ids == self.mask_id
+            has_mask = mask_index.any()
+
+            # Track original vs new masks (introduced by DELETE/SPLIT)
+            is_orig_mask = state["is_orig_mask"]
+            original_mask_count = int((is_orig_mask & mask_index).sum().item())
+            total_mask = mask_index.sum().item()
+            new_mask_count = total_mask - original_mask_count
+
+            # M2T: while original masks remain, fill at least (1 + new_mask_count)
+            # per step by threshold or top-k. Once all original masks are filled,
+            # fill all remaining masks at once.
+            mask_transfer_index = torch.zeros_like(mask_index)
+            if has_mask:
+                confidence = torch.where(mask_index, p, float("-inf"))
+                if original_mask_count > 0:
+                    num_need = 1 + new_mask_count
+                    high_conf = (confidence > self.threshold) & mask_index
+                    if high_conf.sum().item() >= num_need:
+                        mask_transfer_index = high_conf
+                    else:
+                        k_val = min(num_need, total_mask)
+                        if k_val > 0:
+                            _, select_index = torch.topk(confidence, k=k_val)
+                            mask_transfer_index[select_index] = True
+                else:
+                    mask_transfer_index = mask_index
+
+            # Post-edit budget: once all original masks filled, count steps.
+            # After budget exhausted, scrub DELETE/SPLIT from predictions and
+            # do a final decode.
+            force_finish = False
+            if original_mask_count == 0:
+                state["post_edit_steps"] += 1
+                if state["post_edit_steps"] > self.max_post_edit_steps:
+                    force_finish = True
+                    # Replace any DELETE/SPLIT in predictions with next-best token
+                    indel_mask = (x == self.delete_token_id) | (
+                        x == self.split_token_id
+                    )
+                    if indel_mask.any():
+                        indel_indices = indel_mask.nonzero(as_tuple=False).view(-1)
+                        scrub_logits = curr_logits[indel_indices].clone()
+                        scrub_logits[:, self.delete_token_id] = float("-inf")
+                        scrub_logits[:, self.split_token_id] = float("-inf")
+                        x[indel_indices] = torch.argmax(scrub_logits, dim=-1)
+
+            # T2T: edit non-mask, non-prompt positions where model disagrees
+            edit_mask = ~mask_index & ~curr_prompt_mask
+            edit_transfer_index = (
+                (p > self.edit_threshold) & (curr_input_ids != x) & edit_mask
+            )
+
+            transfer_index = mask_transfer_index | edit_transfer_index
+            if not transfer_index.any():
+                state["finished"] = True
+                done[-1] = True
+                continue
+
+            # Anti-loop: if this block state was seen before, inject diversity
+            # at the position with lowest confidence (deterministic).
+            old_block = curr_input_ids.tolist()
+            input_key = tuple(old_block)
+
+            if input_key in state["seen_input_keys"] and not force_finish:
+                changing = transfer_index & (x != curr_input_ids)
+                changing_positions = changing.nonzero(as_tuple=False).view(-1).tolist()
+
+                if changing_positions:
+                    # Pick lowest-confidence position (minimizes quality impact)
+                    pos_tensor = torch.tensor(changing_positions, device=device)
+                    chosen_pos = changing_positions[p[pos_tensor].argmin().item()]
+                    pos_logits = curr_logits[chosen_pos, :].clone()
+                    # Exclude previously sampled tokens at this position
+                    for prev_tok in state["sampled_history"].get(chosen_pos, ()):
+                        pos_logits[prev_tok] = float("-inf")
+                    x[chosen_pos] = torch.argmax(pos_logits)
+            state["seen_input_keys"].add(input_key)
+
+            # Record written tokens for anti-loop history
+            write_positions = transfer_index.nonzero(as_tuple=False).view(-1)
+            for pos in write_positions.tolist():
+                state["sampled_history"].setdefault(pos, set()).add(x[pos].item())
+
+            # Write tokens
+            curr_input_ids[transfer_index] = x[transfer_index]
+
+            # Apply DELETE/SPLIT operations if any edit tokens were written
+            has_indel = (
+                (curr_input_ids == self.delete_token_id)
+                | (curr_input_ids == self.split_token_id)
+            ).any()
+            if has_indel:
+                current_block = curr_input_ids.tolist()
+                edited_block, new_is_orig_mask = self._apply_edit_operations(
+                    current_block, old_block, is_orig_mask.tolist()
+                )
+                forward_batch.input_ids[block_start:block_end] = torch.tensor(
+                    edited_block, device=device, dtype=torch.long
+                )
+                state["is_orig_mask"] = torch.tensor(
+                    new_is_orig_mask, dtype=torch.bool, device=device
+                )
+
+            if force_finish:
+                state["finished"] = True
+                done[-1] = True
+
+        return done
+
+
+Algorithm = JointThresholdInDel

--- a/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
@@ -11,9 +11,9 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 class JointThresholdInDel(DllmAlgorithm):
     """Joint-threshold denoising with InDel (insertion & deletion) support.
 
-    Extends JointThreshold to handle edit tokens that modify block structure:
-    DELETE removes a position (block shrinks, padded with mask), SPLIT (insert)
-    expands a position into [mask, original_token].
+    Extends JointThreshold to handle edit tokens that modify block structure.
+    DELETE removes a position and pads the shortened block with MASK. SPLIT
+    inserts MASK before the previous token at that position.
     """
 
     def __init__(self, config: DllmConfig):
@@ -23,6 +23,7 @@ class JointThresholdInDel(DllmAlgorithm):
         self.max_post_edit_steps = config.algorithm_config.get(
             "max_post_edit_steps", 16
         )
+        self.max_regular_update_steps = self.block_size + self.max_post_edit_steps
         self.delete_token_id = config.delete_token_id
         self.split_token_id = config.split_token_id
         if self.delete_token_id is None or self.split_token_id is None:
@@ -33,16 +34,25 @@ class JointThresholdInDel(DllmAlgorithm):
             )
 
     def max_steps(self, block_size: int) -> int:
-        return block_size + self.max_post_edit_steps + 1
+        # Regular updates, one final cleanup update, and one forward that
+        # persists the cleaned block in KV cache.
+        return block_size + self.max_post_edit_steps + 2
 
     def init_step_state(self, forward_batch: ForwardBatch) -> List[Any]:
         batch_size = forward_batch.batch_size
         input_ids = forward_batch.input_ids.view(batch_size, self.block_size)
+        # The prompt is the immutable contiguous prefix before the first mask.
+        # is_orig_mask marks positions associated with masks in the initial
+        # block. DELETE/SPLIT move the marker with the corresponding token.
+        prompt_lens = (input_ids != self.mask_id).cumprod(dim=1).sum(dim=1).tolist()
+        positions = torch.arange(self.block_size, device=input_ids.device)
         return [
             {
-                "prompt_mask": input_ids[i] != self.mask_id,
+                "prompt_len": prompt_lens[i],
+                "prompt_index": positions < prompt_lens[i],
                 "is_orig_mask": input_ids[i] == self.mask_id,
                 "post_edit_steps": 0,
+                "num_update_steps": 0,
                 "finished": False,
                 "seen_input_keys": set(),
                 "sampled_history": {},
@@ -50,34 +60,44 @@ class JointThresholdInDel(DllmAlgorithm):
             for i in range(batch_size)
         ]
 
-    def _apply_edit_operations(self, block_tokens, old_block_tokens, is_orig_mask):
-        """Process DELETE and SPLIT tokens, tracking which positions were original masks.
+    def _apply_edit_operations(
+        self,
+        block_tokens,
+        old_block_tokens,
+        is_orig_mask,
+        prompt_len,
+    ):
+        """Apply DELETE/SPLIT to the generated suffix.
 
-        - DELETE: remove the position
-        - SPLIT: expand to [mask_id, old_token]
-        - Pad/truncate result to block_size
+        ``block_tokens`` contains this step's selected predictions, while
+        ``old_block_tokens`` contains the input block. The prompt is copied
+        unchanged from the input block. In the suffix, DELETE removes a
+        position and SPLIT expands it to ``[mask_id, old_block_tokens[i]]``.
+        The inserted mask is new; the old token retains its ``is_orig_mask``
+        flag. The result is padded or truncated to ``block_size``.
         """
-        result_tokens = []
-        result_tracking = []
-        for i, token in enumerate(block_tokens):
+        result_tokens = old_block_tokens[:prompt_len]
+        result_is_orig_mask = is_orig_mask[:prompt_len]
+        for i in range(prompt_len, self.block_size):
+            token = block_tokens[i]
             if token == self.delete_token_id:
                 continue
             elif token == self.split_token_id:
                 result_tokens.extend([self.mask_id, old_block_tokens[i]])
-                result_tracking.extend([False, is_orig_mask[i]])
+                result_is_orig_mask.extend([False, is_orig_mask[i]])
             else:
                 result_tokens.append(token)
-                result_tracking.append(is_orig_mask[i])
+                result_is_orig_mask.append(is_orig_mask[i])
 
         if len(result_tokens) > self.block_size:
             result_tokens = result_tokens[: self.block_size]
-            result_tracking = result_tracking[: self.block_size]
+            result_is_orig_mask = result_is_orig_mask[: self.block_size]
         elif len(result_tokens) < self.block_size:
             pad_count = self.block_size - len(result_tokens)
             result_tokens.extend([self.mask_id] * pad_count)
-            result_tracking.extend([False] * pad_count)
+            result_is_orig_mask.extend([False] * pad_count)
 
-        return result_tokens, result_tracking
+        return result_tokens, result_is_orig_mask
 
     def step(
         self,
@@ -100,13 +120,14 @@ class JointThresholdInDel(DllmAlgorithm):
             block_end = block_start + self.block_size
             curr_input_ids = forward_batch.input_ids[block_start:block_end]
             curr_logits = full_logits[block_start:block_end]
-            curr_prompt_mask = state["prompt_mask"]
+            curr_prompt_index = state["prompt_index"]
 
             # Greedy decode: argmax tokens and their confidence
             x = torch.argmax(curr_logits, dim=-1)
+            probabilities = F.softmax(curr_logits, dim=-1)
             p = torch.squeeze(
                 torch.gather(
-                    F.softmax(curr_logits, dim=-1),
+                    probabilities,
                     dim=-1,
                     index=torch.unsqueeze(x, -1),
                 ),
@@ -114,101 +135,140 @@ class JointThresholdInDel(DllmAlgorithm):
             )
 
             mask_index = curr_input_ids == self.mask_id
-            has_mask = mask_index.any()
-
-            # Track original vs new masks (introduced by DELETE/SPLIT)
             is_orig_mask = state["is_orig_mask"]
-            original_mask_count = int((is_orig_mask & mask_index).sum().item())
-            total_mask = mask_index.sum().item()
-            new_mask_count = total_mask - original_mask_count
+            original_mask_index = is_orig_mask & mask_index
+            original_mask_count, total_mask_count = torch.stack(
+                (original_mask_index.sum(), mask_index.sum())
+            ).tolist()
+            introduced_mask_count = total_mask_count - original_mask_count
 
-            # M2T: while original masks remain, fill at least (1 + new_mask_count)
-            # per step by threshold or top-k. Once all original masks are filled,
-            # fill all remaining masks at once.
+            state["num_update_steps"] += 1
+            if original_mask_count == 0:
+                state["post_edit_steps"] += 1
+
+            is_final_cleanup = (
+                state["post_edit_steps"] > self.max_post_edit_steps
+                or state["num_update_steps"] > self.max_regular_update_steps
+            )
+
+            # Replace MASK predictions at unresolved original masks before
+            # selection. Otherwise, a selected position could write MASK back
+            # without resolving the original mask.
+            if not is_final_cleanup:
+                fallback_positions = (
+                    (original_mask_index & (x == self.mask_id))
+                    .nonzero(as_tuple=False)
+                    .view(-1)
+                )
+                if fallback_positions.numel() > 0:
+                    fallback_logits = curr_logits[fallback_positions].clone()
+                    fallback_logits[:, self.mask_id] = float("-inf")
+                    fallback_tokens = torch.argmax(fallback_logits, dim=-1)
+                    x[fallback_positions] = fallback_tokens
+                    p[fallback_positions] = probabilities[
+                        fallback_positions, fallback_tokens
+                    ]
+
+            # M2T: request introduced_mask_count + 1 transfers while original
+            # masks remain. Since only introduced_mask_count masks are new, at
+            # least one selected position must be an original mask. Once no
+            # original masks remain, transfer all masks.
             mask_transfer_index = torch.zeros_like(mask_index)
-            if has_mask:
+            if total_mask_count > 0:
                 confidence = torch.where(mask_index, p, float("-inf"))
-                if original_mask_count > 0:
-                    num_need = 1 + new_mask_count
-                    high_conf = (confidence > self.threshold) & mask_index
-                    if high_conf.sum().item() >= num_need:
-                        mask_transfer_index = high_conf
+                if is_final_cleanup:
+                    mask_transfer_index = mask_index & ~curr_prompt_index
+                elif original_mask_count > 0:
+                    required_mask_transfers = 1 + introduced_mask_count
+                    high_confidence_index = (confidence > self.threshold) & mask_index
+                    if high_confidence_index.sum().item() >= required_mask_transfers:
+                        mask_transfer_index = high_confidence_index
                     else:
-                        k_val = min(num_need, total_mask)
-                        if k_val > 0:
-                            _, select_index = torch.topk(confidence, k=k_val)
-                            mask_transfer_index[select_index] = True
+                        num_transfers = min(required_mask_transfers, total_mask_count)
+                        if num_transfers > 0:
+                            _, selected_positions = torch.topk(
+                                confidence, k=num_transfers
+                            )
+                            mask_transfer_index[selected_positions] = True
                 else:
                     mask_transfer_index = mask_index
 
-            # Post-edit budget: once all original masks filled, count steps.
-            # After budget exhausted, scrub DELETE/SPLIT from predictions and
-            # do a final decode.
-            force_finish = False
-            if original_mask_count == 0:
-                state["post_edit_steps"] += 1
-                if state["post_edit_steps"] > self.max_post_edit_steps:
-                    force_finish = True
-                    # Replace any DELETE/SPLIT in predictions with next-best token
-                    indel_mask = (x == self.delete_token_id) | (
-                        x == self.split_token_id
-                    )
-                    if indel_mask.any():
-                        indel_indices = indel_mask.nonzero(as_tuple=False).view(-1)
-                        scrub_logits = curr_logits[indel_indices].clone()
-                        scrub_logits[:, self.delete_token_id] = float("-inf")
-                        scrub_logits[:, self.split_token_id] = float("-inf")
-                        x[indel_indices] = torch.argmax(scrub_logits, dim=-1)
-
             # T2T: edit non-mask, non-prompt positions where model disagrees
-            edit_mask = ~mask_index & ~curr_prompt_mask
+            edit_mask = ~mask_index & ~curr_prompt_index
             edit_transfer_index = (
                 (p > self.edit_threshold) & (curr_input_ids != x) & edit_mask
             )
 
             transfer_index = mask_transfer_index | edit_transfer_index
-            if not transfer_index.any():
+            write_positions = transfer_index.nonzero(as_tuple=False).view(-1)
+            if write_positions.numel() == 0:
                 state["finished"] = True
                 done[-1] = True
                 continue
+
+            if is_final_cleanup:
+                # Final cleanup must not emit MASK, DELETE, or SPLIT.
+                write_tokens = x[write_positions]
+                forbidden_write_mask = (
+                    (write_tokens == self.mask_id)
+                    | (write_tokens == self.delete_token_id)
+                    | (write_tokens == self.split_token_id)
+                )
+                scrub_positions = write_positions[forbidden_write_mask]
+                if scrub_positions.numel() > 0:
+                    scrub_logits = curr_logits[scrub_positions].clone()
+                    scrub_logits[:, self.mask_id] = float("-inf")
+                    scrub_logits[:, self.delete_token_id] = float("-inf")
+                    scrub_logits[:, self.split_token_id] = float("-inf")
+                    x[scrub_positions] = torch.argmax(scrub_logits, dim=-1)
 
             # Anti-loop: if this block state was seen before, inject diversity
             # at the position with lowest confidence (deterministic).
             old_block = curr_input_ids.tolist()
             input_key = tuple(old_block)
 
-            if input_key in state["seen_input_keys"] and not force_finish:
-                changing = transfer_index & (x != curr_input_ids)
-                changing_positions = changing.nonzero(as_tuple=False).view(-1).tolist()
+            if input_key in state["seen_input_keys"] and not is_final_cleanup:
+                changing_index = transfer_index & (x != curr_input_ids)
+                changing_positions = changing_index.nonzero(as_tuple=False).view(-1)
 
-                if changing_positions:
+                if changing_positions.numel() > 0:
                     # Pick lowest-confidence position (minimizes quality impact)
-                    pos_tensor = torch.tensor(changing_positions, device=device)
-                    chosen_pos = changing_positions[p[pos_tensor].argmin().item()]
-                    pos_logits = curr_logits[chosen_pos, :].clone()
+                    chosen_position = changing_positions[
+                        p[changing_positions].argmin()
+                    ].item()
+                    chosen_position_logits = curr_logits[chosen_position, :].clone()
                     # Exclude previously sampled tokens at this position
-                    for prev_tok in state["sampled_history"].get(chosen_pos, ()):
-                        pos_logits[prev_tok] = float("-inf")
-                    x[chosen_pos] = torch.argmax(pos_logits)
+                    for sampled_token in state["sampled_history"].get(
+                        chosen_position, ()
+                    ):
+                        chosen_position_logits[sampled_token] = float("-inf")
+                    if original_mask_index[chosen_position]:
+                        chosen_position_logits[self.mask_id] = float("-inf")
+                    x[chosen_position] = torch.argmax(chosen_position_logits)
             state["seen_input_keys"].add(input_key)
 
-            # Record written tokens for anti-loop history
-            write_positions = transfer_index.nonzero(as_tuple=False).view(-1)
-            for pos in write_positions.tolist():
-                state["sampled_history"].setdefault(pos, set()).add(x[pos].item())
+            write_pairs = torch.stack(
+                (write_positions, x[write_positions]), dim=1
+            ).tolist()
+            block_tokens = old_block.copy()
+            has_indel = False
+            input_ids_changed = False
+            # Record both M2T and T2T selections for anti-loop resampling.
+            for pos, token in write_pairs:
+                state["sampled_history"].setdefault(pos, set()).add(token)
+                block_tokens[pos] = token
+                has_indel |= token in (
+                    self.delete_token_id,
+                    self.split_token_id,
+                )
+                input_ids_changed |= token != old_block[pos]
 
-            # Write tokens
-            curr_input_ids[transfer_index] = x[transfer_index]
-
-            # Apply DELETE/SPLIT operations if any edit tokens were written
-            has_indel = (
-                (curr_input_ids == self.delete_token_id)
-                | (curr_input_ids == self.split_token_id)
-            ).any()
             if has_indel:
-                current_block = curr_input_ids.tolist()
                 edited_block, new_is_orig_mask = self._apply_edit_operations(
-                    current_block, old_block, is_orig_mask.tolist()
+                    block_tokens,
+                    old_block,
+                    is_orig_mask.tolist(),
+                    state["prompt_len"],
                 )
                 forward_batch.input_ids[block_start:block_end] = torch.tensor(
                     edited_block, device=device, dtype=torch.long
@@ -216,10 +276,14 @@ class JointThresholdInDel(DllmAlgorithm):
                 state["is_orig_mask"] = torch.tensor(
                     new_is_orig_mask, dtype=torch.bool, device=device
                 )
+            else:
+                curr_input_ids[write_positions] = x[write_positions]
 
-            if force_finish:
+            if is_final_cleanup:
                 state["finished"] = True
-                done[-1] = True
+                # If IDs changed, the next forward must persist their KV cache
+                # before the request can be emitted.
+                done[-1] = not input_ids_changed
 
         return done
 

--- a/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
@@ -143,6 +143,8 @@ class JointThresholdInDel(DllmAlgorithm):
             introduced_mask_count = total_mask_count - original_mask_count
 
             state["num_update_steps"] += 1
+            # Consume a cumulative post-edit budget on rounds with no unresolved
+            # original masks; a later MASK reappearance does not reset this budget.
             if original_mask_count == 0:
                 state["post_edit_steps"] += 1
 

--- a/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
@@ -148,8 +148,13 @@ class JointThresholdInDel(DllmAlgorithm):
             if original_mask_count == 0:
                 state["post_edit_steps"] += 1
 
+            post_edit_limit_reached = (
+                self.max_post_edit_steps > 0
+                and state["post_edit_steps"] >= self.max_post_edit_steps
+            )
             is_final_cleanup = (
-                state["post_edit_steps"] > self.max_post_edit_steps
+                post_edit_limit_reached
+                or (self.max_post_edit_steps == 0 and original_mask_count == 0)
                 or state["num_update_steps"] > self.max_regular_update_steps
             )
 
@@ -194,6 +199,16 @@ class JointThresholdInDel(DllmAlgorithm):
                             mask_transfer_index[selected_positions] = True
                 else:
                     mask_transfer_index = mask_index
+
+            # With no post-edit rounds, the update that selects the last
+            # unresolved original masks also performs final cleanup.
+            if (
+                self.max_post_edit_steps == 0
+                and original_mask_count > 0
+                and not (original_mask_index & ~mask_transfer_index).any().item()
+            ):
+                is_final_cleanup = True
+                mask_transfer_index = mask_index & ~curr_prompt_index
 
             # T2T: edit non-mask, non-prompt positions where model disagrees
             edit_mask = ~mask_index & ~curr_prompt_index

--- a/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
@@ -26,10 +26,14 @@ class JointThresholdInDel(DllmAlgorithm):
         self.max_post_edit_steps = config.algorithm_config.get(
             "max_post_edit_steps", 16
         )
-        if self.max_post_edit_steps < 0:
+        if (
+            isinstance(self.max_post_edit_steps, bool)
+            or not isinstance(self.max_post_edit_steps, int)
+            or self.max_post_edit_steps < 0
+        ):
             raise ValueError(
-                "max_post_edit_steps must be non-negative, "
-                f"got {self.max_post_edit_steps}"
+                "max_post_edit_steps must be a non-negative integer, "
+                f"got {self.max_post_edit_steps!r}"
             )
         self.max_regular_update_steps = self.block_size + self.max_post_edit_steps
         self.delete_token_id = config.delete_token_id

--- a/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold_indel.py
@@ -14,6 +14,9 @@ class JointThresholdInDel(DllmAlgorithm):
     Extends JointThreshold to handle edit tokens that modify block structure.
     DELETE removes a position and pads the shortened block with MASK. SPLIT
     inserts MASK before the previous token at that position.
+
+    The post-edit budget is cumulative and is not reset if an original mask
+    reappears. This intentionally differs from the released reference decoder.
     """
 
     def __init__(self, config: DllmConfig):
@@ -23,6 +26,11 @@ class JointThresholdInDel(DllmAlgorithm):
         self.max_post_edit_steps = config.algorithm_config.get(
             "max_post_edit_steps", 16
         )
+        if self.max_post_edit_steps < 0:
+            raise ValueError(
+                "max_post_edit_steps must be non-negative, "
+                f"got {self.max_post_edit_steps}"
+            )
         self.max_regular_update_steps = self.block_size + self.max_post_edit_steps
         self.delete_token_id = config.delete_token_id
         self.split_token_id = config.split_token_id

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -13,6 +13,8 @@ class DllmConfig:
         mask_id: int,
         max_running_requests: int,
         first_done_first_out_mode: bool = False,
+        delete_token_id: int | None = None,
+        split_token_id: int | None = None,
     ):
         self.algorithm = algorithm
         self.algorithm_config = algorithm_config
@@ -20,6 +22,8 @@ class DllmConfig:
         self.mask_id = mask_id
         self.max_running_requests = max_running_requests
         self.first_done_first_out_mode = first_done_first_out_mode
+        self.delete_token_id = delete_token_id
+        self.split_token_id = split_token_id
 
     @staticmethod
     def from_server_args(
@@ -34,7 +38,12 @@ class DllmConfig:
             model_revision=server_args.revision,
         )
         DLLM_PARAMS = {
-            "LLaDA2MoeModelLM": {"block_size": 32, "mask_id": 156895},
+            "LLaDA2MoeModelLM": {
+                "block_size": 32,
+                "mask_id": 156895,
+                "delete_token_id": 156930,
+                "split_token_id": 156931,
+            },
             "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
             "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
         }
@@ -44,6 +53,8 @@ class DllmConfig:
             params = DLLM_PARAMS[arch]
             block_size = params["block_size"]
             mask_id = params["mask_id"]
+            delete_token_id = params.get("delete_token_id")
+            split_token_id = params.get("split_token_id")
         else:
             raise RuntimeError(f"Unknown diffusion LLM: {arch}")
 
@@ -75,4 +86,6 @@ class DllmConfig:
             mask_id=mask_id,
             max_running_requests=max_running_requests,
             first_done_first_out_mode=server_args.dllm_fdfo,
+            delete_token_id=delete_token_id,
+            split_token_id=split_token_id,
         )

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -3,6 +3,13 @@ from typing import Any
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.server_args import ServerArgs
 
+INDEL_CHECKPOINT_PARAMS = {
+    "inclusionAI/LLaDA2.2-flash": {
+        "delete_token_id": 156930,
+        "split_token_id": 156931,
+    },
+}
+
 
 class DllmConfig:
     def __init__(
@@ -44,8 +51,6 @@ class DllmConfig:
             "LLaDA2MoeModelLM": {
                 "block_size": 32,
                 "mask_id": 156895,
-                "delete_token_id": 156930,
-                "split_token_id": 156931,
             },
             "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
             "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
@@ -56,10 +61,36 @@ class DllmConfig:
             params = DLLM_PARAMS[arch]
             block_size = params["block_size"]
             mask_id = params["mask_id"]
-            delete_token_id = params.get("delete_token_id")
-            split_token_id = params.get("split_token_id")
         else:
             raise RuntimeError(f"Unknown diffusion LLM: {arch}")
+
+        delete_token_id = None
+        split_token_id = None
+        if server_args.dllm_algorithm == "JointThresholdInDel":
+            delete_token_id = getattr(model_config.hf_config, "delete_token_id", None)
+            split_token_id = getattr(model_config.hf_config, "split_token_id", None)
+
+            if delete_token_id is None and split_token_id is None:
+                checkpoint_params = INDEL_CHECKPOINT_PARAMS.get(server_args.model_path)
+                if checkpoint_params is not None:
+                    delete_token_id = checkpoint_params["delete_token_id"]
+                    split_token_id = checkpoint_params["split_token_id"]
+
+            if delete_token_id is None or split_token_id is None:
+                override_example = (
+                    '{"delete_token_id": 156930, "split_token_id": 156931}'
+                )
+                raise RuntimeError(
+                    "JointThresholdInDel is not supported for checkpoint "
+                    f"{server_args.model_path!r}: the checkpoint must declare both "
+                    "delete_token_id and split_token_id. Use a checkpoint with "
+                    "explicit Insert/Delete support. If you are certain this "
+                    "checkpoint was trained for Insert/Delete decoding, declare the "
+                    "correct token IDs in config.json or pass them with "
+                    "`--json-model-override-args "
+                    f"'{override_example}'`. "
+                    "Use the token IDs defined by your checkpoint."
+                )
 
         max_running_requests = (
             1 if cfg.max_running_requests is None else cfg.max_running_requests

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -3,13 +3,6 @@ from typing import Any
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.server_args import ServerArgs
 
-INDEL_CHECKPOINT_PARAMS = {
-    "inclusionAI/LLaDA2.2-flash": {
-        "delete_token_id": 156930,
-        "split_token_id": 156931,
-    },
-}
-
 
 class DllmConfig:
     def __init__(
@@ -69,12 +62,6 @@ class DllmConfig:
         if server_args.dllm_algorithm == "JointThresholdInDel":
             delete_token_id = getattr(model_config.hf_config, "delete_token_id", None)
             split_token_id = getattr(model_config.hf_config, "split_token_id", None)
-
-            if delete_token_id is None and split_token_id is None:
-                checkpoint_params = INDEL_CHECKPOINT_PARAMS.get(server_args.model_path)
-                if checkpoint_params is not None:
-                    delete_token_id = checkpoint_params["delete_token_id"]
-                    split_token_id = checkpoint_params["split_token_id"]
 
             if delete_token_id is None or split_token_id is None:
                 override_example = (

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -13,6 +13,8 @@ class DllmConfig:
         mask_id: int,
         max_running_requests: int,
         first_done_first_out_mode: bool = False,
+        delete_token_id: int | None = None,
+        split_token_id: int | None = None,
     ):
         self.algorithm = algorithm
         self.algorithm_config = algorithm_config
@@ -20,6 +22,8 @@ class DllmConfig:
         self.mask_id = mask_id
         self.max_running_requests = max_running_requests
         self.first_done_first_out_mode = first_done_first_out_mode
+        self.delete_token_id = delete_token_id
+        self.split_token_id = split_token_id
 
     @staticmethod
     def from_server_args(
@@ -37,7 +41,12 @@ class DllmConfig:
             model_revision=cfg.revision,
         )
         DLLM_PARAMS = {
-            "LLaDA2MoeModelLM": {"block_size": 32, "mask_id": 156895},
+            "LLaDA2MoeModelLM": {
+                "block_size": 32,
+                "mask_id": 156895,
+                "delete_token_id": 156930,
+                "split_token_id": 156931,
+            },
             "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
             "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
         }
@@ -47,6 +56,8 @@ class DllmConfig:
             params = DLLM_PARAMS[arch]
             block_size = params["block_size"]
             mask_id = params["mask_id"]
+            delete_token_id = params.get("delete_token_id")
+            split_token_id = params.get("split_token_id")
         else:
             raise RuntimeError(f"Unknown diffusion LLM: {arch}")
 
@@ -76,4 +87,6 @@ class DllmConfig:
             mask_id=mask_id,
             max_running_requests=max_running_requests,
             first_done_first_out_mode=cfg.dllm_fdfo,
+            delete_token_id=delete_token_id,
+            split_token_id=split_token_id,
         )

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -59,7 +59,7 @@ class DllmConfig:
 
         delete_token_id = None
         split_token_id = None
-        if server_args.dllm_algorithm == "JointThresholdInDel":
+        if cfg.dllm_algorithm == "JointThresholdInDel":
             delete_token_id = getattr(model_config.hf_config, "delete_token_id", None)
             split_token_id = getattr(model_config.hf_config, "split_token_id", None)
 
@@ -69,7 +69,7 @@ class DllmConfig:
                 )
                 raise RuntimeError(
                     "JointThresholdInDel is not supported for checkpoint "
-                    f"{server_args.model_path!r}: the checkpoint must declare both "
+                    f"{cfg.model_path!r}: the checkpoint must declare both "
                     "delete_token_id and split_token_id. Use a checkpoint with "
                     "explicit Insert/Delete support. If you are certain this "
                     "checkpoint was trained for Insert/Delete decoding, declare the "
@@ -77,6 +77,28 @@ class DllmConfig:
                     "`--json-model-override-args "
                     f"'{override_example}'`. "
                     "Use the token IDs defined by your checkpoint."
+                )
+
+            vocab_size = model_config.vocab_size
+            for token_name, token_id in (
+                ("delete_token_id", delete_token_id),
+                ("split_token_id", split_token_id),
+            ):
+                if isinstance(token_id, bool) or not isinstance(token_id, int):
+                    raise ValueError(
+                        f"{token_name} must be an integer token ID, got {token_id!r}"
+                    )
+                if not 0 <= token_id < vocab_size:
+                    raise ValueError(
+                        f"{token_name} must be within the model vocabulary "
+                        f"[0, {vocab_size}), got {token_id}"
+                    )
+
+            if len({mask_id, delete_token_id, split_token_id}) != 3:
+                raise ValueError(
+                    "JointThresholdInDel token IDs must be distinct, got "
+                    f"mask_id={mask_id}, delete_token_id={delete_token_id}, "
+                    f"split_token_id={split_token_id}"
                 )
 
         max_running_requests = (

--- a/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
+++ b/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
@@ -1,0 +1,472 @@
+"""Unit tests for JointThresholdInDel without a server or model weights."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.dllm.algorithm import get_algorithm
+from sglang.srt.dllm.algorithm.joint_threshold_indel import JointThresholdInDel
+from sglang.srt.dllm.config import DllmConfig
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+MASK = 0
+DELETE = 1
+SPLIT = 2
+VOCAB_SIZE = 12
+
+
+def make_config(
+    block_size=6,
+    *,
+    threshold=0.5,
+    edit_threshold=0,
+    max_post_edit_steps=2,
+    delete_token_id=DELETE,
+    split_token_id=SPLIT,
+):
+    return DllmConfig(
+        algorithm="JointThresholdInDel",
+        algorithm_config={
+            "threshold": threshold,
+            "edit_threshold": edit_threshold,
+            "max_post_edit_steps": max_post_edit_steps,
+        },
+        block_size=block_size,
+        mask_id=MASK,
+        max_running_requests=8,
+        delete_token_id=delete_token_id,
+        split_token_id=split_token_id,
+    )
+
+
+def make_batch(blocks):
+    input_ids = torch.tensor(blocks, dtype=torch.long)
+    return SimpleNamespace(
+        batch_size=input_ids.shape[0],
+        input_ids=input_ids.flatten(),
+    )
+
+
+def make_logits(rows, vocab_size=VOCAB_SIZE):
+    """Build logits from rows of token IDs ordered from most to least likely."""
+    logits = torch.full((len(rows), vocab_size), -20.0)
+    for row_index, candidates in enumerate(rows):
+        for rank, token_id in enumerate(candidates):
+            logits[row_index, token_id] = 10.0 - rank
+    return logits
+
+
+class TestJointThresholdInDelInitialization(CustomTestCase):
+    def test_initial_state_and_step_limits(self):
+        algorithm = JointThresholdInDel(
+            make_config(block_size=6, max_post_edit_steps=3)
+        )
+        batch = make_batch([[3, 4, MASK, MASK, MASK, MASK]])
+
+        state = algorithm.init_step_state(batch)[0]
+
+        self.assertEqual(state["prompt_len"], 2)
+        self.assertEqual(
+            state["prompt_index"].tolist(), [True, True, False, False, False, False]
+        )
+        self.assertEqual(
+            state["is_orig_mask"].tolist(),
+            [False, False, True, True, True, True],
+        )
+        self.assertEqual(state["num_update_steps"], 0)
+        self.assertEqual(algorithm.max_regular_update_steps, 9)
+        self.assertEqual(algorithm.max_steps(6), 11)
+
+    def test_prompt_is_the_contiguous_prefix_not_every_initial_non_mask(self):
+        algorithm = JointThresholdInDel(make_config(block_size=5))
+        batch = make_batch([[3, MASK, 4, MASK, MASK]])
+
+        state = algorithm.init_step_state(batch)[0]
+
+        self.assertEqual(state["prompt_len"], 1)
+        self.assertEqual(
+            state["prompt_index"].tolist(), [True, False, False, False, False]
+        )
+
+    def test_missing_edit_token_ids_preserves_constructor_error(self):
+        config = make_config(delete_token_id=None, split_token_id=None)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "requires delete_token_id and split_token_id"
+        ):
+            get_algorithm(config)
+
+    def test_unknown_algorithm_has_specific_error(self):
+        config = make_config()
+        config.algorithm = "DoesNotExist"
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Unknown diffusion LLM algorithm: DoesNotExist"
+        ):
+            get_algorithm(config)
+
+    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
+    def test_llada_config_provides_edit_token_ids(self, mock_model_config):
+        mock_model_config.return_value.hf_config.architectures = ["LLaDA2MoeModelLM"]
+        server_args = SimpleNamespace(
+            dllm_algorithm="JointThresholdInDel",
+            model_path="model",
+            revision=None,
+            max_running_requests=None,
+            dllm_algorithm_config=None,
+            dllm_fdfo=True,
+        )
+
+        config = DllmConfig.from_server_args(server_args)
+
+        self.assertEqual(config.delete_token_id, 156930)
+        self.assertEqual(config.split_token_id, 156931)
+        self.assertEqual(config.max_running_requests, 1)
+        self.assertTrue(config.first_done_first_out_mode)
+
+    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
+    def test_non_indel_model_has_no_edit_token_ids(self, mock_model_config):
+        mock_model_config.return_value.hf_config.architectures = ["SDARForCausalLM"]
+        server_args = SimpleNamespace(
+            dllm_algorithm="JointThreshold",
+            model_path="model",
+            revision=None,
+            max_running_requests=4,
+            dllm_algorithm_config=None,
+            dllm_fdfo=False,
+        )
+
+        config = DllmConfig.from_server_args(server_args)
+
+        self.assertIsNone(config.delete_token_id)
+        self.assertIsNone(config.split_token_id)
+        self.assertEqual(config.max_running_requests, 4)
+
+
+class TestJointThresholdInDelStructuralEdits(CustomTestCase):
+    def setUp(self):
+        self.algorithm = JointThresholdInDel(make_config(block_size=8))
+
+    def test_mixed_edits_preserve_prompt_and_original_mask_flags(self):
+        old_block_tokens = [DELETE, SPLIT, 3, 4, 5, 6, MASK, MASK]
+        block_tokens = [DELETE, SPLIT, 3, DELETE, SPLIT, 6, MASK, MASK]
+        is_orig_mask = [False, False, True, False, True, False, False, False]
+
+        tokens, result_is_orig_mask = self.algorithm._apply_edit_operations(
+            block_tokens, old_block_tokens, is_orig_mask, prompt_len=2
+        )
+
+        self.assertEqual(tokens, [DELETE, SPLIT, 3, MASK, 5, 6, MASK, MASK])
+        self.assertEqual(
+            result_is_orig_mask,
+            [False, False, True, False, True, False, False, False],
+        )
+
+    def test_delete_pads_only_the_generated_suffix(self):
+        algorithm = JointThresholdInDel(make_config(block_size=6))
+        old_block_tokens = [DELETE, SPLIT, 3, 4, 5, 6]
+        block_tokens = [DELETE, SPLIT, DELETE, DELETE, DELETE, DELETE]
+
+        tokens, result_is_orig_mask = algorithm._apply_edit_operations(
+            block_tokens, old_block_tokens, [False] * 6, prompt_len=2
+        )
+
+        self.assertEqual(tokens, [DELETE, SPLIT, MASK, MASK, MASK, MASK])
+        self.assertEqual(result_is_orig_mask, [False] * 6)
+
+    def test_split_truncates_only_the_generated_suffix(self):
+        algorithm = JointThresholdInDel(make_config(block_size=6))
+        old_block_tokens = [DELETE, SPLIT, 3, 4, 5, 6]
+        block_tokens = [DELETE, SPLIT, SPLIT, SPLIT, SPLIT, SPLIT]
+        initial_is_orig_mask = [False, False, True, False, True, False]
+
+        tokens, result_is_orig_mask = algorithm._apply_edit_operations(
+            block_tokens, old_block_tokens, initial_is_orig_mask, prompt_len=2
+        )
+
+        self.assertEqual(tokens, [DELETE, SPLIT, MASK, 3, MASK, 4])
+        self.assertEqual(result_is_orig_mask, [False, False, False, True, False, False])
+
+    def test_step_never_interprets_reserved_prompt_tokens_as_edits(self):
+        algorithm = JointThresholdInDel(make_config(block_size=5))
+        batch = make_batch([[DELETE, SPLIT, MASK, MASK, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = make_logits(
+            [
+                [5, DELETE],
+                [6, SPLIT],
+                [DELETE, 7],
+                [8],
+                [9],
+            ]
+        )
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids[:2].tolist(), [DELETE, SPLIT])
+        self.assertEqual(state["prompt_len"], 2)
+        self.assertEqual(
+            state["prompt_index"].tolist(), [True, True, False, False, False]
+        )
+
+
+class TestJointThresholdInDelSelection(CustomTestCase):
+    def test_original_mask_to_mask_uses_non_mask_fallback(self):
+        algorithm = JointThresholdInDel(make_config(block_size=3, threshold=1.1))
+        batch = make_batch([[3, MASK, 4]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = make_logits([[3], [MASK, 5], [4]])
+
+        done = algorithm.step(batch, logits, [state])
+
+        self.assertEqual(done, [False])
+        self.assertEqual(batch.input_ids.tolist(), [3, 5, 4])
+
+    def test_fallback_confidence_is_recomputed_for_threshold_selection(self):
+        algorithm = JointThresholdInDel(make_config(block_size=4, threshold=0.6))
+        batch = make_batch([[3, MASK, MASK, 4]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = torch.zeros((4, VOCAB_SIZE))
+        logits[0, 3] = 10
+        logits[1, MASK] = 10
+        logits[1, 5] = 0
+        logits[2, 6] = 4
+        logits[3, 4] = 10
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, MASK, 6, 4])
+
+    def test_introduced_mask_quota_selects_an_unresolved_original_mask(self):
+        algorithm = JointThresholdInDel(make_config(block_size=5, threshold=1.1))
+        batch = make_batch([[3, MASK, MASK, MASK, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        state["is_orig_mask"] = torch.tensor([False, True, True, False, False])
+        logits = torch.zeros((5, VOCAB_SIZE))
+        logits[0, 3] = 10
+        for position, score in zip([3, 4, 1, 2], [9, 8, 7, 6]):
+            logits[position, position + 4] = score
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, 5, MASK, 7, 8])
+
+    def test_split_can_preserve_one_unresolved_original_mask(self):
+        algorithm = JointThresholdInDel(make_config(block_size=4, threshold=1.1))
+        batch = make_batch([[3, MASK, 4, 4]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = make_logits([[3], [SPLIT, 5], [4], [4]])
+        unresolved_original_mask_count_before = (
+            state["is_orig_mask"] & (batch.input_ids == MASK)
+        ).sum()
+
+        done = algorithm.step(batch, logits, [state])
+
+        self.assertEqual(done, [False])
+        self.assertEqual(batch.input_ids.tolist(), [3, MASK, MASK, 4])
+        self.assertEqual(
+            state["is_orig_mask"].tolist(),
+            [False, False, True, False],
+        )
+        unresolved_original_mask_count_after = (
+            state["is_orig_mask"] & (batch.input_ids == MASK)
+        ).sum()
+        self.assertEqual(unresolved_original_mask_count_before.item(), 1)
+        self.assertEqual(unresolved_original_mask_count_after.item(), 1)
+        self.assertEqual(state["num_update_steps"], 1)
+        self.assertFalse(state["finished"])
+
+    def test_ordinary_introduced_mask_to_mask_can_wait_for_final_cleanup(self):
+        algorithm = JointThresholdInDel(
+            make_config(block_size=4, max_post_edit_steps=2)
+        )
+        batch = make_batch([[3, MASK, MASK, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        state["is_orig_mask"] = torch.zeros(4, dtype=torch.bool)
+        logits = make_logits([[3], [MASK, 5], [MASK, 6], [MASK, 7]])
+
+        done = algorithm.step(batch, logits, [state])
+
+        self.assertEqual(done, [False])
+        self.assertEqual(batch.input_ids.tolist(), [3, MASK, MASK, MASK])
+        self.assertEqual(state["post_edit_steps"], 1)
+
+    def test_ordinary_round_fills_all_introduced_masks_with_token_predictions(self):
+        algorithm = JointThresholdInDel(make_config(block_size=4))
+        batch = make_batch([[3, MASK, MASK, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        state["is_orig_mask"] = torch.zeros(4, dtype=torch.bool)
+        logits = make_logits([[3], [5], [6], [7]])
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, 5, 6, 7])
+
+    def test_t2t_respects_prompt_and_edit_threshold(self):
+        algorithm = JointThresholdInDel(make_config(block_size=4, edit_threshold=0.9))
+        batch = make_batch([[3, MASK, 4, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = torch.zeros((4, VOCAB_SIZE))
+        logits[0, 5] = 10
+        logits[1, 7] = 10
+        logits[2, 6] = 0.1
+        logits[3, 8] = 10
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, 7, 4, 8])
+
+    def test_t2t_edits_confident_generated_token(self):
+        algorithm = JointThresholdInDel(make_config(block_size=4, edit_threshold=0.9))
+        batch = make_batch([[3, MASK, 4, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = make_logits([[5], [7], [6], [8]])
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, 7, 6, 8])
+
+
+class TestJointThresholdInDelTermination(CustomTestCase):
+    def test_post_edit_boundary_then_final_cleanup_scrubs_all_reserved_tokens(self):
+        algorithm = JointThresholdInDel(
+            make_config(block_size=4, max_post_edit_steps=1)
+        )
+        batch = make_batch([[3, MASK, MASK, 4]])
+        state = algorithm.init_step_state(batch)[0]
+        state["is_orig_mask"] = torch.zeros(4, dtype=torch.bool)
+        ordinary_logits = make_logits([[3], [MASK, 5], [MASK, 6], [4]])
+
+        done = algorithm.step(batch, ordinary_logits, [state])
+
+        self.assertEqual(done, [False])
+        self.assertEqual(state["post_edit_steps"], 1)
+        self.assertFalse(state["finished"])
+        self.assertEqual(batch.input_ids.tolist(), [3, MASK, MASK, 4])
+
+        logits = make_logits(
+            [
+                [DELETE, 8],
+                [MASK, 5],
+                [DELETE, 6],
+                [SPLIT, 7],
+            ]
+        )
+
+        done = algorithm.step(batch, logits, [state])
+
+        self.assertEqual(done, [False])
+        self.assertEqual(batch.input_ids.tolist(), [3, 5, 6, 7])
+        self.assertTrue(state["finished"])
+        self.assertNotIn(MASK, batch.input_ids[1:].tolist())
+        self.assertNotIn(DELETE, batch.input_ids[1:].tolist())
+        self.assertNotIn(SPLIT, batch.input_ids[1:].tolist())
+
+        confirmed_ids = batch.input_ids.clone()
+        done = algorithm.step(batch, make_logits([[3], [5], [6], [7]]), [state])
+        self.assertEqual(done, [True])
+        self.assertTrue(torch.equal(batch.input_ids, confirmed_ids))
+
+    def test_hard_limit_runs_one_separate_final_cleanup_update(self):
+        algorithm = JointThresholdInDel(
+            make_config(block_size=3, max_post_edit_steps=2)
+        )
+        batch = make_batch([[3, MASK, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        state["num_update_steps"] = algorithm.max_regular_update_steps
+        logits = make_logits([[3], [MASK, SPLIT, 5], [MASK, DELETE, 6]])
+
+        done = algorithm.step(batch, logits, [state])
+
+        self.assertEqual(
+            state["num_update_steps"], algorithm.max_regular_update_steps + 1
+        )
+        self.assertEqual(done, [False])
+        self.assertEqual(batch.input_ids.tolist(), [3, 5, 6])
+        self.assertTrue(state["finished"])
+
+    def test_stable_terminal_step_finishes_immediately(self):
+        algorithm = JointThresholdInDel(make_config(block_size=3))
+        batch = make_batch([[3, 4, 5]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = make_logits([[3], [4], [5]])
+
+        done = algorithm.step(batch, logits, [state])
+
+        self.assertEqual(done, [True])
+        self.assertTrue(state["finished"])
+
+    def test_batch_requests_finish_independently(self):
+        algorithm = JointThresholdInDel(
+            make_config(block_size=3, max_post_edit_steps=0)
+        )
+        batch = make_batch([[3, 4, 5], [3, MASK, 4]])
+        states = algorithm.init_step_state(batch)
+        states[1]["is_orig_mask"] = torch.zeros(3, dtype=torch.bool)
+        logits = make_logits(
+            [
+                [3],
+                [4],
+                [5],
+                [3],
+                [MASK, 6],
+                [4],
+            ]
+        )
+
+        done = algorithm.step(batch, logits, states)
+
+        self.assertEqual(done, [True, False])
+        self.assertTrue(states[0]["finished"])
+        self.assertTrue(states[1]["finished"])
+        self.assertEqual(batch.input_ids.view(2, 3)[1].tolist(), [3, 6, 4])
+
+
+class TestJointThresholdInDelAntiLoop(CustomTestCase):
+    def test_repeated_original_mask_state_never_resamples_mask(self):
+        algorithm = JointThresholdInDel(make_config(block_size=3, threshold=1.1))
+        batch = make_batch([[3, MASK, 4]])
+        state = algorithm.init_step_state(batch)[0]
+        state["seen_input_keys"].add((3, MASK, 4))
+        state["sampled_history"][1] = {5}
+        logits = make_logits([[3], [5, MASK, 6], [4]])
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, 6, 4])
+        self.assertEqual(state["sampled_history"][1], {5, 6})
+
+    def test_split_and_delete_move_original_mask_flags_in_step(self):
+        algorithm = JointThresholdInDel(make_config(block_size=5))
+        batch = make_batch([[3, MASK, MASK, MASK, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = make_logits(
+            [
+                [3],
+                [SPLIT, 5],
+                [DELETE, 6],
+                [7],
+                [8],
+            ]
+        )
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, MASK, MASK, 7, 8])
+        self.assertEqual(
+            state["is_orig_mask"].tolist(),
+            [False, False, True, True, True],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
+++ b/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
@@ -2,7 +2,7 @@
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
@@ -30,6 +30,7 @@ def make_config(
     threshold=0.5,
     edit_threshold=0,
     max_post_edit_steps=2,
+    fdfo=False,
     delete_token_id=DELETE,
     split_token_id=SPLIT,
 ):
@@ -43,6 +44,7 @@ def make_config(
         block_size=block_size,
         mask_id=MASK,
         max_running_requests=8,
+        first_done_first_out_mode=fdfo,
         delete_token_id=delete_token_id,
         split_token_id=split_token_id,
     )
@@ -63,6 +65,13 @@ def make_logits(rows, vocab_size=VOCAB_SIZE):
         for rank, token_id in enumerate(candidates):
             logits[row_index, token_id] = 10.0 - rank
     return logits
+
+
+def make_model_output(logits):
+    return SimpleNamespace(
+        logits_output=SimpleNamespace(full_logits=logits),
+        can_run_graph=False,
+    )
 
 
 class TestJointThresholdInDelInitialization(CustomTestCase):
@@ -376,14 +385,24 @@ class TestJointThresholdInDelTermination(CustomTestCase):
         self.assertEqual(done, [True])
         self.assertTrue(torch.equal(batch.input_ids, confirmed_ids))
 
-    def test_hard_limit_runs_one_separate_final_cleanup_update(self):
+    def test_hard_limit_final_cleanup_resolves_all_mask_tokens(self):
         algorithm = JointThresholdInDel(
             make_config(block_size=3, max_post_edit_steps=2)
         )
         batch = make_batch([[3, MASK, MASK]])
         state = algorithm.init_step_state(batch)[0]
         state["num_update_steps"] = algorithm.max_regular_update_steps
-        logits = make_logits([[3], [MASK, SPLIT, 5], [MASK, DELETE, 6]])
+        logits = torch.zeros((3, VOCAB_SIZE))
+        logits[0, 3] = 1.0
+        logits[1, MASK] = 0.3
+        logits[1, SPLIT] = 0.2
+        logits[1, 5] = 0.1
+        logits[2, MASK] = 0.4
+        logits[2, DELETE] = 0.3
+        logits[2, 6] = 0.2
+
+        mask_confidence = logits[1:].softmax(dim=-1).max(dim=-1).values
+        self.assertTrue((mask_confidence < algorithm.threshold).all())
 
         done = algorithm.step(batch, logits, [state])
 
@@ -392,6 +411,7 @@ class TestJointThresholdInDelTermination(CustomTestCase):
         )
         self.assertEqual(done, [False])
         self.assertEqual(batch.input_ids.tolist(), [3, 5, 6])
+        self.assertNotIn(MASK, batch.input_ids.tolist())
         self.assertTrue(state["finished"])
 
     def test_stable_terminal_step_finishes_immediately(self):
@@ -429,6 +449,61 @@ class TestJointThresholdInDelTermination(CustomTestCase):
         self.assertTrue(states[0]["finished"])
         self.assertTrue(states[1]["finished"])
         self.assertEqual(batch.input_ids.view(2, 3)[1].tolist(), [3, 6, 4])
+
+
+class TestJointThresholdInDelFdfo(CustomTestCase):
+    def test_fdfo_run_preserves_state_across_request_retirement(self):
+        algorithm = JointThresholdInDel(
+            make_config(block_size=3, max_post_edit_steps=0, fdfo=True)
+        )
+        model_runner = Mock()
+        model_runner.forward.side_effect = [
+            make_model_output(
+                make_logits(
+                    [
+                        [3],
+                        [4],
+                        [5],
+                        [3],
+                        [6],
+                        [4],
+                    ]
+                )
+            ),
+            make_model_output(make_logits([[3], [7], [4]])),
+            make_model_output(make_logits([[3], [7], [4]])),
+        ]
+
+        batch = make_batch([[3, 4, 5], [3, MASK, 4]])
+        _, next_token_ids, accept_lengths, algo_states, _ = algorithm.run(
+            model_runner, batch
+        )
+
+        self.assertEqual(accept_lengths, [3, 0])
+        self.assertIsNone(algo_states[0])
+        self.assertEqual(next_token_ids[1], [3, 6, 4])
+        surviving_state = algo_states[1]
+        self.assertEqual(surviving_state["num_update_steps"], 1)
+
+        batch = make_batch([next_token_ids[1]])
+        _, next_token_ids, accept_lengths, algo_states, _ = algorithm.run(
+            model_runner, batch, [surviving_state]
+        )
+
+        self.assertEqual(accept_lengths, [0])
+        self.assertEqual(next_token_ids, [[3, 7, 4]])
+        self.assertIs(algo_states[0], surviving_state)
+        self.assertTrue(surviving_state["finished"])
+
+        batch = make_batch(next_token_ids)
+        _, next_token_ids, accept_lengths, algo_states, _ = algorithm.run(
+            model_runner, batch, algo_states
+        )
+
+        self.assertEqual(accept_lengths, [3])
+        self.assertEqual(next_token_ids, [[3, 7, 4]])
+        self.assertEqual(algo_states, [None])
+        self.assertEqual(model_runner.forward.call_count, 3)
 
 
 class TestJointThresholdInDelAntiLoop(CustomTestCase):

--- a/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
+++ b/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
@@ -106,6 +106,12 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
             state["prompt_index"].tolist(), [True, False, False, False, False]
         )
 
+    def test_negative_max_post_edit_steps_is_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError, "max_post_edit_steps must be non-negative, got -34"
+        ):
+            JointThresholdInDel(make_config(block_size=32, max_post_edit_steps=-34))
+
     def test_missing_edit_token_ids_preserves_constructor_error(self):
         config = make_config(delete_token_id=None, split_token_id=None)
 
@@ -124,28 +130,7 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
             get_algorithm(config)
 
     @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
-    def test_official_llada22_config_provides_edit_token_ids(self, mock_model_config):
-        mock_model_config.return_value.hf_config = SimpleNamespace(
-            architectures=["LLaDA2MoeModelLM"]
-        )
-        server_args = SimpleNamespace(
-            dllm_algorithm="JointThresholdInDel",
-            model_path="inclusionAI/LLaDA2.2-flash",
-            revision=None,
-            max_running_requests=None,
-            dllm_algorithm_config=None,
-            dllm_fdfo=True,
-        )
-
-        config = DllmConfig.from_server_args(server_args)
-
-        self.assertEqual(config.delete_token_id, 156930)
-        self.assertEqual(config.split_token_id, 156931)
-        self.assertEqual(config.max_running_requests, 1)
-        self.assertTrue(config.first_done_first_out_mode)
-
-    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
-    def test_explicit_checkpoint_edit_token_ids_enable_indel(self, mock_model_config):
+    def test_checkpoint_metadata_enables_indel(self, mock_model_config):
         mock_model_config.return_value.hf_config = SimpleNamespace(
             architectures=["LLaDA2MoeModelLM"],
             delete_token_id=9,
@@ -155,54 +140,55 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
             dllm_algorithm="JointThresholdInDel",
             model_path="local/indel-checkpoint",
             revision=None,
-            max_running_requests=4,
+            max_running_requests=None,
             dllm_algorithm_config=None,
-            dllm_fdfo=False,
+            dllm_fdfo=True,
         )
 
         config = DllmConfig.from_server_args(server_args)
 
         self.assertEqual(config.delete_token_id, 9)
         self.assertEqual(config.split_token_id, 10)
+        self.assertEqual(config.max_running_requests, 1)
+        self.assertTrue(config.first_done_first_out_mode)
 
     @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
-    def test_unsupported_checkpoint_rejects_indel_at_startup(self, mock_model_config):
-        mock_model_config.return_value.hf_config = SimpleNamespace(
-            architectures=["LLaDA2MoeModelLM"]
-        )
-        server_args = SimpleNamespace(
-            dllm_algorithm="JointThresholdInDel",
-            model_path="inclusionAI/LLaDA2.0-mini",
-            revision=None,
-            max_running_requests=4,
-            dllm_algorithm_config=None,
-            dllm_fdfo=False,
-        )
+    def test_incomplete_checkpoint_edit_token_ids_are_rejected(self, mock_model_config):
+        test_cases = [
+            ("inclusionAI/LLaDA2.2-flash", None, None),
+            ("inclusionAI/LLaDA2.0-mini", None, None),
+            ("local/incomplete-indel-checkpoint", 9, None),
+            ("local/incomplete-indel-checkpoint", None, 10),
+        ]
 
-        with self.assertRaises(RuntimeError) as context:
-            DllmConfig.from_server_args(server_args)
+        for model_path, delete_token_id, split_token_id in test_cases:
+            with self.subTest(
+                model_path=model_path,
+                delete_token_id=delete_token_id,
+                split_token_id=split_token_id,
+            ):
+                hf_config = {"architectures": ["LLaDA2MoeModelLM"]}
+                if delete_token_id is not None:
+                    hf_config["delete_token_id"] = delete_token_id
+                if split_token_id is not None:
+                    hf_config["split_token_id"] = split_token_id
+                mock_model_config.return_value.hf_config = SimpleNamespace(**hf_config)
+                server_args = SimpleNamespace(
+                    dllm_algorithm="JointThresholdInDel",
+                    model_path=model_path,
+                    revision=None,
+                    max_running_requests=4,
+                    dllm_algorithm_config=None,
+                    dllm_fdfo=False,
+                )
 
-        message = str(context.exception)
-        self.assertIn("inclusionAI/LLaDA2.0-mini", message)
-        self.assertIn("delete_token_id and split_token_id", message)
-        self.assertIn("--json-model-override-args", message)
+                with self.assertRaises(RuntimeError) as context:
+                    DllmConfig.from_server_args(server_args)
 
-    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
-    def test_partial_checkpoint_edit_token_ids_are_rejected(self, mock_model_config):
-        mock_model_config.return_value.hf_config = SimpleNamespace(
-            architectures=["LLaDA2MoeModelLM"], delete_token_id=9
-        )
-        server_args = SimpleNamespace(
-            dllm_algorithm="JointThresholdInDel",
-            model_path="local/incomplete-indel-checkpoint",
-            revision=None,
-            max_running_requests=4,
-            dllm_algorithm_config=None,
-            dllm_fdfo=False,
-        )
-
-        with self.assertRaisesRegex(RuntimeError, "delete_token_id and split_token_id"):
-            DllmConfig.from_server_args(server_args)
+                message = str(context.exception)
+                self.assertIn(model_path, message)
+                self.assertIn("delete_token_id and split_token_id", message)
+                self.assertIn("--json-model-override-args", message)
 
     @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
     def test_non_indel_algorithm_does_not_require_edit_token_ids(
@@ -291,6 +277,28 @@ class TestJointThresholdInDelStructuralEdits(CustomTestCase):
         self.assertEqual(state["prompt_len"], 2)
         self.assertEqual(
             state["prompt_index"].tolist(), [True, True, False, False, False]
+        )
+
+    def test_split_and_delete_move_original_mask_flags_in_step(self):
+        algorithm = JointThresholdInDel(make_config(block_size=5))
+        batch = make_batch([[3, MASK, MASK, MASK, MASK]])
+        state = algorithm.init_step_state(batch)[0]
+        logits = make_logits(
+            [
+                [3],
+                [SPLIT, 5],
+                [DELETE, 6],
+                [7],
+                [8],
+            ]
+        )
+
+        algorithm.step(batch, logits, [state])
+
+        self.assertEqual(batch.input_ids.tolist(), [3, MASK, MASK, 7, 8])
+        self.assertEqual(
+            state["is_orig_mask"].tolist(),
+            [False, False, True, True, True],
         )
 
 
@@ -610,28 +618,6 @@ class TestJointThresholdInDelAntiLoop(CustomTestCase):
 
         self.assertEqual(batch.input_ids.tolist(), [3, 6, 4])
         self.assertEqual(state["sampled_history"][1], {5, 6})
-
-    def test_split_and_delete_move_original_mask_flags_in_step(self):
-        algorithm = JointThresholdInDel(make_config(block_size=5))
-        batch = make_batch([[3, MASK, MASK, MASK, MASK]])
-        state = algorithm.init_step_state(batch)[0]
-        logits = make_logits(
-            [
-                [3],
-                [SPLIT, 5],
-                [DELETE, 6],
-                [7],
-                [8],
-            ]
-        )
-
-        algorithm.step(batch, logits, [state])
-
-        self.assertEqual(batch.input_ids.tolist(), [3, MASK, MASK, 7, 8])
-        self.assertEqual(
-            state["is_orig_mask"].tolist(),
-            [False, False, True, True, True],
-        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
+++ b/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
@@ -124,11 +124,13 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
             get_algorithm(config)
 
     @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
-    def test_llada_config_provides_edit_token_ids(self, mock_model_config):
-        mock_model_config.return_value.hf_config.architectures = ["LLaDA2MoeModelLM"]
+    def test_official_llada22_config_provides_edit_token_ids(self, mock_model_config):
+        mock_model_config.return_value.hf_config = SimpleNamespace(
+            architectures=["LLaDA2MoeModelLM"]
+        )
         server_args = SimpleNamespace(
             dllm_algorithm="JointThresholdInDel",
-            model_path="model",
+            model_path="inclusionAI/LLaDA2.2-flash",
             revision=None,
             max_running_requests=None,
             dllm_algorithm_config=None,
@@ -143,11 +145,75 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
         self.assertTrue(config.first_done_first_out_mode)
 
     @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
-    def test_non_indel_model_has_no_edit_token_ids(self, mock_model_config):
-        mock_model_config.return_value.hf_config.architectures = ["SDARForCausalLM"]
+    def test_explicit_checkpoint_edit_token_ids_enable_indel(self, mock_model_config):
+        mock_model_config.return_value.hf_config = SimpleNamespace(
+            architectures=["LLaDA2MoeModelLM"],
+            delete_token_id=9,
+            split_token_id=10,
+        )
+        server_args = SimpleNamespace(
+            dllm_algorithm="JointThresholdInDel",
+            model_path="local/indel-checkpoint",
+            revision=None,
+            max_running_requests=4,
+            dllm_algorithm_config=None,
+            dllm_fdfo=False,
+        )
+
+        config = DllmConfig.from_server_args(server_args)
+
+        self.assertEqual(config.delete_token_id, 9)
+        self.assertEqual(config.split_token_id, 10)
+
+    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
+    def test_unsupported_checkpoint_rejects_indel_at_startup(self, mock_model_config):
+        mock_model_config.return_value.hf_config = SimpleNamespace(
+            architectures=["LLaDA2MoeModelLM"]
+        )
+        server_args = SimpleNamespace(
+            dllm_algorithm="JointThresholdInDel",
+            model_path="inclusionAI/LLaDA2.0-mini",
+            revision=None,
+            max_running_requests=4,
+            dllm_algorithm_config=None,
+            dllm_fdfo=False,
+        )
+
+        with self.assertRaises(RuntimeError) as context:
+            DllmConfig.from_server_args(server_args)
+
+        message = str(context.exception)
+        self.assertIn("inclusionAI/LLaDA2.0-mini", message)
+        self.assertIn("delete_token_id and split_token_id", message)
+        self.assertIn("--json-model-override-args", message)
+
+    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
+    def test_partial_checkpoint_edit_token_ids_are_rejected(self, mock_model_config):
+        mock_model_config.return_value.hf_config = SimpleNamespace(
+            architectures=["LLaDA2MoeModelLM"], delete_token_id=9
+        )
+        server_args = SimpleNamespace(
+            dllm_algorithm="JointThresholdInDel",
+            model_path="local/incomplete-indel-checkpoint",
+            revision=None,
+            max_running_requests=4,
+            dllm_algorithm_config=None,
+            dllm_fdfo=False,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "delete_token_id and split_token_id"):
+            DllmConfig.from_server_args(server_args)
+
+    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
+    def test_non_indel_algorithm_does_not_require_edit_token_ids(
+        self, mock_model_config
+    ):
+        mock_model_config.return_value.hf_config = SimpleNamespace(
+            architectures=["LLaDA2MoeModelLM"]
+        )
         server_args = SimpleNamespace(
             dllm_algorithm="JointThreshold",
-            model_path="model",
+            model_path="inclusionAI/LLaDA2.0-mini",
             revision=None,
             max_running_requests=4,
             dllm_algorithm_config=None,
@@ -346,22 +412,13 @@ class TestJointThresholdInDelSelection(CustomTestCase):
 
 
 class TestJointThresholdInDelTermination(CustomTestCase):
-    def test_post_edit_boundary_then_final_cleanup_scrubs_all_reserved_tokens(self):
+    def test_budget_one_final_cleanup_scrubs_all_reserved_tokens(self):
         algorithm = JointThresholdInDel(
             make_config(block_size=4, max_post_edit_steps=1)
         )
         batch = make_batch([[3, MASK, MASK, 4]])
         state = algorithm.init_step_state(batch)[0]
         state["is_orig_mask"] = torch.zeros(4, dtype=torch.bool)
-        ordinary_logits = make_logits([[3], [MASK, 5], [MASK, 6], [4]])
-
-        done = algorithm.step(batch, ordinary_logits, [state])
-
-        self.assertEqual(done, [False])
-        self.assertEqual(state["post_edit_steps"], 1)
-        self.assertFalse(state["finished"])
-        self.assertEqual(batch.input_ids.tolist(), [3, MASK, MASK, 4])
-
         logits = make_logits(
             [
                 [DELETE, 8],
@@ -452,7 +509,7 @@ class TestJointThresholdInDelTermination(CustomTestCase):
 
 
 class TestJointThresholdInDelFdfo(CustomTestCase):
-    def test_fdfo_run_preserves_state_across_request_retirement(self):
+    def test_fdfo_budget_zero_cleans_up_while_resolving_last_original_mask(self):
         algorithm = JointThresholdInDel(
             make_config(block_size=3, max_post_edit_steps=0, fdfo=True)
         )
@@ -465,13 +522,12 @@ class TestJointThresholdInDelFdfo(CustomTestCase):
                         [4],
                         [5],
                         [3],
-                        [6],
-                        [4],
+                        [SPLIT, 6],
+                        [DELETE, 7],
                     ]
                 )
             ),
-            make_model_output(make_logits([[3], [7], [4]])),
-            make_model_output(make_logits([[3], [7], [4]])),
+            make_model_output(make_logits([[3], [6], [7]])),
         ]
 
         batch = make_batch([[3, 4, 5], [3, MASK, 4]])
@@ -481,19 +537,54 @@ class TestJointThresholdInDelFdfo(CustomTestCase):
 
         self.assertEqual(accept_lengths, [3, 0])
         self.assertIsNone(algo_states[0])
-        self.assertEqual(next_token_ids[1], [3, 6, 4])
+        self.assertEqual(next_token_ids[1], [3, 6, 7])
         surviving_state = algo_states[1]
         self.assertEqual(surviving_state["num_update_steps"], 1)
+        self.assertEqual(surviving_state["post_edit_steps"], 0)
+        self.assertTrue(surviving_state["finished"])
 
         batch = make_batch([next_token_ids[1]])
         _, next_token_ids, accept_lengths, algo_states, _ = algorithm.run(
             model_runner, batch, [surviving_state]
         )
 
+        self.assertEqual(accept_lengths, [3])
+        self.assertEqual(next_token_ids, [[3, 6, 7]])
+        self.assertEqual(algo_states, [None])
+        self.assertEqual(model_runner.forward.call_count, 2)
+
+    def test_fdfo_budget_one_uses_first_post_edit_round_for_cleanup(self):
+        algorithm = JointThresholdInDel(
+            make_config(block_size=3, max_post_edit_steps=1, fdfo=True)
+        )
+        model_runner = Mock()
+        model_runner.forward.side_effect = [
+            make_model_output(make_logits([[3], [6], [4]])),
+            make_model_output(make_logits([[3], [DELETE, 7], [SPLIT, 8]])),
+            make_model_output(make_logits([[3], [7], [8]])),
+        ]
+
+        batch = make_batch([[3, MASK, 4]])
+        _, next_token_ids, accept_lengths, algo_states, _ = algorithm.run(
+            model_runner, batch
+        )
+
         self.assertEqual(accept_lengths, [0])
-        self.assertEqual(next_token_ids, [[3, 7, 4]])
-        self.assertIs(algo_states[0], surviving_state)
-        self.assertTrue(surviving_state["finished"])
+        self.assertEqual(next_token_ids, [[3, 6, 4]])
+        state = algo_states[0]
+        self.assertEqual(state["post_edit_steps"], 0)
+        self.assertFalse(state["finished"])
+
+        batch = make_batch(next_token_ids)
+        _, next_token_ids, accept_lengths, algo_states, _ = algorithm.run(
+            model_runner, batch, algo_states
+        )
+
+        self.assertEqual(accept_lengths, [0])
+        self.assertEqual(next_token_ids, [[3, 7, 8]])
+        self.assertIs(algo_states[0], state)
+        self.assertEqual(state["post_edit_steps"], 1)
+        self.assertTrue(state["finished"])
 
         batch = make_batch(next_token_ids)
         _, next_token_ids, accept_lengths, algo_states, _ = algorithm.run(
@@ -501,7 +592,7 @@ class TestJointThresholdInDelFdfo(CustomTestCase):
         )
 
         self.assertEqual(accept_lengths, [3])
-        self.assertEqual(next_token_ids, [[3, 7, 4]])
+        self.assertEqual(next_token_ids, [[3, 7, 8]])
         self.assertEqual(algo_states, [None])
         self.assertEqual(model_runner.forward.call_count, 3)
 

--- a/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
+++ b/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
@@ -22,6 +22,8 @@ MASK = 0
 DELETE = 1
 SPLIT = 2
 VOCAB_SIZE = 12
+LLADA2_MASK_ID = 156895
+LLADA2_VOCAB_SIZE = 157184
 
 
 def make_config(
@@ -135,6 +137,7 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
 
     @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
     def test_checkpoint_metadata_enables_indel(self, mock_model_config):
+        mock_model_config.return_value.vocab_size = LLADA2_VOCAB_SIZE
         mock_model_config.return_value.hf_config = SimpleNamespace(
             architectures=["LLaDA2MoeModelLM"],
             delete_token_id=9,
@@ -155,6 +158,38 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
         self.assertEqual(config.split_token_id, 10)
         self.assertEqual(config.max_running_requests, 1)
         self.assertTrue(config.first_done_first_out_mode)
+
+    @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
+    def test_invalid_checkpoint_edit_token_ids_are_rejected(self, mock_model_config):
+        mock_model_config.return_value.vocab_size = LLADA2_VOCAB_SIZE
+        server_args = SimpleNamespace(
+            dllm_algorithm="JointThresholdInDel",
+            model_path="local/indel-checkpoint",
+            revision=None,
+            max_running_requests=4,
+            dllm_algorithm_config=None,
+            dllm_fdfo=False,
+        )
+        test_cases = [
+            ("boolean", True, 10, "delete_token_id must be an integer token ID"),
+            ("non_integer", 1.5, 10, "delete_token_id must be an integer token ID"),
+            ("negative", -1, 10, "delete_token_id must be within"),
+            ("upper_bound", 9, LLADA2_VOCAB_SIZE, "split_token_id must be within"),
+            ("same_edit_ids", 9, 9, "token IDs must be distinct"),
+            ("delete_is_mask", LLADA2_MASK_ID, 10, "token IDs must be distinct"),
+            ("split_is_mask", 9, LLADA2_MASK_ID, "token IDs must be distinct"),
+        ]
+
+        for case_name, delete_token_id, split_token_id, error_pattern in test_cases:
+            with self.subTest(case=case_name):
+                mock_model_config.return_value.hf_config = SimpleNamespace(
+                    architectures=["LLaDA2MoeModelLM"],
+                    delete_token_id=delete_token_id,
+                    split_token_id=split_token_id,
+                )
+
+                with self.assertRaisesRegex(ValueError, error_pattern):
+                    DllmConfig.from_server_args(server_args)
 
     @patch("sglang.srt.dllm.config.ModelConfig.from_server_args")
     def test_incomplete_checkpoint_edit_token_ids_are_rejected(self, mock_model_config):

--- a/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
+++ b/test/registered/unit/dllm/algorithm/test_joint_threshold_indel.py
@@ -106,11 +106,15 @@ class TestJointThresholdInDelInitialization(CustomTestCase):
             state["prompt_index"].tolist(), [True, False, False, False, False]
         )
 
-    def test_negative_max_post_edit_steps_is_rejected(self):
-        with self.assertRaisesRegex(
-            ValueError, "max_post_edit_steps must be non-negative, got -34"
-        ):
-            JointThresholdInDel(make_config(block_size=32, max_post_edit_steps=-34))
+    def test_invalid_max_post_edit_steps_is_rejected(self):
+        for value in (-34, 1.5, True):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    ValueError, "max_post_edit_steps must be a non-negative integer"
+                ):
+                    JointThresholdInDel(
+                        make_config(block_size=32, max_post_edit_steps=value)
+                    )
 
     def test_missing_edit_token_ids_preserves_constructor_error(self):
         config = make_config(delete_token_id=None, split_token_id=None)


### PR DESCRIPTION
## Motivation

This PR introduces the `JointThresholdInDel` algorithm, which extends `JointThreshold` with structural edit token support for diffusion LLMs. It enables the model to not only fill masks and refine tokens, but also **delete** positions (block shrinks) and **insert** new positions via SPLIT (block expands). This is essential for models trained with insertion and deletion capabilities (e.g., LLaDA2.2-flash with InDel training).

## Dependency

- #35998 keeps the reserved dLLM mask token out of text-derived prompts and rejects it in caller-provided prompt IDs. This PR should merge after that common-path fix.

## Modifications

### New Algorithm: `JointThresholdInDel`

- **DELETE token**: When the model predicts a DELETE token at a position, that position is removed from the block, remaining positions shift left, and the block is padded with mask tokens.
- **SPLIT (insert) token**: When the model predicts a SPLIT token, the position expands into `[mask, current_token]`, allowing the model to insert new content.
- **Original mask tracking (`is_orig_mask`)**: Distinguishes masks from the initial block vs. masks introduced by DELETE padding or SPLIT expansion, ensuring correct M2T scheduling.
- **Anti-loop mechanism**: Detects repeated block states and deterministically injects diversity at the lowest-confidence position via `argmin`, preventing infinite loops caused by DELETE/SPLIT cycles.
- **Bounded final cleanup**: When the post-edit budget is reached or the regular-update limit is exceeded, selects every remaining non-prompt mask and suppresses MASK, DELETE, and SPLIT. If token IDs change, one additional forward is performed before emitting the request so the KV cache matches the final block.
- **Cumulative post-edit budget**: The consumed post-edit budget is not reset if an original mask reappears. This intentionally differs from the released reference decoder.
- **FDFO compatible**: All iteration state is carried in the `states` dict, fully compatible with First-Done-First-Out scheduling.

### Config Changes

Added `delete_token_id` and `split_token_id` to `DllmConfig`. `JointThresholdInDel` requires both IDs in checkpoint metadata or an explicit model override, and rejects unsupported or partial configurations at startup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33037709325](https://github.com/sgl-project/sglang/actions/runs/33037709325)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33037709253](https://github.com/sgl-project/sglang/actions/runs/33037709253)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33037709351](https://github.com/sgl-project/sglang/actions/runs/33037709351)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->