### PR TITLE
[disagg][mooncake] Harden PD receiver threads against malformed messages

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -880,50 +880,59 @@ class CommonKVManager(BaseKVManager):
         return src_kv_ptrs, sliced_dst
 
     def _start_heartbeat_checker_thread(self):
-        """Start the heartbeat checker thread for Decode worker."""
+        """Start the heartbeat checker thread for Decode worker.
 
-        def heartbeat_checker():
-            while True:
-                time.sleep(self.heartbeat_interval)
-                with self.connection_lock:
-                    addresses = list(self.prefill_info_table.keys())
+        Runs as a daemon. Wraps the whole per-tick body in a try/except
+        so a bug in ``_handle_node_failure`` or an unexpected exception
+        outside the existing inner request try/except cannot kill the
+        thread and silently stop health monitoring.
+        """
+        threading.Thread(target=self._run_heartbeat_checker_loop, daemon=True).start()
 
-                for bootstrap_addr in addresses:
-                    session = None
-                    try:
-                        with self.session_pool_lock:
-                            session = self.session_pool[bootstrap_addr]
-                        response = session.get(
-                            f"http://{bootstrap_addr}/health",
-                            timeout=(2, 3),
-                            headers={"Connection": "keep-alive"},
-                        )
-                        if response.status_code == 200:
-                            self.heartbeat_failures[bootstrap_addr] = 0
-                            self._on_heartbeat_success(bootstrap_addr)
-                        else:
-                            logger.info(
-                                f"Attempting to reconnect to {bootstrap_addr}..."
-                            )
-                            self.heartbeat_failures[bootstrap_addr] = (
-                                self.heartbeat_failures.get(bootstrap_addr, 0) + 1
-                            )
-                    except Exception:
-                        logger.info(f"Attempting to reconnect to {bootstrap_addr}...")
-                        self.heartbeat_failures[bootstrap_addr] = (
-                            self.heartbeat_failures.get(bootstrap_addr, 0) + 1
-                        )
+    def _run_heartbeat_checker_loop(self):
+        while True:
+            time.sleep(self.heartbeat_interval)
+            try:
+                self._run_one_heartbeat_pass()
+            except Exception:
+                logger.exception(
+                    "heartbeat_checker outer loop caught unexpected exception; "
+                    "continuing next tick"
+                )
 
-                    if (
-                        self.heartbeat_failures.get(bootstrap_addr, 0)
-                        >= self.max_failures
-                    ):
-                        self._handle_node_failure(bootstrap_addr)
-                        with self.session_pool_lock:
-                            if bootstrap_addr in self.session_pool:
-                                del self.session_pool[bootstrap_addr]
+    def _run_one_heartbeat_pass(self):
+        with self.connection_lock:
+            addresses = list(self.prefill_info_table.keys())
 
-        threading.Thread(target=heartbeat_checker, daemon=True).start()
+        for bootstrap_addr in addresses:
+            self._probe_bootstrap_addr(bootstrap_addr)
+            if (
+                self.heartbeat_failures.get(bootstrap_addr, 0)
+                >= self.max_failures
+            ):
+                self._handle_node_failure(bootstrap_addr)
+                with self.session_pool_lock:
+                    self.session_pool.pop(bootstrap_addr, None)
+
+    def _probe_bootstrap_addr(self, bootstrap_addr: str):
+        try:
+            with self.session_pool_lock:
+                session = self.session_pool[bootstrap_addr]
+            response = session.get(
+                f"http://{bootstrap_addr}/health",
+                timeout=(2, 3),
+                headers={"Connection": "keep-alive"},
+            )
+            if response.status_code == 200:
+                self.heartbeat_failures[bootstrap_addr] = 0
+                self._on_heartbeat_success(bootstrap_addr)
+                return
+            logger.info(f"Attempting to reconnect to {bootstrap_addr}...")
+        except Exception:
+            logger.info(f"Attempting to reconnect to {bootstrap_addr}...")
+        self.heartbeat_failures[bootstrap_addr] = (
+            self.heartbeat_failures.get(bootstrap_addr, 0) + 1
+        )
 
     def _on_heartbeat_success(self, bootstrap_addr: str):
         """Hook called on successful heartbeat. Override for backend-specific cleanup."""

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -225,6 +225,9 @@ class CommonKVManager(BaseKVManager):
             self.max_failures = max(
                 envs.SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE.get(), 1
             )
+            # Latch so _start_heartbeat_checker_thread spawns at most one
+            # thread per manager regardless of how often it is called.
+            self._heartbeat_checker_started = False
             # If a timeout happens on the decode side, it means decode instances
             # fail to receive the KV Cache transfer done signal after bootstrapping.
             # These timeout requests should be aborted to release the tree cache.
