### PR TITLE
Fix reward/classification models broken by `load_weights` v2 dispatch (#28671)

### DIFF
--- a/python/sglang/srt/models/llama_classification.py
+++ b/python/sglang/srt/models/llama_classification.py
@@ -83,7 +83,7 @@ class LlamaForClassification(nn.Module):
             elif "lm_head" in name:
                 continue
             else:
-                LlamaForCausalLM.load_weights(self, [(name, loaded_weight)])
+                LlamaForCausalLM._legacy_load_weights(self, [(name, loaded_weight)])
 
 
 EntryClass = LlamaForClassification

--- a/python/sglang/srt/models/llama_reward.py
+++ b/python/sglang/srt/models/llama_reward.py
@@ -74,7 +74,7 @@ class LlamaForSequenceClassification(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        return LlamaForCausalLM.load_weights(self, weights)
+        return LlamaForCausalLM._legacy_load_weights(self, weights)
 
 
 class LlamaForSequenceClassificationWithNormal_Weights(LlamaForSequenceClassification):

--- a/python/sglang/srt/models/qwen2_classification.py
+++ b/python/sglang/srt/models/qwen2_classification.py
@@ -71,7 +71,7 @@ class Qwen2ForSequenceClassification(nn.Module):
         filtered_weights = [
             (name, w) for name, w in weights if not name.startswith("lm_head")
         ]
-        return Qwen2ForCausalLM.load_weights(self, filtered_weights)
+        return Qwen2ForCausalLM._legacy_load_weights(self, filtered_weights)
 
 
 EntryClass = [

--- a/python/sglang/srt/models/qwen2_rm.py
+++ b/python/sglang/srt/models/qwen2_rm.py
@@ -84,7 +84,7 @@ class Qwen2ForRewardModel(nn.Module):
         filtered_weights = [
             (name, w) for name, w in weights if not name.startswith("lm_head")
         ]
-        return Qwen2ForCausalLM.load_weights(self, filtered_weights)
+        return Qwen2ForCausalLM._legacy_load_weights(self, filtered_weights)
 
 
 EntryClass = [


### PR DESCRIPTION
## Motivation
#28671 refactored `LlamaForCausalLM`/`Qwen2ForCausalLM.load_weights` to dispatch to `self._legacy_load_weights` / `self._load_weights_v2`. The reward and classification wrappers (`llama_reward`, `llama_classification`, `qwen2_rm`, `qwen2_classification`) borrow the base loader via an unbound call `Base.load_weights(self, ...)` but inherit only `nn.Module`, so `self` has no `_legacy_load_weights` and weight load fails with `AttributeError` (default path, since v2 is opt-in). This breaks loading of every reward/classification model built on Llama or Qwen2 — e.g. `LxzGordon/URM-LLaMa-3.1-8B` crashes at startup with `'LlamaForSequenceClassificationWithNormal_Weights' object has no attribute '_legacy_load_weights'`.
Call `_legacy_load_weights` directly, restoring the pre-#28671 behavior. These wrapped models are not AutoWeightLoader v2 citizens, so legacy is the correct path.

## Modifications
- Changed the unbound base-loader borrow from `Base.load_weights(self, ...)` to `Base._legacy_load_weights(self, ...)` in the four affected wrappers: `llama_reward.py`, `llama_classification.py`, `qwen2_rm.py`, `qwen2_classification.py`.
- Added a one-line comment at each site explaining why the legacy loader is called directly (so it isn't "fixed" back to `load_weights`).
- gemma2 / internlm2 / mixtral-based wrappers are intentionally untouched: their base models were not converted to the v2 dispatch, so their `load_weights` is still self-contained and works.

## Accuracy Tests
No output change — this restores the exact weight-loading path that ran before #28671 (the refactor renamed that body to `_legacy_load_weights` verbatim). The path is exercised by the existing reward/classification loading tests (`test/registered/prefill_only/test_reward_models.py`, `test_score_engine.py`, `test_pooled_hidden_states.py`), which fail on current trunk and pass with this change. `black` and `py_compile` verified locally.
## Speed Tests and Profiling
N/A — weight-loading path only; no inference-speed impact.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Covered by existing reward/classification model tests.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A — bugfix only.)
- [ ] Provide accuracy and speed benchmark results. (N/A — behavior-preserving loader fix.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29884063179](https://github.com/sgl-project/sglang/actions/runs/29884063179)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29884063091](https://github.com/sgl-project/sglang/actions/runs/29884063091)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->