### PR TITLE
fix(metrics): only export request gauges on attn CP rank 0

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1052,7 +1052,11 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
         enable_hierarchical_cache: bool,
     ) -> SchedulerMetricsCollectorContext:
         enable_metrics = server_args.enable_metrics
-        is_stats_logging_rank = ps.attn_tp_rank == 0
+        # Only one rank per attention replica should export request-level
+        # gauges. Context-parallel ranks each hold a shard of the same
+        # global request, so counting on every CP rank multiplies
+        # num_running_reqs (and similar) by attn_cp_size (issue #31896).
+        is_stats_logging_rank = ps.attn_tp_rank == 0 and ps.attn_cp_rank == 0
         current_scheduler_metrics_enabled = enable_metrics and (
             is_stats_logging_rank or server_args.enable_metrics_for_all_schedulers
         )

--- a/test/registered/unit/observability/test_metrics_logging_rank.py
+++ b/test/registered/unit/observability/test_metrics_logging_rank.py
@@ -1,0 +1,83 @@
+"""Unit tests for scheduler metrics logging rank selection under CP.
+
+Issue #31896: with --cp / attn context parallelism, every CP rank used to
+export the same request gauges, so Prometheus summed num_running_reqs by
+attn_cp_size.
+"""
+
+
+def test_is_stats_logging_rank_requires_attn_cp_rank_zero():
+    # Predicate used in SchedulerMetricsCollectorContext.init_new
+    cases = [
+        (0, 0, True),
+        (0, 1, False),
+        (0, 7, False),
+        (1, 0, False),
+        (1, 1, False),
+    ]
+    for tp, cp, expected in cases:
+        got = tp == 0 and cp == 0
+        assert got is expected, (tp, cp, got, expected)
+
+
+def test_init_new_disables_metrics_on_non_zero_cp_rank():
+    import pytest
+
+    try:
+        from types import SimpleNamespace
+
+        from sglang.srt.disaggregation.utils import DisaggregationMode
+        from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+        from sglang.srt.observability.metrics_collector import (
+            SchedulerMetricsCollectorContext,
+        )
+    except Exception as e:  # pragma: no cover
+        pytest.skip(f"sglang runtime deps unavailable: {e}")
+
+    server_args = SimpleNamespace(
+        enable_metrics=True,
+        enable_metrics_for_all_schedulers=False,
+        kv_events_config=None,
+        disaggregation_mode=DisaggregationMode.NULL
+        if hasattr(DisaggregationMode, "NULL")
+        else "null",
+        served_model_name="test",
+        extra_metric_labels=None,
+        enable_streaming_session=False,
+    )
+
+    # Prefer enum if available
+    if hasattr(DisaggregationMode, "NULL"):
+        server_args.disaggregation_mode = DisaggregationMode.NULL
+
+    ps_cp0 = ParallelState.trivial(attn_tp_rank=0, attn_cp_rank=0, pp_rank=0)
+    ps_cp1 = ParallelState.trivial(attn_tp_rank=0, attn_cp_rank=1, pp_rank=0)
+
+    try:
+        ctx0 = SchedulerMetricsCollectorContext.init_new(
+            server_args=server_args,
+            ps=ps_cp0,
+            tp_rank=0,
+            pp_rank=0,
+            dp_rank=None,
+            enable_priority_scheduling=False,
+            enable_lora=False,
+            enable_hierarchical_cache=False,
+        )
+        ctx1 = SchedulerMetricsCollectorContext.init_new(
+            server_args=server_args,
+            ps=ps_cp1,
+            tp_rank=0,
+            pp_rank=0,
+            dp_rank=None,
+            enable_priority_scheduling=False,
+            enable_lora=False,
+            enable_hierarchical_cache=False,
+        )
+    except Exception as e:  # pragma: no cover
+        pytest.skip(f"init_new needs more runtime deps: {e}")
+
+    assert ctx0.is_stats_logging_rank is True
+    assert ctx0.current_scheduler_metrics_enabled is True
+    assert ctx1.is_stats_logging_rank is False
+    assert ctx1.current_scheduler_metrics_enabled is False

--- a/test/registered/unit/observability/test_metrics_logging_rank.py
+++ b/test/registered/unit/observability/test_metrics_logging_rank.py
@@ -5,6 +5,11 @@ export the same request gauges, so Prometheus summed num_running_reqs by
 attn_cp_size.
 """
 
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="base-c-test-cpu")
+
 
 def test_is_stats_logging_rank_requires_attn_cp_rank_zero():
     # Predicate used in SchedulerMetricsCollectorContext.init_new
@@ -38,9 +43,9 @@ def test_init_new_disables_metrics_on_non_zero_cp_rank():
         enable_metrics=True,
         enable_metrics_for_all_schedulers=False,
         kv_events_config=None,
-        disaggregation_mode=DisaggregationMode.NULL
-        if hasattr(DisaggregationMode, "NULL")
-        else "null",
+        disaggregation_mode=(
+            DisaggregationMode.NULL if hasattr(DisaggregationMode, "NULL") else "null"
+        ),
         served_model_name="test",
         extra_metric_labels=None,
         enable_streaming_session=False,


### PR DESCRIPTION
## Motivation

When starting SGLang with context parallelism (e.g. `--cp 8` / `attn_cp_size=8`), Prometheus gauges such as `sglang:num_running_reqs` are inflated by roughly the CP size (issue #31896).

Root cause: `SchedulerMetricsCollectorContext.init_new` treated every rank with `attn_tp_rank == 0` as a stats-logging rank. Under CP, each context-parallel rank holds a shard of the **same** global request, so exporting the same running-request count on every CP rank makes Prometheus sum them up.

KV-cache event export already gates on `attn_cp_rank == 0`; request gauges did not.

## Modifications

- Require `ps.attn_tp_rank == 0 and ps.attn_cp_rank == 0` for `is_stats_logging_rank`.
- Add a small unit test locking the CP rank predicate (and optional `init_new` coverage when runtime deps are available).

## Checklist

- [x] Format your code according to the [Format and Lint](https://docs.sglang.io/developer_guide/contribution_guide.html#format-and-lint) the code section.
- [x] Add unit tests according to the [Run and Add Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) section.
- [ ] Provide accuracy or performance benchmark results if needed.
- [x] Link to the related issue: #31896
- [ ] (Optional) Trigger the [performance checklist](https://docs.sglang.io/developer_guide/contribution_guide.html#performance-checklist) if needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30080249132](https://github.com/sgl-project/sglang/actions/runs/30080249132)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30080248815](https://github.com/sgl-project/sglang/actions/runs/30080248815)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->