### PR TITLE
[PD+PP] Make decode queue consensus authoritative

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -856,11 +856,61 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             decode_req.kv_receiver.init(prefill_dp_rank)
 
     def pop_preallocated(
-        self, rids_to_check: Optional[List[str]] = None
+        self,
+        rids_to_check: Optional[List[str]] = None,
+        pp_good_rids: Optional[List[str]] = None,
+        pp_bad_rids: Optional[List[str]] = None,
     ) -> Tuple[List[DecodeRequest], List[DecodeRequest]]:
-        """Pop the preallocated requests from the pending queue (FIFO)."""
+        """Pop requests, optionally applying an authoritative PP consensus."""
+        if (pp_good_rids is None) != (pp_bad_rids is None):
+            raise ValueError("pp_good_rids and pp_bad_rids must be provided together")
+        is_pp_mode = pp_good_rids is not None
+        if is_pp_mode and rids_to_check is not None:
+            raise ValueError(
+                "rids_to_check cannot be combined with a PP consensus result"
+            )
+
+        good_rids = set(pp_good_rids or [])
+        bad_rids = set(pp_bad_rids or [])
+        # Failure wins defensively if a malformed payload overlaps.
+        good_rids.difference_update(bad_rids)
+
         self._resolve_pending_reqs()
-        self._update_handshake_waiters(rids_to_check)
+        if not is_pp_mode:
+            self._update_handshake_waiters(rids_to_check)
+        else:
+            # The PP ring has already polled every stage. Do not poll again:
+            # an abort arriving between consensus and application must not make
+            # stages apply different outcomes.
+            for decode_req in self.queue:
+                rid = decode_req.req.rid
+                if rid in good_rids and not decode_req.waiting_for_input:
+                    decode_req.waiting_for_input = True
+                    decode_req.req.time_stats.set_bootstrap_done_time()
+                elif rid in bad_rids:
+                    error_message = (
+                        "Decode handshake failed by PP consensus for request "
+                        f"rank={self.tp_rank} {decode_req.req.rid=} "
+                        f"{decode_req.req.bootstrap_room=}"
+                    )
+                    is_propagated = False
+                    try:
+                        decode_req.kv_receiver.failure_exception()
+                    except Exception as e:
+                        error_message += f" with exception {e}"
+                        is_propagated = getattr(e, "is_from_another_rank", False)
+                    if is_propagated:
+                        logger.debug(error_message)
+                    else:
+                        logger.error(error_message)
+                    if not isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                        prepare_abort(
+                            decode_req.req,
+                            error_message,
+                            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                        )
+                    if self.scheduler.metrics_reporter.enable_metrics:
+                        self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
 
         failed_reqs = []
         preallocated_reqs = []
@@ -903,7 +953,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         # First, remove all failed requests from the queue
         for i, decode_req in enumerate(self.queue):
-            if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
+            rid = decode_req.req.rid
+            if is_pp_mode:
+                if rid not in bad_rids:
+                    continue
+            elif rids_to_check is not None and rid not in rids_to_check:
                 continue
             if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
                 if not getattr(decode_req.req, "finished_output", False):
@@ -941,7 +995,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         # Then, preallocate the remaining requests if possible
         for i, decode_req in enumerate(self.queue):
-            if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
+            rid = decode_req.req.rid
+            if is_pp_mode:
+                if rid not in good_rids:
+                    continue
+            elif rids_to_check is not None and rid not in rids_to_check:
                 continue
 
             if i in indices_to_remove:
@@ -1844,6 +1902,38 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             server_args=self.scheduler.server_args,
         )
 
+    def get_finished_rids(self) -> Tuple[List[str], List[str]]:
+        """Return locally finished transfer rids as (successful, failed)."""
+        if not self.queue:
+            return [], []
+
+        if self.scheduler.enable_decode_hicache:
+            self._process_hicache_local_restores(self.queue)
+
+        if self.enable_staging:
+            polls = self._poll_with_staging()
+        else:
+            polls = self._poll_with_metadata_gate()
+
+        successful_rids: List[str] = []
+        failed_rids: List[str] = []
+        for decode_req, poll in zip(self.queue, polls):
+            hicache_restore_status = decode_req.hicache_restore_status
+            if (
+                poll == KVPoll.Failed
+                or hicache_restore_status == HiCacheRestoreResult.FAILED
+            ):
+                failed_rids.append(decode_req.req.rid)
+            elif poll == KVPoll.Success:
+                if (
+                    self.scheduler.enable_decode_hicache
+                    and hicache_restore_status == HiCacheRestoreResult.PENDING
+                ):
+                    continue
+                successful_rids.append(decode_req.req.rid)
+
+        return successful_rids, failed_rids
+
     def _init_staging_handler(self, kv_manager):
         """Create staging handler from kv_manager. Must be called exactly once."""
         from sglang.srt.disaggregation.common.staging_handler import (
@@ -1855,11 +1945,30 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         )
         kv_manager._staging_handler = self.staging_handler
 
