### PR TITLE
ci(amd): route scheduled jobs to MI300 with model cache

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -142,7 +142,7 @@ jobs:
 
   nightly-test-1-gpu-unit-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-test-1-gpu-unit-rocm720,'))
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -172,7 +172,7 @@ jobs:
 
   nightly-test-1-gpu-kernel-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-test-1-gpu-kernel-rocm720,'))
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -237,7 +237,7 @@ jobs:
 
   nightly-accuracy-2-gpu-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-2-gpu-rocm720,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -336,7 +336,7 @@ jobs:
 
   nightly-accuracy-2-gpu-vlm-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-2-gpu-vlm-rocm720,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -367,7 +367,7 @@ jobs:
 
   nightly-perf-2-gpu-text-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-perf-2-gpu-text-rocm720,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -399,7 +399,7 @@ jobs:
 
   nightly-perf-2-gpu-vlm-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-perf-2-gpu-vlm-rocm720,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -431,7 +431,7 @@ jobs:
 
   nightly-4-gpu-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-4-gpu-rocm720,'))
-    runs-on: linux-mi325-4gpu-sglang
+    runs-on: linux-mi300-4gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -467,7 +467,7 @@ jobs:
 
   nightly-accuracy-8-gpu-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-8-gpu-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -546,7 +546,7 @@ jobs:
 
   nightly-8-gpu-grok1-int4-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok1-int4-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -643,7 +643,7 @@ jobs:
 
   nightly-8-gpu-grok2-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok2-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -740,7 +740,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v31-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v31-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -786,7 +786,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v32-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v32-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -830,7 +830,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v32-mtp-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v32-mtp-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -874,7 +874,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v3-kv-fp8-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v3-kv-fp8-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1435,7 +1435,7 @@ jobs:
 
   nightly-8-gpu-kimi-k26-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-kimi-k26-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1508,7 +1508,7 @@ jobs:
 
   nightly-8-gpu-qwen3-235b-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-qwen3-235b-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1580,7 +1580,7 @@ jobs:
 
   nightly-8-gpu-qwen35-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-qwen35-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1712,7 +1712,7 @@ jobs:
 
   nightly-8-gpu-glm51-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-glm51-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1896,7 +1896,7 @@ jobs:
 
   nightly-8-gpu-minimax-m27-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-minimax-m27-rocm720,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1946,7 +1946,7 @@ jobs:
 
   nightly-1-gpu-zimage-turbo-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-1-gpu-zimage-turbo-rocm720,'))
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -138,7 +138,7 @@ jobs:
 
   nightly-test-1-gpu-unit:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-test-1-gpu-unit,'))
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
 
   nightly-test-1-gpu-kernel:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-test-1-gpu-kernel,'))
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -238,7 +238,7 @@ jobs:
 
   nightly-accuracy-2-gpu:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-2-gpu,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -338,7 +338,7 @@ jobs:
 
   nightly-accuracy-2-gpu-vlm:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-2-gpu-vlm,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -370,7 +370,7 @@ jobs:
 
   nightly-perf-2-gpu-text:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-perf-2-gpu-text,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -403,7 +403,7 @@ jobs:
 
   nightly-perf-2-gpu-vlm:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-perf-2-gpu-vlm,'))
-    runs-on: linux-mi325-2gpu-sglang
+    runs-on: linux-mi300-2gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -436,7 +436,7 @@ jobs:
 
   nightly-4-gpu:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-4-gpu,'))
