### PR TITLE
Fix LoRA usage-counter accounting across request lifecycle paths

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -182,6 +182,13 @@ class ReqState:
     last_completion_tokens: int = 1
     ttft_observed: bool = False
 
+    # Whether the LoRA usage counter for this request has been released.
+    # A request's completion can be observed from multiple paths (scheduler
+    # batch output, abort ack, error finish reason, dispatch failure); the
+    # counter must be decremented exactly once or wait_for_unload hangs
+    # (counter stuck > 0) or unloads adapters still in use (counter < 0).
+    lora_released: bool = False
+
     # For streaming output
     last_output_offset: int = 0
 
@@ -447,6 +454,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.rid_to_state: Dict[str, ReqState] = {}
         self.event_loop = None
         self.asyncio_tasks = set()
+        # Strong references to in-flight LoRA counter release tasks; the event
+        # loop only keeps weak refs, so a bare create_task could be
+        # garbage-collected before it runs and the release silently dropped.
+        self._lora_release_tasks = set()
 
         # Health check
         self.server_status = ServerStatus.Starting
@@ -1452,6 +1463,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             finish_reason.get("type") == "abort"
             and finish_reason.get("status_code") == HTTPStatus.BAD_REQUEST
         ):
+            # Delete the key to prevent resending abort request to the scheduler and
+            # to ensure aborted request state is cleaned up.
+            if state.obj.rid in self.rid_to_state:
+                del self.rid_to_state[state.obj.rid]
+
+            # Mark ongoing LoRA request as finished. This branch previously
+            # released nothing, leaking the usage counter for every
+            # BAD_REQUEST abort delivered through the ack channel.
+            release_task = self._release_lora_once(state)
+            if release_task is not None:
+                await release_task
             if not is_stream:
                 raise ValueError(finish_reason["message"])
             return out
@@ -1468,8 +1490,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 del self.rid_to_state[state.obj.rid]
 
             # Mark ongoing LoRA request as finished.
-            if self.enable_lora and state.obj.lora_path:
-                await self.lora_registry.release(state.obj.lora_id)
+            release_task = self._release_lora_once(state)
+            if release_task is not None:
+                await release_task
             if not is_stream:
                 raise fastapi.HTTPException(
                     status_code=finish_reason["status_code"],
@@ -1478,6 +1501,30 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             return out
 
         return None
+
+    def _release_lora_once(self, state: ReqState) -> Optional[asyncio.Task]:
+        """Release the LoRA usage counter for a request exactly once.
+
+        Every completion path must route through this guard. The success
+        path, the abort ack (_handle_abort_req), the abort finish reasons,
+        and dispatch failures can each observe the same request's
+        completion; unguarded releases either leak the counter (abort paths
+        released nothing: counter stuck > 0, wait_for_unload hangs forever)
+        or double-release (counter negative, adapters unloaded while still
+        in use).
+
+        Returns the release task so async callers can await it, or None when
+        there is nothing to release.
+        """
+        if state.lora_released:
+            return None
+        if not (self.enable_lora and state.obj.lora_path):
+            return None
+        state.lora_released = True
+        task = asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+        self._lora_release_tasks.add(task)
+        task.add_done_callback(self._lora_release_tasks.discard)
+        return task
 
     async def _wait_one_response(
         self,
@@ -1642,9 +1689,33 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 *(self._tokenize_one_request(obj) for obj in objs)
             )
 
+            # Every sub-request below is re-sent under a regenerated rid, so
+            # the parent-entry states created by _init_req_state are never
+            # dispatched. Drop them up front and mark their LoRA accounting
+            # as transferred to the regenerated copies — otherwise an abort
+            # ack for a parent rid (e.g. from create_abort_task on client
+            # disconnect) would release counters the expanded finishers
+            # already own, driving them negative.
+            parent_states = {}
+            for parent_rid in obj.rid if isinstance(obj.rid, list) else [obj.rid]:
+                parent_state = self.rid_to_state.pop(parent_rid, None)
+                if parent_state is not None:
+                    parent_state.lora_released = True
+                    parent_states[parent_rid] = parent_state
+
             # Cache the common prefix for parallel sampling
             for i in range(batch_size):
                 tmp_obj = copy.copy(objs[i])
+                # The LoRA usage counter is acquired once per entry of the
+                # parent's (expanded) lora_path list, i.e. once per expanded
+                # sub-request. This prefix-cache warm-up sub-request is an
+                # extra finisher on top of those: clear lora on the
+                # tokenizer-side state object so its finish does not release
+                # (which drove the counter negative by one per prompt). The
+                # scheduler-side tokenized_obj keeps its lora fields so the
+                # radix prefix is cached under the right adapter key.
+                tmp_obj.lora_path = None
+                tmp_obj.lora_id = None
                 tokenized_obj = copy.copy(tokenized_objs[i])
                 # Ensure independent mm_items so wrap_shm_features won't mutate the original
                 if hasattr(tokenized_obj, "mm_inputs") and tokenized_obj.mm_inputs:
@@ -1681,8 +1752,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     generators.append(self._wait_one_response(tmp_obj, request))
                     rids.append(tmp_obj.rid)
 
-                self.rid_to_state[objs[i].rid].time_stats.set_finished_time()
-                del self.rid_to_state[objs[i].rid]
+                if objs[i].rid in parent_states:
+                    parent_states[objs[i].rid].time_stats.set_finished_time()
 
         # Wait for all requests
         is_stream = hasattr(obj, "stream") and obj.stream
@@ -2164,9 +2235,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
                 del self.rid_to_state[rid]
 
-                # Mark ongoing LoRA request as finished.
-                if self.enable_lora and state.obj.lora_path:
-                    asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+                # Mark ongoing LoRA request as finished. Routed through the
+                # exactly-once guard, which also keeps a strong reference to
+                # the release task (a bare create_task is droppable by GC
+                # before it ever runs).
+                self._release_lora_once(state)
 
             if out_dict is not None:
                 state.out_list.append(out_dict)
@@ -2826,6 +2899,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         }
         del self.rid_to_state[recv_obj.rid]
 
