### PR TITLE
[sglang-miles] Add expected_checksums verification to load_lora_adapter_from_tensors

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2005,6 +2005,7 @@ class LoadLoRAAdapterFromTensorsReqInput(BaseReq, kw_only=True):
     added_tokens_config: Optional[Dict[str, Any]] = None
     lora_id: Optional[str] = None
     load_format: Optional[str] = None
+    expected_checksums: Optional[Dict[str, str]] = None
 
     def to_ref(self) -> LoRARef:
         return LoRARef(

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -29,6 +30,7 @@ from sglang.srt.managers.io_struct import (
     InitWeightsUpdateGroupReqInput,
     LoadLoRAAdapterFromDistributedReqInput,
     LoadLoRAAdapterFromTensorsReqInput,
+    LoadLoRAAdapterFromTensorsReqOutput,
     LoadLoRAAdapterReqInput,
     SendWeightsToRemoteInstanceReqInput,
     UnloadLoRAAdapterReqInput,
@@ -189,8 +191,6 @@ class BaseTpWorker(ABC):
         else:
             tensors = MultiprocessingSerializer.deserialize(serialized)
         if recv_req.expected_checksums is not None:
-            import hashlib
-
             exp = recv_req.expected_checksums
             mismatch, missing = [], []
             for name, want in exp.items():
@@ -211,13 +211,18 @@ class BaseTpWorker(ABC):
                     mismatch.append(name)
             extra = [n for n in tensors if n not in exp]
             if mismatch or missing or extra:
-                raise RuntimeError(
-                    f"[LORA-CHECK] rank{self.tp_rank} adapter sync MISMATCH of {len(exp)} expected: "
+                error_message = (
+                    f"[lora-check] rank{self.tp_rank} adapter sync MISMATCH of {len(exp)} expected: "
                     f"{len(mismatch)} value-diff {mismatch[:5]}, {len(missing)} missing {missing[:5]}, "
                     f"{len(extra)} extra {extra[:5]}"
                 )
+                logger.error(error_message)
+                return LoadLoRAAdapterFromTensorsReqOutput(
+                    success=False,
+                    error_message=error_message,
+                )
             logger.info(
-                f"[LORA-CHECK] rank{self.tp_rank} adapter sync OK: {len(exp)}/{len(exp)} tensors match (sha256)"
+                f"[lora-check] rank{self.tp_rank} adapter sync OK: {len(exp)}/{len(exp)} tensors match (sha256)"
             )
         result = self.model_runner.load_lora_adapter_from_tensors(
             recv_req.to_ref(),

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -188,6 +188,37 @@ class BaseTpWorker(ABC):
             tensors = dict(bucket.reconstruct_tensors())
         else:
             tensors = MultiprocessingSerializer.deserialize(serialized)
+        if recv_req.expected_checksums is not None:
+            import hashlib
+
+            exp = recv_req.expected_checksums
+            mismatch, missing = [], []
+            for name, want in exp.items():
+                if name not in tensors:
+                    missing.append(name)
+                    continue
+                got = hashlib.sha256(
+                    tensors[name]
+                    .detach()
+                    .cpu()
+                    .contiguous()
+                    .flatten()
+                    .view(torch.uint8)
+                    .numpy()
+                    .tobytes()
+                ).hexdigest()
+                if got != want:
+                    mismatch.append(name)
+            extra = [n for n in tensors if n not in exp]
+            if mismatch or missing or extra:
+                raise RuntimeError(
+                    f"[LORA-CHECK] rank{self.tp_rank} adapter sync MISMATCH of {len(exp)} expected: "
+                    f"{len(mismatch)} value-diff {mismatch[:5]}, {len(missing)} missing {missing[:5]}, "
+                    f"{len(extra)} extra {extra[:5]}"
+                )
+            logger.info(
+                f"[LORA-CHECK] rank{self.tp_rank} adapter sync OK: {len(exp)}/{len(exp)} tensors match (sha256)"
+            )
         result = self.model_runner.load_lora_adapter_from_tensors(
             recv_req.to_ref(),
             tensors,


### PR DESCRIPTION
## Summary
- `LoadLoRAAdapterFromTensorsReqInput` gains an optional `expected_checksums: Dict[str, str]` field: a per-tensor-name sha256 manifest of the LoRA adapter as the trainer sent it.
- When set, `TpModelWorker.load_lora_adapter_from_tensors` hashes the tensors each TP rank deserialized and raises (with a `[LORA-CHECK]` message naming the mismatched/missing/extra tensors) before handing off to `model_runner.load_lora_adapter_from_tensors`, instead of silently loading potentially-corrupted weights.
- Companion to miles' `--check-lora-weight-equal` flag (radixark/miles#1727), which computes and sends this manifest on every megatron->sglang LoRA weight sync. Off by default (`expected_checksums=None` skips the check entirely, zero overhead).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29793590351](https://github.com/sgl-project/sglang/actions/runs/29793590351)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29793590214](https://github.com/sgl-project/sglang/actions/runs/29793590214)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->