### PR TITLE
Change the FP8 per-tensor GEMM backend on SM120 to cuBLAS

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1710,7 +1710,7 @@ def apply_fp8_linear_bmm_flashinfer(
     input_scale: torch.Tensor,
     bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Per-tensor static fp8 linear via flashinfer bmm_fp8 (SM10X only)."""
+    """Per-tensor static fp8 linear via flashinfer bmm_fp8 (SM100/SM120 Blackwell)."""
     output_shape = [*input.shape[:-1], weight.shape[1]]
     input_2d = input.view(-1, input.shape[-1])
     qinput, x_scale = static_quant_fp8(input_2d, input_scale, repeat_scale=False)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -499,7 +499,9 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
         super().__init__()
         self.quant_config = quant_config
         self.cutlass_fp8_supported = cutlass_fp8_supported()
-        self.enable_flashinfer_bmm = is_sm100_supported() and is_flashinfer_available()
+        self.enable_flashinfer_bmm = (
+            is_sm100_supported() or is_sm120_supported()
+        ) and is_flashinfer_available()
 
     def create_weights(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Just call bmm_fp8 of Flashinfer API (which call cuBLAS). 

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

No longer call the sgl-kernel. Although CUTLASS might achieve maybe further 5-10% perf improvement, it's not worth maintaining custom kernels and code.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

For example for old CUTLASS FP8 GEMM being called:
<img width="1726" height="906" alt="Screenshot 2026-07-21 at 9 31 47 AM" src="https://github.com/user-attachments/assets/f4137a0c-d7b8-4424-9512-03b536235681" />

New cuBLAS one:
<img width="1735" height="776" alt="Screenshot 2026-07-21 at 9 41 36 AM" src="https://github.com/user-attachments/assets/0013c9d2-77ce-497d-99ef-dfce328c6103" />
(it's OK that cuBLAS is using SM89 kernels, architecturally SM89 is very similar to to SM120). Anyway, when using latest cuBLAS after future Torch upgrades, it will generate `nvjet_sm120_qqtst_mma` (usually using TMA or some further improvements)

<img width="968" height="559" alt="Screenshot 2026-07-21 at 9 48 09 AM" src="https://github.com/user-attachments/assets/133a5799-90a5-4b33-a499-ed74f5881686" />

```
sglang serve --model-path nvidia/Qwen3.6-27B-NVFP4 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder
```

55 -> 65.59 TPS **(around 20%)** for M = 1, which is pretty good speedup.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29850248435](https://github.com/sgl-project/sglang/actions/runs/29850248435)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29854518280](https://github.com/sgl-project/sglang/actions/runs/29854518280)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->