### PR TITLE
:busts_in_silhouette: chore(codeowners): Update codeowners for NPU quantization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,7 @@
 /python/sglang/kernels/ops/attention/fla @yizhang2077 @hebiao064 @yuan-luo
 /python/sglang/multimodal_gen @mickqian @ping1jing2 @HaiShaw @yichiche @AgainstEntropy @BBuf
 /python/sglang/multimodal_gen/runtime/cache @DefTruth
-/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp*_npu.py @TallMessiWu
-/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim_mxfp*_scheme.py @TallMessiWu
+/python/sglang/multimodal_gen/runtime/layers/quantization/ @OrangeRedeng @TallMessiWu
 /python/sglang/multimodal_gen/test/server/ascend  @ping1jing2 @ssshinigami @Makcum888e @e-martirosian
 /python/sglang/srt/batch_invariant_ops @Fridge003 @hebiao064
 /python/sglang/srt/compilation @hebiao064 @Oasis-Git

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,8 @@
 /python/sglang/kernels/ops/attention/fla @yizhang2077 @hebiao064 @yuan-luo
 /python/sglang/multimodal_gen @mickqian @ping1jing2 @HaiShaw @yichiche @AgainstEntropy @BBuf
 /python/sglang/multimodal_gen/runtime/cache @DefTruth
+/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp*_npu.py @TallMessiWu
+/python/sglang/multimodal_gen/runtime/layers/quantization/modelslim_mxfp*_scheme.py @TallMessiWu
 /python/sglang/multimodal_gen/test/server/ascend  @ping1jing2 @ssshinigami @Makcum888e @e-martirosian
 /python/sglang/srt/batch_invariant_ops @Fridge003 @hebiao064
 /python/sglang/srt/compilation @hebiao064 @Oasis-Git
@@ -34,14 +36,14 @@
 /python/sglang/srt/hardware_backend/musa @yeahdongcn
 /python/sglang/srt/hardware_backend/npu @ping1jing2 @iforgetmyname @whybeyoung
 /python/sglang/srt/hardware_backend/gpu/quantization @Alisehen
-/python/sglang/srt/hardware_backend/npu/quantization @OrangeRedeng @TamirBaydasov @Alisehen
+/python/sglang/srt/hardware_backend/npu/quantization @OrangeRedeng @TamirBaydasov @Alisehen @TallMessiWu
 /python/sglang/srt/layers @merrymercy @Ying1123 @Fridge003 @ispobock @HaiShaw @ch-wan @BBuf @Edwardf0t1
 /python/sglang/srt/layers/attention @merrymercy @Fridge003 @ispobock @Qiaolin-Yu @hebiao064 @HaiShaw
 /python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py @yizhang2077 @hebiao064 @hanming-lu @yuan-luo
 /python/sglang/srt/layers/attention/mamba @yizhang2077 @hebiao064
 /python/sglang/srt/layers/attention/dsa @1am9trash @hubertlu-tw @kkHuang-amd @HaiShaw @Fridge003 @YAMY1234 @rainj-me
 /python/sglang/srt/layers/attention/vision.py @mickqian @yuan-luo @yhyang201
-/python/sglang/srt/layers/quantization @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad
+/python/sglang/srt/layers/quantization @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu
 /python/sglang/srt/layers/quantization/quark @kkHuang-amd @yichiche @hubertlu-tw @1am9trash @BowenBao
 /python/sglang/srt/lora @Ying1123 @Fridge003 @lifuhuang @yushengsu-thu @jybsuper
 /python/sglang/srt/managers @merrymercy @Ying1123 @hnyls2002 @xiezhq-hermann


### PR DESCRIPTION
## Motivation

Add @TallMessiWu as a codeowner for the Ascend NPU quantization paths, so that changes to the MXFP8/MXFP4 quantization code are automatically routed for review.

I am the primary author of the MXFP8/MXFP4 quantization support on Ascend NPU, landed across the following merged PRs:

| PR | Scope |
| -- | ----- |
| #20922 | Diffusion MXFP8 (Wan2.2) |
| #22338 | Diffusion MXFP4 |
| #22352 | Qwen3 Dense W8A8 MXFP8 |
| #28505 | Dense MXFP8 refactor (delegate to kernel, `torch.ops.npu`) |
| #23650 | Qwen3 Dense W4A8 MXFP |
| #23795 | Qwen3 Dense W4A4 MXFP4 |
| #24918, #25904 | Quantization docs |

plus #30768 (MoE W8A8 MXFP8), currently in review.

By `git blame` on `main`, I am the second largest contributor to both SRT quantization directories this PR touches:

| Path | Line ownership |
| ---- | -------------- |
| `srt/hardware_backend/npu/quantization/` | 755 of 2213 lines |
| `srt/layers/quantization/modelslim/` | 310 of 1503 lines |

and the sole author of the MXFP-specific files, e.g. `npu_mxfp4.py` (127/127), `npu_mxfp4_w4a4.py` (140/140), `modelslim/schemes/modelslim_mxfp8.py`, `modelslim/schemes/modelslim_mxfp4.py`, `modelslim/schemes/modelslim_mxfp4_w4a8.py`, and on the diffusion side `mxfp8_npu.py`, `mxfp4_npu.py`, `modelslim_mxfp8_scheme.py`, `modelslim_mxfp4_scheme.py`.

This follows #26784, which established the current NPU quantization codeowner list.

## Modifications

`.github/CODEOWNERS`, three entries:

- Append `@TallMessiWu` to `/python/sglang/srt/hardware_backend/npu/quantization`.
- Append `@TallMessiWu` to `/python/sglang/srt/layers/quantization` (covers `npu_mxfp4*.py` and the `modelslim/` subtree).
- Add `/python/sglang/multimodal_gen/runtime/layers/quantization/ @OrangeRedeng @TallMessiWu` for the Diffusion quantization directory.

No existing owner loses coverage anywhere in this PR.

## Note on permissions

I understand CODEOWNERS entries only take effect for accounts with write access to the repository, which I do not currently have. Could a maintainer advise on the right process here, or grant access alongside this PR? Happy to follow whatever nomination process applies.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).

cc @OrangeRedeng @ping1jing2

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30437445831](https://github.com/sgl-project/sglang/actions/runs/30437445831)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30437445733](https://github.com/sgl-project/sglang/actions/runs/30437445733)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->