### PR TITLE
fix(linear-attn): fall back from SM100 CuTe prefill on SM12x

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -156,15 +156,15 @@ class GDNKernelDispatcher:
                 )
 
                 cutedsl_kernel = CuteDSLGDNKernel()
-            # The CuteDSL prefill kernel only exists on SM100+ (Blackwell).
-            # On SM90 (Hopper) fall back to Triton so users can pick
+            # The CuTe DSL prefill kernel is validated only on SM100/SM103.
+            # On other architectures fall back to Triton so users can pick
             # `cutedsl` uniformly across hardware.
             if cutedsl_kernel.supports_prefill:
                 self.extend_kernel = cutedsl_kernel
             else:
                 rank0_log(
                     "CuTe DSL GDN prefill is not supported on this GPU "
-                    "(requires SM100+). Falling back to Triton for prefill."
+                    "(requires SM100/SM103). Falling back to Triton for prefill."
                 )
                 self.extend_kernel = triton_kernel
         elif prefill_backend.is_flashinfer():

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -95,14 +95,14 @@ class KDAKernelDispatcher:
 
             cutedsl_kernel = CuteDSLKDAKernel()
             if getattr(cutedsl_kernel, "supports_prefill", False):
-                # SM100 chunk prefill pipeline.
+                # SM100/SM103 chunk prefill pipeline.
                 self.extend_kernel = cutedsl_kernel
             else:
