### PR TITLE
[Fix] TritonLoRABackend drops lm_head per-pass batch infos (None.append crash)

### DIFF
--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -339,7 +339,7 @@ class TritonLoRABackend(BaseLoRABackend):
                     merged_segments = merge_and_chunk_segments(
                         seg_wi, seg_lens_list, chunk_size=pass_total
                     )
-                    self.lm_head_pass_batch_infos.append(
+                    lm_head_pass_batch_infos.append(
                         self._build_lm_head_batch_info(
                             merged_segments, batch_info, pass_total
                         )

--- a/test/registered/unit/lora/test_triton_lmhead_pass_infos.py
+++ b/test/registered/unit/lora/test_triton_lmhead_pass_infos.py
@@ -1,0 +1,45 @@
+"""Regression: TritonLoRABackend._prepare_lm_head_batch_info must collect the
+per-pass lm_head batch infos into the LOCAL list it returns.
+
+Bug: it created `lm_head_pass_batch_infos = []` but appended to
+`self.lm_head_pass_batch_infos` (which init_lm_head_config sets to None), then
+returned the empty local list. So the first batch that reaches the pass-segments
+branch (lm_head LoRA + chunked logprobs) crashed with
+`AttributeError: 'NoneType' object has no attribute 'append'`, and the consumer
+would otherwise index an empty list. The sibling chunked_backend appends to the
+local list; this matches it.
+
+Drives the real method with the segment helpers stubbed to reach the branch.
+"""
+
+import unittest
+import unittest.mock as mock
+
+import sglang.srt.lora.backend.triton_backend as tb
+from sglang.srt.lora.backend.triton_backend import TritonLoRABackend
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestTritonLmHeadPassInfos(unittest.TestCase):
+    def test_pass_infos_collected_not_dropped(self):
+        be = TritonLoRABackend.__new__(TritonLoRABackend)
+        # init_lm_head_config sets this to None; the buggy code appended to it.
+        be.lm_head_pass_batch_infos = None
+        be._build_lm_head_batch_info = lambda *a, **k: "INFO"
+        be._get_lm_head_pass_segments = lambda wi, pl: [([0], [2, 2]), ([1], [2, 2])]
+
+        with mock.patch.object(
+            tb, "get_lm_head_pruned_lens", lambda fb: [2, 2]
+        ), mock.patch.object(tb, "merge_and_chunk_segments", lambda *a, **k: "SEG"):
+            _, pass_infos = be._prepare_lm_head_batch_info(
+                forward_batch=None, weight_indices=[0, 0], batch_info=None
+            )
+
+        # One LoRABatchInfo per pass; previously this raised or returned [].
+        self.assertEqual(pass_infos, ["INFO", "INFO"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`TritonLoRABackend._prepare_lm_head_batch_info` creates a local `lm_head_pass_batch_infos = []` but appends the per-pass infos to `self.lm_head_pass_batch_infos`, then returns the empty **local** list:

```python
lm_head_pass_batch_infos = []            # local
for seg_wi, seg_lens_list in pass_segments:
    ...
    self.lm_head_pass_batch_infos.append(  # appends to the instance attr
        self._build_lm_head_batch_info(merged_segments, batch_info, pass_total)
    )
...
return lm_head_batch_info, lm_head_pass_batch_infos   # returns the empty local []
```

`init_lm_head_config` sets `self.lm_head_pass_batch_infos = None`, and the caller (`prepare_lora_batch`) immediately does `self.lm_head_batch_info, self.lm_head_pass_batch_infos = self._prepare_lm_head_batch_info(...)`, overwriting the attribute with the empty local list. So the attribute is never a populated list: the first batch that reaches the pass-segments branch (lm_head LoRA + chunked logprobs on `--lora-backend triton`, also reached via the deprecated `flashinfer` alias) hits `None.append(...)` -> `AttributeError` in the model forward, and the consumer `_get_lm_head_batch_info` would otherwise index an empty list.

The sibling `chunked_backend.py` (the default `csgmv` backend) has the identical routine and correctly appends to the **local** list; the two diverge only at this one `self.` prefix.

Repro (CPU, real method with the segment helpers stubbed to reach the branch): `AttributeError: 'NoneType' object has no attribute 'append'`.

## Modifications

Append to the local `lm_head_pass_batch_infos` that is returned, matching `chunked_backend`.

## Tests

`test/registered/unit/lora/test_triton_lmhead_pass_infos.py` drives the real `_prepare_lm_head_batch_info` and asserts it returns one info per pass. Crashes on the pre-fix code.

cc @lifuhuang @jybsuper @Fridge003

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29813425006](https://github.com/sgl-project/sglang/actions/runs/29813425006)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29813424736](https://github.com/sgl-project/sglang/actions/runs/29813424736)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->