### PR TITLE
[Model Loading] Overlap checkpoint staging with CUDA graph capture during startup

### DIFF
--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -349,9 +349,14 @@ def load_model(server_args, port_args, gpu_id, tp_rank):
         model_runner = MlxModelRunnerStub(**runner_kwargs)
     else:
         model_runner = ModelRunner(**runner_kwargs)
-        model_runner.alloc_memory_pool()
-        model_runner.init_attention_backends()
-        model_runner.init_cuda_graphs()
+        try:
+            model_runner.alloc_memory_pool()
+            model_runner.init_attention_backends()
+            model_runner.init_cuda_graphs()
+            model_runner.finalize_startup_weight_load()
+        except Exception:
+            model_runner.cancel_startup_weight_load()
+            raise
     rank_print(f"max_total_num_tokens={model_runner.max_total_num_tokens}")
     tokenizer = get_tokenizer(
         server_args.tokenizer_path,

--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -106,7 +106,15 @@ class MlxModelRunnerStub(ModelRunner):
     # that path working instead of raising AttributeError.
     prefill_aware_swa = False
 
+    @staticmethod
+    def validate_startup_weight_load_mode(server_args) -> None:
+        if server_args.startup_weight_load_mode != "serial":
+            raise ValueError(
+                "--startup-weight-load-mode=overlap is not supported: CUDA only"
+            )
+
     def __init__(self, *args, mlx_pool_size: int | None = None, **kwargs):
+        self.validate_startup_weight_load_mode(kwargs["server_args"])
         self._mlx_pool_size = mlx_pool_size
         super().__init__(*args, **kwargs)
 

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -46,10 +46,13 @@ class MlxTpModelWorker(TpModelWorker):
 
     def _init_model_runner(self):
         """Create MLX runner first (auto-sizes pool), then stub with matching size."""
-        from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
         from sglang.srt.hardware_backend.mlx.model_runner_stub import (
             MlxModelRunnerStub,
         )
+
+        MlxModelRunnerStub.validate_startup_weight_load_mode(self.server_args)
+
+        from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
 
         logger.info("Initializing MlxModelRunner for end-to-end MLX inference")
         init_kwargs = dict(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -842,20 +842,34 @@ class Scheduler(
         if self.draft_worker is not None:
             self.draft_worker.init_cuda_graphs()
 
+    def finalize_startup_weight_load(self):
+        """Commit any weights deferred until after CUDA graph capture."""
+        self.tp_worker.finalize_startup_weight_load()
+
+    def cancel_startup_weight_load(self):
+        """Cancel any weight loading still deferred during worker startup."""
+        self.tp_worker.cancel_startup_weight_load()
+
     def init_model_worker(self):
         # Load model weights.
         self.init_tp_model_worker()
-        self.maybe_init_draft_worker()
+        try:
+            self.maybe_init_draft_worker()
 
-        # Prepare KV cache pools for all workers
-        self.init_memory_pools()
+            # Prepare KV cache pools for all workers
+            self.init_memory_pools()
 
-        self.init_all_attention_backends()
-        self.init_all_cuda_graphs()
+            self.init_all_attention_backends()
+            self.init_all_cuda_graphs()
 
-        model_runner = self.tp_worker.model_runner
-        if model_runner.token_to_kv_pool.post_capture_active:
-            model_runner.post_capture_resize_kv_pool()
+            model_runner = self.tp_worker.model_runner
+            if model_runner.token_to_kv_pool.post_capture_active:
+                model_runner.post_capture_resize_kv_pool()
+
+            self.finalize_startup_weight_load()
+        except Exception:
+            self.cancel_startup_weight_load()
+            raise
 
         # Dispatch the model worker
         if self.spec_algorithm.is_none():

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -307,56 +307,60 @@ class TpModelWorker(BaseTpWorker):
         self._init_model_config()
         self._init_model_runner()
 
-        if is_multi_layer_eagle:
-            self._init_multi_layer_eagle_model_runners()
+        try:
+            if is_multi_layer_eagle:
+                self._init_multi_layer_eagle_model_runners()
 
-        self._init_dllm_algorithm()
+            self._init_dllm_algorithm()
 
-        if server_args.skip_tokenizer_init or self.is_draft_worker:
-            # A draft worker's tokenizer would only duplicate the target's:
-            # tokenizer_path always points at the target model.
-            self.tokenizer = self.processor = None
-        else:
-            if self.model_config.is_multimodal:
-                self.processor = get_processor(
-                    server_args.tokenizer_path,
-                    tokenizer_mode=server_args.tokenizer_mode,
-                    trust_remote_code=server_args.trust_remote_code,
-                    revision=server_args.revision,
-                    tokenizer_backend=server_args.tokenizer_backend,
-                    model_name=server_args.model_path,
-                )
-                self.tokenizer = get_tokenizer_from_processor(self.processor)
+            if server_args.skip_tokenizer_init or self.is_draft_worker:
+                # A draft worker's tokenizer would only duplicate the target's:
+                # tokenizer_path always points at the target model.
+                self.tokenizer = self.processor = None
             else:
-                self.tokenizer = get_tokenizer(
-                    server_args.tokenizer_path,
-                    tokenizer_mode=server_args.tokenizer_mode,
-                    trust_remote_code=server_args.trust_remote_code,
-                    revision=server_args.revision,
-                    tokenizer_backend=server_args.tokenizer_backend,
-                )
-        self.device = self.model_runner.device
+                if self.model_config.is_multimodal:
+                    self.processor = get_processor(
+                        server_args.tokenizer_path,
+                        tokenizer_mode=server_args.tokenizer_mode,
+                        trust_remote_code=server_args.trust_remote_code,
+                        revision=server_args.revision,
+                        tokenizer_backend=server_args.tokenizer_backend,
+                        model_name=server_args.model_path,
+                    )
+                    self.tokenizer = get_tokenizer_from_processor(self.processor)
+                else:
+                    self.tokenizer = get_tokenizer(
+                        server_args.tokenizer_path,
+                        tokenizer_mode=server_args.tokenizer_mode,
+                        trust_remote_code=server_args.trust_remote_code,
+                        revision=server_args.revision,
+                        tokenizer_backend=server_args.tokenizer_backend,
+                    )
+            self.device = self.model_runner.device
 
-        # Init nccl groups
-        self.pp_group = get_pp_group()
-        self.world_group = get_world_group()
+            # Init nccl groups
+            self.pp_group = get_pp_group()
+            self.world_group = get_world_group()
 
-        # Sync random seed across TP workers.
-        # Scale joiners cannot enter the launch-time WORLD broadcast.
-        if server_args.is_ep_scale_joiner:
-            self.random_seed = server_args.random_seed
-        else:
-            self.random_seed = broadcast_pyobj(
-                [server_args.random_seed],
-                self.ps.tp_size * self.ps.pp_rank + self.ps.tp_rank,
-                self.world_group.cpu_group,
-                src=self.world_group.ranks[0],
-            )[0]
-        set_random_seed(self.random_seed)
+            # Sync random seed across TP workers.
+            # Scale joiners cannot enter the launch-time WORLD broadcast.
+            if server_args.is_ep_scale_joiner:
+                self.random_seed = server_args.random_seed
+            else:
+                self.random_seed = broadcast_pyobj(
+                    [server_args.random_seed],
+                    self.ps.tp_size * self.ps.pp_rank + self.ps.tp_rank,
+                    self.world_group.cpu_group,
+                    src=self.world_group.ranks[0],
+                )[0]
+            set_random_seed(self.random_seed)
 
-        self.enable_overlap = not server_args.disable_overlap_schedule
-        self.enable_spec = server_args.speculative_algorithm is not None
-        self.hicache_layer_transfer_counter = None
+            self.enable_overlap = not server_args.disable_overlap_schedule
+            self.enable_spec = server_args.speculative_algorithm is not None
+            self.hicache_layer_transfer_counter = None
+        except Exception:
+            self.cancel_startup_weight_load()
+            raise
 
     def alloc_memory_pool(
         self,
@@ -398,6 +402,18 @@ class TpModelWorker(BaseTpWorker):
         )
         for mr in self.model_runner_list[1:]:
             mr.init_cuda_graphs(capture_decode_cuda_graph=capture_decode_cuda_graph)
+
+    def finalize_startup_weight_load(self):
+        """Commit deferred startup weights for all model runners."""
+        self.model_runner.finalize_startup_weight_load()
+        for mr in self.model_runner_list[1:]:
+            mr.finalize_startup_weight_load()
+
+    def cancel_startup_weight_load(self):
+        """Cancel deferred startup loading for all model runners."""
+        self.model_runner.cancel_startup_weight_load()
+        for mr in self.model_runner_list[1:]:
+            mr.cancel_startup_weight_load()
 
     def _init_model_config(self):
         from sglang.srt.configs.model_config import ModelConfig

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -357,28 +357,37 @@ class ModelRunner:
         # For hisparse (must be set before initialize() so CUDA graph capture can see it)
         self.hisparse_coordinator = None
 
-        # Load model weights and configure
-        self.initialize()
-        self.check_quantized_moe_compatibility()
+        # The native overlap path replaces this during load_model(). Keep the
+        # no-pending-work invariant for lightweight backends that override the
+        # base initialization and weight-loading flow.
+        self.startup_weight_load = None
 
-        self._initialize_elastic_ep_joiner()
+        try:
+            # Load model weights and configure
+            self.initialize()
+            self.check_quantized_moe_compatibility()
 
-        if self.is_multimodal:
-            sanity_check_mm_pad_shift_value(self.model_config.vocab_size)
+            self._initialize_elastic_ep_joiner()
 
-        # Temporary cached values
-        self.support_pp = (
-            "pp_proxy_tensors" in inspect.signature(self.model.forward).parameters
-        )
+            if self.is_multimodal:
+                sanity_check_mm_pad_shift_value(self.model_config.vocab_size)
 
-        if self.ps.pp_size > 1:
-            assert (
-                self.support_pp
-            ), "Pipeline Parallel is not compatible with this model."
+            # Temporary cached values
+            self.support_pp = (
+                "pp_proxy_tensors" in inspect.signature(self.model.forward).parameters
+            )
 
-        # For weight updates
-        self.init_weight_updater()
-        self.init_weight_exporter()
+            if self.ps.pp_size > 1:
+                assert (
+                    self.support_pp
+                ), "Pipeline Parallel is not compatible with this model."
+
+            # For weight updates
+            self.init_weight_updater()
+            self.init_weight_exporter()
+        except Exception:
+            self.cancel_startup_weight_load()
+            raise
 
     def _initialize_elastic_ep_joiner(self) -> None:
         if not (
@@ -950,6 +959,7 @@ class ModelRunner:
         )
         self.loader = loaded.loader
         self.model = loaded.model
+        self.startup_weight_load = loaded.startup_weight_load
         if loaded.remote_instance_weight_info is not None:
             self.remote_instance_weight_transporter.weight_info = (
                 loaded.remote_instance_weight_info
@@ -982,14 +992,15 @@ class ModelRunner:
         # This handles both config.json (standard) and hf_quant_config.json (ModelOpt)
         quant_str = self.model_config.get_quantization_config_log_str()
 
-        logger.info(
-            f"Load weight end. "
-            f"elapsed={time.perf_counter() - tic_total:.2f} s, "
-            f"type={type(self.model).__name__}, "
-            f"{quant_str + ', ' if quant_str else ''}"
-            f"avail mem={after_avail_memory:.2f} GB, "
-            f"mem usage={self.weight_load_mem_usage:.2f} GB."
-        )
+        if self.startup_weight_load is None:
+            logger.info(
+                f"Load weight end. "
+                f"elapsed={time.perf_counter() - tic_total:.2f} s, "
+                f"type={type(self.model).__name__}, "
+                f"{quant_str + ', ' if quant_str else ''}"
+                f"avail mem={after_avail_memory:.2f} GB, "
+                f"mem usage={self.weight_load_mem_usage:.2f} GB."
+            )
 
         report_online_quantization(model=self.model, server_args=self.server_args)
 
@@ -1015,11 +1026,26 @@ class ModelRunner:
             logger,
         )
 
+        if self.startup_weight_load is None:
+            dist_barrier_after_load(
+                elastic_ep_backend=self.server_args.elastic_ep_backend,
+                tp_rank=self.ps.tp_rank,
+                is_ep_scale_joiner=self.server_args.is_ep_scale_joiner,
+            )
+
+    def finalize_startup_weight_load(self):
+        if self.startup_weight_load is None:
+            return
+        self.startup_weight_load.finalize()
         dist_barrier_after_load(
             elastic_ep_backend=self.server_args.elastic_ep_backend,
             tp_rank=self.ps.tp_rank,
             is_ep_scale_joiner=self.server_args.is_ep_scale_joiner,
         )
+
+    def cancel_startup_weight_load(self):
+        if self.startup_weight_load is not None:
+            self.startup_weight_load.cancel()
 
     def maybe_init_dwdp(self):
         if self.is_draft_worker:

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -44,6 +44,7 @@ class LoadedModel(msgspec.Struct, frozen=True, kw_only=True):
     loader: Any
     model: Any
     remote_instance_weight_info: Optional[Any]
+    startup_weight_load: Optional[Any] = None
 
 
 def maybe_downgrade_dtype_for_legacy_gpu(
@@ -219,32 +220,62 @@ def load_model_with_memory_saver(
         is_draft_worker and server_args.enable_draft_weights_cpu_backup
     )
     remote_instance_weight_info = None
-    with memory_saver_adapter.region(
-        GPU_MEMORY_TYPE_WEIGHTS,
-        enable_cpu_backup=enable_cpu_backup,
-    ):
-        loader = get_model_loader(
-            load_config=load_config,
-            model_config=model_config,
-        )
-        model = loader.load_model(
-            model_config=model_config,
-            device_config=DeviceConfig(device, gpu_id),
-        )
-        if hasattr(loader, "remote_instance_transfer_engine_weight_info"):
-            remote_instance_weight_info = (
-                loader.remote_instance_transfer_engine_weight_info
-            )
-    # Cache needs to be cleared after loading model weights (in the loader.load_model function).
-    # To avoid conflict with memory_saver_adapter.region, empty_cache operation is now moved here.
-    if _is_npu:
-        torch.npu.empty_cache()
-    monkey_patch_vllm_parallel_state(reverse=True)
+    startup_weight_load = None
+    try:
+        try:
+            with memory_saver_adapter.region(
+                GPU_MEMORY_TYPE_WEIGHTS,
+                enable_cpu_backup=enable_cpu_backup,
+            ):
+                loader = get_model_loader(
+                    load_config=load_config,
+                    model_config=model_config,
+                )
+                device_config = DeviceConfig(device, gpu_id)
+                if server_args.startup_weight_load_mode != "serial":
+                    from sglang.srt.model_executor.model_runner_components.startup_weight_load import (
+                        StartupWeightLoadManager,
+                        StartupWeightLoadOptions,
+                    )
+
+                    startup_weight_load = StartupWeightLoadManager.create_if_enabled(
+                        loader=loader,
+                        model_config=model_config,
+                        load_config=load_config,
+                        device_config=device_config,
+                        options=StartupWeightLoadOptions.from_server_args(
+                            server_args=server_args,
+                            is_draft_worker=is_draft_worker,
+                        ),
+                    )
+                if startup_weight_load is None:
+                    model = loader.load_model(
+                        model_config=model_config,
+                        device_config=device_config,
+                    )
+                else:
+                    model = startup_weight_load.prepare()
+                if hasattr(loader, "remote_instance_transfer_engine_weight_info"):
+                    remote_instance_weight_info = (
+                        loader.remote_instance_transfer_engine_weight_info
+                    )
+            # Cache needs to be cleared after loading model weights (in the
+            # loader.load_model function). To avoid conflict with the memory saver
+            # region, empty_cache is run after leaving it.
+            if _is_npu:
+                torch.npu.empty_cache()
+        finally:
+            monkey_patch_vllm_parallel_state(reverse=True)
+    except Exception:
+        if startup_weight_load is not None:
+            startup_weight_load.cancel()
+        raise
 
     return LoadedModel(
         loader=loader,
         model=model,
         remote_instance_weight_info=remote_instance_weight_info,
+        startup_weight_load=startup_weight_load,
     )
 
 

--- a/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
+++ b/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
@@ -440,7 +440,7 @@ class StartupWeightLoadManager:
             raise
         self._state = StartupWeightLoadState.READY
         logger.info(
-            "Committed real weights after CUDA graph capture in %.2f s "
+            "Load weight end. Committed real weights after CUDA graph capture in %.2f s "
             "(capture overlap window %.2f s, startup overlap total %.2f s)",
             time.perf_counter() - commit_started_at,
             commit_started_at - self._capture_ready_at,

--- a/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
+++ b/python/sglang/srt/model_executor/model_runner_components/startup_weight_load.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import dataclasses
+import enum
+import logging
+import time
+from typing import TYPE_CHECKING, Literal, Optional, Tuple
+
+import torch
+from torch import nn
+
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+from sglang.srt.distributed.parallel_state import monkey_patch_vllm_parallel_state
+from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+from sglang.srt.model_loader.loader import DefaultModelLoader
+from sglang.srt.model_loader.utils import get_model_architecture
+from sglang.srt.model_loader.weight_utils import CheckpointFilePrefetchHandle
+from sglang.srt.platforms import current_platform
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_ARCHITECTURES = frozenset(
+    {
+        "LlamaForCausalLM",
+        "Qwen2ForCausalLM",
+        "Qwen3ForCausalLM",
+    }
+)
+_SUPPORTED_DTYPES = frozenset({torch.float16, torch.bfloat16})
+
+
+def _get_canonical_model_class(architecture: str):
+    if architecture == "LlamaForCausalLM":
+        from sglang.srt.models.llama import LlamaForCausalLM
+
+        return LlamaForCausalLM
+    if architecture == "Qwen2ForCausalLM":
+        from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+
+        return Qwen2ForCausalLM
+    if architecture == "Qwen3ForCausalLM":
+        from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+
+        return Qwen3ForCausalLM
+    raise ValueError(f"Unsupported startup-overlap architecture: {architecture}")
+
+
+class StartupWeightLoadState(str, enum.Enum):
+    CREATED = "created"
+    PREPARING = "preparing"
+    CAPTURE_READY = "capture_ready"
+    COMMITTING = "committing"
+    READY = "ready"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class StartupWeightLoadOptions:
+    requested_mode: Literal["serial", "overlap"]
+    device: str
+    is_cuda_platform: bool
+    cuda_graph_enabled: bool
+    prefill_cuda_graph_backend: Backend
+    is_draft_worker: bool
+    speculative_algorithm: Optional[str]
+    tp_size: int
+    attn_cp_size: int
+    dcp_size: int
+    pp_size: int
+    dp_size: int
+    ep_size: int
+    cpu_offload_gb: int
+    offload_group_size: int
+    enable_memory_saver: bool
+    enable_weights_cpu_backup: bool
+    torchao_config: str
+    enable_lora: bool
+    has_lora_paths: bool
+    weight_loader_disable_mmap: bool
+    weight_loader_drop_cache_after_load: bool
+    has_custom_weight_loader: bool
+    enable_torch_compile: bool
+    prefetch_num_threads: int
+
+    @classmethod
+    def from_server_args(
+        cls,
+        *,
+        server_args: ServerArgs,
+        is_draft_worker: bool,
+    ) -> StartupWeightLoadOptions:
+        cuda_graph_config = server_args.cuda_graph_config
+        cuda_graph_enabled = any(
+            getattr(cuda_graph_config, phase).backend != Backend.DISABLED
+            for phase in Phase.ALL
+        )
+        return cls(
+            requested_mode=server_args.startup_weight_load_mode,
+            device=server_args.device,
+            is_cuda_platform=current_platform.is_cuda(),
+            cuda_graph_enabled=cuda_graph_enabled,
+            prefill_cuda_graph_backend=cuda_graph_config.prefill.backend,
+            is_draft_worker=is_draft_worker,
+            speculative_algorithm=server_args.speculative_algorithm,
+            tp_size=server_args.tp_size,
+            attn_cp_size=server_args.attn_cp_size,
+            dcp_size=server_args.dcp_size,
+            pp_size=server_args.pp_size,
+            dp_size=server_args.dp_size,
+            ep_size=server_args.ep_size,
+            cpu_offload_gb=server_args.cpu_offload_gb,
+            offload_group_size=server_args.offload_group_size,
+            enable_memory_saver=server_args.enable_memory_saver,
+            enable_weights_cpu_backup=server_args.enable_weights_cpu_backup,
+            torchao_config=server_args.torchao_config,
+            enable_lora=server_args.enable_lora,
+            has_lora_paths=bool(server_args.lora_paths),
+            weight_loader_disable_mmap=server_args.weight_loader_disable_mmap,
+            weight_loader_drop_cache_after_load=(
+                server_args.weight_loader_drop_cache_after_load
+            ),
+            has_custom_weight_loader=bool(server_args.custom_weight_loader),
+            enable_torch_compile=server_args.enable_torch_compile,
+            prefetch_num_threads=server_args.weight_loader_prefetch_num_threads,
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TensorStorageMetadata:
+    object_id: int
+    data_ptr: int
+    shape: Tuple[int, ...]
+    stride: Tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device
+    storage_offset: int
+
+    @classmethod
+    def from_tensor(cls, tensor: torch.Tensor) -> TensorStorageMetadata:
+        return cls(
+            object_id=id(tensor),
+            data_ptr=tensor.data_ptr(),
+            shape=tuple(tensor.shape),
+            stride=tuple(tensor.stride()),
+            dtype=tensor.dtype,
+            device=tensor.device,
+            storage_offset=tensor.storage_offset(),
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ModelStorageManifest:
+    tensors: Tuple[Tuple[str, TensorStorageMetadata], ...]
+
+    @classmethod
+    def capture(cls, model: nn.Module) -> ModelStorageManifest:
+        entries = []
+        for kind, tensors in (
+            ("parameter", model.named_parameters(remove_duplicate=False)),
+            ("buffer", model.named_buffers(remove_duplicate=False)),
+        ):
+            entries.extend(
+                (f"{kind}:{name}", TensorStorageMetadata.from_tensor(tensor))
+                for name, tensor in tensors
+            )
+        return cls(tensors=tuple(sorted(entries)))
+
+    def changed_names(self, model: nn.Module) -> Tuple[str, ...]:
+        before = dict(self.tensors)
+        after = dict(ModelStorageManifest.capture(model).tensors)
+        return tuple(
+            name
+            for name in sorted(before.keys() | after.keys())
+            if before.get(name) != after.get(name)
+        )
+
+
+class StartupWeightLoadManager:
+    """Coordinate native CPU staging with capture and post-capture commit."""
+
+    def __init__(
+        self,
+        *,
+        loader: DefaultModelLoader,
+        model_config: ModelConfig,
+        device_config: DeviceConfig,
+        options: StartupWeightLoadOptions,
+    ) -> None:
+        self._loader = loader
+        self._model_config = model_config
+        self._device_config = device_config
+        self._options = options
+        self._model: Optional[nn.Module] = None
+        self._resolved_sources: Tuple[DefaultModelLoader.ResolvedSource, ...] = ()
+        self._prefetch_handle: Optional[CheckpointFilePrefetchHandle] = None
+        self._state = StartupWeightLoadState.CREATED
+        self._created_at = time.perf_counter()
+        self._capture_ready_at: Optional[float] = None
+
+    @classmethod
+    def create_if_enabled(
+        cls,
+        *,
+        loader,
+        model_config: ModelConfig,
+        load_config: LoadConfig,
+        device_config: DeviceConfig,
+        options: StartupWeightLoadOptions,
+    ) -> Optional[StartupWeightLoadManager]:
+        if options.requested_mode == "serial":
+            return None
+        if options.requested_mode != "overlap":
+            raise ValueError(
+                f"Unknown startup weight load mode: {options.requested_mode}"
+            )
+        unsupported_reason = cls._get_unsupported_reason(
+            loader=loader,
+            model_config=model_config,
+            load_config=load_config,
+            options=options,
+        )
+        if unsupported_reason is not None:
+            raise ValueError(
+                "--startup-weight-load-mode=overlap is not supported: "
+                f"{unsupported_reason}"
+            )
+        return cls(
+            loader=loader,
+            model_config=model_config,
+            device_config=device_config,
+            options=options,
+        )
+
+    @staticmethod
+    def _get_unsupported_reason(
+        *,
+        loader,
+        model_config: ModelConfig,
+        load_config: LoadConfig,
+        options: StartupWeightLoadOptions,
+    ) -> Optional[str]:
+        architectures = tuple(model_config.hf_config.architectures or ())
+        basic_rules = (
+            (not options.is_cuda_platform or options.device != "cuda", "CUDA only"),
+            (not options.cuda_graph_enabled, "CUDA graph capture is disabled"),
+            (
+                options.prefill_cuda_graph_backend == Backend.TC_PIECEWISE,
+                "tc_piecewise prefill CUDA graphs are not supported",
+            ),
+            (type(loader) is not DefaultModelLoader, "DefaultModelLoader only"),
+            (
+                load_config.load_format
+                not in (LoadFormat.AUTO, LoadFormat.SAFETENSORS),
+                "load format must be auto or safetensors",
+            ),
+            (options.is_draft_worker, "draft workers are not supported"),
+            (
+                load_config.draft_model_idx is not None,
+                "draft model loading is unsupported",
+            ),
+            (
+                options.speculative_algorithm is not None,
+                "speculative decoding is not supported",
+            ),
+            (options.tp_size not in (1, 2), "only TP1 and TP2 are supported"),
+            (
+                options.attn_cp_size != 1,
+                "attention context parallelism is not supported",
+            ),
+            (
+                options.dcp_size != 1,
+                "decode context parallelism is not supported",
+            ),
+            (options.pp_size != 1, "pipeline parallelism is not supported"),
+            (options.dp_size != 1, "data parallelism is not supported"),
+            (options.ep_size != 1, "expert parallelism is not supported"),
+            (options.cpu_offload_gb > 0, "CPU offload is not supported"),
+            (
+                options.offload_group_size > 0,
+                "layer-group offloading is not supported",
+            ),
+            (options.enable_memory_saver, "memory saver is not supported"),
+            (
+                options.enable_weights_cpu_backup,
+                "CPU weight backup is not supported",
+            ),
+            (bool(options.torchao_config), "TorchAO is not supported"),
+            (
+                options.enable_lora or options.has_lora_paths,
+                "LoRA is not supported",
+            ),
+            (
+                options.weight_loader_disable_mmap,
+                "safetensors mmap must be enabled",
+            ),
+            (
+                options.weight_loader_drop_cache_after_load,
+                "dropping the page cache during load is not supported",
+            ),
+            (
+                options.has_custom_weight_loader,
+                "custom weight loaders are not supported",
+            ),
+            (options.enable_torch_compile, "torch.compile is not supported"),
+        )
+        unsupported_reason = next(
+            (reason for unsupported, reason in basic_rules if unsupported),
+            None,
+        )
+        if unsupported_reason is not None:
+            return unsupported_reason
+
+        model_rules = (
+            (model_config.dtype not in _SUPPORTED_DTYPES, "FP16 or BF16 only"),
+            (model_config.quantization is not None, "quantization is not supported"),
+            (
+                bool(getattr(model_config, "modelopt_quant", False)),
+                "ModelOpt is not supported",
+            ),
+            (model_config.is_multimodal, "multimodal models are not supported"),
+            (not model_config.is_generation, "generation models only"),
+            (
+                len(architectures) != 1
+                or architectures[0] not in _SUPPORTED_ARCHITECTURES,
+                "model architecture is not in the startup-overlap allowlist",
+            ),
+        )
+        unsupported_reason = next(
+            (reason for unsupported, reason in model_rules if unsupported),
+            None,
+        )
+        if unsupported_reason is not None:
+            return unsupported_reason
+
+        architecture = architectures[0]
+        resolved_model_class, resolved_architecture = get_model_architecture(
+            model_config
+        )
+        if (
+            resolved_architecture != architecture
+            or resolved_model_class is not _get_canonical_model_class(architecture)
+        ):
+            return "the native SGLang model implementation is required"
+        return None
+
+    @property
+    def state(self) -> StartupWeightLoadState:
+        return self._state
+
+    def prepare(self) -> nn.Module:
+        if self._state != StartupWeightLoadState.CREATED:
+            raise RuntimeError(
+                f"Cannot prepare startup weights from state {self._state}"
+            )
+        self._state = StartupWeightLoadState.PREPARING
+        try:
+            model = self._loader.initialize_model_for_startup(
+                model_config=self._model_config,
+                device_config=self._device_config,
+            )
+            resolved_sources = self._loader.resolve_model_weights(
+                self._model_config,
+                model,
+            )
+            if len(resolved_sources) != 1:
+                raise ValueError(
+                    "Startup weight-loading overlap does not support secondary weights"
+                )
+            prefetch_handle = self._loader.start_checkpoint_prefetch(
+                resolved_sources,
+                num_threads=self._options.prefetch_num_threads,
+            )
+            self._model = model
+            self._resolved_sources = resolved_sources
+            self._prefetch_handle = prefetch_handle
+            model = self._loader.prepare_model_for_capture(
+                model=model,
+                model_config=self._model_config,
+            )
+            self._model = model
+            self._capture_ready_at = time.perf_counter()
+            self._state = StartupWeightLoadState.CAPTURE_READY
+            logger.info(
+                "Prepared capture-safe model and started checkpoint prefetching "
+                "in %.2f s",
+                self._capture_ready_at - self._created_at,
+            )
+            return model
+        except Exception:
+            self._state = StartupWeightLoadState.FAILED
+            self._stop_prefetch()
+            raise
+
+    def finalize(self) -> None:
+        if self._state == StartupWeightLoadState.READY:
+            return
+        if self._state != StartupWeightLoadState.CAPTURE_READY:
+            raise RuntimeError(
+                f"Cannot finalize startup weights from state {self._state}"
+            )
+        assert self._model is not None
+        assert self._capture_ready_at is not None
+        manifest = ModelStorageManifest.capture(self._model)
+        commit_started_at = time.perf_counter()
+        self._state = StartupWeightLoadState.COMMITTING
+        parallel_state_patched = False
+        try:
+            try:
+                monkey_patch_vllm_parallel_state()
+                parallel_state_patched = True
+                self._loader.commit_model_weights(
+                    model=self._model,
+                    model_config=self._model_config,
+                    resolved_sources=self._resolved_sources,
+                    target_device=torch.device(self._device_config.device),
+                )
+                torch.cuda.synchronize()
+                changed_names = manifest.changed_names(self._model)
+                if changed_names:
+                    preview = ", ".join(changed_names[:8])
+                    raise RuntimeError(
+                        "Startup weight commit changed graph-visible tensor storage: "
+                        f"{preview}"
+                    )
+            finally:
+                try:
+                    if parallel_state_patched:
+                        monkey_patch_vllm_parallel_state(reverse=True)
+                finally:
+                    self._stop_prefetch()
+        except Exception:
+            self._state = StartupWeightLoadState.FAILED
+            raise
+        self._state = StartupWeightLoadState.READY
+        logger.info(
+            "Committed real weights after CUDA graph capture in %.2f s "
+            "(capture overlap window %.2f s, startup overlap total %.2f s)",
+            time.perf_counter() - commit_started_at,
+            commit_started_at - self._capture_ready_at,
+            time.perf_counter() - self._created_at,
+        )
+
+    def cancel(self) -> None:
+        if self._state in (
+            StartupWeightLoadState.READY,
+            StartupWeightLoadState.FAILED,
+            StartupWeightLoadState.CANCELLED,
+        ):
+            return
+        self._stop_prefetch()
+        self._state = StartupWeightLoadState.CANCELLED
+
+    def _stop_prefetch(self) -> None:
+        if self._prefetch_handle is None:
+            return
+        self._prefetch_handle.cancel()
+        self._prefetch_handle.wait()
+        self._prefetch_handle = None

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -91,6 +91,8 @@ DEFAULT_GPU_MEMORY_FRACTION_FOR_CALIBRATION = (
 )
 from sglang.srt.environ import envs
 from sglang.srt.model_loader.weight_utils import (
+    CheckpointFilePrefetchHandle,
+    _prefetch_all_checkpoints,
     buffered_multi_thread_safetensors_weights_iterator,
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
@@ -389,6 +391,15 @@ class DefaultModelLoader(BaseModelLoader):
                 model_config=model_config,
             )
 
+    @dataclasses.dataclass(frozen=True)
+    class ResolvedSource:
+        """A weight source whose local checkpoint files are already resolved."""
+
+        source: DefaultModelLoader.Source
+        hf_folder: str
+        weight_files: Tuple[str, ...]
+        use_safetensors: bool
+
     counter_before_loading_weights: float = 0.0
     counter_after_loading_weights: float = 0.0
 
@@ -542,22 +553,30 @@ class DefaultModelLoader(BaseModelLoader):
         return hf_folder, hf_weights_files, use_safetensors
 
     def _get_weights_iterator(
-        self, source: Source
+        self,
+        source: Source,
+        *,
+        resolved_source: Optional[ResolvedSource] = None,
+        startup_prefetch_active: bool = False,
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
         extra_config = self.load_config.model_loader_extra_config
         use_multithread = extra_config.get("enable_multithread_load", True)
-        hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
-            source.model_or_path, source.revision, source.fall_back_to_pt
-        )
-
-        if use_safetensors and source.model_config is not None:
-            hf_weights_files = maybe_add_mtp_safetensors(
-                hf_weights_files,
-                hf_folder,
-                "model.safetensors.index.json",
-                source.model_config.hf_config,
+        if resolved_source is None:
+            hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
+                source.model_or_path, source.revision, source.fall_back_to_pt
             )
+            if use_safetensors and source.model_config is not None:
+                hf_weights_files = maybe_add_mtp_safetensors(
+                    hf_weights_files,
+                    hf_folder,
+                    "model.safetensors.index.json",
+                    source.model_config.hf_config,
+                )
+        else:
+            hf_folder = resolved_source.hf_folder
+            hf_weights_files = list(resolved_source.weight_files)
+            use_safetensors = resolved_source.use_safetensors
 
         if self.load_config.load_format == LoadFormat.NPCACHE:
             # Currently np_cache only support *.bin checkpoints
@@ -571,7 +590,14 @@ class DefaultModelLoader(BaseModelLoader):
         elif use_safetensors:
             server_args = get_server_args()
             weight_loader_disable_mmap = server_args.weight_loader_disable_mmap
-            weight_loader_prefetch = server_args.weight_loader_prefetch_checkpoints
+            weight_loader_prefetch = (
+                server_args.weight_loader_prefetch_checkpoints
+                or startup_prefetch_active
+            )
+            start_iterator_prefetch = (
+                server_args.weight_loader_prefetch_checkpoints
+                and not startup_prefetch_active
+            )
             prefetch_num_threads = server_args.weight_loader_prefetch_num_threads
             weight_loader_drop_cache_after_load = (
                 server_args.weight_loader_drop_cache_after_load
@@ -597,7 +623,7 @@ class DefaultModelLoader(BaseModelLoader):
                 )
             ):
                 logger.warning(
-                    "--weight-loader-prefetch-checkpoints is enabled; falling "
+                    "Checkpoint prefetching is active; falling "
                     "back to single-threaded weight loading to avoid I/O "
                     "oversubscription with the prefetch threads. Set "
                     "enable_multithread_load=true in --model-loader-extra-config "
@@ -616,7 +642,7 @@ class DefaultModelLoader(BaseModelLoader):
                         "num_threads", self.DEFAULT_NUM_THREADS
                     ),
                     disable_mmap=weight_loader_disable_mmap,
-                    prefetch=weight_loader_prefetch,
+                    prefetch=start_iterator_prefetch,
                     prefetch_num_threads=prefetch_num_threads,
                     drop_cache_after_load=weight_loader_drop_cache_after_load,
                 )
@@ -624,7 +650,7 @@ class DefaultModelLoader(BaseModelLoader):
                 weights_iterator = safetensors_weights_iterator(
                     hf_weights_files,
                     disable_mmap=weight_loader_disable_mmap,
-                    prefetch=weight_loader_prefetch,
+                    prefetch=start_iterator_prefetch,
                     prefetch_num_threads=prefetch_num_threads,
                     drop_cache_after_load=weight_loader_drop_cache_after_load,
                 )
@@ -684,6 +710,126 @@ class DefaultModelLoader(BaseModelLoader):
         )
         for source in secondary_weights:
             yield from self._get_weights_iterator(source)
+
+    def resolve_model_weights(
+        self,
+        model_config: ModelConfig,
+        model: nn.Module,
+    ) -> Tuple[ResolvedSource, ...]:
+        """Resolve all checkpoint files before background startup prefetching."""
+        sources = [DefaultModelLoader.Source.init_new(model_config, model)]
+        sources.extend(
+            cast(
+                Iterable[DefaultModelLoader.Source],
+                getattr(model, "secondary_weights", ()),
+            )
+        )
+
+        resolved_sources = []
+        for source in sources:
+            hf_folder, weight_files, use_safetensors = self._prepare_weights(
+                source.model_or_path,
+                source.revision,
+                source.fall_back_to_pt,
+            )
+            if use_safetensors and source.model_config is not None:
+                weight_files = maybe_add_mtp_safetensors(
+                    weight_files,
+                    hf_folder,
+                    "model.safetensors.index.json",
+                    source.model_config.hf_config,
+                )
+            resolved_sources.append(
+                DefaultModelLoader.ResolvedSource(
+                    source=source,
+                    hf_folder=hf_folder,
+                    weight_files=tuple(weight_files),
+                    use_safetensors=use_safetensors,
+                )
+            )
+        return tuple(resolved_sources)
+
+    @staticmethod
+    def start_checkpoint_prefetch(
+        resolved_sources: Tuple[ResolvedSource, ...],
+        *,
+        num_threads: int,
+    ) -> CheckpointFilePrefetchHandle:
+        """Start CPU-only page-cache staging for already-resolved sources."""
+        if not all(source.use_safetensors for source in resolved_sources):
+            raise ValueError(
+                "Startup weight-loading overlap requires safetensors checkpoints"
+            )
+        weight_files = sorted(
+            {path for source in resolved_sources for path in source.weight_files}
+        )
+        return _prefetch_all_checkpoints(weight_files, num_threads=num_threads)
+
+    def initialize_model_for_startup(
+        self,
+        *,
+        model_config: ModelConfig,
+        device_config: DeviceConfig,
+    ) -> nn.Module:
+        """Build the final model structure and GPU parameter storage."""
+        target_device = torch.device(device_config.device)
+        quant_config = _get_quantization_config(model_config, self.load_config)
+        with set_default_torch_dtype(model_config.dtype):
+            with target_device:
+                model = _initialize_model(
+                    model_config,
+                    self.load_config,
+                    quant_config,
+                )
+        return model
+
+    def prepare_model_for_capture(
+        self,
+        *,
+        model: nn.Module,
+        model_config: ModelConfig,
+    ) -> nn.Module:
+        """Initialize final storage with values safe for graph warmup."""
+        with set_default_torch_dtype(model_config.dtype):
+            initialize_dummy_weights(model)
+            _post_load_weights(model)
+            for _, module in model.named_modules():
+                quant_method = getattr(module, "quant_method", None)
+                if quant_method is None:
+                    continue
+                if (
+                    hasattr(module, "is_weights_quantized")
+                    and module.is_weights_quantized()
+                ):
+                    continue
+                quant_method.process_weights_after_loading(module)
+        return model.eval()
+
+    def commit_model_weights(
+        self,
+        *,
+        model: nn.Module,
+        model_config: ModelConfig,
+        resolved_sources: Tuple[ResolvedSource, ...],
+        target_device: torch.device,
+    ) -> None:
+        """Load real checkpoint values into a capture-ready model."""
+
+        def weights_iterator():
+            for resolved_source in resolved_sources:
+                yield from self._get_weights_iterator(
+                    resolved_source.source,
+                    resolved_source=resolved_source,
+                    startup_prefetch_active=True,
+                )
+
+        with set_default_torch_dtype(model_config.dtype):
+            self.load_weights_and_postprocess(
+                model,
+                weights_iterator(),
+                target_device,
+            )
+        self.counter_after_loading_weights = time.perf_counter()
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -16,6 +16,7 @@ import os
 import re
 import struct
 import tempfile
+import threading
 from collections import defaultdict
 from pathlib import Path
 from typing import (
@@ -807,21 +808,56 @@ def np_cache_weights_iterator(
         yield name, torch.from_numpy(param)
 
 
-def _prefetch_checkpoint_file(file_path: str) -> None:
+def _prefetch_checkpoint_file(
+    file_path: str,
+    cancel_event: Optional[threading.Event] = None,
+) -> None:
     """Prefetch a checkpoint file into the OS page cache.
 
     Reads the file sequentially in 16 MB blocks so the kernel caches its pages
     before workers load the same file via mmap.
     """
     with open(file_path, "rb") as f:
-        while f.read(_get_prefetch_block_size()):
-            pass
+        while cancel_event is None or not cancel_event.is_set():
+            if not f.read(_get_prefetch_block_size()):
+                break
+
+
+class CheckpointFilePrefetchHandle:
+    """Lifecycle handle for background checkpoint page-cache prefetching."""
+
+    def __init__(
+        self,
+        *,
+        done_event: threading.Event,
+        cancel_event: threading.Event,
+        errors: List[Tuple[str, Exception]],
+    ) -> None:
+        self._done_event = done_event
+        self._cancel_event = cancel_event
+        self._errors = errors
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        if not self._done_event.wait(timeout):
+            raise TimeoutError("Timed out waiting for checkpoint prefetching")
+
+    def cancel(self) -> None:
+        """Stop scheduling shards and interrupt reads at the next block."""
+        self._cancel_event.set()
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancel_event.is_set()
+
+    @property
+    def errors(self) -> Tuple[Tuple[str, Exception], ...]:
+        return tuple(self._errors)
 
 
 def _prefetch_all_checkpoints(
     sorted_files: List[str],
     num_threads: int = 4,
-) -> None:
+) -> CheckpointFilePrefetchHandle:
     """Start prefetching checkpoint files into page cache in a background thread.
 
     When multiple ranks on the same node load the same checkpoint (e.g.
@@ -837,7 +873,6 @@ def _prefetch_all_checkpoints(
     naturally adapts to any RAM size — even if the full checkpoint does
     not fit in page cache, the prefetch thread stays ahead of the loader.
     """
-    import threading
     import time
 
     if num_threads < 1:
@@ -856,6 +891,14 @@ def _prefetch_all_checkpoints(
 
     my_files = sorted_files[local_rank::local_world_size]
     total_for_rank = len(my_files)
+    done_event = threading.Event()
+    cancel_event = threading.Event()
+    errors: List[Tuple[str, Exception]] = []
+    handle = CheckpointFilePrefetchHandle(
+        done_event=done_event,
+        cancel_event=cancel_event,
+        errors=errors,
+    )
 
     logger.info(
         "Rank %d: prefetching %d/%d checkpoint shards into page cache "
@@ -892,7 +935,11 @@ def _prefetch_all_checkpoints(
             pending: Dict[concurrent.futures.Future, str] = {}
 
             for path in itertools.islice(file_iter, num_threads):
-                pending[executor.submit(_prefetch_checkpoint_file, path)] = path
+                if cancel_event.is_set():
+                    break
+                pending[
+                    executor.submit(_prefetch_checkpoint_file, path, cancel_event)
+                ] = path
 
             while pending:
                 done, _ = concurrent.futures.wait(
@@ -903,7 +950,8 @@ def _prefetch_all_checkpoints(
                     path = pending.pop(future)
                     try:
                         future.result()
-                    except Exception:
+                    except Exception as exc:
+                        errors.append((path, exc))
                         logger.warning(
                             "Failed to prefetch checkpoint file %r.",
                             path,
@@ -912,24 +960,32 @@ def _prefetch_all_checkpoints(
                     finally:
                         record_complete()
 
-                    next_path = next(file_iter, None)
+                    next_path = None if cancel_event.is_set() else next(file_iter, None)
                     if next_path is not None:
                         pending[
-                            executor.submit(_prefetch_checkpoint_file, next_path)
+                            executor.submit(
+                                _prefetch_checkpoint_file,
+                                next_path,
+                                cancel_event,
+                            )
                         ] = next_path
 
     def _run_prefetch() -> None:
         start = time.perf_counter()
-        _prefetch_all()
-        elapsed = time.perf_counter() - start
-        logger.info(
-            "Rank %d: prefetching checkpoint files into page cache "
-            "finished in %.2fs",
-            local_rank,
-            elapsed,
-        )
+        try:
+            _prefetch_all()
+        finally:
+            elapsed = time.perf_counter() - start
+            logger.info(
+                "Rank %d: prefetching checkpoint files into page cache "
+                "finished in %.2fs",
+                local_rank,
+                elapsed,
+            )
+            done_event.set()
 
     threading.Thread(target=_run_prefetch, daemon=True).start()
+    return handle
 
 
 def _drop_file_cache_after_load(path: str) -> None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2615,6 +2615,15 @@ class ServerArgs:
     # -------------------------------------------------------------------------
     # Model weight update and weight loading
     # -------------------------------------------------------------------------
+    startup_weight_load_mode: A[
+        Literal["serial", "overlap"],
+        (
+            "Control startup weight loading relative to CUDA graph capture. "
+            "'serial' preserves the existing startup order; 'overlap' stages "
+            "checkpoint files while CUDA graphs are captured and commits the "
+            "real weights afterward."
+        ),
+    ] = "serial"
     custom_weight_loader: A[
         Optional[List[str]],
         Arg(

--- a/test/registered/model_loading/test_startup_weight_load.py
+++ b/test/registered/model_loading/test_startup_weight_load.py
@@ -1,0 +1,74 @@
+"""End-to-end parity test for post-capture startup weight loading."""
+
+import unittest
+
+import sglang as sgl
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    CustomTestCase,
+)
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestStartupWeightLoad(CustomTestCase):
+    @staticmethod
+    def _generate(startup_weight_load_mode=None):
+        kwargs = dict(
+            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            dtype="bfloat16",
+            random_seed=42,
+            cuda_graph_max_bs_decode=1,
+            max_total_tokens=256,
+        )
+        if startup_weight_load_mode is not None:
+            kwargs["startup_weight_load_mode"] = startup_weight_load_mode
+
+        engine = None
+        try:
+            engine = sgl.Engine(**kwargs)
+            return engine.generate(
+                "The capital of France is",
+                sampling_params={
+                    "temperature": 0,
+                    "max_new_tokens": 8,
+                    "ignore_eos": True,
+                },
+                return_logprob=True,
+                logprob_start_len=0,
+            )
+        finally:
+            if engine is not None:
+                engine.shutdown()
+
+    def test_overlap_matches_default_serial_startup(self):
+        # Omitting the flag is intentional: it pins the merge-safe default path.
+        serial = self._generate()
+        overlap = self._generate("overlap")
+
+        self.assertEqual(serial["output_ids"], overlap["output_ids"])
+        self.assertEqual(serial["text"], overlap["text"])
+
+        serial_logprobs = serial["meta_info"]["output_token_logprobs"]
+        overlap_logprobs = overlap["meta_info"]["output_token_logprobs"]
+        self.assertEqual(len(serial_logprobs), len(overlap_logprobs))
+        self.assertGreater(len(serial_logprobs), 0)
+        for index, (serial_item, overlap_item) in enumerate(
+            zip(serial_logprobs, overlap_logprobs)
+        ):
+            self.assertEqual(
+                serial_item[1],
+                overlap_item[1],
+                f"token id differs at output position {index}",
+            )
+            self.assertAlmostEqual(
+                serial_item[0],
+                overlap_item[0],
+                delta=1e-5,
+                msg=f"logprob differs at output position {index}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
+++ b/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
@@ -36,6 +36,7 @@ import torch
 
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
 
 # CPU marker is AST-parsed "this test exists"; actual CPU-side execution is
 # gated by the @skipUnless guard below. MLX marker runs for real on the MLX
@@ -160,7 +161,7 @@ class _FakeBatch:
 
 
 @unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
-class TestMlxExtendRouting(unittest.TestCase):
+class TestMlxExtendRouting(CustomTestCase):
     """Routing contract for MlxTpModelWorker: shared helper + sync + async."""
 
     @staticmethod
@@ -171,6 +172,20 @@ class TestMlxExtendRouting(unittest.TestCase):
         worker._mlx_runner = _FakeRunner(known_rids)
         worker._mlx_active_rids = set()
         return worker
+
+    def test_startup_weight_overlap_is_rejected_before_mlx_model_load(self):
+        from sglang.srt.hardware_backend.mlx.model_runner_stub import (
+            MlxModelRunnerStub,
+        )
+        from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+
+        worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
+        worker.server_args = SimpleNamespace(startup_weight_load_mode="overlap")
+
+        with self.assertRaisesRegex(ValueError, "CUDA only"):
+            MlxModelRunnerStub.validate_startup_weight_load_mode(worker.server_args)
+        with self.assertRaisesRegex(ValueError, "CUDA only"):
+            worker._init_model_runner()
 
     # ---------- the shared decision helper ----------
     # The helper takes no seq_len: length cannot distinguish a 1-token

--- a/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_startup_weight_load.py
@@ -1,0 +1,626 @@
+"""Unit tests for the post-capture startup weight-loading component."""
+
+import dataclasses
+import re
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+from sglang.srt.configs.model_config import ModelImpl
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.model_executor.model_runner_components.startup_weight_load import (
+    ModelStorageManifest,
+    StartupWeightLoadManager,
+    StartupWeightLoadOptions,
+    StartupWeightLoadState,
+)
+from sglang.srt.model_loader.loader import DefaultModelLoader
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+_STARTUP_MODULE = (
+    "sglang.srt.model_executor.model_runner_components.startup_weight_load"
+)
+
+
+class _CanonicalModel:
+    pass
+
+
+class _ExternalModel:
+    pass
+
+
+def _make_options(**overrides):
+    options = StartupWeightLoadOptions(
+        requested_mode="overlap",
+        device="cuda",
+        is_cuda_platform=True,
+        cuda_graph_enabled=True,
+        prefill_cuda_graph_backend=Backend.FULL,
+        is_draft_worker=False,
+        speculative_algorithm=None,
+        tp_size=1,
+        attn_cp_size=1,
+        dcp_size=1,
+        pp_size=1,
+        dp_size=1,
+        ep_size=1,
+        cpu_offload_gb=0,
+        offload_group_size=-1,
+        enable_memory_saver=False,
+        enable_weights_cpu_backup=False,
+        torchao_config="",
+        enable_lora=False,
+        has_lora_paths=False,
+        weight_loader_disable_mmap=False,
+        weight_loader_drop_cache_after_load=False,
+        has_custom_weight_loader=False,
+        enable_torch_compile=False,
+        prefetch_num_threads=4,
+    )
+    return dataclasses.replace(options, **overrides)
+
+
+def _make_model_config(**overrides):
+    values = dict(
+        hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+        dtype=torch.bfloat16,
+        quantization=None,
+        modelopt_quant=None,
+        is_multimodal=False,
+        is_generation=True,
+        model_impl=ModelImpl.SGLANG,
+        _resolved_model_impl=ModelImpl.SGLANG,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _RecordingPrefetchHandle:
+    def __init__(self, trace):
+        self._trace = trace
+
+    def cancel(self):
+        self._trace.append("cancel_prefetch")
+
+    def wait(self, timeout=None):
+        self._trace.append("wait_prefetch")
+
+
+class _RecordingLoader:
+    def __init__(
+        self,
+        model,
+        trace,
+        *,
+        prepare_error=None,
+        commit_error=None,
+        rebind_on_commit=False,
+    ):
+        self._model = model
+        self._trace = trace
+        self._prepare_error = prepare_error
+        self._commit_error = commit_error
+        self._rebind_on_commit = rebind_on_commit
+        self.prefetch_handle = _RecordingPrefetchHandle(trace)
+
+    def initialize_model_for_startup(self, *, model_config, device_config):
+        self._trace.append("initialize")
+        return self._model
+
+    def resolve_model_weights(self, model_config, model):
+        self._trace.append("resolve")
+        return (object(),)
+
+    def start_checkpoint_prefetch(self, resolved_sources, *, num_threads):
+        self._trace.append("start_prefetch")
+        return self.prefetch_handle
+
+    def prepare_model_for_capture(self, *, model, model_config):
+        self._trace.append("prepare_capture")
+        if self._prepare_error is not None:
+            raise self._prepare_error
+        return model
+
+    def commit_model_weights(
+        self,
+        *,
+        model,
+        model_config,
+        resolved_sources,
+        target_device,
+    ):
+        self._trace.append("commit")
+        if self._commit_error is not None:
+            raise self._commit_error
+        if self._rebind_on_commit:
+            model.weight = nn.Parameter(model.weight.detach().clone())
+            return
+        with torch.no_grad():
+            for parameter in model.parameters():
+                parameter.fill_(3)
+
+
+class _TiedWeightModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(2, 2))
+        self.tied_weight = self.weight
+        self.register_buffer("scale", torch.ones(2))
+
+
+class TestStartupWeightLoadSelector(CustomTestCase):
+    def setUp(self):
+        self.load_config = LoadConfig(load_format=LoadFormat.SAFETENSORS)
+        self.loader = DefaultModelLoader(self.load_config)
+        self.device_config = DeviceConfig("cuda", 0)
+
+    def _create(
+        self,
+        *,
+        options=None,
+        model_config=None,
+        load_config=None,
+        loader=None,
+        resolved_model_class=None,
+    ):
+        model_config = _make_model_config() if model_config is None else model_config
+        architecture = model_config.hf_config.architectures[0]
+        with (
+            patch(
+                f"{_STARTUP_MODULE}.get_model_architecture",
+                return_value=(
+                    resolved_model_class or _CanonicalModel,
+                    architecture,
+                ),
+            ),
+            patch(
+                f"{_STARTUP_MODULE}._get_canonical_model_class",
+                return_value=_CanonicalModel,
+            ),
+        ):
+            return StartupWeightLoadManager.create_if_enabled(
+                loader=self.loader if loader is None else loader,
+                model_config=model_config,
+                load_config=self.load_config if load_config is None else load_config,
+                device_config=self.device_config,
+                options=_make_options() if options is None else options,
+            )
+
+    def test_serial_keeps_the_legacy_loader_path(self):
+        self.assertIsNone(self._create(options=_make_options(requested_mode="serial")))
+
+    def test_supported_overlap_creates_a_manager(self):
+        self.assertIsInstance(self._create(), StartupWeightLoadManager)
+        self.assertIsInstance(
+            self._create(options=_make_options(tp_size=2)),
+            StartupWeightLoadManager,
+        )
+
+    def test_invalid_mode_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Unknown startup weight load mode"):
+            self._create(options=_make_options(requested_mode="invalid"))
+
+    def test_unsupported_overlap_is_rejected_instead_of_falling_back(self):
+        cases = (
+            (
+                "non_cuda",
+                dict(options=_make_options(device="cpu", is_cuda_platform=False)),
+                "CUDA only",
+            ),
+            (
+                "graphs_disabled",
+                dict(options=_make_options(cuda_graph_enabled=False)),
+                "CUDA graph capture is disabled",
+            ),
+            (
+                "tc_piecewise_prefill",
+                dict(
+                    options=_make_options(
+                        prefill_cuda_graph_backend=Backend.TC_PIECEWISE
+                    )
+                ),
+                "tc_piecewise prefill CUDA graphs are not supported",
+            ),
+            (
+                "pt_checkpoint",
+                dict(load_config=LoadConfig(load_format=LoadFormat.PT)),
+                "load format must be auto or safetensors",
+            ),
+            (
+                "tp3",
+                dict(options=_make_options(tp_size=3)),
+                "only TP1 and TP2 are supported",
+            ),
+            (
+                "attention_context_parallel",
+                dict(options=_make_options(tp_size=2, attn_cp_size=2)),
+                "attention context parallelism is not supported",
+            ),
+            (
+                "decode_context_parallel",
+                dict(options=_make_options(tp_size=2, dcp_size=2)),
+                "decode context parallelism is not supported",
+            ),
+            (
+                "quantized_model",
+                dict(model_config=_make_model_config(quantization="fp8")),
+                "quantization is not supported",
+            ),
+            (
+                "layer_group_offload",
+                dict(options=_make_options(offload_group_size=1)),
+                "layer-group offloading is not supported",
+            ),
+            (
+                "torch_compile",
+                dict(options=_make_options(enable_torch_compile=True)),
+                "torch.compile is not supported",
+            ),
+            (
+                "transformers_model_impl",
+                dict(
+                    model_config=_make_model_config(
+                        model_impl=ModelImpl.TRANSFORMERS,
+                        _resolved_model_impl=ModelImpl.TRANSFORMERS,
+                    ),
+                    resolved_model_class=_ExternalModel,
+                ),
+                "the native SGLang model implementation is required",
+            ),
+            (
+                "external_model_implementation",
+                dict(resolved_model_class=_ExternalModel),
+                "the native SGLang model implementation is required",
+            ),
+            (
+                "unknown_architecture",
+                dict(
+                    model_config=_make_model_config(
+                        hf_config=SimpleNamespace(architectures=["OtherForCausalLM"])
+                    )
+                ),
+                "model architecture is not in the startup-overlap allowlist",
+            ),
+        )
+        for name, kwargs, reason in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, re.escape(reason)):
+                    self._create(**kwargs)
+
+
+class TestStartupWeightLoadManager(CustomTestCase):
+    def _manager(self, loader):
+        return StartupWeightLoadManager(
+            loader=loader,
+            model_config=_make_model_config(),
+            device_config=DeviceConfig("cpu", 0),
+            options=_make_options(),
+        )
+
+    def test_prepare_capture_finalize_state_and_order(self):
+        trace = []
+        model = _TiedWeightModel()
+        manager = self._manager(_RecordingLoader(model, trace))
+
+        self.assertEqual(manager.state, StartupWeightLoadState.CREATED)
+        self.assertIs(manager.prepare(), model)
+        self.assertEqual(manager.state, StartupWeightLoadState.CAPTURE_READY)
+
+        # CUDA graph capture is owned by Scheduler and occurs between these calls.
+        trace.append("capture")
+        with (
+            patch(f"{_STARTUP_MODULE}.monkey_patch_vllm_parallel_state"),
+            patch(f"{_STARTUP_MODULE}.torch.cuda.synchronize"),
+            patch(f"{_STARTUP_MODULE}.logger.info") as log_info,
+        ):
+            manager.finalize()
+
+        self.assertEqual(manager.state, StartupWeightLoadState.READY)
+        self.assertEqual(
+            trace,
+            [
+                "initialize",
+                "resolve",
+                "start_prefetch",
+                "prepare_capture",
+                "capture",
+                "commit",
+                "cancel_prefetch",
+                "wait_prefetch",
+            ],
+        )
+
+        # Finalization is idempotent after a successful commit.
+        manager.finalize()
+        self.assertEqual(trace.count("commit"), 1)
+        self.assertIs(model.weight, model.tied_weight)
+        torch.testing.assert_close(model.weight, torch.full_like(model.weight, 3))
+        self.assertTrue(log_info.call_args.args[0].startswith("Load weight end."))
+
+    def test_commit_failure_is_fail_closed_and_cleans_up_prefetch(self):
+        trace = []
+        manager = self._manager(
+            _RecordingLoader(
+                nn.Linear(2, 2, bias=False),
+                trace,
+                commit_error=RuntimeError("commit failed"),
+            )
+        )
+        manager.prepare()
+
+        with (
+            patch(f"{_STARTUP_MODULE}.monkey_patch_vllm_parallel_state"),
+            patch(f"{_STARTUP_MODULE}.torch.cuda.synchronize"),
+            self.assertRaisesRegex(RuntimeError, "commit failed"),
+        ):
+            manager.finalize()
+
+        self.assertEqual(manager.state, StartupWeightLoadState.FAILED)
+        self.assertEqual(trace[-2:], ["cancel_prefetch", "wait_prefetch"])
+
+    def test_prepare_failure_is_fail_closed_and_cleans_up_prefetch(self):
+        trace = []
+        manager = self._manager(
+            _RecordingLoader(
+                nn.Linear(2, 2, bias=False),
+                trace,
+                prepare_error=RuntimeError("capture preparation failed"),
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "capture preparation failed"):
+            manager.prepare()
+
+        self.assertEqual(manager.state, StartupWeightLoadState.FAILED)
+        self.assertEqual(trace[-2:], ["cancel_prefetch", "wait_prefetch"])
+
+    def test_capture_failure_can_cancel_pending_prefetch(self):
+        trace = []
+        manager = self._manager(_RecordingLoader(nn.Linear(2, 2, bias=False), trace))
+        manager.prepare()
+
+        manager.cancel()
+        manager.cancel()
+
+        self.assertEqual(manager.state, StartupWeightLoadState.CANCELLED)
+        self.assertEqual(trace[-2:], ["cancel_prefetch", "wait_prefetch"])
+        self.assertEqual(trace.count("cancel_prefetch"), 1)
+
+    def test_storage_rebind_is_fail_closed(self):
+        trace = []
+        manager = self._manager(
+            _RecordingLoader(
+                _TiedWeightModel(),
+                trace,
+                rebind_on_commit=True,
+            )
+        )
+        manager.prepare()
+
+        with (
+            patch(f"{_STARTUP_MODULE}.monkey_patch_vllm_parallel_state"),
+            patch(f"{_STARTUP_MODULE}.torch.cuda.synchronize"),
+            self.assertRaisesRegex(
+                RuntimeError, "changed graph-visible tensor storage"
+            ),
+        ):
+            manager.finalize()
+
+        self.assertEqual(manager.state, StartupWeightLoadState.FAILED)
+        self.assertEqual(trace[-2:], ["cancel_prefetch", "wait_prefetch"])
+
+
+class TestModelStorageManifest(CustomTestCase):
+    def test_in_place_updates_preserve_the_manifest(self):
+        model = _TiedWeightModel()
+        manifest = ModelStorageManifest.capture(model)
+
+        with torch.no_grad():
+            model.weight.fill_(2)
+            model.scale.fill_(3)
+
+        self.assertEqual(manifest.changed_names(model), ())
+
+    def test_parameter_rebind_and_alias_break_are_detected(self):
+        model = _TiedWeightModel()
+        manifest = ModelStorageManifest.capture(model)
+
+        model.tied_weight = nn.Parameter(model.tied_weight.detach().clone())
+
+        self.assertEqual(
+            manifest.changed_names(model),
+            ("parameter:tied_weight",),
+        )
+
+
+class _LifecycleRunner:
+    def __init__(self, name, trace):
+        self._name = name
+        self._trace = trace
+
+    def finalize_startup_weight_load(self):
+        self._trace.append(f"finalize:{self._name}")
+
+    def cancel_startup_weight_load(self):
+        self._trace.append(f"cancel:{self._name}")
+
+
+class TestStartupWeightLoadFanout(CustomTestCase):
+    def test_primary_and_multi_runner_extras_are_finalized_once(self):
+        for multi_runner in (False, True):
+            with self.subTest(multi_runner=multi_runner):
+                trace = []
+                primary = _LifecycleRunner("primary", trace)
+                extra_1 = _LifecycleRunner("extra_1", trace)
+                extra_2 = _LifecycleRunner("extra_2", trace)
+                worker = TpModelWorker.__new__(TpModelWorker)
+                worker._model_runner = primary
+                worker.model_runner_list = (
+                    [primary, extra_1, extra_2] if multi_runner else []
+                )
+
+                worker.finalize_startup_weight_load()
+
+                self.assertEqual(
+                    trace,
+                    (
+                        ["finalize:primary", "finalize:extra_1", "finalize:extra_2"]
+                        if multi_runner
+                        else ["finalize:primary"]
+                    ),
+                )
+
+    def test_primary_and_multi_runner_extras_are_cancelled_once(self):
+        trace = []
+        primary = _LifecycleRunner("primary", trace)
+        extra_1 = _LifecycleRunner("extra_1", trace)
+        extra_2 = _LifecycleRunner("extra_2", trace)
+        worker = TpModelWorker.__new__(TpModelWorker)
+        worker._model_runner = primary
+        worker.model_runner_list = [primary, extra_1, extra_2]
+
+        worker.cancel_startup_weight_load()
+
+        self.assertEqual(
+            trace,
+            ["cancel:primary", "cancel:extra_1", "cancel:extra_2"],
+        )
+
+
+class _SchedulerWorker:
+    def __init__(
+        self,
+        trace,
+        *,
+        fail_finalize=False,
+        post_capture_active=False,
+    ):
+        self._trace = trace
+        self._fail_finalize = fail_finalize
+        self.model_runner = SimpleNamespace(
+            token_to_kv_pool=SimpleNamespace(post_capture_active=post_capture_active),
+            post_capture_resize_kv_pool=lambda: trace.append("resize"),
+        )
+
+    def finalize_startup_weight_load(self):
+        self._trace.append("finalize")
+        if self._fail_finalize:
+            raise RuntimeError("finalize failed")
+
+    def cancel_startup_weight_load(self):
+        self._trace.append("cancel")
+
+
+class _FailingPostRunnerInitWorker(TpModelWorker):
+    def __init__(self, runner):
+        self._test_runner = runner
+        super().__init__(
+            server_args=SimpleNamespace(),
+            gpu_id=0,
+            ps=SimpleNamespace(),
+            nccl_port=0,
+        )
+
+    def _init_model_config(self):
+        self.model_config = SimpleNamespace()
+
+    def _init_model_runner(self):
+        self._model_runner = self._test_runner
+
+    def _init_dllm_algorithm(self):
+        raise RuntimeError("post-runner init failed")
+
+
+class TestStartupWeightLoadWorkerCleanup(CustomTestCase):
+    def test_worker_constructor_failure_cancels_owned_runner(self):
+        trace = []
+        runner = _LifecycleRunner("primary", trace)
+
+        with self.assertRaisesRegex(RuntimeError, "post-runner init failed"):
+            _FailingPostRunnerInitWorker(runner)
+
+        self.assertEqual(trace, ["cancel:primary"])
+
+
+class TestStartupWeightLoadSchedulerCleanup(CustomTestCase):
+    @staticmethod
+    def _scheduler(worker, trace):
+        from sglang.srt.managers.scheduler import Scheduler
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.init_tp_model_worker = lambda: setattr(scheduler, "tp_worker", worker)
+        scheduler.maybe_init_draft_worker = lambda: setattr(
+            scheduler, "draft_worker", None
+        )
+        scheduler.init_memory_pools = lambda: trace.append("memory_pool")
+        scheduler.init_all_attention_backends = lambda: trace.append("attention")
+        scheduler.init_all_cuda_graphs = lambda: trace.append("capture")
+        return scheduler
+
+    def test_success_path_captures_before_finalizing_weights(self):
+        trace = []
+        worker = _SchedulerWorker(trace, post_capture_active=True)
+        scheduler = self._scheduler(worker, trace)
+
+        def stop_after_startup():
+            raise RuntimeError("stop after startup")
+
+        scheduler.spec_algorithm = SimpleNamespace(is_none=stop_after_startup)
+
+        with self.assertRaisesRegex(RuntimeError, "stop after startup"):
+            scheduler.init_model_worker()
+
+        self.assertEqual(
+            trace,
+            ["memory_pool", "attention", "capture", "resize", "finalize"],
+        )
+
+    def test_finalize_failure_cancels_deferred_loading(self):
+        trace = []
+        worker = _SchedulerWorker(trace, fail_finalize=True)
+        scheduler = self._scheduler(worker, trace)
+
+        with self.assertRaisesRegex(RuntimeError, "finalize failed"):
+            scheduler.init_model_worker()
+
+        self.assertEqual(
+            trace,
+            ["memory_pool", "attention", "capture", "finalize", "cancel"],
+        )
+
+    def test_cuda_graph_capture_failure_cancels_deferred_loading(self):
+        trace = []
+        worker = _SchedulerWorker(trace)
+        scheduler = self._scheduler(worker, trace)
+
+        def fail_capture():
+            trace.append("capture")
+            raise RuntimeError("capture failed")
+
+        scheduler.init_all_cuda_graphs = fail_capture
+
+        with self.assertRaisesRegex(RuntimeError, "capture failed"):
+            scheduler.init_model_worker()
+
+        self.assertEqual(
+            trace,
+            ["memory_pool", "attention", "capture", "cancel"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_loader/test_prefetch_checkpoints.py
+++ b/test/registered/unit/model_loader/test_prefetch_checkpoints.py
@@ -7,6 +7,7 @@ to weights loaded without prefetch.
 
 import os
 import tempfile
+import threading
 import unittest
 from concurrent.futures import Future
 from types import SimpleNamespace
@@ -105,9 +106,9 @@ class TestPrefetchCheckpoints(CustomTestCase):
         submitted_paths = []
 
         class RecordingExecutor(_InlineExecutor):
-            def submit(self, fn, path):
+            def submit(self, fn, path, *args):
                 submitted_paths.append(path)
-                return super().submit(fn, path)
+                return super().submit(fn, path, *args)
 
         def record_pending_size(fs, return_when):
             pending_sizes.append(len(fs))
@@ -128,7 +129,7 @@ class TestPrefetchCheckpoints(CustomTestCase):
     def test_prefetch_logs_failed_futures(self, _):
         paths = ["bad.safetensors"]
 
-        def fail_prefetch(path):
+        def fail_prefetch(path, cancel_event):
             raise OSError(f"failed {path}")
 
         with (
@@ -141,8 +142,11 @@ class TestPrefetchCheckpoints(CustomTestCase):
             ),
             patch("sglang.srt.model_loader.weight_utils.logger.warning") as warning,
         ):
-            _prefetch_all_checkpoints(paths, num_threads=1)
+            handle = _prefetch_all_checkpoints(paths, num_threads=1)
 
+        handle.wait()
+        self.assertEqual(handle.errors[0][0], paths[0])
+        self.assertIsInstance(handle.errors[0][1], OSError)
         warning.assert_called_once()
         self.assertEqual(
             warning.call_args.args[0],
@@ -192,12 +196,37 @@ class TestPrefetchCheckpoints(CustomTestCase):
             ),
             patch(
                 "sglang.srt.model_loader.weight_utils._prefetch_checkpoint_file",
-                side_effect=loaded_paths.append,
+                side_effect=lambda path, cancel_event: loaded_paths.append(path),
             ),
         ):
             _prefetch_all_checkpoints(paths, num_threads=2)
 
         self.assertEqual(sorted(loaded_paths), sorted(paths[1::3]))
+
+    @patch("torch.distributed.is_initialized", return_value=False)
+    def test_prefetch_handle_cancels_before_scheduling_next_shard(self, _):
+        paths = [f"model-{i:05d}.safetensors" for i in range(3)]
+        started = threading.Event()
+        release = threading.Event()
+        loaded_paths = []
+
+        def block_first_prefetch(path, cancel_event):
+            loaded_paths.append(path)
+            started.set()
+            self.assertTrue(release.wait(timeout=5))
+
+        with patch(
+            "sglang.srt.model_loader.weight_utils._prefetch_checkpoint_file",
+            side_effect=block_first_prefetch,
+        ):
+            handle = _prefetch_all_checkpoints(paths, num_threads=1)
+            self.assertTrue(started.wait(timeout=5))
+            handle.cancel()
+            release.set()
+            handle.wait(timeout=5)
+
+        self.assertTrue(handle.cancelled)
+        self.assertEqual(loaded_paths, paths[:1])
 
     @patch("torch.distributed.is_initialized", return_value=False)
     def test_buffered_loader_drops_cache_after_each_loaded_shard(self, _):
@@ -257,11 +286,16 @@ class TestPrefetchDispatch(CustomTestCase):
             weight_loader_drop_cache_after_load=False,
         )
 
-    def _run(self, loader):
+    def _run(self, loader, **iterator_kwargs):
         # _get_weights_iterator returns a generator wrapping the chosen
         # iterator; consuming it forces the eager dispatch (the if/elif/else
         # that calls the iterator factory) to execute.
-        list(loader._get_weights_iterator(self._make_source()))
+        list(
+            loader._get_weights_iterator(
+                self._make_source(),
+                **iterator_kwargs,
+            )
+        )
 
     def _patch_dispatch(self, prefetch, disable_mmap=False):
         return (
@@ -364,6 +398,40 @@ class TestPrefetchDispatch(CustomTestCase):
         mock_buffered.assert_called_once()
         mock_single.assert_not_called()
         mock_warning.assert_not_called()
+
+    def test_startup_prefetch_reuses_existing_background_handle(self):
+        """Startup commit reuses resolved shards and the active prefetch handle."""
+        loader = self._make_loader({})
+        source = self._make_source()
+        resolved_source = DefaultModelLoader.ResolvedSource(
+            source=source,
+            hf_folder="/dummy",
+            weight_files=("f.safetensors",),
+            use_safetensors=True,
+        )
+        p_prep, p_args, p_buffered, p_single, p_warn = self._patch_dispatch(
+            prefetch=False
+        )
+        with (
+            p_prep as mock_prepare,
+            p_args,
+            p_buffered as mock_buffered,
+            p_single as mock_single,
+            p_warn as mock_warning,
+        ):
+            list(
+                loader._get_weights_iterator(
+                    source,
+                    resolved_source=resolved_source,
+                    startup_prefetch_active=True,
+                )
+            )
+
+        mock_prepare.assert_not_called()
+        mock_single.assert_called_once()
+        self.assertFalse(mock_single.call_args.kwargs["prefetch"])
+        mock_buffered.assert_not_called()
+        mock_warning.assert_called_once()
 
     def test_prefetch_does_not_override_when_mmap_disabled(self):
         """Prefetch is a no-op without mmap, so the override and its warning

--- a/test/registered/unit/test_server_args_migration.py
+++ b/test/registered/unit/test_server_args_migration.py
@@ -87,6 +87,26 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
         self.assertEqual(sa.deepep_mode, "low_latency")
         self.assertEqual(sa.elastic_ep_backend, "none")
 
+    def test_startup_weight_load_mode(self):
+        """The startup loading mode keeps serial as the safe default."""
+        self.assertEqual(self._parse([]).startup_weight_load_mode, "serial")
+        self.assertEqual(
+            self._parse(
+                ["--startup-weight-load-mode", "overlap"]
+            ).startup_weight_load_mode,
+            "overlap",
+        )
+
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(
+                [
+                    "--model",
+                    "dummy",
+                    "--startup-weight-load-mode",
+                    "unsupported",
+                ]
+            )
+
     def test_deprecated_flags_still_work(self):
         """Deprecated flags set the correct dest field."""
         sa = self._parse(["--stream-output"])


### PR DESCRIPTION
## Motivation

The native/default model-loading path currently finishes loading and post-processing the real weights before CUDA graph capture begins. For large checkpoints, checkpoint I/O and CUDA graph capture are both material parts of engine startup, but they run serially.

This PR introduces an opt-in startup path that stages safetensors checkpoint pages while the runtime initializes and CUDA graphs are captured. It then loads and post-processes the real weights in place, without changing the tensor storage referenced by the captured graphs.

The existing behavior remains the default:

```text
--startup-weight-load-mode serial  # default
```

This PR does not enable overlap by default.

## Modifications

### Startup flow

#### Existing serial startup

```mermaid
flowchart LR
    S1["Load and post-process<br/>real weights"]
    S2["Initialize runtime and<br/>capture CUDA graphs"]
    S3["Ready to serve"]
    S1 --> S2 --> S3
```

#### Opt-in overlap startup

```mermaid
flowchart TB
    O1["Allocate final GPU storage<br/>and resolve safetensors shards"]
    O2["Initialize capture-safe weights<br/>and required post-processing"]
    O3["Background storage-to-OS-page-cache staging"]
    O4["Initialize memory pools and attention backends<br/>and capture CUDA graphs"]
    O5["Load and post-process real weights<br/>in the existing storage"]
    O6["CUDA synchronize, verify storage identity,<br/>and run the TP barrier"]
    O7["Ready to serve"]

    O1 --> O2 --> O4 --> O5 --> O6 --> O7
    O1 --> O3
    O3 -. "runs concurrently" .-> O4
    O3 -. "warms pages consumed by" .-> O5
```

The overlapped work is checkpoint staging from storage into the OS page cache. Real checkpoint iteration, GPU weight commit, and post-load processing still happen after CUDA graph capture.

- Add `--startup-weight-load-mode {serial,overlap}`, defaulting to `serial`.
- Split the exact `DefaultModelLoader` startup lifecycle into model/storage initialization, checkpoint resolution, capture-safe initialization, and post-capture in-place commit.
- Reuse the existing coordinated checkpoint page-cache prefetcher through a cancellable lifecycle handle and reuse the resolved checkpoint source during commit.
- Verify that graph-visible tensor object identity, data pointer, shape, stride, dtype, device, and storage offset remain unchanged after the real-weight commit.
- Propagate finalize/cancel handling through `ModelRunner`, TP workers, scheduler startup, and `sglang.benchmark.one_batch`.
- Cancel and join background prefetch work on preparation, graph-capture, or commit failures.
- Keep `--weight-loader-prefetch-checkpoints` as an independent serial-path control and avoid starting a second prefetch when overlap already owns staging.

### Scope and rollout plan

This is PR 1 of a staged three-PR rollout. The overlap path is intentionally opt-in and fail-closed here. Its initial supported scope is:

- CUDA graph capture with the exact `DefaultModelLoader`
- `auto`/`safetensors` loading with mmap enabled
- Native dense Llama, Qwen2, and Qwen3 generation models
- FP16/BF16, TP1/TP2, and a single primary checkpoint source

Unsupported configurations raise an explicit error instead of silently changing startup behavior. The existing serial path remains unchanged.

Planned follow-ups:

- **PR 2 — generalize and harden:** broaden the validated support matrix, add startup-phase timing/diagnostics, and factor shared lifecycle pieces so the native/default-loader and checkpoint-engine paths can converge where their semantics match. The feature remains opt-in while this coverage expands.
- **PR 3 — default rollout:** introduce an `auto` policy and make it the default after broader CI and benchmark burn-in. Validated configurations select overlap automatically; unsupported configurations retain the serial path, with an explicit serial escape hatch.

## Accuracy Tests

- Added a registered 1-GPU end-to-end test comparing default serial and overlap output token IDs, generated text, and output logprobs (`1e-5` tolerance).
- Added registered CPU unit coverage for compatibility selection, fail-closed rejection, lifecycle transitions, graph-visible storage invariants, checkpoint-source reuse, prefetch ownership, scheduler/worker cleanup, server arguments, and MLX routing.
- Manually validated the `auto` safetensors Engine path and `sglang.benchmark.one_batch` overlap path on H100.
- Qwen3-32B benchmark runs produced matching output IDs, text, and logprobs across all three startup modes.
- `scripts/ci/check_registered_tests.py`, Python compilation, formatting/lint, and `git diff --check` pass.

## Speed Tests and Profiling

Configuration: Qwen3-32B BF16 on H100, Triton decode CUDA graphs through batch size 256, prefill CUDA graphs disabled, three timed runs per configuration, and warmed compiler/graph caches. For the local tests, checkpoint files were present on the NVMe filesystem before timing; before every run, `POSIX_FADV_DONTNEED` was applied and `mincore` verified zero resident checkpoint pages. Prefetch used four threads per rank unless otherwise noted.

### Primary result: incremental overlap benefit

The primary comparison is **B → C**. Both configurations use the same coordinated page-cache prefetch mechanism; C changes the startup order so runtime initialization and CUDA graph capture occur before the real-weight commit. This is the closest measured control for the additional overlap benefit.

| Storage | TP | B: Serial + prefetch | C: Overlap | Wall time saved | B → C reduction | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| Local NVMe | 1 | 39.59 s | 35.57 s | 4.02 s | 10.2% | 1.11x |
| Local NVMe | 2 | 45.87 s | 38.63 s | 7.24 s | 15.8% | 1.19x |
| NFS | 2 | 59.70 s | 54.39 s | 5.31 s | 8.9% | 1.10x |

Across the measured configurations, overlap reduced startup by **8.9–15.8%** relative to serial startup with coordinated prefetch.

### End-to-end context

For context, the complete opt-in path also includes the existing coordinated-prefetch gain:

| Storage | TP | A: Default serial | B: Serial + prefetch | C: Overlap | A → B reduction | A → C reduction |
|---|---:|---:|---:|---:|---:|---:|
| Local NVMe | 1 | 86.39 s | 39.59 s | 35.57 s | 54.2% | 58.8% (2.43x) |
| Local NVMe | 2 | 78.20 s | 45.87 s | 38.63 s | 41.3% | 50.6% (2.02x) |
| NFS | 2 | 129.27 s | 59.70 s | 54.39 s | 53.8% | 57.9% (2.38x) |

Most of the A → C reduction comes from coordinated checkpoint prefetching. A → C describes the end-to-end opt-in startup path; **B → C is the main result attributable to the new startup ordering**. The sequential percentage reductions are not additive because they use different baselines.

These measurements do not establish monotonic scaling with TP size. TP1 and TP2 were measured in separate executions on different nodes. Matching eight aggregate prefetch threads on TP1 produced a 16.1% B → C reduction, compared with 15.8% on TP2 with four threads per rank. Each TP rank captures its own CUDA graph concurrently, so capture time is not summed across ranks. The result demonstrates a benefit at TP1 and TP2, but not increasing percentage savings as TP rank grows.

## Checklist

- [x] Format the code according to the contribution guide.
- [x] Add registered unit and end-to-end tests.
- [x] Update user-facing argument help for the new control.
- [x] Provide accuracy and speed benchmark results.
- [x] Preserve the existing serial startup behavior by default.