@@ -880,13 +883,25 @@ class CommonKVManager(BaseKVManager):
         return src_kv_ptrs, sliced_dst
 
     def _start_heartbeat_checker_thread(self):
-        """Start the heartbeat checker thread for Decode worker.
+        """Start the heartbeat checker thread for Decode worker (at most once).
 
         Runs as a daemon. Wraps the whole per-tick body in a try/except
         so a bug in ``_handle_node_failure`` or an unexpected exception
         outside the existing inner request try/except cannot kill the
         thread and silently stop health monitoring.
+
+        Idempotent by design: this must run once per manager (from
+        ``start_decode_thread``), never from a per-message path. We have
+        measured the failure mode of a misplaced call site (invoked once
+        per KV-status message in a downstream build): decode schedulers
+        accumulated 600-1,600 immortal HTTP-probing threads under abort
+        waves, CPU/GIL starvation stretched ~20 ms decode steps to
+        seconds, and liveness probes killed the pods. The latch makes
+        that class of regression structurally impossible.
         """
+        if self._heartbeat_checker_started:
+            return
+        self._heartbeat_checker_started = True
         threading.Thread(target=self._run_heartbeat_checker_loop, daemon=True).start()
 
     def _run_heartbeat_checker_loop(self):
@@ -906,10 +921,7 @@ class CommonKVManager(BaseKVManager):
 
         for bootstrap_addr in addresses:
             self._probe_bootstrap_addr(bootstrap_addr)
-            if (
-                self.heartbeat_failures.get(bootstrap_addr, 0)
-                >= self.max_failures
-            ):
+            if self.heartbeat_failures.get(bootstrap_addr, 0) >= self.max_failures:
                 self._handle_node_failure(bootstrap_addr)
                 with self.session_pool_lock:
                     self.session_pool.pop(bootstrap_addr, None)

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -66,6 +66,19 @@ FAILED_SESSION_RECOVERIES = Counter(
 )
 
 
+def _summarize_zmq_msg(msg, frame_prefix_bytes: int = 64, max_len: int = 512) -> str:
+    """Return a bounded repr of a multipart ZMQ message for log messages.
+
+    Truncates each frame to ``frame_prefix_bytes`` and the whole repr to
+    ``max_len`` so that a stray large or non-utf8 frame cannot flood
+    logs or raise on formatting.
+    """
+    try:
+        return repr([m[:frame_prefix_bytes] for m in msg])[:max_len]
+    except Exception:
+        return "<unrepresentable>"
+
+
 # decode
 @dataclasses.dataclass
 class TransferInfo:
@@ -1495,181 +1508,296 @@ class MooncakeKVManager(CommonKVManager):
                     self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
 
             except Exception as e:
-                # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
-                raise RuntimeError(
-                    f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
+                # The failed chunk's request will be surfaced as failed by
+                # the normal transfer-failure path (update_status +
+                # sync_status_to_decode_endpoint above); do not let a
+                # single chunk kill the whole transfer thread, which
+                # would silently stall every other in-flight KV transfer
+                # on this prefill.
+                logger.exception(
+                    "transfer_worker chunk failed (bootstrap_port=%s): %s; "
+                    "continuing to next chunk",
+                    self.bootstrap_port,
+                    e,
                 )
+                continue
 
     def start_prefill_thread(self):
-        def bootstrap_thread():
-            """This thread recvs pre-alloc notification from the decode engine"""
-            # KVPoll.Bootstrapping -> KVPoll.WaitingForInput
-            while True:
-                waiting_req_bytes = self.server_socket.recv_multipart()
-                room = waiting_req_bytes[0].decode("ascii")
-                # Staging: decode reports consumption watermark back to prefill
-                if room == "WATERMARK":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_watermark_msg,
-                    )
+        """Start the prefill-side bootstrap receiver thread.
 
