### PR TITLE
Fix FlashInfer fusion for hybrid EP and TP

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -171,6 +171,9 @@ def apply_flashinfer_allreduce_fusion(batch_size: int):
         and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
         and not is_dp_attention_enabled()
         and get_server_args().flashinfer_allreduce_fusion_backend is not None
+        # The fused op can reduce over either the EP or MoE-TP group, not both.
+        # Hybrid EP+MoE-TP therefore needs the normal pair of all-reduces.
+        and not (get_parallel().moe_ep_size > 1 and get_parallel().moe_tp_size > 1)
         and not is_flashinfer_allreduce_unavailable()
     )
 

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -7,6 +7,7 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 import dataclasses
 import os
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import sglang.srt.server_args as server_args_module
@@ -893,6 +894,38 @@ class TestForwardFlags(_IsolatedServerArgs):
         with fwd.scoped(flashinfer_trtllm_bypass=True):
             self.assertTrue(fwd.flashinfer_trtllm_bypass)
         self.assertFalse(fwd.flashinfer_trtllm_bypass)
+
+    def test_flashinfer_allreduce_fusion_rejects_hybrid_ep_tp(self):
+        import sglang.srt.layers.communicator as communicator
+
+        server_args = SimpleNamespace(flashinfer_allreduce_fusion_backend="auto")
+        with (
+            patch.object(communicator, "_is_sm90_supported", True),
+            patch.object(communicator, "_is_sm100_supported", False),
+            patch.object(communicator, "_is_flashinfer_available", True),
+            patch.object(communicator, "is_dp_attention_enabled", return_value=False),
+            patch.object(
+                communicator,
+                "is_flashinfer_allreduce_unavailable",
+                return_value=False,
+            ),
+            patch.object(communicator, "get_server_args", return_value=server_args),
+        ):
+            for moe_ep_size, moe_tp_size, expected in (
+                (1, 8, True),
+                (8, 1, True),
+                (2, 4, False),
+            ):
+                with (
+                    self.subTest(moe_ep_size=moe_ep_size, moe_tp_size=moe_tp_size),
+                    get_parallel().override(
+                        moe_ep_size=moe_ep_size, moe_tp_size=moe_tp_size
+                    ),
+                ):
+                    self.assertEqual(
+                        communicator.apply_flashinfer_allreduce_fusion(batch_size=1),
+                        expected,
+                    )
 
 
 class TestPublishLifecycle(_IsolatedServerArgs):


### PR DESCRIPTION
## Why

FlashInfer all-reduce fusion chooses the expert-parallel group whenever EP is active; otherwise it chooses the MoE tensor-parallel group. In a hybrid layout such as TP8/EP2, both `moe_ep_size=2` and `moe_tp_size=4` require post-expert reductions, but the fused operation can perform only one of them. Enabling fusion therefore omitted the MoE-TP reduction and corrupted the model activations, producing garbage output.

## Summary

Disable FlashInfer all-reduce fusion for hybrid EP+MoE-TP topologies so they use the existing correct pair of post-expert all-reduces.

## Details

- Extend `apply_flashinfer_allreduce_fusion` to reject layouts where both `moe_ep_size` and `moe_tp_size` are greater than one.
- Preserve fusion for pure MoE-TP and pure EP layouts.
- Leave AITER fusion behavior unchanged.
- Add a regression test covering pure MoE-TP `(EP=1, MoE-TP=8)`, pure EP `(EP=8, MoE-TP=1)`, and hybrid `(EP=2, MoE-TP=4)`.

## Test

- `uvx pre-commit run --files python/sglang/srt/layers/communicator.py test/registered/unit/test_runtime_context.py`
- H200: `PYTHONPATH=python python3 -m pytest -q test/registered/unit/test_runtime_context.py` (`64 passed`, `3 subtests passed`)
- Runtime reproduction with Qwen3-235B BF16 on eight H200s: TP8/EP2 produced corrupted output with FlashInfer fusion enabled and coherent output with fusion disabled; TP8/EP1 was coherent.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29890930707](https://github.com/sgl-project/sglang/actions/runs/29890930707)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29890930529](https://github.com/sgl-project/sglang/actions/runs/29890930529)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->