### PR TITLE
Use pip FA4 by default

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_attention_v4.py
+++ b/python/sglang/kernels/ops/attention/flash_attention_v4.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Callable, Optional, Tuple, Union
 
 import torch
@@ -8,19 +7,65 @@ import torch
 from sglang.kernel_api_logging import debug_kernel_api
 
 try:
-    if os.environ.get("SGLANG_INKLING_FA4_USE_PIP") == "1":
-        # A/B debug escape hatch: route through the pip flash-attn-4 package
-        # (dev's stack). rel_bias is vendored-only, so SHEARED must be 0.
-        from flash_attn.cute import flash_attn_varlen_func as _flash_attn_varlen_func
-    else:
-        from sglang.kernels.ops.attention.flash_attn.cute import (
-            flash_attn_varlen_func as _flash_attn_varlen_func,
-        )
+    from flash_attn.cute import flash_attn_varlen_func as _pip_flash_attn_varlen_func
 except Exception as _e:  # pragma: no cover
-    _flash_attn_varlen_func = None
-    _flash_attn_import_error = _e
+    _pip_flash_attn_varlen_func = None
+    _pip_flash_attn_import_error = _e
 else:
-    _flash_attn_import_error = None
+    _pip_flash_attn_import_error = None
+
+try:
+    from sglang.kernels.ops.attention.flash_attn.cute import (
+        flash_attn_varlen_func as _inkling_flash_attn_varlen_func,
+    )
+except Exception as _e:  # pragma: no cover
+    _inkling_flash_attn_varlen_func = None
+    _inkling_flash_attn_import_error = _e
+else:
+    _inkling_flash_attn_import_error = None
+
+
+def _select_flash_attn_varlen_func(
+    *,
+    has_zero_length: bool,
+    rel_bias: Optional[torch.Tensor],
+    rel_bias_prep_cache: Optional[dict],
+    q_descale: Optional[torch.Tensor],
+    k_descale: Optional[torch.Tensor],
+    v_descale: Optional[torch.Tensor],
+    sfq: Optional[torch.Tensor],
+    sfk: Optional[torch.Tensor],
+    sfv: Optional[torch.Tensor],
+):
+    """Select pip FA4 unless the call needs the in-tree implementation."""
+    needs_vendored_impl = has_zero_length or any(
+        value is not None
+        for value in (
+            rel_bias,
+            rel_bias_prep_cache,
+            q_descale,
+            k_descale,
+            v_descale,
+            sfq,
+            sfk,
+            sfv,
+        )
+    )
+
+    if needs_vendored_impl:
+        if _inkling_flash_attn_varlen_func is None:  # pragma: no cover
+            raise ImportError(
+                "The vendored FA4 implementation is not available, but this call "
+                "has a zero-length input or uses rel_bias, FP8 descales, or MXFP8 "
+                "block scales."
+            ) from _inkling_flash_attn_import_error
+        return _inkling_flash_attn_varlen_func
+
+    if _pip_flash_attn_varlen_func is None:  # pragma: no cover
+        raise ImportError(
+            "The pip flash-attn-4 package is required for standard FA4 calls."
+        ) from _pip_flash_attn_import_error
+    return _pip_flash_attn_varlen_func
 
 
 def _maybe_contiguous(x: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
@@ -69,13 +114,6 @@ def flash_attn_varlen_func(
     return_softmax_lse: bool = False,
     **_: object,
 ):
-    if _flash_attn_varlen_func is None:  # pragma: no cover
-        raise ImportError(
-            "FlashAttention-4 CUTE is not available. Install flash-attn-4 with "
-            "its CUDA/CUTE dependencies, or run from a source tree where the "
-            "vendored FA4 package is importable."
-        ) from _flash_attn_import_error
-
     q, k, v, qv = [_maybe_contiguous(t) for t in (q, k, v, qv)]
     cu_seqlens_q, cu_seqlens_k = [
         _maybe_contiguous(t) for t in (cu_seqlens_q, cu_seqlens_k)
@@ -115,7 +153,26 @@ def flash_attn_varlen_func(
         rel_bias_kwargs["rel_bias"] = rel_bias
     if rel_bias_prep_cache is not None:
         rel_bias_kwargs["rel_bias_prep_cache"] = rel_bias_prep_cache
-    result = _flash_attn_varlen_func(
+    flash_attn_impl = _select_flash_attn_varlen_func(
+        # TODO(mmangkad): Remove this fallback once SGLang picks up
+        # flash-attn-4 4.0.0b20 or newer. Version 4.0.0b19 returns the wrong
+        # arity from its zero-work fast path; the vendored version preserves
+        # the established empty output/LSE behavior.
+        has_zero_length=q.numel() == 0 or v.numel() == 0,
+        rel_bias=rel_bias,
+        rel_bias_prep_cache=rel_bias_prep_cache,
+        q_descale=q_descale,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        sfq=sfq,
+        sfk=sfk,
+        sfv=sfv,
+    )
+    if flash_attn_impl is _pip_flash_attn_varlen_func and num_splits == 0:
+        # Preserve the previous pip FA4 behavior. Its automatic SplitKV path
+        # can select a configuration that is unsupported on SM90.
+        num_splits = 1
+    result = flash_attn_impl(
         q=q,
         k=k,
         v=v,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -964,7 +964,6 @@ class Envs:
     # rewrite rejected-draft KV rows before reuse (acc_len repair; on by default).
     SGLANG_ENABLE_MTP_BOUNDARY_KV_FIX = EnvBool(True)
     SGLANG_OPT_USE_INKLING_MULTI_STREAM_OVERLAP = EnvBool(True)
-    SGLANG_OPT_USE_INKLING_SHEARED_BIAS = EnvBool(True)
     # Use feature-stacked GEMMs for the no-LoRA BF16 shared sink. Eligible LoRA
     # serving enables this layout independently of the flag.
     SGLANG_OPT_LINEARIZED_SHARED_SINK = EnvBool(True)

--- a/python/sglang/srt/models/inkling_common/attn.py
+++ b/python/sglang/srt/models/inkling_common/attn.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from functools import cache
-
 import torch
 from torch import nn
 
@@ -31,53 +28,6 @@ from sglang.srt.models.inkling_common.sconv import SconvType, ShortConvolution
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.runtime_context import get_parallel, get_server_args
 from sglang.srt.utils import add_prefix, get_current_device_stream_fast
-
-try:
-    import cutlass.cute as cute
-    from cutlass.cute import Float32
-
-    from sglang.kernels.ops.attention.flash_attn.cute.seqlen_info import SeqlenInfoQK
-except Exception as _import_error:
-    cute = None
-    Float32 = None
-    SeqlenInfoQK = None
-    _cute_import_error = _import_error
-else:
-    _cute_import_error = None
-
-
-@cache
-def get_inkling_relative_attention_score_mod(rel_extent: int) -> Callable:
-    if cute is None or Float32 is None or SeqlenInfoQK is None:
-        raise ImportError(
-            "Inkling relative attention requires the vendored FA4 CUTE interface."
-        ) from _cute_import_error
-
-    @cute.jit
-    def score_mod_rel_bias(
-        scores: cute.TensorSSA,
-        b_idx: cute.TensorSSA,
-        h_idx: cute.TensorSSA,
-        q_idx: cute.TensorSSA,
-        kv_idx: cute.TensorSSA,
-        seqlen_info: SeqlenInfoQK,
-        aux_tensors: list[cute.Tensor],
-    ) -> cute.TensorSSA:
-        rel_logits = aux_tensors[0]
-
-        seqlen_local_offset = seqlen_info.seqlen_k - seqlen_info.seqlen_q
-        rel_dist = (q_idx + seqlen_local_offset) - kv_idx
-        global_q_idx = seqlen_info.offset_q + q_idx
-
-        rel_dist_0 = rel_dist[0]
-        rel_idx = rel_dist_0 if rel_dist_0 >= 0 else 0
-        rel_idx = rel_idx if rel_idx < rel_extent else (rel_extent - 1)
-
-        rel_bias = rel_logits[global_q_idx[0], h_idx[0], rel_idx]
-        rel_bias = Float32(rel_bias) if rel_dist_0 == rel_idx else Float32(0.0)
-        return scores + rel_bias
-
-    return score_mod_rel_bias
 
 
 def compute_log_scaling_tau(
@@ -906,7 +856,7 @@ class InklingAttention(nn.Module):
             # stay bf16 here and the MXFP8 pool's set_kv_buffer quantizes and
             # stores them in one fused kernel (absent descales signal it).
 
-        if envs.SGLANG_OPT_USE_INKLING_SHEARED_BIAS.get() and fa4:
+        if fa4:
             # FA4 sheared-bias kernel: pass rel_logits directly; the kernel shears
             # it into a column-aligned pre-softmax bias.
             attn_output = self.attn(
@@ -920,32 +870,20 @@ class InklingAttention(nn.Module):
                 **extra_attn_kwargs,
             )
         else:
-            # The score_mod / aux_tensors path can't carry the event into the
-            # kernel, so join rel_logits on the current stream before self.attn.
+            # The Triton path can't carry the event into the kernel, so join
+            # rel_logits on the current stream before self.attn.
             if rel_event is not None:
                 get_current_device_stream_fast().wait_event(rel_event)
-            if fa4:
-                attn_output = self.attn(
-                    q,
-                    k,
-                    v,
-                    forward_batch,
-                    save_kv_cache=not prologue_did_store,
-                    score_mod=get_inkling_relative_attention_score_mod(self.rel_extent),
-                    aux_tensors=[rel_logits],
-                    **extra_attn_kwargs,
-                )
-            else:
-                attn_output = self.attn(
-                    q,
-                    k,
-                    v,
-                    forward_batch,
-                    save_kv_cache=not prologue_did_store,
-                    score_mod=triton_relative_bias_score_mod,
-                    aux_tensors=[rel_logits],
-                    **extra_attn_kwargs,
-                )
+            attn_output = self.attn(
+                q,
+                k,
+                v,
+                forward_batch,
+                save_kv_cache=not prologue_did_store,
+                score_mod=triton_relative_bias_score_mod,
+                aux_tensors=[rel_logits],
+                **extra_attn_kwargs,
+            )
         attn_output = attn_output.view(num_tokens, -1)
 
         # Fuse wo_ud's local output GEMM with the all-reduce: write the GEMM


### PR DESCRIPTION
## Summary

- Use pip FA4 by default
- Keep Inkling on the in-tree FA4 from #31681
- Dispatch per call instead of using env flags
- Keep empty inputs in-tree until the pip FA4 fix lands

## Inkling Accuracy Test

```bash
# 8x B300
sglang serve \
  --trust-remote-code \
  --model-path thinkingmachines/Inkling-NVFP4 \
  --tp 8 \
  --quantization modelopt_fp4 \
  --attention-backend fa4 \
  --page-size 128 \
  --fp4-gemm-backend flashinfer_trtllm \
  --moe-runner-backend flashinfer_trtllm_routed \
  --enable-torch-symm-mem \
  --mamba-radix-cache-strategy extra_buffer \
  --mem-fraction-static 0.85 \
  --swa-full-tokens-ratio 0.1 \
  --mamba-full-memory-ratio 0.1 \
  --kv-cache-dtype mxfp8 \
  --enable-multimodal \
  --reasoning-parser inkling \
  --tool-call-parser inkling
```

```bash
sgl-eval run gsm8k \
  --base-url http://127.0.0.1:30000/v1 \
  --max-tokens 65536 \
  --num-threads 512

Run directory: /root/.sgl_eval/sgl_eval_gsm8k_20260721-123714
gsm8k: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:27<00:00, 15.06it/s, acc=97.04%]
== gsm8k ==
1319 examples (single-shot)  |  87.6s  |  4269 tok/s  |  374K tokens

* score           =  97.04%
  stop_rate       =  100.00%
  truncated_rate  =  0.00%
  error_rate      =  0.00%

Metrics: /root/.sgl_eval/sgl_eval_gsm8k_20260721-123714/metrics.json
Predictions: /root/.sgl_eval/sgl_eval_gsm8k_20260721-123714  (1 jsonl file(s))
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30095533599](https://github.com/sgl-project/sglang/actions/runs/30095533599)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30095533418](https://github.com/sgl-project/sglang/actions/runs/30095533418)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->