### PR TITLE
disaggregation/mori: track true end-to-end KV transfer latency + per-chunk avg bandwidth

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -33,6 +33,13 @@ class KVTransferMetric:
     # Backends that cannot isolate allocation wait latency can leave this as None.
     alloc_latency_s: Optional[float] = None
     transfer_total_bytes: Optional[int] = None
+    # Backends that time each chunk's actual RDMA transfer can report the
+    # byte-weighted average per-chunk bandwidth here (GB/s): total bytes moved
+    # divided by total *active* per-chunk transfer time. Unlike a speed derived
+    # from total_bytes / end-to-end latency, this excludes inter-chunk idle
+    # (waiting on the next prefill chunk), so it reflects true NIC throughput.
+    # None if the backend cannot measure per-chunk timing.
+    avg_chunk_bandwidth_gb_s: Optional[float] = None
 
 
 class KVArgs:

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1412,6 +1412,7 @@ class MoriKVSender(CommonKVSender):
         self._notify_lock = threading.Lock()
         self._notified_status: Optional[KVPoll] = None
         self._notified_reason: Optional[str] = None
+        self._transfer_start_time: Optional[float] = None
 
     def send(
         self,
@@ -1423,6 +1424,11 @@ class MoriKVSender(CommonKVSender):
         )
         if should_skip:
             return
