### PR TITLE
[BugFix][NPU] Use cumulative sequence lengths for ViT attention

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -223,6 +223,16 @@ def resolve_max_seqlen(
     return int(seq_lens.max().item())
 
 
+def resolve_ascend_actual_seq_lengths(
+    forward_metadata: VisionAttentionMetadata,
+) -> torch.Tensor:
+    """Return cumulative sequence ends required by Ascend TND attention."""
+    cu_seqlens = forward_metadata.cu_seqlens
+    if cu_seqlens.is_npu:
+        cu_seqlens = cu_seqlens.to("cpu")
+    return cu_seqlens[1:].to(torch.int32)
+
+
 def resolve_precomputed_max_seqlen(
     cu_seqlens: torch.Tensor, max_seqlen: int | torch.Tensor | None
 ) -> int:
@@ -803,11 +813,8 @@ class VisionAscendAttention(nn.Module):
              [b * s, h, head_size]
         """
         if forward_metadata is not None:
-            seq_lens = forward_metadata.seq_lens
-            if seq_lens.is_npu:
-                seq_lens = seq_lens.to("cpu")
             output = torch.empty_like(q)
-            seq_len_arg = seq_lens.to(torch.int32)
+            seq_len_arg = resolve_ascend_actual_seq_lengths(forward_metadata)
         elif envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
             if "output_ws" not in kwargs:
                 raise RuntimeError("output_ws should be prepared for npu-graph mode")

--- a/test/registered/unit/layers/attention/test_vision_seqlens.py
+++ b/test/registered/unit/layers/attention/test_vision_seqlens.py
@@ -1,12 +1,7 @@
 import pytest
 import torch
 
-from sglang.srt.layers.attention.vision import (
-    SingletonCache,
-    prepare_vision_attention_metadata,
-    resolve_ascend_actual_seq_lengths,
-    resolve_max_seqlen,
-)
+from sglang.srt.layers.attention.vision import SingletonCache, resolve_max_seqlen
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
@@ -24,17 +19,6 @@ def test_resolve_max_seqlen_caches_on_singleton_carrier():
 
     assert resolve_max_seqlen(source, cu_seqlens) == 5
     assert source._max_seqlen == 5
-
-
-def test_resolve_ascend_actual_seq_lengths_uses_cumulative_ends():
-    metadata = prepare_vision_attention_metadata(
-        torch.tensor([0, 3, 8, 10], dtype=torch.int32),
-        device=torch.device("cpu"),
-    )
-
-    # Per-image lengths are not valid actual_seq_lengths for the TND layout.
-    assert metadata.seq_lens.tolist() == [3, 5, 2]
-    assert resolve_ascend_actual_seq_lengths(metadata).tolist() == [3, 8, 10]
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_vision_seqlens.py
+++ b/test/registered/unit/layers/attention/test_vision_seqlens.py
@@ -1,7 +1,12 @@
 import pytest
 import torch
 
-from sglang.srt.layers.attention.vision import SingletonCache, resolve_max_seqlen
+from sglang.srt.layers.attention.vision import (
+    SingletonCache,
+    prepare_vision_attention_metadata,
+    resolve_ascend_actual_seq_lengths,
+    resolve_max_seqlen,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
@@ -19,6 +24,17 @@ def test_resolve_max_seqlen_caches_on_singleton_carrier():
 
     assert resolve_max_seqlen(source, cu_seqlens) == 5
     assert source._max_seqlen == 5
+
+
+def test_resolve_ascend_actual_seq_lengths_uses_cumulative_ends():
+    metadata = prepare_vision_attention_metadata(
+        torch.tensor([0, 3, 8, 10], dtype=torch.int32),
+        device=torch.device("cpu"),
+    )
+
+    # Per-image lengths are not valid actual_seq_lengths for the TND layout.
+    assert metadata.seq_lens.tolist() == [3, 5, 2]
+    assert resolve_ascend_actual_seq_lengths(metadata).tolist() == [3, 8, 10]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Ascend fused attention with TND layout expects `actual_seq_lengths` to contain cumulative sequence end positions. `VisionAscendAttention` passed `forward_metadata.seq_lens`, which contains independent per-image sequence lengths. As a result, single-image requests worked, while multi-image requests could fail because the final sequence length did not match the total query-token count, for example: `queryT(66396) must equal last actualSequenceLengthQ(3920)`.

## Modifications

- Derive Ascend ViT `actual_seq_lengths` from `forward_metadata.cu_seqlens[1:]`.
- Preserve the CPU `int32` representation expected by the Ascend attention API.

## Accuracy Tests

- `pytest -q test/registered/unit/layers/attention/test_vision_seqlens.py`: 3 passed.
- Qwen3.6-35B-A3B on Ascend Atlas A2, TP=2:
  - One request containing 35 images: HTTP 200.
  - Four concurrent requests containing 35 images each: 4/4 HTTP 200.
  - 24 concurrent requests containing 35 images with different shapes: 24/24 succeeded without scheduler exceptions or OOM.

This fixes a multi-image request crash. No output change is intended for valid single-image requests.

## Checklist

- [x] Format the code and organize imports.
- [x] Add unit tests for the change.
- [x] Verify the change on Ascend NPU hardware.
- [x] Run `git diff --check` and Python compilation checks.
- [x] Sign off the commit.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29794201863](https://github.com/sgl-project/sglang/actions/runs/29794201863)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29794201753](https://github.com/sgl-project/sglang/actions/runs/29794201753)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->