### PR TITLE
hicache: restore per-tier hit/eviction/load-back bandwidth metrics + Grafana dashboards

### DIFF
--- a/examples/monitoring/grafana/dashboards/config/dashboard.yaml
+++ b/examples/monitoring/grafana/dashboards/config/dashboard.yaml
@@ -9,3 +9,12 @@ providers:
     allowUiUpdates: false
     options:
       path: /var/lib/grafana/dashboards
+  - name: 'UMBP'
+    orgId: 1
+    folder: 'UMBP Monitoring'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/mori_dashboards

--- a/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
+++ b/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
@@ -109,7 +109,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -125,7 +125,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -142,7 +142,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -159,7 +159,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg(rate(sglang_e2e_request_latency_seconds_sum[$__rate_interval]) /  rate(sglang_e2e_request_latency_seconds_count[$__rate_interval]))\r\n",
+          "expr": "avg(rate(sglang:e2e_request_latency_seconds_sum[$__rate_interval]) /  rate(sglang:e2e_request_latency_seconds_count[$__rate_interval]))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -225,7 +225,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -253,7 +253,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(increase(sglang_e2e_request_latency_seconds_bucket{model_name=~\"$model_name\"}[$__rate_interval])) by (le)\r\n",
+          "expr": "sum(increase(sglang:e2e_request_latency_seconds_bucket{model_name=~\"$model_name\"}[$__rate_interval])) by (le)\r\n",
           "format": "heatmap",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -355,7 +355,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -371,7 +371,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -388,7 +388,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -405,7 +405,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg(rate(sglang_time_to_first_token_seconds_sum[$__rate_interval]) /  rate(sglang_time_to_first_token_seconds_count[$__rate_interval]))\r\n",
+          "expr": "avg(rate(sglang:time_to_first_token_seconds_sum[$__rate_interval]) /  rate(sglang:time_to_first_token_seconds_count[$__rate_interval]))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -475,7 +475,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-9
+          "le": 1e-09
         },
         "legend": {
           "show": true
@@ -503,7 +503,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "sum by(le) (increase(sglang_time_to_first_token_seconds_bucket{model_name=~\"$model_name\"}[$__rate_interval]))",
+          "expr": "sum by(le) (increase(sglang:time_to_first_token_seconds_bucket{model_name=~\"$model_name\"}[$__rate_interval]))",
           "format": "heatmap",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -606,7 +606,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sglang_num_running_reqs",
+          "expr": "sglang:num_running_reqs",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -707,7 +707,7 @@
             "uid": "ddyfngn31dg5cf"
           },
           "editorMode": "code",
