### PR TITLE
[Docs] Fix Inkling GB200 (4x192GB) recipes: context cap for pool fit, MTP mem-fraction 0.85

### DIFF
--- a/docs_new/src/snippets/configs/thinkingmachines/inkling.jsx
+++ b/docs_new/src/snippets/configs/thinkingmachines/inkling.jsx
@@ -254,6 +254,10 @@ export const config = {
       ],
     },
     {
+      // GB200 4x192GB: the 1M-token SWA+sconv pools do not fit at TP=4 (weights are
+      // ~148 GB/GPU); without a context cap the pools starve and high-concurrency
+      // throughput plateaus from retraction (measured: interactivity flat cc64->cc128).
+      // Verified e2e on 4xGB200 (GSM8K 5-shot 0.925, 8k/1k sweep cc1-128).
       match: { hw: "gb200", variant: "default", quant: "nvfp4", strategy: "balanced", nodes: "single" },
       env: [
         "SGLANG_ENABLE_UNIFIED_RADIX_TREE=1",
@@ -272,6 +276,7 @@ export const config = {
         "--mem-fraction-static 0.85",
         "--swa-full-tokens-ratio 0.1",
         "--mamba-full-memory-ratio 0.1",
+        "--context-length 131072",
         "--enable-multimodal",
         "--reasoning-parser inkling",
         "--tool-call-parser inkling",
@@ -585,6 +590,12 @@ export const config = {
       ],
     },
     {
+      // GB200 4x192GB MTP: mem-fraction 0.75 cannot boot — the 592 GB checkpoint
+      // (~148 GB/GPU) must fit inside the static budget, and 0.75 x 184 GB leaves the
+      // hybrid (mamba/sconv) cache with a negative allocation
+      // ("Not enough GPU memory for hybrid state cache", max_mamba_cache_size < 0 at
+      // 0.70/0.75). 0.85 + a context cap boots and serves (GSM8K 5-shot 0.940,
+      // 8k/1k sweep cc1-128 verified on 4xGB200).
       match: { hw: "gb200", variant: "default", quant: "nvfp4", strategy: "mtp", nodes: "single" },
       env: [
         "SGLANG_ENABLE_UNIFIED_RADIX_TREE=1",
@@ -600,9 +611,10 @@ export const config = {
         "--moe-runner-backend flashinfer_trtllm_routed",
         "--enable-torch-symm-mem",
         "--mamba-radix-cache-strategy extra_buffer",
-        "--mem-fraction-static 0.75",
+        "--mem-fraction-static 0.85",
         "--swa-full-tokens-ratio 0.1",
         "--mamba-full-memory-ratio 0.1",
+        "--context-length 65536",
         "--enable-multimodal",
         "--reasoning-parser inkling",
         "--tool-call-parser inkling",


### PR DESCRIPTION
## Motivation

The Inkling cookbook's GB200 cells are marked as same-arch extrapolations. Running them verbatim on real 4×GB200 (192 GB, `lmsysorg/sglang:inkling-cu13`):

1. **`mtp` cell cannot boot.** `--mem-fraction-static 0.75` → `RuntimeError: Not enough GPU memory for hybrid (mamba/linear-attention) state cache. Computed max_mamba_cache_size=-85 (total_rest_memory=-12.47 GB…)`. The 592 GB NVFP4 checkpoint is ~148 GB/GPU at TP=4 and must fit inside the static budget: `0.75 × 184 GB = 138 GB < 148 GB`. On 192 GB parts MF must be ≥ ~0.85.
2. **`balanced` cell needs a context cap.** The 1M-token SWA+sconv pools don't fit at TP=4 next to the weights (the file's own TP-sizing note says 192 GB parts need TP=8 for 1M pools). Uncapped it can't allocate sensible pools; with `--context-length 131072` it boots and serves, but the small KV pool still saturates at high concurrency — interactivity pins at ~32.6 tok/s/user from cc64→cc128 (queueing, not batching).

## Modifications

- `gb200 / nvfp4 / balanced`: add `--context-length 131072` (+ comment).
- `gb200 / nvfp4 / mtp`: `--mem-fraction-static 0.75 → 0.85`, add `--context-length 65536` (+ comment).

## Verification (4×GB200, 8k-in/1k-out random, GSM8K 5-shot 200q gate before every sweep)

**balanced + ctx131k** — GSM8K **0.925**:

| cc | 1 | 8 | 32 | 64 | 128 |
|---|---|---|---|---|---|
| tok/s/user | 155.8 | 98.0 | 42.6 | 32.8 | 32.6 |
| out tok/s/GPU | 37.8 | 182.4 | 251.2 | 394.8 | 427.1 |

**mtp @ MF 0.85 + ctx65k** — GSM8K **0.940**, bs1 = 537.6 tok/s/user (vs the 0.75 cell: boot failure).

Boot-failure evidence for the shipped MTP cell (MF 0.70 and 0.75 both reproduce):
`max_mamba_cache_size=-143 (total_rest_memory=-21.00 GB, mamba_cache_per_req=5.22 MB)`.

## Known remaining gap (not addressed here)

Even with the cap, the bf16-KV pool on 192 GB TP4 limits high-concurrency throughput (vLLM on identical hardware reaches 637 out tok/s/GPU at cc128 vs 427 here, both measured). `--kv-cache-dtype mxfp8` recovers a large part of this on the 288 GB sibling (+32% at cc128 on 4×GB300, accuracy-neutral: GSM8K 0.915 vs 0.920); a GB200 mxfp8 verification sweep is running and I can extend this PR (or follow up) to make mxfp8 the recommended GB200 high-concurrency setting once it's confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29809339058](https://github.com/sgl-project/sglang/actions/runs/29809339058)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29809338875](https://github.com/sgl-project/sglang/actions/runs/29809338875)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->