-    runs-on: linux-mi325-4gpu-sglang
+    runs-on: linux-mi300-4gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -472,7 +472,7 @@ jobs:
 
   nightly-accuracy-8-gpu:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-8-gpu,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -551,7 +551,7 @@ jobs:
 
   nightly-8-gpu-grok1-int4:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok1-int4,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -648,7 +648,7 @@ jobs:
 
   nightly-8-gpu-grok2:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok2,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -745,7 +745,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v31:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v31,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -791,7 +791,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v32:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v32,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -835,7 +835,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v32-mtp:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v32-mtp,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -879,7 +879,7 @@ jobs:
 
   nightly-8-gpu-deepseek-v3-kv-fp8:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v3-kv-fp8,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1289,7 +1289,7 @@ jobs:
 
   nightly-8-gpu-kimi-k26:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-kimi-k26,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1362,7 +1362,7 @@ jobs:
 
   nightly-8-gpu-qwen3-235b:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-qwen3-235b,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1434,7 +1434,7 @@ jobs:
 
   nightly-8-gpu-qwen35:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-qwen35,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1566,7 +1566,7 @@ jobs:
 
   nightly-8-gpu-glm51:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-glm51,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1750,7 +1750,7 @@ jobs:
 
   nightly-8-gpu-minimax-m27:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-minimax-m27,'))
-    runs-on: linux-mi325-8gpu-sglang
+    runs-on: linux-mi300-8gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1800,7 +1800,7 @@ jobs:
 
   nightly-1-gpu-zimage-turbo:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-1-gpu-zimage-turbo,'))
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-test-amd-extra.yml
+++ b/.github/workflows/pr-test-amd-extra.yml
@@ -61,6 +61,11 @@ on:
         required: false
         type: string
         default: ''
+      runner_arch:
+        description: 'AMD runner pool to dispatch GPU jobs to'
+        required: false
+        type: string
+        default: mi325
       rocm_version:
         description: 'ROCm container variant (empty = Dockerfile default; rocm720 = ROCm 7.2.0)'
         required: false

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -246,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -292,7 +292,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-2gpu-sglang]
+        runner: [linux-mi300-2gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -333,7 +333,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -371,7 +371,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -409,7 +409,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -448,7 +448,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
         part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
     runs-on: ${{matrix.runner}}
     steps:
@@ -487,7 +487,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
@@ -563,7 +563,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
         part: [0, 1, 2]
     runs-on: ${{matrix.runner}}
     steps:
@@ -602,7 +602,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-2gpu-sglang]
+        runner: [linux-mi300-2gpu-sglang]
         part: [0, 1]
     runs-on: ${{matrix.runner}}
     steps:
@@ -641,7 +641,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-1gpu-sglang]
+        runner: [linux-mi300-1gpu-sglang]
         part: [0, 1, 2, 3]
     runs-on: ${{matrix.runner}}
     steps:
@@ -781,7 +781,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-2gpu-sglang]
+        runner: [linux-mi300-2gpu-sglang]
         part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
     runs-on: ${{matrix.runner}}
     steps:
@@ -920,7 +920,7 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: linux-mi325-1gpu-sglang
+    runs-on: linux-mi300-1gpu-sglang
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -976,7 +976,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-4gpu-sglang]
+        runner: [linux-mi300-4gpu-sglang]
         part: [0]
     runs-on: ${{matrix.runner}}
     steps:
@@ -1030,11 +1030,11 @@ jobs:
         )
       )
     env:
-      RUNNER_LABELS: linux-mi325-8gpu-sglang
+      RUNNER_LABELS: linux-mi300-8gpu-sglang
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux-mi325-8gpu-sglang]
+        runner: [linux-mi300-8gpu-sglang]
         part: [0, 1, 2, 3]
     runs-on: ${{matrix.runner}}
     steps:

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -226,6 +226,7 @@ jobs:
     uses: ./.github/workflows/pr-test-amd-extra.yml
     with:
       ref: ${{ inputs.pr_head_sha || inputs.ref || '' }}
+      runner_arch: mi300
       rocm_version: rocm720
       aiter_ref: ${{ inputs.aiter_ref }}
       continue_on_error: true

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -57,7 +57,8 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Environment:"
       echo "  ENABLE_CACHE_HOST=1|0"
-      echo "      Mount /home/runner/sglang-data to /sgl-data. Defaults to 0."
+      echo "      Mount /home/runner/sglang-data to /sgl-data."
+      echo "      Defaults to 1 for MI300 and MI35x runners, otherwise 0."
       exit 0
       ;;
     *) echo "Unknown option $1"; exit 1;;
@@ -288,7 +289,19 @@ else
 fi
 
 CACHE_HOST=/home/runner/sglang-data
