### PR TITLE
[AMD] Reuse PR test stages and throttle matrix fanout

### DIFF
--- a/.github/workflows/_pr-test-stage-amd.yml
+++ b/.github/workflows/_pr-test-stage-amd.yml
@@ -1,0 +1,144 @@
+name: PR Test Stage (AMD)
+# Reusable workflow for the AMD suites that execute test/run_suite.py. The
+# caller keeps change detection and stage ordering; runner selection, ROCm
+# container setup, matrix fanout, execution, failure artifacts, and cleanup
+# live here so ROCm versions cannot drift independently.
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: 'run_suite.py suite name (without a ROCm-version suffix).'
+        type: string
+        required: true
+      runner_arch:
+        description: 'AMD runner architecture, for example mi300, mi325, or mi35x.'
+        type: string
+        required: true
+      gpu_count:
+        description: 'GPU count encoded in the runner label.'
+        type: number
+        required: true
+      rocm_version:
+        description: 'ROCm image family passed to amd_ci_start_container.sh.'
+        type: string
+        required: true
+      partitions:
+        description: 'JSON object with size and arr fields, for example {"size":3,"arr":[0,1,2]}.'
+        type: string
+        required: true
+      max_parallel:
+        description: 'Maximum number of matrix shards dispatched at once.'
+        type: number
+        required: true
+      auto_partition:
+        description: 'Forward matrix partition arguments to run_suite.py.'
+        type: boolean
+        default: true
+      aiter_ref:
+        description: 'Optional AITER commit override.'
+        type: string
+        default: ''
+      checkout_ref:
+        description: 'Git ref or SHA to test.'
+        type: string
+        required: true
+      continue_on_error:
+        description: 'Forward --continue-on-error to run_suite.py.'
+        type: boolean
+        default: false
+      run_timeout_minutes:
+        description: 'timeout-minutes for the Run test step.'
+        type: number
+        required: true
+      timeout_per_file:
+        description: 'run_suite.py --timeout-per-file value in seconds.'
+        type: number
+        default: 1200
+      rccl_smoke_test:
+        description: 'Run the 8-GPU RCCL communication smoke test before the suite.'
+        type: boolean
+        default: false
+      rccl_workarounds:
+        description: 'Apply the Stage-C RCCL environment overrides.'
+        type: boolean
+        default: false
+      enable_retry:
+        description: 'Enable the Stage-C per-file retry policy.'
+        type: boolean
+        default: false
+
+# Reusable workflows do not inherit workflow-level env from their caller.
+env:
+  AITER_COMMIT_OVERRIDE: ${{ inputs.aiter_ref }}
+  DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+  DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+  RUNNER_LABELS: ${{ inputs.runner_arch == 'mi35x' && format('linux-{0}-gpu-{1}', inputs.runner_arch, inputs.gpu_count) || format('linux-{0}-{1}gpu-sglang', inputs.runner_arch, inputs.gpu_count) }}
+
+jobs:
+  run:
+    name: ${{ format('{0} ({1}, {2})', inputs.suite, inputs.runner_arch == 'mi35x' && format('linux-{0}-gpu-{1}', inputs.runner_arch, inputs.gpu_count) || format('linux-{0}-{1}gpu-sglang', inputs.runner_arch, inputs.gpu_count), matrix.partition) }}
+    runs-on: ${{ inputs.runner_arch == 'mi35x' && format('linux-{0}-gpu-{1}', inputs.runner_arch, inputs.gpu_count) || format('linux-{0}-{1}gpu-sglang', inputs.runner_arch, inputs.gpu_count) }}
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ inputs.max_parallel }}
+      matrix:
+        partition: ${{ fromJson(inputs.partitions).arr }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ inputs.rocm_version }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Test RCCL multi-GPU communication
+        if: inputs.rccl_smoke_test
+        timeout-minutes: 5
+        run: |
+          echo "Testing RCCL multi-GPU communication with debug info..."
+          docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=${{ inputs.gpu_count }} scripts/ci/amd/test_rccl_multi_gpu.py"
+
+      - name: Run test
+        timeout-minutes: ${{ inputs.run_timeout_minutes }}
+        env:
+          CONTINUE_ON_ERROR_FLAG: ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+          PARTITION_ARGS: ${{ inputs.auto_partition && format('--auto-partition-id {0} --auto-partition-size {1}', matrix.partition, fromJson(inputs.partitions).size) || '' }}
+          RCCL_ENV_ARGS: ${{ inputs.rccl_workarounds && '-e NCCL_CUMEM_ENABLE=0 -e NCCL_NVLS_ENABLE=0 -e RCCL_MSCCL_ENABLE=0 -e SGLANG_USE_ROCM700A=1' || '' }}
+          RETRY_ARGS: ${{ inputs.enable_retry && '--enable-retry --max-attempts 2 --retry-wait-seconds 120 --retry-timeout-increase 0' || '' }}
+        run: |
+          set -o pipefail
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            $RCCL_ENV_ARGS \
+            -w "/sglang-checkout/test" \
+            python3 run_suite.py \
+              --hw amd \
+              --suite ${{ inputs.suite }} \
+              $PARTITION_ARGS \
+              --timeout-per-file ${{ inputs.timeout_per_file }} \
+              $RETRY_ARGS \
+              $CONTINUE_ON_ERROR_FLAG \
+            2>&1 | tee amd-ci-test.log
+
+      - name: Upload failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: amd-ci-${{ inputs.suite }}-${{ inputs.rocm_version }}-${{ matrix.partition }}-${{ github.run_attempt }}
+          path: amd-ci-test.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Cleanup container
+        if: always()
+        run: docker rm -f ci_sglang 2>/dev/null || true

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -16,6 +16,7 @@ on:
   #     - "scripts/ci/**"
   #     - "test/**"
   #     - "sgl-kernel/**"
