### PR TITLE
[HiSparse] Add runtime variants to Breakable CUDA Graph (Part 4 of 4)

### DIFF
--- a/python/sglang/srt/mem_cache/sparsity/cuda_graph_support.py
+++ b/python/sglang/srt/mem_cache/sparsity/cuda_graph_support.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Optional
+
+import torch
+
+_DEFAULT_CONTEXT_BUCKETS = (10 * 1024, 33 * 1024)
+
+
+class SparseCudaGraphRuntimeProvider:
+    def __init__(self, coordinator: Any):
+        self.coordinator = coordinator
+        self.page_size = coordinator.page_size
+        self.max_context_len = coordinator.req_to_token_pool.max_context_len
+        if self.page_size <= 0 or self.max_context_len <= 0:
+            raise ValueError("Sparse CUDA graph dimensions must be positive")
+
+        self.max_num_pages = (
+            self.max_context_len + self.page_size - 1
+        ) // self.page_size
+        context_buckets = coordinator.config.sparse_extra_config.get(
+            "cuda_graph_context_buckets", _DEFAULT_CONTEXT_BUCKETS
+        )
+        if (
+            not isinstance(context_buckets, (list, tuple))
+            or not context_buckets
+            or any(
+                not isinstance(value, int) or isinstance(value, bool) or value <= 0
+                for value in context_buckets
+            )
+        ):
+            raise ValueError(
+                "cuda_graph_context_buckets must contain positive integers"
+            )
+
+        page_buckets = {
+            min(
+                (context_len + self.page_size - 1) // self.page_size,
+                self.max_num_pages,
+            )
+            for context_len in context_buckets
+        }
+        page_buckets.add(self.max_num_pages)
+        self.page_buckets = tuple(sorted(page_buckets))
+
+    def cuda_graph_capture_variants(self):
+        return self.page_buckets
+
+    def select_cuda_graph_variant(self, forward_batch):
+        seq_lens = getattr(forward_batch, "seq_lens_cpu", None)
+        if torch.is_tensor(seq_lens):
+            if seq_lens.device.type != "cpu":
+                return True, self.page_buckets[-1]
+            max_seq_len = int(seq_lens.max().item()) if seq_lens.numel() else 0
+        elif seq_lens is None:
+            return True, self.page_buckets[-1]
+        else:
+            try:
+                max_seq_len = max((int(value) for value in seq_lens), default=0)
+            except TypeError:
+                return True, self.page_buckets[-1]
+
+        required_pages = (max_seq_len + self.page_size - 1) // self.page_size
+        runtime_variant = next(
+            (capacity for capacity in self.page_buckets if capacity >= required_pages),
+            None,
+        )
+        return runtime_variant is not None, runtime_variant
+
+    def _publish_variant(self, forward_batch, runtime_variant) -> None:
+        if runtime_variant not in self.page_buckets:
+            raise ValueError(
+                f"Unknown sparse CUDA graph page capacity: {runtime_variant!r}"
+            )
+        forward_batch.runtime_sparse_page_capacity = runtime_variant
+
+    def prepare_cuda_graph_capture(self, forward_batch, runtime_variant) -> None:
+        self._publish_variant(forward_batch, runtime_variant)
+
+    def prepare_cuda_graph_replay(self, forward_batch, runtime_variant) -> None:
+        self._publish_variant(forward_batch, runtime_variant)
+
+    def prepare_cuda_graph_capture_context(self, context):
+        if not dataclasses.is_dataclass(context):
+            return context
+        field_names = {field.name for field in dataclasses.fields(context)}
+        if "runtime_sparse_coordinator" not in field_names:
+            return context
+        return dataclasses.replace(context, runtime_sparse_coordinator=self.coordinator)
+
+
+def create_cuda_graph_runtime_provider(
+    coordinator: Any,
+) -> Optional[SparseCudaGraphRuntimeProvider]:
+    if not is_runtime_sparse_cuda_graph_available(coordinator):
+        return None
+    return SparseCudaGraphRuntimeProvider(coordinator)
+
+
+def is_runtime_sparse_cuda_graph_available(coordinator: Any) -> bool:
+    config = coordinator.config
+    enabled = config.sparse_extra_config.get("enable_cuda_graph_retrieval", True)
+    if not isinstance(enabled, bool):
+        raise ValueError("enable_cuda_graph_retrieval must be a boolean")
+    algorithm_cls = type(coordinator.algorithm)
+    if not enabled or not getattr(
+        algorithm_cls, "supports_fixed_cuda_graph_capacity", False
+    ):
+        return False
+    if config.backend not in ("fa3", "flashattention"):
+        return False
+    if torch.device(coordinator.device).type != "cuda" or torch.version.hip is not None:
+        return False
+    return True

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -29,7 +29,7 @@ import contextlib
 import inspect
 import logging
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import torch
 import tqdm
