### PR TITLE
[Fix] Validate head_dim derivation (ZeroDivisionError / silent truncation from config)

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -767,10 +767,26 @@ class ModelConfig:
         # Unify the config keys for hf_text_config
         self.head_dim = getattr(self.hf_text_config, "head_dim", None)
         if self.head_dim is None:
-            self.head_dim = (
-                self.hf_text_config.hidden_size
-                // self.hf_text_config.num_attention_heads
-            )
+            # head_dim is read from an untrusted config. Deriving it as
+            # hidden_size // num_attention_heads panics with ZeroDivisionError
+            # when num_attention_heads is 0 (and head_dim: null is common in real
+            # configs, so this fallback fires on normal-looking files), and
+            # silently truncates when num_attention_heads does not divide
+            # hidden_size, surfacing much later as a confusing weight-shape
+            # mismatch. Validate both with a clear error.
+            num_heads = self.hf_text_config.num_attention_heads
+            hidden_size = self.hf_text_config.hidden_size
+            if num_heads <= 0:
+                raise ValueError(
+                    f"num_attention_heads must be positive to derive head_dim, "
+                    f"got {num_heads}."
+                )
+            if hidden_size % num_heads != 0:
+                raise ValueError(
+                    f"hidden_size ({hidden_size}) must be divisible by "
+                    f"num_attention_heads ({num_heads}) to derive head_dim."
+                )
+            self.head_dim = hidden_size // num_heads
             setattr(self.hf_text_config, "head_dim", self.head_dim)
 
         self.v_head_dim = getattr(self.hf_text_config, "v_head_dim", None)

--- a/test/registered/unit/configs/test_model_config_shapes.py
+++ b/test/registered/unit/configs/test_model_config_shapes.py
@@ -51,6 +51,32 @@ class TestModelConfigShapes(CustomTestCase):
         self.assertEqual(text_config.swa_head_dim, 128)
         self.assertEqual(text_config.swa_v_head_dim, 128)
 
+    def test_zero_num_attention_heads_raises(self):
+        # head_dim derivation used to hit `hidden_size // 0` -> ZeroDivisionError
+        # (head_dim: null is common in real configs, so the fallback fires).
+        text_config = _make_text_config(head_dim=None, num_attention_heads=0)
+        with self.assertRaises(ValueError):
+            self._derive_shapes(text_config)
+
+    def test_non_divisible_hidden_size_raises(self):
+        # num_attention_heads not dividing hidden_size used to silently truncate
+        # head_dim, surfacing later as a confusing weight-shape mismatch.
+        text_config = _make_text_config(head_dim=None, num_attention_heads=7)
+        with self.assertRaises(ValueError):
+            self._derive_shapes(text_config)
+
+    def test_explicit_head_dim_skips_derivation_guard(self):
+        # An explicit head_dim must be used as-is even if num_attention_heads is 0.
+        text_config = _make_text_config(
+            head_dim=128,
+            v_head_dim=128,
+            swa_head_dim=128,
+            swa_v_head_dim=128,
+            num_attention_heads=0,
+        )
+        model_config = self._derive_shapes(text_config)
+        self.assertEqual(model_config.head_dim, 128)
+
     def test_explicit_head_dims_are_preserved(self):
         text_config = _make_text_config(
             head_dim=128,


### PR DESCRIPTION
## Motivation

`ModelConfig._derive_model_shapes` derives `head_dim` as `hidden_size // num_attention_heads` when the config omits `head_dim`:

```python
self.head_dim = getattr(self.hf_text_config, "head_dim", None)
if self.head_dim is None:
    self.head_dim = self.hf_text_config.hidden_size // self.hf_text_config.num_attention_heads
```

`head_dim: null` is common in real Llama/Mistral configs, so this fallback fires on normal-looking files, and both operands come from an untrusted `config.json`:

- `num_attention_heads == 0` -> uncaught `ZeroDivisionError` at load, before serving.
- `num_attention_heads` not dividing `hidden_size` (e.g. 7 into 4096) -> `head_dim` is silently truncated (585, so `585*7 = 4095 != 4096`), which propagates into qkv sizing and surfaces much later as a confusing weight-shape `AssertionError` far from the root cause.

This is the same class as the GGUF zero-dim / div-by-zero loader crashes: an untrusted config field used as a divisor with no guard.

Reproduced against the real `_derive_model_shapes`: `num_attention_heads=0` raises `ZeroDivisionError`, `num_attention_heads=7` returns a truncated `head_dim`.

## Modifications

Validate `num_attention_heads > 0` and `hidden_size % num_attention_heads == 0` before deriving, raising a clear `ValueError` naming the offending fields. An explicitly-provided `head_dim` still skips the guard (used as-is).

## Tests

Added to `test_model_config_shapes.py`: `num_attention_heads=0` and a non-dividing count both raise; an explicit `head_dim` is honored even when `num_attention_heads=0`. The first two fail on the pre-fix code.

Note: the same unguarded expression appears in a couple of arch-specific MTP branches (`Glm4MoeNextN`, Mistral/Mixtral MTP); happy to extend the guard there in a follow-up if you'd like it centralized.

cc @fzyzcjy @ch-wan

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29901828378](https://github.com/sgl-project/sglang/actions/runs/29901828378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29901828156](https://github.com/sgl-project/sglang/actions/runs/29901828156)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->