### PR TITLE
[Bug-fix] Measure KV transfer speed per actual transfer for disaggregation (Mooncake)

### DIFF
--- a/python/sglang/srt/disaggregation/base/__init__.py
+++ b/python/sglang/srt/disaggregation/base/__init__.py
@@ -5,4 +5,5 @@ from sglang.srt.disaggregation.base.conn import (
     BaseKVSender,
     KVArgs,
     KVPoll,
+    KVTransferMetric,
 )

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1102,6 +1102,11 @@ class CommonKVSender(BaseKVSender):
         return num_pages > 0 or last_chunk
 
     def get_transfer_metric(self) -> KVTransferMetric:
+        if self.kv_mgr.is_dummy_cp_rank:
+            # Dummy CP ranks transfer no KV, so leave the metric at its zero
+            # default. Skipping the estimate also avoids get_kv_replica_factor(),
+            # which never resolves on these ranks (they never bootstrap).
+            return self._transfer_metric
         record = self.kv_mgr._transfer_records.pop(self.bootstrap_room, None)
         if record is not None and record.total_elapsed_s > 0:
             self._transfer_metric.transfer_latency_s = record.total_elapsed_s

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -9,6 +9,7 @@ import time
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+import msgspec
 import numpy as np
 import numpy.typing as npt
 import requests
@@ -115,6 +116,22 @@ class PrefillRankInfo:
         self.rank_port = int(self.rank_port)
 
 
