### PR TITLE
[Scheduler] Restore disaggregated decode overlap with resource leases

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -60,6 +60,11 @@ from sglang.srt.disaggregation.utils import (
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import (
+    AbortReq,
+    BatchTokenizedGenerateReqInput,
+    TokenizedGenerateReqInput,
+)
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     NextBatchPlan,
@@ -67,9 +72,25 @@ from sglang.srt.managers.schedule_batch import (
     ScheduleBatch,
 )
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
+from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+    ForwardResourceLease,
+)
 from sglang.srt.managers.utils import GenerationBatchResult
-from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator import (
+    BaseTokenToKVPoolAllocator,
+    PagedTokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.allocator.swa import (
+    PureSWATokenToKVPoolAllocator,
+    SWATokenToKVPoolAllocator,
+)
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
+from sglang.srt.mem_cache.chunk_cache import (
+    ChunkCache,
+    PureSWAChunkCache,
+    SWAChunkCache,
+)
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     page_align_floor,
@@ -81,6 +102,7 @@ from sglang.srt.mem_cache.memory_pool import (
     KVCache,
     ReqToTokenPool,
 )
+from sglang.srt.mem_cache.radix_cache import RadixCache
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
@@ -1983,6 +2005,65 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
 
 class SchedulerDisaggregationDecodeMixin:
+    def _has_audited_disjoint_decode_admission_resources(self: Scheduler) -> bool:
+        """Fail closed unless every resource owner has disjoint allocation."""
+
+        audited_cache_allocator_pairs = {
+            (ChunkCache, TokenToKVPoolAllocator),
+            (ChunkCache, PagedTokenToKVPoolAllocator),
+            (RadixCache, TokenToKVPoolAllocator),
+            (RadixCache, PagedTokenToKVPoolAllocator),
+            (SWAChunkCache, SWATokenToKVPoolAllocator),
+            (PureSWAChunkCache, PureSWATokenToKVPoolAllocator),
+        }
+        return (
+            type(self.req_to_token_pool) is DecodeReqToTokenPool
+            and (
+                type(self.tree_cache),
+                type(self.token_to_kv_pool_allocator),
+            )
+            in audited_cache_allocator_pairs
+        )
+
+    def _can_overlap_decode_queue_with_forward_resource_lease(
+        self: Scheduler,
+    ) -> bool:
+        """Whether decode admission is disjoint from leased running resources.
+
+        New requests allocate previously free request rows and KV pages. Active
+        request rows remain leased, and finished rows are not returned to either
+        free list until their protecting forward completes. Cache/offload modes
+        that can relocate or mutate active resources retain the immediate global
+        barrier.
+        """
+        return (
+            self._war_barrier_enabled
+            and self._has_audited_disjoint_decode_admission_resources()
+            and not self.tree_cache.supports_streaming_session()
+            and not self.tree_cache.supports_mamba()
+            and not self.enable_decode_hicache
+            and not self.enable_hisparse
+            and not self.enable_unified_memory
+            and not self.disagg_decode_prealloc_queue.enable_staging
+            and not self.server_args.disaggregation_decode_enable_offload_kvcache
+            and not self.model_config.is_multimodal
+        )
+
+    @staticmethod
+    def _can_dispatch_inputs_with_forward_resource_lease(recv_reqs: List) -> bool:
+        """Whether request dispatch cannot release an in-flight resource."""
+
+        def is_safe(req) -> bool:
+            if isinstance(req, AbortReq):
+                return True
+            if isinstance(req, TokenizedGenerateReqInput):
+                return req.session_id is None and req.session_params is None
+            if isinstance(req, BatchTokenizedGenerateReqInput):
+                return all(is_safe(item) for item in req)
+            return False
+
+        return all(is_safe(req) for req in recv_reqs)
+
     @torch.no_grad()
     def event_loop_normal_disagg_decode(self: Scheduler):
         """A normal scheduler loop for decode worker in disaggregation mode."""
@@ -2021,22 +2102,75 @@ class SchedulerDisaggregationDecodeMixin:
     def event_loop_overlap_disagg_decode(self: Scheduler):
         self.result_queue = deque()
         self.last_batch: Optional[ScheduleBatch] = None
+        use_resource_lease = (
+            self._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+        resource_lease = (
+            ForwardResourceLease(
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                wait_for_read_done=self._apply_war_barrier,
+                release_finished_req=(
+                    self.batch_result_processor.release_finished_req_resources
+                ),
+            )
+            if use_resource_lease
+            else None
+        )
+        if resource_lease is not None:
+            logger.info(
+                "Enabling forward resource leases for overlap-safe "
+                "disaggregated decode admission"
+            )
 
         def pop_and_process():
             tmp_batch, tmp_result = self.result_queue.popleft()
-            self.process_batch_result(tmp_batch, tmp_result)
+            tmp_epoch = (
+                getattr(tmp_result, "forward_resource_epoch", None)
+                if resource_lease is not None
+                else None
+            )
+            self.process_batch_result(
+                tmp_batch,
+                tmp_result,
+                resource_lease=resource_lease,
+            )
+            if resource_lease is not None and tmp_epoch is not None:
+                # Decode result processing synchronizes copy_done, which is
+                # ordered after this epoch's complete forward. Fall back to the
+                # scheduler marker if a future/non-decode result has no D2H event.
+                # Use this logical completion point on every TP rank instead of
+                # a timing-sensitive local event query.
+                if tmp_result.copy_done is None:
+                    tmp_epoch.full_done_event.synchronize()
+                resource_lease.mark_forward_completed(tmp_epoch)
+                tmp_result.forward_resource_epoch = None
 
         while True:
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
+            if (
+                resource_lease is not None
+                and not self._can_dispatch_inputs_with_forward_resource_lease(recv_reqs)
+            ):
+                resource_lease.synchronize_all_and_drain()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                if resource_lease is not None:
+                    resource_lease.synchronize_all_and_drain()
                 continue
             self.process_decode_queue()
 
+            # Admission above only consumes rows/pages that were already free.
+            # Mapping writes for planning need the early read fence; physical
+            # rows/pages remain quarantined until logical forward completion.
+            if resource_lease is not None:
+                resource_lease.wait_mapping_read_done()
+
             # Get the next batch to run
             plan = self.get_next_disagg_decode_batch_to_run(
-                running_batch=self.running_batch
+                running_batch=self.running_batch,
+                resource_lease=resource_lease,
             )
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
@@ -2055,7 +2189,18 @@ class SchedulerDisaggregationDecodeMixin:
             # Launch the current batch
             if batch:
                 batch_result = self.run_batch(batch)
-                self._apply_war_barrier()
+                if resource_lease is not None:
+                    # Record this on forward_stream explicitly: the event-loop
+                    # body itself runs under schedule_stream's context.
+                    full_done_event = self.device_module.Event()
+                    full_done_event.record(stream=self.forward_stream)
+                    forward_epoch = resource_lease.arm_after_launch(
+                        batch.reqs,
+                        full_done_event=full_done_event,
+                    )
+                    batch_result.forward_resource_epoch = forward_epoch
+                else:
+                    self._apply_war_barrier()
                 self.result_queue.append((batch.copy(), batch_result))
             else:
                 batch_result = None
@@ -2065,6 +2210,10 @@ class SchedulerDisaggregationDecodeMixin:
                 if not disable_overlap_for_batch:
                     pop_and_process()
             elif batch is None:
+                if resource_lease is not None:
+                    # Idle housekeeping assumes no quarantined request/cache
+                    # ownership remains hidden from the allocator.
+                    resource_lease.synchronize_all_and_drain()
                 self.on_idle()
 
             # Run sample of the current batch
@@ -2087,7 +2236,9 @@ class SchedulerDisaggregationDecodeMixin:
 
     @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_disagg_decode_batch_to_run(
-        self: Scheduler, running_batch: ScheduleBatch
+        self: Scheduler,
+        running_batch: ScheduleBatch,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ) -> NextBatchPlan:
         """Process prebuilt batch and schedule the next decode batch."""
         # Process pending prebuilt batch: output processing + filter + merge
@@ -2110,7 +2261,14 @@ class SchedulerDisaggregationDecodeMixin:
         if running_batch.is_empty():
             ret = None
         else:
-            running_batch = self.update_running_batch(running_batch)
+            running_batch = self.update_running_batch(
+                running_batch,
+                before_decode_retract=(
+                    resource_lease.synchronize_all_and_drain
+                    if resource_lease is not None
+                    else None
+                ),
+            )
             ret = running_batch if not running_batch.is_empty() else None
 
         ret = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(ret)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -61,6 +61,11 @@ from sglang.srt.disaggregation.utils import (
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import (
+    AbortReq,
+    BatchTokenizedGenerateReqInput,
+    TokenizedGenerateReqInput,
+)
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     NextBatchPlan,
@@ -68,9 +73,25 @@ from sglang.srt.managers.schedule_batch import (
     ScheduleBatch,
 )
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
+from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+    ForwardResourceLease,
+)
 from sglang.srt.managers.utils import GenerationBatchResult
-from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator import (
+    BaseTokenToKVPoolAllocator,
+    PagedTokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.allocator.swa import (
+    PureSWATokenToKVPoolAllocator,
+    SWATokenToKVPoolAllocator,
+)
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
+from sglang.srt.mem_cache.chunk_cache import (
+    ChunkCache,
+    PureSWAChunkCache,
+    SWAChunkCache,
+)
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     page_align_floor,
@@ -82,6 +103,7 @@ from sglang.srt.mem_cache.memory_pool import (
     KVCache,
     ReqToTokenPool,
 )
+from sglang.srt.mem_cache.radix_cache import RadixCache
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
@@ -2143,6 +2165,66 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
 
 class SchedulerDisaggregationDecodeMixin:
+    def _has_audited_disjoint_decode_admission_resources(self: Scheduler) -> bool:
+        """Fail closed unless every resource owner has disjoint allocation."""
+
+        audited_cache_allocator_pairs = {
+            (ChunkCache, TokenToKVPoolAllocator),
+            (ChunkCache, PagedTokenToKVPoolAllocator),
+            (RadixCache, TokenToKVPoolAllocator),
+            (RadixCache, PagedTokenToKVPoolAllocator),
+            (SWAChunkCache, SWATokenToKVPoolAllocator),
+            (PureSWAChunkCache, PureSWATokenToKVPoolAllocator),
+        }
+        return (
+            type(self.req_to_token_pool) is DecodeReqToTokenPool
+            and (
+                type(self.tree_cache),
+                type(self.token_to_kv_pool_allocator),
+            )
+            in audited_cache_allocator_pairs
+        )
+
+    def _can_overlap_decode_queue_with_forward_resource_lease(
+        self: Scheduler,
+    ) -> bool:
+        """Whether decode admission is disjoint from leased running resources.
+
+        New requests allocate previously free request rows and KV pages. Active
+        request rows remain leased, and finished rows are not returned to either
+        free list until their protecting forward completes. Cache/offload modes
+        that can relocate or mutate active resources retain the immediate global
+        barrier.
+        """
+        return (
+            envs.SGLANG_ENABLE_DISAGG_DECODE_RESOURCE_LEASE.get()
+            and self._war_barrier_enabled
+            and self._has_audited_disjoint_decode_admission_resources()
+            and not self.tree_cache.supports_streaming_session()
+            and not self.tree_cache.supports_mamba()
+            and not self.enable_decode_hicache
+            and not self.enable_hisparse
+            and not self.enable_unified_memory
+            and not self.disagg_decode_prealloc_queue.enable_staging
+            and not self.server_args.disaggregation_decode_enable_offload_kvcache
+            and not self.model_config.is_multimodal
+        )
+
+    @staticmethod
+    def _can_dispatch_inputs_with_forward_resource_lease(recv_reqs: List) -> bool:
+        """Whether request dispatch cannot release an in-flight resource."""
+
+        def is_safe(req) -> bool:
+            if isinstance(req, AbortReq):
+                return True
+            if isinstance(req, TokenizedGenerateReqInput):
+                return req.session_id is None and req.session_params is None
+            if isinstance(req, BatchTokenizedGenerateReqInput):
+                return all(is_safe(item) for item in req)
+            return False
+
+        return all(is_safe(req) for req in recv_reqs)
+
     @torch.no_grad()
     def event_loop_normal_disagg_decode(self: Scheduler):
         """A normal scheduler loop for decode worker in disaggregation mode."""
@@ -2181,22 +2263,75 @@ class SchedulerDisaggregationDecodeMixin:
     def event_loop_overlap_disagg_decode(self: Scheduler):
         self.result_queue = deque()
         self.last_batch: Optional[ScheduleBatch] = None
+        use_resource_lease = (
+            self._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+        resource_lease = (
+            ForwardResourceLease(
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                wait_for_read_done=self._apply_war_barrier,
+                release_finished_req=(
+                    self.batch_result_processor.release_finished_req_resources
+                ),
+            )
+            if use_resource_lease
+            else None
+        )
+        if resource_lease is not None:
+            logger.info(
+                "Enabling forward resource leases for overlap-safe "
+                "disaggregated decode admission"
+            )
 
         def pop_and_process():
             tmp_batch, tmp_result = self.result_queue.popleft()
-            self.process_batch_result(tmp_batch, tmp_result)
+            tmp_epoch = (
+                getattr(tmp_result, "forward_resource_epoch", None)
+                if resource_lease is not None
+                else None
+            )
+            self.process_batch_result(
+                tmp_batch,
+                tmp_result,
+                resource_lease=resource_lease,
+            )
+            if resource_lease is not None and tmp_epoch is not None:
+                # Decode result processing synchronizes copy_done, which is
+                # ordered after this epoch's complete forward. Fall back to the
+                # scheduler marker if a future/non-decode result has no D2H event.
+                # Use this logical completion point on every TP rank instead of
+                # a timing-sensitive local event query.
+                if tmp_result.copy_done is None:
+                    tmp_epoch.full_done_event.synchronize()
+                resource_lease.mark_forward_completed(tmp_epoch)
+                tmp_result.forward_resource_epoch = None
 
         while True:
             # Receive requests
             recv_reqs = self.request_receiver.recv_requests()
+            if (
+                resource_lease is not None
+                and not self._can_dispatch_inputs_with_forward_resource_lease(recv_reqs)
+            ):
+                resource_lease.synchronize_all_and_drain()
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
+                if resource_lease is not None:
+                    resource_lease.synchronize_all_and_drain()
                 continue
             self.process_decode_queue()
 
+            # Admission above only consumes rows/pages that were already free.
+            # Mapping writes for planning need the early read fence; physical
+            # rows/pages remain quarantined until logical forward completion.
+            if resource_lease is not None:
+                resource_lease.wait_mapping_read_done()
+
             # Get the next batch to run
             plan = self.get_next_disagg_decode_batch_to_run(
-                running_batch=self.running_batch
+                running_batch=self.running_batch,
+                resource_lease=resource_lease,
             )
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
@@ -2215,7 +2350,18 @@ class SchedulerDisaggregationDecodeMixin:
             # Launch the current batch
             if batch:
                 batch_result = self.run_batch(batch)
-                self._apply_war_barrier()
+                if resource_lease is not None:
+                    # Record this on forward_stream explicitly: the event-loop
+                    # body itself runs under schedule_stream's context.
+                    full_done_event = self.device_module.Event()
+                    full_done_event.record(stream=self.forward_stream)
+                    forward_epoch = resource_lease.arm_after_launch(
+                        batch.reqs,
+                        full_done_event=full_done_event,
+                    )
+                    batch_result.forward_resource_epoch = forward_epoch
+                else:
+                    self._apply_war_barrier()
                 self.result_queue.append((batch.copy(), batch_result))
             else:
                 batch_result = None
@@ -2225,6 +2371,10 @@ class SchedulerDisaggregationDecodeMixin:
                 if not disable_overlap_for_batch:
                     pop_and_process()
             elif batch is None:
+                if resource_lease is not None:
+                    # Idle housekeeping assumes no quarantined request/cache
+                    # ownership remains hidden from the allocator.
+                    resource_lease.synchronize_all_and_drain()
                 self.on_idle()
 
             # Run sample of the current batch
@@ -2247,7 +2397,9 @@ class SchedulerDisaggregationDecodeMixin:
 
     @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_disagg_decode_batch_to_run(
-        self: Scheduler, running_batch: ScheduleBatch
+        self: Scheduler,
+        running_batch: ScheduleBatch,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ) -> NextBatchPlan:
         """Process prebuilt batch and schedule the next decode batch."""
         # Process pending prebuilt batch: output processing + filter + merge
@@ -2270,7 +2422,14 @@ class SchedulerDisaggregationDecodeMixin:
         if running_batch.is_empty():
             ret = None
         else:
-            running_batch = self.update_running_batch(running_batch)
+            running_batch = self.update_running_batch(
+                running_batch,
+                before_decode_retract=(
+                    resource_lease.synchronize_all_and_drain
+                    if resource_lease is not None
+                    else None
+                ),
+            )
             ret = running_batch if not running_batch.is_empty() else None
 
         ret = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(ret)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -574,6 +574,9 @@ class Envs:
     SGLANG_FORCE_COARSE_WAR_BARRIER = EnvBool(False)
     # Enable prefill read-done publication after compliant metadata initialization.
     SGLANG_ENABLE_PREFILL_WAR_READ_DONE = EnvBool(False)
+    # Replace the immediate disaggregated-decode WAR fence with fine-grained
+    # request/KV resource leases on audited cache and allocator combinations.
+    SGLANG_ENABLE_DISAGG_DECODE_RESOURCE_LEASE = EnvBool(False)
     # PP: skip output send/recv when the entire batch consists of non-final chunked prefill requests,
     # since process_batch_result_prefill discards next_token_ids for those anyway.
     SGLANG_PP_SKIP_PURE_CHUNKED_OUTPUT_COMM = EnvBool(False)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -25,7 +25,7 @@ from collections import deque
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from http import HTTPStatus
-from typing import Any, Deque, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Deque, Dict, List, Optional, Tuple, Union
 
 from sglang.srt.utils.common import suppress_noisy_warnings  # isort: skip
 
@@ -180,6 +180,9 @@ from sglang.srt.managers.scheduler_components.batch_result_processor import (
 )
 from sglang.srt.managers.scheduler_components.dp_attn import SchedulerDPAttnAdapter
 from sglang.srt.managers.scheduler_components.flush_wrapper import SchedulerFlushWrapper
+from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+    ForwardResourceLease,
+)
 from sglang.srt.managers.scheduler_components.idle_sleeper import IdleSleeper
 from sglang.srt.managers.scheduler_components.invariant_checker import (
     SchedulerInvariantChecker,
@@ -3163,7 +3166,12 @@ class Scheduler(
                 new_lora_set
             )
 
-    def update_running_batch(self, batch: ScheduleBatch) -> Optional[ScheduleBatch]:
+    def update_running_batch(
+        self,
+        batch: ScheduleBatch,
+        *,
+        before_decode_retract: Optional[Callable[[], None]] = None,
+    ) -> Optional[ScheduleBatch]:
         """Update the current running decoding batch."""
         initial_bs = batch.batch_size()
 
@@ -3177,10 +3185,17 @@ class Scheduler(
         if self.enable_hierarchical_cache:
             self.tree_cache.flush_write_through_acks()
 
-        # Check if decode out of memory
-        if (kv_full_retract_flag := not batch.check_decode_mem()) or (
-            TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
-        ):
+        # Check if decode is out of memory. PD decode can have completed-request
+        # resources quarantined behind an in-flight forward event; quiesce that
+        # epoch before retracting a live request, then re-check the pool.
+        kv_full_retract_flag = not batch.check_decode_mem()
+        test_retract = TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
+        if (kv_full_retract_flag or test_retract) and before_decode_retract is not None:
+            before_decode_retract()
+            if kv_full_retract_flag:
+                kv_full_retract_flag = not batch.check_decode_mem()
+
+        if kv_full_retract_flag or test_retract:
             old_available_tokens = self.token_to_kv_pool_allocator.available_size()
             old_ratio = self.new_token_ratio_tracker.current
             mamba_allocator = getattr(
@@ -3593,11 +3608,27 @@ class Scheduler(
         self,
         batch: ScheduleBatch,
         result: Union[GenerationBatchResult, EmbeddingBatchResult],
+        *,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ):
         self.publish_load_snapshot(force=batch.forward_mode.is_extend())
 
+        # Only decode result retirement is resource-lease aware. A previous
+        # prebuilt/extend batch can own the same request row and KV pages as the
+        # decode forward that is now in flight, so fully quiesce that forward
+        # before those handlers mutate or release resources. An IDLE result has
+        # no request resources to release and must not serialize DP idle ranks.
+        if resource_lease is not None and (
+            batch.forward_mode.is_extend() or batch.forward_mode.is_prebuilt()
+        ):
+            resource_lease.synchronize_all_and_drain()
+
         if batch.forward_mode.is_decode():
-            self.batch_result_processor.process_batch_result_decode(batch, result)
+            self.batch_result_processor.process_batch_result_decode(
+                batch,
+                result,
+                resource_lease=resource_lease,
+            )
         elif batch.forward_mode.is_extend():
             if batch.is_dllm():
                 self.process_batch_result_dllm(batch, result)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -25,7 +25,18 @@ from collections import deque
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from sglang.srt.runtime_context import (
     get_device,
@@ -208,6 +219,9 @@ from sglang.srt.managers.scheduler_components.batch_result_processor import (
 )
 from sglang.srt.managers.scheduler_components.dp_attn import SchedulerDPAttnAdapter
 from sglang.srt.managers.scheduler_components.flush_wrapper import SchedulerFlushWrapper
+from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+    ForwardResourceLease,
+)
 from sglang.srt.managers.scheduler_components.idle_sleeper import (
     IdleSleeper,
     RustServerIdleSleeper,
@@ -3475,7 +3489,12 @@ class Scheduler(
                 new_lora_set
             )
 
-    def update_running_batch(self, batch: ScheduleBatch) -> Optional[ScheduleBatch]:
+    def update_running_batch(
+        self,
+        batch: ScheduleBatch,
+        *,
+        before_decode_retract: Optional[Callable[[], None]] = None,
+    ) -> Optional[ScheduleBatch]:
         """Update the current running decoding batch."""
         initial_bs = batch.batch_size()
 
@@ -3484,10 +3503,17 @@ class Scheduler(
             batch.batch_is_full = False
             return batch
 
-        # Check if decode out of memory
-        if (kv_full_retract_flag := not batch.check_decode_mem()) or (
-            TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
-        ):
+        # Check if decode is out of memory. PD decode can have completed-request
+        # resources quarantined behind an in-flight forward event; quiesce that
+        # epoch before retracting a live request, then re-check the pool.
+        kv_full_retract_flag = not batch.check_decode_mem()
+        test_retract = TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
+        if (kv_full_retract_flag or test_retract) and before_decode_retract is not None:
+            before_decode_retract()
+            if kv_full_retract_flag:
+                kv_full_retract_flag = not batch.check_decode_mem()
+
+        if kv_full_retract_flag or test_retract:
             old_available_tokens = self.token_to_kv_pool_allocator.available_size()
             old_ratio = self.new_token_ratio_tracker.current
             mamba_allocator = getattr(
@@ -3918,14 +3944,30 @@ class Scheduler(
         self,
         batch: ScheduleBatch,
         result: Union[GenerationBatchResult, EmbeddingBatchResult],
+        *,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ):
         # Flush async trace ops here: in overlap mode this CPU work runs while
         # the next batch's GPU forward is in flight, giving free overlap.
         flush_trace_batch(batch.reqs)
         self.publish_load_snapshot(force=batch.forward_mode.is_extend())
 
+        # Only decode result retirement is resource-lease aware. A previous
+        # prebuilt/extend batch can own the same request row and KV pages as the
+        # decode forward that is now in flight, so fully quiesce that forward
+        # before those handlers mutate or release resources. An IDLE result has
+        # no request resources to release and must not serialize DP idle ranks.
+        if resource_lease is not None and (
+            batch.forward_mode.is_extend() or batch.forward_mode.is_prebuilt()
+        ):
+            resource_lease.synchronize_all_and_drain()
+
         if batch.forward_mode.is_decode():
-            self.batch_result_processor.process_batch_result_decode(batch, result)
+            self.batch_result_processor.process_batch_result_decode(
+                batch,
+                result,
+                resource_lease=resource_lease,
+            )
         elif batch.forward_mode.is_extend():
             if batch.is_dllm():
                 self.process_batch_result_dllm(batch, result)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
         DecodeKVCacheOffloadManager,
     )
     from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+    from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+        ForwardResourceLease,
+    )
     from sglang.srt.managers.scheduler_components.logprob_result_processor import (
         SchedulerLogprobResultProcessor,
     )
@@ -718,6 +721,8 @@ class SchedulerBatchResultProcessor:
         self,
         batch: ScheduleBatch,
         result: GenerationBatchResult,
+        *,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ):
         if result.copy_done is not None:
             result.copy_done.synchronize()
@@ -778,7 +783,28 @@ class SchedulerBatchResultProcessor:
             req.time_stats.set_last_decode_finish_time()
             req.update_finish_state(new_accept_len)
 
-            self._handle_finish_state_updated_req(req, batch, result, i, logits_output)
+            can_defer_retirement = (
+                resource_lease is not None
+                and req.finished()
+                and req.mamba_ping_pong_track_buffer is None
+                and not self.server_args.disaggregation_decode_enable_offload_kvcache
+                and not self.server_args.enable_hisparse
+            )
+            if resource_lease is not None and (
+                req.mamba_ping_pong_track_buffer is not None
+                or self.server_args.disaggregation_decode_enable_offload_kvcache
+                or (req.finished() and not can_defer_retirement)
+            ):
+                resource_lease.wait_read_done()
+
+            self._handle_finish_state_updated_req(
+                req,
+                batch,
+                result,
+                i,
+                logits_output,
+                resource_lease=resource_lease if can_defer_retirement else None,
+            )
 
             if req.return_logprob:
                 self._apply_decode_logprobs(
@@ -926,6 +952,8 @@ class SchedulerBatchResultProcessor:
         result: GenerationBatchResult,
         i: int,
         logits_output: LogitsProcessorOutput,
+        *,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ):
         # Called here (after update_finish_state) so req.finished() is valid
         # for mamba_lazy_post_decode_at_boundary inside.
@@ -959,21 +987,28 @@ class SchedulerBatchResultProcessor:
             else:
                 if get_memory().enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                prepare_release = getattr(
-                    self.model_worker, "prepare_for_kv_cache_release", None
-                )
-                if callable(prepare_release):
-                    prepare_release(req)
                 is_insert = (
                     req.mamba_lazy_is_insert
                     if get_server_args().enable_mamba_extra_buffer_lazy()
                     else True
                 )
-                release_kv_cache(req, self.tree_cache, is_insert=is_insert)
+                if resource_lease is None or not resource_lease.try_defer_finished_req(
+                    req, is_insert
+                ):
+                    self.release_finished_req_resources(req, is_insert=is_insert)
 
             req.time_stats.set_completion_time()
 
         self._maybe_collect_customized_info(i, req, logits_output)
+
+    def release_finished_req_resources(self, req: Req, *, is_insert: bool) -> None:
+        """Retire every worker/cache resource owned by a finished request."""
+        prepare_release = getattr(
+            self.model_worker, "prepare_for_kv_cache_release", None
+        )
+        if callable(prepare_release):
+            prepare_release(req)
+        release_kv_cache(req, self.tree_cache, is_insert=is_insert)
 
     def _maybe_update_reasoning_tokens(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
         DecodeKVCacheOffloadManager,
     )
     from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+    from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+        ForwardResourceLease,
+    )
     from sglang.srt.managers.scheduler_components.logprob_result_processor import (
         SchedulerLogprobResultProcessor,
     )
@@ -806,6 +809,8 @@ class SchedulerBatchResultProcessor:
         self,
         batch: ScheduleBatch,
         result: GenerationBatchResult,
+        *,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ):
         if result.copy_done is not None:
             result.copy_done.synchronize()
@@ -866,7 +871,28 @@ class SchedulerBatchResultProcessor:
             req.time_stats.set_last_decode_finish_time()
             req.update_finish_state(new_accept_len)
 
-            self._handle_finish_state_updated_req(req, batch, result, i, logits_output)
+            can_defer_retirement = (
+                resource_lease is not None
+                and req.finished()
+                and req.mamba_ping_pong_track_buffer is None
+                and not self.server_args.disaggregation_decode_enable_offload_kvcache
+                and not self.server_args.enable_hisparse
+            )
+            if resource_lease is not None and (
+                req.mamba_ping_pong_track_buffer is not None
+                or self.server_args.disaggregation_decode_enable_offload_kvcache
+                or (req.finished() and not can_defer_retirement)
+            ):
+                resource_lease.wait_read_done()
+
+            self._handle_finish_state_updated_req(
+                req,
+                batch,
+                result,
+                i,
+                logits_output,
+                resource_lease=resource_lease if can_defer_retirement else None,
+            )
 
             if req.return_logprob:
                 self._apply_decode_logprobs(
@@ -1015,6 +1041,8 @@ class SchedulerBatchResultProcessor:
         result: GenerationBatchResult,
         i: int,
         logits_output: LogitsProcessorOutput,
+        *,
+        resource_lease: Optional[ForwardResourceLease] = None,
     ):
         lazy = mamba_extra_buffer_lazy_enabled()
         known_mamba_boundary = None
@@ -1084,21 +1112,28 @@ class SchedulerBatchResultProcessor:
             else:
                 if get_memory().enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                prepare_release = getattr(
-                    self.model_worker, "prepare_for_kv_cache_release", None
-                )
-                if callable(prepare_release):
-                    prepare_release(req)
                 is_insert = (
                     req.mamba_lazy_is_insert
                     if mamba_extra_buffer_lazy_enabled()
                     else True
                 )
-                release_kv_cache(req, self.tree_cache, is_insert=is_insert)
+                if resource_lease is None or not resource_lease.try_defer_finished_req(
+                    req, is_insert
+                ):
+                    self.release_finished_req_resources(req, is_insert=is_insert)
 
             req.time_stats.set_completion_time()
 
         self._maybe_collect_customized_info(i, req, logits_output)
+
+    def release_finished_req_resources(self, req: Req, *, is_insert: bool) -> None:
+        """Retire every worker/cache resource owned by a finished request."""
+        prepare_release = getattr(
+            self.model_worker, "prepare_for_kv_cache_release", None
+        )
+        if callable(prepare_release):
+            prepare_release(req)
+        release_kv_cache(req, self.tree_cache, is_insert=is_insert)
 
     def _maybe_update_reasoning_tokens(
         self,

--- a/python/sglang/srt/managers/scheduler_components/forward_resource_lease.py
+++ b/python/sglang/srt/managers/scheduler_components/forward_resource_lease.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Iterable, Protocol
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+    from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+
+
+@dataclass(frozen=True, slots=True)
+class ReqSlotLease:
+    """Identity of one request-pool row across reuse of the same index."""
+
+    index: int
+    generation: int
+
+    @classmethod
+    def capture(cls, req_to_token_pool: ReqToTokenPool, req: Req) -> ReqSlotLease:
+        index = req.req_pool_idx
+        assert index is not None, "cannot lease an unallocated request"
+        return cls(
+            index=int(index),
+            generation=int(req_to_token_pool.req_generation[index].item()),
+        )
+
+    def validate(self, req_to_token_pool: ReqToTokenPool, req: Req) -> None:
+        assert req.req_pool_idx == self.index, (
+            "request-pool row changed while its retirement was deferred: "
+            f"expected={self.index}, actual={req.req_pool_idx}"
+        )
+        actual_generation = int(req_to_token_pool.req_generation[self.index].item())
+        assert actual_generation == self.generation, (
+            "request-pool row was reused while its retirement was deferred: "
+            f"index={self.index}, expected_generation={self.generation}, "
+            f"actual_generation={actual_generation}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DeferredReqRetirement:
+    req: Req
+    lease: ReqSlotLease
+    is_insert: bool
+
+
+class ForwardDoneEvent(Protocol):
+    """Host-visible completion marker for one submitted forward."""
+
+    def synchronize(self) -> None: ...
+
+
+@dataclass(slots=True)
+class ForwardResourceEpoch:
+    """Resources protected by one submitted forward."""
+
+    full_done_event: ForwardDoneEvent
+    protected_slots: frozenset[ReqSlotLease]
+    retirements: list[DeferredReqRetirement] = field(default_factory=list)
+    completed: bool = False
+
+
+class ForwardResourceLease:
+    """Fence scheduler mutations at the resource, rather than loop, boundary.
+
+    A launched overlap forward leases the request-pool rows it reads. Result
+    handling may retire a request from the preceding result while that request
+    is still present in the launched forward. Mapping writes are ordered after
+    the forward's early read-done marker, while whole request/KV retirements are
+    quarantined until the forward-completion marker. This distinction matters
+    because host-driven transfer engines do not inherit CUDA stream ordering.
+    """
+
+    def __init__(
+        self,
+        *,
+        req_to_token_pool: ReqToTokenPool,
+        token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+        wait_for_read_done: Callable[[], None],
+        release_finished_req: Callable[..., None],
+    ) -> None:
+        self._req_to_token_pool = req_to_token_pool
+        self._token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        self._wait_for_read_done = wait_for_read_done
+        self._release_finished_req = release_finished_req
+        self._read_pending = False
+        self._active_epoch: ForwardResourceEpoch | None = None
+        self._retirement_epochs: list[ForwardResourceEpoch] = []
+
+    @property
+    def read_pending(self) -> bool:
+        return self._read_pending
+
+    @property
+    def num_pending_retirements(self) -> int:
+        return sum(
+            len(epoch.retirements)
+            for epoch in self._retirement_epochs
+            + ([self._active_epoch] if self._active_epoch is not None else [])
+        )
+
+    def arm_after_launch(
+        self,
+        reqs: Iterable[Req],
+        *,
+        full_done_event: ForwardDoneEvent,
+    ) -> ForwardResourceEpoch:
+        assert not self._read_pending, "previous forward read fence is still pending"
+        if self._active_epoch is not None and self._active_epoch.retirements:
+            self._retirement_epochs.append(self._active_epoch)
+        self._active_epoch = ForwardResourceEpoch(
+            full_done_event=full_done_event,
+            protected_slots=frozenset(
+                ReqSlotLease.capture(self._req_to_token_pool, req)
+                for req in reqs
+                if req.req_pool_idx is not None
+            ),
+        )
+        self._read_pending = True
+        return self._active_epoch
+
+    def wait_read_done(self) -> None:
+        if not self._read_pending:
+            return
+        self._wait_for_read_done()
+        self._read_pending = False
+
+    def try_defer_finished_req(self, req: Req, is_insert: bool) -> bool:
+        """Defer a release only when the in-flight forward leased its row.
+
+        A result request outside the active lease is conservatively fenced and
+        returned to the caller for immediate retirement.
+        """
+        epoch = self._active_epoch
+        if epoch is None or epoch.completed:
+            return False
+        if req.req_pool_idx is None:
+            self.wait_read_done()
+            return False
+
+        lease = ReqSlotLease.capture(self._req_to_token_pool, req)
+        if lease not in epoch.protected_slots:
+            self.wait_read_done()
+            return False
+
+        assert all(
+            item.lease != lease for item in epoch.retirements
+        ), f"request-pool row {lease.index} was deferred more than once"
+        epoch.retirements.append(
+            DeferredReqRetirement(req=req, lease=lease, is_insert=is_insert)
+        )
+        return True
+
+    def _epochs_with_retirements(self) -> list[ForwardResourceEpoch]:
+        epochs = list(self._retirement_epochs)
+        if self._active_epoch is not None and self._active_epoch.retirements:
+            epochs.append(self._active_epoch)
+        return epochs
+
+    def _release_epochs(self, epochs: list[ForwardResourceEpoch]) -> None:
+        if not epochs:
+            return
+
+        # Validate the whole transaction before returning any row/page to a
+        # free list. If an invariant is broken, fail without a partial release
+        # that could make retry or crash diagnostics ambiguous.
+        for epoch in epochs:
+            for item in epoch.retirements:
+                item.lease.validate(self._req_to_token_pool, item.req)
+
+        self._token_to_kv_pool_allocator.free_group_begin()
+        try:
+            for epoch in epochs:
+                for item in epoch.retirements:
+                    self._release_finished_req(
+                        item.req,
+                        is_insert=item.is_insert,
+                    )
+        finally:
+            self._token_to_kv_pool_allocator.free_group_end()
+        for epoch in epochs:
+            epoch.retirements.clear()
+        self._retirement_epochs = [
+            epoch for epoch in self._retirement_epochs if epoch.retirements
+        ]
+
+    def mark_forward_completed(self, epoch: ForwardResourceEpoch) -> None:
+        """Complete one logical epoch after its result copy has synchronized.
+
+        Completion is driven by result-queue order instead of rank-local event
+        queries. All TP ranks therefore mutate allocator state in the same
+        logical iteration even if their GPU completion times differ slightly.
+        """
+        epoch.completed = True
+        self._release_epochs(
+            [item for item in self._epochs_with_retirements() if item.completed]
+        )
+
+    def wait_mapping_read_done(self) -> None:
+        self.wait_read_done()
+
+    def synchronize_all_and_drain(self) -> None:
+        """Quiesce in-flight forwards before a control-plane mutation."""
+        self.wait_read_done()
+        epochs = self._epochs_with_retirements()
+
+        # A control handler can mutate the active epoch even when it has no
+        # deferred retirement yet, so synchronize it as well.
+        events = [
+            epoch.full_done_event
+            for epoch in self._retirement_epochs
+            if not epoch.completed
+        ]
+        if self._active_epoch is not None and not self._active_epoch.completed:
+            events.append(self._active_epoch.full_done_event)
+        for event in events:
+            event.synchronize()
+        for epoch in self._retirement_epochs:
+            epoch.completed = True
+        if self._active_epoch is not None:
+            self._active_epoch.completed = True
+        self._release_epochs(epochs)

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -65,6 +65,11 @@ class GenerationBatchResult:
     delay_sample_func: Optional[callable] = None
     future_indices: Optional[torch.Tensor] = None
     speculative_num_draft_tokens: Optional[int] = None
+    # Internal scheduler epoch guarding resources read by this forward. Keeping
+    # it on the result preserves the common ``(batch, result)`` queue contract
+    # used by pause/control paths while allowing specialized schedulers to bind
+    # resource retirement to result completion.
+    forward_resource_epoch: Optional[Any] = None
 
     # Grammar FSM advance memoization (spec-v2 overlap). advance_grammar_fsm sets
     # these once — eagerly via the scheduler's grammar barrier inside verify(), or

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -70,6 +70,11 @@ class GenerationBatchResult:
     delay_sample_func: Optional[callable] = None
     future_indices: Optional[torch.Tensor] = None
     speculative_num_draft_tokens: Optional[int] = None
+    # Internal scheduler epoch guarding resources read by this forward. Keeping
+    # it on the result preserves the common ``(batch, result)`` queue contract
+    # used by pause/control paths while allowing specialized schedulers to bind
+    # resource retirement to result completion.
+    forward_resource_epoch: Optional[Any] = None
 
     # Grammar FSM advance memoization (spec-v2 overlap). advance_grammar_fsm sets
     # these once — eagerly via the scheduler's grammar barrier inside verify(), or

--- a/test/registered/unit/managers/test_forward_resource_lease.py
+++ b/test/registered/unit/managers/test_forward_resource_lease.py
@@ -1,0 +1,865 @@
+import unittest
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.io_struct import (
+    AbortReq,
+    PauseGenerationReqInput,
+    TokenizedGenerateReqInput,
+)
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+    ForwardResourceLease,
+)
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.mem_cache.allocator import (
+    PagedTokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.allocator.swa import (
+    PureSWATokenToKVPoolAllocator,
+    SWATokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.chunk_cache import (
+    ChunkCache,
+    PureSWAChunkCache,
+    SWAChunkCache,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+class TestForwardResourceLease(CustomTestCase):
+    def _make_lease(self):
+        calls = MagicMock()
+        full_done = MagicMock()
+        full_done.synchronize.side_effect = calls.full_synchronize
+        generation = [SimpleNamespace(item=lambda: 0), SimpleNamespace(item=lambda: 7)]
+        req_pool = SimpleNamespace(req_generation=generation)
+        allocator = SimpleNamespace(
+            free_group_begin=calls.free_group_begin,
+            free_group_end=calls.free_group_end,
+        )
+
+        def release(req, *, is_insert):
+            calls.release(req, is_insert=is_insert)
+            req.req_pool_idx = None
+
+        lease = ForwardResourceLease(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=allocator,
+            wait_for_read_done=calls.wait_for_read_done,
+            release_finished_req=release,
+        )
+        return lease, calls, req_pool, full_done
+
+    def test_mapping_fence_does_not_retire_before_full_forward(self):
+        lease, calls, _, full_done = self._make_lease()
+        req = SimpleNamespace(req_pool_idx=1)
+        epoch = lease.arm_after_launch([req], full_done_event=full_done)
+
+        self.assertTrue(lease.try_defer_finished_req(req, is_insert=True))
+        self.assertEqual(req.req_pool_idx, 1)
+        self.assertEqual(lease.num_pending_retirements, 1)
+
+        lease.wait_mapping_read_done()
+
+        self.assertEqual(req.req_pool_idx, 1)
+        calls.release.assert_not_called()
+        full_done.synchronize.assert_not_called()
+
+        lease.mark_forward_completed(epoch)
+
+        self.assertIsNone(req.req_pool_idx)
+        self.assertEqual(
+            [entry[0] for entry in calls.mock_calls],
+            [
+                "wait_for_read_done",
+                "free_group_begin",
+                "release",
+                "free_group_end",
+            ],
+        )
+
+    def test_request_outside_active_lease_fences_and_retires_immediately(self):
+        lease, calls, _, full_done = self._make_lease()
+        active_req = SimpleNamespace(req_pool_idx=1)
+        other_req = SimpleNamespace(req_pool_idx=0)
+        lease.arm_after_launch([active_req], full_done_event=full_done)
+
+        self.assertFalse(lease.try_defer_finished_req(other_req, is_insert=True))
+        self.assertFalse(lease.read_pending)
+        self.assertEqual(lease.num_pending_retirements, 0)
+        calls.wait_for_read_done.assert_called_once_with()
+
+        # Consuming the mapping fence must not discard the physical-resource
+        # guard for another request in the same result batch.
+        self.assertTrue(lease.try_defer_finished_req(active_req, is_insert=False))
+        self.assertEqual(lease.num_pending_retirements, 1)
+
+    def test_generation_change_is_detected_before_retirement(self):
+        lease, _, req_pool, full_done = self._make_lease()
+        req = SimpleNamespace(req_pool_idx=1)
+        epoch = lease.arm_after_launch([req], full_done_event=full_done)
+        self.assertTrue(lease.try_defer_finished_req(req, is_insert=False))
+        lease.wait_read_done()
+        req_pool.req_generation[1] = SimpleNamespace(item=lambda: 8)
+
+        with self.assertRaisesRegex(AssertionError, "was reused"):
+            lease.mark_forward_completed(epoch)
+
+    def test_all_generations_are_validated_before_any_retirement(self):
+        calls = MagicMock()
+        req_pool = SimpleNamespace(
+            req_generation=[
+                SimpleNamespace(item=lambda: 0),
+                SimpleNamespace(item=lambda: 7),
+                SimpleNamespace(item=lambda: 9),
+            ]
+        )
+        lease = ForwardResourceLease(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=SimpleNamespace(
+                free_group_begin=calls.free_group_begin,
+                free_group_end=calls.free_group_end,
+            ),
+            wait_for_read_done=calls.wait_for_read_done,
+            release_finished_req=calls.release,
+        )
+        first = SimpleNamespace(req_pool_idx=1)
+        second = SimpleNamespace(req_pool_idx=2)
+        full_done = MagicMock()
+        epoch = lease.arm_after_launch(
+            [first, second],
+            full_done_event=full_done,
+        )
+        self.assertTrue(lease.try_defer_finished_req(first, is_insert=True))
+        self.assertTrue(lease.try_defer_finished_req(second, is_insert=True))
+        lease.wait_read_done()
+        req_pool.req_generation[2] = SimpleNamespace(item=lambda: 10)
+
+        with self.assertRaisesRegex(AssertionError, "was reused"):
+            lease.mark_forward_completed(epoch)
+
+        calls.free_group_begin.assert_not_called()
+        calls.release.assert_not_called()
+
+    def test_missing_request_row_consumes_fence(self):
+        lease, calls, _, full_done = self._make_lease()
+        active_req = SimpleNamespace(req_pool_idx=1)
+        lease.arm_after_launch([active_req], full_done_event=full_done)
+        active_req.req_pool_idx = None
+
+        self.assertFalse(lease.try_defer_finished_req(active_req, is_insert=True))
+        calls.wait_for_read_done.assert_called_once_with()
+
+    def test_pending_epoch_does_not_block_arming_next_forward(self):
+        lease, calls, _, first_done = self._make_lease()
+        first_req = SimpleNamespace(req_pool_idx=1)
+        first_epoch = lease.arm_after_launch([first_req], full_done_event=first_done)
+        self.assertTrue(lease.try_defer_finished_req(first_req, is_insert=True))
+        lease.wait_read_done()
+
+        second_done = MagicMock()
+        lease.arm_after_launch([], full_done_event=second_done)
+
+        self.assertEqual(lease.num_pending_retirements, 1)
+        lease.mark_forward_completed(first_epoch)
+        self.assertIsNone(first_req.req_pool_idx)
+        second_done.synchronize.assert_not_called()
+
+    def test_control_path_synchronizes_before_release(self):
+        lease, calls, _, full_done = self._make_lease()
+        req = SimpleNamespace(req_pool_idx=1)
+        lease.arm_after_launch([req], full_done_event=full_done)
+        self.assertTrue(lease.try_defer_finished_req(req, is_insert=True))
+
+        lease.synchronize_all_and_drain()
+        lease.synchronize_all_and_drain()
+
+        self.assertIsNone(req.req_pool_idx)
+        self.assertEqual(
+            [entry[0] for entry in full_done.mock_calls],
+            ["synchronize"],
+        )
+        self.assertEqual(
+            [entry[0] for entry in calls.mock_calls],
+            [
+                "wait_for_read_done",
+                "full_synchronize",
+                "free_group_begin",
+                "release",
+                "free_group_end",
+            ],
+        )
+
+
+class TestDisaggDecodeResourceLeaseLoop(CustomTestCase):
+    def _run_overlap_iterations(
+        self,
+        *,
+        use_lease: bool,
+        mutate_result: bool = False,
+        second_recv=None,
+        defer_result_release: bool = False,
+        has_copy_done: bool = True,
+    ):
+        num_iterations = 3 if defer_result_release else 2
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.request_receiver = MagicMock()
+        recv_reqs = [[] for _ in range(num_iterations)]
+        recv_reqs[1] = [] if second_recv is None else second_recv
+        scheduler.request_receiver.recv_requests.side_effect = [
+            *recv_reqs,
+            StopIteration,
+        ]
+        scheduler.process_input_requests = MagicMock()
+        scheduler._engine_paused = False
+        scheduler.running_batch = MagicMock(name="initial_running_batch")
+        scheduler.chunked_req = None
+
+        leased_req = SimpleNamespace(req_pool_idx=0)
+        batches = [MagicMock(name=f"batch_{i}") for i in range(num_iterations)]
+        for batch in batches:
+            batch.reqs = [leased_req]
+        calls = MagicMock()
+        copy_done_events = []
+        for _ in range(num_iterations):
+            if has_copy_done:
+                event = MagicMock()
+                event.synchronize.side_effect = calls.copy_done_synchronize
+                copy_done_events.append(event)
+            else:
+                copy_done_events.append(None)
+        results = [
+            GenerationBatchResult(copy_done=copy_done_events[i])
+            for i in range(num_iterations)
+        ]
+        plans = [
+            SimpleNamespace(
+                running_batch=MagicMock(name=f"running_batch_{i}"),
+                batch_to_run=batches[i],
+            )
+            for i in range(num_iterations)
+        ]
+
+        scheduler.process_decode_queue = calls.process_decode_queue
+        scheduler.get_next_disagg_decode_batch_to_run = calls.plan
+        scheduler.get_next_disagg_decode_batch_to_run.side_effect = plans
+        scheduler.ngram_embedding_manager = MagicMock()
+        scheduler.ngram_embedding_manager.prepare_for_forward.side_effect = (
+            lambda batch, **_: batch
+        )
+        scheduler.is_disable_overlap_for_batch = MagicMock(return_value=False)
+        scheduler._can_overlap_decode_queue_with_forward_resource_lease = MagicMock(
+            return_value=use_lease
+        )
+        scheduler._apply_war_barrier = calls.war_barrier
+        scheduler.run_batch = calls.run_batch
+        scheduler.run_batch.side_effect = results
+        scheduler.forward_stream = object()
+        full_done_events = []
+
+        def make_full_done_event():
+            event = MagicMock()
+            event.synchronize.side_effect = calls.full_done_synchronize
+            full_done_events.append(event)
+            return event
+
+        scheduler.device_module = SimpleNamespace(Event=make_full_done_event)
+        scheduler.token_to_kv_pool_allocator = SimpleNamespace(
+            free_group_begin=calls.free_group_begin,
+            free_group_end=calls.free_group_end,
+        )
+        scheduler.req_to_token_pool = SimpleNamespace(
+            req_generation=[SimpleNamespace(item=lambda: 7)]
+        )
+
+        def release(req, *, is_insert):
+            calls.release_finished_req_resources()
+            req.req_pool_idx = None
+
+        scheduler.batch_result_processor = SimpleNamespace(
+            release_finished_req_resources=release
+        )
+
+        def process_inputs(reqs):
+            if reqs:
+                calls.process_nonempty_input()
+
+        scheduler.process_input_requests.side_effect = process_inputs
+
+        def process_result(_, result, **kwargs):
+            resource_lease = kwargs["resource_lease"]
+            if result.copy_done is not None:
+                result.copy_done.synchronize()
+            if mutate_result:
+                self.assertIsNotNone(resource_lease)
+                resource_lease.wait_read_done()
+            if defer_result_release and calls.process_result.call_count == 1:
+                self.assertIsNotNone(resource_lease)
+                self.assertTrue(resource_lease.try_defer_finished_req(leased_req, True))
+
+        scheduler.process_batch_result = calls.process_result
+        scheduler.process_batch_result.side_effect = process_result
+        scheduler.launch_batch_sample_if_needed = MagicMock()
+
+        with self.assertRaises(StopIteration):
+            scheduler.event_loop_overlap_disagg_decode()
+
+        self._last_full_done_events = full_done_events
+        self._last_forward_stream = scheduler.forward_stream
+        return [entry[0] for entry in calls.mock_calls]
+
+    def test_admission_runs_before_fence(self):
+        self.assertEqual(
+            self._run_overlap_iterations(use_lease=True),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+            ],
+        )
+
+    def test_result_mutation_consumes_fence(self):
+        self.assertEqual(
+            self._run_overlap_iterations(use_lease=True, mutate_result=True),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+                "war_barrier",
+            ],
+        )
+
+    def test_finished_request_stays_leased_through_next_admission(self):
+        self.assertEqual(
+            self._run_overlap_iterations(
+                use_lease=True,
+                defer_result_release=True,
+            ),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+                "free_group_begin",
+                "release_finished_req_resources",
+                "free_group_end",
+            ],
+        )
+
+    def test_full_done_event_is_recorded_on_forward_stream(self):
+        self._run_overlap_iterations(use_lease=True)
+
+        self.assertGreaterEqual(len(self._last_full_done_events), 1)
+        for event in self._last_full_done_events:
+            event.record.assert_called_once_with(stream=self._last_forward_stream)
+
+    def test_control_request_fences_before_dispatch(self):
+        pause = MagicMock(spec=PauseGenerationReqInput)
+        self.assertEqual(
+            self._run_overlap_iterations(
+                use_lease=True,
+                second_recv=[pause],
+            ),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "war_barrier",
+                "full_done_synchronize",
+                "process_nonempty_input",
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+            ],
+        )
+
+    def test_missing_copy_event_uses_full_done_before_release(self):
+        calls = self._run_overlap_iterations(
+            use_lease=True,
+            defer_result_release=True,
+            has_copy_done=False,
+        )
+
+        self.assertLess(
+            calls.index("full_done_synchronize"),
+            calls.index("release_finished_req_resources"),
+        )
+
+    def test_resource_epoch_keeps_common_result_queue_shape(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_overlap = True
+        scheduler.last_batch = MagicMock()
+        scheduler.last_batch.forward_mode.is_extend.return_value = False
+        scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=True)
+        scheduler.chunked_req = None
+        scheduler.disaggregation_mode = DisaggregationMode.DECODE
+        scheduler.result_queue = deque(
+            [
+                (
+                    MagicMock(name="batch"),
+                    GenerationBatchResult(forward_resource_epoch=object()),
+                )
+            ]
+        )
+        scheduler.process_batch_result = MagicMock()
+        scheduler.metrics_reporter = SimpleNamespace(
+            last_gen_throughput=1.0,
+            current_scheduler_metrics_enabled=False,
+        )
+        scheduler.kv_events_publisher = MagicMock()
+
+        scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
+
+        scheduler.process_batch_result.assert_called_once()
+        self.assertEqual(len(scheduler.result_queue), 0)
+        self.assertEqual(scheduler.running_batch.reqs, [])
+
+    def test_fallback_keeps_immediate_post_launch_barrier(self):
+        self.assertEqual(
+            self._run_overlap_iterations(use_lease=False),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "war_barrier",
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "war_barrier",
+                "process_result",
+                "copy_done_synchronize",
+            ],
+        )
+
+
+class TestDisaggDecodeResourceLeaseCapability(CustomTestCase):
+    def _make_scheduler(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._war_barrier_enabled = True
+        scheduler.req_to_token_pool = object.__new__(DecodeReqToTokenPool)
+        scheduler.tree_cache = object.__new__(ChunkCache)
+        scheduler.token_to_kv_pool_allocator = object.__new__(TokenToKVPoolAllocator)
+        scheduler.enable_decode_hicache = False
+        scheduler.enable_hisparse = False
+        scheduler.enable_unified_memory = False
+        scheduler.disagg_decode_prealloc_queue = SimpleNamespace(enable_staging=False)
+        scheduler.server_args = SimpleNamespace(
+            disaggregation_decode_enable_offload_kvcache=False,
+        )
+        scheduler.model_config = SimpleNamespace(is_multimodal=False)
+        return scheduler
+
+    def test_standard_cache_modes_use_resource_leases(self):
+        scheduler = self._make_scheduler()
+        self.assertTrue(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        for cache_cls, allocator_cls in (
+            (ChunkCache, PagedTokenToKVPoolAllocator),
+            (RadixCache, TokenToKVPoolAllocator),
+            (SWAChunkCache, SWATokenToKVPoolAllocator),
+            (PureSWAChunkCache, PureSWATokenToKVPoolAllocator),
+        ):
+            scheduler.tree_cache = object.__new__(cache_cls)
+            scheduler.token_to_kv_pool_allocator = object.__new__(allocator_cls)
+            self.assertTrue(
+                scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+            )
+
+    def test_unknown_resource_wrappers_fail_closed(self):
+        class CustomChunkCache(ChunkCache):
+            pass
+
+        class CustomTokenAllocator(TokenToKVPoolAllocator):
+            pass
+
+        scheduler = self._make_scheduler()
+        scheduler.tree_cache = object.__new__(CustomChunkCache)
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.token_to_kv_pool_allocator = object.__new__(CustomTokenAllocator)
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.req_to_token_pool = MagicMock()
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+    def test_complex_resource_modes_keep_global_barrier(self):
+        scheduler = self._make_scheduler()
+        for attr in (
+            "enable_decode_hicache",
+            "enable_hisparse",
+            "enable_unified_memory",
+        ):
+            setattr(scheduler, attr, True)
+            self.assertFalse(
+                scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+            )
+            setattr(scheduler, attr, False)
+
+        scheduler.server_args.disaggregation_decode_enable_offload_kvcache = True
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.disagg_decode_prealloc_queue.enable_staging = True
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.model_config.is_multimodal = True
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler._war_barrier_enabled = False
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+    def test_only_data_plane_inputs_bypass_pending_fence(self):
+        generate = MagicMock(spec=TokenizedGenerateReqInput)
+        generate.session_id = None
+        generate.session_params = None
+        abort = MagicMock(spec=AbortReq)
+        pause = MagicMock(spec=PauseGenerationReqInput)
+
+        self.assertTrue(Scheduler._can_dispatch_inputs_with_forward_resource_lease([]))
+        self.assertTrue(
+            Scheduler._can_dispatch_inputs_with_forward_resource_lease(
+                [generate, abort]
+            )
+        )
+        self.assertFalse(
+            Scheduler._can_dispatch_inputs_with_forward_resource_lease([pause])
+        )
+        generate.session_id = "session"
+        self.assertFalse(
+            Scheduler._can_dispatch_inputs_with_forward_resource_lease([generate])
+        )
+
+
+class TestProcessBatchResultResourceLease(CustomTestCase):
+    def _make_scheduler(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.publish_load_snapshot = MagicMock()
+        scheduler.batch_result_processor = MagicMock()
+        scheduler.metrics_reporter = MagicMock()
+        scheduler.enable_fpm = False
+        scheduler._maybe_clear_mm_inputs = MagicMock()
+        scheduler.maybe_send_health_check_signal = MagicMock()
+        return scheduler
+
+    def test_prebuilt_result_quiesces_before_releasing_decode_resources(self):
+        scheduler = self._make_scheduler()
+        batch = MagicMock()
+        batch.forward_mode.is_decode.return_value = False
+        batch.forward_mode.is_extend.return_value = False
+        batch.forward_mode.is_prebuilt.return_value = True
+        batch.forward_mode.is_idle.return_value = False
+        result = MagicMock()
+        order = MagicMock()
+        lease = MagicMock()
+        lease.synchronize_all_and_drain.side_effect = order.synchronize_and_drain
+        scheduler.batch_result_processor.process_batch_result_prebuilt.side_effect = (
+            order.process_prebuilt
+        )
+
+        scheduler.process_batch_result(batch, result, resource_lease=lease)
+
+        self.assertEqual(
+            [entry[0] for entry in order.mock_calls],
+            ["synchronize_and_drain", "process_prebuilt"],
+        )
+
+    def test_decode_result_keeps_fine_grained_resource_lease(self):
+        scheduler = self._make_scheduler()
+        batch = MagicMock()
+        batch.forward_mode.is_decode.return_value = True
+        batch.forward_mode.is_extend.return_value = False
+        batch.forward_mode.is_prebuilt.return_value = False
+        result = MagicMock()
+        lease = MagicMock()
+
+        scheduler.process_batch_result(batch, result, resource_lease=lease)
+
+        lease.synchronize_all_and_drain.assert_not_called()
+        scheduler.batch_result_processor.process_batch_result_decode.assert_called_once_with(
+            batch,
+            result,
+            resource_lease=lease,
+        )
+
+    def test_idle_result_does_not_serialize_resource_lease(self):
+        scheduler = self._make_scheduler()
+        batch = MagicMock()
+        batch.forward_mode.is_decode.return_value = False
+        batch.forward_mode.is_extend.return_value = False
+        batch.forward_mode.is_prebuilt.return_value = False
+        batch.forward_mode.is_idle.return_value = True
+        result = MagicMock()
+        lease = MagicMock()
+
+        scheduler.process_batch_result(batch, result, resource_lease=lease)
+
+        lease.synchronize_all_and_drain.assert_not_called()
+        scheduler.batch_result_processor.process_batch_result_idle.assert_called_once_with(
+            batch,
+            result,
+        )
+
+
+class TestDecodeRetractionResourceLease(CustomTestCase):
+    def test_quarantine_is_drained_before_retracting_live_requests(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = False
+        scheduler.new_token_ratio_tracker = MagicMock()
+        batch = MagicMock()
+        batch.batch_size.return_value = 2
+        batch.is_empty.return_value = False
+        batch.check_decode_mem.side_effect = [False, True]
+        before_retract = MagicMock()
+
+        with patch(
+            "sglang.srt.managers.scheduler.TEST_RETRACT",
+            False,
+        ):
+            result = scheduler.update_running_batch(
+                batch,
+                before_decode_retract=before_retract,
+            )
+
+        self.assertIs(result, batch)
+        before_retract.assert_called_once_with()
+        batch.retract_decode.assert_not_called()
+        batch.prepare_for_decode.assert_called_once_with()
+
+    def test_test_retract_quiesces_before_retracting(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = False
+        scheduler.forward_ct = 0
+        scheduler.new_token_ratio_tracker = SimpleNamespace(
+            current=0.5,
+            decay_step=MagicMock(),
+        )
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.token_to_kv_pool_allocator.available_size.side_effect = [10, 20]
+        scheduler.tree_cache = SimpleNamespace(
+            req_to_token_pool=SimpleNamespace(mamba_allocator=None)
+        )
+        scheduler.metrics_reporter = SimpleNamespace(
+            num_retracted_reqs=0,
+            enable_metrics=False,
+        )
+        scheduler.server_args = MagicMock()
+        order = MagicMock()
+        before_retract = MagicMock(side_effect=order.before_retract)
+        batch = MagicMock()
+        batch.batch_size.return_value = 2
+        batch.is_empty.return_value = False
+        batch.check_decode_mem.return_value = True
+
+        def retract_decode(_):
+            order.retract_decode()
+            return [], 0.5, []
+
+        batch.retract_decode.side_effect = retract_decode
+
+        with patch(
+            "sglang.srt.managers.scheduler.TEST_RETRACT",
+            True,
+        ):
+            result = scheduler.update_running_batch(
+                batch,
+                before_decode_retract=before_retract,
+            )
+
+        self.assertIs(result, batch)
+        self.assertEqual(
+            [entry[0] for entry in order.mock_calls],
+            ["before_retract", "retract_decode"],
+        )
+        batch.prepare_for_decode.assert_called_once_with()
+
+
+class TestDecodeResultResourceLease(CustomTestCase):
+    def _make_processor(self):
+        server_args = SimpleNamespace(
+            disaggregation_decode_enable_offload_kvcache=False,
+            enable_metrics=False,
+            enable_hisparse=False,
+        )
+        metrics_reporter = MagicMock()
+        metrics_reporter.num_generated_tokens = 0
+        metrics_reporter.forward_ct_decode = 0
+        return SchedulerBatchResultProcessor(
+            is_generation=True,
+            disaggregation_mode=DisaggregationMode.DECODE,
+            enable_overlap=False,
+            enable_overlap_mlx=False,
+            server_args=server_args,
+            model_config=SimpleNamespace(think_end_id=None),
+            token_to_kv_pool_allocator=MagicMock(),
+            tree_cache=MagicMock(),
+            hisparse_coordinator=None,
+            req_to_token_pool=MagicMock(),
+            decode_offload_manager=None,
+            metrics_collector=MagicMock(),
+            metrics_reporter=metrics_reporter,
+            draft_worker=MagicMock(),
+            model_worker=MagicMock(),
+            logprob_result_processor=MagicMock(),
+            output_streamer=MagicMock(),
+            abort_request=MagicMock(),
+        )
+
+    def _make_decode_case(self, *, finishes: bool):
+        order = MagicMock()
+        req = SimpleNamespace(
+            is_retracted=False,
+            output_ids=[],
+            require_reasoning=False,
+            time_stats=SimpleNamespace(set_last_decode_finish_time=MagicMock()),
+            update_finish_state=order.update_finish_state,
+            finished=MagicMock(return_value=finishes),
+            mamba_ping_pong_track_buffer=None,
+            return_logprob=False,
+            return_sampling_mask=False,
+            return_hidden_states=False,
+            grammar=None,
+        )
+        batch = SimpleNamespace(
+            reqs=[req],
+            spec_algorithm=SimpleNamespace(is_none=MagicMock(return_value=True)),
+            return_logprob=False,
+        )
+        result = SimpleNamespace(
+            copy_done=None,
+            routed_experts_output=None,
+            indexer_topk_output=None,
+            logits_output=SimpleNamespace(hidden_states=None),
+            next_token_ids=[7],
+            can_run_cuda_graph=True,
+            num_correct_drafts=0,
+            num_block_accept_tokens=0,
+            num_cap_tokens=0,
+            speculative_num_draft_tokens=None,
+        )
+        return order, req, batch, result
+
+    def test_finished_request_can_defer_without_waiting(self):
+        processor = self._make_processor()
+        order, _, batch, result = self._make_decode_case(finishes=True)
+        resource_lease = MagicMock()
+        resource_lease.try_defer_finished_req.return_value = True
+
+        with patch.object(
+            SchedulerBatchResultProcessor,
+            "_handle_finish_state_updated_req",
+            side_effect=lambda *_, **kwargs: order.finish_handler(
+                kwargs["resource_lease"]
+            ),
+        ):
+            processor.process_batch_result_decode(
+                batch,
+                result,
+                resource_lease=resource_lease,
+            )
+
+        resource_lease.wait_read_done.assert_not_called()
+        self.assertIs(
+            order.finish_handler.call_args.args[0],
+            resource_lease,
+        )
+
+    def test_unfinished_request_does_not_consume_fence(self):
+        processor = self._make_processor()
+        _, _, batch, result = self._make_decode_case(finishes=False)
+        resource_lease = MagicMock()
+
+        with patch.object(
+            SchedulerBatchResultProcessor,
+            "_handle_finish_state_updated_req",
+        ):
+            processor.process_batch_result_decode(
+                batch,
+                result,
+                resource_lease=resource_lease,
+            )
+
+        resource_lease.wait_read_done.assert_not_called()
+
+    def test_retirement_keeps_worker_hook_and_cache_release_atomic(self):
+        processor = self._make_processor()
+        req = SimpleNamespace()
+        order = MagicMock()
+        processor.model_worker.prepare_for_kv_cache_release.side_effect = (
+            lambda _: order.prepare()
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor."
+            "release_kv_cache",
+            side_effect=lambda *_, **__: order.release(),
+        ):
+            processor.release_finished_req_resources(req, is_insert=False)
+
+        self.assertEqual(
+            [entry[0] for entry in order.mock_calls],
+            ["prepare", "release"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_forward_resource_lease.py
+++ b/test/registered/unit/managers/test_forward_resource_lease.py
@@ -1,0 +1,889 @@
+import unittest
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import (
+    AbortReq,
+    PauseGenerationReqInput,
+    TokenizedGenerateReqInput,
+)
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.managers.scheduler_components.forward_resource_lease import (
+    ForwardResourceLease,
+)
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.mem_cache.allocator import (
+    PagedTokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.allocator.swa import (
+    PureSWATokenToKVPoolAllocator,
+    SWATokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.chunk_cache import (
+    ChunkCache,
+    PureSWAChunkCache,
+    SWAChunkCache,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+class TestForwardResourceLease(CustomTestCase):
+    def _make_lease(self):
+        calls = MagicMock()
+        full_done = MagicMock()
+        full_done.synchronize.side_effect = calls.full_synchronize
+        generation = [SimpleNamespace(item=lambda: 0), SimpleNamespace(item=lambda: 7)]
+        req_pool = SimpleNamespace(req_generation=generation)
+        allocator = SimpleNamespace(
+            free_group_begin=calls.free_group_begin,
+            free_group_end=calls.free_group_end,
+        )
+
+        def release(req, *, is_insert):
+            calls.release(req, is_insert=is_insert)
+            req.req_pool_idx = None
+
+        lease = ForwardResourceLease(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=allocator,
+            wait_for_read_done=calls.wait_for_read_done,
+            release_finished_req=release,
+        )
+        return lease, calls, req_pool, full_done
+
+    def test_mapping_fence_does_not_retire_before_full_forward(self):
+        lease, calls, _, full_done = self._make_lease()
+        req = SimpleNamespace(req_pool_idx=1)
+        epoch = lease.arm_after_launch([req], full_done_event=full_done)
+
+        self.assertTrue(lease.try_defer_finished_req(req, is_insert=True))
+        self.assertEqual(req.req_pool_idx, 1)
+        self.assertEqual(lease.num_pending_retirements, 1)
+
+        lease.wait_mapping_read_done()
+
+        self.assertEqual(req.req_pool_idx, 1)
+        calls.release.assert_not_called()
+        full_done.synchronize.assert_not_called()
+
+        lease.mark_forward_completed(epoch)
+
+        self.assertIsNone(req.req_pool_idx)
+        self.assertEqual(
+            [entry[0] for entry in calls.mock_calls],
+            [
+                "wait_for_read_done",
+                "free_group_begin",
+                "release",
+                "free_group_end",
+            ],
+        )
+
+    def test_request_outside_active_lease_fences_and_retires_immediately(self):
+        lease, calls, _, full_done = self._make_lease()
+        active_req = SimpleNamespace(req_pool_idx=1)
+        other_req = SimpleNamespace(req_pool_idx=0)
+        lease.arm_after_launch([active_req], full_done_event=full_done)
+
+        self.assertFalse(lease.try_defer_finished_req(other_req, is_insert=True))
+        self.assertFalse(lease.read_pending)
+        self.assertEqual(lease.num_pending_retirements, 0)
+        calls.wait_for_read_done.assert_called_once_with()
+
+        # Consuming the mapping fence must not discard the physical-resource
+        # guard for another request in the same result batch.
+        self.assertTrue(lease.try_defer_finished_req(active_req, is_insert=False))
+        self.assertEqual(lease.num_pending_retirements, 1)
+
+    def test_generation_change_is_detected_before_retirement(self):
+        lease, _, req_pool, full_done = self._make_lease()
+        req = SimpleNamespace(req_pool_idx=1)
+        epoch = lease.arm_after_launch([req], full_done_event=full_done)
+        self.assertTrue(lease.try_defer_finished_req(req, is_insert=False))
+        lease.wait_read_done()
+        req_pool.req_generation[1] = SimpleNamespace(item=lambda: 8)
+
+        with self.assertRaisesRegex(AssertionError, "was reused"):
+            lease.mark_forward_completed(epoch)
+
+    def test_all_generations_are_validated_before_any_retirement(self):
+        calls = MagicMock()
+        req_pool = SimpleNamespace(
+            req_generation=[
+                SimpleNamespace(item=lambda: 0),
+                SimpleNamespace(item=lambda: 7),
+                SimpleNamespace(item=lambda: 9),
+            ]
+        )
+        lease = ForwardResourceLease(
+            req_to_token_pool=req_pool,
+            token_to_kv_pool_allocator=SimpleNamespace(
+                free_group_begin=calls.free_group_begin,
+                free_group_end=calls.free_group_end,
+            ),
+            wait_for_read_done=calls.wait_for_read_done,
+            release_finished_req=calls.release,
+        )
+        first = SimpleNamespace(req_pool_idx=1)
+        second = SimpleNamespace(req_pool_idx=2)
+        full_done = MagicMock()
+        epoch = lease.arm_after_launch(
+            [first, second],
+            full_done_event=full_done,
+        )
+        self.assertTrue(lease.try_defer_finished_req(first, is_insert=True))
+        self.assertTrue(lease.try_defer_finished_req(second, is_insert=True))
+        lease.wait_read_done()
+        req_pool.req_generation[2] = SimpleNamespace(item=lambda: 10)
+
+        with self.assertRaisesRegex(AssertionError, "was reused"):
+            lease.mark_forward_completed(epoch)
+
+        calls.free_group_begin.assert_not_called()
+        calls.release.assert_not_called()
+
+    def test_missing_request_row_consumes_fence(self):
+        lease, calls, _, full_done = self._make_lease()
+        active_req = SimpleNamespace(req_pool_idx=1)
+        lease.arm_after_launch([active_req], full_done_event=full_done)
+        active_req.req_pool_idx = None
+
+        self.assertFalse(lease.try_defer_finished_req(active_req, is_insert=True))
+        calls.wait_for_read_done.assert_called_once_with()
+
+    def test_pending_epoch_does_not_block_arming_next_forward(self):
+        lease, calls, _, first_done = self._make_lease()
+        first_req = SimpleNamespace(req_pool_idx=1)
+        first_epoch = lease.arm_after_launch([first_req], full_done_event=first_done)
+        self.assertTrue(lease.try_defer_finished_req(first_req, is_insert=True))
+        lease.wait_read_done()
+
+        second_done = MagicMock()
+        lease.arm_after_launch([], full_done_event=second_done)
+
+        self.assertEqual(lease.num_pending_retirements, 1)
+        lease.mark_forward_completed(first_epoch)
+        self.assertIsNone(first_req.req_pool_idx)
+        second_done.synchronize.assert_not_called()
+
+    def test_control_path_synchronizes_before_release(self):
+        lease, calls, _, full_done = self._make_lease()
+        req = SimpleNamespace(req_pool_idx=1)
+        lease.arm_after_launch([req], full_done_event=full_done)
+        self.assertTrue(lease.try_defer_finished_req(req, is_insert=True))
+
+        lease.synchronize_all_and_drain()
+        lease.synchronize_all_and_drain()
+
+        self.assertIsNone(req.req_pool_idx)
+        self.assertEqual(
+            [entry[0] for entry in full_done.mock_calls],
+            ["synchronize"],
+        )
+        self.assertEqual(
+            [entry[0] for entry in calls.mock_calls],
+            [
+                "wait_for_read_done",
+                "full_synchronize",
+                "free_group_begin",
+                "release",
+                "free_group_end",
+            ],
+        )
+
+
+class TestDisaggDecodeResourceLeaseLoop(CustomTestCase):
+    def _run_overlap_iterations(
+        self,
+        *,
+        use_lease: bool,
+        mutate_result: bool = False,
+        second_recv=None,
+        defer_result_release: bool = False,
+        has_copy_done: bool = True,
+    ):
+        num_iterations = 3 if defer_result_release else 2
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.request_receiver = MagicMock()
+        recv_reqs = [[] for _ in range(num_iterations)]
+        recv_reqs[1] = [] if second_recv is None else second_recv
+        scheduler.request_receiver.recv_requests.side_effect = [
+            *recv_reqs,
+            StopIteration,
+        ]
+        scheduler.process_input_requests = MagicMock()
+        scheduler._engine_paused = False
+        scheduler.running_batch = MagicMock(name="initial_running_batch")
+        scheduler.chunked_req = None
+
+        leased_req = SimpleNamespace(req_pool_idx=0)
+        batches = [MagicMock(name=f"batch_{i}") for i in range(num_iterations)]
+        for batch in batches:
+            batch.reqs = [leased_req]
+        calls = MagicMock()
+        copy_done_events = []
+        for _ in range(num_iterations):
+            if has_copy_done:
+                event = MagicMock()
+                event.synchronize.side_effect = calls.copy_done_synchronize
+                copy_done_events.append(event)
+            else:
+                copy_done_events.append(None)
+        results = [
+            GenerationBatchResult(copy_done=copy_done_events[i])
+            for i in range(num_iterations)
+        ]
+        plans = [
+            SimpleNamespace(
+                running_batch=MagicMock(name=f"running_batch_{i}"),
+                batch_to_run=batches[i],
+            )
+            for i in range(num_iterations)
+        ]
+
+        scheduler.process_decode_queue = calls.process_decode_queue
+        scheduler.get_next_disagg_decode_batch_to_run = calls.plan
+        scheduler.get_next_disagg_decode_batch_to_run.side_effect = plans
+        scheduler.ngram_embedding_manager = MagicMock()
+        scheduler.ngram_embedding_manager.prepare_for_forward.side_effect = (
+            lambda batch, **_: batch
+        )
+        scheduler.is_disable_overlap_for_batch = MagicMock(return_value=False)
+        scheduler._can_overlap_decode_queue_with_forward_resource_lease = MagicMock(
+            return_value=use_lease
+        )
+        scheduler._apply_war_barrier = calls.war_barrier
+        scheduler.run_batch = calls.run_batch
+        scheduler.run_batch.side_effect = results
+        scheduler.forward_stream = object()
+        full_done_events = []
+
+        def make_full_done_event():
+            event = MagicMock()
+            event.synchronize.side_effect = calls.full_done_synchronize
+            full_done_events.append(event)
+            return event
+
+        scheduler.device_module = SimpleNamespace(Event=make_full_done_event)
+        scheduler.token_to_kv_pool_allocator = SimpleNamespace(
+            free_group_begin=calls.free_group_begin,
+            free_group_end=calls.free_group_end,
+        )
+        scheduler.req_to_token_pool = SimpleNamespace(
+            req_generation=[SimpleNamespace(item=lambda: 7)]
+        )
+
+        def release(req, *, is_insert):
+            calls.release_finished_req_resources()
+            req.req_pool_idx = None
+
+        scheduler.batch_result_processor = SimpleNamespace(
+            release_finished_req_resources=release
+        )
+
+        def process_inputs(reqs):
+            if reqs:
+                calls.process_nonempty_input()
+
+        scheduler.process_input_requests.side_effect = process_inputs
+
+        def process_result(_, result, **kwargs):
+            resource_lease = kwargs["resource_lease"]
+            if result.copy_done is not None:
+                result.copy_done.synchronize()
+            if mutate_result:
+                self.assertIsNotNone(resource_lease)
+                resource_lease.wait_read_done()
+            if defer_result_release and calls.process_result.call_count == 1:
+                self.assertIsNotNone(resource_lease)
+                self.assertTrue(resource_lease.try_defer_finished_req(leased_req, True))
+
+        scheduler.process_batch_result = calls.process_result
+        scheduler.process_batch_result.side_effect = process_result
+        scheduler.launch_batch_sample_if_needed = MagicMock()
+
+        with self.assertRaises(StopIteration):
+            scheduler.event_loop_overlap_disagg_decode()
+
+        self._last_full_done_events = full_done_events
+        self._last_forward_stream = scheduler.forward_stream
+        return [entry[0] for entry in calls.mock_calls]
+
+    def test_admission_runs_before_fence(self):
+        self.assertEqual(
+            self._run_overlap_iterations(use_lease=True),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+            ],
+        )
+
+    def test_result_mutation_consumes_fence(self):
+        self.assertEqual(
+            self._run_overlap_iterations(use_lease=True, mutate_result=True),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+                "war_barrier",
+            ],
+        )
+
+    def test_finished_request_stays_leased_through_next_admission(self):
+        self.assertEqual(
+            self._run_overlap_iterations(
+                use_lease=True,
+                defer_result_release=True,
+            ),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+                "process_decode_queue",
+                "war_barrier",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+                "free_group_begin",
+                "release_finished_req_resources",
+                "free_group_end",
+            ],
+        )
+
+    def test_full_done_event_is_recorded_on_forward_stream(self):
+        self._run_overlap_iterations(use_lease=True)
+
+        self.assertGreaterEqual(len(self._last_full_done_events), 1)
+        for event in self._last_full_done_events:
+            event.record.assert_called_once_with(stream=self._last_forward_stream)
+
+    def test_control_request_fences_before_dispatch(self):
+        pause = MagicMock(spec=PauseGenerationReqInput)
+        self.assertEqual(
+            self._run_overlap_iterations(
+                use_lease=True,
+                second_recv=[pause],
+            ),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "war_barrier",
+                "full_done_synchronize",
+                "process_nonempty_input",
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "process_result",
+                "copy_done_synchronize",
+            ],
+        )
+
+    def test_missing_copy_event_uses_full_done_before_release(self):
+        calls = self._run_overlap_iterations(
+            use_lease=True,
+            defer_result_release=True,
+            has_copy_done=False,
+        )
+
+        self.assertLess(
+            calls.index("full_done_synchronize"),
+            calls.index("release_finished_req_resources"),
+        )
+
+    def test_resource_epoch_keeps_common_result_queue_shape(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_overlap = True
+        scheduler.last_batch = MagicMock()
+        scheduler.last_batch.forward_mode.is_extend.return_value = False
+        scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=True)
+        scheduler.chunked_req = None
+        scheduler.disaggregation_mode = DisaggregationMode.DECODE
+        scheduler.result_queue = deque(
+            [
+                (
+                    MagicMock(name="batch"),
+                    GenerationBatchResult(forward_resource_epoch=object()),
+                )
+            ]
+        )
+        scheduler.process_batch_result = MagicMock()
+        scheduler.metrics_reporter = SimpleNamespace(
+            last_gen_throughput=1.0,
+            current_scheduler_metrics_enabled=False,
+        )
+        scheduler.kv_events_publisher = MagicMock()
+
+        scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
+
+        scheduler.process_batch_result.assert_called_once()
+        self.assertEqual(len(scheduler.result_queue), 0)
+        self.assertEqual(scheduler.running_batch.reqs, [])
+
+    def test_fallback_keeps_immediate_post_launch_barrier(self):
+        self.assertEqual(
+            self._run_overlap_iterations(use_lease=False),
+            [
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "war_barrier",
+                "process_decode_queue",
+                "plan",
+                "run_batch",
+                "war_barrier",
+                "process_result",
+                "copy_done_synchronize",
+            ],
+        )
+
+
+class TestDisaggDecodeResourceLeaseCapability(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        override = envs.SGLANG_ENABLE_DISAGG_DECODE_RESOURCE_LEASE.override(True)
+        override.__enter__()
+        self.addCleanup(override.__exit__, None, None, None)
+
+    def _make_scheduler(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._war_barrier_enabled = True
+        scheduler.req_to_token_pool = object.__new__(DecodeReqToTokenPool)
+        scheduler.tree_cache = object.__new__(ChunkCache)
+        scheduler.token_to_kv_pool_allocator = object.__new__(TokenToKVPoolAllocator)
+        scheduler.enable_decode_hicache = False
+        scheduler.enable_hisparse = False
+        scheduler.enable_unified_memory = False
+        scheduler.disagg_decode_prealloc_queue = SimpleNamespace(enable_staging=False)
+        scheduler.server_args = SimpleNamespace(
+            disaggregation_decode_enable_offload_kvcache=False,
+        )
+        scheduler.model_config = SimpleNamespace(is_multimodal=False)
+        return scheduler
+
+    def test_standard_cache_modes_use_resource_leases(self):
+        scheduler = self._make_scheduler()
+        self.assertTrue(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        for cache_cls, allocator_cls in (
+            (ChunkCache, PagedTokenToKVPoolAllocator),
+            (RadixCache, TokenToKVPoolAllocator),
+            (SWAChunkCache, SWATokenToKVPoolAllocator),
+            (PureSWAChunkCache, PureSWATokenToKVPoolAllocator),
+        ):
+            scheduler.tree_cache = object.__new__(cache_cls)
+            scheduler.token_to_kv_pool_allocator = object.__new__(allocator_cls)
+            self.assertTrue(
+                scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+            )
+
+    def test_resource_leases_require_explicit_opt_in(self):
+        scheduler = self._make_scheduler()
+        with envs.SGLANG_ENABLE_DISAGG_DECODE_RESOURCE_LEASE.override(False):
+            self.assertFalse(
+                scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+            )
+
+    def test_unknown_resource_wrappers_fail_closed(self):
+        class CustomChunkCache(ChunkCache):
+            pass
+
+        class CustomTokenAllocator(TokenToKVPoolAllocator):
+            pass
+
+        scheduler = self._make_scheduler()
+        scheduler.tree_cache = object.__new__(CustomChunkCache)
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.token_to_kv_pool_allocator = object.__new__(CustomTokenAllocator)
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.req_to_token_pool = MagicMock()
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+    def test_complex_resource_modes_keep_global_barrier(self):
+        scheduler = self._make_scheduler()
+        for attr in (
+            "enable_decode_hicache",
+            "enable_hisparse",
+            "enable_unified_memory",
+        ):
+            setattr(scheduler, attr, True)
+            self.assertFalse(
+                scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+            )
+            setattr(scheduler, attr, False)
+
+        scheduler.server_args.disaggregation_decode_enable_offload_kvcache = True
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.disagg_decode_prealloc_queue.enable_staging = True
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler.model_config.is_multimodal = True
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+        scheduler = self._make_scheduler()
+        scheduler._war_barrier_enabled = False
+        self.assertFalse(
+            scheduler._can_overlap_decode_queue_with_forward_resource_lease()
+        )
+
+    def test_only_data_plane_inputs_bypass_pending_fence(self):
+        generate = MagicMock(spec=TokenizedGenerateReqInput)
+        generate.session_id = None
+        generate.session_params = None
+        abort = MagicMock(spec=AbortReq)
+        pause = MagicMock(spec=PauseGenerationReqInput)
+
+        self.assertTrue(Scheduler._can_dispatch_inputs_with_forward_resource_lease([]))
+        self.assertTrue(
+            Scheduler._can_dispatch_inputs_with_forward_resource_lease(
+                [generate, abort]
+            )
+        )
+        self.assertFalse(
+            Scheduler._can_dispatch_inputs_with_forward_resource_lease([pause])
+        )
+        generate.session_id = "session"
+        self.assertFalse(
+            Scheduler._can_dispatch_inputs_with_forward_resource_lease([generate])
+        )
+
+
+class TestProcessBatchResultResourceLease(CustomTestCase):
+    def _make_scheduler(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.publish_load_snapshot = MagicMock()
+        scheduler.batch_result_processor = MagicMock()
+        scheduler.metrics_reporter = MagicMock()
+        scheduler.enable_fpm = False
+        scheduler._maybe_clear_mm_inputs = MagicMock()
+        scheduler.maybe_send_health_check_signal = MagicMock()
+        return scheduler
+
+    def test_prebuilt_result_quiesces_before_releasing_decode_resources(self):
+        scheduler = self._make_scheduler()
+        batch = MagicMock()
+        batch.forward_mode.is_decode.return_value = False
+        batch.forward_mode.is_extend.return_value = False
+        batch.forward_mode.is_prebuilt.return_value = True
+        batch.forward_mode.is_idle.return_value = False
+        result = MagicMock()
+        order = MagicMock()
+        lease = MagicMock()
+        lease.synchronize_all_and_drain.side_effect = order.synchronize_and_drain
+        scheduler.batch_result_processor.process_batch_result_prebuilt.side_effect = (
+            order.process_prebuilt
+        )
+
+        scheduler.process_batch_result(batch, result, resource_lease=lease)
+
+        self.assertEqual(
+            [entry[0] for entry in order.mock_calls],
+            ["synchronize_and_drain", "process_prebuilt"],
+        )
+
+    def test_decode_result_keeps_fine_grained_resource_lease(self):
+        scheduler = self._make_scheduler()
+        batch = MagicMock()
+        batch.forward_mode.is_decode.return_value = True
+        batch.forward_mode.is_extend.return_value = False
+        batch.forward_mode.is_prebuilt.return_value = False
+        result = MagicMock()
+        lease = MagicMock()
+
+        scheduler.process_batch_result(batch, result, resource_lease=lease)
+
+        lease.synchronize_all_and_drain.assert_not_called()
+        scheduler.batch_result_processor.process_batch_result_decode.assert_called_once_with(
+            batch,
+            result,
+            resource_lease=lease,
+        )
+
+    def test_idle_result_does_not_serialize_resource_lease(self):
+        scheduler = self._make_scheduler()
+        batch = MagicMock()
+        batch.forward_mode.is_decode.return_value = False
+        batch.forward_mode.is_extend.return_value = False
+        batch.forward_mode.is_prebuilt.return_value = False
+        batch.forward_mode.is_idle.return_value = True
+        result = MagicMock()
+        lease = MagicMock()
+
+        scheduler.process_batch_result(batch, result, resource_lease=lease)
+
+        lease.synchronize_all_and_drain.assert_not_called()
+        scheduler.batch_result_processor.process_batch_result_idle.assert_called_once_with(
+            batch,
+            result,
+        )
+
+
+class TestDecodeRetractionResourceLease(CustomTestCase):
+    def test_quarantine_is_drained_before_retracting_live_requests(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = False
+        scheduler.new_token_ratio_tracker = MagicMock()
+        batch = MagicMock()
+        batch.batch_size.return_value = 2
+        batch.is_empty.return_value = False
+        batch.check_decode_mem.side_effect = [False, True]
+        before_retract = MagicMock()
+
+        with patch(
+            "sglang.srt.managers.scheduler.TEST_RETRACT",
+            False,
+        ):
+            result = scheduler.update_running_batch(
+                batch,
+                before_decode_retract=before_retract,
+            )
+
+        self.assertIs(result, batch)
+        before_retract.assert_called_once_with()
+        batch.retract_decode.assert_not_called()
+        batch.prepare_for_decode.assert_called_once_with()
+
+    def test_test_retract_quiesces_before_retracting(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hierarchical_cache = False
+        scheduler.forward_ct = 0
+        scheduler.new_token_ratio_tracker = SimpleNamespace(
+            current=0.5,
+            decay_step=MagicMock(),
+        )
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.token_to_kv_pool_allocator.available_size.side_effect = [10, 20]
+        scheduler.tree_cache = SimpleNamespace(
+            req_to_token_pool=SimpleNamespace(mamba_allocator=None)
+        )
+        scheduler.metrics_reporter = SimpleNamespace(
+            num_retracted_reqs=0,
+            enable_metrics=False,
+        )
+        scheduler.server_args = MagicMock()
+        order = MagicMock()
+        before_retract = MagicMock(side_effect=order.before_retract)
+        batch = MagicMock()
+        batch.batch_size.return_value = 2
+        batch.is_empty.return_value = False
+        batch.check_decode_mem.return_value = True
+
+        def retract_decode(_):
+            order.retract_decode()
+            return [], 0.5, []
+
+        batch.retract_decode.side_effect = retract_decode
+
+        with patch(
+            "sglang.srt.managers.scheduler.TEST_RETRACT",
+            True,
+        ):
+            result = scheduler.update_running_batch(
+                batch,
+                before_decode_retract=before_retract,
+            )
+
+        self.assertIs(result, batch)
+        self.assertEqual(
+            [entry[0] for entry in order.mock_calls],
+            ["before_retract", "retract_decode"],
+        )
+        batch.prepare_for_decode.assert_called_once_with()
+
+
+class TestDecodeResultResourceLease(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        observability = patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor."
+            "get_observability",
+            return_value=SimpleNamespace(enable_metrics=False),
+        )
+        observability.start()
+        self.addCleanup(observability.stop)
+
+    def _make_processor(self):
+        server_args = SimpleNamespace(
+            disaggregation_decode_enable_offload_kvcache=False,
+            enable_metrics=False,
+            enable_hisparse=False,
+        )
+        metrics_reporter = MagicMock()
+        metrics_reporter.num_generated_tokens = 0
+        metrics_reporter.forward_ct_decode = 0
+        return SchedulerBatchResultProcessor(
+            is_generation=True,
+            disaggregation_mode=DisaggregationMode.DECODE,
+            enable_overlap=False,
+            enable_overlap_mlx=False,
+            server_args=server_args,
+            model_config=SimpleNamespace(think_end_ids=()),
+            token_to_kv_pool_allocator=MagicMock(),
+            tree_cache=MagicMock(),
+            hisparse_coordinator=None,
+            req_to_token_pool=MagicMock(),
+            decode_offload_manager=None,
+            metrics_collector=MagicMock(),
+            metrics_reporter=metrics_reporter,
+            draft_worker=MagicMock(),
+            model_worker=MagicMock(),
+            logprob_result_processor=MagicMock(),
+            output_streamer=MagicMock(),
+            abort_request=MagicMock(),
+        )
+
+    def _make_decode_case(self, *, finishes: bool):
+        order = MagicMock()
+        req = SimpleNamespace(
+            is_retracted=False,
+            output_ids=[],
+            require_reasoning=False,
+            time_stats=SimpleNamespace(set_last_decode_finish_time=MagicMock()),
+            update_finish_state=order.update_finish_state,
+            finished=MagicMock(return_value=finishes),
+            mamba_ping_pong_track_buffer=None,
+            return_logprob=False,
+            return_sampling_mask=False,
+            return_hidden_states=False,
+            grammar=None,
+        )
+        batch = SimpleNamespace(
+            reqs=[req],
+            spec_algorithm=SimpleNamespace(is_none=MagicMock(return_value=True)),
+            return_logprob=False,
+        )
+        result = SimpleNamespace(
+            copy_done=None,
+            routed_experts_output=None,
+            indexer_topk_output=None,
+            logits_output=SimpleNamespace(hidden_states=None),
+            next_token_ids=[7],
+            can_run_cuda_graph=True,
+            num_correct_drafts=0,
+            num_block_accept_tokens=0,
+            num_cap_tokens=0,
+            speculative_num_draft_tokens=None,
+        )
+        return order, req, batch, result
+
+    def test_finished_request_can_defer_without_waiting(self):
+        processor = self._make_processor()
+        order, _, batch, result = self._make_decode_case(finishes=True)
+        resource_lease = MagicMock()
+        resource_lease.try_defer_finished_req.return_value = True
+
+        with patch.object(
+            SchedulerBatchResultProcessor,
+            "_handle_finish_state_updated_req",
+            side_effect=lambda *_, **kwargs: order.finish_handler(
+                kwargs["resource_lease"]
+            ),
+        ):
+            processor.process_batch_result_decode(
+                batch,
+                result,
+                resource_lease=resource_lease,
+            )
+
+        resource_lease.wait_read_done.assert_not_called()
+        self.assertIs(
+            order.finish_handler.call_args.args[0],
+            resource_lease,
+        )
+
+    def test_unfinished_request_does_not_consume_fence(self):
+        processor = self._make_processor()
+        _, _, batch, result = self._make_decode_case(finishes=False)
+        resource_lease = MagicMock()
+
+        with patch.object(
+            SchedulerBatchResultProcessor,
+            "_handle_finish_state_updated_req",
+        ):
+            processor.process_batch_result_decode(
+                batch,
+                result,
+                resource_lease=resource_lease,
+            )
+
+        resource_lease.wait_read_done.assert_not_called()
+
+    def test_retirement_keeps_worker_hook_and_cache_release_atomic(self):
+        processor = self._make_processor()
+        req = SimpleNamespace()
+        order = MagicMock()
+        processor.model_worker.prepare_for_kv_cache_release.side_effect = (
+            lambda _: order.prepare()
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor."
+            "release_kv_cache",
+            side_effect=lambda *_, **__: order.release(),
+        ):
+            processor.release_finished_req_resources(req, is_insert=False)
+
+        self.assertEqual(
+            [entry[0] for entry in order.mock_calls],
+            ["prepare", "release"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

PR #31687 fixed a disaggregated decode use-after-free race by waiting on the WAR fence immediately after every launch. The fence is correct, but it also serializes result processing, queue maintenance, and request admission behind the GPU forward and creates a scheduler bubble.

Moving the fence back later recovers performance but is unsafe: finished requests can release and reuse request-pool rows or KV pages while the in-flight forward still reads them.

## Modifications

- Add a per-forward resource lease over request-pool rows, guarded by row generations.
- Wait on the existing read-done marker only before shared mapping mutations.
- Quarantine finished request slots and KV pages until the protecting forward epoch completes.
- Preserve the immediate global fence for unaudited session, cache, offload, multimodal, staging, and control paths.
- Add focused coverage for lease lifecycle, generation validation, result processing, retraction, admission overlap, and fail-closed fallbacks.

This PR is a new standalone change based on current `main`; it does not reuse or update #31270. The lease path is opt-in with `SGLANG_ENABLE_DISAGG_DECODE_RESOURCE_LEASE=1`; the default keeps the immediate global WAR fence.

## Accuracy Tests

- 28 focused resource-lease tests pass after rebasing onto current `main`.
- Full-repository pre-commit passes.
- The same build also passed six DSV4 WAR regression tests and two parameterized subtests.
- 65,626 benchmark requests completed with zero errors.

## Speed Tests and Profiling

The performance numbers below were collected before this rebase with the resource-lease path enabled.

DeepSeek-V4-Pro, EAGLE MTP step 3, disaggregated 6P+1D topology on 64 GB300 GPUs, concurrency 1024:

| Variant | Output throughput |
| --- | ---: |
| Immediate post-launch WAR fence (#31687 behavior) | ~30,351 tok/s |
| Resource lease (this PR) | 33,413.81 tok/s |
| Earlier unsafe fence placement | 33,613 tok/s |

This change is +10.1% over the safe immediate-fence baseline and within 0.6% of the unsafe placement. Median ITL was 21.98 ms.

## Checklist

- [x] Format code with full-repository pre-commit.
- [x] Add focused unit tests.
- [x] Provide accuracy and speed benchmark results.
- [ ] Documentation update is not applicable; this changes internal scheduler synchronization only.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process.
2. Get approvals from CODEOWNERS and relevant reviewers.
3. Trigger CI after initial review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31766277376](https://github.com/sgl-project/sglang/actions/runs/31766277376)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31766277242](https://github.com/sgl-project/sglang/actions/runs/31766277242)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->