### PR TITLE
Fix MiniMax-M3 crash on ROCm by making its override fields resolvable

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1607,7 +1607,10 @@ class ServerArgs:
     ] = False
     disable_custom_all_reduce: A[
         bool,
-        "Disable the custom all-reduce kernel and fall back to NCCL.",
+        Arg(
+            help="Disable the custom all-reduce kernel and fall back to NCCL.",
+            resolvable=True,
+        ),
     ] = False
     enable_mscclpp: A[
         bool,
@@ -1647,7 +1650,10 @@ class ServerArgs:
             resolvable=True,
         ),
     ] = None
-    enable_aiter_allreduce_fusion: A[bool, "Enable Aiter AllReduce Fusion."] = False
+    enable_aiter_allreduce_fusion: A[
+        bool,
+        Arg(help="Enable Aiter AllReduce Fusion.", resolvable=True),
+    ] = False
 
     # -------------------------------------------------------------------------
     # Torch compile and torchao

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -84,6 +84,8 @@ class TestModelOverridableWhitelist(CustomTestCase):
                     "decode_attention_backend",
                     "flashinfer_allreduce_fusion_backend",
                     "fp8_gemm_runner_backend",
+                    "disable_custom_all_reduce",
+                    "enable_aiter_allreduce_fusion",
                 }
             ),
         )


### PR DESCRIPTION
## Problem

Starting MiniMax-M3 on ROCm (MI355X, `SGLANG_USE_AITER=1`) without `--enable-aiter-allreduce-fusion` crashes the launcher before the engine comes up:

```
File "/sgl-workspace/sglang/python/sglang/srt/arg_groups/overrides.py", line 2211, in validate_declarations
    raise ValueError(
ValueError: _minimax_m3_overrides: ['disable_custom_all_reduce'] not model-overridable; declarations are limited to the fields the publish gate accepts.
```

## Root cause

`_minimax_m3_overrides` on ROCm declares config values through the override registry:

- `disable_custom_all_reduce=True` whenever aiter allreduce fusion is off (the default path), and
- `enable_aiter_allreduce_fusion=False` on the standard-EP path (deferred fused all-reduce corrupts sparse MoE partial outputs).

Both fields lacked `Arg(..., resolvable=True)`, so they are not on the declaration whitelist. `validate_declarations` rejects the declaration at its slot and the launcher aborts.

Passing `--enable-aiter-allreduce-fusion` only *masks* the default-path crash: it flips `aiter_fusion_resolved` to `True`, so the illegal `disable_custom_all_reduce` declaration branch is skipped. It does not fix the standard-EP path, which would still crash on the `enable_aiter_allreduce_fusion` declaration.

## Fix

Tag both fields `resolvable=True` so the model override may legally declare them, and extend the exact whitelist pin in `test_model_overrides.py` in the same commit (as its docstring requires). Defaults are unchanged.

## Repro

Before this PR, the following crashes with the `ValueError` above:

```bash
SGLANG_USE_AITER=1 sglang serve \
  --trust-remote-code \
  --model-path MiniMaxAI/MiniMax-M3-MXFP8 \
  --tp 8 --quantization mxfp8 --dtype bfloat16 \
  --chunked-prefill-size 8192 --mem-fraction-static 0.80 \
  --host 0.0.0.0 --port 30000
```

## Validation (MI355X, tp8 mxfp8)

With this fix, the same command (no `--enable-aiter-allreduce-fusion`) boots and serves:

```
[TP0] Prefill batch, #new-seq: 1, #new-token: 186, #cached-token: 0, ...
INFO:     127.0.0.1 - "POST /v1/chat/completions HTTP/1.1" 200 OK
The server is fired up and ready to roll!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29784984332](https://github.com/sgl-project/sglang/actions/runs/29784984332)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29784984129](https://github.com/sgl-project/sglang/actions/runs/29784984129)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->