### PR TITLE
fix(disagg/mori): pool early-send CUDA events to bound HSA signals

### DIFF
--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Tuple
 import msgspec
 import numpy as np
 import numpy.typing as npt
+import torch
 import zmq
 from mori.cpp import TransferStatus
 from mori.io import (
@@ -320,6 +321,19 @@ class MoriKVManager(CommonKVManager):
         self._socket_local = threading.local()
         self._send_aux_rdma = envs.SGLANG_MORI_SEND_AUX_RDMA.get()
         self._register_local_buffers()
+        # Reusable CUDA-event pool for early-send completion tracking. Each
+        # torch.cuda.Event is backed by an HSA/KFD signal; minting one per
+        # early-send (prefill.maybe_send_cached_prefix_chunk) and never reusing
+        # it lets the live-signal count grow with cumulative sends under
+        # sustained PD warmup and eventually exhausts the per-process signal
+        # pool -> HSA_STATUS_ERROR_OUT_OF_RESOURCES (raised even with GPU memory
+        # free). Pooling + a hard cap keep live events bounded by in-flight
+        # early sends. Cap overridable via SGLANG_MORI_EVENT_POOL_CAP.
+        self._send_event_pool: List[torch.cuda.Event] = []
+        self._send_event_pool_lock = threading.Lock()
+        self._send_event_pool_cap = max(
+            1, int(os.environ.get("SGLANG_MORI_EVENT_POOL_CAP", "512"))
+        )
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self._num_shards = max(1, envs.SGLANG_MORI_TRANSFER_SHARDS.get())
             self._transfer_queues: List[FastQueue] = [
@@ -431,6 +445,28 @@ class MoriKVManager(CommonKVManager):
 
     def enqueue_transfer(self, task: _TransferChunk) -> None:
         self._transfer_queues[task.sender.bootstrap_room % self._num_shards].put(task)
+
+    def acquire_send_event(self) -> torch.cuda.Event:
+        """Return a reusable CUDA event for early-send completion tracking.
+
+        Reuses a pooled event when one is free so the number of live hipEvents
+        (each backed by an HSA/KFD signal) stays bounded by the number of
+        in-flight early sends instead of growing with cumulative sends. See
+        MoriKVManager.__init__ for the failure mode this avoids.
+        """
+        with self._send_event_pool_lock:
+            if self._send_event_pool:
+                return self._send_event_pool.pop()
+        return torch.cuda.Event()
+
+    def release_send_event(self, event: Optional[torch.cuda.Event]) -> None:
+        """Return an early-send event to the pool once it has been waited on."""
+        if event is None:
+            return
+        with self._send_event_pool_lock:
+            if len(self._send_event_pool) < self._send_event_pool_cap:
+                self._send_event_pool.append(event)
+            # Above cap: drop the reference so Python GC frees the surplus event.
 
     def _transfer_worker(self, queue: FastQueue) -> None:
         while True:
@@ -1452,46 +1488,56 @@ class MoriKVSender(CommonKVSender):
             self._finalize_failure()
 
     def _run_chunk(self, task: _TransferChunk) -> None:
-        if self.conclude_state is not None:
-            return
-        if self.kv_mgr.request_status.get(self.bootstrap_room) == KVPoll.Failed:
-            self._finalize_failure()
-            return
+        wait_event = task.wait_event
+        try:
+            if self.conclude_state is not None:
+                return
+            if self.kv_mgr.request_status.get(self.bootstrap_room) == KVPoll.Failed:
+                self._finalize_failure()
+                return
 
-        # Wait for the prefill forward that produced these KV pages before
-        # issuing the RDMA read (early-send overlaps that forward).
-        if task.wait_event is not None:
-            task.wait_event.synchronize()
+            # Wait for the prefill forward that produced these KV pages before
+            # issuing the RDMA read (early-send overlaps that forward).
+            if wait_event is not None:
+                wait_event.synchronize()
 
-        statuses, infos = self.kv_mgr.add_transfer_request(
-            self.bootstrap_room,
-            task.kv_indices,
-            task.index_slice,
-            task.is_last_chunk,
-            aux_index=task.aux_index,
-            state_indices=task.normalized_state,
-        )
-        self.transfer_statuses.extend(statuses)
-        if infos is not None:
-            self.pending_infos = infos
+            statuses, infos = self.kv_mgr.add_transfer_request(
+                self.bootstrap_room,
+                task.kv_indices,
+                task.index_slice,
+                task.is_last_chunk,
+                aux_index=task.aux_index,
+                state_indices=task.normalized_state,
+            )
+            self.transfer_statuses.extend(statuses)
+            if infos is not None:
+                self.pending_infos = infos
 
-        if self.kv_mgr.request_status.get(self.bootstrap_room) == KVPoll.Failed:
-            self._finalize_failure()
-            return
+            if self.kv_mgr.request_status.get(self.bootstrap_room) == KVPoll.Failed:
+                self._finalize_failure()
+                return
 
-        rc = self._wait_chunk(statuses)
-        if self.conclude_state is not None:
-            return
-        if rc != StatusCode.SUCCESS:
-            self._finalize_failure(self._collect_failure_reason())
-            return
-        if task.is_last_chunk:
-            self._notify_decode(KVPoll.Success)
-            with self._notify_lock:
-                if self.conclude_state is None:
-                    self.conclude_state = self._notified_status
-                if self._notified_status == KVPoll.Success:
-                    self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
+            rc = self._wait_chunk(statuses)
+            if self.conclude_state is not None:
+                return
+            if rc != StatusCode.SUCCESS:
+                self._finalize_failure(self._collect_failure_reason())
+                return
+            if task.is_last_chunk:
+                self._notify_decode(KVPoll.Success)
+                with self._notify_lock:
+                    if self.conclude_state is None:
+                        self.conclude_state = self._notified_status
+                    if self._notified_status == KVPoll.Success:
+                        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
+        finally:
+            # Once waited on (or the chunk short-circuited), return the
+            # early-send event to the pool so the live hipEvent/HSA-signal
+            # count stays bounded under sustained load. Safe to recycle even
+            # if not synchronized here: the next user re-records before waiting.
+            if wait_event is not None:
+                task.wait_event = None
+                self.kv_mgr.release_send_event(wait_event)
 
     def _wait_chunk(self, statuses: List[TransferStatus]) -> StatusCode:
         if not statuses:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1043,9 +1043,15 @@ class SchedulerDisaggregationPrefillMixin:
         # event now so the transfer worker can wait on those writes before the
         # RDMA read, instead of racing them.
         if self.enable_overlap:
-            ev = torch.cuda.Event()
+            # Reuse a pooled CUDA event when the disaggregation backend provides
+            # one (mori) so the live hipEvent/HSA-signal count stays bounded
+            # under sustained early-send; other backends keep per-send events.
+            sender = req.disagg_kv_sender
+            kv_mgr = getattr(sender, "kv_mgr", None)
+            acquire = getattr(kv_mgr, "acquire_send_event", None)
+            ev = acquire() if acquire is not None else torch.cuda.Event()
             ev.record(self.forward_stream)
-            req.disagg_kv_sender._early_send_wait_event = ev
+            sender._early_send_wait_event = ev
         self.send_kv_chunk(req, last_chunk=False, end_idx=cached_end)
 
     def send_kv_chunk(


### PR DESCRIPTION
## Summary
On the PD-disaggregation **mori** path, prefill early-send (`maybe_send_cached_prefix_chunk`) mints a fresh `torch.cuda.Event()` per early-send under overlap scheduling. On agentic / high prefix-cache-hit workloads this fires for nearly every request, and each event is backed by an HSA/KFD signal. Under sustained warmup the live-signal count grows with **cumulative** sends until the per-process signal pool is exhausted, aborting a GPU queue with `HSA_STATUS_ERROR_OUT_OF_RESOURCES` (raised with tens of GB of VRAM still free) inside `torch.cuda.Event.synchronize()` in the mori transfer worker (`MoriKVSender._run_chunk`).

Observed signature (MI355X, DSv4 1P1D agentic): prefill throughput decays monotonically over identical chunks (growing signal set) while KV usage stays flat, then a hard abort during warmup — reproducible across `max_running_requests` values and nodes.

## Change
- Add a bounded, reusable CUDA-event pool to `MoriKVManager` (`acquire_send_event` / `release_send_event`; cap via `SGLANG_MORI_EVENT_POOL_CAP`, default 512).
- `prefill.maybe_send_cached_prefix_chunk` acquires from the pool when the backend provides it (via `getattr`, so **other backends keep the existing per-send behavior**).
- `MoriKVSender._run_chunk` returns the event to the pool in a `finally` once it has been waited on.
- Net effect: live events are bounded by **in-flight** early sends instead of cumulative sends.

Companion mori-side fix (bounds the C++ `EventPool` free-list): ROCm/mori#491

## Test plan
- [ ] DSv4 1P1D agentic replay (conc 96/128, HiCache) on MI355X: warmup completes without `HSA_STATUS_ERROR_OUT_OF_RESOURCES`.
- [ ] Confirm prefill throughput no longer decays across warmup.
- [ ] Non-mori backends (mooncake/nixl) unaffected (fallback path).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29742847682](https://github.com/sgl-project/sglang/actions/runs/29742847682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29742847472](https://github.com/sgl-project/sglang/actions/runs/29742847472)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->