-                # CuTe DSL prefill kernels need SM100 (Blackwell); on older GPUs
-                # fall back to the Triton chunk kernel.
+                # CuTe DSL prefill kernels need SM100/SM103; on other GPUs fall
+                # back to the Triton chunk kernel.
                 self.extend_kernel = triton_kernel
                 rank0_log(
-                    "KDA cutedsl prefill needs SM100; falling back to Triton extend."
+                    "KDA cutedsl prefill needs SM100/SM103; falling back to Triton extend."
                 )
         else:
             raise ValueError(

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_cutedsl.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_cutedsl.py
@@ -23,11 +23,11 @@ logger = logging.getLogger(__name__)
 
 
 def _is_blackwell() -> bool:
-    """True iff running on SM100+ (Blackwell) where the ported kernel is valid."""
+    """True iff running on the SM100/SM103 family supported by this prefill kernel."""
     if not torch.cuda.is_available():
         return False
     major, _ = torch.cuda.get_device_capability()
-    return major >= 10
+    return major == 10
 
 
 class CuteDSLGDNKernel(LinearAttnKernelBase):
@@ -35,9 +35,9 @@ class CuteDSLGDNKernel(LinearAttnKernelBase):
 
     Decode: ``cutedsl_fused_sigmoid_gating_delta_rule_update`` (SM90+).
     Extend (prefill): chunkwise ``chunk_gated_delta_rule_cutedsl``
-    (SM100+ only, ``head_k_dim`` must be 128). On SM90 the prefill path is
-    unsupported; callers should query :attr:`supports_prefill` and fall back
-    to another backend (e.g. Triton).
+    (SM100/SM103 only, ``head_k_dim`` must be 128). On other architectures the
+    prefill path is unsupported; callers should query :attr:`supports_prefill`
+    and fall back to another backend (e.g. Triton).
     """
 
     def __init__(self):
@@ -61,7 +61,7 @@ class CuteDSLGDNKernel(LinearAttnKernelBase):
                 else -1
             )
             raise RuntimeError(
-                f"CuTe DSL GDN prefill requires SM100+ (Blackwell); got SM{major}."
+                f"CuTe DSL GDN prefill requires SM100/SM103; got SM{major}."
             )
         if head_k_dim != 128:
             raise RuntimeError(

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_cutedsl.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_cutedsl.py
@@ -14,20 +14,20 @@ logger = logging.getLogger(__name__)
 
 
 def _is_blackwell() -> bool:
-    """True iff running on SM100+ (Blackwell), where the chunk prefill kernels run."""
+    """True iff running on the SM100/SM103 family supported by chunk prefill."""
     if not torch.cuda.is_available():
         return False
     major, _ = torch.cuda.get_device_capability()
-    return major >= 10
+    return major == 10
 
 
 class CuteDSLKDAKernel(LinearAttnKernelBase):
     """CuTe DSL kernel for KDA.
 
     Decode: ``cutedsl_fused_sigmoid_gating_kda_update`` (SM90+).
-    Extend (prefill): SM100 chunk pipeline ``chunk_kda_cutedsl`` (SM100+ only,
-    ``head_k_dim`` must be 128). On SM90 the prefill path is unsupported; callers
-    query :attr:`supports_prefill` and fall back to Triton.
+    Extend (prefill): SM100 chunk pipeline ``chunk_kda_cutedsl`` (SM100/SM103
+    only, ``head_k_dim`` must be 128). On other architectures the prefill path is
+    unsupported; callers query :attr:`supports_prefill` and fall back to Triton.
     """
 
     def __init__(self):
@@ -45,7 +45,7 @@ class CuteDSLKDAKernel(LinearAttnKernelBase):
                 else -1
             )
             raise RuntimeError(
-                f"CuTe DSL KDA prefill requires SM100+ (Blackwell); got SM{major}."
+                f"CuTe DSL KDA prefill requires SM100/SM103; got SM{major}."
             )
         if head_k_dim != 128:
             raise RuntimeError(

--- a/test/registered/unit/layers/attention/test_cutedsl_prefill_arch_gate.py
+++ b/test/registered/unit/layers/attention/test_cutedsl_prefill_arch_gate.py
@@ -1,0 +1,39 @@
+"""Regression for the architecture boundary of CuTe GDN/KDA prefill.
+
+SM120 must use the existing Triton prefill fallback.  The CuTe prefill kernels
+are validated for the SM100/SM103 family only; a broad ``major >= 10`` check
+silently selects them on consumer Blackwell.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.linear.kernels.gdn_cutedsl import CuteDSLGDNKernel
+from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import CuteDSLKDAKernel
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestCuteDSLPrefillArchitectureGate(unittest.TestCase):
+    def test_only_sm10x_advertises_cutedsl_prefill(self):
+        cases = (
+            ((9, 0), False),
+            ((10, 0), True),
+            ((10, 3), True),
+            ((12, 0), False),
+        )
+        for capability, expected in cases:
+            with (
+                self.subTest(capability=capability),
+                patch.object(torch.cuda, "is_available", return_value=True),
+                patch.object(
+                    torch.cuda,
+                    "get_device_capability",
+                    return_value=capability,
+                ),
+            ):
+                self.assertEqual(CuteDSLGDNKernel().supports_prefill, expected)
+                self.assertEqual(CuteDSLKDAKernel().supports_prefill, expected)


### PR DESCRIPTION
## Background

The CuTeDSL GDN prefill kernel does not support SM120. The upper-layer
capability gate was wider than the kernel's actual support range, so compiling
this kernel on SM120 produced a compile error. This tightens the two CuTeDSL
prefill capability gates to an exact match on `major == 10`: GDN/KDA CuTe DSL
prefill is only allowed on SM100; everything else falls back to the existing
Triton prefill fallback.

## Related PR

The original PRs for these two features:
https://github.com/sgl-project/sglang/pull/26200
(Port the SM100 (Blackwell) CuTeDSL chunkwise GDN prefill kernel from vLLM PR
#43273 into SGLang as a new option for `--linear-attn-prefill-backend cutedsl`.)

## Root Cause

The architecture check for CuTeDSL GDN/KDA prefill (before the fix):

```python
def _is_blackwell() -> bool:
    if not torch.cuda.is_available():
        return False
    major, _ = torch.cuda.get_device_capability()
    return major >= 10          # ← problem
```

The fix tightens the gate from `major >= 10` to `major == 10`.

## Before vs After

Same 5060 Ti, before vs after the fix:

| | gate behavior |
|---|---|
| **Before fix** (base worktree, `major >= 10`) | `gdn=True kda=True` - SM120 wrongly accepted as supported, enters the CuTeDSL dead-end (NVVM compile failure) |
| **After fix** (candidate, `major == 10`) | `gdn=False kda=False` - correctly rejected, falls back to Triton |

## Local Reproduction

### Environment

```text
# python fingerprint
torch: 2.11.0+cu130
torch cuda: 13.0
capability: (12, 0)
gpu: NVIDIA GeForce RTX 5060 Ti
cutlass module: /home/yaoheng/envs/sglang-cutedsl/lib/python3.12/site-packages/nvidia_cutlass_dsl/dsl_packages/cutlass/__init__.py

# nvcc --version
Cuda compilation tools, release 13.0, V13.0.88

# nvidia-smi
NVIDIA GeForce RTX 5060 Ti, compute_cap=12.0, driver=596.49, memory.total=16311 MiB
```

### Compile failure on SM120

On SM120 (consumer Blackwell, e.g. RTX 5060 Ti, Compute Capability `(12, 0)`),
the GDN/KDA CuTe DSL prefill fails to compile with:

```text
    error: NVVM backend compilation failed
    error: libNVVM failed while compiling generated device IR.
    note:  target architecture: sm_120a
    note:  backend log: NVVM backend compilation failed
    suggestion: check that CUDA_TOOLKIT_PATH is set correctly and that the CUDA
                 toolkit supports target architecture sm_120a
```

## Test

Test passes:

```python
"""Regression for the architecture boundary of CuTe GDN/KDA prefill.

SM120 must use the existing Triton prefill fallback.  The CuTe prefill kernels
are validated for the SM100/SM103 family only; a broad ``major >= 10`` check
silently selects them on consumer Blackwell.
"""

import unittest
from unittest.mock import patch

import torch

from sglang.srt.layers.attention.linear.kernels.gdn_cutedsl import CuteDSLGDNKernel
from sglang.srt.layers.attention.linear.kernels.kda_cutedsl import CuteDSLKDAKernel
from sglang.test.ci.ci_register import register_cpu_ci

register_cpu_ci(est_time=5, suite="base-a-test-cpu")


class TestCuteDSLPrefillArchitectureGate(unittest.TestCase):
    def test_only_sm10x_advertises_cutedsl_prefill(self):
        cases = (
            ((9, 0), False),
            ((10, 0), True),
            ((10, 3), True),
            ((12, 0), False),
        )
        for capability, expected in cases:
            with (
                self.subTest(capability=capability),
                patch.object(torch.cuda, "is_available", return_value=True),
                patch.object(
                    torch.cuda,
                    "get_device_capability",
                    return_value=capability,
                ),
            ):
                self.assertEqual(CuteDSLGDNKernel().supports_prefill, expected)
                self.assertEqual(CuteDSLKDAKernel().supports_prefill, expected)
```


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29976014516](https://github.com/sgl-project/sglang/actions/runs/29976014516)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29976014432](https://github.com/sgl-project/sglang/actions/runs/29976014432)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->