### PR TITLE
Gate Mamba slot-donation debug asserts behind SGLANG_MAMBA_DEBUG_ASSERTS

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -20,6 +20,7 @@ The radix tree data structure for managing the hybrid (full and Mamba) KV cache.
 """
 
 import heapq
+import os
 from array import array
 from collections import defaultdict
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -61,6 +62,12 @@ import logging
 from sglang.srt.runtime_context import get_parallel
 
 logger = logging.getLogger(__name__)
+
+# Debug-only invariant checks in the Mamba slot-donation path call tensor.item(),
+# which forces a per-request cudaStreamSynchronize on the scheduler thread. Under
+# load this can serialize/stall the scheduler. Gate them off by default; set
+# SGLANG_MAMBA_DEBUG_ASSERTS=1 to re-enable for debugging.
+_MAMBA_DEBUG_ASSERTS = os.environ.get("SGLANG_MAMBA_DEBUG_ASSERTS", "0") == "1"
 
 
 class TreeNode:
@@ -583,13 +590,15 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 src_active = req.mamba_ping_pong_track_buffer[
                     mamba_ping_pong_track_buffer_to_keep
                 ].unsqueeze(-1)
-                assert src_active.item() != -1, (
-                    f"Cached mamba slot is -1: keep_idx={mamba_ping_pong_track_buffer_to_keep}, "
-                    f"buf={req.mamba_ping_pong_track_buffer.tolist()}, "
-                    f"next_track_idx={req.mamba_next_track_idx}, "
-                    f"last_track_seqlen={req.mamba_last_track_seqlen}, "
-                    f"rid={req.rid}"
-                )
+                if _MAMBA_DEBUG_ASSERTS:
+                    # .item() forces a cudaStreamSynchronize; only pay it when debugging.
+                    assert src_active.item() != -1, (
+                        f"Cached mamba slot is -1: keep_idx={mamba_ping_pong_track_buffer_to_keep}, "
+                        f"buf={req.mamba_ping_pong_track_buffer.tolist()}, "
+                        f"next_track_idx={req.mamba_next_track_idx}, "
+                        f"last_track_seqlen={req.mamba_last_track_seqlen}, "
+                        f"rid={req.rid}"
+                    )
                 if self.int8_ckpt_pool is not None:
                     mamba_value = self._commit_int8_checkpoint(src_active)
                     # quantized -> no ping-pong slot needs keeping

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -27,6 +27,7 @@ import copy
 import dataclasses
 import logging
 import math
+import os
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields
 from functools import cached_property
@@ -88,6 +89,12 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# Debug-only invariant in the Mamba slot-donation path calls tensor.item(), which
+# forces a per-request cudaStreamSynchronize on the scheduler thread and can stall
+# the scheduler under load. Off by default; set SGLANG_MAMBA_DEBUG_ASSERTS=1 to
+# re-enable for debugging.
+_MAMBA_DEBUG_ASSERTS = os.environ.get("SGLANG_MAMBA_DEBUG_ASSERTS", "0") == "1"
 
 GB = 1024 * 1024 * 1024
 _is_cuda = is_cuda()
@@ -1167,12 +1174,14 @@ class HybridReqToTokenPool(ReqToTokenPool):
         mamba_value_donated = (
             req.mamba_ping_pong_track_buffer[donate_idx].unsqueeze(-1).clone()
         )
-        assert mamba_value_donated.item() != -1, (
-            f"Donated mamba slot is -1: donate_idx={donate_idx}, "
-            f"buf={req.mamba_ping_pong_track_buffer.tolist()}, "
-            f"next_track_idx={req.mamba_next_track_idx}, "
-            f"rid={req.rid}"
-        )
+        if _MAMBA_DEBUG_ASSERTS:
+            # .item() forces a cudaStreamSynchronize; only pay it when debugging.
+            assert mamba_value_donated.item() != -1, (
+                f"Donated mamba slot is -1: donate_idx={donate_idx}, "
+                f"buf={req.mamba_ping_pong_track_buffer.tolist()}, "
+                f"next_track_idx={req.mamba_next_track_idx}, "
+                f"rid={req.rid}"
+            )
         self.set_mamba_ping_pong_slot(req, donate_idx, new_slot[0])
         return mamba_value_donated
 


### PR DESCRIPTION
## Summary

The Mamba slot-donation path runs debug invariant checks that call `tensor.item()` on every request. `.item()` forces a blocking `cudaStreamSynchronize` on the scheduler thread, adding a device sync to the per-request critical path. Under load (hybrid SSM + overlap scheduler) this serializes the scheduler and can starve the detokenizer heartbeat.

This gates both asserts behind `SGLANG_MAMBA_DEBUG_ASSERTS` (off by default), so the hot path no longer forces a sync. Set `SGLANG_MAMBA_DEBUG_ASSERTS=1` to re-enable them for debugging.

Fixes #31970

## Changes

- `mem_cache/mamba_radix_cache.py`: gate `assert src_active.item() != -1` behind the flag.
- `mem_cache/memory_pool.py`: gate `assert mamba_value_donated.item() != -1` behind the flag.

## Testing

- Verified the flag defaults to off (both modules import with `_MAMBA_DEBUG_ASSERTS is False` when the env var is unset) and turns on with `SGLANG_MAMBA_DEBUG_ASSERTS=1`.
- Served a hybrid-SSM (Mamba) model with the overlap scheduler and ran sustained concurrent load: no functional regression, no `item()` sync on the donation path, and the detokenizer-heartbeat health-check failures under load no longer reproduce.
- Confirmed the asserts still fire as before when the env var is set.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29867380851](https://github.com/sgl-project/sglang/actions/runs/29867380851)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29867380453](https://github.com/sgl-project/sglang/actions/runs/29867380453)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->