### PR TITLE
config: load-time declarations write the config bags

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -261,19 +261,17 @@ def mamba_extra_buffer_of(cfg: Any) -> bool:
 
 def declare_load_time_override(source: str, declared: Dict[str, Any]) -> None:
     """Declare a load-time resolved field (model-file config overrides,
-    weight-resolved dtypes) on the published ``server_args``: resolution has
-    already materialized, so the declaration writes through, joining the
-    declaration stash for provenance and republish consistency."""
+    weight-resolved dtypes) after publish. it is written to the config
+    bags via ``get_context().override`` (namespace readers see it); server_args
+    stays the pristine startup record. Validated against the resolvable
+    whitelist first."""
     from sglang.srt.runtime_context import get_context
 
-    server_args = get_context().server_args
-    validate_declarations(server_args, [(source, dict(declared))])
-    override = getattr(server_args, "override", None)
-    if override is not None:
-        override(source, **declared)
-    else:
-        # Config-shaped fixtures without the mutation entry point.
-        _apply_fields(server_args, declared)
+    context = get_context()
+    validate_declarations(context.server_args, [(source, dict(declared))])
+    # write the config bags (namespace readers see it); server_args
+    # stays the pristine startup record.
+    context.override(source, **declared)
 
 
 def collect_model_override_declarations(


### PR DESCRIPTION
Stacked on https://github.com/sgl-project/sglang/pull/31814. Part of a stacked series introducing a structured RuntimeContext configuration API (resolved config read through domain namespaces; ServerArgs becomes the read-only record). Incremental and behavior-preserving.

declare_load_time_override() routes to the config bags so the migrated readers
observe load-time resolved values.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29903479113](https://github.com/sgl-project/sglang/actions/runs/29903479113)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29903478590](https://github.com/sgl-project/sglang/actions/runs/29903478590)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->