### PR TITLE
[Fix] Call post_load_weights on direct/custom weight-update paths

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -341,15 +341,26 @@ class WeightUpdater:
             (name, _unwrap_tensor(tensor, tp_rank=self.tp_rank, device=infered_device))
             for name, tensor in named_tensors
         ]
+        model = self.get_model()
         if load_format == "direct":
-            _model_load_weights_direct(self.get_model(), named_tensors)
+            _model_load_weights_direct(model, named_tensors)
         elif load_format in self.custom_weight_loaders:
             custom_loader = dynamic_import(load_format)
-            custom_loader(self.get_model(), named_tensors)
+            custom_loader(model, named_tensors)
         elif load_format is None:
-            self.get_model().load_weights(named_tensors)
+            model.load_weights(named_tensors)
         else:
             raise NotImplementedError(f"Unknown load_format={load_format}")
+        # All three load paths above bypass the loader's post-load step (the
+        # direct/custom loaders write params in place, and load_weights is
+        # called here without the loader wrapper that normally follows it with
+        # post_load_weights). Models that rebuild derived weight caches
+        # (fp32-transposed router gates, repacked quant operands, ...) in
+        # post_load_weights would otherwise serve stale derived weights after
+        # an in-place (e.g. RL-style) weight update. Idempotent for loaders
+        # that already ran the hook.
+        if hasattr(model, "post_load_weights"):
+            model.post_load_weights()
         return True, "Success"
 
     def _update_weights_from_flattened_bucket(

--- a/test/registered/unit/model_executor/model_runner_components/test_weight_updater_post_load_weights.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_weight_updater_post_load_weights.py
@@ -1,0 +1,122 @@
+"""Unit test for the weight-update post_load_weights hook — CPU-only.
+
+`update_weights_from_tensor` writes parameters via the "direct", custom-loader,
+or `model.load_weights` (None) formats, none of which run the loader's post-load
+step. Models that rebuild derived weight caches in `post_load_weights`
+(fp32-transposed router gates, repacked quant operands, …) would then serve
+stale derived weights after an in-place update. The fix calls `post_load_weights`
+once after all three load paths when the model exposes it.
+
+The WeightUpdater method is device-agnostic here, so the test runs on CPU with a
+tiny hand-built model — no GPU or checkpoint required.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.model_executor.model_runner_components.weight_updater import (
+    WeightUpdater,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _DerivedCacheModel(nn.Module):
+    """Model whose derived buffer must track the base weight (w_derived = 2*w)."""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.zeros(4, 4))
+        self.register_buffer("w_derived", torch.empty(4, 4))
+        self.post_load_calls = 0
+        self._rebuild()
+
+    def _rebuild(self):
+        self.w_derived.copy_(self.w.detach() * 2)
+
+    def load_weights(self, named_tensors):
+        # Mirrors real models: load_weights copies params but does NOT itself
+        # run post_load_weights (the loader wrapper normally does that).
+        params = dict(self.named_parameters())
+        for name, tensor in named_tensors:
+            params[name].data.copy_(tensor)
+
+    def post_load_weights(self):
+        self.post_load_calls += 1
+        self._rebuild()
+
+
+class _PlainModel(nn.Module):
+    """No post_load_weights hook — the fix must be a no-op, not a crash."""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.zeros(4, 4))
+
+
+def _make_updater(model):
+    # WeightUpdater is a frozen dataclass; build it via the constructor and
+    # stub the fields the load path never meaningfully touches. Upstream's
+    # weight-cache guard reads server_args.weight_cache_mode off the runner,
+    # so the stub runner must expose it as "off".
+    stub_runner = SimpleNamespace(server_args=SimpleNamespace(weight_cache_mode="off"))
+    return WeightUpdater(
+        tp_rank=0,
+        device="cpu",
+        gpu_id=0,
+        model_config=None,
+        custom_weight_loaders={},
+        get_model=lambda: model,
+        update_model_fields=lambda **kwargs: None,
+        recapture_cuda_graph=lambda: None,
+        get_model_runner=lambda: stub_runner,
+    )
+
+
+class TestWeightUpdaterPostLoadWeightsHook(CustomTestCase):
+    def test_direct_load_refreshes_derived_cache(self):
+        model = _DerivedCacheModel()
+        updater = _make_updater(model)
+        new_w = torch.full((4, 4), 1.5)
+
+        ok, _ = updater.update_weights_from_tensor([("w", new_w)], load_format="direct")
+
+        self.assertTrue(ok)
+        # base parameter updated by the direct load
+        torch.testing.assert_close(model.w.detach(), new_w)
+        # hook ran, so the derived cache tracks the new weights (was stale before)
+        self.assertEqual(model.post_load_calls, 1)
+        torch.testing.assert_close(model.w_derived, new_w * 2)
+
+    def test_none_format_refreshes_derived_cache(self):
+        # load_format=None calls model.load_weights directly, which also skips
+        # post_load_weights — the fix must refresh the derived cache here too.
+        model = _DerivedCacheModel()
+        updater = _make_updater(model)
+        new_w = torch.full((4, 4), 2.5)
+
+        ok, _ = updater.update_weights_from_tensor([("w", new_w)], load_format=None)
+
+        self.assertTrue(ok)
+        torch.testing.assert_close(model.w.detach(), new_w)
+        self.assertEqual(model.post_load_calls, 1)
+        torch.testing.assert_close(model.w_derived, new_w * 2)
+
+    def test_model_without_hook_is_noop(self):
+        model = _PlainModel()
+        updater = _make_updater(model)
+        new_w = torch.full((4, 4), 2.0)
+
+        ok, _ = updater.update_weights_from_tensor([("w", new_w)], load_format="direct")
+
+        self.assertTrue(ok)
+        torch.testing.assert_close(model.w.detach(), new_w)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`update_weights_from_tensor` bypasses `model.load_weights` for the `"direct"`
and custom-loader formats: parameters are written via `default_weight_loader`
(`param.data.copy_()`) and nothing else runs.

A growing set of models rebuild **derived weight caches** in `post_load_weights`
(fp32-transposed router gates, repacked quant operands, etc.). The established
call sites — the loader's post-load step and the checkpoint-engine post-hook —
invoke that hook after `model.load_weights`, but the two
`update_weights_from_tensor` branches above do not. After an in-place (e.g.
RL-style) weight update on those paths, such models keep serving **stale derived
weights**: the base parameter is new, the derived cache is old.

## Modifications

After the direct load (`_model_load_weights_direct`) and after the custom loader,
call `self.get_model().post_load_weights()` when the model exposes it.

- No-op for models without the hook.
- Idempotent for loaders that already run the hook themselves (they rebuild into
  the same storage).

## Accuracy Tests

Added
`test/registered/unit/model_executor/model_runner_components/test_weight_updater_post_load_weights.py`:
a tiny CPU model whose derived cache is rebuilt in `post_load_weights`. After
`update_weights_from_tensor(..., load_format="direct")` the derived cache
reflects the new weights (it was stale before this change), and a model without
the hook is a clean no-op. The derived-cache test fails before the fix and
passes after.

## Benchmarking and Profiling

None — hook invocation on an already-slow weight-update path; the inference hot
path is untouched.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests section.
- [ ] Update documentation as needed (N/A).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30340189893](https://github.com/sgl-project/sglang/actions/runs/30340189893)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30340189525](https://github.com/sgl-project/sglang/actions/runs/30340189525)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->