### PR TITLE
[DFlash V2] Add configurable target verify budget

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -241,6 +241,18 @@ def _handle_dflash(server_args: ServerArgs) -> None:
             )
         server_args.speculative_num_draft_tokens = inferred_block_size
 
+    draft_block_size = int(server_args.speculative_num_draft_tokens)
+    if server_args.speculative_dflash_verify_budget is None:
+        server_args.speculative_dflash_verify_budget = draft_block_size
+    else:
+        verify_budget = int(server_args.speculative_dflash_verify_budget)
+        if verify_budget <= 0 or verify_budget > draft_block_size:
+            raise ValueError(
+                "DFLASH requires --speculative-dflash-verify-budget to be in "
+                f"[1, {draft_block_size}], got {verify_budget}."
+            )
+        server_args.speculative_dflash_verify_budget = verify_budget
+
     if server_args.speculative_draft_window_size is not None:
         draft_tokens = int(server_args.speculative_num_draft_tokens)
         if server_args.speculative_draft_window_size < draft_tokens:

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -449,11 +449,12 @@ class TritonAttnBackend(AttentionBackend):
         spec_info,
     ):
         """Fill all cuda-graph buffers for target_verify mode."""
+        verify_width = int(spec_info.draft_token_num)
         qo_indptr = self.qo_indptr[: bs + 1]
         qo_indptr[: bs + 1] = torch.arange(
             0,
-            (1 + bs) * self.num_draft_tokens,
-            step=self.num_draft_tokens,
+            (1 + bs) * verify_width,
+            step=verify_width,
             dtype=torch.int32,
             device=self.device,
         )
@@ -488,8 +489,9 @@ class TritonAttnBackend(AttentionBackend):
             custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
         else:
             custom_mask = None
-        seq_mask_len = self.num_draft_tokens * (seq_lens + self.num_draft_tokens)
+        seq_mask_len = verify_width * (seq_lens + verify_width)
         mask_indptr = self.mask_indptr[: bs + 1]
+        mask_indptr[0] = 0
         mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
         return (
             qo_indptr,
@@ -781,10 +783,11 @@ class TritonAttnBackend(AttentionBackend):
             max_extend_len = None
         elif forward_batch.forward_mode.is_target_verify():
             bs = len(forward_batch.req_pool_indices)
+            verify_width = int(spec_info.draft_token_num)
             qo_indptr = torch.arange(
                 0,
-                (1 + bs) * self.num_draft_tokens,
-                step=self.num_draft_tokens,
+                (1 + bs) * verify_width,
+                step=verify_width,
                 dtype=torch.int32,
                 device=self.device,
             )
@@ -821,13 +824,12 @@ class TritonAttnBackend(AttentionBackend):
                 )
 
             custom_mask = spec_info.custom_mask
-            seq_mask_len = self.num_draft_tokens * (
-                forward_batch.seq_lens + self.num_draft_tokens
-            )
+            seq_mask_len = verify_width * (forward_batch.seq_lens + verify_width)
             mask_indptr = self.mask_indptr
+            mask_indptr[0] = 0
             mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
             mask_indptr = mask_indptr[: bs + 1]
-            max_extend_len = self.num_draft_tokens
+            max_extend_len = verify_width
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
@@ -1062,6 +1064,7 @@ class TritonAttnBackend(AttentionBackend):
                 out_cache_loc_full_physical=out_cache_loc_full_physical,
             )
         elif forward_mode.is_target_verify():
