### PR TITLE
[Fix] Validate user-supplied input_ids against the vocabulary

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1033,6 +1033,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
+            # Only user-supplied token ids can be out of range; ids produced by
+            # the tokenizer are always valid, so skip the scan for text requests.
+            if obj.input_ids is not None:
+                self._validate_input_ids_in_vocab(
+                    input_ids, self.model_config.vocab_size
+                )
             self._validate_token_ids_logprob(obj)
             if (
                 obj.return_hidden_states
@@ -1117,20 +1123,20 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     def _validate_input_ids_in_vocab(
         self, input_ids: Union[List[int], List[List[int]]], vocab_size: int
     ) -> None:
-        # Handle both single sequence and batch of sequences
-        if isinstance(input_ids[0], list):
-            # Batch of sequences
-            for seq in input_ids:
-                if any(id >= vocab_size for id in seq):
+        # Out-of-range ids index the model's embedding out of bounds (on CUDA a
+        # device-side assert that crashes the whole server); an id < 0 wraps to
+        # the end of the embedding table (silently wrong). Both are checked.
+        if not input_ids:
+            return
+        # Handle both a single sequence and a batch of sequences.
+        seqs = input_ids if isinstance(input_ids[0], list) else [input_ids]
+        for seq in seqs:
+            for token_id in seq:
+                if not 0 <= token_id < vocab_size:
                     raise ValueError(
-                        f"The input_ids {seq} contains values greater than the vocab size ({vocab_size})."
+                        f"input_ids contains an out-of-vocabulary token id "
+                        f"{token_id}; valid range is [0, {vocab_size})."
                     )
-        else:
-            # Single sequence
-            if any(id >= vocab_size for id in input_ids):
-                raise ValueError(
-                    f"The input_ids {input_ids} contains values greater than the vocab size ({vocab_size})."
-                )
 
     def _create_tokenized_object(
         self,

--- a/test/registered/unit/managers/test_tokenizer_manager_input_ids_validation.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_input_ids_validation.py
@@ -1,0 +1,56 @@
+"""Unit test for TokenizerManager._validate_input_ids_in_vocab.
+
+Bug: user-supplied input_ids (native /generate and OpenAI token-id prompts) were
+never validated -- _validate_input_ids_in_vocab existed but had zero callers, and
+even it only checked id >= vocab_size (missing id < 0). An out-of-range id indexes
+the model's embedding out of bounds (on CUDA a device-side assert that crashes the
+whole server); a negative id silently wraps to the end of the table.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+VOCAB_SIZE = 32000
+
+
+class TestValidateInputIds(CustomTestCase):
+    def setUp(self):
+        self.tm = TokenizerManager.__new__(TokenizerManager)
+        self.tm.model_config = SimpleNamespace(vocab_size=VOCAB_SIZE)
+
+    def _validate(self, ids):
+        self.tm._validate_input_ids_in_vocab(ids, VOCAB_SIZE)
+
+    def test_above_vocab_raises(self):
+        with self.assertRaises(ValueError):
+            self._validate([1, 2, VOCAB_SIZE])
+        with self.assertRaises(ValueError):
+            self._validate([1, 2, 2_000_000_000])
+
+    def test_negative_raises(self):
+        # The previous check only guarded id >= vocab_size, so this used to pass.
+        with self.assertRaises(ValueError):
+            self._validate([1, -1, 2])
+
+    def test_batch_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            self._validate([[1, 2], [3, VOCAB_SIZE + 5]])
+        with self.assertRaises(ValueError):
+            self._validate([[1, 2], [-4, 5]])
+
+    def test_in_range_passes(self):
+        self._validate([0, 1, VOCAB_SIZE - 1])
+        self._validate([[0, 1], [2, VOCAB_SIZE - 1]])
+
+    def test_empty_passes(self):
+        self._validate([])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #31597.

## Motivation

`_validate_input_ids_in_vocab` exists but has **zero callers**, so user-supplied `input_ids` (native `/generate`, and OpenAI token-id prompts) are never validated. And the method itself only checks `id >= vocab_size` — it misses `id < 0`. Consequences:

- an id `>= vocab_size` indexes the model's embedding (`nn.Embedding(vocab, hidden)`) out of bounds. On CUDA that is a device-side assert that poisons the context and takes down the whole server from a single request (e.g. `POST /generate {"input_ids":[1000000000],"sampling_params":{"max_new_tokens":1}}`).
- a negative id wraps to the end of the embedding table (silently wrong output).

This is the same untrusted-input class as `logit_bias` / `token_ids_logprob` / `stop_token_ids`, which are already validated.

## Modifications

Wire `_validate_input_ids_in_vocab` into `_validate_one_request`, guarded on `obj.input_ids is not None` so it only scans user-provided token ids (tokenizer output is always valid, so text requests pay nothing). Reject both out-of-range and negative ids, and add an empty-input guard.

## Tests

`test_tokenizer_manager_input_ids_validation.py`: ids `>= vocab_size`, `== vocab_size`, and negative all raise (single and batch); in-range and empty pass. The negative case used to pass under the old `>= vocab_size`-only check.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29813122122](https://github.com/sgl-project/sglang/actions/runs/29813122122)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29813121808](https://github.com/sgl-project/sglang/actions/runs/29813121808)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->