### PR TITLE
Align reasoning_effort schema across chat, tokenize, and responses

### DIFF
--- a/docs_new/cookbook/autoregressive/ThinkingMachines/Inkling.mdx
+++ b/docs_new/cookbook/autoregressive/ThinkingMachines/Inkling.mdx
@@ -100,6 +100,7 @@ import { Playground } from "/src/snippets/_playground.jsx";
   </thead>
   <tbody>
     <tr><td style={{padding: "6px 12px"}}><code>none</code></td><td style={{padding: "6px 12px"}}>0.0</td></tr>
+    <tr><td style={{padding: "6px 12px"}}><code>minimal</code></td><td style={{padding: "6px 12px"}}>0.1</td></tr>
     <tr><td style={{padding: "6px 12px"}}><code>low</code></td><td style={{padding: "6px 12px"}}>0.2</td></tr>
     <tr><td style={{padding: "6px 12px"}}><code>medium</code></td><td style={{padding: "6px 12px"}}>0.7</td></tr>
     <tr><td style={{padding: "6px 12px"}}><code>high</code></td><td style={{padding: "6px 12px"}}>0.9</td></tr>

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -687,6 +687,23 @@ class ToolChoice(BaseModel):
     type: Literal["function"] = Field(default="function", examples=["function"])
 
 
+# OpenAI-spec string tiers for reasoning effort (current Responses/Chat API):
+# none/minimal/low/medium/high/xhigh/max. Used as-is by /v1/responses.
+ReasoningEffortTier = Literal[
+    "none", "minimal", "low", "medium", "high", "xhigh", "max"
+]
+# Chat Completions and /v1/tokenize additionally accept a fine-grained float in
+# [0.0, 0.99] as an sglang extension (not part of the OpenAI schema, so the
+# /v1/responses surface deliberately keeps the string tiers only). Single-sourced
+# so these surfaces cannot drift apart.
+ReasoningEffortType = Optional[
+    Union[
+        ReasoningEffortTier,
+        Annotated[float, Field(ge=0.0, le=0.99, allow_inf_nan=False)],
+    ]
+]
+
+
 class ChatCompletionRequest(BaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
@@ -730,16 +747,11 @@ class ChatCompletionRequest(BaseModel):
     return_cached_tokens_details: bool = False
     return_prompt_token_ids: bool = False
     return_meta_info: bool = False
-    reasoning_effort: Optional[
-        Union[
-            Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"],
-            Annotated[float, Field(ge=0.0, le=0.99, allow_inf_nan=False)],
-        ]
-    ] = Field(
+    reasoning_effort: ReasoningEffortType = Field(
         default=None,
         description="Constrains effort on reasoning for reasoning models. "
         "Accepts string levels ('none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max') or a "
-        "float in [0.0, 1.0] for fine-grained control. "
+        "float in [0.0, 0.99] for fine-grained control. "
         "'none' disables reasoning entirely, 'low' is the least effort, 'high' is the most effort. "
         "Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning "
         "in a response. 'none' defaults thinking and enable_thinking to false in "
@@ -858,6 +870,7 @@ class ChatCompletionRequest(BaseModel):
                 effort = r.get("reasoning_effort")
             if isinstance(effort, str) and effort in {
                 "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -1301,9 +1314,7 @@ class TokenizeRequest(BaseModel):
     tool_choice: Optional[Union[ToolChoice, Literal["auto", "required", "none"]]] = (
         Field(default=None, examples=["auto"])
     )
-    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high"]] = (
-        None
-    )
+    reasoning_effort: ReasoningEffortType = None
     continue_final_message: bool = False
     chat_template_kwargs: Optional[Dict] = None
     add_special_tokens: bool = Field(
@@ -1369,9 +1380,11 @@ OpenAIServingRequest = Union[
 class ResponseReasoningParam(BaseModel):
     """Reasoning parameters for responses."""
 
-    effort: Optional[Literal["low", "medium", "high"]] = Field(
+    effort: Optional[ReasoningEffortTier] = Field(
         default="medium",
-        description="Constrains effort on reasoning for reasoning models.",
+        description="Constrains effort on reasoning for reasoning models. "
+        "Accepts the OpenAI string tiers "
+        "('none','minimal','low','medium','high','xhigh','max').",
     )
     summary: Optional[Literal["auto", "concise", "detailed"]] = Field(
         default=None,


### PR DESCRIPTION
## Motivation

`reasoning_effort` accepts the OpenAI string tiers (`none/minimal/low/medium/high/xhigh/max`, string-only [per the spec](https://developers.openai.com/api/docs/guides/reasoning)) plus an sglang float extension in `[0.0, 0.99]`. The schema had drifted across the surfaces that take it:

- `/v1/responses` (`ResponseReasoningParam.effort`) only listed `low/medium/high`, rejecting `none/minimal/xhigh/max`.
- The nested `reasoning.effort` normalizer omitted `minimal` from its allowlist, so `{"reasoning": {"effort": "minimal"}}` fell through to the float path and raised.
- `/v1/tokenize` used a stale 5-tier `Literal` with no float.
- `ChatCompletionRequest` documented the float range as `[0.0, 1.0]` while the real cap is `0.99`.

This single-sources the tier list into shared type aliases so the surfaces cannot drift again. Per the OpenAI spec `effort` is string-only, so `/v1/responses` keeps the tiers without the float extension; Chat Completions and `/v1/tokenize` keep the float.

## Modifications

- Add `ReasoningEffortTier` (the 7 OpenAI string tiers) and `ReasoningEffortType` (tiers + float `[0.0, 0.99]`) aliases, single-sourced.
- `ChatCompletionRequest` / `TokenizeRequest.reasoning_effort` → `ReasoningEffortType`; fix the `[0.0, 1.0]` → `[0.0, 0.99]` description.
- `ResponseReasoningParam.effort` → `ReasoningEffortTier` (string-only, all 7 tiers).
- Add `minimal` to the nested `reasoning.effort` allowlist.
- Add the `minimal` (0.1) row to the Inkling cookbook effort table.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29746493356](https://github.com/sgl-project/sglang/actions/runs/29746493356)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29746493008](https://github.com/sgl-project/sglang/actions/runs/29746493008)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->