+            verify_width = int(spec_info.draft_token_num)
             custom_mask = (
                 self.cuda_graph_custom_mask
                 if spec_info is not None
@@ -1071,7 +1074,7 @@ class TritonAttnBackend(AttentionBackend):
             return ForwardMetadata(
                 attn_logits=None,
                 attn_lse=None,
-                max_extend_len=self.num_draft_tokens,
+                max_extend_len=verify_width,
                 num_kv_splits=None,
                 kv_indptr=self.kv_indptr[: bs + 1],
                 kv_indices=self.cuda_graph_kv_indices,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1732,7 +1732,13 @@ class ServerArgs:
     ] = None
     speculative_dflash_block_size: A[
         Optional[int],
-        "DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
+        "DFLASH only. Draft block size. Alias of --speculative-num-draft-tokens for DFLASH.",
+    ] = None
+    speculative_dflash_verify_budget: A[
+        Optional[int],
+        "DFLASH only. Number of draft tokens verified by the target per decode step. "
+        "The draft model still runs with its configured block size. Must be between "
+        "1 and --speculative-num-draft-tokens; defaults to the full draft block.",
     ] = None
     speculative_dspark_block_size: A[
         Optional[int],

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -212,6 +212,9 @@ class DFlashWorkerV2(BaseSpecWorker):
                     model_block_size,
                 )
         self.speculative_num_draft_tokens = int(self.block_size)
+        self.verify_budget = int(
+            server_args.speculative_dflash_verify_budget or self.block_size
+        )
 
         self._mask_token = draft_config.mask_token
         self._mask_token_id_override = draft_config.mask_token_id
@@ -221,10 +224,11 @@ class DFlashWorkerV2(BaseSpecWorker):
         )
         if self.ps.tp_rank == 0:
             logger.info(
-                "Initialized DFLASH draft runner. attention_backend=%s, model=%s, block_size=%s, draft_window_size=%s, compact_cache=%s",
+                "Initialized DFLASH draft runner. attention_backend=%s, model=%s, block_size=%s, verify_budget=%s, draft_window_size=%s, compact_cache=%s",
                 bundle.resolved_attention_backend,
                 self.draft_model.__class__.__name__,
                 self.block_size,
+                self.verify_budget,
                 self.draft_window_size,
                 self.use_compact_draft_cache,
             )
@@ -248,6 +252,9 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_verify_out_cache_loc_buf: Optional[torch.Tensor] = (
             None  # [cap_bs, block_size]
         )
+        self._verify_tokens_buf: Optional[torch.Tensor] = None
+        self._verify_positions_buf: Optional[torch.Tensor] = None
+        self._verify_out_cache_loc_buf: Optional[torch.Tensor] = None
         self._draft_block_end_buf: Optional[torch.Tensor] = None  # [cap_bs]
         self._draft_seq_lens_cpu_buf: Optional[torch.Tensor] = None  # [cap_bs] on CPU
         self._draft_block_spec_info = make_draft_block_spec_info(
@@ -281,6 +288,8 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._commit_lens_bufs: List[torch.Tensor] = []
         self._bonus_id_bufs: List[torch.Tensor] = []
         self._out_tokens_bufs: List[torch.Tensor] = []
+        self._result_tokens_bufs: List[torch.Tensor] = []
+        self._result_tokens_buffer_slot: int = 0
         self._new_seq_lens_bufs: List[torch.Tensor] = []
 
     @property
@@ -511,6 +520,16 @@ class DFlashWorkerV2(BaseSpecWorker):
         )
         self._draft_verify_out_cache_loc_buf = torch.empty(
             (new_cap, block_size), dtype=torch.int64, device=device
+        )
+        verify_budget = int(self.verify_budget)
+        self._verify_tokens_buf = torch.empty(
+            (new_cap, verify_budget), dtype=torch.long, device=device
+        )
+        self._verify_positions_buf = torch.empty(
+            (new_cap, verify_budget), dtype=torch.int64, device=device
+        )
+        self._verify_out_cache_loc_buf = torch.empty(
+            (new_cap, verify_budget), dtype=torch.int64, device=device
         )
         self._draft_block_end_buf = torch.empty(
             (new_cap,), dtype=torch.int32, device=device
@@ -1294,7 +1313,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             ),
         )
         device = self.device
-        block_size = int(self.block_size)
+        block_size = int(self.verify_budget)
         self._accept_len_buf = torch.empty((new_cap,), dtype=torch.int32, device=device)
         self._commit_lens_bufs = [
             torch.empty((new_cap,), dtype=torch.int32, device=device) for _ in range(2)
@@ -1305,6 +1324,12 @@ class DFlashWorkerV2(BaseSpecWorker):
         ]
         self._out_tokens_bufs = [
             torch.empty((new_cap, block_size), dtype=torch.int64, device=device)
+            for _ in range(2)
+        ]
+        self._result_tokens_bufs = [
+            torch.empty(
+                (new_cap, int(self.block_size)), dtype=torch.int64, device=device
+            )
             for _ in range(2)
         ]
         self._new_seq_lens_bufs = [
@@ -1330,6 +1355,17 @@ class DFlashWorkerV2(BaseSpecWorker):
             self._out_tokens_bufs[slot][:bs],
             self._new_seq_lens_bufs[slot][:bs],
         )
