### PR TITLE
[AMD] Add msgpack to ROCm diffusion deps (fix multimodal-gen unit test ModuleNotFoundError)

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -76,6 +76,7 @@ diffusion_common = [
   "imageio==2.36.0",
   "imageio-ffmpeg==0.5.1",
   "moviepy>=2.0.0",
+  "msgpack",
   "opencv-python-headless==4.10.0.84",
   "PyYAML==6.0.1",
   "remote-pdb",


### PR DESCRIPTION
### Problem

The `multimodal-gen-unit-test-amd-rocm720` job fails **every night** (7/8 days in the CI window) with:
```
ModuleNotFoundError: No module named 'msgpack'
FAILED test/unit/test_pi05_action_api.py::test_msgpack_roundtrip_preserves_string_keys_and_numpy_payloads
```

`msgpack` is a **runtime** dependency of `multimodal_gen`: `runtime/entrypoints/vla/protocol.py` uses `pack_msgpack`/`unpack_msgpack` (`msgpack.packb` / `msgpack.unpackb`), and the unit test imports them.

### Root cause

The ROCm wheel/image installs deps from `python/pyproject_other.toml` (via `pip install python[srt_hip,diffusion_hip]` in `docker/rocm.Dockerfile`, which swaps `pyproject_other.toml` in as the active manifest). Its `diffusion_common` group is **missing `msgpack`**, while the mainline `python/pyproject.toml` `diffusion` group already lists it.

The ROCm 7.0 lane (`multimodal-gen-unit-test-amd`) happens to pass because its base image ships `msgpack` transitively, but the ROCm 7.2 `rocm/pytorch` base does not — so the dependency must be declared explicitly.

### Fix

Add `msgpack` to the `diffusion_common` group in `python/pyproject_other.toml` (alphabetical position, matching the file's sorting convention). All AMD platforms (`diffusion_hip`/`diffusion_musa`/`diffusion_mps`) pull `diffusion_common`, so this covers them all.

### Scope

One line, dependency-only. No code change. Fixes the `msgpack` `ModuleNotFoundError` on the ROCm 7.2 multimodal-gen unit-test job.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29812298757](https://github.com/sgl-project/sglang/actions/runs/29812298757)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29812923290](https://github.com/sgl-project/sglang/actions/runs/29812923290)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->