### PR TITLE
Fix stale L3 storage hit length in decode HiCache prefetch

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1041,15 +1041,24 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                     break
 
+            decode_req.prefix_match = prefix_match
+            if self.scheduler.enable_decode_hicache:
+                self._start_hicache_prefetch(decode_req.req, prefix_match)
+                # _start_hicache_prefetch may clear l3_storage_hit_length when the prefetch could not be registered (e.g., below threshold, rate limited, or insufficient host memory). 
+                # Recompute total_prefix_len so _pre_alloc and the PD protocol use the actual prefix length, not the stale L3-inflated value.
+                if (
+                    prefix_match is not None
+                    and prefix_match.l3_storage_hit_length == 0
+                    and total_prefix_len > prefix_len
+                ):
+                    total_prefix_len = prefix_match.decode_prefix_len
+
             dst_kv_indices = self._pre_alloc(
                 decode_req.req,
                 prefix_indices,
                 prefix_len,
                 total_prefix_len,
             )
-            decode_req.prefix_match = prefix_match
-            if self.scheduler.enable_decode_hicache:
-                self._start_hicache_prefetch(decode_req.req, prefix_match)
             hisparse_req_budget -= 1
             # Recompute from actual pool state for the next queue entry.
             # This accounts for page rounding and newly locked evictable cache.

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1044,7 +1044,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             decode_req.prefix_match = prefix_match
             if self.scheduler.enable_decode_hicache:
                 self._start_hicache_prefetch(decode_req.req, prefix_match)
-                # _start_hicache_prefetch may clear l3_storage_hit_length when the prefetch could not be registered (e.g., below threshold, rate limited, or insufficient host memory). 
+                # _start_hicache_prefetch may clear l3_storage_hit_length when the prefetch could not be registered (e.g., below threshold, rate limited, or insufficient host memory).
                 # Recompute total_prefix_len so _pre_alloc and the PD protocol use the actual prefix length, not the stale L3-inflated value.
                 if (
                     prefix_match is not None

--- a/python/sglang/srt/disaggregation/decode_hicache_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_hicache_mixin.py
@@ -128,7 +128,7 @@ class DecodeHiCachePreallocMixin:
                 req.rid in self.tree_cache.ongoing_prefetch
             )
             if not prefix_match.prefetch_registered:
-                # prefetch_from_storage returned without registering (e.g.below prefetch_threshold, rate limited, or insufficient host memory). 
+                # prefetch_from_storage returned without registering (e.g.below prefetch_threshold, rate limited, or insufficient host memory).
                 # Clear l3 so _try_hicache_queue_load_back does not attempt load_back from non-existent host data.
                 prefix_match.l3_storage_hit_length = 0
         except Exception as e:
@@ -196,9 +196,7 @@ class DecodeHiCacheTransferMixin:
         if pm.l3_storage_hit_length > 0:
             if not self.tree_cache.check_prefetch_progress(dr.req.rid):
                 return False
-            loaded_from_storage = self.tree_cache.pop_prefetch_loaded_tokens(
-                dr.req.rid
-            )
+            loaded_from_storage = self.tree_cache.pop_prefetch_loaded_tokens(dr.req.rid)
             if loaded_from_storage == 0:
                 # Prefetch completed but loaded 0 tokens (e.g., hash mismatch or data evicted from storage between query and prefetch).
                 # Clear l3 so the coverage check uses the actual prefix length.

--- a/python/sglang/srt/disaggregation/decode_hicache_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_hicache_mixin.py
@@ -127,6 +127,10 @@ class DecodeHiCachePreallocMixin:
             prefix_match.prefetch_registered = (
                 req.rid in self.tree_cache.ongoing_prefetch
             )
+            if not prefix_match.prefetch_registered:
+                # prefetch_from_storage returned without registering (e.g.below prefetch_threshold, rate limited, or insufficient host memory). 
+                # Clear l3 so _try_hicache_queue_load_back does not attempt load_back from non-existent host data.
+                prefix_match.l3_storage_hit_length = 0
         except Exception as e:
             logger.warning(
                 "HiCache L3 prefetch failed for rid=%s: %s; falling back to L2-only LoadingBack",
@@ -192,7 +196,13 @@ class DecodeHiCacheTransferMixin:
         if pm.l3_storage_hit_length > 0:
             if not self.tree_cache.check_prefetch_progress(dr.req.rid):
                 return False
-            self.tree_cache.pop_prefetch_loaded_tokens(dr.req.rid)
+            loaded_from_storage = self.tree_cache.pop_prefetch_loaded_tokens(
+                dr.req.rid
+            )
+            if loaded_from_storage == 0:
+                # Prefetch completed but loaded 0 tokens (e.g., hash mismatch or data evicted from storage between query and prefetch).
+                # Clear l3 so the coverage check uses the actual prefix length.
+                pm.l3_storage_hit_length = 0
 
         # Re-match: req.last_node / prefix_indices updated to current device state.
         rematch = match_prefix_for_req(


### PR DESCRIPTION
Fixes #30322

## Motivation

### Problem
When PD disaggregation is used with --disaggregation-decode-enable-radix-cache and HiCache, the decode side may report a stale L3 storage hit length that was never actually fetched. 

This causes:
- HiCache load_back failed for rid=...: device_indices=0, new_indices=0, expected decode_prefix_len=64 (l1=0, l2=0, l3=64)
- The request fails and the KV cache is left incomplete.

### Root cause
prefetch_from_storage can return without registering (below prefetch_threshold, rate limited, or insufficient host memory), but l3_storage_hit_length is not cleared. The stale value propagates to two places:
  1. _pre_alloc receives an inflated total_prefix_len, telling prefill "I have 64 tokens" when the decode side has 0.
  2. _try_hicache_queue_load_back expects 64 tokens of coverage but finds 0, failing the coverage check.

## Modifications

1. decode_hicache_mixin.py — Clear l3_storage_hit_length in _start_hicache_prefetch when prefetch_registered is False.
2. decode.py — Move _start_hicache_prefetch before _pre_alloc so the cleared l3 is reflected in total_prefix_len before it's sent to prefill.
3. decode_hicache_mixin.py — Clear l3_storage_hit_length in _try_hicache_queue_load_back when pop_prefetch_loaded_tokens returns 0 (prefetch was registered but yielded no data).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29805108462](https://github.com/sgl-project/sglang/actions/runs/29805108462)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29805108282](https://github.com/sgl-project/sglang/actions/runs/29805108282)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->