### PR TITLE
[Fix] Validate multimodal embedding hidden size before scatter

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -732,6 +732,22 @@ def _adjust_embedding_length(
     return embedding
 
 
+def _check_mm_embedding_hidden_size(dest: torch.Tensor, src: torch.Tensor) -> None:
+    """Guard the masked_scatter of multimodal embeddings into the token stream.
+
+    ``_adjust_embedding_length`` reconciles only the row count, not the hidden
+    dimension. A user-supplied ``precomputed_embedding`` with a wrong hidden size
+    would otherwise reach ``masked_scatter_`` and either crash the scheduler
+    (src smaller than the number of masked positions) or, worse, be silently
+    misaligned row-major (src larger), producing wrong embeddings with no error.
+    """
+    if src.shape[-1] != dest.shape[-1]:
+        raise ValueError(
+            f"Multimodal embedding hidden size {src.shape[-1]} does not match the "
+            f"model hidden size {dest.shape[-1]}."
+        )
+
+
 def get_embedding_and_mask(
     data_embedding_func: DataEmbeddingFunc,
     embedding_items: List[MultimodalDataItem],
@@ -909,6 +925,7 @@ def embed_mm_inputs(
     # 4. scatter embeddings into input embedding
     # masked_scatter_ avoids the cudaStreamSynchronize that torch.where triggers.
     def _scatter(dest, mask, src):
+        _check_mm_embedding_hidden_size(dest, src)
         dest.masked_scatter_(mask.expand_as(dest), src.to(dest.device, dest.dtype))
 
     for i, modality, embedding, mask in zip(

--- a/test/registered/unit/managers/test_mm_embedding_hidden_check.py
+++ b/test/registered/unit/managers/test_mm_embedding_hidden_check.py
@@ -1,0 +1,38 @@
+"""Unit test for the multimodal embedding hidden-size guard.
+
+Bug: _adjust_embedding_length reconciles only the row count of a multimodal
+embedding, not its hidden dimension. A user-supplied precomputed_embedding with
+a wrong hidden size then reached masked_scatter_ and either crashed the
+scheduler (src smaller than the masked positions) or was silently misaligned
+row-major (src larger), producing wrong embeddings with no error.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.managers.mm_utils import _check_mm_embedding_hidden_size
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMMEmbeddingHiddenCheck(CustomTestCase):
+    def test_smaller_hidden_raises(self):
+        # src smaller -> masked_scatter_ would raise a cryptic "number of
+        # elements of source < number of ones in mask".
+        with self.assertRaises(ValueError):
+            _check_mm_embedding_hidden_size(torch.zeros(5, 4), torch.zeros(2, 3))
+
+    def test_larger_hidden_raises(self):
+        # src larger -> masked_scatter_ would silently misalign (no error).
+        with self.assertRaises(ValueError):
+            _check_mm_embedding_hidden_size(torch.zeros(5, 4), torch.zeros(2, 6))
+
+    def test_matching_hidden_passes(self):
+        _check_mm_embedding_hidden_size(torch.zeros(5, 4), torch.zeros(2, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`_adjust_embedding_length` (`managers/mm_utils.py`) reconciles only the **row count** of a multimodal embedding against the number of placeholder tokens — it never checks the hidden dimension. The mask is `(seq, 1)` and the scatter does `dest.masked_scatter_(mask.expand_as(dest), src)`, which consumes `src.numel()` elements. So a user-supplied `precomputed_embedding` whose feature tensor has the right row count but a wrong hidden size reaches `masked_scatter_` and:

- if `src_hidden < model_hidden`: `RuntimeError: number of elements of source < number of ones in mask` propagates out of the model forward and crashes the scheduler;
- if `src_hidden > model_hidden`: it is **silently misaligned** row-major, producing wrong embeddings with no error.

`precomputed_embedding` items come straight from the request, and the hidden dim is never validated against `model_config.hidden_size` (`_validate_mm_limits` guards only item count, and only when `limit_mm_data_per_request` is set, which defaults to `None`). Same untrusted-input class as the already-validated request fields.

Both cases reproduced on CPU against the real `_adjust_embedding_length` + scatter.

## Modifications

Add `_check_mm_embedding_hidden_size(dest, src)` and call it in `_scatter` before `masked_scatter_`. It raises a clear `ValueError` when the embedding hidden size does not match the model hidden size, catching both the crash and the silent-misalignment case. Valid embeddings (produced by the vision encoder, or a correctly-shaped precomputed one) always match, so there is no behavior change on the happy path.

## Tests

`test_mm_embedding_hidden_check.py`: a smaller and a larger hidden size both raise; a matching hidden size passes.

cc @mickqian @hnyls2002

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29814651922](https://github.com/sgl-project/sglang/actions/runs/29814651922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29814651354](https://github.com/sgl-project/sglang/actions/runs/29814651354)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->