+  #     - ".github/workflows/_pr-test-stage-amd.yml"
   #     - ".github/workflows/pr-test-amd-rocm720.yml"
   #     - "docker/rocm.Dockerfile"
   # pull_request:
@@ -24,6 +25,7 @@ on:
   #     - "scripts/ci/**"
   #     - "test/**"
   #     - "sgl-kernel/**"
+  #     - ".github/workflows/_pr-test-stage-amd.yml"
   #     - ".github/workflows/pr-test-amd-rocm720.yml"
   #     - "docker/rocm.Dockerfile"
   workflow_dispatch:
@@ -193,13 +195,16 @@ jobs:
               - "scripts/ci/amd/*"
               - "scripts/ci/utils/*"
               - "test/**/!(*.md)"
+              - ".github/workflows/_pr-test-stage-amd.yml"
               - ".github/workflows/pr-test-amd-rocm720.yml"
             sgl_kernel:
               - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
+              - ".github/workflows/_pr-test-stage-amd.yml"
               - ".github/workflows/pr-test-amd-rocm720.yml"
             jit_kernel:
               - "python/sglang/jit_kernel/**"
               - "test/registered/jit/**"
+              - ".github/workflows/_pr-test-stage-amd.yml"
               - ".github/workflows/pr-test-amd-rocm720.yml"
             multimodal_gen:
               - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
@@ -289,32 +294,20 @@ jobs:
           needs.check-changes.outputs.sgl_kernel == 'true'
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-2gpu-sglang]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite sgl-kernel-unit-test-2-gpu-amd
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: sgl-kernel-unit-test-2-gpu-amd
+      runner_arch: mi325
+      gpu_count: 2
+      rocm_version: rocm720
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: false
+      run_timeout_minutes: 30
+    secrets: inherit
 
   # =============================================== primary ====================================================
 
@@ -330,32 +323,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-1gpu-sglang]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-gpu-small-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-a-test-1-gpu-small-amd
+      runner_arch: mi325
+      gpu_count: 1
+      rocm_version: rocm720
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   jit-kernel-unit-test-amd-rocm720:
     needs: [check-changes]
@@ -368,32 +349,20 @@ jobs:
           needs.check-changes.outputs.jit_kernel == 'true'
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-1gpu-sglang]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run JIT kernel unit tests
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: jit-kernel-unit-test-amd
+      runner_arch: mi325
+      gpu_count: 1
+      rocm_version: rocm720
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ inputs.continue_on_error }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   jit-kernel-benchmark-test-amd-rocm720:
     needs: [check-changes]
@@ -406,32 +375,20 @@ jobs:
           needs.check-changes.outputs.jit_kernel == 'true'
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-1gpu-sglang]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run JIT kernel benchmarks
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-benchmark-test-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: jit-kernel-benchmark-test-amd
+      runner_arch: mi325
+      gpu_count: 1
+      rocm_version: rocm720
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ inputs.continue_on_error }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   stage-b-test-1-gpu-small-amd-rocm720:
     needs: [check-changes]
