### PR TITLE
[AMD] ci: harden AITER rebuild so a bad commit can't wipe out aiter

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -299,43 +299,72 @@ fi
 if [[ "${NEED_REBUILD}" == "true" ]]; then
     echo "[CI-AITER-CHECK] === AITER REBUILD START ==="
 
-    # uninstall existing aiter
-    docker exec ci_sglang pip uninstall -y amd-aiter || true
-
-    # delete old aiter directory
-    docker exec ci_sglang rm -rf /sgl-workspace/aiter
-
-    # clone a fresh copy to /sgl-workspace/aiter
-    docker exec ci_sglang git clone https://github.com/ROCm/aiter.git /sgl-workspace/aiter
-
-    # checkout correct version and install requirements
-    # Use `checkout -f` so the smudge-filter-induced "dirty" working tree from
-    # AITER's .gitattributes (*.csv text eol=lf, added in ROCm/aiter#3370) does
-    # not block switching to commits that predate that rule. The working tree
-    # was just produced by `rm -rf` + fresh `git clone` above, so there are no
-    # real user changes to preserve.
-    docker exec ci_sglang bash -c "
-        cd /sgl-workspace/aiter && \
-        git fetch --all && \
-        git checkout -f ${REPO_AITER_COMMIT} && \
-        git submodule update --init --recursive && \
-        pip install -r requirements.txt
-    "
-
-    if [[ "${GPU_ARCH}" == "mi35x" ]]; then
-        GPU_ARCH_LIST="gfx950"
-    else
-        GPU_ARCH_LIST="gfx942"
+    # Clone + verify the target commit is reachable BEFORE touching the AITER
+    # that shipped in the image. This block used to uninstall aiter and
+    # `rm -rf` its checkout first, then `git checkout -f <commit>`. A commit
+    # that is not reachable in ROCm/aiter (a stale `aiter_ref` dispatch
+    # override, or a fork-only SHA) makes that checkout die with
+    # `fatal: reference is not a tree` (git exit 128) under `set -e`, which
+    # leaves the container with NO aiter at all -- so every aiter-dependent
+    # test then fails with a confusing `ModuleNotFoundError: No module named
+    # 'aiter'`. Verifying first keeps the working image aiter intact when the
+    # requested commit is bad.
+    docker exec ci_sglang rm -rf /sgl-workspace/aiter.new
+    AITER_COMMIT_OK=1
+    docker exec ci_sglang git clone https://github.com/ROCm/aiter.git /sgl-workspace/aiter.new || AITER_COMMIT_OK=0
+    if [[ "${AITER_COMMIT_OK}" == "1" ]]; then
+        # `git fetch --all --tags` so commits on any branch/tag are present,
+        # then confirm the target resolves to a real commit object.
+        docker exec ci_sglang bash -c "
+            cd /sgl-workspace/aiter.new && \
+            git fetch --all --tags --quiet && \
+            git cat-file -e '${REPO_AITER_COMMIT}^{commit}'
+        " || AITER_COMMIT_OK=0
     fi
-    echo "[CI-AITER-CHECK] GPU_ARCH_LIST=${GPU_ARCH_LIST}"
 
-    # build AITER
-    docker exec ci_sglang bash -c "
-        cd /sgl-workspace/aiter && \
-        AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
-    "
+    if [[ "${AITER_COMMIT_OK}" != "1" ]]; then
+        docker exec ci_sglang rm -rf /sgl-workspace/aiter.new || true
+        if [[ "${IMAGE_AITER_VERSION}" == "vnone" || "${IMAGE_AITER_VERSION}" == "v" ]]; then
+            echo "[CI-AITER-CHECK] ERROR: AITER commit '${REPO_AITER_COMMIT}' is not reachable in https://github.com/ROCm/aiter.git and the image ships no AITER to fall back to."
+            echo "[CI-AITER-CHECK] Fix the aiter_ref override or the AITER_COMMIT_DEFAULT in docker/rocm.Dockerfile."
+            exit 1
+        fi
+        echo "[CI-AITER-CHECK] WARNING: AITER commit '${REPO_AITER_COMMIT}' is not reachable in https://github.com/ROCm/aiter.git."
+        echo "[CI-AITER-CHECK] Keeping the AITER already installed in the image (${IMAGE_AITER_VERSION}) so aiter-dependent tests still run. Fix the aiter_ref override or the AITER_COMMIT_DEFAULT in docker/rocm.Dockerfile."
+    else
+        # Target commit verified reachable -> safe to replace the working AITER.
+        docker exec ci_sglang pip uninstall -y amd-aiter || true
+        docker exec ci_sglang rm -rf /sgl-workspace/aiter
+        docker exec ci_sglang mv /sgl-workspace/aiter.new /sgl-workspace/aiter
 