@@ -438,11 +438,73 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
     def _cache_loc_dtype(self):
         return torch.int64
 
-    def _make_graph_key(self, size, stream_idx=None, variant_label=None):
+    def _runtime_graph_extension(self):
+        # Optional capability contract. Providers own their runtime state;
+        # this runner only selects, keys, and prepares stable graph variants.
+        return getattr(self.model_runner, "cuda_graph_runtime_extension", None)
+
+    def _runtime_graph_capture_variants(self):
+        extension = self._runtime_graph_extension()
+        get_variants = getattr(extension, "cuda_graph_capture_variants", None)
+        if get_variants is None:
+            return (None,)
+        variants = tuple(get_variants())
+        if not variants:
+            raise ValueError(
+                "CUDA graph runtime extension returned no capture variants"
+            )
+        return variants
+
+    def _select_runtime_graph_variant(self, forward_batch: ForwardBatch):
+        extension = self._runtime_graph_extension()
+        select_variant = getattr(extension, "select_cuda_graph_variant", None)
+        if select_variant is None:
+            return True, None
+        is_supported, runtime_variant = select_variant(forward_batch)
+        return bool(is_supported), runtime_variant
+
+    def _select_captured_runtime_graph_variant(self, forward_batch: ForwardBatch):
+        is_supported, runtime_variant = self._select_runtime_graph_variant(
+            forward_batch
+        )
+        return (
+            is_supported and runtime_variant in self._runtime_graph_capture_variants(),
+            runtime_variant,
+        )
+
+    def _prepare_runtime_graph_capture(
+        self, forward_batch: ForwardBatch, runtime_variant: Any
+    ) -> None:
+        extension = self._runtime_graph_extension()
+        prepare = getattr(extension, "prepare_cuda_graph_capture", None)
+        if prepare is not None:
+            prepare(forward_batch, runtime_variant)
+
+    def _prepare_runtime_graph_replay(
+        self, forward_batch: ForwardBatch, runtime_variant: Any
+    ) -> None:
+        extension = self._runtime_graph_extension()
+        prepare = getattr(extension, "prepare_cuda_graph_replay", None)
+        if prepare is not None:
+            prepare(forward_batch, runtime_variant)
+
+    def _prepare_runtime_graph_capture_context(self, context: ForwardContext):
+        extension = self._runtime_graph_extension()
+        prepare = getattr(extension, "prepare_cuda_graph_capture_context", None)
+        return context if prepare is None else prepare(context)
+
+    def _make_graph_key(
+        self,
+        size,
+        stream_idx=None,
+        variant_label=None,
+        runtime_variant=None,
+    ):
         return ShapeKey(
             size=size,
             stream_idx=stream_idx,
             variant_label=variant_label,
+            runtime_variant=runtime_variant,
         )
 
     def _capture_graph_size(self, *, bs: int, num_tokens: int) -> int:
@@ -532,10 +594,14 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         else:
             cuda_graph_bs = forward_batch.batch_size
 
