### PR TITLE
[Fix] DeepSeek tool-call parser: one malformed call drops all valid calls

### DIFF
--- a/python/sglang/srt/function_call/deepseekv31_detector.py
+++ b/python/sglang/srt/function_call/deepseekv31_detector.py
@@ -71,21 +71,26 @@ class DeepSeekV31Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=[])
         match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
         calls = []
-        try:
-            for match_result in match_result_list:
-                # Get function name
+        # Isolate per-call parsing: a single malformed tool call (a non-matching
+        # detail regex, so `.group()` raises, or invalid JSON arguments) must not
+        # discard the valid calls parsed before it and leak the raw markup back as
+        # normal text. Skip the bad call and keep the good ones.
+        for match_result in match_result_list:
+            try:
                 func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
+                if func_detail is None:
+                    continue
                 func_name = func_detail.group(1)
-                func_args = func_detail.group(2)
-                func_args = json.loads(func_args)
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": func_args}
-                calls.extend(self.parse_base_json(match_result, tools))
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            # return the normal text if parsing fails
-            return StreamingParseResult(normal_text=text)
+                func_args = json.loads(func_detail.group(2))
+                calls.extend(
+                    self.parse_base_json(
+                        {"name": func_name, "parameters": func_args}, tools
+                    )
+                )
+            except Exception as e:
+                logger.error(f"Error parsing DeepSeek tool call: {e}")
+                continue
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]

--- a/python/sglang/srt/function_call/deepseekv3_detector.py
+++ b/python/sglang/srt/function_call/deepseekv3_detector.py
@@ -69,21 +69,26 @@ class DeepSeekV3Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=normal_text, calls=[])
         match_result_list = re.findall(self.func_call_regex, text, re.DOTALL)
         calls = []
-        try:
-            for match_result in match_result_list:
-                # Get function name
+        # Isolate per-call parsing: a single malformed tool call (a non-matching
+        # detail regex, so `.group()` raises, or invalid JSON arguments) must not
+        # discard the valid calls parsed before it and leak the raw markup back as
+        # normal text. Skip the bad call and keep the good ones.
+        for match_result in match_result_list:
+            try:
                 func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
+                if func_detail is None:
+                    continue
                 func_name = func_detail.group(2)
-                func_args = func_detail.group(3)
-                func_args = json.loads(func_args)
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": func_args}
-                calls.extend(self.parse_base_json(match_result, tools))
-            return StreamingParseResult(normal_text=normal_text, calls=calls)
-        except Exception as e:
-            logger.error(f"Error in detect_and_parse: {e}")
-            # return the normal text if parsing fails
-            return StreamingParseResult(normal_text=text)
+                func_args = json.loads(func_detail.group(3))
+                calls.extend(
+                    self.parse_base_json(
+                        {"name": func_name, "parameters": func_args}, tools
+                    )
+                )
+            except Exception as e:
+                logger.error(f"Error parsing DeepSeek tool call: {e}")
+                continue
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
 
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]

