### PR TITLE
hicache: restore per-tier (L1/L2/L3) KV cache hit metrics

### DIFF
--- a/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
+++ b/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json
@@ -918,6 +918,235 @@
       ],
       "title": "Number Queued Requests",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Per-tier cache hit rate. Total hit rate = (L1+L2+L3) / (L1+L2+L3+Miss). Each tier's share uses raw token counts without page alignment.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "Total Hit Rate (L1+L2+L3)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "L1 Hit Rate (GPU)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "L2 Hit Rate (Host DRAM)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) / clamp_min((sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l1_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l2_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:cache_hit_tokens_l3_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])) + sum without (dp_rank, tp_rank, pp_rank, moe_ep_rank, instance, job) (rate(sglang:uncached_prompt_tokens_histogram_sum{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval]))), 1e-9)",
+          "instant": false,
+          "legendFormat": "L3 Hit Rate (Storage)",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Cache Hit Rate (Per-Tier)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "description": "Rate of tokens served from cache, tokens/s, including HiCache hits.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "default": true,
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sglang:cached_tokens_total{instance=~\"$instance\",model_name=~\"$model_name\"}[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "\u547d\u4e2d tokens/s ({{cache_source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cached Tokens Rate (hit tokens/s)",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -483,6 +483,11 @@ class PrefillAdder:
         # TODO(lsyin): report the real input tokens excluding page alignment
         self.log_input_tokens = 0
         self.reprocessed_log_input_tokens = 0
+        # Per-tier cache hit breakdown (raw token counts, no page alignment)
+        self.log_l1_hit_tokens = 0
+        self.log_l2_hit_tokens = 0
+        self.log_l3_hit_tokens = 0
+        self.log_miss_tokens = 0
 
         if running_batch is not None:
             # Estimate the offset in the remaining token space
@@ -749,6 +754,12 @@ class PrefillAdder:
         if retracted_stain:
             self.reprocessed_log_hit_tokens += prefix_len
             self.reprocessed_log_input_tokens += extend_input_len
+
+    def _accumulate_per_tier_hits(self, l1: int, l2: int, l3: int, miss: int) -> None:
+        self.log_l1_hit_tokens += l1
+        self.log_l2_hit_tokens += l2
+        self.log_l3_hit_tokens += l3
+        self.log_miss_tokens += miss
 
     def _get_dllm_remain_tokens(self) -> int:
         _rem_tokens = min(
@@ -1042,6 +1053,7 @@ class PrefillAdder:
         real_input_tokens = cand_extend_input_len - req.host_hit_length
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
+        l1_hit = prefix_len  # L1 GPU device hits before host load-back
 
         if total_tokens >= self.rem_total_tokens:
             return AddReqResult.NO_TOKEN
@@ -1086,6 +1098,7 @@ class PrefillAdder:
                         return AddReqResult.NO_TOKEN
                     chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
 
+            loaded_back = 0
             if req.needs_host_load_back():
                 new_indices, req.last_node = self.tree_cache.init_load_back(
                     InitLoadBackParams(
@@ -1097,6 +1110,12 @@ class PrefillAdder:
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
+                loaded_back = len(new_indices)
+
+            # L3 storage hits are the promoted portion of the load-back; the
+            # remainder came from L2 host DRAM.
+            l3_hit = min(req.storage_hit_length, loaded_back)
+            l2_hit = loaded_back - l3_hit
 
             input_tokens = self.ceil_paged_tokens(
                 len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
@@ -1122,6 +1141,12 @@ class PrefillAdder:
 
                 self._add_dllm_req(req, prefix_len)
                 self._req_inc_lock_ref(req)
+                self._accumulate_per_tier_hits(
+                    l1_hit,
+                    l2_hit,
+                    l3_hit,
+                    req.extend_range.end - req.extend_range.start,
+                )
             elif chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit:
                 # Non-chunked prefill — the whole sequence is committed this iter.
                 req.set_extend_range(
@@ -1139,6 +1164,12 @@ class PrefillAdder:
                     ),
                     req.retracted_stain,
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
+                )
+                self._accumulate_per_tier_hits(
+                    l1_hit,
+                    l2_hit,
+                    l3_hit,
+                    req.extend_range.end - req.extend_range.start,
                 )
             else:
                 # Make sure at least one page is available
@@ -1181,6 +1212,7 @@ class PrefillAdder:
                     req.retracted_stain,
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
                 )
+                self._accumulate_per_tier_hits(l1_hit, l2_hit, l3_hit, trunc_len)
 
         return self.budget_state()
 

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -63,6 +63,11 @@ class PrefillStats:
     reprocessed_log_input_tokens: int = 0
     reprocessed_log_hit_tokens: int = 0
     num_pending_tokens: int = 0
+    # Per-tier cache hit breakdown (raw token counts, no page alignment)
+    log_l1_hit_tokens: int = 0
+    log_l2_hit_tokens: int = 0
+    log_l3_hit_tokens: int = 0
+    log_miss_tokens: int = 0
 
     @classmethod
     def from_adder(
@@ -83,6 +88,10 @@ class PrefillStats:
             ),
             num_new_seqs=len(adder.can_run_list),
             num_pending_tokens=num_pending_tokens,
+            log_l1_hit_tokens=adder.log_l1_hit_tokens,
+            log_l2_hit_tokens=adder.log_l2_hit_tokens,
+            log_l3_hit_tokens=adder.log_l3_hit_tokens,
+            log_miss_tokens=adder.log_miss_tokens,
         )
 
 
@@ -651,6 +660,10 @@ class SchedulerMetricsReporter:
             )
             self.stats.num_grammar_queue_reqs = len(self.scheduler.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.l1_hit_tokens = prefill_stats.log_l1_hit_tokens
+            self.stats.l2_hit_tokens = prefill_stats.log_l2_hit_tokens
+            self.stats.l3_hit_tokens = prefill_stats.log_l3_hit_tokens
+            self.stats.cache_miss_tokens = prefill_stats.log_miss_tokens
 
             # Memory pool usage ratios / Absolute token counts
             pool_stats.update_scheduler_stats(self.stats)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -70,6 +70,11 @@ class SchedulerStats:
     gen_throughput: float = 0.0
     cache_hit_rate: float = 0.0
     decode_sum_seq_lens: int = 0
+    # Per-tier cache hit token counts (incremental, reset after each log_stats call)
+    l1_hit_tokens: int = 0
+    l2_hit_tokens: int = 0
+    l3_hit_tokens: int = 0
+    cache_miss_tokens: int = 0
 
     # Memory pool usage ratios (0.0–1.0).
     # Each pool tracks: used = total - available - evictable, usage = used / total.
@@ -301,6 +306,27 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             documentation="The sum of all sequence lengths in decode.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
+        )
+        # Per-tier cache hit counters (L1=GPU radix, L2=Host DRAM, L3=Storage)
+        self.cache_hit_tokens_l1_total = Counter(
+            name="sglang:cache_hit_tokens_l1_total",
+            documentation="Total tokens matched from L1 GPU device cache (radix tree).",
+            labelnames=labels.keys(),
+        )
+        self.cache_hit_tokens_l2_total = Counter(
+            name="sglang:cache_hit_tokens_l2_total",
+            documentation="Total tokens loaded back from L2 Host DRAM cache (excluding L3 storage-promoted tokens).",
+            labelnames=labels.keys(),
+        )
+        self.cache_hit_tokens_l3_total = Counter(
+            name="sglang:cache_hit_tokens_l3_total",
+            documentation="Total tokens prefetched from L3 storage backend (promoted through Host to GPU).",
+            labelnames=labels.keys(),
+        )
+        self.cache_miss_tokens_total = Counter(
+            name="sglang:cache_miss_tokens_total",
+            documentation="Total tokens not found in any cache tier, requiring full prefill computation.",
+            labelnames=labels.keys(),
         )
 
         # =================================================================
@@ -1278,6 +1304,14 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         self._log_gauge(self.num_grammar_queue_reqs, stats.num_grammar_queue_reqs)
         self._log_gauge(self.gen_throughput, stats.gen_throughput)
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self.cache_hit_tokens_l1_total.labels(**self.labels).inc(stats.l1_hit_tokens)
+        self.cache_hit_tokens_l2_total.labels(**self.labels).inc(stats.l2_hit_tokens)
+        self.cache_hit_tokens_l3_total.labels(**self.labels).inc(stats.l3_hit_tokens)
+        self.cache_miss_tokens_total.labels(**self.labels).inc(stats.cache_miss_tokens)
+        stats.l1_hit_tokens = 0
+        stats.l2_hit_tokens = 0
+        stats.l3_hit_tokens = 0
+        stats.cache_miss_tokens = 0
         self._log_gauge(self.decode_sum_seq_lens, stats.decode_sum_seq_lens)
 
         # Memory pool usage ratios


### PR DESCRIPTION
## Summary
Split out of #31879 (general per-tier hit counters only, no UMBP-specific or eviction/load-back changes).

Re-adds the per-tier cache hit breakdown that was previously reverted in `feat/umbp-pr` (001e9ce957) and never carried forward: `PrefillAdder` tracks L1 (GPU device), L2 (host DRAM), and L3 (storage) hit tokens plus cache misses, reported via `SchedulerStats` and exported as `sglang:cache_hit_tokens_l{1,2,3}_total` / `cache_miss_tokens_total` Prometheus counters. Adapted to current code: uses `req.storage_hit_length` directly (no `getattr`) and `req.extend_range` instead of the since-removed `req.extend_input_len`.

Backend-agnostic — `req.storage_hit_length` is set generically by `scheduler.pop_prefetch_loaded_tokens()` regardless of which L3 storage backend (mooncake, hf3fs, file, UMBP, ...) served the prefetch.

Also restores the corresponding Grafana panels: "Cache Hit Rate (Per-Tier)" (new metric, percentage view split by tier) and "Cached Tokens Rate (hit tokens/s)" (existing `sglang:cached_tokens_total` counter, restored alongside it as a natural companion). Uses `"datasource": {"default": true}` rather than a hardcoded UID so it works on any fresh Grafana instance.

## Test plan
- [ ] Existing scheduler/metrics unit tests pass
- [ ] Manual: run with `--enable-metrics --enable-hierarchical-cache` and confirm `sglang:cache_hit_tokens_l1/l2/l3_total` and `cache_miss_tokens_total` populate correctly, and the two Grafana panels render

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29801015638](https://github.com/sgl-project/sglang/actions/runs/29801015638)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29801015521](https://github.com/sgl-project/sglang/actions/runs/29801015521)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->