### PR TITLE
perf(diffusion): full-forward CUDA graph for the DiT (opt-in)

### DIFF
--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -90,7 +90,8 @@ Use `sglang generate --help` and `sglang serve --help` for the full argument lis
 - `--warmup-mode {off|request|server}`: control startup warmup for `sglang serve`; `off` skips warmup, `request` primes the request path, and `server` runs a full synthetic server warmup before serving traffic
 - `--enable-torch-compile {true|false}`: compile native diffusion hot paths. When no warmup mode is configured, this also enables server warmup so first real requests do not pay compile latency.
 - `--offload-during-compile {true|false}`: when compile warmup is active, temporarily layerwise-offload DiT weights and move resident non-DiT components off-device so `max-autotune` fits on tighter-memory GPUs; the configured serving residency is restored before real traffic. Skipped under existing layerwise offload, Cache-DiT, or FSDP.
-- `--enable-breakable-cuda-graph {true|false}`: capture supported DiT forwards as breakable CUDA graph segments to reduce launch overhead. Requires `--warmup-resolutions` for every served resolution because each resolution is captured separately.
+- `--dit-cuda-graph {off|breakable|full}`: DiT CUDA-graph mode. `breakable` captures the forward as segments split at attention, which keeps per-step attention metadata live; `full` captures the whole forward as one graph, which removes the remaining per-segment launch overhead but bakes every branch taken at capture time. Both need `--warmup-resolutions` for every served resolution, because each resolution is captured separately. `full` additionally stays off — falling back to eager with a warning — when Cache-DiT is enabled, when the attention backend rebuilds per-step metadata (STA/VSA/SVG2/VMoBA/block-sparse/rain-fusion), or on a sharded run, since a collective recorded into the graph is not replay-safe (see [Multi-GPU and `full`](#multi-gpu-and-full)).
+- `--enable-breakable-cuda-graph {true|false}`: **deprecated**, superseded by `--dit-cuda-graph breakable` and scheduled for removal in the next release. Still accepted: passing it logs `--enable-breakable-cuda-graph is deprecated; use --dit-cuda-graph breakable.` and selects `breakable` unless `--dit-cuda-graph` was set explicitly.
 - `--bcg-text-buckets {N...}`: prompt-length padding buckets for breakable CUDA graph capture/replay reuse.
 - `--attention-backend {BACKEND}`: attention backend for native SGLang and diffusers pipelines
 - `--component-attention-backends {MAP}`: per-component attention backend overrides, for example `text_encoder=torch_sdpa,transformer=fa`
@@ -185,7 +186,11 @@ HTTP server-only arguments are ignored by `sglang generate`.
 
 For supported native pipelines, set `SGLANG_CACHE_DIT_ENABLED=true` to enable Cache-DiT. For the diffusers backend, use `--backend diffusers --cache-dit-config ...`. See [Cache-DiT](../cache_dit).
 
-For supported image pipelines, breakable CUDA graph can be enabled with `--enable-breakable-cuda-graph`, but you must declare every served resolution in `--warmup-resolutions` so warmup captures matching graph signatures.
+For supported image pipelines, CUDA-graph capture is selected with `--dit-cuda-graph breakable` (or `full`), and you must declare every served resolution in `--warmup-resolutions` so warmup captures matching graph signatures. `--enable-breakable-cuda-graph` is the deprecated spelling of `--dit-cuda-graph breakable`.
+
+#### Multi-GPU and `full`
+
+`full` captures the entire DiT forward, so every collective the forward performs is recorded into the graph. A `torch.distributed` NCCL collective is not replay-safe: its host-side per-op bookkeeping advances once at capture and never again, so on replay the ranks disagree about which collective is running and hang. `full` therefore refuses to engage on any sharded run (`sp_size > 1` or `tp_size > 1`) and logs `DiT full CUDA graph disabled: ...`, leaving that run eager — it does not hang, and it does not need to be disabled by hand. Use `breakable` for sharded runs; it splits its segments at attention and keeps the collectives outside the captured regions.
 
 ### Layerwise Offload
 

--- a/docs/docs/sglang-diffusion/deployment_cookbook.mdx
+++ b/docs/docs/sglang-diffusion/deployment_cookbook.mdx
@@ -91,7 +91,12 @@ The modes tune residency for native pipeline components declared to the componen
 
 When `torch.compile` is enabled, `--offload-during-compile` stays on by default. During compile warmup it temporarily offloads the DiT and evicts resident non-DiT components so `max-autotune` fits on tighter-memory GPUs, then restores the configured serving residency before real traffic.
 
-Breakable CUDA graph is a separate manual opt-in for supported image pipelines. If you enable `--enable-breakable-cuda-graph`, declare every served resolution in `--warmup-resolutions` so warmup captures matching graph signatures.
+DiT CUDA-graph capture is a separate manual opt-in for supported image pipelines, selected with `--dit-cuda-graph {off|breakable|full}`. Whichever mode you pick, declare every served resolution in `--warmup-resolutions` so warmup captures matching graph signatures.
+
+- `breakable` captures the forward as segments split at attention, so per-step attention metadata and the collectives of a sharded run stay outside the captured regions. This is the mode to use on more than one GPU.
+- `full` captures the whole forward as a single graph, removing the remaining per-segment launch overhead. It bakes in every branch taken at capture time, so it declines — logging `DiT full CUDA graph disabled: ...` and running eager — under Cache-DiT, under attention backends that rebuild per-step metadata (STA/VSA/SVG2/VMoBA/block-sparse/rain-fusion), and on any sharded run (`sp_size > 1` or `tp_size > 1`), because a `torch.distributed` NCCL collective recorded into a graph is not replay-safe: its host-side per-op bookkeeping advances once at capture, so replays leave the ranks disagreeing about which collective is in flight. Single-GPU runs are where `full` applies today.
+
+`--enable-breakable-cuda-graph` is deprecated in favour of `--dit-cuda-graph breakable` and will be removed in the next release; it is still accepted and logs a warning.
 
 > [!NOTE]
 > The preset is intentionally coarse. A future continuous value such as `0.0` to `1.0` could express the speed-memory tradeoff more precisely, but it would need model-specific memory models and clearer user expectations. Until then, use the preset plus explicit flags for overrides.

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     # distinct (n_local, n_peer, dtype) staging pairs kept; each is two
     # slots and is never freed, so multi-resolution serving needs a cap
     SGLANG_DIFFUSION_IPC_A2A_MAX_BUFFERS: int = 16
+    SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH: bool = False
     SGLANG_CACHE_DIT_ENABLED: bool = False
     SGLANG_CACHE_DIT_FN: int = 1
     SGLANG_CACHE_DIT_BN: int = 0
@@ -237,6 +238,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "SGLANG_DIFFUSION_IPC_A2A_MAX_BUFFERS": _lazy_int(
         "SGLANG_DIFFUSION_IPC_A2A_MAX_BUFFERS", 16
+    ),
+    # Capture the whole DiT forward (incl. SP collectives) into one CUDA graph
+    "SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH": _lazy_bool(
+        "SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH"
     ),
     "SGLANG_CACHE_DIT_ENABLED": _lazy_bool("SGLANG_CACHE_DIT_ENABLED"),
     # Number of first blocks to always compute (DBCache F parameter)

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     # distinct (n_local, n_peer, dtype) staging pairs kept; each is two
     # slots and is never freed, so multi-resolution serving needs a cap
     SGLANG_DIFFUSION_IPC_A2A_MAX_BUFFERS: int = 16
-    SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH: bool = False
     SGLANG_CACHE_DIT_ENABLED: bool = False
     SGLANG_CACHE_DIT_FN: int = 1
     SGLANG_CACHE_DIT_BN: int = 0
@@ -238,10 +237,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "SGLANG_DIFFUSION_IPC_A2A_MAX_BUFFERS": _lazy_int(
         "SGLANG_DIFFUSION_IPC_A2A_MAX_BUFFERS", 16
-    ),
-    # Capture the whole DiT forward (incl. SP collectives) into one CUDA graph
-    "SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH": _lazy_bool(
-        "SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH"
     ),
     "SGLANG_CACHE_DIT_ENABLED": _lazy_bool("SGLANG_CACHE_DIT_ENABLED"),
     # Number of first blocks to always compute (DBCache F parameter)

--- a/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/runner.py
+++ b/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/runner.py
@@ -39,6 +39,16 @@ import torch.nn as nn
 from sglang.multimodal_gen.runtime.breakable_cuda_graph.replay_token import (
     replay_token_scope,
 )
+
+# Log under the multimodal_gen namespace so the diffusion server's logging
+# config surfaces the "[Diffusion BCG] captured ..." lines.
+from sglang.multimodal_gen.runtime.utils.graph_tensor_tree import (
+    clone_output,
+    flatten_kwargs,
+    map_tensors,
+    signature_kwargs,
+    static_buffer_like,
+)
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.breakable_cuda_graph import (
     BreakableCUDAGraph,
     BreakableCUDAGraphCapture,
@@ -47,8 +57,6 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context
     enable_breakable_cuda_graph,
 )
 
-# Log under the multimodal_gen namespace so the diffusion server's logging
-# config surfaces the "[Diffusion BCG] captured ..." lines.
 logger = logging.getLogger(__name__)
 
 
@@ -72,61 +80,6 @@ def _env_float(name: str, default: float) -> float:
     except ValueError:
         logger.warning("[BCG] ignoring invalid float %s=%r", name, raw)
         return default
-
-
-def _map_tensors(obj, fn):
-    """Rebuild ``obj`` applying ``fn`` to every tensor leaf, recursing into
-    list/tuple/dict containers; everything else passes through unchanged."""
-    if torch.is_tensor(obj):
-        return fn(obj)
-    if isinstance(obj, tuple):
-        return tuple(_map_tensors(o, fn) for o in obj)
-    if isinstance(obj, list):
-        return [_map_tensors(o, fn) for o in obj]
-    if isinstance(obj, dict):
-        return {k: _map_tensors(v, fn) for k, v in obj.items()}
-    return obj
-
-
-def _flatten_tensors(obj, out: list):
-    """Depth-first collect every tensor leaf into ``out`` (deterministic order:
-    dicts traversed in sorted-key order to match across calls)."""
-    if torch.is_tensor(obj):
-        out.append(obj)
-    elif isinstance(obj, (list, tuple)):
-        for o in obj:
-            _flatten_tensors(o, out)
-    elif isinstance(obj, dict):
-        for k in sorted(obj):
-            _flatten_tensors(obj[k], out)
-
-
-def _flatten_kwargs(kwargs: dict[str, Any]) -> list[torch.Tensor]:
-    out: list[torch.Tensor] = []
-    for name in sorted(kwargs):
-        _flatten_tensors(kwargs[name], out)
-    return out
-
-
-def _signature_leaf(obj: Any) -> Any:
-    if torch.is_tensor(obj):
-        return ("tensor", tuple(obj.shape), str(obj.dtype))
-    if isinstance(obj, tuple):
-        return ("tuple", tuple(_signature_leaf(o) for o in obj))
-    if isinstance(obj, list):
-        return ("list", tuple(_signature_leaf(o) for o in obj))
-    if isinstance(obj, dict):
-        return (
-            "dict",
-            tuple((k, _signature_leaf(obj[k])) for k in sorted(obj)),
-        )
-    if obj is None or isinstance(obj, (bool, int, float, str)):
-        return ("const", obj)
-    return ("object", type(obj).__module__, type(obj).__qualname__, id(obj))
-
-
-def _signature_kwargs(kwargs: dict[str, Any]) -> tuple:
-    return tuple((name, _signature_leaf(kwargs[name])) for name in sorted(kwargs))
 
 
 def _signature_summary_leaf(sig: Any, *, depth: int = 0) -> Any:
@@ -171,22 +124,12 @@ def _signature_summary(key: tuple) -> tuple:
     )
 
 
-def _clone_output(out: Any) -> Any:
-    if torch.is_tensor(out):
-        return out.clone()
-    if isinstance(out, tuple):
-        return tuple(_clone_output(o) for o in out)
-    if isinstance(out, list):
-        return [_clone_output(o) for o in out]
-    return out
-
-
 @dataclass
 class _CaptureEntry:
     graph: BreakableCUDAGraph
     # full captured kwargs with persistent static buffers at every tensor leaf
     static_kwargs: dict[str, Any]
-    # the same static buffers, flattened in _flatten_kwargs order (replay copies
+    # the same static buffers, flattened in flatten_kwargs order (replay copies
     # live tensors into these positionally)
     static_leaves: list[torch.Tensor]
     output: Any
@@ -313,7 +256,7 @@ class BaseBreakableCudaGraphRunner:
         return self.replay(entry, kwargs)
 
     def replay(self, entry: _CaptureEntry, kwargs: dict[str, Any]) -> Any:
-        live_leaves = _flatten_kwargs(kwargs)
+        live_leaves = flatten_kwargs(kwargs)
         if len(live_leaves) != len(entry.static_leaves):
             # Structure changed under a matching shape key — should not happen;
             # fall back to eager rather than copy mismatched buffers.
@@ -325,7 +268,7 @@ class BaseBreakableCudaGraphRunner:
         # Clone so the caller can hold the result across the next replay / the
         # other CFG branch (which shares this static output buffer when shapes
         # match). The clone is one cheap DtoD copy relative to the full DiT.
-        return _clone_output(entry.output)
+        return clone_output(entry.output)
 
     # ------------------------------------------------------------------ #
     # Internals
@@ -339,7 +282,7 @@ class BaseBreakableCudaGraphRunner:
         objects are keyed by identity to avoid replaying a graph whose eager
         break points still reference a previous request's state object.
         """
-        return _signature_kwargs(kwargs)
+        return signature_kwargs(kwargs)
 
     def _empty_cache(self) -> None:
         empty_cache = getattr(self.device_module, "empty_cache", None)
@@ -392,24 +335,11 @@ class BaseBreakableCudaGraphRunner:
             self._pool = self.device_module.graph_pool_handle()
 
         # Persistent static buffers at every tensor leaf; bake non-tensors.
-        def _to_static(t: torch.Tensor) -> torch.Tensor:
-            # Static buffers live on the capture device. A CPU input (e.g. a
-            # scalar timestep/sigma or an index tensor built on the host)
-            # would otherwise force a CPU->CUDA copy inside the captured
-            # region, which is illegal; place its buffer on the device so the
-            # only host->device copy happens here, before capture, and replay
-            # is device-to-device.
-            if t.device.type == "cpu":
-                buf = torch.empty(t.shape, dtype=t.dtype, device=self.device)
-            else:
-                buf = torch.empty_like(t)
-            buf.copy_(t)
-            return buf
-
         static_kwargs = {
-            name: _map_tensors(v, _to_static) for name, v in kwargs.items()
+            name: map_tensors(v, lambda t: static_buffer_like(t, self.device))
+            for name, v in kwargs.items()
         }
-        static_leaves = _flatten_kwargs(static_kwargs)
+        static_leaves = flatten_kwargs(static_kwargs)
 
         # Warm up on the capture stream so cuBLAS/cuDNN/Triton workspaces and
         # any lazy JIT are materialized before capture (mirrors the LLM runner

--- a/python/sglang/multimodal_gen/runtime/distributed/sp_shard_utils.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/sp_shard_utils.py
@@ -182,6 +182,9 @@ def should_shard_text(txt_len: int) -> bool:
     return get_sp_world_size() > 1 and plan_text_strategy(txt_len) == "shard"
 
 
+_TAIL_META_CACHE: dict = {}
+
+
 def tail_attn_meta(
     shard: SpShard,
     batch_size: int,
@@ -194,19 +197,33 @@ def tail_attn_meta(
     repacking. Built once per request, reused by every block."""
     if shard.sp_size <= 1 or shard.num_pad == 0:
         return None
+    key = (
+        shard.sp_size,
+        shard.local_len,
+        shard.num_pad,
+        shard.local_pad,
+        batch_size,
+        image_seq_len,
+        str(device),
+    )
+    cached = _TAIL_META_CACHE.get(key)
+    if cached is not None:
+        return cached
     seq = shard.sp_size * (shard.local_len + image_seq_len)
     valid = seq - shard.num_pad
     row = torch.tensor([valid, shard.num_pad], dtype=torch.int32, device=device)
     seglens = row.repeat(batch_size)
     cu_seqlens = torch.zeros(2 * batch_size + 1, dtype=torch.int32, device=device)
     cu_seqlens[1:] = torch.cumsum(seglens, dim=0)
-    return {
+    meta = {
         "pad_start": valid,
         "pad_end": seq,
         "local_pad": shard.local_pad,
         "cu_seqlens_tail": cu_seqlens,
         "max_seqlen_tail": max(valid, shard.num_pad),
     }
+    _TAIL_META_CACHE[key] = meta
+    return meta
 
 
 def plan_text_strategy(txt_len: int) -> str:

--- a/python/sglang/multimodal_gen/runtime/distributed/sp_shard_utils.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/sp_shard_utils.py
@@ -211,7 +211,13 @@ def tail_attn_meta(
         return cached
     seq = shard.sp_size * (shard.local_len + image_seq_len)
     valid = seq - shard.num_pad
-    row = torch.tensor([valid, shard.num_pad], dtype=torch.int32, device=device)
+    # Pinned staging keeps a cache-miss build legal inside CUDA graph capture
+    # (a plain list->CUDA tensor is an unpinned H2D copy, which aborts capture).
+    row_cpu = torch.tensor([valid, shard.num_pad], dtype=torch.int32)
+    if device.type == "cuda":
+        row = row_cpu.pin_memory().to(device, non_blocking=True)
+    else:
+        row = row_cpu.to(device)
     seglens = row.repeat(batch_size)
     cu_seqlens = torch.zeros(2 * batch_size + 1, dtype=torch.int32, device=device)
     cu_seqlens[1:] = torch.cumsum(seglens, dim=0)

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -667,6 +667,38 @@ class USPAttention(nn.Module):
         if isinstance(attn_mask_meta, DynamicVarlenMaskMeta):
             attn_mask_meta = attn_mask_meta.resolve(attn_mask)
 
+        if (
+            isinstance(attn_mask_meta, dict)
+            and attn_mask_meta.get("static_no_pack_cu") is not None
+        ):
+            # Fixed-shape varlen: the sequence is [valid rows..., tail pad] and
+            # the pad is excluded by cu_seqlens VALUES, not by packing — no
+            # gather/scatter, no nonzero, capturable into a CUDA graph. Padding
+            # rows receive garbage output; callers must drop them.
+            assert attn_mask is None, "static_no_pack_cu excludes attn_mask"
+            assert (
+                get_sequence_parallel_world_size() == 1 or effective_skip_sp
+            ), "static_no_pack_cu is a single-rank path"
+            assert self.backend == AttentionBackendEnum.FA
+            cu = attn_mask_meta["static_no_pack_cu"]
+            bs, seq = q.shape[0], q.shape[1]
+            assert bs == 1, "static_no_pack_cu supports batch size 1"
+            out = flash_attn_varlen_func(
+                q=q.reshape(bs * seq, *q.shape[2:]),
+                k=k.reshape(bs * seq, *k.shape[2:]),
+                v=v.reshape(bs * seq, *v.shape[2:]),
+                cu_seqlens_q=cu,
+                cu_seqlens_k=cu,
+                max_seqlen_q=bs * seq,
+                max_seqlen_k=bs * seq,
+                softmax_scale=self.softmax_scale,
+                causal=False,
+                ver=_fa_backend.fa_ver,
+            )
+            if isinstance(out, tuple):
+                out = out[0]
+            return out.view(bs, seq, *out.shape[1:])
+
         # Tail-pad meta alone (sp_shard.tail_attn_meta; mask derivable from the
         # pad span) also opts into the masked SP branch. gap_* = legacy alias.
         meta_pad_start = meta_pad_end = None

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -679,25 +679,45 @@ class USPAttention(nn.Module):
             assert (
                 get_sequence_parallel_world_size() == 1 or effective_skip_sp
             ), "static_no_pack_cu is a single-rank path"
-            assert self.backend == AttentionBackendEnum.FA
             cu = attn_mask_meta["static_no_pack_cu"]
             bs, seq = q.shape[0], q.shape[1]
             assert bs == 1, "static_no_pack_cu supports batch size 1"
-            out = flash_attn_varlen_func(
-                q=q.reshape(bs * seq, *q.shape[2:]),
-                k=k.reshape(bs * seq, *k.shape[2:]),
-                v=v.reshape(bs * seq, *v.shape[2:]),
-                cu_seqlens_q=cu,
-                cu_seqlens_k=cu,
-                max_seqlen_q=bs * seq,
-                max_seqlen_k=bs * seq,
-                softmax_scale=self.softmax_scale,
-                causal=False,
-                ver=_fa_backend.fa_ver,
+            if self.backend == AttentionBackendEnum.FA:
+                out = flash_attn_varlen_func(
+                    q=q.reshape(bs * seq, *q.shape[2:]),
+                    k=k.reshape(bs * seq, *k.shape[2:]),
+                    v=v.reshape(bs * seq, *v.shape[2:]),
+                    cu_seqlens_q=cu,
+                    cu_seqlens_k=cu,
+                    max_seqlen_q=bs * seq,
+                    max_seqlen_k=bs * seq,
+                    softmax_scale=self.softmax_scale,
+                    causal=False,
+                    ver=_fa_backend.fa_ver,
+                )
+                if isinstance(out, tuple):
+                    out = out[0]
+                return out.view(bs, seq, *out.shape[1:])
+            # SDPA-family backends take a dense mask derived from the cu VALUE:
+            # arange < valid is shape-static, so it stays capturable.
+            tail_mask = (
+                torch.arange(seq, device=q.device, dtype=torch.int32)
+                < cu[1].to(torch.int32)
+            )[None, None, None, :]
+            sdpa_context = (
+                sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
+                if self.allow_cudnn_sdp and q.device.type == "cuda"
+                else nullcontext()
             )
-            if isinstance(out, tuple):
-                out = out[0]
-            return out.view(bs, seq, *out.shape[1:])
+            with sdpa_context:
+                out = torch.nn.functional.scaled_dot_product_attention(
+                    q.transpose(1, 2),
+                    k.transpose(1, 2),
+                    v.transpose(1, 2),
+                    attn_mask=tail_mask,
+                    scale=self.softmax_scale,
+                )
+            return out.transpose(1, 2)
 
         # Tail-pad meta alone (sp_shard.tail_attn_meta; mask derivable from the
         # pad span) also opts into the masked SP branch. gap_* = legacy alias.

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -782,8 +782,16 @@ class QwenImageCrossAttention(nn.Module):
                 img_value,
                 sp_txt_pad,
             )
+        txt_tail_join = cross_attention_kwargs.get("txt_tail_join", False)
         if seg_qkv is not None:
             joint_query, joint_key, joint_value = seg_qkv
+        elif txt_tail_join:
+            # [image, text-bucket]: the bucket's tail padding becomes a joint
+            # suffix without any pad-relocation slicing (shape-static, see the
+            # static_no_pack_cu path in USPAttention).
+            joint_query = torch.cat([img_query, txt_query], dim=1)
+            joint_key = torch.cat([img_key, txt_key], dim=1)
+            joint_value = torch.cat([img_value, txt_value], dim=1)
         else:
             joint_query = join_seqs(txt_query, img_query, sp_txt_pad)
             joint_key = join_seqs(txt_key, img_key, sp_txt_pad)
@@ -815,9 +823,14 @@ class QwenImageCrossAttention(nn.Module):
         joint_hidden_states = joint_hidden_states.to(joint_query.dtype)
 
         # Split attention outputs back
-        txt_attn_output, img_attn_output = split_seqs(
-            joint_hidden_states, seq_len_txt, sp_txt_pad
-        )
+        if txt_tail_join:
+            img_len = joint_hidden_states.shape[1] - seq_len_txt
+            img_attn_output = joint_hidden_states[:, :img_len]
+            txt_attn_output = joint_hidden_states[:, img_len:]
+        else:
+            txt_attn_output, img_attn_output = split_seqs(
+                joint_hidden_states, seq_len_txt, sp_txt_pad
+            )
 
         # Apply output projections
         img_attn_output, _ = self.to_out[0](img_attn_output)
@@ -1488,6 +1501,7 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         freqs_cis: tuple[torch.Tensor, torch.Tensor] = None,
         additional_t_cond: Optional[torch.Tensor] = None,
         guidance: torch.Tensor = None,
+        txt_bucket_tail_cu: Optional[torch.Tensor] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         controlnet_block_samples=None,
         return_dict: bool = True,
@@ -1545,7 +1559,19 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
 
         block_attention_kwargs = attention_kwargs.copy() if attention_kwargs else {}
         sp_text_sharded = False
-        if encoder_hidden_states_mask is not None:
+        if txt_bucket_tail_cu is not None:
+            # Bucketed single-request path for whole-forward CUDA graphs: the
+            # text buffer is padded to a fixed bucket, blocks join the sequence
+            # as [image, text] so the pad is a joint-tail suffix, and attention
+            # clamps it via cu_seqlens VALUES — every shape stays static, so
+            # the forward is capturable and needs no nonzero()-based metadata.
+            joint_len = txt_bucket_tail_cu.to(torch.int32) + hidden_states.shape[1]
+            joint_cu = torch.cat(
+                [torch.zeros_like(joint_len), joint_len]
+            ).contiguous()
+            block_attention_kwargs["attn_mask_meta"] = {"static_no_pack_cu": joint_cu}
+            block_attention_kwargs["txt_tail_join"] = True
+        elif encoder_hidden_states_mask is not None:
             encoder_hidden_states_mask = encoder_hidden_states_mask.to(
                 device=hidden_states.device, dtype=torch.bool
             )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -182,6 +182,12 @@ class _FullGraphRunner:
                     k: (v.clone() if isinstance(v, torch.Tensor) else v)
                     for k, v in kwargs.items()
                 }
+                # Run the exact captured path once eagerly first: first-step
+                # branches and lazy allocations (e.g. IPC staging keyed on
+                # this step's shapes) must settle so the recording bakes the
+                # steady-state path — a capture-time staging miss falls back
+                # to NCCL mid-graph and deadlocks replay.
+                self.model(**self.static_kwargs)
                 torch.cuda.synchronize()
                 graph = torch.cuda.CUDAGraph()
                 with torch.cuda.graph(graph):

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -141,6 +141,72 @@ from sglang.multimodal_gen.utils import dict_to_3d_list
 logger = init_logger(__name__)
 
 
+class _FullGraphRunner:
+    """Replays the whole DiT forward (incl. SP collectives) as one CUDA graph;
+    any tensor-signature change falls back to eager permanently."""
+
+    def __init__(self, model):
+        self.model = model
+        self.graph = None
+        self.static_kwargs = None
+        self.static_out = None
+        self.eager_left = 1
+        self.sig = None
+        self.disabled = False
+
+    @staticmethod
+    def _signature(kwargs):
+        return tuple(
+            (k, tuple(v.shape), str(v.dtype))
+            for k, v in sorted(kwargs.items())
+            if isinstance(v, torch.Tensor)
+        )
+
+    def run(self, kwargs):
+        if self.disabled:
+            return self.model(**kwargs)
+        sig = self._signature(kwargs)
+        if self.sig is not None and sig != self.sig:
+            self.disabled = True
+            logger.warning(
+                "DiT full CUDA graph: tensor signature changed, eager fallback"
+            )
+            return self.model(**kwargs)
+        if self.eager_left > 0:
+            self.eager_left -= 1
+            self.sig = sig
+            return self.model(**kwargs)
+        if self.graph is None:
+            try:
+                self.static_kwargs = {
+                    k: (v.clone() if isinstance(v, torch.Tensor) else v)
+                    for k, v in kwargs.items()
+                }
+                torch.cuda.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    self.static_out = self.model(**self.static_kwargs)
+                self.graph = graph
+                # capture records without executing; replay to produce this
+                # step's real output
+                self.graph.replay()
+                torch.cuda.synchronize()
+                logger.info("DiT full CUDA graph captured")
+                return self.static_out
+            except Exception:
+                logger.exception("DiT full CUDA graph capture failed, eager fallback")
+                self.graph = None
+                self.disabled = True
+                torch.cuda.synchronize()
+                return self.model(**kwargs)
+        for k, v in kwargs.items():
+            sv = self.static_kwargs.get(k)
+            if isinstance(sv, torch.Tensor) and isinstance(v, torch.Tensor):
+                sv.copy_(v, non_blocking=True)
+        self.graph.replay()
+        return self.static_out
+
+
 def _ensure_tensor_model_output(model_output):
     sample = getattr(model_output, "sample", None)
     if isinstance(sample, torch.Tensor):
@@ -2102,6 +2168,12 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         runner = self._maybe_get_bcg_runner(current_model)
         if runner is not None:
             model_output = self._bcg_run(runner, call_kwargs, current_model)
+        elif envs.SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH and not self._bcg_is_warmup():
+            fcg = getattr(current_model, "_full_graph_runner", None)
+            if fcg is None:
+                fcg = _FullGraphRunner(current_model)
+                current_model._full_graph_runner = fcg
+            model_output = fcg.run(call_kwargs)
         else:
             model_output = current_model(**call_kwargs)
         return _ensure_tensor_model_output(model_output)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -170,7 +170,18 @@ class _FullGraphRunner:
         sig = signature_kwargs(kwargs)
         if self.sig is not None and sig != self.sig:
             self.disabled = True
-            logger.warning("DiT full CUDA graph: signature changed, eager fallback")
+            if len(sig) == len(self.sig):
+                changed = [
+                    f"{prev} != {cur}"
+                    for prev, cur in zip(self.sig, sig)
+                    if prev != cur
+                ]
+            else:
+                changed = ["kwarg set changed"]
+            logger.warning(
+                "DiT full CUDA graph: signature changed, eager fallback: %s",
+                "; ".join(changed[:4]) or "?",
+            )
             return self.model(**kwargs)
         if self.eager_left > 0:
             self.eager_left -= 1

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -2204,9 +2204,25 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             # this the signature is keyed to one prompt length (the warmup
             # request's), and the first differently-sized prompt disables the
             # graph permanently.
+            raw_txt_lens = call_kwargs.get("txt_seq_lens")
             call_kwargs = self._bcg_pad_prompt_kwargs(
                 call_kwargs, current_model=current_model
             )
+            mask = call_kwargs.get("encoder_hidden_states_mask")
+            if (
+                mask is not None
+                and raw_txt_lens is not None
+                and len(raw_txt_lens) == 1
+            ):
+                # The bucketed mask marks a contiguous text tail pad; hand the
+                # model the valid length as a device value instead so the whole
+                # forward stays shape-static and free of nonzero() (a mask-based
+                # varlen path cannot be captured into one graph).
+                call_kwargs = dict(call_kwargs)
+                call_kwargs["encoder_hidden_states_mask"] = None
+                call_kwargs["txt_bucket_tail_cu"] = torch.tensor(
+                    [raw_txt_lens[0]], dtype=torch.int32, device=mask.device
+                )
             fcg = self._fcg_runners.get(id(current_model))
             if fcg is None:
                 fcg = _FullGraphRunner(current_model, self._fcg_device(call_kwargs))

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -52,6 +52,7 @@ from sglang.multimodal_gen.runtime.distributed import (
     get_sp_group,
     get_sp_world_size,
     get_tp_group,
+    get_tp_world_size,
     get_world_group,
     get_world_size,
     model_parallel_is_initialized,
@@ -2203,7 +2204,9 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         Sparse backends (STA/VSA/SVG2/VMoBA/block-sparse/rain-fusion) rebuild
         their attention metadata every step — a replay would reuse step 0's
         block layout — and Cache-DiT decides per step whether to skip blocks,
-        which cannot be baked into one graph. Both keep eager."""
+        which cannot be baked into one graph. A sharded run puts NCCL
+        collectives inside the captured region, which hang on replay. All three
+        keep eager."""
         if self.server_args.dit_cuda_graph != "full" or self._bcg_is_warmup():
             return False
         if self._cache_dit_enabled:
@@ -2213,6 +2216,20 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             self._fcg_log_skip(
                 f"attention backend {self.attn_backend.get_enum()} rebuilds "
                 "per-step metadata"
+            )
+            return False
+        if get_sp_world_size() > 1 or get_tp_world_size() > 1:
+            # A NCCL collective recorded into the graph deadlocks on replay:
+            # ProcessGroupNCCL bakes its per-op sequence number into the
+            # capture, so replayed kernels no longer match the peer's. (This is
+            # why BCG splits its segments at attention instead.) Whole-forward
+            # capture therefore needs every in-forward collective to come from a
+            # capture-safe transport; until one is wired up, sharded runs stay
+            # eager. Measured on 2xH100 Ulysses: both ranks hang in
+            # graph.replay() with the NCCL all-to-all captured.
+            self._fcg_log_skip(
+                f"sp={get_sp_world_size()} tp={get_tp_world_size()}: NCCL "
+                "collectives inside the forward are not replay-safe"
             )
             return False
         return True

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -2200,6 +2200,13 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         if runner is not None:
             model_output = self._bcg_run(runner, call_kwargs, current_model)
         elif self._fcg_eligible():
+            # Bucket the prompt-conditioning inputs exactly like BCG: without
+            # this the signature is keyed to one prompt length (the warmup
+            # request's), and the first differently-sized prompt disables the
+            # graph permanently.
+            call_kwargs = self._bcg_pad_prompt_kwargs(
+                call_kwargs, current_model=current_model
+            )
             fcg = self._fcg_runners.get(id(current_model))
             if fcg is None:
                 fcg = _FullGraphRunner(current_model, self._fcg_device(call_kwargs))

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -117,6 +117,13 @@ from sglang.multimodal_gen.runtime.post_training.rollout_denoising_mixin import 
     RolloutDenoisingMixin,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.graph_tensor_tree import (
+    clone_output,
+    flatten_kwargs,
+    map_tensors,
+    signature_kwargs,
+    static_buffer_like,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.nvtx_pytorch_hooks import maybe_nvtx_range
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
@@ -145,32 +152,24 @@ class _FullGraphRunner:
     """Replays the whole DiT forward (incl. SP collectives) as one CUDA graph;
     any tensor-signature change falls back to eager permanently."""
 
-    def __init__(self, model):
+    def __init__(self, model, device: torch.device):
         self.model = model
+        self.device = device
         self.graph = None
         self.static_kwargs = None
+        self.static_leaves = None
         self.static_out = None
         self.eager_left = 1
         self.sig = None
         self.disabled = False
 
-    @staticmethod
-    def _signature(kwargs):
-        return tuple(
-            (k, tuple(v.shape), str(v.dtype))
-            for k, v in sorted(kwargs.items())
-            if isinstance(v, torch.Tensor)
-        )
-
     def run(self, kwargs):
         if self.disabled:
             return self.model(**kwargs)
-        sig = self._signature(kwargs)
+        sig = signature_kwargs(kwargs)
         if self.sig is not None and sig != self.sig:
             self.disabled = True
-            logger.warning(
-                "DiT full CUDA graph: tensor signature changed, eager fallback"
-            )
+            logger.warning("DiT full CUDA graph: signature changed, eager fallback")
             return self.model(**kwargs)
         if self.eager_left > 0:
             self.eager_left -= 1
@@ -179,9 +178,10 @@ class _FullGraphRunner:
         if self.graph is None:
             try:
                 self.static_kwargs = {
-                    k: (v.clone() if isinstance(v, torch.Tensor) else v)
-                    for k, v in kwargs.items()
+                    name: map_tensors(v, lambda t: static_buffer_like(t, self.device))
+                    for name, v in kwargs.items()
                 }
+                self.static_leaves = flatten_kwargs(self.static_kwargs)
                 # Run the exact captured path once eagerly first: first-step
                 # branches and lazy allocations (e.g. IPC staging keyed on
                 # this step's shapes) must settle so the recording bakes the
@@ -198,19 +198,28 @@ class _FullGraphRunner:
                 self.graph.replay()
                 torch.cuda.synchronize()
                 logger.info("DiT full CUDA graph captured")
-                return self.static_out
+                return self._captured_output()
             except Exception:
                 logger.exception("DiT full CUDA graph capture failed, eager fallback")
                 self.graph = None
                 self.disabled = True
                 torch.cuda.synchronize()
                 return self.model(**kwargs)
-        for k, v in kwargs.items():
-            sv = self.static_kwargs.get(k)
-            if isinstance(sv, torch.Tensor) and isinstance(v, torch.Tensor):
-                sv.copy_(v, non_blocking=True)
+        live_leaves = flatten_kwargs(kwargs)
+        if len(live_leaves) != len(self.static_leaves):
+            # Structure changed under a matching signature — should not happen;
+            # fall back to eager rather than copy mismatched buffers.
+            return self.model(**kwargs)
+        for buf, live in zip(self.static_leaves, live_leaves):
+            buf.copy_(live, non_blocking=True)
         self.graph.replay()
-        return self.static_out
+        return self._captured_output()
+
+    def _captured_output(self):
+        """Copy this replay's result off the static output buffer. Unwrap first:
+        a diffusers-style output object would pass through clone_output intact,
+        leaving its .sample aliased to the buffer the next replay overwrites."""
+        return clone_output(_ensure_tensor_model_output(self.static_out))
 
 
 def _ensure_tensor_model_output(model_output):
@@ -310,6 +319,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         self._bcg_runners: dict[int, Any] = {}
         # Full-forward CUDA graph runners, one per transformer module (lazy).
         self._fcg_runners: dict[int, Any] = {}
+        self._fcg_skip_logged = False
 
         hidden_size = self.server_args.pipeline_config.dit_config.hidden_size
         num_attention_heads = (
@@ -712,9 +722,10 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         transformers with (potentially) different configurations.
 
         """
-        if self.server_args.enable_breakable_cuda_graph:
+        if self.server_args.dit_cuda_graph != "off":
             # Cache-DiT wraps transformer.forward with step-skipping control
-            # flow that must not be baked into a captured CUDA graph.
+            # flow that must not be baked into a captured CUDA graph (either
+            # mode); the graph takes priority.
             return
         # NOTE: When a new request arrives, we need to refresh the cache-dit context.
         if self._cache_dit_enabled:
@@ -2176,15 +2187,48 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         runner = self._maybe_get_bcg_runner(current_model)
         if runner is not None:
             model_output = self._bcg_run(runner, call_kwargs, current_model)
-        elif self.server_args.dit_cuda_graph == "full" and not self._bcg_is_warmup():
+        elif self._fcg_eligible():
             fcg = self._fcg_runners.get(id(current_model))
             if fcg is None:
-                fcg = _FullGraphRunner(current_model)
+                fcg = _FullGraphRunner(current_model, self._fcg_device(call_kwargs))
                 self._fcg_runners[id(current_model)] = fcg
             model_output = fcg.run(call_kwargs)
         else:
             model_output = current_model(**call_kwargs)
         return _ensure_tensor_model_output(model_output)
+
+    def _fcg_eligible(self) -> bool:
+        """True when the full-forward graph may run this step.
+
+        Sparse backends (STA/VSA/SVG2/VMoBA/block-sparse/rain-fusion) rebuild
+        their attention metadata every step — a replay would reuse step 0's
+        block layout — and Cache-DiT decides per step whether to skip blocks,
+        which cannot be baked into one graph. Both keep eager."""
+        if self.server_args.dit_cuda_graph != "full" or self._bcg_is_warmup():
+            return False
+        if self._cache_dit_enabled:
+            self._fcg_log_skip("Cache-DiT is enabled (per-step block skipping)")
+            return False
+        if self.attn_backend.get_enum().is_sparse:
+            self._fcg_log_skip(
+                f"attention backend {self.attn_backend.get_enum()} rebuilds "
+                "per-step metadata"
+            )
+            return False
+        return True
+
+    def _fcg_log_skip(self, reason: str) -> None:
+        if not self._fcg_skip_logged:
+            self._fcg_skip_logged = True
+            logger.warning("DiT full CUDA graph disabled: %s", reason)
+
+    @staticmethod
+    def _fcg_device(call_kwargs: dict) -> torch.device:
+        """Capture device: the first CUDA tensor leaf, else the current device."""
+        for leaf in flatten_kwargs(call_kwargs):
+            if leaf.device.type == "cuda":
+                return leaf.device
+        return torch.device("cuda", torch.cuda.current_device())
 
     @staticmethod
     def _bcg_is_warmup() -> bool:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -302,6 +302,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         self._torch_compile_registry = CompiledModuleRegistry()
         # Breakable CUDA graph runners, one per transformer module (lazy).
         self._bcg_runners: dict[int, Any] = {}
+        # Full-forward CUDA graph runners, one per transformer module (lazy).
+        self._fcg_runners: dict[int, Any] = {}
 
         hidden_size = self.server_args.pipeline_config.dit_config.hidden_size
         num_attention_heads = (
@@ -2168,14 +2170,11 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         runner = self._maybe_get_bcg_runner(current_model)
         if runner is not None:
             model_output = self._bcg_run(runner, call_kwargs, current_model)
-        elif (
-            getattr(self.server_args, "dit_cuda_graph", "off") == "full"
-            and not self._bcg_is_warmup()
-        ):
-            fcg = getattr(current_model, "_full_graph_runner", None)
+        elif self.server_args.dit_cuda_graph == "full" and not self._bcg_is_warmup():
+            fcg = self._fcg_runners.get(id(current_model))
             if fcg is None:
                 fcg = _FullGraphRunner(current_model)
-                current_model._full_graph_runner = fcg
+                self._fcg_runners[id(current_model)] = fcg
             model_output = fcg.run(call_kwargs)
         else:
             model_output = current_model(**call_kwargs)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -2168,7 +2168,10 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         runner = self._maybe_get_bcg_runner(current_model)
         if runner is not None:
             model_output = self._bcg_run(runner, call_kwargs, current_model)
-        elif envs.SGLANG_DIFFUSION_DIT_FULL_CUDA_GRAPH and not self._bcg_is_warmup():
+        elif (
+            getattr(self.server_args, "dit_cuda_graph", "off") == "full"
+            and not self._bcg_is_warmup()
+        ):
             fcg = getattr(current_model, "_full_graph_runner", None)
             if fcg is None:
                 fcg = _FullGraphRunner(current_model)

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -306,6 +306,11 @@ class ServerArgs(DisaggServerArgsMixin):
     # when BCG is enabled: every requested resolution is captured at warmup so
     # serving never triggers a fresh capture.
     enable_breakable_cuda_graph: bool = False
+    # DiT CUDA-graph mode: "off", "breakable" (same as
+    # --enable-breakable-cuda-graph), or "full" -- capture the whole forward,
+    # SP collectives included, as one graph (model-agnostic; any tensor
+    # signature change falls back to eager permanently).
+    dit_cuda_graph: str = "off"
     # Text/prompt sequence-length padding budget for BCG. Prompt-conditioning
     # inputs are padded up to the smallest bucket that fits, so prompts of
     # different lengths reuse one captured graph. Warmup captures one graph per
@@ -518,6 +523,18 @@ class ServerArgs(DisaggServerArgsMixin):
             )
 
     def _adjust_breakable_cuda_graph_support(self):
+        if self.dit_cuda_graph not in ("off", "breakable", "full"):
+            raise ValueError(
+                f"--dit-cuda-graph must be off/breakable/full, got "
+                f"{self.dit_cuda_graph!r}"
+            )
+        if self.enable_breakable_cuda_graph and self.dit_cuda_graph == "off":
+            logger.warning(
+                "--enable-breakable-cuda-graph is deprecated; use "
+                "--dit-cuda-graph breakable."
+            )
+            self.dit_cuda_graph = "breakable"
+        self.enable_breakable_cuda_graph = self.dit_cuda_graph == "breakable"
         if not self.enable_breakable_cuda_graph:
             return
 
@@ -537,6 +554,7 @@ class ServerArgs(DisaggServerArgsMixin):
             pipeline_config_name,
         )
         self.enable_breakable_cuda_graph = False
+        self.dit_cuda_graph = "off"
 
     def _is_breakable_cuda_graph_supported_model(self) -> bool:
         refs = _normalized_bcg_model_refs(self.model_id)
@@ -1537,6 +1555,17 @@ class ServerArgs(DisaggServerArgsMixin):
             action=StoreBoolean,
             default=ServerArgs.offload_during_compile,
             help="Offload components during the torch.compile warmup (the DiT layerwise) so max-autotune fits on tighter-memory GPUs, then restore the configured residency for serving. Skipped when the DiT is already layerwise-offloaded, or under cache-dit / FSDP.",
+        )
+        parser.add_argument(
+            "--dit-cuda-graph",
+            type=str,
+            choices=["off", "breakable", "full"],
+            default=ServerArgs.dit_cuda_graph,
+            help="DiT CUDA-graph mode. 'breakable' captures graph segments "
+            "split at attention (dynamic shapes via text buckets; see "
+            "--bcg-text-buckets). 'full' captures the whole forward, SP "
+            "collectives included, as one graph: model-agnostic, and any "
+            "tensor-signature change falls back to eager permanently.",
         )
         parser.add_argument(
             "--enable-breakable-cuda-graph",

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -1563,9 +1563,12 @@ class ServerArgs(DisaggServerArgsMixin):
             default=ServerArgs.dit_cuda_graph,
             help="DiT CUDA-graph mode. 'breakable' captures graph segments "
             "split at attention (dynamic shapes via text buckets; see "
-            "--bcg-text-buckets). 'full' captures the whole forward, SP "
-            "collectives included, as one graph: model-agnostic, and any "
-            "tensor-signature change falls back to eager permanently.",
+            "--bcg-text-buckets). 'full' captures the whole forward as one "
+            "graph: model-agnostic, and any signature change falls back to "
+            "eager permanently. 'full' needs a forward with no NCCL "
+            "collectives in it (those hang on replay), so it stays eager when "
+            "tp/sp is sharded, when Cache-DiT is on, or under a sparse "
+            "attention backend.",
         )
         parser.add_argument(
             "--enable-breakable-cuda-graph",

--- a/python/sglang/multimodal_gen/runtime/utils/graph_tensor_tree.py
+++ b/python/sglang/multimodal_gen/runtime/utils/graph_tensor_tree.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tensor-tree helpers shared by the CUDA-graph runners (breakable and full).
+
+A DiT's kwargs are not flat: tensors hide inside lists/tuples/dicts (RoPE
+caches, per-branch controls) alongside non-tensor values that get baked into
+the captured Python control flow. Graph capture therefore needs to (1) key on
+the whole structure, (2) place a persistent static buffer at every tensor leaf,
+and (3) hand the caller a copy of the output, since the static output buffer is
+overwritten by the next replay.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+def map_tensors(obj: Any, fn) -> Any:
+    """Rebuild ``obj`` applying ``fn`` to every tensor leaf, recursing into
+    list/tuple/dict containers; everything else passes through unchanged."""
+    if torch.is_tensor(obj):
+        return fn(obj)
+    if isinstance(obj, tuple):
+        return tuple(map_tensors(o, fn) for o in obj)
+    if isinstance(obj, list):
+        return [map_tensors(o, fn) for o in obj]
+    if isinstance(obj, dict):
+        return {k: map_tensors(v, fn) for k, v in obj.items()}
+    return obj
+
+
+def flatten_tensors(obj: Any, out: list) -> None:
+    """Depth-first collect every tensor leaf into ``out`` (deterministic order:
+    dicts traversed in sorted-key order to match across calls)."""
+    if torch.is_tensor(obj):
+        out.append(obj)
+    elif isinstance(obj, (list, tuple)):
+        for o in obj:
+            flatten_tensors(o, out)
+    elif isinstance(obj, dict):
+        for k in sorted(obj):
+            flatten_tensors(obj[k], out)
+
+
+def flatten_kwargs(kwargs: dict[str, Any]) -> list[torch.Tensor]:
+    out: list[torch.Tensor] = []
+    for name in sorted(kwargs):
+        flatten_tensors(kwargs[name], out)
+    return out
+
+
+def signature_leaf(obj: Any) -> Any:
+    if torch.is_tensor(obj):
+        return ("tensor", tuple(obj.shape), str(obj.dtype))
+    if isinstance(obj, tuple):
+        return ("tuple", tuple(signature_leaf(o) for o in obj))
+    if isinstance(obj, list):
+        return ("list", tuple(signature_leaf(o) for o in obj))
+    if isinstance(obj, dict):
+        return (
+            "dict",
+            tuple((k, signature_leaf(obj[k])) for k in sorted(obj)),
+        )
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return ("const", obj)
+    return ("object", type(obj).__module__, type(obj).__qualname__, id(obj))
+
+
+def signature_kwargs(kwargs: dict[str, Any]) -> tuple:
+    """Capture key for ``kwargs``: tensors by shape+dtype (values are copied
+    into static buffers), non-tensors by value (they are baked into the
+    captured control flow), mutable objects by identity (so a graph that closed
+    over another request's state is never replayed)."""
+    return tuple((name, signature_leaf(kwargs[name])) for name in sorted(kwargs))
+
+
+def clone_output(out: Any) -> Any:
+    """Copy a captured output off the static buffer so the caller can hold it
+    across the next replay (serial CFG holds both branch results at once)."""
+    if torch.is_tensor(out):
+        return out.clone()
+    if isinstance(out, tuple):
+        return tuple(clone_output(o) for o in out)
+    if isinstance(out, list):
+        return [clone_output(o) for o in out]
+    if isinstance(out, dict):
+        return {k: clone_output(v) for k, v in out.items()}
+    return out
+
+
+def static_buffer_like(t: torch.Tensor, device: torch.device) -> torch.Tensor:
+    """Persistent capture buffer for one tensor leaf. A CPU leaf (a host-built
+    timestep or index tensor) gets a device buffer: leaving it on the host would
+    put an unpinned host-to-device copy inside the captured region, which aborts
+    capture."""
+    if t.device.type == "cpu":
+        buf = torch.empty(t.shape, dtype=t.dtype, device=device)
+    else:
+        buf = torch.empty_like(t)
+    buf.copy_(t)
+    return buf

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
@@ -7,7 +7,6 @@ import torch
 from sglang.multimodal_gen.runtime.breakable_cuda_graph.runner import (
     DiffusionBreakableCudaGraphRunner,
     _CaptureEntry,
-    _signature_kwargs,
 )
 from sglang.multimodal_gen.runtime.layers.attention import (
     DynamicVarlenMaskMeta,
@@ -23,6 +22,7 @@ from sglang.multimodal_gen.runtime.server_args import (
     BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS,
     BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS,
 )
+from sglang.multimodal_gen.runtime.utils.graph_tensor_tree import signature_kwargs
 
 
 class QwenImageTransformer2DModel(torch.nn.Module):
@@ -98,7 +98,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
         self.assertEqual(short["freqs_cis"][1].shape, (256, 128))
         self.assertEqual(short["txt_seq_lens"], [256])
         self.assertEqual(longer["txt_seq_lens"], [256])
-        self.assertEqual(_signature_kwargs(short), _signature_kwargs(longer))
+        self.assertEqual(signature_kwargs(short), signature_kwargs(longer))
 
     def test_qwen_prompt_content_changes_do_not_change_signature(self):
         with self._patch_buckets(256, 512, 1024):
@@ -115,7 +115,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
                 second["encoder_hidden_states"][0],
             )
         )
-        self.assertEqual(_signature_kwargs(first), _signature_kwargs(second))
+        self.assertEqual(signature_kwargs(first), signature_kwargs(second))
 
     def test_qwen_dynamic_varlen_meta_is_not_tail_pad_meta(self):
         self.assertEqual(_attn_mask_meta_local_pad(None), 0)
@@ -145,7 +145,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
         self.assertFalse(first["encoder_hidden_states_mask"][0, 19:].any())
         self.assertTrue(second["encoder_hidden_states_mask"][0, :47].all())
         self.assertFalse(second["encoder_hidden_states_mask"][0, 47:].any())
-        self.assertEqual(_signature_kwargs(first), _signature_kwargs(second))
+        self.assertEqual(signature_kwargs(first), signature_kwargs(second))
 
     def test_non_qwen_kwargs_do_not_take_qwen_padding_path(self):
         kwargs = self._qwen_kwargs(47)
@@ -195,7 +195,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
         self.assertFalse(short["encoder_hidden_states_mask"][0, 19:].any())
         self.assertFalse(longer["encoder_hidden_states_mask"][0, 47:].any())
         self.assertEqual(short["freqs_cis"][0].shape, (64, 8))
-        self.assertEqual(_signature_kwargs(short), _signature_kwargs(longer))
+        self.assertEqual(signature_kwargs(short), signature_kwargs(longer))
 
     def _minimax_h3_kwargs(self, text_seq: int):
         image_seq = 4
@@ -321,7 +321,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
         self.assertFalse(short["attn_mask"][0, 23:].any())
         self.assertIsInstance(short["attn_mask_meta"], DynamicVarlenMaskMeta)
         self.assertIs(short["attn_mask_meta"], longer["attn_mask_meta"])
-        self.assertEqual(_signature_kwargs(short), _signature_kwargs(longer))
+        self.assertEqual(signature_kwargs(short), signature_kwargs(longer))
 
     def test_ideogram_image_only_kwargs_are_not_prompt_padded(self):
         kwargs = self._ideogram_kwargs(0)

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
@@ -408,6 +408,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
         self.stage.server_args = SimpleNamespace(
             enable_breakable_cuda_graph=False,
             enable_torch_compile=False,
+            dit_cuda_graph="off",
         )
         self.stage._bcg_runners = {}
         self.stage._cache_dit_enabled = False

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
@@ -282,7 +282,7 @@ class TestDiffusionBCGPadding(unittest.TestCase):
             longer["text_pos_info"]["position_ids"][47:].tolist(),
             list(range(53, 70)),
         )
-        self.assertEqual(_signature_kwargs(short), _signature_kwargs(longer))
+        self.assertEqual(signature_kwargs(short), signature_kwargs(longer))
 
     def _ideogram_kwargs(self, text_seq: int, *, image_seq: int = 4):
         total_seq = text_seq + image_seq

--- a/python/sglang/multimodal_gen/test/unit/test_dit_full_cuda_graph.py
+++ b/python/sglang/multimodal_gen/test/unit/test_dit_full_cuda_graph.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the DiT full-forward CUDA graph runner (--dit-cuda-graph full)
+and the tensor-tree helpers it shares with the breakable-graph runner."""
+
+import unittest
+
+import torch
+
+from sglang.multimodal_gen.runtime.utils.graph_tensor_tree import (
+    clone_output,
+    flatten_kwargs,
+    map_tensors,
+    signature_kwargs,
+    static_buffer_like,
+)
+
+
+class TestGraphTensorTree(unittest.TestCase):
+    def test_signature_covers_nested_tensors_and_controls(self):
+        """A change hidden in a nested container or a non-tensor control must
+        change the key — DiT kwargs carry both (qwen freqs_cis, txt_seq_lens)."""
+        base = {
+            "hidden_states": torch.zeros(2, 4),
+            "freqs_cis": (torch.zeros(4, 8), torch.zeros(4, 8)),
+            "txt_seq_lens": [3, 5],
+            "guidance": 3.5,
+        }
+        self.assertEqual(signature_kwargs(base), signature_kwargs(dict(base)))
+
+        nested_shape = dict(base, freqs_cis=(torch.zeros(4, 8), torch.zeros(6, 8)))
+        self.assertNotEqual(signature_kwargs(base), signature_kwargs(nested_shape))
+
+        control = dict(base, txt_seq_lens=[3, 7])
+        self.assertNotEqual(signature_kwargs(base), signature_kwargs(control))
+
+        scalar = dict(base, guidance=4.0)
+        self.assertNotEqual(signature_kwargs(base), signature_kwargs(scalar))
+
+    def test_flatten_collects_nested_leaves_deterministically(self):
+        kwargs = {
+            "b": [torch.zeros(1), {"y": torch.zeros(2), "x": torch.zeros(3)}],
+            "a": torch.zeros(4),
+        }
+        leaves = flatten_kwargs(kwargs)
+        self.assertEqual([tuple(t.shape) for t in leaves], [(4,), (1,), (3,), (2,)])
+        self.assertEqual(
+            [tuple(t.shape) for t in flatten_kwargs(kwargs)],
+            [tuple(t.shape) for t in leaves],
+        )
+
+    def test_map_tensors_rebuilds_structure(self):
+        kwargs = {"t": (torch.zeros(2), [torch.zeros(3)]), "flag": True}
+        mapped = map_tensors(kwargs, lambda t: torch.ones_like(t))
+        self.assertIs(mapped["flag"], True)
+        self.assertTrue(torch.equal(mapped["t"][0], torch.ones(2)))
+        self.assertTrue(torch.equal(mapped["t"][1][0], torch.ones(3)))
+
+    def test_clone_output_detaches_from_static_buffer(self):
+        static = {"sample": torch.zeros(2), "extra": [torch.zeros(2)]}
+        cloned = clone_output(static)
+        static["sample"].fill_(9)
+        static["extra"][0].fill_(9)
+        self.assertTrue(torch.equal(cloned["sample"], torch.zeros(2)))
+        self.assertTrue(torch.equal(cloned["extra"][0], torch.zeros(2)))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA graph capture needs a GPU")
+class TestFullGraphRunner(unittest.TestCase):
+    """Capture/replay behaviour of _FullGraphRunner on a toy module."""
+
+    def setUp(self):
+        from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
+            _FullGraphRunner,
+        )
+
+        self.runner_cls = _FullGraphRunner
+        self.device = torch.device("cuda", torch.cuda.current_device())
+
+    def _make_runner(self, model):
+        return self.runner_cls(model, self.device)
+
+    def test_serial_cfg_branches_do_not_alias(self):
+        """Serial CFG calls the runner twice per step and holds both results
+        while combining them; the second replay must not overwrite the first."""
+
+        def model(hidden_states):
+            return hidden_states * 2
+
+        runner = self._make_runner(model)
+        pos_in = torch.ones(4, device=self.device)
+        neg_in = torch.full((4,), 3.0, device=self.device)
+
+        for _ in range(3):  # eager step, capture step, then replay steps
+            pos = runner.run({"hidden_states": pos_in})
+            neg = runner.run({"hidden_states": neg_in})
+            self.assertTrue(torch.equal(pos, torch.full((4,), 2.0, device=self.device)))
+            self.assertTrue(torch.equal(neg, torch.full((4,), 6.0, device=self.device)))
+        self.assertIsNotNone(runner.graph)
+
+    def test_consecutive_requests_replay_fresh_inputs(self):
+        """A second request reuses the graph; its own inputs must reach it."""
+
+        def model(hidden_states, freqs_cis):
+            return hidden_states + freqs_cis[0]
+
+        runner = self._make_runner(model)
+        freqs = (torch.ones(4, device=self.device),)
+        for value in (1.0, 2.0, 5.0, 7.0):
+            out = runner.run(
+                {
+                    "hidden_states": torch.full((4,), value, device=self.device),
+                    "freqs_cis": freqs,
+                }
+            )
+            self.assertTrue(
+                torch.equal(out, torch.full((4,), value + 1.0, device=self.device))
+            )
+        self.assertIsNotNone(runner.graph)
+
+    def test_nested_tensor_inputs_are_copied_on_replay(self):
+        """Tensors inside containers get static buffers too (the shallow copy
+        this replaces left them pointing at the captured request's data)."""
+
+        def model(hidden_states, freqs_cis):
+            return hidden_states + freqs_cis[0] + freqs_cis[1]["bias"]
+
+        runner = self._make_runner(model)
+        for value in (1.0, 2.0, 4.0, 6.0):
+            out = runner.run(
+                {
+                    "hidden_states": torch.zeros(4, device=self.device),
+                    "freqs_cis": (
+                        torch.full((4,), value, device=self.device),
+                        {"bias": torch.full((4,), value, device=self.device)},
+                    ),
+                }
+            )
+            self.assertTrue(
+                torch.equal(out, torch.full((4,), 2 * value, device=self.device))
+            )
+
+    def test_signature_change_falls_back_to_eager(self):
+        def model(hidden_states):
+            return hidden_states * 2
+
+        runner = self._make_runner(model)
+        for _ in range(3):
+            runner.run({"hidden_states": torch.ones(4, device=self.device)})
+        out = runner.run({"hidden_states": torch.ones(8, device=self.device)})
+        self.assertTrue(runner.disabled)
+        self.assertTrue(torch.equal(out, torch.full((8,), 2.0, device=self.device)))
+
+    def test_cpu_leaf_gets_device_static_buffer(self):
+        """A host-built timestep must not leave an unpinned H2D copy inside the
+        captured region."""
+        buf = static_buffer_like(torch.zeros(2), self.device)
+        self.assertEqual(buf.device.type, "cuda")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_usp_static_no_pack.py
+++ b/python/sglang/multimodal_gen/test/unit/test_usp_static_no_pack.py
@@ -1,0 +1,50 @@
+"""The static no-pack varlen path: fixed shapes, pad clamped by cu values."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.multimodal_gen.runtime.layers.attention.layer import USPAttention
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+
+_LAYER = "sglang.multimodal_gen.runtime.layers.attention.layer"
+
+
+class TestStaticNoPackVarlen(unittest.TestCase):
+    def test_full_buffers_and_cu_values_reach_the_kernel(self):
+        obj = USPAttention.__new__(USPAttention)
+        obj.skip_sequence_parallel = False
+        obj.softmax_scale = 0.5
+        obj.backend = AttentionBackendEnum.FA
+
+        seq, valid, heads, dim = 8, 5, 2, 4
+        q = torch.randn(1, seq, heads, dim)
+        cu = torch.tensor([0, valid], dtype=torch.int32)
+        seen = {}
+
+        def fake_varlen(**kw):
+            seen.update(kw)
+            return torch.zeros(seq, heads, dim)
+
+        with (
+            patch(
+                f"{_LAYER}.get_forward_context",
+                return_value=SimpleNamespace(attn_metadata=None),
+            ),
+            patch(f"{_LAYER}.get_sequence_parallel_world_size", return_value=1),
+            patch(f"{_LAYER}.flash_attn_varlen_func", side_effect=fake_varlen),
+        ):
+            out = obj.forward(
+                q, q, q, attn_mask_meta={"static_no_pack_cu": cu}
+            )
+
+        self.assertEqual(out.shape, (1, seq, heads, dim))
+        self.assertEqual(seen["q"].shape, (seq, heads, dim))
+        self.assertIs(seen["cu_seqlens_q"], cu)
+        self.assertEqual(seen["max_seqlen_q"], seq)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

For fixed-shape no-CFG image workloads the whole denoising step is static, but each step launches >1000 kernels eagerly and every SP collective pays a fresh NCCL rendezvous. Profiling qwen-image on 2 GPUs showed `ncclDevKernel_SendRecv` at ~46% of kernel time, with an average of ~340µs per all-to-all against a ~25µs pure-transfer cost over NVLink — most of it inter-rank rendezvous/skew wait.

## Modifications

1. **Cache `tail_attn_meta` per shard signature.** It is a pure function of a few ints but was rebuilt from a CPU list on every block of every step (~3000 non-pinned H2D copies per 50-step request). The H2D also makes the forward uncapturable.
2. **`--dit-cuda-graph {off,breakable,full}`** (default `off`) replaces the standalone BCG boolean as the single DiT CUDA-graph knob:
   - `breakable` keeps the existing BCG semantics; `--enable-breakable-cuda-graph` remains as a deprecated alias.
   - `full` captures the entire DiT forward — all blocks and the SP collectives inside them — as **one** CUDA graph. Step 0 runs eager, step 1 captures, later steps copy inputs into static buffers and replay. Warmup never captures; any tensor-signature change (new resolution, batched text length, CFG branch) permanently falls back to eager for that model. Capturing the collectives puts the ranks in lockstep and removes the rendezvous wait.

The full-graph runner hooks the generic `DenoisingStage._predict_noise`, so it is model-agnostic (the BCG model allowlist only gates `breakable`): any DiT with a static per-step signature can opt in, and shape changes degrade safely to eager. No graph splitting or replay tokens are needed for this workload class.

## Benchmark

2×H100, 50 steps, fixed seed, `--enable-torch-compile false`, steady-state:

| model | eager | `--dit-cuda-graph full` |
|---|---|---|
| Qwen-Image-2512 1024², ulysses=2 | 88.3 ms/step (4.55s) | **81.3 ms/step (4.41s)** |
| FLUX.1-dev 1024², ulysses=2 (with #31854) | 4.858s | **4.447-4.463s** |
| Wan2.1-T2V-1.3B 480p·81f, cfg-parallel | 26.02s (440 ms/step) | 26.02s (433 ms/step) |

Outputs bitwise-identical to eager in all three cases (same b64/mp4 payload md5 across requests). Verified as a stack with #31849 + #31854 on latest main: qwen e2e 3.93-3.95s, md5 unchanged.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31148990146](https://github.com/sgl-project/sglang/actions/runs/31148990146)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31148989932](https://github.com/sgl-project/sglang/actions/runs/31148989932)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->