-    def pop_transferred(self, rids_to_check: Optional[List[str]] = None) -> List[Req]:
+    def pop_transferred(
+        self,
+        rids_to_check: Optional[List[str]] = None,
+        pp_good_rids: Optional[List[str]] = None,
+        pp_bad_rids: Optional[List[str]] = None,
+    ) -> List[Req]:
+        """Pop finished transfers, optionally applying a PP consensus result.
+
+        In PP mode, the consensus is authoritative. Re-polling local state here
+        can make stages apply different outcomes when a failure or abort arrives
+        between consensus and queue processing.
+        """
+        if (pp_good_rids is None) != (pp_bad_rids is None):
+            raise ValueError("pp_good_rids and pp_bad_rids must be provided together")
+        is_pp_mode = pp_good_rids is not None
+        if is_pp_mode and rids_to_check is not None:
+            raise ValueError(
+                "rids_to_check cannot be combined with a PP consensus result"
+            )
+
         if not self.queue:
             return []
 
-        if self.scheduler.enable_decode_hicache:
+        if self.scheduler.enable_decode_hicache and not is_pp_mode:
             self._process_hicache_local_restores(
                 [
                     decode_req
@@ -1868,7 +1977,20 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 ]
             )
 
-        if self.enable_staging:
+        if is_pp_mode:
+            good_rids = set(pp_good_rids or [])
+            bad_rids = set(pp_bad_rids or [])
+            polls = []
+            for decode_req in self.queue:
+                rid = decode_req.req.rid
+                if rid in bad_rids:
+                    # Failure wins defensively if a malformed payload overlaps.
+                    polls.append(KVPoll.Failed)
+                elif rid in good_rids:
+                    polls.append(KVPoll.Success)
+                else:
+                    polls.append(None)
+        elif self.enable_staging:
             polls = self._poll_with_staging()
         else:
             polls = self._poll_with_metadata_gate()
