### PR TITLE
fix: validate logit bias before scheduling

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2213,6 +2213,18 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
+        # Tokenized requests normally pass SamplingParams.verify() in the
+        # tokenizer manager. Re-validate at the scheduler trust boundary so
+        # malformed requests from internal/RPC paths cannot reach GPU tensor
+        # construction and terminate the scheduler process.
+        try:
+            req.sampling_params.verify(self.model_config.vocab_size)
+        except (TypeError, ValueError, OverflowError) as exc:
+            req.set_finish_with_abort(f"Invalid sampling parameters: {exc}")
+            self.init_req_max_new_tokens(req)
+            self._add_request_to_queue(req)
+            return
+
         self._maybe_namespace_elastic_radix_cache(req)
 
         if self.spec_algorithm.is_dflash_family():

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2213,10 +2213,7 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
-        # Tokenized requests normally pass SamplingParams.verify() in the
-        # tokenizer manager. Re-validate at the scheduler trust boundary so
-        # malformed requests from internal/RPC paths cannot reach GPU tensor
-        # construction and terminate the scheduler process.
+        # Re-validate requests that bypass the tokenizer manager.
         try:
             req.sampling_params.verify(self.model_config.vocab_size)
         except (TypeError, ValueError, OverflowError) as exc:

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -37,6 +37,8 @@ CustomParamValue = Union[
 ]
 
 _SAMPLING_EPS = 1e-6
+_LOGIT_BIAS_MIN = -100.0
+_LOGIT_BIAS_MAX = 100.0
 TOP_K_ALL = 1 << 30
 
 logger = logging.getLogger(__name__)
@@ -215,11 +217,48 @@ class SamplingParams(msgspec.Struct, kw_only=True, omit_defaults=True):
                     f"{self.min_new_tokens}."
                 )
         if self.logit_bias is not None:
-            for token_id in self.logit_bias:
-                if not 0 <= int(token_id) < vocab_size:
+            for token_id, bias in self.logit_bias.items():
+                if isinstance(token_id, bool) or not isinstance(token_id, (str, int)):
                     raise ValueError(
-                        f"logit_bias must has keys in [0, {vocab_size - 1}], got "
+                        f"logit_bias token ids must be integers, got {token_id!r}."
+                    )
+                try:
+                    token_id_int = int(token_id)
+                except (TypeError, ValueError, OverflowError) as exc:
+                    raise ValueError(
+                        f"logit_bias token ids must be integers, got {token_id!r}."
+                    ) from exc
+                if not 0 <= token_id_int < vocab_size:
+                    raise ValueError(
+                        f"logit_bias must have keys in [0, {vocab_size - 1}], got "
                         f"{token_id}."
+                    )
+                if isinstance(bias, bool) or not isinstance(bias, (int, float)):
+                    raise ValueError(
+                        "logit_bias values must be numbers in "
+                        f"[{_LOGIT_BIAS_MIN:g}, {_LOGIT_BIAS_MAX:g}], got "
+                        f"{bias!r} for token id {token_id_int}."
+                    )
+                try:
+                    bias_value = float(bias)
+                except (TypeError, ValueError, OverflowError) as exc:
+                    raise ValueError(
+                        "logit_bias values must be numbers in "
+                        f"[{_LOGIT_BIAS_MIN:g}, {_LOGIT_BIAS_MAX:g}], got "
+                        f"{bias!r} for token id {token_id_int}."
+                    ) from exc
+                # Negative infinity is a safe and useful internal hard mask
+                # (for example, to suppress think-control tokens). Other
+                # non-finite values and finite values outside the public API
+                # range can poison sampling or overflow the float32 tensor.
+                if bias_value != -math.inf and (
+                    not math.isfinite(bias_value)
+                    or not (_LOGIT_BIAS_MIN <= bias_value <= _LOGIT_BIAS_MAX)
+                ):
+                    raise ValueError(
+                        "logit_bias values must be negative infinity or finite numbers in "
+                        f"[{_LOGIT_BIAS_MIN:g}, {_LOGIT_BIAS_MAX:g}], got "
+                        f"{bias!r} for token id {token_id_int}."
                     )
 
         grammars = [

--- a/test/registered/core/test_srt_endpoint.py
+++ b/test/registered/core/test_srt_endpoint.py
@@ -585,6 +585,31 @@ class TestSRTEndpoint(CustomTestCase):
             f"Expected all tokens to be {target_token_id}, but got {sampled_tokens}",
         )
 
+    def test_invalid_logit_bias_does_not_crash_server(self):
+        """An invalid bias fails only its request and leaves the server healthy."""
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "max_new_tokens": 1,
+                    "logit_bias": {"0": -8.988465674311579e307},
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("logit_bias values", response.json()["error"]["message"])
+
+        healthy_response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"max_new_tokens": 1},
+            },
+        )
+        self.assertEqual(healthy_response.status_code, 200)
+        self.assertIn("text", healthy_response.json())
+
     def test_forbidden_token(self):
         """Test that a forbidden token (very negative logit bias) doesn't appear in the output."""
         # Choose a token ID to forbid (using 10 as an example)

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -272,6 +272,46 @@ class TestSamplingParamsVerify(CustomTestCase):
         sp = self._make(logit_bias={"0": 1.0, "31999": -0.5})
         sp.verify(self.VOCAB_SIZE)
 