@@ -445,32 +402,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-1gpu-sglang]
-        part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 60
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-small-amd
+      runner_arch: mi325
+      gpu_count: 1
+      rocm_version: rocm720
+      partitions: '{"size":14,"arr":[0,1,2,3,4,5,6,7,8,9,10,11,12,13]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 4 || 14 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 60
+      timeout_per_file: 1800
+    secrets: inherit
 
   stage-b-test-1-gpu-small-amd-nondeterministic-rocm720:
     needs: [check-changes]
@@ -484,31 +429,21 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-1gpu-sglang]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 75
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-small-amd-nondeterministic
+      runner_arch: mi325
+      gpu_count: 1
+      rocm_version: rocm720
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 75
+      timeout_per_file: 3600
+    secrets: inherit
 
   stage-b-test-1-gpu-small-amd-mi35x-rocm720:
     needs: [check-changes]
@@ -522,31 +457,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi35x-gpu-1]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-mi35x ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-small-amd-mi35x
+      runner_arch: mi35x
+      gpu_count: 1
+      rocm_version: rocm720
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   stage-b-test-1-gpu-large-amd-rocm720:
     needs: [check-changes]
@@ -560,32 +484,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-1gpu-sglang]
-        part: [0, 1, 2]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 45
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-large-amd
+      runner_arch: mi325
+      gpu_count: 1
+      rocm_version: rocm720
+      partitions: '{"size":3,"arr":[0,1,2]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 3 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 45
+      timeout_per_file: 1800
+    secrets: inherit
 
   stage-b-test-2-gpu-large-amd-rocm720:
     needs: [check-changes]
@@ -599,32 +511,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-2gpu-sglang]
-        part: [0, 1]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 45
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-2-gpu-large-amd
+      runner_arch: mi325
+      gpu_count: 2
+      rocm_version: rocm720
+      partitions: '{"size":2,"arr":[0,1]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 2 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 45
+      timeout_per_file: 1800
+    secrets: inherit
 
   multimodal-gen-test-1-gpu-amd-rocm720:
     needs: [check-changes]
@@ -640,6 +540,7 @@ jobs:
       )
     strategy:
       fail-fast: false
+      max-parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 4 }}
       matrix:
         runner: [linux-mi325-1gpu-sglang]
         part: [0, 1, 2, 3]
@@ -780,6 +681,7 @@ jobs:
       )
     strategy:
       fail-fast: false
+      max-parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 3 }}
       matrix:
         runner: [linux-mi325-2gpu-sglang]
         part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
@@ -973,49 +875,22 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-4gpu-sglang]
-        part: [0]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 60
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh \
-            -e NCCL_CUMEM_ENABLE=0 \
-            -e NCCL_NVLS_ENABLE=0 \
-            -e RCCL_MSCCL_ENABLE=0 \
-            -e SGLANG_USE_ROCM700A=1 \
-            -w "/sglang-checkout/test" \
-            python3 run_suite.py \
-              --hw amd \
-              --suite stage-c-test-4-gpu-amd \
-              --auto-partition-id ${{ matrix.part }} \
-              --auto-partition-size 1 \
-              --timeout-per-file 1800 \
-              --enable-retry \
-              --max-attempts 2 \
-              --retry-wait-seconds 120 \
-              --retry-timeout-increase 0 \
-              ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-c-test-4-gpu-amd
+      runner_arch: mi325
+      gpu_count: 4
+      rocm_version: rocm720
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 60
+      timeout_per_file: 1800
+      rccl_workarounds: true
+      enable_retry: true
+    secrets: inherit
 
   stage-c-test-large-8-gpu-amd-rocm720:
     needs: [check-changes]
@@ -1029,40 +904,21 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    env:
-      RUNNER_LABELS: linux-mi325-8gpu-sglang
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi325-8gpu-sglang]
-        part: [0, 1, 2, 3]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Test RCCL multi-GPU communication
-        timeout-minutes: 5
-        run: |
-          echo "Testing RCCL multi-GPU communication with debug info..."
-          docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=8 scripts/ci/amd/test_rccl_multi_gpu.py"
-
-      - name: Run test
-        timeout-minutes: 120
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-c-test-large-8-gpu-amd
+      runner_arch: mi325
+      gpu_count: 8
+      rocm_version: rocm720
+      partitions: '{"size":4,"arr":[0,1,2,3]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 4 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ github.event_name == 'schedule' || inputs.continue_on_error }}
+      run_timeout_minutes: 120
+      timeout_per_file: 5400
+      rccl_smoke_test: true
+    secrets: inherit
 
   stage-c-test-large-8-gpu-amd-mi35x-rocm720:
     needs: [check-changes]
