### PR TITLE
[MiniMax-M3] Add SM90 MXFP8 Inference Support with DeepGEMM

### DIFF
--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -40,6 +40,7 @@ from sglang.srt.utils import (
     is_cuda,
     is_hip,
     is_musa,
+    is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
     log_info_on_rank0,
@@ -51,6 +52,7 @@ _is_hip = is_hip()
 _is_cuda = is_cuda()
 _is_cpu = is_cpu()
 _is_musa = is_musa()
+_is_sm90_supported = is_sm90_supported()
 _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
@@ -117,6 +119,31 @@ if _is_musa:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _format_ue8m0_scale_for_deepgemm(
+    sf: torch.Tensor,
+    *,
+    num_groups: Optional[int],
+    mn: int,
+    k: int,
+    group_size: int,
+) -> torch.Tensor:
+    if _is_sm90_supported and not _is_sm100_supported:
+        import deep_gemm.utils.layout
+
+        return deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor(sf)
+
+    from deep_gemm import transform_sf_into_required_layout
+
+    return transform_sf_into_required_layout(
+        sf,
+        num_groups=num_groups,
+        mn=mn,
+        k=k,
+        recipe=(1, group_size, group_size),
+        is_sfa=True,
+    )
 
 
 @lru_cache()
@@ -344,15 +371,12 @@ def _per_token_group_quant_8bit_raw(
         )
 
     if scale_ue8m0:
-        from deep_gemm import transform_sf_into_required_layout
-
-        x_s = transform_sf_into_required_layout(
+        x_s = _format_ue8m0_scale_for_deepgemm(
             x_s,
             num_groups=None,
             mn=x_q.shape[0],
             k=x_q.shape[1],
-            recipe=(1, group_size, group_size),
-            is_sfa=True,
+            group_size=group_size,
         )
 
     return x_q, x_s
@@ -378,8 +402,6 @@ def _per_token_group_quant_8bit_fuse_silu_and_mul(
     #     scale_tma_aligned=scale_tma_aligned,
     #     scale_ue8m0=scale_ue8m0,
     # )
-
-    from deep_gemm import transform_sf_into_required_layout
 
     from sglang.kernels.ops.moe.ep_moe_kernels import silu_and_mul_masked_post_quant_fwd
 
@@ -415,13 +437,12 @@ def _per_token_group_quant_8bit_fuse_silu_and_mul(
         scale_ue8m0=scale_ue8m0,
     )
 
-    output_scale = transform_sf_into_required_layout(
+    output_scale = _format_ue8m0_scale_for_deepgemm(
         output_scale_for_kernel,
         num_groups=output.shape[0],
         mn=output.shape[-2],
         k=output.shape[-1],
-        recipe=(1, group_size, group_size),
-        is_sfa=True,
+        group_size=group_size,
     )
 
     if needs_unsqueeze:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -528,9 +528,13 @@ def _minimax_m3_overrides(server_args: Any, hf_config: Any) -> dict:
         ):
             overrides["page_size"] = 128
             page_resolved = 128
+        # Only DeepGEMM currently supports MiniMax-M3's MXFP8 MoE on Hopper.
+        if server_args.moe_runner_backend == "auto" and quant_resolved == "mxfp8":
+            overrides["moe_runner_backend"] = "deep_gemm"
         logger.info(
             "MiniMax-M3 on Hopper: attention_backend="
-            f"{overrides.get('attention_backend', server_args.attention_backend)}, page_size={page_resolved} "
+            f"{overrides.get('attention_backend', server_args.attention_backend)}, page_size={page_resolved}, "
+            f"moe_runner_backend={overrides.get('moe_runner_backend', server_args.moe_runner_backend)} "
             "(MSA is SM100-only; sparse attention runs on the Triton path)."
         )
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -973,6 +973,11 @@ class Envs:
     SGLANG_MINIMAX_M3_FUSED_SWIGLU_MXFP8 = EnvBool(False)
     SGLANG_MINIMAX_M3_FUSED_MOE_COMBINE = EnvBool(False)
 
+    # SM90 MXFP8 dense linear: route dense linear layers through the custom
+    # DeepGEMM grouped MXFP8 path. Disable to fall back to the regular MXFP8
+    # linear backend selected by --fp8-gemm-backend, without changing MoE.
+    SGLANG_OPT_USE_SM90_MXFP8_DEEPGEMM_LINEAR = EnvBool(True)
+
     # GEMM / kernel fusion
     SGLANG_OPT_FP8_WO_A_GEMM = EnvBool(True)
     SGLANG_OPT_BF16_FP32_GEMM_ALGO = EnvStr("cublas")

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -101,6 +101,8 @@ def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
 class DeepGemmKernelType(IntEnum):
     GROUPED_GEMM_NT_F8F8BF16_MASKED = auto()
     GROUPED_GEMM_NT_F8F8BF16_CONTIG = auto()
+    GROUPED_GEMM_NT_MXFP8_F8BF16_MASKED = auto()
+    GROUPED_GEMM_NT_MXFP8_F8BF16_CONTIG = auto()
     GROUPED_GEMM_NT_BF16_MASKED = auto()
     GROUPED_GEMM_NT_BF16_CONTIG = auto()
     GEMM_NT_F8F8BF16 = auto()
@@ -167,7 +169,10 @@ def _compile_deep_gemm_one_type_all(
     # Temporary disable symmetric memory during compilation since it only runs on the first rank.
     saved_context = disable_symmetric_memory_context()
     try:
-        if kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG:
+        if kernel_type in (
+            DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG,
+            DeepGemmKernelType.GROUPED_GEMM_NT_MXFP8_F8BF16_CONTIG,
+        ):
             m_alignment = deep_gemm.get_mk_alignment_for_contiguous_layout()
             m_list = sorted(list(set(m for m in m_list if m % m_alignment == 0)))
         elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG:
@@ -234,6 +239,8 @@ class _BaseWarmupExecutor:
             DeepGemmKernelType.GEMM_NT_F8F8BF16: _NormalWarmupExecutor,
             DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG: _GroupedContWarmupExecutor,
             DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_MASKED: _GroupedMaskedWarmupExecutor,
+            DeepGemmKernelType.GROUPED_GEMM_NT_MXFP8_F8BF16_CONTIG: _MXFP8GroupedContWarmupExecutor,
+            DeepGemmKernelType.GROUPED_GEMM_NT_MXFP8_F8BF16_MASKED: _MXFP8GroupedMaskedWarmupExecutor,
             DeepGemmKernelType.GEMM_NT_BF16BF16F32: _BF16F32WarmupExecutor,
             DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG: _BF16GroupedContWarmupExecutor,
             DeepGemmKernelType.GROUPED_GEMM_NT_BF16_MASKED: _BF16GroupedMaskedWarmupExecutor,
@@ -249,6 +256,15 @@ class _BaseWarmupExecutor:
             return (max_m * k + n * k + max_m * n * 2) / _GB
         elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_CONTIG:
             return (max_m * k + num_groups * n * k + max_m * 4 + max_m * n * 2) / _GB
+        elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_MXFP8_F8BF16_CONTIG:
+            return (
+                max_m * k
+                + max_m * ceil_div(k, 32)
+                + num_groups * n * k
+                + num_groups * n * ceil_div(k, 32)
+                + max_m * 4
+                + max_m * n * 2
+            ) / _GB
         elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG:
             return (
                 max_m * k * 2 + num_groups * n * k * 2 + max_m * 4 + max_m * n * 2
@@ -257,6 +273,15 @@ class _BaseWarmupExecutor:
             return (
                 num_groups * max_m * k
                 + num_groups * n * k
+                + num_groups * 4
+                + num_groups * max_m * n * 2
+            ) / _GB
+        elif kernel_type == DeepGemmKernelType.GROUPED_GEMM_NT_MXFP8_F8BF16_MASKED:
+            return (
+                num_groups * max_m * k
+                + num_groups * max_m * ceil_div(k, 32)
+                + num_groups * n * k
+                + num_groups * n * ceil_div(k, 32)
                 + num_groups * 4
                 + num_groups * max_m * n * 2
             ) / _GB
@@ -364,6 +389,57 @@ class _GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
             self.out,
             masked_m=self.masked_m,
             # DeepGEMM uses `expect_m` instead of input shape for `get_best_config`
+            expected_m=m,
+        )
+
+
+def _empty_mxfp8_lhs(size):
+    *dims, k = size
+    return (
+        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
+        torch.empty((*dims, ceil_div(k, 32)), device="cuda", dtype=torch.uint8),
+    )
+
+
+def _empty_mxfp8_rhs(size):
+    *dims, n, k = size
+    return (
+        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
+        torch.empty((*dims, n, ceil_div(k, 32)), device="cuda", dtype=torch.uint8),
+    )
+
+
+class _MXFP8GroupedContWarmupExecutor(_BaseWarmupExecutor):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+        self.lhs_q, self.lhs_s = _empty_mxfp8_lhs((max_m, k))
+        self.rhs_q, self.rhs_s = _empty_mxfp8_rhs((num_groups, n, k))
+        self.m_indices = torch.zeros((max_m,), device="cuda", dtype=torch.int32)
+        self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
+
+    def execute(self, m):
+        deep_gemm.m_grouped_mxfp8_fp8_gemm_nt_contiguous(
+            (self.lhs_q[:m], self.lhs_s[:m]),
+            (self.rhs_q, self.rhs_s),
+            self.out[:m],
+            self.m_indices[:m],
+        )
+
+
+class _MXFP8GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+        self.lhs_q, self.lhs_s = _empty_mxfp8_lhs((num_groups, max_m, k))
+        self.rhs_q, self.rhs_s = _empty_mxfp8_rhs((num_groups, n, k))
+        self.masked_m = torch.zeros((num_groups,), device="cuda", dtype=torch.int32)
+        self.out = torch.empty(
+            (num_groups, max_m, n), device="cuda", dtype=torch.bfloat16
+        )
+
+    def execute(self, m):
+        deep_gemm.m_grouped_mxfp8_fp8_gemm_nt_masked(
+            (self.lhs_q, self.lhs_s),
+            (self.rhs_q, self.rhs_s),
+            self.out,
+            masked_m=self.masked_m,
             expected_m=m,
         )
 

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -1,4 +1,3 @@
-import logging
 from contextlib import contextmanager
 from typing import Any, Optional, Tuple
 
@@ -13,14 +12,142 @@ from sglang.srt.layers.deep_gemm_wrapper.configurer import (  # noqa: F401
     ENABLE_JIT_DEEPGEMM,
 )
 from sglang.srt.server_args import ServerArgs
-
-logger = logging.getLogger(__name__)
+from sglang.srt.utils import is_cuda, is_sm90_supported, is_sm100_supported
 
 if ENABLE_JIT_DEEPGEMM:
     import deep_gemm
     from deep_gemm.utils.layout import get_mn_major_tma_aligned_tensor  # noqa: F401
 
 _SANITY_CHECK = envs.SGLANG_DEEPGEMM_SANITY_CHECK.get()
+
+
+def supports_sm90_mxfp8_fp8_grouped_gemm() -> bool:
+    if not ENABLE_JIT_DEEPGEMM:
+        return False
+    return hasattr(deep_gemm, "m_grouped_mxfp8_fp8_gemm_nt_contiguous") and hasattr(
+        deep_gemm, "m_grouped_mxfp8_fp8_gemm_nt_masked"
+    )
+
+
+def is_sm90_mxfp8_deepgemm_enabled() -> bool:
+    return (
+        is_cuda()
+        and is_sm90_supported()
+        and not is_sm100_supported()
+        and supports_sm90_mxfp8_fp8_grouped_gemm()
+    )
+
+
+def supports_mxfp8_deepgemm() -> bool:
+    return DEEPGEMM_BLACKWELL or is_sm90_mxfp8_deepgemm_enabled()
+
+
+def _ceil_align(x: int, align: int) -> int:
+    return ((x + align - 1) // align) * align
+
+
+def _sm90_mxfp8_scale_expected_last_dim(
+    scale: torch.Tensor,
+    k: int,
+    recipe: Optional[Tuple[int, int]],
+) -> Optional[int]:
+    if recipe is None:
+        return None
+    pack_factor = 4 if scale.dtype in (torch.int, torch.int32) else 1
+    return (k + recipe[1] * pack_factor - 1) // (recipe[1] * pack_factor)
+
+
+def _assert_sm90_mxfp8_scale_matches_recipe(
+    scale: torch.Tensor,
+    k: int,
+    recipe: Optional[Tuple[int, int]],
+    *,
+    role: str,
+) -> None:
+    expected_last_dim = _sm90_mxfp8_scale_expected_last_dim(scale, k, recipe)
+    if expected_last_dim is None:
+        return
+    if scale.shape[-1] != expected_last_dim:
+        pack_factor = 4 if scale.dtype in (torch.int, torch.int32) else 1
+        raise RuntimeError(
+            f"SM90 MXFP8 {role} scale shape does not match recipe: "
+            f"K={k}, recipe={recipe}, scale_dtype={scale.dtype}, "
+            f"scale_shape={tuple(scale.shape)}, pack_factor={pack_factor}, "
+            f"expected_last_dim={expected_last_dim}."
+        )
+
+
+def _e8m0_fp32_to_u8(sf: torch.Tensor) -> torch.Tensor:
+    sf_i32 = sf.to(torch.float32).view(torch.int32)
+    exp = torch.bitwise_right_shift(sf_i32, 23)
+    mant = torch.bitwise_and(sf_i32, 0x7FFFFF)
+    round_up = torch.logical_and(
+        torch.logical_and(mant > 0, exp != 0xFE),
+        ~torch.logical_and(exp == 0, mant <= 0x400000),
+    )
+    return torch.where(round_up, exp + 1, exp).to(torch.uint8).contiguous()
+
+
+def _normalize_sm90_mxfp8_pair(
+    pair: Tuple[torch.Tensor, torch.Tensor],
+    *,
+    scale_role: str,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    x, sf = pair
+    k = x.shape[-1]
+    k32 = _ceil_align(k, 32) // 32
+
+    if (
+        sf.dtype == torch.uint8
+        and sf.shape[-1] == k32
+        and x.dtype == torch.float8_e4m3fn
+    ):
+        return x, sf.contiguous()
+
+    if sf.dtype == torch.int32:
+        if x.dtype == torch.float8_e4m3fn:
+            return x, sf
+        raise RuntimeError(
+            f"SM90 MXFP8 {scale_role} scale received packed UE8M0 scales "
+            f"but activation dtype is {x.dtype}; expected torch.float8_e4m3fn."
+        )
+
+    if (
+        sf.dtype == torch.float32
+        and sf.shape[-1] == k32
+        and x.dtype == torch.float8_e4m3fn
+    ):
+        return x, _e8m0_fp32_to_u8(sf)
+
+    raise RuntimeError(
+        f"SM90 MXFP8 {scale_role} wrapper only performs lossless scale layout adaptation. "
+        f"Got activation dtype={x.dtype}, scale dtype={sf.dtype}, "
+        f"scale_last_dim={sf.shape[-1]}, expected K/32={k32}."
+    )
+
+
+def _pad_sm90_mxfp8_lhs(
+    lhs: Tuple[torch.Tensor, torch.Tensor], expected_m: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    x, sf = lhs
+    if x.shape[-2] >= expected_m:
+        return lhs
+    padded_x = torch.empty(
+        (*x.shape[:-2], expected_m, x.shape[-1]), device=x.device, dtype=x.dtype
+    )
+    padded_sf = torch.empty(
+        (*sf.shape[:-2], expected_m, sf.shape[-1]), device=sf.device, dtype=sf.dtype
+    )
+    if sf.dtype == torch.int32 and not sf.is_contiguous() and sf.dim() >= 2:
+        padded_sf_storage = torch.empty(
+            (*sf.shape[:-2], sf.shape[-1], expected_m),
+            device=sf.device,
+            dtype=sf.dtype,
+        )
+        padded_sf = padded_sf_storage.transpose(-1, -2)
+    padded_x[..., : x.shape[-2], :] = x
+    padded_sf[..., : sf.shape[-2], :] = sf
+    return padded_x, padded_sf
 
 
 # TODO maybe rename these functions
@@ -75,6 +202,56 @@ def grouped_gemm_nt_f8f8bf16_masked(
                     else {}
                 ),
             )
+
+
+def grouped_gemm_nt_mxfp8_f8f8bf16_masked(
+    lhs: Tuple[torch.Tensor, torch.Tensor],
+    rhs: Tuple[torch.Tensor, torch.Tensor],
+    out: torch.Tensor,
+    masked_m: torch.Tensor,
+    expected_m: int,
+    recipe_a: Optional[Tuple[int, int]] = None,
+    recipe_b: Optional[Tuple[int, int]] = None,
+):
+    if not supports_sm90_mxfp8_fp8_grouped_gemm():
+        raise RuntimeError(
+            "The installed deep_gemm does not expose SM90 MXFP8 grouped GEMM APIs."
+        )
+
+    num_groups, _, k = lhs[0].shape
+    _, n, _ = rhs[0].shape
+    kernel_type = compile_utils.DeepGemmKernelType.GROUPED_GEMM_NT_MXFP8_F8BF16_MASKED
+
+    lhs = _normalize_sm90_mxfp8_pair(_ensure_cuda(lhs), scale_role="lhs")
+    rhs = _normalize_sm90_mxfp8_pair(_ensure_cuda(rhs), scale_role="rhs")
+    _assert_sm90_mxfp8_scale_matches_recipe(lhs[1], k, recipe_a, role="lhs")
+    _assert_sm90_mxfp8_scale_matches_recipe(rhs[1], k, recipe_b, role="rhs")
+
+    padded_expected_m = _ceil_align(max(lhs[0].shape[-2], expected_m), 128)
+    lhs = _pad_sm90_mxfp8_lhs(lhs, padded_expected_m)
+    kernel_out = out
+    if out.shape[-2] < padded_expected_m:
+        kernel_out = torch.empty(
+            (*out.shape[:-2], padded_expected_m, out.shape[-1]),
+            device=out.device,
+            dtype=out.dtype,
+        )
+
+    with compile_utils.deep_gemm_execution_hook(
+        padded_expected_m, n, k, num_groups, kernel_type
+    ):
+        ret = deep_gemm.m_grouped_mxfp8_fp8_gemm_nt_masked(
+            lhs,
+            rhs,
+            kernel_out,
+            masked_m,
+            padded_expected_m,
+            recipe_a=recipe_a,
+            recipe_b=recipe_b,
+        )
+    if kernel_out is not out:
+        out.copy_(kernel_out[..., : out.shape[-2], :])
+    return ret
 
 
 def _ensure_cuda(
@@ -136,6 +313,42 @@ def grouped_gemm_nt_f8f8bf16_contig(
     with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
         deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
             lhs, rhs, out, m_indices, **fp4_kwargs
+        )
+
+
+def grouped_gemm_nt_mxfp8_f8f8bf16_contig(
+    lhs: Tuple[torch.Tensor, torch.Tensor],
+    rhs: Tuple[torch.Tensor, torch.Tensor],
+    out: torch.Tensor,
+    m_indices: torch.Tensor,
+    recipe_a: Optional[Tuple[int, int]] = None,
+    recipe_b: Optional[Tuple[int, int]] = None,
+):
+    if not supports_sm90_mxfp8_fp8_grouped_gemm():
+        raise RuntimeError(
+            "The installed deep_gemm does not expose SM90 MXFP8 grouped GEMM APIs."
+        )
+
+    m, k = lhs[0].shape
+    num_groups, n, _ = rhs[0].shape
+    kernel_type = compile_utils.DeepGemmKernelType.GROUPED_GEMM_NT_MXFP8_F8BF16_CONTIG
+
+    if m == 0:
+        return
+
+    lhs = _normalize_sm90_mxfp8_pair(_ensure_cuda(lhs), scale_role="lhs")
+    rhs = _normalize_sm90_mxfp8_pair(_ensure_cuda(rhs), scale_role="rhs")
+    _assert_sm90_mxfp8_scale_matches_recipe(lhs[1], k, recipe_a, role="lhs")
+    _assert_sm90_mxfp8_scale_matches_recipe(rhs[1], k, recipe_b, role="rhs")
+
+    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+        deep_gemm.m_grouped_mxfp8_fp8_gemm_nt_contiguous(
+            lhs,
+            rhs,
+            out,
+            m_indices,
+            recipe_a=recipe_a,
+            recipe_b=recipe_b,
         )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -66,6 +66,67 @@ _MASKED_GEMM_FAST_ACT = get_bool_env_var("SGLANG_MASKED_GEMM_FAST_ACT")
 _DEEPGEMM_ON_H20 = get_bool_env_var("SGLANG_DEEPGEMM_ON_H20")
 
 
+def _apply_gemm1_alpha_activation(
+    gateup: torch.Tensor,
+    *,
+    gemm1_alpha: float,
+    gemm1_clamp_limit: Optional[float],
+    gate_up_interleaved: bool,
+) -> torch.Tensor:
+    if gate_up_interleaved:
+        gate, up = gateup[..., ::2], gateup[..., 1::2]
+    else:
+        gate, up = torch.chunk(gateup, chunks=2, dim=-1)
+    if gemm1_clamp_limit is not None and gemm1_clamp_limit > 0:
+        gate = torch.clamp(gate, max=gemm1_clamp_limit)
+        up = torch.clamp(up, min=-gemm1_clamp_limit, max=gemm1_clamp_limit)
+    return gate * torch.sigmoid(gate * gemm1_alpha) * (up + 1.0)
+
+
+def _use_sm90_mxfp8_fp8_grouped_gemm(quant_info: DeepGemmMoeQuantInfo) -> bool:
+    return quant_info.use_mxfp8 and deep_gemm_wrapper.is_sm90_mxfp8_deepgemm_enabled()
+
+
+def _infer_mxfp8_gran_k_from_scale(
+    scale: torch.Tensor,
+    k: int,
+    *,
+    preferred_gran_k: Optional[int] = None,
+) -> int:
+    pack_factor = 4 if scale.dtype in (torch.int, torch.int32) else 1
+    last_dim = scale.shape[-1]
+    candidates = []
+    if preferred_gran_k in (32, 128):
+        candidates.append(preferred_gran_k)
+    candidates.extend(gran_k for gran_k in (32, 128) if gran_k not in candidates)
+    for gran_k in candidates:
+        if last_dim == ceil_div(k, gran_k * pack_factor):
+            return gran_k
+    raise AssertionError(
+        "MXFP8 scale shape does not match supported gran_k: "
+        f"K={k}, scale_dtype={scale.dtype}, scale_last_dim={last_dim}, "
+        f"expected_k32={ceil_div(k, 32 * pack_factor)}, "
+        f"expected_k128={ceil_div(k, 128 * pack_factor)}"
+    )
+
+
+def _assert_mxfp8_scale_matches_recipe(
+    scale: torch.Tensor,
+    k: int,
+    recipe: Tuple[int, int],
+    location: str,
+) -> None:
+    gran_k = recipe[1]
+    pack_factor = 4 if scale.dtype in (torch.int, torch.int32) else 1
+    expected_last_dim = ceil_div(k, gran_k * pack_factor)
+    assert scale.shape[-1] == expected_last_dim, (
+        f"MXFP8 scale/recipe mismatch at {location}: "
+        f"K={k}, recipe={recipe}, scale_dtype={scale.dtype}, "
+        f"scale_shape={tuple(scale.shape)}, scale_last_dim={scale.shape[-1]}, "
+        f"pack_factor={pack_factor}, expected_last_dim={expected_last_dim}"
+    )
+
+
 # TODO(kaixih@nvidia): ideally we should merge this logic into
 # `fill_gateup_input_triton_kernel` to directly generate e8m0 scale.
 @torch.compile(disable=_is_hip or _is_npu)
@@ -132,9 +193,10 @@ class DeepGemmMoeQuantInfo(MoeQuantInfo):
                 1,
                 32,
             ], f"MXFP8 requires block_shape [1, 32], got {self.block_shape}"
-            assert (
-                deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
-            ), "MXFP8 requires DEEPGEMM_SCALE_UE8M0=True"
+            if not (deep_gemm_wrapper.is_sm90_mxfp8_deepgemm_enabled()):
+                assert (
+                    deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+                ), "MXFP8 requires DEEPGEMM_SCALE_UE8M0=True"
 
 
 class DeepGemmRunnerCore(MoeRunnerCore):
@@ -144,7 +206,17 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         assert self.config.is_gated
         self.swiglu_limit = self.config.swiglu_limit
         self.use_swizzle = False
-        if envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get():
+        self.use_sigmoid_alpha_swiglu = self.config.gemm1_alpha is not None
+        assert not (self.use_sigmoid_alpha_swiglu and self.swiglu_limit is not None), (
+            "gemm1_alpha selects sigmoid-alpha SwiGLU, while "
+            "swiglu_limit configures standard clamped SwiGLU. "
+            "Only one activation variant can be configured."
+        )
+        self.use_fused_contiguous_activation = (
+            envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get()
+            and not self.use_sigmoid_alpha_swiglu
+        )
+        if self.use_fused_contiguous_activation:
             assert envs.SGLANG_OPT_SWIGLU_CLAMP_FUSION.get()
             assert envs.SGLANG_OPT_USE_JIT_EP_ACTIVATION.get()
             self.use_swizzle = True
@@ -199,11 +271,26 @@ class DeepGemmRunnerCore(MoeRunnerCore):
 
         N = quant_info.w13_weight.size(1)
         K = hidden_states_shape[1]
-        scale_block_size = 128
-
-        recipe_a, recipe_b = (
-            ((1, 128), (1, 32)) if quant_info.is_fp4_experts else (None, None)
+        use_sm90_mxfp8 = _use_sm90_mxfp8_fp8_grouped_gemm(quant_info)
+        use_mxfp8_ue8m0_scales = (
+            deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or use_sm90_mxfp8
         )
+        scale_block_size = quant_info.block_shape[1] if quant_info.block_shape else 128
+
+        if use_sm90_mxfp8:
+            gran_k_act = _infer_mxfp8_gran_k_from_scale(
+                hidden_states_scale,
+                K,
+                preferred_gran_k=running_state.get("mxfp8_act_gran_k"),
+            )
+            recipe_a, recipe_b = (
+                (1, gran_k_act),
+                (1, scale_block_size),
+            )
+        else:
+            recipe_a, recipe_b = (
+                ((1, 128), (1, 32)) if quant_info.is_fp4_experts else (None, None)
+            )
 
         w13_weight_fp8 = (
             quant_info.w13_weight,
@@ -217,21 +304,32 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             dtype=torch.bfloat16,
         )
         if deep_gemm_wrapper.DEEPGEMM_NEED_TMA_ALIGNED_SCALES:
-            hidden_states_scale = tma_align_input_scale(hidden_states_scale)
+            if not use_sm90_mxfp8:
+                hidden_states_scale = tma_align_input_scale(hidden_states_scale)
 
-        deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
-            (hidden_states, hidden_states_scale),
-            w13_weight_fp8,
-            gateup_output,
-            m_indices,
-            recipe_a=recipe_a,
-            recipe_b=recipe_b,
-        )
+        if use_sm90_mxfp8:
+            deep_gemm_wrapper.grouped_gemm_nt_mxfp8_f8f8bf16_contig(
+                (hidden_states, hidden_states_scale),
+                w13_weight_fp8,
+                gateup_output,
+                m_indices,
+                recipe_a=recipe_a,
+                recipe_b=recipe_b,
+            )
+        else:
+            deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
+                (hidden_states, hidden_states_scale),
+                w13_weight_fp8,
+                gateup_output,
+                m_indices,
+                recipe_a=recipe_a,
+                recipe_b=recipe_b,
+            )
 
         dispose_tensor(hidden_states)
         dispose_tensor(hidden_states_scale)
 
-        if envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get():
+        if self.use_fused_contiguous_activation:
             swiglu_limit_arg: Optional[float] = self.swiglu_limit
 
             down_input_fp8 = torch.empty(
@@ -243,51 +341,59 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 x_shape=(all_tokens, N // 2),
                 device=gateup_output.device,
                 group_size=scale_block_size,
-                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                column_major_scales=use_mxfp8_ue8m0_scales,
+                scale_tma_aligned=use_mxfp8_ue8m0_scales,
+                scale_ue8m0=use_mxfp8_ue8m0_scales,
             )
             silu_and_mul_contig_post_quant(
                 input=gateup_output,
                 output=down_input_fp8,
                 output_scale=down_input_scale,
                 quant_group_size=scale_block_size,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                transposed=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                scale_ue8m0=use_mxfp8_ue8m0_scales,
+                transposed=use_mxfp8_ue8m0_scales,
                 swiglu_limit=swiglu_limit_arg,
                 swizzle=self.use_swizzle,
             )
             del gateup_output
         else:
-            # Hacky byte-equal fallback that reproduces the optimize-branch
-            # code path exactly: bf16 silu_and_mul then a separate per-token
-            # group fp8 quant. Kept behind the mega-moe-memory flag.
+            # Use the unfused path for activation variants that the contiguous
+            # JIT activation does not support, then quantize in a separate pass.
             from sglang.kernels.ops.quantization.fp8_kernel import (
                 sglang_per_token_group_quant_fp8,
             )
 
-            if self.swiglu_limit is not None:
-                gateup_output = _apply_swiglu_limit(
-                    gateup_output, swiglu_limit=self.swiglu_limit
+            if self.use_sigmoid_alpha_swiglu:
+                down_input = _apply_gemm1_alpha_activation(
+                    gateup_output,
+                    gemm1_alpha=self.config.gemm1_alpha,
+                    gemm1_clamp_limit=self.config.gemm1_clamp_limit,
+                    gate_up_interleaved=self.config.gate_up_interleaved,
                 )
-
-            if not _is_musa:
-                down_input = torch.empty(
-                    (all_tokens, N // 2),
-                    device=gateup_output.device,
-                    dtype=torch.bfloat16,
-                )
-                _legacy_silu_and_mul(gateup_output.view(-1, N), down_input)
             else:
-                down_input = _silu_and_mul_musa(gateup_output.view(-1, N))
+                # Standard SwiGLU, optionally clamped by swiglu_limit.
+                if self.swiglu_limit is not None:
+                    gateup_output = _apply_swiglu_limit(
+                        gateup_output, swiglu_limit=self.swiglu_limit
+                    )
+
+                if not _is_musa:
+                    down_input = torch.empty(
+                        (all_tokens, N // 2),
+                        device=gateup_output.device,
+                        dtype=torch.bfloat16,
+                    )
+                    _legacy_silu_and_mul(gateup_output.view(-1, N), down_input)
+                else:
+                    down_input = _silu_and_mul_musa(gateup_output.view(-1, N))
             del gateup_output
 
             down_input_fp8, down_input_scale = sglang_per_token_group_quant_fp8(
                 down_input,
                 scale_block_size,
-                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                column_major_scales=use_mxfp8_ue8m0_scales,
+                scale_tma_aligned=use_mxfp8_ue8m0_scales,
+                scale_ue8m0=use_mxfp8_ue8m0_scales,
             )
             del down_input
 
@@ -304,16 +410,44 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 dtype=torch.bfloat16,
             )
         if deep_gemm_wrapper.DEEPGEMM_NEED_TMA_ALIGNED_SCALES:
-            down_input_scale = tma_align_input_scale(down_input_scale)
+            if not use_sm90_mxfp8:
+                down_input_scale = tma_align_input_scale(down_input_scale)
+        if use_sm90_mxfp8 and down_input_scale.dtype == torch.float32:
+            import deep_gemm.utils.layout
 
-        deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
-            (down_input_fp8, down_input_scale),
-            w2_weight_fp8,
-            down_output,
-            m_indices,
-            recipe_a=recipe_a,
-            recipe_b=recipe_b,
-        )
+            down_input_scale = (
+                deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor(
+                    down_input_scale
+                )
+            )
+
+        recipe_a_down = (1, scale_block_size)
+        if use_sm90_mxfp8:
+            _assert_mxfp8_scale_matches_recipe(
+                down_input_scale,
+                down_input_fp8.shape[-1],
+                recipe_a_down,
+                "deep_gemm.py:_run_contiguous_gemm:down_input_scale",
+            )
+
+        if use_sm90_mxfp8:
+            deep_gemm_wrapper.grouped_gemm_nt_mxfp8_f8f8bf16_contig(
+                (down_input_fp8, down_input_scale),
+                w2_weight_fp8,
+                down_output,
+                m_indices,
+                recipe_a=recipe_a_down,
+                recipe_b=recipe_b,
+            )
+        else:
+            deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
+                (down_input_fp8, down_input_scale),
+                w2_weight_fp8,
+                down_output,
+                m_indices,
+                recipe_a=recipe_a,
+                recipe_b=recipe_b,
+            )
 
         return down_output
 
@@ -406,9 +540,17 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         hidden_states_device = running_state["hidden_states_device"]
 
         use_mxfp8 = quant_info.use_mxfp8
+        use_sm90_mxfp8 = _use_sm90_mxfp8_fp8_grouped_gemm(quant_info)
         scale_block_size = quant_info.block_shape[1] if quant_info.block_shape else 128
-
-        if use_mxfp8:
+        if use_sm90_mxfp8:
+            _, _, k_for_recipe = hidden_states.shape
+            gran_k_act = _infer_mxfp8_gran_k_from_scale(
+                hidden_states_scale,
+                k_for_recipe,
+                preferred_gran_k=running_state.get("mxfp8_act_gran_k"),
+            )
+            recipe_a, recipe_b = (1, gran_k_act), (1, scale_block_size)
+        elif use_mxfp8:
             recipe_b = tuple(quant_info.block_shape)
             # gran_k is set by the dispatch path (standard=block_shape[1], DeepEP-LL=128),
             # not inferable from K; inferring it silently mis-reads the activation scale.
@@ -429,7 +571,9 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             recipe_a, recipe_b = None, None
 
         # GroupGemm-0
-        if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+        if use_sm90_mxfp8:
+            pass
+        elif deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
             if hidden_states_scale.dtype != torch.int:
                 b, s_mn, s_k = hidden_states_scale.shape
                 assert (
@@ -448,15 +592,26 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         gateup_output = torch.empty(
             (num_groups, m, n), device=hidden_states_device, dtype=torch.bfloat16
         )
-        deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
-            (hidden_states, hidden_states_scale),
-            (w13_weight, w13_scale),
-            gateup_output,
-            masked_m,
-            expected_m,
-            recipe_a=recipe_a,
-            recipe_b=recipe_b,
-        )
+        if use_sm90_mxfp8:
+            deep_gemm_wrapper.grouped_gemm_nt_mxfp8_f8f8bf16_masked(
+                (hidden_states, hidden_states_scale),
+                (w13_weight, w13_scale),
+                gateup_output,
+                masked_m,
+                expected_m,
+                recipe_a=recipe_a,
+                recipe_b=recipe_b,
+            )
+        else:
+            deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
+                (hidden_states, hidden_states_scale),
+                (w13_weight, w13_scale),
+                gateup_output,
+                masked_m,
+                expected_m,
+                recipe_a=recipe_a,
+                recipe_b=recipe_b,
+            )
         dispose_tensor(hidden_states)
         dispose_tensor(hidden_states_scale)
 
@@ -492,7 +647,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             topk_ids_rs.shape[0]
             if (
                 use_mxfp8
-                and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+                and (deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or use_sm90_mxfp8)
                 and topk_ids_rs is not None
                 and "src2dst" in running_state
             )
@@ -503,6 +658,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             masked_m,
             group_size=scale_block_size,
             topk=self.config.top_k,
+            packed_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or use_sm90_mxfp8,
             swiglu_limit=swiglu_limit_arg,
             swizzle=self.use_swizzle,
             gemm1_alpha=self.config.gemm1_alpha,
@@ -520,21 +676,26 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         # GroupGemm-1
         n = w2_weight.shape[1]
 
-        if (
-            use_mxfp8
-            and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
-            and down_input_scale.dtype != torch.int32
-        ):
-            import deep_gemm.utils.layout
+        if use_sm90_mxfp8 or (use_mxfp8 and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0):
+            if down_input_scale.dtype == torch.float32:
+                import deep_gemm.utils.layout
 
-            down_input_scale = (
-                deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor(
-                    down_input_scale
+                down_input_scale = (
+                    deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor(
+                        down_input_scale
+                    )
                 )
-            )
         elif deep_gemm_wrapper.DEEPGEMM_NEED_TMA_ALIGNED_SCALES:
             down_input_scale = deep_gemm_wrapper.get_mn_major_tma_aligned_tensor(
                 down_input_scale
+            )
+
+        if use_mxfp8:
+            _assert_mxfp8_scale_matches_recipe(
+                down_input_scale,
+                down_input.shape[-1],
+                recipe_a_down,
+                "deep_gemm.py:_run_masked_gemm:down_input_scale",
             )
 
         with use_symmetric_memory(
@@ -547,6 +708,8 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         down_gemm_overlap_args = running_state.get("down_gemm_overlap_args", None)
         if down_gemm_overlap_args is None:
             gemm_overlap_args_dict = {}
+        elif use_sm90_mxfp8:
+            gemm_overlap_args_dict = {}
         else:
             down_gemm_overlap_args.start_event.record()
             max_block_n = (
@@ -557,16 +720,29 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 "max_block_n": max_block_n,
             }
 
-        deep_gemm_return_value = deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
-            (down_input, down_input_scale),
-            (w2_weight, w2_scale),
-            down_output,
-            masked_m,
-            expected_m,
-            recipe_a=recipe_a_down,
-            recipe_b=recipe_b,
-            **gemm_overlap_args_dict,
-        )
+        if use_sm90_mxfp8:
+            deep_gemm_return_value = (
+                deep_gemm_wrapper.grouped_gemm_nt_mxfp8_f8f8bf16_masked(
+                    (down_input, down_input_scale),
+                    (w2_weight, w2_scale),
+                    down_output,
+                    masked_m,
+                    expected_m,
+                    recipe_a=recipe_a_down,
+                    recipe_b=recipe_b,
+                )
+            )
+        else:
+            deep_gemm_return_value = deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
+                (down_input, down_input_scale),
+                (w2_weight, w2_scale),
+                down_output,
+                masked_m,
+                expected_m,
+                recipe_a=recipe_a_down,
+                recipe_b=recipe_b,
+                **gemm_overlap_args_dict,
+            )
         meta_overlap_args = running_state.get("meta_overlap_args", None)
         # Returns (block_m, threshold) only with down-gemm overlap, else None;
         # meta_overlap_args may be set without overlap, so guard the unpack.
@@ -824,6 +1000,10 @@ def pre_permute_deepep_normal_to_deep_gemm(
     hidden_states_device = hidden_states.device
     hidden_states_dtype = hidden_states.dtype
 
+    scale_ue8m0 = (
+        hidden_states_scale is not None and hidden_states_scale.dtype == torch.int32
+    )
+
     running_state["hidden_states_shape"] = hidden_states_shape
     running_state["hidden_states_device"] = hidden_states_device
     running_state["hidden_states_dtype"] = hidden_states_dtype
@@ -835,8 +1015,14 @@ def pre_permute_deepep_normal_to_deep_gemm(
         device=hidden_states.device,
         dtype=hidden_states.dtype,
     )
-    if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
-        # TODO check whether need `zeros`
+    is_fp8_input = (
+        hidden_states_scale is not None and hidden_states.dtype != torch.bfloat16
+    )
+    if is_fp8_input:
+        # ep_scatter only writes real routed tokens. Keep per-expert padded rows as
+        # zero activations so grouped GEMM never consumes uninitialized FP8 payloads.
+        input_tensor.zero_()
+    if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or scale_ue8m0:
         input_tensor_scale = torch.zeros(
             (ceil_div(K // 128, 4), all_tokens),
             device=hidden_states.device,
@@ -848,6 +1034,8 @@ def pre_permute_deepep_normal_to_deep_gemm(
             device=hidden_states.device,
             dtype=torch.float32,
         )
+        if is_fp8_input:
+            input_tensor_scale.zero_()
     m_indices = torch.empty(all_tokens, device=hidden_states.device, dtype=torch.int32)
     output_index = torch.empty_like(topk_ids)
 
@@ -874,7 +1062,13 @@ def pre_permute_deepep_normal_to_deep_gemm(
         input_tensor_scale,
         m_indices,
         output_index,
-        scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+        scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or scale_ue8m0,
+        quant_block_size=128,
+    )
+    valid_topk = topk_ids >= 0
+    m_indices.fill_(-1)
+    m_indices[output_index[valid_topk].to(torch.long)] = topk_ids[valid_topk].to(
+        torch.int32
     )
     dispose_tensor(hidden_states)
     if hidden_states_scale is not None:
@@ -924,6 +1118,7 @@ def _varlen_deep_gemm_silu_mul_quant(
     masked_m: Optional[torch.Tensor],
     group_size: int,
     topk: int,
+    packed_ue8m0: bool = False,
     swiglu_limit: Optional[float] = None,
     swizzle: bool = False,
     gemm1_alpha: Optional[float] = None,
@@ -953,7 +1148,7 @@ def _varlen_deep_gemm_silu_mul_quant(
             masked_m=masked_m,
             column_major_scales=True,
             scale_tma_aligned=True,
-            scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+            scale_ue8m0=packed_ue8m0,
             fuse_silu_and_mul=True,
             enable_v2=True,
         )
@@ -968,7 +1163,7 @@ def _varlen_deep_gemm_silu_mul_quant(
     # Fused UE8M0 pack needs 4 groups per packed int32 (the G%4 and D guards below).
     if (
         gemm1_alpha is not None
-        and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+        and packed_ue8m0
         and num_real_tokens is not None
         and G % 4 == 0
         and D % (group_size * 4) == 0
@@ -1013,7 +1208,6 @@ def _varlen_deep_gemm_silu_mul_quant(
         use_jit_ep_activation = False
 
     if use_jit_ep_activation:
-        packed_ue8m0 = deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
         down_input_scale = torch.empty(
             (E, G // 4, N) if packed_ue8m0 else (E, N, G),
             device=hidden_states_device,
@@ -1046,7 +1240,9 @@ def _varlen_deep_gemm_silu_mul_quant(
             assert (
                 not swizzle
             ), "SGLANG_OPT_FIX_MEGA_MOE_MEMORY requires SGLANG_OPT_USE_JIT_EP_ACTIVATION=True"
-        down_input_scale = torch.empty(
+        # Initialize skipped padding scales; invalid UE8M0 values can break the GEMM.
+        scale_factory = torch.ones if packed_ue8m0 else torch.empty
+        down_input_scale = scale_factory(
             (E, N, G),
             device=hidden_states_device,
             dtype=torch.float32,
@@ -1057,7 +1253,7 @@ def _varlen_deep_gemm_silu_mul_quant(
             down_input_scale,
             group_size,
             masked_m,
-            scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+            scale_ue8m0=packed_ue8m0,
             gemm1_alpha=gemm1_alpha or 0.0,
             gemm1_clamp_limit=gemm1_clamp_limit or 0.0,
         )

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -417,6 +417,14 @@ class _DeepEPDispatcherImplBase:
         self.quant_config = quant_config
         self.set_deepep_dispatcher_dtype()
 
+    def use_sm90_mxfp8_deepgemm(self) -> bool:
+        return (
+            self.use_fp8
+            and self.quant_config is not None
+            and self.quant_config.get("use_mxfp8", False)
+            and deep_gemm_wrapper.is_sm90_mxfp8_deepgemm_enabled()
+        )
+
     def set_deepep_dispatcher_dtype(self) -> None:
         self.deepep_output_dtype = get_deepep_output_dtype(self)
 
@@ -509,12 +517,15 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
         topk_ids = topk_ids.to(torch.int64)
         if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and self.use_fp8:
             # TODO hard code 128 block quant,use fp8 communication
+            use_ue8m0_scales = (
+                deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or self.use_sm90_mxfp8_deepgemm()
+            )
             hidden_states = sglang_per_token_group_quant_fp8(
                 hidden_states,
                 128,
-                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                column_major_scales=use_ue8m0_scales,
+                scale_tma_aligned=use_ue8m0_scales,
+                scale_ue8m0=use_ue8m0_scales,
             )
         previous_event = Buffer.capture() if self.async_finish else None
         return hidden_states, topk_ids, topk_weights, previous_event
@@ -729,16 +740,21 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         topk_weights: torch.Tensor,
     ):
         input_global_scale = self.quant_config.get("input_global_scale", None)
-
         # round_scale / use_ue8m0 are FP8-DeepGEMM specific; they cause DeepEP
         # to return int32-packed UE8M0 scales that don't feed the flashinfer
         # cutedsl kernel.
         fp8_deepgemm_scale_opts = (
             dict(
                 round_scale=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
+                and (
+                    deep_gemm_wrapper.DEEPGEMM_BLACKWELL
+                    or self.use_sm90_mxfp8_deepgemm()
+                ),
                 use_ue8m0=deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                and deep_gemm_wrapper.DEEPGEMM_BLACKWELL,
+                and (
+                    deep_gemm_wrapper.DEEPGEMM_BLACKWELL
+                    or self.use_sm90_mxfp8_deepgemm()
+                ),
             )
             if self.use_fp8
             else dict()

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -217,6 +217,30 @@ def cast_e2m1fn_to_e4m3fn(
     )
 
 
+def _infer_sm90_mxfp8_gran_k_from_scale(
+    scale: torch.Tensor,
+    k: int,
+    *,
+    preferred_gran_k: Optional[int] = None,
+) -> int:
+    def expected_last_dim(gran_k: int) -> int:
+        pack_factor = 4 if scale.dtype == torch.int32 else 1
+        return (k + gran_k * pack_factor - 1) // (gran_k * pack_factor)
+
+    candidates = (32, 128)
+    if preferred_gran_k in candidates and scale.shape[-1] == expected_last_dim(
+        preferred_gran_k
+    ):
+        return preferred_gran_k
+    for gran_k in candidates:
+        if scale.shape[-1] == expected_last_dim(gran_k):
+            return gran_k
+    raise RuntimeError(
+        "Unable to infer SM90 MXFP8 activation gran_k from scale shape: "
+        f"scale_dtype={scale.dtype}, scale_shape={tuple(scale.shape)}, K={k}."
+    )
+
+
 class Fp8Config(QuantizationConfig):
     """Config class for FP8."""
 
@@ -265,7 +289,7 @@ class Fp8Config(QuantizationConfig):
                 raise ValueError(
                     f"The block-wise quantization only supports dynamic activation scheme for now, but got {activation_scheme} activation scheme."
                 )
-        if self.use_mxfp8:
+        elif self.use_mxfp8:
             if weight_block_size is None:
                 weight_block_size = [1, 32]
             elif weight_block_size != [1, 32]:
@@ -286,6 +310,13 @@ class Fp8Config(QuantizationConfig):
             return 31
         if self.use_mxfp8 and _is_hip and _is_gfx95_supported:
             return 95
+        if (
+            self.use_mxfp8
+            and _is_cuda
+            and is_sm90_supported()
+            and get_moe_runner_backend().is_deep_gemm()
+        ):
+            return 90
         if self.use_mxfp8 and _mxfp8_to_block_fp8_required:
             return 94
 
@@ -448,11 +479,50 @@ class Fp8LinearMethod(LinearMethodBase):
         self.block_quant = (
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
-        self.convert_mxfp8_to_block = self.use_mxfp8 and _mxfp8_to_block_fp8_required
+        self.use_sm90_mxfp8_deepgemm_linear = False
+        self.convert_sm90_mxfp8_to_block = False
+        if self.use_mxfp8:
+            from sglang.srt.layers import deep_gemm_wrapper
+
+            use_sm90_mxfp8_deepgemm_linear = (
+                envs.SGLANG_OPT_USE_SM90_MXFP8_DEEPGEMM_LINEAR.get()
+            )
+            self.use_sm90_mxfp8_deepgemm_linear = (
+                deep_gemm_wrapper.is_sm90_mxfp8_deepgemm_enabled()
+                and use_sm90_mxfp8_deepgemm_linear
+            )
+            self.convert_sm90_mxfp8_to_block = (
+                _is_cuda
+                and is_sm90_supported()
+                and not is_sm100_supported()
+                and not use_sm90_mxfp8_deepgemm_linear
+            )
+            if (
+                _is_cuda
+                and is_sm90_supported()
+                and not is_sm100_supported()
+                and not self.use_sm90_mxfp8_deepgemm_linear
+                and use_sm90_mxfp8_deepgemm_linear
+            ):
+                raise RuntimeError(
+                    "SM90 MXFP8 dense linear requires DeepGEMM grouped MXFP8 APIs."
+                )
+        # gfx942 lacks dense MXFP8 matmul support. When custom DeepGEMM MXFP8
+        # dense linear is disabled on SM90, convert dense MXFP8 to block-fp8
+        # [128,128] at load and run native block-fp8 kernels.
+        self.convert_mxfp8_to_block = (
+            self.use_mxfp8
+            and (_mxfp8_to_block_fp8_required or self.convert_sm90_mxfp8_to_block)
+            and not self.use_sm90_mxfp8_deepgemm_linear
+        )
+        # Effective per-instance block size for the apply path. Defaults to the
+        # config value; conversion overrides it to [128,128].
         self.weight_block_size = self.quant_config.weight_block_size
         self.w8a8_block_fp8_linear = None
         self.w8a8_mxfp8_linear = None
-        if self.use_mxfp8 and not self.convert_mxfp8_to_block:
+        if self.use_sm90_mxfp8_deepgemm_linear:
+            pass
+        elif self.use_mxfp8 and not self.convert_mxfp8_to_block:
             self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear()
         else:
             self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
@@ -602,6 +672,8 @@ class Fp8LinearMethod(LinearMethodBase):
                 layer.register_parameter("input_scale", None)
 
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
+        # Convert dense MXFP8 (e4m3fn + 1x32 UE8M0) to block-fp8 [128,128]
+        # when no direct MXFP8 path is available.
         if self.convert_mxfp8_to_block:
             from sglang.srt.layers.quantization.mxfp8_block_convert import (
                 convert_mxfp8_weight_to_block_fp8,
@@ -625,6 +697,9 @@ class Fp8LinearMethod(LinearMethodBase):
             # Keep parameter object to preserve weight_loader attrs for hot reload.
             layer.weight_scale_inv.requires_grad_(False)
             layer.weight_scale_inv.format_ue8m0 = True
+            if self.use_sm90_mxfp8_deepgemm_linear:
+                layer.weight_scale_inv.data = layer.weight_scale_inv.data.contiguous()
+                return
             self._process_mxfp8_linear_weight_scale(layer)
             return
         # If ROCm, normalize the weights and scales to e4m3fnuz
@@ -891,6 +966,71 @@ class Fp8LinearMethod(LinearMethodBase):
             # Activations not quantized for marlin.
             del layer.input_scale
 
+    def _apply_sm90_mxfp8_deepgemm_linear(
+        self,
+        layer: torch.nn.Module,
+        x: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        from sglang.srt.layers import deep_gemm_wrapper
+
+        if isinstance(x, tuple):
+            x_data, x_scale = x
+            output_shape = (*x_data.shape[:-1], layer.weight.shape[0])
+            x_2d = x_data.reshape(-1, x_data.shape[-1]).contiguous()
+            x_scale_2d = x_scale.reshape(x_2d.shape[0], -1)
+            if x_scale_2d.dtype != torch.int32:
+                x_scale_2d = x_scale_2d.contiguous()
+        else:
+            output_shape = (*x.shape[:-1], layer.weight.shape[0])
+            x_2d = x.reshape(-1, x.shape[-1]).contiguous()
+            x_2d, x_scale_2d = mxfp8_group_quantize(x_2d)
+
+        m = x_2d.shape[0]
+        n = layer.weight.shape[0]
+        k = x_2d.shape[-1]
+        out = torch.empty((m, n), device=x_2d.device, dtype=torch.bfloat16)
+        if m == 0:
+            return out.reshape(output_shape)
+
+        weight = layer.weight.unsqueeze(0)
+        weight_scale = layer.weight_scale_inv.unsqueeze(0)
+        recipe_a = (1, _infer_sm90_mxfp8_gran_k_from_scale(x_scale_2d, k))
+        recipe_b = (1, _infer_sm90_mxfp8_gran_k_from_scale(weight_scale, k))
+
+        padded_m = ((m + 127) // 128) * 128
+        if padded_m == m:
+            kernel_x = x_2d
+            kernel_scale = x_scale_2d
+            kernel_out = out
+        else:
+            kernel_x = torch.zeros((padded_m, k), device=x_2d.device, dtype=x_2d.dtype)
+            kernel_x[:m] = x_2d
+            kernel_scale = torch.zeros(
+                (padded_m, x_scale_2d.shape[-1]),
+                device=x_scale_2d.device,
+                dtype=x_scale_2d.dtype,
+            )
+            kernel_scale[:m] = x_scale_2d
+            kernel_out = torch.empty((padded_m, n), device=out.device, dtype=out.dtype)
+
+        m_indices = torch.full((padded_m,), -1, device=x_2d.device, dtype=torch.int32)
+        m_indices[:m] = 0
+        deep_gemm_wrapper.grouped_gemm_nt_mxfp8_f8f8bf16_contig(
+            (kernel_x, kernel_scale),
+            (weight, weight_scale),
+            kernel_out,
+            m_indices,
+            recipe_a=recipe_a,
+            recipe_b=recipe_b,
+        )
+        if kernel_out is not out:
+            out.copy_(kernel_out[:m])
+
+        if bias is not None:
+            out = out + bias
+        return out.reshape(output_shape)
+
     def apply(
         self,
         layer: torch.nn.Module,
@@ -910,6 +1050,8 @@ class Fp8LinearMethod(LinearMethodBase):
 
         if self.use_mxfp8:
             backend = get_fp8_gemm_runner_backend()
+            if self.use_sm90_mxfp8_deepgemm_linear:
+                return self._apply_sm90_mxfp8_deepgemm_linear(layer, x, bias)
             if backend.is_flashinfer_cutlass():
                 weight_scale = layer.weight_scale_inv_swizzled
             elif backend.is_flashinfer_trtllm():
@@ -1625,11 +1767,19 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
     def _process_mxfp8_moe_weights(self, layer: Module, quantize: bool = True) -> None:
 
+        use_sm90_deepgemm_mxfp8 = (
+            _is_cuda
+            and is_sm90_supported()
+            and not is_sm100_supported()
+            and get_moe_runner_backend().is_deep_gemm()
+        )
         if not (
-            (_is_cuda and is_sm100_supported()) or (_is_hip and _is_gfx95_supported)
+            (_is_cuda and is_sm100_supported())
+            or use_sm90_deepgemm_mxfp8
+            or (_is_hip and _is_gfx95_supported)
         ):
             raise RuntimeError(
-                "MXFP8 MoE quantization requires SM100 or ROCm gfx95 "
+                "MXFP8 MoE quantization requires SM100, SM90+DeepGEMM, or ROCm gfx95 "
                 "(gfx942 converts MXFP8 to block-fp8 at load instead)."
             )
 
@@ -1735,6 +1885,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
 
         def _quantize_for_deepgemm(weight: torch.Tensor):
+            """Quantize weights to MXFP8 scales consumed by the active DeepGEMM API."""
             weight = weight.contiguous()
             num_experts, m, k = weight.shape
             assert k % 32 == 0, f"{k=} must be divisible by 32 for MXFP8"
@@ -1742,6 +1893,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             weight_flat = weight.view(-1, k).contiguous()
             qweight, scale_u8 = mxfp8_group_quantize(weight_flat)
             qweight = qweight.view_as(weight)
+            if use_sm90_deepgemm_mxfp8:
+                return qweight, scale_u8.view(num_experts, m, k // 32)
             scale_fp32 = _ue8m0_to_fp32(scale_u8).view(num_experts, m, k // 32)
             scale_packed = _pack_moe_scale_for_deepgemm(scale_fp32)
             return qweight, scale_packed
@@ -1765,7 +1918,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         def _convert_ue8m0_scales_for_deepgemm(
             scale_u8: torch.Tensor, shape: tuple
         ) -> torch.Tensor:
+            """Convert checkpoint UE8M0 scales to the active DeepGEMM scale layout."""
             num_experts, m, k_groups = shape[0], shape[1], scale_u8.shape[-1]
+            scale_u8 = scale_u8.contiguous().view(num_experts, m, k_groups)
+            if use_sm90_deepgemm_mxfp8:
+                return scale_u8
             scale_fp32 = _ue8m0_to_fp32(scale_u8.contiguous().view(-1)).view(
                 num_experts, m, k_groups
             )
@@ -2019,7 +2176,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 align_fp8_moe_weights_for_flashinfer_trtllm(layer)
 
         if hasattr(layer, "dispatcher"):
-            layer.dispatcher.set_quant_config({"weight_dtype": layer.w13_weight.dtype})
+            layer.dispatcher.set_quant_config(
+                {
+                    "weight_dtype": layer.w13_weight.dtype,
+                    "use_mxfp8": self.use_mxfp8,
+                    "weight_block_size": self.quant_config.weight_block_size,
+                }
+            )
 
     def process_weights_hip_int4(self, layer: Module):
         # TODO: _use_aiter: add after triton kernel added

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -1274,11 +1274,18 @@ class MiniMaxM3DecoderLayer(nn.Module):
             forward_batch
         )
 
-        if self.is_layer_sparse or hidden_states.shape[0] != 0:
+        if self.is_layer_sparse:
             hidden_states = self.mlp(
                 hidden_states,
-                should_allreduce_fusion,
-                use_reduce_scatter,
+                forward_batch=forward_batch,
+                should_allreduce_fusion=should_allreduce_fusion,
+                use_reduce_scatter=use_reduce_scatter,
+            )
+        elif hidden_states.shape[0] != 0:
+            hidden_states = self.mlp(
+                hidden_states,
+                should_allreduce_fusion=should_allreduce_fusion,
+                use_reduce_scatter=use_reduce_scatter,
             )
 
         if should_allreduce_fusion:

--- a/test/registered/jit/test_deepgemm_sm90_mxfp8_fp8.py
+++ b/test/registered/jit/test_deepgemm_sm90_mxfp8_fp8.py
@@ -1,0 +1,309 @@
+from unittest.mock import patch
+
+import pytest
+import torch
+from torch import nn
+
+from sglang.srt.layers import deep_gemm_wrapper
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+def _require_sm90_mxfp8_grouped_gemm() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for SM90 MXFP8 grouped GEMM tests")
+    major, _ = torch.cuda.get_device_capability()
+    if major != 9:
+        pytest.skip(f"SM90 MXFP8 grouped GEMM tests require sm_90, got sm_{major}x")
+    if not deep_gemm_wrapper.supports_sm90_mxfp8_fp8_grouped_gemm():
+        pytest.skip("deep_gemm does not expose SM90 MXFP8 grouped GEMM APIs")
+
+
+def _calc_diff(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    sim = 2 * (x * y).sum() / denominator
+    return 1 - sim
+
+
+def _cast_back_from_fp8_1d(
+    x: torch.Tensor, sf: torch.Tensor, gran_k: int
+) -> torch.Tensor:
+    group_idx = torch.arange(x.size(-1), device=x.device) // gran_k
+    return x.float() * sf[..., group_idx]
+
+
+def _e8m0_from_fp32_pow2(sf: torch.Tensor) -> torch.Tensor:
+    return ((sf.view(torch.int32) >> 23) & 0xFF).to(torch.uint8)
+
+
+def _e8m0_to_fp32(sf: torch.Tensor) -> torch.Tensor:
+    return (sf.to(torch.int32) << 23).view(torch.float32)
+
+
+def _pack_ue8m0_u8_to_i32(sf: torch.Tensor) -> torch.Tensor:
+    padded_k = ((sf.shape[-1] + 3) // 4) * 4
+    if padded_k != sf.shape[-1]:
+        padded = torch.zeros(
+            (*sf.shape[:-1], padded_k), device=sf.device, dtype=torch.uint8
+        )
+        padded[..., : sf.shape[-1]] = sf
+        sf = padded
+    sf_i32 = sf.to(torch.int32).reshape(*sf.shape[:-1], sf.shape[-1] // 4, 4)
+    return (
+        sf_i32[..., 0]
+        | (sf_i32[..., 1] << 8)
+        | (sf_i32[..., 2] << 16)
+        | (sf_i32[..., 3] << 24)
+    ).contiguous()
+
+
+def _unpack_ue8m0_i32_to_u8(sf: torch.Tensor) -> torch.Tensor:
+    sf_i32 = sf.to(torch.int32)
+    return torch.stack(
+        [
+            torch.bitwise_and(torch.bitwise_right_shift(sf_i32, shift), 0xFF).to(
+                torch.uint8
+            )
+            for shift in (0, 8, 16, 24)
+        ],
+        dim=-1,
+    ).reshape(*sf.shape[:-1], sf.shape[-1] * 4)
+
+
+def test_sm90_mxfp8_e8m0_rounding_helpers_match():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for SM90 MXFP8 rounding helper test")
+
+    from sglang.srt.layers.deep_gemm_wrapper.entrypoint import _e8m0_fp32_to_u8
+    from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+        _cast_to_e8m0_with_rounding_up,
+    )
+
+    torch.manual_seed(0)
+    random_values = torch.exp2(
+        torch.empty((2, 3, 8), device="cuda", dtype=torch.float32).uniform_(-20, 20)
+    )
+    edge_values = torch.tensor(
+        [
+            0.0,
+            torch.finfo(torch.float32).tiny / 2,
+            torch.finfo(torch.float32).tiny,
+            1.0,
+            1.0 + 2**-24,
+            1.0 + 2**-10,
+            448.0,
+            57344.0,
+        ],
+        device="cuda",
+        dtype=torch.float32,
+    ).reshape(1, 1, 8)
+    sf = torch.cat([random_values, edge_values.expand(2, 1, 8)], dim=1)
+
+    expected = _e8m0_fp32_to_u8(sf)
+    packed = _cast_to_e8m0_with_rounding_up(sf)
+    actual = _unpack_ue8m0_i32_to_u8(packed)[..., : sf.shape[-1]]
+
+    assert torch.equal(actual, expected)
+
+
+def test_ue8m0_scale_layout_isolated_between_sm90_and_sm100():
+    _require_sm90_mxfp8_grouped_gemm()
+
+    from sglang.kernels.ops.quantization import fp8_kernel
+
+    sf = torch.ones((17, 8), device="cuda", dtype=torch.float32)
+    kwargs = dict(num_groups=None, mn=17, k=1024, group_size=128)
+
+    sm90_scale = fp8_kernel._format_ue8m0_scale_for_deepgemm(sf, **kwargs)
+    assert sm90_scale.dtype == torch.int32
+    assert sm90_scale.shape == (17, 2)
+
+    with (
+        patch.object(fp8_kernel, "_is_sm90_supported", False),
+        patch.object(fp8_kernel, "_is_sm100_supported", True),
+    ):
+        sm100_scale = fp8_kernel._format_ue8m0_scale_for_deepgemm(sf, **kwargs)
+
+    assert sm100_scale.dtype == torch.float32
+    assert sm100_scale.shape == sf.shape
+
+
+def test_sm90_mxfp8_grouped_contiguous_wrapper_accuracy():
+    _require_sm90_mxfp8_grouped_gemm()
+
+    from deep_gemm.utils.math import per_token_cast_to_fp8
+
+    groups, m_per_group, n, k = 2, 128, 48, 512
+    m = groups * m_per_group
+    a_ref = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    b_ref = torch.randn((groups, n, k), device="cuda", dtype=torch.bfloat16)
+
+    a_data, a_sf_fp32 = per_token_cast_to_fp8(a_ref, use_ue8m0=True, gran_k=128)
+    a = (a_data, _pack_ue8m0_u8_to_i32(_e8m0_from_fp32_pow2(a_sf_fp32)))
+    b_data = torch.empty((groups, n, k), device="cuda", dtype=torch.float8_e4m3fn)
+    b_sf_fp32 = torch.empty((groups, n, k // 32), device="cuda", dtype=torch.float32)
+    for group_id in range(groups):
+        b_data[group_id], b_sf_fp32[group_id] = per_token_cast_to_fp8(
+            b_ref[group_id], use_ue8m0=True, gran_k=32
+        )
+
+    grouped_layout = torch.arange(groups, device="cuda", dtype=torch.int32)
+    grouped_layout = grouped_layout.repeat_interleave(m_per_group)
+    d = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+    deep_gemm_wrapper.grouped_gemm_nt_mxfp8_f8f8bf16_contig(
+        a,
+        (b_data, _e8m0_from_fp32_pow2(b_sf_fp32)),
+        d,
+        grouped_layout,
+        recipe_a=(1, 128),
+        recipe_b=(1, 32),
+    )
+
+    a_dequant = _cast_back_from_fp8_1d(a_data, a_sf_fp32, gran_k=128)
+    ref = torch.empty_like(d)
+    for group_id in range(groups):
+        start = group_id * m_per_group
+        end = start + m_per_group
+        b_dequant = _cast_back_from_fp8_1d(
+            b_data[group_id], b_sf_fp32[group_id], gran_k=32
+        )
+        ref[start:end] = (a_dequant[start:end] @ b_dequant.t()).to(torch.bfloat16)
+
+    assert _calc_diff(d, ref) < 0.03
+
+
+def test_sm90_mxfp8_grouped_masked_wrapper_accuracy():
+    _require_sm90_mxfp8_grouped_gemm()
+
+    from deep_gemm.utils.math import per_token_cast_to_fp8
+
+    groups, max_m, n, k = 2, 32, 48, 512
+    masked_m = torch.tensor([7, 19], device="cuda", dtype=torch.int32)
+    a_ref = torch.randn((groups, max_m, k), device="cuda", dtype=torch.bfloat16)
+    b_ref = torch.randn((groups, n, k), device="cuda", dtype=torch.bfloat16)
+
+    a_data = torch.empty((groups, max_m, k), device="cuda", dtype=torch.float8_e4m3fn)
+    a_sf_fp32 = torch.empty(
+        (groups, max_m, k // 128), device="cuda", dtype=torch.float32
+    )
+    b_data = torch.empty((groups, n, k), device="cuda", dtype=torch.float8_e4m3fn)
+    b_sf_fp32 = torch.empty((groups, n, k // 32), device="cuda", dtype=torch.float32)
+    for group_id in range(groups):
+        a_data[group_id], a_sf_fp32[group_id] = per_token_cast_to_fp8(
+            a_ref[group_id], use_ue8m0=True, gran_k=128
+        )
+        b_data[group_id], b_sf_fp32[group_id] = per_token_cast_to_fp8(
+            b_ref[group_id], use_ue8m0=True, gran_k=32
+        )
+
+    d = torch.empty((groups, max_m, n), device="cuda", dtype=torch.bfloat16)
+    deep_gemm_wrapper.grouped_gemm_nt_mxfp8_f8f8bf16_masked(
+        (a_data, _pack_ue8m0_u8_to_i32(_e8m0_from_fp32_pow2(a_sf_fp32))),
+        (b_data, _e8m0_from_fp32_pow2(b_sf_fp32)),
+        d,
+        masked_m,
+        expected_m=max_m,
+        recipe_a=(1, 128),
+        recipe_b=(1, 32),
+    )
+
+    a_dequant = _cast_back_from_fp8_1d(a_data, a_sf_fp32, gran_k=128)
+    ref = torch.zeros_like(d)
+    for group_id, valid_m in enumerate(masked_m.tolist()):
+        b_dequant = _cast_back_from_fp8_1d(
+            b_data[group_id], b_sf_fp32[group_id], gran_k=32
+        )
+        ref[group_id, :valid_m] = (a_dequant[group_id, :valid_m] @ b_dequant.t()).to(
+            torch.bfloat16
+        )
+
+    diff = max(
+        _calc_diff(d[group_id, :valid_m], ref[group_id, :valid_m])
+        for group_id, valid_m in enumerate(masked_m.tolist())
+    )
+    assert diff < 0.03
+
+
+@pytest.mark.parametrize("m", [1, 7, 32, 181, 128])
+def test_sm90_mxfp8_dense_linear_uses_grouped_kernel_accuracy(m):
+    _require_sm90_mxfp8_grouped_gemm()
+
+    from deep_gemm.utils.math import per_token_cast_to_fp8
+
+    from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+    from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
+
+    n, k = 48, 128
+    x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    w_ref = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    w_data, w_sf_fp32 = per_token_cast_to_fp8(w_ref, use_ue8m0=True, gran_k=32)
+
+    layer = nn.Module()
+    layer.weight = nn.Parameter(w_data, requires_grad=False)
+    layer.weight_scale_inv = nn.Parameter(
+        _e8m0_from_fp32_pow2(w_sf_fp32), requires_grad=False
+    )
+
+    config = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        weight_block_size=[1, 32],
+        use_mxfp8=True,
+    )
+    quant_method = Fp8LinearMethod(config)
+    assert quant_method.use_sm90_mxfp8_deepgemm_linear
+
+    out = quant_method.apply(layer, x)
+
+    x_data, x_sf_u8 = mxfp8_group_quantize(x.contiguous())
+    x_dequant = _cast_back_from_fp8_1d(x_data, _e8m0_to_fp32(x_sf_u8), gran_k=32)
+    w_dequant = _cast_back_from_fp8_1d(w_data, w_sf_fp32, gran_k=32)
+    ref = (x_dequant @ w_dequant.t()).to(torch.bfloat16)
+
+    assert _calc_diff(out, ref) < 0.03
+
+
+@pytest.mark.parametrize("m,n,k", [(65, 256, 7168), (181, 128, 7168)])
+def test_sm90_mxfp8_dense_linear_contig_tail_large_k_accuracy(m, n, k):
+    _require_sm90_mxfp8_grouped_gemm()
+
+    from deep_gemm.utils.math import per_token_cast_to_fp8
+
+    from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+    from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
+
+    torch.manual_seed(0)
+    x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    w_ref = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    w_data, w_sf_fp32 = per_token_cast_to_fp8(w_ref, use_ue8m0=True, gran_k=32)
+
+    layer = nn.Module()
+    layer.weight = nn.Parameter(w_data, requires_grad=False)
+    layer.weight_scale_inv = nn.Parameter(
+        _e8m0_from_fp32_pow2(w_sf_fp32), requires_grad=False
+    )
+
+    config = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        weight_block_size=[1, 32],
+        use_mxfp8=True,
+    )
+    quant_method = Fp8LinearMethod(config)
+    assert quant_method.use_sm90_mxfp8_deepgemm_linear
+    assert m % 128 != 0
+
+    out = quant_method.apply(layer, x)
+
+    x_data, x_sf_u8 = mxfp8_group_quantize(x.contiguous())
+    x_dequant = _cast_back_from_fp8_1d(x_data, _e8m0_to_fp32(x_sf_u8), gran_k=32)
+    w_dequant = _cast_back_from_fp8_1d(w_data, w_sf_fp32, gran_k=32)
+    ref = (x_dequant @ w_dequant.t()).to(torch.bfloat16)
+
+    assert _calc_diff(out, ref) < 0.03
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/unit/layers/moe/test_deep_gemm_runner.py
+++ b/test/registered/unit/layers/moe/test_deep_gemm_runner.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+    DeepGemmRunnerCore,
+    _apply_gemm1_alpha_activation,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDeepGemmRunnerActivation(CustomTestCase):
+    @patch(
+        "sglang.srt.layers.moe.moe_runner.deep_gemm.envs."
+        "SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get",
+        return_value=True,
+    )
+    def test_gemm1_alpha_disables_incompatible_fused_activation(self, _get_flag):
+        runner = DeepGemmRunnerCore(
+            MoeRunnerConfig(
+                activation="silu",
+                is_gated=True,
+                gemm1_alpha=1.702,
+                gemm1_clamp_limit=7.0,
+            )
+        )
+
+        self.assertTrue(runner.use_sigmoid_alpha_swiglu)
+        self.assertFalse(runner.use_fused_contiguous_activation)
+
+    def test_gemm1_alpha_rejects_standard_swiglu_limit(self):
+        config = MoeRunnerConfig(
+            activation="silu",
+            is_gated=True,
+            gemm1_alpha=1.702,
+            swiglu_limit=7.0,
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError, "Only one activation variant can be configured"
+        ):
+            DeepGemmRunnerCore(config)
+
+    def test_non_interleaved_gemm1_alpha_activation(self):
+        gate = torch.tensor([[8.0, -2.0]])
+        up = torch.tensor([[9.0, -9.0]])
+        gateup = torch.cat([gate, up], dim=-1)
+
+        actual = _apply_gemm1_alpha_activation(
+            gateup,
+            gemm1_alpha=1.702,
+            gemm1_clamp_limit=7.0,
+            gate_up_interleaved=False,
+        )
+        clamped_gate = gate.clamp(max=7.0)
+        clamped_up = up.clamp(min=-7.0, max=7.0)
+        expected = (
+            clamped_gate * torch.sigmoid(clamped_gate * 1.702) * (clamped_up + 1.0)
+        )
+
+        torch.testing.assert_close(actual, expected)
+
+    def test_interleaved_gemm1_alpha_activation(self):
+        gateup = torch.tensor([[8.0, 9.0, -2.0, -9.0]])
+
+        actual = _apply_gemm1_alpha_activation(
+            gateup,
+            gemm1_alpha=1.702,
+            gemm1_clamp_limit=7.0,
+            gate_up_interleaved=True,
+        )
+        gate = gateup[..., ::2].clamp(max=7.0)
+        up = gateup[..., 1::2].clamp(min=-7.0, max=7.0)
+        expected = gate * torch.sigmoid(gate * 1.702) * (up + 1.0)
+
+        torch.testing.assert_close(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_minimax_m3_config.py
+++ b/test/registered/unit/models/test_minimax_m3_config.py
@@ -1,0 +1,90 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+
+from sglang.srt.models.minimax_m3 import MiniMaxM3DecoderLayer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestMiniMaxM3DecoderLayer(CustomTestCase):
+    def _make_layer(self, *, is_sparse, hidden_states, mlp_output):
+        layer = MiniMaxM3DecoderLayer.__new__(MiniMaxM3DecoderLayer)
+        nn.Module.__init__(layer)
+        layer.layer_id = 0
+        layer.is_layer_sparse = is_sparse
+        layer.self_attn = SimpleNamespace(is_sparse_attention_layer=False)
+        layer.mlp = MagicMock(return_value=mlp_output)
+        communicator = MagicMock()
+        communicator.prepare_attn_and_capture_last_layer_outputs.return_value = (
+            hidden_states,
+            None,
+        )
+        communicator.prepare_mlp.return_value = (hidden_states, None)
+        communicator.should_fuse_mlp_allreduce_with_next_layer.return_value = False
+        communicator.should_use_reduce_scatter.return_value = True
+        communicator.postprocess_layer.return_value = (mlp_output, None)
+        layer.layer_communicator = communicator
+        return layer
+
+    @patch("sglang.srt.models.minimax_m3.get_parallel")
+    def test_sparse_mlp_receives_forward_batch(self, get_parallel):
+        get_parallel.return_value = SimpleNamespace(tp_size=1)
+        hidden_states = torch.empty((0, 4))
+        mlp_output = torch.empty_like(hidden_states)
+        forward_batch = SimpleNamespace(num_token_non_padded=0)
+        layer = self._make_layer(
+            is_sparse=True,
+            hidden_states=hidden_states,
+            mlp_output=mlp_output,
+        )
+
+        layer(
+            positions=torch.empty(0),
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            residual=None,
+        )
+
+        layer.mlp.assert_called_once_with(
+            hidden_states,
+            forward_batch=forward_batch,
+            should_allreduce_fusion=False,
+            use_reduce_scatter=True,
+        )
+
+    @patch("sglang.srt.models.minimax_m3.get_parallel")
+    def test_dense_mlp_keeps_dense_signature(self, get_parallel):
+        get_parallel.return_value = SimpleNamespace(tp_size=1)
+        hidden_states = torch.empty((1, 4))
+        mlp_output = torch.empty_like(hidden_states)
+        forward_batch = SimpleNamespace(num_token_non_padded=1)
+        layer = self._make_layer(
+            is_sparse=False,
+            hidden_states=hidden_states,
+            mlp_output=mlp_output,
+        )
+        layer.self_attn = MagicMock(return_value=hidden_states)
+        layer.self_attn.is_sparse_attention_layer = False
+
+        layer(
+            positions=torch.empty(1),
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            residual=None,
+        )
+
+        layer.mlp.assert_called_once_with(
+            hidden_states,
+            should_allreduce_fusion=False,
+            use_reduce_scatter=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -338,6 +338,30 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self.assertTrue(flags.enable_tf32_matmul)
         self.assertFalse(flags.enable_multi_layer_eagle)  # pristine materialize
 
+    def test_minimax_m3_sm90_mxfp8_defaults_to_deep_gemm(self):
+        from sglang.srt.arg_groups.overrides import _minimax_m3_overrides
+
+        server_args = SimpleNamespace(
+            quantization="mxfp8",
+            _quantization_explicitly_unset=False,
+            attention_backend=None,
+            page_size=None,
+            moe_runner_backend="auto",
+            is_attention_backend_not_set=lambda: True,
+        )
+        hf_config = SimpleNamespace(quantization_config={"quant_method": "mxfp8"})
+
+        with (
+            patch.object(overrides_module, "is_hip", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm90_supported", return_value=True),
+        ):
+            declarations = _minimax_m3_overrides(server_args, hf_config)
+
+        self.assertEqual(declarations["attention_backend"], "fa3")
+        self.assertEqual(declarations["page_size"], 128)
+        self.assertEqual(declarations["moe_runner_backend"], "deep_gemm")
+
     def test_mimo_v2_declarations(self):
         # Callable-level golden: MiMoV2 archs are hybrid (config-shape heavy),
         # so the declaration is pinned directly for both provider inputs.


### PR DESCRIPTION
Add SM90 MXFP8 inference support for MiniMax-M3 by wiring DeepGEMM's Hopper MXFP8 grouped GEMM APIs into SGLang's dense linear, MoE, DeepEP, quantization, and JIT warmup paths.

Dependency: [deepseek-ai/DeepGEMM#362](https://github.com/deepseek-ai/DeepGEMM/pull/362)

Co-authored-by: [zhangxiaolei123456](https://github.com/zhangxiaolei123456)

> [!WARNING]
> The current H20 MXFP8 operators are slower than BF16.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

SGLang does not currently have a MiniMax-M3 MXFP8 execution path for Hopper/SM90. This PR enables it through DeepGEMM grouped MXFP8 kernels, supporting the model's K128 activation scales, K32 weight scales, and DeepEP packed UE8M0 layout.


## Modifications

- Add SM90 DeepGEMM MXFP8 grouped contiguous/masked wrappers and JIT warmup.
- Route MiniMax-M3 MXFP8 dense linear and MoE paths through DeepGEMM.
- Support K32/K128 UE8M0 scale recipes and DeepEP packed scale layouts.
- Add MiniMax-M3 sigmoid-alpha SwiGLU handling and SM90 backend defaults.
- Add JIT and unit coverage for the new execution path.

## Accuracy Tests

The initial GSM8K, MMLU, and LongBench-v2 validation used 8 x NVIDIA H20 96 GB with TP8/DeepEP EP8, SGLang, and DeepGEMM `2.5.0+b343627`. The final GPQA comparison used 2 nodes with 8 x H20 per node and TP16. Initial MXFP8 service command:

```bash
GLOO_SOCKET_IFNAME=eth0 \
NCCL_MIN_NCHANNELS=24 \
NCCL_IB_QPS_PER_CONNECTION=8 \
sglang serve \
  --trust-remote-code \
  --model-path /path/to/MiniMax-M3-MXFP8 \
  --tp 8 \
  --cuda-graph-max-bs 256 \
  --max-running-requests 256 \
  --enable-metrics \
  --host 0.0.0.0 \
  --port 30300 \
  --mem-fraction-static 0.85 \
  --reasoning-parser auto \
  --tool-call-parser auto \
  --moe-runner-backend deep_gemm \
  --moe-a2a-backend deepep
```

MiniMax-M3 prefill CUDA graphs are disabled on Hopper by the model override. DeepEP used its default 20 communication SMs.

All evaluations used deterministic sampling with `temperature=0`, `top_p=1`, and identical datasets for the compared runs. The initial evaluations used 512 client threads; the final GPQA comparison used 198. The commands below use the following common variables:

```bash
MODEL=/path/to/MiniMax-M3-MXFP8
DATA=/path/to/datasets
COMMON_ARGS=(
  --host 127.0.0.1
  --port 30300
  --model "${MODEL}"
  --temperature 0
  --top-p 1
)
```

### GSM8K

```bash
OPENAI_API_KEY=EMPTY python -u -m sglang.test.run_eval \
  "${COMMON_ARGS[@]}" \
  --eval-name gsm8k \
  --num-examples 5000 \
  --num-threads 512 \
  --max-tokens 2048 \
  --num-shots 5 \
  --gsm8k-data-path "${DATA}/gsm8k_test.jsonl"
```

```text
Dataset: GSM8K
Examples: 1314 effective / 5000 requested
Score: 0.968037
Latency: 450.792 s
Output throughput: 717.308 tok/s
```

### MMLU

`run_eval_local_data.py` redirects the standard evaluator to the fixed local MMLU and GPQA files used by both precision runs.

```bash
OPENAI_API_KEY=EMPTY python -u scripts/run_eval_local_data.py \
  --local-dataset-dir "${DATA}" \
  "${COMMON_ARGS[@]}" \
  --eval-name mmlu \
  --num-examples 1000 \
  --num-threads 512 \
  --max-tokens 2048
```

```text
Dataset: MMLU
Examples: 1000
Score: 0.816000
Latency: 845.344 s
Output throughput: 943.797 tok/s
```

### GPQA

The final GPQA comparison used the same two-node TP16 topology, prompts, `random_seed=0`, deterministic inference mode, FA3 attention, and disabled prefill CUDA graphs. BF16 used Triton/EP1; MXFP8 used DeepGEMM/DeepEP EP16.

```bash
OPENAI_API_KEY=EMPTY python -u scripts/run_eval_local_data.py \
  --local-dataset-dir "${DATA}" \
  "${COMMON_ARGS[@]}" \
  --eval-name gpqa \
  --num-examples 198 \
  --num-threads 198 \
  --max-tokens 32768
```

| Precision | Correct | Score | Stop / length | Request errors |
|---|---:|---:|---:|---:|
| BF16 | 180/198 | 90.909% | 187 / 11 | 0 |
| MXFP8 | 181/198 | 91.414% | 195 / 3 | 0 |

The paired comparison has nine BF16-only and ten MXFP8-only correct answers. MXFP8 is `+0.505` percentage points over BF16, with exact McNemar `p=1.0`.

### LongBench-v2

```bash
OPENAI_API_KEY=EMPTY python -u -m sglang.test.run_eval \
  "${COMMON_ARGS[@]}" \
  --eval-name longbench_v2 \
  --num-examples 32 \
  --num-threads 512 \
  --max-tokens 8192 \
  --max-context-length 440000 \
  --dataset-path "${DATA}/longbench_v2_first128_length_stratified_32.jsonl"
```

```text
Dataset: LongBench-v2
Examples: 32
Score: 0.718750
Easy score: 0.750000
Hard score: 0.700000
Latency: 1961.818 s
Output throughput: 28.092 tok/s
```

### BF16 Comparison

| Dataset | BF16 | MXFP8 | Delta | BF16-only / MXFP8-only | Exact McNemar p |
|---|---:|---:|---:|---:|---:|
| GSM8K | 1279/1314 = 97.336% | 1272/1314 = 96.804% | -0.533 pp | 14 / 7 | 0.1892 |
| MMLU-1000 | 823/1000 = 82.300% | 816/1000 = 81.600% | -0.700 pp | 37 / 30 | 0.4638 |
| GPQA Diamond | 180/198 = 90.909% | 181/198 = 91.414% | +0.505 pp | 9 / 10 | 1.0000 |
| LongBench-v2 subset | 23/32 = 71.875% | 23/32 = 71.875% | 0.000 pp | 1 / 1 | 1.0000 |

### Accuracy Summary

GSM8K and MMLU show small, statistically non-significant decreases, and LongBench-v2 is unchanged. The final 32K GPQA comparison shows MXFP8 at `+0.505` percentage points over BF16 with `p=1.0`; no GPQA accuracy regression is observed.

The GSM8K, MMLU, and LongBench-v2 BF16 reference used TP16/EP1, while the MXFP8 runs used TP8/EP8. The final GPQA comparison used TP16 for both precisions; BF16 used Triton/EP1 and MXFP8 used DeepGEMM/DeepEP EP16.

## Speed Tests and Profiling

### Serving Throughput

The serving comparison uses the same 2 x 8 H20 machines, TP16 topology, request sets, concurrency, warmup, seed, and cache behavior. BF16 uses EP1 with the Triton MoE backend; MXFP8 uses EP16 with DeepGEMM and DeepEP. This is a deployment-level performance comparison, and each case was run once.

| Workload | Primary metric | BF16 | MXFP8 | Change | TTFT BF16/MX | TPOT BF16/MX |
|---|---|---:|---:|---:|---:|---:|
| ShareGPT, 128 requests, output 256, concurrency 64 | Output tok/s | 401.98 | 557.78 | +38.8% | 5852/2012 ms | 136.83/107.09 ms |
| Input 128, output 1024, 64 requests, concurrency 32 | Output tok/s | 1384.79 | 350.13 | -74.7% | 304/739 ms | 22.82/90.72 ms |
| Input 1024, output 256, 128 requests, concurrency 64 | Total tok/s | 2715.76 | 2411.45 | -11.2% | 1967/5459 ms | 110.52/111.61 ms |
| Input 8192, output 128, 64 requests, concurrency 32 | Input tok/s | 14377.19 | 5949.86 | -58.6% | 8079/18789 ms | 79.78/198.59 ms |

All requests completed successfully. MXFP8 improves ShareGPT throughput, but regresses on decode, balanced, and long-prefill workloads. The current results do not show a general end-to-end speedup over BF16.

### Operator Performance

The operator benchmark runs on one H20 with MiniMax-M3 TP8/EP8 shapes and 16 local experts per rank. `MX E2E` includes dynamic activation quantization. Relative performance is BF16 latency divided by MXFP8 latency, so values below `1x` mean MXFP8 is slower.

| Operator | M | BF16 ms | MX GEMM ms | MX E2E ms | MX GEMM relative perf. | MX E2E relative perf. |
|---|---:|---:|---:|---:|---:|---:|
| Dense | 1 | 0.0396 | 0.1548 | 0.2355 | 0.256x | 0.168x |
| Dense | 2048 | 1.1308 | 2.0714 | 2.1599 | 0.546x | 0.524x |
| MoE gate/up | 128 | 0.0883 | 0.1465 | 0.1896 | 0.603x | 0.466x |
| MoE gate/up | 8192 | 4.4566 | 6.8481 | 6.9205 | 0.651x | 0.644x |
| MoE down | 128 | 0.0529 | 0.0908 | 0.1329 | 0.582x | 0.398x |
| MoE down | 8192 | 2.2470 | 3.8057 | 3.9084 | 0.590x | 0.575x |

Across all 13 tested shapes, cosine error is `6.96e-4` to `7.10e-4`, with no NaN or Inf. None outperform BF16 on H20: MXFP8 GEMM reaches `0.256x-0.651x` of BF16 and MXFP8 E2E reaches `0.168x-0.644x`.

### Current SM90 Performance Bottleneck

MiniMax-M3 uses K128 activation scales and K32 weight scales. On SM90, the current kernel drains each K32 result and applies scale promotion through FP32 FMA. The current hypothesis is that these promotions, together with limited pipeline overlap under the register budget, are the main prefill bottleneck. The `BLOCK_N=96` kernel uses a two-stage pipeline.

Representative prefill GEMM (`E=16, M=8192, N=K=6144`):

| Backend | Median | Useful TFLOPS | Relative to BF16 |
|---|---:|---:|---:|
| BF16 | 4.4395 ms | 139.31 | 1.000x |
| MXFP8 | 6.7766 ms | 91.27 | 0.655x |

Nsight Compute evidence for the same prefill shape:

| Metric | BF16 | MXFP8 |
|---|---:|---:|
| Kernel tile | 128 x 256 | 128 x 96 |
| Registers/thread | 168 | 168 |
| Achieved occupancy | 14.06% | 14.06% |
| DRAM throughput | 5.19% | 1.55% |
| Executed instructions | 54.49 M | 1423.74 M |
| FMA-pipe warp instructions | 1.19 M | 656.07 M |
| Tensor pipe active | 24.33% | 8.01% |

The equal occupancy shows that low occupancy alone is not the cause. The main difference is per-K32 FP32 promotion: MXFP8 executes 26.1x more instructions and about 550x more FMA-pipe warp instructions.

Decode is additionally limited by coarse M tiling. For 16 experts and `N=K=6144`, active rows per expert from 1 to 64 all take about 1.59 ms because each non-empty expert triggers at least one 64-row WGMMA wave. Decode-specific `BLOCK_M=64` and `BLOCK_N=64/96` tuning is planned.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29753478832](https://github.com/sgl-project/sglang/actions/runs/29753478832)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29753478030](https://github.com/sgl-project/sglang/actions/runs/29753478030)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
