### PR TITLE
[CI] Point diffusion CI writes to sgl-project/ci-data-diffusion

### DIFF
--- a/.github/workflows/diffusion-ci-gt-gen-npu.yml
+++ b/.github/workflows/diffusion-ci-gt-gen-npu.yml
@@ -61,6 +61,16 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Verify write access to sgl-project/ci-data-diffusion
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          if [ "$(gh api repos/sgl-project/ci-data-diffusion --jq .permissions.push)" != "true" ]; then
+            echo "::error::GH_PAT_FOR_NIGHTLY_CI_DATA lacks write (push) access to sgl-project/ci-data-diffusion. Grant it before running GT generation."
+            exit 1
+          fi
+          echo "OK: write access to sgl-project/ci-data-diffusion confirmed"
+
       - name: Compute partitions
         env:
           USE_NPU_CONFIGS: true

--- a/.github/workflows/diffusion-ci-gt-gen-npu.yml
+++ b/.github/workflows/diffusion-ci-gt-gen-npu.yml
@@ -19,7 +19,7 @@ on:
         default: ''
         type: string
       publish_target_dir:
-        description: 'Remote target directory in sgl-project/ci-data. Leave empty to use diffusion-ci/consistency_gt/sglang_generated/ascend.'
+        description: 'Remote target directory in sgl-project/ci-data-diffusion. Leave empty to use diffusion-ci/consistency_gt/sglang_generated/ascend.'
         required: false
         default: ''
         type: string
@@ -135,7 +135,7 @@ jobs:
           path: python/${{ env.OUTPUT_NAME }}
           retention-days: 7
 
-      - name: Publish GT images to sgl-project/ci-data
+      - name: Publish GT images to sgl-project/ci-data-diffusion
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -205,7 +205,7 @@ jobs:
           path: python/${{ env.OUTPUT_NAME }}
           retention-days: 7
 
-      - name: Publish GT images to sgl-project/ci-data
+      - name: Publish GT images to sgl-project/ci-data-diffusion
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |

--- a/.github/workflows/diffusion-ci-gt-gen.yml
+++ b/.github/workflows/diffusion-ci-gt-gen.yml
@@ -71,6 +71,16 @@ jobs:
       matrix: ${{ steps.compute.outputs.matrix }}
       case-count: ${{ steps.compute.outputs.case-count }}
     steps:
+      - name: Verify write access to sgl-project/ci-data-diffusion
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          if [ "$(gh api repos/sgl-project/ci-data-diffusion --jq .permissions.push)" != "true" ]; then
+            echo "::error::GH_PAT_FOR_NIGHTLY_CI_DATA lacks write (push) access to sgl-project/ci-data-diffusion. Grant it before running GT generation."
+            exit 1
+          fi
+          echo "OK: write access to sgl-project/ci-data-diffusion confirmed"
+
       - name: Compute official case matrix
         id: compute
         env:
@@ -334,6 +344,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+
+      - name: Verify write access to sgl-project/ci-data-diffusion
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+        run: |
+          if [ "$(gh api repos/sgl-project/ci-data-diffusion --jq .permissions.push)" != "true" ]; then
+            echo "::error::GH_PAT_FOR_NIGHTLY_CI_DATA lacks write (push) access to sgl-project/ci-data-diffusion. Grant it before running GT generation."
+            exit 1
+          fi
+          echo "OK: write access to sgl-project/ci-data-diffusion confirmed"
 
       - name: Compute partitions
         id: compute

--- a/.github/workflows/diffusion-ci-gt-gen.yml
+++ b/.github/workflows/diffusion-ci-gt-gen.yml
@@ -19,7 +19,7 @@ on:
         default: ''
         type: string
       publish_target_dir:
-        description: 'Remote target directory in sgl-project/ci-data. Leave empty to use sglang_generated, or official_generated when run_official_cases is true.'
+        description: 'Remote target directory in sgl-project/ci-data-diffusion. Leave empty to use sglang_generated, or official_generated when run_official_cases is true.'
         required: false
         default: ''
         type: string
@@ -44,7 +44,7 @@ on:
         default: ''
         type: string
       ci_data_ref:
-        description: 'ci-data ref to use for repro scripts when running official GT cases.'
+        description: 'ci-data-diffusion ref to use for repro scripts when running official GT cases.'
         required: false
         default: 'main'
         type: string
@@ -163,10 +163,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Checkout ci-data repro scripts
+      - name: Checkout ci-data-diffusion repro scripts
         uses: actions/checkout@v4
         with:
