### PR TITLE
DSpark support DeepEP & MegaMoE

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -280,10 +280,16 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     if server_args.enable_dp_attention:
         if not server_args.enable_dp_lm_head:
             raise ValueError("DSpark with dp attention requires --enable-dp-lm-head.")
-        if server_args.moe_a2a_backend != "none":
+        supports_dspark_dp_moe = server_args.moe_a2a_backend == "none" or (
+            server_args.moe_a2a_backend == "deepep"
+            and server_args.moe_runner_backend == "deep_gemm"
+        )
+        if not supports_dspark_dp_moe:
             raise ValueError(
-                "DSpark with dp attention only supports the built-in TP MoE "
-                f"(moe_a2a_backend='none'), got {server_args.moe_a2a_backend!r}."
+                "DSpark with dp attention only supports moe_a2a_backend='none' "
+                "or moe_a2a_backend='deepep' with moe_runner_backend='deep_gemm'; "
+                f"got moe_a2a_backend={server_args.moe_a2a_backend!r}, "
+                f"moe_runner_backend={server_args.moe_runner_backend!r}."
             )
         if server_args.attn_cp_size > 1:
             raise ValueError(

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -286,10 +286,14 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     if server_args.enable_dp_attention and server_args.dp_size > 1:
         if not server_args.enable_dp_lm_head:
             raise ValueError("DSpark with dp attention requires --enable-dp-lm-head.")
-        if not _is_npu and server_args.moe_a2a_backend not in ("none", "megamoe"):
+        if not _is_npu and server_args.moe_a2a_backend not in (
+            "none",
+            "deepep",
+            "megamoe",
+        ):
             raise ValueError(
                 "DSpark with dp attention supports moe_a2a_backend 'none' "
-                "(built-in TP MoE) or 'megamoe', got "
+                "(built-in TP MoE), 'deepep' or 'megamoe', got "
                 f"{server_args.moe_a2a_backend!r}."
             )
         if not _is_npu and server_args.moe_a2a_backend != "none":

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -277,7 +278,10 @@ class DeepEPBuffer:
         #            auto-enables fabric in C++ when supported, so we skip it:
         #            https://github.com/fzyzcjy/DeepEP/blob/814e508537c6ffc775d59f6f1b9ba43f3a65968c/csrc/deep_ep.cpp#L52
         is_cu12 = get_cuda_version()[0] == 12
-        if not is_cu12 and use_mnnvl_fabric:
+        supports_use_fabric = (
+            "use_fabric" in inspect.signature(Buffer.__init__).parameters
+        )
+        if not is_cu12 and use_mnnvl_fabric and supports_use_fabric:
             buffer_kwargs["use_fabric"] = True
 
         state.buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes, **buffer_kwargs)

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -333,6 +333,10 @@ class DraftBlockProposer:
             spec_info=self._draft_block_spec_info,
             capture_hidden_mode=CaptureHiddenMode.NULL,
         )
+        idle_batch.num_token_non_padded = torch.zeros(
+            (1,), dtype=torch.int32, device=device
+        )
+        idle_batch.num_token_non_padded_cpu = 0
         self._fill_dp_moe_sync_metadata(idle_batch, batch)
         with torch.inference_mode():
             self.draft_model_runner.forward(idle_batch)
@@ -389,6 +393,10 @@ class DraftBlockProposer:
             spec_info=self._draft_block_spec_info,
             capture_hidden_mode=CaptureHiddenMode.NULL,
         )
+        draft_forward_batch.num_token_non_padded = torch.tensor(
+            draft_block_ids.numel(), dtype=torch.int32, device=device
+        )
+        draft_forward_batch.num_token_non_padded_cpu = draft_block_ids.numel()
         self._fill_dp_moe_sync_metadata(draft_forward_batch, batch)
         with torch.inference_mode():
             draft_out = self.draft_model_runner.forward(draft_forward_batch)
@@ -415,6 +423,7 @@ class DraftBlockProposer:
             batch.global_num_tokens_for_logprob,
         )
         device = self.draft_model_runner.device
+        forward_batch.original_global_num_tokens_cpu = batch.global_num_tokens
         forward_batch.global_num_tokens_cpu = gnt
         forward_batch.global_num_tokens_for_logprob_cpu = gnt_logprob
         forward_batch.global_num_tokens_gpu = torch.tensor(gnt, dtype=torch.int64).to(

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -303,6 +303,10 @@ class DraftBlockProposer:
             spec_info=self._draft_block_spec_info,
             capture_hidden_mode=CaptureHiddenMode.NULL,
         )
+        idle_batch.num_token_non_padded = torch.zeros(
+            (1,), dtype=torch.int32, device=device
+        )
+        idle_batch.num_token_non_padded_cpu = 0
         self._fill_dp_moe_sync_metadata(idle_batch, batch)
         with torch.inference_mode():
             self.draft_model_runner.forward(idle_batch)
@@ -366,6 +370,10 @@ class DraftBlockProposer:
             num_token_non_padded=_make_num_token_non_padded(draft_num_tokens, device),
             num_token_non_padded_cpu=draft_num_tokens,
         )
