### PR TITLE
[perf] Compute input logprobs without materializing the full-vocab log-softmax

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1017,6 +1017,10 @@ class Envs:
     SGLANG_LOGPROB_CHUNK_SIZE = EnvIntWithAlias(
         2048, deprecated_name="SGLANG_LOGITS_PROCESSER_CHUNK_SIZE"
     )
+    # Compute input logprobs from logits via per-row logsumexp instead of
+    # materializing the full-vocab log-softmax. Escape hatch only; the two
+    # paths are mathematically identical.
+    SGLANG_ENABLE_FAST_INPUT_LOGPROBS = EnvBool(True)
 
     # Tool-Call behavior
     SGLANG_TOOL_STRICT_LEVEL = EnvInt(ToolStrictLevel.OFF)

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -61,6 +61,32 @@ class LogprobResult:
             )
 
 
+def compute_row_logsumexp(
+    logits: torch.Tensor, vocab_slice_size: int = 32768
+) -> torch.Tensor:
+    """Per-row logsumexp in fp32 without materializing a full-vocab fp32 copy.
+
+    CUDA uses a single-pass online kernel (one read of the logits). Elsewhere,
+    low-precision logits are upcast one vocab slice at a time, so the peak
+    transient is [rows, vocab_slice_size] fp32 rather than [rows, vocab].
+    """
+    if logits.is_cuda:
+        try:
+            from sglang.srt.layers.logsumexp import row_logsumexp
+
+            return row_logsumexp(logits)
+        except ImportError:
+            pass
+    vocab_size = logits.shape[-1]
+    if logits.dtype == torch.float32 or vocab_size <= vocab_slice_size:
+        return torch.logsumexp(logits.float(), dim=-1)
+    partials = [
+        torch.logsumexp(logits[:, s : s + vocab_slice_size].float(), dim=-1)
+        for s in range(0, vocab_size, vocab_slice_size)
+    ]
+    return torch.logsumexp(torch.stack(partials, dim=-1), dim=-1)
+
+
 def get_top_logprobs_raw(
     logprobs: torch.Tensor,
     top_logprobs_nums: List[int],
@@ -170,16 +196,20 @@ def get_top_logprobs_chunk(
     top_logprobs_val: List,
     top_logprobs_idx: List,
     split_pruned_len: int,
+    log_normalizer: Optional[torch.Tensor] = None,
 ) -> int:
     """Get top-k logprobs for each sequence in the chunk.
 
     Args:
-        logprobs: Log probabilities tensor of shape [seq_len, vocab_size]
+        logprobs: Log probabilities tensor of shape [seq_len, vocab_size].
+            With ``log_normalizer`` set, raw logits instead; top-k runs on the
+            logits (same order) and values are normalized by subtraction.
         top_k_nums: List of top-k numbers for each sequence
         pruned_lens: List of pruned lengths for each sequence
         top_logprobs_val: List to store top-k logprob values
         top_logprobs_idx: List to store top-k token indices
         split_pruned_len: Length of pruned tokens from previous chunk
+        log_normalizer: Per-row logsumexp of the logits, shape [seq_len]
 
     Returns:
         int: Number of remaining tokens to process in next chunk
@@ -187,7 +217,10 @@ def get_top_logprobs_chunk(
     # Empty chunks still walk the slice to emit placeholder entries.
     max_k = max(top_k_nums)
     ret = logprobs.topk(max_k, dim=1)
-    values = ret.values.tolist()
+    values_tensor = ret.values
+    if log_normalizer is not None:
+        values_tensor = values_tensor.float() - log_normalizer[:, None]
+    values = values_tensor.tolist()
     indices = ret.indices.tolist()
 
     pt = 0
@@ -240,16 +273,20 @@ def get_token_ids_logprobs_chunk(
     token_ids_logprobs_val: List,
     token_ids_logprobs_idx: List,
     split_pruned_len: int = 0,
+    log_normalizer: Optional[torch.Tensor] = None,
 ):
     """Get token_ids logprobs for each sequence in the chunk.
 
     Args:
-        logprobs: Log probabilities tensor of shape [seq_len, vocab_size]
+        logprobs: Log probabilities tensor of shape [seq_len, vocab_size].
+            With ``log_normalizer`` set, raw logits instead; gathered rows are
+            normalized by subtraction.
         token_ids_logprobs: List of token IDs for each sequence
         pruned_lens: List of pruned lengths for each sequence
         token_ids_logprobs_val: List to store token logprob values
         token_ids_logprobs_idx: List to store token indices
         split_pruned_len: Length of pruned tokens from previous chunk
+        log_normalizer: Per-row logsumexp of the logits, shape [seq_len]
 
     Returns:
         int: Number of remaining tokens to process in next chunk
@@ -285,7 +322,10 @@ def get_token_ids_logprobs_chunk(
                 next_split_pruned_len = split_pruned_len + j
                 break
             if token_ids is not None:
-                val.append(logprobs[pt + j, token_ids].tolist())
+                row = logprobs[pt + j, token_ids]
+                if log_normalizer is not None:
+                    row = row.float() - log_normalizer[pt + j]
+                val.append(row.tolist())
                 idx.append(token_ids)
 
         # Split-sequence continuations extend; everyone else owns a fresh
@@ -379,6 +419,9 @@ class InputLogprobProcessor:
         self.enable_logprobs_chunk = envs.SGLANG_ENABLE_LOGPROB_CHUNK.get()
         # chunk size for logprobs processing
         self.logprobs_chunk_size = envs.SGLANG_LOGPROB_CHUNK_SIZE.get()
+        # compute logprobs from logits + logsumexp, skipping the full-vocab
+        # log-softmax materialization
+        self.enable_fast_input_logprobs = envs.SGLANG_ENABLE_FAST_INPUT_LOGPROBS.get()
 
     def forward(
         self,
@@ -496,12 +539,19 @@ class InputLogprobProcessor:
                 sampled_logits[chunk_sample_mask] = chunk_logits[chunk_sample_indices]
 
             # Zero-logprob-row chunks still need the per-sequence bookkeeping below.
-            # Compute the logprobs of the chunk. Free the raw logits before the
-            # out-of-place log_softmax: keeping all three alive is a 3x peak,
-            # which OOMs when the single chunk covers a large batch.
             chunk_logprobs = chunk_logits[chunk_indices]
             del chunk_logits
-            chunk_logprobs = torch.nn.functional.log_softmax(chunk_logprobs, dim=-1)
+            if self.enable_fast_input_logprobs:
+                # Every consumer below needs only small gathers / top-k plus a
+                # per-row normalizer, so keep the raw logits and skip the
+                # full-vocab log-softmax materialization entirely.
+                chunk_log_normalizer = compute_row_logsumexp(chunk_logprobs)
+            else:
+                # Free the raw logits before the out-of-place log_softmax:
+                # keeping all three alive is a 3x peak, which OOMs when the
+                # single chunk covers a large batch.
+                chunk_log_normalizer = None
+                chunk_logprobs = torch.nn.functional.log_softmax(chunk_logprobs, dim=-1)
 
             # End at the last row inside the chunk; token_to_seq_idx[end_idx]
             # belongs to the next chunk and would emit its sequence twice.
@@ -522,6 +572,7 @@ class InputLogprobProcessor:
                     top_logprobs_val,
                     top_logprobs_idx,
                     split_len_topk,
+                    log_normalizer=chunk_log_normalizer,
                 )
 
             # Get the logprob of given token id
@@ -537,6 +588,7 @@ class InputLogprobProcessor:
                     token_ids_logprobs_val,
                     token_ids_logprobs_idx,
                     split_len_token_ids,
+                    log_normalizer=chunk_log_normalizer,
                 )
 
             # Get the logprob of the requested token ids
@@ -544,6 +596,10 @@ class InputLogprobProcessor:
                 torch.arange(chunk_logprobs.shape[0], device=chunk_logprobs.device),
                 logits_metadata.extend_input_logprob_token_ids_gpu[mask_indices],
             ]
+            if chunk_log_normalizer is not None:
+                chunk_token_logprobs = (
+                    chunk_token_logprobs.float() - chunk_log_normalizer
+                )
             token_logprobs.append(chunk_token_logprobs)
             # Free before the next chunk's logits (bf16 + fp32) materialize.
             del chunk_logprobs

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -89,15 +89,13 @@ def _logits_topk(logits: torch.Tensor, k: int):
     radix select at LLM vocab sizes) but breaks value ties in
     implementation-defined order rather than lowest-index-first.
     """
-    if logits.is_cuda and is_flashinfer_available():
-        import flashinfer
+    if not logits.is_cuda:
+        return torch.topk(logits, k=k, dim=-1, sorted=True)
+    import flashinfer
 
-        values, indices = flashinfer.top_k(
-            logits, k=k, sorted=False, deterministic=True
-        )
-        order = values.argsort(dim=-1, descending=True)
-        return values.gather(-1, order), indices.gather(-1, order)
-    return torch.topk(logits, k=k, dim=-1, sorted=True)
+    values, indices = flashinfer.top_k(logits, k=k, sorted=False, deterministic=True)
+    order = values.argsort(dim=-1, descending=True)
+    return values.gather(-1, order), indices.gather(-1, order)
 
 
 def get_top_logprobs_raw(
@@ -440,6 +438,12 @@ class InputLogprobProcessor:
         # compute logprobs from logits + logsumexp, skipping the full-vocab
         # log-softmax materialization
         self.enable_fast_input_logprobs = envs.SGLANG_ENABLE_FAST_INPUT_LOGPROBS.get()
+        if self.enable_fast_input_logprobs and torch.cuda.is_available():
+            assert is_flashinfer_available(), (
+                "The fast input-logprob path requires flashinfer for top-k; "
+                "set SGLANG_ENABLE_FAST_INPUT_LOGPROBS=0 to use the "
+                "log-softmax path."
+            )
 
     def forward(
         self,

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -87,6 +87,31 @@ def compute_row_logsumexp(
     return torch.logsumexp(torch.stack(partials, dim=-1), dim=-1)
 
 
+_INT32_MAX = 2**31 - 1
+
+
+def _logits_topk(logits: torch.Tensor, k: int):
+    """Row-wise top-k, sorted descending.
+
+    flashinfer's top_k reads the row once (3-6x over torch.topk's multi-pass
+    radix select at LLM vocab sizes) but breaks value ties in
+    implementation-defined order rather than lowest-index-first.
+    """
+    if logits.is_cuda and logits.shape[-1] <= _INT32_MAX:
+        try:
+            from flashinfer import top_k as flashinfer_top_k
+        except ImportError:
+            flashinfer_top_k = None
+        if flashinfer_top_k is not None:
+            values, indices = flashinfer_top_k(
+                logits, k=k, sorted=False, deterministic=True
+            )
+            order = values.argsort(dim=-1, descending=True)
+            return values.gather(-1, order), indices.gather(-1, order)
+    values, indices = torch.topk(logits, k=k, dim=-1, sorted=True)
+    return values, indices
+
+
 def get_top_logprobs_raw(
     logprobs: torch.Tensor,
     top_logprobs_nums: List[int],
@@ -216,12 +241,13 @@ def get_top_logprobs_chunk(
     """
     # Empty chunks still walk the slice to emit placeholder entries.
     max_k = max(top_k_nums)
-    ret = logprobs.topk(max_k, dim=1)
-    values_tensor = ret.values
     if log_normalizer is not None:
