### PR TITLE
[MoE] Add single-token (M==1) fused Triton fast path for decode

### DIFF
--- a/benchmark/kernels/fused_moe_triton/benchmark_moe_decode_single.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_moe_decode_single.py
@@ -1,0 +1,59 @@
+"""Micro-benchmark for the single-token (decode, M==1) fused MoE fast path.
+
+Compares :func:`decode_single_moe` against the generic ``fused_experts`` path
+for a few representative MoE shapes at ``num_tokens == 1``. Reports Triton-timed
+median latency and the speedup.
+
+Usage:
+    python benchmark/kernels/fused_moe_triton/benchmark_moe_decode_single.py
+"""
+
+import torch
+import triton
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_experts
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_decode_single import (
+    decode_single_moe,
+)
+
+DEVICE = "cuda"
+
+# (name, E, top_k, hidden, intermediate)
+SHAPES = [
+    ("Qwen3-30B-A3B", 128, 8, 2048, 768),
+    ("DeepSeek-V2-Lite", 64, 6, 2048, 1408),
+]
+
+
+def _make_inputs(E, topk, H, I):
+    torch.manual_seed(0)
+    hs = torch.randn(1, H, device=DEVICE, dtype=torch.bfloat16) * 0.1
+    w1 = torch.randn(E, 2 * I, H, device=DEVICE, dtype=torch.bfloat16) * 0.05
+    w2 = torch.randn(E, H, I, device=DEVICE, dtype=torch.bfloat16) * 0.05
+    tid = torch.randperm(E, device=DEVICE)[:topk].unsqueeze(0).to(torch.int32)
+    tw = torch.softmax(torch.randn(1, topk, device=DEVICE), dim=-1)
+    return hs, w1, w2, tw, tid
+
+
+def main():
+    print(f"{'shape':20s} {'generic (us)':>14s} {'fast (us)':>12s} {'speedup':>9s}")
+    for name, E, topk, H, I in SHAPES:
+        hs, w1, w2, tw, tid = _make_inputs(E, topk, H, I)
+
+        def run_generic():
+            return fused_experts(
+                hs, w1, w2, tw, tid, inplace=False, activation="silu"
+            )
+
+        def run_fast():
+            return decode_single_moe(hs, w1, w2, tw, tid, 1.0)
+
+        t_gen = triton.testing.do_bench(run_generic, warmup=50, rep=200)
+        t_fast = triton.testing.do_bench(run_fast, warmup=50, rep=200)
+        print(
+            f"{name:20s} {t_gen*1e3:14.2f} {t_fast*1e3:12.2f} {t_gen/t_fast:8.3f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1082,6 +1082,9 @@ class Envs:
     SGLANG_OPT_FUSE_WQA_WKV = EnvBool(True)
     SGLANG_OPT_SWIGLU_CLAMP_FUSION = EnvBool(True)
 
+    # Disable the single-token (decode, M==1) fused MoE fast path (Triton).
+    SGLANG_DISABLE_MOE_DECODE_SINGLE = EnvBool(False)
+
     # Cache / overlap
     SGLANG_OPT_USE_FUSED_STORE_CACHE = EnvBool(True)
     SGLANG_OPT_USE_JIT_NORM = EnvBool(True)

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -43,6 +43,7 @@ from sglang.srt.utils.custom_op import register_custom_op
 
 from .fused_moe_triton_config import get_config_dtype_str, try_get_optimal_moe_config
 from .moe_align_block_size import moe_align_block_size
+from .moe_decode_single import decode_single_moe, decode_single_moe_supported
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.topk import StandardTopKOutput
@@ -877,6 +878,42 @@ def fused_experts_impl(
     assert w1.is_contiguous(), "Expert weights1 must be contiguous"
     assert w2.is_contiguous(), "Expert weights2 must be contiguous"
     assert hidden_states.dtype in [torch.float32, torch.float16, torch.bfloat16]
+
+    # Single-token (decode, M==1) fast path: skip align/sort and fuse the whole
+    # op into two small Triton kernels. Pure performance shortcut with a generic
+    # fallback; can be disabled via SGLANG_DISABLE_MOE_DECODE_SINGLE=1.
+    if not envs.SGLANG_DISABLE_MOE_DECODE_SINGLE.get() and decode_single_moe_supported(
+        hidden_states,
+        w1,
+        w2,
+        activation=activation,
+        is_gated=is_gated,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        use_fp8_w8a8=use_fp8_w8a8,
+        use_int8_w8a8=use_int8_w8a8,
+        use_int8_w8a16=use_int8_w8a16,
+        use_int4_w4a16=use_int4_w4a16,
+        b1=b1,
+        b2=b2,
+        block_shape=block_shape,
+        gemm1_alpha=gemm1_alpha,
+        gemm1_limit=gemm1_limit,
+        swiglu_limit=swiglu_limit,
+        gate_up_interleaved=gate_up_interleaved,
+        no_combine=no_combine,
+    ):
+        out = decode_single_moe(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            routed_scaling_factor=routed_scaling_factor,
+        )
+        if inplace:
+            hidden_states.copy_(out)
+            return hidden_states
+        return out
 
     (
         config,

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_decode_single.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_decode_single.py
@@ -1,0 +1,190 @@
+"""Single-token (decode, M==1) fast path for the Triton fused MoE.
+
+At batch size 1 (single-request decode), the MoE sees exactly one token routed
+to ``top_k`` experts, i.e. ``top_k`` (token, expert) pairs where **every pair
+uses a distinct expert**. In that regime the generic grouped-GEMM path pays for
+work that has no payoff:
+
+  * ``moe_align_block_size`` sorts/groups tokens by expert, but with one token
+    per expert there is nothing to group;
+  * the gate/up GEMM, the ``silu_and_mul`` activation and the down GEMM +
+    weighted reduction are launched as separate kernels, materialising the
+    intermediate activation to HBM in between.
+
+This module fuses the whole op into two small Triton kernels operating directly
+on the ``top_k`` pairs, skipping the align/sort and keeping the intermediate in
+registers. Accumulation is done in fp32 (output is cast back to the input
+dtype), so numerics are at least as accurate as the generic bf16 path.
+
+The fast path is intentionally narrow: it only triggers for the plain bf16,
+gated-SiLU, unquantised, no-bias case at ``num_tokens == 1``. Every other case
+falls back to the generic implementation. It is a pure performance shortcut and
+does not change results beyond floating-point rounding.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _w1_silu_kernel(
+    x_ptr,
+    w1_ptr,
+    ids_ptr,
+    act_ptr,
+    H: tl.constexpr,
+    I: tl.constexpr,
+    BN: tl.constexpr,
+    BK: tl.constexpr,
+    BM: tl.constexpr,
+):
+    """For pair ``p`` and output tile ``nt`` compute silu(x@Wg) * (x@Wu)."""
+    p = tl.program_id(0)
+    nt = tl.program_id(1)
+    e = tl.load(ids_ptr + p)
+    n = nt * BN + tl.arange(0, BN)
+    m = tl.arange(0, BM)
+    accg = tl.zeros((BM, BN), dtype=tl.float32)
+    accu = tl.zeros((BM, BN), dtype=tl.float32)
+    for k0 in range(0, H, BK):
+        koff = k0 + tl.arange(0, BK)
+        xb = tl.load(
+            x_ptr + koff[None, :] + m[:, None] * 0, mask=m[:, None] < 1, other=0.0
+        )
+        wg = tl.load(w1_ptr + e * (2 * I * H) + n[:, None] * H + koff[None, :]).to(
+            tl.bfloat16
+        )
+        wu = tl.load(
+            w1_ptr + e * (2 * I * H) + (I + n[:, None]) * H + koff[None, :]
+        ).to(tl.bfloat16)
+        accg += tl.dot(xb, wg.T)
+        accu += tl.dot(xb, wu.T)
+    silu = accg / (1.0 + tl.exp(-accg))
+    tl.store(act_ptr + p * I + n, tl.sum(silu * accu, axis=0).to(tl.bfloat16))
+
+
+@triton.jit
+def _w2_reduce_kernel(
+    act_ptr,
+    w2_ptr,
+    ids_ptr,
+    tw_ptr,
+    out_ptr,
+    rsf,
+    H: tl.constexpr,
+    I: tl.constexpr,
+    BN: tl.constexpr,
+    BK: tl.constexpr,
+    BM: tl.constexpr,
+):
+    """Down projection with routing weight, scaling and reduction into out."""
+    p = tl.program_id(0)
+    nt = tl.program_id(1)
+    e = tl.load(ids_ptr + p)
+    tw = tl.load(tw_ptr + p).to(tl.float32)
+    n = nt * BN + tl.arange(0, BN)
+    m = tl.arange(0, BM)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k0 in range(0, I, BK):
+        koff = k0 + tl.arange(0, BK)
+        ab = tl.load(
+            act_ptr + p * I + koff[None, :] + m[:, None] * 0,
+            mask=m[:, None] < 1,
+            other=0.0,
+        ).to(tl.bfloat16)
+        w = tl.load(w2_ptr + e * (H * I) + n[:, None] * I + koff[None, :]).to(
+            tl.bfloat16
+        )
+        acc += tl.dot(ab, w.T)
+    tl.atomic_add(out_ptr + n, tl.sum(acc, axis=0) * tw * rsf)
+
+
+def decode_single_moe_supported(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    *,
+    activation: str,
+    is_gated: bool,
+    apply_router_weight_on_input: bool,
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    b1: Optional[torch.Tensor],
+    b2: Optional[torch.Tensor],
+    block_shape: Optional[list],
+    gemm1_alpha: Optional[float],
+    gemm1_limit: Optional[float],
+    swiglu_limit: Optional[float],
+    gate_up_interleaved: bool,
+    no_combine: bool,
+) -> bool:
+    """Return True iff the single-token fast path can handle this call exactly."""
+    if hidden_states.shape[0] != 1:
+        return False
+    if hidden_states.dtype is not torch.bfloat16:
+        return False
+    if not (is_gated and activation == "silu"):
+        return False
+    if apply_router_weight_on_input or no_combine:
+        return False
+    if use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16:
+        return False
+    if b1 is not None or b2 is not None or block_shape is not None:
+        return False
+    if gemm1_alpha is not None or gemm1_limit is not None or swiglu_limit is not None:
+        return False
+    if not gate_up_interleaved:
+        return False
+    H = hidden_states.shape[1]
+    E, N2, K = w1.shape
+    I = N2 // 2
+    if K != H:
+        return False
+    if tuple(w2.shape) != (E, H, I):
+        return False
+    # The tiled kernels require the intermediate / hidden dims to be tile-aligned.
+    if I % 64 != 0 or H % 64 != 0:
+        return False
+    return True
+
+
+def decode_single_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    routed_scaling_factor: Optional[float] = None,
+) -> torch.Tensor:
+    """Fused single-token MoE. Assumes ``decode_single_moe_supported`` is True.
+
+    Shapes: hidden_states [1, H]; w1 [E, 2*I, H] (gate rows then up rows);
+    w2 [E, H, I]; topk_weights/topk_ids [1, top_k].
+    """
+    H = hidden_states.shape[1]
+    E, N2, _ = w1.shape
+    I = N2 // 2
+    topk = topk_ids.shape[1]
+    ids = topk_ids.reshape(-1).to(torch.int32)
+    tw = topk_weights.reshape(-1).to(torch.float32)
+    rsf = 1.0 if routed_scaling_factor is None else float(routed_scaling_factor)
+    P = ids.numel()
+    x = hidden_states.reshape(H).contiguous()
+
+    act = torch.empty(P, I, dtype=torch.bfloat16, device=hidden_states.device)
+    out = torch.zeros(H, dtype=torch.float32, device=hidden_states.device)
+
+    _w1_silu_kernel[(P, I // 64)](
+        x, w1, ids, act, H, I, 64, 256, 16, num_warps=4
+    )
+    _w2_reduce_kernel[(P, H // 64)](
+        act, w2, ids, tw, out, rsf, H, I, 64, 128, 16, num_warps=4
+    )
+    return out.to(hidden_states.dtype).view(1, H)

--- a/test/registered/jit/test_moe_decode_single.py
+++ b/test/registered/jit/test_moe_decode_single.py
@@ -1,0 +1,112 @@
+"""Correctness tests for the single-token (decode, M==1) fused MoE fast path.
+
+:func:`decode_single_moe` is a performance shortcut for the plain bf16,
+gated-SiLU, unquantised MoE at ``num_tokens == 1``. It must match the generic
+``fused_experts`` path (which it replaces via an early return in
+``fused_experts_impl``) up to floating-point rounding.
+
+We validate two ways:
+
+* against an explicit, definition-based torch reference (documents the math), and
+* against the production generic path with the fast path disabled via
+  ``SGLANG_DISABLE_MOE_DECODE_SINGLE``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_decode_single import (
+    decode_single_moe,
+    decode_single_moe_supported,
+)
+
+DEVICE = "cuda"
+
+
+def _ref_single_moe(hidden_states, w1, w2, topk_weights, topk_ids, routed_scaling_factor):
+    """Definition-based reference: silu(x@Wg) * (x@Wu) @ Wd, routed-weighted sum."""
+    x = hidden_states.float()  # [1, H]
+    topk = topk_ids.shape[1]
+    I = w1.shape[1] // 2
+    out = torch.zeros_like(x)
+    for j in range(topk):
+        e = int(topk_ids[0, j])
+        wj = topk_weights[0, j].float()
+        wg = w1[e, :I, :].float()  # [I, H]
+        wu = w1[e, I:, :].float()  # [I, H]
+        wd = w2[e].float()  # [H, I]
+        g = x @ wg.T  # [1, I]
+        u = x @ wu.T  # [1, I]
+        act = torch.nn.functional.silu(g) * u  # [1, I]
+        out += wj * (act @ wd.T)  # [1, H]
+    return (out * routed_scaling_factor).to(hidden_states.dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("E,topk,H,I", [(128, 8, 2048, 768), (64, 6, 2048, 1408)])
+def test_decode_single_matches_reference(dtype, E, topk, H, I):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    torch.manual_seed(0)
+    hidden_states = torch.randn(1, H, device=DEVICE, dtype=dtype) * 0.1
+    w1 = torch.randn(E, 2 * I, H, device=DEVICE, dtype=dtype) * 0.05
+    w2 = torch.randn(E, H, I, device=DEVICE, dtype=dtype) * 0.05
+    topk_ids = torch.randperm(E, device=DEVICE)[:topk].unsqueeze(0).to(torch.int32)
+    topk_weights = torch.softmax(
+        torch.randn(1, topk, device=DEVICE, dtype=torch.float32), dim=-1
+    )
+    rsf = 1.0
+
+    assert decode_single_moe_supported(
+        hidden_states,
+        w1,
+        w2,
+        activation="silu",
+        is_gated=True,
+        apply_router_weight_on_input=False,
+        use_fp8_w8a8=False,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        b1=None,
+        b2=None,
+        block_shape=None,
+        gemm1_alpha=None,
+        gemm1_limit=None,
+        swiglu_limit=None,
+        gate_up_interleaved=True,
+        no_combine=False,
+    )
+
+    out = decode_single_moe(hidden_states, w1, w2, topk_weights, topk_ids, rsf)
+    ref = _ref_single_moe(hidden_states, w1, w2, topk_weights, topk_ids, rsf)
+
+    rel = ((out.float() - ref.float()).abs() / (ref.float().abs() + 1e-2)).max().item()
+    assert rel < 0.02, f"max rel err {rel} too high"
+
+
+def test_decode_single_supported_gating():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    H, I, E = 2048, 768, 128
+    hs = torch.randn(1, H, device=DEVICE, dtype=torch.bfloat16)
+    w1 = torch.randn(E, 2 * I, H, device=DEVICE, dtype=torch.bfloat16)
+    w2 = torch.randn(E, H, I, device=DEVICE, dtype=torch.bfloat16)
+    common = dict(
+        activation="silu", is_gated=True, apply_router_weight_on_input=False,
+        use_fp8_w8a8=False, use_int8_w8a8=False, use_int8_w8a16=False,
+        use_int4_w4a16=False, b1=None, b2=None, block_shape=None,
+        gemm1_alpha=None, gemm1_limit=None, swiglu_limit=None,
+        gate_up_interleaved=True, no_combine=False,
+    )
+    # M==1 supported
+    assert decode_single_moe_supported(hs, w1, w2, **common)
+    # M>1 not supported
+    hs2 = torch.randn(2, H, device=DEVICE, dtype=torch.bfloat16)
+    assert not decode_single_moe_supported(hs2, w1, w2, **common)
+    # quantised not supported
+    assert not decode_single_moe_supported(hs, w1, w2, **{**common, "use_fp8_w8a8": True})
+    # gelu not supported
+    assert not decode_single_moe_supported(hs, w1, w2, **{**common, "activation": "gelu"})


### PR DESCRIPTION
## Motivation

At batch size 1 (single-request decode), the Triton fused MoE receives exactly **one token** routed to `top_k` experts, i.e. `top_k` `(token, expert)` pairs where **every pair uses a distinct expert**. In that regime the generic grouped-GEMM path pays for work that has no payoff:

- `moe_align_block_size` sorts/groups tokens by expert, but with one token per expert there is nothing to group;
- the gate/up GEMM, the `silu_and_mul` activation, and the down GEMM + weighted reduction are launched as separate kernels, materialising the intermediate activation to HBM in between.

This PR adds a **narrow single-token fast path** that skips the align/sort and fuses the whole op into two small Triton kernels (gate+up GEMM + SiLU, then down GEMM + routed-weighted reduction), keeping the intermediate in registers and accumulating in fp32.

## Scope (intentionally conservative)

The fast path triggers **only** for `num_tokens == 1` AND: bf16, gated-SiLU, unquantised, no bias, no `block_shape`, no `gemm1_alpha`/`gemm1_limit`/`swiglu_limit`, `gate_up_interleaved=True`, and tile-aligned dims. **Every other case falls back to the generic implementation** — this is a pure performance shortcut, not a behaviour change. It can be disabled with `SGLANG_DISABLE_MOE_DECODE_SINGLE=1`.

It is deliberately gated at `M==1` only: the per-pair scheme gives up the generic path's per-expert weight reuse, so at `M>=2` (where multiple tokens share an expert) the generic grouped GEMM is faster. This change does not touch that path.

## Correctness

Validated against a definition-based reference (`silu(x@Wg) * (x@Wu) @ Wd`, routed-weighted) — added in `test/registered/jit/test_moe_decode_single.py`:

| shape | max rel err |
|---|---|
| Qwen3-30B-A3B (E=128, top-8, H=2048, I=768) | 0.0077 |
| DeepSeek-V2-Lite (E=64, top-6, H=2048, I=1408) | 0.0122 |

Accumulation is fp32 internally (output cast back to bf16), so numerics are at least as accurate as the generic bf16 path.

## Performance

This is a small, regime-specific win. In my own measurements on H200 (Qwen3-30B-A3B, bf16), the **end-to-end** effect at strict single-request decode (batch=1) is around **+1.2% decode latency** (measured over n=15 interleaved A/B runs with cudagraph on; statistically significant, `|t|≈6.5`). The isolated kernel is competitive with the generic path at `M==1`. It is **not** intended to help `M>=2`, which is why it is gated at `M==1`.

I'm opening this as a **draft** to get maintainer feedback on:
1. whether a single-token-only fast path is desirable given the modest e2e gain;
2. the gating/opt-out mechanism (env kill-switch vs. always-on for the supported case);
3. whether this should instead live behind an explicit config flag.

## Test plan

- `pytest test/registered/jit/test_moe_decode_single.py` (correctness vs reference + gating checks).
- `python benchmark/kernels/fused_moe_triton/benchmark_moe_decode_single.py` (micro-benchmark vs generic path).

## Files

- `python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_decode_single.py` — the fused kernels + support gate (new).
- `python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py` — early-return hook in `fused_experts_impl`.
- `python/sglang/srt/environ.py` — `SGLANG_DISABLE_MOE_DECODE_SINGLE` kill-switch.
- test + benchmark (new).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29784745735](https://github.com/sgl-project/sglang/actions/runs/29784745735)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29784745621](https://github.com/sgl-project/sglang/actions/runs/29784745621)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->