### PR TITLE
[Perf] Skip page-table columns past kv length in DSA draft-extend metadata kernel

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa_metadata.py
+++ b/python/sglang/kernels/ops/attention/dsa_metadata.py
@@ -524,6 +524,16 @@ def _fused_dsa_draft_extend_metadata_kernel(
         mask=req_row < bs,
         other=0,
     ).to(tl.int32)
+    # Columns past the request's kv length are never read by any consumer
+    # (attention and the indexer both stay within cache_seqlens); skip whole
+    # column blocks instead of copying the full captured table width.
+    kv_len = tl.load(
+        seq_lens + req_row * seq_lens_stride,
+        mask=req_row < bs,
+        other=0,
+    ).to(tl.int32)
+    if col_block * BLOCK_N >= kv_len:
+        return
     if STATIC_EXTEND_LEN:
         prefix = req_row * qo_len
     else:

--- a/python/sglang/kernels/ops/attention/dsa_metadata.py
+++ b/python/sglang/kernels/ops/attention/dsa_metadata.py
@@ -524,9 +524,8 @@ def _fused_dsa_draft_extend_metadata_kernel(
         mask=req_row < bs,
         other=0,
     ).to(tl.int32)
-    # Columns past the request's kv length are never read by any consumer
-    # (attention and the indexer both stay within cache_seqlens); skip whole
-    # column blocks instead of copying the full captured table width.
+    # Skip column blocks past the request's kv length: no consumer reads there
+    # (attention and the indexer both stay within cache_seqlens).
     kv_len = tl.load(
         seq_lens + req_row * seq_lens_stride,
         mask=req_row < bs,

--- a/test/registered/kernels/test_dsa_metadata.py
+++ b/test/registered/kernels/test_dsa_metadata.py
@@ -304,12 +304,9 @@ class TestDSAMetadataKernels(CustomTestCase):
         )
         expected_dsa = _dsa_seqlens(expected_expanded, dsa_index_topk)
 
-        # Columns at or past a request's kv length are undefined: the kernel
-        # skips whole page-table column blocks once they begin beyond kv_len
-        # (no consumer reads there -- attention and the indexer both stay
-        # within cache_seqlens). Only the live prefix [:kv_len] per request is
-        # part of the contract, so assert just that region. All expanded rows
-        # of a request share the request's kv length.
+        # Only the live prefix [:kv_len] per request is defined; the kernel
+        # leaves columns past kv_len untouched. All expanded rows of a request
+        # share its kv length.
         row_kv_lens = torch.repeat_interleave(seq_lens.to(torch.int32), extend_seq_lens)
         cols = torch.arange(max_seqlen_k, dtype=torch.int32, device=self.device)
         live_mask = cols.view(1, -1) < row_kv_lens.view(-1, 1)
@@ -333,8 +330,7 @@ class TestDSAMetadataKernels(CustomTestCase):
             "draft dsa_cu_seqlens_k",
         )
         if real_page_size > 1:
-            # A real-page column maps to source column real_col * real_page_size;
-            # it is live iff that source column is within the request's kv_len.
+            # Real-page column real_col maps to source column real_col*real_page_size.
             real_width = real_page_table.shape[1]
             real_cols = torch.arange(real_width, dtype=torch.int32, device=self.device)
             real_live_mask = (

--- a/test/registered/kernels/test_dsa_metadata.py
+++ b/test/registered/kernels/test_dsa_metadata.py
@@ -304,10 +304,22 @@ class TestDSAMetadataKernels(CustomTestCase):
         )
         expected_dsa = _dsa_seqlens(expected_expanded, dsa_index_topk)
 
+        # Columns at or past a request's kv length are undefined: the kernel
+        # skips whole page-table column blocks once they begin beyond kv_len
+        # (no consumer reads there -- attention and the indexer both stay
+        # within cache_seqlens). Only the live prefix [:kv_len] per request is
+        # part of the contract, so assert just that region. All expanded rows
+        # of a request share the request's kv length.
+        row_kv_lens = torch.repeat_interleave(seq_lens.to(torch.int32), extend_seq_lens)
+        cols = torch.arange(max_seqlen_k, dtype=torch.int32, device=self.device)
+        live_mask = cols.view(1, -1) < row_kv_lens.view(-1, 1)
+
         _assert_equal(cache_seqlens, expected_cache, "draft cache_seqlens")
         _assert_equal(cu_seqlens_k, _cu_seqlens(expected_cache), "draft cu_seqlens_k")
         _assert_equal(
-            page_table_1[:total_len], expected_page_table, "draft page_table_1"
+            page_table_1[:total_len][live_mask],
+            expected_page_table[live_mask],
+            "draft page_table_1 (live [:kv_len] prefix)",
         )
         _assert_equal(
             seqlens_expanded[:total_len], expected_expanded, "draft seqlens_expanded"
@@ -321,10 +333,18 @@ class TestDSAMetadataKernels(CustomTestCase):
             "draft dsa_cu_seqlens_k",
         )
         if real_page_size > 1:
+            # A real-page column maps to source column real_col * real_page_size;
+            # it is live iff that source column is within the request's kv_len.
+            real_width = real_page_table.shape[1]
+            real_cols = torch.arange(real_width, dtype=torch.int32, device=self.device)
+            real_live_mask = (
+                real_cols.view(1, -1) * real_page_size
+            ) < row_kv_lens.view(-1, 1)
+            expected_real = _real_page_table(expected_page_table, real_page_size)
             _assert_equal(
-                real_page_table[:total_len],
-                _real_page_table(expected_page_table, real_page_size),
-                "draft real_page_table",
+                real_page_table[:total_len][real_live_mask],
+                expected_real[real_live_mask],
+                "draft real_page_table (live [:kv_len] prefix)",
             )
 
     def test_decode_matches_eager_reference(self):


### PR DESCRIPTION
The DSA draft-extend metadata kernel copies the page table over the full captured context width, but each request's real kv length is far smaller. Add a per-program early-exit: skip whole column blocks whose start is past the request's kv length (downstream attention and the indexer both bound their reads by `cache_seqlens`, so those columns are never read).

The kernel runs once per draft-extend step, so this is a per-step metadata-prep saving on the speculative-decoding hot path; the win grows with the gap between the captured graph's context bucket and the real sequence length. In a bs=1 draft-extend profile the prep drops from ~74.9us to ~40.9us.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29873763586](https://github.com/sgl-project/sglang/actions/runs/29873763586)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29873763150](https://github.com/sgl-project/sglang/actions/runs/29873763150)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