-ENABLE_CACHE_HOST="${ENABLE_CACHE_HOST:-0}"
+if [[ -z "${ENABLE_CACHE_HOST:-}" ]]; then
+  CACHE_RUNNER_NAME="${RUNNER_NAME:-${HOSTNAME_VALUE}}"
+  CACHE_RUNNER_NAME_LOWER="${CACHE_RUNNER_NAME,,}"
+  case "${CACHE_RUNNER_NAME_LOWER}" in
+    *mi300*|*mi35x*)
+      ENABLE_CACHE_HOST="1"
+      echo "Enabling persistent CI data by default for runner: ${CACHE_RUNNER_NAME}"
+      ;;
+    *)
+      ENABLE_CACHE_HOST="0"
+      ;;
+  esac
+fi
 case "${ENABLE_CACHE_HOST,,}" in
   1|true|yes|on|pvc|persistent)
     if [[ ! -d "$CACHE_HOST" ]]; then

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -41,6 +41,11 @@ while [[ $# -gt 0 ]]; do
       shift 2;;
     -h|--help)
       echo "Usage: $0 [--mi30x-base-tag TAG] [--mi35x-base-tag TAG] [--rocm-version VERSION]"
+      echo ""
+      echo "Environment:"
+      echo "  ENABLE_CACHE_HOST=1|0"
+      echo "      Mount /home/runner/sglang-data to /sgl-data."
+      echo "      Defaults to 1 for MI300 and MI35x runners, otherwise 0."
       exit 0
       ;;
     *) echo "Unknown option $1"; exit 1;;
@@ -228,13 +233,39 @@ else
   retry_with_backoff 6 docker pull "${IMAGE}"
 fi
 
-# CACHE_HOST=/home/runner/sgl-data
-CACHE_HOST=/home/runner/temp-sglang-data
-if [[ -d "$CACHE_HOST" ]]; then
-    CACHE_VOLUME="-v $CACHE_HOST:/sgl-data"
-else
-    CACHE_VOLUME=""
+CACHE_HOST=/home/runner/sglang-data
+if [[ -z "${ENABLE_CACHE_HOST:-}" ]]; then
+  CACHE_RUNNER_NAME="${RUNNER_NAME:-${HOSTNAME_VALUE}}"
+  CACHE_RUNNER_NAME_LOWER="${CACHE_RUNNER_NAME,,}"
+  case "${CACHE_RUNNER_NAME_LOWER}" in
+    *mi300*|*mi35x*)
+      ENABLE_CACHE_HOST="1"
+      echo "Enabling persistent CI data by default for runner: ${CACHE_RUNNER_NAME}"
+      ;;
+    *)
+      ENABLE_CACHE_HOST="0"
+      ;;
+  esac
 fi
+case "${ENABLE_CACHE_HOST,,}" in
+  1|true|yes|on|pvc|persistent)
+    if [[ ! -d "$CACHE_HOST" ]]; then
+      echo "Error: ENABLE_CACHE_HOST=1 but ${CACHE_HOST} does not exist." >&2
+      exit 1
+    fi
+    CACHE_VOLUME="-v $CACHE_HOST:/sgl-data"
+    echo "Mounting persistent CI data: ${CACHE_HOST} -> /sgl-data"
+    ;;
+  0|false|no|off|"")
+    CACHE_VOLUME=""
+    echo "Not mounting ${CACHE_HOST}; /sgl-data will be container-local."
+    ;;
+  *)
+    echo "Error: unsupported ENABLE_CACHE_HOST='${ENABLE_CACHE_HOST}'" >&2
+    echo "Use 1/true/pvc/persistent or 0/false/off." >&2
+    exit 1
+    ;;
+esac
 
 # Detect libionic library for RDMA support
 LIBIONIC_MOUNT=""
@@ -324,6 +355,12 @@ docker run -dt --user root \
   -w /sglang-checkout \
   --name ci_sglang \
   "${IMAGE}"