-                    handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
-                    continue
-                # Staging: decode replies with allocated staging offset
-                if room == "STAGING_RSP":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_staging_rsp,
-                    )
+        The thread transitions rooms from ``KVPoll.Bootstrapping`` to
+        ``KVPoll.WaitingForInput`` and handles decode-side abort
+        notifications. It must never die: dispatch errors on a single
+        message are logged and the loop continues on the next message,
+        because a dead receiver silently freezes all in-flight KV
+        transfers on this prefill (decode sees no incoming chunks and
+        eventually times out its bootstrap window).
+        """
+        threading.Thread(target=self._run_bootstrap_receiver_loop).start()
 
-                    handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
-                    continue
-                # Decode-side abort notification: mark room as failed and ACK
-                if room == "ABORT":
-                    room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
-                    decode_ip = waiting_req_bytes[2].decode("ascii")
-                    decode_port = int(waiting_req_bytes[3].decode("ascii"))
-                    # No need to abort the room if it has already succeeded
-                    if (
-                        room_to_be_aborted in self.request_status
-                        and self.check_status(room_to_be_aborted) != KVPoll.Success
-                    ):
-                        self.update_status(room_to_be_aborted, KVPoll.Failed)
-                        logger.debug(
-                            f"Received abort notification for room {room_to_be_aborted}, "
-                            f"marked as Failed"
-                        )
-                    else:
-                        logger.debug(
-                            f"Received abort notification for room {room_to_be_aborted}, "
-                            f"ignoring (already completed or unknown)"
-                        )
-                    # Send ACK back to decode endpoint
-                    try:
-                        na = NetworkAddress(decode_ip, decode_port)
-                        self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
-                            [
-                                b"ABORT_ACK",
-                                str(room_to_be_aborted).encode("ascii"),
-                            ]
-                        )
-                        logger.debug(
-                            f"Sent ABORT_ACK for room {room_to_be_aborted} to "
-                            f"{decode_ip}:{decode_port}"
-                        )
-                    except Exception as e:
-                        logger.debug(
-                            f"Failed to send ABORT_ACK for room {room_to_be_aborted}: {e}"
-                        )
-                    continue
-                mooncake_session_id = waiting_req_bytes[3].decode("ascii")
-                if room == "None":
-                    self.decode_kv_args_table[mooncake_session_id] = (
-                        KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
-                    )
-                    with self.session_lock:
-                        if mooncake_session_id in self.failed_sessions:
-                            self.failed_sessions.remove(mooncake_session_id)
-                        if mooncake_session_id in self.session_failures:
-                            del self.session_failures[mooncake_session_id]
-                    logger.debug(
-                        f"Register KVArgs from {mooncake_session_id} successfully"
-                    )
-                    continue
-                else:
-                    required_dst_info_num = int(waiting_req_bytes[7].decode("ascii"))
-                    room = int(room)
-                    if room not in self.transfer_infos:
-                        self.transfer_infos[room] = {}
+    def _run_bootstrap_receiver_loop(self):
+        while True:
+            try:
+                msg = self.server_socket.recv_multipart()
+            except Exception:
+                logger.exception(
+                    "bootstrap_thread recv_multipart failed; retrying after 50ms"
+                )
+                time.sleep(0.05)
+                continue
+            try:
+                self._dispatch_bootstrap_msg(msg)
+            except Exception:
+                logger.exception(
+                    "bootstrap_thread dispatch failed for msg=%s; continuing",
+                    _summarize_zmq_msg(msg),
+                )
 
-                    self.transfer_infos[room][mooncake_session_id] = (
-                        TransferInfo.from_zmq(waiting_req_bytes)
-                    )
-                    # NOTE: after bootstrapping we can mark the req as waiting for input
-                    if len(self.transfer_infos[room]) == required_dst_info_num:
-                        self.resolve_kv_replica_factor(self.transfer_infos[room])
-                        self.req_to_decode_prefix_len[room] = next(
-                            (
-                                info.decode_prefix_len
-                                for info in self.transfer_infos[room].values()
-                                if info.decode_prefix_len is not None
-                            ),
-                            0,
-                        )
-                        self.update_status(room, KVPoll.WaitingForInput)
+    def _dispatch_bootstrap_msg(self, msg):
+        """Handle one message received by the prefill bootstrap thread.
 