+        draft_forward_batch.num_token_non_padded = torch.tensor(
+            draft_block_ids.numel(), dtype=torch.int32, device=device
+        )
+        draft_forward_batch.num_token_non_padded_cpu = draft_block_ids.numel()
         self._fill_dp_moe_sync_metadata(draft_forward_batch, batch)
         graph_runner = self.draft_model_runner.decode_cuda_graph_runner
         if (

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -1,5 +1,5 @@
 import logging
-from contextlib import nullcontext
+from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from typing import Optional
 
@@ -7,6 +7,10 @@ import torch
 
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
+from sglang.srt.layers.moe.utils import (
+    speculative_moe_a2a_backend_context,
+    speculative_moe_backend_context,
+)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -272,10 +276,14 @@ class DSparkWorkerV2(BaseSpecWorker):
             raise AttributeError(name)
         return getattr(self.target_worker, name)
 
+    @contextmanager
     def _draft_context(self):
-        if self._draft_dp_context_enabled:
-            return draft_tp_context(get_parallel().attn_tp_group)
-        return nullcontext()
+        with ExitStack() as stack:
+            if self._draft_dp_context_enabled:
+                stack.enter_context(draft_tp_context(get_parallel().attn_tp_group))
+            stack.enter_context(speculative_moe_backend_context())
+            stack.enter_context(speculative_moe_a2a_backend_context())
+            yield
 
     def alloc_memory_pool(
         self,
@@ -489,7 +497,8 @@ class DSparkWorkerV2(BaseSpecWorker):
             self._observers.note_idle_decode_step()
             if self.server_args.enable_dp_attention:
                 if self._draft_is_moe:
-                    self._proposer.run_idle_participation(batch)
+                    with self._draft_context():
+                        self._proposer.run_idle_participation(batch)
                 self._verify_executor.run_idle_participation(
                     batch=batch, idle_layout=self._idle_verify_ragged_layout(batch)
                 )

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -1,5 +1,5 @@
 import logging
-from contextlib import nullcontext
+from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from typing import Optional
 
@@ -12,6 +12,10 @@ from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
 from sglang.srt.layers.logprob_processor import compute_spec_logprobs
+from sglang.srt.layers.moe.utils import (
+    speculative_moe_a2a_backend_context,
+    speculative_moe_backend_context,
+)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -318,10 +322,14 @@ class DSparkWorkerV2(BaseSpecWorker):
             raise AttributeError(name)
         return getattr(self.target_worker, name)
 
+    @contextmanager
     def _draft_context(self):
-        if self._draft_dp_context_enabled:
-            return draft_tp_context(get_parallel().attn_tp_group)
-        return nullcontext()
+        with ExitStack() as stack:
+            if self._draft_dp_context_enabled:
+                stack.enter_context(draft_tp_context(get_parallel().attn_tp_group))
+            stack.enter_context(speculative_moe_backend_context())
+            stack.enter_context(speculative_moe_a2a_backend_context())
+            yield
 
     def alloc_memory_pool(
         self,
@@ -568,7 +576,8 @@ class DSparkWorkerV2(BaseSpecWorker):
             self._observers.note_idle_decode_step()
             if get_parallel().enable_dp_attention:
                 if self._draft_is_moe:
-                    self._proposer.run_idle_participation(batch)
+                    with self._draft_context():
+                        self._proposer.run_idle_participation(batch)
                 self._verify_executor.run_idle_participation(
                     batch=batch, idle_layout=self._idle_verify_ragged_layout(batch)
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Reference：https://github.com/sgl-project/sglang/pull/30513

DSpark speculative decoding with DP attention previously only supported the
built-in TP MoE backend (`moe_a2a_backend='none'`). This prevented running
DSpark together with all-to-all expert-parallel dispatchers such as DeepEP and
MegaMoE, which are needed for efficient large-scale expert-parallel
deployments.

This PR enables DSpark to run with `moe_a2a_backend='deepep'` and
`moe_a2a_backend='megamoe'` under DP attention, and fixes the draft-path token
metadata / MoE backend selection issues that surfaced once these backends were
enabled.

## Modifications

- **`arg_groups/speculative_hook.py`**: Relax the DSpark + DP-attention
  validation from `moe_a2a_backend='none'` only to a whitelist of
  `'none'` (built-in TP MoE), `'deepep'` and `'megamoe'`. Any other A2A backend
  still raises, since the remaining `MoeA2ABackend` values are unverified with
  DSpark. The existing `SGLANG_RAGGED_VERIFY_MODE=static` requirement for
  non-`none` backends is unchanged.

- **`speculative/dspark_components/dspark_draft.py`**: Populate
  `num_token_non_padded` / `num_token_non_padded_cpu` for both the idle batch
  (zeros) and the draft forward batch (actual draft-block token count), so the
  DP MoE path receives correct token metadata during draft forwarding.

- **`speculative/dspark_components/dspark_worker_v2.py`**: Rework
  `_draft_context` into a `contextmanager` backed by an `ExitStack` that layers
  in `speculative_moe_backend_context()` and
  `speculative_moe_a2a_backend_context()` (temporarily switching to the
  configured speculative MoE runner / A2A backend and disabling FP4 allgather
  for unquantized MTP layers). Idle-decode participation for MoE draft models is
  now wrapped in this context so it uses the correct MoE backend.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.