### PR TITLE
[Fix] Chat-template content-format detection matches media keywords as substrings

### DIFF
--- a/python/sglang/srt/parser/jinja_template_utils.py
+++ b/python/sglang/srt/parser/jinja_template_utils.py
@@ -5,6 +5,7 @@ including content format detection and message processing.
 """
 
 import logging
+import re
 
 import jinja2
 import transformers.utils.chat_template_utils as hf_chat_utils
@@ -89,9 +90,19 @@ def detect_jinja_template_content_format(chat_template: str) -> str:
     - If template has loops like {%- for content in message['content'] -%} → 'openai'
     - Otherwise → 'string'
     """
-    # Shortcut for multimodal templates
-    if any(
-        keyword in chat_template for keyword in ["image", "audio", "video", "vision"]
+    # Shortcut for multimodal templates. Match the media keywords only as whole
+    # tokens, not as substrings of unrelated words: a bare `keyword in template`
+    # test fires on words like "revision"/"provision"/"television", so a
+    # text-only template that happens to contain one is misclassified as "openai"
+    # and an OpenAI parts-list content then renders as a Python list repr into the
+    # prompt. The negative letter look-around still matches real content-type
+    # tokens (`image`, `image_url`, `input_audio`, `video`, ...). Genuine
+    # multimodal templates that iterate `message['content']` are also caught by
+    # the AST check below regardless.
+    if re.search(
+        r"(?<![a-z])(image|audio|video|vision)(?![a-z])",
+        chat_template,
+        re.IGNORECASE,
     ):
         return "openai"
 

--- a/test/registered/unit/parser/test_jinja_template_utils.py
+++ b/test/registered/unit/parser/test_jinja_template_utils.py
@@ -50,6 +50,33 @@ class TestTemplateContentFormatDetection(CustomTestCase):
         result = detect_jinja_template_content_format(deepseek_pattern)
         self.assertEqual(result, "string")
 
+    def test_media_substring_in_word_is_not_multimodal(self):
+        """A text-only template containing a media keyword only as a substring of
+        an unrelated word (e.g. 'revision') must stay 'string'; classifying it as
+        'openai' renders a parts-list content as a Python list repr."""
+        for word in ["revision", "provision", "television", "supervision"]:
+            pattern = (
+                "{# handles the "
+                + word
+                + " case #}"
+                + "{%- for message in messages %}{{ message['content'] }}{%- endfor %}"
+            )
+            self.assertEqual(
+                detect_jinja_template_content_format(pattern),
+                "string",
+                f"template mentioning {word!r} should be 'string'",
+            )
+
+    def test_real_media_keyword_still_openai(self):
+        """A real content-type media token still classifies as 'openai'."""
+        for token in ["'image'", "'image_url'", "'input_audio'", "'video'"]:
+            pattern = "{% if part['type'] == " + token + " %}x{% endif %}"
+            self.assertEqual(
+                detect_jinja_template_content_format(pattern),
+                "openai",
+                f"template with {token} should be 'openai'",
+            )
+
     def test_detect_invalid_template(self):
         """Test handling of invalid template (should default to 'string')."""
         invalid_pattern = "{{{{ invalid jinja syntax }}}}"


### PR DESCRIPTION
## Motivation

`detect_jinja_template_content_format` shortcuts to the `"openai"` content format when the template contains any of `image`/`audio`/`video`/`vision`:

```python
if any(keyword in chat_template for keyword in ["image", "audio", "video", "vision"]):
    return "openai"
```

This is a bare substring test over the whole template, so it fires on unrelated words: `revision`, `provision`, `division`, `supervision`, `television`, `envision` (all contain `vision`), or `imagemagick`. A **text-only** template that happens to contain one of these anywhere (a comment, an embedded system prompt, a tool description, or ordinary English) is then classified `"openai"`.

When that happens, an OpenAI request whose content is a parts list — `{"role": "user", "content": [{"type": "text", "text": "hello world"}]}`, which the OpenAI SDK and SGLang's own examples send even for pure text — is kept as a list and rendered by the string-expecting template (`{{ message['content'] }}`) as a Python list repr:

```
model sees:  "[{'type': 'text', 'text': 'hello world'}]"
correct:     "hello world"
```

Reproduced against the real detector: a text-only template containing `revision` returns `"openai"`.

## Modifications

Match the media keywords only when not surrounded by ASCII letters (`(?<![a-z])(image|audio|video|vision)(?![a-z])`, case-insensitive). Real content-type tokens (`image`, `image_url`, `input_audio`, `video`, …) still hit the shortcut, but substrings of unrelated words no longer do. Genuine multimodal templates that iterate `message['content']` are also caught by the AST check that follows, so the shortcut is only a fast path.

## Tests

Added to `test_jinja_template_utils.py`: text-only templates mentioning `revision`/`provision`/`television`/`supervision` stay `"string"`; templates with a real `'image'`/`'image_url'`/`'input_audio'`/`'video'` content-type token stay `"openai"`. The first group fails on the pre-fix code.

cc @JustinTong0323

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29902115621](https://github.com/sgl-project/sglang/actions/runs/29902115621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29902115502](https://github.com/sgl-project/sglang/actions/runs/29902115502)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->