### PR TITLE
[Bugfix][ROCm] Fix vllm fused_add_rms_norm 6-arg crash on non-AITER path

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -465,14 +465,11 @@ class RMSNorm(MultiPlatformOp):
             # NOTE: Remove this if aiter kernel supports discontinuous input
             x = x.contiguous()
         if residual is not None:
-            out = torch.empty_like(x)
-            residual_out = torch.empty_like(x)
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
-            fused_add_rms_norm(
-                out, x, residual_out, residual, self.weight.data, self.variance_epsilon
-            )
-            return out, residual_out
+            residual = residual.contiguous()
+            fused_add_rms_norm(x, residual, self.weight.data, self.variance_epsilon)
+            return x, residual
         out = torch.empty_like(x)
         rms_norm(out, x, self.weight.data, self.variance_epsilon)
         return out
@@ -788,19 +785,14 @@ class GemmaRMSNorm(MultiPlatformOp):
             return self.forward_native(x, residual, post_residual_addition)
         else:
             w = self.gemma_weight
-            # vllm API: rms_norm(out, input, weight, eps) -> None (in-place)
-            #           fused_add_rms_norm(out, input, residual_out, residual, weight, eps)
             if not x.is_contiguous():
                 x = x.contiguous()
             if residual is not None:
-                out = torch.empty_like(x)
-                residual_out = torch.empty_like(x)
                 if post_residual_addition is not None:
                     residual = residual + post_residual_addition
-                fused_add_rms_norm(
-                    out, x, residual_out, residual, w, self.variance_epsilon
-                )
-                return out, residual_out
+                residual = residual.contiguous()
+                fused_add_rms_norm(x, residual, w, self.variance_epsilon)
+                return x, residual
             out = torch.empty_like(x)
             rms_norm(out, x, w, self.variance_epsilon)
             return out


### PR DESCRIPTION
## Motivation

When running SGLang on ROCm with `SGLANG_USE_AITER=0`, the vllm fallback path for `fused_add_rms_norm` crashes with:

```
TypeError: fused_add_rms_norm() takes 4 positional arguments but 6 were given
```

This is because the current code calls `fused_add_rms_norm` with 6 arguments (matching aiter's `rmsnorm2d_fwd_with_add` signature), but vllm's `fused_add_rms_norm` uses a 4-arg in-place API: `fused_add_rms_norm(input, residual, weight, eps)`.

## Modifications

- **`RMSNorm.forward_hip`**: Changed `fused_add_rms_norm` from 6-arg call to vllm's 4-arg in-place API. Removed unnecessary `torch.empty_like` allocations for `out` and `residual_out`.
- **`GemmaRMSNorm.forward_hip`**: Same fix as above.
- Added `residual = residual.contiguous()` before the in-place call to ensure the tensor is contiguous.

## Accuracy Tests

N/A - This is a bug fix that makes the vllm fallback path callable. The aiter path (`SGLANG_USE_AITER=1`) is unaffected.

## Speed Tests and Profiling

N/A - No performance-sensitive logic changed. The fix removes two `torch.empty_like` allocations, which should be neutral or slightly beneficial.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29903193782](https://github.com/sgl-project/sglang/actions/runs/29903193782)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29903193058](https://github.com/sgl-project/sglang/actions/runs/29903193058)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->