### PR TITLE
qwen3_5: fix multimodal mrope positions being collapsed by the CUDA fused rope kernel

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1020,12 +1020,12 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        if _is_cuda and self.attn_output_gate:
+        if _is_cuda and self.attn_output_gate and positions.ndim == 1:
             q, k, v, gate = self.forward_prepare_cuda_fused(
                 positions=positions,
                 hidden_states=hidden_states,
             )
-        elif (_is_hip or _is_xpu or _is_cpu) and self.attn_output_gate:
+        elif (_is_cuda or _is_hip or _is_xpu or _is_cpu) and self.attn_output_gate:
             q, k, v, gate = self.forward_prepare_fused_gate(
                 positions=positions,
                 hidden_states=hidden_states,


### PR DESCRIPTION
## Motivation

On CUDA, `Qwen3_5AttentionDecoderLayer.self_attention` always takes `forward_prepare_cuda_fused` when `attn_output_gate` is set. Its `fused_qk_gemma_rmsnorm_rope_gate` kernel indexes `positions` as a flat `[T]` tensor, but multimodal requests on Qwen3.5/Qwen3.6 (`Qwen3_5ForConditionalGeneration`) pass mrope positions shaped `(3, T)` — the kernel silently applies only the temporal position row across the whole rotary dim, so image-conditioned outputs are corrupted with no error raised.

## Modifications

Route 2-D positions to `forward_prepare_fused_gate` instead (2-line change): its Triton norm+gate kernel runs fine on CUDA and its `rotary_emb` call dispatches to the fused Triton mrope kernel. Text-only requests (1-D positions) keep the existing CUDA fused path.

## Accuracy Tests

Validated serving Qwen3.6-27B-FP8 on 8xB200 with screenshot-heavy multimodal traffic: without this change the model consistently misreads image content; with it, image-conditioned responses are correct. Text-only outputs are unaffected (that path is untouched).

## Speed Tests and Profiling

No change to the text-only hot path. Multimodal batches move from the (incorrect for mrope) CUDA fused kernel to the Triton fused-gate path — correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29765376799](https://github.com/sgl-project/sglang/actions/runs/29765376799)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29765376670](https://github.com/sgl-project/sglang/actions/runs/29765376670)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->