@@ -1076,32 +932,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi35x-gpu-8]
-        part: [0, 1]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-      - name: Run test
-        timeout-minutes: 60
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd-mi35x --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-c-test-large-8-gpu-amd-mi35x
+      runner_arch: mi35x
+      gpu_count: 8
+      rocm_version: rocm720
+      partitions: '{"size":2,"arr":[0,1]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 2 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 60
+      timeout_per_file: 3600
+    secrets: inherit
 
   # =============================================== Disaggregation ====================================================
   stage-b-test-large-8-gpu-mi35x-disaggregation-amd-rocm720:

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/ci/**"
       - "test/**"
       - "sgl-kernel/**"
+      - ".github/workflows/_pr-test-stage-amd.yml"
       - ".github/workflows/pr-test-amd.yml"
       - "docker/rocm.Dockerfile"
   workflow_dispatch:
@@ -181,13 +182,16 @@ jobs:
               - "scripts/ci/amd/*"
               - "scripts/ci/utils/*"
               - "test/**/!(*.md)"
+              - ".github/workflows/_pr-test-stage-amd.yml"
               - ".github/workflows/pr-test-amd.yml"
             sgl_kernel:
               - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
+              - ".github/workflows/_pr-test-stage-amd.yml"
               - ".github/workflows/pr-test-amd.yml"
             jit_kernel:
               - "python/sglang/jit_kernel/**"
               - "test/registered/jit/**"
+              - ".github/workflows/_pr-test-stage-amd.yml"
               - ".github/workflows/pr-test-amd.yml"
             multimodal_gen:
               - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
@@ -278,7 +282,6 @@ jobs:
           exit $failures
 
   sgl-kernel-unit-test-2-gpu-amd:
