### PR TITLE
fix(http): propagate per-routing-key queue rejections as HTTP 429

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1459,6 +1459,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if finish_reason.get("type") == "abort" and finish_reason.get(
             "status_code"
         ) in (
+            HTTPStatus.TOO_MANY_REQUESTS,
             HTTPStatus.SERVICE_UNAVAILABLE,
             HTTPStatus.INTERNAL_SERVER_ERROR,
         ):

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -14,8 +14,10 @@ Covers:
 
 import asyncio
 import unittest
+from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, Mock
 
+import fastapi
 import msgspec
 
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -247,6 +249,29 @@ class TestRidToStateCleanupOnAbort(CustomTestCase):
         self.assertEqual(len(state.out_list), 1)
         self.assertEqual(
             state.out_list[0]["meta_info"]["finish_reason"]["type"], "abort"
+        )
+
+
+class TestAbortFinishReason(CustomTestCase):
+    def test_queue_limit_uses_http_429_only_for_non_streaming(self):
+        tm = _make_tokenizer_manager()
+        state = _make_req_state("queue_limit")
+        out = {
+            "meta_info": {
+                "finish_reason": {
+                    "type": "abort",
+                    "status_code": HTTPStatus.TOO_MANY_REQUESTS,
+                    "message": "The request queue for this routing key is full.",
+                }
+            }
+        }
+
+        with self.assertRaises(fastapi.HTTPException) as ctx:
+            asyncio.run(tm._handle_abort_finish_reason(out, state, is_stream=False))
+
+        self.assertEqual(ctx.exception.status_code, HTTPStatus.TOO_MANY_REQUESTS)
+        self.assertIs(
+            asyncio.run(tm._handle_abort_finish_reason(out, state, is_stream=True)), out
         )
 
 


### PR DESCRIPTION
## Motivation

Per-routing-key queue admission emits a scheduler abort with `HTTPStatus.TOO_MANY_REQUESTS`. `TokenizerManager._handle_abort_finish_reason()` only converted 503/500 aborts into HTTP errors, so non-streaming `/generate` returned HTTP 200 with an abort payload. Clients and gateways therefore could not apply rate-limit retry/backoff correctly.

## Modifications

- Propagate scheduler 429 aborts through the existing `fastapi.HTTPException` path for non-streaming requests.
- Preserve streaming behavior: return the terminal abort chunk because response headers may already have been sent.
- Add CPU regression coverage for both branches.

## Accuracy Tests

N/A. This does not change model execution or generated output.

## Speed Tests and Profiling

N/A. This adds one enum value to an abort-only status check.

## Test Plan

- `python3 test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py`: 16/16 passed with HIP devices hidden on KiloLab, including non-streaming 429 and unchanged streaming terminal-abort output.
- Live `final119` on a Radeon RX 7900 XTX, native non-streaming `/generate`: 20 filler requests accepted; 2 fillers and all 16 probes returned HTTP 429; no 503; the recovery request succeeded.
- After the live gate: running=0, queued=0, health=200, and `NRestarts=0`.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Documentation not required; no public API or configuration changed.
- [x] Accuracy/speed benchmarks not applicable to this abort-path status propagation fix.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29759725969](https://github.com/sgl-project/sglang/actions/runs/29759725969)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29759725813](https://github.com/sgl-project/sglang/actions/runs/29759725813)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->