+        is_runtime_variant_supported, runtime_variant = (
+            self._select_captured_runtime_graph_variant(forward_batch)
+        )
         graph_key = self._make_graph_key(
             cuda_graph_bs,
             stream_idx=get_current_stream_idx() if self.enable_pdmux else None,
             variant_label=self._resolve_lora_variant(forward_batch),
+            runtime_variant=runtime_variant,
         )
 
         is_bs_supported = (
@@ -584,6 +650,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         return (
             is_bs_supported
+            and is_runtime_variant_supported
             and is_encoder_lens_supported
             and is_tbo_supported
             and capture_hidden_mode_matches
@@ -593,6 +660,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
     def _can_run_ragged_verify_graph(self, forward_batch: ForwardBatch, ragged_layout):
         if not self.attn_backend.supports_ragged_verify_graph:
             return False
+
+        is_runtime_variant_supported, _ = self._select_captured_runtime_graph_variant(
+            forward_batch
+        )
 
         admission_tokens = ragged_layout.graph_num_tokens
         is_tokens_supported = admission_tokens <= self.capture_num_tokens[
@@ -625,6 +696,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         return (
             is_tokens_supported
+            and is_runtime_variant_supported
             and is_dp_supported
             and is_encoder_lens_supported
             and capture_hidden_mode_matches
@@ -669,6 +741,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         size: int,
         stream_idx: Optional[int] = None,
         num_tokens: Optional[int] = None,
+        runtime_variant: Any = None,
     ):
         """Build the dummy decode ForwardBatch for capture at size (=bs),
         populate static input buffers, choose the active attn backend, and
@@ -810,6 +883,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             rids_int=rids_int,
             bootstrap_room_ids_int=bootstrap_room_ids_int,
         )
+        self._prepare_runtime_graph_capture(forward_batch, runtime_variant)
 
         # Trip the coordinator so the hisparse code path is captured into the
         # graph; backends read it from self.model_runner.hisparse_coordinator.
@@ -878,18 +952,24 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.model_runner.gpu_id,
             empty_cache=False,
         )
-        # Reverse so cuda graphs share memory better.
+        # Reverse so cuda graphs share memory better. Runtime extensions may
+        # capture more than one stable variant for each batch shape.
+        capture_shapes = [
+            (bs, runtime_variant)
+            for bs in self.capture_bs
+            for runtime_variant in self._runtime_graph_capture_variants()
+        ]
         capture_range = (
-            tqdm.tqdm(list(reversed(self.capture_bs)))
+            tqdm.tqdm(list(reversed(capture_shapes)))
             if get_parallel().tp_rank == 0
-            else reversed(self.capture_bs)
+            else reversed(capture_shapes)
         )
         lora_variants = (
             [("lora", True), ("nolora", False)]
             if getattr(self, "record_nolora_graph", False)
             else [(None, None)]
         )
-        for bs in capture_range:
+        for bs, runtime_variant in capture_range:
             if get_parallel().tp_rank == 0:
                 avail_mem = get_available_gpu_memory(
                     self.model_runner.device,
@@ -897,7 +977,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     empty_cache=False,
                 )
                 capture_range.set_description(
-                    f"Capturing batches ({bs=} {avail_mem=:.2f} GB)"
+                    "Capturing batches "
+                    f"({bs=} variant={runtime_variant!r} {avail_mem=:.2f} GB)"
                 )
 
             for variant_label, _variant_has_lora in lora_variants:
@@ -908,7 +989,13 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     num_tokens=bs * self.captured_req_width,
                     tp_group=self.model_runner.tp_group,
                 ) as forward:
-                    self.capture_one_shape(bs, forward, stream_idx, variant_label)
+                    self.capture_one_shape(
+                        bs,
+                        forward,
+                        stream_idx,
+                        variant_label,
+                        runtime_variant,
+                    )
 
     def capture_one_shape(
         self,
@@ -916,6 +1003,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         forward: Callable,
         stream_idx: Optional[int] = None,
         variant_label: Optional[str] = None,
+        runtime_variant: Any = None,
     ):
         num_tokens = size * self.captured_req_width
         bs = self._ragged_capture_slots(num_tokens) if self.ragged_verify_mode else size
@@ -927,13 +1015,19 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             ), "Breakable CUDA graph is required for --debug-cuda-graph"
 
         forward_batch, attn_backend, pp_proxy_tensors = self.capture_prepare(
-            bs, stream_idx=stream_idx, num_tokens=num_tokens
+            bs,
+            stream_idx=stream_idx,
+            num_tokens=num_tokens,
+            runtime_variant=runtime_variant,
         )
 
         # All setup hooks below read get_attn_backend() (TboForwardBatchPreparer,
         # DeepEP adapter, …) so they must run inside the same ForwardContext
         # that wraps the warmup/capture forward.
-        with forward_context(ForwardContext(attn_backend=attn_backend)):
+        capture_context = self._prepare_runtime_graph_capture_context(
+            ForwardContext(attn_backend=attn_backend)
+        )
+        with forward_context(capture_context):
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
 
             if forward_batch.lora_ids is not None:
@@ -1003,6 +1097,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     self._capture_graph_size(bs=bs, num_tokens=num_tokens),
                     stream_idx,
                     variant_label,
+                    runtime_variant,
                 )
                 post_warmup_hook = getattr(
                     self.model_runner.attn_backend,
@@ -1097,8 +1192,19 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 )
             variant_label = self._resolve_lora_variant(forward_batch)
             stream_idx = get_current_stream_idx() if self.enable_pdmux else None
+            is_runtime_variant_supported, runtime_variant = (
+                self._select_captured_runtime_graph_variant(forward_batch)
+            )
+            if not is_runtime_variant_supported:
+                raise RuntimeError(
+                    "Unsupported CUDA graph runtime variant reached replay preparation"
+                )
+            self._prepare_runtime_graph_replay(forward_batch, runtime_variant)
             self._replay_graph_key = self._make_graph_key(
-                graph_size_key, stream_idx, variant_label
+                graph_size_key,
+                stream_idx,
+                variant_label,
+                runtime_variant,
             )
             return
 
@@ -1198,8 +1304,19 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         variant_label = self._resolve_lora_variant(forward_batch)
         stream_idx = get_current_stream_idx() if self.enable_pdmux else None
+        is_runtime_variant_supported, runtime_variant = (
+            self._select_captured_runtime_graph_variant(forward_batch)
+        )
+        if not is_runtime_variant_supported:
+            raise RuntimeError(
+                "Unsupported CUDA graph runtime variant reached replay preparation"
+            )
+        self._prepare_runtime_graph_replay(forward_batch, runtime_variant)
         self._replay_graph_key = self._make_graph_key(
-            graph_size_key, stream_idx, variant_label
+            graph_size_key,
+            stream_idx,
+            variant_label,
+            runtime_variant,
         )
 
     def _ragged_graph_num_tokens(self, total_verify_tokens: int) -> int:

--- a/python/sglang/srt/model_executor/runner/shape_key.py
+++ b/python/sglang/srt/model_executor/runner/shape_key.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Hashable, Optional
 
 
 @dataclass(frozen=True)
@@ -29,8 +29,11 @@ class ShapeKey:
     stream_idx:   pdmux stream index, or None for single-stream runners.
     variant_label: LoRA-variant label ("lora" / "nolora"), or None
         for runners that don't record per-variant graphs.
+    runtime_variant: optional key selected by a runtime capability that needs
+        more than one graph for the same batch shape.
     """
 
     size: int
     stream_idx: Optional[int] = None
     variant_label: Optional[str] = None
+    runtime_variant: Optional[Hashable] = None

--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -18,6 +18,7 @@ No torch.compile.
 
 from __future__ import annotations
 
+import dataclasses
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
@@ -51,6 +52,19 @@ if TYPE_CHECKING:
         BaseCudaGraphRunner,
     )
     from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
+
+def _is_dataclass_instance(value: Any) -> bool:
+    return dataclasses.is_dataclass(value) and not isinstance(value, type)
+
+
+def _is_buffered_output(value: Any) -> bool:
+    return (
+        value is None
+        or torch.is_tensor(value)
+        or isinstance(value, (PPProxyTensors, list, tuple))
+        or _is_dataclass_instance(value)
+    )
 
 
 class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
@@ -152,8 +166,21 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
         if isinstance(output, PPProxyTensors):
             rows = [t.shape[0] for t in output.tensors.values()]
             return min([cap, *rows])
+        if _is_dataclass_instance(output):
+            values = [
+                getattr(output, field.name)
+                for field in dataclasses.fields(output)
+                if _is_buffered_output(getattr(output, field.name))
+                and getattr(output, field.name) is not None
+            ]
+            return min([cap, *(self._output_rows(value, cap) for value in values)])
         if isinstance(output, (list, tuple)) and output:
-            return min(self._output_rows(o, cap) for o in output if o is not None)
+            values = [
+                value
+                for value in output
+                if _is_buffered_output(value) and value is not None
+            ]
+            return min([cap, *(self._output_rows(value, cap) for value in values)])
         return cap
 
     def _alloc_full_buffer(self, output: Any, size: int) -> Any:
@@ -169,10 +196,35 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
                     for key, t in output.tensors.items()
                 }
             )
