### PR TITLE
[Bugfix] Fix CUDA import on non-CUDA platforms

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -78,7 +78,6 @@ from sglang.srt.layers.cp.utils import (
     get_cp_strategy,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.moe.dwdp import DwdpManager
 from sglang.srt.layers.sampler import create_sampler
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
@@ -1027,6 +1026,8 @@ class ModelRunner:
             return
         if self.server_args.dwdp_size <= 1:
             return
+        from sglang.srt.layers.moe.dwdp import DwdpManager
+
         manager = DwdpManager(self.server_args)
         set_global_dwdp_manager(manager)
         manager.setup(self.model)

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import tempfile
 import unittest
 
@@ -125,6 +126,11 @@ class TestUnifiedMambaHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.process.terminate()
+        try:
+            cls.process.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            pass
         kill_process_tree(cls.process.pid)
 
 

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
@@ -192,6 +192,11 @@ class TestUnifiedMambaHiCacheL3(AccuracyTwoPassMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.process.terminate()
+        try:
+            cls.process.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            pass
         kill_process_tree(cls.process.pid)
         if os.path.isdir(cls.hicache_dir):
             shutil.rmtree(cls.hicache_dir, ignore_errors=True)

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mamba.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import subprocess
 import tempfile
 import unittest
 
@@ -126,11 +125,6 @@ class TestUnifiedMambaHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.process.terminate()
-        try:
-            cls.process.wait(timeout=60)
-        except subprocess.TimeoutExpired:
-            pass
         kill_process_tree(cls.process.pid)
 
 
@@ -192,11 +186,6 @@ class TestUnifiedMambaHiCacheL3(AccuracyTwoPassMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.process.terminate()
-        try:
-            cls.process.wait(timeout=60)
-        except subprocess.TimeoutExpired:
-            pass
         kill_process_tree(cls.process.pid)
         if os.path.isdir(cls.hicache_dir):
             shutil.rmtree(cls.hicache_dir, ignore_errors=True)


### PR DESCRIPTION
## Motivation

PR #29778 introduced DWDP and added a top-level import of `DwdpManager` in `model_runner.py`. Importing the DWDP package loads modules that require `cuda.bindings`.

On environments without `cuda-python`, this makes SGLang fail during module import even when DWDP is disabled:

```text
ModuleNotFoundError: No module named 'cuda'
```

## Modifications

Move the `DwdpManager` import into `maybe_init_dwdp()`, after the draft-worker and `dwdp_size` guards. The CUDA-specific DWDP modules are now loaded only when DWDP is enabled.

DWDP behavior itself is unchanged.

## Accuracy Tests

Not applicable. This change does not affect model computation or outputs.

## Speed Tests and Profiling

Not applicable. This only changes when the optional DWDP module is imported.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29820085106](https://github.com/sgl-project/sglang/actions/runs/29820085106)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29820084878](https://github.com/sgl-project/sglang/actions/runs/29820084878)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->