-        threading.Thread(target=bootstrap_thread).start()
+        Recognized frame layouts (multipart, ASCII):
+          [b"WATERMARK", ...]        staging consumption watermark
+          [b"STAGING_RSP", ...]      staging allocation reply
+          [b"ABORT", room, ip, port] decode-side abort notification
+          [room_str, ...]            session-register or transfer-info
+
+        Malformed messages are logged and dropped so the receiver keeps
+        running for the rest of the load.
+        """
+        if not msg:
+            logger.warning("bootstrap_thread got empty message; dropping")
+            return
+
+        room = msg[0].decode("ascii")
+
+        # Staging: decode reports consumption watermark back to prefill
+        if room == "WATERMARK":
+            from sglang.srt.disaggregation.common.staging_handler import (
+                handle_watermark_msg,
+            )
+
+            handle_watermark_msg(self._staging_ctx, msg)
+            return
+
+        # Staging: decode replies with allocated staging offset
+        if room == "STAGING_RSP":
+            from sglang.srt.disaggregation.common.staging_handler import (
+                handle_staging_rsp,
+            )
+
+            handle_staging_rsp(msg, self.transfer_infos)
+            return
+
+        # Decode-side abort notification: mark room as failed and ACK
+        if room == "ABORT":
+            if len(msg) < 4:
+                logger.warning(
+                    "bootstrap_thread ABORT msg too short (%d frames); dropping",
+                    len(msg),
+                )
+                return
+            self._handle_bootstrap_abort_msg(msg)
+            return
+
+        # From here on the message is a session-register or transfer-info
+        # frame keyed by mooncake session id at index 3.
+        if len(msg) < 4:
+            logger.warning(
+                "bootstrap_thread session-register msg too short "
+                "(%d frames, room=%r); dropping",
+                len(msg),
+                room,
+            )
+            return
+        mooncake_session_id = msg[3].decode("ascii")
+
+        if room == "None":
+            self.decode_kv_args_table[mooncake_session_id] = (
+                KVArgsRegisterInfo.from_zmq(msg)
+            )
+            with self.session_lock:
+                self.failed_sessions.discard(mooncake_session_id)
+                self.session_failures.pop(mooncake_session_id, None)
+            logger.debug(f"Register KVArgs from {mooncake_session_id} successfully")
+            return
+
+        # Transfer-info frame carries the required_dst_info_num at index 7.
+        if len(msg) < 8:
+            logger.warning(
+                "bootstrap_thread transfer-info msg too short "
+                "(%d frames, room=%r); dropping",
+                len(msg),
+                room,
+            )
+            return
+        required_dst_info_num = int(msg[7].decode("ascii"))
+        room = int(room)
+        if room not in self.transfer_infos:
+            self.transfer_infos[room] = {}
+        self.transfer_infos[room][mooncake_session_id] = TransferInfo.from_zmq(msg)
+        if len(self.transfer_infos[room]) == required_dst_info_num:
+            self.resolve_kv_replica_factor(self.transfer_infos[room])
+            self.req_to_decode_prefix_len[room] = next(
+                (
+                    info.decode_prefix_len
+                    for info in self.transfer_infos[room].values()
+                    if info.decode_prefix_len is not None
+                ),
+                0,
+            )
+            self.update_status(room, KVPoll.WaitingForInput)
+
+    def _handle_bootstrap_abort_msg(self, msg):
+        room_to_be_aborted = int(msg[1].decode("ascii"))
+        decode_ip = msg[2].decode("ascii")
+        decode_port = int(msg[3].decode("ascii"))
+        # No need to abort the room if it has already succeeded
+        if (
+            room_to_be_aborted in self.request_status
+            and self.check_status(room_to_be_aborted) != KVPoll.Success
+        ):
+            self.update_status(room_to_be_aborted, KVPoll.Failed)
+            logger.debug(
+                f"Received abort notification for room {room_to_be_aborted}, "
+                f"marked as Failed"
+            )
+        else:
+            logger.debug(
+                f"Received abort notification for room {room_to_be_aborted}, "
+                f"ignoring (already completed or unknown)"
+            )
+        # Send ACK back to decode endpoint
+        try:
+            na = NetworkAddress(decode_ip, decode_port)
+            self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
+                [
+                    b"ABORT_ACK",
+                    str(room_to_be_aborted).encode("ascii"),
+                ]
+            )
+            logger.debug(
+                f"Sent ABORT_ACK for room {room_to_be_aborted} to "
+                f"{decode_ip}:{decode_port}"
+            )
+        except Exception as e:
+            logger.debug(f"Failed to send ABORT_ACK for room {room_to_be_aborted}: {e}")
 
     def start_decode_thread(self):
-        def decode_thread():
-            while True:
-                msg = self.server_socket.recv_multipart()
-                if msg[0] == MooncakeKVManager.AUX_DATA_HEADER:
-                    self._handle_aux_data(msg)
-                    continue
+        """Start the decode-side response receiver thread.
 