-          "expr": "sglang_gen_throughput",
+          "expr": "sglang:gen_throughput",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -805,7 +805,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sglang_cache_hit_rate",
+          "expr": "sglang:cache_hit_rate",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -906,7 +906,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sglang_num_queue_reqs",
+          "expr": "sglang:num_queue_reqs",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -917,6 +917,1151 @@
         }
       ],
       "title": "Number Queued Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Per-tier cache hit rate. Total hit rate = (L1+L2+L3) / (L1+L2+L3+Miss). Each tier's share uses raw token counts without page alignment.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "Total Hit Rate (L1+L2+L3)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "L1 Hit Rate (GPU)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "L2 Hit Rate (Host DRAM)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "L3 Hit Rate (Storage)",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Cache Hit Rate (Per-Tier)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Host-tier (L2) KV cache utilization (0-1). Only populated when HiCache is enabled.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sglang:hicache_host_used_tokens{instance=~\"$instance\",model_name=~\"$model_name\"} / sglang:hicache_host_total_tokens{instance=~\"$instance\",model_name=~\"$model_name\"}",
+          "instant": false,
+          "legendFormat": "HiCache host \u4f7f\u7528\u7387",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HiCache Host Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Host-tier used / total capacity, in tokens. Only populated when HiCache is enabled.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sglang:hicache_host_used_tokens{instance=~\"$instance\",model_name=~\"$model_name\"}",
+          "instant": false,
+          "legendFormat": "Host \u5df2\u7528 (tokens)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sglang:hicache_host_total_tokens{instance=~\"$instance\",model_name=~\"$model_name\"}",
+          "instant": false,
+          "legendFormat": "Host \u603b\u5bb9\u91cf (tokens)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HiCache Host Used / Total Capacity (tokens)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "L3 storage prefetch (L3->Host DRAM) and writeback (Host DRAM->L3) rates, tokens/s.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tokens/s",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:prefetched_tokens_total{instance=~\"$instance\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "\u9884\u53d6 L3\u2192Host",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:backuped_tokens_total{instance=~\"$instance\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "\u56de\u5199 Host\u2192L3",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HiCache L3 Prefetch / Writeback Rate (Host<->Storage)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "L1 (GPU) KV cache eviction rate (dropped without HiCache, written to L2 with it) and load-back rate from L2 (Host) to GPU, tokens/s.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tokens/s",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:evicted_tokens_total{instance=~\"$instance\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "L1 \u6dd8\u6c70 (total)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:evicted_backuped_tokens_total{instance=~\"$instance\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "L1 \u6dd8\u6c70-backuped (\u6570\u636e\u7559L2)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:evicted_regular_tokens_total{instance=~\"$instance\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "L1 \u6dd8\u6c70-regular (\u76f4\u63a5\u5220\u9664)",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:load_back_tokens_total{instance=~\"$instance\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "L2\u2192L1 \u52a0\u8f7d\u56de GPU",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HiCache L1<->L2 Eviction / Load-back to GPU Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Rate of tokens served from cache, tokens/s, including HiCache hits.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:cached_tokens_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "\u547d\u4e2d tokens/s ({{cache_source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cached Tokens Rate (hit tokens/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "GPU KV cache utilization (0-1). Higher utilization means HiCache is more likely to kick in.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (sglang:gpu_kv_cache_occupancy{instance=~\"$instance\",model_name=~\"$model_name\",engine_type=~\"decode|unified\"})",
+          "instant": false,
+          "legendFormat": "L1 \u5360\u7528\u7387 (locked+cached)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (sglang:token_usage{instance=~\"$instance\",model_name=~\"$model_name\",engine_type=~\"decode|unified\"})",
+          "instant": false,
+          "legendFormat": "L1 \u9501\u5b9a\u7387 (locked only)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU KV Cache Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Distribution of L1->L2 PCIe write bandwidth (logical KV bytes / CUDA event duration), GB/s. Reflects actual GPU->Host transfer rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "GBs",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang:eviction_bandwidth_gb_s_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang:eviction_bandwidth_gb_s_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang:eviction_bandwidth_gb_s_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(sglang:eviction_bandwidth_gb_s_sum{instance=~\"$instance\"}[$__rate_interval])) / sum(rate(sglang:eviction_bandwidth_gb_s_count{instance=~\"$instance\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "Avg",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "HiCache L1->L2 PCIe Write Bandwidth (GB/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Distribution of L2->L1 PCIe load bandwidth (logical KV bytes / CUDA event duration), GB/s. Reflects actual Host->GPU transfer rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "GBs",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang:load_back_bandwidth_gb_s_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang:load_back_bandwidth_gb_s_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang:load_back_bandwidth_gb_s_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(sglang:load_back_bandwidth_gb_s_sum{instance=~\"$instance\"}[$__rate_interval])) / sum(rate(sglang:load_back_bandwidth_gb_s_count{instance=~\"$instance\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "Avg",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "HiCache L2->L1 PCIe Load Bandwidth (GB/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "L3 storage read/write bandwidth. Write = Host->Storage (backup), Read = Storage->Host (prefetch).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 73
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(sglang:backuped_bytes_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "Write (Host\u2192Storage)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(sglang:prefetched_bytes_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "Read (Storage\u2192Host)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HiCache L3 Storage Read/Write Bandwidth",
       "type": "timeseries"
     }
   ],

--- a/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
+++ b/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
@@ -105,7 +105,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -121,7 +121,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -138,7 +138,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -155,7 +155,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -249,7 +249,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -351,7 +351,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -367,7 +367,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -384,7 +384,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -401,7 +401,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -498,7 +498,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -602,7 +602,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -704,7 +704,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "editorMode": "code",
           "expr": "sglang:gen_throughput",
@@ -801,7 +801,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -902,7 +902,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "ddyfngn31dg5cf"
+            "default": true
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -2073,14 +2073,14 @@
     "list": [
       {
         "current": {
-          "text": "127.0.0.1:30000",
-          "value": "127.0.0.1:30000"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus"
         },
         "definition": "label_values(instance)",
-        "includeAll": false,
+        "includeAll": true,
         "label": "instance",
         "name": "instance",
         "options": [],
@@ -2095,14 +2095,14 @@
       },
       {
         "current": {
-          "text": "meta-llama/Llama-3.1-8B-Instruct",
-          "value": "meta-llama/Llama-3.1-8B-Instruct"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus"
         },
         "definition": "label_values(model_name)",
-        "includeAll": false,
+        "includeAll": true,
         "label": "model name",
         "name": "model_name",
         "options": [],

--- a/examples/monitoring/grafana/datasources/datasource.yaml
+++ b/examples/monitoring/grafana/datasources/datasource.yaml
@@ -3,6 +3,6 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://10.235.192.86:9090
+    url: http://10.235.192.83:9090
     isDefault: true
     editable: false

--- a/examples/monitoring/grafana/datasources/datasource.yaml
+++ b/examples/monitoring/grafana/datasources/datasource.yaml
@@ -3,6 +3,6 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://localhost:9090
+    url: http://10.235.192.86:9090
     isDefault: true
     editable: false

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -70,8 +70,14 @@ def make_timing_event_pair():
 class LayerLoadingEvent:
     def __init__(self, num_layers: int):
         self._num_layers = num_layers
-        self.load_events = [device_module.Event() for _ in range(num_layers)]
-        self.start_event = device_module.Event()  # start event on controller stream
+        # enable_timing=True: needed for start_event.elapsed_time(finish_event)
+        # to derive load-back PCIe bandwidth (sglang:load_back_bandwidth_gb_s).
+        self.load_events = [
+            device_module.Event(enable_timing=True) for _ in range(num_layers)
+        ]
+        self.start_event = device_module.Event(
+            enable_timing=True
+        )  # start event on controller stream
 
     def complete(self, layer_index: int):
         assert 0 <= layer_index < self._num_layers
@@ -161,6 +167,9 @@ class HiCacheAck(NamedTuple):
     start_event: device_module.Event
     finish_event: device_module.Event
     node_ids: List[int]
+    # Tokens moved by this batch; paired with start_event.elapsed_time(finish_event)
+    # to derive PCIe bandwidth (sglang:eviction_bandwidth_gb_s / load_back_bandwidth_gb_s)
+    # when timing_enabled.
     num_tokens: int = 0
     timing_enabled: bool = False
 
@@ -713,8 +722,9 @@ class HiCacheController:
             )
         self.write_queue.clear()
 
-        start_event = device_module.Event()
-        finish_event = device_module.Event()
+        # timing_enabled gates elapsed_time() use downstream: derives eviction
+        # (L1->L2) PCIe bandwidth (sglang:eviction_bandwidth_gb_s) where supported.
+        start_event, finish_event, timing_enabled = make_timing_event_pair()
 
         start_event.record()
         with device_module.stream(self.write_stream):
@@ -738,7 +748,15 @@ class HiCacheController:
             if device_indices.is_cuda:
                 device_indices.record_stream(self.write_stream)
 
-        self.ack_write_queue.append(HiCacheAck(start_event, finish_event, op.node_ids))
+        self.ack_write_queue.append(
+            HiCacheAck(
+                start_event,
+                finish_event,
+                op.node_ids,
+                num_tokens=len(device_indices),
+                timing_enabled=timing_enabled,
+            )
+        )
 
     def load(
         self,
@@ -828,7 +846,7 @@ class HiCacheController:
                 start_event=ack_start_event,
                 finish_event=ack_finish_event,
                 node_ids=op.node_ids,
-                num_tokens=len(op.device_indices),
+                num_tokens=len(device_indices),
                 timing_enabled=timing_enabled,
             )
         )

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -483,6 +483,11 @@ class PrefillAdder:
         # TODO(lsyin): report the real input tokens excluding page alignment
         self.log_input_tokens = 0
         self.reprocessed_log_input_tokens = 0
+        # Per-tier cache hit breakdown (raw token counts, no page alignment)
+        self.log_l1_hit_tokens = 0
+        self.log_l2_hit_tokens = 0
+        self.log_l3_hit_tokens = 0
+        self.log_miss_tokens = 0
 
         if running_batch is not None:
             # Estimate the offset in the remaining token space
@@ -749,6 +754,12 @@ class PrefillAdder:
         if retracted_stain:
             self.reprocessed_log_hit_tokens += prefix_len
             self.reprocessed_log_input_tokens += extend_input_len
+
+    def _accumulate_per_tier_hits(self, l1: int, l2: int, l3: int, miss: int) -> None:
+        self.log_l1_hit_tokens += l1
+        self.log_l2_hit_tokens += l2
+        self.log_l3_hit_tokens += l3
+        self.log_miss_tokens += miss
 
     def _get_dllm_remain_tokens(self) -> int:
         _rem_tokens = min(
@@ -1042,6 +1053,7 @@ class PrefillAdder:
         real_input_tokens = cand_extend_input_len - req.host_hit_length
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
+        l1_hit = prefix_len  # L1 GPU device hits before host load-back
 
         if total_tokens >= self.rem_total_tokens:
             return AddReqResult.NO_TOKEN
@@ -1086,6 +1098,7 @@ class PrefillAdder:
                         return AddReqResult.NO_TOKEN
                     chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
 
+            loaded_back = 0
             if req.needs_host_load_back():
                 new_indices, req.last_node = self.tree_cache.init_load_back(
                     InitLoadBackParams(
@@ -1097,6 +1110,12 @@ class PrefillAdder:
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
+                loaded_back = len(new_indices)
+
+            # L3 storage hits are the promoted portion of the load-back; the
+            # remainder came from L2 host DRAM.
+            l3_hit = min(req.storage_hit_length, loaded_back)
+            l2_hit = loaded_back - l3_hit
 
             input_tokens = self.ceil_paged_tokens(
                 len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
@@ -1122,6 +1141,12 @@ class PrefillAdder:
 
                 self._add_dllm_req(req, prefix_len)
                 self._req_inc_lock_ref(req)
+                self._accumulate_per_tier_hits(
+                    l1_hit,
+                    l2_hit,
+                    l3_hit,
+                    req.extend_range.end - req.extend_range.start,
+                )
             elif chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit:
                 # Non-chunked prefill — the whole sequence is committed this iter.
                 req.set_extend_range(
@@ -1139,6 +1164,12 @@ class PrefillAdder:
                     ),
                     req.retracted_stain,
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
+                )
+                self._accumulate_per_tier_hits(
+                    l1_hit,
+                    l2_hit,
+                    l3_hit,
+                    req.extend_range.end - req.extend_range.start,
                 )
             else:
                 # Make sure at least one page is available
@@ -1181,6 +1212,7 @@ class PrefillAdder:
                     req.retracted_stain,
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
                 )
+                self._accumulate_per_tier_hits(l1_hit, l2_hit, l3_hit, trunc_len)
 
         return self.budget_state()
 

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -63,6 +63,11 @@ class PrefillStats:
     reprocessed_log_input_tokens: int = 0
     reprocessed_log_hit_tokens: int = 0
     num_pending_tokens: int = 0
+    # Per-tier cache hit breakdown (raw token counts, no page alignment)
+    log_l1_hit_tokens: int = 0
+    log_l2_hit_tokens: int = 0
+    log_l3_hit_tokens: int = 0
+    log_miss_tokens: int = 0
 
     @classmethod
     def from_adder(
@@ -83,6 +88,10 @@ class PrefillStats:
             ),
             num_new_seqs=len(adder.can_run_list),
             num_pending_tokens=num_pending_tokens,
+            log_l1_hit_tokens=adder.log_l1_hit_tokens,
+            log_l2_hit_tokens=adder.log_l2_hit_tokens,
+            log_l3_hit_tokens=adder.log_l3_hit_tokens,
+            log_miss_tokens=adder.log_miss_tokens,
         )
 
 
@@ -651,6 +660,10 @@ class SchedulerMetricsReporter:
             )
             self.stats.num_grammar_queue_reqs = len(self.scheduler.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.l1_hit_tokens = prefill_stats.log_l1_hit_tokens
+            self.stats.l2_hit_tokens = prefill_stats.log_l2_hit_tokens
+            self.stats.l3_hit_tokens = prefill_stats.log_l3_hit_tokens
+            self.stats.cache_miss_tokens = prefill_stats.log_miss_tokens
 
             # Memory pool usage ratios / Absolute token counts
             pool_stats.update_scheduler_stats(self.stats)

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -664,6 +664,10 @@ class HiRadixCache(RadixCache):
                     self.storage_metrics_collector.log_backuped_tokens(
                         operation.completed_tokens
                     )
+                    self.storage_metrics_collector.log_backuped_bytes(
+                        operation.completed_tokens
+                        * self.cache_controller.mem_pool_host.get_size_per_token()
+                    )
 
         def _drain_release():
             host_indices_list = []
@@ -978,12 +982,30 @@ class HiRadixCache(RadixCache):
                 # write to host if the node is not backuped
                 self.write_backup(node)
 
+    def _report_transfer_bandwidth(self, ack, is_eviction: bool) -> None:
+        # PCIe bandwidth per ack'd batch, via CUDA event timing bracketing the
+        # actual D2H (write-back) / H2D (load-back) copy -- see start_writing()/
+        # start_loading() in cache_controller.py. timing_enabled is False on
+        # backends where the CUDA/HIP event timing API is unavailable.
+        if self.metrics_collector is None or ack.num_tokens <= 0 or not ack.timing_enabled:
+            return
+        elapsed_ms = ack.start_event.elapsed_time(ack.finish_event)
+        if elapsed_ms <= 0:
+            return
+        bytes_per_token = self.cache_controller.mem_pool_host.get_size_per_token()
+        gb_per_s = (ack.num_tokens * bytes_per_token / 1e9) / (elapsed_ms / 1000.0)
+        if is_eviction:
+            self.metrics_collector.observe_eviction_bandwidth_gb_s(gb_per_s)
+        else:
+            self.metrics_collector.observe_load_back_bandwidth_gb_s(gb_per_s)
+
     def writing_check(self, write_back=False):
         if write_back:
             # blocking till all write back complete
             while len(self.ongoing_write_through) > 0:
                 for ack in self.cache_controller.ack_write_queue:
                     ack.finish_event.synchronize()
+                    self._report_transfer_bandwidth(ack, is_eviction=True)
                     for ack_id in ack.node_ids:
                         self._finish_write_through_ack(ack_id, release_lock=False)
                 self.cache_controller.ack_write_queue.clear()
@@ -1009,6 +1031,7 @@ class HiRadixCache(RadixCache):
         while finish_count > 0:
             ack = self.cache_controller.ack_write_queue.pop(0)
             ack.finish_event.synchronize()
+            self._report_transfer_bandwidth(ack, is_eviction=True)
             for ack_id in ack.node_ids:
                 self._finish_write_through_ack(ack_id, release_lock=True)
             finish_count -= 1
@@ -1029,6 +1052,7 @@ class HiRadixCache(RadixCache):
         while finish_count > 0:
             ack = self.cache_controller.ack_load_queue.pop(0)
             ack.finish_event.synchronize()
+            self._report_transfer_bandwidth(ack, is_eviction=False)
             for ack_id in ack.node_ids:
                 end_node = self.ongoing_load_back.pop(ack_id)
                 self.dec_lock_ref(end_node)
@@ -1116,10 +1140,21 @@ class HiRadixCache(RadixCache):
         start_time = time.perf_counter()
         num_tokens = params.num_tokens
         if self.cache_controller.write_policy == "write_back":
-            num_evicted = self._evict_write_back(num_tokens)
+            num_evicted, num_backuped_evicted = self._evict_write_back(num_tokens)
         else:
-            num_evicted = self._evict_write_through(num_tokens)
+            num_evicted, num_backuped_evicted = self._evict_write_through(num_tokens)
         self.update_eviction_metrics(num_evicted, start_time)
+        if self.metrics_collector is not None and num_evicted > 0:
+            # Split of evicted_tokens_total: "backuped" nodes were already on
+            # host (cheap detach, no data loss); "regular" nodes are dropped
+            # without a host copy (write-through under pressure, or plain
+            # write_through mode with no host tier at all).
+            self.metrics_collector.increment_evicted_backuped_tokens(
+                num_backuped_evicted
+            )
+            self.metrics_collector.increment_evicted_regular_tokens(
+                num_evicted - num_backuped_evicted
+            )
         return EvictResult(num_tokens_evicted=num_evicted)
 
     def _make_eviction_heap(self):
@@ -1136,30 +1171,38 @@ class HiRadixCache(RadixCache):
         if p is not self.root_node and all(c.evicted for c in p.children.values()):
             heapq.heappush(heap, (self.eviction_strategy.get_priority(p), p))
 
-    def _evict_write_through(self, num_tokens: int) -> int:
+    def _evict_write_through(self, num_tokens: int) -> Tuple[int, int]:
         """write_through / write_through_selective: drop non-backuped leaves,
         demote already-backuped ones. Nothing is staged to host during eviction,
         so this is a plain on-the-fly pass.
+
+        Returns (num_evicted, num_backuped_evicted).
         """
         heap = self._make_eviction_heap()
         num_evicted = 0
+        num_backuped_evicted = 0
         while num_evicted < num_tokens and heap:
             _, x = heapq.heappop(heap)
             if x.lock_ref > 0:
                 continue
             if x.backuped:
-                num_evicted += self._evict_backuped(x)
+                n = self._evict_backuped(x)
+                num_evicted += n
+                num_backuped_evicted += n
             else:
                 num_evicted += self._evict_regular(x)
             self._promote_parent(x, heap)
-        return num_evicted
+        return num_evicted, num_backuped_evicted
 
-    def _evict_write_back(self, num_tokens: int) -> int:
+    def _evict_write_back(self, num_tokens: int) -> Tuple[int, int]:
         """eviction for write_back mode: demote already-backuped leaves, stage non-backuped ones to host if possible, otherwise drop them.
         note this path will be deprecated in the future.
+
+        Returns (num_evicted, num_backuped_evicted).
         """
         heap = self._make_eviction_heap()
         num_evicted = 0
+        num_backuped_evicted = 0
         staged: List[Tuple[TreeNode, torch.Tensor]] = []
 
         def flush_staged() -> None:
@@ -1176,17 +1219,21 @@ class HiRadixCache(RadixCache):
             if x.lock_ref > 0:
                 continue
             if x.backuped:
-                num_evicted += self._evict_backuped(x)
+                n = self._evict_backuped(x)
+                num_evicted += n
+                num_backuped_evicted += n
             elif self.write_backup(x, write_back=True) > 0:
                 x.protect_host()
                 staged.append((x, x.value))
-                num_evicted += self._detach_backuped(x)
+                n = self._detach_backuped(x)
+                num_evicted += n
+                num_backuped_evicted += n
             else:
                 flush_staged()
                 num_evicted += self._drop_subtree_no_host(x)
             self._promote_parent(x, heap)
         flush_staged()
-        return num_evicted
+        return num_evicted, num_backuped_evicted
 
     def _detach_backuped(self, node: TreeNode) -> int:
         # detach nodes from tree while keeping device slots, for write-back eviction
@@ -1592,6 +1639,10 @@ class HiRadixCache(RadixCache):
 
         if self.enable_storage_metrics:
             self.storage_metrics_collector.log_prefetched_tokens(loaded_from_storage)
+            self.storage_metrics_collector.log_prefetched_bytes(
+                loaded_from_storage
+                * self.cache_controller.mem_pool_host.get_size_per_token()
+            )
 
         return True
 

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -411,8 +411,7 @@ class HybridCacheController(BaseHiCacheController):
                 self.move_hybrid_indices(op)
             )
         self.write_queue.clear()
-        start_event = device_module.Event()
-        finish_event = device_module.Event()
+        start_event, finish_event, timing_enabled = make_timing_event_pair()
         start_event.record()
         with device_module.stream(self.write_stream):
             start_event.wait(self.write_stream)
@@ -437,7 +436,15 @@ class HybridCacheController(BaseHiCacheController):
                 device_indices,
                 resolved_pool_transfers,
             )
-        self.ack_write_queue.append(HiCacheAck(start_event, finish_event, op.node_ids))
+        self.ack_write_queue.append(
+            HiCacheAck(
+                start_event,
+                finish_event,
+                op.node_ids,
+                num_tokens=len(device_indices),
+                timing_enabled=timing_enabled,
+            )
+        )
 
     def load(
         self,
@@ -533,7 +540,7 @@ class HybridCacheController(BaseHiCacheController):
                 ack_start_event,
                 ack_finish_event,
                 op.node_ids,
-                num_tokens=len(op.device_indices),
+                num_tokens=len(device_indices),
                 timing_enabled=timing_enabled,
             )
         )

--- a/python/sglang/srt/mem_cache/storage/umbp/umbp_store.py
+++ b/python/sglang/srt/mem_cache/storage/umbp/umbp_store.py
@@ -10,6 +10,7 @@ import logging
 import os
 import socket
 import threading
+import time
 from typing import Any, List, Optional
 
 import torch
@@ -20,6 +21,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageExtraInfo,
 )
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
+from sglang.srt.observability.metrics_collector import StorageMetrics
 
 logger = logging.getLogger(__name__)
 
@@ -250,12 +252,14 @@ class UMBPStore(HiCacheStorage):
             self.pp_rank = storage_config.pp_rank
             self.pp_size = storage_config.pp_size
             self.tp_size = storage_config.tp_size
+            self.enable_storage_metrics = storage_config.enable_storage_metrics
         else:
             self.is_mla_backend = False
             self.local_rank = 0
             self.pp_rank = 0
             self.pp_size = 1
             self.tp_size = 1
+            self.enable_storage_metrics = False
 
         cfg = UMBPConfig.from_environment()
         # UMBPStore owns role selection explicitly. Do not inherit LOCAL_RANK /
@@ -809,6 +813,15 @@ class UMBPStore(HiCacheStorage):
             else:
                 self.mha_suffix = [f"{rank}" for rank in target_ranks]
 
+        # Storage bandwidth metrics (mirrors MooncakeStore / HiCacheHF3FS):
+        # one GB/s sample is appended per batch_get_v1 (L3->L2 prefetch) and
+        # batch_set_v1 (L2->L3 backup); get_stats() drains them into the
+        # sglang:prefetch_bandwidth / sglang:backup_bandwidth histograms.
+        self.prefetch_pgs: List[int] = []
+        self.backup_pgs: List[int] = []
+        self.prefetch_bandwidth: List[float] = []
+        self.backup_bandwidth: List[float] = []
+
         logger.info(
             "UMBPStore initialized: dram=%d MB, ssd=%s, mla=%s, rank=%d, ssd_backend=%s",
             cfg.dram.capacity_bytes // (1024 * 1024),
@@ -1025,13 +1038,28 @@ class UMBPStore(HiCacheStorage):
             len(key_strs),
             total_bytes,
         )
+        start_time = time.perf_counter()
         get_results = self.client.batch_get_into_ptr(key_strs, list(buffer_ptrs), sizes)
+        end_time = time.perf_counter()
         success_count = sum(1 for r in get_results if r)
         logger.debug(
             "[UMBPStore] batch_get_v1: UMBP BatchGet done: success=%d/%d",
             success_count,
             len(get_results),
         )
+
+        if self.enable_storage_metrics:
+            elapsed = end_time - start_time
+            if elapsed > 0:
+                # Effective L3-get bandwidth: in distributed mode a BatchGet may
+                # resolve to local DRAM or an RDMA hop to a peer, so this is the
+                # blended delivered GB/s, not pure wire speed. total_bytes is the
+                # exact summed transfer size (layout-aware), which UMBP already
+                # computes; we deliberately do not reuse get_ksize_per_token()
+                # (over-counts for NSA, see dram_page_size note above).
+                self.prefetch_pgs.append(len(keys))
+                self.prefetch_bandwidth.append(total_bytes / (1 << 30) / elapsed)
+
         return self._batch_postprocess(get_results)
 
     def _compute_expanded_depths(
@@ -1097,6 +1125,7 @@ class UMBPStore(HiCacheStorage):
             bool(expanded_depths),
         )
 
+        start_time = time.perf_counter()
         if expanded_depths:
             put_results = self.client.batch_put_from_ptr_with_depth(
                 key_strs, list(buffer_ptrs), sizes, expanded_depths
@@ -1105,6 +1134,7 @@ class UMBPStore(HiCacheStorage):
             put_results = self.client.batch_put_from_ptr(
                 key_strs, list(buffer_ptrs), sizes
             )
+        end_time = time.perf_counter()
 
         success_count = sum(1 for r in put_results if r)
         logger.debug(
@@ -1112,6 +1142,15 @@ class UMBPStore(HiCacheStorage):
             success_count,
             len(put_results),
         )
+
+        if self.enable_storage_metrics:
+            elapsed = end_time - start_time
+            if elapsed > 0:
+                # Effective L3-put bandwidth (blended local DRAM / peer RDMA),
+                # from the exact summed transfer size. See batch_get_v1 note.
+                self.backup_pgs.append(len(keys))
+                self.backup_bandwidth.append(total_bytes / (1 << 30) / elapsed)
+
         return self._batch_postprocess(put_results, is_set_operate=True)
 
     def batch_exists(
@@ -1213,6 +1252,18 @@ class UMBPStore(HiCacheStorage):
         if self.client is None or not hasattr(self.client, "flush"):
             return True
         return bool(self.client.flush())
+
+    def get_stats(self):
+        storage_metrics = StorageMetrics()
+        storage_metrics.prefetch_pgs.extend(self.prefetch_pgs)
+        storage_metrics.backup_pgs.extend(self.backup_pgs)
+        storage_metrics.prefetch_bandwidth.extend(self.prefetch_bandwidth)
+        storage_metrics.backup_bandwidth.extend(self.backup_bandwidth)
+        self.prefetch_pgs.clear()
+        self.backup_pgs.clear()
+        self.prefetch_bandwidth.clear()
+        self.backup_bandwidth.clear()
+        return storage_metrics
 
     def close(self) -> None:
         if getattr(self, "_kv_events_subscriber", None) is not None:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -70,6 +70,11 @@ class SchedulerStats:
     gen_throughput: float = 0.0
     cache_hit_rate: float = 0.0
     decode_sum_seq_lens: int = 0
+    # Per-tier cache hit token counts (incremental, reset after each log_stats call)
+    l1_hit_tokens: int = 0
+    l2_hit_tokens: int = 0
+    l3_hit_tokens: int = 0
+    cache_miss_tokens: int = 0
 
     # Memory pool usage ratios (0.0–1.0).
     # Each pool tracks: used = total - available - evictable, usage = used / total.
@@ -301,6 +306,27 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             documentation="The sum of all sequence lengths in decode.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
+        )
+        # Per-tier cache hit counters (L1=GPU radix, L2=Host DRAM, L3=Storage)
+        self.cache_hit_tokens_l1_total = Counter(
+            name="sglang:cache_hit_tokens_l1_total",
+            documentation="Total tokens matched from L1 GPU device cache (radix tree).",
+            labelnames=labels.keys(),
+        )
+        self.cache_hit_tokens_l2_total = Counter(
+            name="sglang:cache_hit_tokens_l2_total",
+            documentation="Total tokens loaded back from L2 Host DRAM cache (excluding L3 storage-promoted tokens).",
+            labelnames=labels.keys(),
+        )
+        self.cache_hit_tokens_l3_total = Counter(
+            name="sglang:cache_hit_tokens_l3_total",
+            documentation="Total tokens prefetched from L3 storage backend (promoted through Host to GPU).",
+            labelnames=labels.keys(),
+        )
+        self.cache_miss_tokens_total = Counter(
+            name="sglang:cache_miss_tokens_total",
+            documentation="Total tokens not found in any cache tier, requiring full prefill computation.",
+            labelnames=labels.keys(),
         )
 
         # =================================================================
@@ -1278,6 +1304,14 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         self._log_gauge(self.num_grammar_queue_reqs, stats.num_grammar_queue_reqs)
         self._log_gauge(self.gen_throughput, stats.gen_throughput)
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self.cache_hit_tokens_l1_total.labels(**self.labels).inc(stats.l1_hit_tokens)
+        self.cache_hit_tokens_l2_total.labels(**self.labels).inc(stats.l2_hit_tokens)
+        self.cache_hit_tokens_l3_total.labels(**self.labels).inc(stats.l3_hit_tokens)
+        self.cache_miss_tokens_total.labels(**self.labels).inc(stats.cache_miss_tokens)
+        stats.l1_hit_tokens = 0
+        stats.l2_hit_tokens = 0
+        stats.l3_hit_tokens = 0
+        stats.cache_miss_tokens = 0
         self._log_gauge(self.decode_sum_seq_lens, stats.decode_sum_seq_lens)
 
         # Memory pool usage ratios

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -338,6 +338,12 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
+        self.gpu_kv_cache_occupancy = Gauge(
+            name="sglang:gpu_kv_cache_occupancy",
+            documentation="GPU KV cache occupancy (0-1). Alias of token_usage kept for HiCache dashboards.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
         self.full_token_usage = Gauge(
             name="sglang:full_token_usage",
             documentation="The token usage for full attention layers.",
@@ -1316,6 +1322,7 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
 
         # Memory pool usage ratios
         self._log_gauge(self.token_usage, stats.token_usage)
+        self._log_gauge(self.gpu_kv_cache_occupancy, stats.token_usage)
         self._log_gauge(self.full_token_usage, stats.full_token_usage)
         self._log_gauge(self.swa_token_usage, stats.swa_token_usage)
         self._log_gauge(self.mamba_usage, stats.mamba_usage)
@@ -1803,6 +1810,18 @@ class StorageMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
         )
 
+        self.prefetched_bytes_total = Counter(
+            name="sglang:prefetched_bytes_total",
+            documentation="Number of bytes prefetched from L3 storage to host.",
+            labelnames=labels.keys(),
+        )
+
+        self.backuped_bytes_total = Counter(
+            name="sglang:backuped_bytes_total",
+            documentation="Number of bytes backed up from host to L3 storage.",
+            labelnames=labels.keys(),
+        )
+
         bucket_io = [
             1,
             5,
@@ -1856,6 +1875,14 @@ class StorageMetricsCollector(_StatLoggerDIMixin):
     def log_backuped_tokens(self, backuped_tokens: int):
         if backuped_tokens > 0:
             self.backuped_tokens_total.labels(**self.labels).inc(backuped_tokens)
+
+    def log_prefetched_bytes(self, num_bytes: int):
+        if num_bytes > 0:
+            self.prefetched_bytes_total.labels(**self.labels).inc(num_bytes)
+
+    def log_backuped_bytes(self, num_bytes: int):
+        if num_bytes > 0:
+            self.backuped_bytes_total.labels(**self.labels).inc(num_bytes)
 
     def _log_histogram(self, histogram, data: Union[int, float]):
         histogram.labels(**self.labels).observe(data)
@@ -1966,6 +1993,21 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
         )
 
+        # Split of evicted_tokens_total by whether the node had already been
+        # backed up to host (cheap detach) vs dropped without a host copy
+        # (write-through under host memory pressure, or write_through mode
+        # without a host tier at all).
+        self.evicted_backuped_tokens_total = Counter(
+            name="sglang:evicted_backuped_tokens_total",
+            documentation="Number of evicted GPU tokens that had already been backed up to host (cheap detach, no data loss).",
+            labelnames=labels.keys(),
+        )
+        self.evicted_regular_tokens_total = Counter(
+            name="sglang:evicted_regular_tokens_total",
+            documentation="Number of evicted GPU tokens dropped without a host backup (data is gone, must be recomputed).",
+            labelnames=labels.keys(),
+        )
+
         self.load_back_duration_seconds = Histogram(
             name="sglang:load_back_duration_seconds",
             documentation="Time taken to load KV cache from CPU back to GPU in seconds.",
@@ -1979,8 +2021,35 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
         )
 
+        bucket_bandwidth_gb_s = [0.1, 0.5, 1, 5, 10, 20, 40, 80, 160, 320]
+
+        # PCIe bandwidth, measured via CUDA start/finish events bracketing the
+        # actual D2H (eviction/write-back) and H2D (load-back) copy on the
+        # dedicated write/load streams -- not wall-clock time around the
+        # (often async) Python call.
+        self.eviction_bandwidth_gb_s = Histogram(
+            name="sglang:eviction_bandwidth_gb_s",
+            documentation="L1(GPU)->L2(Host) PCIe write bandwidth in GB/s, measured per write-back batch via CUDA events.",
+            labelnames=labels.keys(),
+            buckets=bucket_bandwidth_gb_s,
+        )
+        self.load_back_bandwidth_gb_s = Histogram(
+            name="sglang:load_back_bandwidth_gb_s",
+            documentation="L2(Host)->L1(GPU) PCIe load bandwidth in GB/s, measured per load-back batch via CUDA events.",
+            labelnames=labels.keys(),
+            buckets=bucket_bandwidth_gb_s,
+        )
+
     def increment_eviction_num_tokens(self, num_tokens: int) -> None:
         self.eviction_num_tokens.labels(**self.labels).inc(num_tokens)
+
+    def increment_evicted_backuped_tokens(self, num_tokens: int) -> None:
+        if num_tokens > 0:
+            self.evicted_backuped_tokens_total.labels(**self.labels).inc(num_tokens)
+
+    def increment_evicted_regular_tokens(self, num_tokens: int) -> None:
+        if num_tokens > 0:
+            self.evicted_regular_tokens_total.labels(**self.labels).inc(num_tokens)
 
     def increment_load_back_num_tokens(self, num_tokens: int) -> None:
         self.load_back_num_tokens.labels(**self.labels).inc(num_tokens)
@@ -1990,6 +2059,12 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
 
     def observe_load_back_duration(self, duration_seconds: float) -> None:
         self.load_back_duration_seconds.labels(**self.labels).observe(duration_seconds)
+
+    def observe_eviction_bandwidth_gb_s(self, gb_per_s: float) -> None:
+        self.eviction_bandwidth_gb_s.labels(**self.labels).observe(gb_per_s)
+
+    def observe_load_back_bandwidth_gb_s(self, gb_per_s: float) -> None:
+        self.load_back_bandwidth_gb_s.labels(**self.labels).observe(gb_per_s)
 
 
 class EncoderMetricsCollector(_StatLoggerDIMixin):


### PR DESCRIPTION
## Summary
Re-adds HiCache observability that was reverted in `feat/umbp-pr` (001e9ce957) and never carried forward, adapted to the current async write/load pipeline and reconciled with `timing_enabled`/`make_timing_event_pair()` (the portability guard main already added for backends without CUDA/HIP event-timing support):

- **Per-tier (L1/L2/L3) cache hit/miss token counters**: `PrefillAdder` now tracks L1 (GPU device), L2 (host DRAM), and L3 (storage) hit tokens plus misses, exported as `sglang:cache_hit_tokens_l{1,2,3}_total` / `cache_miss_tokens_total`.
- **Eviction/load-back bandwidth + byte-level metrics**: `sglang:evicted_backuped_tokens_total` / `evicted_regular_tokens_total` (split by whether the node was already backed up before eviction), `sglang:gpu_kv_cache_occupancy` (alias gauge for dashboards querying the old name), `sglang:eviction_bandwidth_gb_s` / `load_back_bandwidth_gb_s` (real per-batch PCIe bandwidth derived from `HiCacheAck.num_tokens` + CUDA/HIP event timing, gated on `timing_enabled`), and `sglang:backuped_bytes_total` / `prefetched_bytes_total` (byte-scaled counterparts of the existing token counters).
  - Extended the write/eviction path (`cache_controller.py`, `hybrid_cache_controller.py`) to also use `make_timing_event_pair()` instead of unguarded `enable_timing=True`, matching the load path's existing portability handling, and to carry `timing_enabled` through `HiCacheAck` so the new bandwidth metrics degrade gracefully on backends without event-timing support.
- **UMBP L3 get/put bandwidth**: `UMBPStore` now populates `prefetch_bandwidth`/`backup_bandwidth`, drained by `HiRadixCache` under `--enable-metrics` and exported as `sglang:prefetch_bandwidth` / `sglang:backup_bandwidth`.
- **Grafana**: restores per-tier Cache Hit Rate, HiCache Host Utilization/Capacity, L3 Prefetch/Writeback Rate, L1<->L2 Eviction/Load-back Rate, Cached Tokens Rate, GPU KV Cache Utilization, and L1<->L2 / L3 PCIe bandwidth panels; fixes an orphaned datasource UID + stale template vars, a stale datasource IP, and adds a UMBP dashboard provider.

Deliberately excludes the `sglang:prefetch_wait_stall_ms` histogram (separate concern, not included in this PR).

## Test plan
- [ ] Existing hicache/metrics unit tests pass
- [ ] Manual: run with `--enable-metrics --enable-hierarchical-cache` and confirm the new Prometheus counters/histograms populate and the restored Grafana panels render

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29799315685](https://github.com/sgl-project/sglang/actions/runs/29799315685)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29799315587](https://github.com/sgl-project/sglang/actions/runs/29799315587)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->