### PR TITLE
[bugfix][NPU] Fix startup bug in olmoe 1b 7b

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/ascend_tp.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/ascend_tp.py
@@ -95,6 +95,7 @@ class AscendTPDispatcher(BaseDispatcher):
         topk_weights, topk_ids, _ = topk_output
         topk_weights = topk_weights.to(hidden_states.dtype)
         topk_ids = topk_ids.to(torch.int32)
+        top_k = topk_weights.shape[-1]
 
         (
             permuted_hidden_states,
@@ -105,7 +106,7 @@ class AscendTPDispatcher(BaseDispatcher):
             hidden_states,
             topk_ids,
             self.num_experts,
-            self.top_k,
+            top_k,
         )
 
         self._dispatch_output = AscendTPDispatchOutput(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Serving `OLMoE-1B-7B-0924-Instruct` on Ascend NPU crashes on the first forward pass:

```
File ".../srt/hardware_backend/npu/moe/init_routing.py", line 88, in _init_routing
    active_num=num_tokens * top_k,
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

`top_k` reaches `npu_moe_init_routing_v2` as `None`.

**Root cause:** The NPU MoE refactor (#25663) moved `top_k` from being derived at runtime — the old `fused_moe_method_npu.py` always took `top_k = topk_ids.shape[1]` / `topk_weights.shape[-1]` inside forward — to being read once at construction time from `moe_runner_config.top_k` (cached as `AscendTPDispatcher.top_k`). Models that do not pass `top_k` into `FusedMoE` (e.g. `olmoe.py`, currently the only MoE model in-tree that omits it) leave `moe_runner_config.top_k = None`, and that `None` propagates through `AscendTPDispatcher.top_k` into `_init_routing`, blowing up at `num_tokens * top_k`.


## Modifications

<!-- Detail the changes made in this pull request. -->

- `python/sglang/srt/layers/moe/token_dispatcher/ascend_tp.py`: In `AscendTPDispatcher.dispatch()`, re-derive `self.top_k` from the actual topk output shape (`self.top_k = topk_weights.shape[-1]`) right before invoking `self.init._init_routing`.

This restores the pre-refactor protection where the routing kernel always used the runtime topk width, making the dispatcher robust to a `None` config `top_k` regardless of whether the model layer supplied it to `FusedMoE`. Single-file, minimal, no new compute (the topk tensor is already materialized in `dispatch()`).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

NA

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A — correctness fix only. The change reassigns a scalar from a tensor shape that is already materialized in `dispatch()`; no new kernel calls or compute are introduced.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29792268116](https://github.com/sgl-project/sglang/actions/runs/29792268116)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29792268134](https://github.com/sgl-project/sglang/actions/runs/29792268134)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->