-                # Staging: prefill notifies a chunk written to staging buffer
-                if msg[0] == b"CHUNK_READY":
-                    room = int(msg[1].decode("ascii"))
-                    chunk_idx = int(msg[2].decode("ascii"))
-                    page_start = int(msg[3].decode("ascii"))
-                    num_pages = int(msg[4].decode("ascii"))
-                    session_id = msg[5].decode("ascii")
-                    handler = self._staging_handler
-                    assert (
-                        handler is not None
-                    ), "CHUNK_READY received before staging handler initialized"
-                    handler.handle_chunk_arrived(
-                        room,
-                        chunk_idx,
-                        page_start,
-                        num_pages,
-                        session_id,
-                        self._chunk_writer_counts,
-                    )
-                    continue
-
-                # Staging: prefill pre-requests staging allocation before forward
-                if msg[0] == b"STAGING_REQ":
-                    self._handle_staging_req(msg)
-                    continue
-
-                # Prefill acknowledges abort notification
-                if msg[0] == b"ABORT_ACK":
-                    # TODO(shangming): use this info to implement the deferred release mechanism if needed
-                    ack_aborted_room = int(msg[1].decode("ascii"))
-                    logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
-                    continue
-
-                bootstrap_room, status, prefill_rank = msg
-                status = int(status.decode("ascii"))
-                bootstrap_room = int(bootstrap_room.decode("ascii"))
-                prefill_rank = int(prefill_rank.decode("ascii"))
-
-                if status == KVPoll.Success:
-                    if bootstrap_room in self.request_status:
-                        self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
-                        expected_response_num = (
-                            self.required_prefill_response_num_table[bootstrap_room]
-                        )
-                        arrived_response_num = len(
-                            self.prefill_response_tracker[bootstrap_room]
-                        )
-                        if arrived_response_num == expected_response_num:
-                            if self.enable_staging:
-                                handler = self._staging_handler
-                                if handler.is_staging_room(bootstrap_room):
-                                    handler.submit_last_scatter_async(bootstrap_room)
-                                self._chunk_writer_counts.pop(bootstrap_room, None)
-                            self.update_status(bootstrap_room, KVPoll.Success)
-                elif status == KVPoll.Failed:
-                    self.record_failure(
-                        bootstrap_room,
-                        "Failed to get kvcache from prefill instance, it might be dead",
-                    )
-                    self.update_status(bootstrap_room, status)
-
-        threading.Thread(target=decode_thread).start()
+        The thread updates room status from prefill KVPoll responses and
+        handles staging/abort acknowledgements. As with
+        ``start_prefill_thread``, it must not die on a single bad
+        message: dispatch errors are logged and the loop advances.
+        """
+        threading.Thread(target=self._run_decode_receiver_loop).start()
         self._start_heartbeat_checker_thread()
+
+    def _run_decode_receiver_loop(self):
+        while True:
+            try:
+                msg = self.server_socket.recv_multipart()
+            except Exception:
+                logger.exception(
+                    "decode_thread recv_multipart failed; retrying after 50ms"
+                )
+                time.sleep(0.05)
+                continue
+            try:
+                self._dispatch_decode_msg(msg)
+            except Exception:
+                logger.exception(
+                    "decode_thread dispatch failed for msg=%s; continuing",
+                    _summarize_zmq_msg(msg),
+                )
+
+    def _dispatch_decode_msg(self, msg):
+        """Handle one message received by the decode response thread."""
+        if not msg:
+            logger.warning("decode_thread got empty message; dropping")
+            return
+
+        header = msg[0]
+
+        if header == MooncakeKVManager.AUX_DATA_HEADER:
+            self._handle_aux_data(msg)
+            return
+
+        # Staging: prefill notifies a chunk written to staging buffer
+        if header == b"CHUNK_READY":
+            room = int(msg[1].decode("ascii"))
+            chunk_idx = int(msg[2].decode("ascii"))
+            page_start = int(msg[3].decode("ascii"))
+            num_pages = int(msg[4].decode("ascii"))
+            session_id = msg[5].decode("ascii")
+            handler = self._staging_handler
+            assert (
+                handler is not None
+            ), "CHUNK_READY received before staging handler initialized"
+            handler.handle_chunk_arrived(
+                room,
+                chunk_idx,
+                page_start,
+                num_pages,
+                session_id,
+                self._chunk_writer_counts,
+            )
+            return
+
+        # Staging: prefill pre-requests staging allocation before forward
+        if header == b"STAGING_REQ":
+            self._handle_staging_req(msg)
+            return
+
+        # Prefill acknowledges abort notification
+        if header == b"ABORT_ACK":
+            # TODO(shangming): use this info to implement the deferred release mechanism if needed
+            ack_aborted_room = int(msg[1].decode("ascii"))
+            logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
+            return
+
+        # Remaining case: a KVPoll response frame (room, status, prefill_rank).
+        # Guard the unpack so a stray message (observed under abort_all
+        # pressure) does not raise ValueError and kill the thread.
+        if len(msg) != 3:
+            logger.warning(
+                "decode_thread got unexpected %d-frame message "
+                "(first_frame=%s); dropping",
+                len(msg),
+                _summarize_zmq_msg(msg),
+            )
+            return
+
+        bootstrap_room, status, prefill_rank = msg
+        status = int(status.decode("ascii"))
+        bootstrap_room = int(bootstrap_room.decode("ascii"))
+        prefill_rank = int(prefill_rank.decode("ascii"))
+        self._handle_prefill_response(bootstrap_room, status, prefill_rank)
+
+    def _handle_prefill_response(self, bootstrap_room, status, prefill_rank):
+        if status == KVPoll.Success:
+            if bootstrap_room in self.request_status:
+                self.prefill_response_tracker[bootstrap_room].add(prefill_rank)
+                expected_response_num = self.required_prefill_response_num_table[
+                    bootstrap_room
+                ]
+                arrived_response_num = len(
+                    self.prefill_response_tracker[bootstrap_room]
+                )
+                if arrived_response_num == expected_response_num:
+                    if self.enable_staging:
+                        handler = self._staging_handler
+                        if handler.is_staging_room(bootstrap_room):
+                            handler.submit_last_scatter_async(bootstrap_room)
+                        self._chunk_writer_counts.pop(bootstrap_room, None)
+                    self.update_status(bootstrap_room, KVPoll.Success)
+        elif status == KVPoll.Failed:
+            self.record_failure(
+                bootstrap_room,
+                "Failed to get kvcache from prefill instance, it might be dead",
+            )
+            self.update_status(bootstrap_room, status)
 
     def add_transfer_request(
         self,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1692,6 +1692,9 @@ class MooncakeKVManager(CommonKVManager):
         message: dispatch errors are logged and the loop advances.
         """
         threading.Thread(target=self._run_decode_receiver_loop).start()
