### PR TITLE
disaggregation/mooncake: time out KV receivers stuck in Transferring

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1373,7 +1373,7 @@ class CommonKVReceiver(BaseKVReceiver):
         self.kv_mgr.record_failure(
             self.bootstrap_room,
             f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s "
-            f"in KVPoll.WaitingForInput",
+            f"waiting for KV Cache transfer to complete",
         )
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         if (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1997,7 +1997,14 @@ class MooncakeKVReceiver(CommonKVReceiver):
         status = self.kv_mgr.check_status(self.bootstrap_room)
         if status in (KVPoll.Success, KVPoll.Failed):
             self.conclude_state = status
-        elif status == KVPoll.WaitingForInput:
+        elif status in (KVPoll.WaitingForInput, KVPoll.Transferring):
+            # Apply the timeout to both WaitingForInput (transfer not yet
+            # started) and Transferring (transfer started but never signalled
+            # done). A request that stalls mid-transfer otherwise stays pinned
+            # forever, holding its req_to_token_pool slot on the decode side and
+            # eventually starving admission. This mirrors the NIXL receiver,
+            # which already checks the timeout unconditionally once the transfer
+            # has been initiated.
             timeout_result = self._check_waiting_timeout()
             if timeout_result is not None:
                 return timeout_result


### PR DESCRIPTION
## Motivation

The Mooncake KV receiver only applies `_check_waiting_timeout()` while the request is in `KVPoll.WaitingForInput`:

```python
# python/sglang/srt/disaggregation/mooncake/conn.py  (MooncakeKVReceiver.poll)
status = self.kv_mgr.check_status(self.bootstrap_room)
if status in (KVPoll.Success, KVPoll.Failed):
    self.conclude_state = status
elif status == KVPoll.WaitingForInput:          # <-- only WaitingForInput
    timeout_result = self._check_waiting_timeout()
    ...
```

A request whose transfer has already started but never receives the "done" signal stays in `KVPoll.Transferring` indefinitely. In that state the timeout is never evaluated, so the request is never marked `Failed`, never sends an abort notification, and never releases its `req_to_token_pool` slot on the decode side (`DecodeTransferQueue.pop_transferred` only frees the slot on `Failed`/aborted-`Success`).

Under high request turnover this slowly leaks admission slots. Once the pool is exhausted the decode scheduler can no longer admit new requests, the running batch drains to near-zero, and throughput collapses even though the KV cache is nearly empty.

We hit this on DeepSeek-V4 PD-disaggregation runs (8 prefill / 16 decode): `#transfer-req` frozen, `#running-req` ~1, KV cache usage ~0.04, decode throughput dropping to a small fraction of nominal — with no recovery, because the `SGLANG_DISAGGREGATION_WAITING_TIMEOUT` knob is simply never consulted for requests parked in `Transferring`.

## Modification

Extend the timeout check to cover `KVPoll.Transferring` as well as `KVPoll.WaitingForInput`.

This mirrors the **NIXL** receiver, whose `poll()` already calls `_check_waiting_timeout()` unconditionally once the transfer has been initiated (`started_transfer`), regardless of the fine-grained state — which is why NIXL does not exhibit this stall. The change brings the Mooncake receiver to parity.

`init_time` is set when the receiver initiates the handshake, so `_check_waiting_timeout()` already measures total elapsed transfer time; no double-counting is introduced. On timeout the request is marked `Failed`, an abort notification is sent, and the decode scheduler frees the pinned slot so admission can resume.

The shared timeout log/failure message in `common/conn.py` is generalized (it previously hard-coded "in KVPoll.WaitingForInput").

## Checklist

- [x] Minimal change; behavior unchanged for the healthy path (transfers that complete before `waiting_timeout` are unaffected).
- [x] No API/config change; controlled by the existing `SGLANG_DISAGGREGATION_WAITING_TIMEOUT`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29758656339](https://github.com/sgl-project/sglang/actions/runs/29758656339)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29758655838](https://github.com/sgl-project/sglang/actions/runs/29758655838)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->