### PR TITLE
fix: create empty vision embeddings on model device

### DIFF
--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -707,7 +707,7 @@ def run_dp_sharded_mrope_vision_model(
             out_dim = getattr(vision_model.config, "hidden_size", None)
             image_embeds_local = torch.empty(
                 (0, embed_dim_reduction_factor, out_dim),
-                device=input_device,
+                device=vision_model.device,
                 dtype=input_dtype,
             )
     else:
@@ -725,7 +725,7 @@ def run_dp_sharded_mrope_vision_model(
                 out_dim = vision_model.config.hidden_size
             image_embeds_local = torch.empty(
                 (0, out_dim),
-                device=input_device,
+                device=vision_model.device,
                 dtype=input_dtype,
             )
 


### PR DESCRIPTION
 ## Motivation

  Fix Qwen multimodal inference when encoder data parallelism is enabled and an attention-TP rank is assigned no images.

  In this case, the empty Qwen `rope_3d` embedding can remain on CPU and then be passed to the device communication group, causing HCCL/NCCL `all_gather` to fail with:

  RuntimeError: No backend type associated with device type cpu

  ## Modifications

  - Create the empty Qwen rope_3d embedding on get_parallel().attn_tp_group.device instead of input_device.
  - Ensure empty encoder-DP ranks pass device tensors to the attention-TP all_gather.
  - Preserve the batched H2D optimization for ranks that are assigned images.
  - Keep the packed 2D RoPE path and normal vision-model path unchanged.
  - Keep embedding shapes, dtypes, and model outputs unchanged.

  ## Accuracy Tests

  MMMU validation completed with:
  - Samples: 50
  - Thinking: enable
  - Accuracy: 0.72
  the accuracy the same as before
<img width="1636" height="177" alt="qwen3 6" src="https://github.com/user-attachments/assets/38a3bebb-e5cd-44e8-9df4-6c3fa073a15d" />


  ## Local Validation

  The issue was reproduced with the Qwen3.6 multimodal NPU performance case using:

  - Attention TP size: 2
  - --mm-enable-dp-encoder
  - Fewer images than encoder-DP ranks, leaving one rank empty

  Before the change, the empty rank failed during HCCL all_gather because a CPU tensor was passed to the device communication group.

  After the change, the same multimodal performance case completed successfully.

  ## Checklist

  - [ ] Format code with the repository-pinned Ruff, Black, and isort versions.
  - [ ] Add/complete NPU unit and end-to-end tests.
  - [x] Add accuracy results.
  - [ ] Add speed and profiling results.
  - [x] Follow the SGLang code style guidance.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29763625515](https://github.com/sgl-project/sglang/actions/runs/29763625515)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29763624286](https://github.com/sgl-project/sglang/actions/runs/29763624286)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->