-          repository: sgl-project/ci-data
+          repository: sgl-project/ci-data-diffusion
           ref: ${{ inputs.ci_data_ref || 'main' }}
           path: ci-data
           token: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
@@ -303,7 +303,7 @@ jobs:
             --target-dir "${{ env.PUBLISH_TARGET_DIR }}" \
             --check-only
 
-      - name: Publish official GT images to sgl-project/ci-data
+      - name: Publish official GT images to sgl-project/ci-data-diffusion
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -412,7 +412,7 @@ jobs:
             --target-dir "${{ env.PUBLISH_TARGET_DIR }}" \
             --check-only
 
-      - name: Publish GT images to sgl-project/ci-data
+      - name: Publish GT images to sgl-project/ci-data-diffusion
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -487,7 +487,7 @@ jobs:
             --target-dir "${{ env.PUBLISH_TARGET_DIR }}" \
             --check-only
 
-      - name: Publish GT images to sgl-project/ci-data
+      - name: Publish GT images to sgl-project/ci-data-diffusion
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |
@@ -562,7 +562,7 @@ jobs:
             --target-dir "${{ env.PUBLISH_TARGET_DIR }}" \
             --check-only
 
-      - name: Publish GT images to sgl-project/ci-data
+      - name: Publish GT images to sgl-project/ci-data-diffusion
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |

--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -626,13 +626,13 @@ class DiffusionServerBase:
 --- MISSING GROUND TRUTH DETECTED ---
 GT image(s) not found for '{case.id}'.
 
-Add the expected file(s) to sgl-project/ci-data in diffusion-ci/consistency_gt/sglang_generated/ with naming (n=num_gpus).
+Add the expected file(s) to sgl-project/ci-data-diffusion in diffusion-ci/consistency_gt/sglang_generated/ with naming (n=num_gpus).
   Image: {case.id}_{{n}}gpu.<ext> (ext from output_format: png, jpg, webp)
   Video: {case.id}_{{n}}gpu_frame_0.png, {case.id}_{{n}}gpu_frame_mid.png, {case.id}_{{n}}gpu_frame_last.png
 
 For this case, expected file(s): {names}
 
-Repository: https://github.com/sgl-project/ci-data (path: diffusion-ci/consistency_gt/sglang_generated/, with optional platform subdirectories such as 5090/)
+Repository: https://github.com/sgl-project/ci-data-diffusion (path: diffusion-ci/consistency_gt/sglang_generated/, with optional platform subdirectories such as 5090/)
 Pinned revision used by this check: {SGL_TEST_FILES_CI_DATA_REVISION}
 
 (Optional) Per-case override in {get_consistency_threshold_path()}:
@@ -768,12 +768,12 @@ Pinned revision used by this check: {SGL_TEST_FILES_CI_DATA_REVISION}
 --- MISSING ACTION GROUND TRUTH DETECTED ---
 GT action JSON not found for '{case.id}'.
 
-Add the expected file to sgl-project/ci-data in diffusion-ci/consistency_gt/sglang_generated/ with naming:
+Add the expected file to sgl-project/ci-data-diffusion in diffusion-ci/consistency_gt/sglang_generated/ with naming:
   Action: {case.id}_{{n}}gpu.json
 
 For this case, expected file(s): {names}
 
