### PR TITLE
[AMD] [GLM5] Opt-in prefill-only FP8 dense projection GEMM for MLA q_b/o_proj (gfx950)

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1643,6 +1643,32 @@ def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     )
 
 
+def quant_weight_ue8m0(
+    weight_dequant: torch.Tensor,
+    weight_block_size: List[int],
+):
+    assert weight_block_size == [128, 128]
+    assert (
+        weight_dequant.dtype == torch.bfloat16
+    ), f"{weight_dequant.dtype=} {weight_dequant.shape=}"
+
+    *batch_dims, n, k = weight_dequant.shape
+
+    weight_dequant_flat = weight_dequant.view((-1, k))
+    out_w_flat, out_s_flat = per_block_cast_to_fp8(weight_dequant_flat)
+
+    out_w = out_w_flat.view((*batch_dims, n, k))
+    out_s = out_s_flat.view(
+        (
+            *batch_dims,
+            ceil_div(n, weight_block_size[0]),
+            ceil_div(k, weight_block_size[1]),
+        )
+    )
+
+    return out_w, out_s
+
+
 # COPIED FROM DeepGEMM
 def ceil_to_ue8m0(x: torch.Tensor):
     bits = x.abs().float().view(torch.int32)

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -34,6 +34,7 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
     is_cpu,
+    is_gfx95_supported,
     is_hip,
     is_npu,
     set_weight_attrs,
@@ -58,6 +59,28 @@ _is_hip = is_hip()
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_is_gfx95_supported = is_gfx95_supported()
+# Opt-in (gfx950): run bf16 dense projections that carry a `_fp8_proj_gemm`
+# marker (the quark-excluded GLM-5.2 MLA q_a/q_b/o_proj) on the aiter FP8 CK GEMM
+# instead of the bf16 tgemm. Load-time block-quant bf16 -> FP8 e4m3 + 128x128
+# scale (+ bpreshuffle) kept as a private FP8 copy; the bf16 weight is retained.
+# PREFILL-ONLY: only the large-M (prefill) GEMM takes the FP8 path; decode
+# (small-M cuda-graph batch sizes) stays bf16, because the small-M FP8 GEMM
+# regresses vs bf16 (see results/glm52_i1k_o1k_baseline_scratch.md). Default off.
+_DSA_FP8_PROJ_GEMM = get_bool_env_var("SGLANG_DSA_FP8_PROJ_GEMM")
+# Token-count gate: tokens beyond this count are treated as prefill and take the
+# FP8 projection GEMM. Decode cuda-graph batch sizes top out at 512, so M <= 512
+# stays bf16.
+_FP8_PROJ_PREFILL_M_MIN = 512
+
+
+def _fp8_proj_gemm_enabled(layer: torch.nn.Module) -> bool:
+    return (
+        _DSA_FP8_PROJ_GEMM
+        and _is_gfx95_supported
+        and getattr(layer, "_fp8_proj_gemm", False)
+    )
+
 
 if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
@@ -175,8 +198,40 @@ class UnquantizedLinearMethod(LinearMethodBase):
         set_weight_attrs(weight, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if _fp8_proj_gemm_enabled(layer):
+            self._repack_bf16_to_fp8_block(layer)
+            return
         if _is_cpu and _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["weight"])
