### PR TITLE
[CI] Graceful teardown in kl_mamba hicache tests to release pinned host pool

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import tempfile
 import unittest
 
@@ -125,6 +126,11 @@ class TestUnifiedMambaHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.process.terminate()
+        try:
+            cls.process.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            pass
         kill_process_tree(cls.process.pid)
 
 
@@ -186,6 +192,11 @@ class TestUnifiedMambaHiCacheL3(AccuracyTwoPassMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.process.terminate()
+        try:
+            cls.process.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            pass
         kill_process_tree(cls.process.pid)
         if os.path.isdir(cls.hicache_dir):
             shutil.rmtree(cls.hicache_dir, ignore_errors=True)


### PR DESCRIPTION
## Motivation

Same fix as #31746, applied to `test_unified_radix_cache_kl_mamba.py`.

The two hicache classes tear down their TP=4 servers with a bare `kill_process_tree` (SIGKILL), leaving the kernel to unpin the large pinned host KV pool during process reclaim. On slower hosts this holds ~71 GiB of GPU memory for >30s with no surviving process, tripping the per-class GPU-idle gate (#31509) in the next class's `setUpClass`:

```
RuntimeError: GPU(s) still not idle after waiting 30s before setUpClass: GPU 4 uses 71.50 GiB (no other compute processes)
```

Failed in the last two scheduled runs ([1](https://github.com/sgl-project/sglang/actions/runs/29740288286/job/88345289527), [2](https://github.com/sgl-project/sglang/actions/runs/29787005348/job/88500664768)); the run before passed the same gate with only ~2s to spare on the same machine.

## Modifications

`terminate()` and wait for graceful shutdown before `kill_process_tree`, so the server unregisters the pinned host pool in userspace (via the #31746 scheduler shutdown path).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29798201542](https://github.com/sgl-project/sglang/actions/runs/29798201542)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29798201633](https://github.com/sgl-project/sglang/actions/runs/29798201633)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->