### PR TITLE
[AMD] [CI] Enable 3 nested unit tests needing harness stub fixes

### DIFF
--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -1091,6 +1091,11 @@ _AMD_READY_NESTED_UNIT_TESTS = (
     "sana_wm/test_streaming_cached.py",
     "sana_wm/test_streaming_stage.py",
     "sana_wm/test_streaming_vae.py",
+    # Enabled with small test-harness stub fixes (see this PR's test edits).
+    "progressive_resolution/test_progressive.py",
+    "sana_wm/test_streaming_realtime_path.py",
+    # Stub gap already fixed upstream; only needs enabling here.
+    "realtime/test_lingbot_causal_denoising.py",
 )
 
 

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -1078,6 +1078,10 @@ _AMD_READY_NESTED_UNIT_TESTS = (
     "sana_wm/test_streaming_cached.py",
     "sana_wm/test_streaming_stage.py",
     "sana_wm/test_streaming_vae.py",
+    # Enabled with small test-harness stub fixes (see this PR's test edits).
+    "progressive_resolution/test_progressive.py",
+    "realtime/test_lingbot_causal_denoising.py",
+    "sana_wm/test_streaming_realtime_path.py",
 )
 
 

--- a/python/sglang/multimodal_gen/test/unit/progressive_resolution/test_progressive.py
+++ b/python/sglang/multimodal_gen/test/unit/progressive_resolution/test_progressive.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import torch
 
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.runtime.distributed.cfg_policy import CFGPolicy
 from sglang.multimodal_gen.runtime.pipelines_core.stages.progressive_resolution.denoising import (
     ProgressiveDenoisingStage,
     ProgressiveDenoisingStageRouter,
@@ -500,6 +501,9 @@ class TestIdeogram4OnResolutionChange(unittest.TestCase):
         ctx = SimpleNamespace(
             latents=torch.zeros(B, new_num_img, self._IN_C),
             extra=self._make_ctx_extra(B, old_num_img, max_text_tokens),
+            # Non-None so _on_resolution_change proceeds (it early-returns when
+            # cfg_policy is None); the value itself is not used further here.
+            cfg_policy=CFGPolicy(),
         )
         batch = SimpleNamespace(
             extra={
@@ -555,6 +559,9 @@ class TestIdeogram4OnResolutionChange(unittest.TestCase):
         ctx = SimpleNamespace(
             latents=torch.zeros(B, new_grid_h * new_grid_w, self._IN_C),
             extra=self._make_ctx_extra(B, old_grid_h * old_grid_w, max_text_tokens),
+            # Non-None so _on_resolution_change proceeds (it early-returns when
+            # cfg_policy is None); the value itself is not used further here.
+            cfg_policy=CFGPolicy(),
         )
         batch = SimpleNamespace(extra={"ideogram4": old_data})
 
@@ -594,6 +601,9 @@ class TestIdeogram4OnResolutionChange(unittest.TestCase):
         ctx = SimpleNamespace(
             latents=torch.zeros(B, grid_h * grid_w, self._IN_C),
             extra=self._make_ctx_extra(B, old_num_img, max_text_tokens),
+            # Non-None so _on_resolution_change proceeds (it early-returns when
+            # cfg_policy is None); the value itself is not used further here.
+            cfg_policy=CFGPolicy(),
         )
         batch = SimpleNamespace(
             extra={

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_lingbot_causal_denoising.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_lingbot_causal_denoising.py
@@ -72,6 +72,9 @@ def test_lingbot_realtime_cache_config_overrides_checkpoint_defaults():
     stage.sink_size = 9
     stage.sliding_window_num_frames = 18
     stage.num_token_per_frame = 10
+    # Unit stub built via __new__ has no real transformer; None makes
+    # _reset_causal_cache_config_defaults() a no-op (getattr chain -> None).
+    stage.transformer = None
 
     server_args = SimpleNamespace(
         pipeline_config=SimpleNamespace(
@@ -93,6 +96,9 @@ def test_lingbot_realtime_cache_config_uses_request_overrides():
     stage.sink_size = 9
     stage.sliding_window_num_frames = 18
     stage.num_token_per_frame = 10
+    # Unit stub built via __new__ has no real transformer; None makes
+    # _reset_causal_cache_config_defaults() a no-op (getattr chain -> None).
+    stage.transformer = None
 
     batch = SimpleNamespace(
         realtime_causal_sink_size=4,

--- a/python/sglang/multimodal_gen/test/unit/sana_wm/test_streaming_realtime_path.py
+++ b/python/sglang/multimodal_gen/test/unit/sana_wm/test_streaming_realtime_path.py
@@ -47,6 +47,7 @@ def _global_args():
             comfyui_mode=False,
             enable_cfg_parallel=False,
             enable_torch_compile=False,
+            enable_breakable_cuda_graph=False,
             attention_backend=None,
             # DenoisingStage.__init__ reads this for its CFG-parallel plumbing.
             pipeline_config=SimpleNamespace(

--- a/scripts/ci/utils/ci_coverage_report.py
+++ b/scripts/ci/utils/ci_coverage_report.py
@@ -101,6 +101,10 @@ _MM_GEN_FILE_BACKENDS = {
     "unit/sana_wm/test_streaming_cached.py": ("AMD",),
     "unit/sana_wm/test_streaming_stage.py": ("AMD",),
     "unit/sana_wm/test_streaming_vae.py": ("AMD",),
+    # Enabled with small test-harness stub fixes.
+    "unit/progressive_resolution/test_progressive.py": ("AMD",),
+    "unit/realtime/test_lingbot_causal_denoising.py": ("AMD",),
+    "unit/sana_wm/test_streaming_realtime_path.py": ("AMD",),
 }
 
 # Filenames that match `test_*.py` by convention but contain no real tests

--- a/scripts/ci/utils/ci_coverage_report.py
+++ b/scripts/ci/utils/ci_coverage_report.py
@@ -101,6 +101,11 @@ _MM_GEN_FILE_BACKENDS = {
     "unit/sana_wm/test_streaming_cached.py": ("AMD",),
     "unit/sana_wm/test_streaming_stage.py": ("AMD",),
     "unit/sana_wm/test_streaming_vae.py": ("AMD",),
+    # Enabled with small test-harness stub fixes.
+    "unit/progressive_resolution/test_progressive.py": ("AMD",),
+    "unit/sana_wm/test_streaming_realtime_path.py": ("AMD",),
+    # Stub gap already fixed upstream; only needs enabling here.
+    "unit/realtime/test_lingbot_causal_denoising.py": ("AMD",),
 }
 
 # Filenames that match `test_*.py` by convention but contain no real tests


### PR DESCRIPTION
## What

Enable 3 more nested `multimodal_gen` `unit/` files on AMD, each of which needs a small **test-harness stub fix**. These stub gaps are pre-existing and would also fail on CUDA, so the fixes are portable rather than AMD-specific; the files are enabled on AMD only for now, consistent with #31483.

| File | Fix |
|---|---|
| `unit/progressive_resolution/test_progressive.py` (3 tests) | give the `_on_resolution_change` ctxs a non-None `cfg_policy` (stage early-returns when it is `None`) |
| `unit/sana_wm/test_streaming_realtime_path.py` (4 tests) | add `enable_breakable_cuda_graph` to the `_global_args` stub (`DenoisingStage.__init__` reads it) |
| `unit/realtime/test_lingbot_causal_denoising.py` (2 tests) | set `stage.transformer = None` on the two `__new__`-built stubs so `_reset_causal_cache_config_defaults()` is a no-op |

Each file is added to `_AMD_READY_NESTED_UNIT_TESTS` (`gpu_cases.py`) and `_MM_GEN_FILE_BACKENDS` (`ci_coverage_report.py`).

## AMD-only by construction

Every part of this change is inert on non-AMD lanes:

- **Test edits cannot run on CUDA.** `_discover_unit_tests()` returns only the flat `unit/test_*.py` glob unless `current_platform.is_hip()`. All three files here live in nested subdirs (`progressive_resolution/`, `sana_wm/`, `realtime/`), so no non-HIP lane collects them. The CUDA `multimodal-gen-unit-test` job is byte-identical.
- **Allowlist entry is HIP-gated.** `_AMD_READY_NESTED_UNIT_TESTS` is only consulted inside the `is_hip()` branch.
- **Coverage entry is AMD-tagged.** `_MM_GEN_FILE_BACKENDS` maps each of the 3 files to `("AMD",)`.
- No production code is touched — only test-harness stubs and the coverage classifier.

Verified by running the real report on this head: the 3 files are credited to AMD with no extras, and the files deferred to #31844 / #31846 correctly remain CUDA-tagged.

## Rebase

#31483 has merged, so this is no longer stacked. Rebased onto current `main` as `3dfe2a3ecde3`; git dropped the already-merged commit automatically. The PR is now **1 commit, 5 files, +25/-0**.

## Test

Targeted `multimodal-gen-unit-test` on `3dfe2a3ecde3` with `continue_on_error: false`:

| lane | result | run |
|---|---|---|
| ROCm 7.0 | 1118 passed, 3 skipped | [job 92704086756](https://github.com/sgl-project/sglang/actions/runs/31127226182/job/92704086756) |
| ROCm 7.2 | 1118 passed, 3 skipped | [job 92704227179](https://github.com/sgl-project/sglang/actions/runs/31127227943/job/92704227179) |

Both executed 12 nested files (the 9 from #31483 plus these 3); all three added here pass on both lanes. The CUDA `multimodal-gen-unit-test` job also passed ([job 92704999943](https://github.com/sgl-project/sglang/actions/runs/31127518745/job/92704999943)), confirming the CUDA lane is unaffected.

The single failure on both AMD lanes is inherited from `main` and unrelated to this PR: `test_output_materialization.py::test_file_path_transport_clears_in_memory_outputs` raises `AttributeError: 'GPUWorker' object has no attribute 'is_output_rank'`, because that test stubs a worker via `GPUWorker.__new__(GPUWorker)` and [#33725](https://github.com/sgl-project/sglang/pull/33725) later added `is_output_rank` in `__init__`. That file was enabled by #31483 and is untouched here.

## Test plan

- [x] `multimodal-gen-unit-test-amd` (ROCm 7.0.0) green
- [x] `multimodal-gen-unit-test-amd-rocm720` (ROCm 7.2.0) green
- [x] CUDA `multimodal-gen-unit-test` unaffected
- [x] coverage classifier credits the 3 files to AMD only

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31297749467](https://github.com/sgl-project/sglang/actions/runs/31297749467)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31297749410](https://github.com/sgl-project/sglang/actions/runs/31297749410)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