-Repository: https://github.com/sgl-project/ci-data (path: diffusion-ci/consistency_gt/sglang_generated/, with optional platform subdirectories such as 5090/)
+Repository: https://github.com/sgl-project/ci-data-diffusion (path: diffusion-ci/consistency_gt/sglang_generated/, with optional platform subdirectories such as 5090/)
 Pinned revision used by this check: {SGL_TEST_FILES_CI_DATA_REVISION}
 """)
             pytest.fail(

--- a/python/sglang/multimodal_gen/test/server/test_server_utils.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_utils.py
@@ -734,7 +734,9 @@ class MeshValidator(PerformanceValidator):
 
 # Pinned to a ci-data commit (not main): invalidates the per-URL download cache
 # whenever the reference is regenerated, and keeps the mesh GT reproducible.
-# Bump this SHA when pushing a new hunyuan3d.glb to ci-data.
+# New GT now publishes to sgl-project/ci-data-diffusion, so when you push a new
+# hunyuan3d.glb, switch the repo in the URL below to it and bump the SHA together
+# (this frozen SHA stays readable on sgl-project/ci-data).
 HUNYUAN3D_REFERENCE_URL = (
     "https://raw.githubusercontent.com/sgl-project/ci-data/"
     "395f6e49c37d22a57d79fbcd3653d43984099ae2"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -34,6 +34,14 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# GT is read from <repo>@<revision>. A given SHA only exists in the repo it was
+# committed to, so REPO and REVISION must be bumped together. New GT now
+# publishes to sgl-project/ci-data-diffusion; the pins below still resolve
+# against sgl-project/ci-data (readable but frozen). When you bump REVISION to a
+# freshly generated commit, switch REPO to sgl-project/ci-data-diffusion too
+# (and update the URL assertion in the consistency-metrics unit test).
+SGL_TEST_FILES_CI_DATA_REPO = "sgl-project/ci-data"
+
 SGL_TEST_FILES_CI_DATA_REVISION = "320949ecc2587474a2f535229ffc8f47ed16ee51"
 
 if current_platform.is_npu():
@@ -41,7 +49,7 @@ if current_platform.is_npu():
 
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
-    f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"
+    f"{SGL_TEST_FILES_CI_DATA_REPO}/{SGL_TEST_FILES_CI_DATA_REVISION}/"
     "diffusion-ci/consistency_gt"
 )
 SGL_TEST_FILES_OFFICIAL_CONSISTENCY_GT_BASE = (

--- a/scripts/ci/utils/diffusion/generate_diffusion_dashboard.py
+++ b/scripts/ci/utils/diffusion/generate_diffusion_dashboard.py
@@ -1,6 +1,6 @@
 """Generate a Markdown dashboard for SGLang-Diffusion nightly benchmarks.
 
-Reads current comparison results + historical data from sgl-project/ci-data repo
+Reads current comparison results + historical data from sgl-project/ci-data-diffusion repo
 and produces a Markdown report with tables and trend charts saved as PNG files.
 
 Usage:
@@ -18,16 +18,16 @@ import os
 from datetime import datetime, timezone
 
 # ---------------------------------------------------------------------------
-# History fetching (from sgl-project/ci-data repo via GitHub API)
+# History fetching (from sgl-project/ci-data-diffusion repo via GitHub API)
 # ---------------------------------------------------------------------------
 
 CI_DATA_REPO_OWNER = "sgl-project"
-CI_DATA_REPO_NAME = "ci-data"
+CI_DATA_REPO_NAME = "ci-data-diffusion"
 CI_DATA_BRANCH = "main"
 HISTORY_PREFIX = "diffusion-comparisons"
 MAX_HISTORY_RUNS = 29
 
