### PR TITLE
fix: replace bare except with specific exception types in llama32_detector

### DIFF
--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -40,7 +40,7 @@ class Llama32Detector(BaseFormatDetector):
             parsed = ast.literal_eval(text.strip())
             if isinstance(parsed, dict):
                 return json.dumps(parsed, ensure_ascii=False)
-        except:
+        except (ValueError, SyntaxError, json.JSONDecodeError):
             pass
         return text
 
@@ -94,7 +94,7 @@ class Llama32Detector(BaseFormatDetector):
                             idx = dict_end + len(self.tool_call_separator)
                             safe_idx = idx
                             continue
-                except:
+                except (json.JSONDecodeError, ValueError, KeyError):
                     pass
 
                 next_obj_start = action_text.find('{"name":', idx + 1)
@@ -131,7 +131,7 @@ class Llama32Detector(BaseFormatDetector):
         try:
             result = super().parse_streaming_increment("", tools)
             return result
-        except:
+        except (json.JSONDecodeError, ValueError, KeyError):
             # Fall back to original buffer
             self._buffer = original_buffer
             return super().parse_streaming_increment(new_text, tools)


### PR DESCRIPTION
## Summary
This PR fixes bare except clauses in llama32_detector.py to improve error handling precision.

## Changes
- `python/sglang/srt/function_call/llama32_detector.py:43`: Replace bare except with specific exception types
- `python/sglang/srt/function_call/llama32_detector.py:97`: Replace bare except with specific exception types
- `python/sglang/srt/function_call/llama32_detector.py:134`: Replace bare except with specific exception types

## Rationale
Bare except clauses catch all exceptions including SystemExit and KeyboardInterrupt. Using specific exception types improves code quality and makes debugging easier.

## Testing
- Changes maintain the same error handling behavior for expected exceptions
- System-level exceptions are no longer caught

Note: Local environment limitations, relying on CI/CD automated testing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29801307353](https://github.com/sgl-project/sglang/actions/runs/29801307353)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29801307221](https://github.com/sgl-project/sglang/actions/runs/29801307221)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->