### PR TITLE
[DFlash] Fix hybrid recurrent-state commit for radix cache

### DIFF
--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -47,7 +47,10 @@ from sglang.srt.speculative.draft_worker_common import (
     make_draft_sampler_capture_hook,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
+from sglang.srt.speculative.spec_utils import (
+    assign_req_to_token_pool_func,
+    prepare_mamba_track_for_verify,
+)
 from sglang.srt.utils import get_available_gpu_memory, is_cuda, is_hip, is_npu
 
 _is_npu = is_npu()
@@ -56,6 +59,31 @@ _is_npu = is_npu()
 logger = logging.getLogger(__name__)
 
 _FusedKVMaterializeHelper = None
+
+
+def _compute_linear_mamba_verify_commit_steps(
+    *,
+    seq_lens_pre_verify: torch.Tensor,
+    commit_lens: torch.Tensor,
+    track_interval: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map accepted linear verify tokens to persistent and radix-track states."""
+    last_correct_step_indices = commit_lens.to(torch.int64) - 1
+    seq_lens_post_verify = seq_lens_pre_verify + commit_lens.to(
+        seq_lens_pre_verify.dtype
+    )
+    crossed_boundary = (
+        seq_lens_pre_verify // track_interval != seq_lens_post_verify // track_interval
+    )
+    latest_boundary = seq_lens_post_verify // track_interval * track_interval
+    boundary_step = latest_boundary - seq_lens_pre_verify - 1
+    can_track = crossed_boundary & (boundary_step < commit_lens.to(boundary_step.dtype))
+    steps_to_track = torch.where(
+        can_track,
+        boundary_step.to(torch.int64),
+        torch.full_like(boundary_step, -1, dtype=torch.int64),
+    )
+    return last_correct_step_indices, steps_to_track
 
 
 def _get_fused_kv_materialize_helper():
@@ -1252,27 +1280,18 @@ class DFlashWorkerV2(BaseSpecWorker):
             return
         attn_backend = self.target_worker.model_runner.attn_backend
 
-        last_correct_step_indices = commit_lens.to(torch.int64) - 1
         mamba_steps_to_track = None
 
         if batch.mamba_track_indices is not None:
-            mamba_track_interval = self.server_args.mamba_track_interval
-            to_track_mask = (
-                seq_lens_pre_verify // mamba_track_interval
-                != batch.seq_lens // mamba_track_interval
+            last_correct_step_indices, mamba_steps_to_track = (
+                _compute_linear_mamba_verify_commit_steps(
+                    seq_lens_pre_verify=seq_lens_pre_verify,
+                    commit_lens=commit_lens,
+                    track_interval=self.server_args.mamba_track_interval,
+                )
             )
-            tracking_point = (
-                batch.seq_lens // mamba_track_interval * mamba_track_interval
-            )
-            to_track_ith = torch.clamp(tracking_point - seq_lens_pre_verify - 1, min=0)
-            can_track_mask = to_track_mask & (
-                to_track_ith < commit_lens.to(to_track_ith.dtype)
-            )
-            mamba_steps_to_track = torch.where(
-                can_track_mask,
-                to_track_ith.to(torch.int64),
-                torch.full_like(to_track_ith, -1, dtype=torch.int64),
-            )
+        else:
+            last_correct_step_indices = commit_lens.to(torch.int64) - 1
 
         attn_backend.update_mamba_state_after_mtp_verify(
             last_correct_step_indices=last_correct_step_indices,
@@ -1662,6 +1681,9 @@ class DFlashWorkerV2(BaseSpecWorker):
         elif draft_input.reserved_seq_lens_cpu is not None:
             batch.seq_lens_cpu = draft_input.reserved_seq_lens_cpu
             batch.seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
+
+        if self._need_mamba_verify_commit:
+            prepare_mamba_track_for_verify(batch)
 
         verify_forward_batch, _ = verify_input.prepare_for_verify(
             batch, self.target_worker

--- a/test/registered/spec/dflash/test_dflash_qwen35_hybrid.py
+++ b/test/registered/spec/dflash/test_dflash_qwen35_hybrid.py
@@ -1,0 +1,109 @@
+import os
+import unittest
+
+import requests
+from transformers import AutoTokenizer
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=180, stage="extra-a", runner_config="1-gpu-large")
+
+TARGET_MODEL = os.environ.get("SGLANG_TEST_QWEN35_MODEL", "Qwen/Qwen3.5-4B")
+DRAFT_MODEL = os.environ.get(
+    "SGLANG_TEST_QWEN35_DFLASH_MODEL", "z-lab/Qwen3.5-4B-DFlash"
+)
+
+
+class TestDFlashQwen35HybridRadixCache(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.tokenizer = AutoTokenizer.from_pretrained(
+            TARGET_MODEL, trust_remote_code=True
+        )
+        cls.process = popen_launch_server(
+            TARGET_MODEL,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "triton",
+                "--speculative-algorithm",
+                "DFLASH",
+                "--speculative-draft-model-path",
+                DRAFT_MODEL,
+                "--speculative-num-draft-tokens",
+                "16",
+                "--mamba-radix-cache-strategy",
+                "extra_buffer",
+                "--mamba-track-interval",
+                "256",
+                "--context-length",
+                "8192",
+                "--max-running-requests",
+                "4",
+                "--cuda-graph-max-bs-decode",
+                "4",
+                "--mem-fraction-static",
+                "0.65",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _generate(self, input_ids, max_new_tokens):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "input_ids": input_ids,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def test_generated_prefix_cache_matches_full_prefill(self):
+        paragraph = (
+            "Speculative verification must commit recurrent state at every tracking "
+            "boundary crossed by accepted tokens. The next request may reuse generated "
+            "tokens through radix prefix caching, so token KV and recurrent state must "
+            "refer to exactly the same sequence position. "
+        )
+        base_ids = self.tokenizer.encode(paragraph * 160, add_special_tokens=False)[
+            :4600
+        ]
+        suffix_ids = self.tokenizer.encode(
+            "\nContinue from the cached generated prefix and state the final invariant.",
+            add_special_tokens=False,
+        )
+
+        requests.post(self.base_url + "/flush_cache").raise_for_status()
+        seed = self._generate(base_ids, max_new_tokens=320)
+        self.assertGreater(seed["meta_info"]["spec_verify_ct"], 0)
+        continuation_ids = base_ids + seed["output_ids"] + suffix_ids
+        cached = self._generate(continuation_ids, max_new_tokens=32)
+
+        self.assertGreaterEqual(cached["meta_info"]["cached_tokens"], 4864)
+        requests.post(self.base_url + "/flush_cache").raise_for_status()
+        full_prefill = self._generate(continuation_ids, max_new_tokens=32)
+
+        self.assertEqual(full_prefill["meta_info"]["cached_tokens"], 0)
+        self.assertEqual(cached["output_ids"], full_prefill["output_ids"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_mamba_commit.py
+++ b/test/registered/unit/spec/test_dflash_mamba_commit.py
@@ -1,0 +1,100 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from sglang.srt.speculative.dflash_worker_v2 import (
+    DFlashWorkerV2,
+    _compute_linear_mamba_verify_commit_steps,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestDFlashMambaCommit(CustomTestCase):
+    def test_commit_steps_cover_none_single_and_multiple_boundaries(self):
+        last_steps, track_steps = _compute_linear_mamba_verify_commit_steps(
+            seq_lens_pre_verify=torch.tensor([256, 250, 250], dtype=torch.int32),
+            commit_lens=torch.tensor([4, 10, 300], dtype=torch.int32),
+            track_interval=256,
+        )
+
+        torch.testing.assert_close(last_steps, torch.tensor([3, 9, 299]))
+        # The third request crosses both 256 and 512. The scheduler caches the
+        # latest complete boundary, so verify step 261 (state length 512) wins.
+        torch.testing.assert_close(track_steps, torch.tensor([-1, 5, 261]))
+
+    def test_commit_steps_use_post_verify_length(self):
+        _, track_steps = _compute_linear_mamba_verify_commit_steps(
+            seq_lens_pre_verify=torch.tensor([500, 511], dtype=torch.int64),
+            commit_lens=torch.tensor([12, 1], dtype=torch.int32),
+            track_interval=256,
+        )
+
+        torch.testing.assert_close(track_steps, torch.tensor([11, 0]))
+
+    def test_worker_commits_active_and_radix_track_states(self):
+        update_mamba_state = Mock()
+        model = object()
+        worker = object.__new__(DFlashWorkerV2)
+        worker._need_mamba_verify_commit = True
+        worker.server_args = SimpleNamespace(mamba_track_interval=256)
+        worker._target_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(
+                attn_backend=SimpleNamespace(
+                    update_mamba_state_after_mtp_verify=update_mamba_state
+                ),
+                model=model,
+            )
+        )
+        track_indices = torch.tensor([7, 8, 9], dtype=torch.int64)
+        batch = SimpleNamespace(mamba_track_indices=track_indices)
+
+        worker._update_target_mamba_state_after_verify(
+            batch=batch,
+            seq_lens_pre_verify=torch.tensor([250, 256, 500], dtype=torch.int32),
+            commit_lens=torch.tensor([10, 4, 12], dtype=torch.int32),
+        )
+
+        kwargs = update_mamba_state.call_args.kwargs
+        torch.testing.assert_close(
+            kwargs["last_correct_step_indices"], torch.tensor([9, 3, 11])
+        )
+        torch.testing.assert_close(
+            kwargs["mamba_steps_to_track"], torch.tensor([5, -1, 11])
+        )
+        self.assertIs(kwargs["mamba_track_indices"], track_indices)
+        self.assertIs(kwargs["model"], model)
+
+    def test_worker_without_extra_buffer_still_commits_active_state(self):
+        update_mamba_state = Mock()
+        worker = object.__new__(DFlashWorkerV2)
+        worker._need_mamba_verify_commit = True
+        worker.server_args = SimpleNamespace(mamba_track_interval=256)
+        worker._target_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(
+                attn_backend=SimpleNamespace(
+                    update_mamba_state_after_mtp_verify=update_mamba_state
+                ),
+                model=object(),
+            )
+        )
+
+        worker._update_target_mamba_state_after_verify(
+            batch=SimpleNamespace(mamba_track_indices=None),
+            seq_lens_pre_verify=torch.tensor([100], dtype=torch.int32),
+            commit_lens=torch.tensor([3], dtype=torch.int32),
+        )
+
+        kwargs = update_mamba_state.call_args.kwargs
+        torch.testing.assert_close(
+            kwargs["last_correct_step_indices"], torch.tensor([2])
+        )
+        self.assertIsNone(kwargs["mamba_steps_to_track"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DFlash target verification on hybrid recurrent models computes one intermediate
state per verified token while persistent state updates are disabled. After
acceptance, DFlash must commit the last accepted state and, with the
`extra_buffer` radix strategy, the state at a crossed tracking boundary.

The DFlash V2 path did not refresh `mamba_track_indices` before verification and
derived boundary tracking from the pre-verify length. A generated radix prefix
could therefore be stored with recurrent state from a different sequence
position. Reusing that prefix changed deterministic output relative to a full
prefill.

This completes the DFlash chain-layout follow-up to #27966. #28010 adds
reduced-cache replay, while #29449 handles freed recurrent-state slots; neither
change fixes tracking-index refresh on the existing full-cache DFlash V2 path.

## Modifications

- Refresh Mamba tracking indices before DFlash target verification.
- Commit the recurrent state for the last accepted token.
- Select the accepted state at the latest crossed tracking boundary from the
  post-verify sequence length.
- Add focused CPU tests and a registered Qwen3.5 DFlash GPU regression.

## Accuracy Tests

Target: `Qwen/Qwen3.5-4B`

Draft: `z-lab/Qwen3.5-4B-DFlash`

Configuration: Triton attention, 16 draft tokens, `extra_buffer` Mamba radix
cache, tracking interval 256, one H100 80GB.

The GPU regression generates 320 tokens from a 4600-token prompt, reuses the
generated prefix, and compares a 32-token greedy continuation with a
cache-flushed full prefill.

- CPU state-commit tests: 4 passed.
- Existing DFlash overlap/host-sync tests: 7 passed.
- Style checks: Black, isort, ruff, codespell, and `git diff --check` passed.
- Registered GPU regression: passed. The reused generated prefix hit
  4864 cached tokens, and all 32 continuation token IDs matched the full-prefill
  reference.

## Speed Tests and Profiling

No additional model forward or synchronization is introduced. The change
refreshes existing tracking metadata and adjusts indices consumed by the
existing state-commit kernel.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit and registered GPU regression tests.
- [x] Documentation is not required; there is no user-facing interface change.
- [x] Provide an accuracy regression result.
- [x] Follow the SGLang code style guidance.
