### PR TITLE
[CI] Fix Marlin MoE test ServerArgs initialization

### DIFF
--- a/test/registered/quant/test_marlin_moe.py
+++ b/test/registered/quant/test_marlin_moe.py
@@ -14,7 +14,7 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=108, stage="base-b", runner_config="1-gpu-small")
 
-set_global_server_args_for_scheduler(object.__new__(ServerArgs))
+set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
 
 
 def stack_and_dev(tensors: list[torch.Tensor]):


### PR DESCRIPTION
## Summary

Caused by #31810

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29912592963](https://github.com/sgl-project/sglang/actions/runs/29912592963)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29912592351](https://github.com/sgl-project/sglang/actions/runs/29912592351)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->