-    name: ${{ format('sgl-kernel-unit-test-2-gpu-amd (linux-{0}-2gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -290,36 +293,24 @@ jobs:
           needs.check-changes.outputs.sgl_kernel == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 30
-        env:
-          CONTINUE_ON_ERROR: ${{ needs.check-changes.outputs.continue_on_error }}
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite sgl-kernel-unit-test-2-gpu-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: sgl-kernel-unit-test-2-gpu-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 2
+      rocm_version: rocm700
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   # =============================================== primary ====================================================
 
   stage-a-test-1-gpu-small-amd:
-    name: ${{ format('stage-a-test-1-gpu-small-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -331,32 +322,22 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-a-test-1-gpu-small-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-a-test-1-gpu-small-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 1
+      rocm_version: rocm700
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   jit-kernel-unit-test-amd:
-    name: ${{ format('jit-kernel-unit-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -368,32 +349,22 @@ jobs:
           needs.check-changes.outputs.jit_kernel == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run JIT kernel unit tests
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: jit-kernel-unit-test-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 1
+      rocm_version: rocm700
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   jit-kernel-benchmark-test-amd:
-    name: ${{ format('jit-kernel-benchmark-test-amd (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, call-gate]
     if: |
       always() && !cancelled() &&
@@ -405,29 +376,20 @@ jobs:
           needs.check-changes.outputs.jit_kernel == 'true'
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run JIT kernel benchmarks
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-benchmark-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: jit-kernel-benchmark-test-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 1
+      rocm_version: rocm700
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   # =============================================== Wait Jobs for Sequential PR Execution ====================================================
   # These jobs poll GitHub API to wait for previous stages to complete.
@@ -456,7 +418,6 @@ jobs:
           max-wait-minutes: '240'
 
   stage-b-test-1-gpu-small-amd:
-    name: ${{ format('stage-b-test-1-gpu-small-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -468,35 +429,22 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 60
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-small-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 1
+      rocm_version: rocm700
+      partitions: '{"size":14,"arr":[0,1,2,3,4,5,6,7,8,9,10,11,12,13]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 4 || 14 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 60
+      timeout_per_file: 2400
+    secrets: inherit
 
   stage-b-test-1-gpu-small-amd-nondeterministic:
-    name: ${{ format('stage-b-test-1-gpu-small-amd-nondeterministic (linux-{0}-1gpu-sglang)', inputs.runner_arch || 'mi325') }}
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -508,28 +456,21 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 75
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-nondeterministic --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-small-amd-nondeterministic
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 1
+      rocm_version: rocm700
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 75
+      timeout_per_file: 3600
+    secrets: inherit
 
   stage-b-test-1-gpu-small-amd-mi35x:
     needs: [check-changes, wait-for-stage-a-amd]
@@ -543,35 +484,22 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi35x-gpu-1]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 30
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd-mi35x ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-small-amd-mi35x
+      runner_arch: mi35x
+      gpu_count: 1
+      rocm_version: rocm700
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      auto_partition: false
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 30
+    secrets: inherit
 
   stage-b-test-1-gpu-large-amd:
-    name: ${{ format('stage-b-test-1-gpu-large-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -583,35 +511,22 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        part: [0, 1, 2]
-    runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 45
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 3 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-1-gpu-large-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 1
+      rocm_version: rocm700
+      partitions: '{"size":3,"arr":[0,1,2]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 3 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 45
+      timeout_per_file: 2700
+    secrets: inherit
 
   stage-b-test-2-gpu-large-amd:
-    name: ${{ format('stage-b-test-2-gpu-large-amd (linux-{0}-2gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, wait-for-stage-a-amd]
     if: |
       always() &&
@@ -623,32 +538,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        part: [0, 1]
-    runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 45
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-b-test-2-gpu-large-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 2
+      rocm_version: rocm700
+      partitions: '{"size":2,"arr":[0,1]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 2 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 45
+      timeout_per_file: 2700
+    secrets: inherit
 
   multimodal-gen-test-1-gpu-amd:
     name: ${{ format('multimodal-gen-test-1-gpu-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
@@ -665,6 +568,7 @@ jobs:
       )
     strategy:
       fail-fast: false
+      max-parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 4 }}
       matrix:
         part: [0, 1, 2, 3]
     runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi325') }}
@@ -805,6 +709,7 @@ jobs:
       )
     strategy:
       fail-fast: false
+      max-parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 3 }}
       matrix:
         part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
     runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi325') }}
@@ -1016,7 +921,6 @@ jobs:
           max-wait-minutes: '480'
 
   stage-c-test-4-gpu-amd:
-    name: ${{ format('stage-c-test-4-gpu-amd (linux-{0}-4gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
     if: |
       always() &&
@@ -1028,51 +932,24 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        part: [0]
-    runs-on: ${{ format('linux-{0}-4gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 90
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh \
-            -e NCCL_CUMEM_ENABLE=0 \
-            -e NCCL_NVLS_ENABLE=0 \
-            -e RCCL_MSCCL_ENABLE=0 \
-            -e SGLANG_USE_ROCM700A=1 \
-            -w "/sglang-checkout/test" \
-            python3 run_suite.py \
-              --hw amd \
-              --suite stage-c-test-4-gpu-amd \
-              --auto-partition-id ${{ matrix.part }} \
-              --auto-partition-size 1 \
-              --timeout-per-file 5400 \
-              --enable-retry \
-              --max-attempts 2 \
-              --retry-wait-seconds 120 \
-              --retry-timeout-increase 0 \
-              ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-c-test-4-gpu-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 4
+      rocm_version: rocm700
+      partitions: '{"size":1,"arr":[0]}'
+      max_parallel: 1
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 90
+      timeout_per_file: 5400
+      rccl_workarounds: true
+      enable_retry: true
+    secrets: inherit
 
   stage-c-test-large-8-gpu-amd:
-    name: ${{ format('stage-c-test-large-8-gpu-amd (linux-{0}-8gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
     if: |
       always() &&
@@ -1084,40 +961,21 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    env:
-      RUNNER_LABELS: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || 'mi325') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        part: [0, 1, 2, 3]
-    runs-on: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || 'mi325') }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Test RCCL multi-GPU communication
-        timeout-minutes: 5
-        run: |
-          echo "Testing RCCL multi-GPU communication with debug info..."
-          docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=8 scripts/ci/amd/test_rccl_multi_gpu.py"
-
-      - name: Run test
-        timeout-minutes: 120
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 4 --timeout-per-file 5400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-c-test-large-8-gpu-amd
+      runner_arch: ${{ inputs.runner_arch || 'mi325' }}
+      gpu_count: 8
+      rocm_version: rocm700
+      partitions: '{"size":4,"arr":[0,1,2,3]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 4 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 120
+      timeout_per_file: 5400
+      rccl_smoke_test: true
+    secrets: inherit
 
   stage-c-test-large-8-gpu-amd-mi35x:
     needs: [check-changes, call-gate, wait-for-stage-b-amd]
@@ -1131,33 +989,20 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [linux-mi35x-gpu-8]
-        part: [0, 1]
-    runs-on: ${{matrix.runner}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Start CI container
-        run: bash scripts/ci/amd/amd_ci_start_container.sh
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
-
-      - name: Run test
-        timeout-minutes: 60
-        run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-c-test-large-8-gpu-amd-mi35x --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 3600 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+    uses: ./.github/workflows/_pr-test-stage-amd.yml
+    with:
+      suite: stage-c-test-large-8-gpu-amd-mi35x
+      runner_arch: mi35x
+      gpu_count: 8
+      rocm_version: rocm700
+      partitions: '{"size":2,"arr":[0,1]}'
+      max_parallel: ${{ github.event_name == 'pull_request' && !(inputs.run_all_tests || inputs.ref) && !contains(github.event.pull_request.labels.*.name, 'high priority') && 1 || 2 }}
+      aiter_ref: ${{ inputs.aiter_ref || '' }}
+      checkout_ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+      continue_on_error: ${{ needs.check-changes.outputs.continue_on_error == 'true' }}
+      run_timeout_minutes: 60
+      timeout_per_file: 3600
+    secrets: inherit
 
   # =============================================== Disaggregation ====================================================
   stage-b-test-large-8-gpu-mi35x-disaggregation-amd:


### PR DESCRIPTION
## Summary

- add `_pr-test-stage-amd.yml` as the shared lifecycle for AMD `run_suite.py` jobs: checkout, runner-label resolution, VRAM cleanup, ROCm container setup, dependency install, matrix execution, failure-log artifact, and container cleanup
- migrate the same 12 standard suites in both ROCm 7.0 and ROCm 7.2 while keeping multimodal, custom sgl-kernel pytest, MI35X disaggregation, and DSV4 jobs inline
- cap matrix fanout for ordinary PRs without changing scheduled, manual/full, workflow-call/ref, or `high priority` parallelism

## Ordinary PR concurrency

| Matrix | Shards | Ordinary PR max | Full-priority max |
|---|---:|---:|---:|
| Stage-B 1-GPU small | 14 | 4 | 14 |
| Stage-B 1-GPU large | 3 | 1 | 3 |
| Stage-B 2-GPU large | 2 | 1 | 2 |
| Multimodal 1-GPU | 4 | 1 | 4 |
| Multimodal 2-GPU | 3 | 1 | 3 |
| Stage-C MI325 8-GPU | 4 | 1 | 4 |
| Stage-C MI35X 8-GPU | 2 | 1 | 2 |

This uses matrix `max-parallel`, not shared job-level concurrency groups, so sibling shards do not cancel each other (the failure mode seen in #24282).

## Motivation

Recent AMD capacity data shows queueing dominates wall time:

- [AMD monitor run 29791375307](https://github.com/sgl-project/sglang/actions/runs/29791375307): MI325 1-GPU average queue 5h21m (P50 4h20m, P99 14h33m); MI325 2-GPU average 6h18m; MI325 8-GPU average 5h25m
- [AMD PR run 29795655926](https://github.com/sgl-project/sglang/actions/runs/29795655926): Stage A queued 3h34m and the waiter timed out

Capping one ordinary PR prevents a single 14-shard matrix from occupying the whole pool while preserving the existing escape hatches for urgent or comprehensive runs.

## Reusable stage

The shared workflow takes `suite`, `runner_arch`, `gpu_count`, `rocm_version`, `partitions`, `max_parallel`, and `aiter_ref`, plus explicit timeout and Stage-C RCCL/retry switches. ROCm-version-specific timeout differences remain visible at the call sites; the runner/container/install/run/artifact/cleanup mechanics now have one implementation.

## Validation

- repository pre-commit hooks, including YAML and duplicate workflow-job-name checks
- `actionlint` on the new reusable workflow and both callers (existing empty-choice/custom-runner warnings excluded)
- static parity check: all 23 job IDs, `needs`, and gate expressions preserved in each caller
- static parameter check: runner, partition count, timeout, ROCm version, RCCL smoke/workaround, and retry settings match the pre-refactor jobs
- wait-job expected counts match the reusable matrices

Live ROCm 7.0 and 7.2 targeted workflow links will be posted after dispatch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29812311459](https://github.com/sgl-project/sglang/actions/runs/29812311459)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29812311258](https://github.com/sgl-project/sglang/actions/runs/29812311258)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->