+class _TransferRecord(msgspec.Struct):
+    # Summed transfer time and bytes across all sends and dst ranks of a request.
+    total_elapsed_s: float = 0.0
+    total_bytes: int = 0
+
+
+def count_state_indices(state_indices: Optional[List]) -> int:
+    if not state_indices:
+        return 0
+    return sum(
+        len(component_indices)
+        for component_indices in state_indices
+        if component_indices is not None
+    )
+
+
 class CommonKVManager(BaseKVManager):
     def __init__(
         self,
@@ -176,6 +193,10 @@ class CommonKVManager(BaseKVManager):
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
         self.request_status: Dict[int, KVPoll] = {}
+        self._transfer_records: Dict[int, _TransferRecord] = {}
+        # Serializes (status, _transfer_records) transitions so a late transfer
+        # cannot re-create a record that a concurrent teardown just drained.
+        self.status_record_lock = threading.Lock()
         self._socket_cache: Dict[str, zmq.Socket] = {}
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_lock = threading.Lock()
@@ -247,22 +268,48 @@ class CommonKVManager(BaseKVManager):
     def check_status(self, bootstrap_room: int) -> KVPoll:
         return self.request_status[bootstrap_room]
 
-    def update_status(self, bootstrap_room: int, status: KVPoll):
-        if bootstrap_room not in self.request_status:
-            # Do not resurrect a cleared entry with Failed: once clear() has
-            # popped the room from request_status, any late update_status(Failed)
-            # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
-            # pollute a future request that reuses the same bootstrap_room.
-            if status == KVPoll.Failed:
+    def _transfer_bytes(self, num_kv_indices: int, num_state_indices: int) -> int:
+        return (
+            num_kv_indices * self.kv_item_lens_sum
+            + num_state_indices * self.state_item_lens_sum
+        )
+
+    def _record_transfer(
+        self,
+        bootstrap_room: int,
+        nbytes: int,
+        elapsed_s: float,
+    ):
+        # Callers pass the bytes actually put on the wire for one send (a chunk
+        # to a single dst rank), so replication across dst ranks is summed here.
+        if elapsed_s <= 0 or nbytes <= 0:
+            return
+        with self.status_record_lock:
+            status = self.request_status.get(bootstrap_room)
+            if status is None or status == KVPoll.Failed:
+                # Room torn down: don't let a late transfer re-create a drained record.
                 return
-            self.request_status[bootstrap_room] = status
-        else:
+            record = self._transfer_records.setdefault(
+                bootstrap_room, _TransferRecord()
+            )
+            record.total_elapsed_s += elapsed_s
+            record.total_bytes += nbytes
+
+    def update_status(self, bootstrap_room: int, status: KVPoll):
+        with self.status_record_lock:
             if status == KVPoll.Failed:
-                self.request_status[bootstrap_room] = KVPoll.Failed
-            else:
+                # A late Failed (e.g. from abort()) must never resurrect a
+                # cleared room, and must drop any record so it can't pollute a
+                # future reuse of this room.
+                self._transfer_records.pop(bootstrap_room, None)
+                if bootstrap_room in self.request_status:
+                    self.request_status[bootstrap_room] = KVPoll.Failed
+            elif bootstrap_room in self.request_status:
                 self.request_status[bootstrap_room] = max(
                     self.request_status[bootstrap_room], status
                 )
+            else:
+                self.request_status[bootstrap_room] = status
 
     def record_failure(self, bootstrap_room: int, failure_reason: str):
         with self.failure_lock:
@@ -1055,13 +1102,18 @@ class CommonKVSender(BaseKVSender):
         return num_pages > 0 or last_chunk
 
     def get_transfer_metric(self) -> KVTransferMetric:
-        total_bytes = self._transfer_num_kv_indices * self.kv_mgr.kv_item_lens_sum
-        total_bytes += (
-            self._transfer_num_state_indices * self.kv_mgr.state_item_lens_sum
-        )
-        # Pinned to 1 for MHA (disjoint slices); only MLA replication makes it > 1.
-        total_bytes *= self.kv_mgr.get_kv_replica_factor()
-        self._transfer_metric.transfer_total_bytes = total_bytes
+        record = self.kv_mgr._transfer_records.pop(self.bootstrap_room, None)
+        if record is not None and record.total_elapsed_s > 0:
+            self._transfer_metric.transfer_latency_s = record.total_elapsed_s
+            self._transfer_metric.transfer_total_bytes = record.total_bytes
+        else:
+            self._transfer_metric.transfer_total_bytes = (
+                self.kv_mgr._transfer_bytes(
+                    self._transfer_num_kv_indices, self._transfer_num_state_indices
+                )
+                * self.kv_mgr.get_kv_replica_factor()
+            )
+
         return self._transfer_metric
 
     def _record_transfer_indices(
@@ -1070,10 +1122,7 @@ class CommonKVSender(BaseKVSender):
         state_indices: Optional[List],
     ):
         self._transfer_num_kv_indices += len(kv_indices)
-        if state_indices:
-            for component_indices in state_indices:
-                if component_indices is not None:
-                    self._transfer_num_state_indices += len(component_indices)
+        self._transfer_num_state_indices += count_state_indices(state_indices)
 
     def _prepare_send_indices(
         self,
@@ -1142,7 +1191,9 @@ class CommonKVSender(BaseKVSender):
         raise Exception("Fake KVReceiver Exception")
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+        with self.kv_mgr.status_record_lock:
+            self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+            self.kv_mgr._transfer_records.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
             self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "transfer_infos"):

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -21,6 +21,7 @@ from sglang.srt.disaggregation.common.conn import (
     CommonKVReceiver,
     CommonKVSender,
     KVTransferError,
+    count_state_indices,
 )
 from sglang.srt.disaggregation.common.staging_handler import (
     DecodeStagingContext,
@@ -1446,6 +1447,25 @@ class MooncakeKVManager(CommonKVManager):
                                 kv_chunk.prefill_aux_index,
                                 target_rank_registration_info.dst_aux_ptrs,
                             )
+
+                        # Record before flipping to Success (scheduler pops on
+                        # Success). State is only on the wire in the last chunk.
+                        num_state_indices = (
+                            count_state_indices(kv_chunk.state_indices)
+                            if kv_chunk.is_last_chunk
+                            else 0
+                        )
+                        bytes_sent = self._transfer_bytes(
+                            len(kv_chunk.prefill_kv_indices),
+                            num_state_indices,
+                        )
+                        self._record_transfer(
+                            kv_chunk.room,
+                            bytes_sent,
+                            time.perf_counter() - start_ts,
+                        )
+
+                        if kv_chunk.is_last_chunk:
                             polls.append(True if ret == 0 else False)
                             dst_ranks_infos.append(
                                 (req.endpoint, req.dst_port, req.room)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -820,6 +820,9 @@ class SchedulerDisaggregationPrefillMixin:
                 release_kv_cache(req, self.tree_cache)  # unlock the tree
                 if not isinstance(req.finished_reason, FINISH_ABORT):
                     req.finished_reason = FINISH_LENGTH(length=0)
+                # Snapshot the transfer metric before clear() drains the record
+                # it reads (chunked prefill sums per-chunk send time there).
+                req.transfer_metric = req.disagg_kv_sender.get_transfer_metric()
                 # FIXME: clean up req's data in transfer engine
                 req.disagg_kv_sender.clear()
                 done_reqs.append(req)
@@ -844,7 +847,7 @@ class SchedulerDisaggregationPrefillMixin:
             if kv_mgr and getattr(kv_mgr, "is_dummy_cp_rank", False):
                 continue
             metrics = req.time_stats.compute_and_observe_kv_transfer_metrics(
-                req.disagg_kv_sender.get_transfer_metric()
+                req.transfer_metric
             )
             if metrics:
                 # Update last-value for REST API

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -63,7 +63,7 @@ import numpy as np
 import torch
 
 from sglang.srt.constrained.base_grammar_backend import BaseGrammarObject
-from sglang.srt.disaggregation.base import BaseKVSender
+from sglang.srt.disaggregation.base import BaseKVSender, KVTransferMetric
 from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
     ScheduleBatchDisaggregationDecodeMixin,
 )
@@ -1050,6 +1050,9 @@ class Req(ReqDllmMixin):
         self.pd_rebootstrap_forced_output_id: Optional[int] = None
         self.skip_radix_cache_insert = bootstrap_host == FAKE_BOOTSTRAP_HOST
         self.disagg_kv_sender: Optional[BaseKVSender] = None
+        # Snapshotted from the sender before clear() drains its transfer record,
+        # so the record-based KV transfer metric survives teardown.
+        self.transfer_metric: Optional[KVTransferMetric] = None
 
         self.routed_dp_rank: Optional[int] = routed_dp_rank
         self.disagg_prefill_dp_rank: Optional[int] = disagg_prefill_dp_rank

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -922,6 +922,8 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
             result["speed_gb_s"] = speed_gb_s
 
             if self.enable_metrics:
+                # Note that latency notion differs by backend,
+                # so speeds aren't cross-comparable.
                 self.metrics_collector.observe_kv_transfer_metrics(
                     latency_ms=latency_ms,
                     total_mb=total_mb,

--- a/test/registered/unit/disaggregation/test_kv_transfer_metrics.py
+++ b/test/registered/unit/disaggregation/test_kv_transfer_metrics.py
@@ -65,13 +65,13 @@ class TestTransferMetric(unittest.TestCase):
         self.assertNotIn(room, mgr._transfer_records)
 
     def test_measured_record_pops_and_ignores_replica_factor(self):
-        # Regression: on the measured path _record_transfer accumulates
-        # bytes once per destination rank (called inside the per-dst-rank send
-        # loop), so replication is already baked into record.total_bytes. For
-        # MLA (replica_factor = required_dst_info_num > 1) the buggy code
-        # multiplied by the factor again, over-counting bytes/speed by that
-        # factor. The measured total must equal the raw recorded bytes, and the
-        # record must be popped so a reused room can't inherit it.
+        # On the measured path _record_transfer accumulates bytes once per
+        # destination rank (called inside the per-dst-rank send loop), so
+        # replication is already baked into record.total_bytes. For MLA
+        # (replica_factor = required_dst_info_num > 1) it must NOT be scaled by
+        # the factor again -- that would double-count bytes/speed. The measured
+        # total must equal the raw recorded bytes, and the record must be popped
+        # so a reused room can't inherit it.
         mgr = _make_manager(replica_factor=4)
         room = 42
         mgr.request_status[room] = KVPoll.Transferring
@@ -100,12 +100,13 @@ class TestTransferMetric(unittest.TestCase):
         self.assertEqual(metric.transfer_total_bytes, 4 * mgr._transfer_bytes(4, 1))
 
     def test_dummy_cp_rank_skips_estimate_and_replica_lookup(self):
-        # Regression: dummy CP ranks transfer no KV and never bootstrap, so
-        # _kv_replica_factor never resolves. The pre-guard code fell through to
-        # the fallback estimate and called get_kv_replica_factor(), logging a
+        # Dummy CP ranks transfer no KV and never bootstrap, so
+        # _kv_replica_factor never resolves. get_transfer_metric must
+        # short-circuit to the zero-default metric for such ranks without
+        # touching the replica factor; otherwise it falls through to the
+        # fallback estimate and calls get_kv_replica_factor(), logging a
         # spurious "called before resolve_kv_replica_factor" warning on every
-        # such rank. The guard must short-circuit to the zero-default metric
-        # without touching the replica factor.
+        # dummy rank.
         mgr = _make_manager(replica_factor=None)
         mgr.is_dummy_cp_rank = True
 
@@ -123,7 +124,7 @@ class TestTransferMetric(unittest.TestCase):
         self.assertIsNone(metric.transfer_total_bytes)
 
     def test_status_record_lock_serializes_teardown_against_transfer(self):
-        # Regression: a send-worker transfer that passed _record_transfer's
+        # A send-worker transfer that passed _record_transfer's
         # guard must not run its setdefault after a concurrent
         # update_status(Failed) flips the status and pops the record, or it
         # leaks a record across bootstrap_room reuse. Forced deterministically:
@@ -158,7 +159,8 @@ class TestTransferMetric(unittest.TestCase):
 
         updater = threading.Thread(target=_teardown)
         updater.start()
-        # Fixed: update_status is blocked on the lock. Buggy: it completes now.
+        # update_status must contend for status_record_lock, still held by the
+        # parked worker, so the teardown cannot complete within this window.
         self.assertFalse(update_done.wait(timeout=0.3))
 
         release_worker.set()

--- a/test/registered/unit/disaggregation/test_kv_transfer_metrics.py
+++ b/test/registered/unit/disaggregation/test_kv_transfer_metrics.py
@@ -1,0 +1,209 @@
+"""CPU unit tests for measured KV transfer speed accounting (CommonKVManager /
+CommonKVSender). Covers accumulation, the measured-vs-fallback branch of
+get_transfer_metric (incl. the dummy-CP short-circuit), record cleanup on
+failure/abort resurrection, and the lock that serializes _record_transfer
+against teardown."""
+
+import threading
+import unittest
+
+from sglang.srt.disaggregation.base.conn import KVPoll, KVTransferMetric
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVManager,
+    CommonKVSender,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_manager(kv_item_lens_sum=10, state_item_lens_sum=3, replica_factor=1):
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.request_status = {}
+    mgr._transfer_records = {}
+    mgr.status_record_lock = threading.Lock()
+    mgr.kv_item_lens_sum = kv_item_lens_sum
+    mgr.state_item_lens_sum = state_item_lens_sum
+    mgr._kv_replica_factor = replica_factor
+    mgr.is_dummy_cp_rank = False
+    return mgr
+
+
+def _make_sender(mgr, room, num_kv_indices=5, num_state_indices=2):
+    sender = CommonKVSender.__new__(CommonKVSender)
+    sender.bootstrap_room = room
+    sender.kv_mgr = mgr
+    sender._transfer_metric = KVTransferMetric()
+    sender._transfer_num_kv_indices = num_kv_indices
+    sender._transfer_num_state_indices = num_state_indices
+    return sender
+
+
+class TestTransferMetric(unittest.TestCase):
+    def test_transfer_bytes(self):
+        mgr = _make_manager(kv_item_lens_sum=10, state_item_lens_sum=3)
+        self.assertEqual(mgr._transfer_bytes(5, 2), 5 * 10 + 2 * 3)
+
+    def test_record_transfer_accumulates(self):
+        mgr = _make_manager()
+        room = 1
+        mgr.request_status[room] = KVPoll.Transferring
+        mgr._record_transfer(room, mgr._transfer_bytes(5, 2), 0.1)
+        mgr._record_transfer(room, mgr._transfer_bytes(3, 0), 0.2)
+        record = mgr._transfer_records[room]
+        self.assertAlmostEqual(record.total_elapsed_s, 0.3)
+        self.assertEqual(
+            record.total_bytes, mgr._transfer_bytes(5, 2) + mgr._transfer_bytes(3, 0)
+        )
+
+    def test_record_transfer_skips_nonpositive(self):
+        mgr = _make_manager()
+        room = 1
+        mgr.request_status[room] = KVPoll.Transferring
+        mgr._record_transfer(room, mgr._transfer_bytes(5, 2), 0.0)  # zero elapsed
+        mgr._record_transfer(room, 0, 0.1)  # zero bytes
+        self.assertNotIn(room, mgr._transfer_records)
+
+    def test_measured_record_pops_and_ignores_replica_factor(self):
+        # Regression: on the measured path _record_transfer accumulates
+        # bytes once per destination rank (called inside the per-dst-rank send
+        # loop), so replication is already baked into record.total_bytes. For
+        # MLA (replica_factor = required_dst_info_num > 1) the buggy code
+        # multiplied by the factor again, over-counting bytes/speed by that
+        # factor. The measured total must equal the raw recorded bytes, and the
+        # record must be popped so a reused room can't inherit it.
+        mgr = _make_manager(replica_factor=4)
+        room = 42
+        mgr.request_status[room] = KVPoll.Transferring
+        # Two dst ranks recorded -> replication already summed into the record.
+        mgr._record_transfer(room, mgr._transfer_bytes(5, 2), 0.1)
+        mgr._record_transfer(room, mgr._transfer_bytes(5, 2), 0.15)
+        sender = _make_sender(mgr, room)
+
+        metric = sender.get_transfer_metric()
+
+        self.assertAlmostEqual(metric.transfer_latency_s, 0.25)
+        self.assertEqual(metric.transfer_total_bytes, 2 * mgr._transfer_bytes(5, 2))
+        self.assertNotIn(room, mgr._transfer_records)
+
+    def test_fallback_scales_by_replica_factor(self):
+        # Fallback path: _transfer_num_kv/state_indices is a single source-side
+        # count with no dst-rank dimension, so it must be scaled by the replica
+        # factor to reflect the KV being replicated to each dst rank (MLA).
+        mgr = _make_manager(replica_factor=4)
+        room = 7
+        sender = _make_sender(mgr, room, num_kv_indices=4, num_state_indices=1)
+
+        metric = sender.get_transfer_metric()
+
+        self.assertIsNone(metric.transfer_latency_s)
+        self.assertEqual(metric.transfer_total_bytes, 4 * mgr._transfer_bytes(4, 1))
+
+    def test_dummy_cp_rank_skips_estimate_and_replica_lookup(self):
+        # Regression: dummy CP ranks transfer no KV and never bootstrap, so
+        # _kv_replica_factor never resolves. The pre-guard code fell through to
+        # the fallback estimate and called get_kv_replica_factor(), logging a
+        # spurious "called before resolve_kv_replica_factor" warning on every
+        # such rank. The guard must short-circuit to the zero-default metric
+        # without touching the replica factor.
+        mgr = _make_manager(replica_factor=None)
+        mgr.is_dummy_cp_rank = True
+
+        def _must_not_call():
+            raise AssertionError(
+                "get_kv_replica_factor must not be called on dummy CP ranks"
+            )
+
+        mgr.get_kv_replica_factor = _must_not_call
+        sender = _make_sender(mgr, room=1, num_kv_indices=4, num_state_indices=1)
+
+        metric = sender.get_transfer_metric()
+
+        self.assertIsNone(metric.transfer_latency_s)
+        self.assertIsNone(metric.transfer_total_bytes)
+
+    def test_status_record_lock_serializes_teardown_against_transfer(self):
+        # Regression: a send-worker transfer that passed _record_transfer's
+        # guard must not run its setdefault after a concurrent
+        # update_status(Failed) flips the status and pops the record, or it
+        # leaks a record across bootstrap_room reuse. Forced deterministically:
+        # the worker is parked inside its critical section (at setdefault) while
+        # update_status runs; the lock must make update_status block until the
+        # worker releases.
+        worker_in_cs = threading.Event()
+        release_worker = threading.Event()
+
+        class _PausingRecords(dict):
+            def setdefault(self, *args, **kwargs):
+                worker_in_cs.set()
+                release_worker.wait(timeout=5)
+                return super().setdefault(*args, **kwargs)
+
+        mgr = _make_manager()
+        room = 55
+        mgr._transfer_records = _PausingRecords()
+        mgr.request_status[room] = KVPoll.Transferring
+
+        worker = threading.Thread(
+            target=mgr._record_transfer, args=(room, mgr._transfer_bytes(5, 2), 0.1)
+        )
+        worker.start()
+        self.assertTrue(worker_in_cs.wait(timeout=5))  # parked mid-critical-section
+
+        update_done = threading.Event()
+
+        def _teardown():
+            mgr.update_status(room, KVPoll.Failed)
+            update_done.set()
+
+        updater = threading.Thread(target=_teardown)
+        updater.start()
+        # Fixed: update_status is blocked on the lock. Buggy: it completes now.
+        self.assertFalse(update_done.wait(timeout=0.3))
+
+        release_worker.set()
+        worker.join(timeout=5)
+        updater.join(timeout=5)
+        self.assertTrue(update_done.is_set())
+
+        # Whatever the interleaving, the failure teardown leaves no record.
+        self.assertNotIn(room, mgr._transfer_records)
+
+    def test_clear_drains_transfer_record(self):
+        # clear() tears the room down and must not leave a stale transfer record
+        # behind; a reused bootstrap_room would otherwise inherit its bytes/time.
+        mgr = _make_manager()
+        room = 99
+        mgr.request_status[room] = KVPoll.Transferring
+        mgr._record_transfer(room, mgr._transfer_bytes(5, 2), 0.1)
+        self.assertIn(room, mgr._transfer_records)
+        sender = _make_sender(mgr, room)
+
+        sender.clear()
+
+        self.assertNotIn(room, mgr.request_status)
+        self.assertNotIn(room, mgr._transfer_records)
+
+    def test_record_transfer_does_not_resurrect_untracked_room(self):
+        # A late in-flight transfer must not re-create a record (via setdefault) for
+        # a room that is no longer tracked, which nothing would drain -- leaking
+        # _transfer_records across bootstrap_room reuse. Both guard branches:
+        #   Failed: abort/failure race popped the record on another thread.
+        #   None:   on Success, clear() popped request_status before
+        #           get_transfer_metric drained the record, so status reads None.
+        for status in (KVPoll.Failed, None):
+            with self.subTest(status=status):
+                mgr = _make_manager()
+                room = 13
+                if status is not None:
+                    mgr.request_status[room] = status
+                else:
+                    self.assertNotIn(room, mgr.request_status)
+
+                mgr._record_transfer(room, mgr._transfer_bytes(5, 2), 0.1)
+
+                self.assertNotIn(room, mgr._transfer_records)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The current implementation of KV-transfer metrics can substantially over-estimate transfer speed whenever a transfer overlaps computation. For example, in a setup with Infiniband NDR NICs, KV transfer speed is observed to be well above 100 GB/s while the line rate is only 50 GB/s. This makes diagnostics on KV transfer unreliable.

## Cause
This happens only when KV transfer occurs multiple times on a single request: the recorded byte count spans the whole transfer while the recorded latency covers only the last transfer, resulting in the transfer speed being inflated. Two specific examples:

- **Chunked prefill**: latency is captured only for the *last* chunk, but the byte count covers *all* chunks — a large byte count divided by a small slice of time.
- **Early-send of cached prefix**: when available, the cached prefix KV is sent to the decode side at the very start of the prefill phase. Latency is measured only over the *newly generated* tokens transferred after prefill — pairing a full byte count with a partial latency window.

The fix measures time and bytes **together, on every actual transfer**, so the ratio stays correct no matter how a transfer overlaps computation or splits across chunks.


## Implementation
Common interfaces are introduced in `disaggregation/common/conn.py` with implementations provided for Mooncake.

Inside `transfer_worker`, each KV transfer is recorded into a per-request `_TransferRecord`. On completion, `get_transfer_metric()` pops the record and sources **both** latency and bytes from it.

If no record exists, it falls back to the old index-derived byte count with `None` latency (unchanged behavior for backends that don't record, e.g. NIXL).

Some points to consider:
- **Teardown**: `prefill.py` snapshots the record onto the new `Req.transfer_metric` field before the scheduler's `clear()` drains it.
- **Replica factor**: the measured path sums bytes across destination ranks and does *not* re-apply the factor; the fallback path scales by `get_kv_replica_factor()`. Conflating them would reintroduce the MLA byte over-count.
- **Concurrency**: a single `status_record_lock` guards all sites that touch status and the record together (`_record_transfer`, `update_status`, `clear()`), preventing a late chunk from leaking a stale record into the next request reusing the same `bootstrap_room`.

## Unit tests
```
python -m pytest test/registered/unit/disaggregation/test_kv_transfer_metrics.py
```

## E2E tests
Environments are as follows:
- DeepSeek-V2-Lite used Prefill CP2 and Decode TP2
- Qwen3-8B used TP2 for both Prefill and Decode
- NVIDIA H100 and Infiniband NDR NICs were used

All the values are from prometheus metrics.

Before the patch, transfer speeds show unrealistic values.
After the patch, transfer speeds show reasonable values.

### Chunked prefill
`prompt_tokens` = 8192+1655 (chunked)

Value = KV transfer speed (GiB/s)
| Model | Before patch | After patch |
|---| --- | --- |
| DeepSeek-V2-Lite | 106 | 18.5 |
| Qwen3-8B | 80 | 35 |

### Early-send of cached prefix
`prompt_tokens` = 6554

Value = KV transfer speed (GiB/s)
| Model  | Before patch | After patch |
|---| --- | --- |
| DeepSeek-V2-Lite | 231 | 19.2 |
| Qwen3-8B | 141 | 35 |


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29968160092](https://github.com/sgl-project/sglang/actions/runs/29968160092)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #29968159916](https://github.com/sgl-project/sglang/actions/runs/29968159916)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->