### PR TITLE
[Fix] Normalize --speculative-algorithm NONE to None during arg resolution

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3999,6 +3999,19 @@ class ServerArgs:
             self.prefill_delayer_token_usage_low_watermark = x
 
     def _handle_missing_default_values(self):
+        # Normalize the explicit speculative-decoding off-switch before any
+        # consumer reads the field: downstream gates test
+        # `speculative_algorithm is None`, so a "NONE" string surviving past
+        # this point half-enables speculative decoding (wrong decode
+        # CUDA-graph batch sizes, spurious dcp validation, skipped attention
+        # backend defaults) with no worker behind it. Case-insensitive
+        # because the value is only uppercased later, in the speculative
+        # hook. SpeculativeAlgorithm.from_string already accepts "NONE".
+        if (
+            self.speculative_algorithm is not None
+            and self.speculative_algorithm.upper() == "NONE"
+        ):
+            self.speculative_algorithm = None
         if self.tokenizer_path is None:
             self.tokenizer_path = self.model_path
         if self.served_model_name is None:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -26,6 +26,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
 )
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
 from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
@@ -995,6 +996,41 @@ class TestNgramExternalSamArgs(CustomTestCase):
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
         self.assertIn("external-corpus-max-tokens", str(context.exception))
+
+
+class TestSpeculativeAlgorithmNoneNormalization(CustomTestCase):
+    """`--speculative-algorithm NONE` must resolve to a real ``None``.
+
+    ``SpeculativeAlgorithm.from_string`` accepts ``"NONE"``, so the CLI flag is
+    a documented off-switch, but ~10 downstream gates test
+    ``speculative_algorithm is None``. A surviving ``"NONE"`` string leaves the
+    server half-enabled for speculative decoding. ``_handle_missing_default_values``
+    normalizes it (case-insensitively) before any of those gates run.
+    """
+
+    def _resolve(self, value):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = value
+        args._handle_missing_default_values()
+        return args.speculative_algorithm
+
+    def test_none_variants_normalize_to_none(self):
+        for value in ("NONE", "none", "None", "nOnE"):
+            with self.subTest(value=value):
+                self.assertIsNone(self._resolve(value))
+
+    def test_none_is_still_disabled_algorithm(self):
+        resolved = self._resolve("NONE")
+        self.assertEqual(
+            SpeculativeAlgorithm.from_string(resolved),
+            SpeculativeAlgorithm.NONE,
+        )
+
+    def test_real_algorithm_passthrough(self):
+        self.assertEqual(self._resolve("EAGLE"), "EAGLE")
+
+    def test_none_input_passthrough(self):
+        self.assertIsNone(self._resolve(None))
 
 
 class TestDecoupledSpecArgs(CustomTestCase):


### PR DESCRIPTION
## Motivation

`SpeculativeAlgorithm.from_string` accepts `"NONE"` (the enum has a `NONE`
member), so `--speculative-algorithm NONE` is a documented way to disable
speculative decoding from the CLI. But `server_args` never normalizes the
string: `"NONE"` survives `__post_init__` as a non-`None` value while roughly a
dozen downstream gates test `speculative_algorithm is None` (dcp validation,
the decode CUDA-graph batch-size ladder, attention-backend defaults,
overlap-schedule handling, and so on).

A server launched with `--speculative-algorithm NONE` therefore ends up in an
incoherent half-enabled speculative state, concretely:

- spurious `dcp_size > 1` + speculative validation error,
- the spec-branch decode CUDA-graph batch-size ladder on a spec-off server,
- platform attention-backend defaults (e.g. `trtllm_mha` on SM100) not applied
  because the speculative branch was taken instead.

## Modifications

Normalize the value case-insensitively at the top of
`_handle_missing_default_values` (called early in `__post_init__`, before dcp
validation, CUDA-graph config, attention-backend defaulting, and the
speculative hook): if `speculative_algorithm` upper-cases to `"NONE"`, set it to
`None`. This mirrors the existing `--quantization unquant` normalization.
Runtime behavior for all other values is unchanged.

## Accuracy Tests

Added `TestSpeculativeAlgorithmNoneNormalization` in
`test/registered/unit/server_args/test_server_args.py`: asserts that `NONE`,
`none`, `None`, and mixed case all resolve to `None`; that the disabled state
still maps to `SpeculativeAlgorithm.NONE` via `from_string`; and that real
algorithms (e.g. `EAGLE`) and an already-`None` value pass through unchanged.

## Benchmarking and Profiling

None — argument resolution only.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests section.
- [ ] Update documentation as needed (optionally document `NONE` in the
  `--speculative-algorithm` help text).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30340185283](https://github.com/sgl-project/sglang/actions/runs/30340185283)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30340185190](https://github.com/sgl-project/sglang/actions/runs/30340185190)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->