### PR TITLE
perf(hicache): add configurable concurrent storage prefetch I/O workers

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -276,6 +276,8 @@ class HiCacheController:
 
         # Dedicated stop event for storage background threads (prefetch/backup).
         self.storage_stop_event = threading.Event()
+        self.prefetch_io_workers = 1
+        self.prefetch_io_aux_threads: List[threading.Thread] = []
 
         self.device = self.mem_pool_device.device
         self.layer_num = self.mem_pool_device.layer_num
@@ -401,7 +403,8 @@ class HiCacheController:
             if hasattr(self, "backup_queue"):
                 self.backup_queue.put_nowait(None)
             if hasattr(self, "prefetch_buffer"):
-                self.prefetch_buffer.put_nowait(None)
+                for _ in range(self._prefetch_io_worker_count()):
+                    self.prefetch_buffer.put_nowait(None)
         except Exception:
             pass
 
@@ -413,6 +416,9 @@ class HiCacheController:
             threads.append(self.backup_thread)
         if hasattr(self, "prefetch_io_aux_thread"):
             threads.append(self.prefetch_io_aux_thread)
+        for t in getattr(self, "prefetch_io_aux_threads", []):
+            if t not in threads:
+                threads.append(t)
 
         for t in threads:
             try:
@@ -427,6 +433,7 @@ class HiCacheController:
                 [getattr(t, "name", repr(t)) for t in alive],
             )
             raise RuntimeError("Failed to stop HiCache storage threads cleanly.")
