### PR TITLE
[Cookbook] Add poolside/Laguna-S-2.1

### DIFF
--- a/docs_new/cookbook/autoregressive/Poolside/Laguna-M.1.mdx
+++ b/docs_new/cookbook/autoregressive/Poolside/Laguna-M.1.mdx
@@ -1,7 +1,6 @@
 ---
 title: Laguna-M.1
 description: "Deploy poolside's Laguna-M.1 — a 225B-parameter Mixture-of-Experts model (23B active) for agentic coding — with SGLang on NVIDIA H200, B200, B300, GB200, and GB300, across BF16, FP8, and NVFP4."
-tag: NEW
 ---
 
 ## Deployment

--- a/docs_new/cookbook/autoregressive/Poolside/Laguna-S-2.1.mdx
+++ b/docs_new/cookbook/autoregressive/Poolside/Laguna-S-2.1.mdx
@@ -1,0 +1,232 @@
+---
+title: Laguna-S-2.1
+description: "Deploy poolside's Laguna-S-2.1 — a 118B hybrid-SWA Mixture-of-Experts model (8B active) for agentic coding — with SGLang on NVIDIA H200, B300, and GB300 in BF16, FP8, NVFP4, and INT4."
+tag: NEW
+---
+
+## Deployment
+
+<a id="install" />
+
+<Accordion title="Install SGLang">
+
+Laguna-S-2.1 uses the same `laguna` model architecture as [Laguna-XS-2.1](./Laguna-XS-2.1), which is fully supported in SGLang `main`. The model ships custom config code on the Hub, so `--trust-remote-code` is required (included in the launch commands).
+
+<Tabs>
+
+<Tab title="Python (pip / uv)">
+
+```bash Command
+pip install -U uv
+uv venv --python 3.12 && source .venv/bin/activate
+
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+uv pip install -e python
+```
+
+Then run the **Python** output of the command panel below in that environment.
+
+</Tab>
+
+<Tab title="Docker">
+
+```bash Command
+docker pull lmsysorg/sglang:dev
+```
+
+For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.
+
+</Tab>
+
+</Tabs>
+
+</Accordion>
+
+Pick your hardware + quantization + strategy to generate the launch command. The two serving strategies cover the common operating points:
+
+- **Low-latency** — DFlash speculative decoding with a matched draft model. Pick for chat and interactive agents.
+- **High-throughput** — plain serving. Best for batch workloads, where speculation's draft + rejection overhead costs more than it saves.
+
+On the 8-GPU HGX platforms (H200 / B300) all quantizations run `--tp 8`. The 4-GPU GB300 node runs `--tp 4` throughout. NVFP4 is Blackwell-only (B300 / GB300 only).
+
+import { Deployment } from "/src/snippets/_deployment.jsx";
+import { config }     from "/src/snippets/configs/poolside/laguna-s21.jsx";
+import { benchmarks } from "/src/snippets/configs/poolside/laguna-s21-benchmarks.jsx";
+
+<Deployment config={config} benchmarks={benchmarks} />
+
+## Playground
+
+The Playground is where you experiment with **SGLang features beyond the verified matrix**. The Deploy panel above only emits combinations that have been signed off; the Playground lets you turn on additional knobs (TP degree, parsers) on top of whichever cell the Deploy panel is currently showing.
+
+import { Playground } from "/src/snippets/_playground.jsx";
+
+<Playground config={config} />
+
+## 1. Model Introduction
+
+[Laguna-S-2.1](https://huggingface.co/poolside/Laguna-S-2.1) is an open-weight **118B-parameter** hybrid sliding-window-attention MoE model (**~8B active per token**) from [poolside](https://poolside.ai), built for agentic coding and long-horizon software engineering. It sits between [Laguna XS 2.1](./Laguna-XS-2.1) (33B/3B active) and Laguna M.1 (222B/23B active) in the Laguna family.
+
+**Key Features:**
+
+- **Sparse MoE**: 48 layers, 256 routed experts, top-10 routing, plus 1 shared expert.
+- **Hybrid attention**: 36 sliding-window layers (window 512) interleaved with 12 full-attention layers (1:3 global-to-SWA ratio); 8 KV heads, head dim 128; per-head sigmoid output gating with per-layer-type rotary scales.
+- **Long context**: 1,048,576 tokens.
+- **DFlash drafts**: matched draft models ship per quantization for low-latency serving.
+- **Hybrid reasoning**: `<think>…</think>` toggled per request via `chat_template_kwargs={"enable_thinking": …}`.
+
+**Available quantizations:**
+
+<table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
+  <colgroup>
+    <col style={{width: "14%"}} />
+    <col style={{width: "43%"}} />
+    <col style={{width: "43%"}} />
+  </colgroup>
+  <thead>
+    <tr style={{borderBottom: "2px solid #d55816"}}>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700}}>Precision</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700}}>Target model</th>
+      <th style={{textAlign: "left", padding: "10px 12px", fontWeight: 700}}>Draft model</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500}}><strong>BF16</strong></td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1`](https://huggingface.co/poolside/Laguna-S-2.1)</td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1-DFlash`](https://huggingface.co/poolside/Laguna-S-2.1-DFlash)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500}}><strong>FP8</strong></td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1-FP8`](https://huggingface.co/poolside/Laguna-S-2.1-FP8)</td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1-DFlash-FP8`](https://huggingface.co/poolside/Laguna-S-2.1-DFlash-FP8)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500}}><strong>NVFP4</strong></td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1-NVFP4`](https://huggingface.co/poolside/Laguna-S-2.1-NVFP4)</td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1-DFlash-NVFP4`](https://huggingface.co/poolside/Laguna-S-2.1-DFlash-NVFP4)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500}}><strong>INT4</strong></td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1-INT4`](https://huggingface.co/poolside/Laguna-S-2.1-INT4)</td>
+      <td style={{padding: "9px 12px"}}>[`poolside/Laguna-S-2.1-DFlash-INT4`](https://huggingface.co/poolside/Laguna-S-2.1-DFlash-INT4)</td>
+    </tr>
+  </tbody>
+</table>
+
+The drafts are small BF16 models, each *calibrated against its quantized target* — always pair a target with its matched draft (mixing precisions degrades accept-length).
+
+**License:** [OpenMDW-1.1](https://openmdw.ai/)
+
+**Resources:** [Hugging Face](https://huggingface.co/poolside/Laguna-S-2.1) · [Technical report](https://poolside.ai/assets/laguna/laguna-m1-xs2-technical-report.pdf) · [API platform](https://platform.poolside.ai)
+
+## 2. Configuration Tips
+
+**Attention backend**
+
+Leave `--attention-backend` unset for High-throughput cells — auto-select is correct (`fa3` on Hopper, `trtllm_mha` on Blackwell). With DFlash active, auto-select instead falls back to `flashinfer`, which breaks this hybrid-SWA model at `tp ≥ 4` on Blackwell (reproduced on Laguna-XS-2.1, greedy GSM8K 76% → 28%), so the Low-latency commands pin the target backend explicitly. Leave `--speculative-draft-attention-backend` unset. Other attention backend choices have not been fully validated on Laguna; keep the default.
+
+**FP8 shared expert**
+
+The generated FP8 commands include `SGLANG_SHARED_EXPERT_TP1=1` as a precaution. The Laguna family's FP8 checkpoint block-quantizes the shared expert; this env var replicates it instead of TP-sharding it (consistent with the Laguna-XS-2.1 verified recipe). Remove it only after confirming shared-expert sharding works on this model.
+
+**DFlash memory**
+
+Low-latency cells carry `--mem-fraction-static 0.7`: at larger TP degrees the default fraction may OOM in the draft vocab all-gather. Dense cells use the default heuristic.
+
+**Chat template**
+
+On transformers ≥ 5.10 the standalone `chat_template.jinja` auto-loads — no flag needed (the server logs `Auto-detected template features: reasoning_parser=poolside_v1, ...`). On older transformers (≤ ~5.8) pass `--chat-template <model-dir>/chat_template.jinja` explicitly.
+
+**Thinking**
+
+Off by default; opt in per request with `extra_body={"chat_template_kwargs": {"enable_thinking": True}}`. The template gates on `enable_thinking` — the generic `thinking` key is ignored.
+
+**Served model id**
+
+The server registers the model under whatever you pass to `--model-path`; a client's `model` field must match it (`poolside/Laguna-S-2.1`, or the `-FP8` / `-NVFP4` / `-INT4` id).
+
+## 3. Advanced Usage
+
+### 3.1 DFlash Speculative Decoding
+
+DFlash is a block-wise speculative decoder: the draft proposes a block of tokens and the target verifies the whole block in one forward pass — output quality is the target's by construction. The speedup lever is **accept-length**, the number of draft tokens surviving verification per target step.
+
+Best for interactive / few-stream serving. Under batch-saturated load prefer High-throughput: once the GPU is compute-bound, draft + rejected-token overhead costs aggregate throughput. The generated commands always pair the draft calibrated for the selected target precision.
+
+### 3.2 Reasoning
+
+Launch with `--reasoning-parser poolside_v1` (baked into every generated command). Reasoning is opt-in via `enable_thinking=True`; the `<think>` trace lands in `message.reasoning_content`, separate from the final answer in `message.content`.
+
+<Accordion title="Reasoning Example (Python)">
+
+```python Example
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:30000/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="poolside/Laguna-S-2.1",
+    messages=[{"role": "user", "content": "What is 15% of 240? Explain briefly."}],
+    max_tokens=4096,
+    extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+)
+
+message = response.choices[0].message
+print("=============== Reasoning ===============")
+print(message.reasoning_content)
+print("=============== Answer ==================")
+print(message.content)
+```
+
+</Accordion>
+
+<Note>
+Give generous `max_tokens` when thinking is enabled — hard problems regularly reason
+for thousands of tokens. Keep thinking off for short-form tasks.
+</Note>
+
+### 3.3 Tool Calling
+
+Launch with `--tool-call-parser poolside_v1` (baked into every generated command). The parser converts Laguna's `<tool_call>` output into the standard OpenAI `tool_calls` structure. Tool calling works with reasoning off (the default).
+
+<Accordion title="Tool Calling Example (Python)">
+
+```python Example
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:30000/v1", api_key="EMPTY")
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "The city name"},
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+response = client.chat.completions.create(
+    model="poolside/Laguna-S-2.1",
+    messages=[{"role": "user", "content": "What's the weather in Beijing?"}],
+    tools=tools,
+)
+
+message = response.choices[0].message
+if message.tool_calls:
+    for call in message.tool_calls:
+        print(f"Tool: {call.function.name}")
+        print(f"Args: {call.function.arguments}")
+```
+
+</Accordion>

--- a/docs_new/cookbook/autoregressive/Poolside/Laguna-XS-2.1.mdx
+++ b/docs_new/cookbook/autoregressive/Poolside/Laguna-XS-2.1.mdx
@@ -1,7 +1,6 @@
 ---
 title: Laguna-XS-2.1
 description: "Deploy poolside's Laguna-XS-2.1 — a 33B hybrid-SWA Mixture-of-Experts model (3B active) for agentic coding — with SGLang on NVIDIA H200, B300, and GB300 in BF16, FP8, NVFP4, and INT4."
-tag: NEW
 ---
 
 ## Deployment

--- a/docs_new/cookbook/autoregressive/intro.mdx
+++ b/docs_new/cookbook/autoregressive/intro.mdx
@@ -160,7 +160,7 @@ metatags:
   <Card
     title="Poolside"
     mode="card"
-    href="/cookbook/autoregressive/Poolside/Laguna-XS-2.1"
+    href="/cookbook/autoregressive/Poolside/Laguna-S-2.1"
     img="/cards/logos/poolside.png"
   />
 </CardGroup>

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1172,6 +1172,7 @@
                   {
                     "group": "Poolside",
                     "pages": [
+                      "cookbook/autoregressive/Poolside/Laguna-S-2.1",
                       "cookbook/autoregressive/Poolside/Laguna-XS-2.1",
                       "cookbook/autoregressive/Poolside/Laguna-M.1",
                       "cookbook/autoregressive/Poolside/Laguna-XS.2"

--- a/docs_new/src/snippets/configs/poolside/laguna-s21-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/poolside/laguna-s21-benchmarks.jsx
@@ -1,0 +1,42 @@
+// Laguna-S-2.1 benchmarks — one entry per cell `match` (same 5 keys as laguna-s21.jsx cells).
+//
+// All entries below are PENDING stubs — no measurements yet. Fill in real numbers as cells
+// are verified (set verified:true in laguna-s21.jsx and add accuracy + sglang_version here).
+// The benchmark card renders "pending" for bare { match } stubs.
+//
+// Target eval set:
+//   GSM8K  — sgl-eval run gsm8k, full 1319 questions, greedy/non-thinking.
+//   AIME25 — sgl-eval run aime25, 30 problems × 16 repeats, temperature 1.0, top-p 0.95,
+//             max-tokens 64000, 128 threads. Requires serving with enable_thinking=true
+//             (Laguna's template gates on enable_thinking, not the generic 'thinking' key;
+//             see Configuration Tips: Thinking in the cookbook page).
+
+export const benchmarks = [
+  // ===== H200 (8-GPU HGX, --tp 8) — PENDING =====
+  { match: { hw: "h200", variant: "default", quant: "bf16",  strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "h200", variant: "default", quant: "bf16",  strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "h200", variant: "default", quant: "fp8",   strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "h200", variant: "default", quant: "fp8",   strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "h200", variant: "default", quant: "int4",  strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "h200", variant: "default", quant: "int4",  strategy: "low-latency",     nodes: "single" } },
+
+  // ===== B300 (8-GPU HGX, --tp 8) — PENDING =====
+  { match: { hw: "b300", variant: "default", quant: "bf16",  strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "b300", variant: "default", quant: "bf16",  strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "b300", variant: "default", quant: "fp8",   strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "b300", variant: "default", quant: "fp8",   strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "b300", variant: "default", quant: "int4",  strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "b300", variant: "default", quant: "int4",  strategy: "low-latency",     nodes: "single" } },
+
+  // ===== GB300 (4-GPU single node, --tp 4) — PENDING =====
+  { match: { hw: "gb300", variant: "default", quant: "bf16",  strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "gb300", variant: "default", quant: "bf16",  strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "gb300", variant: "default", quant: "fp8",   strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "gb300", variant: "default", quant: "fp8",   strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "low-latency",     nodes: "single" } },
+  { match: { hw: "gb300", variant: "default", quant: "int4",  strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "gb300", variant: "default", quant: "int4",  strategy: "low-latency",     nodes: "single" } },
+];

--- a/docs_new/src/snippets/configs/poolside/laguna-s21.jsx
+++ b/docs_new/src/snippets/configs/poolside/laguna-s21.jsx
@@ -1,0 +1,548 @@
+// Laguna-S-2.1 (poolside) — config-driven cookbook page.
+// Consumed by the shared _deployment.jsx + _playground.jsx engines (no model code there).
+//
+// Architecture: 118B total / ~8B active per token (top-10 routing over 256 routed experts
+// + 1 shared expert). 48 layers: 12 full-attention + 36 sliding-window (window 512).
+// 1,048,576-token context window. Per-head sigmoid output gating on attention.
+//
+// Build: uses the same `laguna` model type as Laguna-XS-2.1. All support is in SGLang main.
+// The model ships custom config code on the Hub, so --trust-remote-code is required.
+//
+// Attention backend (same rules as Laguna-XS-2.1 — hybrid-SWA is backend-sensitive):
+//   - Dense (High-Throughput): leave --attention-backend UNSET. Auto-select is correct:
+//     fa3 on Hopper (H200), trtllm_mha on Blackwell (B300/GB300).
+//   - DFlash (Low-Latency): MUST pin the target backend explicitly — with a speculative
+//     algorithm active, the resolver falls back to flashinfer, which breaks this
+//     hybrid-SWA model at tp≥4 on Blackwell (reproduced on Laguna-XS-2.1 at GB300,
+//     GSM8K 76%→28%). Pin fa3 on H200, trtllm_mha on B300/GB300.
+//   - NEVER use --attention-backend triton for Laguna (broken SWA handling).
+//
+// TP sizing (118B BF16 ≈ 236 GB; FP8 ≈ 118 GB; NVFP4/INT4 ≈ 59 GB):
+//   - H200 8-GPU (8×141 GB): --tp 8 for all quants (29.5 GB weights/GPU for BF16).
+//     Unlike Laguna-XS-2.1, the much larger moe_intermediate_size of this 118B model
+//     is expected to allow plain TP=8 for FP8 and INT4 without --ep-size (the XS-2.1
+//     constraint was 512/8=64 < block_size=128; that does not hold at the larger expert
+//     width in S-2.1). FP8 cells include SGLANG_SHARED_EXPERT_TP1=1 as a precaution
+//     (unverified whether the shared expert needs replication here).
+//   - B300 8-GPU (8×288 GB): same --tp 8 reasoning.
+//   - GB300 4-GPU (4×288 GB): --tp 4 throughout (59 GB/GPU for BF16, ≥229 GB KV budget).
+//
+// NVFP4 is Blackwell-only → no h200×nvfp4 cells.
+//
+// DFlash memory: Low-Latency cells carry --mem-fraction-static 0.7 (consistent with
+// Laguna-XS-2.1; the larger model makes draft-vocab all-gather OOM more likely).
+//
+// verified:false on all cells — commands follow the XS-2.1 verified shape + the TP
+// scaling above but have not yet been run against Laguna-S-2.1. Replace with
+// verified:true after confirming each cell with a full GSM8K pass.
+//
+// Draft/target precision ALWAYS matches: each quantized target pairs with the DFlash
+// draft calibrated for it (poolside/Laguna-S-2.1-DFlash[-FP8/-NVFP4/-INT4]).
+
+export const config = {
+  modelName: "Laguna-S-2.1",
+
+  supportedHardware: ["h200", "b300", "gb300"],
+
+  variants: [
+    { id: "default", label: "Default" },
+  ],
+
+  quantizations: [
+    { id: "bf16",  label: "BF16"  },
+    { id: "fp8",   label: "FP8"   },
+    { id: "nvfp4", label: "NVFP4" },
+    { id: "int4",  label: "INT4"  },
+  ],
+
+  // Two operating points:
+  //   low-latency  = DFlash speculative decoding (matched-precision draft) — interactive /
+  //                  few-stream serving.
+  //   high-throughput = plain serving (no speculation) — batch-saturated workloads, where
+  //                  speculation's draft+rejection overhead costs more than it saves.
+  strategies: [
+    { id: "low-latency",     label: "Low-latency" },
+    { id: "high-throughput", label: "High-throughput" },
+  ],
+
+  nodesOptions: [
+    { id: "single", label: "Single Node" },
+  ],
+
+  modelNames: {
+    "default|bf16":  "poolside/Laguna-S-2.1",
+    "default|fp8":   "poolside/Laguna-S-2.1-FP8",
+    "default|nvfp4": "poolside/Laguna-S-2.1-NVFP4",
+    "default|int4":  "poolside/Laguna-S-2.1-INT4",
+  },
+
+  placeholders: {
+    HOST_IP:   { target: "command", label: "Bind host",         default: "0.0.0.0"         },
+    PORT:      { target: "command", label: "Bind port",         default: "30000"           },
+    HF_TOKEN:  { target: "command", label: "HF token (Docker)", default: "<your-hf-token>" },
+    CURL_HOST: { target: "curl",    label: "Server host",       default: "localhost"       },
+    CURL_PORT: { target: "curl",    label: "Server port",       default: "30000"           },
+  },
+
+  curl: `curl http://{{CURL_HOST}}:{{CURL_PORT}}/v1/chat/completions \\
+-H 'Content-Type: application/json' \\
+-d '{ "model": "{{MODEL_NAME}}", "messages": [{"role":"user","content":"Hello"}] }'`,
+
+  benchmarkCommands: {
+    speed:
+`python3 -m sglang.bench_serving \\
+  --backend sglang \\
+  --host {{CURL_HOST}} --port {{CURL_PORT}} \\
+  --model {{MODEL_NAME}} \\
+  --dataset-name {{DATASET}} \\
+  --random-input-len {{ISL}} --random-output-len {{OSL}} \\
+  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}}`,
+    // GSM8K is the required accuracy sanity on every verified cell, via sgl-eval.
+    accuracy: {
+      gsm8k_pct:
+`# pip install git+https://github.com/sgl-project/sgl-eval
+sgl-eval run gsm8k \\
+  --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1 \\
+  --num-threads 128`,
+      // Laguna's template gates on enable_thinking (not the generic 'thinking' key).
+      // To run AIME25 with thinking, serve with a copy of the model's chat template
+      // whose enable_thinking default is flipped to true, passed via --chat-template.
+      aime25_pct:
+`# pip install git+https://github.com/sgl-project/sgl-eval
+# Serve with an enable_thinking=true chat template (see Configuration Tips: Thinking).
+sgl-eval run aime25 \\
+  --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1 \\
+  --n-repeats 16 --max-tokens 64000 \\
+  --temperature 1.0 --top-p 0.95 --thinking \\
+  --num-threads 128`,
+    },
+    numPromptsByConc: { 1: 8, 16: 32, 64: 128, 128: 256, 256: 512, 1024: 2048, 4096: 4096 },
+  },
+
+  // No variant-wide accuracy default; real numbers are per-cell in laguna-s21-benchmarks.jsx.
+  defaultAccuracy: {
+    default: { gsm8k_pct: null, aime25_pct: null },
+  },
+
+  accuracyLabels: [
+    ["gsm8k_pct", "GSM8K", "%"],
+    ["aime25_pct", "AIME25", "%"],
+  ],
+
+  dockerImages: {
+    h200:  "lmsysorg/sglang:dev",
+    b300:  "lmsysorg/sglang:dev",
+    gb300: "lmsysorg/sglang:dev",
+  },
+
+  github: {
+    cookbookModel: "poolside/Laguna-S-2.1",
+  },
+
+  playgroundFeatures: {
+
+    // Hybrid-SWA GQA model (8 KV heads) — TP shards cleanly at 1/2/4/8.
+    // No DP-Attention / CP knobs: unvalidated on this model family.
+    attention: {
+      knobs: [
+        { id: "tp", label: "TP", values: [null, 1, 2, 4, 8] },
+      ],
+    },
+
+    // Reasoning + tool-call parsers (poolside_v1, same family as Laguna-XS-2.1).
+    // Baked into every Deploy cell. The chat template auto-detects both on
+    // transformers ≥ 5.10 (`Auto-detected template features: reasoning_parser=poolside_v1,
+    // tool_call_parser=poolside_v1`), so these are explicit-but-redundant there.
+    parsers: {
+      items: [
+        { id: "reasoning", label: "Reasoning Parser", flag: "--reasoning-parser poolside_v1" },
+        { id: "toolCall",  label: "Tool Call Parser", flag: "--tool-call-parser poolside_v1" },
+      ],
+    },
+  },
+
+  // Cells: (h200 × {bf16,fp8,int4} + b300/gb300 × {bf16,fp8,nvfp4,int4}) × {low-latency, high-throughput}.
+  // All verified:false — not yet measured on Laguna-S-2.1.
+  // NVFP4 is Blackwell-only: no h200×nvfp4 cells.
+  cells: [
+
+    // ══════════════ NVIDIA Hopper H200 (8-GPU HGX, --tp 8) ══════════════
+    // Dense auto-selects fa3 on Hopper (no flag needed). LL pins fa3 (DFlash-safe on
+    // Hopper; with a spec algorithm active, auto would fall back to flashinfer).
+    {
+      match: { hw: "h200", variant: "default", quant: "bf16", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h200", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--attention-backend fa3",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      // SGLANG_SHARED_EXPERT_TP1=1 included as precaution — the shared expert is likely
+      // also block-FP8-quantized (same architecture family as XS-2.1). Unverified.
+      match: { hw: "h200", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: ["SGLANG_SHARED_EXPERT_TP1=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h200", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: ["SGLANG_SHARED_EXPERT_TP1=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--attention-backend fa3",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-FP8",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h200", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h200", variant: "default", quant: "int4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--attention-backend fa3",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-INT4",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+
+    // ══════════════ NVIDIA Blackwell Ultra B300 (8-GPU HGX) ══════════════
+    // Dense auto-selects trtllm_mha on Blackwell (no flag). LL MUST pin trtllm_mha —
+    // with DFlash active, auto falls back to flashinfer, which is broken for this
+    // hybrid-SWA model at tp≥4 (reproduced + bisected on GB300 with Laguna-XS-2.1).
+    {
+      match: { hw: "b300", variant: "default", quant: "bf16", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: ["SGLANG_SHARED_EXPERT_TP1=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: ["SGLANG_SHARED_EXPERT_TP1=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-FP8",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-NVFP4",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b300", variant: "default", quant: "int4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 8",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-INT4",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+
+    // ══════════════ NVIDIA Grace-Blackwell GB300 (4-GPU single node, --tp 4) ══════════════
+    // BF16 118B at tp 4 = 59 GB/GPU (out of 288 GB): ample KV budget.
+    // Dense auto-selects trtllm_mha on Blackwell. LL pins trtllm_mha (same flashinfer
+    // concern as B300 above).
+    {
+      match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-FP8",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "nvfp4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-NVFP4",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "int4", strategy: "low-latency", nodes: "single" },
+      verified: false,
+      env: [],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--trust-remote-code",
+        "--reasoning-parser poolside_v1",
+        "--tool-call-parser poolside_v1",
+        "--tp 4",
+        "--attention-backend trtllm_mha",
+        "--speculative-algorithm DFLASH",
+        "--speculative-draft-model-path poolside/Laguna-S-2.1-DFlash-INT4",
+        "--page-size 1",
+        "--mem-fraction-static 0.7",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- Adds config-driven cookbook page for [poolside/Laguna-S-2.1](https://huggingface.co/poolside/Laguna-S-2.1) — 118B hybrid-SWA MoE (8B active per token, 1M context), the mid-size Laguna family member between XS-2.1 and M.1
- Hardware grid: H200 / B300 / GB300 × BF16 / FP8 / NVFP4 / INT4 (NVFP4 Blackwell-only) × low-latency (DFlash speculative decoding) / high-throughput
- All cells marked `verified: false`; benchmarks (GSM8K, AIME25) are pending stubs — will be filled in after measurement
- Strips `tag: NEW` from Laguna-XS-2.1 and Laguna-M.1 siblings; updates Poolside homepage card href and docs.json nav

## Files changed

| File | Change |
|---|---|
| `docs_new/cookbook/autoregressive/Poolside/Laguna-S-2.1.mdx` | New page |
| `docs_new/src/snippets/configs/poolside/laguna-s21.jsx` | New config (24 cells) |
| `docs_new/src/snippets/configs/poolside/laguna-s21-benchmarks.jsx` | Pending benchmark stubs |
| `docs_new/docs.json` | Add nav entry (top of Poolside group) |
| `docs_new/cookbook/autoregressive/intro.mdx` | Update Poolside card href |
| `docs_new/cookbook/autoregressive/Poolside/Laguna-XS-2.1.mdx` | Strip `tag: NEW` |
| `docs_new/cookbook/autoregressive/Poolside/Laguna-M.1.mdx` | Strip `tag: NEW` |

## Test plan

- [ ] `mint validate` passes in `docs_new/`
- [ ] Cells render correct commands; URL-hash nav persists across reload
- [ ] NEW badge shows on Laguna-S-2.1 only (stripped from XS-2.1 and M.1)
- [ ] Poolside homepage card links to Laguna-S-2.1
- [ ] Fill `verified: true` + benchmark numbers after measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29790980949](https://github.com/sgl-project/sglang/actions/runs/29790980949)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29790980890](https://github.com/sgl-project/sglang/actions/runs/29790980890)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->