### PR TITLE
Route /rerun-test for b200 multimodal tests to the b200 pool

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -462,6 +462,7 @@ MULTIMODAL_TEST_DIR = "python/sglang/multimodal_gen/test"
 MULTIMODAL_PATH_TO_RUNNER = {
     "2_gpu": "2-gpu-h100",
     "2-gpu": "2-gpu-h100",
+    "b200": _B200_DEFAULT_RUNNER,
 }
 MULTIMODAL_DEFAULT_RUNNER = "1-gpu-h100"
 


### PR DESCRIPTION
`/rerun-test test_server_b200.py` dispatches to `1-gpu-h100`, where the B200-only NVFP4 tests crash immediately with `mm_fp4 does not support backend 'trtllm' with capability 90` (example: run [29819541869](https://github.com/sgl-project/sglang/actions/runs/29819541869), triggered from #31923).

The handler's multimodal runner map only knows a `2-gpu` path hint; everything else falls through to `1-gpu-h100`:

```python
MULTIMODAL_PATH_TO_RUNNER = {
    "2_gpu": "2-gpu-h100",
    "2-gpu": "2-gpu-h100",
}
MULTIMODAL_DEFAULT_RUNNER = "1-gpu-h100"
```

This adds a `b200` path hint mapped to `_B200_DEFAULT_RUNNER` (`4-gpu-b200`), the same pool `pr-test.yml` uses for `multimodal-gen-test-1-b200`. `test_server_b200.py` is currently the only hardware-suffixed multimodal test file.

Verified: `detect_multimodal_suite("python/sglang/multimodal_gen/test/server/test_server_b200.py")` → `4-gpu-b200`; plain and `2_gpu` paths unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29824916378](https://github.com/sgl-project/sglang/actions/runs/29824916378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29824916112](https://github.com/sgl-project/sglang/actions/runs/29824916112)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->