+
+        if self._transfer_start_time is None and (
+            len(kv_indices) > 0 or state_indices is not None
+        ):
+            self._transfer_start_time = time.perf_counter()
 
         normalized_state = (
             _normalize_state_indices_per_component(state_indices)
@@ -1486,6 +1492,13 @@ class MoriKVSender(CommonKVSender):
             self._finalize_failure(self._collect_failure_reason())
             return
         if task.is_last_chunk:
+            if (
+                self._transfer_start_time is not None
+                and self._transfer_metric.transfer_latency_s is None
+            ):
+                self._transfer_metric.transfer_latency_s = (
+                    time.perf_counter() - self._transfer_start_time
+                )
             self._notify_decode(KVPoll.Success)
             with self._notify_lock:
                 if self.conclude_state is None:
@@ -1549,6 +1562,13 @@ class MoriKVSender(CommonKVSender):
             return sent_status
 
         if status == KVPoll.Success:
+            if (
+                self._transfer_start_time is not None
+                and self._transfer_metric.transfer_latency_s is None
+            ):
+                self._transfer_metric.transfer_latency_s = (
+                    time.perf_counter() - self._transfer_start_time
+                )
             self.conclude_state = KVPoll.Success
             return KVPoll.Success
 

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -26,7 +26,7 @@ from mori.io import (
     StatusCode,
 )
 
-from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
+from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, KVTransferMetric
 from sglang.srt.disaggregation.common.conn import (
     CommonKVBootstrapServer,
     CommonKVManager,
@@ -1412,7 +1412,11 @@ class MoriKVSender(CommonKVSender):
         self._notify_lock = threading.Lock()
         self._notified_status: Optional[KVPoll] = None
         self._notified_reason: Optional[str] = None
-        self._transfer_start_time: Optional[float] = None
+        # Per-chunk transfer accounting for the byte-weighted average bandwidth:
+        # bytes actually moved and active transfer time summed across chunks
+        # (inter-chunk idle excluded). Consumed by get_transfer_metric().
+        self._chunk_bytes_sum = 0
+        self._chunk_transfer_time_s = 0.0
 
     def send(
         self,
@@ -1424,11 +1428,6 @@ class MoriKVSender(CommonKVSender):
         )
         if should_skip:
             return
-
-        if self._transfer_start_time is None and (
-            len(kv_indices) > 0 or state_indices is not None
-        ):
-            self._transfer_start_time = time.perf_counter()
 
         normalized_state = (
             _normalize_state_indices_per_component(state_indices)
@@ -1457,6 +1456,23 @@ class MoriKVSender(CommonKVSender):
         if self.kv_mgr.request_status.get(self.bootstrap_room) == KVPoll.Failed:
             self._finalize_failure()
 
+    def _chunk_transfer_bytes(self, task: _TransferChunk) -> int:
+        """Bytes moved by a single chunk (kv + state), mirroring the totals in
+        CommonKVSender.get_transfer_metric / _record_transfer_indices."""
+        total = len(task.kv_indices) * self.kv_mgr.kv_item_lens_sum
+        if task.normalized_state:
+            for component_indices in task.normalized_state:
+                if component_indices is not None:
+                    total += len(component_indices) * self.kv_mgr.state_item_lens_sum
+        return total
+
+    def get_transfer_metric(self) -> KVTransferMetric:
+        metric = super().get_transfer_metric()
+        if self._chunk_transfer_time_s > 0 and self._chunk_bytes_sum > 0:
+            gb = self._chunk_bytes_sum / (1024**3)
+            metric.avg_chunk_bandwidth_gb_s = gb / self._chunk_transfer_time_s
+        return metric
+
     def _run_chunk(self, task: _TransferChunk) -> None:
         if self.conclude_state is not None:
             return
@@ -1469,6 +1485,7 @@ class MoriKVSender(CommonKVSender):
         if task.wait_event is not None:
             task.wait_event.synchronize()
 
+        chunk_start = time.perf_counter()
         statuses, infos = self.kv_mgr.add_transfer_request(
             self.bootstrap_room,
             task.kv_indices,
@@ -1491,14 +1508,16 @@ class MoriKVSender(CommonKVSender):
         if rc != StatusCode.SUCCESS:
             self._finalize_failure(self._collect_failure_reason())
             return
+        # Successful chunk: accumulate bytes moved + active transfer time for the
+        # byte-weighted per-chunk average bandwidth (see get_transfer_metric()).
+        # Skip empty/aux-only chunks (0 KV+state bytes) so they don't add time
+        # without bytes and deflate the average.
+        chunk_elapsed = time.perf_counter() - chunk_start
+        chunk_bytes = self._chunk_transfer_bytes(task)
+        if chunk_elapsed > 0 and chunk_bytes > 0:
+            self._chunk_bytes_sum += chunk_bytes
+            self._chunk_transfer_time_s += chunk_elapsed
         if task.is_last_chunk:
-            if (
-                self._transfer_start_time is not None
-                and self._transfer_metric.transfer_latency_s is None
-            ):
-                self._transfer_metric.transfer_latency_s = (
-                    time.perf_counter() - self._transfer_start_time
-                )
             self._notify_decode(KVPoll.Success)
             with self._notify_lock:
                 if self.conclude_state is None:
@@ -1562,13 +1581,6 @@ class MoriKVSender(CommonKVSender):
             return sent_status
 
         if status == KVPoll.Success:
-            if (
-                self._transfer_start_time is not None
-                and self._transfer_metric.transfer_latency_s is None
-            ):
-                self._transfer_metric.transfer_latency_s = (
-                    time.perf_counter() - self._transfer_start_time
-                )
             self.conclude_state = KVPoll.Success
             return KVPoll.Success
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -514,6 +514,16 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
             buckets=(0.1, 0.5, 1, 5, 10, 25, 50, 100, 200, 400),
         )
+        self.kv_transfer_avg_chunk_bw_gb_s = Histogram(
+            name="sglang:kv_transfer_avg_chunk_bw_gb_s",
+            documentation=(
+                "Histogram of byte-weighted average per-chunk KV cache transfer "
+                "bandwidth in GB/s (total bytes / total active per-chunk transfer "
+                "time; excludes inter-chunk idle)."
+            ),
+            labelnames=labels.keys(),
+            buckets=(0.1, 0.5, 1, 5, 10, 25, 50, 100, 200, 400),
+        )
         self.kv_transfer_latency_ms = Histogram(
             name="sglang:kv_transfer_latency_ms",
             documentation="Histogram of KV cache transfer latency in ms.",
@@ -1138,6 +1148,9 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         self._log_histogram(self.kv_transfer_latency_ms, latency_ms)
         self._log_histogram(self.kv_transfer_total_mb, total_mb)
         self._log_histogram(self.kv_transfer_speed_gb_s, speed_gb_s)
+
+    def observe_kv_transfer_avg_chunk_bw(self, avg_chunk_bw_gb_s: float) -> None:
+        self._log_histogram(self.kv_transfer_avg_chunk_bw_gb_s, avg_chunk_bw_gb_s)
 
     def observe_kv_transfer_bootstrap(
         self,

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -894,6 +894,17 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         if transfer_metric.transfer_total_bytes is None:
             return result if result else None
 
+        # Backend-measured byte-weighted per-chunk average bandwidth (GB/s).
+        # Independent of the transfer-latency computation below: reflects true
+        # NIC throughput (Σ bytes / Σ active per-chunk transfer time), so it is
+        # not inflated by inter-chunk idle the way total_bytes / latency is.
+        if transfer_metric.avg_chunk_bandwidth_gb_s is not None:
+            result["avg_chunk_bw_gb_s"] = transfer_metric.avg_chunk_bandwidth_gb_s
+            if self.enable_metrics:
+                self.metrics_collector.observe_kv_transfer_avg_chunk_bw(
+                    transfer_metric.avg_chunk_bandwidth_gb_s
+                )
+
         # Transfer latency, size, and speed
         if transfer_metric.transfer_latency_s is not None:
             transfer_latency_s = transfer_metric.transfer_latency_s


### PR DESCRIPTION
## Summary
- `MoriKVSender` never populated `KVTransferMetric.transfer_latency_s`, so `req_time_stats.compute_and_observe_kv_transfer_metrics()` fell back to `completion_time - prefill_transfer_queue_entry_time`, which only spans the last chunk. Dividing the full multi-chunk transfer's total bytes by that last-chunk-only duration inflated `sglang:kv_transfer speed_gb_s` past physical NIC bandwidth on chunked prefill requests.
- First attempt mirrored the `NixlKVSender` pattern (stamp `_transfer_start_time` on first `send()`, set `transfer_latency_s` on success) but was reverted in favor of a byte-weighted **per-chunk average bandwidth** metric instead: `sglang:kv_transfer_avg_chunk_bw_gb_s`. `MoriKVSender` times each chunk's actual RDMA transfer and reports `sum(bytes) / sum(active transfer time)`, excluding inter-chunk idle time so it reflects true NIC throughput rather than end-to-end (which includes queueing/scheduling gaps).
- `kv_transfer_latency_ms` is left at sglang's existing default (last-chunk latency) since the true end-to-end latency stamp turned out not to be the more useful signal here.

## Test plan
- [ ] Existing disaggregation/mori unit tests pass
- [ ] Manual: run a chunked-prefill mori PD workload and confirm `sglang:kv_transfer_avg_chunk_bw_gb_s` reports plausible NIC-bound values (not inflated past physical bandwidth)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29799285830](https://github.com/sgl-project/sglang/actions/runs/29799285830)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29799285769](https://github.com/sgl-project/sglang/actions/runs/29799285769)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->