### PR TITLE
[Fix] Apply gemm1_clamp_limit in silu-mul-quant kernels without gemm1_alpha

### DIFF
--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -340,6 +340,14 @@ def _silu_and_mul_post_quant_kernel(
             gate_up = gate * tl.sigmoid(gate * GEMM1_ALPHA) * (up + 1)
         else:
             gate = gate / (1 + tl.exp(-gate))
+            if GEMM1_CLAMP_LIMIT > 0:
+                # gemm1_clamp_limit without gemm1_alpha must not be dropped:
+                # mirror _swiglu_silu_clamp_mul — clamp after silu on gate
+                # (max only), symmetric clamp on up.
+                gate = tl.minimum(gate, GEMM1_CLAMP_LIMIT)
+                up = tl.clamp(up, -GEMM1_CLAMP_LIMIT, GEMM1_CLAMP_LIMIT).to(
+                    input_ptr.dtype.element_ty
+                )
             gate = gate.to(input_ptr.dtype.element_ty)
             gate_up = up * gate
 
@@ -558,6 +566,14 @@ def _silu_and_mul_post_quant_packed_kernel(
         gate_up = gate * tl.sigmoid(gate * GEMM1_ALPHA) * (up + 1)
     else:
         gate = gate / (1 + tl.exp(-gate))
+        if GEMM1_CLAMP_LIMIT > 0:
+            # gemm1_clamp_limit without gemm1_alpha must not be dropped:
+            # mirror _swiglu_silu_clamp_mul — clamp after silu on gate
+            # (max only), symmetric clamp on up.
+            gate = tl.minimum(gate, GEMM1_CLAMP_LIMIT)
+            up = tl.clamp(up, -GEMM1_CLAMP_LIMIT, GEMM1_CLAMP_LIMIT).to(
+                input_ptr.dtype.element_ty
+            )
         gate = gate.to(input_ptr.dtype.element_ty)
         gate_up = up * gate
 

--- a/test/registered/moe/test_silu_mul_post_quant_clamp.py
+++ b/test/registered/moe/test_silu_mul_post_quant_clamp.py
@@ -1,0 +1,232 @@
+import unittest
+
+import torch
+import triton
+
+from sglang.kernels.ops.moe.ep_moe_kernels import (
+    _silu_and_mul_post_quant_packed_kernel,
+    silu_and_mul_masked_post_quant_fwd,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+FP8_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
+GROUP = 128
+E, M_MAX, SIZE_N = 4, 256, 512  # SIZE_N = half-width (gate/up each); 4 groups
+MASKED_M = [7, 100, 200, 256]
+LIMIT = 7.0
+
+
+def _build_inputs():
+    """[E, M, 2*SIZE_N] bf16 with saturating values in both halves."""
+    torch.manual_seed(31)
+    gateup = torch.randn(E, M_MAX, 2 * SIZE_N) * 1.5
+    for g, m in enumerate(MASKED_M):
+        for r in range(0, m, 3):  # every 3rd valid row saturates
+            gateup[g, r, torch.arange(0, SIZE_N, 17)] = 9.0 + (r % 5)  # gate > limit
+            gateup[g, r, SIZE_N + torch.arange(0, SIZE_N, 23)] = -(
+                8.0 + (r % 7)
+            )  # up < -limit
+    return gateup.to(torch.bfloat16)
+
+
+def _silu_mul_post_quant_packed_fwd(
+    input,
+    output,
+    output_scale_packed,
+    quant_group_size,
+    masked_m,
+    num_real_tokens,
+    topk,
+    gemm1_alpha=0.0,
+    gemm1_clamp_limit=0.0,
+):
+    """Local launcher for the packed UE8M0 kernel.
+
+    Mirrors the removed `silu_and_mul_masked_post_quant_packed_fwd` wrapper
+    (upstream dropped the public wrapper; the Triton kernel remains).
+    """
+    E, m_max, _ = input.shape
+    size_n = input.shape[-1] // 2
+    BLOCK_N = quant_group_size * 4
+    hidden_dim_split = size_n // BLOCK_N
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    grid = (num_real_tokens * topk, hidden_dim_split)
+    _silu_and_mul_post_quant_packed_kernel[grid](
+        input,
+        *input.stride(),
+        output,
+        *output.stride(),
+        output_scale_packed,
+        *output_scale_packed.stride(),
+        masked_m,
+        E,
+        size_n,
+        fp8_max,
+        -fp8_max,
+        QUANT_GROUP_SIZE=quant_group_size,
+        BLOCK_N=BLOCK_N,
+        GEMM1_ALPHA=gemm1_alpha if gemm1_alpha is not None else 0.0,
+        GEMM1_CLAMP_LIMIT=gemm1_clamp_limit if gemm1_clamp_limit is not None else 0.0,
+        E_PADDED=triton.next_power_of_2(E),
+        num_warps=1,
+    )
+
+
+def _reference_dequant(gateup, limit, ue8m0):
+    """fp32 reference of silu-mul + per-token-group quant-dequant.
+
+    Mirrors the kernel's op order: silu in fp32, optional clamp, bf16 cast
+    boundary, bf16 product, group absmax scale.
+    """
+    gate = gateup[..., :SIZE_N].float()
+    up = gateup[..., SIZE_N:].float()
+    gate = gate / (1 + torch.exp(-gate))  # silu
+    if limit > 0:
+        # _swiglu_silu_clamp_mul semantics: clamp after silu on gate (max
+        # only), symmetric clamp on up.
+        gate = torch.minimum(gate, torch.tensor(limit))
+        up = up.clamp(-limit, limit)
+    gate_up = (gate.bfloat16() * up.bfloat16()).float()
+
+    grouped = gate_up.reshape(*gate_up.shape[:-1], SIZE_N // GROUP, GROUP)
+    absmax = grouped.abs().amax(dim=-1).clamp_min(1e-10)
+    s = absmax / FP8_MAX
+    if ue8m0:
+        s = torch.exp2(torch.ceil(torch.log2(s)))
+    q = (grouped / s.unsqueeze(-1)).clamp(-FP8_MAX, FP8_MAX)
+    deq = q * s.unsqueeze(-1)
+    return deq.reshape(*gate_up.shape)
+
+
+def _kernel_dequant(output_q, output_s, ue8m0_exponent_packed=False):
+    if ue8m0_exponent_packed:
+        # output_s: [E, SIZE_N//(4*GROUP), M] int32, 4 exponent bytes LE per int32
+        bytes_ = output_s.view(torch.uint8)  # [E, G4, M*4]
+        expo = bytes_.reshape(E, -1, M_MAX, 4).permute(0, 2, 1, 3)
+        expo = expo.reshape(E, M_MAX, -1).float()
+        s = torch.exp2(expo - 127.0)  # [E, M, groups]
+    else:
+        s = output_s  # [E, M, groups]
+    grouped = output_q.float().reshape(*output_q.shape[:-1], SIZE_N // GROUP, GROUP)
+    return (grouped * s.unsqueeze(-1)).reshape(*output_q.shape)
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestSiluMulPostQuantClamp(CustomTestCase):
+    def _assert_dequant_close(self, got, want, msg):
+        # fp8 e4m3 has 3 mantissa bits: relative quantization error <= 2^-4,
+        # plus the kernel's bf16 product rounding. Compare per element.
+        diff = (got - want).abs()
+        tol = 0.25 + 0.08 * want.abs()
+        self.assertTrue(
+            bool((diff <= tol).all()),
+            f"{msg}: max diff {diff.max().item():.4f} exceeds fp8 rounding bound",
+        )
+
+    def _run_main_kernel(self, gateup, limit):
+        output_q = torch.empty(
+            E, M_MAX, SIZE_N, dtype=torch.float8_e4m3fn, device="cuda"
+        )
+        output_s = torch.empty(
+            E, M_MAX, SIZE_N // GROUP, dtype=torch.float32, device="cuda"
+        )
+        masked_m = torch.tensor(MASKED_M, dtype=torch.int32, device="cuda")
+        silu_and_mul_masked_post_quant_fwd(
+            gateup.cuda(),
+            output_q,
+            output_s,
+            GROUP,
+            masked_m,
+            scale_ue8m0=False,
+            gemm1_alpha=0.0,  # alpha-less branch: the clamp must still apply
+            gemm1_clamp_limit=limit,
+        )
+        return output_q.cpu(), output_s.cpu()
+
+    def _valid_rows(self):
+        for e in range(E):
+            yield e, slice(0, MASKED_M[e])
+
+    def test_clamp_limit_applied_without_alpha(self):
+        """Regression: gemm1_clamp_limit without gemm1_alpha was silently dropped."""
+        gateup = _build_inputs()
+        q, s = self._run_main_kernel(gateup, LIMIT)
+        got = _kernel_dequant(q, s)
+        want = _reference_dequant(gateup, LIMIT, ue8m0=False)
+        for e, rows in self._valid_rows():
+            self._assert_dequant_close(
+                got[e, rows],
+                want[e, rows],
+                f"expert {e}: clamped kernel output diverges from reference",
+            )
+            # Structural: clamped output must never exceed limit^2 (=49).
+            self.assertLessEqual(
+                got[e, rows].abs().max().item(),
+                LIMIT * LIMIT * 1.05,
+                f"expert {e}: clamp not engaged",
+            )
+
+    def test_zero_limit_path_unchanged(self):
+        """limit=0 layers must compute the plain silu-mul (no clamp)."""
+        gateup = _build_inputs()
+        q, s = self._run_main_kernel(gateup, 0.0)
+        got = _kernel_dequant(q, s)
+        want = _reference_dequant(gateup, 0.0, ue8m0=False)
+        for e, rows in self._valid_rows():
+            self._assert_dequant_close(
+                got[e, rows],
+                want[e, rows],
+                f"expert {e}: limit=0 path altered",
+            )
+            # Divergence detector: with saturation present, unclamped output
+            # must exceed limit^2 somewhere.
+            self.assertGreater(
+                want[e, rows].abs().max().item(),
+                LIMIT * LIMIT,
+                "test inputs fail to exercise the clamp",
+            )
+
+    def test_packed_kernel_clamp_limit(self):
+        """Same regression on the packed UE8M0 variant."""
+        gateup = _build_inputs().cuda()
+        output_q = torch.empty(
+            E, M_MAX, SIZE_N, dtype=torch.float8_e4m3fn, device="cuda"
+        )
+        scale_packed = torch.empty(
+            E, SIZE_N // (4 * GROUP), M_MAX, dtype=torch.int32, device="cuda"
+        )
+        masked_m = torch.tensor(MASKED_M, dtype=torch.int32, device="cuda")
+        _silu_mul_post_quant_packed_fwd(
+            gateup,
+            output_q,
+            scale_packed,
+            GROUP,
+            masked_m,
+            # grid covers sum(masked_m) work items (one per valid token here)
+            num_real_tokens=sum(MASKED_M),
+            topk=1,
+            gemm1_alpha=0.0,
+            gemm1_clamp_limit=LIMIT,
+        )
+        got = _kernel_dequant(
+            output_q.cpu(), scale_packed.cpu(), ue8m0_exponent_packed=True
+        )
+        want = _reference_dequant(gateup.cpu(), LIMIT, ue8m0=True)
+        for e, rows in self._valid_rows():
+            self._assert_dequant_close(
+                got[e, rows],
+                want[e, rows],
+                f"expert {e}: packed clamped output diverges from reference",
+            )
+            self.assertLessEqual(
+                got[e, rows].abs().max().item(),
+                LIMIT * LIMIT * 1.05,
+                f"expert {e}: packed kernel clamp not engaged",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The fused SiLU-mul-quant kernels `_silu_and_mul_post_quant_kernel` and
`_silu_and_mul_post_quant_packed_kernel` only consume `gemm1_clamp_limit`
inside the `GEMM1_ALPHA > 0` branch. A model that passes a clamp limit but no
`gemm1_alpha` therefore has the clamp **silently dropped** on this Triton path,
while the reference SwiGLU clamp path (`_swiglu_silu_clamp_mul`) and the
DeepGEMM path apply it — so the MoE backends diverge numerically for the same
configuration. A model configured with a gate/up clamp then gets different (and
incorrect) activations depending on which fused kernel runs.

## Modifications

Apply `gemm1_clamp_limit` in the no-`gemm1_alpha` branch of both kernels,
mirroring `_swiglu_silu_clamp_mul`: clamp after SiLU on the gate (max only) and
apply the symmetric clamp on the up projection. Behavior for models that set
`gemm1_alpha` is unchanged; behavior when no clamp limit is provided
(`GEMM1_CLAMP_LIMIT <= 0`) is unchanged.

## Accuracy Tests

Added `test/registered/moe/test_silu_mul_post_quant_clamp.py`: parity tests
asserting that when a clamp limit is provided without `gemm1_alpha`, the fused
output matches the reference clamp semantics (within the fp8 rounding bound),
covering both kernel variants. The tests fail before this change and pass after.

## Benchmarking and Profiling

None — same kernel, one extra clamp on a code path that previously skipped it.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests section.
- [ ] Update documentation as needed (N/A — kernel-internal fix).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30340181669](https://github.com/sgl-project/sglang/actions/runs/30340181669)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30340182894](https://github.com/sgl-project/sglang/actions/runs/30340182894)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->