### PR TITLE
[Fix][AMD] Qwen3.5 MoE: disable global-slot shared-expert fusion under per-rank EP backends (MoRI + dp-attention init crash)

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -68,6 +68,7 @@ from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
     is_deepep_class_backend,
+    uses_per_rank_fused_shared_slots,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
@@ -249,6 +250,30 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 self.num_shared_experts > 0
                 and can_fuse_shared_expert(config, quant_config)
             )
+        # Qwen shared-expert fusion appends the shared expert at a single global
+        # slot (see _append_shared_to_topk_output, base id N == num_experts) and
+        # applies a per-token shared_expert_gate. That global-slot layout is
+        # incompatible with per-rank EP shared-slot backends (DeepEP / Mooncake /
+        # MoRI / MegaMoE) once moe_ep_size > 1: those backends tile the expert id
+        # space into contiguous per-rank blocks (num_experts == num_local_experts
+        # * ep_size), which requires per-rank shared slots. Mixing the two trips
+        # FusedMoE's (num_experts - num_shared_slots) % ep_size == 0 assertion at
+        # init (issue #31336) and, even past it, misroutes experts. Fall back to
+        # the separate shared-expert MLP (correct, slightly less fused) there.
+        if (
+            self.enable_shared_expert_fusion
+            and uses_per_rank_fused_shared_slots()
+            and get_parallel().moe_ep_size > 1
+        ):
+            logger.warning_once(
+                "Disabling Qwen shared-expert fusion: it uses a single global "
+                "shared slot with a per-token gate, which is incompatible with "
+                "per-rank EP shared-slot backends (e.g. DeepEP/MoRI) at "
+                "moe_ep_size=%d. Using the separate shared-expert MLP instead.",
+                get_parallel().moe_ep_size,
+            )
+            self.enable_shared_expert_fusion = False
+
         if self.enable_shared_expert_fusion:
             self.num_fused_shared_experts = self.num_shared_experts
 

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -250,16 +250,6 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 self.num_shared_experts > 0
                 and can_fuse_shared_expert(config, quant_config)
             )
-        # Qwen shared-expert fusion appends the shared expert at a single global
-        # slot (see _append_shared_to_topk_output, base id N == num_experts) and
-        # applies a per-token shared_expert_gate. That global-slot layout is
-        # incompatible with per-rank EP shared-slot backends (DeepEP / Mooncake /
-        # MoRI / MegaMoE) once moe_ep_size > 1: those backends tile the expert id
-        # space into contiguous per-rank blocks (num_experts == num_local_experts
-        # * ep_size), which requires per-rank shared slots. Mixing the two trips
-        # FusedMoE's (num_experts - num_shared_slots) % ep_size == 0 assertion at
-        # init (issue #31336) and, even past it, misroutes experts. Fall back to
-        # the separate shared-expert MLP (correct, slightly less fused) there.
         if (
             self.enable_shared_expert_fusion
             and uses_per_rank_fused_shared_slots()


### PR DESCRIPTION
## Motivation

Fixes #31336.

Serving **Qwen/Qwen3.5-397B-A17B-FP8** (512 routed + 1 fused shared expert) with `--moe-a2a-backend mori --enable-dp-attention` on MI355X/ROCm crashes at model init. Every scheduler rank aborts in `FusedMoE.__init__`:

```
File ".../srt/layers/moe/fused_moe_triton/layer.py", line 227, ...
    assert (num_experts - num_shared_slots) % self.moe_ep_size == 0
AssertionError
```

With `--enable-dp-attention`, `moe_ep_size` is promoted to `tp_size` (8). `has_per_rank_fused_shared_slots()` is `True` for MoRI (deepep-class), so `num_shared_slots = 1 * 8 = 8`, and `(513 - 8) % 8 = 505 % 8 = 1 != 0`.

### Root cause (and why the layout matters)

MoRI's dispatcher (`token_dispatcher/moriep.py`) masks experts with a **contiguous per-rank block**: `expert_mask[ep_rank * num_local_experts : + num_local_experts] = 1`. This is valid only when the blocks tile the id space exactly, i.e. `num_experts == num_local_experts * ep_size`, which requires **per-rank** shared slots (one shared slot per EP rank). DeepSeek-V2 already builds `num_experts` this way for per-rank backends.

Qwen's shared-expert fusion, however, is a **global-slot** design: `Qwen2MoeSparseMoeBlock` constructs its `TopK` **without** `num_fused_shared_experts` (so the per-rank remap in `topk.py` never fires) and instead appends the shared expert manually at a **single global id** (`_append_shared_to_topk_output`, base id `N == num_experts`) with a **per-token `shared_expert_gate`**. This global-slot-with-gate layout cannot be expressed in MoRI's per-rank contiguous tiling, and it can't reuse DeepSeek's (gate-less) per-rank remap machinery.

The alternative floated in the issue — treating MoRI as "global" (`num_shared_slots = 1`) — passes the `__init__` assertion but then breaks MoRI's contiguous dispatch mask (`num_local_experts * ep_size = 65 * 8 = 520 != 513`, so rank 7's block runs out of bounds) and silently misroutes experts.