+
+docker exec ci_sglang mkdir -p \
+  /sgl-data/hf-cache/hub \
+  /sgl-data/pip-cache \
+  /sgl-data/miopen-cache \
+  /sgl-data/aiter-kernels
 
 # The checkout is owned by the runner (non-root) but the container runs as
 # root.  Git >= 2.35.2 rejects cross-user repos; mark the mount as safe so


### PR DESCRIPTION
## Motivation

The MI30x jobs in three scheduled AMD workflows still target MI325 runner pools. After routing them to MI300, both shared container launchers also need to mount the persistent model cache automatically; otherwise jobs without an explicit `ENABLE_CACHE_HOST=1` use a container-local `/sgl-data`.

## Modifications

- Replace all 55 `linux-mi325-{1,2,4,8}gpu-sglang` references with the matching `linux-mi300-{1,2,4,8}gpu-sglang` labels in:
  - `nightly-test-amd.yml`
  - `nightly-test-amd-rocm720.yml`
  - `pr-test-amd-rocm720.yml`
- In `amd_ci_start_container.sh`, default `ENABLE_CACHE_HOST` to `1` when the case-insensitive runner identity contains `mi300` or `mi35x`, mounting `/home/runner/sglang-data` at `/sgl-data` for the Hugging Face model cache.
- Apply the same cache-selection behavior to `amd_ci_start_container_disagg.sh`, replacing its temporary cache path and initializing the HF, pip, MIOpen, and AITER cache directories after launch.
- Pass `runner_arch: mi300` from the ROCm 7.2 scheduled workflow into its reusable extra suite, so its three transitive GPU jobs do not fall back to MI325. Other callers retain the existing MI325 default.
- Preserve explicit `ENABLE_CACHE_HOST=0/1` overrides and keep the default disabled for other runner families, including MI325.
- Leave MI35x job routing, job filters, schedules, test commands, and disaggregation/RDMA settings unchanged.

## Testing

- `pre-commit run check-yaml --files .github/workflows/nightly-test-amd-rocm720.yml .github/workflows/nightly-test-amd.yml .github/workflows/pr-test-amd-rocm720.yml`
- Commit-time pre-commit hooks, including duplicate workflow job-name validation
- `bash -n scripts/ci/amd/amd_ci_start_container.sh`
- `bash -n scripts/ci/amd/amd_ci_start_container_disagg.sh`
- Verified the regular and disaggregated launchers use an identical cache-selection block and initialize the same cache directories.
- Verified the ROCm 7.2 reusable extra-suite call exposes and receives `runner_arch: mi300`; pre-commit workflow validation passes.
- Extracted launcher-default checks: MI300 -> on, MI35x -> on, MI325 -> off, hostname fallback -> on, explicit `0/1` overrides preserved
- Baseline runner-routing run passed and confirmed the old behavior was container-local: https://github.com/sgl-project/sglang/actions/runs/29889615566
- Cache-enabled run passed on the regular launcher: https://github.com/sgl-project/sglang/actions/runs/29890835966
  - Runner label: `linux-mi300-1gpu-sglang`
  - Mounted `/home/runner/sglang-data -> /sgl-data`
  - Reused local Hugging Face snapshots from `/sgl-data/hf-cache`
  - Test summary: 10/10 passed
- MI300-only targeted workflow runs:
  - Nightly ROCm 7.2 (20 MI300 jobs): https://github.com/sgl-project/sglang/actions/runs/29898225714
  - Nightly AMD (20 MI300 jobs): https://github.com/sgl-project/sglang/actions/runs/29898248327
  - PR ROCm 7.2 (14 MI300 stages): https://github.com/sgl-project/sglang/actions/runs/29898274929
  - Live job inspection confirms every MI35x job is skipped with no runner assigned; only MI300 GPU jobs are running or queued.

## Accuracy Tests

Not applicable; this PR only changes CI runner routing and cache mounting.

## Speed Tests and Profiling

Not applicable; this PR only changes CI runner routing and cache mounting.

## Checklist

- [x] Format and static checks pass with pre-commit.
- [x] No documentation changes are required for this CI-only update.
- [x] Focused cache-enabled CI run completes successfully.