@@ -1876,6 +1998,8 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         transferred_reqs = []
         indices_to_remove = set()
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
+            if poll is None:
+                continue
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
 

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -46,6 +46,17 @@ if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
 
 
+def _split_decode_transfer_rids(release_rids):
+    if (
+        isinstance(release_rids, list)
+        and len(release_rids) == 2
+        and isinstance(release_rids[0], list)
+        and isinstance(release_rids[1], list)
+    ):
+        return release_rids[0], release_rids[1]
+    return release_rids, []
+
+
 def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
     """Check if output send/recv can be skipped for this batch."""
     return (
@@ -1372,29 +1383,27 @@ class SchedulerPPMixin:
         return [good_prealloc_rids, bad_prealloc_rids]
 
     def _pp_pd_get_decode_transferred_ids(self: Scheduler):
-        # get the current stage transfer success
+        # Successful transfers require every PP stage to observe success. A
+        # failure observed by any stage must be applied by every stage.
         if self.pp_group.is_first_rank:
-            transferred_rids = self.get_rids(
-                self.disagg_decode_transfer_queue.queue,
-                False,
-                [KVPoll.Success, KVPoll.Failed],
+            good_transferred_rids, bad_transferred_rids = (
+                self.disagg_decode_transfer_queue.get_finished_rids()
             )
-        # if other ranks, do intersection with the previous rank's transferred rids
         else:
-            # 2 (Release): Receive the transferred rids from the previous rank
-            # 1. recv previous stage's transferred reqs info
             prev_transferred_rids = self._pp_recv_pyobj_from_prev_stage()
-            # 2. get the current stage's transferred reqs info
-            curr_transferred_rids = self.get_rids(
-                self.disagg_decode_transfer_queue.queue,
-                False,
-                [KVPoll.Success, KVPoll.Failed],
+            prev_good_transferred_rids, prev_bad_transferred_rids = (
+                _split_decode_transfer_rids(prev_transferred_rids)
             )
-            # 3. new consensus rids = intersection(previous consensus rids, transfer finished rids)
-            transferred_rids = list(
-                set(prev_transferred_rids) & set(curr_transferred_rids)
+            curr_good_transferred_rids, curr_bad_transferred_rids = (
+                self.disagg_decode_transfer_queue.get_finished_rids()
             )
-        return transferred_rids
+            good_transferred_rids = list(
+                set(prev_good_transferred_rids) & set(curr_good_transferred_rids)
+            )
+            bad_transferred_rids = list(
+                set(prev_bad_transferred_rids) | set(curr_bad_transferred_rids)
+            )
+        return [good_transferred_rids, bad_transferred_rids]
 
     def process_retract_queue(self: Scheduler, retract_rids: Optional[List[str]]):
         if retract_rids is not None:
@@ -1416,29 +1425,32 @@ class SchedulerPPMixin:
                 good_consensus_prealloc_rids,
                 bad_consensus_prealloc_rids,
             ) = prealloc_rids
-            good_reqs, failed_reqs = self.disagg_decode_prealloc_queue.pop_preallocated(
-                rids_to_check=good_consensus_prealloc_rids
-                + bad_consensus_prealloc_rids,
+            good_reqs, _ = self.disagg_decode_prealloc_queue.pop_preallocated(
+                pp_good_rids=good_consensus_prealloc_rids,
+                pp_bad_rids=bad_consensus_prealloc_rids,
             )
             self.disagg_decode_transfer_queue.extend(good_reqs)
-            return [
-                [req.req.rid for req in good_reqs],
-                [req.req.rid for req in failed_reqs],
-            ]
+            # Keep both consensus classes intact around the PP ring. Rebuilding
+            # this payload from local outcomes can lose a global failure.
+            return prealloc_rids
         return None
 
     def process_decode_transfer_queue(
         self: Scheduler, release_rids: Optional[List[str]]
     ):
         if release_rids is not None:
-            released_reqs = self.disagg_decode_transfer_queue.pop_transferred(
+            good_release_rids, bad_release_rids = _split_decode_transfer_rids(
                 release_rids
+            )
+            released_reqs = self.disagg_decode_transfer_queue.pop_transferred(
+                pp_good_rids=good_release_rids,
+                pp_bad_rids=bad_release_rids,
             )
             if self.enable_hisparse:
                 for req in released_reqs:
                     self.hisparse_coordinator.admit_request_direct(req)
             self.waiting_queue.extend(released_reqs)
-            return [req.rid for req in released_reqs]
+            return release_rids
         return None
 
 

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -12,6 +12,7 @@ from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.managers.schedule_batch import FINISH_ABORT
 from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -185,6 +186,216 @@ class TestDecodeQueueCleanup(CustomTestCase):
         mock_release_kv_cache.assert_called_once_with(
             req, queue.tree_cache, is_insert=False
         )
+
+    @patch("sglang.srt.disaggregation.decode.release_kv_cache")
+    @patch("sglang.srt.disaggregation.decode.prepare_abort")
+    @patch("sglang.srt.disaggregation.decode.poll_and_all_reduce")
+    def test_pp_failed_consensus_overrides_local_success(
+        self, mock_poll, mock_prepare_abort, mock_release_kv_cache
+    ):
+        receiver = FakeReceiver()
+        req = SimpleNamespace(
+            rid="global-failed-local-success",
+            bootstrap_room=7,
+            return_logprob=False,
+        )
+        decode_req = SimpleNamespace(
+            req=req,
+            kv_receiver=receiver,
+            metadata_buffer_index=3,
+            hicache_restore_status=HiCacheRestoreResult.READY,
+        )
+
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.queue = [decode_req]
+        queue.enable_staging = False
+        queue.gloo_group = MagicMock()
+        queue.req_to_metadata_buffer_idx_allocator = MagicMock()
+        queue.tp_rank = 0
+        queue.tree_cache = MagicMock()
+        queue.metadata_buffers = SimpleNamespace(bootstrap_room=[None] * 4)
+        queue._clean_hicache_prefetch_resources = MagicMock()
+        queue._process_hicache_local_restores = MagicMock()
+
+        scheduler = MagicMock()
+        scheduler.enable_decode_hicache = True
+        scheduler.enable_hisparse = False
+        scheduler.output_streamer = MagicMock()
+        scheduler.metrics_reporter.enable_metrics = False
+        queue.scheduler = scheduler
+
+        # A second local poll would report success, but the PP failure consensus
+        # must force the request down the failure cleanup path on every stage.
+        mock_poll.return_value = [KVPoll.Success]
+
+        transferred = queue.pop_transferred(pp_good_rids=[], pp_bad_rids=[req.rid])
+
+        self.assertEqual(transferred, [])
+        self.assertEqual(queue.queue, [])
+        self.assertTrue(receiver.clear_called)
+        self.assertIsNone(decode_req.kv_receiver)
+        mock_poll.assert_not_called()
+        queue._process_hicache_local_restores.assert_not_called()
+        queue._clean_hicache_prefetch_resources.assert_called_once_with(decode_req)
+        mock_prepare_abort.assert_called_once()
+        mock_release_kv_cache.assert_called_once_with(
+            req, queue.tree_cache, is_insert=False
+        )
+
+    @patch("sglang.srt.disaggregation.decode.poll_and_all_reduce")
+    def test_pp_success_consensus_skips_second_local_poll(self, mock_poll):
+        receiver = FakeReceiver()
+        req = SimpleNamespace(
+            rid="global-success-local-changed",
+            bootstrap_room=8,
+            return_logprob=False,
+            finished_reason=None,
+        )
+        decode_req = SimpleNamespace(
+            req=req,
+            kv_receiver=receiver,
+            metadata_buffer_index=2,
+            hicache_restore_status=HiCacheRestoreResult.READY,
+        )
+
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.queue = [decode_req]
+        queue.enable_staging = False
+        queue.gloo_group = MagicMock()
+        queue.req_to_metadata_buffer_idx_allocator = MagicMock()
+        queue.metadata_buffers = SimpleNamespace(bootstrap_room=[None] * 3)
+        queue._commit_transfer_to_req = MagicMock()
+
+        scheduler = MagicMock()
+        scheduler.enable_decode_hicache = False
+        scheduler.metrics_reporter.enable_metrics = False
+        queue.scheduler = scheduler
+        mock_poll.return_value = [KVPoll.Failed]
+
+        transferred = queue.pop_transferred(pp_good_rids=[req.rid], pp_bad_rids=[])
+
+        self.assertEqual(transferred, [req])
+        self.assertEqual(queue.queue, [])
+        mock_poll.assert_not_called()
+        queue._commit_transfer_to_req.assert_called_once_with(decode_req)
+        queue.req_to_metadata_buffer_idx_allocator.free.assert_called_once_with(2)
+
+    def test_process_decode_transfer_queue_preserves_consensus_classes(self):
+        queue = MagicMock()
+        released_req = SimpleNamespace(rid="good")
+        queue.pop_transferred.return_value = [released_req]
+        scheduler = SimpleNamespace(
+            disagg_decode_transfer_queue=queue,
+            enable_hisparse=False,
+            waiting_queue=[],
+        )
+        release_payload = [["good"], ["bad"]]
+
+        forwarded = SchedulerPPMixin.process_decode_transfer_queue(
+            scheduler, release_payload
+        )
+
+        self.assertIs(forwarded, release_payload)
+        self.assertEqual(scheduler.waiting_queue, [released_req])
+        queue.pop_transferred.assert_called_once_with(
+            pp_good_rids=["good"], pp_bad_rids=["bad"]
+        )
+
+    def test_decode_transfer_consensus_intersects_success_and_unions_failure(self):
+        queue = MagicMock()
+        queue.get_finished_rids.return_value = (
+            ["good-on-both", "good-only-current"],
+            ["bad-current"],
+        )
+        scheduler = SimpleNamespace(
+            pp_group=SimpleNamespace(is_first_rank=False),
+            disagg_decode_transfer_queue=queue,
+            _pp_recv_pyobj_from_prev_stage=MagicMock(
+                return_value=[
+                    ["good-on-both", "good-only-previous"],
+                    ["bad-previous"],
+                ]
+            ),
+        )
+
+        good_rids, bad_rids = SchedulerPPMixin._pp_pd_get_decode_transferred_ids(
+            scheduler
+        )
+
+        self.assertEqual(set(good_rids), {"good-on-both"})
+        self.assertEqual(set(bad_rids), {"bad-current", "bad-previous"})
+
+    @patch("sglang.srt.disaggregation.decode.prepare_abort")
+    def test_pp_prealloc_failed_consensus_overrides_local_success(
+        self, mock_prepare_abort
+    ):
+        receiver = FakeReceiver()
+        req = SimpleNamespace(
+            rid="global-failed-local-waiting",
+            bootstrap_room=9,
+            return_logprob=False,
+            finished_reason=None,
+        )
+        decode_req = SimpleNamespace(
+            req=req,
+            kv_receiver=receiver,
+            waiting_for_input=True,
+        )
+
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.queue = [decode_req]
+        queue.pending_reqs = []
+        queue.tp_rank = 0
+        queue._resolve_pending_reqs = MagicMock()
+        queue._update_handshake_waiters = MagicMock()
+        queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
+        queue._allocatable_token_budgets = MagicMock(return_value=0)
+        queue._hicache_pending_restore_tokens = MagicMock(return_value=0)
+
+        scheduler = MagicMock()
+        scheduler.running_batch.reqs = []
+        scheduler.enable_priority_scheduling = False
+        scheduler.enable_hisparse = False
+        scheduler.output_streamer = MagicMock()
+        scheduler.metrics_reporter.enable_metrics = False
+        queue.scheduler = scheduler
+        mock_prepare_abort.side_effect = lambda target, *_args, **_kwargs: setattr(
+            target, "finished_reason", FINISH_ABORT("PP consensus failure")
+        )
+
+        good, failed = queue.pop_preallocated(pp_good_rids=[], pp_bad_rids=[req.rid])
+
+        self.assertEqual(good, [])
+        self.assertEqual(failed, [decode_req])
+        self.assertEqual(queue.queue, [])
+        self.assertTrue(receiver.clear_called)
+        self.assertIsNone(decode_req.kv_receiver)
+        queue._update_handshake_waiters.assert_not_called()
+        mock_prepare_abort.assert_called_once()
+        scheduler.output_streamer.stream_output.assert_called_once_with(
+            [req], req.return_logprob
+        )
+
+    def test_process_prealloc_queue_preserves_consensus_classes(self):
+        queue = MagicMock()
+        good_req = SimpleNamespace(req=SimpleNamespace(rid="good"))
+        failed_req = SimpleNamespace(req=SimpleNamespace(rid="bad"))
+        queue.pop_preallocated.return_value = ([good_req], [failed_req])
+        transfer_queue = MagicMock()
+        scheduler = SimpleNamespace(
+            disagg_decode_prealloc_queue=queue,
+            disagg_decode_transfer_queue=transfer_queue,
+        )
+        queue.retracted_queue = []
+        payload = [["good"], ["bad"]]
+
+        forwarded = SchedulerPPMixin.process_prealloc_queue(scheduler, payload)
+
+        self.assertIs(forwarded, payload)
+        queue.pop_preallocated.assert_called_once_with(
+            pp_good_rids=["good"], pp_bad_rids=["bad"]
+        )
+        transfer_queue.extend.assert_called_once_with([good_req])
 
     def test_retracted_decode_requests_keep_scheduler_non_idle(self):
         scheduler = Scheduler.__new__(Scheduler)


### PR DESCRIPTION
## Motivation

In PD disaggregation with pipeline parallelism, decode PP stages can observe different local transfer or handshake states for the same request. The existing ring computes a preallocation consensus, but flattens the good/bad classes before applying it and polls local state again. Transfer release also treats local success and failure as one finished set.

If an abort or failure arrives between consensus and queue pop, one stage can admit the request while another aborts it. Their local queues then diverge and later enter different conditional PP/Gloo communication phases. This is the decode-side analogue of #30476 and follows the authoritative-consensus principle proposed in #31030.

## Modifications

- Compute decode transfer success as the intersection across PP stages.
- Compute decode transfer failure as the union across PP stages.
- Preserve the structured `[successful_rids, failed_rids]` payload around the PP ring.
- Make both decode preallocation and transfer pop apply the PP decision directly instead of polling local state again.
- Give failure precedence for malformed overlapping payloads and leave non-consensus requests queued.
- Keep the non-PP polling path unchanged.
- Add unit coverage for local-success/global-failure, success without a second poll, payload preservation, and intersection/union semantics.

## Tests

- `PYTHONPATH=python python -m pytest -q test/registered/unit/disaggregation`
  - `89 passed, 18 subtests passed`
- `python -m py_compile` on the changed Python files
- `black --check` and `git diff --check`
- 8x H200 control-plane stress run with Qwen3-30B-A3B, prefill PP=4 + HiCache, decode PP=4 + HiCache, PD router, and GuideLLM 8k/1k sweep:
  - synchronous and unbounded-throughput stages both completed
  - throughput concurrency median/mean = 512
  - 970 successful throughput requests, no request errors
  - no Traceback or forced exit; PP queue counts stayed aligned

The stress environment still shows the existing transient deep `/health` timeout while synchronous HiCache work occupies the scheduler, then recovers. This PR intentionally does not change health endpoint semantics or claim to solve that separate scheduler-latency issue.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29757945503](https://github.com/sgl-project/sglang/actions/runs/29757945503)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29757945284](https://github.com/sgl-project/sglang/actions/runs/29757945284)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->