### PR TITLE
[Bug] Fix multi-tokenizer BatchEmbeddingOutput repack dropping fields

### DIFF
--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -252,6 +252,14 @@ def _handle_output_by_index(output, i):
             cached_tokens=_extract_field_by_index(output, "cached_tokens", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
+            retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
+            cached_tokens_details=_extract_field_by_index(
+                output, "cached_tokens_details", i
+            ),
+            time_stats=_extract_field_by_index(output, "time_stats", i),
+            pooled_hidden_states=_extract_field_by_index(
+                output, "pooled_hidden_states", i, check_length=False
+            ),
         )
     elif isinstance(output, BatchStrOutput):
         new_output = BatchStrOutput(

--- a/test/registered/unit/managers/test_multi_tokenizer_embedding_repack.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_embedding_repack.py
@@ -1,0 +1,60 @@
+"""Unit tests for the multi-tokenizer BatchEmbeddingOutput repack."""
+
+import unittest
+
+from sglang.srt.managers.io_struct import (
+    BatchEmbeddingOutput,
+    unwrap_from_pickle,
+    wrap_as_pickle,
+)
+from sglang.srt.managers.multi_tokenizer_mixin import _handle_output_by_index
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _batch_output():
+    return BatchEmbeddingOutput(
+        rids=["req-0", "req-1"],
+        finished_reasons=[{"type": "length"}, {"type": "length"}],
+        embeddings=[[0.1, 0.2], [0.3, 0.4]],
+        prompt_tokens=[3, 5],
+        cached_tokens=[0, 2],
+        placeholder_tokens_idx=None,
+        placeholder_tokens_val=None,
+        retraction_counts=[0, 7],
+        cached_tokens_details=[{"radix": 0}, {"radix": 2}],
+        time_stats=wrap_as_pickle(["stats-0", "stats-1"]),
+        pooled_hidden_states=[[1.0], [2.0]],
+    )
+
+
+class TestMultiTokenizerEmbeddingRepack(CustomTestCase):
+    def test_repack_preserves_per_request_fields(self):
+        out = _handle_output_by_index(_batch_output(), 1)
+        self.assertEqual(out.rids, ["req-1"])
+        self.assertEqual(out.embeddings, [[0.3, 0.4]])
+        self.assertEqual(out.prompt_tokens, [5])
+        self.assertEqual(out.cached_tokens, [2])
+        # The regression: these were dropped, and the tokenizer manager
+        # indexes retraction_counts unconditionally on every response.
+        self.assertEqual(out.retraction_counts, [7])
+        self.assertEqual(out.cached_tokens_details, [{"radix": 2}])
+        self.assertEqual(unwrap_from_pickle(out.time_stats), ["stats-1"])
+        self.assertEqual(out.pooled_hidden_states, [[2.0]])
+
+    def test_repack_handles_absent_optional_fields(self):
+        output = _batch_output()
+        output.retraction_counts = None
+        output.time_stats = None
+        output.pooled_hidden_states = None
+        out = _handle_output_by_index(output, 0)
+        self.assertEqual(out.rids, ["req-0"])
+        self.assertIsNone(out.retraction_counts)
+        self.assertIsNone(out.time_stats)
+        self.assertIsNone(out.pooled_hidden_states)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Embedding serving with `--tokenizer-worker-num > 1` is broken: every response — including the server's own warmup request — crashes the tokenizer workers with

```text
  File ".../tokenizer_manager.py", line 1894, in _handle_batch_output
    "num_retractions": recv_obj.retraction_counts[i],
TypeError: 'NoneType' object is not subscriptable
```

Root cause: the per-worker output repack (`_handle_output_by_index` in `multi_tokenizer_mixin.py`) rebuilds `BatchEmbeddingOutput` with only 5 of its fields. The scheduler's output streamer always populates `retraction_counts`, but the repack drops it, so the per-worker copy arrives at its `None` default and the unconditional index crashes. The same repack also silently drops `time_stats` (per-request time stats / metrics), `cached_tokens_details`, and `pooled_hidden_states` (breaking `return_pooled_hidden_states` through multi-tokenizer mode). The neighboring `BatchTokenIDOutput` / `BatchStrOutput` branches extract these fields; the embedding branch was never completed.

Single-tokenizer mode (the default) is unaffected, which is presumably why this went unnoticed. Fixes #31890.

## Modifications

Complete the `BatchEmbeddingOutput` repack with the four missing fields, using the same `_extract_field_by_index` form as the adjacent branches (8 lines in `multi_tokenizer_mixin.py`).

## Accuracy Tests

- Unit (CPU, `test/registered/unit/managers/test_multi_tokenizer_embedding_repack.py`, `base-a-test-cpu`) — **2 passed**: the repack preserves every per-request field (including the four previously dropped), and still passes `None` through for absent optional fields.
- End-to-end on an A6000: `--is-embedding --tokenizer-worker-num 2` previously died on the warmup request; with this fix the server serves a full saturation benchmark (2048 requests, c=128) with zero failures. Also validated as part of a same-GPU DP study where extra tokenizer workers are what make colocated data parallelism pay off (805.8 -> 1367.8 req/s at dp2; details in the companion PR).

## Speed Tests and Profiling

Not applicable — the change only carries fields that were already produced by the scheduler; no additional work per response.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29805144802](https://github.com/sgl-project/sglang/actions/runs/29805144802)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29805144632](https://github.com/sgl-project/sglang/actions/runs/29805144632)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->