### PR TITLE
[Bugfix][HiCache] Fix allocator_type for decode in Mooncake standalone mode

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -53,6 +53,32 @@ class DecodeKVCacheOffloadManager:
             self.offload_stride = max(
                 self.page_size, (env_stride // self.page_size) * self.page_size
             )
+
+        # Parse extra config early to check standalone_storage before creating
+        # the host pool. Only standalone mode requires MooncakeHostTensorAllocator.
+        hicache_storage_backend_extra_config = {}
+        standalone_storage = False
+        if server_args.hicache_storage_backend_extra_config:
+            try:
+                hicache_storage_backend_extra_config = json.loads(
+                    server_args.hicache_storage_backend_extra_config
+                )
+                standalone_storage = str(
+                    hicache_storage_backend_extra_config.get(
+                        "standalone_storage", False
+                    )
+                ).lower() in ("true", "1")
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"Invalid hicache storage backend extra config JSON: {e}"
+                )
+
+        allocator_type = (
+            server_args.hicache_storage_backend
+            if standalone_storage and server_args.hicache_storage_backend == "mooncake"
+            else "default"
+        )
+
         kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
         if isinstance(kv_cache, MHATokenToKVPool):
             self.decode_host_mem_pool = get_mha_host_pool_cls(kv_cache)(
@@ -61,6 +87,7 @@ class DecodeKVCacheOffloadManager:
                 server_args.hicache_size,
                 self.page_size,
                 server_args.hicache_mem_layout,
+                allocator_type=allocator_type,
             )
         elif isinstance(kv_cache, MLATokenToKVPool):
             self.decode_host_mem_pool = MLATokenToKVPoolHost(
@@ -69,23 +96,13 @@ class DecodeKVCacheOffloadManager:
                 server_args.hicache_size,
                 self.page_size,
                 server_args.hicache_mem_layout,
+                allocator_type=allocator_type,
             )
         else:
             raise ValueError("Unsupported KV cache type for decode offload")
 
         self.tp_group = tp_group
         self.tp_world_size = torch.distributed.get_world_size(group=self.tp_group)
-
-        hicache_storage_backend_extra_config = {}
-        if server_args.hicache_storage_backend_extra_config:
-            try:
-                hicache_storage_backend_extra_config = json.loads(
-                    server_args.hicache_storage_backend_extra_config
-                )
-            except json.JSONDecodeError as e:
-                raise ValueError(
-                    f"Invalid hicache storage backend extra config JSON: {e}"
-                )
 
         self.cache_controller = HiCacheController(
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
The DecodeKVCacheOffloadManager constructs its host memory pool without specifying an allocator_type, defaulting to the generic HostTensorAllocator. When Mooncake standalone_storage is enabled, the MooncakeStore requires a MooncakeHostTensorAllocator to manage host-side buffers, and the mismatch triggers:

    RuntimeError: MooncakeStore with standalone_storage=True requires MooncakeHostTensorAllocator

The prefill path (HiRadixCache) has passed allocator_type since commit ef4b3c0e9 (PR #14873), but the decode offload path was omitted.

Fix by plumbing allocator_type=server_args.hicache_storage_backend into both MHATokenToKVPoolHost and MLATokenToKVPoolHost constructors in DecodeKVCacheOffloadManager.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29973988473](https://github.com/sgl-project/sglang/actions/runs/29973988473)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29973988402](https://github.com/sgl-project/sglang/actions/runs/29973988402)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->