### PR TITLE
test: publish resolved config in unit fixtures for the namespace API

### DIFF
--- a/test/registered/unit/test_legacy_global_ratchet.py
+++ b/test/registered/unit/test_legacy_global_ratchet.py
@@ -31,7 +31,7 @@ _RATCHETS = [
     (
         "set_global_server_args_for_*",
         r"\bset_global_server_args_for_(?:scheduler|tokenizer)\s*\(",
-        5,
+        4,
     ),
 ]
 

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -10,7 +10,7 @@ import unittest
 from unittest.mock import patch
 
 import sglang.srt.server_args as server_args_module
-from sglang.srt.arg_groups.arg_utils import A, Arg
+from sglang.srt.arg_groups.arg_utils import NS, A, Arg
 from sglang.srt.runtime_context import (
     Flags,
     ParallelContext,
@@ -18,6 +18,7 @@ from sglang.srt.runtime_context import (
     _FlagGroupBase,
     get_context,
     get_flags,
+    get_memory,
     get_parallel,
     get_server_args,
     reset_context,
@@ -215,8 +216,10 @@ class TestServerArgsOwnership(_IsolatedServerArgs):
         self.assertIs(get_server_args(), sentinel)
         self.assertIs(get_context().server_args, sentinel)
 
-    def test_tokenizer_alias_is_same_function(self):
-        self.assertIs(
+    def test_tokenizer_and_scheduler_setters_are_distinct_role_shims(self):
+        # The per-role publish shims are no longer aliases: each records its own
+        # process role via publish(role=...).
+        self.assertIsNot(
             server_args_module.set_global_server_args_for_tokenizer,
             server_args_module.set_global_server_args_for_scheduler,
         )
@@ -373,8 +376,10 @@ class TestFlagsTier(_IsolatedServerArgs):
 class _FakeResolvedArgs:
     """Publishable fixture with a resolvable whitelist (real flat leaves)."""
 
-    page_size: A[int | None, Arg(help="p", resolvable=True)] = None
-    sampling_backend: A[str | None, Arg(help="s", resolvable=True)] = None
+    page_size: A[int | None, Arg(help="p", resolvable=True), NS("memory")] = None
+    sampling_backend: A[
+        str | None, Arg(help="s", resolvable=True), NS("exec.kernel")
+    ] = None
     _resolved_overrides: list = dataclasses.field(default_factory=list)
 
 
@@ -916,12 +921,15 @@ class TestPublishLifecycle(_IsolatedServerArgs):
         get_context().set_server_args(object())
         self.assertFalse(get_flags().capture.enable_torch_compile)
 
-    def test_declare_load_time_override_writes_through(self):
+    def test_declare_load_time_override_writes_the_bag(self):
         from sglang.srt.arg_groups.overrides import declare_load_time_override
 
         args = self._publish(page_size=1)
         declare_load_time_override("model.load_time", {"page_size": 64})
-        self.assertEqual(args.page_size, 64)
+        # The declaration lands on the config bag; the pristine startup record
+        # (server_args) is untouched.
+        self.assertEqual(get_memory().page_size, 64)
+        self.assertEqual(args.page_size, 1)
 
     def test_declare_load_time_override_validates_whitelist(self):
         from sglang.srt.arg_groups.overrides import declare_load_time_override
@@ -933,16 +941,14 @@ class TestPublishLifecycle(_IsolatedServerArgs):
 
     def test_declare_load_time_override_records_provenance(self):
         from sglang.srt.arg_groups.overrides import declare_load_time_override
-        from sglang.srt.server_args import ServerArgs
 
-        class _Args(_FakeResolvedArgs):
-            override = ServerArgs.override
-
-        args = _Args(page_size=1)
-        get_context().set_server_args(args)
+        self._publish(page_size=1)
         declare_load_time_override("model.load_time", {"page_size": 64})
-        self.assertEqual(args.page_size, 64)
-        self.assertIn(("model.load_time", {"page_size": 64}), args._resolved_overrides)
+        self.assertEqual(get_memory().page_size, 64)
+        self.assertIn(
+            ("model.load_time", {"page_size": 64}),
+            get_context().overrides_log(),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on https://github.com/sgl-project/sglang/pull/31816. Part of a stacked series introducing a structured RuntimeContext configuration API (resolved config read through domain namespaces; ServerArgs becomes the read-only record). Incremental and behavior-preserving.

Components now read resolved config through the published namespace bags
(get_model()/get_serving()/get_exec()/...), so unit fixtures publish a real
resolved ServerArgs (+ autouse reset) instead of bare mocks, and stale
get_server_args monkeypatch targets move to the accessor each module imports.
Also update the runtime_context / deepseek_v4 tests to assert the config bag
rather than server_args write-through, and lower the legacy-accessor ratchet.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29903524896](https://github.com/sgl-project/sglang/actions/runs/29903524896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #29903524640](https://github.com/sgl-project/sglang/actions/runs/29903524640)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->