### PR TITLE
  [Quant] Support NVFP4_AWQ checkpoints in ModelOpt FP4 path

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1176,6 +1176,7 @@ class ModelOptFp4Config(ModelOptQuantConfig):
         exclude_modules: List[str] = None,
         packed_modules_mapping: Optional[Dict[str, List[str]]] = None,
         use_per_token_activation: Optional[bool] = None,
+        is_awq: bool = False,
     ) -> None:
         super().__init__(kv_cache_quant_algo, exclude_modules, packed_modules_mapping)
         self.is_checkpoint_nvfp4_serialized = is_checkpoint_nvfp4_serialized
@@ -1184,6 +1185,7 @@ class ModelOptFp4Config(ModelOptQuantConfig):
                 "Detected nvfp4 checkpoint. Please note that the "
                 "format is experimental and subject to change."
             )
+        self.is_awq = is_awq
         self.group_size = group_size
         self.use_per_token_activation = (
             envs.SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION.get()
@@ -1288,6 +1290,9 @@ class ModelOptFp4Config(ModelOptQuantConfig):
                     first_group = next(iter(config_groups.values()), {})
                     weights_config = first_group.get("weights", {})
                     group_size = weights_config.get("group_size")
+            # NVFP4 (incl. NVFP4_AWQ) always uses group_size 16
+            if group_size is None and quant_method and "NVFP4" in quant_method:
+                group_size = 16
 
             exclude_modules = config.get("ignore", [])
         else:
@@ -1306,10 +1311,10 @@ class ModelOptFp4Config(ModelOptQuantConfig):
                     "Expected either flat format (config.json) or nested format (hf_quant_config.json)."
                 )
 
-        if quant_method not in ["FP8", "NVFP4"]:
+        if quant_method not in ["FP8", "NVFP4", "NVFP4_AWQ"]:
             raise ValueError(
-                "ModelOpt currently only supports: FP8, NVFP4"
-                " quantizations in sglang. Please check the "
+                "ModelOpt currently only supports: FP8, NVFP4, NVFP4_AWQ "
+                "quantizations in sglang. Please check the "
                 "quantization config for your model's configuration."
             )
         is_checkpoint_nvfp4_serialized = "NVFP4" in quant_method
@@ -1330,6 +1335,7 @@ class ModelOptFp4Config(ModelOptQuantConfig):
             group_size,
             exclude_modules,
             config.get("packed_modules_mapping"),
+            is_awq="AWQ" in quant_method,
         )
 
     def get_quant_method(self, layer: torch.nn.Module, prefix: str):
@@ -1454,6 +1460,18 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
             needs_scalar_to_array=True,
         )
         layer.register_parameter("input_scale", input_scale)
+
+        # NVFP4_AWQ: per-input-channel activation pre-scale baked into the weights
+        # offline. Length == input_size_per_partition; shards along the input dim
+        # (input_dim=0) so it splits correctly on row-parallel linears.
+        if self.quant_config.is_awq:
+            pre_quant_scale = ModelWeightParameter(
+                data=torch.ones(input_size_per_partition, dtype=params_dtype),
+                input_dim=0,
+                output_dim=0,
+                weight_loader=weight_loader,
+            )
+            layer.register_parameter("pre_quant_scale", pre_quant_scale)
 
         weight_scale_2 = _make_per_tensor_scale_parameter(
             (len(output_partition_sizes),),
@@ -1674,6 +1692,9 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
             x_m = x_fp4.shape[0]
             output_dtype = layer.params_dtype
         else:
+            # NVFP4_AWQ: apply the per-input-channel pre_quant_scale.
+            if self.quant_config.is_awq:
+                x = x * layer.pre_quant_scale
             x_fp4, x_scale_interleaved = fp4_quantize(x, layer.input_scale_inv)
             x_m, _ = x.shape
             output_dtype = x.dtype

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -456,6 +456,7 @@ class TestParseQuantHfConfig(CustomTestCase):
         ({"quant_method": "modelopt", "quant_algo": "FP8"}, "modelopt_fp8"),
         ({"quant_method": "modelopt", "quant_algo": "FP4"}, "modelopt_fp4"),
         ({"quant_method": "modelopt", "quant_algo": "NVFP4"}, "modelopt_fp4"),
+        ({"quant_algo": "NVFP4_AWQ"}, "modelopt_fp4"),
         ({"quant_method": "modelopt", "quant_algo": "MIXED_PRECISION"}, "w4afp8"),
         ({"quant_algo": "FP8"}, "modelopt_fp8"),
         ({"quant_algo": "FP4"}, "modelopt_fp4"),
@@ -492,6 +493,18 @@ class TestParseQuantHfConfig(CustomTestCase):
                 self.model_config.hf_config.quantization_config = dict(quant_cfg_input)
                 result = self.model_config._parse_quant_hf_config()
                 self.assertEqual(result["quant_method"], expected)
+
+    def test_awq_flat_config_defaults_group_size(self):
+        """NVFP4_AWQ flat config.json omits group_size; from_config must default it to 16."""
+        cfg = ModelOptFp4Config.from_config(
+            {
+                "quant_algo": "NVFP4_AWQ",
+                "ignore": ["lm_head"],
+                "quant_method": "modelopt",
+            }
+        )
+        self.assertEqual(cfg.group_size, 16)
+        self.assertTrue(cfg.is_awq)
 
     def test_non_modelopt_quant_method_unchanged(self):
         """Non-modelopt quant_method (e.g. 'gptq') must NOT enter the modelopt path."""


### PR DESCRIPTION
  Load and run ModelOpt NVFP4_AWQ checkpoints, which share the NVFP4 weight
  layout plus a per-input-channel pre_quant_scale that AWQ folds into the
  weights offline.

  - Accept NVFP4_AWQ in the quant_algo allowlist; set is_awq on the config.
  - Register a per-input-channel pre_quant_scale param for AWQ layers and apply it to activations before fp4_quantize (non-AWQ layers unaffected).
  - Default group_size to 16 on the flat config.json path, which ModelOpt's AWQ export omits (present only in nested hf_quant_config.json).
  - Add unit coverage for AWQ config parsing.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This was done to support easier serving of AWQ quantized models. I used Nvidia Model Optimizer for the quantization: https://github.com/NVIDIA/Model-Optimizer/tree/main 

## Modifications

- [python/sglang/srt/layers/quantization/modelopt_quant.py](https://github.com/sgl-project/sglang/compare/main...kfhfar:sglang:nvfp4-awq-quant?expand=1#diff-e6012ff06af318a10c5fcae7128f89c478fef7a6b52671881c05fb9fc2b7cb5b) 
- [test/registered/unit/model_loader/test_modelopt_loader.py](https://github.com/sgl-project/sglang/compare/main...kfhfar:sglang:nvfp4-awq-quant?expand=1#diff-6740a8cd806de4c4e85d4302a3fbca57ad3dbc6576b1d1411da586c46aa09000)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29778563277](https://github.com/sgl-project/sglang/actions/runs/29778563277)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29778563134](https://github.com/sgl-project/sglang/actions/runs/29778563134)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->