### PR TITLE
[Perf] Fold dspark dense draft embedding into the draft graph via forward_embed

### DIFF
--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -404,9 +404,13 @@ class DFlashDraftModel(nn.Module):
         pp_proxy_tensors=None,
     ) -> LogitsProcessorOutput:
         if input_embeds is None:
-            raise ValueError(
-                "DFlashDraftModel requires `input_embeds` (use the target embedding)."
-            )
+            if hasattr(self, "forward_embed"):
+                input_embeds = self.forward_embed(input_ids)
+            else:
+                raise ValueError(
+                    "DFlashDraftModel requires `input_embeds` (use the target "
+                    "embedding)."
+                )
         hidden_states = input_embeds
         residual: Optional[torch.Tensor] = None
 

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -376,8 +376,14 @@ class DSparkDraftMixin:
     def attach_shared_modules(
         self, *, embed_tokens: nn.Module, lm_head: nn.Module
     ) -> None:
-        del embed_tokens
+        self.embed_tokens = embed_tokens
         self.lm_head = lm_head
+
+    def forward_embed(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # Embeds with the shared target embedding INSIDE the draft graph
+        # (the runner skips the eager input_embeds staging when the draft
+        # model exposes forward_embed).
+        return self.embed_tokens(input_ids)
 
     def compute_base_logits(
         self, hidden: torch.Tensor


### PR DESCRIPTION
The dense DSpark draft model drops the shared embedding in `attach_shared_modules`, so the runner stages `input_embeds` eagerly before every draft graph replay. `deepseek_v4_dspark` already opts into the `forward_embed` mechanism that the cuda-graph runner and draft proposer support (keep `embed_tokens`, expose `forward_embed`). Wire the dense dspark model in the same way so the embedding lookup runs inside the draft graph and the eager staging copy is skipped. Same lookup, just moved into the graph; the `dflash` base keeps the raise for models without `forward_embed`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29877734498](https://github.com/sgl-project/sglang/actions/runs/29877734498)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29877734406](https://github.com/sgl-project/sglang/actions/runs/29877734406)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->