### PR TITLE
Fix dropped Inkling reasoning at stream end

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -782,6 +782,20 @@ class InklingDetector(BaseReasoningFormatDetector):
             self._buffer = ""
         return self._parse_blocks(text)
 
+    def finish(self) -> StreamingParseResult:
+        # Flush reasoning buffered under stream_reasoning=False when the stream
+        # ends before a control/end token closes the block (e.g. max_tokens cut
+        # a thinking block short). Mirrors the non-streaming flush in
+        # detect_and_parse; without it the trailing reasoning trace is dropped.
+        reasoning_text = ""
+        if self._kind == "reasoning" and not self.stream_reasoning:
+            reasoning_text = self._pending_reasoning
+        self._buffer = ""
+        self._pending_reasoning = ""
+        self._pending_header = ""
+        self._kind = None
+        return StreamingParseResult(reasoning_text=reasoning_text)
+
     @staticmethod
     def _partial_control_length(text: str) -> int:
         max_token_len = max(map(len, _INKLING_CONTROL_TOKENS))

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -249,6 +249,22 @@ class TestInklingDetector(CustomTestCase):
                 content += detector.parse_streaming_increment(chunk).normal_text
             self.assertEqual(content, " worldnext", msg=f"chunks={chunks!r}")
 
+    def test_finish_flushes_reasoning_truncated_before_end_token(self):
+        """Bug regression: with stream_reasoning=False the detector buffers the
+        thinking block and only flushes it on a control/end token. When
+        generation is cut mid-block (e.g. max_tokens) the stream ends with no
+        end token, so the buffered trace was dropped entirely; finish() must
+        emit it, matching the non-streaming detect_and_parse path."""
+        detector = InklingDetector(stream_reasoning=False)
+        source = "<|message_model|><|content_thinking|>truncated thinking"
+        streamed_reasoning = ""
+        for char in source:
+            streamed_reasoning += detector.parse_streaming_increment(char).reasoning_text
+        # The block never closed, so nothing surfaces mid-stream.
+        self.assertEqual(streamed_reasoning, "")
+        # finish() flushes the buffered trace instead of dropping it.
+        self.assertEqual(detector.finish().reasoning_text, "truncated thinking")
+
 
 class TestKimiDetector(CustomTestCase):
     def setUp(self):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -259,7 +259,9 @@ class TestInklingDetector(CustomTestCase):
         source = "<|message_model|><|content_thinking|>truncated thinking"
         streamed_reasoning = ""
         for char in source:
-            streamed_reasoning += detector.parse_streaming_increment(char).reasoning_text
+            streamed_reasoning += detector.parse_streaming_increment(
+                char
+            ).reasoning_text
         # The block never closed, so nothing surfaces mid-stream.
         self.assertEqual(streamed_reasoning, "")
         # finish() flushes the buffered trace instead of dropping it.


### PR DESCRIPTION
## Motivation

With `stream_reasoning=False`, the Inkling reasoning detector buffers the thinking block into `_pending_reasoning` and only flushes it when a control/end token closes the block. When generation is cut mid-block (e.g. `max_tokens` truncates a `<|content_thinking|>` block), the stream ends with no end token, so the buffered trace is dropped entirely — the whole reasoning disappears from the streamed response.

The non-streaming `detect_and_parse` path already flushes `_pending_reasoning` at the end, but `InklingDetector` had no `finish()` override, so at stream end `parse_stream_end()` fell through to the base `finish()` (which only handles `_force_nonempty_content`/`_in_reasoning`, neither used by this detector) and emitted nothing.

## Modifications

- Override `InklingDetector.finish()` to emit any buffered `_pending_reasoning` (when mid-reasoning under `stream_reasoning=False`) and reset the detector's block state, mirroring the non-streaming flush.
- Add a regression test that streams a thinking block truncated before its end token and asserts `finish()` surfaces the trailing reasoning (fails on the pre-fix code, passes after).

Verified on a live server that BFCL live tool-calling accuracy is unchanged (`tool_parse_errors=0`), i.e. the added stream-end flush does not perturb the tool-call path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29753147981](https://github.com/sgl-project/sglang/actions/runs/29753147981)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29753146335](https://github.com/sgl-project/sglang/actions/runs/29753146335)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->