### PR TITLE
[MoE] Validate runner backend in PermuteMethodPool registration

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -161,7 +161,10 @@ class PermuteMethodPool:
         :param runner_backend_name: The MoeRunnerBackend name.
         :param permute_func: The permute function to register.
         """
-        # TODO: check if registration is valid
+        # Validate the runner name eagerly. The format name can't be checked
+        # here without a circular import through token_dispatcher.
+        MoeRunnerBackend(runner_backend_name)  # raises if not a valid runner
+
         key = (dispatch_output_name, runner_backend_name)
         if key in cls._pre_permute_methods:
             raise ValueError(
@@ -183,7 +186,10 @@ class PermuteMethodPool:
         :param combine_input_name: The CombineInputFormat name.
         :param permute_func: The permute function to register.
         """
-        # TODO: check if registration is valid
+        # Validate the runner name eagerly. The format name can't be checked
+        # here without a circular import through token_dispatcher.
+        MoeRunnerBackend(runner_backend_name)  # raises if not a valid runner
+
         key = (runner_backend_name, combine_input_name)
         if key in cls._post_permute_methods:
             raise ValueError(

--- a/test/registered/unit/layers/moe/test_permute_registration.py
+++ b/test/registered/unit/layers/moe/test_permute_registration.py
@@ -1,0 +1,42 @@
+import unittest
+
+from sglang.srt.layers.moe.moe_runner.base import PermuteMethodPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+
+def _noop_permute(*args, **kwargs):
+    return None
+
+
+class TestPermuteRegistrationValidation(CustomTestCase):
+    """An unknown runner-backend name must be rejected at register_{pre,post}_permute,
+    not left to fail later at get_{pre,post}_permute() lookup time."""
+
+    def test_pre_permute_rejects_unknown_runner_backend(self):
+        """register_pre_permute validates its runner slot (arg 2)."""
+        with self.assertRaises(ValueError):
+            PermuteMethodPool.register_pre_permute(
+                "standard", "not_a_runner", _noop_permute
+            )
+
+    def test_post_permute_rejects_a2a_name_in_runner_slot(self):
+        """'mori' is a valid MoeA2ABackend but not a MoeRunnerBackend; register_post_permute
+        validates its runner slot (arg 1 -- the order flips vs register_pre_permute)."""
+        with self.assertRaises(ValueError):
+            PermuteMethodPool.register_post_permute("mori", "standard", _noop_permute)
+
+    def test_rejected_registration_does_not_mutate_pool(self):
+        """A rejected name leaves the registry untouched (validation precedes insert)."""
+        before = dict(PermuteMethodPool._pre_permute_methods)
+        with self.assertRaises(ValueError):
+            PermuteMethodPool.register_pre_permute(
+                "standard", "not_a_runner", _noop_permute
+            )
+        self.assertEqual(PermuteMethodPool._pre_permute_methods, before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Validate the `MoeRunnerBackend` name in `PermuteMethodPool.register_pre_permute` / `register_post_permute` so an unknown runner name raises `ValueError` at registration instead of surfacing later as an unrelated lookup assertion.

## Motivation

Both `register_pre_permute` and `register_post_permute` stored their `(name, name)` key behind a `# TODO: check if registration is valid` placeholder, with no validation. An unknown runner-backend name was accepted, then never matched at `get_{pre,post}_permute()`, which asserts the looked-up function is not `None` and fails with `"... is not registered"`. That error appears at MoE-forward time and points at the lookup site, not at the bad registration. This replaces the TODO with the same runner-name check `FusedOpPool.register_fused_func` already performs, so the failure lands at the registration call site.

## Modifications

- `python/sglang/srt/layers/moe/moe_runner/base.py`: call `MoeRunnerBackend(runner_backend_name)` at the top of both register methods (the `MoeRunnerBackend` argument is arg 2 of `register_pre_permute` and arg 1 of `register_post_permute`), which raises `ValueError` for an unknown value. `MoeRunnerBackend` is already imported at runtime from `moe.utils`, so no new import is introduced. The check precedes the dict insert, so a rejected name does not mutate the registry.
- The dispatch/combine format names are intentionally not validated here: their enums live in `token_dispatcher`, which cannot be imported at import-time registration without a circular import, so a bad format name is still caught at `get_*_permute()` lookup time.
- `test/registered/unit/layers/moe/test_permute_registration.py` (new, `base-c-test-cpu`): three cases. An unknown runner name is rejected by `register_pre_permute` (arg 2). A name valid for a different MoE enum but not a runner (`"mori"`, a `MoeA2ABackend`) is rejected by `register_post_permute` (arg 1, exercising the flipped argument order). A rejected registration leaves `_pre_permute_methods` unchanged.

## Accuracy Tests

N/A. No change to model outputs or forward code; the set of accepted registrations is unchanged.

## Speed Tests and Profiling

N/A. The check runs once per registration at startup, with no inference-path impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29839970987](https://github.com/sgl-project/sglang/actions/runs/29839970987)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29839970265](https://github.com/sgl-project/sglang/actions/runs/29839970265)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->