+        if _is_dataclass_instance(output):
+            return type(output)(
+                **{
+                    field.name: (
+                        self._alloc_full_buffer(getattr(output, field.name), size)
+                        if _is_buffered_output(getattr(output, field.name))
+                        else getattr(output, field.name)
+                    )
+                    for field in dataclasses.fields(output)
+                }
+            )
         if isinstance(output, tuple):
-            return tuple(self._alloc_full_buffer(o, size) for o in output)
+            return tuple(
+                (
+                    self._alloc_full_buffer(value, size)
+                    if _is_buffered_output(value)
+                    else value
+                )
+                for value in output
+            )
         if isinstance(output, list):
-            return [self._alloc_full_buffer(o, size) for o in output]
+            return [
+                (
+                    self._alloc_full_buffer(value, size)
+                    if _is_buffered_output(value)
+                    else value
+                )
+                for value in output
+            ]
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _slice_output(self, output: Any, num_tokens: int) -> Any:
@@ -182,10 +234,35 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return output[:num_tokens]
         if isinstance(output, PPProxyTensors):
             return output[:num_tokens]
+        if _is_dataclass_instance(output):
+            return type(output)(
+                **{
+                    field.name: (
+                        self._slice_output(getattr(output, field.name), num_tokens)
+                        if _is_buffered_output(getattr(output, field.name))
+                        else getattr(output, field.name)
+                    )
+                    for field in dataclasses.fields(output)
+                }
+            )
         if isinstance(output, tuple):