--- a/test/registered/unit/function_call/test_deepseek_detector.py
+++ b/test/registered/unit/function_call/test_deepseek_detector.py
@@ -1,0 +1,91 @@
+"""Unit tests for the DeepSeek V3 / V3.1 tool-call detectors — no server.
+
+Regression: detect_and_parse wrapped the whole loop over tool calls in one
+try/except, so a single malformed call (a non-matching detail regex, or invalid
+JSON arguments) discarded every valid call parsed before it and returned the raw
+markup as normal text. Each call must be parsed in isolation.
+"""
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.srt.function_call.deepseekv31_detector import DeepSeekV31Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+BEGIN = "<｜tool▁calls▁begin｜>"
+END = "<｜tool▁calls▁end｜>"
+CB = "<｜tool▁call▁begin｜>"
+CE = "<｜tool▁call▁end｜>"
+SEP = "<｜tool▁sep｜>"
+
+
+def _tools(*names):
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name=n, description=n, parameters={"type": "object", "properties": {}}
+            ),
+        )
+        for n in names
+    ]
+
+
+def _v3_call(name, args):
+    return f"{CB}function{SEP}{name}\n```json\n{args}\n```{CE}"
+
+
+def _v31_call(name, args):
+    return f"{CB}{name}{SEP}{args}{CE}"
+
+
+class TestDeepSeekV3Detector(CustomTestCase):
+    def _parse(self, text, tools):
+        return DeepSeekV3Detector().detect_and_parse(text, tools)
+
+    def test_malformed_call_does_not_discard_valid_call(self):
+        text = (
+            "Sure. "
+            + BEGIN
+            + _v3_call("get_weather", '{"city": "Boston"}')
+            + _v3_call("search", "{bad json")  # invalid JSON args
+            + END
+        )
+        res = self._parse(text, _tools("get_weather", "search"))
+        self.assertEqual([c.name for c in res.calls], ["get_weather"])
+        self.assertNotIn(BEGIN, res.normal_text or "")
+
+    def test_two_valid_calls_both_parse(self):
+        text = (
+            BEGIN
+            + _v3_call("get_weather", '{"city": "Boston"}')
+            + _v3_call("search", '{"q": "hi"}')
+            + END
+        )
+        res = self._parse(text, _tools("get_weather", "search"))
+        self.assertEqual([c.name for c in res.calls], ["get_weather", "search"])
+
+
+class TestDeepSeekV31Detector(CustomTestCase):
+    def _parse(self, text, tools):
+        return DeepSeekV31Detector().detect_and_parse(text, tools)
+
+    def test_malformed_call_does_not_discard_valid_call(self):
+        text = (
+            "Sure. "
+            + BEGIN
+            + _v31_call("get_weather", '{"city": "Boston"}')
+            + _v31_call("search", "{bad json")
+            + END
+        )
+        res = self._parse(text, _tools("get_weather", "search"))
+        self.assertEqual([c.name for c in res.calls], ["get_weather"])
+        self.assertNotIn(BEGIN, res.normal_text or "")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Part of #31915.

## Motivation

`DeepSeekV3Detector.detect_and_parse` (and `DeepSeekV31Detector`) wraps the whole loop over the matched tool calls in a single `try/except`:

```python
try:
    for match_result in match_result_list:
        func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
        func_name = func_detail.group(2)          # AttributeError if no match
        func_args = json.loads(func_detail.group(3))  # raises on invalid JSON
        calls.extend(self.parse_base_json({"name": func_name, "parameters": func_args}, tools))
    return StreamingParseResult(normal_text=normal_text, calls=calls)
except Exception as e:
    logger.error(...)
    return StreamingParseResult(normal_text=text)   # discards `calls`, leaks raw markup
```

So a single malformed call in a multi-call response (a non-matching detail regex, so `func_detail.group()` raises, or invalid JSON arguments) jumps to the `except`, which **discards every valid call parsed before it** and returns the raw `<｜tool▁calls▁begin｜>…` markup to the client as normal text.

Reproduced against the real detector: a valid `get_weather` call followed by a `search` call with invalid JSON args yields `calls=[]` and `normal_text` containing the raw tool-call tokens.

## Modifications

Parse each call in its own `try/except`: skip a malformed call (and a `None` detail match) and keep the valid ones, returning the pre-tool-call text as `normal_text`. Applied to both the V3 and V3.1 detectors (identical structure).

## Tests

`test_deepseek_detector.py`: for both V3 and V3.1, a valid call followed by a malformed one keeps the valid call and does not leak markup; two valid calls both parse. Fails on the pre-fix code.

cc @JustinTong0323

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29901659367](https://github.com/sgl-project/sglang/actions/runs/29901659367)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29901659318](https://github.com/sgl-project/sglang/actions/runs/29901659318)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->