### PR TITLE
[Perf] Support ragged verify graphs in the DSA attention backend

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa_metadata.py
+++ b/python/sglang/kernels/ops/attention/dsa_metadata.py
@@ -432,6 +432,7 @@ def _fused_dsa_draft_extend_metadata_kernel(
     dsa_cache_seqlens,
     dsa_cu_seqlens_k,
     real_page_table,
+    qo_indptr,
     seq_lens_stride: tl.constexpr,
     extend_seq_lens_stride: tl.constexpr,
     req_pool_indices_stride: tl.constexpr,
@@ -449,6 +450,7 @@ def _fused_dsa_draft_extend_metadata_kernel(
     HAS_REAL_PAGE_TABLE: tl.constexpr,
     HAS_PAGE_TABLE_1: tl.constexpr,
     STATIC_EXTEND_LEN: tl.constexpr,
+    HAS_QO_INDPTR: tl.constexpr,
     BLOCK_BS: tl.constexpr,
     BLOCK_EXPANDED: tl.constexpr,
     BLOCK_ROWS: tl.constexpr,
@@ -474,6 +476,7 @@ def _fused_dsa_draft_extend_metadata_kernel(
             req_row = offs_e // static_qo_len
             local_off = offs_e - req_row * static_qo_len
             qo_len_for_row = tl.zeros((BLOCK_EXPANDED,), tl.int32) + static_qo_len
+            covered = mask_e
         else:
             req_row = tl.full((BLOCK_EXPANDED,), 0, tl.int32)
             local_off = tl.full((BLOCK_EXPANDED,), 0, tl.int32)
@@ -490,6 +493,12 @@ def _fused_dsa_draft_extend_metadata_kernel(
                 qo_len_for_row = tl.where(in_row, qo_len, qo_len_for_row)
                 prefix += qo_len
 
+            # Rows past sum(extend_seq_lens) belong to no request: a capped
+            # ragged verify layout leaves the tier's tail slack unclaimed rather
+            # than widening a row past the compiled BLOCK_ROWS. Treat them like
+            # the padded rows below -- length 0 keeps them on the trivial path.
+            covered = mask_e & (offs_e < prefix)
+
         base_seq = tl.load(
             seq_lens + req_row * seq_lens_stride,
             mask=mask_e,
@@ -503,7 +512,7 @@ def _fused_dsa_draft_extend_metadata_kernel(
         # access. 0 keeps padded rows on the trivial all-(-1) output path.
         expanded_seq = base_seq - qo_len_for_row + local_off + 1
         expanded_seq = tl.maximum(expanded_seq, 0)
-        expanded_seq = tl.where(mask_e, expanded_seq, 0)
+        expanded_seq = tl.where(covered, expanded_seq, 0)
         dsa_seq = tl.minimum(expanded_seq, dsa_index_topk)
         dsa_cu = tl.cumsum(dsa_seq, 0)
 
@@ -535,6 +544,10 @@ def _fused_dsa_draft_extend_metadata_kernel(
         return
     if STATIC_EXTEND_LEN:
         prefix = req_row * qo_len
+    elif HAS_QO_INDPTR:
+        # Staged row offsets: without them every one of the bs * num_col_blocks
+        # page programs re-walks the whole extend_seq_lens prefix (O(bs) each).
+        prefix = tl.load(qo_indptr + req_row, mask=req_row < bs, other=0).to(tl.int32)
     else:
         prefix = tl.full((), 0, tl.int32)
         for i in tl.range(0, bs):
@@ -602,7 +615,12 @@ def fused_dsa_draft_extend_metadata(
     max_extend_len: int,
     max_total_len: int,
     static_extend_len: bool = False,
+    qo_indptr: Optional[torch.Tensor] = None,
 ) -> None:
+    """`qo_indptr` (bs + 1 row offsets) is an optional fast path for the ragged
+    (`static_extend_len=False`) case: supply it to skip the per-program prefix
+    walk over extend_seq_lens. Rows past qo_indptr[bs] are emitted with length 0.
+    """
     assert seq_lens.is_cuda
     assert extend_seq_lens.is_cuda
     assert req_pool_indices.is_cuda
@@ -648,6 +666,13 @@ def fused_dsa_draft_extend_metadata(
     else:
         assert page_table_1.is_cuda
 
+    has_qo_indptr = qo_indptr is not None
+    if has_qo_indptr:
+        assert qo_indptr.is_cuda
+        assert qo_indptr.numel() >= bs + 1, f"{qo_indptr.numel()=} < {bs + 1=}"
+    else:
+        qo_indptr = extend_seq_lens  # dummy pointer, never dereferenced
+
     block_bs = triton.next_power_of_2(bs)
     block_expanded = triton.next_power_of_2(max_total_len)
     block_rows = triton.next_power_of_2(max_extend_len)
@@ -667,6 +692,7 @@ def fused_dsa_draft_extend_metadata(
         dsa_cache_seqlens,
         dsa_cu_seqlens_k,
         real_page_table,
+        qo_indptr,
         seq_lens.stride(0),
         extend_seq_lens.stride(0),
         req_pool_indices.stride(0),
@@ -684,6 +710,7 @@ def fused_dsa_draft_extend_metadata(
         has_real_page_table,
         has_page_table_1,
         static_extend_len,
+        has_qo_indptr,
         BLOCK_BS=block_bs,
         BLOCK_EXPANDED=block_expanded,
         BLOCK_ROWS=block_rows,

--- a/python/sglang/kernels/ops/speculative/ragged_verify_kernels.py
+++ b/python/sglang/kernels/ops/speculative/ragged_verify_kernels.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import msgspec
 import torch
 import triton
@@ -15,6 +17,7 @@ class PaddedToBucket:
         graph_num_tokens: int,
         bs: int,
         padded_bs: int,
+        max_row_len: Optional[int] = None,
     ) -> torch.Tensor:
         impl = cls.triton if verify_lens.is_cuda else cls.torch
         return impl(
@@ -22,6 +25,7 @@ class PaddedToBucket:
             graph_num_tokens=graph_num_tokens,
             bs=bs,
             padded_bs=padded_bs,
+            max_row_len=max_row_len,
         )
 
     @classmethod
@@ -32,12 +36,14 @@ class PaddedToBucket:
         graph_num_tokens: int,
         bs: int,
         padded_bs: int,
+        max_row_len: Optional[int] = None,
     ) -> torch.Tensor:
         return pad_verify_lens_to_bucket(
             verify_lens=verify_lens,
             graph_num_tokens=graph_num_tokens,
             bs=bs,
             padded_bs=padded_bs,
+            max_row_len=max_row_len,
         )
 
     @classmethod
@@ -48,12 +54,14 @@ class PaddedToBucket:
         graph_num_tokens: int,
         bs: int,
         padded_bs: int,
+        max_row_len: Optional[int] = None,
     ) -> torch.Tensor:
         return pad_verify_lens_to_bucket_triton(
             verify_lens=verify_lens,
             graph_num_tokens=graph_num_tokens,
             bs=bs,
             padded_bs=padded_bs,
+            max_row_len=max_row_len,
         )
 
 
@@ -63,7 +71,18 @@ def pad_verify_lens_to_bucket(
     graph_num_tokens: int,
     bs: int,
     padded_bs: int,
+    max_row_len: Optional[int] = None,
 ) -> torch.Tensor:
+    """Grow the batch's verify lens to the captured tier's `padded_bs` slots.
+
+    `max_row_len` caps every padding row at that width and never touches a real
+    request's width. Any slack that does not fit stays UNCOVERED (row-sum <
+    graph_num_tokens): consumers that key metadata off a fixed per-request width
+    need this bound, and leaving tail rows unclaimed is cheaper than admitting a
+    row wider than the width their kernels were compiled for. Without it (the
+    legacy behaviour) all slack is absorbed -- padding rows first, then the last
+    real request -- so the row-sum always equals graph_num_tokens.
+    """
     assert padded_bs >= bs, (
         f"padded_bs {padded_bs} < bs {bs}: the captured tier cannot hold this "
         "batch's requests"
@@ -78,10 +97,16 @@ def pad_verify_lens_to_bucket(
         pad_block = base + (
             torch.arange(num_pad_reqs, device=device, dtype=torch.int64) < rem
         )
+        if max_row_len is not None:
+            pad_block = pad_block.clamp(max=max_row_len)
         padded = torch.cat([padded, pad_block.to(torch.int32)])
-    else:
+    elif max_row_len is None:
         padded = padded.clone()
         padded[-1] = (padded[-1].to(torch.int64) + leftover).to(torch.int32)
+    else:
+        # No padding row to absorb the slack, and inflating the last real
+        # request past max_row_len is exactly what the cap forbids.
+        padded = padded.clone()
     return padded
 
 
@@ -92,6 +117,8 @@ def _padded_to_bucket_kernel(
     bs,
     padded_bs,
     graph_num_tokens,
+    max_row_len,
+    HAS_MAX_ROW_LEN: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     idx = tl.arange(0, BLOCK)
@@ -104,8 +131,14 @@ def _padded_to_bucket_kernel(
     base = leftover // num_pad_safe
     rem = leftover - base * num_pad_safe
     pad_len = base + tl.where((idx - bs) < rem, 1, 0)
-    final = tl.where(is_real, vl, pad_len)
-    final = final + tl.where((num_pad == 0) & (idx == bs - 1), leftover, 0)
+    if HAS_MAX_ROW_LEN:
+        # Cap padding rows and leave any residual slack uncovered; see
+        # pad_verify_lens_to_bucket for why real rows are never inflated.
+        pad_len = tl.minimum(pad_len, max_row_len)
+        final = tl.where(is_real, vl, pad_len)
+    else:
+        final = tl.where(is_real, vl, pad_len)
+        final = final + tl.where((num_pad == 0) & (idx == bs - 1), leftover, 0)
     tl.store(out_ptr + idx, final.to(tl.int32), mask=valid)
 
 
@@ -115,6 +148,7 @@ def pad_verify_lens_to_bucket_triton(
     graph_num_tokens: int,
     bs: int,
     padded_bs: int,
+    max_row_len: Optional[int] = None,
 ) -> torch.Tensor:
     assert padded_bs >= bs, (
         f"padded_bs {padded_bs} < bs {bs}: the captured tier cannot hold this "
@@ -130,6 +164,8 @@ def pad_verify_lens_to_bucket_triton(
         bs,
         padded_bs,
         graph_num_tokens,
+        max_row_len if max_row_len is not None else 0,
+        HAS_MAX_ROW_LEN=max_row_len is not None,
         BLOCK=BLOCK,
     )
     return out

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -61,12 +61,10 @@ from sglang.srt.speculative.dspark_components.kernels.dspark_attn_metadata impor
 )
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.speculative.ragged_verify import (
-    RaggedVerifyMode,
     compute_ragged_extend_lengths,
     compute_target_verify_graph_key,
     compute_uniform_extend_lengths,
-    read_ragged_verify_mode,
-    resolve_ragged_verify_layout,
+    resolve_compact_verify_layout,
 )
 from sglang.srt.utils import ceil_align, is_cuda, is_xpu
 from sglang.srt.utils.common import is_sm120_supported
@@ -578,26 +576,19 @@ class DeepseekV4AttnBackend(
         forward_batch: ForwardBatch,
         bs: int,
     ) -> Optional[RaggedVerifyLayout]:
-        layout = resolve_ragged_verify_layout(forward_batch)
+        layout = resolve_compact_verify_layout(
+            getattr(forward_batch, "spec_info", None),
+            padded_bs=None,
+            backend_name="DSV4",
+        )
         if layout is None:
             return None
-        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
-            return None
-        if get_parallel().attn_cp_size > 1:
-            raise NotImplementedError(
-                "DSV4 ragged verify does not support context parallel (CP); "
-                "set SGLANG_RAGGED_VERIFY_MODE off for CP runs."
-            )
         if self.online_c128_mtp.enabled():
             raise NotImplementedError(
                 "DSV4 ragged verify does not support online c128 MTP; "
                 "set SGLANG_RAGGED_VERIFY_MODE off or disable online compress."
             )
-        # Layout invariants (verify_lens >= 1, total == sum) are enforced in
-        # RaggedVerifyLayout.__post_init__; don't re-check the device tensor
-        # here -- that would D2H-sync the host-free verify prep path.
-        layout = layout.padded_to_bucket(padded_bs=bs)
-        return layout
+        return layout.padded_to_bucket(padded_bs=bs)
 
     def _target_verify_graph_key(
         self,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -817,9 +817,8 @@ class DeepseekSparseAttnBackend(
                 # one-time host-driven build, a D2H sync is fine here.
                 verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
             capture_extend_lens = [int(v) for v in verify_lens_cpu]
-            # Stage the capture lens so the warmup execution of the
-            # graph-recorded prep (init_forward_metadata_in_graph) sees
-            # non-zero lengths.
+            # Stage the capture lens so the warmup run of the graph-recorded
+            # prep sees non-zero lengths.
             self._ragged_verify_lens_buf[: len(capture_extend_lens)].copy_(
                 verify_layout.verify_lens
             )
@@ -1652,12 +1651,9 @@ class DeepseekSparseAttnBackend(
                     metadata.cu_seqlens_k[1:].copy_(
                         torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
                     )
-                    # Sync-free ragged expansion: map each expanded row to its
-                    # request by searchsorted over the device qo_indptr. The
-                    # padded layout covers the full tier (padding rows absorb
-                    # the slack tokens), so every row maps to a real or padded
-                    # request; padded rows' outputs are discarded by the
-                    # runner's output slice.
+                    # Sync-free row->request map via searchsorted over the
+                    # device qo_indptr; padding rows cover the tier's slack and
+                    # their outputs are discarded by the runner's output slice.
                     qo_indptr = verify_layout.qo_indptr_device
                     row_ids = torch.arange(
                         total_rows, dtype=qo_indptr.dtype, device=self.device
@@ -1694,9 +1690,8 @@ class DeepseekSparseAttnBackend(
                     )
                     metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
 
-                    # Fill the constant per-req qo lengths on-device;
-                    # torch.tensor(list, device=cuda) does a pageable H2D copy
-                    # that blocks the host.
+                    # Fill on-device: torch.tensor(list, device=cuda) is a
+                    # blocking pageable H2D copy.
                     extend_seq_lens = torch.full(
                         (bs,),
                         self.speculative_num_draft_tokens,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -67,6 +67,7 @@ from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
     compute_target_verify_graph_key,
     read_ragged_verify_mode,
+    resolve_compact_verify_layout,
 )
 from sglang.srt.utils import (
     get_bool_env_var,
@@ -344,11 +345,9 @@ class DeepseekSparseAttnBackend(
     # (page-table width) and never reads seq_lens_cpu / seq_lens_sum; opt out of
     # the D2H sync. The eager fallback derives lengths from GPU seq_lens.
     needs_cpu_seq_lens: bool = False
-    # Target-verify metadata is built per expanded token row (cu_seqlens_q is a
-    # unit arange, seqlens are expanded per request), so a ragged layout only
-    # changes the expanded row count. The SM100 DG-native [bs, next_n] paged-MQA
-    # schedule is the one uniform-width construct; it is bypassed (per-token
-    # schedule) when a ragged layout is present.
+    # Target-verify metadata is per expanded token row, so a ragged layout only
+    # changes the row count; the sole uniform-width construct (SM100 DG-native
+    # [bs, next_n] schedule) is bypassed when a ragged layout is present.
     supports_ragged_verify_graph: bool = True
 
     def __init__(
@@ -660,8 +659,7 @@ class DeepseekSparseAttnBackend(
     ) -> torch.Tensor:
         # target_verify with next_n>=2 uses DG-native q=[B,next_n,H,D] which
         # needs a [B, next_n] schedule; everything else stays per-token.
-        # A ragged verify layout has no uniform per-request width, so it always
-        # takes the per-token schedule.
+        # A ragged layout has no uniform width, so it also stays per-token.
         # TODO: SM90 supports DG-native next_n in {1,2} too — enable once
         # validated; for now DG-native is SM100+ only.
         next_n = self.speculative_num_draft_tokens
@@ -755,33 +753,6 @@ class DeepseekSparseAttnBackend(
         )
         return page_table[:, strided_indices] // page_size
 
-    def _resolve_verify_layout(
-        self,
-        spec_info,
-        bs: int,
-        pad_to_slots: bool = True,
-    ) -> Optional[RaggedVerifyLayout]:
-        layout = getattr(spec_info, "ragged_verify_layout", None)
-        if layout is None:
-            return None
-        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
-            return None
-        if get_parallel().attn_cp_size > 1:
-            raise NotImplementedError(
-                "DSA ragged verify does not support context parallel (CP); "
-                "set SGLANG_RAGGED_VERIFY_MODE off for CP runs."
-            )
-        if not pad_to_slots:
-            # Eager forward: the batch carries exactly the real verify tokens,
-            # so the raw layout is the geometry (padding would add rows beyond
-            # the batch's q tokens).
-            return layout
-        # Graph capture/replay: pad to the captured slot count. The padded
-        # layout absorbs the tier's slack tokens into the padding rows
-        # (total == graph_num_tokens), so the whole tier stays covered and
-        # every metadata build below is sync-free.
-        return layout.padded_to_bucket(padded_bs=bs)
-
     def _target_verify_graph_key(
         self,
         bs: int,
@@ -821,8 +792,8 @@ class DeepseekSparseAttnBackend(
 
         if forward_batch.forward_mode.is_target_verify():
             draft_token_num = self.speculative_num_draft_tokens
-            verify_layout = self._resolve_verify_layout(
-                forward_batch.spec_info, batch_size, pad_to_slots=False
+            verify_layout = resolve_compact_verify_layout(
+                forward_batch.spec_info, padded_bs=None, backend_name="DSA"
             )
         else:
             draft_token_num = 0
@@ -1520,7 +1491,9 @@ class DeepseekSparseAttnBackend(
         """
         verify_layout = None
         if forward_mode.is_target_verify():
-            verify_layout = self._resolve_verify_layout(spec_info, bs)
+            verify_layout = resolve_compact_verify_layout(
+                spec_info, padded_bs=bs, backend_name="DSA"
+            )
         graph_key = self._target_verify_graph_key(bs, verify_layout)
 
         if graph_key not in self.decode_cuda_graph_metadata:
@@ -1596,10 +1569,8 @@ class DeepseekSparseAttnBackend(
             max_seqlen_k = self._graph_page_table_width(metadata)
 
             if verify_layout is not None and is_cuda() and not _is_hip:
-                # The whole ragged prep chain (fused metadata kernel,
-                # paged-MQA schedule, top-k plan) is recorded INSIDE the
-                # verify graph (init_forward_metadata_in_graph); replay only
-                # stages the per-step verify lens.
+                # The ragged prep chain is recorded inside the verify graph
+                # (init_forward_metadata_in_graph); replay only stages the lens.
                 self._ragged_verify_lens_buf[:bs].copy_(verify_layout.verify_lens)
                 total_rows = int(verify_layout.graph_num_tokens)
                 cache_seqlens = metadata.cache_seqlens_int32

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1583,8 +1583,46 @@ class DeepseekSparseAttnBackend(
         elif forward_mode.is_target_verify():
             max_seqlen_k = self._graph_page_table_width(metadata)
 
-            # The fused metadata kernel assumes a uniform per-request width
-            # (next_n); ragged layouts take the layout-driven build below.
+            if verify_layout is not None and is_cuda() and not _is_hip:
+                from sglang.kernels.ops.attention.dsa_metadata import (
+                    fused_dsa_draft_extend_metadata,
+                )
+
+                # The ragged draft-extend fused kernel is the exact geometry
+                # needed here: per-request extend lengths (verify_lens),
+                # row->request mapping, expanded/dsa seqlens + cumsums, and
+                # the page-table expansion in one launch. Base lengths are
+                # seq + verify_len.
+                total_rows = int(verify_layout.graph_num_tokens)
+                fused_dsa_draft_extend_metadata(
+                    seq_lens=seq_lens + verify_layout.verify_lens,
+                    extend_seq_lens=verify_layout.verify_lens,
+                    req_pool_indices=req_pool_indices,
+                    req_to_token=self.req_to_token,
+                    cache_seqlens=metadata.cache_seqlens_int32,
+                    cu_seqlens_k=metadata.cu_seqlens_k,
+                    page_table_1=metadata.page_table_1,
+                    seqlens_expanded=metadata.dsa_seqlens_expanded,
+                    dsa_cache_seqlens=metadata.dsa_cache_seqlens_int32,
+                    dsa_cu_seqlens_k=metadata.dsa_cu_seqlens_k,
+                    real_page_table=metadata.real_page_table,
+                    bs=bs,
+                    total_len=total_rows,
+                    max_seqlen_k=max_seqlen_k,
+                    dsa_index_topk=self.dsa_index_topk,
+                    real_page_size=self.real_page_size,
+                    max_extend_len=self.speculative_num_draft_tokens,
+                    max_total_len=total_rows,
+                    static_extend_len=False,
+                )
+                cache_seqlens = metadata.cache_seqlens_int32
+                seqlens_expanded = metadata.dsa_seqlens_expanded[:total_rows]
+                dsa_cache_seqlens = metadata.dsa_cache_seqlens_int32[:total_rows]
+                page_indices = None
+                used_fused_metadata_generation = True
+
+            # The uniform fused metadata kernel assumes a fixed per-request
+            # width (next_n); non-CUDA ragged falls to the torch build below.
             if verify_layout is None and is_cuda() and not _is_hip:
                 from sglang.kernels.ops.attention.dsa_metadata import (
                     fused_dsa_target_verify_metadata,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1253,6 +1253,11 @@ class DeepseekSparseAttnBackend(
             and self.dsa_index_topk <= 2048
         )
 
+        # Staged per-step verify lens for the graph-recorded ragged verify
+        # prep (init_forward_metadata_in_graph).
+        self._ragged_verify_lens_buf = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
+        )
         max_ctx_len = self.req_to_token.shape[1]
         self.decode_cuda_graph_metadata: Dict = {
             "cache_seqlens": torch.ones(
@@ -1366,6 +1371,12 @@ class DeepseekSparseAttnBackend(
                     # one-time host-driven build, a D2H sync is fine here.
                     verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
                 capture_extend_lens = [int(v) for v in verify_lens_cpu]
+                # Stage the capture lens so the warmup execution of the
+                # graph-recorded prep (init_forward_metadata_in_graph) sees
+                # non-zero lengths.
+                self._ragged_verify_lens_buf[: len(capture_extend_lens)].copy_(
+                    verify_layout.verify_lens
+                )
                 cache_seqlens_int32 = (seq_lens + verify_layout.verify_lens).to(
                     torch.int32
                 )
@@ -1537,6 +1548,7 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata = self.decode_cuda_graph_metadata[graph_key]
         used_fused_metadata_generation = False
         target_verify_ctx_lens_written = False
+        prep_recorded_in_graph = False
         if forward_mode.is_decode_or_idle():
             # Normal Decode
             max_len = self._graph_page_table_width(metadata)
@@ -1584,42 +1596,18 @@ class DeepseekSparseAttnBackend(
             max_seqlen_k = self._graph_page_table_width(metadata)
 
             if verify_layout is not None and is_cuda() and not _is_hip:
-                from sglang.kernels.ops.attention.dsa_metadata import (
-                    fused_dsa_draft_extend_metadata,
-                )
-
-                # The ragged draft-extend fused kernel is the exact geometry
-                # needed here: per-request extend lengths (verify_lens),
-                # row->request mapping, expanded/dsa seqlens + cumsums, and
-                # the page-table expansion in one launch. Base lengths are
-                # seq + verify_len.
+                # The whole ragged prep chain (fused metadata kernel,
+                # paged-MQA schedule, top-k plan) is recorded INSIDE the
+                # verify graph (init_forward_metadata_in_graph); replay only
+                # stages the per-step verify lens.
+                self._ragged_verify_lens_buf[:bs].copy_(verify_layout.verify_lens)
                 total_rows = int(verify_layout.graph_num_tokens)
-                fused_dsa_draft_extend_metadata(
-                    seq_lens=seq_lens + verify_layout.verify_lens,
-                    extend_seq_lens=verify_layout.verify_lens,
-                    req_pool_indices=req_pool_indices,
-                    req_to_token=self.req_to_token,
-                    cache_seqlens=metadata.cache_seqlens_int32,
-                    cu_seqlens_k=metadata.cu_seqlens_k,
-                    page_table_1=metadata.page_table_1,
-                    seqlens_expanded=metadata.dsa_seqlens_expanded,
-                    dsa_cache_seqlens=metadata.dsa_cache_seqlens_int32,
-                    dsa_cu_seqlens_k=metadata.dsa_cu_seqlens_k,
-                    real_page_table=metadata.real_page_table,
-                    bs=bs,
-                    total_len=total_rows,
-                    max_seqlen_k=max_seqlen_k,
-                    dsa_index_topk=self.dsa_index_topk,
-                    real_page_size=self.real_page_size,
-                    max_extend_len=self.speculative_num_draft_tokens,
-                    max_total_len=total_rows,
-                    static_extend_len=False,
-                )
                 cache_seqlens = metadata.cache_seqlens_int32
                 seqlens_expanded = metadata.dsa_seqlens_expanded[:total_rows]
                 dsa_cache_seqlens = metadata.dsa_cache_seqlens_int32[:total_rows]
                 page_indices = None
                 used_fused_metadata_generation = True
+                prep_recorded_in_graph = True
 
             # The uniform fused metadata kernel assumes a fixed per-request
             # width (next_n); non-CUDA ragged falls to the torch build below.
@@ -1819,11 +1807,17 @@ class DeepseekSparseAttnBackend(
                 )
                 metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
 
-        # Update DeepGEMM paged MQA schedule metadata outside the captured graph.
-        if is_cuda() and (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend_v2()
+        # Update DeepGEMM paged MQA schedule metadata outside the captured
+        # graph -- except for the ragged verify path, whose whole prep chain
+        # (schedule included) is recorded in-graph.
+        if (
+            not prep_recorded_in_graph
+            and is_cuda()
+            and (
+                forward_mode.is_decode_or_idle()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend_v2()
+            )
         ):
             if forward_mode.is_draft_extend_v2():
                 schedule_seqlens_expanded = metadata.dsa_seqlens_expanded
@@ -1882,6 +1876,57 @@ class DeepseekSparseAttnBackend(
             )
 
         self.forward_metadata = metadata
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Graph-recorded ragged verify prep: re-derives all target-verify
+        metadata inside the captured graph from the staged verify lens and
+        the runner's static seq_lens/req_pool_indices buffers, so replay-side
+        prep reduces to one staging copy (_apply_cuda_graph_metadata)."""
+        if not forward_batch.forward_mode.is_target_verify():
+            return
+        if not is_cuda() or _is_hip:
+            return
+        layout = getattr(forward_batch.spec_info, "ragged_verify_layout", None)
+        if layout is None:
+            return
+        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
+            return
+        from sglang.kernels.ops.attention.dsa_metadata import (
+            fused_dsa_draft_extend_metadata,
+        )
+
+        metadata = self.forward_metadata
+        bs = int(forward_batch.batch_size)
+        total_rows = int(layout.graph_num_tokens)
+        verify_lens = self._ragged_verify_lens_buf[:bs]
+        max_seqlen_k = self._graph_page_table_width(metadata)
+        seq_lens = forward_batch.seq_lens[:bs]
+        fused_dsa_draft_extend_metadata(
+            seq_lens=seq_lens + verify_lens,
+            extend_seq_lens=verify_lens,
+            req_pool_indices=forward_batch.req_pool_indices[:bs],
+            req_to_token=self.req_to_token,
+            cache_seqlens=metadata.cache_seqlens_int32,
+            cu_seqlens_k=metadata.cu_seqlens_k,
+            page_table_1=metadata.page_table_1,
+            seqlens_expanded=metadata.dsa_seqlens_expanded,
+            dsa_cache_seqlens=metadata.dsa_cache_seqlens_int32,
+            dsa_cu_seqlens_k=metadata.dsa_cu_seqlens_k,
+            real_page_table=metadata.real_page_table,
+            bs=bs,
+            total_len=total_rows,
+            max_seqlen_k=max_seqlen_k,
+            dsa_index_topk=self.dsa_index_topk,
+            real_page_size=self.real_page_size,
+            max_extend_len=self.speculative_num_draft_tokens,
+            max_total_len=total_rows,
+            static_extend_len=False,
+        )
+        ctx_lens_2d = metadata.dsa_seqlens_expanded[:total_rows].view(-1, 1)
+        if metadata.paged_mqa_ctx_lens_2d is not None:
+            metadata.paged_mqa_ctx_lens_2d.copy_(ctx_lens_2d)
+        self._refresh_paged_mqa_schedule_metadata(metadata, ctx_lens_2d)
+        self._refresh_topk_v2_plan(metadata)
 
     def init_forward_metadata_replay_cuda_graph_from_precomputed(
         self,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -766,6 +766,73 @@ class DeepseekSparseAttnBackend(
             ragged_layout=ragged_layout,
         )
 
+    def _target_verify_eager_geometry(
+        self,
+        verify_layout: Optional[RaggedVerifyLayout],
+        batch_size: int,
+        cache_seqlens_int32: torch.Tensor,
+        page_table: torch.Tensor,
+        device,
+    ):
+        """Eager target-verify q geometry (extend_seq_lens_cpu, cu_seqlens_q,
+        seqlens_expanded, expanded page_table). The uniform path is the
+        verify_lens == next_n special case of the ragged one."""
+        if verify_layout is not None:
+            verify_lens_cpu = verify_layout.verify_lens_cpu
+            if verify_lens_cpu is None:
+                # Eager target-verify only runs off the graph path (e.g.
+                # over-capture-bs); a one-off host sync is acceptable here.
+                verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
+            extend_seq_lens_cpu = [int(v) for v in verify_lens_cpu]
+            verify_lens = verify_layout.verify_lens
+            max_extend_len = max(extend_seq_lens_cpu)
+        else:
+            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
+            verify_lens = torch.tensor(
+                extend_seq_lens_cpu, dtype=torch.int32, device=device
+            )
+            max_extend_len = self.speculative_num_draft_tokens
+        total_q = int(sum(extend_seq_lens_cpu))
+        cu_seqlens_q = torch.arange(0, total_q + 1, 1, dtype=torch.int32, device=device)
+        seqlens_expanded = seqlens_expand_triton(
+            verify_lens, cache_seqlens_int32, total_q, max_extend_len
+        )
+        page_table = torch.repeat_interleave(
+            page_table, repeats=verify_lens, dim=0, output_size=total_q
+        )
+        return extend_seq_lens_cpu, cu_seqlens_q, seqlens_expanded, page_table
+
+    def _capture_verify_widths(
+        self,
+        verify_layout: Optional[RaggedVerifyLayout],
+        bs: int,
+        seq_lens: torch.Tensor,
+    ):
+        """Per-request verify widths for graph capture: (capture_extend_lens,
+        cache_seqlens_int32, real_rows)."""
+        if verify_layout is not None:
+            verify_lens_cpu = verify_layout.verify_lens_cpu
+            if verify_lens_cpu is None:
+                # padded_to_bucket drops host mirrors; capture is a
+                # one-time host-driven build, a D2H sync is fine here.
+                verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
+            capture_extend_lens = [int(v) for v in verify_lens_cpu]
+            # Stage the capture lens so the warmup execution of the
+            # graph-recorded prep (init_forward_metadata_in_graph) sees
+            # non-zero lengths.
+            self._ragged_verify_lens_buf[: len(capture_extend_lens)].copy_(
+                verify_layout.verify_lens
+            )
+            cache_seqlens_int32 = (seq_lens + verify_layout.verify_lens).to(torch.int32)
+            real_rows = int(verify_layout.graph_num_tokens)
+        else:
+            capture_extend_lens = [self.speculative_num_draft_tokens] * bs
+            cache_seqlens_int32 = (seq_lens + self.speculative_num_draft_tokens).to(
+                torch.int32
+            )
+            real_rows = bs * self.speculative_num_draft_tokens
+        return capture_extend_lens, cache_seqlens_int32, real_rows
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -856,50 +923,15 @@ class DeepseekSparseAttnBackend(
             seqlens_expanded = cache_seqlens_int32
         elif forward_batch.forward_mode.is_target_verify():
             max_seqlen_q = 1
-            if verify_layout is not None:
-                verify_lens_cpu = verify_layout.verify_lens_cpu
-                if verify_lens_cpu is None:
-                    # Eager target-verify only runs off the graph path (e.g.
-                    # over-capture-bs); a one-off host sync is acceptable here.
-                    verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
-                extend_seq_lens_cpu = [int(v) for v in verify_lens_cpu]
-                total_q = int(sum(extend_seq_lens_cpu))
-                cu_seqlens_q = torch.arange(
-                    0, total_q + 1, 1, dtype=torch.int32, device=device
-                )
-                forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
-                seqlens_expanded = seqlens_expand_triton(
-                    verify_layout.verify_lens,
-                    cache_seqlens_int32,
-                    total_q,
-                    max(extend_seq_lens_cpu),
-                )
-                page_table = torch.repeat_interleave(
-                    page_table,
-                    repeats=verify_layout.verify_lens,
-                    dim=0,
-                    output_size=total_q,
-                )
-            else:
-                cu_seqlens_q = torch.arange(
-                    0,
-                    batch_size * self.speculative_num_draft_tokens + 1,
-                    1,
-                    dtype=torch.int32,
-                    device=device,
-                )
-                extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
-                forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
-
-                seqlens_expanded = seqlens_expand_triton(
-                    torch.tensor(extend_seq_lens_cpu, dtype=torch.int32, device=device),
-                    cache_seqlens_int32,
-                    self.speculative_num_draft_tokens * batch_size,
-                    self.speculative_num_draft_tokens,
-                )
-                page_table = torch.repeat_interleave(
-                    page_table, repeats=self.speculative_num_draft_tokens, dim=0
-                )
+            (
+                extend_seq_lens_cpu,
+                cu_seqlens_q,
+                seqlens_expanded,
+                page_table,
+            ) = self._target_verify_eager_geometry(
+                verify_layout, batch_size, cache_seqlens_int32, page_table, device
+            )
+            forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
         elif forward_batch.forward_mode.is_draft_extend_v2():
             if forward_batch.extend_prefix_lens_cpu is None:
                 assert forward_batch.extend_prefix_lens is not None
@@ -1335,29 +1367,11 @@ class DeepseekSparseAttnBackend(
             else:
                 flashmla_metadata = None
         elif forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
-            if verify_layout is not None:
-                verify_lens_cpu = verify_layout.verify_lens_cpu
-                if verify_lens_cpu is None:
-                    # padded_to_bucket drops host mirrors; capture is a
-                    # one-time host-driven build, a D2H sync is fine here.
-                    verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
-                capture_extend_lens = [int(v) for v in verify_lens_cpu]
-                # Stage the capture lens so the warmup execution of the
-                # graph-recorded prep (init_forward_metadata_in_graph) sees
-                # non-zero lengths.
-                self._ragged_verify_lens_buf[: len(capture_extend_lens)].copy_(
-                    verify_layout.verify_lens
-                )
-                cache_seqlens_int32 = (seq_lens + verify_layout.verify_lens).to(
-                    torch.int32
-                )
-                real_rows = int(verify_layout.graph_num_tokens)
-            else:
-                capture_extend_lens = [self.speculative_num_draft_tokens] * bs
-                cache_seqlens_int32 = (seq_lens + self.speculative_num_draft_tokens).to(
-                    torch.int32
-                )
-                real_rows = bs * self.speculative_num_draft_tokens
+            (
+                capture_extend_lens,
+                cache_seqlens_int32,
+                real_rows,
+            ) = self._capture_verify_widths(verify_layout, bs, seq_lens)
             cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
             max_seqlen_q = 1
             if self.dsa_drop_wide_page_table:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -62,6 +62,12 @@ from sglang.srt.layers.utils.cp_utils import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_buffer
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    RaggedVerifyMode,
+    compute_target_verify_graph_key,
+    read_ragged_verify_mode,
+)
 from sglang.srt.utils import (
     get_bool_env_var,
     is_cuda,
@@ -338,6 +344,12 @@ class DeepseekSparseAttnBackend(
     # (page-table width) and never reads seq_lens_cpu / seq_lens_sum; opt out of
     # the D2H sync. The eager fallback derives lengths from GPU seq_lens.
     needs_cpu_seq_lens: bool = False
+    # Target-verify metadata is built per expanded token row (cu_seqlens_q is a
+    # unit arange, seqlens are expanded per request), so a ragged layout only
+    # changes the expanded row count. The SM100 DG-native [bs, next_n] paged-MQA
+    # schedule is the one uniform-width construct; it is bypassed (per-token
+    # schedule) when a ragged layout is present.
+    supports_ragged_verify_graph: bool = True
 
     def __init__(
         self,
@@ -644,14 +656,18 @@ class DeepseekSparseAttnBackend(
         cache_seqlens_int32: torch.Tensor,
         seqlens_expanded: torch.Tensor,
         batch_size: int,
+        ragged: bool = False,
     ) -> torch.Tensor:
         # target_verify with next_n>=2 uses DG-native q=[B,next_n,H,D] which
         # needs a [B, next_n] schedule; everything else stays per-token.
+        # A ragged verify layout has no uniform per-request width, so it always
+        # takes the per-token schedule.
         # TODO: SM90 supports DG-native next_n in {1,2} too — enable once
         # validated; for now DG-native is SM100+ only.
         next_n = self.speculative_num_draft_tokens
         if (
             forward_mode.is_target_verify()
+            and not ragged
             and next_n
             and next_n >= 2
             and is_sm100_supported()
@@ -739,6 +755,46 @@ class DeepseekSparseAttnBackend(
         )
         return page_table[:, strided_indices] // page_size
 
+    def _resolve_verify_layout(
+        self,
+        spec_info,
+        bs: int,
+        pad_to_slots: bool = True,
+    ) -> Optional[RaggedVerifyLayout]:
+        layout = getattr(spec_info, "ragged_verify_layout", None)
+        if layout is None:
+            return None
+        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
+            return None
+        if get_parallel().attn_cp_size > 1:
+            raise NotImplementedError(
+                "DSA ragged verify does not support context parallel (CP); "
+                "set SGLANG_RAGGED_VERIFY_MODE off for CP runs."
+            )
+        if not pad_to_slots:
+            # Eager forward: the batch carries exactly the real verify tokens,
+            # so the raw layout is the geometry (padding would add rows beyond
+            # the batch's q tokens).
+            return layout
+        # Graph capture/replay: pad to the captured slot count. The padded
+        # layout absorbs the tier's slack tokens into the padding rows
+        # (total == graph_num_tokens), so the whole tier stays covered and
+        # every metadata build below is sync-free.
+        return layout.padded_to_bucket(padded_bs=bs)
+
+    def _target_verify_graph_key(
+        self,
+        bs: int,
+        ragged_layout: Optional[RaggedVerifyLayout],
+    ):
+        if ragged_layout is None:
+            return bs
+        return compute_target_verify_graph_key(
+            bs=bs,
+            num_draft_tokens=self.speculative_num_draft_tokens,
+            ragged_layout=ragged_layout,
+        )
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -765,10 +821,21 @@ class DeepseekSparseAttnBackend(
 
         if forward_batch.forward_mode.is_target_verify():
             draft_token_num = self.speculative_num_draft_tokens
+            verify_layout = self._resolve_verify_layout(
+                forward_batch.spec_info, batch_size, pad_to_slots=False
+            )
         else:
             draft_token_num = 0
+            verify_layout = None
 
-        cache_seqlens_int32 = (forward_batch.seq_lens + draft_token_num).to(torch.int32)
+        if verify_layout is not None:
+            cache_seqlens_int32 = (
+                forward_batch.seq_lens + verify_layout.verify_lens
+            ).to(torch.int32)
+        else:
+            cache_seqlens_int32 = (forward_batch.seq_lens + draft_token_num).to(
+                torch.int32
+            )
         cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
         if forward_batch.seq_lens_cpu is not None:
             max_seqlen_k = int(
@@ -818,25 +885,50 @@ class DeepseekSparseAttnBackend(
             seqlens_expanded = cache_seqlens_int32
         elif forward_batch.forward_mode.is_target_verify():
             max_seqlen_q = 1
-            cu_seqlens_q = torch.arange(
-                0,
-                batch_size * self.speculative_num_draft_tokens + 1,
-                1,
-                dtype=torch.int32,
-                device=device,
-            )
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
-            forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
+            if verify_layout is not None:
+                verify_lens_cpu = verify_layout.verify_lens_cpu
+                if verify_lens_cpu is None:
+                    # Eager target-verify only runs off the graph path (e.g.
+                    # over-capture-bs); a one-off host sync is acceptable here.
+                    verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
+                extend_seq_lens_cpu = [int(v) for v in verify_lens_cpu]
+                total_q = int(sum(extend_seq_lens_cpu))
+                cu_seqlens_q = torch.arange(
+                    0, total_q + 1, 1, dtype=torch.int32, device=device
+                )
+                forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
+                seqlens_expanded = seqlens_expand_triton(
+                    verify_layout.verify_lens,
+                    cache_seqlens_int32,
+                    total_q,
+                    max(extend_seq_lens_cpu),
+                )
+                page_table = torch.repeat_interleave(
+                    page_table,
+                    repeats=verify_layout.verify_lens,
+                    dim=0,
+                    output_size=total_q,
+                )
+            else:
+                cu_seqlens_q = torch.arange(
+                    0,
+                    batch_size * self.speculative_num_draft_tokens + 1,
+                    1,
+                    dtype=torch.int32,
+                    device=device,
+                )
+                extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * batch_size
+                forward_batch.extend_seq_lens_cpu = extend_seq_lens_cpu
 
-            seqlens_expanded = seqlens_expand_triton(
-                torch.tensor(extend_seq_lens_cpu, dtype=torch.int32, device=device),
-                cache_seqlens_int32,
-                self.speculative_num_draft_tokens * batch_size,
-                self.speculative_num_draft_tokens,
-            )
-            page_table = torch.repeat_interleave(
-                page_table, repeats=self.speculative_num_draft_tokens, dim=0
-            )
+                seqlens_expanded = seqlens_expand_triton(
+                    torch.tensor(extend_seq_lens_cpu, dtype=torch.int32, device=device),
+                    cache_seqlens_int32,
+                    self.speculative_num_draft_tokens * batch_size,
+                    self.speculative_num_draft_tokens,
+                )
+                page_table = torch.repeat_interleave(
+                    page_table, repeats=self.speculative_num_draft_tokens, dim=0
+                )
         elif forward_batch.forward_mode.is_draft_extend_v2():
             if forward_batch.extend_prefix_lens_cpu is None:
                 assert forward_batch.extend_prefix_lens is not None
@@ -1221,6 +1313,8 @@ class DeepseekSparseAttnBackend(
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
         actual_forward_mode: Optional[ForwardMode] = None,
+        verify_layout: Optional[RaggedVerifyLayout] = None,
+        graph_key=None,
     ):
         """Create and store DSAMetadata for a new batch size during CUDA graph capture."""
         self.set_dsa_prefill_impl(forward_batch=None)
@@ -1265,12 +1359,25 @@ class DeepseekSparseAttnBackend(
             else:
                 flashmla_metadata = None
         elif forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
-            cache_seqlens_int32 = (seq_lens + self.speculative_num_draft_tokens).to(
-                torch.int32
-            )
+            if verify_layout is not None:
+                verify_lens_cpu = verify_layout.verify_lens_cpu
+                if verify_lens_cpu is None:
+                    # padded_to_bucket drops host mirrors; capture is a
+                    # one-time host-driven build, a D2H sync is fine here.
+                    verify_lens_cpu = verify_layout.verify_lens.cpu().tolist()
+                capture_extend_lens = [int(v) for v in verify_lens_cpu]
+                cache_seqlens_int32 = (seq_lens + verify_layout.verify_lens).to(
+                    torch.int32
+                )
+                real_rows = int(verify_layout.graph_num_tokens)
+            else:
+                capture_extend_lens = [self.speculative_num_draft_tokens] * bs
+                cache_seqlens_int32 = (seq_lens + self.speculative_num_draft_tokens).to(
+                    torch.int32
+                )
+                real_rows = bs * self.speculative_num_draft_tokens
             cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
             max_seqlen_q = 1
-            real_rows = bs * self.speculative_num_draft_tokens
             if self.dsa_drop_wide_page_table:
                 page_table_1 = None
                 max_seqlen_k = self.req_to_token.shape[1]
@@ -1282,17 +1389,19 @@ class DeepseekSparseAttnBackend(
 
             cu_seqlens_q = torch.arange(
                 0,
-                bs * self.speculative_num_draft_tokens + 1,
+                real_rows + 1,
                 1,
                 dtype=torch.int32,
                 device=self.device,
             )
 
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
+            extend_seq_lens_cpu = capture_extend_lens
 
             seqlens_int32_cpu = [
-                self.speculative_num_draft_tokens + kv_len
-                for kv_len in seq_lens.tolist()
+                qo_len + kv_len
+                for qo_len, kv_len in zip(
+                    capture_extend_lens, seq_lens.tolist(), strict=True
+                )
             ]
             seqlens_expanded = torch.cat(
                 [
@@ -1312,12 +1421,12 @@ class DeepseekSparseAttnBackend(
             dsa_cache_seqlens_int32 = compute_dsa_seqlens(
                 seqlens_expanded, dsa_index_topk=self.dsa_index_topk
             )
-            dsa_extend_seq_lens_list = [1] * bs * self.speculative_num_draft_tokens
+            dsa_extend_seq_lens_list = [1] * real_rows
 
             if self.dsa_decode_impl == "flashmla_kv":
                 flashmla_metadata = self.decode_cuda_graph_metadata[
                     "flashmla_metadata"
-                ].slice(slice(0, bs * self.speculative_num_draft_tokens + 1))
+                ].slice(slice(0, real_rows + 1))
 
                 flashmla_metadata.copy_(
                     self._compute_flashmla_metadata(
@@ -1347,7 +1456,11 @@ class DeepseekSparseAttnBackend(
             or forward_mode.is_draft_extend_v2()
         ):
             paged_mqa_ctx_lens_2d = self._build_paged_mqa_schedule_2d_ctx_lens(
-                forward_mode, cache_seqlens_int32, seqlens_expanded, bs
+                forward_mode,
+                cache_seqlens_int32,
+                seqlens_expanded,
+                bs,
+                ragged=verify_layout is not None,
             )
             paged_mqa_schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
                 paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
@@ -1372,7 +1485,9 @@ class DeepseekSparseAttnBackend(
             dsa_extend_seq_lens_list=dsa_extend_seq_lens_list,
             topk_v2_plan=self._build_topk_v2_plan(seqlens_expanded),
         )
-        self.decode_cuda_graph_metadata[bs] = metadata
+        self.decode_cuda_graph_metadata[graph_key if graph_key is not None else bs] = (
+            metadata
+        )
         self.forward_metadata = metadata
 
     def _apply_cuda_graph_metadata(
@@ -1392,7 +1507,12 @@ class DeepseekSparseAttnBackend(
         also call this directly via _apply_cuda_graph_metadata when they
         need to pass out_cache_loc / actual_forward_mode explicitly.
         """
-        if bs not in self.decode_cuda_graph_metadata:
+        verify_layout = None
+        if forward_mode.is_target_verify():
+            verify_layout = self._resolve_verify_layout(spec_info, bs)
+        graph_key = self._target_verify_graph_key(bs, verify_layout)
+
+        if graph_key not in self.decode_cuda_graph_metadata:
             self._build_forward_metadata_cuda_graph(
                 bs,
                 None,
@@ -1403,6 +1523,8 @@ class DeepseekSparseAttnBackend(
                 spec_info,
                 out_cache_loc,
                 actual_forward_mode,
+                verify_layout=verify_layout,
+                graph_key=graph_key,
             )
             return
 
@@ -1412,7 +1534,7 @@ class DeepseekSparseAttnBackend(
         req_pool_indices = req_pool_indices[:bs]
 
         # Normal Decode
-        metadata: DSAMetadata = self.decode_cuda_graph_metadata[bs]
+        metadata: DSAMetadata = self.decode_cuda_graph_metadata[graph_key]
         used_fused_metadata_generation = False
         target_verify_ctx_lens_written = False
         if forward_mode.is_decode_or_idle():
@@ -1461,7 +1583,9 @@ class DeepseekSparseAttnBackend(
         elif forward_mode.is_target_verify():
             max_seqlen_k = self._graph_page_table_width(metadata)
 
-            if is_cuda() and not _is_hip:
+            # The fused metadata kernel assumes a uniform per-request width
+            # (next_n); ragged layouts take the layout-driven build below.
+            if verify_layout is None and is_cuda() and not _is_hip:
                 from sglang.kernels.ops.attention.dsa_metadata import (
                     fused_dsa_target_verify_metadata,
                 )
@@ -1508,38 +1632,77 @@ class DeepseekSparseAttnBackend(
                 used_fused_metadata_generation = True
 
             if not used_fused_metadata_generation:
-                cache_seqlens = (seq_lens + self.speculative_num_draft_tokens).to(
-                    torch.int32
-                )
-                metadata.cache_seqlens_int32.copy_(cache_seqlens)
-                metadata.cu_seqlens_k[1:].copy_(
-                    torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
-                )
-                page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
-                page_indices = torch.repeat_interleave(
-                    page_indices, repeats=self.speculative_num_draft_tokens, dim=0
-                )
-                metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
+                if verify_layout is not None:
+                    total_rows = int(verify_layout.graph_num_tokens)
+                    cache_seqlens = (seq_lens + verify_layout.verify_lens).to(
+                        torch.int32
+                    )
+                    metadata.cache_seqlens_int32.copy_(cache_seqlens)
+                    metadata.cu_seqlens_k[1:].copy_(
+                        torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
+                    )
+                    # Sync-free ragged expansion: map each expanded row to its
+                    # request by searchsorted over the device qo_indptr. The
+                    # padded layout covers the full tier (padding rows absorb
+                    # the slack tokens), so every row maps to a real or padded
+                    # request; padded rows' outputs are discarded by the
+                    # runner's output slice.
+                    qo_indptr = verify_layout.qo_indptr_device
+                    row_ids = torch.arange(
+                        total_rows, dtype=qo_indptr.dtype, device=self.device
+                    )
+                    row_to_req = torch.searchsorted(
+                        qo_indptr[1:], row_ids, right=True
+                    ).clamp_(max=bs - 1)
+                    pos_in_req = row_ids - qo_indptr[row_to_req]
+                    seqlens_expanded = (seq_lens[row_to_req] + pos_in_req + 1).to(
+                        torch.int32
+                    )
+                    metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
+                    dsa_cache_seqlens = compute_dsa_seqlens(
+                        seqlens_expanded, self.dsa_index_topk
+                    )
+                    metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
+                    page_indices = self.req_to_token[
+                        req_pool_indices[row_to_req], :max_seqlen_k
+                    ]
+                    metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
+                else:
+                    cache_seqlens = (seq_lens + self.speculative_num_draft_tokens).to(
+                        torch.int32
+                    )
+                    metadata.cache_seqlens_int32.copy_(cache_seqlens)
+                    metadata.cu_seqlens_k[1:].copy_(
+                        torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32)
+                    )
+                    page_indices = self.req_to_token[req_pool_indices, :max_seqlen_k]
+                    page_indices = torch.repeat_interleave(
+                        page_indices,
+                        repeats=self.speculative_num_draft_tokens,
+                        dim=0,
+                    )
+                    metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
 
-                # Fill the constant per-req qo lengths on-device; torch.tensor(list,
-                # device=cuda) does a pageable H2D copy that blocks the host.
-                extend_seq_lens = torch.full(
-                    (bs,),
-                    self.speculative_num_draft_tokens,
-                    dtype=torch.int32,
-                    device=self.device,
-                )
-                seqlens_expanded = seqlens_expand_triton(
-                    extend_seq_lens,
-                    cache_seqlens,
-                    self.speculative_num_draft_tokens * bs,
-                    self.speculative_num_draft_tokens,
-                )
-                metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
-                dsa_cache_seqlens = compute_dsa_seqlens(
-                    seqlens_expanded, self.dsa_index_topk
-                )
-                metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
+                    # Fill the constant per-req qo lengths on-device;
+                    # torch.tensor(list, device=cuda) does a pageable H2D copy
+                    # that blocks the host.
+                    extend_seq_lens = torch.full(
+                        (bs,),
+                        self.speculative_num_draft_tokens,
+                        dtype=torch.int32,
+                        device=self.device,
+                    )
+                    seqlens_expanded = seqlens_expand_triton(
+                        extend_seq_lens,
+                        cache_seqlens,
+                        self.speculative_num_draft_tokens * bs,
+                        self.speculative_num_draft_tokens,
+                    )
+                    metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
+                    dsa_cache_seqlens = compute_dsa_seqlens(
+                        seqlens_expanded, self.dsa_index_topk
+                    )
+                    metadata.dsa_cache_seqlens_int32.copy_(dsa_cache_seqlens)
         elif forward_mode.is_draft_extend_v2():
             # V2 draft-extend processes the full padded tree width
             # (speculative_num_draft_tokens) per req -- a static shape, like
@@ -1636,6 +1799,7 @@ class DeepseekSparseAttnBackend(
                     metadata.cache_seqlens_int32,
                     schedule_seqlens_expanded,
                     bs,
+                    ragged=verify_layout is not None,
                 )
             self._refresh_paged_mqa_schedule_metadata(metadata, seqlens_32_2d)
             self._refresh_topk_v2_plan(metadata)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -64,9 +64,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.runtime_context import get_buffer
 from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyLayout,
-    RaggedVerifyMode,
     compute_target_verify_graph_key,
-    read_ragged_verify_mode,
     resolve_compact_verify_layout,
 )
 from sglang.srt.utils import (
@@ -802,6 +800,14 @@ class DeepseekSparseAttnBackend(
         )
         return extend_seq_lens_cpu, cu_seqlens_q, seqlens_expanded, page_table
 
+    def _stage_ragged_verify_layout(
+        self, verify_layout: RaggedVerifyLayout, *, bs: int
+    ) -> None:
+        """Copy this step's ragged layout into the static buffers the
+        graph-recorded prep reads (init_forward_metadata_in_graph)."""
+        self._ragged_verify_lens_buf[:bs].copy_(verify_layout.verify_lens)
+        self._ragged_qo_indptr_buf[: bs + 1].copy_(verify_layout.qo_indptr_device)
+
     def _capture_verify_widths(
         self,
         verify_layout: Optional[RaggedVerifyLayout],
@@ -819,9 +825,7 @@ class DeepseekSparseAttnBackend(
             capture_extend_lens = [int(v) for v in verify_lens_cpu]
             # Stage the capture lens so the warmup run of the graph-recorded
             # prep sees non-zero lengths.
-            self._ragged_verify_lens_buf[: len(capture_extend_lens)].copy_(
-                verify_layout.verify_lens
-            )
+            self._stage_ragged_verify_layout(verify_layout, bs=bs)
             cache_seqlens_int32 = (seq_lens + verify_layout.verify_lens).to(torch.int32)
             real_rows = int(verify_layout.graph_num_tokens)
         else:
@@ -1255,10 +1259,13 @@ class DeepseekSparseAttnBackend(
             and self.dsa_index_topk <= 2048
         )
 
-        # Staged per-step verify lens for the graph-recorded ragged verify
-        # prep (init_forward_metadata_in_graph).
+        # Staged per-step verify lens / row offsets for the graph-recorded ragged
+        # verify prep (init_forward_metadata_in_graph).
         self._ragged_verify_lens_buf = torch.zeros(
             max_bs, dtype=torch.int32, device=self.device
+        )
+        self._ragged_qo_indptr_buf = torch.zeros(
+            max_bs + 1, dtype=torch.int32, device=self.device
         )
         max_ctx_len = self.req_to_token.shape[1]
         self.decode_cuda_graph_metadata: Dict = {
@@ -1504,8 +1511,14 @@ class DeepseekSparseAttnBackend(
         """
         verify_layout = None
         if forward_mode.is_target_verify():
+            # max_row_len: the graph-recorded prep compiles its page-table write
+            # for at most next_n rows per request, so padding must not widen a
+            # row past that (see RaggedVerifyLayout.padded_to_bucket).
             verify_layout = resolve_compact_verify_layout(
-                spec_info, padded_bs=bs, backend_name="DSA"
+                spec_info,
+                padded_bs=bs,
+                backend_name="DSA",
+                max_row_len=self.speculative_num_draft_tokens,
             )
         graph_key = self._target_verify_graph_key(bs, verify_layout)
 
@@ -1584,7 +1597,7 @@ class DeepseekSparseAttnBackend(
             if verify_layout is not None and is_cuda() and not _is_hip:
                 # The ragged prep chain is recorded inside the verify graph
                 # (init_forward_metadata_in_graph); replay only stages the lens.
-                self._ragged_verify_lens_buf[:bs].copy_(verify_layout.verify_lens)
+                self._stage_ragged_verify_layout(verify_layout, bs=bs)
                 total_rows = int(verify_layout.graph_num_tokens)
                 cache_seqlens = metadata.cache_seqlens_int32
                 seqlens_expanded = metadata.dsa_seqlens_expanded[:total_rows]
@@ -1665,6 +1678,12 @@ class DeepseekSparseAttnBackend(
                     seqlens_expanded = (seq_lens[row_to_req] + pos_in_req + 1).to(
                         torch.int32
                     )
+                    # A width-capped layout can leave the tier's tail unclaimed;
+                    # zero those rows so they take the trivial path, matching the
+                    # fused kernel's `covered` handling.
+                    seqlens_expanded = torch.where(
+                        row_ids < qo_indptr[bs], seqlens_expanded, 0
+                    ).to(torch.int32)
                     metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
                     dsa_cache_seqlens = compute_dsa_seqlens(
                         seqlens_expanded, self.dsa_index_topk
@@ -1844,7 +1863,10 @@ class DeepseekSparseAttnBackend(
         else:
             assert metadata.real_page_table is metadata.page_table_1
 
-        if self.dsa_decode_impl == "flashmla_kv":
+        # Ragged path fills dsa_cache_seqlens only via the in-graph fused rebuild,
+        # so its flashmla refresh is recorded in init_forward_metadata_in_graph
+        # instead -- computing it here would use stale seqlens.
+        if self.dsa_decode_impl == "flashmla_kv" and not prep_recorded_in_graph:
             flashmla_metadata = metadata.flashmla_metadata.slice(
                 slice(0, seqlens_expanded_size + 1)
             )
@@ -1866,10 +1888,14 @@ class DeepseekSparseAttnBackend(
             return
         if not is_cuda() or _is_hip:
             return
-        layout = getattr(forward_batch.spec_info, "ragged_verify_layout", None)
+        # Same gate as _apply_cuda_graph_metadata's prep_recorded_in_graph: if the
+        # two ever disagree this prep is silently skipped and the metadata stays
+        # stale, so both must resolve through the shared helper. padded_bs=None:
+        # only graph_num_tokens is read here, which padding does not change.
+        layout = resolve_compact_verify_layout(
+            forward_batch.spec_info, padded_bs=None, backend_name="DSA"
+        )
         if layout is None:
-            return
-        if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
             return
         from sglang.kernels.ops.attention.dsa_metadata import (
             fused_dsa_draft_extend_metadata,
@@ -1901,12 +1927,31 @@ class DeepseekSparseAttnBackend(
             max_extend_len=self.speculative_num_draft_tokens,
             max_total_len=total_rows,
             static_extend_len=False,
+            qo_indptr=self._ragged_qo_indptr_buf[: bs + 1],
         )
+        # The ragged schedule is per-token, so _build_paged_mqa_schedule_2d_ctx_lens
+        # returned a view of dsa_seqlens_expanded -- the fused rebuild above already
+        # refreshed it in place; copying it onto itself would just record a no-op.
         ctx_lens_2d = metadata.dsa_seqlens_expanded[:total_rows].view(-1, 1)
-        if metadata.paged_mqa_ctx_lens_2d is not None:
-            metadata.paged_mqa_ctx_lens_2d.copy_(ctx_lens_2d)
+        assert (
+            metadata.paged_mqa_ctx_lens_2d is None
+            or metadata.paged_mqa_ctx_lens_2d.data_ptr() == ctx_lens_2d.data_ptr()
+        )
         self._refresh_paged_mqa_schedule_metadata(metadata, ctx_lens_2d)
         self._refresh_topk_v2_plan(metadata)
+        if self.dsa_decode_impl == "flashmla_kv":
+            # Track the dsa_cache_seqlens the fused kernel just rebuilt; the
+            # out-graph refresh in _apply_cuda_graph_metadata is skipped for
+            # this path (prep_recorded_in_graph).
+            flashmla_metadata = metadata.flashmla_metadata.slice(
+                slice(0, total_rows + 1)
+            )
+            flashmla_metadata.copy_(
+                self._compute_flashmla_metadata(
+                    cache_seqlens=metadata.dsa_cache_seqlens_int32[:total_rows],
+                    seq_len_q=1,
+                )
+            )
 
     def init_forward_metadata_replay_cuda_graph_from_precomputed(
         self,

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -209,14 +209,11 @@ def resolve_compact_verify_layout(
     padded_bs: Optional[int],
     backend_name: str,
 ) -> Optional[RaggedVerifyLayout]:
-    """Resolve a spec input's layout for a compact-verify-capable backend:
-    None unless a layout is present and compact mode is on; CP is rejected.
-    padded_bs=None keeps the raw layout (eager: the batch carries exactly the
-    real verify tokens); otherwise pad to the captured slot count so the
-    tier's slack lands in the padding rows and the metadata build stays
-    sync-free. Layout invariants (verify_lens >= 1, total == sum) are enforced
-    in RaggedVerifyLayout.__post_init__; don't re-check the device tensor
-    here -- that would D2H-sync the host-free verify prep path.
+    """None unless a layout is present and compact mode is on; CP is rejected.
+    padded_bs=None keeps the raw layout (eager); otherwise pad to the captured
+    slot count so the tier's slack lands in the padding rows. Layout invariants
+    are enforced in __post_init__; don't re-check the device tensor here --
+    that would D2H-sync the host-free verify prep path.
     """
     from sglang.srt.runtime_context import get_parallel
 

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -203,6 +203,38 @@ def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
     return spec_info.ragged_verify_layout
 
 
+def resolve_compact_verify_layout(
+    spec_info,
+    *,
+    padded_bs: Optional[int],
+    backend_name: str,
+) -> Optional[RaggedVerifyLayout]:
+    """Resolve a spec input's layout for a compact-verify-capable backend:
+    None unless a layout is present and compact mode is on; CP is rejected.
+    padded_bs=None keeps the raw layout (eager: the batch carries exactly the
+    real verify tokens); otherwise pad to the captured slot count so the
+    tier's slack lands in the padding rows and the metadata build stays
+    sync-free. Layout invariants (verify_lens >= 1, total == sum) are enforced
+    in RaggedVerifyLayout.__post_init__; don't re-check the device tensor
+    here -- that would D2H-sync the host-free verify prep path.
+    """
+    from sglang.srt.runtime_context import get_parallel
+
+    layout = getattr(spec_info, "ragged_verify_layout", None)
+    if layout is None:
+        return None
+    if read_ragged_verify_mode() is not RaggedVerifyMode.COMPACT:
+        return None
+    if get_parallel().attn_cp_size > 1:
+        raise NotImplementedError(
+            f"{backend_name} ragged verify does not support context parallel "
+            "(CP); set SGLANG_RAGGED_VERIFY_MODE off for CP runs."
+        )
+    if padded_bs is None:
+        return layout
+    return layout.padded_to_bucket(padded_bs=padded_bs)
+
+
 class RaggedTargetVerifyGeometry(msgspec.Struct):
     cache_seqlens_int32: torch.Tensor
     cu_seqlens_q: torch.Tensor

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -154,7 +154,9 @@ class RaggedVerifyLayout(msgspec.Struct, frozen=True):
             device=device,
         )
 
-    def padded_to_bucket(self, *, padded_bs: int) -> RaggedVerifyLayout:
+    def padded_to_bucket(
+        self, *, padded_bs: int, max_row_len: Optional[int] = None
+    ) -> RaggedVerifyLayout:
         from sglang.kernels.ops.speculative.ragged_verify_kernels import (
             PaddedToBucket,
         )
@@ -164,13 +166,29 @@ class RaggedVerifyLayout(msgspec.Struct, frozen=True):
             graph_num_tokens=self.graph_num_tokens,
             bs=self.bs,
             padded_bs=padded_bs,
+            max_row_len=max_row_len,
         )
 
         return RaggedVerifyLayout._assemble_device(
             verify_lens=padded,
             graph_num_tokens=self.graph_num_tokens,
-            total_verify_tokens=self.graph_num_tokens,
+            total_verify_tokens=self._padded_total_verify_tokens(
+                padded_bs=padded_bs, max_row_len=max_row_len
+            ),
         )
+
+    def _padded_total_verify_tokens(
+        self, *, padded_bs: int, max_row_len: Optional[int]
+    ) -> Optional[int]:
+        """Row-sum of the padded lens, derived host-side (no D2H sync), or None
+        when it cannot be. Uncapped padding always absorbs the whole tier; a
+        capped one absorbs at most max_row_len per padding row."""
+        if max_row_len is None:
+            return self.graph_num_tokens
+        if self.total_verify_tokens is None:
+            return None
+        absorbed = (padded_bs - self.bs) * max_row_len
+        return min(self.graph_num_tokens, self.total_verify_tokens + absorbed)
 
 
 def build_capture_verify_lens(
@@ -208,12 +226,15 @@ def resolve_compact_verify_layout(
     *,
     padded_bs: Optional[int],
     backend_name: str,
+    max_row_len: Optional[int] = None,
 ) -> Optional[RaggedVerifyLayout]:
     """None unless a layout is present and compact mode is on; CP is rejected.
     padded_bs=None keeps the raw layout (eager); otherwise pad to the captured
-    slot count so the tier's slack lands in the padding rows. Layout invariants
-    are enforced in __post_init__; don't re-check the device tensor here --
-    that would D2H-sync the host-free verify prep path.
+    slot count so the tier's slack lands in the padding rows. max_row_len bounds
+    every padded row (see RaggedVerifyLayout.padded_to_bucket) -- pass it when
+    the backend's graph metadata assumes a maximum per-request width. Layout
+    invariants are enforced in __post_init__; don't re-check the device tensor
+    here -- that would D2H-sync the host-free verify prep path.
     """
     from sglang.srt.runtime_context import get_parallel
 
@@ -229,7 +250,7 @@ def resolve_compact_verify_layout(
         )
     if padded_bs is None:
         return layout
-    return layout.padded_to_bucket(padded_bs=padded_bs)
+    return layout.padded_to_bucket(padded_bs=padded_bs, max_row_len=max_row_len)
 
 
 class RaggedTargetVerifyGeometry(msgspec.Struct):

--- a/test/registered/kernels/test_dsa_metadata.py
+++ b/test/registered/kernels/test_dsa_metadata.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Optional
 
 import torch
 
@@ -19,6 +20,10 @@ def _cu_seqlens(seqlens: torch.Tensor) -> torch.Tensor:
     out[:1].zero_()
     out[1:].copy_(torch.cumsum(seqlens.to(torch.int32), dim=0, dtype=torch.int32))
     return out
+
+
+def _qo_indptr(extend_seq_lens: torch.Tensor) -> torch.Tensor:
+    return _cu_seqlens(extend_seq_lens)
 
 
 def _dsa_seqlens(seqlens: torch.Tensor, topk: int) -> torch.Tensor:
@@ -225,9 +230,15 @@ class TestDSAMetadataKernels(CustomTestCase):
         max_extend_len: int,
         max_total_len: int,
         static_extend_len: bool,
+        total_len: Optional[int] = None,
+        pass_qo_indptr: bool = False,
     ):
         bs = len(seq_lens_values)
-        total_len = sum(extend_seq_lens_values)
+        # Rows claimed by a request; `total_len` may exceed it when a width-capped
+        # ragged layout leaves the graph tier's tail slack unclaimed.
+        covered_len = sum(extend_seq_lens_values)
+        total_len = covered_len if total_len is None else total_len
+        assert total_len >= covered_len
         pool_size = max(bs + 4, 8)
         seq_lens = torch.tensor(seq_lens_values, dtype=torch.int64, device=self.device)
         extend_seq_lens = torch.tensor(
@@ -280,6 +291,7 @@ class TestDSAMetadataKernels(CustomTestCase):
             max_extend_len=max_extend_len,
             max_total_len=max_total_len,
             static_extend_len=static_extend_len,
+            qo_indptr=(_qo_indptr(extend_seq_lens) if pass_qo_indptr else None),
         )
 
         expected_cache = seq_lens.to(torch.int32)
@@ -314,21 +326,46 @@ class TestDSAMetadataKernels(CustomTestCase):
         _assert_equal(cache_seqlens, expected_cache, "draft cache_seqlens")
         _assert_equal(cu_seqlens_k, _cu_seqlens(expected_cache), "draft cu_seqlens_k")
         _assert_equal(
-            page_table_1[:total_len][live_mask],
+            page_table_1[:covered_len][live_mask],
             expected_page_table[live_mask],
             "draft page_table_1 (live [:kv_len] prefix)",
         )
         _assert_equal(
-            seqlens_expanded[:total_len], expected_expanded, "draft seqlens_expanded"
+            seqlens_expanded[:covered_len], expected_expanded, "draft seqlens_expanded"
         )
         _assert_equal(
-            dsa_cache_seqlens[:total_len], expected_dsa, "draft dsa_cache_seqlens"
+            dsa_cache_seqlens[:covered_len], expected_dsa, "draft dsa_cache_seqlens"
         )
         _assert_equal(
-            dsa_cu_seqlens_k[: total_len + 1],
+            dsa_cu_seqlens_k[: covered_len + 1],
             _cu_seqlens(expected_dsa),
             "draft dsa_cu_seqlens_k",
         )
+        if total_len > covered_len:
+            # Unclaimed tail rows must be length 0 so consumers take the trivial
+            # all-(-1) path; their page-table rows are never read.
+            tail = torch.zeros(
+                total_len - covered_len, dtype=torch.int32, device=self.device
+            )
+            _assert_equal(
+                seqlens_expanded[covered_len:total_len], tail, "draft uncovered rows"
+            )
+            _assert_equal(
+                dsa_cache_seqlens[covered_len:total_len],
+                tail,
+                "draft uncovered dsa_cache_seqlens",
+            )
+            flat = torch.full(
+                (total_len - covered_len + 1,),
+                int(expected_dsa.sum()),
+                dtype=torch.int32,
+                device=self.device,
+            )
+            _assert_equal(
+                dsa_cu_seqlens_k[covered_len : total_len + 1],
+                flat,
+                "draft uncovered dsa_cu_seqlens_k stays flat",
+            )
         if real_page_size > 1:
             # Real-page column real_col maps to source column real_col*real_page_size.
             real_width = real_page_table.shape[1]
@@ -338,7 +375,7 @@ class TestDSAMetadataKernels(CustomTestCase):
             ) < row_kv_lens.view(-1, 1)
             expected_real = _real_page_table(expected_page_table, real_page_size)
             _assert_equal(
-                real_page_table[:total_len][real_live_mask],
+                real_page_table[:covered_len][real_live_mask],
                 expected_real[real_live_mask],
                 "draft real_page_table (live [:kv_len] prefix)",
             )
@@ -404,6 +441,41 @@ class TestDSAMetadataKernels(CustomTestCase):
             max_total_len=16,
             static_extend_len=False,
         )
+
+    def test_ragged_staged_qo_indptr_matches_prefix_walk(self):
+        # DSA's ragged verify replay stages qo_indptr instead of letting every
+        # page program re-walk extend_seq_lens; both must agree.
+        for pass_qo_indptr in (False, True):
+            with self.subTest(pass_qo_indptr=pass_qo_indptr):
+                self._check_draft_extend(
+                    [12, 31, 80, 7],
+                    [1, 4, 2, 3],
+                    max_seqlen_k=193,
+                    dsa_index_topk=64,
+                    real_page_size=64,
+                    max_extend_len=4,
+                    max_total_len=16,
+                    static_extend_len=False,
+                    pass_qo_indptr=pass_qo_indptr,
+                )
+
+    def test_ragged_uncovered_tail_rows_are_inert(self):
+        # A width-capped ragged verify layout can leave the graph tier's tail
+        # slack claimed by no request; those rows must come out length 0.
+        for pass_qo_indptr in (False, True):
+            with self.subTest(pass_qo_indptr=pass_qo_indptr):
+                self._check_draft_extend(
+                    [12, 31, 80],
+                    [1, 2, 1],
+                    max_seqlen_k=193,
+                    dsa_index_topk=64,
+                    real_page_size=64,
+                    max_extend_len=4,
+                    max_total_len=12,
+                    static_extend_len=False,
+                    total_len=8,
+                    pass_qo_indptr=pass_qo_indptr,
+                )
 
     def test_empty_batch(self):
         self._check_decode(

--- a/test/registered/spec/dspark/test_dsa_ragged_verify_graph_metadata.py
+++ b/test/registered/spec/dspark/test_dsa_ragged_verify_graph_metadata.py
@@ -1,0 +1,224 @@
+"""DSA ragged verify: graph-recorded prep must match the eager build.
+
+`DeepseekSparseAttnBackend.init_forward_metadata_in_graph` re-derives every
+target-verify metadata tensor from the staged verify lens with one fused triton
+kernel, replacing the eager torch chain. Nothing else pins the two against each
+other, so this drives both against the same batch and diffs the tensors the
+attention/indexer kernels actually read.
+
+Also covers the two failure modes that are invisible in end-to-end output:
+  * a consumer refreshed OUTSIDE the graph reads the pre-replay (stale) buffer
+    -- checked here for the flashmla_kv schedule;
+  * a width-capped padded layout leaves the tier's tail rows claimed by no
+    request; they must come out length 0, not carry a neighbour's kv length.
+"""
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    build_capture_verify_lens,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+NEXT_N = 4
+# Ragged widths, each <= NEXT_N. Sum 10 < TIER, so the padded layout also leaves
+# uncovered tail rows (padded_bs == bs leaves no padding row to absorb slack).
+VERIFY_LENS = [1, 4, 2, 3]
+# Keep every seq_len well under the indexer's top-k width: `compute_dsa_seqlens`
+# clamps to dsa_index_topk, and a saturated vector hides per-row differences --
+# with 128-token prefixes the flashmla schedule comes out identical for the
+# capture and replay layouts, which silently defuses the staleness check below.
+PREFIX_LENS = (8, 20, 5, 12)
+BS = len(VERIFY_LENS)
+TIER = BS * NEXT_N
+COVERED = sum(VERIFY_LENS)
+
+# Tensors the fused in-graph rebuild owns, with the row count each is valid for.
+_PER_REQ_FIELDS = ("cache_seqlens_int32",)
+_PER_ROW_FIELDS = ("dsa_seqlens_expanded", "dsa_cache_seqlens_int32")
+
+
+def _make_case():
+    from sglang.test.kits.attention_unittest.attention_methods.dsa_attention import (
+        DSA_PAGE_SIZE,
+        DSAAttentionCase,
+    )
+
+    return DSAAttentionCase(
+        name="dsa_ragged_verify_graph_metadata",
+        backend="dsa",
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        num_heads=4,
+        num_kv_heads=1,
+        page_size=DSA_PAGE_SIZE,
+        prefix_lens=PREFIX_LENS,
+        # DSAMockModelRunner derives speculative_num_draft_tokens from this.
+        extend_lens=(NEXT_N,) * BS,
+    )
+
+
+def _layout(verify_lens_cpu, device):
+    return RaggedVerifyLayout.from_verify_lens(
+        verify_lens_cpu=list(verify_lens_cpu), device=device, grid=[TIER]
+    )
+
+
+def _spec_info(layout):
+    return types.SimpleNamespace(ragged_verify_layout=layout)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestDsaRaggedVerifyGraphMetadata(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self.device = torch.device("cuda")
+
+    def _build(self):
+        from sglang.test.kits.attention_unittest.attention_methods.dsa_attention import (
+            build_dsa_sparse_attention_fixture,
+        )
+
+        return build_dsa_sparse_attention_fixture(
+            self,
+            _make_case(),
+            device=str(self.device),
+            dsa_decode_backend="flashmla_kv",
+        )
+
+    def _run_both_paths(self, *, flashmla_calls=None):
+        """Return (eager_metadata_snapshot, graph_metadata, backend).
+
+        `flashmla_calls`: optional list; the `cache_seqlens` handed to
+        `_compute_flashmla_metadata` during the replay step is appended to it.
+        """
+        from sglang.srt.model_executor.forward_context import (
+            ForwardContext,
+            forward_context,
+        )
+
+        fixture = self._build()
+        backend = fixture.backend
+        fb = fixture.forward_batch
+        raw = _layout(VERIFY_LENS, self.device)
+
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), torch.no_grad():
+            with forward_context(ForwardContext(attn_backend=backend)):
+                # --- eager reference (raw layout, no padding) ---
+                fb.spec_info = _spec_info(raw)
+                backend.init_forward_metadata(fb)
+                eager = {
+                    name: getattr(backend.forward_metadata, name).clone()
+                    for name in _PER_REQ_FIELDS + _PER_ROW_FIELDS
+                }
+
+                # --- graph path: capture at the tier, then replay the raw layout ---
+                backend.init_cuda_graph_state(max_bs=BS, max_num_tokens=TIER)
+                capture_lens = build_capture_verify_lens(
+                    num_tokens=TIER, num_slots=BS, num_draft_tokens=NEXT_N
+                )
+                fb.spec_info = _spec_info(_layout(capture_lens, self.device))
+                backend.init_forward_metadata_out_graph(fb, in_capture=True)
+                backend.init_forward_metadata_in_graph(fb)
+
+                if flashmla_calls is not None:
+                    original = backend._compute_flashmla_metadata
+
+                    def _spy(*, cache_seqlens, seq_len_q):
+                        flashmla_calls.append(cache_seqlens.detach().clone())
+                        return original(
+                            cache_seqlens=cache_seqlens, seq_len_q=seq_len_q
+                        )
+
+                    backend._compute_flashmla_metadata = _spy
+
+                fb.spec_info = _spec_info(raw)
+                backend.init_forward_metadata_out_graph(fb)
+                backend.init_forward_metadata_in_graph(fb)
+                graph = backend.forward_metadata
+
+                if flashmla_calls is not None:
+                    del backend._compute_flashmla_metadata
+
+        return eager, graph, backend
+
+    def test_graph_prep_matches_eager_metadata(self):
+        eager, graph, _ = self._run_both_paths()
+
+        for name in _PER_REQ_FIELDS:
+            torch.testing.assert_close(
+                getattr(graph, name)[:BS],
+                eager[name][:BS],
+                rtol=0,
+                atol=0,
+                msg=f"{name} (per request)",
+            )
+        for name in _PER_ROW_FIELDS:
+            torch.testing.assert_close(
+                getattr(graph, name)[:COVERED],
+                eager[name][:COVERED],
+                rtol=0,
+                atol=0,
+                msg=f"{name} (claimed rows)",
+            )
+        # cu_seqlens_k is a prefix sum over requests; compare the live prefix.
+        torch.testing.assert_close(
+            graph.cu_seqlens_k[: BS + 1],
+            torch.nn.functional.pad(
+                torch.cumsum(graph.cache_seqlens_int32[:BS], dim=0, dtype=torch.int32),
+                (1, 0),
+            ),
+            rtol=0,
+            atol=0,
+            msg="cu_seqlens_k",
+        )
+
+    def test_uncovered_tail_rows_are_zero(self):
+        _, graph, _ = self._run_both_paths()
+        self.assertLess(COVERED, TIER, "fixture must leave unclaimed tail rows")
+        tail = torch.zeros(TIER - COVERED, dtype=torch.int32, device=self.device)
+        for name in _PER_ROW_FIELDS:
+            torch.testing.assert_close(
+                getattr(graph, name)[COVERED:TIER],
+                tail,
+                rtol=0,
+                atol=0,
+                msg=f"{name} (unclaimed rows)",
+            )
+
+    def test_flashmla_schedule_sees_rebuilt_seqlens(self):
+        """The flashmla_kv schedule derives from dsa_cache_seqlens, which only the
+        in-graph rebuild fills, so its refresh must run after that rebuild -- doing
+        it in the out-graph step reads the previous step's buffer.
+
+        Asserted on the refresh's INPUT rather than on the resulting schedule:
+        `get_mla_metadata` leaves one column of its output uninitialized, so two
+        calls on identical seqlens are not bitwise equal and diffing the schedule
+        tensor would compare scratch memory.
+        """
+        calls = []
+        _, graph, backend = self._run_both_paths(flashmla_calls=calls)
+        if backend.dsa_decode_impl != "flashmla_kv":
+            self.skipTest(f"dsa_decode_impl={backend.dsa_decode_impl}, not flashmla_kv")
+        self.assertIsNotNone(graph.flashmla_metadata)
+        self.assertTrue(calls, "flashmla schedule was never refreshed on replay")
+
+        torch.testing.assert_close(
+            calls[-1],
+            graph.dsa_cache_seqlens_int32[: calls[-1].numel()],
+            rtol=0,
+            atol=0,
+            msg="flashmla refresh ran on pre-rebuild (stale) dsa_cache_seqlens",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/dspark/test_dsa_ragged_verify_resolve.py
+++ b/test/registered/spec/dspark/test_dsa_ragged_verify_resolve.py
@@ -1,8 +1,7 @@
-"""UT for the DSA backend's ragged-verify layout resolution and graph keying.
+"""UT for compact verify layout resolution (shared helper) and DSA graph keying.
 
-These paths are dormant until a model runs compact verify on DSA, so pin the
-gating logic directly: mode gate, eager-vs-graph pad semantics, the CP guard,
-and the token-keyed graph selection.
+Dormant until a model runs compact verify on DSA, so pin the gating logic:
+mode gate, eager-vs-graph pad semantics, CP guard, token-keyed graph selection.
 """
 
 import types
@@ -11,9 +10,11 @@ from unittest import mock
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyLayout,
     compute_target_verify_graph_key,
+    resolve_compact_verify_layout,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -23,19 +24,6 @@ register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 DEVICE = torch.device("cuda")
 GRID = [8, 16, 32]
 NUM_DRAFT_TOKENS = 6
-
-
-def _make_backend(num_draft_tokens=NUM_DRAFT_TOKENS):
-    from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
-
-    backend = types.SimpleNamespace(speculative_num_draft_tokens=num_draft_tokens)
-    for name in ("_resolve_verify_layout", "_target_verify_graph_key"):
-        setattr(
-            backend,
-            name,
-            types.MethodType(getattr(DeepseekSparseAttnBackend, name), backend),
-        )
-    return backend
 
 
 def _make_layout(verify_lens_cpu=(2, 3, 1)):
@@ -50,49 +38,40 @@ def _spec_info(layout):
 
 def _parallel(attn_cp_size=1):
     return mock.patch(
-        "sglang.srt.layers.attention.dsa_backend.get_parallel",
+        "sglang.srt.runtime_context.get_parallel",
         return_value=types.SimpleNamespace(attn_cp_size=attn_cp_size),
     )
 
 
+def _resolve(spec_info, padded_bs):
+    return resolve_compact_verify_layout(
+        spec_info, padded_bs=padded_bs, backend_name="DSA"
+    )
+
+
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
-class TestDsaResolveVerifyLayout(CustomTestCase):
-    def setUp(self):
-        super().setUp()
-        from sglang.srt.environ import envs
-
-        self.envs = envs
-        self.backend = _make_backend()
-
+class TestResolveCompactVerifyLayout(CustomTestCase):
     def test_no_layout_returns_none(self):
-        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
-            self.assertIsNone(
-                self.backend._resolve_verify_layout(_spec_info(None), bs=4)
-            )
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            self.assertIsNone(_resolve(_spec_info(None), padded_bs=4))
+            self.assertIsNone(_resolve(None, padded_bs=4))
 
     def test_non_compact_mode_returns_none(self):
         layout = _make_layout()
         for mode in ("static", "cap-accept"):
-            with self.envs.SGLANG_RAGGED_VERIFY_MODE.override(mode), _parallel():
-                self.assertIsNone(
-                    self.backend._resolve_verify_layout(_spec_info(layout), bs=4)
-                )
+            with envs.SGLANG_RAGGED_VERIFY_MODE.override(mode), _parallel():
+                self.assertIsNone(_resolve(_spec_info(layout), padded_bs=4))
 
     def test_eager_returns_raw_layout(self):
         layout = _make_layout()
-        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
-            resolved = self.backend._resolve_verify_layout(
-                _spec_info(layout), bs=4, pad_to_slots=False
-            )
-        self.assertIs(resolved, layout)
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            self.assertIs(_resolve(_spec_info(layout), padded_bs=None), layout)
 
     def test_graph_pads_to_slots(self):
         layout = _make_layout((2, 3, 1))  # total 6 -> bucket 8
         padded_bs = 5
-        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
-            resolved = self.backend._resolve_verify_layout(
-                _spec_info(layout), bs=padded_bs
-            )
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            resolved = _resolve(_spec_info(layout), padded_bs=padded_bs)
         self.assertEqual(resolved.verify_lens.numel(), padded_bs)
         # Padding rows absorb the tier's slack: total == graph_num_tokens.
         self.assertEqual(int(resolved.verify_lens.sum().item()), 8)
@@ -101,21 +80,28 @@ class TestDsaResolveVerifyLayout(CustomTestCase):
 
     def test_cp_raises(self):
         layout = _make_layout()
-        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel(2):
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel(2):
             with self.assertRaises(NotImplementedError):
-                self.backend._resolve_verify_layout(_spec_info(layout), bs=4)
+                _resolve(_spec_info(layout), padded_bs=4)
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestDsaTargetVerifyGraphKey(CustomTestCase):
+    def _backend(self):
+        from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+
+        backend = types.SimpleNamespace(speculative_num_draft_tokens=NUM_DRAFT_TOKENS)
+        backend._target_verify_graph_key = types.MethodType(
+            DeepseekSparseAttnBackend._target_verify_graph_key, backend
+        )
+        return backend
+
     def test_no_layout_keys_by_bs(self):
-        backend = _make_backend()
-        self.assertEqual(backend._target_verify_graph_key(4, None), 4)
+        self.assertEqual(self._backend()._target_verify_graph_key(4, None), 4)
 
     def test_ragged_layout_keys_by_tokens(self):
-        backend = _make_backend()
         layout = _make_layout((2, 3, 1))  # bucket 8 <= 6*4
-        key = backend._target_verify_graph_key(4, layout)
+        key = self._backend()._target_verify_graph_key(4, layout)
         self.assertEqual(key, (8, 8))
         self.assertEqual(
             key,

--- a/test/registered/spec/dspark/test_dsa_ragged_verify_resolve.py
+++ b/test/registered/spec/dspark/test_dsa_ragged_verify_resolve.py
@@ -1,0 +1,129 @@
+"""UT for the DSA backend's ragged-verify layout resolution and graph keying.
+
+These paths are dormant until a model runs compact verify on DSA, so pin the
+gating logic directly: mode gate, eager-vs-graph pad semantics, the CP guard,
+and the token-keyed graph selection.
+"""
+
+import types
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    compute_target_verify_graph_key,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+DEVICE = torch.device("cuda")
+GRID = [8, 16, 32]
+NUM_DRAFT_TOKENS = 6
+
+
+def _make_backend(num_draft_tokens=NUM_DRAFT_TOKENS):
+    from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+
+    backend = types.SimpleNamespace(speculative_num_draft_tokens=num_draft_tokens)
+    for name in ("_resolve_verify_layout", "_target_verify_graph_key"):
+        setattr(
+            backend,
+            name,
+            types.MethodType(getattr(DeepseekSparseAttnBackend, name), backend),
+        )
+    return backend
+
+
+def _make_layout(verify_lens_cpu=(2, 3, 1)):
+    return RaggedVerifyLayout.from_verify_lens(
+        verify_lens_cpu=list(verify_lens_cpu), device=DEVICE, grid=GRID
+    )
+
+
+def _spec_info(layout):
+    return types.SimpleNamespace(ragged_verify_layout=layout)
+
+
+def _parallel(attn_cp_size=1):
+    return mock.patch(
+        "sglang.srt.layers.attention.dsa_backend.get_parallel",
+        return_value=types.SimpleNamespace(attn_cp_size=attn_cp_size),
+    )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestDsaResolveVerifyLayout(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        from sglang.srt.environ import envs
+
+        self.envs = envs
+        self.backend = _make_backend()
+
+    def test_no_layout_returns_none(self):
+        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            self.assertIsNone(
+                self.backend._resolve_verify_layout(_spec_info(None), bs=4)
+            )
+
+    def test_non_compact_mode_returns_none(self):
+        layout = _make_layout()
+        for mode in ("static", "cap-accept"):
+            with self.envs.SGLANG_RAGGED_VERIFY_MODE.override(mode), _parallel():
+                self.assertIsNone(
+                    self.backend._resolve_verify_layout(_spec_info(layout), bs=4)
+                )
+
+    def test_eager_returns_raw_layout(self):
+        layout = _make_layout()
+        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            resolved = self.backend._resolve_verify_layout(
+                _spec_info(layout), bs=4, pad_to_slots=False
+            )
+        self.assertIs(resolved, layout)
+
+    def test_graph_pads_to_slots(self):
+        layout = _make_layout((2, 3, 1))  # total 6 -> bucket 8
+        padded_bs = 5
+        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            resolved = self.backend._resolve_verify_layout(
+                _spec_info(layout), bs=padded_bs
+            )
+        self.assertEqual(resolved.verify_lens.numel(), padded_bs)
+        # Padding rows absorb the tier's slack: total == graph_num_tokens.
+        self.assertEqual(int(resolved.verify_lens.sum().item()), 8)
+        self.assertEqual(resolved.graph_num_tokens, 8)
+        self.assertEqual(resolved.total_verify_tokens, 8)
+
+    def test_cp_raises(self):
+        layout = _make_layout()
+        with self.envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel(2):
+            with self.assertRaises(NotImplementedError):
+                self.backend._resolve_verify_layout(_spec_info(layout), bs=4)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestDsaTargetVerifyGraphKey(CustomTestCase):
+    def test_no_layout_keys_by_bs(self):
+        backend = _make_backend()
+        self.assertEqual(backend._target_verify_graph_key(4, None), 4)
+
+    def test_ragged_layout_keys_by_tokens(self):
+        backend = _make_backend()
+        layout = _make_layout((2, 3, 1))  # bucket 8 <= 6*4
+        key = backend._target_verify_graph_key(4, layout)
+        self.assertEqual(key, (8, 8))
+        self.assertEqual(
+            key,
+            compute_target_verify_graph_key(
+                bs=4, num_draft_tokens=NUM_DRAFT_TOKENS, ragged_layout=layout
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/dspark/test_dsa_ragged_verify_resolve.py
+++ b/test/registered/spec/dspark/test_dsa_ragged_verify_resolve.py
@@ -86,6 +86,68 @@ class TestResolveCompactVerifyLayout(CustomTestCase):
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestPaddedRowWidthCap(CustomTestCase):
+    """DSA's graph-recorded prep compiles its page-table write for at most
+    next_n rows per request, so `max_row_len` must bound every padded row."""
+
+    MAX_ROW_LEN = 3
+
+    def _resolve_capped(self, layout, padded_bs):
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            return resolve_compact_verify_layout(
+                _spec_info(layout),
+                padded_bs=padded_bs,
+                backend_name="DSA",
+                max_row_len=self.MAX_ROW_LEN,
+            )
+
+    def test_padding_rows_are_capped(self):
+        # total 3 -> bucket 8; one padding row cannot legally absorb 5 tokens.
+        layout = _make_layout((1, 1, 1))
+        resolved = self._resolve_capped(layout, padded_bs=4)
+        lens = resolved.verify_lens.tolist()
+        self.assertEqual(len(lens), 4)
+        self.assertLessEqual(max(lens), self.MAX_ROW_LEN)
+        self.assertEqual(lens[:3], [1, 1, 1], "real rows must not be rewritten")
+        # Residual slack stays uncovered rather than widening a row.
+        self.assertLess(sum(lens), resolved.graph_num_tokens)
+        self.assertEqual(resolved.total_verify_tokens, sum(lens))
+
+    def test_no_padding_row_does_not_inflate_last_real_row(self):
+        # padded_bs == bs: the legacy path dumped all slack onto the last real
+        # row, which is exactly what overflows the compiled row block.
+        layout = _make_layout((2, 3, 1))  # total 6 -> bucket 8
+        resolved = self._resolve_capped(layout, padded_bs=3)
+        self.assertEqual(resolved.verify_lens.tolist(), [2, 3, 1])
+        self.assertEqual(resolved.total_verify_tokens, 6)
+        self.assertEqual(resolved.graph_num_tokens, 8)
+
+    def test_uncapped_resolve_keeps_absorbing_all_slack(self):
+        layout = _make_layout((2, 3, 1))
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"), _parallel():
+            resolved = _resolve(_spec_info(layout), padded_bs=3)
+        self.assertEqual(int(resolved.verify_lens.sum().item()), 8)
+        self.assertEqual(resolved.total_verify_tokens, 8)
+
+    def test_torch_and_triton_impls_agree(self):
+        from sglang.kernels.ops.speculative.ragged_verify_kernels import PaddedToBucket
+
+        verify_lens = torch.tensor([1, 1, 1], dtype=torch.int32, device=DEVICE)
+        for padded_bs in (3, 4, 6):
+            for max_row_len in (None, self.MAX_ROW_LEN):
+                with self.subTest(padded_bs=padded_bs, max_row_len=max_row_len):
+                    kwargs = dict(
+                        graph_num_tokens=16,
+                        bs=3,
+                        padded_bs=padded_bs,
+                        max_row_len=max_row_len,
+                    )
+                    got = PaddedToBucket.triton(verify_lens=verify_lens, **kwargs)
+                    want = PaddedToBucket.torch(verify_lens=verify_lens.cpu(), **kwargs)
+                    self.assertEqual(got.cpu().tolist(), want.tolist())
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
 class TestDsaTargetVerifyGraphKey(CustomTestCase):
     def _backend(self):
         from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend

--- a/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
+++ b/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
@@ -25,6 +25,7 @@ class TestRaggedVerifyGraphCapability(CustomTestCase):
         from sglang.srt.layers.attention.deepseek_v4_backend import (
             DeepseekV4AttnBackend,
         )
+        from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
         from sglang.srt.layers.attention.flashattention_backend import (
             FlashAttentionBackend,
         )
@@ -34,6 +35,7 @@ class TestRaggedVerifyGraphCapability(CustomTestCase):
             TRTLLMHAAttnBackend,
             DeepseekV4AttnBackend,
             FlashAttentionBackend,
+            DeepseekSparseAttnBackend,
         ):
             with self.subTest(backend=backend.__name__):
                 self.assertTrue(backend.supports_ragged_verify_graph)


### PR DESCRIPTION
DSA is the last spec-capable attention backend without `supports_ragged_verify_graph` (fa3 / trtllm / dsv4 already set it), so ragged/compact verify falls back to fixed-width graphs there. DSA's target-verify metadata is already built per expanded token row (unit-arange `cu_seqlens_q`, per-request expanded seqlens), so a ragged layout only changes the expanded row count; the SM100 DG-native `[bs, next_n]` paged-MQA schedule is the one uniform-width construct and is bypassed (per-token schedule) when a ragged layout is present.

- Declare `supports_ragged_verify_graph = True` and resolve the `RaggedVerifyLayout` in metadata builds (eager uses the raw layout, capture/replay uses `padded_to_bucket`); graphs are keyed via `compute_target_verify_graph_key`. CP raises `NotImplementedError`.
- Fuse the ragged replay metadata rebuild into the existing fused metadata kernel path instead of a separate torch chain.
- Record ragged verify prep (fused metadata + deepgemm paged-MQA schedule + top-k plan) inside the target-verify graph, re-derived from staged verify lens and the runner's static buffers, removing the remaining per-step eager prep.

All metadata builds on this path are sync-free (no `seq_lens_cpu` reads; `needs_cpu_seq_lens` stays False).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->