### PR TITLE
disaggregation: pass allocator_type to decode-side offload host mem pool

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -54,6 +54,11 @@ class DecodeKVCacheOffloadManager:
                 self.page_size, (env_stride // self.page_size) * self.page_size
             )
         kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
+        # Only UMBP ("mori") needs its hugepage-backed allocator (for
+        # RegisterRdmaMemoryRegion); other backends use the default mmap one.
+        allocator_type = (
+            "mori" if server_args.hicache_storage_backend == "mori" else "default"
+        )
         if isinstance(kv_cache, MHATokenToKVPool):
             self.decode_host_mem_pool = get_mha_host_pool_cls(kv_cache)(
                 kv_cache,
@@ -61,6 +66,7 @@ class DecodeKVCacheOffloadManager:
                 server_args.hicache_size,
                 self.page_size,
                 server_args.hicache_mem_layout,
+                allocator_type=allocator_type,
             )
         elif isinstance(kv_cache, MLATokenToKVPool):
             self.decode_host_mem_pool = MLATokenToKVPoolHost(
@@ -69,6 +75,7 @@ class DecodeKVCacheOffloadManager:
                 server_args.hicache_size,
                 self.page_size,
                 server_args.hicache_mem_layout,
+                allocator_type=allocator_type,
             )
         else:
             raise ValueError("Unsupported KV cache type for decode offload")


### PR DESCRIPTION
## Summary
`DecodeKVCacheOffloadManager` built its host mem pool without `allocator_type`, so it silently fell back to the plain mmap allocator instead of `UMBPHostTensorAllocator` when the L3 backend is UMBP (`mori`). Pensando AINIC requires hugepage-backed host memory to register an RDMA memory region, so the plain mmap buffer makes `RegisterRdmaMemoryRegion` fail with `EINVAL` on large decode-side offload pools.

Only pass `allocator_type` through when the storage backend is actually UMBP (`"mori"`); other backends (mooncake, hf3fs, file, ...) have no matching host allocator and are fine with the plain mmap one that `"default"` resolves to.

## Test plan
- [ ] Existing decode offload manager unit tests pass
- [ ] Manual: run decode-side KV cache offload with UMBP (mori) on Pensando AINIC hardware with a large pool and confirm `RegisterRdmaMemoryRegion` no longer fails with `EINVAL`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29799598343](https://github.com/sgl-project/sglang/actions/runs/29799598343)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29799598219](https://github.com/sgl-project/sglang/actions/runs/29799598219)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
