### PR TITLE
Add OrangeRedeng and Alisehen to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -27,6 +27,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
+    "Alisehen": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "AniZpZ": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -250,6 +257,13 @@
         "can_rerun_stage": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
+    },
+    "OrangeRedeng": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
     },
     "Prozac614": {
         "can_tag_run_ci_label": true,


### PR DESCRIPTION
## Motivation

Grant CI permissions to `OrangeRedeng` and `Alisehen` so they can trigger and rerun CI workflows as Collaborators.

## Modifications

- Add `OrangeRedeng` to `.github/CI_PERMISSIONS.json`.
- Add `Alisehen` to `.github/CI_PERMISSIONS.json`.
- Allow both users to:
  - apply the run-CI label;
  - rerun failed CI;
  - rerun individual stages.
- Set a 60-minute cooldown for both entries.

### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29839678217](https://github.com/sgl-project/sglang/actions/runs/29839678217)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29839677716](https://github.com/sgl-project/sglang/actions/runs/29839677716)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29839924699](https://github.com/sgl-project/sglang/actions/runs/29839924699)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29839924623](https://github.com/sgl-project/sglang/actions/runs/29839924623)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->