+        # The abort ack is a terminal state for this request — release the
+        # LoRA usage counter (previously leaked one count per queued abort,
+        # e.g. /abort_request or client disconnect while waiting, wedging
+        # every later unload of the adapter).
+        self._release_lora_once(state)
+
         state.out_list.append(out)
         state.event.set()
 
@@ -3031,13 +3110,21 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         Safe to call after a partial/failed dispatch: only entries still present
         are removed, and the scheduler-response path looks up state with
         ``.get(...)`` so a later output for a discarded rid is ignored, not fatal.
+
+        Also releases the LoRA usage counter for each dropped entry:
+        _resolve_lora_path acquires *before* tokenization/validation, so a
+        request failing there never reaches the scheduler and no output or
+        abort ack can balance the counter. The per-state guard makes this
+        safe even when some sub-requests were already dispatched.
         """
         if not hasattr(obj, "is_single") or obj.is_single:
             rids = [obj.rid]
         else:
             rids = obj.rid
         for rid in rids:
-            self.rid_to_state.pop(rid, None)
+            state = self.rid_to_state.pop(rid, None)
+            if state is not None:
+                self._release_lora_once(state)
 
     def _should_dispatch_to_encoder(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/test/registered/lora/test_lora_usage_counter.py
+++ b/test/registered/lora/test_lora_usage_counter.py
@@ -1,0 +1,244 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Regression tests for LoRA usage-counter accounting (LoRARegistry).
+
+Every request lifecycle must balance the registry's acquire/release exactly:
+``unload_lora_adapter`` waits for the usage counter to reach zero, so a
+leaked acquire makes the unload hang forever, and an extra release lets an
+adapter unload while requests still use it. Each test drives one lifecycle
+shape against a freshly loaded adapter and then asserts the unload completes
+promptly (i.e. the counter returned to zero).
+
+Lifecycles covered: parallel-sampling success (n>1), client disconnect
+mid-generation (n=1 and n=4), /abort_request on queued and running requests,
+tokenizer-side validation failure (oversized prompt), scheduler-side
+BAD_REQUEST (invalid grammar), and streaming n>1 disconnect (whose abort
+acks target the parent request ids).
+"""
+
+import threading
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(
+    est_time=480,
+    stage="base-b",
+    runner_config="1-gpu-large",
+)
+
+BASE_MODEL = "meta-llama/Llama-3.1-8B-Instruct"
+ADAPTER = "philschmid/code-llama-3-1-8b-text-to-sql-lora"
+SENTINEL_NAME = "sentinel"  # stays loaded for the whole server lifetime
+TEST_NAME = "lifecycle_test_adapter"  # loaded/unloaded once per test
+PROMPT = "Write a SQL query that selects all columns from a table."
+CONTEXT_LEN = 2048
+UNLOAD_TIMEOUT = 60  # generous; a balanced unload returns in milliseconds
+
+
+class TestLoRAUsageCounter(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            BASE_MODEL,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--enable-lora",
+                "--lora-paths",
+                f"{SENTINEL_NAME}={ADAPTER}",
+                "--max-loras-per-batch",
+                "2",
+                "--max-running-requests",
+                "1",
+                "--context-length",
+                str(CONTEXT_LEN),
+                "--mem-fraction-static",
+                "0.8",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    # ---------- helpers ----------
+
+    def _post(self, path, payload, timeout=120):
+        return requests.post(f"{self.base_url}{path}", json=payload, timeout=timeout)
+
+    def _gen_payload(self, n=1, max_new_tokens=64, rid=None, stream=False):
+        payload = {
+            "text": PROMPT,
+            "lora_path": TEST_NAME,
+            "sampling_params": {
+                "temperature": 0.0,
+                "max_new_tokens": max_new_tokens,
+                "ignore_eos": True,
+            },
+            "stream": stream,
+        }
+        if n > 1:
+            payload["sampling_params"]["n"] = n
+        if rid is not None:
+            payload["rid"] = rid
+        return payload
+
+    def _load_test_adapter(self):
+        resp = self._post(
+            "/load_lora_adapter",
+            {"lora_name": TEST_NAME, "lora_path": ADAPTER},
+        )
+        self.assertTrue(resp.json().get("success"), resp.text)
+
+    def _assert_unload_completes(self, case: str, quiesce: float = 8.0):
+        """Unload the test adapter and assert it does not hang.
+
+        A leaked usage counter makes /unload_lora_adapter wait for a counter
+        that never reaches zero; run the unload on a worker thread with a
+        deadline so the test fails crisply instead of timing out the suite.
+        """
+        time.sleep(quiesce)  # let in-flight aborts/finishes drain
+        result = {}
+
+        def unload():
+            resp = self._post(
+                "/unload_lora_adapter", {"lora_name": TEST_NAME}, timeout=UNLOAD_TIMEOUT
+            )
+            result["status"] = resp.status_code
+            result["body"] = resp.text
+
+        start = time.monotonic()
+        worker = threading.Thread(target=unload, daemon=True)
+        worker.start()
+        worker.join(UNLOAD_TIMEOUT)
+        elapsed = time.monotonic() - start
+
+        self.assertFalse(
+            worker.is_alive(),
+            f"[{case}] unload_lora_adapter still blocked after {UNLOAD_TIMEOUT}s "
+            "— LoRA usage counter leaked (never returned to zero).",
+        )
+        self.assertEqual(result.get("status"), 200, f"[{case}] {result}")
+        self.assertLess(
+            elapsed,
+            10.0,
+            f"[{case}] unload took {elapsed:.1f}s; a balanced counter unloads "
+            "immediately, a slow unload means the counter was nonzero.",
+        )
+
+    def _gen_in_thread(self, results, key, **kwargs):
+        def run():
+            try:
+                results[key] = self._post(
+                    "/generate", self._gen_payload(**kwargs), timeout=120
+                ).json()
+            except Exception as exc:  # disconnects are expected in some tests
+                results[key] = repr(exc)
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        return thread
+
+    # ---------- lifecycle cases ----------
+
+    def test_parallel_sampling_success(self):
+        """n>1 success: the prefix-cache warm-up sub-request must not release."""
+        self._load_test_adapter()
+        resp = self._post("/generate", self._gen_payload(n=4, max_new_tokens=32))
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(len(resp.json()), 4)
+        self._assert_unload_completes("n4-success", quiesce=2.0)
+
+    def test_disconnect_mid_generation(self):
+        """Client disconnects while generating (n=1 and n=4, non-streaming)."""
+        self._load_test_adapter()
+        for n in (1, 4):
+            with self.assertRaises(requests.exceptions.RequestException):
+                self._post(
+                    "/generate",
+                    self._gen_payload(n=n, max_new_tokens=1500),
+                    timeout=3,  # hard-close the connection mid-generation
+                )
+        self._assert_unload_completes("disconnect-midgen", quiesce=15.0)
+
+    def test_abort_request_queued_and_running(self):
+        """/abort_request on a running and a queued request (1 running slot)."""
+        self._load_test_adapter()
+        results = {}
+        running = self._gen_in_thread(
+            results, "running", rid="usage-counter-running", max_new_tokens=1500
+        )
+        time.sleep(2)
+        queued = self._gen_in_thread(
+            results, "queued", rid="usage-counter-queued", max_new_tokens=1500
+        )
+        time.sleep(2)  # max-running-requests=1 -> second request is queued
+        self._post("/abort_request", {"rid": "usage-counter-queued"})
+        time.sleep(1)
+        self._post("/abort_request", {"rid": "usage-counter-running"})
+        running.join(60)
+        queued.join(60)
+        self._assert_unload_completes("abort-queued-running", quiesce=8.0)
+
+    def test_validation_failure_after_acquire(self):
+        """Oversized prompt: rejected after the LoRA counter was acquired."""
+        self._load_test_adapter()
+        resp = self._post(
+            "/generate",
+            {
+                "input_ids": [10] * (CONTEXT_LEN + 100),
+                "lora_path": TEST_NAME,
+                "sampling_params": {"max_new_tokens": 8},
+            },
+        )
+        self.assertEqual(resp.status_code, 400, resp.text)
+        self._assert_unload_completes("oversized-prompt", quiesce=2.0)
+
+    def test_scheduler_bad_request(self):
+        """Invalid grammar: scheduler-side BAD_REQUEST finish."""
+        self._load_test_adapter()
+        payload = self._gen_payload(max_new_tokens=16)
+        payload["sampling_params"]["json_schema"] = '{"type":'  # unparseable
+        resp = self._post("/generate", payload)
+        self.assertEqual(resp.status_code, 400, resp.text)
+        self._assert_unload_completes("scheduler-bad-request", quiesce=8.0)
+
+    def test_streaming_parallel_disconnect(self):
+        """Streaming n>1 disconnect: abort acks target the parent rids."""
+        self._load_test_adapter()
+        resp = requests.post(
+            f"{self.base_url}/generate",
+            json=self._gen_payload(n=4, max_new_tokens=100, stream=True),
+            stream=True,
+            timeout=30,
+        )
+        next(resp.iter_content(chunk_size=64))
+        resp.close()  # create_abort_task fires ~2s later on the parent rids
+        self._assert_unload_completes("stream-n4-disconnect", quiesce=25.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`LoRARegistry` tracks per-adapter in-flight usage with a `ConcurrentCounter`:
`acquire()` (+1 per request entry) when `_resolve_lora_path` runs, `release()`
(−1) when the request finishes. `/unload_lora_adapter` →
`LoRARegistry.wait_for_unload()` waits for the counter to reach **exactly
zero** before unloading. Any accounting imbalance therefore turns into one of
two production failures:

- **counter stuck > 0** (leaked acquire): the unload hangs forever, and
  because the tokenizer manager serializes LoRA update operations, every
  subsequent load/unload wedges behind it;
- **counter < 0** (extra release): `wait_for_zero` can also never fire (it
  waits for equality), same hang — and had it fired, the adapter could be
  unloaded while requests still use it.

We hit this in an RL setting (adapter hot-swap between rollout waves,
engine-native parallel sampling, occasional client disconnects/aborts): usage
counters drifted by hundreds per adapter per rollout, after which every
generation-used adapter's unload hung (>130 s with an external watchdog, vs
0.03 s for an unused adapter on the same engine).

Related: #23141, #5525, #8162, #2686, #6184, #14338.

## Root causes fixed

1. **Parallel sampling (`n>1`) over-release** — `_handle_batch_request`
   sends a prefix-cache warm-up sub-request (`max_new_tokens=0`) that is
   `copy.copy`'d from the parent with `lora_id` intact. Acquire is once per
   entry of the expanded `lora_path` list (= n per prompt), but finishers are
   n expansions **+ 1 warm-up** per prompt → net −1 per prompt on the pure
   success path. Fixed by clearing `lora_path`/`lora_id` on the
   tokenizer-side state object only (the scheduler-side object keeps them so
   the radix prefix is cached under the right adapter key).
2. **Droppable success release** — the success path released via a bare
   `asyncio.create_task(...)` with no strong reference; the event loop keeps
   only weak refs, so the release can be garbage-collected unrun.
3. **Abort-ack leak** — `_handle_abort_req` (the scheduler's abort ack for
   `/abort_request`, or a client disconnect while queued) marked the request
   finished, deleted the `rid_to_state` entry, but never released. Note this
   is not limited to queued aborts: the ack races the final batch output for
   *running* aborts (see the existing comment in `_handle_abort_req`), and
   when the ack lands first it deletes the state entry, the batch output is
   skipped, and the success-path release is lost too — so running aborts
   leak timing-dependently.
4. **`BAD_REQUEST` abort finish leak** — the `BAD_REQUEST` branch of
   `_handle_abort_finish_reason` raised/returned without releasing (and
   without dropping the `rid_to_state` entry, unlike the adjacent
   `SERVICE_UNAVAILABLE` branch).
5. **Validation-failure leak** — `_resolve_lora_path` acquires **before**
   tokenization/validation, so a request rejected by `_validate_one_request`
   (e.g. oversized prompt) has acquired but never reaches the scheduler — no
   output or abort ack can ever balance it.
6. **Parallel-sampling parent-state hazard** — the `n>1` path re-sends every
   sub-request under regenerated rids, leaving the parent-entry `ReqState`s
   created by `_init_req_state` orphaned (all but the first per prompt were
   also never removed from `rid_to_state`). `create_abort_task` aborts the
   *parent* rids on streaming disconnect, so naively adding a release to the
   abort ack (fix 3) would release counters the expanded finishers already
   own, driving them negative.

## Modifications

All completion paths now route through one idempotent guard:

- `ReqState.lora_released` flag + `TokenizerManager._release_lora_once(state)`
  (releases exactly once per tracked request state; keeps a strong reference
  to the release task in `self._lora_release_tasks`).
- Success path (`_handle_batch_output`), abort ack (`_handle_abort_req`), and
  both error branches of `_handle_abort_finish_reason` call the guard; the
  `BAD_REQUEST` branch now also cleans up `rid_to_state`, mirroring the
  `SERVICE_UNAVAILABLE` branch.
- `_discard_pending_req_states` (already called from `generate_request`'s
  `except`) now releases the counter for each dropped state, closing the
  validation-failure leak.
- The `n>1` branch pops all parent-entry states up front and marks their
  accounting as transferred (`lora_released = True`) to the regenerated
  copies; parent-rid abort acks become harmless no-ops, and the
  `rid_to_state` growth from orphaned parent entries is gone.
- The `n>1` prefix-cache warm-up sub-request no longer carries
  `lora_path`/`lora_id` on the tokenizer-side state object.

Behavioral invariant: for every request shape, total releases == total
acquires, exactly once each, regardless of which combination of batch
output / abort ack / error branch / dispatch failure observes the finish.

## Test & verification

New `test/registered/lora/test_lora_usage_counter.py` drives one lifecycle
shape per test against a freshly loaded adapter and asserts
`/unload_lora_adapter` completes promptly (a leaked counter blocks it
forever): parallel-sampling success, mid-generation client disconnect (n=1
and n=4), `/abort_request` on queued + running requests, oversized-prompt
400, invalid-grammar 400, and streaming n=4 disconnect.

Standalone verification against the official nightly image built from main
(`lmsysorg/sglang:nightly-dev-20260708-b3632494`, single GPU, tiny model,
instrumented registry that logs the counter value at unload time). Counter
value at unload per case:

| case | stock main | with this PR |
|---|---|---|
| unused adapter (control) | 0 | 0 |
| `n=4` success | **−1** (hang) | 0, instant |
| disconnect mid-gen (n=1 + n=4) | **+3** (hang) | 0, instant |
| `/abort_request` queued + running | **+1** (hang) | 0, instant |
| oversized prompt → 400 | **+1** (hang) | 0, instant |
| invalid `json_schema` → 400 | 0 | 0 |
| streaming `n=4` disconnect | **−1** (hang) | 0, instant |

("hang" = `wait_for_unload` never returns upstream; bounded in the harness
only to keep the runs finite. The same matrix on 0.5.12.post1 differs only
in the disconnect case: +2 instead of +3, because there the running abort's
release always arrived via batch output, while on main the abort ack can
preempt it — root cause 3.)

## Checklist

- [x] Format your code with `pre-commit run --all-files` *(run before push)*
- [x] Add unit tests
- [x] Update documentation as needed *(no user-facing docs affected)*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29766191882](https://github.com/sgl-project/sglang/actions/runs/29766191882)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29766190319](https://github.com/sgl-project/sglang/actions/runs/29766190319)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->