### PR TITLE
[AMD] Cache AITER expert mask across decode

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -200,7 +200,7 @@ class StandardDispatcher(BaseDispatcher):
                     )
 
         if self.local_expert_mapping is not None and not self.skip_local_expert_mapping:
-            if self.use_aiter_moe_runner:
+            if self.use_aiter_moe_runner and self.expert_mask_gpu is None:
                 self.expert_mask_gpu = (
                     (
                         (self.local_expert_mapping >= 0)
@@ -209,7 +209,7 @@ class StandardDispatcher(BaseDispatcher):
                     .to(torch.int32)
                     .to(device="cuda")
                 )
-            else:
+            elif not self.use_aiter_moe_runner:
                 if TopKOutputChecker.format_is_standard(topk_output):
                     topk_output = topk_output._replace(
                         topk_ids=self.local_expert_mapping[topk_output.topk_ids]


### PR DESCRIPTION
## Motivation

The AITER MoE runner rebuilds `expert_mask_gpu` from the local expert mapping on every dispatch. The local expert mapping is fixed for the lifetime of the dispatcher, so recomputing the mask (which includes a host→device copy) on every decode step is wasteful.

## Modifications

- Guard the AITER mask build with `expert_mask_gpu is None` so it is materialized lazily on first use and cached for subsequent steps.
- Keep the non-AITER path unchanged by switching the fallback branch to `elif not self.use_aiter_moe_runner`.

## Original commits

- `f93d6634e`

## Checklist

- [x] Verified on an internal AMD setup with the AITER MoE runner.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29803574512](https://github.com/sgl-project/sglang/actions/runs/29803574512)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29803574436](https://github.com/sgl-project/sglang/actions/runs/29803574436)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->