### PR TITLE
[Test] add kernel io-backend end-to-end test for mamba HiCache

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
@@ -128,6 +128,65 @@ class TestUnifiedMambaHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):
         kill_process_tree(cls.process.pid)
 
 
+# ─── Mamba + HiCache L2 + kernel io-backend ──────────────────────────────────
+
+
+class TestUnifiedMambaHiCacheKernel(UnifiedRadixTreeTestMixin, CustomTestCase):
+    """Mamba hybrid + HiCache L2 + kernel io-backend + UnifiedRadixCache."""
+
+    kl_threshold = 0.005
+    prefill_cache_assert = staticmethod(
+        make_mamba_prefill_assert(chunk_size=MAMBA_CHUNK_SIZE)
+    )
+    decode_cache_assert = staticmethod(
+        make_mamba_decode_assert(track_interval=MAMBA_TRACK_INTERVAL)
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = MAMBA_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "4",
+                "--chunked-prefill-size",
+                str(MAMBA_CHUNKED_PREFILL_SIZE),
+                "--mem-fraction-static",
+                "0.85",
+                "--mamba-scheduler-strategy",
+                "extra_buffer",
+                "--mamba-track-interval",
+                str(MAMBA_TRACK_INTERVAL),
+                "--enable-hierarchical-cache",
+                "--hicache-ratio",
+                "4",
+                "--hicache-write-policy",
+                "write_through",
+                "--hicache-io-backend",
+                "kernel",
+                "--hicache-mem-layout",
+                "page_first",
+                "--max-total-tokens",
+                "12000",
+                "--max-mamba-cache-size",
+                "500",
+                "--max-running-requests",
+                "4",
+                "--weight-loader-prefetch-checkpoints",
+            ],
+            env={"SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"},
+        )
+        cls.input_ids = get_input_ids(cls.model, num_samples=18)
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
 # ─── Mamba + HiCache L3 (file backend) ───────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Add `TestUnifiedMambaHiCacheKernel` to `test_unified_radix_cache_kl_mamba.py` for CI to automatically cover the kernel io-backend path correctness for mamba HiCache.

The existing `TestUnifiedMambaHiCache` uses the `direct` io-backend (data transfer via PyTorch tensors). This new test class uses the `kernel` io-backend (data transfer via custom CUDA kernels), with all other parameters identical, so that CI can verify the kernel path produces numerically equivalent results to the direct path.

## Changes

- New test class `TestUnifiedMambaHiCacheKernel` that configures:
  - `--hicache-io-backend kernel`
  - `--hicache-mem-layout page_first`
- All other parameters identical to `TestUnifiedMambaHiCache` (same model, same cache config, same KL threshold)

## Accuracy Tests

Verified on 4×H20 with Qwen3-Next-80B. All 5 test methods passed:

1. **`test_gsm8k`** — Few-shot GSM8K math reasoning accuracy (200 questions). Threshold: accuracy ≥ 0.93. Result: ✅ PASSED
2. **`test_mmlu`** — MMLU multi-task knowledge accuracy (64 questions). Threshold: score ≥ 0.8. Result: ✅ PASSED
3. **`test_multiturn_logprobs_match`** — 3-turn conversation, output logprobs match the no-cache baseline. Threshold: KL divergence < 0.005. Result: ✅ PASSED
4. **`test_multiturn_prefill_cache_hit_branching`** — Prefill cache hit + multi-branch interleaving (3 groups × 3 branches). Threshold: KL divergence < 0.005. Result: ✅ PASSED
5. **`test_multiturn_decode_cache_hit_branching`** — Decode cache hit + multi-branch interleaving (3 groups × 3 branches). Threshold: KL divergence < 0.005. Result: ✅ PASSED

The 3 KL-divergence tests verify that the kernel path produces the same output distribution as the direct path, confirming that data transfer through the custom CUDA kernel introduces no numerical errors. The 2 accuracy tests (GSM8K, MMLU) verify end-to-end generation quality is preserved.

## Speed Tests and Profiling

Not applicable — this PR only adds a test class, no inference speed changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29751985228](https://github.com/sgl-project/sglang/actions/runs/29751985228)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29751984918](https://github.com/sgl-project/sglang/actions/runs/29751984918)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->