+
+    def _pad_result_tokens(self, out_tokens: torch.Tensor) -> torch.Tensor:
+        if int(self.verify_budget) == int(self.block_size):
+            return out_tokens
+        self._ensure_accept_bonus_buffers(out_tokens.shape[0])
+        slot = self._result_tokens_buffer_slot
+        self._result_tokens_buffer_slot = (slot + 1) % 2
+        result_tokens = self._result_tokens_bufs[slot][: out_tokens.shape[0]]
+        result_tokens.zero_()
+        result_tokens[:, : int(self.verify_budget)].copy_(out_tokens)
+        return result_tokens
 
     def _validate_phase1_sampling_support(self, batch: ScheduleBatch) -> None:
         sampling_info = batch.sampling_info
@@ -1637,11 +1673,25 @@ class DFlashWorkerV2(BaseSpecWorker):
         # TARGET_VERIFY uses standard causal masking; custom masks are unnecessary here.
         custom_mask = None
 
-        verify_input_ids = draft_tokens.reshape(-1)
+        verify_budget = int(self.verify_budget)
+        assert self._verify_tokens_buf is not None
+        assert self._verify_positions_buf is not None
+        assert self._verify_out_cache_loc_buf is not None
+        verify_tokens = self._verify_tokens_buf[:bs]
+        verify_positions_2d = self._verify_positions_buf[:bs]
+        verify_out_cache_loc_2d = self._verify_out_cache_loc_buf[:bs]
+        verify_tokens.copy_(draft_tokens[:, :verify_budget])
+        verify_positions_2d.copy_(positions_2d[:, :verify_budget])
+        verify_out_cache_loc_2d.copy_(
+            self._draft_verify_out_cache_loc_buf[:bs, :verify_budget]
+        )
+        verify_input_ids = verify_tokens.reshape(-1)
+        verify_positions = verify_positions_2d.reshape(-1)
+        verify_out_cache_loc = verify_out_cache_loc_2d.reshape(-1)
         verify_input = DFlashVerifyInput(
             draft_token=verify_input_ids,
-            positions=positions,
-            draft_token_num=int(self.block_size),
+            positions=verify_positions,
+            draft_token_num=verify_budget,
             custom_mask=custom_mask,
             capture_hidden_mode=CaptureHiddenMode.FULL,
         )
@@ -1655,8 +1705,8 @@ class DFlashWorkerV2(BaseSpecWorker):
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
         if seq_lens_cpu_backup is not None:
-            # Verify host bound = committed prefix + one verify block (matches draft).
-            verify_host_seq_lens = seq_lens_cpu_backup + block_size
+            # Verify host bound tracks the target prefix, not the full draft block.
+            verify_host_seq_lens = seq_lens_cpu_backup + verify_budget
             batch.seq_lens_cpu = verify_host_seq_lens
             batch.seq_lens_sum = int(verify_host_seq_lens.sum())
         elif draft_input.reserved_seq_lens_cpu is not None:
@@ -1682,10 +1732,10 @@ class DFlashWorkerV2(BaseSpecWorker):
             apply_dflash_verify_logits_adjustments(
                 next_token_logits=logits_output.next_token_logits,
                 sampling_info=sampling_info,
-                draft_token_num=int(self.block_size),
+                draft_token_num=verify_budget,
             )
 
-        candidates = draft_tokens
+        candidates = verify_tokens
         new_seq_lens = None
         if (
             sampling_info is not None
@@ -1701,15 +1751,15 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
             commit_lens = accept_len.to(torch.int32) + 1  # [bs]
             out_tokens = torch.empty(
-                (bs, int(self.block_size)), dtype=torch.int64, device=device
+                (bs, verify_budget), dtype=torch.int64, device=device
             )
-            if int(self.block_size) > 1:
-                out_tokens[:, : int(self.block_size) - 1].copy_(candidates[:, 1:])
-            out_tokens[:, int(self.block_size) - 1].fill_(0)
+            if verify_budget > 1:
+                out_tokens[:, : verify_budget - 1].copy_(candidates[:, 1:])
+            out_tokens[:, verify_budget - 1].fill_(0)
             out_tokens.scatter_(1, accept_len.to(torch.int64)[:, None], bonus[:, None])
         else:
             target_predict = torch.argmax(logits_output.next_token_logits, dim=-1).view(
-                bs, int(self.block_size)
+                bs, verify_budget
             )
             if self._use_triton_accept_bonus:
                 try:
@@ -1742,15 +1792,13 @@ class DFlashWorkerV2(BaseSpecWorker):
                     )
                     commit_lens = accept_len.to(torch.int32) + 1  # [bs]
                     out_tokens = torch.empty(
-                        (bs, int(self.block_size)),
+                        (bs, verify_budget),
                         dtype=torch.int64,
                         device=device,
                     )