-# Base URL for chart images pushed to sgl-project/ci-data
+# Base URL for chart images pushed to sgl-project/ci-data-diffusion
 CHARTS_RAW_BASE_URL = (
     f"https://raw.githubusercontent.com/{CI_DATA_REPO_OWNER}/{CI_DATA_REPO_NAME}"
     f"/{CI_DATA_BRANCH}/{HISTORY_PREFIX}/charts"
@@ -57,7 +57,7 @@ def _github_get(url: str, token: str) -> dict | list | None:
 
 
 def fetch_history_from_github(token: str) -> list[dict]:
-    """Fetch recent comparison result JSONs from sgl-project/ci-data repo."""
+    """Fetch recent comparison result JSONs from sgl-project/ci-data-diffusion repo."""
     print("Fetching historical comparison data from GitHub...")
     url = (
         f"https://api.github.com/repos/{CI_DATA_REPO_OWNER}/{CI_DATA_REPO_NAME}"
@@ -774,7 +774,7 @@ def main():
     parser.add_argument(
         "--fetch-history",
         action="store_true",
-        help="Fetch history from ci-data GitHub repo",
+        help="Fetch history from ci-data-diffusion GitHub repo",
     )
     parser.add_argument(
         "--step-summary",

--- a/scripts/ci/utils/diffusion/publish_comparison_results.py
+++ b/scripts/ci/utils/diffusion/publish_comparison_results.py
@@ -1,7 +1,7 @@
-"""Publish SGLang-Diffusion nightly benchmark results to sgl-project/ci-data repo.
+"""Publish SGLang-Diffusion nightly benchmark results to sgl-project/ci-data-diffusion repo.
 
 Pushes comparison-results.json, dashboard.md, and chart PNG files to the
-ci-data repository for historical tracking. Chart PNGs are stored under
+ci-data-diffusion repository for historical tracking. Chart PNGs are stored under
 diffusion-comparisons/charts/ so they can be referenced via
 raw.githubusercontent URLs in the dashboard markdown (GitHub Step Summary
 blocks data: URIs).
@@ -50,7 +50,7 @@ else:
 
 # Repository configuration
 REPO_OWNER = "sgl-project"
-REPO_NAME = "ci-data"
+REPO_NAME = "ci-data-diffusion"
 BRANCH = "main"
 STORAGE_PREFIX = "diffusion-comparisons"
 
@@ -81,7 +81,7 @@ def publish_comparison(
     dashboard_path: str | None = None,
     charts_dir: str | None = None,
 ) -> None:
-    """Publish comparison results, dashboard, and charts to ci-data repo."""
+    """Publish comparison results, dashboard, and charts to ci-data-diffusion repo."""
     token = os.environ.get("GH_PAT_FOR_NIGHTLY_CI_DATA") or os.environ.get(
         "GITHUB_TOKEN"
     )
@@ -196,7 +196,7 @@ def publish_comparison(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Publish SGLang-Diffusion nightly benchmark results to ci-data"
+        description="Publish SGLang-Diffusion nightly benchmark results to ci-data-diffusion"
     )
     parser.add_argument(
         "--results",

--- a/scripts/ci/utils/diffusion/publish_diffusion_gt.py
+++ b/scripts/ci/utils/diffusion/publish_diffusion_gt.py
@@ -1,5 +1,5 @@
 """
-Publish diffusion CI ground-truth images to sgl-project/ci-data
+Publish diffusion CI ground-truth images to sgl-project/ci-data-diffusion
 via the GitHub API (same pattern as publish_traces.py).
 """
 
@@ -48,7 +48,7 @@ else:
     )
 
 REPO_OWNER = "sgl-project"
-REPO_NAME = "ci-data"
+REPO_NAME = "ci-data-diffusion"
 BRANCH = "main"
 DEFAULT_TARGET_DIR = "diffusion-ci/consistency_gt/sglang_generated"
 


### PR DESCRIPTION
## Problem

`sgl-project/ci-data` reached GitHub's repository size limit (~100 GB, dominated by accumulated torch-profiler trace history under `traces/`) and can no longer accept pushes. This breaks the diffusion CI **write** paths — GT generation (`diffusion-ci-gt-gen*.yml`) and the nightly benchmark publish (`nightly-test-diffusion`) both push to it.

## Change

Diffusion CI content has been split into a new repo **[`sgl-project/ci-data-diffusion`](https://github.com/sgl-project/ci-data-diffusion)**, seeded from `ci-data@main` with everything **except** `traces/` (diffusion-ci GT baselines + repro scripts + diffusion-comparisons history; 351 files, ~113 MB). This PR re-points the diffusion CI **write path** to the new repo:

| File | Change |
|------|--------|
| `scripts/ci/utils/diffusion/publish_diffusion_gt.py` | `REPO_NAME → ci-data-diffusion` |
| `scripts/ci/utils/diffusion/publish_comparison_results.py` | `REPO_NAME → ci-data-diffusion` |
| `scripts/ci/utils/diffusion/generate_diffusion_dashboard.py` | `CI_DATA_REPO_NAME → ci-data-diffusion` (history fetch + chart URLs) |
| `.github/workflows/diffusion-ci-gt-gen.yml` | repro-scripts checkout `repository:` + publish step labels |
| `.github/workflows/diffusion-ci-gt-gen-npu.yml` | publish step labels |

## Deliberately out of scope

- **Read path stays on `sgl-project/ci-data`.** The consistency-test GT pins (`test_utils.py` `SGL_TEST_FILES_CI_DATA_REVISION`, `test_server_utils.py` hunyuan3d `.glb` SHA) still point at the old repo, which remains **readable** (over-quota blocks pushes, not reads). This keeps all consistency tests green with zero disruption; the read pins migrate naturally to `ci-data-diffusion` on the next GT refresh + revision bump.
- **`publish_traces.py` is unchanged.** Trace publishing is a separate concern (and the trace *serving* URL is a different repo, `sglang-bot/sglang-ci-data`).

## ⚠️ Required before this takes effect

The publish steps push with the **`GH_PAT_FOR_NIGHTLY_CI_DATA`** secret. That PAT must have **write** access to `sgl-project/ci-data-diffusion`, or the GT-gen / comparison-publish steps will fail with a permission error. Please confirm/grant before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHyqoN8FAfRjoqnt3jZCsy

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29883179046](https://github.com/sgl-project/sglang/actions/runs/29883179046)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29883178923](https://github.com/sgl-project/sglang/actions/runs/29883178923)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->