### PR TITLE
[HiSparse] Add standalone Quest GPU kernel primitives (Part 3 of 4)

### DIFF
--- a/python/sglang/srt/mem_cache/sparsity/kernels/quest_finalize.py
+++ b/python/sglang/srt/mem_cache/sparsity/kernels/quest_finalize.py
@@ -1,0 +1,156 @@
+import torch
+import triton
+import triton.language as tl
+
+QUEST_FINALIZE_MAX_WIDTH = 1024
+
+
+@triton.jit
+def _quest_finalize_selected_pages_kernel(
+    topk_scores_ptr,
+    topk_indices_ptr,
+    k_per_req_ptr,
+    recent_indices_ptr,
+    recent_valid_ptr,
+    output_indices_ptr,
+    output_lengths_ptr,
+    TOPK_WIDTH: tl.constexpr,
+    RECENT_WIDTH: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+
+    topk_mask = offsets < TOPK_WIDTH
+    sentinel = 0x7FFFFFFF
+    topk_indices = tl.zeros((BLOCK_SIZE,), dtype=tl.int64)
+    topk_valid = offsets < 0
+    if TOPK_WIDTH > 0:
+        safe_topk_offsets = tl.where(topk_mask, offsets, 0)
+        topk_scores = tl.load(
+            topk_scores_ptr + batch_idx * TOPK_WIDTH + safe_topk_offsets,
+            mask=topk_mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        topk_indices = tl.load(
+            topk_indices_ptr + batch_idx * TOPK_WIDTH + safe_topk_offsets,
+            mask=topk_mask,
+            other=-1,
+        ).to(tl.int64)
+        k_per_req = tl.load(k_per_req_ptr + batch_idx)
+        topk_valid = (
+            topk_mask
+            & (offsets < k_per_req)
+            & (topk_scores > -float("inf"))
+            & (topk_scores < float("inf"))
+            & (topk_indices >= 0)
+            & (topk_indices < sentinel)
+        )
+
+    recent_offsets = offsets - TOPK_WIDTH
+    recent_mask = (recent_offsets >= 0) & (recent_offsets < RECENT_WIDTH)
+    recent_indices = tl.zeros((BLOCK_SIZE,), dtype=tl.int64)
+    recent_valid = offsets < 0
+    if RECENT_WIDTH > 0:
+        safe_recent_offsets = tl.where(recent_mask, recent_offsets, 0)
+        recent_indices = tl.load(
+            recent_indices_ptr + batch_idx * RECENT_WIDTH + safe_recent_offsets,
+            mask=recent_mask,
+            other=-1,
+        ).to(tl.int64)
+        recent_valid = tl.load(
+            recent_valid_ptr + batch_idx * RECENT_WIDTH + safe_recent_offsets,
+            mask=recent_mask,
+            other=0,
+        ).to(tl.int1)
+        recent_valid &= (recent_indices >= 0) & (recent_indices < sentinel)
+
+    selected = tl.where(
+        topk_valid,
+        topk_indices.to(tl.int32),
+        tl.where(recent_mask & recent_valid, recent_indices.to(tl.int32), sentinel),
+    )
+    sorted_indices = tl.sort(selected, descending=False)
+    valid = sorted_indices != sentinel
+
+    output_mask = offsets < OUTPUT_WIDTH
+    safe_output_offsets = tl.where(output_mask, offsets, 0)
+    output_offsets = batch_idx * OUTPUT_WIDTH + safe_output_offsets
+    tl.store(
+        output_indices_ptr + output_offsets,
+        tl.where(valid, sorted_indices, -1),
+        mask=output_mask,
+    )
+    tl.store(output_lengths_ptr + batch_idx, tl.sum(valid.to(tl.int32), axis=0))
+
+
+def quest_finalize_selected_pages(
+    topk_scores: torch.Tensor,
+    topk_indices: torch.Tensor,
+    k_per_req: torch.Tensor,
+    recent_indices: torch.Tensor,
+    recent_valid: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Finalize fixed-width Quest selections in one CUDA kernel."""
+    if not topk_scores.is_cuda or torch.version.hip is not None:
+        raise ValueError("Quest Triton finalize requires NVIDIA CUDA tensors")
+    if topk_scores.dim() != 2 or topk_indices.shape != topk_scores.shape:
+        raise ValueError("Quest top-k scores and indices must have matching 2D shapes")
+    if not topk_scores.dtype.is_floating_point:
+        raise ValueError("Quest top-k scores must use a floating-point dtype")
+    if topk_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Quest top-k indices must use int32 or int64")
+
+    batch_size, topk_width = topk_scores.shape
+    if k_per_req.shape != (batch_size,) or k_per_req.dtype not in (
+        torch.int32,
+        torch.int64,
+    ):
+        raise ValueError("Quest per-request k must be an int32/int64 [batch] tensor")
+    if recent_indices.dim() != 2 or recent_indices.shape[0] != batch_size:
+        raise ValueError("Quest recent indices must have shape [batch, recent]")
+    if recent_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Quest recent indices must use int32 or int64")
+    if recent_valid.shape != recent_indices.shape or recent_valid.dtype != torch.bool:
+        raise ValueError("Quest recent validity must be a matching bool tensor")
+
+    tensors = (topk_indices, k_per_req, recent_indices, recent_valid)
+    if any(tensor.device != topk_scores.device for tensor in tensors):
+        raise ValueError("Quest finalize tensors must be on the same CUDA device")
+    if not all(tensor.is_contiguous() for tensor in (topk_scores, *tensors)):
+        raise ValueError("Quest finalize tensors must be contiguous")
+
+    recent_width = recent_indices.shape[1]
+    output_width = topk_width + recent_width
+    if output_width <= 0 or output_width > QUEST_FINALIZE_MAX_WIDTH:
+        raise ValueError(
+            f"Quest Triton finalize width must be in [1, "
+            f"{QUEST_FINALIZE_MAX_WIDTH}], got {output_width}"
+        )
+
+    output_indices = torch.empty(
+        (batch_size, output_width), dtype=torch.int32, device=topk_scores.device
+    )
+    output_lengths = torch.empty(
+        batch_size, dtype=torch.int32, device=topk_scores.device
+    )
+    if batch_size == 0:
+        return output_indices, output_lengths
+
+    block_size = triton.next_power_of_2(output_width)
+    _quest_finalize_selected_pages_kernel[(batch_size,)](
+        topk_scores,
+        topk_indices,
+        k_per_req,
+        recent_indices,
+        recent_valid,
+        output_indices,
+        output_lengths,
+        TOPK_WIDTH=topk_width,
+        RECENT_WIDTH=recent_width,
+        OUTPUT_WIDTH=output_width,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return output_indices, output_lengths

--- a/python/sglang/srt/mem_cache/sparsity/kernels/quest_flashattention_metadata.py
+++ b/python/sglang/srt/mem_cache/sparsity/kernels/quest_flashattention_metadata.py
@@ -1,0 +1,632 @@
+import torch
+import triton
+import triton.language as tl
+
+QUEST_DIRECT_METADATA_MAX_WIDTH = 1024
+
+
+@triton.jit
+def _quest_count_valid_selected_pages(
+    topk_scores_ptr,
+    topk_indices_ptr,
+    k_per_req_ptr,
+    recent_indices_ptr,
+    recent_valid_ptr,
+    batch_idx,
+    max_logical_pages,
+    TOPK_WIDTH: tl.constexpr,
+    RECENT_WIDTH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    topk_mask = offsets < TOPK_WIDTH
+    topk_valid = offsets < 0
+    if TOPK_WIDTH > 0:
+        safe_topk_offsets = tl.where(topk_mask, offsets, 0)
+        topk_scores = tl.load(
+            topk_scores_ptr + batch_idx * TOPK_WIDTH + safe_topk_offsets,
+            mask=topk_mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        topk_indices = tl.load(
+            topk_indices_ptr + batch_idx * TOPK_WIDTH + safe_topk_offsets,
+            mask=topk_mask,
+            other=-1,
+        ).to(tl.int64)
+        k_per_req = tl.load(k_per_req_ptr + batch_idx).to(tl.int32)
+        topk_valid = (
+            topk_mask
+            & (offsets < k_per_req)
+            & (topk_scores > -float("inf"))
+            & (topk_scores < float("inf"))
+            & (topk_indices >= 0)
+            & (topk_indices < max_logical_pages)
+        )
+
+    recent_offsets = offsets - TOPK_WIDTH
+    recent_mask = (recent_offsets >= 0) & (recent_offsets < RECENT_WIDTH)
+    recent_is_valid = offsets < 0
+    if RECENT_WIDTH > 0:
+        safe_recent_offsets = tl.where(recent_mask, recent_offsets, 0)
+        recent_indices = tl.load(
+            recent_indices_ptr + batch_idx * RECENT_WIDTH + safe_recent_offsets,
+            mask=recent_mask,
+            other=-1,
+        ).to(tl.int64)
+        recent_valid = tl.load(
+            recent_valid_ptr + batch_idx * RECENT_WIDTH + safe_recent_offsets,
+            mask=recent_mask,
+            other=0,
+        ).to(tl.int1)
+        recent_is_valid = (
+            recent_mask
+            & recent_valid
+            & (recent_indices >= 0)
+            & (recent_indices < max_logical_pages)
+        )
+    return tl.sum((topk_valid | recent_is_valid).to(tl.int32), axis=0)
+
+
+@triton.jit
+def _quest_finalize_to_flashattention_metadata_kernel(
+    topk_scores_ptr,
+    topk_indices_ptr,
+    k_per_req_ptr,
+    recent_indices_ptr,
+    recent_valid_ptr,
+    valid_lengths_ptr,
+    sparse_mask_ptr,
+    sparse_mask_stride_b,
+    seq_lens_ptr,
+    seq_lens_stride_b,
+    req_pool_indices_ptr,
+    req_pool_indices_stride_b,
+    req_to_token_ptr,
+    req_to_token_stride_b,
+    req_to_token_stride_t,
+    num_req_slots,
+    req_to_token_width,
+    page_table_ptr,
+    page_table_stride_b,
+    page_table_stride_p,
+    cache_seqlens_ptr,
+    cache_seqlens_stride_b,
+    cu_seqlens_ptr,
+    cu_seqlens_stride_b,
+    TOPK_WIDTH: tl.constexpr,
+    RECENT_WIDTH: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    BATCH_SIZE: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    UPDATE_LENGTHS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+
+    if batch_idx < BATCH_SIZE:
+        seq_len = tl.load(seq_lens_ptr + batch_idx * seq_lens_stride_b).to(tl.int64)
+        bounded_seq_len = tl.minimum(tl.maximum(seq_len, 0), req_to_token_width)
+        max_logical_pages = (bounded_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+
+        topk_mask = offsets < TOPK_WIDTH
+        topk_indices = tl.zeros((BLOCK_SIZE,), dtype=tl.int64)
+        topk_valid = offsets < 0
+        if TOPK_WIDTH > 0:
+            safe_topk_offsets = tl.where(topk_mask, offsets, 0)
+            topk_scores = tl.load(
+                topk_scores_ptr + batch_idx * TOPK_WIDTH + safe_topk_offsets,
+                mask=topk_mask,
+                other=-float("inf"),
+            ).to(tl.float32)
+            topk_indices = tl.load(
+                topk_indices_ptr + batch_idx * TOPK_WIDTH + safe_topk_offsets,
+                mask=topk_mask,
+                other=-1,
+            ).to(tl.int64)
+            k_per_req = tl.load(k_per_req_ptr + batch_idx).to(tl.int32)
+            topk_valid = (
+                topk_mask
+                & (offsets < k_per_req)
+                & (topk_scores > -float("inf"))
+                & (topk_scores < float("inf"))
+                & (topk_indices >= 0)
+                & (topk_indices < max_logical_pages)
+            )
+
+        recent_offsets = offsets - TOPK_WIDTH
+        recent_mask = (recent_offsets >= 0) & (recent_offsets < RECENT_WIDTH)
+        recent_indices = tl.zeros((BLOCK_SIZE,), dtype=tl.int64)
+        recent_valid = offsets < 0
+        if RECENT_WIDTH > 0:
+            safe_recent_offsets = tl.where(recent_mask, recent_offsets, 0)
+            recent_indices = tl.load(
+                recent_indices_ptr + batch_idx * RECENT_WIDTH + safe_recent_offsets,
+                mask=recent_mask,
+                other=-1,
+            ).to(tl.int64)
+            recent_valid = tl.load(
+                recent_valid_ptr + batch_idx * RECENT_WIDTH + safe_recent_offsets,
+                mask=recent_mask,
+                other=0,
+            ).to(tl.int1)
+            recent_valid &= (recent_indices >= 0) & (recent_indices < max_logical_pages)
+
+        sentinel = 0x7FFFFFFF
+        selected = tl.where(
+            topk_valid,
+            topk_indices.to(tl.int32),
+            tl.where(recent_mask & recent_valid, recent_indices.to(tl.int32), sentinel),
+        )
+        sorted_indices = tl.sort(selected, descending=False)
+        valid = sorted_indices != sentinel
+        safe_sorted_indices = tl.where(valid, sorted_indices, 0)
+        valid_length = tl.sum(valid.to(tl.int32), axis=0)
+
+        use_sparse = tl.load(sparse_mask_ptr + batch_idx * sparse_mask_stride_b)
+        req_idx = tl.load(
+            req_pool_indices_ptr + batch_idx * req_pool_indices_stride_b,
+        ).to(tl.int64)
+        req_valid = (req_idx >= 0) & (req_idx < num_req_slots)
+        safe_req_idx = tl.where(req_valid, req_idx, 0)
+        active_valid_length = tl.where(use_sparse & req_valid, valid_length, 0)
+        tl.store(valid_lengths_ptr + batch_idx, active_valid_length)
+        active = active_valid_length > 0
+        output_mask = offsets < OUTPUT_WIDTH
+        write_mask = active & output_mask & valid
+        token_offsets = safe_sorted_indices.to(tl.int64) * PAGE_SIZE
+        first_tokens = tl.load(
+            req_to_token_ptr
+            + safe_req_idx * req_to_token_stride_b
+            + token_offsets * req_to_token_stride_t,
+            mask=write_mask,
+            other=0,
+        ).to(tl.int64)
+        physical_pages = first_tokens // PAGE_SIZE
+        safe_output_offsets = tl.where(output_mask, offsets, 0)
+        tl.store(
+            page_table_ptr
+            + batch_idx * page_table_stride_b
+            + safe_output_offsets * page_table_stride_p,
+            physical_pages.to(tl.int32),
+            mask=write_mask,
+        )
+
+    if UPDATE_LENGTHS and batch_idx == BATCH_SIZE:
+        cumulative_length = 0
+        for idx in range(BATCH_SIZE):
+            seq_len = tl.load(seq_lens_ptr + idx * seq_lens_stride_b).to(tl.int64)
+            bounded_seq_len = tl.minimum(tl.maximum(seq_len, 0), req_to_token_width)
+            max_logical_pages = (bounded_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+            row_valid_length = _quest_count_valid_selected_pages(
+                topk_scores_ptr,
+                topk_indices_ptr,
+                k_per_req_ptr,
+                recent_indices_ptr,
+                recent_valid_ptr,
+                idx,
+                max_logical_pages,
+                TOPK_WIDTH,
+                RECENT_WIDTH,
+                BLOCK_SIZE,
+            ).to(tl.int64)
+            row_sparse = tl.load(sparse_mask_ptr + idx * sparse_mask_stride_b)
+            row_req_idx = tl.load(
+                req_pool_indices_ptr + idx * req_pool_indices_stride_b
+            ).to(tl.int64)
+            row_req_valid = (row_req_idx >= 0) & (row_req_idx < num_req_slots)
+            row_active = row_sparse & row_req_valid & (row_valid_length > 0)
+            last_page_length = tl.where(seq_len > 0, (seq_len - 1) % PAGE_SIZE + 1, 0)
+            sparse_seq_len = (row_valid_length - 1) * PAGE_SIZE + last_page_length
+            cache_seq_len = tl.where(row_active, sparse_seq_len, seq_len).to(tl.int32)
+
+            tl.store(cache_seqlens_ptr + idx * cache_seqlens_stride_b, cache_seq_len)
+            tl.store(cu_seqlens_ptr + idx * cu_seqlens_stride_b, cumulative_length)
+            cumulative_length += cache_seq_len
+
+        tl.store(cu_seqlens_ptr + BATCH_SIZE * cu_seqlens_stride_b, cumulative_length)
+
+
+def quest_finalize_to_flashattention_metadata_(
+    topk_scores: torch.Tensor,
+    topk_indices: torch.Tensor,
+    k_per_req: torch.Tensor,
+    recent_indices: torch.Tensor,
+    recent_valid: torch.Tensor,
+    valid_lengths: torch.Tensor,
+    sparse_mask: torch.Tensor,
+    seq_lens: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    req_to_token: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    page_size: int,
+    *,
+    update_lengths: bool,
+) -> None:
+    """Finalize Quest top-k output directly into FlashAttention metadata."""
+    if not topk_scores.is_cuda or torch.version.hip is not None:
+        raise ValueError("Quest direct FlashAttention metadata requires CUDA tensors")
+    if topk_scores.ndim != 2 or topk_indices.shape != topk_scores.shape:
+        raise ValueError("Quest top-k scores and indices must have matching 2D shapes")
+    batch_size, topk_width = topk_scores.shape
+    if recent_indices.ndim != 2 or recent_indices.shape[0] != batch_size:
+        raise ValueError("Quest recent indices must have shape [batch, recent]")
+    if recent_valid.shape != recent_indices.shape:
+        raise ValueError("Quest recent validity must match recent indices")
+    if k_per_req.shape != (batch_size,):
+        raise ValueError("Quest per-request k must have shape [batch]")
+    recent_width = recent_indices.shape[1]
+    output_width = topk_width + recent_width
+    if output_width <= 0 or output_width > QUEST_DIRECT_METADATA_MAX_WIDTH:
+        raise ValueError(
+            f"Quest direct metadata width must be in [1, "
+            f"{QUEST_DIRECT_METADATA_MAX_WIDTH}], got {output_width}"
+        )
+    if valid_lengths.shape != (batch_size,):
+        raise ValueError("valid_lengths must have shape [batch]")
+    if sparse_mask.shape != (batch_size,):
+        raise ValueError("sparse_mask must have shape [batch]")
+    if seq_lens.shape != (batch_size,):
+        raise ValueError("seq_lens must have shape [batch]")
+    if req_pool_indices.shape != (batch_size,):
+        raise ValueError("req_pool_indices must have shape [batch]")
+    if req_to_token.ndim != 2:
+        raise ValueError("req_to_token must be a two-dimensional tensor")
+    if req_to_token.shape[0] == 0 or req_to_token.shape[1] == 0:
+        raise ValueError(
+            "req_to_token must have non-empty request and token dimensions"
+        )
+    if page_table.ndim != 2 or page_table.shape[0] != batch_size:
+        raise ValueError("page_table must have shape [batch, pages]")
+    if page_table.shape[1] < output_width:
+        raise ValueError(
+            f"page_table width {page_table.shape[1]} is smaller than "
+            f"selection width {output_width}"
+        )
+    if cache_seqlens_int32.shape != (batch_size,):
+        raise ValueError("cache_seqlens_int32 must have shape [batch]")
+    if cu_seqlens_k.shape != (batch_size + 1,):
+        raise ValueError("cu_seqlens_k must have shape [batch + 1]")
+    if topk_scores.dtype != torch.float32:
+        raise ValueError("Quest direct metadata top-k scores must use float32")
+    if topk_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Quest direct metadata top-k indices must use int32 or int64")
+    if k_per_req.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Quest direct metadata k-per-request must use int32 or int64")
+    if valid_lengths.dtype != torch.int32:
+        raise ValueError("Quest direct metadata valid lengths must use int32")
+    if recent_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Quest recent indices must use int32 or int64")
+    if recent_valid.dtype != torch.bool:
+        raise ValueError("Quest recent validity must use bool")
+    if sparse_mask.dtype != torch.bool:
+        raise ValueError("sparse_mask must use bool")
+    if seq_lens.dtype not in (torch.int32, torch.int64):
+        raise ValueError("seq_lens must use int32 or int64")
+    if req_pool_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("req_pool_indices must use int32 or int64")
+    if req_to_token.dtype not in (torch.int32, torch.int64):
+        raise ValueError("req_to_token must use int32 or int64")
+    if page_table.dtype != torch.int32:
+        raise ValueError("page_table must use int32")
+    if cache_seqlens_int32.dtype != torch.int32 or cu_seqlens_k.dtype != torch.int32:
+        raise ValueError("FlashAttention sequence metadata must use int32")
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+
+    tensors = (
+        topk_indices,
+        k_per_req,
+        recent_indices,
+        recent_valid,
+        valid_lengths,
+        sparse_mask,
+        seq_lens,
+        req_pool_indices,
+        req_to_token,
+        page_table,
+        cache_seqlens_int32,
+        cu_seqlens_k,
+    )
+    if any(tensor.device != topk_scores.device for tensor in tensors):
+        raise ValueError("Quest direct metadata tensors must share one device")
+    if not all(
+        tensor.is_contiguous()
+        for tensor in (
+            topk_scores,
+            topk_indices,
+            k_per_req,
+            recent_indices,
+            recent_valid,
+            valid_lengths,
+        )
+    ):
+        raise ValueError(
+            "Quest direct metadata top-k/recent/output tensors must be contiguous"
+        )
+    if batch_size == 0:
+        return
+
+    block_size = triton.next_power_of_2(output_width)
+    grid = (batch_size + (1 if update_lengths else 0),)
+    _quest_finalize_to_flashattention_metadata_kernel[grid](
+        topk_scores,
+        topk_indices,
+        k_per_req,
+        recent_indices,
+        recent_valid,
+        valid_lengths,
+        sparse_mask,
+        sparse_mask.stride(0),
+        seq_lens,
+        seq_lens.stride(0),
+        req_pool_indices,
+        req_pool_indices.stride(0),
+        req_to_token,
+        req_to_token.stride(0),
+        req_to_token.stride(1),
+        req_to_token.shape[0],
+        req_to_token.shape[1],
+        page_table,
+        page_table.stride(0),
+        page_table.stride(1),
+        cache_seqlens_int32,
+        cache_seqlens_int32.stride(0),
+        cu_seqlens_k,
+        cu_seqlens_k.stride(0),
+        TOPK_WIDTH=topk_width,
+        RECENT_WIDTH=recent_width,
+        OUTPUT_WIDTH=output_width,
+        BATCH_SIZE=batch_size,
+        PAGE_SIZE=page_size,
+        UPDATE_LENGTHS=update_lengths,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _quest_update_flashattention_metadata_kernel(
+    selected_indices_ptr,
+    selected_indices_stride_b,
+    selected_indices_stride_p,
+    valid_lengths_ptr,
+    valid_lengths_stride_b,
+    sparse_mask_ptr,
+    sparse_mask_stride_b,
+    seq_lens_ptr,
+    seq_lens_stride_b,
+    req_pool_indices_ptr,
+    req_pool_indices_stride_b,
+    req_to_token_ptr,
+    req_to_token_stride_b,
+    req_to_token_stride_t,
+    num_req_slots,
+    req_to_token_width,
+    page_table_ptr,
+    page_table_stride_b,
+    page_table_stride_p,
+    cache_seqlens_ptr,
+    cache_seqlens_stride_b,
+    cu_seqlens_ptr,
+    cu_seqlens_stride_b,
+    max_selected,
+    BATCH_SIZE: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    UPDATE_LENGTHS: tl.constexpr,
+    HAS_SELECTED: tl.constexpr,
+    BLOCK_PAGES: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    page_offsets = tl.program_id(1) * BLOCK_PAGES + tl.arange(0, BLOCK_PAGES)
+
+    valid_length = tl.load(valid_lengths_ptr + batch_idx * valid_lengths_stride_b).to(
+        tl.int32
+    )
+    valid_length = tl.minimum(tl.maximum(valid_length, 0), max_selected)
+    use_sparse = tl.load(sparse_mask_ptr + batch_idx * sparse_mask_stride_b)
+    active = use_sparse & (valid_length > 0)
+    if HAS_SELECTED:
+        page_lane_mask = page_offsets < max_selected
+        write_mask = active & page_lane_mask & (page_offsets < valid_length)
+        safe_page_offsets = tl.where(page_lane_mask, page_offsets, 0)
+
+        selected_pages = tl.load(
+            selected_indices_ptr
+            + batch_idx * selected_indices_stride_b
+            + safe_page_offsets * selected_indices_stride_p,
+            mask=write_mask,
+            other=-1,
+        ).to(tl.int64)
+        seq_len = tl.load(seq_lens_ptr + batch_idx * seq_lens_stride_b).to(tl.int64)
+        bounded_seq_len = tl.minimum(tl.maximum(seq_len, 0), req_to_token_width)
+        max_logical_pages = (bounded_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+        selected_page_in_bounds = (
+            write_mask & (selected_pages >= 0) & (selected_pages < max_logical_pages)
+        )
+        safe_selected_pages = tl.where(selected_page_in_bounds, selected_pages, 0)
+        req_idx = tl.load(
+            req_pool_indices_ptr + batch_idx * req_pool_indices_stride_b,
+            mask=active,
+            other=0,
+        ).to(tl.int64)
+        req_valid = (req_idx >= 0) & (req_idx < num_req_slots)
+        safe_req_idx = tl.where(req_valid, req_idx, 0)
+        metadata_write = write_mask & req_valid
+        token_offsets = safe_selected_pages * PAGE_SIZE
+        first_tokens = tl.load(
+            req_to_token_ptr
+            + safe_req_idx * req_to_token_stride_b
+            + token_offsets * req_to_token_stride_t,
+            mask=metadata_write,
+            other=0,
+        ).to(tl.int64)
+        physical_pages = first_tokens // PAGE_SIZE
+        tl.store(
+            page_table_ptr
+            + batch_idx * page_table_stride_b
+            + safe_page_offsets * page_table_stride_p,
+            physical_pages.to(tl.int32),
+            mask=metadata_write,
+        )
+
+    # One program computes the small batch prefix sum. Page-table programs are
+    # independent, and the following attention launch provides stream ordering.
+    if UPDATE_LENGTHS:
+        if (batch_idx == 0) & (tl.program_id(1) == 0):
+            cumulative_length = 0
+            for idx in range(BATCH_SIZE):
+                seq_len = tl.load(seq_lens_ptr + idx * seq_lens_stride_b).to(tl.int64)
+                row_valid_length = tl.load(
+                    valid_lengths_ptr + idx * valid_lengths_stride_b
+                ).to(tl.int64)
+                row_valid_length = tl.minimum(
+                    tl.maximum(row_valid_length, 0), max_selected
+                )
+                row_sparse = tl.load(sparse_mask_ptr + idx * sparse_mask_stride_b)
+                row_req_idx = tl.load(
+                    req_pool_indices_ptr + idx * req_pool_indices_stride_b
+                ).to(tl.int64)
+                row_req_valid = (row_req_idx >= 0) & (row_req_idx < num_req_slots)
+                row_active = row_sparse & row_req_valid & (row_valid_length > 0)
+                last_page_length = tl.where(
+                    seq_len > 0, (seq_len - 1) % PAGE_SIZE + 1, 0
+                )
+                sparse_seq_len = (row_valid_length - 1) * PAGE_SIZE + last_page_length
+                cache_seq_len = tl.where(row_active, sparse_seq_len, seq_len).to(
+                    tl.int32
+                )
+
+                tl.store(
+                    cache_seqlens_ptr + idx * cache_seqlens_stride_b,
+                    cache_seq_len,
+                )
+                tl.store(
+                    cu_seqlens_ptr + idx * cu_seqlens_stride_b,
+                    cumulative_length,
+                )
+                cumulative_length += cache_seq_len
+
+            tl.store(
+                cu_seqlens_ptr + BATCH_SIZE * cu_seqlens_stride_b,
+                cumulative_length,
+            )
+
+
+def quest_update_flashattention_metadata_(
+    selected_indices: torch.Tensor,
+    valid_lengths: torch.Tensor,
+    sparse_mask: torch.Tensor,
+    seq_lens: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    req_to_token: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens_int32: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    page_size: int,
+    *,
+    update_lengths: bool,
+) -> None:
+    """Update fixed-address FA metadata from logical Quest pages.
+
+    ``selected_indices[:, :valid_lengths]`` must contain valid logical pages.
+    Invalid values are defensively mapped to page zero so malformed input cannot
+    create unsafe pointers or leave holes in FlashAttention's fixed-width prefix.
+    """
+    if not selected_indices.is_cuda:
+        raise ValueError("Quest FlashAttention metadata kernel requires CUDA tensors")
+    if selected_indices.ndim != 2:
+        raise ValueError("selected_indices must have shape [batch, pages]")
+
+    batch_size, max_selected = selected_indices.shape
+    if valid_lengths.shape != (batch_size,):
+        raise ValueError("valid_lengths must have shape [batch]")
+    if sparse_mask.shape != (batch_size,):
+        raise ValueError("sparse_mask must have shape [batch]")
+    if seq_lens.shape != (batch_size,):
+        raise ValueError("seq_lens must have shape [batch]")
+    if req_pool_indices.shape != (batch_size,):
+        raise ValueError("req_pool_indices must have shape [batch]")
+    if cache_seqlens_int32.shape != (batch_size,):
+        raise ValueError("cache_seqlens_int32 must have shape [batch]")
+    if cu_seqlens_k.shape != (batch_size + 1,):
+        raise ValueError("cu_seqlens_k must have shape [batch + 1]")
+    if page_table.ndim != 2 or page_table.shape[0] != batch_size:
+        raise ValueError("page_table must have shape [batch, pages]")
+    if page_table.shape[1] < max_selected:
+        raise ValueError(
+            f"page_table width {page_table.shape[1]} is smaller than "
+            f"selection width {max_selected}"
+        )
+    if req_to_token.ndim != 2:
+        raise ValueError("req_to_token must be a two-dimensional tensor")
+    if req_to_token.shape[0] == 0 or req_to_token.shape[1] == 0:
+        raise ValueError(
+            "req_to_token must have non-empty request and token dimensions"
+        )
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    if selected_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("selected_indices must use int32 or int64")
+    if valid_lengths.dtype not in (torch.int32, torch.int64):
+        raise ValueError("valid_lengths must use int32 or int64")
+    if sparse_mask.dtype != torch.bool:
+        raise ValueError("sparse_mask must use bool")
+    if req_to_token.dtype not in (torch.int32, torch.int64):
+        raise ValueError("req_to_token must use int32 or int64")
+    if page_table.dtype != torch.int32:
+        raise ValueError("page_table must use int32")
+    if cache_seqlens_int32.dtype != torch.int32 or cu_seqlens_k.dtype != torch.int32:
+        raise ValueError("FlashAttention sequence metadata must use int32")
+
+    tensors = (
+        valid_lengths,
+        sparse_mask,
+        seq_lens,
+        req_pool_indices,
+        req_to_token,
+        page_table,
+        cache_seqlens_int32,
+        cu_seqlens_k,
+    )
+    if any(tensor.device != selected_indices.device for tensor in tensors):
+        raise ValueError("Quest FlashAttention metadata tensors must share one device")
+    if batch_size == 0:
+        return
+
+    block_pages = 128
+    page_blocks = max(triton.cdiv(max_selected, block_pages), 1)
+    _quest_update_flashattention_metadata_kernel[(batch_size, page_blocks)](
+        selected_indices,
+        selected_indices.stride(0),
+        selected_indices.stride(1),
+        valid_lengths,
+        valid_lengths.stride(0),
+        sparse_mask,
+        sparse_mask.stride(0),
+        seq_lens,
+        seq_lens.stride(0),
+        req_pool_indices,
+        req_pool_indices.stride(0),
+        req_to_token,
+        req_to_token.stride(0),
+        req_to_token.stride(1),
+        req_to_token.shape[0],
+        req_to_token.shape[1],
+        page_table,
+        page_table.stride(0),
+        page_table.stride(1),
+        cache_seqlens_int32,
+        cache_seqlens_int32.stride(0),
+        cu_seqlens_k,
+        cu_seqlens_k.stride(0),
+        max_selected,
+        BATCH_SIZE=batch_size,
+        PAGE_SIZE=page_size,
+        UPDATE_LENGTHS=update_lengths,
+        HAS_SELECTED=max_selected > 0,
+        BLOCK_PAGES=block_pages,
+        num_warps=4,
+    )

--- a/python/sglang/srt/mem_cache/sparsity/kernels/quest_page_update.py
+++ b/python/sglang/srt/mem_cache/sparsity/kernels/quest_page_update.py
@@ -1,0 +1,285 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _quest_update_page_representations_kernel(
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    req_to_token_ptr,
+    k_buffer_ptr,
+    repr_constructed_ptr,
+    last_constructed_page_ptr,
+    page_k_min_ptr,
+    page_k_max_ptr,
+    page_valid_ptr,
+    req_pool_indices_stride,
+    seq_lens_stride,
+    req_to_token_stride_r,
+    req_to_token_stride_t,
+    k_buffer_stride_t,
+    k_buffer_stride_h,
+    k_buffer_stride_d,
+    num_k_tokens,
+    num_pool_pages,
+    num_req_slots,
+    req_to_token_width,
+    PAGE_SIZE: tl.constexpr,
+    KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    kv_head = tl.program_id(1)
+
+    req_idx = tl.load(req_pool_indices_ptr + batch_idx * req_pool_indices_stride).to(
+        tl.int64
+    )
+    req_valid = (req_idx >= 0) & (req_idx < num_req_slots)
+    safe_req_idx = tl.where(req_valid, req_idx, 0)
+    seq_len = tl.load(seq_lens_ptr + batch_idx * seq_lens_stride).to(tl.int64)
+    bounded_seq_len = tl.minimum(tl.maximum(seq_len, 0), req_to_token_width)
+    constructed = tl.load(repr_constructed_ptr + safe_req_idx, mask=req_valid, other=0)
+    tracked_page = tl.load(
+        last_constructed_page_ptr + safe_req_idx, mask=req_valid, other=0
+    ).to(tl.int64)
+    end_page = bounded_seq_len // PAGE_SIZE
+    start_page = tl.where(constructed, tracked_page, 0)
+    logical_page = tl.minimum(tl.maximum(start_page, 0), end_page)
+
+    token_offsets = tl.arange(0, BLOCK_T)
+    dim_offsets = tl.arange(0, BLOCK_D)
+    token_mask = token_offsets < PAGE_SIZE
+    dim_mask = dim_offsets < HEAD_DIM
+    safe_dim_offsets = tl.where(dim_mask, dim_offsets, 0)
+
+    while req_valid & (logical_page < end_page):
+        logical_tokens = logical_page * PAGE_SIZE + token_offsets
+        safe_logical_tokens = tl.where(token_mask, logical_tokens, 0)
+        physical_tokens = tl.load(
+            req_to_token_ptr
+            + safe_req_idx * req_to_token_stride_r
+            + safe_logical_tokens * req_to_token_stride_t,
+            mask=token_mask,
+            other=0,
+        ).to(tl.int64)
+
+        # Match the portable implementation for malformed table entries while
+        # loading each token through req_to_token (physical tokens need not be
+        # contiguous within a logical page).
+        safe_physical_tokens = tl.minimum(
+            tl.maximum(physical_tokens, 0), num_k_tokens - 1
+        )
+        key_offsets = (
+            safe_physical_tokens[:, None] * k_buffer_stride_t
+            + kv_head * k_buffer_stride_h
+            + safe_dim_offsets[None, :] * k_buffer_stride_d
+        )
+        load_mask = token_mask[:, None] & dim_mask[None, :]
+        keys = tl.load(k_buffer_ptr + key_offsets, mask=load_mask, other=0.0).to(
+            tl.float32
+        )
+        page_min = tl.min(tl.where(load_mask, keys, float("inf")), axis=0)
+        page_max = tl.max(tl.where(load_mask, keys, -float("inf")), axis=0)
+
+        first_physical_token = tl.load(
+            req_to_token_ptr
+            + safe_req_idx * req_to_token_stride_r
+            + logical_page * PAGE_SIZE * req_to_token_stride_t
+        ).to(tl.int64)
+        physical_page = tl.minimum(
+            tl.maximum(first_physical_token // PAGE_SIZE, 0), num_pool_pages - 1
+        )
+        output_offsets = (
+            physical_page * KV_HEADS * HEAD_DIM + kv_head * HEAD_DIM + safe_dim_offsets
+        )
+        tl.store(
+            page_k_min_ptr + output_offsets,
+            page_min,
+            mask=dim_mask,
+        )
+        tl.store(
+            page_k_max_ptr + output_offsets,
+            page_max,
+            mask=dim_mask,
+        )
+        tl.store(page_valid_ptr + physical_page, 1, mask=kv_head == 0)
+
+        logical_page += 1
+
+
+@triton.jit
+def _quest_advance_page_trackers_kernel(
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    repr_constructed_ptr,
+    last_constructed_page_ptr,
+    req_pool_indices_stride,
+    seq_lens_stride,
+    num_req_slots,
+    req_to_token_width,
+    PAGE_SIZE: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    req_idx = tl.load(req_pool_indices_ptr + batch_idx * req_pool_indices_stride).to(
+        tl.int64
+    )
+    req_valid = (req_idx >= 0) & (req_idx < num_req_slots)
+    safe_req_idx = tl.where(req_valid, req_idx, 0)
+    seq_len = tl.load(seq_lens_ptr + batch_idx * seq_lens_stride).to(tl.int64)
+    bounded_seq_len = tl.minimum(tl.maximum(seq_len, 0), req_to_token_width)
+    end_page = bounded_seq_len // PAGE_SIZE
+    constructed = tl.load(repr_constructed_ptr + safe_req_idx, mask=req_valid, other=0)
+    tracked_page = tl.load(
+        last_constructed_page_ptr + safe_req_idx, mask=req_valid, other=0
+    ).to(tl.int64)
+    start_page = tl.where(constructed, tracked_page, 0)
+    update = req_valid & (start_page < end_page)
+
+    tl.store(repr_constructed_ptr + safe_req_idx, 1, mask=update)
+    tl.store(last_constructed_page_ptr + safe_req_idx, end_page, mask=update)
+
+
+def quest_update_page_representations_(
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    req_to_token: torch.Tensor,
+    k_buffer: torch.Tensor,
+    repr_constructed: torch.Tensor,
+    last_constructed_page: torch.Tensor,
+    page_k_min: torch.Tensor,
+    page_k_max: torch.Tensor,
+    page_valid: torch.Tensor,
+    page_size: int,
+    *,
+    advance_trackers: bool,
+) -> None:
+    """Update complete Quest pages without reading device state on the host."""
+    if not req_pool_indices.is_cuda or torch.version.hip is not None:
+        raise ValueError("Quest page update requires NVIDIA CUDA tensors")
+    if req_pool_indices.ndim != 1 or seq_lens.shape != req_pool_indices.shape:
+        raise ValueError("Quest request indices and sequence lengths must be 1D")
+    if req_pool_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Quest request indices must use int32 or int64")
+    if seq_lens.dtype not in (torch.int32, torch.int64):
+        raise ValueError("Quest sequence lengths must use int32 or int64")
+    if req_to_token.ndim != 2 or req_to_token.dtype not in (
+        torch.int32,
+        torch.int64,
+    ):
+        raise ValueError("Quest req_to_token must be a 2D integer tensor")
+    if k_buffer.ndim != 3 or k_buffer.dtype not in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ):
+        raise ValueError("Quest key buffer must be a 3D floating-point tensor")
+    if page_k_min.ndim != 3 or page_k_max.shape != page_k_min.shape:
+        raise ValueError("Quest page min/max pools must have matching 3D shapes")
+    if page_k_min.dtype != torch.float32 or page_k_max.dtype != torch.float32:
+        raise ValueError("Quest page min/max pools must use float32")
+    if not page_k_min.is_contiguous() or not page_k_max.is_contiguous():
+        raise ValueError("Quest page min/max pools must be contiguous")
+
+    num_pool_pages, kv_heads, head_dim = page_k_min.shape
+    if k_buffer.shape[1:] != (kv_heads, head_dim):
+        raise ValueError("Quest key buffer and representation dimensions must match")
+    if (
+        page_valid.shape != (num_pool_pages,)
+        or page_valid.dtype != torch.bool
+        or not page_valid.is_contiguous()
+    ):
+        raise ValueError("Quest page validity must be a contiguous bool vector")
+    if (
+        repr_constructed.ndim != 1
+        or repr_constructed.dtype != torch.bool
+        or not repr_constructed.is_contiguous()
+    ):
+        raise ValueError("Quest constructed tracker must be a contiguous bool vector")
+    if (
+        last_constructed_page.shape != repr_constructed.shape
+        or last_constructed_page.dtype not in (torch.int32, torch.int64)
+        or not last_constructed_page.is_contiguous()
+    ):
+        raise ValueError(
+            "Quest last-page tracker must be a matching contiguous integer vector"
+        )
+    if page_size <= 0:
+        raise ValueError(f"Quest page size must be positive, got {page_size}")
+    if req_to_token.shape[1] < page_size:
+        raise ValueError("Quest req_to_token width must hold at least one page")
+    if req_to_token.shape[0] == 0:
+        raise ValueError("Quest req_to_token must contain at least one request slot")
+    if repr_constructed.shape != (req_to_token.shape[0],):
+        raise ValueError("Quest page trackers must match req_to_token request slots")
+    if k_buffer.shape[0] == 0 or num_pool_pages == 0:
+        raise ValueError("Quest key and representation pools cannot be empty")
+    if kv_heads <= 0 or head_dim <= 0:
+        raise ValueError("Quest representation dimensions must be positive")
+
+    tensors = (
+        seq_lens,
+        req_to_token,
+        k_buffer,
+        repr_constructed,
+        last_constructed_page,
+        page_k_min,
+        page_k_max,
+        page_valid,
+    )
+    if any(tensor.device != req_pool_indices.device for tensor in tensors):
+        raise ValueError("Quest page update tensors must share one CUDA device")
+
+    batch_size = req_pool_indices.numel()
+    if batch_size == 0:
+        return
+
+    block_t = triton.next_power_of_2(page_size)
+    block_d = triton.next_power_of_2(head_dim)
+    _quest_update_page_representations_kernel[(batch_size, kv_heads)](
+        req_pool_indices,
+        seq_lens,
+        req_to_token,
+        k_buffer,
+        repr_constructed,
+        last_constructed_page,
+        page_k_min,
+        page_k_max,
+        page_valid,
+        req_pool_indices.stride(0),
+        seq_lens.stride(0),
+        req_to_token.stride(0),
+        req_to_token.stride(1),
+        k_buffer.stride(0),
+        k_buffer.stride(1),
+        k_buffer.stride(2),
+        k_buffer.shape[0],
+        num_pool_pages,
+        req_to_token.shape[0],
+        req_to_token.shape[1],
+        PAGE_SIZE=page_size,
+        KV_HEADS=kv_heads,
+        HEAD_DIM=head_dim,
+        BLOCK_T=block_t,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+
+    # Keep tracker writes in a following launch: updating from one KV-head
+    # program inside the representation kernel could race with another head
+    # that has not read last_constructed_page yet.
+    if advance_trackers:
+        _quest_advance_page_trackers_kernel[(batch_size,)](
+            req_pool_indices,
+            seq_lens,
+            repr_constructed,
+            last_constructed_page,
+            req_pool_indices.stride(0),
+            seq_lens.stride(0),
+            req_to_token.shape[0],
+            req_to_token.shape[1],
+            PAGE_SIZE=page_size,
+            num_warps=1,
+        )

--- a/python/sglang/srt/mem_cache/sparsity/kernels/quest_score.py
+++ b/python/sglang/srt/mem_cache/sparsity/kernels/quest_score.py
@@ -1,0 +1,231 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _quest_page_score_kernel(
+    queries_ptr,
+    page_k_min_ptr,
+    page_k_max_ptr,
+    page_valid_ptr,
+    physical_pages_ptr,
+    active_mask_ptr,
+    history_page_counts_ptr,
+    output_ptr,
+    num_pages,
+    num_pool_pages,
+    APPLY_RETRIEVAL_MASK: tl.constexpr,
+    Q_HEADS: tl.constexpr,
+    KV_HEADS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    page_idx = tl.program_id(0)
+    batch_idx = tl.program_id(1)
+    physical_page_raw = tl.load(physical_pages_ptr + batch_idx * num_pages + page_idx)
+    page_in_bounds = (physical_page_raw >= 0) & (physical_page_raw < num_pool_pages)
+    page_is_selected = page_in_bounds
+    if APPLY_RETRIEVAL_MASK:
+        request_is_active = tl.load(active_mask_ptr + batch_idx).to(tl.int1)
+        history_page_count = tl.load(history_page_counts_ptr + batch_idx)
+        page_is_selected &= request_is_active & (page_idx < history_page_count)
+    physical_page = tl.where(page_in_bounds, physical_page_raw, 0)
+    page_is_valid = tl.load(
+        page_valid_ptr + physical_page, mask=page_is_selected, other=0
+    )
+
+    dim_offsets = tl.arange(0, BLOCK_D)
+    dim_mask = (dim_offsets < HEAD_DIM) & page_is_selected & page_is_valid
+    safe_dim_offsets = tl.where(dim_mask, dim_offsets, 0)
+    page_bound = 0.0
+
+    for kv_head in range(KV_HEADS):
+        key_offsets = (
+            physical_page * KV_HEADS * HEAD_DIM + kv_head * HEAD_DIM + safe_dim_offsets
+        )
+        key_min = tl.load(page_k_min_ptr + key_offsets, mask=dim_mask, other=0.0).to(
+            tl.float32
+        )
+        key_max = tl.load(page_k_max_ptr + key_offsets, mask=dim_mask, other=0.0).to(
+            tl.float32
+        )
+
+        query_sum = tl.zeros((BLOCK_D,), dtype=tl.float32)
+        for group_idx in range(GROUP_SIZE):
+            query_head = kv_head * GROUP_SIZE + group_idx
+            query_offsets = (
+                batch_idx * Q_HEADS * HEAD_DIM
+                + query_head * HEAD_DIM
+                + safe_dim_offsets
+            )
+            query_sum += tl.load(
+                queries_ptr + query_offsets, mask=dim_mask, other=0.0
+            ).to(tl.float32)
+
+        # Match the portable Quest fallback: average the query heads sharing a
+        # KV head, round to the query dtype, then sum bounds over all KV heads.
+        query = (query_sum / GROUP_SIZE).to(queries_ptr.dtype.element_ty).to(tl.float32)
+        bound_keys = tl.where(query >= 0, key_max, key_min)
+        page_bound += tl.sum(query * bound_keys, axis=0)
+
+    score = tl.where(page_is_selected & page_is_valid, page_bound, -float("inf"))
+    tl.store(output_ptr + batch_idx * num_pages + page_idx, score)
+
+
+def quest_page_scores(
+    queries: torch.Tensor,
+    page_k_min: torch.Tensor,
+    page_k_max: torch.Tensor,
+    page_valid: torch.Tensor,
+    physical_pages: torch.Tensor,
+    *,
+    active_mask: torch.Tensor | None = None,
+    history_page_counts: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute Quest's per-page score without materializing intermediates.
+
+    Out-of-range physical pages are masked to ``-inf``. When ``active_mask``
+    and ``history_page_counts`` are provided, inactive requests and logical
+    recent/padding pages are masked in the same kernel. The representation
+    tensors are persistent contiguous pools in Quest; they are deliberately
+    not copied here because doing so would dominate scoring.
+    """
+    if not queries.is_cuda:
+        raise ValueError("quest_page_scores requires CUDA tensors")
+    if page_k_min.dim() != 3 or page_k_max.shape != page_k_min.shape:
+        raise ValueError(
+            "Quest page min/max tensors must have matching [pages, heads, dim] shapes"
+        )
+    if page_k_min.dtype != torch.float32 or page_k_max.dtype != torch.float32:
+        raise ValueError("Quest page min/max tensors must use float32")
+    if not page_k_min.is_contiguous() or not page_k_max.is_contiguous():
+        raise ValueError("Quest page min/max tensors must be contiguous")
+    if (
+        page_valid.dim() != 1
+        or page_valid.shape[0] != page_k_min.shape[0]
+        or page_valid.dtype != torch.bool
+    ):
+        raise ValueError("Quest page validity must be a bool tensor of shape [pages]")
+    if not page_valid.is_contiguous():
+        raise ValueError("Quest page validity tensor must be contiguous")
+    if physical_pages.dim() != 2 or physical_pages.dtype not in (
+        torch.int32,
+        torch.int64,
+    ):
+        raise ValueError(
+            "Quest physical pages must be an int32/int64 [batch, pages] tensor"
+        )
+    if any(
+        tensor.device != queries.device
+        for tensor in (page_k_min, page_k_max, page_valid, physical_pages)
+    ):
+        raise ValueError("Quest score tensors must be on the same CUDA device")
+
+    apply_retrieval_mask = active_mask is not None or history_page_counts is not None
+    if apply_retrieval_mask:
+        if active_mask is None or history_page_counts is None:
+            raise ValueError(
+                "Quest active mask and history page counts must be provided together"
+            )
+        if (
+            active_mask.shape != (physical_pages.shape[0],)
+            or active_mask.dtype != torch.bool
+        ):
+            raise ValueError("Quest active mask must be bool with shape [batch]")
+        if history_page_counts.shape != (
+            physical_pages.shape[0],
+        ) or history_page_counts.dtype not in (
+            torch.int32,
+            torch.int64,
+        ):
+            raise ValueError(
+                "Quest history page counts must be int32/int64 with shape [batch]"
+            )
+        if (
+            active_mask.device != queries.device
+            or history_page_counts.device != queries.device
+        ):
+            raise ValueError("Quest retrieval masks must share the score tensor device")
+
+    num_pool_pages, kv_heads, head_dim = page_k_min.shape
+    if kv_heads <= 0 or head_dim <= 0:
+        raise ValueError("Quest page representations require positive head dimensions")
+    if queries.dim() == 2:
+        batch_size, hidden_size = queries.shape
+        if hidden_size % head_dim != 0:
+            raise ValueError(
+                f"Quest query hidden size {hidden_size} not divisible by "
+                f"head_dim {head_dim}"
+            )
+        query_heads = hidden_size // head_dim
+        queries = queries.reshape(batch_size, query_heads, head_dim)
+    elif queries.dim() == 3:
+        batch_size, query_heads, query_head_dim = queries.shape
+        if query_head_dim != head_dim:
+            raise ValueError(
+                f"Quest query head_dim {query_head_dim} does not match {head_dim}"
+            )
+    else:
+        raise ValueError(f"Unsupported query shape for Quest: {queries.shape}")
+
+    if query_heads <= 0:
+        raise ValueError("Quest queries require at least one attention head")
+    if physical_pages.shape[0] != batch_size:
+        raise ValueError(
+            f"Quest physical page batch {physical_pages.shape[0]} does not match "
+            f"query batch {batch_size}"
+        )
+    if query_heads % kv_heads != 0:
+        raise ValueError(
+            f"Query heads {query_heads} not divisible by KV heads {kv_heads}"
+        )
+    if head_dim > 256:
+        raise ValueError(
+            f"Quest Triton score kernel supports head_dim <= 256, got {head_dim}"
+        )
+    if not queries.is_contiguous():
+        queries = queries.contiguous()
+    if not physical_pages.is_contiguous():
+        physical_pages = physical_pages.contiguous()
+    if apply_retrieval_mask:
+        if not active_mask.is_contiguous():
+            active_mask = active_mask.contiguous()
+        if not history_page_counts.is_contiguous():
+            history_page_counts = history_page_counts.contiguous()
+
+    num_pages = physical_pages.shape[1]
+    output = torch.empty(
+        (batch_size, num_pages), dtype=torch.float32, device=queries.device
+    )
+    if batch_size == 0 or num_pages == 0:
+        return output
+    if num_pool_pages == 0:
+        raise ValueError("Quest page representation pool cannot be empty")
+
+    block_d = triton.next_power_of_2(head_dim)
+    active_mask_arg = active_mask if apply_retrieval_mask else physical_pages
+    history_page_counts_arg = (
+        history_page_counts if apply_retrieval_mask else physical_pages
+    )
+    _quest_page_score_kernel[(num_pages, batch_size)](
+        queries,
+        page_k_min,
+        page_k_max,
+        page_valid,
+        physical_pages,
+        active_mask_arg,
+        history_page_counts_arg,
+        output,
+        num_pages,
+        num_pool_pages,
+        APPLY_RETRIEVAL_MASK=apply_retrieval_mask,
+        Q_HEADS=query_heads,
+        KV_HEADS=kv_heads,
+        GROUP_SIZE=query_heads // kv_heads,
+        HEAD_DIM=head_dim,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+    return output


### PR DESCRIPTION
## Overview

This PR adds four focused NVIDIA CUDA/Triton primitives for the tensor-heavy parts of Quest page selection and FlashAttention 3 metadata preparation:

- compute page upper-bound scores;
- finalize Top-K results together with recent pages;
- write FA3 page metadata directly or from an existing selection;
- update page min/max representations and tracker state after KV writes.

This PR only adds the kernel modules and their focused tests. It does not modify runtime, algorithm, coordinator, adaptor, dispatch, or CUDA Graph call sites, so merging it alone does not change serving behavior.

## PR series

| Part | PR | Scope |
|---|---|---|
| Part 1 | [#30277](https://github.com/sgl-project/sglang/pull/30277) | Eager runtime integration and portable FA3 metadata fallback |
| Part 2 | [#29666](https://github.com/sgl-project/sglang/pull/29666) | Batched retrieval, host-sync reduction, and full-page fast path |
| Part 3, this PR | [#31790](https://github.com/sgl-project/sglang/pull/31790) | Standalone GPU kernels for page selection and FA3 metadata updates |
| Part 4 | [#31951](https://github.com/sgl-project/sglang/pull/31951) | Breakable CUDA Graph runtime variants and capture/replay |

Parts 1 and 2 own the optional discovery and wiring that call these kernels when they are available. This PR supplies the implementations only; it does not register or dispatch them. 

## What this PR changes

### 1. Page score

`quest_page_scores` fuses page-bound lookup, validity/retrieval masking, and score reduction. For GQA, query heads sharing a KV head use the same portable **mean** semantics, including the query-dtype round trip before float32 accumulation. This PR does not introduce conservative-max selection behavior.

### 2. Finalize selected pages

`quest_finalize_selected_pages` removes non-finite candidates, merges recent pages, sorts the fixed-width result, fills unused entries with `-1`, and returns the valid length. The wrapper rejects unsupported devices, layouts, dtypes, and widths above 1024.

### 3. FA3 metadata

The metadata primitives map logical pages through `req_to_token` and update `page_table`, `valid_lengths`, `cache_seqlens_int32`, and `cu_seqlens_k` in place. Invalid or padded logical pages are masked before dereference. The public wrappers validate CUDA device, shape, dtype, output width, and stride before launch.

### 4. Page representations

`quest_update_page_representations_` reads every token through `req_to_token`, so a logical page does not need contiguous physical KV storage. It writes float32 min/max representations first and advances trackers in a following launch to avoid cross-head races.

## Historical performance evidence

The previous stacked implementation observed the following sequential endpoint change when the GPU-kernel stage was added after the eager runtime stage:

| Workload | Before, Quest/Dense | After, Quest/Dense | Change | Relative uplift |
|---|---:|---:|---:|---:|
| `8k-c8` | 33.34% | 45.99% | +12.65 pp | +37.94% |
| `32k-c1` | 47.64% | 55.83% | +8.19 pp | +17.19% |
| `32k-c4` | 46.24% | 55.15% | +8.91 pp | +19.27% |

## Test Plan

- On NVIDIA CUDA, compare score, finalize, direct/adaptor metadata, and page update value-for-value with portable references.
- Cover GQA mean with float16/bfloat16, 2D/3D non-contiguous queries, invalid/out-of-range pages, non-contiguous trackers, mapped physical tokens, unsafe shapes/strides, and CUDA Graph replay reading updated input.
- Verify the PR independently against `main`; separately validate the four-PR combination to confirm optional-hook dispatch and end-to-end performance attribution.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30327037960](https://github.com/sgl-project/sglang/actions/runs/30327037960)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30327037945](https://github.com/sgl-project/sglang/actions/runs/30327037945)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->