+        # Exactly once per manager — keep this out of the per-message
+        # receiver/dispatch path (see the latch + rationale in
+        # CommonKVManager._start_heartbeat_checker_thread).
         self._start_heartbeat_checker_thread()
 
     def _run_decode_receiver_loop(self):

--- a/test/registered/unit/disaggregation/test_mooncake_receiver_resilience.py
+++ b/test/registered/unit/disaggregation/test_mooncake_receiver_resilience.py
@@ -1,0 +1,130 @@
+"""Unit tests for MooncakeKVManager receiver-thread resilience.
+
+The mooncake ``bootstrap_thread`` / ``decode_thread`` and the shared
+``heartbeat_checker`` in ``common/conn.py`` must never die from a bad
+message. These tests exercise the dispatch helpers with malformed
+inputs (empty, short, stray) and assert the handler drops the message
+rather than raising.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.disaggregation.mooncake.conn import (
+    MooncakeKVManager,
+    _summarize_zmq_msg,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestSummarizeZmqMsg(CustomTestCase):
+    """Log-formatter must never itself raise, and must produce bounded output."""
+
+    def test_bounded_length(self):
+        # 20 frames of 200 bytes each = 4000 raw bytes; repr must be capped.
+        summary = _summarize_zmq_msg([b"x" * 200] * 20)
+        self.assertLessEqual(len(summary), 512)
+
+    def test_readable_ascii_prefix(self):
+        summary = _summarize_zmq_msg([b"ABORT", b"1234", b"10.0.0.1", b"9001"])
+        self.assertIn("ABORT", summary)
+
+    def test_never_raises_on_broken_input(self):
+        # Passing something that isn't iterable should still return a
+        # placeholder rather than crashing the caller.
+        summary = _summarize_zmq_msg(object())
+        self.assertEqual(summary, "<unrepresentable>")
+
+
+class TestDispatchBootstrapMsg(CustomTestCase):
+    """``_dispatch_bootstrap_msg`` must drop malformed messages instead of
+    raising (which used to kill the receiver thread)."""
+
+    def _make_manager(self):
+        mgr = MagicMock()
+        mgr._dispatch_bootstrap_msg = MooncakeKVManager._dispatch_bootstrap_msg.__get__(
+            mgr, MooncakeKVManager
+        )
+        mgr._handle_bootstrap_abort_msg = MagicMock()
+        return mgr
+
+    def test_empty_msg_is_dropped(self):
+        mgr = self._make_manager()
+        # Must not raise.
+        mgr._dispatch_bootstrap_msg([])
+        mgr._handle_bootstrap_abort_msg.assert_not_called()
+
+    def test_short_abort_msg_is_dropped(self):
+        # ABORT frame layout is [b"ABORT", room, ip, port]; only 2 frames
+        # here so the original unconditional access to msg[3] would raise
+        # IndexError.
+        mgr = self._make_manager()
+        mgr._dispatch_bootstrap_msg([b"ABORT", b"12345"])
+        mgr._handle_bootstrap_abort_msg.assert_not_called()
+
+    def test_short_session_register_msg_is_dropped(self):
+        # room != known-prefix and len(msg) < 4 => cannot read
+        # mooncake_session_id at index 3.
+        mgr = self._make_manager()
+        mgr._dispatch_bootstrap_msg([b"None", b"one", b"two"])
+
+    def test_short_transfer_info_msg_is_dropped(self):
+        # Transfer-info needs at least 8 frames; only 4 here => cannot
+        # read required_dst_info_num at index 7.
+        mgr = self._make_manager()
+        mgr._dispatch_bootstrap_msg([b"123", b"one", b"two", b"session-id"])
+
+    def test_well_formed_abort_dispatches_to_helper(self):
+        # Sanity: on a valid ABORT frame the dispatcher delegates to
+        # _handle_bootstrap_abort_msg exactly once.
+        mgr = self._make_manager()
+        msg = [b"ABORT", b"42", b"10.0.0.1", b"9001"]
+        mgr._dispatch_bootstrap_msg(msg)
+        mgr._handle_bootstrap_abort_msg.assert_called_once_with(msg)
+
+
+class TestDispatchDecodeMsg(CustomTestCase):
+    """``_dispatch_decode_msg`` must drop malformed messages instead of
+    raising ``ValueError`` on the 3-tuple unpack (the observed prod
+    failure mode)."""
+
+    def _make_manager(self):
+        mgr = MagicMock()
+        mgr._dispatch_decode_msg = MooncakeKVManager._dispatch_decode_msg.__get__(
+            mgr, MooncakeKVManager
+        )
+        mgr._handle_prefill_response = MagicMock()
+        return mgr
+
+    def test_empty_msg_is_dropped(self):
+        mgr = self._make_manager()
+        mgr._dispatch_decode_msg([])
+        mgr._handle_prefill_response.assert_not_called()
+
+    def test_stray_1_frame_msg_is_dropped(self):
+        # No recognized header, only 1 frame => vanilla code would raise
+        # ValueError on the unpack.
+        mgr = self._make_manager()
+        mgr._dispatch_decode_msg([b"stray-frame"])
+        mgr._handle_prefill_response.assert_not_called()
+
+    def test_stray_5_frame_msg_is_dropped(self):
+        # 5 frames, no recognized header => also mismatches the 3-tuple
+        # unpack that ends the dispatch.
+        mgr = self._make_manager()
+        mgr._dispatch_decode_msg([b"a", b"b", b"c", b"d", b"e"])
+        mgr._handle_prefill_response.assert_not_called()
+
+    def test_well_formed_3tuple_dispatches_to_helper(self):
+        mgr = self._make_manager()
+        # (room, status, prefill_rank) — all ASCII int-encoded bytes.
+        mgr._dispatch_decode_msg([b"7", b"3", b"0"])
+        mgr._handle_prefill_response.assert_called_once_with(7, 3, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Three long-lived receiver threads on a PD engine — mooncake
`bootstrap_thread` and `decode_thread` in
`disaggregation/mooncake/conn.py`, and the shared `heartbeat_checker`
in `disaggregation/common/conn.py` — silently die on any exception
raised inside their `while True:` bodies. Any single malformed ZMQ
message takes the receiver down, KV-transfer completions never fire,
the main scheduler stalls, `/health` blocks, and the pod eventually
gets SIGTERM'd by the kubelet.

Root-caused in production on 2026-07-17: under `abort_all` pressure on
a GLM-5.1 24P+24D fleet, a rare 1-frame ZMQ message reached the
3-tuple unpack in `decode_thread`:

```python
bootstrap_room, status, prefill_rank = msg   # ValueError: not enough values to unpack
```

The thread died, KV completions never arrived, and the pod took ~5
minutes to be reaped. Analogous vulnerabilities existed in
`bootstrap_thread` on the unconditional `waiting_req_bytes[3]` and
`waiting_req_bytes[7]` indexed-frame accesses.

Separately, `transfer_worker` explicitly re-raised on any per-chunk
exception, tearing down the whole prefill-side transfer thread when
a single chunk failed. The original code carries the author's own
TODO acknowledging this:

```python
# NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
raise RuntimeError(...)
```

A dead transfer thread silently freezes all in-flight KV transfers
on that prefill (decode side sees no incoming chunks and eventually
times out on the bootstrap window), which is the same failure mode
as a dead receiver thread.

## Modifications

Behavior-preserving refactor + fix. All existing frame layouts
(WATERMARK, STAGING_RSP, ABORT, session-register, transfer-info,
AUX_DATA_HEADER, CHUNK_READY, STAGING_REQ, ABORT_ACK, and the
trailing KVPoll response 3-tuple) are handled identically to the
vanilla code path; log-message wording for each recognized frame is
preserved verbatim.

**`disaggregation/mooncake/conn.py`**

* Split each receiver-thread body into a `_run_*_receiver_loop`
  driver and a `_dispatch_*_msg` per-message handler. The driver
  wraps `recv_multipart` and dispatch in **separate** `try`/`except`
  blocks so a persistent socket failure does not tight-loop (50 ms
  sleep between retries) and a bad message does not skip the next
  legitimate `recv`.
* Add explicit length guards on multipart frame accesses that the
  original code performed unconditionally: `msg[3]` and `msg[7]` in
  the bootstrap thread; 3-tuple unpack in the decode thread.
  Malformed messages are logged and dropped.
* Add a small module-level `_summarize_zmq_msg` helper so log lines
  cannot carry unbounded / non-utf8 frame content.
* `transfer_worker`: log the exception and `continue` to the next
  chunk instead of raising. The failed chunk's request is already
  surfaced via `update_status` + `sync_status_to_decode_endpoint` on
  the send-error path above.

**`disaggregation/common/conn.py`**

* Split `_start_heartbeat_checker_thread` into
  `_run_heartbeat_checker_loop` + `_run_one_heartbeat_pass` +
  `_probe_bootstrap_addr`.
* Wrap the per-tick pass in a broad `try`/`except` so an unexpected
  exception in `_handle_node_failure` cannot silently stop health
  monitoring. Public interface `_start_heartbeat_checker_thread` is
  unchanged; the nixl subclass that also calls it is unaffected.

## Accuracy Tests

N/A — the new guarded code paths only run on malformed or racing
messages, which the original code aborted on. Well-formed KV
transfers are byte-identical.

## Speed Tests and Profiling

N/A — no per-request or hot-path work. The added guards are cheap
length checks and a per-loop `try`/`except`.

Verified end-to-end in production against a 24P+24D GLM-5.1 fleet:

| Signal | Vanilla image | With these guards |
| --- | --- | --- |
| Total aborts absorbed | ~74k until stall | 480k+ ongoing |
| Guard hits caught | N/A (crash) | 58 real bad-frame events |
| Receiver-thread deaths | 4–5 | 0 |
| Pod restarts across 4 workers | dec-0 stuck NotReady | 0 |
| Client completions during storm | 23 (stuck) | ~3,600 (150× more) |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — `pre-commit run --all-files` clean.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — Adds `test/registered/unit/disaggregation/test_mooncake_receiver_resilience.py` covering `_summarize_zmq_msg` (bounded output, non-iterable input) and malformed-input handling for both `_dispatch_bootstrap_msg` and `_dispatch_decode_msg` (empty message, short ABORT, short session-register, short transfer-info, stray 1-frame and 5-frame decode messages), plus positive cases that assert well-formed frames dispatch to the sub-helper exactly once. Registered under the `base-a-test-cpu` suite.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A (internal robustness fix; no user-visible surface change).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — N/A (see Accuracy Tests / Speed Tests sections above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30412654699](https://github.com/sgl-project/sglang/actions/runs/30412654699)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30412654626](https://github.com/sgl-project/sglang/actions/runs/30412654626)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

## Update 2026-07-29: idempotent heartbeat start + production validation

Second commit makes `_start_heartbeat_checker_thread` a no-op after the
first call (latch in `CommonKVManager.__init__`, decode branch).

Why: a downstream rebase of this branch accidentally relocated the call
from `start_decode_thread` (once per manager) into the per-message
dispatch path. Measured blast radius on a B300 PD fleet under abort
waves: 600–1,600 leaked immortal HTTP-probing threads per decode
scheduler, 100%+ CPU per rank at idle, GIL starvation stretching ~20 ms
decode steps to multi-second, liveness-probe kills. The latch makes this
regression class structurally impossible; the invariant is documented at
the mooncake call site.

Production validation of the guards in this PR (2026-07-28, 8P+8D
TP8/EP8 PD fleet, 550B hybrid-mamba model, B300s): a 10-minute max-rate
abort storm (22,125 aborts, ~37/s) plus a realistic-rate storm (15%
aborts + 10 s cancel-waves) both completed with zero receiver-thread
deaths, zero readiness flaps, zero liveness kills, and heartbeat thread
count flat at 1 per manager. The same guard build has been serving
production traffic since.