-                    if int(self.block_size) > 1:
-                        out_tokens[:, : int(self.block_size) - 1].copy_(
-                            candidates[:, 1:]
-                        )
-                    out_tokens[:, int(self.block_size) - 1].fill_(0)
+                    if verify_budget > 1:
+                        out_tokens[:, : verify_budget - 1].copy_(candidates[:, 1:])
+                    out_tokens[:, verify_budget - 1].fill_(0)
                     out_tokens.scatter_(
                         1, accept_len.to(torch.int64)[:, None], bonus[:, None]
                     )
@@ -1761,11 +1809,11 @@ class DFlashWorkerV2(BaseSpecWorker):
                 )
                 commit_lens = accept_len.to(torch.int32) + 1  # [bs]
                 out_tokens = torch.empty(
-                    (bs, int(self.block_size)), dtype=torch.int64, device=device
+                    (bs, verify_budget), dtype=torch.int64, device=device
                 )
-                if int(self.block_size) > 1:
-                    out_tokens[:, : int(self.block_size) - 1].copy_(candidates[:, 1:])
-                out_tokens[:, int(self.block_size) - 1].fill_(0)
+                if verify_budget > 1:
+                    out_tokens[:, : verify_budget - 1].copy_(candidates[:, 1:])
+                out_tokens[:, verify_budget - 1].fill_(0)
                 out_tokens.scatter_(
                     1, accept_len.to(torch.int64)[:, None], bonus[:, None]
                 )
@@ -1789,13 +1837,13 @@ class DFlashWorkerV2(BaseSpecWorker):
             raise RuntimeError(
                 "DFLASH verify requires target hidden states, but got None."
             )
-        hidden = hidden.view(bs, int(self.block_size), -1)
+        hidden = hidden.view(bs, verify_budget, -1)
 
         self._append_target_hidden_to_draft_kv_by_loc(
             target_hidden=hidden.reshape(-1, hidden.shape[-1]),
             cache_loc=verify_out_cache_loc,
             cache_loc_2d=verify_out_cache_loc_2d,
-            positions=positions,
+            positions=verify_positions,
             commit_lens=commit_lens,
         )
 
@@ -1806,10 +1854,11 @@ class DFlashWorkerV2(BaseSpecWorker):
             bonus_tokens=bonus,
             new_seq_lens=new_seq_lens,
         )
