### PR TITLE
Fix extra_buffer_lazy guard bypass

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4822,14 +4822,12 @@ class ServerArgs:
                 "extra_buffer_lazy unsupported under PD disaggregation; use "
                 "--mamba-radix-cache-strategy extra_buffer."
             )
+            algo = (view.speculative_algorithm or "").upper()
+            assert algo not in ("DFLASH", "DSPARK"), (
+                f"extra_buffer_lazy unsupported with {view.speculative_algorithm}; "
+                "use --mamba-radix-cache-strategy extra_buffer."
+            )
         if view.speculative_num_draft_tokens is not None:
-            if view.mamba_radix_cache_strategy == "extra_buffer_lazy":
-                # The dflash family's verify bypasses prepare_mamba_track_for_verify.
-                assert view.speculative_algorithm not in ("DFLASH", "DSPARK"), (
-                    f"extra_buffer_lazy unsupported with "
-                    f"{view.speculative_algorithm}; use "
-                    "--mamba-radix-cache-strategy extra_buffer."
-                )
             assert view.mamba_track_interval >= view.speculative_num_draft_tokens
         if view.page_size is not None:
             assert view.mamba_track_interval % view.page_size == 0


### PR DESCRIPTION
## Motivation

#30437 blocks `extra_buffer_lazy` for the DFLASH/DSPARK spec algorithms (their verify bypasses `prepare_mamba_track_for_verify`, so the lazy pending slot never receives the checkpoint scatter yet is still promoted in result processing). The guard was nested under `if view.speculative_num_draft_tokens is not None`, but `_validate_mamba_extra_buffer` runs before `handle_speculative_decoding` resolves that value, and DFLASH derives it from `--speculative-dflash-block-size`. So `--speculative-algorithm DFLASH --speculative-dflash-block-size N --mamba-radix-cache-strategy extra_buffer_lazy` (without an explicit `--speculative-num-draft-tokens`) sees `None` at validation and the guard is skipped; a lowercase `dflash` also slips past the uppercase string compare.

This keys the check on the algorithm name (present and case-normalized at validation time) instead of `speculative_num_draft_tokens`, so the unsupported combination is rejected regardless of how the block size is passed or cased.

Verified the previously-bypassing configs (`DFLASH`+block_size, lowercase `dflash`, `DSPARK`) now raise at startup, while `EAGLE` / `NEXTN` + `extra_buffer_lazy` stay allowed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29830661282](https://github.com/sgl-project/sglang/actions/runs/29830661282)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29830661097](https://github.com/sgl-project/sglang/actions/runs/29830661097)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->