### PR TITLE
[AMD] register diffusion qknorm-rope benchmark for jit-kernel-benchmark-test-amd

### DIFF
--- a/test/registered/kernels/benchmark/diffusion/bench_qknorm_rope.py
+++ b/test/registered/kernels/benchmark/diffusion/bench_qknorm_rope.py
@@ -11,11 +11,17 @@ from sglang.kernels.jit.benchmark.utils import (
     get_benchmark_range,
     run_benchmark_no_cudagraph,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(
     est_time=13, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
 )
+register_amd_ci(est_time=13, stage="jit-kernel-benchmark", runner_config="amd")
+
+# The "split" provider uses FlashInfer RoPE (CUDA-only); on ROCm we benchmark
+# the fully-fused SGL JIT QKNorm+RoPE kernel alone.
+_IS_HIP = is_hip()
 
 MAX_SEQ_LEN = 131072
 ROPE_BASE = 10000.0
@@ -45,9 +51,14 @@ CASE_NAMES = get_benchmark_range(
     full_range=[case.name for case in BENCH_CASES],
     ci_range=[case.name for case in BENCH_CASES],
 )
-LINE_VALS = ["split", "fused"]
-LINE_NAMES = ["JIT QKNorm + FlashInfer RoPE", "SGL JIT Fused QKNorm+RoPE"]
-STYLES = [("red", "-"), ("blue", "--")]
+if _IS_HIP:
+    LINE_VALS = ["fused"]
+    LINE_NAMES = ["SGL JIT Fused QKNorm+RoPE"]
+    STYLES = [("blue", "--")]
+else:
+    LINE_VALS = ["split", "fused"]
+    LINE_NAMES = ["JIT QKNorm + FlashInfer RoPE", "SGL JIT Fused QKNorm+RoPE"]
+    STYLES = [("red", "-"), ("blue", "--")]
 
 
 def create_cos_sin_cache(


### PR DESCRIPTION
## Summary
Part of [ROCm/sglang-ci#349](https://github.com/ROCm/sglang-ci/issues/349). Registers the **diffusion QKNorm+RoPE** kernel benchmark for AMD.

`diffusion/bench_qknorm_rope.py` compared two providers: `split` (JIT QKNorm + **FlashInfer** RoPE, CUDA-only) and `fused` (SGL JIT). Guard the `split` provider behind `is_hip()` so ROCm benchmarks the fully-fused SGL JIT QKNorm+RoPE kernel alone, and register it for `jit-kernel-benchmark-test-amd`.

## Scope note — this PR is 1 bench, not 4
I initially probed 4 flashinfer-using benches. The probe ([ROCm 7.0 run](https://github.com/sgl-project/sglang/actions/runs/29785219561)) showed only `diffusion/bench_qknorm_rope` actually runs on ROCm. The other 3 fail because their **underlying SGL JIT kernel is itself CUDA-only** (not just the flashinfer provider):
- `bench_qknorm` → `qknorm.cuh: 'cuda_bf16.h' file not found`
- `bench_norm` → `fused_add_rmsnorm.cuh: 'cooperative_groups/reduce.h' file not found`
- `bench_rope` → `pos_enc.cuh: 'cuda_fp16.h' file not found`

Those need kernel-source HIP porting (not an `is_hip()` provider guard), so they're reclassified as CUDA-only and tracked on #349 rather than shipped here.

## Verification (`continue_on_error=false` — true gate)
- ROCm 7.2 → https://github.com/sgl-project/sglang/actions/runs/29880264279
- ROCm 7.0 → https://github.com/sgl-project/sglang/actions/runs/29880265539

## Test plan
- [x] `diffusion/bench_qknorm_rope` passes on ROCm 7.0 (probe run 29785219561).
- [ ] Gate runs green on ROCm 7.0 + 7.2.
- [ ] Mark ready for review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30491658236](https://github.com/sgl-project/sglang/actions/runs/30491658236)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #30491810142](https://github.com/sgl-project/sglang/actions/runs/30491810142)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->