-            return tuple(self._slice_output(item, num_tokens) for item in output)
+            return tuple(
+                (
+                    self._slice_output(value, num_tokens)
+                    if _is_buffered_output(value)
+                    else value
+                )
+                for value in output
+            )
         if isinstance(output, list):
-            return [self._slice_output(item, num_tokens) for item in output]
+            return [
+                (
+                    self._slice_output(value, num_tokens)
+                    if _is_buffered_output(value)
+                    else value
+                )
+                for value in output
+            ]
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _copy_output_to_buffer(
@@ -214,6 +291,18 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
                     tensor, output_buffer.tensors[key], num_tokens
                 )
             return
+        if _is_dataclass_instance(output) and type(output_buffer) is type(output):
+            for field in dataclasses.fields(output):
+                value = getattr(output, field.name)
+                buffer = getattr(output_buffer, field.name)
+                if _is_buffered_output(value):
+                    self._copy_output_to_buffer(value, buffer, num_tokens)
+                elif value != buffer:
+                    raise ValueError(
+                        "BCG output value changed between capture sizes: "
+                        f"{field.name}={value!r} != {buffer!r}"
+                    )
+            return
         if isinstance(output, (list, tuple)) and isinstance(
             output_buffer, type(output)
         ):
@@ -223,7 +312,13 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
                     f"{len(output)} != {len(output_buffer)}"
                 )
             for item, buffer in zip(output, output_buffer):