+    def test_logit_bias_boundary_values_are_valid(self):
+        """The documented -100 and 100 boundaries are accepted."""
+        sp = self._make(logit_bias={"0": -100, "1": 100.0})
+        sp.verify(self.VOCAB_SIZE)
+
+    def test_logit_bias_out_of_range_raises(self):
+        """Values outside the documented [-100, 100] range are rejected."""
+        for bias in (-100.01, 100.01):
+            with self.subTest(bias=bias):
+                sp = self._make(logit_bias={"0": bias})
+                with self.assertRaisesRegex(ValueError, "negative infinity"):
+                    sp.verify(self.VOCAB_SIZE)
+
+    def test_logit_bias_non_finite_raises(self):
+        """NaN and positive infinity are unsafe sampling biases."""
+        for bias in (float("nan"), float("inf")):
+            with self.subTest(bias=bias):
+                sp = self._make(logit_bias={"0": bias})
+                with self.assertRaisesRegex(ValueError, "negative infinity"):
+                    sp.verify(self.VOCAB_SIZE)
+
+    def test_logit_bias_negative_infinity_hard_mask_is_valid(self):
+        """Negative infinity is supported as an internal hard-token mask."""
+        sp = self._make(logit_bias={"0": float("-inf")})
+        sp.verify(self.VOCAB_SIZE)
+
+    def test_logit_bias_float64_overflow_regression(self):
+        """Regression test for a float64 value that overflows float32 tensors."""
+        sp = self._make(logit_bias={"0": -8.988465674311579e307})
+        with self.assertRaisesRegex(ValueError, "negative infinity"):
+            sp.verify(self.VOCAB_SIZE)
+
+    def test_logit_bias_non_numeric_value_raises(self):
+        """Strings and booleans are not valid numeric bias values."""
+        for bias in ("-50", True):
+            with self.subTest(bias=bias):
+                sp = self._make(logit_bias={"0": bias})
+                with self.assertRaisesRegex(ValueError, "must be numbers"):
+                    sp.verify(self.VOCAB_SIZE)
+
     def test_multiple_grammars_raises(self):
         """Test that verify() rejects setting both json_schema and regex (mutually exclusive)."""
         sp = self._make(json_schema='{"type":"object"}', regex="abc")


### PR DESCRIPTION
## Summary

- validate `logit_bias` token IDs and reject non-numeric, non-finite, or out-of-range values before tensor construction
- preserve negative infinity as an internal hard-mask value
- revalidate sampling parameters at the scheduler trust boundary so internal/RPC paths cannot bypass tokenizer validation
- add unit and endpoint regressions for float-overflow inputs and server liveness

## Why

A request can currently reach the scheduler with a finite float64 `logit_bias` value that is too large for the float32 bias tensor. Assigning it raises an overflow error in the scheduler process. Invalid request data should fail the request instead of terminating the engine.

The accepted finite range is `[-100, 100]`, matching the public API contract and existing SGLang test usage.

## Failure

Observed at `2026-07-21 10:23:02` on scheduler rank `TP4_EP4`:

```text
Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 4369, in run_scheduler_process
    scheduler.run_event_loop()
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 1513, in run_event_loop
    dispatch_event_loop(self)
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 4234, in dispatch_event_loop
    scheduler.event_loop_overlap()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 1590, in event_loop_overlap
    plan = self.get_next_batch_to_run(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/utils/nvtx_utils.py", line 109, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 2695, in get_next_batch_to_run
    prefill_plan = self.get_new_batch_prefill(running_batch)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 2754, in get_new_batch_prefill
    ret, running_batch = self._get_new_batch_prefill_raw(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 2984, in _get_new_batch_prefill_raw
    new_batch.prepare_for_extend()
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/schedule_batch.py", line 2359, in prepare_for_extend
    self.sampling_info = SamplingBatchInfo.from_schedule_batch(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/sampling/sampling_batch_info.py", line 131, in from_schedule_batch
    logit_bias[i, int(key)] = value
    ~~~~~~~~~~^^^^^^^^^^^^^
RuntimeError: value cannot be converted to type float without overflow
```

## Testing

- `PYTHONPATH=python .venv/bin/python -m pytest -q test/registered/unit/sampling/test_sampling_params.py test/registered/unit/sampling/test_sampling_batch_info.py` (`117 passed`, `6 subtests passed`)
- Python bytecode compilation for all changed Python files
- Ruff checks for all changed Python files
- repository pre-commit hooks

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29797204519](https://github.com/sgl-project/sglang/actions/runs/29797204519)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29797204411](https://github.com/sgl-project/sglang/actions/runs/29797204411)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
