### PR TITLE
fix: preserve content before DeepSeek streaming tool calls

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -258,6 +258,14 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     current_text = current_text.replace(e_token, "")
             return StreamingParseResult(normal_text=current_text)
 
+        normal_text = ""
+        if self.current_tool_id == -1:
+            bot_token_idx = current_text.find(self.bot_token)
+            if bot_token_idx != -1:
+                normal_text = current_text[:bot_token_idx]
+                self._buffer = current_text[bot_token_idx:]
+                current_text = self._buffer
+
         all_calls: list[ToolCallItem] = []
         try:
             # Loop to handle multiple consecutive invoke blocks
@@ -355,11 +363,11 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     break
 
             # No more invoke blocks found
-            return StreamingParseResult(normal_text="", calls=all_calls)
+            return StreamingParseResult(normal_text=normal_text, calls=all_calls)
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            return StreamingParseResult(normal_text=current_text)
+            return StreamingParseResult(normal_text=normal_text + current_text)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/test/registered/unit/function_call/test_deepseek_detectors.py
+++ b/test/registered/unit/function_call/test_deepseek_detectors.py
@@ -1,0 +1,109 @@
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
+from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDeepSeekStreamingContent(CustomTestCase):
+    detector_cases = (
+        (DeepSeekV32Detector, "function_calls"),
+        (DeepSeekV4Detector, "tool_calls"),
+    )
+    content = "I'll navigate there now."
+
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="navigate",
+                    description="Navigate to a destination.",
+                    parameters={
+                        "type": "object",
+                        "properties": {"destination": {"type": "string"}},
+                        "required": ["destination"],
+                    },
+                ),
+            )
+        ]
+
+    @staticmethod
+    def _wire_text(section_name, destinations=("library",)):
+        invokes = "".join(
+            f'<｜DSML｜invoke name="navigate">{{"destination":"{destination}"}}'
+            "</｜DSML｜invoke>"
+            for destination in destinations
+        )
+        return (
+            f"{TestDeepSeekStreamingContent.content}<｜DSML｜{section_name}>"
+            f"{invokes}</｜DSML｜{section_name}>"
+        )
+
+    def _parse_chunks(self, detector, chunks):
+        normal_text = []
+        calls = {}
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal_text.append(result.normal_text)
+            for call in result.calls:
+                parsed = calls.setdefault(
+                    call.tool_index, {"name": None, "parameters": ""}
+                )
+                if call.name is not None:
+                    parsed["name"] = call.name
+                parsed["parameters"] += call.parameters
+        return "".join(normal_text), calls
+
+    def _assert_parsed(self, detector, chunks, destinations=("library",)):
+        normal_text, calls = self._parse_chunks(detector, chunks)
+        self.assertEqual(normal_text, self.content)
+        self.assertEqual(len(calls), len(destinations))
+        for index, destination in enumerate(destinations):
+            self.assertEqual(calls[index]["name"], "navigate")
+            self.assertEqual(
+                json.loads(calls[index]["parameters"]),
+                {"destination": destination},
+            )
+
+    def test_content_and_complete_tool_call_in_single_increment(self):
+        """A delta containing content and a complete DSML call preserves both."""
+        for detector_class, section_name in self.detector_cases:
+            with self.subTest(detector=detector_class.__name__):
+                wire_text = self._wire_text(section_name)
+                self._assert_parsed(detector_class(), [wire_text])
+
+    def test_content_is_invariant_across_opener_split_boundaries(self):
+        """Every split around the DSML opener preserves content exactly once."""
+        for detector_class, section_name in self.detector_cases:
+            opener = f"<｜DSML｜{section_name}>"
+            wire_text = self._wire_text(section_name)
+            opener_start = wire_text.index(opener)
+            split_start = opener_start - 1
+            split_end = opener_start + len(opener) + 1
+            for split_at in range(split_start, split_end + 1):
+                with self.subTest(detector=detector_class.__name__, split_at=split_at):
+                    self._assert_parsed(
+                        detector_class(),
+                        [wire_text[:split_at], wire_text[split_at:]],
+                    )
+
+    def test_content_prefix_with_consecutive_tool_calls(self):
+        """Preserving the prefix does not disrupt consecutive DSML calls."""
+        destinations = ("library", "museum")
+        for detector_class, section_name in self.detector_cases:
+            with self.subTest(detector=detector_class.__name__):
+                wire_text = self._wire_text(section_name, destinations)
+                self._assert_parsed(
+                    detector_class(), [wire_text], destinations=destinations
+                )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DeepSeekV32Detector.parse_streaming_increment()` can silently drop normal assistant content when a single streaming delta contains both the end of that content and the beginning of a DSML tool call:

```text
I'll navigate there now.<｜DSML｜function_calls>...
```

The parser recognizes the tool call, but previously returned `normal_text=""`. Non-streaming `detect_and_parse()` already preserves `text[:idx]`, so the response depended on how the server happened to chunk the same generated text.

This is chunk-boundary dependent and becomes more visible when multi-token deltas are produced, including with speculative decoding.

Related to #30480: this is the same failure class in which streaming and non-streaming tool-call parsing diverge at a truncation or chunk boundary. The issue also explicitly notes that streaming can swallow the last content characters before a tool-call opener.

## Modifications

- On the first complete DSML opener, emit the buffered prefix as normal content.
- Retain only the opener and following text in the detector buffer for tool-call parsing.
- Preserve existing partial-opener buffering, incremental argument parsing, consecutive tool calls, and parser error fallback behavior.
- Add CPU detector-level regression tests for both `DeepSeekV32Detector` and the inheriting `DeepSeekV4Detector`.

The implementation is local to `DeepSeekV32Detector` and shared by V4 through inheritance.

> Make DeepSeek streaming tool-call parsing chunk-boundary invariant by emitting normal content before the DSML opener instead of silently dropping it.

## Accuracy Tests

This does not change model generation. Detector-level tests verify that concatenated `normal_text` exactly matches the original content, without loss or duplication, and that tool names and JSON arguments remain correct.

The detector suite was run locally in a CPU-isolated test harness because the full SGLang accelerator dependency stack was not installed in the local environment. The registered upstream `base-a-test-cpu` job remains the authoritative full-environment run.

```text
pytest -q test/registered/unit/function_call/test_deepseek_detectors.py
3 passed, 50 subtests passed
```

The split-boundary test covers every character boundary immediately before, through, and immediately after the V3.2 and V4 DSML openers.

Additional checks:

```text
ruff 0.15.1: passed
black 26.1.0: 2 files left unchanged
isort 7.0.0: passed
python scripts/ci/check_registered_tests.py: passed
git diff --check: passed
```

## Speed Tests and Profiling

Not applicable. This parser-local fix adds one `str.find()` and one buffer slice when the first tool-call opener is detected; it does not affect model execution.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required because this is an internal parser correctness fix with no API or configuration change.
- [x] Accuracy and speed benchmarks are not applicable because this does not affect model generation or inference execution.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29748517792](https://github.com/sgl-project/sglang/actions/runs/29748517792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29748517591](https://github.com/sgl-project/sglang/actions/runs/29748517591)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
