### PR TITLE
[AMD] quantization: import AITER only when available

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib.util
 import logging
 from typing import Any, Callable, Optional
 
@@ -11,7 +12,12 @@ from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import direct_register_custom_op, mxfp_supported
 
 _is_hip = is_hip()
-if _is_hip:
+# aiter is optional on ROCm, so is_hip() alone must not trigger
+# these imports -- a default RDNA/no-aiter startup would otherwise crash importing this
+# module. Gate on availability, NOT SGLANG_USE_AITER.
+# If aiter is present but unimportable, the import below fails loud.
+_has_aiter = _is_hip and importlib.util.find_spec("aiter") is not None
+if _has_aiter:
     from aiter.ops.triton.gemm.fused.fused_gemm_afp4wfp4_split_cat import (
         fused_gemm_afp4wfp4_split_cat as _fused_gemm_afp4wfp4_split_cat_orig,
     )

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -31,13 +32,17 @@ _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 __all__ = ["QuarkW4A4MXFp4MoE"]
 
 _is_hip = is_hip()
+# _use_aiter selects the aiter MoE kernel at runtime (is_aiter_moe below). _has_aiter
+# gates the aiter imports on availability -- same as the other quark schemes -- so a
+# no-aiter startup (RDNA) doesn't crash, while CDNA (aiter installed) imports them
+# regardless of SGLANG_USE_AITER. dynamic_mxfp4_quant stays None when unavailable
+# (the online MoE path guards for it).
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
-if _use_aiter:
+_has_aiter = _is_hip and importlib.util.find_spec("aiter") is not None
+if _has_aiter:
     from aiter.ops.shuffle import shuffle_weight
-    from aiter.utility.fp4_utils import e8m0_shuffle
-
-if _is_hip:
     from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    from aiter.utility.fp4_utils import e8m0_shuffle
 else:
     dynamic_mxfp4_quant = None
 

--- a/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/quark_int4fp8_moe.py
@@ -1,3 +1,4 @@
+import importlib.util
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -24,11 +25,17 @@ if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import DispatchOutput
 
 _is_hip = is_hip()
+# aiter is optional on ROCm, so is_hip() alone must not trigger
+# these imports -- a default RDNA/no-aiter startup would otherwise crash importing this
+# module. Gate on availability, NOT SGLANG_USE_AITER.
+# If aiter is present but unimportable, the import below fails loud.
+_has_aiter = _is_hip and importlib.util.find_spec("aiter") is not None
 
-
-if _is_hip:
+if _has_aiter:
     from aiter.ops.shuffle import shuffle_weight
 
+# ON_GFX950 is an arch probe unrelated to aiter, so keep it under is_hip().
+if _is_hip:
     ON_GFX950 = "gfx950" in torch.cuda.get_device_properties("cuda").gcnArchName
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Motivation

AITER is optional on ROCm (opt-in via `SGLANG_USE_AITER`, default off; no published wheel), but
several quark quant modules import it **unconditionally at import time**. On an AMD device without
AITER (e.g. RDNA) this crashes the server at startup for *every* model, before any model is selected.

## Change

Gate the AITER imports in the quark MXFP4 / INT4-FP8 schemes on aiter availability.

## No regression

`SGLANG_USE_AITER` defaults to off, so CDNA/NVIDIA behavior is unchanged - AITER was already opt-in;
this just stops importing it when it isn't found on system.

## Context

Required alongside #31803 (sgl-kernel RDNA build) to run models on RDNA. Alternative to #31421
(env-gated + fail-loud instead of `try/except`).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29766564540](https://github.com/sgl-project/sglang/actions/runs/29766564540)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29766563721](https://github.com/sgl-project/sglang/actions/runs/29766563721)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->