### PR TITLE
[Scheduler] Dev-only debug mode: fault-tolerant event loop (phase 1 of #31021)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3779,14 +3779,8 @@ class Scheduler(
         if self.is_fully_idle():
             self.cur_batch_for_debug = None
             self.last_batch = None
-            self.tree_cache.reset()
-            self.req_to_token_pool.clear()
-            self.token_to_kv_pool_allocator.clear()
-            self.grammar_manager.clear()
+            self._reset_memory_pools()
             self.metrics_reporter.reset_metrics()
-
-            if self.draft_worker:
-                self.draft_worker.clear_cache_pool()
 
             if empty_cache:
                 current_platform.empty_cache()
@@ -3803,6 +3797,22 @@ class Scheduler(
             )
             success = False
         return success
+
+    def _reset_memory_pools(self) -> None:
+        """Clear every memory pool (KV cache, req pool, grammar, draft) to empty.
+
+        Single source of truth for which pools exist and how they are cleared,
+        shared by flush_cache (idle path) and _abort_all_and_reset (debug-mode
+        recovery path) so a newly-added pool is never cleared by one but forgotten
+        by the other. Callers own their surrounding state (batch/queue resets,
+        metrics, device cache); this only touches the pools.
+        """
+        self.tree_cache.reset()
+        self.req_to_token_pool.clear()
+        self.token_to_kv_pool_allocator.clear()
+        self.grammar_manager.clear()
+        if self.draft_worker:
+            self.draft_worker.clear_cache_pool()
 
     def _recover_from_iteration_error(self, exc: Exception) -> None:
         """Debug-mode best-effort recovery from a serving-time exception.
@@ -3878,12 +3888,7 @@ class Scheduler(
             )
 
         # Wipe all memory pools wholesale so no KV is leaked across the reset.
-        self.tree_cache.reset()
-        self.req_to_token_pool.clear()
-        self.token_to_kv_pool_allocator.clear()
-        self.grammar_manager.clear()
-        if self.draft_worker:
-            self.draft_worker.clear_cache_pool()
+        self._reset_memory_pools()
 
         # Reset loop-carried state to its __init__ values.
         self.waiting_queue = []

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -361,6 +361,7 @@ class Scheduler(
         self.enable_hisparse = server_args.enable_hisparse
         self.enable_dp_attention = server_args.enable_dp_attention
         self.enable_unified_memory = server_args.enable_unified_memory
+        self.debug_mode = server_args.debug_mode
 
         # Distributed rank info
         attn_tp_rank, attn_tp_size, attn_dp_rank, attn_dp_size = (
@@ -1497,32 +1498,40 @@ class Scheduler(
             if self.gracefully_exit:
                 break
 
-            # Receive requests
-            recv_reqs = self.request_receiver.recv_requests()
-            self.process_input_requests(recv_reqs)
-            if self._engine_paused:
-                continue
+            try:
+                # Receive requests
+                recv_reqs = self.request_receiver.recv_requests()
+                self.process_input_requests(recv_reqs)
+                if self._engine_paused:
+                    continue
 
-            # Get the next batch to run
-            plan = self.get_next_batch_to_run(
-                running_batch=self.running_batch, last_batch=self.last_batch
-            )
-            self.running_batch = plan.running_batch
-            batch = plan.batch_to_run
-            self.cur_batch_for_debug = batch
+                # Get the next batch to run
+                plan = self.get_next_batch_to_run(
+                    running_batch=self.running_batch, last_batch=self.last_batch
+                )
+                self.running_batch = plan.running_batch
+                batch = plan.batch_to_run
+                self.cur_batch_for_debug = batch
 
-            # Launch the current batch
-            if batch:
-                result = self.run_batch(batch)
-                self.process_batch_result(batch, result)
-            else:
-                # When the server is idle, do self-check and re-init some states.
-                self.on_idle()
+                # Launch the current batch
+                if batch:
+                    result = self.run_batch(batch)
+                    self.process_batch_result(batch, result)
+                else:
+                    # When the server is idle, do self-check and re-init some states.
+                    self.on_idle()
 
-            # Update last_batch
-            self.last_batch = batch
-            if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
-                self.invariant_checker.self_check_during_busy()
+                # Update last_batch
+                self.last_batch = batch
+                if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
+                    self.invariant_checker.self_check_during_busy()
+            except Exception as e:
+                # Default: re-raise so run_scheduler_process tears the process
+                # down exactly as it does today. Debug mode opts into surviving
+                # the error instead (see _recover_from_iteration_error).
+                if not self.debug_mode:
+                    raise
+                self._recover_from_iteration_error(e)
 
     @DynamicGradMode()
     def event_loop_overlap(self):
@@ -3794,6 +3803,97 @@ class Scheduler(
             )
             success = False
         return success
+
+    def _recover_from_iteration_error(self, exc: Exception) -> None:
+        """Debug-mode best-effort recovery from a serving-time exception.
+
+        All in-flight and queued requests are aborted and every pool/queue is reset
+        to its freshly-started state. If the reset itself raises, the process is in an
+        unrecoverable state (e.g. a poisoned CUDA context after an illegal memory
+        access), so the original exception is re-raised and the normal crash path
+        (SIGQUIT in run_scheduler_process) takes over. This only recovers CPU-side
+        Python exceptions; GPU-side faults are out of scope.
+        """
+        inflight_rids = [req.rid for req in self._all_inflight_reqs()]
+        logger.error(
+            "Scheduler iteration raised an exception. Debug mode is on; aborting "
+            "all in-flight/queued requests and resetting scheduler state instead "
+            "of tearing down the process.\n"
+            f"  in-flight rids: {inflight_rids}\n"
+            f"{get_exception_traceback()}"
+        )
+        try:
+            self._abort_all_and_reset()
+            # Verify the reset actually reached the scheduler's canonical idle
+            # state before trusting the loop to continue. is_fully_idle() checks
+            # every batch/queue plus collaborator staging (grammar, dllm, hicache),
+            # so a reset that left any of them non-empty is caught here and treated
+            # as unrecoverable rather than silently resuming on stale state.
+            if not self.is_fully_idle():
+                raise RuntimeError(
+                    "debug-mode reset did not return the scheduler to a fully-idle "
+                    "state; treating the recovery as failed."
+                )
+        except Exception:
+            logger.error(
+                "Debug-mode recovery failed; the scheduler state is "
+                "unrecoverable. Falling back to the normal crash path.\n"
+                f"{get_exception_traceback()}"
+            )
+            raise exc
+        logger.warning("Debug-mode recovery complete; resuming the event loop.")
+
+    def _all_inflight_reqs(self) -> List[Req]:
+        """De-duplicated requests tracked in any in-flight batch or chunked slot."""
+        reqs: Dict[str, Req] = {}
+        for batch in (self.running_batch, self.last_batch, self.cur_batch_for_debug):
+            if batch is not None:
+                for req in batch.reqs:
+                    reqs[req.rid] = req
+        if self.chunked_req is not None:
+            reqs.setdefault(self.chunked_req.rid, self.chunked_req)
+        return list(reqs.values())
+
+    def _abort_all_and_reset(self) -> None:
+        """Abort every request and reset pools/queues to the empty state.
+
+        Reuses the same pool-clearing primitives as flush_cache, minus its idle
+        guard (we are recovering precisely because we are not idle).
+        """
+        # abort_request notifies queued requests and marks running requests for
+        # abort, but it does not free the running requests' KV or notify their
+        # clients — the normal flow relies on a later forward pass for that. Since
+        # we discard the batch instead of running another forward, notify the
+        # in-flight clients explicitly (KV is freed wholesale by the reset below).
+        inflight_reqs = self._all_inflight_reqs()
+        self.abort_request(AbortReq(abort_all=True))
+        for req in inflight_reqs:
+            self.ipc_channels.send_to_tokenizer.send_output(
+                AbortReq(
+                    rid=req.rid,
+                    abort_message="Aborted by debug-mode recovery after "
+                    "a serving-time exception.",
+                ),
+                req,
+            )
+
+        # Wipe all memory pools wholesale so no KV is leaked across the reset.
+        self.tree_cache.reset()
+        self.req_to_token_pool.clear()
+        self.token_to_kv_pool_allocator.clear()
+        self.grammar_manager.clear()
+        if self.draft_worker:
+            self.draft_worker.clear_cache_pool()
+
+        # Reset loop-carried state to its __init__ values.
+        self.waiting_queue = []
+        self.running_batch = ScheduleBatch(reqs=[], batch_is_full=False)
+        self.last_batch = None
+        self.cur_batch_for_debug = None
+        self.chunked_req = None
+        # abort_request may have recorded a deferred chunked abort; drop it so the
+        # next iteration's process_pending_chunked_abort has no stale reference.
+        self._pending_chunked_abort_req = None
 
     def get_internal_state(self, recv_req: GetInternalStateReq):
         ret = dict(vars(get_server_args()))  # vars returns a ref to obj.__dict__

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3799,14 +3799,7 @@ class Scheduler(
         return success
 
     def _reset_memory_pools(self) -> None:
-        """Clear every memory pool (KV cache, req pool, grammar, draft) to empty.
-
-        Single source of truth for which pools exist and how they are cleared,
-        shared by flush_cache (idle path) and _abort_all_and_reset (debug-mode
-        recovery path) so a newly-added pool is never cleared by one but forgotten
-        by the other. Callers own their surrounding state (batch/queue resets,
-        metrics, device cache); this only touches the pools.
-        """
+        """Clear every memory pool (KV cache, req pool, grammar, draft) to empty."""
         self.tree_cache.reset()
         self.req_to_token_pool.clear()
         self.token_to_kv_pool_allocator.clear()
@@ -3835,10 +3828,7 @@ class Scheduler(
         try:
             self._abort_all_and_reset()
             # Verify the reset actually reached the scheduler's canonical idle
-            # state before trusting the loop to continue. is_fully_idle() checks
-            # every batch/queue plus collaborator staging (grammar, dllm, hicache),
-            # so a reset that left any of them non-empty is caught here and treated
-            # as unrecoverable rather than silently resuming on stale state.
+            # state before trusting the loop to continue.
             if not self.is_fully_idle():
                 raise RuntimeError(
                     "debug-mode reset did not return the scheduler to a fully-idle "
@@ -3870,13 +3860,11 @@ class Scheduler(
         Reuses the same pool-clearing primitives as flush_cache, minus its idle
         guard (we are recovering precisely because we are not idle).
         """
-        # abort_request notifies queued requests and marks running requests for
-        # abort, but it does not free the running requests' KV or notify their
-        # clients — the normal flow relies on a later forward pass for that. Since
-        # we discard the batch instead of running another forward, notify the
-        # in-flight clients explicitly (KV is freed wholesale by the reset below).
         inflight_reqs = self._all_inflight_reqs()
         self.abort_request(AbortReq(abort_all=True))
+        # abort_request doesn't notify in-flight clients or free their KV, so we do
+        # that explicitly since we're discarding the batch instead of running another
+        # forward pass.
         for req in inflight_reqs:
             self.ipc_channels.send_to_tokenizer.send_output(
                 AbortReq(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1555,6 +1555,16 @@ class ServerArgs:
         bool,
         "Enable debug/eager mode for CUDA graph using breakable CUDA graph. When enabled, graph breaks are inserted so every operation runs eagerly while still going through the CUDA graph capture / replay path. Useful for debugging CUDA graph capture / replay issues.",
     ] = False
+    debug_mode: A[
+        bool,
+        "Dev-only debug mode (never use in production). Keeps the system alive when a "
+        "serving-time exception is raised inside the event loop. On error, all "
+        "in-flight and queued requests are aborted (their clients receive an abort), "
+        "the KV cache and scheduler queues are reset, and the loop resumes, so a "
+        "serving-time bug can be reproduced repeatedly without paying weight load + "
+        "graph capture on every crash. Only supported with tp_size=pp_size=dp_size=1 "
+        "and the non-overlap scheduler (overlap is force-disabled).",
+    ] = False
 
     # -------------------------------------------------------------------------
     # Communication and kernels
@@ -6156,6 +6166,32 @@ class ServerArgs:
                     "Debug mode for CUDA graph is enabled via breakable CUDA graph. "
                     "All operations will run eagerly through the graph capture/replay path."
                 )
+        if self.debug_mode:
+            # MVP scope: only the plain single-rank event_loop_normal is wrapped.
+            # Reject any configuration that resolves to a different event loop so
+            # the flag never silently does nothing.
+            if self.tp_size != 1 or self.pp_size != 1 or self.dp_size != 1:
+                raise ValueError(
+                    "--debug-mode is only supported with "
+                    "tp_size=pp_size=dp_size=1 (a single scheduler process with no "
+                    "cross-rank lockstep). Got "
+                    f"tp_size={self.tp_size}, pp_size={self.pp_size}, "
+                    f"dp_size={self.dp_size}."
+                )
+            if self.disaggregation_mode != "null" or self.enable_pdmux:
+                raise ValueError(
+                    "--debug-mode is not supported with PD "
+                    "disaggregation or PD multiplexing; those use event loops that "
+                    "are out of MVP scope. Got "
+                    f"disaggregation_mode={self.disaggregation_mode!r}, "
+                    f"enable_pdmux={self.enable_pdmux}."
+                )
+            if not self.disable_overlap_schedule:
+                logger.warning(
+                    "--debug-mode only wraps the non-overlap "
+                    "scheduler loop; force-disabling overlap schedule."
+                )
+                self.disable_overlap_schedule = True
         if self.enable_deepseek_v4_fp4_indexer and not is_sm100_supported():
             raise ValueError(
                 "--enable-deepseek-v4-fp4-indexer requires SM100 GPUs with "

--- a/test/registered/unit/managers/test_scheduler_fault_tolerance.py
+++ b/test/registered/unit/managers/test_scheduler_fault_tolerance.py
@@ -103,12 +103,17 @@ class TestDevFaultToleranceRecovery(CustomTestCase):
         # process_pending_chunked_abort from touching a discarded req.
         self.assertIsNone(sched._pending_chunked_abort_req)
 
-    def test_recover_resets_state_and_resumes_on_success(self):
-        # Guards the wiring event-loop -> _recover -> _abort_all_and_reset: a
-        # successful recovery must actually reset (not just swallow the error).
+    def test_recover_drives_reset_and_verification_on_success(self):
+        # Guards the success-path orchestration of _recover: it must drive the
+        # reset (abort_request) AND the post-reset verification (is_fully_idle),
+        # then return without raising. This is the only case exercising the happy
+        # path, so it catches a _recover that wrongly raises even on success.
         sched = _make_scheduler_stub(running_rids=("r1",))
-        sched._recover_from_iteration_error(RuntimeError("boom"))
-        self.assertEqual(sched.waiting_queue, [])
+
+        sched._recover_from_iteration_error(RuntimeError("boom"))  # must not raise
+
+        sched.abort_request.assert_called_once()
+        sched.is_fully_idle.assert_called_once()
 
     def test_recover_reraises_when_reset_leaves_non_idle_state(self):
         # Post-reset verification: if the scheduler is not fully idle after the

--- a/test/registered/unit/managers/test_scheduler_fault_tolerance.py
+++ b/test/registered/unit/managers/test_scheduler_fault_tolerance.py
@@ -1,0 +1,139 @@
+"""Unit tests for the dev-only fault-tolerant scheduler event loop recovery.
+
+Covers Scheduler._all_inflight_reqs / _abort_all_and_reset /
+_recover_from_iteration_error (see --debug-mode). These run the
+recovery logic directly on a hand-built Scheduler stub, so no model, GPU, or
+event loop is needed.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import AbortReq
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class _FakeReq:
+    def __init__(self, rid: str):
+        self.rid = rid
+
+
+def _fake_batch(rids):
+    return MagicMock(reqs=[_FakeReq(r) for r in rids])
+
+
+def _make_scheduler_stub(
+    *, running_rids=(), last_rids=(), cur_rids=(), chunked_rid=None
+) -> Scheduler:
+    """A Scheduler carrying only the attributes the recovery path reads/writes,
+    built without the heavy __init__ (no model / GPU)."""
+    sched = Scheduler.__new__(Scheduler)
+
+    sched.running_batch = _fake_batch(running_rids)
+    sched.last_batch = _fake_batch(last_rids) if last_rids else None
+    sched.cur_batch_for_debug = _fake_batch(cur_rids) if cur_rids else None
+    sched.chunked_req = _FakeReq(chunked_rid) if chunked_rid else None
+    sched.waiting_queue = [_FakeReq("w1")]
+    sched._pending_chunked_abort_req = _FakeReq("stale")
+
+    sched.abort_request = MagicMock()
+    sched.ipc_channels = MagicMock()
+    sched.tree_cache = MagicMock()
+    sched.req_to_token_pool = MagicMock()
+    sched.token_to_kv_pool_allocator = MagicMock()
+    sched.grammar_manager = MagicMock()
+    sched.draft_worker = None
+    # Post-reset verification hook; individual tests override the return value.
+    sched.is_fully_idle = MagicMock(return_value=True)
+    return sched
+
+
+class TestDevFaultToleranceRecovery(CustomTestCase):
+    def test_all_inflight_reqs_dedups_by_rid(self):
+        # r1 is in both running and last batches; the chunked req adds c1. A
+        # req must be reported once, or _abort_all_and_reset double-notifies it.
+        sched = _make_scheduler_stub(
+            running_rids=("r1", "r2"), last_rids=("r1",), chunked_rid="c1"
+        )
+        rids = sorted(req.rid for req in sched._all_inflight_reqs())
+        self.assertEqual(rids, ["c1", "r1", "r2"])
+
+    def test_abort_all_and_reset_notifies_inflight_and_resets_state(self):
+        sched = _make_scheduler_stub(running_rids=("r1", "r2"), chunked_rid="c1")
+
+        sched._abort_all_and_reset()
+
+        # Queued requests are handled via abort_request(abort_all=True).
+        sched.abort_request.assert_called_once()
+        (abort_arg,) = sched.abort_request.call_args.args
+        self.assertIsInstance(abort_arg, AbortReq)
+        self.assertTrue(abort_arg.abort_all)
+
+        # Running/chunked requests are notified EXPLICITLY: abort_request only
+        # marks them (relying on a later forward), so without this loop their
+        # clients would hang forever. Guard that every in-flight rid is sent.
+        notified = {
+            call.args[0].rid
+            for call in sched.ipc_channels.send_to_tokenizer.send_output.call_args_list
+        }
+        self.assertEqual(notified, {"r1", "r2", "c1"})
+
+        # All memory pools are wiped so no KV is leaked across the reset.
+        sched.tree_cache.reset.assert_called_once()
+        sched.req_to_token_pool.clear.assert_called_once()
+        sched.token_to_kv_pool_allocator.clear.assert_called_once()
+        sched.grammar_manager.clear.assert_called_once()
+
+        # Loop-carried state returns to the empty __init__ values.
+        self.assertEqual(sched.waiting_queue, [])
+        self.assertIsInstance(sched.running_batch, ScheduleBatch)
+        self.assertEqual(len(sched.running_batch.reqs), 0)
+        self.assertIsNone(sched.last_batch)
+        self.assertIsNone(sched.cur_batch_for_debug)
+        self.assertIsNone(sched.chunked_req)
+        # Dropping this marker prevents next iteration's
+        # process_pending_chunked_abort from touching a discarded req.
+        self.assertIsNone(sched._pending_chunked_abort_req)
+
+    def test_recover_resets_state_and_resumes_on_success(self):
+        # Guards the wiring event-loop -> _recover -> _abort_all_and_reset: a
+        # successful recovery must actually reset (not just swallow the error).
+        sched = _make_scheduler_stub(running_rids=("r1",))
+        sched._recover_from_iteration_error(RuntimeError("boom"))
+        self.assertEqual(sched.waiting_queue, [])
+
+    def test_recover_reraises_when_reset_leaves_non_idle_state(self):
+        # Post-reset verification: if the scheduler is not fully idle after the
+        # reset, the recovery is unrecoverable and must re-raise the ORIGINAL
+        # exception (crash path) rather than resuming on stale state.
+        sched = _make_scheduler_stub(running_rids=("r1",))
+        sched.is_fully_idle = MagicMock(return_value=False)
+        original = RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            sched._recover_from_iteration_error(original)
+        self.assertIs(ctx.exception, original)
+
+    def test_recover_reraises_original_when_reset_fails(self):
+        # Best-effort contract: if the reset itself fails the state is
+        # unrecoverable, so the ORIGINAL exception must propagate (falling back
+        # to the normal crash path) rather than being swallowed.
+        sched = _make_scheduler_stub(running_rids=("r1",))
+        sched.abort_request.side_effect = RuntimeError("cleanup failed")
+        original = RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            sched._recover_from_iteration_error(original)
+        self.assertIs(ctx.exception, original)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

Phase 1 of the dev/hot-reload debug mode proposed in #31021. When debugging
serving-time behavior (NaNs, scheduler bugs, sampling/attention issues), an
unhandled exception in the scheduler event loop today tears down the process, so
every reproduction pays full weight load + CUDA graph capture again. This adds an
opt-in, dev-only mode that survives such exceptions and keeps the process (and its
already-loaded weights and captured graphs) alive.

## What this does

`--debug-mode` (off by default; dev-only) wraps each `event_loop_normal`
iteration in try/except. On a CPU-side exception the scheduler:

1. aborts all in-flight/queued requests (queued via `abort_request`; in-flight
   clients notified explicitly, since we discard the batch instead of running the
   later forward pass the normal abort flow relies on),
2. wipes the KV cache / all memory pools and resets every queue to the empty state,
3. verifies it reached the canonical idle state (`is_fully_idle()`), then resumes.

Recovery is **best-effort**: if the reset raises, or the scheduler is not fully
idle afterward, the original exception is re-raised and the normal crash path
(SIGQUIT) takes over — so the worst case equals today's behavior.

The pool-clearing block is extracted into a shared `_reset_memory_pools()` used by
both `flush_cache` and the recovery path, so a newly-added pool can't be cleared by
one and silently forgotten by the other.

## Scope (MVP)

Enforced in `ServerArgs` validation: `tp_size=pp_size=dp_size=1`, no PD
disaggregation / pdmux, and overlap schedule is force-disabled (only
`event_loop_normal` is wrapped). Covers CPU-side exceptions only; GPU-side faults
(illegal access, device asserts) poison the CUDA context and are out of scope.
Never for production. `--debug-mode` is intended as the umbrella flag for further
dev-only debugging aids (e.g. the hot-reload work in #31021 phase 2).

## Verification

- [x] Unit test (CPU, mocked scheduler), 5/5 pass — in-flight req de-dup, reset
  contract (notify + pool clear + full state reset), post-reset `is_fully_idle`
  verification, and the best-effort re-raise contract on both reset-raises and
  non-idle-after-reset.
- [x] E2E on 1x L4 (Qwen3-0.6B, TP=1): with `--debug-mode`, an injected
  serving-time fault aborts the in-flight request (client gets a clean abort), the
  scheduler recovers and keeps serving, and token usage stays 0.00 across 20+
  crash/recover cycles (no KV leak).
- [x] Control run without the flag: the same fault crashes the process (SIGQUIT),
  as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29901392082](https://github.com/sgl-project/sglang/actions/runs/29901392082)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29901391939](https://github.com/sgl-project/sglang/actions/runs/29901391939)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->