### PR TITLE
fix(vlm): return invalid media input as HTTP 400

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1013,6 +1013,17 @@ class BaseMultimodalProcessor(ABC):
         for modality, idx, future in futures:
             try:
                 result = await asyncio.wrap_future(future)
+            except ValueError as e:
+                logger.info(
+                    "[load_mm_data(simple)] invalid %s data at index=%d: %s",
+                    modality.name,
+                    idx,
+                    e,
+                )
+                raise ValueError(
+                    f"An exception occurred while loading {modality.name} data "
+                    f"at index {idx}: {e}"
+                ) from e
             except Exception as e:
                 logger.exception(
                     "[load_mm_data(simple)] error loading %s data at index=%d",
@@ -1154,6 +1165,10 @@ class BaseMultimodalProcessor(ABC):
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"
                 )
+            except ValueError as e:
+                raise ValueError(
+                    f"An exception occurred while loading multimodal data: {e}"
+                ) from e
             except Exception as e:
                 raise RuntimeError(
                     f"An exception occurred while loading multimodal data: {e}"

--- a/test/registered/unit/multimodal/test_base_processor_image_decode.py
+++ b/test/registered/unit/multimodal/test_base_processor_image_decode.py
@@ -13,8 +13,11 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
+import asyncio
+import concurrent.futures
 import io
 import unittest
+from unittest.mock import Mock
 
 import numpy as np
 from PIL import Image
@@ -29,6 +32,9 @@ class _StubProcessor(BaseMultimodalProcessor):
     # exercises exactly the lazy-decode branch the fix targets. The abstract methods
     # are never called: we only invoke the _load_single_item classmethod.
     gpu_image_decode = False
+
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
 
 
 def _png_bytes(mode: str = "RGB", size=(8, 8)) -> bytes:
@@ -74,6 +80,23 @@ class TestLoadSingleItemImageDecode(CustomTestCase):
         img = _StubProcessor._load_single_item(data, Modality.IMAGE)
         ref = Image.open(io.BytesIO(data)).convert("RGB")
         np.testing.assert_array_equal(np.asarray(img), np.asarray(ref))
+
+    def test_fast_loader_preserves_invalid_input_as_value_error(self):
+        processor = object.__new__(_StubProcessor)
+        future = concurrent.futures.Future()
+        future.set_exception(ValueError("invalid base64 image"))
+        processor._submit_mm_data_loading_tasks_simple = Mock(
+            side_effect=[[(Modality.IMAGE, 0, future)], [], []]
+        )
+
+        with self.assertRaisesRegex(ValueError, "invalid base64 image"):
+            asyncio.run(
+                processor.fast_load_mm_data(
+                    prompt="<image>",
+                    multimodal_tokens=Mock(),
+                    image_data=["bad-image"],
+                )
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Invalid client-supplied multimodal data (for example malformed base64 image bytes) is classified as `ValueError` by `_load_single_item`, but both fast and legacy loaders wrap it in `RuntimeError`. The OpenAI serving layer therefore returns HTTP 500 instead of HTTP 400.

## Changes

- Preserve `ValueError` through both multimodal loading paths.
- Keep unexpected loader failures as `RuntimeError`/HTTP 500.
- Add a CPU regression test for the fast loader.

## Validation

- `test_base_processor_image_decode.py`, Kimi processor tests, and OpenAI serving-chat unit tests: **101 passed + 15 subtests** on NVIDIA B300.
- Real Kimi-K3 TP8/GB300 protocol probe before this patch reproduced malformed base64 image as HTTP 500; post-patch validation at Kimi PR head `bac10440f` on real Kimi-K3 weights, NVIDIA GB300 TP8, returned HTTP 400. The complete protocol/error matrix passed **5/5**, and the server log contained **0 Traceback, 0 ERROR**.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29830822824](https://github.com/sgl-project/sglang/actions/runs/29830822824)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29830822508](https://github.com/sgl-project/sglang/actions/runs/29830822508)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->