### PR TITLE
Optimize MXFP4 Marlin repack memory usage

### DIFF
--- a/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
@@ -336,7 +336,7 @@ def prepare_moe_mxfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
             size_n, size_k = hidden_size, padded_intermediate_size
         assert weight.shape == (num_experts, size_n, size_k // 2)
 
-        tensor_list = []
+        output: torch.Tensor | None = None
         for i in range(num_experts):
             qweight = weight[i].view(torch.int32).T.contiguous()
             marlin_qweight = gptq_marlin_repack(
@@ -346,8 +346,15 @@ def prepare_moe_mxfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
                 size_n=size_n,
                 num_bits=4,
             )
-            tensor_list.append(marlin_qweight)
-        return torch.stack(tensor_list)
+            if output is None:
+                output = torch.empty(
+                    (num_experts, *marlin_qweight.shape),
+                    dtype=marlin_qweight.dtype,
+                    device=marlin_qweight.device,
+                )
+            output[i].copy_(marlin_qweight)
+        assert output is not None
+        return output
 
     def _permute_scales(scales: torch.Tensor, is_w13: bool) -> torch.Tensor:
         if is_w13:

--- a/test/registered/jit/test_moe_wna16_marlin.py
+++ b/test/registered/jit/test_moe_wna16_marlin.py
@@ -6,13 +6,19 @@ import pytest
 import torch
 from sgl_kernel.scalar_type import scalar_types
 
+from sglang.jit_kernel.gptq_marlin_repack import gptq_marlin_repack
 from sglang.jit_kernel.moe_wna16_marlin import moe_wna16_marlin_gemm
 from sglang.srt.layers.moe.fused_moe_triton import moe_align_block_size
 from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import fused_marlin_moe
 from sglang.srt.layers.quantization.marlin_utils_fp4 import (
+    prepare_moe_mxfp4_layer_for_marlin,
     prepare_moe_nvfp4_layer_for_marlin,
 )
-from sglang.srt.utils.common import is_sm80_supported, is_sm90_supported
+from sglang.srt.utils.common import (
+    is_sm80_supported,
+    is_sm90_supported,
+    is_sm120_supported,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_marlin_utils import (
     awq_marlin_quantize,
@@ -30,6 +36,92 @@ def _has_aot_moe_wna16_marlin_gemm() -> bool:
 
 
 AOT_AVAILABLE = _has_aot_moe_wna16_marlin_gemm()
+
+
+@pytest.mark.skipif(
+    not (is_sm90_supported() or is_sm120_supported()),
+    reason="MXFP4 Marlin repack requires CUDA SM90 or SM120",
+)
+def test_prepare_moe_mxfp4_drops_source_scale_parameters():
+    num_experts = 2
+    hidden_size = 256
+    intermediate_size = 128
+    group_size = 32
+
+    layer = torch.nn.Module()
+    layer.orig_dtype = torch.bfloat16
+    layer.w13_weight = torch.nn.Parameter(
+        torch.randint(
+            -128,
+            128,
+            (num_experts, 2 * intermediate_size, hidden_size // 2),
+            device="cuda",
+            dtype=torch.int8,
+        ),
+        requires_grad=False,
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.randint(
+            -128,
+            128,
+            (num_experts, hidden_size, intermediate_size // 2),
+            device="cuda",
+            dtype=torch.int8,
+        ),
+        requires_grad=False,
+    )
+    layer.w13_weight_scale_inv = torch.nn.Parameter(
+        torch.ones(
+            (num_experts, 2 * intermediate_size, hidden_size // group_size),
+            device="cuda",
+            dtype=torch.float32,
+        ),
+        requires_grad=False,
+    )
+    layer.w2_weight_scale_inv = torch.nn.Parameter(
+        torch.ones(
+            (num_experts, hidden_size, intermediate_size // group_size),
+            device="cuda",
+            dtype=torch.float32,
+        ),
+        requires_grad=False,
+    )
+
+    perm = torch.empty(0, dtype=torch.int, device="cuda")
+    expected_w13 = torch.stack(
+        [
+            gptq_marlin_repack(
+                layer.w13_weight[i].view(torch.int32).T.contiguous(),
+                perm=perm,
+                size_k=hidden_size,
+                size_n=2 * intermediate_size,
+                num_bits=4,
+            )
+            for i in range(num_experts)
+        ]
+    )
+    expected_w2 = torch.stack(
+        [
+            gptq_marlin_repack(
+                layer.w2_weight[i].view(torch.int32).T.contiguous(),
+                perm=perm,
+                size_k=intermediate_size,
+                size_n=hidden_size,
+                num_bits=4,
+            )
+            for i in range(num_experts)
+        ]
+    )
+
+    prepare_moe_mxfp4_layer_for_marlin(layer)
+
+    parameter_names = dict(layer.named_parameters())
+    assert "w13_weight_scale_inv" not in parameter_names
+    assert "w2_weight_scale_inv" not in parameter_names
+    torch.testing.assert_close(layer.w13_weight, expected_w13, rtol=0, atol=0)
+    torch.testing.assert_close(layer.w2_weight, expected_w2, rtol=0, atol=0)
+    assert layer.w13_weight_scale.dtype == torch.float8_e8m0fnu
+    assert layer.w2_weight_scale.dtype == torch.float8_e8m0fnu
 
 
 def stack_and_dev(tensors: list[torch.Tensor]):


### PR DESCRIPTION
## Motivation

MXFP4 Marlin MoE weight repacking previously collected every repacked expert tensor in a Python list and then called `torch.stack` to construct the final tensor.

During repacking, this kept all per-expert outputs alive while allocating another full-size output tensor. For a DeepSeek V4 routed MoE `w13` layer with 256 experts, this resulted in approximately 2 GiB of temporary GPU allocation for a 1 GiB final repacked tensor.

This PR reduces peak GPU memory during model loading and improves repacking performance without changing the final Marlin weight layout, dtype, kernels, or model forward path.

## Modifications

- Preallocate the final Marlin weight tensor after repacking the first expert.
- Copy each repacked expert directly into its corresponding slice of the preallocated output.
- Remove the intermediate list of all repacked expert tensors and the final `torch.stack`.
- Preserve the existing lifecycle cleanup of loader-format MXFP4 scale parameters.
- Extend the MXFP4 Marlin test to verify that:
  - Preallocated `w13` and `w2` results are bitwise identical to the previous `torch.stack` implementation.
  - Loader-format scale parameters are removed after repacking.
  - Final Marlin scales use `torch.float8_e8m0fnu`.

An additional attempt to replace the original layer parameters immediately after each weight was repacked was evaluated and rejected because it reduced the available KV-cache capacity. That change is not included in this PR.

## Accuracy Tests

The final Marlin weights are compared against results produced by the previous `torch.stack` implementation:

```python
torch.testing.assert_close(
    layer.w13_weight, expected_w13, rtol=0, atol=0
)
torch.testing.assert_close(
    layer.w2_weight, expected_w2, rtol=0, atol=0
)
```

Test command:

```bash
python -m pytest -q \
  test/registered/jit/test_moe_wna16_marlin.py::test_prepare_moe_mxfp4_drops_source_scale_parameters
```

Result:

```text
1 passed, 20 warnings in 26.50s
```

The test was executed on an NVIDIA H20 GPU. Both repacked weight tensors were bitwise identical to the previous implementation.

A complete DeepSeek V4 Flash TP=2 model load also completed successfully through KV-cache memory-pool initialization.

## Speed Tests and Profiling

### Repacking microbenchmark

The microbenchmark used the DeepSeek V4 TP=2 `w13` dimensions:

- GPU: NVIDIA H20
- Experts: 256
- `size_k`: 4096
- `size_n`: 2048
- Final repacked tensor size: 1 GiB

| Implementation | Repacking time | Peak extra GPU memory |
|---|---:|---:|
| List + `torch.stack`, run 1 | 16.53 ms | 2.004 GiB |
| List + `torch.stack`, run 2 | 12.46 ms | 2.004 GiB |
| Preallocated output, run 1 | 11.03 ms | 1.012 GiB |
| Preallocated output, run 2 | 10.44 ms | 1.012 GiB |

Observed results:

- Peak temporary GPU allocation decreased by approximately **0.992 GiB**, or **49.5%**.
- Average isolated repacking time decreased by approximately **26%**.

### Full model loading

Configuration:

- Model: DeepSeek V4 Flash
- GPUs: 2 × NVIDIA H20
- Tensor parallel size: 2
- MoE backend: Marlin
- Context length: 16,384
- GPU memory fraction: 0.90

| Version | Weight loading time |
|---|---:|
| Baseline scale-cleanup image | 844.97 s |
| Preallocated repack image | 760.92 s |
| Difference | -84.05 s (-9.9%) |

The FP8 conversion/repacking portion decreased from approximately 750 seconds to 681 seconds.

Full model loading is sensitive to filesystem page cache, JIT cache, and driver cache state. Hot-cache runs varied significantly, so the end-to-end 9.9% result should be treated as an observed cold-loading result rather than a stable performance guarantee. The isolated repacking benchmark and peak-memory reduction are deterministic.

### Persistent memory and KV-cache capacity

The final implementation does not change persistent model memory or KV-cache capacity:

| Metric | Baseline | This PR |
|---|---:|---:|
| Model weight memory per GPU | 75.04 GB | 75.04 GB |
| Available memory after weight loading | 18.81 GB | 18.81 GB |
| Memory available for DSV4 cache | 9.42 GB | 9.42 GB |
| Full-token capacity | 635,904 | 635,904 |
| Available memory after pool initialization | 9.20 GB | 9.20 GB |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is required because this is an internal loading-memory optimization with no user-facing API changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29807774708](https://github.com/sgl-project/sglang/actions/runs/29807774708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29807774572](https://github.com/sgl-project/sglang/actions/runs/29807774572)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->