### PR TITLE
[disagg] Guard kv_receiver.abort() in handle_abort_req against None

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -300,6 +300,21 @@ _is_npu = is_npu()
 _is_hip = is_hip()
 
 
+def _abort_decode_kv_receiver(decode_req) -> None:
+    """Abort a queued decode request's kv_receiver, tolerating None.
+
+    DecodeTransferQueue clears ``kv_receiver`` after a successful KV
+    transfer commit or a metadata-corruption abort. Under an abort_all
+    wave (client-side cancels or upstream prefill bootstrap timeouts)
+    ``handle_abort_req`` can race with that cleanup and observe an
+    already-nulled receiver; guarding the .abort() call keeps the
+    scheduler thread alive.
+    """
+    receiver = decode_req.kv_receiver
+    if receiver is not None:
+        receiver.abort()
+
+
 class Scheduler(
     SchedulerDisaggregationDecodeMixin,
     SchedulerDisaggregationPrefillMixin,
@@ -4139,13 +4154,13 @@ class Scheduler(
             for decode_req in self.disagg_decode_prealloc_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
-                    decode_req.kv_receiver.abort()
+                    _abort_decode_kv_receiver(decode_req)
 
             # Abort requests waiting for kvcache to release tree cache
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
-                    decode_req.kv_receiver.abort()
+                    _abort_decode_kv_receiver(decode_req)
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/test/registered/unit/managers/test_scheduler_abort_null_guard.py
+++ b/test/registered/unit/managers/test_scheduler_abort_null_guard.py
@@ -1,0 +1,50 @@
+"""Unit tests for the kv_receiver null-guard used by Scheduler.handle_abort_req.
+
+DecodeTransferQueue clears ``decode_req.kv_receiver`` after a successful
+KV transfer commit or a metadata-corruption abort. Under an ``abort_all``
+wave, ``handle_abort_req`` may iterate the prealloc / transfer queues
+and observe an already-nulled receiver; calling ``.abort()`` on ``None``
+would raise ``AttributeError`` and kill the scheduler thread. PR #29834
+added the same guard for the sibling call site in
+``disaggregation/decode.py``; the two DECODE call sites in
+``handle_abort_req`` are now guarded by the same shape.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.managers.scheduler import _abort_decode_kv_receiver
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestAbortDecodeKVReceiver(CustomTestCase):
+    def test_none_receiver_is_noop(self):
+        """kv_receiver set to None => helper must not raise."""
+        decode_req = SimpleNamespace(kv_receiver=None)
+        _abort_decode_kv_receiver(decode_req)
+
+    def test_live_receiver_is_aborted_once(self):
+        """kv_receiver present => .abort() called exactly once."""
+        receiver = MagicMock()
+        decode_req = SimpleNamespace(kv_receiver=receiver)
+        _abort_decode_kv_receiver(decode_req)
+        receiver.abort.assert_called_once_with()
+
+    def test_receiver_flipped_to_none_between_reads(self):
+        """Simulate the exact race: attribute exists but resolves to None."""
+
+        class RacyReq:
+            @property
+            def kv_receiver(self):
+                return None
+
+        _abort_decode_kv_receiver(RacyReq())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Follow-up to PR #29834 ("Fix scheduler crash on prefill-unreachable
decode abort"), which added a `kv_receiver is not None` guard on the
retry-failure path in `disaggregation/decode.py`. The two matching
abort sites in `Scheduler.handle_abort_req`'s DECODE branch race with
the same cleanup and can crash the scheduler thread — and therefore
the whole engine — under an `abort_all` wave.

Observed in production during a heavy-load cutover event on 2026-07-17:

```
[TP1] Scheduler hit an exception: Traceback (most recent call last):
  File ".../managers/scheduler.py", line 4142, in handle_abort_req
    decode_req.kv_receiver.abort()
AttributeError: 'NoneType' object has no attribute 'abort'
```

Under sudden traffic burst with EAGLE MTP verify, hundreds of prefill
bootstrap timeouts fire concurrently. Each timeout triggers an
`abort_all` wave hitting `handle_abort_req`, and a subset of decode
requests already have their `kv_receiver` cleared by
`DecodeTransferQueue.pop_transferred_reqs` — either from a successful
transfer commit or a metadata-corruption abort. About 5–8% of decode
engines crashed this way over 30 minutes, and LWS pod recreation
dropped decode capacity, cascading into further load pressure and
further crashes.

PR #29834 fixed the same crash class in `disaggregation/decode.py`
but did not touch the two matching call sites in
`Scheduler.handle_abort_req`, which this PR addresses.

## Modifications

Extract the guarded `.abort()` call into a small module-level
helper `_abort_decode_kv_receiver(decode_req)` so the race is
documented in one place, and call it from both queue-iteration sites
(`disagg_decode_prealloc_queue.queue` and
`disagg_decode_transfer_queue.queue`) instead of calling
`decode_req.kv_receiver.abort()` unconditionally.

Safe because both paths that null `kv_receiver` in `decode.py` call
`.clear()` on the receiver right before nulling it — so the transfer
is already committed or cancelled by the time `handle_abort_req`
observes `None`. Same reasoning as PR #29834.

## Accuracy Tests

N/A — scheduler bug fix on an error path. Well-formed requests never
reach the guarded branch; model outputs on non-abort traffic are
byte-identical.

## Speed Tests and Profiling

N/A — adds a single `is not None` check on the abort path, which is
already an exceptional path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — Adds `test/registered/unit/managers/test_scheduler_abort_null_guard.py`: three deterministic cases (None → noop, live receiver → aborted exactly once, property-backed None to model the race explicitly). Registered under the `base-a-test-cpu` suite.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A (internal bug fix; no user-visible surface change).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — N/A (see Accuracy Tests / Speed Tests sections above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29861577652](https://github.com/sgl-project/sglang/actions/runs/29861577652)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29861577634](https://github.com/sgl-project/sglang/actions/runs/29861577634)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->