+        values_tensor, indices_tensor = _logits_topk(logprobs, max_k)
         values_tensor = values_tensor.float() - log_normalizer[:, None]
+    else:
+        values_tensor, indices_tensor = logprobs.topk(max_k, dim=1)
     values = values_tensor.tolist()
-    indices = ret.indices.tolist()
+    indices = indices_tensor.tolist()
 
     pt = 0
     next_split_pruned_len = 0

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.utils.common import is_flashinfer_available
 
 if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsMetadata, LogitsProcessorOutput
@@ -61,33 +62,24 @@ class LogprobResult:
             )
 
 
-def compute_row_logsumexp(
-    logits: torch.Tensor, vocab_slice_size: int = 32768
-) -> torch.Tensor:
-    """Per-row logsumexp in fp32 without materializing a full-vocab fp32 copy.
+def compute_row_log_normalizer(
+    logits: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-row ``(max, logsumexp - max)`` in fp32.
 
-    CUDA uses a single-pass online kernel (one read of the logits). Elsewhere,
-    low-precision logits are upcast one vocab slice at a time, so the peak
-    transient is [rows, vocab_slice_size] fp32 rather than [rows, vocab].
+    Consumers compute ``logprob[i] = (logit[i] - max) - log_sum``, the same
+    shift-invariant order as log-softmax; a single absolute normalizer would
+    round the log_sum term away for rows with a large common offset.
     """
     if logits.is_cuda:
-        try:
-            from sglang.srt.layers.logsumexp import row_logsumexp
+        from sglang.srt.layers.logsumexp import row_logsumexp
 
-            return row_logsumexp(logits)
-        except ImportError:
-            pass
-    vocab_size = logits.shape[-1]
-    if logits.dtype == torch.float32 or vocab_size <= vocab_slice_size:
-        return torch.logsumexp(logits.float(), dim=-1)
-    partials = [
-        torch.logsumexp(logits[:, s : s + vocab_slice_size].float(), dim=-1)
-        for s in range(0, vocab_size, vocab_slice_size)
-    ]
-    return torch.logsumexp(torch.stack(partials, dim=-1), dim=-1)
-
-
-_INT32_MAX = 2**31 - 1
+        return row_logsumexp(logits)
+    x = logits.float()
+    row_max = x.amax(dim=-1)
+    row_log_sum = torch.logsumexp(x - row_max[:, None], dim=-1)
+    row_log_sum = torch.where(row_max.isinf(), 0.0, row_log_sum)
+    return row_max, row_log_sum
 
 
 def _logits_topk(logits: torch.Tensor, k: int):
@@ -97,19 +89,15 @@ def _logits_topk(logits: torch.Tensor, k: int):
     radix select at LLM vocab sizes) but breaks value ties in
     implementation-defined order rather than lowest-index-first.
     """
-    if logits.is_cuda and logits.shape[-1] <= _INT32_MAX:
-        try:
-            from flashinfer import top_k as flashinfer_top_k
-        except ImportError:
-            flashinfer_top_k = None
-        if flashinfer_top_k is not None:
-            values, indices = flashinfer_top_k(
-                logits, k=k, sorted=False, deterministic=True
-            )
-            order = values.argsort(dim=-1, descending=True)
-            return values.gather(-1, order), indices.gather(-1, order)
-    values, indices = torch.topk(logits, k=k, dim=-1, sorted=True)
-    return values, indices
+    if logits.is_cuda and is_flashinfer_available():
+        import flashinfer
+
+        values, indices = flashinfer.top_k(
+            logits, k=k, sorted=False, deterministic=True
+        )
+        order = values.argsort(dim=-1, descending=True)
+        return values.gather(-1, order), indices.gather(-1, order)
+    return torch.topk(logits, k=k, dim=-1, sorted=True)
 
 
 def get_top_logprobs_raw(
@@ -221,7 +209,7 @@ def get_top_logprobs_chunk(
     top_logprobs_val: List,
     top_logprobs_idx: List,
     split_pruned_len: int,
-    log_normalizer: Optional[torch.Tensor] = None,
+    log_normalizer: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
 ) -> int:
     """Get top-k logprobs for each sequence in the chunk.
 
