### PR TITLE
[sglang-miles] Fix flush_cache() no-op after pause_generation in retract

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3751,9 +3751,6 @@ class Scheduler(
 
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
-        # Only ignore waiting requests while genuinely paused — otherwise this would
-        # mask a caller bug that flushes without pausing first, e.g. during a
-        # memory-pressure retract_decode.
         if self.is_fully_idle(ignore_waiting=self._engine_paused):
             self.cur_batch = None
             self.last_batch = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3610,12 +3610,7 @@ class Scheduler(
             and self._pp_microbatches_drained()
         )
 
-        # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode).
-        # ignore_waiting is set by flush-while-paused callers: with generation paused
-        # and running_batch drained, nothing in waiting_queue holds KV/pool state —
-        # neither requests pause_generation(mode="retract") just moved here nor
-        # requests that were never scheduled at all (the latter are always present
-        # under high concurrency, where in-flight targets exceed engine parallelism).
+        # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode)
         if not ignore_waiting:
             idle &= len(self.waiting_queue) == 0
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3593,7 +3593,7 @@ class Scheduler(
         # sleep until next event
         self.maybe_sleep_on_idle()
 
-    def is_fully_idle(self, for_health_check=False) -> bool:
+    def is_fully_idle(self, for_health_check=False, ignore_retracted=False) -> bool:
         # Health check piggybacks on running requests in process_output.
         # Only running_batch + waiting_queue guarantee active GPU processing;
         # disagg queues (bootstrap/prealloc/transfer) may have items without
@@ -3610,8 +3610,13 @@ class Scheduler(
             and self._pp_microbatches_drained()
         )
 
-        # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode)
-        idle &= len(self.waiting_queue) == 0
+        # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode).
+        # ignore_retracted excludes requests pause_generation(mode="retract") just moved
+        # here — they hold no KV/pool state, so they don't block a cache flush.
+        waiting_queue = self.waiting_queue
+        if ignore_retracted:
+            waiting_queue = [r for r in waiting_queue if not r.is_retracted]
+        idle &= len(waiting_queue) == 0
 
         if not for_health_check:
             # Grammar queue and prefill inflight queue may not produce batch
@@ -3750,7 +3755,10 @@ class Scheduler(
 
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
-        if self.is_fully_idle():
+        # Only ignore retracted requests while genuinely paused (pause_generation already
+        # moved them into waiting_queue) — otherwise this would mask a caller bug that
+        # flushes without pausing first, e.g. during a memory-pressure retract_decode.
+        if self.is_fully_idle(ignore_retracted=self._engine_paused):
             self.cur_batch = None
             self.last_batch = None
             self.tree_cache.reset()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3593,7 +3593,7 @@ class Scheduler(
         # sleep until next event
         self.maybe_sleep_on_idle()
 
-    def is_fully_idle(self, for_health_check=False, ignore_retracted=False) -> bool:
+    def is_fully_idle(self, for_health_check=False, ignore_waiting=False) -> bool:
         # Health check piggybacks on running requests in process_output.
         # Only running_batch + waiting_queue guarantee active GPU processing;
         # disagg queues (bootstrap/prealloc/transfer) may have items without
@@ -3611,12 +3611,13 @@ class Scheduler(
         )
 
         # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode).
-        # ignore_retracted excludes requests pause_generation(mode="retract") just moved
-        # here — they hold no KV/pool state, so they don't block a cache flush.
-        waiting_queue = self.waiting_queue
-        if ignore_retracted:
-            waiting_queue = [r for r in waiting_queue if not r.is_retracted]
-        idle &= len(waiting_queue) == 0
+        # ignore_waiting is set by flush-while-paused callers: with generation paused
+        # and running_batch drained, nothing in waiting_queue holds KV/pool state —
+        # neither requests pause_generation(mode="retract") just moved here nor
+        # requests that were never scheduled at all (the latter are always present
+        # under high concurrency, where in-flight targets exceed engine parallelism).
+        if not ignore_waiting:
+            idle &= len(self.waiting_queue) == 0
 
         if not for_health_check:
             # Grammar queue and prefill inflight queue may not produce batch
@@ -3755,10 +3756,10 @@ class Scheduler(
 
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
-        # Only ignore retracted requests while genuinely paused (pause_generation already
-        # moved them into waiting_queue) — otherwise this would mask a caller bug that
-        # flushes without pausing first, e.g. during a memory-pressure retract_decode.
-        if self.is_fully_idle(ignore_retracted=self._engine_paused):
+        # Only ignore waiting requests while genuinely paused — otherwise this would
+        # mask a caller bug that flushes without pausing first, e.g. during a
+        # memory-pressure retract_decode.
+        if self.is_fully_idle(ignore_waiting=self._engine_paused):
             self.cur_batch = None
             self.last_batch = None
             self.tree_cache.reset()

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -325,8 +325,9 @@ class SchedulerWeightUpdaterManager:
         return EndWeightUpdateReqOutput(success=True, message="Success")
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
-        assert (
-            self.is_fully_idle()
+        scheduler = self.scheduler
+        assert self.is_fully_idle(
+            ignore_retracted=scheduler is not None and scheduler._engine_paused
         ), "release_memory_occupation should be called only when server is idle."
 
         tags = recv_req.tags
@@ -338,7 +339,6 @@ class SchedulerWeightUpdaterManager:
             self.offload_tags.add(tag)
 
         if GPU_MEMORY_TYPE_KV_CACHE in tags:
-            scheduler = self.scheduler
             if scheduler is not None:
                 if scheduler.disaggregation_mode == DisaggregationMode.DECODE:
                     for queue_name in (

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -327,7 +327,7 @@ class SchedulerWeightUpdaterManager:
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
         scheduler = self.scheduler
         assert self.is_fully_idle(
-            ignore_retracted=scheduler is not None and scheduler._engine_paused
+            ignore_waiting=scheduler is not None and scheduler._engine_paused
         ), "release_memory_occupation should be called only when server is idle."
 
         tags = recv_req.tags

--- a/test/registered/unit/managers/test_scheduler_flush_cache_after_retract.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache_after_retract.py
@@ -21,9 +21,15 @@ def _make_req(is_retracted: bool) -> MagicMock:
 
 
 class TestSchedulerFlushCacheAfterRetract(unittest.TestCase):
-    """Regression coverage for flush_cache() no-oping right after
-    pause_generation(mode="retract") repopulates waiting_queue with requests
-    that hold no KV/pool state (see RETRACT_MODE_FLUSH_CACHE_FIX.md in miles)."""
+    """Regression coverage for flush_cache() no-oping while the engine is paused.
+
+    With generation paused and running_batch drained, nothing in waiting_queue
+    holds KV/pool state: neither requests pause_generation(mode="retract") just
+    moved there, nor requests that were never scheduled at all. The latter are
+    always present under high concurrency (in-flight targets exceed engine
+    parallelism), where gating the flush on them starves weight updates until
+    the caller's retry budget times out (reproduced in RL training at 512
+    in-flight requests). See RETRACT_MODE_FLUSH_CACHE_FIX.md in miles."""
 
     def _new_scheduler(self) -> Scheduler:
         scheduler = Scheduler.__new__(Scheduler)
@@ -60,36 +66,36 @@ class TestSchedulerFlushCacheAfterRetract(unittest.TestCase):
         scheduler.req_to_token_pool.clear.assert_called_once()
         scheduler.token_to_kv_pool_allocator.clear.assert_called_once()
 
-    def test_flush_cache_still_blocks_on_a_genuinely_new_request(self):
-        """Closes the vacuous-fix gap: a request that arrived independently of
-        retract (is_retracted=False) must still defer the flush."""
+    def test_flush_cache_succeeds_with_never_scheduled_reqs_while_paused(self):
+        """A request that was queued but never scheduled holds no KV/pool state
+        either; a paused-engine flush must not starve on it."""
         scheduler = self._new_scheduler()
         scheduler.waiting_queue = [_make_req(is_retracted=False)]
 
-        self.assertFalse(scheduler.flush_cache())
-        scheduler.tree_cache.reset.assert_not_called()
+        self.assertTrue(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_called_once()
 
-    def test_flush_cache_blocks_on_mixed_queue(self):
+    def test_flush_cache_succeeds_on_mixed_queue_while_paused(self):
         scheduler = self._new_scheduler()
         scheduler.waiting_queue = [
             _make_req(is_retracted=True),
             _make_req(is_retracted=False),
         ]
 
-        self.assertFalse(scheduler.flush_cache())
-        scheduler.tree_cache.reset.assert_not_called()
+        self.assertTrue(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_called_once()
 
     def test_is_fully_idle_default_ignores_nothing(self):
         """Regression guard: every other is_fully_idle() caller passes no args,
-        so a retracted-only waiting_queue must still report not-idle by default."""
+        so a non-empty waiting_queue must still report not-idle by default."""
         scheduler = self._new_scheduler()
         scheduler.waiting_queue = [_make_req(is_retracted=True)]
 
         self.assertFalse(scheduler.is_fully_idle())
-        self.assertTrue(scheduler.is_fully_idle(ignore_retracted=True))
+        self.assertTrue(scheduler.is_fully_idle(ignore_waiting=True))
 
-    def test_flush_cache_does_not_ignore_retracted_reqs_while_unpaused(self):
-        """ignore_retracted is gated on _engine_paused inside flush_cache — a
+    def test_flush_cache_does_not_ignore_waiting_reqs_while_unpaused(self):
+        """ignore_waiting is gated on _engine_paused inside flush_cache — a
         flush issued without pausing first must not be silently permissive."""
         scheduler = self._new_scheduler()
         scheduler._engine_paused = False

--- a/test/registered/unit/managers/test_scheduler_flush_cache_after_retract.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache_after_retract.py
@@ -1,0 +1,103 @@
+import unittest
+from collections import deque
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=6, suite="base-c-test-cpu")
+
+
+def _make_req(is_retracted: bool) -> MagicMock:
+    req = MagicMock()
+    req.is_retracted = is_retracted
+    return req
+
+
+class TestSchedulerFlushCacheAfterRetract(unittest.TestCase):
+    """Regression coverage for flush_cache() no-oping right after
+    pause_generation(mode="retract") repopulates waiting_queue with requests
+    that hold no KV/pool state (see RETRACT_MODE_FLUSH_CACHE_FIX.md in miles)."""
+
+    def _new_scheduler(self) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._engine_paused = True
+        scheduler.enable_overlap = False
+        scheduler.last_batch = None
+        scheduler.cur_batch = None
+        scheduler.chunked_req = None
+        scheduler.disaggregation_mode = DisaggregationMode.NULL
+        scheduler.running_batch = MagicMock()
+        scheduler.running_batch.is_empty.return_value = True
+        scheduler.result_queue = deque()
+        scheduler.waiting_queue = []
+        scheduler.dllm_manager = MagicMock()
+        scheduler.dllm_manager.any_staging_reqs.return_value = False
+        scheduler._pp_microbatches_drained = MagicMock(return_value=True)
+        scheduler.grammar_manager = MagicMock()
+        scheduler.grammar_manager.grammar_queue = []
+        scheduler.enable_hierarchical_cache = False
+        scheduler.enable_hisparse = False
+        scheduler.tree_cache = MagicMock()
+        scheduler.req_to_token_pool = MagicMock()
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.draft_worker = None
+        scheduler.metrics_reporter = MagicMock()
+        return scheduler
+
+    def test_flush_cache_succeeds_when_only_retracted_reqs_are_waiting(self):
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [_make_req(is_retracted=True)]
+
+        self.assertTrue(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_called_once()
+        scheduler.req_to_token_pool.clear.assert_called_once()
+        scheduler.token_to_kv_pool_allocator.clear.assert_called_once()
+
+    def test_flush_cache_still_blocks_on_a_genuinely_new_request(self):
+        """Closes the vacuous-fix gap: a request that arrived independently of
+        retract (is_retracted=False) must still defer the flush."""
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [_make_req(is_retracted=False)]
+
+        self.assertFalse(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_not_called()
+
+    def test_flush_cache_blocks_on_mixed_queue(self):
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [
+            _make_req(is_retracted=True),
+            _make_req(is_retracted=False),
+        ]
+
+        self.assertFalse(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_not_called()
+
+    def test_is_fully_idle_default_ignores_nothing(self):
+        """Regression guard: every other is_fully_idle() caller passes no args,
+        so a retracted-only waiting_queue must still report not-idle by default."""
+        scheduler = self._new_scheduler()
+        scheduler.waiting_queue = [_make_req(is_retracted=True)]
+
+        self.assertFalse(scheduler.is_fully_idle())
+        self.assertTrue(scheduler.is_fully_idle(ignore_retracted=True))
+
+    def test_flush_cache_does_not_ignore_retracted_reqs_while_unpaused(self):
+        """ignore_retracted is gated on _engine_paused inside flush_cache — a
+        flush issued without pausing first must not be silently permissive."""
+        scheduler = self._new_scheduler()
+        scheduler._engine_paused = False
+        scheduler.waiting_queue = [_make_req(is_retracted=True)]
+
+        self.assertFalse(scheduler.flush_cache())
+        scheduler.tree_cache.reset.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`is_fully_idle()` requires an empty `waiting_queue`, but `pause_generation(mode="retract")`
re-queues every retracted request into `waiting_queue` via `_add_request_to_queue`. So calling
`flush_cache()` right after a retract-mode pause always returned `success=False` and skipped the
actual `tree_cache`/pool reset. One internal caller, `weight_updater.py`'s
`flush_cache_after_weight_update`, asserts on that return value and crashes the whole scheduler
process outright when it hits this (confirmed live -- see below).

Retracted requests already released their KV (`release_req` -> `release_kv_cache(is_insert=False)`,
tagged via `req.is_retracted = True`, cleared on re-admission) and hold no pool/tree_cache state,
so they were never a real reason to block a flush -- the `waiting_queue` check just wasn't written
to distinguish them from a genuinely new, still-pending request.

An `is_retracted`-only exemption turned out to be insufficient under production load: with high
concurrency (in-flight target > engine parallelism) the `waiting_queue` always *also* holds
requests that were **never scheduled at all**. Those carry `is_retracted=False` yet hold no
KV/pool state either -- by definition they never prefilled, and `chunked_req` is cleared by the
retract pause path. Gating the paused-engine flush on them starves weight updates until the
caller's retry budget times out, reproducing the original symptom (hit in RL training at 512
in-flight requests, and in a minimal repro: 64 requests with `--max-running-requests 8` leaves a
~56-request never-scheduled backlog that fails every flush attempt).

**Fix**: `is_fully_idle()` gets an opt-in, default-off `ignore_waiting` param that exempts the
whole `waiting_queue` -- while generation is paused and `running_batch` is drained, nothing queued
holds allocator state, whether it was retracted here or never scheduled. Every existing caller
(`on_idle`, `attach/detach_hicache_storage_wrapped`, `process_input_requests`,
`SchedulerFlushWrapper`) is provably unaffected (regression-tested, default path unchanged).
`flush_cache()` passes `ignore_waiting=self._engine_paused` -- gated on the pause flag
specifically so a flush issued without pausing first can't become silently permissive. Same fix
applied to `release_memory_occupation`'s `assert self.is_fully_idle()`, which crashed outright
under the same condition today.

## Verification

- New test `test/registered/unit/managers/test_scheduler_flush_cache_after_retract.py` (5 cases:
  retracted-only, never-scheduled, and mixed queues flush successfully while paused; the default
  `is_fully_idle()` path and the unpaused flush stay strict).
- Live-server repro on an 8xH200 dev box: raced a real in-flight `/generate` request against
  `pause_generation(mode="retract")` + `/flush_cache`. Pre-fix: `400 "Flush cache failed."`. Same
  scenario post-fix: `200 "Cache flushed."`, with debug instrumentation confirming `retract_all`
  really does move the request into `waiting_queue` in both cases -- the scheduler fix alone
  changes the outcome.
- Never-scheduled-backlog repro (single GPU, Qwen3.5-4B, 64 requests with
  `--max-running-requests 8`): with only the `is_retracted` exemption, every flush attempt after
  a retract pause returns `400`; with the widened gate, the first attempt returns `200`.
- Separately confirmed this fixes a full scheduler crash for callers whose weight-update RPC
  doesn't pass `flush_cache=False` explicitly (defaults to `True` on
  `UpdateWeightsFromTensorReqInput`): reproduced the exact sequence
  (`pause_generation(mode="retract")` with a genuinely in-flight request -> standalone
  `flush_cache` -> `begin_weight_update` -> `/update_weights_from_tensor` with the default
  `flush_cache=True`) against a real Qwen3-4B server. Pre-fix: `AssertionError: Cache flush
  failed after updating weights` inside `flush_cache_after_weight_update`, `SIGQUIT`, engine dies.
  Post-fix: every step returns `200 {"success": true}`.
- Full qwen3.5-4b RL training run on the miles project's torchtitan backend (100/100 rollouts, no
  crashes, functional correctness + GPU utilization confirmed via 3 samples spanning the run) --
  see the paired miles PR (radixark/miles#1750) for the full validation writeup.
- High-concurrency RL stress run (miles fully-async megatron backend, 512 in-flight requests,
  4 retract-mode weight broadcasts per rollout, 20 rollouts ≈ 80 broadcasts, pause-the-world
  eval bursts of 1319 requests): previously died at the first deep-queue weight update; with the
  widened gate it completes with zero flush warnings and intact eval version pinning.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29976553084](https://github.com/sgl-project/sglang/actions/runs/29976553084)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29976553063](https://github.com/sgl-project/sglang/actions/runs/29976553063)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