## Modifications

`python/sglang/srt/models/qwen2_moe.py`: when shared-expert fusion is enabled **and** a per-rank EP shared-slot backend is active (`uses_per_rank_fused_shared_slots()`) **and** `moe_ep_size > 1`, disable the fusion and fall back to the separate (correct) shared-expert MLP path. A one-time warning is logged. `moe_ep_size == 1` and non-per-rank backends are unaffected (fusion stays on).

This is the correct-by-construction fix: with fusion off, `num_experts = 512` tiles exactly (`64 * 8`), the shared expert is computed by the dense `shared_expert` MLP (with its gate) and added after the experts. The fully-fused per-rank shared expert with a per-token gate is a larger enablement task (needs a per-rank remap+append kernel that also applies the gate) and is left as follow-up.

## Accuracy Tests

GSM8K sweep on Qwen3.5-397B-A17B-FP8 (MI355X), **with this PR applied** so the MoRI configs get past the #31336 init crash. Flags added one at a time. `Accuracy` = correct fraction, `Invalid` = unparseable/garbage fraction.

```
┌─────┬───────────────────────────────────────────┬──────────┬─────────┬───────────────┐
│ Run │                Added flag                 │ Accuracy │ Invalid │    Verdict    │
├─────┼───────────────────────────────────────────┼──────────┼─────────┼───────────────┤
│ R0  │ (baseline)                                │    0.925 │   0.005 │ ✓             │
├─────┼───────────────────────────────────────────┼──────────┼─────────┼───────────────┤
│ R1  │ --kv-cache-dtype fp8_e4m3                 │    0.915 │   0.010 │ clean         │
├─────┼───────────────────────────────────────────┼──────────┼─────────┼───────────────┤
│ R2  │ --enable-dp-attention --enable-dp-lm-head │    0.935 │   0.000 │ clean         │
├─────┼───────────────────────────────────────────┼──────────┼─────────┼───────────────┤
│ R3  │ --moe-a2a-backend mori                    │    0.010 │   0.420 │ ← breaks      │
├─────┼───────────────────────────────────────────┼──────────┼─────────┼───────────────┤
│ R4  │ mori + fp8-KV                             │    0.010 │   0.455 │ breaks (mori) │
├─────┼───────────────────────────────────────────┼──────────┼─────────┼───────────────┤
│ R5  │ full (dp-attn + mori + fp8-KV)            │    0.000 │   0.415 │ breaks (mori) │
└─────┴───────────────────────────────────────────┴──────────┴─────────┴───────────────┘
```

Reading:
- **This PR's scope (init crash) is resolved:** the MoRI + dp-attention configs now load and run instead of aborting in `FusedMoE.__init__`.
- **No regression on the clean paths:** baseline (R0), fp8-KV (R1), and `--enable-dp-attention` alone (R2, **0.935**) are all healthy. R2 is the path this PR most directly enables and it is clean.
- **A separate MoRI issue remains:** every run that adds `--moe-a2a-backend mori` (R3/R4/R5) collapses to ~0.01 accuracy with a high invalid rate, **independent of dp-attention and of fp8-KV**. That is a MoRI all-to-all correctness problem, **out of scope for this init-crash fix** and tracked separately (likely part of the ROCm-MoRI enablement in #21886). This PR is a prerequisite that lets that issue be reached and debugged at all.

Assertion-level validation (mocked MoRI, `ep_size=8`): pre-fix `num_experts=513, num_shared_slots=8` → assertion fails; with fix, fusion disabled → `num_experts=512, num_shared_slots=0` → assertion passes and MoRI's contiguous mask tiles `[0, 512)` exactly. `ep_size==1` and non-per-rank backends keep fusion (no behavior change).

## Checklist

- [x] Format with `pre-commit run --all-files` (isort/ruff/black pass)
- [x] Linked the issue (#31336)
- [x] Added a clear explanation of the root cause and the tradeoff

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29797490050](https://github.com/sgl-project/sglang/actions/runs/29797490050)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29797489930](https://github.com/sgl-project/sglang/actions/runs/29797489930)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->