### PR TITLE
[Feature] Support same-GPU data parallelism via --gpu-id-step 0

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -318,10 +318,17 @@ class DataParallelController:
             sock.close()
 
         # Start all threads
-        for thread in threads:
-            thread.start()
-        for event in ready_events:
-            event.wait()
+        if server_args.gpu_id_step == 0:
+            # Same-GPU DP: colocated workers race each other's startup memory
+            # profiling and CUDA graph capture, so start them one at a time.
+            for thread, event in zip(threads, ready_events):
+                thread.start()
+                event.wait()
+        else:
+            for thread in threads:
+                thread.start()
+            for event in ready_events:
+                event.wait()
 
     def launch_tensor_parallel_group_thread(
         self,

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -252,6 +252,14 @@ def _handle_output_by_index(output, i):
             cached_tokens=_extract_field_by_index(output, "cached_tokens", i),
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
+            retraction_counts=_extract_field_by_index(output, "retraction_counts", i),
+            cached_tokens_details=_extract_field_by_index(
+                output, "cached_tokens_details", i
+            ),
+            time_stats=_extract_field_by_index(output, "time_stats", i),
+            pooled_hidden_states=_extract_field_by_index(
+                output, "pooled_hidden_states", i, check_length=False
+            ),
         )
     elif isinstance(output, BatchStrOutput):
         new_output = BatchStrOutput(

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -244,6 +244,14 @@ def _handle_output_by_index(output, i):
             dp_ranks=_extract_field_by_index(output, "dp_ranks", i, check_length=False),
         )
     elif isinstance(output, BatchEmbeddingOutput):
+        # pooled_hidden_states uses two IPC formats (see output_streamer.py):
+        # stacked ([one tensor holding all N requests], len 1) or per-request
+        # (len == N). For the stacked format, index into the tensor's dim 0.
+        phs = output.pooled_hidden_states
+        if phs is not None and len(phs) == 1 and len(output.rids) > 1:
+            new_phs = [phs[0][i]]
+        else:
+            new_phs = _extract_field_by_index(output, "pooled_hidden_states", i)
         new_output = BatchEmbeddingOutput(
             rids=[output.rids[i]],
             finished_reasons=_extract_field_by_index(output, "finished_reasons", i),
@@ -257,9 +265,7 @@ def _handle_output_by_index(output, i):
                 output, "cached_tokens_details", i
             ),
             time_stats=_extract_field_by_index(output, "time_stats", i),