-    echo "[CI-AITER-CHECK] === AITER REBUILD COMPLETE ==="
+        # checkout correct version and install requirements
+        # Use `checkout -f` so the smudge-filter-induced "dirty" working tree from
+        # AITER's .gitattributes (*.csv text eol=lf, added in ROCm/aiter#3370) does
+        # not block switching to commits that predate that rule. The working tree
+        # was just produced by a fresh `git clone` above, so there are no real
+        # user changes to preserve.
+        docker exec ci_sglang bash -c "
+            cd /sgl-workspace/aiter && \
+            git checkout -f ${REPO_AITER_COMMIT} && \
+            git submodule update --init --recursive && \
+            pip install -r requirements.txt
+        "
+
+        if [[ "${GPU_ARCH}" == "mi35x" ]]; then
+            GPU_ARCH_LIST="gfx950"
+        else
+            GPU_ARCH_LIST="gfx942"
+        fi
+        echo "[CI-AITER-CHECK] GPU_ARCH_LIST=${GPU_ARCH_LIST}"
+
+        # build AITER
+        docker exec ci_sglang bash -c "
+            cd /sgl-workspace/aiter && \
+            AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
+        "
+
+        echo "[CI-AITER-CHECK] === AITER REBUILD COMPLETE ==="
+    fi
 fi
 
 echo "[CI-AITER-CHECK] === AITER VERSION CHECK END ==="


### PR DESCRIPTION
## Problem

The MI35x DeepSeek 8-GPU jobs on the ROCm 7.2 nightly failed with:

```
ModuleNotFoundError: No module named 'aiter'
ImportError: aiter is required when SGLANG_USE_AITER is set to True
```

Root cause is in `scripts/ci/amd/amd_ci_install_dependency.sh`. The AITER rebuild block **uninstalls the aiter that ships in the image and `rm -rf`s its checkout first**, then runs `git checkout -f <commit>`:

```
[CI-AITER-CHECK] AITER_COMMIT_OVERRIDE=11546f33... -> forcing rebuild
[CI-AITER-CHECK] === AITER REBUILD START ===
Successfully uninstalled amd-aiter-0.1.17.dev110+g9127c94a1   # <-- working aiter gone
Cloning into '/sgl-workspace/aiter'...
fatal: reference is not a tree: 11546f33...                    # <-- checkout fails, git exit 128
##[error]Process completed with exit code 128.
```

When the target commit isn't reachable in `ROCm/aiter` (a stale `aiter_ref` `workflow_dispatch` override, or a fork-only SHA), the `git checkout` dies with `fatal: reference is not a tree` (exit 128). Under `set -euo pipefail` the install step aborts — and since the working aiter was **already** removed, the container is left with **no aiter at all**. Every downstream aiter-dependent test then fails with a confusing `ModuleNotFoundError` that looks unrelated to the real cause.

## Fix

Clone to a temp dir and **verify the target commit resolves (`git cat-file -e <commit>^{commit}`) before uninstalling/replacing the existing aiter**:

- **Commit reachable** -> swap in the new checkout and build (unchanged behavior).
- **Commit unreachable, image has aiter** -> keep the image's aiter, continue, and print a clear warning (aiter-dependent tests still run).
- **Commit unreachable, image has no aiter** -> fail fast with an actionable message instead of a cryptic exit 128.

This makes a bad `aiter_ref`/`AITER_COMMIT_DEFAULT` degrade gracefully instead of nuking a working environment for the whole job.

## Notes / scope

- This is the fragility surfaced by manual `workflow_dispatch` experiments that passed an `aiter_ref` commit not present in the cloned repo. It does **not** by itself fix the scheduled ROCm 7.2 nightly red, which is a separate set of genuine test failures (e.g. `nightly-accuracy-8-gpu-mi35x-deepseek-v32`: `accuracy=0.895 < threshold=0.93`).
- No behavior change on the happy path (valid commit).

## Test plan
- [x] `bash -n` syntax check
- [ ] Dispatch ROCm 7.2 nightly with a valid `aiter_ref` -> aiter rebuilds as before
- [ ] Dispatch with a bogus `aiter_ref` -> job keeps image aiter + warns, tests still run (no `ModuleNotFoundError`)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29781892509](https://github.com/sgl-project/sglang/actions/runs/29781892509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29781892283](https://github.com/sgl-project/sglang/actions/runs/29781892283)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->