+        result_tokens = self._pad_result_tokens(out_tokens)
 
         return GenerationBatchResult(
             logits_output=logits_output,
-            next_token_ids=out_tokens.reshape(-1),
+            next_token_ids=result_tokens.reshape(-1),
             accept_lens=commit_lens,
             can_run_cuda_graph=can_run_cuda_graph,
             next_draft_input=next_draft_input,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -107,6 +107,10 @@ def resolve_num_tokens_per_req(
     if phase == "target_verify":
         if num_draft_tokens is None:
             num_draft_tokens = server_args.speculative_num_draft_tokens
+        if spec_algorithm.is_dflash() and not is_draft_worker:
+            num_draft_tokens = (
+                server_args.speculative_dflash_verify_budget or num_draft_tokens
+            )
         return spec_algorithm.get_num_tokens_per_req_for_target_verify(
             num_draft_tokens, is_draft_worker
         )

--- a/test/registered/unit/spec/test_dflash_verify_budget.py
+++ b/test/registered/unit/spec/test_dflash_verify_budget.py
@@ -1,0 +1,79 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDFlashVerifyBudget(unittest.TestCase):
+    def _server_args(self, verify_budget):
+        return SimpleNamespace(
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=16,
+            speculative_dflash_verify_budget=verify_budget,
+        )
+
+    def test_target_verify_width_uses_independent_budget(self):
+        server_args = self._server_args(4)
+
+        target_width = resolve_num_tokens_per_req(
+            phase="target_verify",
+            server_args=server_args,
+            spec_algorithm=SpeculativeAlgorithm.DFLASH,
+            is_draft_worker=False,
+        )
+        draft_width = resolve_num_tokens_per_req(
+            phase="target_verify",
+            server_args=server_args,
+            spec_algorithm=SpeculativeAlgorithm.DFLASH,
+            is_draft_worker=True,
+        )
+
+        self.assertEqual(target_width, 4)
+        self.assertEqual(draft_width, 16)
+
+    def test_unset_budget_preserves_full_block(self):
+        server_args = self._server_args(None)
+        width = resolve_num_tokens_per_req(
+            phase="target_verify",
+            server_args=server_args,
+            spec_algorithm=SpeculativeAlgorithm.DFLASH,
+            is_draft_worker=False,
+        )
+        self.assertEqual(width, 16)
+
+    def test_triton_verify_metadata_uses_runtime_width(self):
+        backend = object.__new__(TritonAttnBackend)
+        backend.num_draft_tokens = 16
+        backend.device = torch.device("cpu")
+        backend.qo_indptr = torch.empty(3, dtype=torch.int32)
+        backend.cuda_graph_kv_indices = torch.empty(1, dtype=torch.int64)
+        backend.cuda_graph_custom_mask = torch.empty(1, dtype=torch.bool)
+        backend.mask_indptr = torch.empty(3, dtype=torch.int64)
+        backend.sliding_window_size = None
+        backend.window_kv_indptr = None
+        backend._fill_kv_indptr_and_indices = MagicMock(
+            return_value=torch.tensor([0, 10, 30], dtype=torch.int32)
+        )
+
+        metadata = backend._update_target_verify_buffers(
+            bs=2,
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            spec_info=SimpleNamespace(draft_token_num=4, custom_mask=None),
+        )
+
+        qo_indptr, _, _, mask_indptr = metadata[:4]
+        self.assertEqual(qo_indptr.tolist(), [0, 4, 8])
+        self.assertEqual(mask_indptr.tolist(), [0, 56, 152])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

A DFlash checkpoint proposes a fixed draft block, but the target need not verify
the entire block when acceptance is much shorter. With Qwen3.5-4B-DFlash, the
native block is 16 tokens while measured mean accepted length was approximately
2.4-3.1 tokens, making target verification the dominant GPU phase.

#24596 adds an adaptive controller to the original DFlash worker. This change is
narrower and targets DFlash V2: it adds the fixed verify-width primitive needed
by target attention, acceptance, hidden-state/KV injection, and CUDA Graph
capture. It does not add an adaptive policy.

## Modifications

- Add `--speculative-dflash-verify-budget` for the target verify prefix.
- Keep draft execution and the scheduler result layout at the checkpoint-native
  block size.
- Use the selected width for target attention, logits, acceptance,
  hidden-state extraction, KV injection, and target CUDA Graph capture.
- Derive Triton target-verify metadata from the runtime width and initialize the
  first mask offset explicitly.
- Require Triton on the backend selected for TARGET_VERIFY when the budget is
  smaller than the draft block; other backends retain the full-width path.
- Zero-initialize scheduler padding only when buffers grow, avoiding a padding
  clear kernel on every speculative step.
- Add CPU contract tests and a registered Qwen3.5 DFlash Batch 16 GPU test.

## Accuracy Tests

- Verify-width and backend-gate tests: 8 passed.
- Existing DFlash overlap/host-sync tests: 7 passed.
- Style checks: Black, isort, ruff, codespell, and `git diff --check` passed.
- Registered Qwen3.5 DFlash GPU test: passed. The server captured
  target verify graphs with K4 through Batch 16 while draft graphs remained K16,
  then completed a real internal Batch 16 request.

## Speed Tests and Profiling

Refreshed same-machine H100 measurements use the refreshed latest-main commit,
fixed prompts, Triton attention, CUDA graphs, and four measured rounds:

| Concurrency | K16 | K4 | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 357.11 tok/s | 373.46 tok/s | +4.58% |
| 8 | 1746.56 tok/s | 2094.03 tok/s | +19.89% |
| 16 | 2474.31 tok/s | 3475.81 tok/s | +40.48% |

Mean accepted length decreased from 2.72/2.75/2.70 to 2.44/2.38/2.38 for
concurrency 1/8/16. The target-compute reduction still improved end-to-end
throughput despite verifying fewer candidates.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit and registered GPU tests.
- [x] Document the new server argument in `ServerArgs` help text.
- [x] Provide real-checkpoint accuracy and speed results.
- [x] Follow the SGLang code style guidance.