+
+    @staticmethod
+    def _repack_bf16_to_fp8_block(layer: torch.nn.Module) -> None:
+        # Prefill-only FP8: precompute an FP8 e4m3 (+128x128 UE8M0 scale) copy of
+        # the bf16 projection weight for the large-M (prefill) GEMM, matching the
+        # aiter CK bpreshuffle w8a8-block path. Keep the bf16 weight as
+        # layer.weight so decode (small-M) runs the original bf16 GEMM. Storing the
+        # FP8 copy in private attrs (not layer.weight) also keeps the layer
+        # bf16-typed, so the MLA forward never pre-quantizes the activation for it
+        # and decode receives a plain bf16 tensor. Validated on gfx950: CK FP8
+        # output matches the torch block-fp8 reference to cos>0.9994.
+        from aiter.ops.shuffle import shuffle_weight
+
+        from sglang.srt.layers.quantization.fp8_utils import (
+            _use_aiter_bpreshuffle_gfx95,
+            quant_weight_ue8m0,
+        )
+
+        w = layer.weight.data
+        if w.dtype != torch.bfloat16 or w.dim() != 2:
+            return
+        fp8_w, w_scale = quant_weight_ue8m0(w, [128, 128])
+        if _use_aiter_bpreshuffle_gfx95:
+            fp8_w = shuffle_weight(fp8_w, (16, 16))
+        # Private FP8 copy (not a Parameter, not layer.weight) used only by the
+        # prefill branch in apply(); layer.weight stays bf16 for decode.
+        layer._fp8_proj_weight = fp8_w.contiguous()
+        layer._fp8_proj_weight_scale = w_scale.contiguous()
+        layer._fp8_proj_ready = True
 
     def apply(
         self,
@@ -184,6 +239,46 @@ class UnquantizedLinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if getattr(layer, "_fp8_proj_ready", False):
+            # Prefill-only FP8 gate. Compute the token count M; prefill (large M)
+            # takes the tuned FP8 CK GEMM (using the private FP8 weight copy),
+            # decode (M <= _FP8_PROJ_PREFILL_M_MIN — the cuda-graph batch sizes)
+            # falls through to the bf16 GEMM below, since small-M FP8 regresses vs
+            # bf16 (TTFT/TPOT). See results/glm52_i1k_o1k_baseline_scratch.md.
+            if isinstance(x, tuple):
+                x_q, x_scale = x
+                m_tokens = x_q.shape[0]
+            else:
+                m_tokens = x.numel() // x.shape[-1]
+
+            # A pre-quantized (fp8_act, scale) tuple should not occur while
+            # layer.weight stays bf16, but if it does the bf16 activation is
+            # unavailable, so keep FP8 for that case regardless of M.
+            if m_tokens > _FP8_PROJ_PREFILL_M_MIN or isinstance(x, tuple):
+                from sglang.srt.layers.quantization.fp8_utils import (
+                    aiter_w8a8_block_fp8_linear,
+                )
+
+                if isinstance(x, tuple):
+                    return aiter_w8a8_block_fp8_linear(
+                        x_q,
+                        layer._fp8_proj_weight,
+                        [128, 128],
+                        layer._fp8_proj_weight_scale,
+                        input_scale=x_scale,
+                        bias=bias,
+                    )
+                out = aiter_w8a8_block_fp8_linear(
+                    x.view(-1, x.shape[-1]),
+                    layer._fp8_proj_weight,
+                    [128, 128],
+                    layer._fp8_proj_weight_scale,
+                    input_scale=None,
+                    bias=bias,
+                )
+                return out.view(*x.shape[:-1], -1)
+            # decode: fall through to the bf16 GEMM (layer.weight stays bf16)
+
         if use_intel_amx_backend(layer):
             x_shapes = x.shape
             if len(x_shapes) == 3:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1706,6 +1706,15 @@ class DeepseekV2AttentionMLA(
             tp_rank=attn_tp_rank,
             tp_size=attn_tp_size,
         )
+        # Opt-in FP8 GEMM (gfx950) for the bf16 dense MLA projections. Marker
+        # only; unquant.py acts on it when SGLANG_DSA_FP8_PROJ_GEMM + gfx950 and
+        # the layer is unquantized (quark-excluded bf16). Only 128-aligned
+        # projections qualify (q_b [.,2048], o_proj [6144,.]); fused_qkv_a
+        # (out=2624) is not 128-aligned, and kv_b_proj is the absorbed-bmm path.
+        for _fp8_proj_name in ("q_b_proj", "o_proj"):
+            _fp8_proj = getattr(self, _fp8_proj_name, None)
+            if _fp8_proj is not None:
+                _fp8_proj._fp8_proj_gemm = True
         self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
 
         if not skip_rope:


### PR DESCRIPTION
## Motivation

On gfx950 (MI355X), the GLM-5.2 MLA dense projections `q_b_proj` / `o_proj` are quark-excluded and run in bf16. For prefill (large M) these are dense-GEMM bound. Running them on the aiter FP8 `a8w8_blockscale_bpreshuffle` CK GEMM for prefill only — while decode (small-M cuda-graph batch sizes) stays bf16 — reduces the dense-GEMM section without regressing decode.

Opt-in via `SGLANG_DSA_FP8_PROJ_GEMM` (default off), gfx950-gated. No effect off-arch or with the flag unset.

The tuned `a8w8_blockscale_bpreshuffle` GLM-5.2 configs are merged in aiter ([ROCm/aiter#4243](https://github.com/ROCm/aiter/pull/4243)), so aiter selects the tuned tiles automatically — no config override needed. Untuned, the small-M FP8 GEMM regresses vs bf16, which is why the path is prefill-only (M > 512).

## Modifications

- `layers/quantization/unquant.py`: `UnquantizedLinearMethod` gains an opt-in FP8 path for layers tagged `_fp8_proj_gemm`. At load, the bf16 weight is repacked into a private FP8 e4m3 (+128×128 UE8M0 scale, bpreshuffle) copy; `layer.weight` stays bf16. `apply()` gates on token count: M > 512 → FP8 CK GEMM (`aiter_w8a8_block_fp8_linear`), M ≤ 512 → bf16.
- `models/deepseek_v2.py`: mark `q_b_proj`/`o_proj` with `_fp8_proj_gemm` (128-aligned; `fused_qkv_a` out=2624 is not 128-aligned, `kv_b_proj` is the absorbed-bmm path).
- `layers/quantization/fp8_utils.py`: add `quant_weight_ue8m0()` helper.

## Accuracy Tests

GSM8K (400 questions, 5-shot), `SGLANG_DSA_FP8_PROJ_GEMM=1`, TP4, MI355X:

| config                     | accuracy |
| -------------------------- | -------- |
| prefill-only FP8 proj gate | 0.943    |

Pass bar ≥ 0.92.

## Speed Benchmarks

`sglang.bench_serving` (random, input=1024, output=1024, num-prompts=conc×4), TP4 MI355X, graphs-on. Each value is the mean of 3 reps after dropping the single obvious outlier per point (run-to-run / RNG noise). Baseline = flag off (bf16); Feature = `SGLANG_DSA_FP8_PROJ_GEMM=1`.

A. Baseline (flag off)*:

| concurrency | TTFT (ms) | ITL (ms) | E2EL (ms) | output tok/s |
| ----------- | --------- | -------- | --------- | ------------ |
| 4           | 199.0     | 11.81    | 12293     | 333.1        |
| 8           | 257.1     | 13.70    | 14312     | 572.0        |
| 16          | 525.0     | 16.40    | 17338     | 942.1        |
| 32          | 755.4     | 20.35    | 21900     | 1498.0       |
| 64          | 1176.8    | 27.08    | 29723     | 2205.8       |

B. Feature on (Δ vs baseline):

| concurrency | TTFT (ms) | Δ     | ITL (ms) | Δ     | E2EL (ms) | Δ     | output tok/s | Δ     |
| ----------- | --------- | ----- | -------- | ----- | --------- | ----- | ------------ | ----- |
| 4           | 197.2     | −0.9% | 11.81    | −0.0% | 12283     | −0.1% | 332.9        | −0.1% |
| 8           | 255.4     | −0.6% | 13.69    | −0.0% | 14310     | −0.0% | 572.2        | +0.0% |
| 16          | 498.8     | −5.0% | 16.39    | −0.0% | 17291     | −0.3% | 946.9        | +0.5% |
| 32          | 716.0     | −5.2% | 20.25    | −0.5% | 21781     | −0.5% | 1505.6       | +0.5% |
| 64          | 1110.5    | −5.6% | 27.05    | −0.1% | 29630     | −0.3% | 2210.5       | +0.2% |

TTFT improves monotonically with concurrency (−0.9% → −5.6%) as more prefill GEMM amortizes the FP8 path; ITL, E2EL, and output-throughput deltas are within run-to-run noise (decode stays bf16).

*Baseline and Feature both measured with [#30519](https://github.com/sgl-project/sglang/pull/30519), [#30715](https://github.com/sgl-project/sglang/pull/30715), [#31323](https://github.com/sgl-project/sglang/pull/31323), [#31324](https://github.com/sgl-project/sglang/pull/31324), and the tuned aiter MoE configs for GLM-5.2.

## Checklist

- [x] Format your code according to the Contributor Guide (pre-commit).
- [x] Add unit tests as outlined in the Contributor Guide. (n/a — opt-in, arch-gated inference path; covered by GSM8K + bench above)
- [x] Update documentation as needed.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29845180487](https://github.com/sgl-project/sglang/actions/runs/29845180487)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29845180047](https://github.com/sgl-project/sglang/actions/runs/29845180047)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->