-            pooled_hidden_states=_extract_field_by_index(
-                output, "pooled_hidden_states", i, check_length=False
-            ),
+            pooled_hidden_states=new_phs,
         )
     elif isinstance(output, BatchStrOutput):
         new_output = BatchStrOutput(

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -1301,6 +1301,18 @@ class ModelRunnerKVCacheMixin:
         # Apply user-specified upper bound
         if user_limit is not None:
             if user_limit > token_capacity:
+                if self.server_args.gpu_id_step == 0:
+                    # Same-GPU DP relies on --max-total-tokens to give every
+                    # colocated worker an identical KV pool; falling back to
+                    # the profiled value would silently produce asymmetric
+                    # pools across DP workers.
+                    raise RuntimeError(
+                        f"gpu_id_step=0 (same-GPU DP) requires max_total_tokens="
+                        f"{user_limit} to fit on every colocated worker, but this "
+                        f"worker only profiled capacity for {token_capacity} tokens. "
+                        f"Reduce --max-total-tokens or --dp-size, or raise "
+                        f"--mem-fraction-static."
+                    )
                 logging.warning(
                     f"max_total_tokens={user_limit} is larger than the profiled value "
                     f"{token_capacity}. Use the profiled value instead."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -948,7 +948,7 @@ class ServerArgs:
     ] = 0
     gpu_id_step: A[
         int,
-        "The delta between consecutive GPU IDs that are used. For example, setting it to 2 will use GPU 0,2,4,...",
+        "The delta between consecutive GPU IDs that are used. For example, setting it to 2 will use GPU 0,2,4,... Setting it to 0 colocates all data-parallel workers on the base GPU (same-GPU data parallelism); this requires tp_size=1, pp_size=1, and --max-total-tokens, and works best with CUDA MPS.",
     ] = 1
     random_seed: A[Optional[int], "The random seed."] = None
     watchdog_timeout: A[
@@ -6707,6 +6707,19 @@ class ServerArgs:
                 "(DeepSeek-V4 non-EP DP TBO path)."
             )
 
+    def _check_same_gpu_dp(self):
+        assert self.gpu_id_step >= 0, "gpu_id_step must be non-negative"
+        if self.gpu_id_step == 0:
+            assert self.dp_size > 1, "gpu_id_step=0 (same-GPU DP) requires dp_size > 1"
+            assert (
+                self.tp_size == 1 and self.pp_size == 1
+            ), "gpu_id_step=0 (same-GPU DP) colocates whole replicas, so tp_size and pp_size must be 1"
+            # Colocated workers each profile the remaining free memory at
+            # startup, so pool sizes must be declared, not profiled.
+            assert (
+                self.max_total_tokens is not None
+            ), "gpu_id_step=0 (same-GPU DP) requires --max-total-tokens to bound each worker's KV pool"
+
     def check_server_args(self):
         # Check parallel size constraints
         assert (
@@ -6738,7 +6751,7 @@ class ServerArgs:
         ), "multi-node data parallel is not supported unless dp attention!"
 
         assert self.base_gpu_id >= 0, "base_gpu_id must be non-negative"
-        assert self.gpu_id_step >= 1, "gpu_id_step must be positive"
+        self._check_same_gpu_dp()
 
         assert self.moe_dense_tp_size in (
             None,

--- a/test/registered/prefill_only/test_same_gpu_dp_embedding.py
+++ b/test/registered/prefill_only/test_same_gpu_dp_embedding.py
@@ -1,0 +1,88 @@
+"""E2E test for same-GPU data parallelism on the embedding path.
+
+Launches one server with two colocated DP workers (--dp-size 2
+--gpu-id-step 0) and checks the built-in load balancer serves embedding
+requests correctly. Functional only: CI runners have no CUDA MPS daemon, so
+workers share the GPU by time-slicing here; the throughput benefits of MPS
+are documented in the PR, not asserted in CI.
+"""
+
+import unittest
+
+import openai
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_EMBEDDING_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=180, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestSameGpuDpEmbedding(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_EMBEDDING_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # No api_key: multi-tokenizer mode (--tokenizer-worker-num > 1)
+        # asserts that API keys are unsupported.
+        cls.api_key = "unused"
+        other_args = [
+            "--is-embedding",
+            "--dp-size",
+            "2",
+            "--gpu-id-step",
+            "0",
+            "--max-total-tokens",
+            "32768",
+            "--mem-fraction-static",
+            "0.35",
+            # The recommended combination: without extra tokenizer workers the
+            # shared frontend caps colocated-DP throughput. Also exercises the
+            # multi-tokenizer BatchEmbeddingOutput repack fixed in this change.
+            "--tokenizer-worker-num",
+            "2",
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_server_reports_dp_size(self):
+        info = requests.get(f"{self.base_url}/server_info").json()
+        self.assertEqual(info["dp_size"], 2)
+        self.assertEqual(info["gpu_id_step"], 0)
+
+    def test_embeddings_across_workers(self):
+        client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")
+        # More requests than workers so round-robin exercises both.
+        texts = [f"same-gpu dp request {i}" for i in range(8)]
+        dims = set()
+        for text in texts:
+            resp = client.embeddings.create(model=self.model, input=text)
+            self.assertEqual(len(resp.data), 1)
+            dims.add(len(resp.data[0].embedding))
+        self.assertEqual(len(dims), 1, "all workers must produce same-dim embeddings")
+
+    def test_batch_embedding(self):
+        client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")
+        resp = client.embeddings.create(
+            model=self.model, input=["batched one", "batched two", "batched three"]
+        )
+        self.assertEqual(len(resp.data), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_multi_tokenizer_embedding_repack.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_embedding_repack.py
@@ -1,0 +1,60 @@
+"""Unit tests for the multi-tokenizer BatchEmbeddingOutput repack."""
+
+import unittest
+
+from sglang.srt.managers.io_struct import (
+    BatchEmbeddingOutput,
+    unwrap_from_pickle,
+    wrap_as_pickle,
+)
+from sglang.srt.managers.multi_tokenizer_mixin import _handle_output_by_index
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _batch_output():
+    return BatchEmbeddingOutput(
+        rids=["req-0", "req-1"],
+        finished_reasons=[{"type": "length"}, {"type": "length"}],
+        embeddings=[[0.1, 0.2], [0.3, 0.4]],
+        prompt_tokens=[3, 5],
+        cached_tokens=[0, 2],
+        placeholder_tokens_idx=None,
+        placeholder_tokens_val=None,
+        retraction_counts=[0, 7],
+        cached_tokens_details=[{"radix": 0}, {"radix": 2}],
+        time_stats=wrap_as_pickle(["stats-0", "stats-1"]),
+        pooled_hidden_states=[[1.0], [2.0]],
+    )
+
+
+class TestMultiTokenizerEmbeddingRepack(CustomTestCase):
+    def test_repack_preserves_per_request_fields(self):
+        out = _handle_output_by_index(_batch_output(), 1)
+        self.assertEqual(out.rids, ["req-1"])
+        self.assertEqual(out.embeddings, [[0.3, 0.4]])
+        self.assertEqual(out.prompt_tokens, [5])
+        self.assertEqual(out.cached_tokens, [2])
+        # The regression: these were dropped, and the tokenizer manager
+        # indexes retraction_counts unconditionally on every response.
+        self.assertEqual(out.retraction_counts, [7])
+        self.assertEqual(out.cached_tokens_details, [{"radix": 2}])
+        self.assertEqual(unwrap_from_pickle(out.time_stats), ["stats-1"])
+        self.assertEqual(out.pooled_hidden_states, [[2.0]])
+
+    def test_repack_handles_absent_optional_fields(self):
+        output = _batch_output()
+        output.retraction_counts = None
+        output.time_stats = None
+        output.pooled_hidden_states = None
+        out = _handle_output_by_index(output, 0)
+        self.assertEqual(out.rids, ["req-0"])
+        self.assertIsNone(out.retraction_counts)
+        self.assertIsNone(out.time_stats)
+        self.assertIsNone(out.pooled_hidden_states)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_multi_tokenizer_embedding_repack.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_embedding_repack.py
@@ -2,6 +2,8 @@
 
 import unittest
 
+import torch
+
 from sglang.srt.managers.io_struct import (
     BatchEmbeddingOutput,
     unwrap_from_pickle,
@@ -43,6 +45,19 @@ class TestMultiTokenizerEmbeddingRepack(CustomTestCase):
         self.assertEqual(out.cached_tokens_details, [{"radix": 2}])
         self.assertEqual(unwrap_from_pickle(out.time_stats), ["stats-1"])
         self.assertEqual(out.pooled_hidden_states, [[2.0]])
+
+    def test_repack_unstacks_pooled_hidden_states(self):
+        # The scheduler's output streamer may pack pooled_hidden_states as a
+        # single stacked tensor ([tensor(N, ...)], len 1) when all requests
+        # share a shape; the repack must index into the tensor, not the list.
+        output = _batch_output()
+        stacked = torch.tensor([[1.0, 10.0], [2.0, 20.0]])
+        output.pooled_hidden_states = [stacked]
+        out = _handle_output_by_index(output, 1)
+        self.assertEqual(len(out.pooled_hidden_states), 1)
+        self.assertTrue(
+            torch.equal(out.pooled_hidden_states[0], torch.tensor([2.0, 20.0]))
+        )
 
     def test_repack_handles_absent_optional_fields(self):
         output = _batch_output()

--- a/test/registered/unit/test_same_gpu_dp_args.py
+++ b/test/registered/unit/test_same_gpu_dp_args.py
@@ -1,0 +1,47 @@
+"""Unit tests for same-GPU data parallelism argument validation (gpu_id_step=0)."""
+
+import unittest
+
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _args(**kwargs):
+    return ServerArgs(model_path="dummy", **kwargs)
+
+
+class TestSameGpuDpArgs(CustomTestCase):
+    def test_same_gpu_dp_accepted(self):
+        args = _args(dp_size=2, gpu_id_step=0, max_total_tokens=65536)
+        args._check_same_gpu_dp()
+        self.assertEqual(args.gpu_id_step, 0)
+
+    def test_default_step_unchanged(self):
+        args = _args()
+        args._check_same_gpu_dp()
+        self.assertEqual(args.gpu_id_step, 1)
+
+    def test_negative_step_rejected(self):
+        with self.assertRaisesRegex(AssertionError, "non-negative"):
+            _args(gpu_id_step=-1)._check_same_gpu_dp()
+
+    def test_same_gpu_dp_requires_dp_size(self):
+        with self.assertRaisesRegex(AssertionError, "dp_size > 1"):
+            _args(gpu_id_step=0, max_total_tokens=65536)._check_same_gpu_dp()
+
+    def test_same_gpu_dp_requires_tp1(self):
+        with self.assertRaisesRegex(AssertionError, "tp_size and pp_size"):
+            _args(
+                dp_size=2, tp_size=2, gpu_id_step=0, max_total_tokens=65536
+            )._check_same_gpu_dp()
+
+    def test_same_gpu_dp_requires_token_cap(self):
+        with self.assertRaisesRegex(AssertionError, "max-total-tokens"):
+            _args(dp_size=2, gpu_id_step=0)._check_same_gpu_dp()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Implements the proposal in #31891.

Short-input prefill-only serving (embeddings, scoring) is CPU-bound at saturation: on an RTX A6000 a tuned single Qwen3-Embedding-0.6B replica tops out around 800 req/s with GPU SM-active at only ~33%. Colocating multiple replicas on one GPU reclaims that idle capacity — the pattern the SGLang-Omni team documented for TTS ([same-GPU DP with CUDA MPS](https://sgl-project.github.io/sglang-omni/basic_usage/same_gpu_dp.html)), Snowflake ships for embedding inference, and roadmap #15344 tracks as *"Multi-replica execution per single GPU (DP-style)"* (citing arXiv 2512.07846: multiple worker processes parallelize CPU-side overhead).

sglang is nearly there natively: `--dp-size N` already launches N schedulers behind the built-in DP load balancer, and the GPU assignment arithmetic (`base_gpu_id += tp_size * pp_size * gpu_id_step`) already colocates all workers on the base GPU at `gpu_id_step=0` — but validation rejects step 0, and two more things stand between "starts" and "is actually faster" (measured below): colocated startup races, and the shared tokenizer frontend.

## Modifications

- `server_args.py`: allow `--gpu-id-step 0` as the explicit same-GPU DP opt-in. Validation lives in a `_check_same_gpu_dp()` helper (same shape as the neighboring `_check_two_batch_overlap`): step 0 requires `dp_size > 1`, `tp_size == pp_size == 1` (whole-replica colocation only), and `--max-total-tokens` — colocated workers each profile the *remaining free* memory at startup, so pools must be declared, not profiled (the same mitigation the Omni guide arrived at; with the cap, both workers get identical pools instead of 161k/85k-style asymmetry).
- `data_parallel_controller.py`: start colocated workers sequentially (per-worker ready-event gate). Concurrent colocated startups race each other's memory profiling and CUDA graph capture; the multi-GPU path keeps the concurrent launch.
- Depends on the multi-tokenizer `BatchEmbeddingOutput` repack fix (split into its own PR: #31892): the recommended `--tokenizer-worker-num` pairing crashes without it.
- `--gpu-id-step` help text documents the new value.

CUDA MPS stays external (daemon lifecycle is deployment, not server code); without MPS colocated workers share the GPU by ordinary time-slicing, which works but leaves throughput on the table.

## Accuracy Tests

- Unit (CPU, `test/registered/unit/test_same_gpu_dp_args.py`, `base-a-test-cpu`) — **6 passed**: accepts the valid combination, keeps the default unchanged, rejects negative step, and rejects step 0 without `dp_size>1` / with TP or PP / without a token cap.
- E2E (GPU, `test/registered/prefill_only/test_same_gpu_dp_embedding.py`, `1-gpu-small`): launches the recommended combination (`--dp-size 2 --gpu-id-step 0 --max-total-tokens 32768 --tokenizer-worker-num 2`), checks `/server_info` reports the colocated topology, and runs single and batch embeddings through the built-in round-robin balancer — this also exercises the repack fix on every response. Functional only; CI runners have no MPS daemon.
- Guard tests pass (`test_server_args_cli_metadata`, `test_legacy_global_ratchet`).

## Speed Tests and Profiling

A6000, Qwen3-Embedding-0.6B, 50-token token-exact inputs, saturation (`--request-rate inf`), seeded, radix cache flushed per run, equal total server cores across arms; MPS unless noted.

External orchestration study (per-replica clients, own port each; mean of 3 fresh-server repetitions at 2048 prompts per replica, range in parentheses):

```text
single           1x mf=0.80        816.2 req/s (84.9)   1.00x
2 full servers   2x mf=0.40       1283.9 req/s (27.1)   1.57x
3 full servers   3x mf=0.26       1490.4 req/s (166.5)  1.83x
2 full servers, no MPS            1135.6 req/s (30.2)   1.39x  (time-slicing)
```

(A short scout pass had shown DP2 at 1.92x; sustained windows flatten it to 1.57x — short-window numbers are upper bounds.)

Native path enabled by this PR (one endpoint, built-in round-robin, c=128; same-session paired runs):

```text
--dp-size 2 --gpu-id-step 0                              749.0 req/s   0.93x
  (shared single tokenizer frontend caps throughput)
--dp-size 2 --gpu-id-step 0 --tokenizer-worker-num 2   1367.8 req/s   1.70x
```

Per-process CPU sampling attributes the remaining sub-linear behavior to per-worker CPU isolation, not IPC: at saturation one scheduler pegs at ~97% while the other is held at ~73% by core contention with the tokenizer workers on the shared cpuset — the split is stable across `--load-balance-method` choices and snapshots, the router/main process sits at 17%, and a detokenizer-bypass stack recovered only +1.9%, ruling out dispatch imbalance, router funnel, and detokenizer relay respectively. External orchestration sidesteps this by pinning each full server to its own core block. A deployment note applies (give colocated DP a generous cpuset); per-DP-worker CPU affinity closes it natively and is submitted as a stacked follow-up (`--dp-cpu-affinity`, +3.1% mean and ~3x variance reduction in paired A/B; branch ready, will be submitted once this PR settles). The dp2-without-extra-tokenizers number is kept deliberately: it shows the colocation mechanism alone is not enough for CPU-bound workloads, which is why the recommended `--tokenizer-worker-num` pairing (and its prerequisite repack fix) matter.

## H200 Reproduction (2026-07-12)

Repeated on 2x NVIDIA H200 NVL (driver 580.159.03), same model/scenario/protocol, three repetitions:

- **External arms**: single 573.0 -> DP2+MPS 908.3 (1.59x) -> DP3+MPS 1507.1 (2.63x, best; conservative min/max ratio 2.33x) -> DP2 time-slicing 1038.6 (1.81x). The colocation gain and the equal-mem-fraction KV asymmetry both reproduce. One honest divergence: at DP2 the MPS-over-time-slicing margin did **not** reproduce on this shared-tenant host (overlapping/inverted distributions) — that margin is host-dependent; the A6000 figure stays A6000-scoped.
- **Native path (this PR), 3x3 Latin square, fixed `--max-total-tokens 262144`, 4096 prompts, c=128**: shared frontend 489.2 -> `--tokenizer-worker-num 2` 911.4 req/s, paired ratios **1.583x / 2.134x / 1.899x (3/3 positive)** — the recommended pairing's contribution reproduces strongly on datacenter hardware. Native tw2 throughput matched the external two-server arm's scale on this host (different client protocol, so stated as scale-match, not a ratio).

Full protocol, integrity gates, and raw artifacts: `bench_v2/results/h200/` (native/report.md).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->