@@ -234,7 +222,7 @@ def get_top_logprobs_chunk(
         top_logprobs_val: List to store top-k logprob values
         top_logprobs_idx: List to store top-k token indices
         split_pruned_len: Length of pruned tokens from previous chunk
-        log_normalizer: Per-row logsumexp of the logits, shape [seq_len]
+        log_normalizer: Per-row (max, logsumexp - max) of the logits
 
     Returns:
         int: Number of remaining tokens to process in next chunk
@@ -242,8 +230,11 @@ def get_top_logprobs_chunk(
     # Empty chunks still walk the slice to emit placeholder entries.
     max_k = max(top_k_nums)
     if log_normalizer is not None:
+        row_max, row_log_sum = log_normalizer
         values_tensor, indices_tensor = _logits_topk(logprobs, max_k)
-        values_tensor = values_tensor.float() - log_normalizer[:, None]
+        values_tensor = (values_tensor.float() - row_max[:, None]) - row_log_sum[
+            :, None
+        ]
     else:
         values_tensor, indices_tensor = logprobs.topk(max_k, dim=1)
     values = values_tensor.tolist()
@@ -299,7 +290,7 @@ def get_token_ids_logprobs_chunk(
     token_ids_logprobs_val: List,
     token_ids_logprobs_idx: List,
     split_pruned_len: int = 0,
-    log_normalizer: Optional[torch.Tensor] = None,
+    log_normalizer: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
 ):
     """Get token_ids logprobs for each sequence in the chunk.
 
@@ -312,7 +303,7 @@ def get_token_ids_logprobs_chunk(
         token_ids_logprobs_val: List to store token logprob values
         token_ids_logprobs_idx: List to store token indices
         split_pruned_len: Length of pruned tokens from previous chunk
-        log_normalizer: Per-row logsumexp of the logits, shape [seq_len]
+        log_normalizer: Per-row (max, logsumexp - max) of the logits
 
     Returns:
         int: Number of remaining tokens to process in next chunk
@@ -350,7 +341,8 @@ def get_token_ids_logprobs_chunk(
             if token_ids is not None:
                 row = logprobs[pt + j, token_ids]
                 if log_normalizer is not None:
-                    row = row.float() - log_normalizer[pt + j]
+                    row_max, row_log_sum = log_normalizer
+                    row = (row.float() - row_max[pt + j]) - row_log_sum[pt + j]
                 val.append(row.tolist())
                 idx.append(token_ids)
 
@@ -571,7 +563,7 @@ class InputLogprobProcessor:
                 # Every consumer below needs only small gathers / top-k plus a
                 # per-row normalizer, so keep the raw logits and skip the
                 # full-vocab log-softmax materialization entirely.
-                chunk_log_normalizer = compute_row_logsumexp(chunk_logprobs)
+                chunk_log_normalizer = compute_row_log_normalizer(chunk_logprobs)
             else:
                 # Free the raw logits before the out-of-place log_softmax:
                 # keeping all three alive is a 3x peak, which OOMs when the
@@ -623,9 +615,10 @@ class InputLogprobProcessor:
                 logits_metadata.extend_input_logprob_token_ids_gpu[mask_indices],
             ]
             if chunk_log_normalizer is not None:
+                row_max, row_log_sum = chunk_log_normalizer
                 chunk_token_logprobs = (
-                    chunk_token_logprobs.float() - chunk_log_normalizer
-                )
+                    chunk_token_logprobs.float() - row_max
+                ) - row_log_sum
             token_logprobs.append(chunk_token_logprobs)
             # Free before the next chunk's logits (bf16 + fp32) materialize.
             del chunk_logprobs

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.utils.common import is_flashinfer_available
 
 if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsMetadata, LogitsProcessorOutput
@@ -80,22 +79,6 @@ def compute_row_log_normalizer(
     row_log_sum = torch.logsumexp(x - row_max[:, None], dim=-1)
     row_log_sum = torch.where(row_max.isinf(), 0.0, row_log_sum)
     return row_max, row_log_sum
-
-
-def _logits_topk(logits: torch.Tensor, k: int):
-    """Row-wise top-k, sorted descending.
-
-    flashinfer's top_k reads the row once (3-6x over torch.topk's multi-pass
-    radix select at LLM vocab sizes) but breaks value ties in
-    implementation-defined order rather than lowest-index-first.
-    """
-    if not logits.is_cuda:
-        return torch.topk(logits, k=k, dim=-1, sorted=True)
-    import flashinfer
-
-    values, indices = flashinfer.top_k(logits, k=k, sorted=False, deterministic=True)
-    order = values.argsort(dim=-1, descending=True)
-    return values.gather(-1, order), indices.gather(-1, order)
 
 
 def get_top_logprobs_raw(
@@ -208,6 +191,7 @@ def get_top_logprobs_chunk(
     top_logprobs_idx: List,
     split_pruned_len: int,
     log_normalizer: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    precomputed_topk: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
 ) -> int:
     """Get top-k logprobs for each sequence in the chunk.
 
@@ -221,6 +205,8 @@ def get_top_logprobs_chunk(
         top_logprobs_idx: List to store top-k token indices
         split_pruned_len: Length of pruned tokens from previous chunk
         log_normalizer: Per-row (max, logsumexp - max) of the logits
+        precomputed_topk: (raw fp32 top values, indices) from the fused
+            logsumexp+top-k kernel, sorted with lowest-index tie-breaking
 
     Returns:
         int: Number of remaining tokens to process in next chunk
@@ -229,7 +215,10 @@ def get_top_logprobs_chunk(
     max_k = max(top_k_nums)
     if log_normalizer is not None:
         row_max, row_log_sum = log_normalizer
-        values_tensor, indices_tensor = _logits_topk(logprobs, max_k)
+        if precomputed_topk is not None:
+            values_tensor, indices_tensor = precomputed_topk
+        else:
+            values_tensor, indices_tensor = logprobs.topk(max_k, dim=1)
         values_tensor = (values_tensor.float() - row_max[:, None]) - row_log_sum[
             :, None
         ]
@@ -438,12 +427,6 @@ class InputLogprobProcessor:
         # compute logprobs from logits + logsumexp, skipping the full-vocab
         # log-softmax materialization
         self.enable_fast_input_logprobs = envs.SGLANG_ENABLE_FAST_INPUT_LOGPROBS.get()
-        if self.enable_fast_input_logprobs and torch.cuda.is_available():
-            assert is_flashinfer_available(), (
-                "The fast input-logprob path requires flashinfer for top-k; "
-                "set SGLANG_ENABLE_FAST_INPUT_LOGPROBS=0 to use the "
-                "log-softmax path."
-            )
 
     def forward(
         self,
@@ -563,23 +546,47 @@ class InputLogprobProcessor:
             # Zero-logprob-row chunks still need the per-sequence bookkeeping below.
             chunk_logprobs = chunk_logits[chunk_indices]
             del chunk_logits
-            if self.enable_fast_input_logprobs:
-                # Every consumer below needs only small gathers / top-k plus a
-                # per-row normalizer, so keep the raw logits and skip the
-                # full-vocab log-softmax materialization entirely.
-                chunk_log_normalizer = compute_row_log_normalizer(chunk_logprobs)
-            else:
-                # Free the raw logits before the out-of-place log_softmax:
-                # keeping all three alive is a 3x peak, which OOMs when the
-                # single chunk covers a large batch.
-                chunk_log_normalizer = None
-                chunk_logprobs = torch.nn.functional.log_softmax(chunk_logprobs, dim=-1)
 
             # End at the last row inside the chunk; token_to_seq_idx[end_idx]
             # belongs to the next chunk and would emit its sequence twice.
             chunk_slice = slice(
                 token_to_seq_idx[start_idx], token_to_seq_idx[end_idx - 1] + 1
             )
+
+            chunk_precomputed_topk = None
+            if self.enable_fast_input_logprobs:
+                # Every consumer below needs only small gathers / top-k plus a
+                # per-row normalizer, so keep the raw logits and skip the
+                # full-vocab log-softmax materialization entirely. When top-k
+                # is requested, the fused kernel produces the normalizer and
+                # the top-k in the same single read of the logits.
+                max_k = (
+                    max(logits_metadata.top_logprobs_nums[chunk_slice])
+                    if logits_metadata.extend_return_top_logprob
+                    else 0
+                )
+                use_fused = False
+                if chunk_logprobs.is_cuda and max_k > 0:
+                    from sglang.srt.layers.logsumexp import (
+                        FUSED_TOPK_MAX_K,
+                        row_logsumexp_topk,
+                    )
+
+                    use_fused = max_k <= FUSED_TOPK_MAX_K
+                if use_fused:
+                    row_max, row_log_sum, top_vals, top_idx = row_logsumexp_topk(
+                        chunk_logprobs, max_k
+                    )
+                    chunk_log_normalizer = (row_max, row_log_sum)
+                    chunk_precomputed_topk = (top_vals, top_idx)
+                else:
+                    chunk_log_normalizer = compute_row_log_normalizer(chunk_logprobs)
+            else:
+                # Free the raw logits before the out-of-place log_softmax:
+                # keeping all three alive is a 3x peak, which OOMs when the
+                # single chunk covers a large batch.
+                chunk_log_normalizer = None
+                chunk_logprobs = torch.nn.functional.log_softmax(chunk_logprobs, dim=-1)
 
             # Get the logprob of top-k tokens
             if logits_metadata.extend_return_top_logprob:
@@ -595,6 +602,7 @@ class InputLogprobProcessor:
                     top_logprobs_idx,
                     split_len_topk,
                     log_normalizer=chunk_log_normalizer,
+                    precomputed_topk=chunk_precomputed_topk,
                 )
 
             # Get the logprob of given token id

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -296,6 +296,8 @@ def get_token_ids_logprobs_chunk(
         int: Number of remaining tokens to process in next chunk
     """
     # Empty chunks still walk the slice to emit placeholder entries.
+    if log_normalizer is not None:
+        row_max, row_log_sum = log_normalizer
     pt = 0
     next_split_pruned_len = 0
     for n, (token_ids, pruned_len) in enumerate(
@@ -328,7 +330,6 @@ def get_token_ids_logprobs_chunk(
             if token_ids is not None:
                 row = logprobs[pt + j, token_ids]
                 if log_normalizer is not None:
-                    row_max, row_log_sum = log_normalizer
                     row = (row.float() - row_max[pt + j]) - row_log_sum[pt + j]
                 val.append(row.tolist())
                 idx.append(token_ids)
@@ -495,6 +496,15 @@ class InputLogprobProcessor:
         split_len_topk = 0
         split_len_token_ids = 0
 
+        fused_kernel, fused_max_k = None, 0
+        if self.enable_fast_input_logprobs and pruned_states.is_cuda:
+            from sglang.srt.layers.logsumexp import (
+                FUSED_TOPK_MAX_K,
+                row_logsumexp_topk,
+            )
+
+            fused_kernel, fused_max_k = row_logsumexp_topk, FUSED_TOPK_MAX_K
+
         for i in range(num_chunks):
             start_idx = i * chunk_size
             end_idx = min((i + 1) * chunk_size, total_size)
@@ -565,16 +575,8 @@ class InputLogprobProcessor:
                     if logits_metadata.extend_return_top_logprob
                     else 0
                 )
-                use_fused = False
-                if chunk_logprobs.is_cuda and max_k > 0:
-                    from sglang.srt.layers.logsumexp import (
-                        FUSED_TOPK_MAX_K,
-                        row_logsumexp_topk,
-                    )
-
-                    use_fused = max_k <= FUSED_TOPK_MAX_K
-                if use_fused:
-                    row_max, row_log_sum, top_vals, top_idx = row_logsumexp_topk(
+                if 0 < max_k <= fused_max_k:
+                    row_max, row_log_sum, top_vals, top_idx = fused_kernel(
                         chunk_logprobs, max_k
                     )
                     chunk_log_normalizer = (row_max, row_log_sum)

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_exec
 
 if TYPE_CHECKING:
     from sglang.srt.layers.logits_processor import LogitsMetadata, LogitsProcessorOutput
@@ -412,6 +413,18 @@ def compute_spec_v2_logprobs(
         )
 
 
+def _deterministic_inference_enabled() -> bool:
+    """True when serving with --enable-deterministic-inference.
+
+    Fails open: bare constructions (unit tests) have no published config
+    namespaces, and plain serving is the not-deterministic case.
+    """
+    try:
+        return bool(get_exec().deterministic.enable_deterministic_inference)
+    except ValueError:
+        return False
+
+
 class InputLogprobProcessor:
     """Input (prefill) logprob processing: single-pass or chunked.
 
@@ -425,9 +438,15 @@ class InputLogprobProcessor:
         self.enable_logprobs_chunk = envs.SGLANG_ENABLE_LOGPROB_CHUNK.get()
         # chunk size for logprobs processing
         self.logprobs_chunk_size = envs.SGLANG_LOGPROB_CHUNK_SIZE.get()
-        # compute logprobs from logits + logsumexp, skipping the full-vocab
-        # log-softmax materialization
-        self.enable_fast_input_logprobs = envs.SGLANG_ENABLE_FAST_INPUT_LOGPROBS.get()
+        # Compute input logprobs from logits + logsumexp, skipping the
+        # full-vocab log-softmax materialization. Deterministic inference
+        # keeps the exact log_softmax path: the fused logsumexp reduces in a
+        # different order, which breaks the prefill/decode logprob
+        # bit-identity that mode guarantees.
+        self.enable_fast_input_logprobs = (
+            envs.SGLANG_ENABLE_FAST_INPUT_LOGPROBS.get()
+            and not _deterministic_inference_enabled()
+        )
 
     def forward(
         self,

--- a/python/sglang/srt/layers/logsumexp.py
+++ b/python/sglang/srt/layers/logsumexp.py
@@ -1,0 +1,86 @@
+"""Single-pass online row logsumexp.
+
+Reads the input exactly once with fp32 accumulation and writes one fp32 value
+per row. This is the memory-optimal normalizer for computing logprobs
+directly from logits (``logprob[i] = logit[i] - logsumexp(logits)``) without
+materializing a full-vocab log-softmax.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _combine_lse(m_a, l_a, m_b, l_b):
+    """Merge two (max, sum_exp) accumulators.
+
+    The tl.where guards keep fully -inf inputs nan-free: exp(-inf - -inf)
+    would otherwise poison the sum.
+    """
+    m_new = tl.maximum(m_a, m_b)
+    l_new = l_a * tl.exp(tl.where(m_a == m_new, 0.0, m_a - m_new)) + l_b * tl.exp(
+        tl.where(m_b == m_new, 0.0, m_b - m_new)
+    )
+    return m_new, l_new
+
+
+@triton.jit(do_not_specialize=["num_rows"])
+def _row_logsumexp_kernel(
+    x_ptr,
+    out_ptr,
+    row_stride,
+    col_stride,
+    num_rows,
+    # int rather than tl.constexpr so triton does not unroll the loop
+    num_cols,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    if row >= num_rows:
+        return
+    row_ptr = x_ptr + row * row_stride
+
+    m_i = float("-inf")
+    l_i = 0.0
+    for start in range(0, num_cols, BLOCK_N):
+        offs = start + tl.arange(0, BLOCK_N)
+        x = tl.load(
+            row_ptr + offs * col_stride, mask=offs < num_cols, other=float("-inf")
+        ).to(tl.float32)
+        # Per-block max first: a single dominant logit stays exact instead of
+        # being renormalized against a stale running max.
+        m_blk = tl.max(x)
+        l_blk = tl.sum(tl.exp(x - m_blk))
+        # +/-inf block max: exp(x - m_blk) is nan there; the true sum_exp
+        # normalized by m_blk is 1.
+        l_blk = tl.where((m_blk == float("inf")) | (m_blk == float("-inf")), 1.0, l_blk)
+        m_i, l_i = _combine_lse(m_i, l_i, m_blk, l_blk)
+
+    tl.store(out_ptr + row, m_i + tl.log(l_i))
+
+
+def row_logsumexp(x: torch.Tensor) -> torch.Tensor:
+    """Per-row logsumexp of a 2D tensor, returned as fp32."""
+    assert x.ndim == 2
+    assert x.dtype in (torch.float16, torch.bfloat16, torch.float32)
+
+    num_rows, num_cols = x.shape
+    out = torch.empty(num_rows, device=x.device, dtype=torch.float32)
+    if num_rows == 0:
+        return out
+    if num_cols == 0:
+        return out.fill_(float("-inf"))
+
+    BLOCK_N = triton.next_power_of_2(min(num_cols, 16384))
+    _row_logsumexp_kernel[(num_rows,)](
+        x,
+        out,
+        x.stride(0),
+        x.stride(1),
+        num_rows,
+        num_cols,
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+    )
+    return out

--- a/python/sglang/srt/layers/logsumexp.py
+++ b/python/sglang/srt/layers/logsumexp.py
@@ -1,9 +1,11 @@
 """Single-pass online row logsumexp.
 
-Reads the input exactly once with fp32 accumulation and writes one fp32 value
-per row. This is the memory-optimal normalizer for computing logprobs
-directly from logits (``logprob[i] = logit[i] - logsumexp(logits)``) without
-materializing a full-vocab log-softmax.
+Reads the input exactly once with fp32 accumulation and writes per-row
+``(max, log_sum_exp - max)`` fp32 pairs. Keeping the two terms separate lets
+callers compute ``logprob[i] = (logit[i] - max) - log_sum`` the same
+shift-invariant way log-softmax does: folding them into one absolute
+normalizer would round the small log-sum term away whenever rows carry a
+large common offset.
 """
 
 import torch
@@ -28,7 +30,8 @@ def _combine_lse(m_a, l_a, m_b, l_b):
 @triton.jit(do_not_specialize=["num_rows"])
 def _row_logsumexp_kernel(
     x_ptr,
-    out_ptr,
+    out_max_ptr,
+    out_log_sum_ptr,
     row_stride,
     col_stride,
     num_rows,
@@ -57,25 +60,28 @@ def _row_logsumexp_kernel(
         l_blk = tl.where((m_blk == float("inf")) | (m_blk == float("-inf")), 1.0, l_blk)
         m_i, l_i = _combine_lse(m_i, l_i, m_blk, l_blk)
 
-    tl.store(out_ptr + row, m_i + tl.log(l_i))
+    tl.store(out_max_ptr + row, m_i)
+    tl.store(out_log_sum_ptr + row, tl.log(l_i))
 
 
-def row_logsumexp(x: torch.Tensor) -> torch.Tensor:
-    """Per-row logsumexp of a 2D tensor, returned as fp32."""
+def row_logsumexp(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-row ``(max, logsumexp - max)`` of a 2D tensor, as fp32."""
     assert x.ndim == 2
     assert x.dtype in (torch.float16, torch.bfloat16, torch.float32)
 
     num_rows, num_cols = x.shape
-    out = torch.empty(num_rows, device=x.device, dtype=torch.float32)
+    out_max = torch.empty(num_rows, device=x.device, dtype=torch.float32)
+    out_log_sum = torch.empty(num_rows, device=x.device, dtype=torch.float32)
     if num_rows == 0:
-        return out
+        return out_max, out_log_sum
     if num_cols == 0:
-        return out.fill_(float("-inf"))
+        return out_max.fill_(float("-inf")), out_log_sum.zero_()
 
     BLOCK_N = triton.next_power_of_2(min(num_cols, 16384))
     _row_logsumexp_kernel[(num_rows,)](
         x,
-        out,
+        out_max,
+        out_log_sum,
         x.stride(0),
         x.stride(1),
         num_rows,
@@ -83,4 +89,4 @@ def row_logsumexp(x: torch.Tensor) -> torch.Tensor:
         BLOCK_N=BLOCK_N,
         num_warps=8,
     )
-    return out
+    return out_max, out_log_sum

--- a/python/sglang/srt/layers/logsumexp.py
+++ b/python/sglang/srt/layers/logsumexp.py
@@ -37,21 +37,19 @@ def _combine_lse(m_a, l_a, m_b, l_b):
     return m_new, l_new
 
 
-@triton.jit(do_not_specialize=["num_rows"])
+@triton.jit
 def _row_logsumexp_kernel(
     x_ptr,
     out_max_ptr,
     out_log_sum_ptr,
     row_stride,
     col_stride,
-    num_rows,
     # int rather than tl.constexpr so triton does not unroll the loop
     num_cols,
     BLOCK_N: tl.constexpr,
 ):
+    # One program per row.
     row = tl.program_id(0).to(tl.int64)
-    if row >= num_rows:
-        return
     row_ptr = x_ptr + row * row_stride
 
     m_i = float("-inf")
@@ -94,7 +92,6 @@ def row_logsumexp(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         out_log_sum,
         x.stride(0),
         x.stride(1),
-        num_rows,
         num_cols,
         BLOCK_N=BLOCK_N,
         num_warps=8,
@@ -134,7 +131,7 @@ def _unpack_idx(keys):
     return 2147483647 - (keys & 0x7FFFFFFF).to(tl.int32)
 
 
-@triton.jit(do_not_specialize=["num_rows"])
+@triton.jit
 def _row_logsumexp_topk_kernel(
     x_ptr,
     out_max_ptr,
@@ -143,7 +140,6 @@ def _row_logsumexp_topk_kernel(
     out_top_idx_ptr,
     row_stride,
     col_stride,
-    num_rows,
     # int rather than tl.constexpr so triton does not unroll the loop
     num_cols,
     K: tl.constexpr,
@@ -152,9 +148,8 @@ def _row_logsumexp_topk_kernel(
     K_PAD: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
+    # One program per row.
     row = tl.program_id(0).to(tl.int64)
-    if row >= num_rows:
-        return
     row_ptr = x_ptr + row * row_stride
 
     m_i = float("-inf")
@@ -275,7 +270,6 @@ def row_logsumexp_topk(
         top_idx,
         x.stride(0),
         x.stride(1),
-        num_rows,
         num_cols,
         K=k,
         # Floor 2: K_PAD=1 would degenerate the kernel's [BLOCK_N // K_PAD,

--- a/python/sglang/srt/layers/logsumexp.py
+++ b/python/sglang/srt/layers/logsumexp.py
@@ -16,11 +16,33 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.layers.moe.moe_runner.triton_utils.gate_topk import (
+    fpval_to_key,
+    key_to_fpval,
+)
+
 # Maximum k for the fused top-k kernel; larger k should fall back to
 # torch.topk. The per-block selection cost grows with k: measured on GB300
 # at vocab=151936 the fused kernel beats a separate logsumexp + top-k up to
 # k~6 and drops below plain torch.topk near k=32.
 FUSED_TOPK_MAX_K = 8
+
+
+@triton.jit
+def _accumulate_block_lse(x, m_i, l_i):
+    """Fold one block of fp32 values into the running (max, sum_exp).
+
+    Per-block max first: a single dominant logit stays exact instead of
+    being renormalized against a stale running max. A +/-inf block max
+    makes exp(x - m_blk) nan; the true normalized sum_exp there is 1.
+    Shared by both kernels so their (max, log_sum) outputs are bitwise
+    identical by construction.
+    """
+    m_blk = tl.max(x)
+    l_blk = tl.sum(tl.exp(x - m_blk))
+    l_blk = tl.where((m_blk == float("inf")) | (m_blk == float("-inf")), 1.0, l_blk)
+    m_i, l_i = _combine_lse(m_i, l_i, m_blk, l_blk)
+    return m_i, l_i, m_blk
 
 
 @triton.jit
@@ -59,14 +81,7 @@ def _row_logsumexp_kernel(
         x = tl.load(
             row_ptr + offs * col_stride, mask=offs < num_cols, other=float("-inf")
         ).to(tl.float32)
-        # Per-block max first: a single dominant logit stays exact instead of
-        # being renormalized against a stale running max.
-        m_blk = tl.max(x)
-        l_blk = tl.sum(tl.exp(x - m_blk))
-        # +/-inf block max: exp(x - m_blk) is nan there; the true sum_exp
-        # normalized by m_blk is 1.
-        l_blk = tl.where((m_blk == float("inf")) | (m_blk == float("-inf")), 1.0, l_blk)
-        m_i, l_i = _combine_lse(m_i, l_i, m_blk, l_blk)
+        m_i, l_i, _ = _accumulate_block_lse(x, m_i, l_i)
 
     tl.store(out_max_ptr + row, m_i)
     tl.store(out_log_sum_ptr + row, tl.log(l_i))
@@ -104,26 +119,22 @@ def _pack_key(vals, idxs):
     """Pack fp32 value + int32 index into one order-encoding int64 key.
 
     Key order == candidate order: higher value wins, value ties go to the
-    LOWER index. The fp32 bits are mapped through the standard
-    sign-flip transform so unsigned bit order matches float order, then
-    placed above the complemented index; all keys land in [0, 2**63), so
-    signed int64 comparison is the candidate comparison. The 2147483647
-    (int32 max) index sentinel yields the smallest key for a given value,
-    so "empty" (-inf, sentinel) candidates lose against everything,
-    including genuine -inf lanes.
+    LOWER index. The fp32 bits are mapped through gate_topk's sign-flip
+    transform so unsigned bit order matches float order, then placed above
+    the complemented index; all keys land in [0, 2**63), so signed int64
+    comparison is the candidate comparison. The 2147483647 (int32 max)
+    index sentinel yields the smallest key for a given value, so "empty"
+    (-inf, sentinel) candidates lose against everything, including genuine
+    -inf lanes.
     """
-    bits = vals.to(tl.int32, bitcast=True)
-    sortable = bits ^ ((bits >> 31) | -2147483648)
-    return ((sortable.to(tl.int64) & 0xFFFFFFFF) << 31) | (2147483647 - idxs).to(
-        tl.int64
-    )
+    sortable = fpval_to_key(vals.to(tl.uint32, bitcast=True))
+    return (sortable.to(tl.int64) << 31) | (2147483647 - idxs).to(tl.int64)
 
 
 @triton.jit
 def _unpack_val(keys):
-    sortable = ((keys >> 31) & 0xFFFFFFFF).to(tl.int32)
-    bits = sortable ^ ((~sortable >> 31) | -2147483648)
-    return bits.to(tl.float32, bitcast=True)
+    sortable = ((keys >> 31) & 0xFFFFFFFF).to(tl.uint32)
+    return key_to_fpval(sortable).to(tl.float32, bitcast=True)
 
 
 @triton.jit
@@ -169,14 +180,7 @@ def _row_logsumexp_topk_kernel(
             row_ptr + offs * col_stride, mask=offs < num_cols, other=float("-inf")
         ).to(tl.float32)
 
-        # Same op sequence as _row_logsumexp_kernel so the (max, log_sum)
-        # outputs stay bitwise identical to the non-fused kernel.
-        m_blk = tl.max(x)
-        l_blk = tl.sum(tl.exp(x - m_blk))
-        # +/-inf block max: exp(x - m_blk) is nan there; the true sum_exp
-        # normalized by m_blk is 1.
-        l_blk = tl.where((m_blk == float("inf")) | (m_blk == float("-inf")), 1.0, l_blk)
-        m_i, l_i = _combine_lse(m_i, l_i, m_blk, l_blk)
+        m_i, l_i, m_blk = _accumulate_block_lse(x, m_i, l_i)
 
         # Top-k maintenance. Blocks are visited in ascending column order and
         # the wrapper guarantees the first block holds >= K in-row lanes, so

--- a/python/sglang/srt/layers/logsumexp.py
+++ b/python/sglang/srt/layers/logsumexp.py
@@ -1,4 +1,4 @@
-"""Single-pass online row logsumexp.
+"""Single-pass online row logsumexp, optionally fused with a small top-k.
 
 Reads the input exactly once with fp32 accumulation and writes per-row
 ``(max, log_sum_exp - max)`` fp32 pairs. Keeping the two terms separate lets
@@ -6,11 +6,21 @@ callers compute ``logprob[i] = (logit[i] - max) - log_sum`` the same
 shift-invariant way log-softmax does: folding them into one absolute
 normalizer would round the small log-sum term away whenever rows carry a
 large common offset.
+
+``row_logsumexp_topk`` additionally maintains a running top-k (k <= 32) in
+registers during the same pass, so callers that need both the normalizer and
+the top-k tokens pay for a single read of the input.
 """
 
 import torch
 import triton
 import triton.language as tl
+
+# Maximum k for the fused top-k kernel; larger k should fall back to
+# torch.topk. The per-block selection cost grows with k: measured on GB300
+# at vocab=151936 the fused kernel beats a separate logsumexp + top-k up to
+# k~6 and drops below plain torch.topk near k=32.
+FUSED_TOPK_MAX_K = 8
 
 
 @triton.jit
@@ -90,3 +100,188 @@ def row_logsumexp(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         num_warps=8,
     )
     return out_max, out_log_sum
+
+
+@triton.jit
+def _pack_key(vals, idxs):
+    """Pack fp32 value + int32 index into one order-encoding int64 key.
+
+    Key order == candidate order: higher value wins, value ties go to the
+    LOWER index. The fp32 bits are mapped through the standard
+    sign-flip transform so unsigned bit order matches float order, then
+    placed above the complemented index; all keys land in [0, 2**63), so
+    signed int64 comparison is the candidate comparison. The 2147483647
+    (int32 max) index sentinel yields the smallest key for a given value,
+    so "empty" (-inf, sentinel) candidates lose against everything,
+    including genuine -inf lanes.
+    """
+    bits = vals.to(tl.int32, bitcast=True)
+    sortable = bits ^ ((bits >> 31) | -2147483648)
+    return ((sortable.to(tl.int64) & 0xFFFFFFFF) << 31) | (2147483647 - idxs).to(
+        tl.int64
+    )
+
+
+@triton.jit
+def _unpack_val(keys):
+    sortable = ((keys >> 31) & 0xFFFFFFFF).to(tl.int32)
+    bits = sortable ^ ((~sortable >> 31) | -2147483648)
+    return bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _unpack_idx(keys):
+    return 2147483647 - (keys & 0x7FFFFFFF).to(tl.int32)
+
+
+@triton.jit(do_not_specialize=["num_rows"])
+def _row_logsumexp_topk_kernel(
+    x_ptr,
+    out_max_ptr,
+    out_log_sum_ptr,
+    out_top_vals_ptr,
+    out_top_idx_ptr,
+    row_stride,
+    col_stride,
+    num_rows,
+    # int rather than tl.constexpr so triton does not unroll the loop
+    num_cols,
+    K: tl.constexpr,
+    # K rounded up to a power of 2: register tensors need pow2 shapes. The
+    # padding slots hold (-inf, sentinel) and lose every comparison.
+    K_PAD: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    if row >= num_rows:
+        return
+    row_ptr = x_ptr + row * row_stride
+
+    m_i = float("-inf")
+    l_i = 0.0
+    slots = tl.arange(0, K_PAD)
+    # Running top-K as packed keys, sorted descending. Slots beyond the
+    # genuine entries hold the (-inf, sentinel) key, which loses everything.
+    run_keys = _pack_key(
+        tl.full((K_PAD,), float("-inf"), tl.float32),
+        tl.full((K_PAD,), 2147483647, tl.int32),
+    )
+    kth_key = tl.min(run_keys)
+
+    for start in range(0, num_cols, BLOCK_N):
+        offs = start + tl.arange(0, BLOCK_N)
+        x = tl.load(
+            row_ptr + offs * col_stride, mask=offs < num_cols, other=float("-inf")
+        ).to(tl.float32)
+
+        # Same op sequence as _row_logsumexp_kernel so the (max, log_sum)
+        # outputs stay bitwise identical to the non-fused kernel.
+        m_blk = tl.max(x)
+        l_blk = tl.sum(tl.exp(x - m_blk))
+        # +/-inf block max: exp(x - m_blk) is nan there; the true sum_exp
+        # normalized by m_blk is 1.
+        l_blk = tl.where((m_blk == float("inf")) | (m_blk == float("-inf")), 1.0, l_blk)
+        m_i, l_i = _combine_lse(m_i, l_i, m_blk, l_blk)
+
+        # Top-k maintenance. Blocks are visited in ascending column order and
+        # the wrapper guarantees the first block holds >= K in-row lanes, so
+        # after the first block every running slot carries a genuine index
+        # smaller than any later block's. A later block whose max does not
+        # strictly beat the running k-th value therefore cannot contribute:
+        # on equal values the running entry's lower index wins. The first
+        # block must merge unconditionally to displace the sentinel slots.
+        # View the block as K_PAD contiguous segments of SEG lanes (a
+        # row-major reshape, so no data movement) and surface up to K_PAD
+        # candidates per pass: the best available lane of each segment, via
+        # minor-axis reductions. Random rows spread their top-K across
+        # segments, so a contributing block usually needs one merge pass;
+        # the worst case (all K in one segment) needs K.
+        SEG: tl.constexpr = BLOCK_N // K_PAD
+        x2 = tl.reshape(x, (K_PAD, SEG))
+        i2 = start + tl.arange(0, K_PAD)[:, None] * SEG + tl.arange(0, SEG)[None, :]
+        avail2 = i2 < num_cols
+        go = (start == 0) | (m_blk > _unpack_val(kth_key))
+        while go:
+            xa2 = tl.where(avail2, x2, float("-inf"))
+            cand_vals = tl.max(xa2, axis=1)
+            attain = avail2 & (xa2 == cand_vals[:, None])
+            cand_idxs = tl.min(tl.where(attain, i2, 2147483647), axis=1)
+            # Surfaced lanes are spent either way: winners enter the running
+            # top-K and losers lost against a set that only ever improves,
+            # so neither can matter again.
+            avail2 = avail2 & (i2 != cand_idxs[:, None])
+
+            cand_keys = _pack_key(cand_vals, cand_idxs)
+            go = tl.max(cand_keys) > kth_key
+            if go:
+                # Sorted-sequence merge: max(A, reverse(B)) holds exactly the
+                # top-K_PAD of the union (both inputs sorted descending, keys
+                # distinct), then re-sort. Compare-exchange networks only; no
+                # reductions.
+                cand_sorted = tl.sort(cand_keys, descending=True)
+                merged = tl.maximum(run_keys, tl.flip(cand_sorted, 0))
+                run_keys = tl.sort(merged, descending=True)
+                kth_key = tl.max(tl.where(slots == K - 1, run_keys, -1))
+
+    tl.store(out_max_ptr + row, m_i)
+    tl.store(out_log_sum_ptr + row, tl.log(l_i))
+    out_mask = slots < K
+    tl.store(out_top_vals_ptr + row * K + slots, _unpack_val(run_keys), mask=out_mask)
+    tl.store(
+        out_top_idx_ptr + row * K + slots,
+        _unpack_idx(run_keys).to(tl.int64),
+        mask=out_mask,
+    )
+
+
+def row_logsumexp_topk(
+    x: torch.Tensor, k: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-row ``(max, logsumexp - max, top_vals, top_idx)`` in one read.
+
+    ``top_vals`` are the RAW input values upcast to fp32 (normalize with
+    ``(v - max) - log_sum``; the subtraction is shift-invariant), sorted
+    descending with value ties broken by the lowest index. ``top_idx`` is
+    int64 like torch.topk's. The (max, log_sum) pair is bitwise identical to
+    ``row_logsumexp`` on the same input.
+
+    k is a tl.constexpr, so each distinct k compiles its own kernel: k is the
+    per-batch max of the requested top-logprob counts and rarely varies
+    within a deployment, while padding every launch to k=32 would make the
+    common k<=2 case do 16x the selection work.
+    """
+    assert x.ndim == 2
+    assert x.dtype in (torch.float16, torch.bfloat16, torch.float32)
+    num_rows, num_cols = x.shape
+    # Like torch.topk, selecting more entries than a row holds is an error.
+    assert 1 <= k <= min(FUSED_TOPK_MAX_K, num_cols), (k, num_cols)
+
+    out_max = torch.empty(num_rows, device=x.device, dtype=torch.float32)
+    out_log_sum = torch.empty(num_rows, device=x.device, dtype=torch.float32)
+    top_vals = torch.empty((num_rows, k), device=x.device, dtype=torch.float32)
+    top_idx = torch.empty((num_rows, k), device=x.device, dtype=torch.int64)
+    if num_rows == 0:
+        return out_max, out_log_sum, top_vals, top_idx
+
+    # next_power_of_2(num_cols) >= num_cols >= k when num_cols < 16384, and
+    # 16384 > FUSED_TOPK_MAX_K otherwise: the kernel's first block always
+    # sees at least k in-row lanes.
+    BLOCK_N = triton.next_power_of_2(min(num_cols, 16384))
+    _row_logsumexp_topk_kernel[(num_rows,)](
+        x,
+        out_max,
+        out_log_sum,
+        top_vals,
+        top_idx,
+        x.stride(0),
+        x.stride(1),
+        num_rows,
+        num_cols,
+        K=k,
+        # Floor 2: K_PAD=1 would degenerate the kernel's [BLOCK_N // K_PAD,
+        # K_PAD] view (and flip/sort of single-lane tensors).
+        K_PAD=max(2, triton.next_power_of_2(k)),
+        BLOCK_N=BLOCK_N,
+        num_warps=8,
+    )
+    return out_max, out_log_sum, top_vals, top_idx

--- a/python/sglang/srt/layers/logsumexp.py
+++ b/python/sglang/srt/layers/logsumexp.py
@@ -7,19 +7,15 @@ shift-invariant way log-softmax does: folding them into one absolute
 normalizer would round the small log-sum term away whenever rows carry a
 large common offset.
 
-``row_logsumexp_topk`` additionally maintains a running top-k (k <= 32) in
-registers during the same pass, so callers that need both the normalizer and
-the top-k tokens pay for a single read of the input.
+``row_logsumexp_topk`` additionally maintains a running top-k
+(k <= FUSED_TOPK_MAX_K) in registers during the same pass, so callers that
+need both the normalizer and the top-k tokens pay for a single read of the
+input.
 """
 
 import torch
 import triton
 import triton.language as tl
-
-from sglang.srt.layers.moe.moe_runner.triton_utils.gate_topk import (
-    fpval_to_key,
-    key_to_fpval,
-)
 
 # Maximum k for the fused top-k kernel; larger k should fall back to
 # torch.topk. The per-block selection cost grows with k: measured on GB300
@@ -115,11 +111,26 @@ def row_logsumexp(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
 
 
 @triton.jit
+def _fpval_to_key(x):
+    """fp32 bits (as uint32) -> unsigned key with float order.
+
+    The standard sign-flip transform, specialized to 32-bit from
+    kernels.ops.moe.gate_topk's generic helpers.
+    """
+    return x ^ tl.where((x & 0x80000000) != 0, 0xFFFFFFFF, 0x80000000)
+
+
+@triton.jit
+def _key_to_fpval(x):
+    return x ^ tl.where((x & 0x80000000) == 0, 0xFFFFFFFF, 0x80000000)
+
+
+@triton.jit
 def _pack_key(vals, idxs):
     """Pack fp32 value + int32 index into one order-encoding int64 key.
 
     Key order == candidate order: higher value wins, value ties go to the
-    LOWER index. The fp32 bits are mapped through gate_topk's sign-flip
+    LOWER index. The fp32 bits are mapped through the sign-flip
     transform so unsigned bit order matches float order, then placed above
     the complemented index; all keys land in [0, 2**63), so signed int64
     comparison is the candidate comparison. The 2147483647 (int32 max)
@@ -127,14 +138,14 @@ def _pack_key(vals, idxs):
     (-inf, sentinel) candidates lose against everything, including genuine
     -inf lanes.
     """
-    sortable = fpval_to_key(vals.to(tl.uint32, bitcast=True))
+    sortable = _fpval_to_key(vals.to(tl.uint32, bitcast=True))
     return (sortable.to(tl.int64) << 31) | (2147483647 - idxs).to(tl.int64)
 
 
 @triton.jit
 def _unpack_val(keys):
     sortable = ((keys >> 31) & 0xFFFFFFFF).to(tl.uint32)
-    return key_to_fpval(sortable).to(tl.float32, bitcast=True)
+    return _key_to_fpval(sortable).to(tl.float32, bitcast=True)
 
 
 @triton.jit
@@ -262,10 +273,14 @@ def row_logsumexp_topk(
     if num_rows == 0:
         return out_max, out_log_sum, top_vals, top_idx
 
+    # Floor 2: K_PAD=1 would degenerate the kernel's [K_PAD, SEG] view
+    # (and flip/sort of single-lane tensors).
+    k_pad = max(2, triton.next_power_of_2(k))
     # next_power_of_2(num_cols) >= num_cols >= k when num_cols < 16384, and
     # 16384 > FUSED_TOPK_MAX_K otherwise: the kernel's first block always
-    # sees at least k in-row lanes.
-    BLOCK_N = triton.next_power_of_2(min(num_cols, 16384))
+    # sees at least k in-row lanes. The K_PAD floor keeps SEG =
+    # BLOCK_N // K_PAD >= 1 for tiny vocabularies.
+    BLOCK_N = max(triton.next_power_of_2(min(num_cols, 16384)), k_pad)
     _row_logsumexp_topk_kernel[(num_rows,)](
         x,
         out_max,
@@ -276,9 +291,7 @@ def row_logsumexp_topk(
         x.stride(1),
         num_cols,
         K=k,
-        # Floor 2: K_PAD=1 would degenerate the kernel's [BLOCK_N // K_PAD,
-        # K_PAD] view (and flip/sort of single-lane tensors).
-        K_PAD=max(2, triton.next_power_of_2(k)),
+        K_PAD=k_pad,
         BLOCK_N=BLOCK_N,
         num_warps=8,
     )

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -227,6 +227,27 @@ class TestFastInputLogprobs(CustomTestCase):
             torch.testing.assert_close(ref, got, rtol=1e-3, atol=1e-3)
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_logits_topk_matches_torch(self):
+        from sglang.srt.layers.logprob_processor import _logits_topk
+
+        torch.manual_seed(0)
+        # fp32 randn is tie-free w.h.p., so indices must match torch exactly.
+        logits = torch.randn(64, 151936, device="cuda")
+        ref_v, ref_i = torch.topk(logits, k=5, dim=-1, sorted=True)
+        got_v, got_i = _logits_topk(logits, 5)
+        torch.testing.assert_close(ref_v, got_v.to(ref_v.dtype))
+        self.assertTrue(torch.equal(ref_i, got_i.to(ref_i.dtype)))
+        # bf16 has value ties; only the sorted values are contractual.
+        logits = torch.randn(64, 151936, device="cuda", dtype=torch.bfloat16)
+        ref_v, _ = torch.topk(logits, k=5, dim=-1, sorted=True)
+        got_v, got_i = _logits_topk(logits, 5)
+        self.assertTrue(torch.equal(ref_v, got_v.to(ref_v.dtype)))
+        # Returned indices must point at the returned values.
+        self.assertTrue(
+            torch.equal(logits.gather(-1, got_i.long()).to(got_v.dtype), got_v)
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_row_logsumexp_kernel_matches_reference(self):
         from sglang.srt.layers.logsumexp import row_logsumexp
 

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -1,0 +1,263 @@
+"""Fast input-logprob path must match the log-softmax reference.
+
+The fast path (SGLANG_ENABLE_FAST_INPUT_LOGPROBS) computes token / top-k /
+token-ids logprobs directly from logits with a per-row logsumexp normalizer,
+never materializing the full-vocab log-softmax. Same math, so results must
+agree with the reference path to floating-point tolerance, with identical
+top-k indices, across chunk splits and heterogeneous per-sequence params.
+"""
+
+import itertools
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.logprob_processor import (
+    InputLogprobProcessor,
+    compute_row_logsumexp,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+VOCAB = 11
+# Heterogeneous per-sequence parameters; uniform ones hide misalignment.
+TOPK_CYCLE = [2, 0, 3]
+# [] is a valid probe set distinct from None (opt-out).
+TOKEN_IDS_CYCLE = [[0, 3], None, [1], []]
+
+
+def _build_batch(seq_specs, dtype):
+    """seq_specs: list of (extend_len, logprob_start_len). Mirrors
+    LogitsProcessor._get_pruned_states for the extend-with-logprobs path."""
+    pruned_rows = []
+    token_to_seq_idx = []
+    sample_indices = []
+    input_logprob_indices = []
+    pruned_lens = []
+    sample_pt = -1
+    lp_pt = 0
+    for idx, (extend_len, start) in enumerate(seq_specs):
+        eff_start = start - 1 if extend_len == start else start
+        rows = extend_len - eff_start
+        pruned_rows.append(torch.randn(rows, VOCAB).to(dtype))
+        token_to_seq_idx.extend([idx] * rows)
+        sample_pt += rows
+        sample_indices.append(sample_pt)
+        n_lp = extend_len - start
+        input_logprob_indices.extend([lp_pt + i for i in range(n_lp)])
+        lp_pt += rows
+        pruned_lens.append(n_lp)
+    metadata = SimpleNamespace(
+        extend_return_top_logprob=True,
+        extend_token_ids_logprob=True,
+        top_logprobs_nums=[TOPK_CYCLE[i % 3] for i in range(len(seq_specs))],
+        extend_logprob_pruned_lens_cpu=pruned_lens,
+        extend_input_logprob_token_ids_gpu=torch.zeros(
+            len(input_logprob_indices), dtype=torch.int64
+        ),
+        token_ids_logprobs=[
+            TOKEN_IDS_CYCLE[i % len(TOKEN_IDS_CYCLE)] for i in range(len(seq_specs))
+        ],
+    )
+    return (
+        torch.cat(pruned_rows),
+        torch.tensor(sample_indices, dtype=torch.int64),
+        torch.tensor(input_logprob_indices, dtype=torch.int64),
+        token_to_seq_idx,
+        metadata,
+    )
+
+
+def _run(proc, batch, fast, chunk_size):
+    pruned_states, sample_indices, input_logprob_indices, t2s, metadata = batch
+    proc.enable_logprobs_chunk = chunk_size is not None
+    proc.logprobs_chunk_size = chunk_size if chunk_size is not None else 10**9
+    proc.enable_fast_input_logprobs = fast
+
+    def get_logits_fn(states, lm_head, logits_metadata, **kwargs):
+        return states
+
+    return proc.forward(
+        pruned_states=pruned_states,
+        sample_indices=sample_indices,
+        input_logprob_indices=input_logprob_indices,
+        token_to_seq_idx=t2s,
+        lm_head=None,
+        get_logits_fn=get_logits_fn,
+        logits_metadata=metadata,
+    )
+
+
+def _assert_nested_close(test, ref, got, label, rtol, atol):
+    test.assertEqual(_shape_of(ref), _shape_of(got), label)
+    ref_flat = _flatten(ref)
+    got_flat = _flatten(got)
+    if ref_flat:
+        torch.testing.assert_close(
+            torch.tensor(ref_flat, dtype=torch.float64),
+            torch.tensor(got_flat, dtype=torch.float64),
+            rtol=rtol,
+            atol=atol,
+            msg=label,
+        )
+
+
+def _flatten(nested):
+    if isinstance(nested, list):
+        return [x for item in nested for x in _flatten(item)]
+    return [nested]
+
+
+def _shape_of(nested):
+    if isinstance(nested, list):
+        return [_shape_of(item) for item in nested]
+    return None
+
+
+class TestFastInputLogprobs(CustomTestCase):
+    def _sweep(self, dtype, rtol, atol):
+        torch.manual_seed(0)
+        proc = InputLogprobProcessor()
+        # (extend_len, start); start == extend_len is the degenerate
+        # zero-logprob-row shape.
+        menu = [(1, 1), (3, 0), (4, 1), (5, 5), (6, 2)]
+        tried = 0
+        for n_seqs in (1, 2, 3):
+            for combo in itertools.product(menu, repeat=n_seqs):
+                batch = _build_batch(list(combo), dtype)
+                for chunk_size in (None, 1, 2, 3, 5):
+                    tried += 1
+                    ref, ref_sampled = _run(proc, batch, False, chunk_size)
+                    got, got_sampled = _run(proc, batch, True, chunk_size)
+                    label = f"specs={list(combo)} chunk={chunk_size} dtype={dtype}"
+                    # Top-k order comes from the same values shifted by a
+                    # per-row constant, so indices must match exactly.
+                    self.assertEqual(ref.top_logprobs_idx, got.top_logprobs_idx, label)
+                    self.assertEqual(
+                        ref.token_ids_logprobs_idx, got.token_ids_logprobs_idx, label
+                    )
+                    _assert_nested_close(
+                        self,
+                        ref.top_logprobs_val,
+                        got.top_logprobs_val,
+                        label,
+                        rtol,
+                        atol,
+                    )
+                    _assert_nested_close(
+                        self,
+                        ref.token_ids_logprobs_val,
+                        got.token_ids_logprobs_val,
+                        label,
+                        rtol,
+                        atol,
+                    )
+                    torch.testing.assert_close(
+                        ref.token_logprobs.float(),
+                        got.token_logprobs.float(),
+                        rtol=rtol,
+                        atol=atol,
+                        msg=label,
+                    )
+                    torch.testing.assert_close(ref_sampled, got_sampled, msg=label)
+        self.assertGreater(tried, 100)
+
+    def test_fast_matches_reference_fp32(self):
+        self._sweep(torch.float32, rtol=1e-5, atol=1e-5)
+
+    def test_fast_matches_float64_truth_bf16(self):
+        # bf16 log_softmax rounds near-ties together, so the reference path's
+        # top-k ORDER is not reproducible from raw logits; validate the fast
+        # path against float64 ground truth instead. The fast path only
+        # rounds at the bf16 logits themselves (normalizer is fp32), so it
+        # sits much closer to the truth than bf16 resolution.
+        torch.manual_seed(0)
+        proc = InputLogprobProcessor()
+        menu = [(1, 1), (3, 0), (4, 1), (5, 5), (6, 2)]
+        for n_seqs in (1, 2, 3):
+            for combo in itertools.product(menu, repeat=n_seqs):
+                batch = _build_batch(list(combo), torch.bfloat16)
+                pruned_states, _, input_logprob_indices, _, metadata = batch
+                truth = torch.log_softmax(pruned_states.double(), dim=-1)[
+                    input_logprob_indices
+                ]
+                for chunk_size in (None, 2, 5):
+                    got, _ = _run(proc, batch, True, chunk_size)
+                    label = f"specs={list(combo)} chunk={chunk_size}"
+                    self._assert_rows_match_truth(
+                        got, truth, metadata, label, atol=1e-4
+                    )
+
+    def _assert_rows_match_truth(self, got, truth, metadata, label, atol):
+        pt = 0
+        for s, pruned_len in enumerate(metadata.extend_logprob_pruned_lens_cpu):
+            if pruned_len <= 0:
+                self.assertEqual(got.top_logprobs_val[s], [], label)
+                continue
+            k = metadata.top_logprobs_nums[s]
+            probe_ids = metadata.token_ids_logprobs[s]
+            for j in range(pruned_len):
+                row_truth = truth[pt + j]
+                vals = got.top_logprobs_val[s][j]
+                idxs = got.top_logprobs_idx[s][j]
+                self.assertEqual(len(vals), k, label)
+                for v, i in zip(vals, idxs):
+                    self.assertAlmostEqual(
+                        v, row_truth[i].item(), delta=atol, msg=label
+                    )
+                if probe_ids is not None:
+                    probe_vals = got.token_ids_logprobs_val[s][j]
+                    for v, i in zip(probe_vals, probe_ids):
+                        self.assertAlmostEqual(
+                            v, row_truth[i].item(), delta=atol, msg=label
+                        )
+            pt += pruned_len
+
+    def test_row_logsumexp_sliced_matches_reference(self):
+        torch.manual_seed(0)
+        for rows in (0, 1, 7):
+            # Vocab deliberately not a multiple of the slice size.
+            logits = torch.randn(rows, 1000, dtype=torch.bfloat16) * 8
+            ref = torch.logsumexp(logits.double(), dim=-1).float()
+            got = compute_row_logsumexp(logits, vocab_slice_size=64)
+            self.assertEqual(got.dtype, torch.float32)
+            torch.testing.assert_close(ref, got, rtol=1e-3, atol=1e-3)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_row_logsumexp_kernel_matches_reference(self):
+        from sglang.srt.layers.logsumexp import row_logsumexp
+
+        torch.manual_seed(0)
+        for rows, cols in ((0, 128), (3, 0), (1, 1), (7, 1000), (64, 151936)):
+            for dtype in (torch.bfloat16, torch.float32):
+                logits = torch.randn(rows, cols, dtype=dtype, device="cuda") * 8
+                ref = torch.logsumexp(logits.double(), dim=-1).float()
+                got = row_logsumexp(logits)
+                self.assertEqual(got.dtype, torch.float32)
+                torch.testing.assert_close(
+                    ref, got, rtol=1e-4, atol=1e-4, msg=f"{rows}x{cols} {dtype}"
+                )
+        # Rows dominated by -inf (masked-vocab shapes) must stay nan-free.
+        logits = torch.full((4, 1000), float("-inf"), device="cuda")
+        logits[1, 3] = 2.5
+        logits[2, :] = torch.randn(1000, device="cuda")
+        got = row_logsumexp(logits.bfloat16())
+        self.assertEqual(got[0].item(), float("-inf"))
+        self.assertAlmostEqual(got[1].item(), 2.5, delta=1e-2)
+        self.assertFalse(got.isnan().any().item())
+        # Non-contiguous input (sliced rows) exercises the stride args.
+        base = torch.randn(8, 512, device="cuda", dtype=torch.bfloat16)
+        view = base[::2]
+        torch.testing.assert_close(
+            torch.logsumexp(view.double(), dim=-1).float(),
+            row_logsumexp(view),
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -15,7 +15,8 @@ import torch
 
 from sglang.srt.layers.logprob_processor import (
     InputLogprobProcessor,
-    compute_row_logsumexp,
+    _logits_topk,
+    compute_row_log_normalizer,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -216,20 +217,33 @@ class TestFastInputLogprobs(CustomTestCase):
                         )
             pt += pruned_len
 
-    def test_row_logsumexp_sliced_matches_reference(self):
+    def test_shift_invariant_large_offset(self):
+        # Regression: a large common fp32 offset must not round the log-sum
+        # term away. Uniform logits at 1e8 have true logprob -log(vocab).
+        for device in ("cpu", "cuda") if torch.cuda.is_available() else ("cpu",):
+            logits = torch.full((4, 1000), 1e8, dtype=torch.float32, device=device)
+            row_max, row_log_sum = compute_row_log_normalizer(logits)
+            logprob = (logits[:, 0].float() - row_max) - row_log_sum
+            expected = -torch.log(torch.tensor(1000.0))
+            torch.testing.assert_close(
+                logprob.cpu(), expected.expand(4), rtol=1e-5, atol=1e-5
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_fast_path_run_to_run_deterministic(self):
+        from sglang.srt.layers.logsumexp import row_logsumexp
+
         torch.manual_seed(0)
-        for rows in (0, 1, 7):
-            # Vocab deliberately not a multiple of the slice size.
-            logits = torch.randn(rows, 1000, dtype=torch.bfloat16) * 8
-            ref = torch.logsumexp(logits.double(), dim=-1).float()
-            got = compute_row_logsumexp(logits, vocab_slice_size=64)
-            self.assertEqual(got.dtype, torch.float32)
-            torch.testing.assert_close(ref, got, rtol=1e-3, atol=1e-3)
+        logits = torch.randn(512, 151936, dtype=torch.bfloat16, device="cuda")
+        m1, l1 = row_logsumexp(logits)
+        m2, l2 = row_logsumexp(logits)
+        self.assertTrue(torch.equal(m1, m2) and torch.equal(l1, l2))
+        v1, i1 = _logits_topk(logits, 5)
+        v2, i2 = _logits_topk(logits, 5)
+        self.assertTrue(torch.equal(v1, v2) and torch.equal(i1, i2))
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_logits_topk_matches_torch(self):
-        from sglang.srt.layers.logprob_processor import _logits_topk
-
         torch.manual_seed(0)
         # fp32 randn is tie-free w.h.p., so indices must match torch exactly.
         logits = torch.randn(64, 151936, device="cuda")
@@ -255,26 +269,39 @@ class TestFastInputLogprobs(CustomTestCase):
         for rows, cols in ((0, 128), (3, 0), (1, 1), (7, 1000), (64, 151936)):
             for dtype in (torch.bfloat16, torch.float32):
                 logits = torch.randn(rows, cols, dtype=dtype, device="cuda") * 8
-                ref = torch.logsumexp(logits.double(), dim=-1).float()
-                got = row_logsumexp(logits)
-                self.assertEqual(got.dtype, torch.float32)
+                got_max, got_log_sum = row_logsumexp(logits)
+                self.assertEqual(got_max.dtype, torch.float32)
+                self.assertEqual(got_log_sum.dtype, torch.float32)
+                if not cols:
+                    self.assertTrue((got_max == float("-inf")).all())
+                    self.assertTrue((got_log_sum == 0).all())
+                    continue
+                self.assertTrue(torch.equal(got_max, logits.float().amax(-1)))
+                ref_log_sum = torch.logsumexp(
+                    logits.double() - got_max.double()[:, None], dim=-1
+                ).float()
                 torch.testing.assert_close(
-                    ref, got, rtol=1e-4, atol=1e-4, msg=f"{rows}x{cols} {dtype}"
+                    ref_log_sum,
+                    got_log_sum,
+                    rtol=1e-4,
+                    atol=1e-4,
+                    msg=f"{rows}x{cols} {dtype}",
                 )
         # Rows dominated by -inf (masked-vocab shapes) must stay nan-free.
         logits = torch.full((4, 1000), float("-inf"), device="cuda")
         logits[1, 3] = 2.5
         logits[2, :] = torch.randn(1000, device="cuda")
-        got = row_logsumexp(logits.bfloat16())
-        self.assertEqual(got[0].item(), float("-inf"))
-        self.assertAlmostEqual(got[1].item(), 2.5, delta=1e-2)
-        self.assertFalse(got.isnan().any().item())
+        got_max, got_log_sum = row_logsumexp(logits.bfloat16())
+        self.assertEqual(got_max[0].item(), float("-inf"))
+        self.assertAlmostEqual((got_max[1] + got_log_sum[1]).item(), 2.5, delta=1e-2)
+        self.assertFalse(got_max.isnan().any() or got_log_sum.isnan().any())
         # Non-contiguous input (sliced rows) exercises the stride args.
         base = torch.randn(8, 512, device="cuda", dtype=torch.bfloat16)
         view = base[::2]
+        got_max, got_log_sum = row_logsumexp(view)
         torch.testing.assert_close(
             torch.logsumexp(view.double(), dim=-1).float(),
-            row_logsumexp(view),
+            got_max + got_log_sum,
             rtol=1e-4,
             atol=1e-4,
         )

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -15,7 +15,6 @@ import torch
 
 from sglang.srt.layers.logprob_processor import (
     InputLogprobProcessor,
-    _logits_topk,
     compute_row_log_normalizer,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -30,7 +29,7 @@ TOPK_CYCLE = [2, 0, 3]
 TOKEN_IDS_CYCLE = [[0, 3], None, [1], []]
 
 
-def _build_batch(seq_specs, dtype):
+def _build_batch(seq_specs, dtype, vocab=VOCAB):
     """seq_specs: list of (extend_len, logprob_start_len). Mirrors
     LogitsProcessor._get_pruned_states for the extend-with-logprobs path."""
     pruned_rows = []
@@ -43,7 +42,7 @@ def _build_batch(seq_specs, dtype):
     for idx, (extend_len, start) in enumerate(seq_specs):
         eff_start = start - 1 if extend_len == start else start
         rows = extend_len - eff_start
-        pruned_rows.append(torch.randn(rows, VOCAB).to(dtype))
+        pruned_rows.append(torch.randn(rows, vocab).to(dtype))
         token_to_seq_idx.extend([idx] * rows)
         sample_pt += rows
         sample_indices.append(sample_pt)
@@ -230,36 +229,95 @@ class TestFastInputLogprobs(CustomTestCase):
             )
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    def test_fast_path_run_to_run_deterministic(self):
-        from sglang.srt.layers.logsumexp import row_logsumexp
+    def test_fused_run_to_run_deterministic(self):
+        from sglang.srt.layers.logsumexp import row_logsumexp_topk
 
         torch.manual_seed(0)
         logits = torch.randn(512, 151936, dtype=torch.bfloat16, device="cuda")
-        m1, l1 = row_logsumexp(logits)
-        m2, l2 = row_logsumexp(logits)
-        self.assertTrue(torch.equal(m1, m2) and torch.equal(l1, l2))
-        v1, i1 = _logits_topk(logits, 5)
-        v2, i2 = _logits_topk(logits, 5)
-        self.assertTrue(torch.equal(v1, v2) and torch.equal(i1, i2))
+        a = row_logsumexp_topk(logits, 5)
+        b = row_logsumexp_topk(logits, 5)
+        self.assertTrue(all(torch.equal(p, q) for p, q in zip(a, b)))
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-    def test_logits_topk_matches_torch(self):
+    def test_fused_logsumexp_topk_matches_torch(self):
+        from sglang.srt.layers.logsumexp import row_logsumexp, row_logsumexp_topk
+
         torch.manual_seed(0)
-        # fp32 randn is tie-free w.h.p., so indices must match torch exactly.
-        logits = torch.randn(64, 151936, device="cuda")
-        ref_v, ref_i = torch.topk(logits, k=5, dim=-1, sorted=True)
-        got_v, got_i = _logits_topk(logits, 5)
-        torch.testing.assert_close(ref_v, got_v.to(ref_v.dtype))
-        self.assertTrue(torch.equal(ref_i, got_i.to(ref_i.dtype)))
-        # bf16 has value ties; only the sorted values are contractual.
-        logits = torch.randn(64, 151936, device="cuda", dtype=torch.bfloat16)
-        ref_v, _ = torch.topk(logits, k=5, dim=-1, sorted=True)
-        got_v, got_i = _logits_topk(logits, 5)
-        self.assertTrue(torch.equal(ref_v, got_v.to(ref_v.dtype)))
-        # Returned indices must point at the returned values.
-        self.assertTrue(
-            torch.equal(logits.gather(-1, got_i.long()).to(got_v.dtype), got_v)
-        )
+        for k in (1, 2, 3, 5, 8):
+            for dtype in (torch.float32, torch.bfloat16):
+                logits = torch.randn(64, 151936, dtype=dtype, device="cuda")
+                got_m, got_ls, got_v, got_i = row_logsumexp_topk(logits, k)
+                # The (max, log_sum) pair is bitwise the non-fused kernel's.
+                ref_m, ref_ls = row_logsumexp(logits)
+                self.assertTrue(torch.equal(got_m, ref_m), (k, dtype))
+                self.assertTrue(torch.equal(got_ls, ref_ls), (k, dtype))
+                ref_v, ref_i = torch.topk(logits, k, dim=-1, sorted=True)
+                self.assertTrue(torch.equal(got_v, ref_v.float()), (k, dtype))
+                if dtype == torch.float32:
+                    # fp32 randn is tie-free w.h.p.: indices match exactly.
+                    self.assertTrue(torch.equal(got_i, ref_i), (k, dtype))
+                else:
+                    # bf16 has value ties; indices must point at the values.
+                    self.assertTrue(
+                        torch.equal(logits.gather(-1, got_i).float(), got_v),
+                        (k, dtype),
+                    )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_fused_topk_tie_break_is_lowest_index(self):
+        from sglang.srt.layers.logsumexp import row_logsumexp_topk
+
+        logits = torch.zeros(1, 1000, device="cuda")
+        logits[0, [7, 3, 500]] = 5.0
+        _, _, _, got_i = row_logsumexp_topk(logits, 3)
+        self.assertEqual(got_i[0].tolist(), [3, 7, 500])
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_fused_topk_inf_rows(self):
+        from sglang.srt.layers.logsumexp import row_logsumexp_topk
+
+        logits = torch.full((3, 1000), float("-inf"), device="cuda")
+        logits[1, 3] = 2.5
+        _, _, got_v, got_i = row_logsumexp_topk(logits.bfloat16(), 2)
+        self.assertEqual(got_i[0].tolist(), [0, 1])
+        self.assertEqual(got_i[1, 0].item(), 3)
+        self.assertFalse(got_v.isnan().any().item())
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_fast_path_end_to_end_on_cuda(self):
+        # Exercises the fused-kernel integration inside _forward_by_chunk
+        # (the CPU sweeps only cover the torch fallbacks), including the
+        # k > FUSED_TOPK_MAX_K fallback.
+        torch.manual_seed(0)
+        proc = InputLogprobProcessor()
+        for k_override in (None, 20):
+            # k=20 exceeds FUSED_TOPK_MAX_K, exercising the torch fallback;
+            # it needs a vocab that can supply 20 entries.
+            batch = _build_batch([(4, 1), (6, 2), (3, 0)], torch.float32, vocab=64)
+            pruned_states, sample_indices, lp_indices, t2s, metadata = batch
+            if k_override is not None:
+                metadata.top_logprobs_nums = [k_override] * 3
+            batch = (
+                pruned_states.cuda(),
+                sample_indices.cuda(),
+                lp_indices.cuda(),
+                t2s,
+                metadata,
+            )
+            metadata.extend_input_logprob_token_ids_gpu = (
+                metadata.extend_input_logprob_token_ids_gpu.cuda()
+            )
+            for chunk_size in (None, 2, 5):
+                ref, _ = _run(proc, batch, False, chunk_size)
+                got, _ = _run(proc, batch, True, chunk_size)
+                label = f"k_override={k_override} chunk={chunk_size}"
+                self.assertEqual(ref.top_logprobs_idx, got.top_logprobs_idx, label)
+                _assert_nested_close(
+                    self, ref.top_logprobs_val, got.top_logprobs_val, label, 1e-5, 1e-5
+                )
+                torch.testing.assert_close(
+                    ref.token_logprobs, got.token_logprobs, rtol=1e-5, atol=1e-5
+                )
 
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_row_logsumexp_kernel_matches_reference(self):

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -228,6 +228,19 @@ class TestFastInputLogprobs(CustomTestCase):
                 logprob.cpu(), expected.expand(4), rtol=1e-5, atol=1e-5
             )
 
+    def test_fast_path_emits_fp32_logprobs(self):
+        # Chosen dtype policy: the fast path returns fp32 token logprobs
+        # regardless of logits dtype (the normalizer is fp32, so fp32 is the
+        # true precision of the result), while the log_softmax path keeps
+        # the logits dtype. Runs on CPU CI so the policy is pinned even
+        # where the CUDA kernels never execute.
+        proc = InputLogprobProcessor()
+        batch = _build_batch([(4, 1), (3, 0)], torch.bfloat16)
+        got, _ = _run(proc, batch, True, None)
+        self.assertEqual(got.token_logprobs.dtype, torch.float32)
+        ref, _ = _run(proc, batch, False, None)
+        self.assertEqual(ref.token_logprobs.dtype, torch.bfloat16)
+
     def test_logsumexp_module_imports(self):
         # Runs on CPU CI too: catches import rot in the CUDA-only kernel
         # module, whose imports otherwise only execute on GPU machines.

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -228,6 +228,28 @@ class TestFastInputLogprobs(CustomTestCase):
                 logprob.cpu(), expected.expand(4), rtol=1e-5, atol=1e-5
             )
 
+    def test_logsumexp_module_imports(self):
+        # Runs on CPU CI too: catches import rot in the CUDA-only kernel
+        # module, whose imports otherwise only execute on GPU machines.
+        import sglang.srt.layers.logsumexp  # noqa: F401
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_fused_tiny_shapes(self):
+        from sglang.srt.layers.logsumexp import row_logsumexp_topk
+
+        for rows, cols, k in ((1, 1, 1), (3, 2, 2), (2, 3, 1), (2, 5, 5)):
+            logits = torch.randn(rows, cols, device="cuda")
+            got_m, got_ls, got_v, got_i = row_logsumexp_topk(logits, k)
+            ref_v, ref_i = torch.topk(logits, k, dim=-1, sorted=True)
+            self.assertTrue(torch.equal(got_v, ref_v.float()), (rows, cols, k))
+            self.assertTrue(torch.equal(got_i, ref_i), (rows, cols, k))
+            torch.testing.assert_close(
+                got_m + got_ls,
+                torch.logsumexp(logits.double(), dim=-1).float(),
+                rtol=1e-5,
+                atol=1e-5,
+            )
+
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_fused_run_to_run_deterministic(self):
         from sglang.srt.layers.logsumexp import row_logsumexp_topk


### PR DESCRIPTION
## Motivation

Input (prefill) logprob processing runs an out-of-place `log_softmax` over `[rows, vocab]` before extracting per-token logprobs, top-k, and token-ids probes (`InputLogprobProcessor._forward_by_chunk`). Everything downstream needs only small gathers plus a per-row normalizer, so the full-vocab materialization is pure memory traffic — at 32k rows x 152k vocab it allocates 10–20 GB of transient auxiliary memory. This is what forces small `SGLANG_LOGPROB_CHUNK_SIZE` values (each chunk pays a separate lm_head pass) and OOMs large-batch prefill with logprobs enabled, e.g. RL teacher / distillation workloads that request prompt top-k logprobs at scale.

## Modifications

- Keep the raw logits and compute a per-row logsumexp normalizer instead: `logprob[i] = logit[i] - lse(row)`. Top-k runs directly on the logits (identical order — the shift is a per-row constant), then values are normalized by subtraction; token-ids probes and the target-token gather do the same.
- New `srt/layers/logsumexp.py`: single-pass online-logsumexp Triton kernel (one read of the logits, fp32 accumulation, inf-safe). It returns per-row `(max, logsumexp - max)` and consumers compute `(logit - max) - log_sum`, preserving log-softmax's shift invariance for rows with a large common offset. When top-k is requested with k<=8, a fused variant maintains the running top-k in registers during the same single read (packed value+index keys, value ties broken by the lowest index); k>8 falls back to torch.topk on the raw logits. Non-CUDA falls back to torch. No dependencies beyond triton.
- `get_top_logprobs_chunk` / `get_token_ids_logprobs_chunk` accept an optional `log_normalizer`; behavior is unchanged when it is not passed.
- Opt-out escape hatch: `SGLANG_ENABLE_FAST_INPUT_LOGPROBS=0` restores the previous path.

Results are mathematically identical; for bf16 logits they are strictly *closer* to the exact values than the old path, because normalization happens in fp32 instead of rounding through a bf16 log-softmax.

## Benchmark

GB300, vocab=151936, k=2, 20-iter mean (isolated microbench of the replaced region: log_softmax+topk+gather vs logsumexp+topk+gather):

| rows | k | dtype | baseline | fast (fused kernel) | peak aux mem |
|---|---|---|---|---|---|
| 8192 | 2 | bf16 | 9.55 ms / 2532 MB | **2.39 ms (4.0x)** | 43 MB (**58.6x smaller**) |
| 32768 | 2 | bf16 | 42.34 ms / 10.1 GB | **9.39 ms (4.5x)** | 173 MB (**58.6x smaller**) |
| 8192 | 2 | fp32 | 15.54 ms / 5.0 GB | **2.47 ms (6.3x)** | 43 MB (**116.1x smaller**) |
| 8192 | 8 | bf16 | 9.58 ms | **3.84 ms (2.5x)** | 43 MB |

The commit history shows the evolution: an intermediate version used flashinfer's `top_k` (3.2-5.7x, but implementation-defined tie order and a hard dependency); the final fused kernel is faster at production k, dependency-free, and tie-deterministic. Above k=8 the fused selection cost overtakes a separate top-k pass (measured crossover ~k=6; below plain torch.topk near k=32), so larger k uses `logsumexp kernel + torch.topk` (~1.1x, never below baseline).

## Numerics

- **Shift-invariant**: normalization computes `(logit - max) - log_sum`, the same order as log-softmax; regression-tested at a 1e8 common offset.
- **Deterministic**: fixed reduction order, no atomics; run-to-run bitwise reproducibility is asserted in tests.
- **Tie-stable**: top-k value ties break by lowest index. fp32 indices are tested exactly equal to torch.topk's; a crafted-duplicates test pins the tie rule.
- **vs the old path**: the normalizer is an online logsumexp (the FlashAttention-style running max/sum) rather than torch's two-pass log-softmax. The algebra is identical — exactly equal in exact arithmetic — but the floating-point reduction order differs, so values agree to ulp level rather than bitwise (tested at 1e-5 fp32 across chunk splits; neither result is more correct than the other). For bf16 the fast path is strictly *closer* to the exact answer than before, because the old path rounds through a bf16 log-softmax while the normalizer here accumulates in fp32 (tested against float64 ground truth).
- **dtype**: the fast path returns fp32 token/top-k logprobs regardless of logits dtype (the normalizer is fp32, so fp32 is the true precision of the result); the old path returned the logits dtype. Responses serialize to python floats either way.
- `SGLANG_ENABLE_FAST_INPUT_LOGPROBS=0` reproduces today's behavior exactly, including torch.topk tie order.

## Test

- `test/registered/unit/layers/test_logprob_fast_input.py` (registered CPU CI):
  - fp32 sweep: fast vs log-softmax reference across heterogeneous per-sequence top-k/probe params and chunk splits — identical indices, values to 1e-5.
  - bf16 sweep: fast path vs float64 ground truth to 1e-4 (tighter than bf16 resolution; the old path cannot be used as an order reference because bf16 log-softmax rounds near-ties together).
  - Kernels vs float64 `logsumexp` / torch.topk for k in 1..8, including rows=0, cols=0, -inf-dominated rows, non-contiguous inputs, crafted value ties, the fused pair bitwise-equal to the non-fused kernel, a shift-invariance regression at offset 1e8, run-to-run bitwise determinism, and an end-to-end CUDA pass through the chunked processor including the k>8 fallback (CUDA tests skipped on CPU CI).
- Existing `test_logprob_chunk_stitching.py` passes with the fast path enabled (default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu65mfsbTu7wG37jggXEqW

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31134524752](https://github.com/sgl-project/sglang/actions/runs/31134524752)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31134524558](https://github.com/sgl-project/sglang/actions/runs/31134524558)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->