-                self._copy_output_to_buffer(item, buffer, num_tokens)
+                if _is_buffered_output(item):
+                    self._copy_output_to_buffer(item, buffer, num_tokens)
+                elif item != buffer:
+                    raise ValueError(
+                        "BCG output value changed between capture sizes: "
+                        f"{item!r} != {buffer!r}"
+                    )
             return
         raise TypeError(
             "Unsupported BCG output buffer pair: "

--- a/test/registered/unit/model_executor/test_breakable_cuda_graph_runtime_extension.py
+++ b/test/registered/unit/model_executor/test_breakable_cuda_graph_runtime_extension.py
@@ -1,0 +1,215 @@
+import dataclasses
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.mem_cache.sparsity.cuda_graph_support import (
+    create_cuda_graph_runtime_provider,
+    is_runtime_sparse_cuda_graph_available,
+)
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+from sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend import (
+    BreakableCudaGraphBackend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestBreakableCudaGraphStructuredOutput(unittest.TestCase):
+    def setUp(self):
+        self.backend = BreakableCudaGraphBackend.__new__(BreakableCudaGraphBackend)
+
+    def test_dataclass_tensor_fields_use_stable_buffers(self):
+        output = LogitsProcessorOutput(
+            next_token_logits=torch.arange(6, dtype=torch.float32).view(2, 3),
+            hidden_states=torch.arange(8, dtype=torch.float32).view(2, 4),
+            customized_info={"source": ["decode"]},
+        )
+
+        self.assertEqual(self.backend._output_rows(output, cap=4), 2)
+        buffer = self.backend._alloc_full_buffer(output, size=4)
+        self.backend._copy_output_to_buffer(output, buffer, num_tokens=2)
+        sliced = self.backend._slice_output(buffer, num_tokens=2)
+
+        torch.testing.assert_close(sliced.next_token_logits, output.next_token_logits)
+        torch.testing.assert_close(sliced.hidden_states, output.hidden_states)
+        self.assertEqual(sliced.customized_info, {"source": ["decode"]})
+
+    def test_non_tensor_dataclass_fields_must_remain_stable(self):
+        output = LogitsProcessorOutput(
+            next_token_logits=torch.ones((1, 3)),
+            hidden_states=None,
+            customized_info={"mode": "decode"},
+        )
+        buffer = self.backend._alloc_full_buffer(output, size=2)
+        changed = dataclasses.replace(output, customized_info={"mode": "extend"})
+
+        with self.assertRaisesRegex(ValueError, "customized_info"):
+            self.backend._copy_output_to_buffer(changed, buffer, num_tokens=1)
+
+
+class _RuntimeExtension:
+    def __init__(self):
+        self.calls = []
+
+    def cuda_graph_capture_variants(self):
+        return (256, 1024)
+
+    def select_cuda_graph_variant(self, forward_batch):
+        return forward_batch.supported, forward_batch.variant
+
+    def prepare_cuda_graph_capture(self, forward_batch, runtime_variant):
+        self.calls.append(("capture", runtime_variant))
+
+    def prepare_cuda_graph_replay(self, forward_batch, runtime_variant):
+        self.calls.append(("replay", runtime_variant))
+
+    def prepare_cuda_graph_capture_context(self, context):
+        self.calls.append(("context", context))
+        return "extended-context"
+
+
+class TestDecodeCudaGraphRuntimeExtension(unittest.TestCase):
+    def _runner(self, extension=None):
+        runner = object.__new__(DecodeCudaGraphRunner)
+        runner.model_runner = SimpleNamespace(cuda_graph_runtime_extension=extension)
+        return runner
+
+    def test_absent_extension_preserves_the_default_graph_key(self):
+        runner = self._runner()
+        forward_batch = SimpleNamespace()
+
+        self.assertEqual(runner._runtime_graph_capture_variants(), (None,))
+        self.assertEqual(
+            runner._select_runtime_graph_variant(forward_batch), (True, None)
+        )
+        self.assertIsNone(runner._make_graph_key(8).runtime_variant)
+
+    def test_extension_selects_and_prepares_an_isolated_variant(self):
+        extension = _RuntimeExtension()
+        runner = self._runner(extension)
+        forward_batch = SimpleNamespace(supported=True, variant=1024)
+
+        self.assertEqual(runner._runtime_graph_capture_variants(), (256, 1024))
+        supported, variant = runner._select_runtime_graph_variant(forward_batch)
+        self.assertTrue(supported)
+        self.assertEqual(variant, 1024)
+        runner._prepare_runtime_graph_capture(forward_batch, variant)
+        runner._prepare_runtime_graph_replay(forward_batch, variant)
+        context = SimpleNamespace(attn_backend="backend")
+        self.assertEqual(
+            runner._prepare_runtime_graph_capture_context(context),
+            "extended-context",
+        )
+
+        self.assertEqual(
+            runner._make_graph_key(8, runtime_variant=256).runtime_variant, 256
+        )
+        self.assertNotEqual(
+            runner._make_graph_key(8, runtime_variant=256),
+            runner._make_graph_key(8, runtime_variant=1024),
+        )
+        self.assertEqual(
+            [call[0] for call in extension.calls], ["capture", "replay", "context"]
+        )
+
+    def test_ragged_verify_rejects_an_uncaptured_runtime_variant(self):
+        extension = _RuntimeExtension()
+        runner = self._runner(extension)
+        runner.attn_backend = SimpleNamespace(supports_ragged_verify_graph=True)
+        runner.capture_num_tokens = [8]
+        runner._ragged_capture_slots = lambda _: 2
+        runner.require_mlp_sync = False
+        runner.is_encoder_decoder = False
+        runner.capture_hidden_mode = CaptureHiddenMode.NULL
+        forward_batch = SimpleNamespace(
+            supported=True,
+            variant=2048,
+            batch_size=1,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+            spec_info=None,
+        )
+
+        self.assertFalse(
+            runner._can_run_ragged_verify_graph(
+                forward_batch, SimpleNamespace(graph_num_tokens=8)
+            )
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class _Context:
+    attn_backend: str
+    runtime_sparse_coordinator: object = None
+
+
+class _FixedCapacityAlgorithm:
+    supports_fixed_cuda_graph_capacity = True
+
+
+class TestSparseCudaGraphRuntimeProvider(unittest.TestCase):
+    def _provider(self):
+        coordinator = SimpleNamespace(
+            page_size=16,
+            device=torch.device("cuda"),
+            req_to_token_pool=SimpleNamespace(max_context_len=40 * 1024),
+            config=SimpleNamespace(
+                backend="fa3",
+                sparse_extra_config={
+                    "enable_cuda_graph_retrieval": True,
+                    "cuda_graph_context_buckets": [8 * 1024, 32 * 1024],
+                },
+            ),
+            algorithm=_FixedCapacityAlgorithm(),
+        )
+        return coordinator, create_cuda_graph_runtime_provider(coordinator)
+
+    def test_preflight_requires_a_class_level_fixed_capacity_capability(self):
+        coordinator, provider = self._provider()
+        self.assertTrue(is_runtime_sparse_cuda_graph_available(coordinator))
+        self.assertIsNotNone(provider)
+
+        coordinator.algorithm = SimpleNamespace(supports_fixed_cuda_graph_capacity=True)
+        self.assertFalse(is_runtime_sparse_cuda_graph_available(coordinator))
+        self.assertIsNone(create_cuda_graph_runtime_provider(coordinator))
+
+    def test_bucket_selection_and_out_of_range_fallback(self):
+        _, provider = self._provider()
+        self.assertEqual(provider.cuda_graph_capture_variants(), (512, 2048, 2560))
+
+        cases = (
+            ([1, 8192], (True, 512)),
+            (torch.tensor([8193, 32768]), (True, 2048)),
+            ([40 * 1024], (True, 2560)),
+            ([40 * 1024 + 1], (False, None)),
+        )
+        for seq_lens, expected in cases:
+            with self.subTest(seq_lens=seq_lens):
+                self.assertEqual(
+                    provider.select_cuda_graph_variant(
+                        SimpleNamespace(seq_lens_cpu=seq_lens)
+                    ),
+                    expected,
+                )
+
+    def test_capture_and_replay_publish_capacity_and_context(self):
+        coordinator, provider = self._provider()
+        forward_batch = SimpleNamespace()
+        provider.prepare_cuda_graph_capture(forward_batch, 512)
+        self.assertEqual(forward_batch.runtime_sparse_page_capacity, 512)
+
+        provider.prepare_cuda_graph_replay(forward_batch, 2048)
+        self.assertEqual(forward_batch.runtime_sparse_page_capacity, 2048)
+
+        context = provider.prepare_cuda_graph_capture_context(_Context("backend"))
+        self.assertIs(context.runtime_sparse_coordinator, coordinator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview

This PR adds a generic runtime-variant/provider contract to decode CUDA Graphs and teaches the Breakable CUDA Graph backend to preserve structured model outputs. Quest uses that contract to capture fixed-capacity sparse decode variants and replay the smallest compatible variant for the live batch.

## PR series

| Part | PR | Scope |
|---|---|---|
| Part 1 | [#30277](https://github.com/sgl-project/sglang/pull/30277) | Eager runtime integration and portable FA3 metadata fallback |
| Part 2 | [#29666](https://github.com/sgl-project/sglang/pull/29666) | Batched retrieval, host-sync reduction, and full-page fast path |
| Part 3 | [#31790](https://github.com/sgl-project/sglang/pull/31790) | Standalone GPU kernels for page selection and FA3 metadata updates |
| Part 4, this PR | [#31951](https://github.com/sgl-project/sglang/pull/31951) | Breakable CUDA Graph runtime variants and capture/replay |

## What this PR changes

This PR lets decode CUDA Graphs capture multiple runtime variants and safely select the right one during replay.

- Adds an optional runtime-variant interface and includes the selected variant in `ShapeKey`, keeping incompatible captured graphs isolated.
- Adds fixed-capacity Quest page buckets. Each batch shape is captured at the declared capacities, and replay selects the smallest capacity that fits the live batch.
- Falls back to eager execution when no captured capacity is compatible, including ragged verification paths.
- Extends the Breakable backend to preserve structured model outputs in stable buffers and reject unsafe output changes.

## Historical performance evidence

The stacked implementation observed the following change when Breakable CUDA Graph capture/replay was added after the GPU-kernel stage:

| Workload | Before, Quest/Dense | After, Quest/Dense | Change | Relative uplift |
|---|---:|---:|---:|---:|
| `8k-c8` | 45.99% | 95.53% | +49.54 pp | +107.72% |
| `32k-c1` | 55.83% | 87.52% | +31.69 pp | +56.76% |
| `32k-c4` | 55.15% | 84.75% | +29.60 pp | +53.67% |

## Test plan

- Run focused tests for variant selection, graph keys, eager fallback, and structured-output buffering.
- Validate real GPU capture/replay and deterministic eager-vs-BCG token equivalence on the combined series.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30327039857](https://github.com/sgl-project/sglang/actions/runs/30327039857)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30327039686](https://github.com/sgl-project/sglang/actions/runs/30327039686)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->