### PR TITLE
[Fix][AMD] Qwen3.5 GatedDeltaNet: guard empty DP-rank batch in GDN forward paths (HIP invalid configuration)

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -360,6 +360,14 @@ class GDNAttnBackend(MambaAttnBackendBase):
         b: torch.Tensor,
         **kwargs,
     ):
+        # Empty batch (idle DP-attention rank): the GatedDeltaNet update kernels
+        # would launch with a zero-sized grid, which HIP rejects with `invalid
+        # configuration argument` (surfacing asynchronously later in the Mamba
+        # allocator). Linear attention is purely local (no cross-rank
+        # collective), so returning an empty output here is safe. See #31594.
+        if isinstance(mixed_qkv, torch.Tensor) and mixed_qkv.shape[0] == 0:
+            return mixed_qkv.new_zeros((1, 0, layer.num_v_heads, layer.head_v_dim))
+
         layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
         conv_states = layer_cache.conv[0]
         ssm_states = layer_cache.temporal
@@ -453,6 +461,15 @@ class GDNAttnBackend(MambaAttnBackendBase):
     ):
         assert isinstance(mixed_qkv, torch.Tensor)
         seq_len = mixed_qkv.shape[0]
+
+        # Empty batch (idle DP-attention rank): the GatedDeltaNet conv/chunk
+        # kernels (causal_conv1d_fn, chunk_gated_delta_rule) would launch with a
+        # zero-sized grid, which HIP rejects with `invalid configuration
+        # argument` (surfacing asynchronously later in the Mamba allocator).
+        # Linear attention is purely local (no cross-rank collective), so
+        # returning an empty output here is safe. See issue #31594.
+        if seq_len == 0:
+            return mixed_qkv.new_zeros((1, 0, layer.num_v_heads, layer.head_v_dim))
 
         is_target_verify = forward_batch.forward_mode.is_target_verify()
         forward_metadata = self.forward_metadata

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -362,11 +362,6 @@ class GDNAttnBackend(MambaAttnBackendBase):
     ):
         assert isinstance(mixed_qkv, torch.Tensor)
 
-        # Empty batch (idle DP-attention rank): the GatedDeltaNet update kernels
-        # would launch with a zero-sized grid, which HIP rejects with `invalid
-        # configuration argument` (surfacing asynchronously later in the Mamba
-        # allocator). Linear attention is purely local (no cross-rank
-        # collective), so returning an empty output here is safe. See #31594.
         if mixed_qkv.shape[0] == 0:
             return mixed_qkv.new_zeros((1, 0, layer.num_v_heads, layer.head_v_dim))
 
@@ -463,12 +458,6 @@ class GDNAttnBackend(MambaAttnBackendBase):
         assert isinstance(mixed_qkv, torch.Tensor)
         seq_len = mixed_qkv.shape[0]
 
-        # Empty batch (idle DP-attention rank): the GatedDeltaNet conv/chunk
-        # kernels (causal_conv1d_fn, chunk_gated_delta_rule) would launch with a
-        # zero-sized grid, which HIP rejects with `invalid configuration
-        # argument` (surfacing asynchronously later in the Mamba allocator).
-        # Linear attention is purely local (no cross-rank collective), so
-        # returning an empty output here is safe. See issue #31594.
         if seq_len == 0:
             return mixed_qkv.new_zeros((1, 0, layer.num_v_heads, layer.head_v_dim))
 

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -360,12 +360,14 @@ class GDNAttnBackend(MambaAttnBackendBase):
         b: torch.Tensor,
         **kwargs,
     ):
+        assert isinstance(mixed_qkv, torch.Tensor)
+
         # Empty batch (idle DP-attention rank): the GatedDeltaNet update kernels
         # would launch with a zero-sized grid, which HIP rejects with `invalid
         # configuration argument` (surfacing asynchronously later in the Mamba
         # allocator). Linear attention is purely local (no cross-rank
         # collective), so returning an empty output here is safe. See #31594.
-        if isinstance(mixed_qkv, torch.Tensor) and mixed_qkv.shape[0] == 0:
+        if mixed_qkv.shape[0] == 0:
             return mixed_qkv.new_zeros((1, 0, layer.num_v_heads, layer.head_v_dim))
 
         layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
@@ -385,7 +387,6 @@ class GDNAttnBackend(MambaAttnBackendBase):
         replayssm_k = layer_cache.replayssm_k
         replayssm_g = layer_cache.replayssm_g
 
-        assert isinstance(mixed_qkv, torch.Tensor)
         mixed_qkv = causal_conv1d_update(
             mixed_qkv,
             conv_states,


### PR DESCRIPTION
## Motivation

Fixes #31594.

Enabling `--enable-dp-attention` for **Qwen/Qwen3.5-397B-A17B-FP8** (a GatedDeltaNet hybrid MoE) with `--moe-a2a-backend mori` on MI355X/ROCm aborts during warmup / first batch with a HIP `invalid configuration argument` on the GatedDeltaNet (linear-attention / Mamba-state) path. With `dp-attention` **off** the same model + MoRI runs correctly; DeepSeek-R1 (MLA, no GatedDeltaNet) runs fine with `dp-attention` — isolating the GatedDeltaNet + dp-attention combination.

### Root cause

Under data-parallel attention, an idle DP rank can get an **empty batch**. `GDNAttnBackend.forward_extend` / `forward_decode` then launch the GatedDeltaNet conv/chunk kernels (`causal_conv1d_fn`, `chunk_gated_delta_rule`) on zero-length input, i.e. with a zero-sized grid, which HIP rejects. Because HIP reports kernel errors asynchronously, the Python traceback surfaces at the next Mamba-pool op (`mem_cache/allocator/mamba.py` `torch.cat`, or `memory_pool.py` `torch.stack(...).to(int32)`) — a red herring, not the real fault site.

## Modifications

`python/sglang/srt/layers/attention/linear/gdn_backend.py`: guard both `forward_extend` and `forward_decode` — when the batch is empty (`mixed_qkv.shape[0] == 0`) return an empty output `[1, 0, num_v_heads, head_v_dim]` **before** touching the Mamba pool or launching any kernel. Linear attention is purely local (no cross-rank collective), so an early return is safe (unlike MoE, no all-to-all needs the idle rank to participate). The empty shape matches the non-empty `[1, T, H, V]` output and the caller's `reshape(-1, head_v_dim)`.

## Accuracy Tests

Validated on MI355X/ROCm 7.2:

- **Root cause reproduced:** calling `chunk_gated_delta_rule` with a zero-length sequence fails on the empty batch (here as a host-side `torch.cat(): expected a non-empty list of Tensors`; on the reported v0.5.14 build it surfaced as the async HIP `invalid configuration argument`). Non-empty returns `[1, T, H, V]`.
- **Guard verified:** calling the real `GDNAttnBackend.forward_extend` / `forward_decode` with an empty batch and a sentinel `self` that raises on any attribute access confirms both paths early-return the correct empty output (`[1, 0, 8, 128]` → `reshape` `[0, 128]`) **without** touching `req_to_token_pool` / `forward_metadata` or launching the kernels.

Full E2E on 397B (8×MI355X, 2-node PD) was not run here (hardware).

## Checklist

- [x] Format with `pre-commit run --all-files` (isort/ruff/black pass)
- [x] Linked the issue (#31594)
- [x] Guarded both the extend and decode paths

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29797531054](https://github.com/sgl-project/sglang/actions/runs/29797531054)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29797530832](https://github.com/sgl-project/sglang/actions/runs/29797530832)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->