### PR TITLE
Add Inkling to nightly test

### DIFF
--- a/test/registered/8-gpu-models/test_inkling_nvfp4_nightly.py
+++ b/test/registered/8-gpu-models/test_inkling_nvfp4_nightly.py
@@ -1,0 +1,79 @@
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.test.accuracy_test_runner import AccuracyTestParams
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.performance_test_runner import PerformanceTestParams
+from sglang.test.run_combined_tests import run_combined_tests
+from sglang.test.test_utils import ModelLaunchSettings, is_blackwell_system
+
+# NVFP4 needs Blackwell FP4 kernels, so this runs on the Blackwell leg of the
+# common 8-GPU suite (Hopper is skipped below).
+register_cuda_ci(est_time=3600, suite="nightly-8-gpu-common", nightly=True)
+
+INKLING_NVFP4_MODEL = "thinkingmachines/Inkling-NVFP4"
+
+# Verified Blackwell NVFP4 recipe; see the SGLang cookbook Inkling page.
+NVFP4_ARGS = [
+    "--tp=8",
+    "--trust-remote-code",
+    "--quantization=modelopt_fp4",
+    "--attention-backend=fa4",
+    "--page-size=128",
+    "--fp4-gemm-backend=flashinfer_trtllm",
+    "--moe-runner-backend=flashinfer_trtllm_routed",
+    "--enable-torch-symm-mem",
+    "--mamba-radix-cache-strategy=extra_buffer",
+    "--mem-fraction-static=0.85",
+    "--swa-full-tokens-ratio=0.1",
+    "--mamba-full-memory-ratio=0.1",
+    "--reasoning-parser=inkling",
+]
+
+# gsm8k measured ~0.98 (temp 0, 300 examples); floored with margin for the
+# temperature=1.0 nightly config and FP4-kernel variance.
+GSM8K_BASELINE = 0.93
+
+
+class TestInklingNVFP4Nightly(unittest.TestCase):
+    """Nightly test for Inkling-NVFP4 (975B MoE), TP=8, Blackwell only.
+
+    Runs BOTH:
+    - Performance test (using NightlyBenchmarkRunner)
+    - Accuracy test (using run_eval with gsm8k)
+    """
+
+    @unittest.skipIf(not is_blackwell_system(), "NVFP4 requires Blackwell")
+    def test_inkling_nvfp4(self):
+        """Run performance and accuracy for Inkling-NVFP4 (TP8)."""
+        variants = [
+            ModelLaunchSettings(
+                INKLING_NVFP4_MODEL,
+                tp_size=8,
+                extra_args=NVFP4_ARGS,
+                variant="TP8",
+            ),
+        ]
+
+        with envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.override(1):
+            run_combined_tests(
+                models=variants,
+                test_name="Inkling-NVFP4",
+                accuracy_params=AccuracyTestParams(
+                    dataset="gsm8k",
+                    baseline_accuracy=GSM8K_BASELINE,
+                    num_examples=1314,
+                    num_threads=512,
+                    max_tokens=16000,
+                    temperature=1.0,
+                    top_p=0.95,
+                    repeat=1,
+                ),
+                performance_params=PerformanceTestParams(
+                    profile_dir="performance_profiles_inkling_nvfp4",
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/8-gpu-models/test_inkling_nvfp4_nightly.py
+++ b/test/registered/8-gpu-models/test_inkling_nvfp4_nightly.py
@@ -32,7 +32,7 @@ NVFP4_ARGS = [
 
 # gsm8k measured ~0.98 (temp 0, 300 examples); floored with margin for the
 # temperature=1.0 nightly config and FP4-kernel variance.
-GSM8K_BASELINE = 0.93
+GSM8K_BASELINE = 0.95
 
 
 class TestInklingNVFP4Nightly(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Add Inkling-NVFP4 to the 8-GPU nightly, running both the accuracy (gsm8k) and performance legs via `run_combined_tests`, matching the other `test/registered/8-gpu-models/` entries.

NVFP4 needs Blackwell FP4 kernels, so the test registers on `nightly-8-gpu-common` and skips the Hopper leg with `is_blackwell_system()` (same pattern as the Nemotron-3-Super NVFP4 test). Launch flags are the verified Blackwell NVFP4 recipe from the cookbook Inkling page (`modelopt_fp4` + `fa4` + `flashinfer_trtllm` / `flashinfer_trtllm_routed`).

`baseline_accuracy=0.93`: gsm8k measured ~0.98 (temperature 0, 300 examples) on an NVFP4 server; floored to leave margin for the `temperature=1.0` nightly config and FP4-kernel variance.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29840178932](https://github.com/sgl-project/sglang/actions/runs/29840178932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29840178508](https://github.com/sgl-project/sglang/actions/runs/29840178508)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->