+        self.prefetch_io_aux_threads = []
 
     def attach_storage_backend(
         self,
@@ -443,6 +450,11 @@ class HiCacheController:
         if self.enable_storage:
             raise RuntimeError("Storage backend already attached.")
 
+        if storage_backend_extra_config is None:
+            storage_backend_extra_config = {}
+        else:
+            storage_backend_extra_config = dict(storage_backend_extra_config)
+
         # Defensive: a previous partial detach may have flipped `enable_storage` but
         # left background threads alive. Attaching on top of them is unsafe.
         try:
@@ -451,6 +463,10 @@ class HiCacheController:
             raise RuntimeError(
                 "Cannot attach storage backend: previous detach did not stop storage threads cleanly."
             ) from e
+
+        self.prefetch_io_workers = self._parse_prefetch_io_workers(
+            storage_backend_extra_config.pop("prefetch_io_workers", 1)
+        )
 
         # Rollback-safe init: if creation fails, keep controller state consistent
         # for future attach attempts.
@@ -527,6 +543,7 @@ class HiCacheController:
             self.storage_backend = None
             self.storage_backend_type = None
             self.enable_storage = False
+            self.prefetch_io_workers = 1
             self.page_get_func = self._generic_page_get
             self.page_set_func = self._generic_page_set
             self.draft_page_get_func = None
@@ -576,6 +593,7 @@ class HiCacheController:
         self.draft_page_set_func = None
         # Now it's safe to clear the stop event for future re-attach.
         self.storage_stop_event.clear()
+        self.prefetch_io_workers = 1
 
     def _generate_storage_config(
         self,
@@ -640,6 +658,22 @@ class HiCacheController:
             extra_config=storage_backend_extra_config,
         )
 
+    def _parse_prefetch_io_workers(self, value) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(
+                "prefetch_io_workers must be a positive integer, got "
+                f"{type(value).__name__}"
+            )
+        if value < 1:
+            raise ValueError("prefetch_io_workers must be >= 1")
+        return value
+
+    def _prefetch_io_worker_count(self) -> int:
+        threads = getattr(self, "prefetch_io_aux_threads", [])
+        if threads:
+            return len(threads)
+        return max(1, int(getattr(self, "prefetch_io_workers", 1)))
+
     def reset(self):
         self.storage_stop_event.set()
 
@@ -648,12 +682,13 @@ class HiCacheController:
         self.ack_write_queue.clear()
         self.ack_load_queue.clear()
         if self.enable_storage:
-            self.prefetch_thread.join()
-            self.backup_thread.join()
+            self._stop_storage_threads()
             self.prefetch_queue.queue.clear()
             self.backup_queue.queue.clear()
             self.prefetch_revoke_queue.queue.clear()
             self.prefetch_hit_queue.queue.clear()
+            if hasattr(self, "prefetch_buffer"):
+                self.prefetch_buffer.queue.clear()
             self.ack_backup_queue.queue.clear()
             self.host_mem_release_queue.queue.clear()
             self.prefetch_tokens_occupied = 0
@@ -661,14 +696,7 @@ class HiCacheController:
         self.storage_stop_event.clear()
 
         if self.enable_storage:
-            self.prefetch_thread = threading.Thread(
-                target=self.prefetch_thread_func, daemon=True
-            )
-            self.backup_thread = threading.Thread(
-                target=self.backup_thread_func, daemon=True
-            )
-            self.prefetch_thread.start()
-            self.backup_thread.start()
+            self._start_storage_threads()
 
     def write(
         self,
@@ -993,22 +1021,52 @@ class HiCacheController:
             if prefix_keys and len(prefix_keys) > 0:
                 prefix_keys += batch_hashes
 
+    def _release_prefetch_remainder(self, operation):
+        try:
+            self.append_host_mem_release(
+                operation.host_indices[operation.completed_tokens :]
+            )
+        except Exception:
+            logger.exception(
+                "Failed to release unfinished HiCache prefetch host memory for request %s.",
+                getattr(operation, "request_id", "<unknown>"),
+            )
+
     def prefetch_io_aux_func(self):
         """
         Auxiliary function conducting IO operations for prefetching.
         """
         while not self.storage_stop_event.is_set():
+            operation = None
             try:
                 operation = self.prefetch_buffer.get(block=True, timeout=1)
                 if operation is None:
                     continue
                 self._page_transfer(operation)
-                # operation terminated by controller, release pre-allocated memory
-                self.append_host_mem_release(
-                    operation.host_indices[operation.completed_tokens :]
-                )
             except Empty:
                 continue
+            except Exception:
+                if operation is None:
+                    logger.exception(
+                        "HiCache prefetch IO worker failed before receiving an operation."
+                    )
+                    continue
+                logger.exception(
+                    "HiCache prefetch IO worker failed for request %s.",
+                    getattr(operation, "request_id", "<unknown>"),
+                )
+                try:
+                    operation.mark_terminate()
+                except Exception:
+                    logger.exception(
+                        "Failed to mark HiCache prefetch operation %s as terminated.",
+                        getattr(operation, "request_id", "<unknown>"),
+                    )
+                self._release_prefetch_remainder(operation)
+            else:
+                # Operation terminated by controller or completed normally; release
+                # any pre-allocated host memory that was not filled.
+                self._release_prefetch_remainder(operation)
 
     def prefetch_rate_limited(self) -> bool:
         """
@@ -1049,10 +1107,21 @@ class HiCacheController:
         Manage prefetching operations from storage backend to host memory.
         """
         self.prefetch_buffer = Queue()
-        self.prefetch_io_aux_thread = threading.Thread(
-            target=self.prefetch_io_aux_func, daemon=True
+        self.prefetch_io_aux_threads = [
+            threading.Thread(
+                target=self.prefetch_io_aux_func,
+                daemon=True,
+                name=f"hicache-prefetch-io-{i}",
+            )
+            for i in range(self.prefetch_io_workers)
+        ]
+        self.prefetch_io_aux_thread = self.prefetch_io_aux_threads[0]
+        for thread in self.prefetch_io_aux_threads:
+            thread.start()
+        logger.info(
+            "Started %d HiCache prefetch IO worker(s).",
+            self.prefetch_io_workers,
         )
-        self.prefetch_io_aux_thread.start()
         while (not self.storage_stop_event.is_set()) or not self.prefetch_queue.empty():
             try:
                 operation = self.prefetch_queue.get(block=True, timeout=1)

--- a/test/registered/unit/test_hicache_prefetch_io_workers.py
+++ b/test/registered/unit/test_hicache_prefetch_io_workers.py
@@ -1,0 +1,319 @@
+"""Unit tests for HiCache prefetch I/O worker concurrency.
+
+Tests cover:
+- _parse_prefetch_io_workers() input validation
+- _prefetch_io_worker_count() thread count resolution
+- prefetch_io_aux_func() exception handling and normal completion
+- _stop_storage_threads() multi-worker sentinel and join behavior
+- _release_prefetch_remainder() memory release on failure and normal completion
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import threading
+import time
+import unittest
+from queue import Queue
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.managers.cache_controller import HiCacheController, PrefetchOperation
+
+
+def make_controller():
+    """Create a HiCacheController without calling __init__ (avoids GPU deps)."""
+    return HiCacheController.__new__(HiCacheController)
+
+
+class TestParsePrefetchIoWorkers(unittest.TestCase):
+    """Tests for _parse_prefetch_io_workers()."""
+
+    def setUp(self):
+        self.controller = make_controller()
+
+    def test_valid_positive_integers(self):
+        for value in [1, 2, 4, 8, 100]:
+            with self.subTest(value=value):
+                result = self.controller._parse_prefetch_io_workers(value)
+                self.assertEqual(result, value)
+
+    def test_bool_rejected(self):
+        for value in [True, False]:
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError) as ctx:
+                    self.controller._parse_prefetch_io_workers(value)
+                self.assertIn("must be a positive integer", str(ctx.exception))
+
+    def test_zero_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.controller._parse_prefetch_io_workers(0)
+        self.assertIn("must be >= 1", str(ctx.exception))
+
+    def test_negative_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.controller._parse_prefetch_io_workers(-1)
+        self.assertIn("must be >= 1", str(ctx.exception))
+
+    def test_float_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.controller._parse_prefetch_io_workers(1.5)
+        self.assertIn("must be a positive integer", str(ctx.exception))
+
+    def test_string_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.controller._parse_prefetch_io_workers("2")
+        self.assertIn("must be a positive integer", str(ctx.exception))
+
+    def test_none_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.controller._parse_prefetch_io_workers(None)
+        self.assertIn("must be a positive integer", str(ctx.exception))
+
+
+class TestPrefetchIoWorkerCount(unittest.TestCase):
+    """Tests for _prefetch_io_worker_count()."""
+
+    def setUp(self):
+        self.controller = make_controller()
+
+    def test_returns_thread_list_length_when_non_empty(self):
+        self.controller.prefetch_io_aux_threads = [
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        ]
+        self.assertEqual(self.controller._prefetch_io_worker_count(), 3)
+
+    def test_falls_back_to_prefetch_io_workers_when_empty(self):
+        self.controller.prefetch_io_aux_threads = []
+        self.controller.prefetch_io_workers = 4
+        self.assertEqual(self.controller._prefetch_io_worker_count(), 4)
+
+    def test_defaults_to_one_when_neither_set(self):
+        # Neither attribute is set on the bare __new__ instance.
+        # getattr defaults: [] and 1.
+        self.assertEqual(self.controller._prefetch_io_worker_count(), 1)
+
+    def test_empty_list_with_workers_set(self):
+        self.controller.prefetch_io_aux_threads = []
+        self.controller.prefetch_io_workers = 2
+        self.assertEqual(self.controller._prefetch_io_worker_count(), 2)
+
+
+class TestPrefetchIoAuxFunc(unittest.TestCase):
+    """Tests for prefetch_io_aux_func() exception handling."""
+
+    def setUp(self):
+        self.controller = make_controller()
+        self.controller.storage_stop_event = threading.Event()
+        self.controller.prefetch_buffer = Queue()
+
+    def _run_and_join(self, timeout=10):
+        """Run prefetch_io_aux_func in a thread, then signal stop and join."""
+        thread = threading.Thread(
+            target=self.controller.prefetch_io_aux_func, daemon=True
+        )
+        thread.start()
+        # Give the worker time to process queued items.
+        time.sleep(0.5)
+        self.controller.storage_stop_event.set()
+        thread.join(timeout=timeout)
+        self.assertFalse(thread.is_alive(), "Worker thread did not stop in time.")
+
+    def test_normal_completion_releases_remainder(self):
+        self.controller._page_transfer = MagicMock()
+        self.controller._release_prefetch_remainder = MagicMock()
+
+        op = PrefetchOperation("req-normal", [1, 2, 3])
+        op.host_indices = torch.tensor([0, 1, 2])
+        self.controller.prefetch_buffer.put(op)
+
+        self._run_and_join()
+
+        self.controller._page_transfer.assert_called_once_with(op)
+        self.controller._release_prefetch_remainder.assert_called_once_with(op)
+        self.assertFalse(op.is_terminated())
+
+    def test_exception_marks_terminate_and_releases(self):
+        self.controller._page_transfer = MagicMock(
+            side_effect=RuntimeError("simulated transfer failure")
+        )
+        self.controller._release_prefetch_remainder = MagicMock()
+
+        op = PrefetchOperation("req-fail", [1, 2, 3])
+        op.host_indices = torch.tensor([0, 1, 2])
+        self.controller.prefetch_buffer.put(op)
+
+        self._run_and_join()
+
+        self.controller._page_transfer.assert_called_once_with(op)
+        self.assertTrue(op.is_terminated())
+        self.controller._release_prefetch_remainder.assert_called_once_with(op)
+
+    def test_none_sentinel_does_not_crash(self):
+        self.controller._page_transfer = MagicMock()
+        self.controller._release_prefetch_remainder = MagicMock()
+
+        self.controller.prefetch_buffer.put(None)
+
+        self._run_and_join()
+
+        self.controller._page_transfer.assert_not_called()
+        self.controller._release_prefetch_remainder.assert_not_called()
+
+    def test_worker_continues_after_exception(self):
+        """Worker should process subsequent operations after one fails."""
+        call_count = [0]
+
+        def side_effect(op):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("first operation fails")
+
+        self.controller._page_transfer = MagicMock(side_effect=side_effect)
+        self.controller._release_prefetch_remainder = MagicMock()
+
+        op1 = PrefetchOperation("req-fail", [1, 2])
+        op1.host_indices = torch.tensor([0, 1])
+        op2 = PrefetchOperation("req-ok", [3, 4])
+        op2.host_indices = torch.tensor([2, 3])
+
+        self.controller.prefetch_buffer.put(op1)
+        self.controller.prefetch_buffer.put(op2)
+
+        self._run_and_join(timeout=15)
+
+        self.assertEqual(self.controller._page_transfer.call_count, 2)
+        self.assertTrue(op1.is_terminated())
+        self.assertFalse(op2.is_terminated())
+
+
+class TestStopStorageThreadsMultiWorker(unittest.TestCase):
+    """Tests for _stop_storage_threads() with multiple IO workers."""
+
+    def setUp(self):
+        self.controller = make_controller()
+        self.controller.storage_stop_event = threading.Event()
+
+    def _make_mock_thread(self):
+        t = MagicMock()
+        t.is_alive.return_value = False
+        return t
+
+    def _setup_controller(self, num_workers):
+        """Set up a controller with the given number of mock IO workers."""
+        mock_threads = [self._make_mock_thread() for _ in range(num_workers)]
+        self.controller.prefetch_io_aux_threads = mock_threads
+        self.controller.prefetch_io_aux_thread = mock_threads[0]
+        self.controller.prefetch_queue = Queue()
+        self.controller.backup_queue = Queue()
+        self.controller.prefetch_buffer = Queue()
+        self.controller.prefetch_thread = self._make_mock_thread()
+        self.controller.backup_thread = self._make_mock_thread()
+
+    def test_sends_correct_number_of_sentinels(self):
+        num_workers = 3
+        self._setup_controller(num_workers)
+
+        self.controller._stop_storage_threads()
+
+        sentinel_count = 0
+        while not self.controller.prefetch_buffer.empty():
+            item = self.controller.prefetch_buffer.get_nowait()
+            if item is None:
+                sentinel_count += 1
+        self.assertEqual(sentinel_count, num_workers)
+
+    def test_single_worker_sends_one_sentinel(self):
+        self._setup_controller(1)
+
+        self.controller._stop_storage_threads()
+
+        sentinel_count = 0
+        while not self.controller.prefetch_buffer.empty():
+            item = self.controller.prefetch_buffer.get_nowait()
+            if item is None:
+                sentinel_count += 1
+        self.assertEqual(sentinel_count, 1)
+
+    def test_clears_prefetch_io_aux_threads(self):
+        self._setup_controller(2)
+
+        self.controller._stop_storage_threads()
+
+        self.assertEqual(self.controller.prefetch_io_aux_threads, [])
+
+    def test_joins_all_io_worker_threads(self):
+        num_workers = 4
+        mock_threads = [self._make_mock_thread() for _ in range(num_workers)]
+        self.controller.prefetch_io_aux_threads = mock_threads
+        self.controller.prefetch_io_aux_thread = mock_threads[0]
+        self.controller.prefetch_queue = Queue()
+        self.controller.backup_queue = Queue()
+        self.controller.prefetch_buffer = Queue()
+        self.controller.prefetch_thread = self._make_mock_thread()
+        self.controller.backup_thread = self._make_mock_thread()
+
+        self.controller._stop_storage_threads()
+
+        for t in mock_threads:
+            t.join.assert_called_once_with(timeout=10)
+
+    def test_raises_runtime_error_if_thread_still_alive(self):
+        self._setup_controller(2)
+        # Make one thread appear still alive after join.
+        self.controller.prefetch_io_aux_threads[0].is_alive.return_value = True
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.controller._stop_storage_threads()
+        self.assertIn("Failed to stop", str(ctx.exception))
+
+
+class TestReleasePrefetchRemainder(unittest.TestCase):
+    """Tests for _release_prefetch_remainder()."""
+
+    def setUp(self):
+        self.controller = make_controller()
+        self.controller.host_mem_release_queue = Queue()
+        self.controller.mem_pool_host = MagicMock()
+        self.controller.mem_pool_host.page_size = 1
+
+    def test_releases_unfilled_host_memory(self):
+        op = PrefetchOperation("req-1", [1, 2, 3, 4])
+        op.host_indices = torch.tensor([10, 20, 30, 40])
+        op.completed_tokens = 2
+
+        self.controller._release_prefetch_remainder(op)
+
+        released = []
+        while not self.controller.host_mem_release_queue.empty():
+            released.append(self.controller.host_mem_release_queue.get_nowait())
+        self.assertEqual(len(released), 2)
+        self.assertTrue(torch.equal(released[0], torch.tensor([30])))
+        self.assertTrue(torch.equal(released[1], torch.tensor([40])))
+
+    def test_no_release_when_all_completed(self):
+        op = PrefetchOperation("req-1", [1, 2])
+        op.host_indices = torch.tensor([10, 20])
+        op.completed_tokens = 2
+
+        self.controller._release_prefetch_remainder(op)
+
+        self.assertTrue(self.controller.host_mem_release_queue.empty())
+
+    def test_logs_but_does_not_raise_on_failure(self):
+        op = PrefetchOperation("req-1", [1, 2])
+        # host_indices is None by default from PrefetchOperation.__init__,
+        # which will cause a TypeError when slicing.
+        self.assertIsNone(op.host_indices)
+
+        with patch("sglang.srt.managers.cache_controller.logger") as mock_logger:
+            self.controller._release_prefetch_remainder(op)
+            mock_logger.exception.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

HiCache currently uses a single auxiliary I/O worker per controller to consume `prefetch_buffer` and execute storage-to-host `_page_transfer()` operations.

Under bursty long-context workloads, multiple prefetch operations can finish the storage hit query and TP synchronization within a short period, but their actual storage reads are still serialized by that single worker. A large prefetch operation can therefore head-of-line block smaller operations behind it until they exhaust their prefetch timeout budget and fall back to KV recomputation.

In one TP8 Mooncake deployment, a request was identified as having 157 prefetchable pages:

```text
[01:09:56] Prefetching 157 pages for request 96fb5efb...
```

but later completed with no usable prefetched tokens:

```text
[01:10:00] Prefetch 96fb5efb... completed with 0 tokens
```

This PR makes the storage prefetch I/O worker count configurable so independent storage-to-host transfers can run concurrently, while leaving storage hit queries and distributed collectives serialized.

## Modifications

Add configurable `prefetch_io_workers` support in `HiCacheController`, with a default value of `1` to preserve the current behavior. The option is consumed from `storage_backend_extra_config` and is not forwarded to the storage backend.

`prefetch_thread_func()` still performs `_storage_hit_query()` and `_all_reduce_prefetch_groups()` in the existing single thread, preserving collective ordering. Only operations already placed in `prefetch_buffer` are processed concurrently by multiple named I/O workers running `_page_transfer()`.

The patch also updates the worker lifecycle and error handling:

- wake and join all prefetch I/O workers during storage shutdown;
- reuse the bounded shutdown path during controller reset;
- catch per-operation I/O failures so one failure does not silently kill a worker;
- terminate failed operations and release unused preallocated host memory;
- restore the default worker count after detach or failed backend attachment;
- reject non-positive or non-integer worker counts.

Example configuration:

```bash
python -m sglang.launch_server \
  ... \
  --enable-hierarchical-cache \
  --hicache-storage-backend mooncake \
  --hicache-storage-backend-extra-config '{
    "prefetch_io_workers": 2
  }'
```

The value is per scheduler/rank. For example, TP8 with `prefetch_io_workers=2` can issue up to approximately 16 rank-level prefetch reads concurrently.

## Accuracy Tests

N/A — this PR does not change model kernels, forward computation, tokenization, sampling, KV-cache representation, or cache-key semantics. It only changes the concurrency of storage-to-host prefetch transfers.

No end-to-end model accuracy test was run for this draft.

## Speed Tests and Profiling

## Testing

Added `test/registered/unit/test_hicache_prefetch_io_workers.py` with 23 CPU-only unit tests covering the new helper methods, worker lifecycle, error handling, and host-memory cleanup paths.

The tests cover:

- `prefetch_io_workers` validation:
  - positive integers are accepted;
  - `bool`, zero, negative integers, `float`, string, and `None` are rejected with `ValueError`;
- worker-count resolution:
  - use the active worker-thread list length when available;
  - fall back to the configured worker count;
  - default to one worker when neither state is initialized;
- prefetch I/O worker behavior:
  - release unused host memory after a successful transfer;
  - call `mark_terminate()` and release memory after a transfer failure;
  - handle the `None` shutdown sentinel;
  - continue processing subsequent operations after one transfer fails;
- multi-worker shutdown:
  - enqueue one sentinel per active I/O worker;
  - join every storage thread;
  - clear the worker-thread list after shutdown;
  - raise `RuntimeError` when a thread remains alive after the join timeout;
- prefetch remainder cleanup:
  - release only the unfilled host-memory range;
  - skip release when the operation completed fully;
  - log cleanup failures without crashing the worker.

Test result:

```text
Ran 23 tests in 4.056s

OK
```

The following checks also pass on the current branch:

```text
python -m py_compile python/sglang/srt/managers/cache_controller.py
pre-commit run --all-files
git diff --check
```

Relevant commits:

```text
47d4e26 test(hicache): add unit tests for prefetch I/O worker concurrency
7e637ea perf(hicache): add concurrent storage prefetch I/O workers
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29756850988](https://github.com/sgl-project/sglang/actions/runs/29756850988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29756853446](https://github.com/sgl-project/sglang/actions/runs/29756853446)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->