### PR TITLE
[Fix] Evict only the KV shortfall in evict_from_tree_cache

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2614,6 +2614,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         return total
 
     def check_decode_mem(self, selected_indices: Optional[List[int]] = None):
+        """Reclaim evictable tree-cache entries (shortfall only), then report
+        whether the next decode step fits in the KV pool."""
         num_tokens = self.new_tokens_required_next_decode(selected_indices)
         evict_from_tree_cache(self.tree_cache, num_tokens)
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -123,9 +123,10 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
                 EvictParams(num_tokens=full_num_tokens, swa_num_tokens=swa_num_tokens)
             )
     else:
-        # Standard allocator
-        if allocator.available_size() < num_tokens:
-            tree_cache.evict(EvictParams(num_tokens=num_tokens))
+        # Standard allocator: evict only the shortfall (mirrors the SWA arm)
+        available_size = allocator.available_size()
+        if available_size < num_tokens:
+            tree_cache.evict(EvictParams(num_tokens=num_tokens - available_size))
 
 
 def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = True):


### PR DESCRIPTION
- The standard-allocator arm of `evict_from_tree_cache` evicts the full `num_tokens` requirement instead of the shortfall; the SWA arm in the same function already computes `max(0, num_tokens - available)`
- The helper runs on every memory-pressured decode round (`check_decode_mem`) and on the token-allocation paths, so each pressure event destroys up to `available_size` of extra cached prefixes; on `MambaRadixCache` an evicted leaf also frees its mamba checkpoint, which cannot be rebuilt incrementally
- Evict `num_tokens - available` instead, matching the SWA semantics; the predicate outcome is unchanged

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29892044001](https://github.com/sgl-project/sglang/actions/runs/29892044001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29892043974](https://github.com/sgl-project/sglang/actions/runs/29892043974)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->